### PR TITLE
Use correct setting for -mfpu when building for Cortex-M4 targets, and add a setting for using hard or soft floating point.

### DIFF
--- a/workspace_tools/settings.py
+++ b/workspace_tools/settings.py
@@ -71,6 +71,9 @@ IAR_PATH = "C:/Program Files (x86)/IAR Systems/Embedded Workbench 6.0/arm"
 GCC_CW_PATH  = "C:/Freescale/CW MCU v10.3/Cross_Tools/arm-none-eabi-gcc-4_6_2/bin"
 EWL_LIB_PATH = "C:/Freescale/CW MCU v10.3/MCU/ARM_GCC_Support/ewl/lib"
 
+# GCC float ABI
+M4_FLOAT_ABI = "softfp"
+
 try:
     # Allow to overwrite the default settings without the need to edit the
     # settings file stored in the repository

--- a/workspace_tools/toolchains.py
+++ b/workspace_tools/toolchains.py
@@ -556,7 +556,8 @@ class GCC(mbedToolchain):
             self.cpu.append("-mthumb")
         
         if target.core == "Cortex-M4":
-            self.cpu.append("-mfpu=vfp")
+            self.cpu.append("-mfpu=fpv4-sp-d16")
+            self.cpu.append("-mfloat-abi=%s" % M4_FLOAT_ABI)
         
         # Note: We are using "-O2" instead of "-Os" to avoid this known GCC bug:
         # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=46762


### PR DESCRIPTION
Change discussed in https://groups.google.com/forum/#!topic/mbed-devel/didoeCqf3fI
