### PR TITLE
Fix NXP unfiltered analog in compile error.

### DIFF
--- a/libraries/mbed/vendor/NXP/capi/analogin_api.c
+++ b/libraries/mbed/vendor/NXP/capi/analogin_api.c
@@ -180,7 +180,7 @@ static inline uint32_t adc_read_u32(analogin_t *obj) {
     order(&v1, &v2);
     value = v2;
 #else
-    value = adc_read(adc);
+    value = adc_read(obj);
 #endif
     return value;
 }


### PR DESCRIPTION
There is a typo which prevents the NXP analog in from compiling when median filtering is disabled.  This is a quick one-liner to fix that.
