### PR TITLE
LPC43xx port from Micromint

### DIFF
--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/LPC43xx.h
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/LPC43xx.h
@@ -1,0 +1,1987 @@
+/*
+ * @brief LPC43xx/LPC18xx MCU header
+ *
+ * Copyright(C) NXP Semiconductors, 2012
+ * All rights reserved.
+ *
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * LPC products.  This software is supplied "AS IS" without any warranties of
+ * any kind, and NXP Semiconductors and its licensor disclaim any and
+ * all warranties, express or implied, including all implied warranties of
+ * merchantability, fitness for a particular purpose and non-infringement of
+ * intellectual property rights.  NXP Semiconductors assumes no responsibility
+ * or liability for the use of the software, conveys no license or rights under any
+ * patent, copyright, mask work right, or any other intellectual property rights in
+ * or to any products. NXP Semiconductors reserves the right to make changes
+ * in the software without notification. NXP Semiconductors also makes no
+ * representation or warranty that such application will be suitable for the
+ * specified use without further testing or modification.
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation is hereby granted, under NXP Semiconductors' and its
+ * licensor's relevant copyrights in the software, without fee, provided that it
+ * is used in conjunction with NXP Semiconductors microcontrollers.  This
+ * copyright, permission, and disclaimer notice must appear in all copies of
+ * this code.
+ *
+ * Simplified version of NXP LPCOPEN LPC43XX/LPC18XX headers
+ *   05/15/13  Micromint USA <support@micromint.com>
+ */
+
+#ifndef __LPC43XX_H
+#define __LPC43XX_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @defgroup LPC43XX_H: LPC43xx include file
+ * @ingroup LPC43XX_Headers
+ * @{
+ */
+
+/* Treat __CORE_Mx as CORE_Mx for mbed builds */
+#if defined(__CORTEX_M0) && !defined(CORE_M0)
+  #define CORE_M0
+#endif
+#if defined(__CORTEX_M3) && !defined(CORE_M3)
+  #define CORE_M3
+#endif
+/* Default to M4 core if no core explicitly declared */
+#if !defined(CORE_M0) && !defined(CORE_M3)
+  #define CORE_M4
+#endif
+
+/* Start of section using anonymous unions */
+#if defined(__ARMCC_VERSION)
+// Kill warning "#pragma push with no matching #pragma pop"
+  #pragma diag_suppress 2525
+  #pragma push
+  #pragma anon_unions
+#elif defined(__CWCC__)
+  #pragma push
+  #pragma cpp_extensions on
+#elif defined(__IAR_SYSTEMS_ICC__)
+  //#pragma push // FIXME not usable for IAR
+  #pragma language=extended
+#else /* defined(__GNUC__) and others */
+  /* Assume anonymous unions are enabled by default */
+#endif
+
+#if defined(CORE_M4)
+/**
+ * @brief LPC43xx Cortex CMSIS definitions
+ */
+
+#define __CM4_REV              0x0000		/*!< Cortex-M4 Core Revision               */
+#define __MPU_PRESENT             1			/*!< MPU present or not                    */
+#define __NVIC_PRIO_BITS          3			/*!< Number of Bits used for Priority Levels */
+#define __Vendor_SysTickConfig    0			/*!< Set to 1 if different SysTick Config is used */
+#define __FPU_PRESENT             1			/*!< FPU present or not                    */
+#define CHIP_LPC43XX                    /*!< LPCOPEN                               */
+
+/**
+ * @brief LPC43xx peripheral interrupt numbers
+ */
+
+typedef enum {
+	/* -------------------------  Cortex-M4 Processor Exceptions Numbers  ----------------------------- */
+	Reset_IRQn                        = -15,/*!<   1  Reset Vector, invoked on Power up and warm reset */
+	NonMaskableInt_IRQn               = -14,/*!<   2  Non maskable Interrupt, cannot be stopped or preempted */
+	HardFault_IRQn                    = -13,/*!<   3  Hard Fault, all classes of Fault */
+	MemoryManagement_IRQn             = -12,/*!<   4  Memory Management, MPU mismatch, including Access Violation and No Match */
+	BusFault_IRQn                     = -11,/*!<   5  Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault */
+	UsageFault_IRQn                   = -10,/*!<   6  Usage Fault, i.e. Undef Instruction, Illegal State Transition */
+	SVCall_IRQn                       =  -5,/*!<  11  System Service Call via SVC instruction */
+	DebugMonitor_IRQn                 =  -4,/*!<  12  Debug Monitor                    */
+	PendSV_IRQn                       =  -2,/*!<  14  Pendable request for system service */
+	SysTick_IRQn                      =  -1,/*!<  15  System Tick Timer                */
+
+	/* ---------------------------  LPC18xx/43xx Specific Interrupt Numbers  ------------------------------- */
+	DAC_IRQn                          =   0,/*!<   0  DAC                              */
+	M0CORE_IRQn                       =   1,/*!<   1  M0a                              */
+	DMA_IRQn                          =   2,/*!<   2  DMA                              */
+	RESERVED1_IRQn                    =   3,/*!<   3  EZH/EDM                          */
+	RESERVED2_IRQn                    =   4,
+	ETHERNET_IRQn                     =   5,/*!<   5  ETHERNET                         */
+	SDIO_IRQn                         =   6,/*!<   6  SDIO                             */
+	LCD_IRQn                          =   7,/*!<   7  LCD                              */
+	USB0_IRQn                         =   8,/*!<   8  USB0                             */
+	USB1_IRQn                         =   9,/*!<   9  USB1                             */
+	SCT_IRQn                          =  10,/*!<  10  SCT                              */
+	RITIMER_IRQn                      =  11,/*!<  11  RITIMER                          */
+	TIMER0_IRQn                       =  12,/*!<  12  TIMER0                           */
+	TIMER1_IRQn                       =  13,/*!<  13  TIMER1                           */
+	TIMER2_IRQn                       =  14,/*!<  14  TIMER2                           */
+	TIMER3_IRQn                       =  15,/*!<  15  TIMER3                           */
+	MCPWM_IRQn                        =  16,/*!<  16  MCPWM                            */
+	ADC0_IRQn                         =  17,/*!<  17  ADC0                             */
+	I2C0_IRQn                         =  18,/*!<  18  I2C0                             */
+	I2C1_IRQn                         =  19,/*!<  19  I2C1                             */
+	SPI_INT_IRQn                      =  20,/*!<  20  SPI_INT                          */
+	ADC1_IRQn                         =  21,/*!<  21  ADC1                             */
+	SSP0_IRQn                         =  22,/*!<  22  SSP0                             */
+	SSP1_IRQn                         =  23,/*!<  23  SSP1                             */
+	USART0_IRQn                       =  24,/*!<  24  USART0                           */
+	UART1_IRQn                        =  25,/*!<  25  UART1                            */
+	USART2_IRQn                       =  26,/*!<  26  USART2                           */
+	USART3_IRQn                       =  27,/*!<  27  USART3                           */
+	I2S0_IRQn                         =  28,/*!<  28  I2S0                             */
+	I2S1_IRQn                         =  29,/*!<  29  I2S1                             */
+	RESERVED4_IRQn                    =  30,
+	SGPIO_INT_IRQn                    =  31,/*!<  31  SGPIO_IINT                       */
+	PIN_INT0_IRQn                     =  32,/*!<  32  PIN_INT0                         */
+	PIN_INT1_IRQn                     =  33,/*!<  33  PIN_INT1                         */
+	PIN_INT2_IRQn                     =  34,/*!<  34  PIN_INT2                         */
+	PIN_INT3_IRQn                     =  35,/*!<  35  PIN_INT3                         */
+	PIN_INT4_IRQn                     =  36,/*!<  36  PIN_INT4                         */
+	PIN_INT5_IRQn                     =  37,/*!<  37  PIN_INT5                         */
+	PIN_INT6_IRQn                     =  38,/*!<  38  PIN_INT6                         */
+	PIN_INT7_IRQn                     =  39,/*!<  39  PIN_INT7                         */
+	GINT0_IRQn                        =  40,/*!<  40  GINT0                            */
+	GINT1_IRQn                        =  41,/*!<  41  GINT1                            */
+	EVENTROUTER_IRQn                  =  42,/*!<  42  EVENTROUTER                      */
+	C_CAN1_IRQn                       =  43,/*!<  43  C_CAN1                           */
+	RESERVED6_IRQn                    =  44,
+	RESERVED7_IRQn                    =  45,/*!<  45  VADC                             */
+	ATIMER_IRQn                       =  46,/*!<  46  ATIMER                           */
+	RTC_IRQn                          =  47,/*!<  47  RTC                              */
+	RESERVED8_IRQn                    =  48,
+	WWDT_IRQn                         =  49,/*!<  49  WWDT                             */
+	RESERVED9_IRQn                    =  50,
+	C_CAN0_IRQn                       =  51,/*!<  51  C_CAN0                           */
+	QEI_IRQn                          =  52,/*!<  52  QEI                              */
+} IRQn_Type;
+
+#include "core_cm4.h"						/*!< Cortex-M4 processor and core peripherals */
+
+#elif defined(CORE_M3)
+/**
+ * @brief LPC18xx Cortex CMSIS definitions
+ */
+#define __MPU_PRESENT             1			/*!< MPU present or not                    */
+#define __NVIC_PRIO_BITS          3			/*!< Number of Bits used for Priority Levels */
+#define __Vendor_SysTickConfig    0			/*!< Set to 1 if different SysTick Config is used */
+#define __FPU_PRESENT             0			/*!< FPU present or not                    */
+#define CHIP_LPC18XX                    /*!< LPCOPEN                               */
+
+/**
+ * @brief LPC18xx peripheral interrupt numbers
+ */
+
+typedef enum {
+	/* -------------------------  Cortex-M3 Processor Exceptions Numbers  ----------------------------- */
+	Reset_IRQn                        = -15,/*!<   1  Reset Vector, invoked on Power up and warm reset */
+	NonMaskableInt_IRQn               = -14,/*!<   2  Non maskable Interrupt, cannot be stopped or preempted */
+	HardFault_IRQn                    = -13,/*!<   3  Hard Fault, all classes of Fault */
+	MemoryManagement_IRQn             = -12,/*!<   4  Memory Management, MPU mismatch, including Access Violation and No Match */
+	BusFault_IRQn                     = -11,/*!<   5  Bus Fault, Pre-Fetch-, Memory Access Fault, other address/memory related Fault */
+	UsageFault_IRQn                   = -10,/*!<   6  Usage Fault, i.e. Undef Instruction, Illegal State Transition */
+	SVCall_IRQn                       = -5,	/*!<  11  System Service Call via SVC instruction */
+	DebugMonitor_IRQn                 = -4,	/*!<  12  Debug Monitor                    */
+	PendSV_IRQn                       = -2,	/*!<  14  Pendable request for system service */
+	SysTick_IRQn                      = -1,	/*!<  15  System Tick Timer                */
+
+	/* ---------------------------  LPC18xx/43xx Specific Interrupt Numbers  ------------------------------- */
+	DAC_IRQn                          =   0,/*!<   0  DAC                              */
+	RESERVED0_IRQn                    =   1,
+	DMA_IRQn                          =   2,/*!<   2  DMA                              */
+	RESERVED1_IRQn                    =   3,/*!<   3  EZH/EDM                          */
+	RESERVED2_IRQn                    =   4,
+	ETHERNET_IRQn                     =   5,/*!<   5  ETHERNET                         */
+	SDIO_IRQn                         =   6,/*!<   6  SDIO                             */
+	LCD_IRQn                          =   7,/*!<   7  LCD                              */
+	USB0_IRQn                         =   8,/*!<   8  USB0                             */
+	USB1_IRQn                         =   9,/*!<   9  USB1                             */
+	SCT_IRQn                          =  10,/*!<  10  SCT                              */
+	RITIMER_IRQn                      =  11,/*!<  11  RITIMER                          */
+	TIMER0_IRQn                       =  12,/*!<  12  TIMER0                           */
+	TIMER1_IRQn                       =  13,/*!<  13  TIMER1                           */
+	TIMER2_IRQn                       =  14,/*!<  14  TIMER2                           */
+	TIMER3_IRQn                       =  15,/*!<  15  TIMER3                           */
+	MCPWM_IRQn                        =  16,/*!<  16  MCPWM                            */
+	ADC0_IRQn                         =  17,/*!<  17  ADC0                             */
+	I2C0_IRQn                         =  18,/*!<  18  I2C0                             */
+	I2C1_IRQn                         =  19,/*!<  19  I2C1                             */
+	RESERVED3_IRQn                    =  20,
+	ADC1_IRQn                         =  21,/*!<  21  ADC1                             */
+	SSP0_IRQn                         =  22,/*!<  22  SSP0                             */
+	SSP1_IRQn                         =  23,/*!<  23  SSP1                             */
+	USART0_IRQn                       =  24,/*!<  24  USART0                           */
+	UART1_IRQn                        =  25,/*!<  25  UART1                            */
+	USART2_IRQn                       =  26,/*!<  26  USART2                           */
+	USART3_IRQn                       =  27,/*!<  27  USART3                           */
+	I2S0_IRQn                         =  28,/*!<  28  I2S0                             */
+	I2S1_IRQn                         =  29,/*!<  29  I2S1                             */
+	RESERVED4_IRQn                    =  30,
+	RESERVED5_IRQn                    =  31,
+	PIN_INT0_IRQn                     =  32,/*!<  32  PIN_INT0                         */
+	PIN_INT1_IRQn                     =  33,/*!<  33  PIN_INT1                         */
+	PIN_INT2_IRQn                     =  34,/*!<  34  PIN_INT2                         */
+	PIN_INT3_IRQn                     =  35,/*!<  35  PIN_INT3                         */
+	PIN_INT4_IRQn                     =  36,/*!<  36  PIN_INT4                         */
+	PIN_INT5_IRQn                     =  37,/*!<  37  PIN_INT5                         */
+	PIN_INT6_IRQn                     =  38,/*!<  38  PIN_INT6                         */
+	PIN_INT7_IRQn                     =  39,/*!<  39  PIN_INT7                         */
+	GINT0_IRQn                        =  40,/*!<  40  GINT0                            */
+	GINT1_IRQn                        =  41,/*!<  41  GINT1                            */
+	EVENTROUTER_IRQn                  =  42,/*!<  42  EVENTROUTER                      */
+	C_CAN1_IRQn                       =  43,/*!<  43  C_CAN1                           */
+	RESERVED6_IRQn                    =  44,
+	RESERVED7_IRQn                    =  45,/*!<  45  VADC                             */
+	ATIMER_IRQn                       =  46,/*!<  46  ATIMER                           */
+	RTC_IRQn                          =  47,/*!<  47  RTC                              */
+	RESERVED8_IRQn                    =  48,
+	WWDT_IRQn                         =  49,/*!<  49  WWDT                             */
+	RESERVED9_IRQn                    =  50,
+	C_CAN0_IRQn                       =  51,/*!<  51  C_CAN0                           */
+	QEI_IRQn                          =  52,/*!<  52  QEI                              */
+} IRQn_Type;
+
+#include "core_cm3.h"						/*!< Cortex-M3 processor and core peripherals */
+
+#elif defined(CORE_M0)
+/**
+ * @brief LPC43xx (M0 Core) Cortex CMSIS definitions
+ */
+
+#define __MPU_PRESENT             0			/*!< MPU present or not                    */
+#define __NVIC_PRIO_BITS          2			/*!< Number of Bits used for Priority Levels */
+#define __Vendor_SysTickConfig    0			/*!< Set to 1 if different SysTick Config is used */
+#define __FPU_PRESENT             0			/*!< FPU present or not                    */
+#define CHIP_LPC43XX                    /*!< LPCOPEN                               */
+
+/**
+ * @brief LPC43xx (M0 Core) peripheral interrupt numbers
+ */
+
+typedef enum {
+	/* -------------------------  Cortex-M0 Processor Exceptions Numbers  ----------------------------- */
+	Reset_IRQn                        = -15,/*!<   1  Reset Vector, invoked on Power up and warm reset */
+	NonMaskableInt_IRQn               = -14,/*!<   2  Non maskable Interrupt, cannot be stopped or preempted */
+	HardFault_IRQn                    = -13,/*!<   3  Hard Fault, all classes of Fault */
+	SVCall_IRQn                       = -5,	/*!<  11  System Service Call via SVC instruction */
+	DebugMonitor_IRQn                 = -4,	/*!<  12  Debug Monitor                    */
+	PendSV_IRQn                       = -2,	/*!<  14  Pendable request for system service */
+	SysTick_IRQn                      = -1,	/*!<  15  System Tick Timer           */
+
+	/* ---------------------------  LPC18xx/43xx Specific Interrupt Numbers  ------------------------------- */
+	DAC_IRQn                          =   0,/*!<   0  DAC                              */
+	M0_M4CORE_IRQn                    =   1,/*!<   1  M0a                              */
+	DMA_IRQn                          =   2,/*!<   2  DMA  r                            */
+	RESERVED1_IRQn                    =   3,/*!<   3  EZH/EDM                          */
+	FLASHEEPROM_IRQn                  =   4,/*!<   4  ORed Flash EEPROM Bank A, B, EEPROM   */
+	ETHERNET_IRQn                     =   5,/*!<   5  ETHERNET                         */
+	SDIO_IRQn                         =   6,/*!<   6  SDIO                             */
+	LCD_IRQn                          =   7,/*!<   7  LCD                              */
+	USB0_IRQn                         =   8,/*!<   8  USB0                             */
+	USB1_IRQn                         =   9,/*!<   9  USB1                             */
+	SCT_IRQn                          =  10,/*!<  10  SCT                              */
+	RITIMER_IRQn                      =  11,/*!<  11  ORed RITIMER, WDT                */
+	TIMER0_IRQn                       =  12,/*!<  12  TIMER0                           */
+	GINT1_IRQn                        =  13,/*!<  13  GINT1                            */
+	PIN_INT4_IRQn                     =  14,/*!<  14  GPIO 4                           */
+	TIMER3_IRQn                       =  15,/*!<  15  TIMER3                           */
+	MCPWM_IRQn                        =  16,/*!<  16  MCPWM                            */
+	ADC0_IRQn                         =  17,/*!<  17  ADC0                             */
+	I2C0_IRQn                         =  18,/*!<  18  ORed I2C0, I2C1                  */
+	SGPIO_INT_IRQn                    =  19,/*!<  19  SGPIO                            */
+	SPI_INT_IRQn                      =  20,/*!<  20  SPI_INT                          */
+	ADC1_IRQn                         =  21,/*!<  21  ADC1                             */
+	SSP0_IRQn                         =  22,/*!<  22  ORed SSP0, SSP1                  */
+	EVENTROUTER_IRQn                  =  23,/*!<  23  EVENTROUTER                      */
+	USART0_IRQn                       =  24,/*!<  24  USART0                           */
+	UART1_IRQn                        =  25,/*!<  25  UART1                            */
+	USART2_IRQn                       =  26,/*!<  26  USART2                           */
+	USART3_IRQn                       =  27,/*!<  27  USART3                           */
+	I2S0_IRQn                         =  28,/*!<  28  ORed I2S0, I2S1                  */
+	C_CAN0_IRQn                       =  29,/*!<  29  C_CAN0                           */
+	I2S1_IRQn                         =  29,/*!<  29  I2S1                             */
+	RESERVED2_IRQn                    =  30,
+	RESERVED3_IRQn                    =  31,
+} IRQn_Type;
+
+#include "core_cm0.h"						/*!< Cortex-M4 processor and core peripherals */
+#else
+#error Please #define CORE_M0, CORE_M3 or CORE_M4
+#endif
+
+#include "system_LPC43xx.h"
+
+/**
+ * @brief State Configurable Timer register block structure
+ */
+#define LPC_SCT_BASE              0x40000000
+#define CONFIG_SCT_nEV   (16)			/*!< Number of events */
+#define CONFIG_SCT_nRG   (16)			/*!< Number of match/compare registers */
+#define CONFIG_SCT_nOU   (16)			/*!< Number of outputs */
+
+typedef struct {
+	__IO  uint32_t CONFIG;				/*!< Configuration Register */
+	union {
+		__IO uint32_t CTRL_U;			/*!< Control Register */
+		struct {
+			__IO uint16_t CTRL_L;		/*!< Low control register */
+			__IO uint16_t CTRL_H;		/*!< High control register */
+		};
+
+	};
+
+	__IO uint16_t LIMIT_L;				/*!< limit register for counter L */
+	__IO uint16_t LIMIT_H;				/*!< limit register for counter H */
+	__IO uint16_t HALT_L;				/*!< halt register for counter L */
+	__IO uint16_t HALT_H;				/*!< halt register for counter H */
+	__IO uint16_t STOP_L;				/*!< stop register for counter L */
+	__IO uint16_t STOP_H;				/*!< stop register for counter H */
+	__IO uint16_t START_L;				/*!< start register for counter L */
+	__IO uint16_t START_H;				/*!< start register for counter H */
+	uint32_t RESERVED1[10];				/*!< 0x03C reserved */
+	union {
+		__IO uint32_t COUNT_U;			/*!< counter register */
+		struct {
+			__IO uint16_t COUNT_L;		/*!< counter register for counter L */
+			__IO uint16_t COUNT_H;		/*!< counter register for counter H */
+		};
+
+	};
+
+	__IO uint16_t STATE_L;				/*!< state register for counter L */
+	__IO uint16_t STATE_H;				/*!< state register for counter H */
+	__I  uint32_t INPUT;				/*!< input register */
+	__IO uint16_t REGMODE_L;			/*!< match - capture registers mode register L */
+	__IO uint16_t REGMODE_H;			/*!< match - capture registers mode register H */
+	__IO uint32_t OUTPUT;				/*!< output register */
+	__IO uint32_t OUTPUTDIRCTRL;		/*!< output counter direction Control Register */
+	__IO uint32_t RES;					/*!< conflict resolution register */
+	__IO uint32_t DMA0REQUEST;			/*!< DMA0 Request Register */
+	__IO uint32_t DMA1REQUEST;			/*!< DMA1 Request Register */
+	uint32_t RESERVED2[35];
+	__IO uint32_t EVEN;					/*!< event enable register */
+	__IO uint32_t EVFLAG;				/*!< event flag register */
+	__IO uint32_t CONEN;				/*!< conflict enable register */
+	__IO uint32_t CONFLAG;				/*!< conflict flag register */
+	union {
+		__IO union {					/*!< ... Match / Capture value */
+			uint32_t U;					/*!<       SCTMATCH[i].U  Unified 32-bit register */
+			struct {
+				uint16_t L;				/*!<       SCTMATCH[i].L  Access to L value */
+				uint16_t H;				/*!<       SCTMATCH[i].H  Access to H value */
+			};
+
+		} MATCH[CONFIG_SCT_nRG];
+
+		__I union {
+			uint32_t U;					/*!<       SCTCAP[i].U  Unified 32-bit register */
+			struct {
+				uint16_t L;				/*!<       SCTCAP[i].L  Access to L value */
+				uint16_t H;				/*!<       SCTCAP[i].H  Access to H value */
+			};
+
+		} CAP[CONFIG_SCT_nRG];
+
+	};
+
+	uint32_t RESERVED3[32 - CONFIG_SCT_nRG];		/*!< ...-0x17C reserved */
+	union {
+		__IO uint16_t MATCH_L[CONFIG_SCT_nRG];		/*!< 0x180-... Match Value L counter */
+		__I  uint16_t CAP_L[CONFIG_SCT_nRG];		/*!< 0x180-... Capture Value L counter */
+	};
+
+	uint16_t RESERVED4[32 - CONFIG_SCT_nRG];		/*!< ...-0x1BE reserved */
+	union {
+		__IO uint16_t MATCH_H[CONFIG_SCT_nRG];		/*!< 0x1C0-... Match Value H counter */
+		__I  uint16_t CAP_H[CONFIG_SCT_nRG];		/*!< 0x1C0-... Capture Value H counter */
+	};
+
+	uint16_t RESERVED5[32 - CONFIG_SCT_nRG];		/*!< ...-0x1FE reserved */
+	union {
+		__IO union {					/*!< 0x200-... Match Reload / Capture Control value */
+			uint32_t U;					/*!<       SCTMATCHREL[i].U  Unified 32-bit register */
+			struct {
+				uint16_t L;				/*!<       SCTMATCHREL[i].L  Access to L value */
+				uint16_t H;				/*!<       SCTMATCHREL[i].H  Access to H value */
+			};
+
+		} MATCHREL[CONFIG_SCT_nRG];
+
+		__IO union {
+			uint32_t U;					/*!<       SCTCAPCTRL[i].U  Unified 32-bit register */
+			struct {
+				uint16_t L;				/*!<       SCTCAPCTRL[i].L  Access to L value */
+				uint16_t H;				/*!<       SCTCAPCTRL[i].H  Access to H value */
+			};
+
+		} CAPCTRL[CONFIG_SCT_nRG];
+
+	};
+
+	uint32_t RESERVED6[32 - CONFIG_SCT_nRG];		/*!< ...-0x27C reserved */
+	union {
+		__IO uint16_t MATCHREL_L[CONFIG_SCT_nRG];	/*!< 0x280-... Match Reload value L counter */
+		__IO uint16_t CAPCTRL_L[CONFIG_SCT_nRG];	/*!< 0x280-... Capture Control value L counter */
+	};
+
+	uint16_t RESERVED7[32 - CONFIG_SCT_nRG];		/*!< ...-0x2BE reserved */
+	union {
+		__IO uint16_t MATCHREL_H[CONFIG_SCT_nRG];	/*!< 0x2C0-... Match Reload value H counter */
+		__IO uint16_t CAPCTRL_H[CONFIG_SCT_nRG];	/*!< 0x2C0-... Capture Control value H counter */
+	};
+
+	uint16_t RESERVED8[32 - CONFIG_SCT_nRG];		/*!< ...-0x2FE reserved */
+	__IO struct {						/*!< 0x300-0x3FC  SCTEVENT[i].STATE / SCTEVENT[i].CTRL*/
+		uint32_t STATE;					/*!< Event State Register */
+		uint32_t CTRL;					/*!< Event Control Register */
+	} EVENT[CONFIG_SCT_nEV];
+
+	uint32_t RESERVED9[128 - 2 * CONFIG_SCT_nEV];	/*!< ...-0x4FC reserved */
+	__IO struct {						/*!< 0x500-0x57C  SCTOUT[i].SET / SCTOUT[i].CLR */
+		uint32_t SET;					/*!< Output n Set Register */
+		uint32_t CLR;					/*!< Output n Clear Register */
+	} OUT[CONFIG_SCT_nOU];
+
+	uint32_t RESERVED10[191 - 2 * CONFIG_SCT_nOU];	/*!< ...-0x7F8 reserved */
+	__I  uint32_t MODULECONTENT;		/*!< 0x7FC Module Content */
+} LPC_SCT_T;
+
+/**
+ * @brief GPDMA Channel register block structure
+ */
+#define LPC_GPDMA_BASE            0x40002000
+
+typedef struct {
+	__IO uint32_t  SRCADDR;				/*!< DMA Channel Source Address Register */
+	__IO uint32_t  DESTADDR;			/*!< DMA Channel Destination Address Register */
+	__IO uint32_t  LLI;					/*!< DMA Channel Linked List Item Register */
+	__IO uint32_t  CONTROL;				/*!< DMA Channel Control Register */
+	__IO uint32_t  CONFIG;				/*!< DMA Channel Configuration Register */
+	__I  uint32_t  RESERVED1[3];
+} LPC_GPDMA_CH_T;
+
+#define GPDMA_CHANNELS 8
+
+/**
+ * @brief GPDMA register block
+ */
+typedef struct {						/*!< GPDMA Structure */
+	__I  uint32_t  INTSTAT;				/*!< DMA Interrupt Status Register */
+	__I  uint32_t  INTTCSTAT;			/*!< DMA Interrupt Terminal Count Request Status Register */
+	__O  uint32_t  INTTCCLEAR;			/*!< DMA Interrupt Terminal Count Request Clear Register */
+	__I  uint32_t  INTERRSTAT;			/*!< DMA Interrupt Error Status Register */
+	__O  uint32_t  INTERRCLR;			/*!< DMA Interrupt Error Clear Register */
+	__I  uint32_t  RAWINTTCSTAT;		/*!< DMA Raw Interrupt Terminal Count Status Register */
+	__I  uint32_t  RAWINTERRSTAT;		/*!< DMA Raw Error Interrupt Status Register */
+	__I  uint32_t  ENBLDCHNS;			/*!< DMA Enabled Channel Register */
+	__IO uint32_t  SOFTBREQ;			/*!< DMA Software Burst Request Register */
+	__IO uint32_t  SOFTSREQ;			/*!< DMA Software Single Request Register */
+	__IO uint32_t  SOFTLBREQ;			/*!< DMA Software Last Burst Request Register */
+	__IO uint32_t  SOFTLSREQ;			/*!< DMA Software Last Single Request Register */
+	__IO uint32_t  CONFIG;				/*!< DMA Configuration Register */
+	__IO uint32_t  SYNC;				/*!< DMA Synchronization Register */
+	__I  uint32_t  RESERVED0[50];
+	LPC_GPDMA_CH_T CH[GPDMA_CHANNELS];
+} LPC_GPDMA_T;
+
+/**
+ * @brief SD/MMC & SDIO register block structure
+ */
+#define LPC_SDMMC_BASE            0x40004000
+
+typedef struct {				/*!< SDMMC Structure        */
+	__IO uint32_t  CTRL;		/*!< Control Register       */
+	__IO uint32_t  PWREN;		/*!< Power Enable Register  */
+	__IO uint32_t  CLKDIV;		/*!< Clock Divider Register */
+	__IO uint32_t  CLKSRC;		/*!< SD Clock Source Register */
+	__IO uint32_t  CLKENA;		/*!< Clock Enable Register  */
+	__IO uint32_t  TMOUT;		/*!< Timeout Register       */
+	__IO uint32_t  CTYPE;		/*!< Card Type Register     */
+	__IO uint32_t  BLKSIZ;		/*!< Block Size Register    */
+	__IO uint32_t  BYTCNT;		/*!< Byte Count Register    */
+	__IO uint32_t  INTMASK;		/*!< Interrupt Mask Register */
+	__IO uint32_t  CMDARG;		/*!< Command Argument Register */
+	__IO uint32_t  CMD;			/*!< Command Register       */
+	__I  uint32_t  RESP0;		/*!< Response Register 0    */
+	__I  uint32_t  RESP1;		/*!< Response Register 1    */
+	__I  uint32_t  RESP2;		/*!< Response Register 2    */
+	__I  uint32_t  RESP3;		/*!< Response Register 3    */
+	__I  uint32_t  MINTSTS;		/*!< Masked Interrupt Status Register */
+	__IO uint32_t  RINTSTS;		/*!< Raw Interrupt Status Register */
+	__I  uint32_t  STATUS;		/*!< Status Register        */
+	__IO uint32_t  FIFOTH;		/*!< FIFO Threshold Watermark Register */
+	__I  uint32_t  CDETECT;		/*!< Card Detect Register   */
+	__I  uint32_t  WRTPRT;		/*!< Write Protect Register */
+	__IO uint32_t  GPIO;		/*!< General Purpose Input/Output Register */
+	__I  uint32_t  TCBCNT;		/*!< Transferred CIU Card Byte Count Register */
+	__I  uint32_t  TBBCNT;		/*!< Transferred Host to BIU-FIFO Byte Count Register */
+	__IO uint32_t  DEBNCE;		/*!< Debounce Count Register */
+	__IO uint32_t  USRID;		/*!< User ID Register       */
+	__I  uint32_t  VERID;		/*!< Version ID Register    */
+	__I  uint32_t  RESERVED0;
+	__IO uint32_t  UHS_REG;		/*!< UHS-1 Register         */
+	__IO uint32_t  RST_N;		/*!< Hardware Reset         */
+	__I  uint32_t  RESERVED1;
+	__IO uint32_t  BMOD;		/*!< Bus Mode Register      */
+	__O  uint32_t  PLDMND;		/*!< Poll Demand Register   */
+	__IO uint32_t  DBADDR;		/*!< Descriptor List Base Address Register */
+	__IO uint32_t  IDSTS;		/*!< Internal DMAC Status Register */
+	__IO uint32_t  IDINTEN;		/*!< Internal DMAC Interrupt Enable Register */
+	__I  uint32_t  DSCADDR;		/*!< Current Host Descriptor Address Register */
+	__I  uint32_t  BUFADDR;		/*!< Current Buffer Descriptor Address Register */
+} LPC_SDMMC_T;
+
+/**
+ * @brief External Memory Controller (EMC) register block structure
+ */
+#define LPC_EMC_BASE              0x40005000
+
+typedef struct {							/*!< EMC Structure          */
+	__IO uint32_t  CONTROL;					/*!< Controls operation of the memory controller. */
+	__I  uint32_t  STATUS;					/*!< Provides EMC status information. */
+	__IO uint32_t  CONFIG;					/*!< Configures operation of the memory controller. */
+	__I  uint32_t  RESERVED0[5];
+	__IO uint32_t  DYNAMICCONTROL;			/*!< Controls dynamic memory operation. */
+	__IO uint32_t  DYNAMICREFRESH;			/*!< Configures dynamic memory refresh operation. */
+	__IO uint32_t  DYNAMICREADCONFIG;		/*!< Configures the dynamic memory read strategy. */
+	__I  uint32_t  RESERVED1;
+	__IO uint32_t  DYNAMICRP;				/*!< Selects the precharge command period. */
+	__IO uint32_t  DYNAMICRAS;				/*!< Selects the active to precharge command period. */
+	__IO uint32_t  DYNAMICSREX;				/*!< Selects the self-refresh exit time. */
+	__IO uint32_t  DYNAMICAPR;				/*!< Selects the last-data-out to active command time. */
+	__IO uint32_t  DYNAMICDAL;				/*!< Selects the data-in to active command time. */
+	__IO uint32_t  DYNAMICWR;				/*!< Selects the write recovery time. */
+	__IO uint32_t  DYNAMICRC;				/*!< Selects the active to active command period. */
+	__IO uint32_t  DYNAMICRFC;				/*!< Selects the auto-refresh period. */
+	__IO uint32_t  DYNAMICXSR;				/*!< Selects the exit self-refresh to active command time. */
+	__IO uint32_t  DYNAMICRRD;				/*!< Selects the active bank A to active bank B latency. */
+	__IO uint32_t  DYNAMICMRD;				/*!< Selects the load mode register to active command time. */
+	__I  uint32_t  RESERVED2[9];
+	__IO uint32_t  STATICEXTENDEDWAIT;		/*!< Selects time for long static memory read and write transfers. */
+	__I  uint32_t  RESERVED3[31];
+	__IO uint32_t  DYNAMICCONFIG0;			/*!< Selects the configuration information for dynamic memory chip select n. */
+	__IO uint32_t  DYNAMICRASCAS0;			/*!< Selects the RAS and CAS latencies for dynamic memory chip select n. */
+	__I  uint32_t  RESERVED4[6];
+	__IO uint32_t  DYNAMICCONFIG1;			/*!< Selects the configuration information for dynamic memory chip select n. */
+	__IO uint32_t  DYNAMICRASCAS1;			/*!< Selects the RAS and CAS latencies for dynamic memory chip select n. */
+	__I  uint32_t  RESERVED5[6];
+	__IO uint32_t  DYNAMICCONFIG2;			/*!< Selects the configuration information for dynamic memory chip select n. */
+	__IO uint32_t  DYNAMICRASCAS2;			/*!< Selects the RAS and CAS latencies for dynamic memory chip select n. */
+	__I  uint32_t  RESERVED6[6];
+	__IO uint32_t  DYNAMICCONFIG3;			/*!< Selects the configuration information for dynamic memory chip select n. */
+	__IO uint32_t  DYNAMICRASCAS3;			/*!< Selects the RAS and CAS latencies for dynamic memory chip select n. */
+	__I  uint32_t  RESERVED7[38];
+	__IO uint32_t  STATICCONFIG0;			/*!< Selects the memory configuration for static chip select n. */
+	__IO uint32_t  STATICWAITWEN0;			/*!< Selects the delay from chip select n to write enable. */
+	__IO uint32_t  STATICWAITOEN0;			/*!< Selects the delay from chip select n or address change, whichever is later, to output enable. */
+	__IO uint32_t  STATICWAITRD0;			/*!< Selects the delay from chip select n to a read access. */
+	__IO uint32_t  STATICWAITPAG0;			/*!< Selects the delay for asynchronous page mode sequential accesses for chip select n. */
+	__IO uint32_t  STATICWAITWR0;			/*!< Selects the delay from chip select n to a write access. */
+	__IO uint32_t  STATICWAITTURN0;			/*!< Selects bus turnaround cycles */
+	__I  uint32_t  RESERVED8;
+	__IO uint32_t  STATICCONFIG1;			/*!< Selects the memory configuration for static chip select n. */
+	__IO uint32_t  STATICWAITWEN1;			/*!< Selects the delay from chip select n to write enable. */
+	__IO uint32_t  STATICWAITOEN1;			/*!< Selects the delay from chip select n or address change, whichever is later, to output enable. */
+	__IO uint32_t  STATICWAITRD1;			/*!< Selects the delay from chip select n to a read access. */
+	__IO uint32_t  STATICWAITPAG1;			/*!< Selects the delay for asynchronous page mode sequential accesses for chip select n. */
+	__IO uint32_t  STATICWAITWR1;			/*!< Selects the delay from chip select n to a write access. */
+	__IO uint32_t  STATICWAITTURN1;			/*!< Selects bus turnaround cycles */
+	__I  uint32_t  RESERVED9;
+	__IO uint32_t  STATICCONFIG2;			/*!< Selects the memory configuration for static chip select n. */
+	__IO uint32_t  STATICWAITWEN2;			/*!< Selects the delay from chip select n to write enable. */
+	__IO uint32_t  STATICWAITOEN2;			/*!< Selects the delay from chip select n or address change, whichever is later, to output enable. */
+	__IO uint32_t  STATICWAITRD2;			/*!< Selects the delay from chip select n to a read access. */
+	__IO uint32_t  STATICWAITPAG2;			/*!< Selects the delay for asynchronous page mode sequential accesses for chip select n. */
+	__IO uint32_t  STATICWAITWR2;			/*!< Selects the delay from chip select n to a write access. */
+	__IO uint32_t  STATICWAITTURN2;			/*!< Selects bus turnaround cycles */
+	__I  uint32_t  RESERVED10;
+	__IO uint32_t  STATICCONFIG3;			/*!< Selects the memory configuration for static chip select n. */
+	__IO uint32_t  STATICWAITWEN3;			/*!< Selects the delay from chip select n to write enable. */
+	__IO uint32_t  STATICWAITOEN3;			/*!< Selects the delay from chip select n or address change, whichever is later, to output enable. */
+	__IO uint32_t  STATICWAITRD3;			/*!< Selects the delay from chip select n to a read access. */
+	__IO uint32_t  STATICWAITPAG3;			/*!< Selects the delay for asynchronous page mode sequential accesses for chip select n. */
+	__IO uint32_t  STATICWAITWR3;			/*!< Selects the delay from chip select n to a write access. */
+	__IO uint32_t  STATICWAITTURN3;			/*!< Selects bus turnaround cycles */
+} LPC_EMC_T;
+
+/**
+ * @brief USB High-Speed register block structure
+ */
+#define LPC_USB0_BASE             0x40006000
+#define LPC_USB1_BASE             0x40007000
+
+typedef struct {							/*!< USB Structure         */
+	__I  uint32_t  RESERVED0[64];
+	__I  uint32_t  CAPLENGTH;				/*!< Capability register length */
+	__I  uint32_t  HCSPARAMS;				/*!< Host controller structural parameters */
+	__I  uint32_t  HCCPARAMS;				/*!< Host controller capability parameters */
+	__I  uint32_t  RESERVED1[5];
+	__I  uint32_t  DCIVERSION;				/*!< Device interface version number */
+	__I  uint32_t  RESERVED2[7];
+	union {
+		__IO uint32_t  USBCMD_H;			/*!< USB command (host mode) */
+		__IO uint32_t  USBCMD_D;			/*!< USB command (device mode) */
+	};
+
+	union {
+		__IO uint32_t  USBSTS_H;			/*!< USB status (host mode) */
+		__IO uint32_t  USBSTS_D;			/*!< USB status (device mode) */
+	};
+
+	union {
+		__IO uint32_t  USBINTR_H;			/*!< USB interrupt enable (host mode) */
+		__IO uint32_t  USBINTR_D;			/*!< USB interrupt enable (device mode) */
+	};
+
+	union {
+		__IO uint32_t  FRINDEX_H;			/*!< USB frame index (host mode) */
+		__I  uint32_t  FRINDEX_D;			/*!< USB frame index (device mode) */
+	};
+
+	__I  uint32_t  RESERVED3;
+	union {
+		__IO uint32_t  PERIODICLISTBASE;	/*!< Frame list base address */
+		__IO uint32_t  DEVICEADDR;			/*!< USB device address     */
+	};
+
+	union {
+		__IO uint32_t  ASYNCLISTADDR;		/*!< Address of endpoint list in memory (host mode) */
+		__IO uint32_t  ENDPOINTLISTADDR;	/*!< Address of endpoint list in memory (device mode) */
+	};
+
+	__IO uint32_t  TTCTRL;					/*!< Asynchronous buffer status for embedded TT (host mode) */
+	__IO uint32_t  BURSTSIZE;				/*!< Programmable burst size */
+	__IO uint32_t  TXFILLTUNING;			/*!< Host transmit pre-buffer packet tuning (host mode) */
+	__I  uint32_t  RESERVED4[2];
+	__IO uint32_t  ULPIVIEWPORT;			/*!< ULPI viewport          */
+	__IO uint32_t  BINTERVAL;				/*!< Length of virtual frame */
+	__IO uint32_t  ENDPTNAK;				/*!< Endpoint NAK (device mode) */
+	__IO uint32_t  ENDPTNAKEN;				/*!< Endpoint NAK Enable (device mode) */
+	__I  uint32_t  RESERVED5;
+	union {
+		__IO uint32_t  PORTSC1_H;			/*!< Port 1 status/control (host mode) */
+		__IO uint32_t  PORTSC1_D;			/*!< Port 1 status/control (device mode) */
+	};
+
+	__I  uint32_t  RESERVED6[7];
+	__IO uint32_t  OTGSC;					/*!< OTG status and control */
+	union {
+		__IO uint32_t  USBMODE_H;			/*!< USB mode (host mode)   */
+		__IO uint32_t  USBMODE_D;			/*!< USB mode (device mode) */
+	};
+
+	__IO uint32_t  ENDPTSETUPSTAT;			/*!< Endpoint setup status  */
+	__IO uint32_t  ENDPTPRIME;				/*!< Endpoint initialization */
+	__IO uint32_t  ENDPTFLUSH;				/*!< Endpoint de-initialization */
+	__I  uint32_t  ENDPTSTAT;				/*!< Endpoint status        */
+	__IO uint32_t  ENDPTCOMPLETE;			/*!< Endpoint complete      */
+	__IO uint32_t  ENDPTCTRL[6];			/*!< Endpoint control 0     */
+} LPC_USBHS_T;
+
+/**
+ * @brief LCD Controller register block structure
+ */
+#define LPC_LCD_BASE              0x40008000
+
+typedef struct {				/*!< LCD Structure          */
+	__IO uint32_t  TIMH;		/*!< Horizontal Timing Control register */
+	__IO uint32_t  TIMV;		/*!< Vertical Timing Control register */
+	__IO uint32_t  POL;			/*!< Clock and Signal Polarity Control register */
+	__IO uint32_t  LE;			/*!< Line End Control register */
+	__IO uint32_t  UPBASE;		/*!< Upper Panel Frame Base Address register */
+	__IO uint32_t  LPBASE;		/*!< Lower Panel Frame Base Address register */
+	__IO uint32_t  CTRL;		/*!< LCD Control register   */
+	__IO uint32_t  INTMSK;		/*!< Interrupt Mask register */
+	__I  uint32_t  INTRAW;		/*!< Raw Interrupt Status register */
+	__I  uint32_t  INTSTAT;		/*!< Masked Interrupt Status register */
+	__O  uint32_t  INTCLR;		/*!< Interrupt Clear register */
+	__I  uint32_t  UPCURR;		/*!< Upper Panel Current Address Value register */
+	__I  uint32_t  LPCURR;		/*!< Lower Panel Current Address Value register */
+	__I  uint32_t  RESERVED0[115];
+	__IO uint16_t PAL[256];		/*!< 256x16-bit Color Palette registers */
+	__I  uint32_t  RESERVED1[256];
+	__IO uint32_t CRSR_IMG[256];/*!< Cursor Image registers */
+	__IO uint32_t  CRSR_CTRL;	/*!< Cursor Control register */
+	__IO uint32_t  CRSR_CFG;	/*!< Cursor Configuration register */
+	__IO uint32_t  CRSR_PAL0;	/*!< Cursor Palette register 0 */
+	__IO uint32_t  CRSR_PAL1;	/*!< Cursor Palette register 1 */
+	__IO uint32_t  CRSR_XY;		/*!< Cursor XY Position register */
+	__IO uint32_t  CRSR_CLIP;	/*!< Cursor Clip Position register */
+	__I  uint32_t  RESERVED2[2];
+	__IO uint32_t  CRSR_INTMSK;	/*!< Cursor Interrupt Mask register */
+	__O  uint32_t  CRSR_INTCLR;	/*!< Cursor Interrupt Clear register */
+	__I  uint32_t  CRSR_INTRAW;	/*!< Cursor Raw Interrupt Status register */
+	__I  uint32_t  CRSR_INTSTAT;/*!< Cursor Masked Interrupt Status register */
+} LPC_LCD_T;
+
+/**
+ * @brief EEPROM register block structure
+ */
+#define LPC_EEPROM_BASE           0x4000E000
+
+typedef struct {				/* EEPROM Structure */
+	__IO uint32_t CMD;			/*!< EEPROM command register */
+	uint32_t RESERVED0;
+	__IO uint32_t RWSTATE;		/*!< EEPROM read wait state register */
+	__IO uint32_t AUTOPROG;		/*!< EEPROM auto programming register */
+	__IO uint32_t WSTATE;		/*!< EEPROM wait state register */
+	__IO uint32_t CLKDIV;		/*!< EEPROM clock divider register */
+	__IO uint32_t PWRDWN;		/*!< EEPROM power-down register */
+	uint32_t RESERVED2[1007];
+	__O  uint32_t INTENCLR;		/*!< EEPROM interrupt enable clear */
+	__O  uint32_t INTENSET;		/*!< EEPROM interrupt enable set */
+	__I  uint32_t INTSTAT;		/*!< EEPROM interrupt status */
+	__I  uint32_t INTEN;		/*!< EEPROM interrupt enable */
+	__O  uint32_t INTSTATCLR;	/*!< EEPROM interrupt status clear */
+	__O  uint32_t INTSTATSET;	/*!< EEPROM interrupt status set */
+} LPC_EEPROM_T;
+
+/**
+ * @brief 10/100 MII & RMII Ethernet with timestamping register block structure
+ */
+#define LPC_ETHERNET_BASE         0x40010000
+
+typedef struct {							/*!< ETHERNET Structure */
+	__IO uint32_t  MAC_CONFIG;				/*!< MAC configuration register */
+	__IO uint32_t  MAC_FRAME_FILTER;		/*!< MAC frame filter */
+	__IO uint32_t  MAC_HASHTABLE_HIGH;		/*!< Hash table high register */
+	__IO uint32_t  MAC_HASHTABLE_LOW;		/*!< Hash table low register */
+	__IO uint32_t  MAC_MII_ADDR;			/*!< MII address register */
+	__IO uint32_t  MAC_MII_DATA;			/*!< MII data register */
+	__IO uint32_t  MAC_FLOW_CTRL;			/*!< Flow control register */
+	__IO uint32_t  MAC_VLAN_TAG;			/*!< VLAN tag register */
+	__I  uint32_t  RESERVED0;
+	__I  uint32_t  MAC_DEBUG;				/*!< Debug register */
+	__IO uint32_t  MAC_RWAKE_FRFLT;			/*!< Remote wake-up frame filter */
+	__IO uint32_t  MAC_PMT_CTRL_STAT;		/*!< PMT control and status */
+	__I  uint32_t  RESERVED1[2];
+	__I  uint32_t  MAC_INTR;				/*!< Interrupt status register */
+	__IO uint32_t  MAC_INTR_MASK;			/*!< Interrupt mask register */
+	__IO uint32_t  MAC_ADDR0_HIGH;			/*!< MAC address 0 high register */
+	__IO uint32_t  MAC_ADDR0_LOW;			/*!< MAC address 0 low register */
+	__I  uint32_t  RESERVED2[430];
+	__IO uint32_t  MAC_TIMESTP_CTRL;		/*!< Time stamp control register */
+	__IO uint32_t  SUBSECOND_INCR;			/*!< Sub-second increment register */
+	__I  uint32_t  SECONDS;					/*!< System time seconds register */
+	__I  uint32_t  NANOSECONDS;				/*!< System time nanoseconds register */
+	__IO uint32_t  SECONDSUPDATE;			/*!< System time seconds update register */
+	__IO uint32_t  NANOSECONDSUPDATE;		/*!< System time nanoseconds update register */
+	__IO uint32_t  ADDEND;					/*!< Time stamp addend register */
+	__IO uint32_t  TARGETSECONDS;			/*!< Target time seconds register */
+	__IO uint32_t  TARGETNANOSECONDS;		/*!< Target time nanoseconds register */
+	__IO uint32_t  HIGHWORD;				/*!< System time higher word seconds register */
+	__I  uint32_t  TIMESTAMPSTAT;			/*!< Time stamp status register */
+	__IO uint32_t  PPSCTRL;					/*!< PPS control register */
+	__I  uint32_t  AUXNANOSECONDS;			/*!< Auxiliary time stamp nanoseconds register */
+	__I  uint32_t  AUXSECONDS;				/*!< Auxiliary time stamp seconds register */
+	__I  uint32_t  RESERVED3[562];
+	__IO uint32_t  DMA_BUS_MODE;			/*!< Bus Mode Register      */
+	__IO uint32_t  DMA_TRANS_POLL_DEMAND;	/*!< Transmit poll demand register */
+	__IO uint32_t  DMA_REC_POLL_DEMAND;		/*!< Receive poll demand register */
+	__IO uint32_t  DMA_REC_DES_ADDR;		/*!< Receive descriptor list address register */
+	__IO uint32_t  DMA_TRANS_DES_ADDR;		/*!< Transmit descriptor list address register */
+	__IO uint32_t  DMA_STAT;				/*!< Status register */
+	__IO uint32_t  DMA_OP_MODE;				/*!< Operation mode register */
+	__IO uint32_t  DMA_INT_EN;				/*!< Interrupt enable register */
+	__I  uint32_t  DMA_MFRM_BUFOF;			/*!< Missed frame and buffer overflow register */
+	__IO uint32_t  DMA_REC_INT_WDT;			/*!< Receive interrupt watchdog timer register */
+	__I  uint32_t  RESERVED4[8];
+	__I  uint32_t  DMA_CURHOST_TRANS_DES;	/*!< Current host transmit descriptor register */
+	__I  uint32_t  DMA_CURHOST_REC_DES;		/*!< Current host receive descriptor register */
+	__I  uint32_t  DMA_CURHOST_TRANS_BUF;	/*!< Current host transmit buffer address register */
+	__I  uint32_t  DMA_CURHOST_REC_BUF;		/*!< Current host receive buffer address register */
+} LPC_ENET_T;
+
+/**
+ * @brief Alarm Timer register block structure
+ */
+#define LPC_ATIMER_BASE           0x40040000
+
+typedef struct {					/*!< ATIMER Structure       */
+	__IO uint32_t DOWNCOUNTER;		/*!< Downcounter register   */
+	__IO uint32_t PRESET;			/*!< Preset value register  */
+	__I  uint32_t RESERVED0[1012];
+	__O  uint32_t CLR_EN;			/*!< Interrupt clear enable register */
+	__O  uint32_t SET_EN;			/*!< Interrupt set enable register */
+	__I  uint32_t STATUS;			/*!< Status register        */
+	__I  uint32_t ENABLE;			/*!< Enable register        */
+	__O  uint32_t CLR_STAT;			/*!< Clear register         */
+	__O  uint32_t SET_STAT;			/*!< Set register           */
+} LPC_ATIMER_T;
+
+/**
+ * @brief Register File register block structure
+ */
+#define LPC_REGFILE_BASE          0x40041000
+
+typedef struct {
+	__IO uint32_t REGFILE[64];	/*!< General purpose storage register */
+} LPC_REGFILE_T;
+
+/**
+ * @brief Power Management Controller register block structure
+ */
+#define LPC_PMC_BASE              0x40042000
+
+typedef struct {						/*!< PMC Structure          */
+	__IO uint32_t  PD0_SLEEP0_HW_ENA;	/*!< Hardware sleep event enable register */
+	__I  uint32_t  RESERVED0[6];
+	__IO uint32_t  PD0_SLEEP0_MODE;		/*!< Sleep power mode register */
+} LPC_PMC_T;
+
+/**
+ * @brief CREG Register Block
+ */
+#define LPC_CREG_BASE             0x40043000
+
+typedef struct {						/*!< CREG Structure         */
+	__I  uint32_t  RESERVED0;
+	__IO uint32_t  CREG0;				/*!< Chip configuration register 32 kHz oscillator output and BOD control register. */
+	__I  uint32_t  RESERVED1[62];
+	__IO uint32_t  MXMEMMAP;			/*!< ARM Cortex-M3/M4 memory mapping */
+#if defined(CHIP_LPC18XX)
+	__I  uint32_t  RESERVED2[5];
+#else
+	__I  uint32_t  RESERVED2;
+	__I  uint32_t  CREG1;				/*!< Configuration Register 1 */
+	__I  uint32_t  CREG2;				/*!< Configuration Register 2 */
+	__I  uint32_t  CREG3;				/*!< Configuration Register 3 */
+	__I  uint32_t  CREG4;				/*!< Configuration Register 4 */
+#endif
+	__IO uint32_t  CREG5;				/*!< Chip configuration register 5. Controls JTAG access. */
+	__IO uint32_t  DMAMUX;				/*!< DMA muxing control     */
+	__IO uint32_t  FLASHCFGA;			/*!< Flash accelerator configuration register for flash bank A */
+	__IO uint32_t  FLASHCFGB;			/*!< Flash accelerator configuration register for flash bank B */
+	__IO uint32_t  ETBCFG;				/*!< ETB RAM configuration  */
+	__IO uint32_t  CREG6;				/*!< Chip configuration register 6. */
+#if defined(CHIP_LPC18XX)
+	__I  uint32_t  RESERVED4[52];
+#else
+	__IO uint32_t  M4TXEVENT;			/*!< M4 IPC event register */
+	__I  uint32_t  RESERVED4[51];
+#endif
+	__I  uint32_t  CHIPID;				/*!< Part ID                */
+#if defined(CHIP_LPC18XX)
+	__I  uint32_t  RESERVED5[191];
+#else
+	__I  uint32_t  RESERVED5[127];
+	__IO uint32_t  M0TXEVENT;			/*!< M0 IPC Event register */
+	__IO uint32_t  M0APPMEMMAP;			/*!< ARM Cortex M0 memory mapping */
+	__I  uint32_t  RESERVED6[62];
+#endif
+	__IO uint32_t  USB0FLADJ;			/*!< USB0 frame length adjust register */
+	__I  uint32_t  RESERVED7[63];
+	__IO uint32_t  USB1FLADJ;			/*!< USB1 frame length adjust register */
+} LPC_CREG_T;
+
+/**
+ * @brief Event Router register structure
+ */
+#define LPC_EVRT_BASE             0x40044000
+
+typedef struct {						/*!< EVENTROUTER Structure  */
+	__IO uint32_t HILO;					/*!< Level configuration register */
+	__IO uint32_t EDGE;					/*!< Edge configuration     */
+	__I  uint32_t RESERVED0[1012];
+	__O  uint32_t CLR_EN;				/*!< Event clear enable register */
+	__O  uint32_t SET_EN;				/*!< Event set enable register */
+	__I  uint32_t STATUS;				/*!< Status register        */
+	__I  uint32_t ENABLE;				/*!< Enable register        */
+	__O  uint32_t CLR_STAT;				/*!< Clear register         */
+	__O  uint32_t SET_STAT;				/*!< Set register           */
+} LPC_EVRT_T;
+
+/**
+ * @brief Real Time Clock register block structure
+ */
+#define LPC_RTC_BASE              0x40046000
+#define RTC_EV_SUPPORT      1			/* Event Monitor/Recorder support */
+
+typedef enum IP_RTC_TIMEINDEX {
+	RTC_TIMETYPE_SECOND,		/*!< Second */
+	RTC_TIMETYPE_MINUTE,		/*!< Month */
+	RTC_TIMETYPE_HOUR,			/*!< Hour */
+	RTC_TIMETYPE_DAYOFMONTH,	/*!< Day of month */
+	RTC_TIMETYPE_DAYOFWEEK,		/*!< Day of week */
+	RTC_TIMETYPE_DAYOFYEAR,		/*!< Day of year */
+	RTC_TIMETYPE_MONTH,			/*!< Month */
+	RTC_TIMETYPE_YEAR,			/*!< Year */
+	RTC_TIMETYPE_LAST
+} IP_RTC_TIMEINDEX_T;
+
+#if RTC_EV_SUPPORT
+typedef enum LPC_RTC_EV_CHANNEL {
+	RTC_EV_CHANNEL_1 = 0,
+	RTC_EV_CHANNEL_2,
+	RTC_EV_CHANNEL_3,
+	RTC_EV_CHANNEL_NUM,
+} LPC_RTC_EV_CHANNEL_T;
+#endif /*RTC_EV_SUPPORT*/
+
+typedef struct {							/*!< RTC Structure          */
+	__IO uint32_t  ILR;						/*!< Interrupt Location Register */
+	__I  uint32_t  RESERVED0;
+	__IO uint32_t  CCR;						/*!< Clock Control Register */
+	__IO uint32_t  CIIR;					/*!< Counter Increment Interrupt Register */
+	__IO uint32_t  AMR;						/*!< Alarm Mask Register    */
+	__I  uint32_t  CTIME[3];				/*!< Consolidated Time Register 0,1,2 */
+	__IO uint32_t  TIME[RTC_TIMETYPE_LAST];	/*!< Timer field registers */
+	__IO uint32_t  CALIBRATION;				/*!< Calibration Value Register */
+	__I  uint32_t  RESERVED1[7];
+	__IO uint32_t  ALRM[RTC_TIMETYPE_LAST];	/*!< Alarm field registers */
+#if RTC_EV_SUPPORT
+	__IO uint32_t ERSTATUS;					/*!< Event Monitor/Recorder Status register*/
+	__IO uint32_t ERCONTROL;				/*!< Event Monitor/Recorder Control register*/
+	__I  uint32_t ERCOUNTERS;				/*!< Event Monitor/Recorder Counters register*/
+	__I  uint32_t RESERVED2;
+	__I  uint32_t ERFIRSTSTAMP[RTC_EV_CHANNEL_NUM];			/*!<Event Monitor/Recorder First Stamp registers*/
+	__I  uint32_t RESERVED3;
+	__I  uint32_t ERLASTSTAMP[RTC_EV_CHANNEL_NUM];			/*!<Event Monitor/Recorder Last Stamp registers*/
+#endif /*RTC_EV_SUPPORT*/
+} LPC_RTC_T;
+
+/**
+ * @brief LPC18XX/43XX CGU register block structure
+ */
+#define LPC_CGU_BASE              0x40050000
+#define LPC_CCU1_BASE             0x40051000
+#define LPC_CCU2_BASE             0x40052000
+/**
+ * These are possible input clocks for the CGU and can come
+ * from both external (crystal) and internal (PLL) sources. These
+ * clock inputs can be routed to the base clocks (@ref CGU_BASE_CLK_T).
+ */
+typedef enum CGU_CLKIN {
+	CLKIN_32K,      /*!< External 32KHz input */
+	CLKIN_IRC,      /*!< Internal IRC (12MHz) input */
+	CLKIN_ENET_RX,  /*!< External ENET_RX pin input */
+	CLKIN_ENET_TX,  /*!< External ENET_TX pin input */
+	CLKIN_CLKIN,    /*!< External GPCLKIN pin input */
+	CLKIN_RESERVED1,
+	CLKIN_CRYSTAL,  /*!< External (main) crystal pin input */
+	CLKIN_USBPLL,   /*!< Internal USB PLL input */
+	CLKIN_AUDIOPLL, /*!< Internal Audio PLL input */
+	CLKIN_MAINPLL,  /*!< Internal Main PLL input */
+	CLKIN_RESERVED2,
+	CLKIN_RESERVED3,
+	CLKIN_IDIVA,    /*!< Internal divider A input */
+	CLKIN_IDIVB,    /*!< Internal divider B input */
+	CLKIN_IDIVC,    /*!< Internal divider C input */
+	CLKIN_IDIVD,    /*!< Internal divider D input */
+	CLKIN_IDIVE,    /*!< Internal divider E input */
+	CLKINPUT_PD     /*!< External 32KHz input */
+} CGU_CLKIN_T;
+
+#define CLKIN_PLL0USB    CLKIN_USBPLL
+#define CLKIN_PLL0AUDIO  CLKIN_AUDIOPLL
+#define CLKIN_PLL1       CLKIN_MAINPLL
+
+/**
+ * CGU base clocks are clocks that are associated with a single input clock
+ * and are routed out to 1 or more peripherals. For example, the CLK_BASE_PERIPH
+ * clock can be configured to use the CLKIN_MAINPLL input clock, which will in
+ * turn route that clock to the CLK_PERIPH_BUS, CLK_PERIPH_CORE, and
+ * CLK_PERIPH_SGPIO periphral clocks.
+ */
+typedef enum CGU_BASE_CLK {
+	CLK_BASE_SAFE,		/*!< Base clock for WDT oscillator, IRC input only */
+	CLK_BASE_USB0,		/*!< Base USB clock for USB0, USB PLL input only */
+#if defined(CHIP_LPC43XX)
+	CLK_BASE_PERIPH,	/*!< Base clock for SGPIO */
+#else
+	CLK_BASE_RESERVED1,
+#endif
+	CLK_BASE_USB1,		/*!< Base USB clock for USB1 */
+	CLK_BASE_MX,		/*!< Base clock for CPU core */
+	CLK_BASE_SPIFI,		/*!< Base clock for SPIFI */
+#if defined(CHIP_LPC43XX)
+	CLK_BASE_SPI,		/*!< Base clock for SPI */
+#else
+	CLK_BASE_RESERVED2,
+#endif
+	CLK_BASE_PHY_RX,	/*!< Base clock for PHY RX */
+	CLK_BASE_PHY_TX,	/*!< Base clock for PHY TX */
+	CLK_BASE_APB1,		/*!< Base clock for APB1 group */
+	CLK_BASE_APB3,		/*!< Base clock for APB3 group */
+	CLK_BASE_LCD,		/*!< Base clock for LCD pixel clock */
+#if defined(CHIP_LPC43XX)
+	CLK_BASE_VADC,		/*!< Base clock for VADC */
+#else
+	CLK_BASE_RESERVED3,
+#endif
+	CLK_BASE_SDIO,		/*!< Base clock for SDIO */
+	CLK_BASE_SSP0,		/*!< Base clock for SSP0 */
+	CLK_BASE_SSP1,		/*!< Base clock for SSP1 */
+	CLK_BASE_UART0,		/*!< Base clock for UART0 */
+	CLK_BASE_UART1,		/*!< Base clock for UART1 */
+	CLK_BASE_UART2,		/*!< Base clock for UART2 */
+	CLK_BASE_UART3,		/*!< Base clock for UART3 */
+	CLK_BASE_OUT,		/*!< Base clock for CLKOUT pin */
+	CLK_BASE_RESERVED4,
+	CLK_BASE_RESERVED5,
+	CLK_BASE_RESERVED6,
+	CLK_BASE_RESERVED7,
+	CLK_BASE_APLL,		/*!< Base clock for audio PLL */
+	CLK_BASE_CGU_OUT0,	/*!< Base clock for CGUOUT0 pin */
+	CLK_BASE_CGU_OUT1,	/*!< Base clock for CGUOUT1 pin */
+	CLK_BASE_LAST,
+	CLK_BASE_NONE = CLK_BASE_LAST
+} CGU_BASE_CLK_T;
+
+/**
+ * CGU dividers provide an extra clock state where a specific clock can be
+ * divided before being routed to a peripheral group. A divider accepts an
+ * input clock and then divides it. To use the divided clock for a base clock
+ * group, use the divider as the input clock for the base clock (for example,
+ * use CLKIN_IDIVB, where CLKIN_MAINPLL might be the input into the divider).
+ */
+typedef enum CGU_IDIV {
+	CLK_IDIV_A,		/*!< CGU clock divider A */
+	CLK_IDIV_B,		/*!< CGU clock divider B */
+	CLK_IDIV_C,		/*!< CGU clock divider A */
+	CLK_IDIV_D,		/*!< CGU clock divider D */
+	CLK_IDIV_E,		/*!< CGU clock divider E */
+	CLK_IDIV_LAST
+} CGU_IDIV_T;
+
+/**
+ * Peripheral clocks are individual clocks routed to peripherals. Although
+ * multiple peripherals may share a same base clock, each peripheral's clock
+ * can be enabled or disabled individually. Some peripheral clocks also have
+ * additional dividers associated with them.
+ */
+typedef enum CCU_CLK {
+	/* CCU1 clocks */
+	CLK_APB3_BUS,		/*!< APB3 bus clock from base clock CLK_BASE_APB3 */
+	CLK_APB3_I2C1,		/*!< I2C1 register/perigheral clock from base clock CLK_BASE_APB3 */
+	CLK_APB3_DAC,		/*!< DAC peripheral clock from base clock CLK_BASE_APB3 */
+	CLK_APB3_ADC0,		/*!< ADC0 register/perigheral clock from base clock CLK_BASE_APB3 */
+	CLK_APB3_ADC1,		/*!< ADC1 register/perigheral clock from base clock CLK_BASE_APB3 */
+	CLK_APB3_CAN0,		/*!< CAN0 register/perigheral clock from base clock CLK_BASE_APB3 */
+	CLK_APB1_BUS = 32,	/*!< APB1 bus clock clock from base clock CLK_BASE_APB1 */
+	CLK_APB1_MOTOCON,	/*!< Motor controller register/perigheral clock from base clock CLK_BASE_APB1 */
+	CLK_APB1_I2C0,		/*!< I2C0 register/perigheral clock from base clock CLK_BASE_APB1 */
+	CLK_APB1_I2S,		/*!< I2S register/perigheral clock from base clock CLK_BASE_APB1 */
+	CLK_APB1_CAN1,		/*!< CAN1 register/perigheral clock from base clock CLK_BASE_APB1 */
+	CLK_SPIFI = 64,		/*!< SPIFI SCKI input clock from base clock CLK_BASE_SPIFI */
+	CLK_MX_BUS = 96,	/*!< M3/M4 BUS core clock from base clock CLK_BASE_MX */
+	CLK_MX_SPIFI,		/*!< SPIFI register clock from base clock CLK_BASE_MX */
+	CLK_MX_GPIO,		/*!< GPIO register clock from base clock CLK_BASE_MX */
+	CLK_MX_LCD,			/*!< LCD register clock from base clock CLK_BASE_MX */
+	CLK_MX_ETHERNET,	/*!< ETHERNET register clock from base clock CLK_BASE_MX */
+	CLK_MX_USB0,		/*!< USB0 register clock from base clock CLK_BASE_MX */
+	CLK_MX_EMC,			/*!< EMC clock from base clock CLK_BASE_MX */
+	CLK_MX_SDIO,		/*!< SDIO register clock from base clock CLK_BASE_MX */
+	CLK_MX_DMA,			/*!< DMA register clock from base clock CLK_BASE_MX */
+	CLK_MX_MXCORE,		/*!< M3/M4 CPU core clock from base clock CLK_BASE_MX */
+	RESERVED_ALIGN = CLK_MX_MXCORE + 3,
+	CLK_MX_SCT,			/*!< SCT register clock from base clock CLK_BASE_MX */
+	CLK_MX_USB1,		/*!< USB1 register clock from base clock CLK_BASE_MX */
+	CLK_MX_EMC_DIV,		/*!< ENC divider clock from base clock CLK_BASE_MX */
+	CLK_MX_FLASHA,		/*!< FLASHA bank clock from base clock CLK_BASE_MX */
+	CLK_MX_FLASHB,		/*!< FLASHB bank clock from base clock CLK_BASE_MX */
+#if defined(CHIP_LPC43XX)
+	CLK_M4_M0APP,		/*!< M0 app CPU core clock from base clock CLK_BASE_MX */
+	CLK_MX_VADC,		/*!< VADC clock from base clock CLK_BASE_MX */
+#else
+	CLK_RESERVED1,
+	CLK_RESERVED2,
+#endif
+	CLK_MX_EEPROM,		/*!< EEPROM clock from base clock CLK_BASE_MX */
+	CLK_MX_WWDT = 128,	/*!< WWDT register clock from base clock CLK_BASE_MX */
+	CLK_MX_UART0,		/*!< UART0 register clock from base clock CLK_BASE_MX */
+	CLK_MX_UART1,		/*!< UART1 register clock from base clock CLK_BASE_MX */
+	CLK_MX_SSP0,		/*!< SSP0 register clock from base clock CLK_BASE_MX */
+	CLK_MX_TIMER0,		/*!< TIMER0 register/perigheral clock from base clock CLK_BASE_MX */
+	CLK_MX_TIMER1,		/*!< TIMER1 register/perigheral clock from base clock CLK_BASE_MX */
+	CLK_MX_SCU,			/*!< SCU register/perigheral clock from base clock CLK_BASE_MX */
+	CLK_MX_CREG,		/*!< CREG clock from base clock CLK_BASE_MX */
+	CLK_MX_RITIMER = 160,	/*!< RITIMER register/perigheral clock from base clock CLK_BASE_MX */
+	CLK_MX_UART2,		/*!< UART3 register clock from base clock CLK_BASE_MX */
+	CLK_MX_UART3,		/*!< UART4 register clock from base clock CLK_BASE_MX */
+	CLK_MX_TIMER2,		/*!< TIMER2 register/perigheral clock from base clock CLK_BASE_MX */
+	CLK_MX_TIMER3,		/*!< TIMER3 register/perigheral clock from base clock CLK_BASE_MX */
+	CLK_MX_SSP1,		/*!< SSP1 register clock from base clock CLK_BASE_MX */
+	CLK_MX_QEI,			/*!< QEI register/perigheral clock from base clock CLK_BASE_MX */
+#if defined(CHIP_LPC43XX)
+	CLK_PERIPH_BUS = 192,	/*!< Peripheral bus clock from base clock CLK_BASE_PERIPH */
+	CLK_RESERVED3,
+	CLK_PERIPH_CORE,	/*!< Peripheral core clock from base clock CLK_BASE_PERIPH */
+	CLK_PERIPH_SGPIO,	/*!< SGPIO clock from base clock CLK_BASE_PERIPH */
+#else
+	CLK_RESERVED3 = 192,
+	CLK_RESERVED3A,
+	CLK_RESERVED4,
+	CLK_RESERVED5,
+#endif
+	CLK_USB0 = 224,			/*!< USB0 clock from base clock CLK_BASE_USB0 */
+	CLK_USB1 = 256,			/*!< USB1 clock from base clock CLK_BASE_USB1 */
+#if defined(CHIP_LPC43XX)
+	CLK_SPI = 288,			/*!< SPI clock from base clock CLK_BASE_SPI */
+	CLK_VADC,				/*!< VADC clock from base clock CLK_BASE_VADC */
+#else
+	CLK_RESERVED7 = 320,
+	CLK_RESERVED8,
+#endif
+	CLK_CCU1_LAST,
+
+	/* CCU2 clocks */
+	CLK_CCU2_START,
+	CLK_APLL = CLK_CCU2_START,	/*!< Audio PLL clock from base clock CLK_BASE_APLL */
+	RESERVED_ALIGNB = CLK_CCU2_START + 31,
+	CLK_APB2_UART3,			/*!< UART3 clock from base clock CLK_BASE_UART3 */
+	RESERVED_ALIGNC = CLK_CCU2_START + 63,
+	CLK_APB2_UART2,			/*!< UART2 clock from base clock CLK_BASE_UART2 */
+	RESERVED_ALIGND = CLK_CCU2_START + 95,
+	CLK_APB0_UART1,			/*!< UART1 clock from base clock CLK_BASE_UART1 */
+	RESERVED_ALIGNE = CLK_CCU2_START + 127,
+	CLK_APB0_UART0,			/*!< UART0 clock from base clock CLK_BASE_UART0 */
+	RESERVED_ALIGNF = CLK_CCU2_START + 159,
+	CLK_APB2_SSP1,			/*!< SSP1 clock from base clock CLK_BASE_SSP1 */
+	RESERVED_ALIGNG = CLK_CCU2_START + 191,
+	CLK_APB0_SSP0,			/*!< SSP0 clock from base clock CLK_BASE_SSP0 */
+	RESERVED_ALIGNH = CLK_CCU2_START + 223,
+	CLK_APB2_SDIO,			/*!< SDIO clock from base clock CLK_BASE_SDIO */
+	CLK_CCU2_LAST
+} CCU_CLK_T;
+
+/**
+ * Audio or USB PLL selection
+ */
+typedef enum CHIP_CGU_USB_AUDIO_PLL {
+	CGU_USB_PLL,
+	CGU_AUDIO_PLL
+} CHIP_CGU_USB_AUDIO_PLL_T;
+
+/**
+ * PLL register block
+ */
+typedef struct {
+	__I  uint32_t  PLL_STAT;				/*!< PLL status register */
+	__IO uint32_t  PLL_CTRL;				/*!< PLL control register */
+	__IO uint32_t  PLL_MDIV;				/*!< PLL M-divider register */
+	__IO uint32_t  PLL_NP_DIV;				/*!< PLL N/P-divider register */
+} CGU_PLL_REG_T;
+
+typedef struct {							/*!< (@ 0x40050000) CGU Structure          */
+	__I  uint32_t  RESERVED0[5];
+	__IO uint32_t  FREQ_MON;				/*!< (@ 0x40050014) Frequency monitor register */
+	__IO uint32_t  XTAL_OSC_CTRL;			/*!< (@ 0x40050018) Crystal oscillator control register */
+	CGU_PLL_REG_T  PLL[CGU_AUDIO_PLL + 1];	/*!< (@ 0x4005001C) USB and audio PLL blocks */
+	__IO uint32_t  PLL0AUDIO_FRAC;			/*!< (@ 0x4005003C) PLL0 (audio)           */
+	__I  uint32_t  PLL1_STAT;				/*!< (@ 0x40050040) PLL1 status register   */
+	__IO uint32_t  PLL1_CTRL;				/*!< (@ 0x40050044) PLL1 control register  */
+	__IO uint32_t  IDIV_CTRL[CLK_IDIV_LAST];/*!< (@ 0x40050048) Integer divider A-E control registers */
+	__IO uint32_t  BASE_CLK[CLK_BASE_LAST];	/*!< (@ 0x4005005C) Start of base clock registers */
+} LPC_CGU_T;
+
+/**
+ * @brief CCU clock config/status register pair
+ */
+typedef struct {
+	__IO uint32_t  CFG;						/*!< CCU clock configuration register */
+	__I  uint32_t  STAT;					/*!< CCU clock status register */
+} CCU_CFGSTAT_T;
+
+/**
+ * @brief CCU1 register block structure
+ */
+typedef struct {							/*!< (@ 0x40051000) CCU1 Structure         */
+	__IO uint32_t  PM;						/*!< (@ 0x40051000) CCU1 power mode register */
+	__I  uint32_t  BASE_STAT;				/*!< (@ 0x40051004) CCU1 base clocks status register */
+	__I  uint32_t  RESERVED0[62];
+	CCU_CFGSTAT_T  CLKCCU[CLK_CCU1_LAST];	/*!< (@ 0x40051100) Start of CCU1 clock registers */
+} LPC_CCU1_T;
+
+/**
+ * @brief CCU2 register block structure
+ */
+typedef struct {							/*!< (@ 0x40052000) CCU2 Structure         */
+	__IO uint32_t  PM;						/*!< (@ 0x40052000) Power mode register    */
+	__I  uint32_t  BASE_STAT;				/*!< (@ 0x40052004) CCU base clocks status register */
+	__I  uint32_t  RESERVED0[62];
+	CCU_CFGSTAT_T  CLKCCU[CLK_CCU2_LAST - CLK_CCU1_LAST];	/*!< (@ 0x40052100) Start of CCU2 clock registers */
+} LPC_CCU2_T;
+
+/**
+ * @brief RGU register structure
+ */
+#define LPC_RGU_BASE              0x40053000
+
+typedef enum CHIP_RGU_RST {
+	RGU_CORE_RST,
+	RGU_PERIPH_RST,
+	RGU_MASTER_RST,
+	RGU_WWDT_RST = 4,
+	RGU_CREG_RST,
+	RGU_BUS_RST = 8,
+	RGU_SCU_RST,
+	RGU_M3_RST = 13,
+	RGU_LCD_RST = 16,
+	RGU_USB0_RST,
+	RGU_USB1_RST,
+	RGU_DMA_RST,
+	RGU_SDIO_RST,
+	RGU_EMC_RST,
+	RGU_ETHERNET_RST,
+	RGU_FLASHA_RST = 25,
+	RGU_EEPROM_RST = 27,
+	RGU_GPIO_RST,
+	RGU_FLASHB_RST,
+	RGU_TIMER0_RST = 32,
+	RGU_TIMER1_RST,
+	RGU_TIMER2_RST,
+	RGU_TIMER3_RST,
+	RGU_RITIMER_RST,
+	RGU_SCT_RST,
+	RGU_MOTOCONPWM_RST,
+	RGU_QEI_RST,
+	RGU_ADC0_RST,
+	RGU_ADC1_RST,
+	RGU_DAC_RST,
+	RGU_UART0_RST = 44,
+	RGU_UART1_RST,
+	RGU_UART2_RST,
+	RGU_UART3_RST,
+	RGU_I2C0_RST,
+	RGU_I2C1_RST,
+	RGU_SSP0_RST,
+	RGU_SSP1_RST,
+	RGU_I2S_RST,
+	RGU_SPIFI_RST,
+	RGU_CAN1_RST,
+	RGU_CAN0_RST,
+#ifdef CHIP_LPC43XX
+	RGU_M0APP_RST,
+	RGU_SGPIO_RST,
+	RGU_SPI_RST,
+#endif
+	RGU_LAST_RST = 63,
+} CHIP_RGU_RST_T;
+
+typedef struct {							/*!< RGU Structure          */
+	__I  uint32_t  RESERVED0[64];
+	__O  uint32_t  RESET_CTRL0;				/*!< Reset control register 0 */
+	__O  uint32_t  RESET_CTRL1;				/*!< Reset control register 1 */
+	__I  uint32_t  RESERVED1[2];
+	__IO uint32_t  RESET_STATUS0;			/*!< Reset status register 0 */
+	__IO uint32_t  RESET_STATUS1;			/*!< Reset status register 1 */
+	__IO uint32_t  RESET_STATUS2;			/*!< Reset status register 2 */
+	__IO uint32_t  RESET_STATUS3;			/*!< Reset status register 3 */
+	__I  uint32_t  RESERVED2[12];
+	__I  uint32_t  RESET_ACTIVE_STATUS0;	/*!< Reset active status register 0 */
+	__I  uint32_t  RESET_ACTIVE_STATUS1;	/*!< Reset active status register 1 */
+	__I  uint32_t  RESERVED3[170];
+	__IO uint32_t  RESET_EXT_STAT[RGU_LAST_RST + 1];/*!< Reset external status registers */
+} LPC_RGU_T;
+
+/**
+ * @brief Windowed Watchdog register block structure
+ */
+#define LPC_WWDT_BASE             0x40080000
+
+typedef struct {				/*!< WWDT Structure         */
+	__IO uint32_t  MOD;			/*!< Watchdog mode register. This register contains the basic mode and status of the Watchdog Timer. */
+	__IO uint32_t  TC;			/*!< Watchdog timer constant register. This register determines the time-out value. */
+	__O  uint32_t  FEED;		/*!< Watchdog feed sequence register. Writing 0xAA followed by 0x55 to this register reloads the Watchdog timer with the value contained in WDTC. */
+	__I  uint32_t  TV;			/*!< Watchdog timer value register. This register reads out the current value of the Watchdog timer. */
+#ifdef WATCHDOG_CLKSEL_SUPPORT
+	__IO uint32_t CLKSEL;		/*!< Watchdog clock select register. */
+#else
+	__I  uint32_t  RESERVED0;
+#endif
+#ifdef WATCHDOG_WINDOW_SUPPORT
+	__IO uint32_t  WARNINT;		/*!< Watchdog warning interrupt register. This register contains the Watchdog warning interrupt compare value. */
+	__IO uint32_t  WINDOW;		/*!< Watchdog timer window register. This register contains the Watchdog window value. */
+#endif
+} LPC_WWDT_T;
+
+/**
+ * @brief USART register block structure
+ */
+#define LPC_USART0_BASE           0x40081000
+#define LPC_UART1_BASE            0x40082000
+#define LPC_USART2_BASE           0x400C1000
+#define LPC_USART3_BASE           0x400C2000
+
+typedef struct {							/*!< USARTn Structure       */
+
+	union {
+		__IO uint32_t  DLL;					/*!< Divisor Latch LSB. Least significant byte of the baud rate divisor value. The full divisor is used to generate a baud rate from the fractional rate divider (DLAB = 1). */
+		__O  uint32_t  THR;					/*!< Transmit Holding Register. The next character to be transmitted is written here (DLAB = 0). */
+		__I  uint32_t  RBR;					/*!< Receiver Buffer Register. Contains the next received character to be read (DLAB = 0). */
+	};
+
+	union {
+		__IO uint32_t IER;					/*!< Interrupt Enable Register. Contains individual interrupt enable bits for the 7 potential UART interrupts (DLAB = 0). */
+		__IO uint32_t DLM;					/*!< Divisor Latch MSB. Most significant byte of the baud rate divisor value. The full divisor is used to generate a baud rate from the fractional rate divider (DLAB = 1). */
+	};
+
+	union {
+		__O  uint32_t FCR;					/*!< FIFO Control Register. Controls UART FIFO usage and modes. */
+		__I  uint32_t IIR;					/*!< Interrupt ID Register. Identifies which interrupt(s) are pending. */
+	};
+
+	__IO uint32_t LCR;						/*!< Line Control Register. Contains controls for frame formatting and break generation. */
+	__IO uint32_t MCR;						/*!< Modem Control Register. Only present on USART ports with full modem support. */
+	__I  uint32_t LSR;						/*!< Line Status Register. Contains flags for transmit and receive status, including line errors. */
+	__I  uint32_t MSR;						/*!< Modem Status Register. Only present on USART ports with full modem support. */
+	__IO uint32_t SCR;						/*!< Scratch Pad Register. Eight-bit temporary storage for software. */
+	__IO uint32_t ACR;						/*!< Auto-baud Control Register. Contains controls for the auto-baud feature. */
+	__IO uint32_t ICR;						/*!< IrDA control register (not all UARTS) */
+	__IO uint32_t FDR;						/*!< Fractional Divider Register. Generates a clock input for the baud rate divider. */
+	__IO uint32_t OSR;						/*!< Oversampling Register. Controls the degree of oversampling during each bit time. Only on some UARTS. */
+	__IO uint32_t TER1;						/*!< Transmit Enable Register. Turns off USART transmitter for use with software flow control. */
+	uint32_t  RESERVED0[3];
+	__IO uint32_t HDEN;						/*!< Half-duplex enable Register- only on some UARTs */
+	__I  uint32_t RESERVED1[1];
+	__IO uint32_t SCICTRL;					/*!< Smart card interface control register- only on some UARTs */
+	__IO uint32_t RS485CTRL;				/*!< RS-485/EIA-485 Control. Contains controls to configure various aspects of RS-485/EIA-485 modes. */
+	__IO uint32_t RS485ADRMATCH;			/*!< RS-485/EIA-485 address match. Contains the address match value for RS-485/EIA-485 mode. */
+	__IO uint32_t RS485DLY;					/*!< RS-485/EIA-485 direction control delay. */
+	union {
+		__IO uint32_t SYNCCTRL;				/*!< Synchronous mode control register. Only on USARTs. */
+		__I  uint32_t FIFOLVL;				/*!< FIFO Level register. Provides the current fill levels of the transmit and receive FIFOs. */
+	};
+
+	__IO uint32_t TER2;						/*!< Transmit Enable Register. Only on LPC177X_8X UART4 and LPC18XX/43XX USART0/2/3. */
+} LPC_USART_T;
+
+/**
+ * @brief SSP register block structure
+ */
+#define LPC_SSP0_BASE             0x40083000
+#define LPC_SSP1_BASE             0x400C5000
+
+typedef struct {			/*!< SSPn Structure         */
+	__IO uint32_t CR0;		/*!< Control Register 0. Selects the serial clock rate, bus type, and data size. */
+	__IO uint32_t CR1;		/*!< Control Register 1. Selects master/slave and other modes. */
+	__IO uint32_t DR;		/*!< Data Register. Writes fill the transmit FIFO, and reads empty the receive FIFO. */
+	__I  uint32_t SR;		/*!< Status Register        */
+	__IO uint32_t CPSR;		/*!< Clock Prescale Register */
+	__IO uint32_t IMSC;		/*!< Interrupt Mask Set and Clear Register */
+	__I  uint32_t RIS;		/*!< Raw Interrupt Status Register */
+	__I  uint32_t MIS;		/*!< Masked Interrupt Status Register */
+	__O  uint32_t ICR;		/*!< SSPICR Interrupt Clear Register */
+	__IO uint32_t DMACR;	/*!< SSPn DMA control register */
+} LPC_SSP_T;
+
+/**
+ * @brief 32-bit Standard timer register block structure
+ */
+typedef struct {					/*!< TIMERn Structure       */
+	__IO uint32_t IR;				/*!< Interrupt Register. The IR can be written to clear interrupts. The IR can be read to identify which of eight possible interrupt sources are pending. */
+	__IO uint32_t TCR;				/*!< Timer Control Register. The TCR is used to control the Timer Counter functions. The Timer Counter can be disabled or reset through the TCR. */
+	__IO uint32_t TC;				/*!< Timer Counter. The 32 bit TC is incremented every PR+1 cycles of PCLK. The TC is controlled through the TCR. */
+	__IO uint32_t PR;				/*!< Prescale Register. The Prescale Counter (below) is equal to this value, the next clock increments the TC and clears the PC. */
+	__IO uint32_t PC;				/*!< Prescale Counter. The 32 bit PC is a counter which is incremented to the value stored in PR. When the value in PR is reached, the TC is incremented and the PC is cleared. The PC is observable and controllable through the bus interface. */
+	__IO uint32_t MCR;				/*!< Match Control Register. The MCR is used to control if an interrupt is generated and if the TC is reset when a Match occurs. */
+	__IO uint32_t MR[4];			/*!< Match Register. MR can be enabled through the MCR to reset the TC, stop both the TC and PC, and/or generate an interrupt every time MR matches the TC. */
+	__IO uint32_t CCR;				/*!< Capture Control Register. The CCR controls which edges of the capture inputs are used to load the Capture Registers and whether or not an interrupt is generated when a capture takes place. */
+	__IO uint32_t CR[4];			/*!< Capture Register. CR is loaded with the value of TC when there is an event on the CAPn.0 input. */
+	__IO uint32_t EMR;				/*!< External Match Register. The EMR controls the external match pins MATn.0-3 (MAT0.0-3 and MAT1.0-3 respectively). */
+	__I  uint32_t RESERVED0[12];
+	__IO uint32_t CTCR;				/*!< Count Control Register. The CTCR selects between Timer and Counter mode, and in Counter mode selects the signal and edge(s) for counting. */
+} LPC_TIMER_T;
+
+#define LPC_TIMER0_BASE           0x40084000
+#define LPC_TIMER1_BASE           0x40085000
+#define LPC_TIMER2_BASE           0x400C3000
+#define LPC_TIMER3_BASE           0x400C4000
+
+/**
+ * @brief System Control Unit register block
+ */
+#define LPC_SCU_BASE              0x40086000
+
+typedef struct {
+	__IO uint32_t  SFSP[16][32];
+	__I  uint32_t  RESERVED0[256];
+	__IO uint32_t  SFSCLK[4];			/*!< Pin configuration register for pins CLK0-3 */
+	__I  uint32_t  RESERVED16[28];
+	__IO uint32_t  SFSUSB;				/*!< Pin configuration register for USB */
+	__IO uint32_t  SFSI2C0;				/*!< Pin configuration register for I2C0-bus pins */
+	__IO uint32_t  ENAIO[3];			/*!< Analog function select registers */
+	__I  uint32_t  RESERVED17[27];
+	__IO uint32_t  EMCDELAYCLK;			/*!< EMC clock delay register */
+	__I  uint32_t  RESERVED18[63];
+	__IO uint32_t  PINTSEL0;			/*!< Pin interrupt select register for pin interrupts 0 to 3. */
+	__IO uint32_t  PINTSEL1;			/*!< Pin interrupt select register for pin interrupts 4 to 7. */
+} LPC_SCU_T;
+
+/**
+ * SCU function and mode selection definitions
+ * See the User Manual for specific modes and functions supoprted by the
+ * various LPC18xx/43xx devices. Functionality can vary per device.
+ */
+#define SCU_MODE_MODE_INACT        (0x0 << 3)		/*!< Disable pull-down and pull-up resistor at resistor at pad */
+#define SCU_MODE_MODE_PULLDOWN     (0x1 << 3)		/*!< Enable pull-down resistor at pad */
+#define SCU_MODE_MODE_PULLUP_DIS   (0x2 << 3)		/*!< Disable pull-up resistor at pad */
+#define SCU_MODE_MODE_REPEATER     (0x3 << 3)		/*!< Enable pull-down and pull-up resistor at resistor at pad (repeater mode) */
+#define SCU_MODE_HIGHSPEEDSLEW_EN  (0x1 << 5)		/*!< Enable high-speed slew */
+#define SCU_MODE_INBUFF_EN         (0x1 << 6)		/*!< Enable Input buffer */
+#define SCU_MODE_ZIF_DIS           (0x1 << 7)		/*!< Disable input glitch filter */
+#define SCU_MODE_4MA_DRIVESTR      (0x0 << 8)		/*!< Normal drive: 4mA drive strength */
+#define SCU_MODE_8MA_DRIVESTR      (0x1 << 8)		/*!< Medium drive: 8mA drive strength */
+#define SCU_MODE_14MA_DRIVESTR     (0x2 << 8)		/*!< High drive: 14mA drive strength */
+#define SCU_MODE_20MA_DRIVESTR     (0x3 << 8)		/*!< Ultra high- drive: 20mA drive strength */
+
+/* Common SCU configurations */
+#define SCU_PINIO_FAST             (SCU_MODE_MODE_PULLUP_DIS | SCU_MODE_HIGHSPEEDSLEW_EN | SCU_MODE_INBUFF_EN | SCU_MODE_ZIF_DIS)
+#define SCU_PINIO_PULLUP           (SCU_MODE_INBUFF_EN)
+#define SCU_PINIO_PULLDOWN         (SCU_MODE_MODE_PULLDOWN  | SCU_MODE_MODE_PULLUP_DIS | SCU_MODE_INBUFF_EN)
+#define SCU_PINIO_PULLNONE         (SCU_MODE_MODE_PULLUP_DIS | SCU_MODE_INBUFF_EN)
+
+/* Calculate SCU offset and register address from group and pin number */
+#define SCU_OFF(group, num)        ((0x80 * group) + (0x04 * num))
+#define SCU_REG(group, num)        ((__IO uint32_t *)(LPC_SCU_BASE + SCU_OFF(group, num)))
+
+/**
+ * @brief GPIO pin interrupt register block structure
+ */
+#define LPC_GPIO_PIN_INT_BASE     0x40087000
+
+typedef struct {				/*!< GPIO_PIN_INT Structure */
+	__IO uint32_t  ISEL;		/*!< Pin Interrupt Mode register */
+	__IO uint32_t  IENR;		/*!< Pin Interrupt Enable (Rising) register */
+	__O  uint32_t  SIENR;		/*!< Set Pin Interrupt Enable (Rising) register */
+	__O  uint32_t  CIENR;		/*!< Clear Pin Interrupt Enable (Rising) register */
+	__IO uint32_t  IENF;		/*!< Pin Interrupt Enable Falling Edge / Active Level register */
+	__O  uint32_t  SIENF;		/*!< Set Pin Interrupt Enable Falling Edge / Active Level register */
+	__O  uint32_t  CIENF;		/*!< Clear Pin Interrupt Enable Falling Edge / Active Level address */
+	__IO uint32_t  RISE;		/*!< Pin Interrupt Rising Edge register */
+	__IO uint32_t  FALL;		/*!< Pin Interrupt Falling Edge register */
+	__IO uint32_t  IST;			/*!< Pin Interrupt Status register */
+} LPC_GPIOPININT_T;
+
+typedef enum LPC_GPIOPININT_MODE {
+	GPIOPININT_RISING_EDGE = 0x01,
+	GPIOPININT_FALLING_EDGE = 0x02,
+	GPIOPININT_ACTIVE_HIGH_LEVEL = 0x04,
+	GPIOPININT_ACTIVE_LOW_LEVEL = 0x08
+} LPC_GPIOPININT_MODE_T;
+
+/**
+ * @brief GPIO grouped interrupt register block structure
+ */
+#define LPC_GPIO_GROUP_INT0_BASE  0x40088000
+#define LPC_GPIO_GROUP_INT1_BASE  0x40089000
+
+typedef struct {					/*!< GPIO_GROUP_INTn Structure */
+	__IO uint32_t  CTRL;			/*!< GPIO grouped interrupt control register */
+	__I  uint32_t  RESERVED0[7];
+	__IO uint32_t  PORT_POL[8];		/*!< GPIO grouped interrupt port polarity register */
+	__IO uint32_t  PORT_ENA[8];		/*!< GPIO grouped interrupt port m enable register */
+} LPC_GPIOGROUPINT_T;
+
+/**
+ * @brief Motor Control PWM register block structure
+ */
+#define LPC_MCPWM_BASE            0x400A0000
+
+typedef struct {					/*!< MCPWM Structure        */
+	__I  uint32_t  CON;				/*!< PWM Control read address */
+	__O  uint32_t  CON_SET;			/*!< PWM Control set address */
+	__O  uint32_t  CON_CLR;			/*!< PWM Control clear address */
+	__I  uint32_t  CAPCON;			/*!< Capture Control read address */
+	__O  uint32_t  CAPCON_SET;		/*!< Capture Control set address */
+	__O  uint32_t  CAPCON_CLR;		/*!< Event Control clear address */
+	__IO uint32_t TC[3];			/*!< Timer Counter register */
+	__IO uint32_t LIM[3];			/*!< Limit register         */
+	__IO uint32_t MAT[3];			/*!< Match register         */
+	__IO uint32_t  DT;				/*!< Dead time register     */
+	__IO uint32_t  CCP;				/*!< Communication Pattern register */
+	__I  uint32_t CAP[3];			/*!< Capture register       */
+	__I  uint32_t  INTEN;			/*!< Interrupt Enable read address */
+	__O  uint32_t  INTEN_SET;		/*!< Interrupt Enable set address */
+	__O  uint32_t  INTEN_CLR;		/*!< Interrupt Enable clear address */
+	__I  uint32_t  CNTCON;			/*!< Count Control read address */
+	__O  uint32_t  CNTCON_SET;		/*!< Count Control set address */
+	__O  uint32_t  CNTCON_CLR;		/*!< Count Control clear address */
+	__I  uint32_t  INTF;			/*!< Interrupt flags read address */
+	__O  uint32_t  INTF_SET;		/*!< Interrupt flags set address */
+	__O  uint32_t  INTF_CLR;		/*!< Interrupt flags clear address */
+	__O  uint32_t  CAP_CLR;			/*!< Capture clear address  */
+} LPC_MCPWM_T;
+
+/**
+ * @brief I2C register block structure
+ */
+#define LPC_I2C0_BASE             0x400A1000
+#define LPC_I2C1_BASE             0x400E0000
+
+typedef struct {				/* I2C0 Structure         */
+	__IO uint32_t CONSET;		/*!< I2C Control Set Register. When a one is written to a bit of this register, the corresponding bit in the I2C control register is set. Writing a zero has no effect on the corresponding bit in the I2C control register. */
+	__I  uint32_t STAT;			/*!< I2C Status Register. During I2C operation, this register provides detailed status codes that allow software to determine the next action needed. */
+	__IO uint32_t DAT;			/*!< I2C Data Register. During master or slave transmit mode, data to be transmitted is written to this register. During master or slave receive mode, data that has been received may be read from this register. */
+	__IO uint32_t ADR0;			/*!< I2C Slave Address Register 0. Contains the 7-bit slave address for operation of the I2C interface in slave mode, and is not used in master mode. The least significant bit determines whether a slave responds to the General Call address. */
+	__IO uint32_t SCLH;			/*!< SCH Duty Cycle Register High Half Word. Determines the high time of the I2C clock. */
+	__IO uint32_t SCLL;			/*!< SCL Duty Cycle Register Low Half Word. Determines the low time of the I2C clock. SCLL and SCLH together determine the clock frequency generated by an I2C master and certain times used in slave mode. */
+	__O  uint32_t CONCLR;		/*!< I2C Control Clear Register. When a one is written to a bit of this register, the corresponding bit in the I2C control register is cleared. Writing a zero has no effect on the corresponding bit in the I2C control register. */
+	__IO uint32_t MMCTRL;		/*!< Monitor mode control register. */
+	__IO uint32_t ADR1;			/*!< I2C Slave Address Register. Contains the 7-bit slave address for operation of the I2C interface in slave mode, and is not used in master mode. The least significant bit determines whether a slave responds to the General Call address. */
+	__IO uint32_t ADR2;			/*!< I2C Slave Address Register. Contains the 7-bit slave address for operation of the I2C interface in slave mode, and is not used in master mode. The least significant bit determines whether a slave responds to the General Call address. */
+	__IO uint32_t ADR3;			/*!< I2C Slave Address Register. Contains the 7-bit slave address for operation of the I2C interface in slave mode, and is not used in master mode. The least significant bit determines whether a slave responds to the General Call address. */
+	__I  uint32_t DATA_BUFFER;	/*!< Data buffer register. The contents of the 8 MSBs of the DAT shift register will be transferred to the DATA_BUFFER automatically after every nine bits (8 bits of data plus ACK or NACK) has been received on the bus. */
+	__IO uint32_t MASK[4];		/*!< I2C Slave address mask register */
+} LPC_I2C_T;
+
+/**
+ * @brief I2S register block structure
+ */
+#define LPC_I2S0_BASE             0x400A2000
+#define LPC_I2S1_BASE             0x400A3000
+
+typedef struct {				/*!< I2S Structure */
+	__IO uint32_t DAO;			/*!< I2S Digital Audio Output Register. Contains control bits for the I2S transmit channel */
+	__IO uint32_t DAI;			/*!< I2S Digital Audio Input Register. Contains control bits for the I2S receive channel */
+	__O uint32_t TXFIFO;		/*!< I2S Transmit FIFO. Access register for the 8 x 32-bit transmitter FIFO */
+	__I uint32_t RXFIFO;		/*!< I2S Receive FIFO. Access register for the 8 x 32-bit receiver FIFO */
+	__I uint32_t STATE;			/*!< I2S Status Feedback Register. Contains status information about the I2S interface */
+	__IO uint32_t DMA1;			/*!< I2S DMA Configuration Register 1. Contains control information for DMA request 1 */
+	__IO uint32_t DMA2;			/*!< I2S DMA Configuration Register 2. Contains control information for DMA request 2 */
+	__IO uint32_t IRQ;			/*!< I2S Interrupt Request Control Register. Contains bits that control how the I2S interrupt request is generated */
+	__IO uint32_t TXRATE;		/*!< I2S Transmit MCLK divider. This register determines the I2S TX MCLK rate by specifying the value to divide PCLK by in order to produce MCLK */
+	__IO uint32_t RXRATE;		/*!< I2S Receive MCLK divider. This register determines the I2S RX MCLK rate by specifying the value to divide PCLK by in order to produce MCLK */
+	__IO uint32_t TXBITRATE;	/*!< I2S Transmit bit rate divider. This register determines the I2S transmit bit rate by specifying the value to divide TX_MCLK by in order to produce the transmit bit clock */
+	__IO uint32_t RXBITRATE;	/*!< I2S Receive bit rate divider. This register determines the I2S receive bit rate by specifying the value to divide RX_MCLK by in order to produce the receive bit clock */
+	__IO uint32_t TXMODE;		/*!< I2S Transmit mode control */
+	__IO uint32_t RXMODE;		/*!< I2S Receive mode control */
+} LPC_I2S_T;
+
+/**
+ * @brief CCAN Controller Area Network register block structure
+ */
+#define LPC_C_CAN1_BASE           0x400A4000
+#define LPC_C_CAN0_BASE           0x400E2000
+
+typedef struct {	/*!< C_CAN message interface Structure       */
+	__IO uint32_t IF_CMDREQ;			/*!< Message interface command request  */
+	union {
+		__IO uint32_t IF_CMDMSK_R;		/*!< Message interface command mask (read direction) */
+		__IO uint32_t IF_CMDMSK_W;		/*!< Message interface command mask (write direction) */
+	};
+
+	__IO uint32_t IF_MSK1;				/*!< Message interface mask 1 */
+	__IO uint32_t IF_MSK2;				/*!< Message interface mask 2 */
+	__IO uint32_t IF_ARB1;				/*!< Message interface arbitration 1 */
+	__IO uint32_t IF_ARB2;				/*!< Message interface arbitration 2 */
+	__IO uint32_t IF_MCTRL;			/*!< Message interface message control */
+	__IO uint32_t IF_DA1;				/*!< Message interface data A1 */
+	__IO uint32_t IF_DA2;				/*!< Message interface data A2 */
+	__IO uint32_t IF_DB1;				/*!< Message interface data B1 */
+	__IO uint32_t IF_DB2;				/*!< Message interface data B2 */
+	__I  uint32_t  RESERVED[13];
+} LPC_CCAN_IF_T;
+
+typedef struct {						/*!< C_CAN Structure       */
+	__IO uint32_t CNTL;					/*!< CAN control            */
+	__IO uint32_t STAT;					/*!< Status register        */
+	__I  uint32_t EC;					/*!< Error counter          */
+	__IO uint32_t BT;					/*!< Bit timing register    */
+	__I  uint32_t INT;					/*!< Interrupt register     */
+	__IO uint32_t TEST;					/*!< Test register          */
+	__IO uint32_t BRPE;					/*!< Baud rate prescaler extension register */
+	__I  uint32_t  RESERVED0;
+	LPC_CCAN_IF_T IF[2];
+	__I  uint32_t  RESERVED2[8];
+	__I  uint32_t TXREQ1;				/*!< Transmission request 1 */
+	__I  uint32_t TXREQ2;				/*!< Transmission request 2 */
+	__I  uint32_t  RESERVED3[6];
+	__I  uint32_t ND1;					/*!< New data 1             */
+	__I  uint32_t ND2;					/*!< New data 2             */
+	__I  uint32_t  RESERVED4[6];
+	__I  uint32_t IR1;					/*!< Interrupt pending 1    */
+	__I  uint32_t IR2;					/*!< Interrupt pending 2    */
+	__I  uint32_t  RESERVED5[6];
+	__I  uint32_t MSGV1;				/*!< Message valid 1        */
+	__I  uint32_t MSGV2;				/*!< Message valid 2        */
+	__I  uint32_t  RESERVED6[6];
+	__IO uint32_t CLKDIV;				/*!< CAN clock divider register */
+} LPC_CCAN_T;
+
+/**
+ * @brief Repetitive Interrupt Timer register block structure
+ */
+#define LPC_RITIMER_BASE          0x400C0000
+
+typedef struct {				/*!< RITIMER Structure      */
+	__IO uint32_t  COMPVAL;		/*!< Compare register       */
+	__IO uint32_t  MASK;		/*!< Mask register. This register holds the 32-bit mask value. A 1 written to any bit will force a compare on the corresponding bit of the counter and compare register. */
+	__IO uint32_t  CTRL;		/*!< Control register.      */
+	__IO uint32_t  COUNTER;		/*!< 32-bit counter         */
+#if defined(CHIP_LPC1347)
+	__IO uint32_t  COMPVAL_H;	/*!< Compare upper register */
+	__IO uint32_t  MASK_H;		/*!< Mask upper register    */
+	__I  uint32_t  RESERVED0[1]; 
+	__IO uint32_t  COUNTER_H;	/*!< Counter upper register */
+#endif
+} LPC_RITIMER_T;
+
+/**
+ * @brief Quadrature Encoder Interface register block structure
+ */
+#define LPC_QEI_BASE              0x400C6000
+
+typedef struct {				/*!< QEI Structure          */
+	__O  uint32_t  CON;			/*!< Control register       */
+	__I  uint32_t  STAT;		/*!< Encoder status register */
+	__IO uint32_t  CONF;		/*!< Configuration register */
+	__I  uint32_t  POS;			/*!< Position register      */
+	__IO uint32_t  MAXPOS;		/*!< Maximum position register */
+	__IO uint32_t  CMPOS0;		/*!< position compare register 0 */
+	__IO uint32_t  CMPOS1;		/*!< position compare register 1 */
+	__IO uint32_t  CMPOS2;		/*!< position compare register 2 */
+	__I  uint32_t  INXCNT;		/*!< Index count register   */
+	__IO uint32_t  INXCMP0;		/*!< Index compare register 0 */
+	__IO uint32_t  LOAD;		/*!< Velocity timer reload register */
+	__I  uint32_t  TIME;		/*!< Velocity timer register */
+	__I  uint32_t  VEL;			/*!< Velocity counter register */
+	__I  uint32_t  CAP;			/*!< Velocity capture register */
+	__IO uint32_t  VELCOMP;		/*!< Velocity compare register */
+	__IO uint32_t  FILTERPHA;	/*!< Digital filter register on input phase A (QEI_A) */
+	__IO uint32_t  FILTERPHB;	/*!< Digital filter register on input phase B (QEI_B) */
+	__IO uint32_t  FILTERINX;	/*!< Digital filter register on input index (QEI_IDX) */
+	__IO uint32_t  WINDOW;		/*!< Index acceptance window register */
+	__IO uint32_t  INXCMP1;		/*!< Index compare register 1 */
+	__IO uint32_t  INXCMP2;		/*!< Index compare register 2 */
+	__I  uint32_t  RESERVED0[993];
+	__O  uint32_t  IEC;			/*!< Interrupt enable clear register */
+	__O  uint32_t  IES;			/*!< Interrupt enable set register */
+	__I  uint32_t  INTSTAT;		/*!< Interrupt status register */
+	__I  uint32_t  IE;			/*!< Interrupt enable register */
+	__O  uint32_t  CLR;			/*!< Interrupt status clear register */
+	__O  uint32_t  SET;			/*!< Interrupt status set register */
+} LPC_QEI_T;
+
+/**
+ * @brief Global Input Multiplexer Array (GIMA) register block structure
+ */
+#define LPC_GIMA_BASE             0x400C7000
+
+typedef struct {						/*!< GIMA Structure */
+	__IO uint32_t  CAP0_IN[4][4];		/*!< Timer x CAP0_y capture input multiplexer (GIMA output ((x*4)+y)) */
+	__IO uint32_t  CTIN_IN[8];			/*!< SCT CTIN_x capture input multiplexer (GIMA output (16+x)) */
+	__IO uint32_t  VADC_TRIGGER_IN;		/*!< VADC trigger input multiplexer (GIMA output 24) */
+	__IO uint32_t  EVENTROUTER_13_IN;	/*!< Event router input 13 multiplexer (GIMA output 25) */
+	__IO uint32_t  EVENTROUTER_14_IN;	/*!< Event router input 14 multiplexer (GIMA output 26) */
+	__IO uint32_t  EVENTROUTER_16_IN;	/*!< Event router input 16 multiplexer (GIMA output 27) */
+	__IO uint32_t  ADCSTART0_IN;		/*!< ADC start0 input multiplexer (GIMA output 28) */
+	__IO uint32_t  ADCSTART1_IN;		/*!< ADC start1 input multiplexer (GIMA output 29) */
+} LPC_GIMA_T;
+
+/**
+ * @brief DAC register block structure
+ */
+#define LPC_DAC_BASE              0x400E1000
+
+typedef struct {			/*!< DAC Structure          */
+	__IO uint32_t  CR;		/*!< DAC register. Holds the conversion data. */
+	__IO uint32_t  CTRL;	/*!< DAC control register.  */
+	__IO uint32_t  CNTVAL;	/*!< DAC counter value register. */
+} LPC_DAC_T;
+
+/* After the selected settling time after this field is written with a
+ * new VALUE, the voltage on the AOUT pin (with respect to VSSA)
+ * is VALUE/1024 ? VREF
+ */
+#define DAC_RANGE           0x3FF
+#define DAC_VALUE(n)        ((uint32_t) ((n & DAC_RANGE) << 6))
+/* If this bit = 0: The settling time of the DAC is 1 microsecond max,
+ * and the maximum current is 700 microAmpere
+ * If this bit = 1: The settling time of the DAC is 2.5 microsecond
+ * and the maximum current is 350 microAmpere
+ */
+#define DAC_BIAS_EN         ((uint32_t) (1 << 16))
+/* Value to reload interrupt DMA counter */
+#define DAC_CCNT_VALUE(n)   ((uint32_t) (n & 0xffff))
+
+#define DAC_DBLBUF_ENA      ((uint32_t) (1 << 1))
+#define DAC_CNT_ENA         ((uint32_t) (1 << 2))
+#define DAC_DMA_ENA         ((uint32_t) (1 << 3))
+#define DAC_DACCTRL_MASK    ((uint32_t) (0x0F))
+
+/* Current option in DAC configuration option */
+typedef enum IP_DAC_CURRENT_OPT {
+	DAC_MAX_UPDATE_RATE_1MHz = 0,	/*!< Shorter settling times and higher power consumption;
+									    allows for a maximum update rate of 1 MHz */
+	DAC_MAX_UPDATE_RATE_400kHz		/*!< Longer settling times and lower power consumption;
+									    allows for a maximum update rate of 400 kHz */
+} IP_DAC_CURRENT_OPT_T;
+
+/**
+ * @brief  ADC register block structure
+ */
+#define LPC_ADC0_BASE             0x400E3000
+#define LPC_ADC1_BASE             0x400E4000
+#define ADC_ACC_10BITS
+
+/**
+ * @brief 10 or 12-bit ADC register block structure
+ */
+typedef struct {					/*!< ADCn Structure */
+	__IO uint32_t CR;				/*!< A/D Control Register. The AD0CR register must be written to select the operating mode before A/D conversion can occur. */
+	__I  uint32_t GDR;				/*!< A/D Global Data Register. Contains the result of the most recent A/D conversion. */
+	__I  uint32_t RESERVED0;
+	__IO uint32_t INTEN;			/*!< A/D Interrupt Enable Register. This register contains enable bits that allow the DONE flag of each A/D channel to be included or excluded from contributing to the generation of an A/D interrupt. */
+	__I  uint32_t DR[8];			/*!< A/D Channel Data Register. This register contains the result of the most recent conversion completed on channel n. */
+	__I  uint32_t STAT;				/*!< A/D Status Register. This register contains DONE and OVERRUN flags for all of the A/D channels, as well as the A/D interrupt flag. */
+} LPC_ADC_T;
+
+/* ADC register support bitfields and mask */
+#define ADC_RANGE               0x3FF
+#define ADC_DR_RESULT(n)        ((((n) >> 6) & 0x3FF))	/*!< Mask for getting the 10 bits ADC data read value */
+#define ADC_CR_BITACC(n)        ((((n) & 0x7) << 17))	/*!< Number of ADC accuracy bits */
+#define ADC_DR_DONE(n)          (((n) >> 31))			/*!< Mask for reading the ADC done status */
+#define ADC_DR_OVERRUN(n)       ((((n) >> 30) & (1UL)))	/*!< Mask for reading the ADC overrun status */
+#define ADC_CR_CH_SEL(n)        ((1UL << (n)))			/*!< Selects which of the AD0.0:7 pins is (are) to be sampled and converted */
+#define ADC_CR_CLKDIV(n)        ((((n) & 0xFF) << 8))	/*!< The APB clock (PCLK) is divided by (this value plus one) to produce the clock for the A/D */
+#define ADC_CR_BURST            ((1UL << 16))			/*!< Repeated conversions A/D enable bit */
+#define ADC_CR_PDN              ((1UL << 21))			/*!< ADC convert is operational */
+#define ADC_CR_START_MASK       ((7UL << 24))			/*!< ADC start mask bits */
+#define ADC_CR_START_MODE_SEL(SEL)  ((SEL << 24))		/*!< Select Start Mode */
+#define ADC_CR_START_NOW        ((1UL << 24))			/*!< Start conversion now */
+#define ADC_CR_START_CTOUT15    ((2UL << 24))			/*!< Start conversion when the edge selected by bit 27 occurs on CTOUT_15 */
+#define ADC_CR_START_CTOUT8     ((3UL << 24))			/*!< Start conversion when the edge selected by bit 27 occurs on CTOUT_8 */
+#define ADC_CR_START_ADCTRIG0   ((4UL << 24))			/*!< Start conversion when the edge selected by bit 27 occurs on ADCTRIG0 */
+#define ADC_CR_START_ADCTRIG1   ((5UL << 24))			/*!< Start conversion when the edge selected by bit 27 occurs on ADCTRIG1 */
+#define ADC_CR_START_MCOA2      ((6UL << 24))			/*!< Start conversion when the edge selected by bit 27 occurs on Motocon PWM output MCOA2 */
+#define ADC_CR_EDGE             ((1UL << 27))			/*!< Start conversion on a falling edge on the selected CAP/MAT signal */
+#define ADC_CONFIG_MASK         (ADC_CR_CLKDIV(0xFF) | ADC_CR_BITACC(0x07) | ADC_CR_PDN)
+
+/*	ADC status register used for IP drivers */
+typedef enum IP_ADC_STATUS {
+	ADC_DR_DONE_STAT,	/*!< ADC data register staus */
+	ADC_DR_OVERRUN_STAT,/*!< ADC data overrun staus */
+	ADC_DR_ADINT_STAT	/*!< ADC interrupt status */
+} IP_ADC_STATUS_T;
+
+/**
+ * @brief  GPIO port register block structure
+ */
+#define LPC_GPIO_PORT_BASE        0x400F4000
+
+typedef struct {				/*!< GPIO_PORT Structure */
+	__IO uint8_t B[128][32];	/*!< Offset 0x0000: Byte pin registers ports 0 to n; pins PIOn_0 to PIOn_31 */
+	__IO uint32_t W[32][32];	/*!< Offset 0x1000: Word pin registers port 0 to n */
+	__IO uint32_t DIR[32];		/*!< Offset 0x2000: Direction registers port n */
+	__IO uint32_t MASK[32];		/*!< Offset 0x2080: Mask register port n */
+	__IO uint32_t PIN[32];		/*!< Offset 0x2100: Portpin register port n */
+	__IO uint32_t MPIN[32];		/*!< Offset 0x2180: Masked port register port n */
+	__IO uint32_t SET[32];		/*!< Offset 0x2200: Write: Set register for port n Read: output bits for port n */
+	__O  uint32_t CLR[32];		/*!< Offset 0x2280: Clear port n */
+	__O  uint32_t NOT[32];		/*!< Offset 0x2300: Toggle port n */
+} LPC_GPIO_T;
+
+/* Calculate GPIO offset and port register address from group and pin number */
+#define GPIO_OFF(port, pin)        ((port << 5) + pin)
+#define GPIO_REG(port, pin)        ((__IO uint32_t *)(LPC_GPIO_PORT_BASE + 0x2000 + GPIO_OFF(port, pin)))
+
+/**
+ * @brief SPI register block structure
+ */
+#define LPC_SPI_BASE              0x40100000
+
+typedef struct {					/*!< SPI Structure          */
+	__IO uint32_t  CR;				/*!< SPI Control Register. This register controls the operation of the SPI. */
+	__I  uint32_t  SR;				/*!< SPI Status Register. This register shows the status of the SPI. */
+	__IO uint32_t  DR;				/*!< SPI Data Register. This bi-directional register provides the transmit and receive data for the SPI. Transmit data is provided to the SPI0 by writing to this register. Data received by the SPI0 can be read from this register. */
+	__IO uint32_t  CCR;				/*!< SPI Clock Counter Register. This register controls the frequency of a master's SCK0. */
+	__I  uint32_t  RESERVED0[3];
+	__IO uint32_t  INT;				/*!< SPI Interrupt Flag. This register contains the interrupt flag for the SPI interface. */
+} LPC_SPI_T;
+
+/* SPI CFG Register BitMask */
+#define SPI_CR_BITMASK       ((uint32_t) 0xFFC)
+/* Enable of controlling the number of bits per transfer  */
+#define SPI_CR_BIT_EN         ((uint32_t) (1 << 2))
+/* Mask of field of bit controlling */
+#define SPI_CR_BITS_MASK      ((uint32_t) 0xF00)
+/* Set the number of bits per a transfer */
+#define SPI_CR_BITS(n)        ((uint32_t) ((n << 8) & 0xF00))	/* n is in range 8-16 */
+/* SPI Clock Phase Select*/
+#define SPI_CR_CPHA_FIRST     ((uint32_t) (0))	/*Capture data on the first edge, Change data on the following edge*/
+#define SPI_CR_CPHA_SECOND    ((uint32_t) (1 << 3))	/*Change data on the first edge, Capture data on the following edge*/
+/* SPI Clock Polarity Select*/
+#define SPI_CR_CPOL_LO        ((uint32_t) (0))	/* The rest state of the clock (between frames) is low.*/
+#define SPI_CR_CPOL_HI        ((uint32_t) (1 << 4))	/* The rest state of the clock (between frames) is high.*/
+/* SPI Slave Mode Select */
+#define SPI_CR_SLAVE_EN       ((uint32_t) 0)
+/* SPI Master Mode Select */
+#define SPI_CR_MASTER_EN      ((uint32_t) (1 << 5))
+/* SPI MSB First mode enable */
+#define SPI_CR_MSB_FIRST_EN   ((uint32_t) 0)	/*Data will be transmitted and received in standard order (MSB first).*/
+/* SPI LSB First mode enable */
+#define SPI_CR_LSB_FIRST_EN   ((uint32_t) (1 << 6))	/*Data will be transmitted and received in reverse order (LSB first).*/
+/* SPI interrupt enable */
+#define SPI_CR_INT_EN         ((uint32_t) (1 << 7))
+/* SPI STAT Register BitMask */
+#define SPI_SR_BITMASK        ((uint32_t) 0xF8)
+/* Slave abort Flag */
+#define SPI_SR_ABRT           ((uint32_t) (1 << 3))	/* When 1, this bit indicates that a slave abort has occurred. */
+/* Mode fault Flag */
+#define SPI_SR_MODF           ((uint32_t) (1 << 4))	/* when 1, this bit indicates that a Mode fault error has occurred. */
+/* Read overrun flag*/
+#define SPI_SR_ROVR           ((uint32_t) (1 << 5))	/* When 1, this bit indicates that a read overrun has occurred. */
+/* Write collision flag. */
+#define SPI_SR_WCOL           ((uint32_t) (1 << 6))	/* When 1, this bit indicates that a write collision has occurred.. */
+/* SPI transfer complete flag. */
+#define SPI_SR_SPIF           ((uint32_t) (1 << 7))		/* When 1, this bit indicates when a SPI data transfer is complete.. */
+/**SPI error flag */
+#define SPI_SR_ERROR          (SPI_SR_ABRT | SPI_SR_MODF | SPI_SR_ROVR | SPI_SR_WCOL)
+/* Enable SPI Test Mode */
+#define SPI_TCR_TEST(n)       ((uint32_t) ((n & 0x3F) << 1))
+/* SPI interrupt flag */
+#define SPI_INT_SPIF          ((uint32_t) (1 << 0))
+/* Receiver Data  */
+#define SPI_DR_DATA(n)        ((uint32_t) ((n) & 0xFFFF))
+
+/* SPI Mode*/
+typedef enum LPC_SPI_MODE {
+	SPI_MODE_MASTER = SPI_CR_MASTER_EN,			/* Master Mode */
+	SPI_MODE_SLAVE = SPI_CR_SLAVE_EN,			/* Slave Mode */
+} LPC_SPI_MODE_T;
+
+/* SPI Clock Mode*/
+typedef enum LPC_SPI_CLOCK_MODE {
+	SPI_CLOCK_CPHA0_CPOL0 = SPI_CR_CPOL_LO | SPI_CR_CPHA_FIRST,		/**< CPHA = 0, CPOL = 0 */
+	SPI_CLOCK_CPHA0_CPOL1 = SPI_CR_CPOL_HI | SPI_CR_CPHA_FIRST,		/**< CPHA = 0, CPOL = 1 */
+	SPI_CLOCK_CPHA1_CPOL0 = SPI_CR_CPOL_LO | SPI_CR_CPHA_SECOND,	/**< CPHA = 1, CPOL = 0 */
+	SPI_CLOCK_CPHA1_CPOL1 = SPI_CR_CPOL_HI | SPI_CR_CPHA_SECOND,	/**< CPHA = 1, CPOL = 1 */
+	SPI_CLOCK_MODE0 = SPI_CLOCK_CPHA0_CPOL0, /**< alias */
+	SPI_CLOCK_MODE1 = SPI_CLOCK_CPHA1_CPOL0, /**< alias */
+	SPI_CLOCK_MODE2 = SPI_CLOCK_CPHA0_CPOL1, /**< alias */
+	SPI_CLOCK_MODE3 = SPI_CLOCK_CPHA1_CPOL1, /**< alias */
+} LPC_SPI_CLOCK_MODE_T;
+
+/* SPI Data Order Mode*/
+typedef enum LPC_SPI_DATA_ORDER {
+	SPI_DATA_MSB_FIRST = SPI_CR_MSB_FIRST_EN,			/* Standard Order */
+	SPI_DATA_LSB_FIRST = SPI_CR_LSB_FIRST_EN,			/* Reverse Order */
+} LPC_SPI_DATA_ORDER_T;
+
+/**
+ * @brief Serial GPIO register block structure
+ */
+#define LPC_SGPIO_BASE            0x40101000
+
+typedef struct {						/*!< SGPIO Structure        */
+	__IO uint32_t  OUT_MUX_CFG[16];		/*!< Pin multiplexer configurationregisters. */
+	__IO uint32_t  SGPIO_MUX_CFG[16];	/*!< SGPIO multiplexer configuration registers. */
+	__IO uint32_t  SLICE_MUX_CFG[16];	/*!< Slice multiplexer configuration registers. */
+	__IO uint32_t  REG[16];				/*!< Slice data registers. Eachtime COUNT0 reaches 0x0 the register shifts loading bit 31 withdata captured from DIN(n). DOUT(n) is set to REG(0) */
+	__IO uint32_t  REG_SS[16];			/*!< Slice data shadow registers. Each time POSreaches 0x0 the contents of REG_SS is exchanged with the contentof REG */
+	__IO uint32_t  PRESET[16];			/*!< Reload valueof COUNT0, loaded when COUNT0 reaches 0x0 */
+	__IO uint32_t  COUNT[16];			/*!< Down counter, counts down each clock cycle. */
+	__IO uint32_t  POS[16];				/*!< Each time COUNT0 reaches 0x0 */
+	__IO uint32_t  MASK_A;				/*!< Mask for pattern match function of slice A */
+	__IO uint32_t  MASK_H;				/*!< Mask for pattern match function of slice H */
+	__IO uint32_t  MASK_I;				/*!< Mask for pattern match function of slice I */
+	__IO uint32_t  MASK_P;				/*!< Mask for pattern match function of slice P */
+	__I  uint32_t  GPIO_INREG;			/*!< GPIO input status register */
+	__IO uint32_t  GPIO_OUTREG;			/*!< GPIO output control register */
+	__IO uint32_t  GPIO_OENREG;			/*!< GPIO OE control register */
+	__IO uint32_t  CTRL_ENABLED;		/*!< Enables the slice COUNT counter */
+	__IO uint32_t  CTRL_DISABLED;		/*!< Disables the slice COUNT counter */
+	__I  uint32_t  RESERVED0[823];
+	__O  uint32_t  CLR_EN_0;			/*!< Shift clock interrupt clear mask */
+	__O  uint32_t  SET_EN_0;			/*!< Shift clock interrupt set mask */
+	__I  uint32_t  ENABLE_0;			/*!< Shift clock interrupt enable */
+	__I  uint32_t  STATUS_0;			/*!< Shift clock interrupt status */
+	__O  uint32_t  CTR_STATUS_0;		/*!< Shift clock interrupt clear status */
+	__O  uint32_t  SET_STATUS_0;		/*!< Shift clock interrupt set status */
+	__I  uint32_t  RESERVED1[2];
+	__O  uint32_t  CLR_EN_1;			/*!< Capture clock interrupt clear mask */
+	__O  uint32_t  SET_EN_1;			/*!< Capture clock interrupt set mask */
+	__I  uint32_t  ENABLE_1;			/*!< Capture clock interrupt enable */
+	__I  uint32_t  STATUS_1;			/*!< Capture clock interrupt status */
+	__O  uint32_t  CTR_STATUS_1;		/*!< Capture clock interrupt clear status */
+	__O  uint32_t  SET_STATUS_1;		/*!< Capture clock interrupt set status */
+	__I  uint32_t  RESERVED2[2];
+	__O  uint32_t  CLR_EN_2;			/*!< Pattern match interrupt clear mask */
+	__O  uint32_t  SET_EN_2;			/*!< Pattern match interrupt set mask */
+	__I  uint32_t  ENABLE_2;			/*!< Pattern match interrupt enable */
+	__I  uint32_t  STATUS_2;			/*!< Pattern match interrupt status */
+	__O  uint32_t  CTR_STATUS_2;		/*!< Pattern match interrupt clear status */
+	__O  uint32_t  SET_STATUS_2;		/*!< Pattern match interrupt set status */
+	__I  uint32_t  RESERVED3[2];
+	__O  uint32_t  CLR_EN_3;			/*!< Input interrupt clear mask */
+	__O  uint32_t  SET_EN_3;			/*!< Input bit match interrupt set mask */
+	__I  uint32_t  ENABLE_3;			/*!< Input bit match interrupt enable */
+	__I  uint32_t  STATUS_3;			/*!< Input bit match interrupt status */
+	__O  uint32_t  CTR_STATUS_3;		/*!< Input bit match interrupt clear status */
+	__O  uint32_t  SET_STATUS_3;		/*!< Shift clock interrupt set status */
+} LPC_SGPIO_T;
+
+/* End of section using anonymous unions */
+#if defined(__ARMCC_VERSION)
+  #pragma pop
+#elif defined(__CWCC__)
+  #pragma pop
+#elif defined(__IAR_SYSTEMS_ICC__)
+  //#pragma pop // FIXME not usable for IAR
+#else /* defined(__GNUC__) and others */
+  /* Leave anonymous unions enabled */
+#endif
+
+/**
+ * @brief  LPC43xx Peripheral register set declarations
+ */
+#define LPC_SCT                   ((LPC_SCT_T               *) LPC_SCT_BASE)
+#define LPC_GPDMA                 ((LPC_GPDMA_T             *) LPC_GPDMA_BASE)
+#define LPC_SDMMC                 ((LPC_SDMMC_T             *) LPC_SDMMC_BASE)
+#define LPC_EMC                   ((LPC_EMC_T               *) LPC_EMC_BASE)
+#define LPC_USB0                  ((LPC_USBHS_T             *) LPC_USB0_BASE)
+#define LPC_USB1                  ((LPC_USBHS_T             *) LPC_USB1_BASE)
+#define LPC_LCD                   ((LPC_LCD_T               *) LPC_LCD_BASE)
+#define LPC_EEPROM                ((LPC_EEPROM_T            *) LPC_EEPROM_BASE)
+#define LPC_ETHERNET              ((LPC_ENET_T              *) LPC_ETHERNET_BASE)
+#define LPC_ATIMER                ((LPC_ATIMER_T            *) LPC_ATIMER_BASE)
+#define LPC_REGFILE               ((LPC_REGFILE_T           *) LPC_REGFILE_BASE)
+#define LPC_PMC                   ((LPC_PMC_T               *) LPC_PMC_BASE)
+#define LPC_CREG                  ((LPC_CREG_T              *) LPC_CREG_BASE)
+#define LPC_EVRT                  ((LPC_EVRT_T              *) LPC_EVRT_BASE)
+#define LPC_RTC                   ((LPC_RTC_T               *) LPC_RTC_BASE)
+#define LPC_CGU                   ((LPC_CGU_T               *) LPC_CGU_BASE)
+#define LPC_CCU1                  ((LPC_CCU1_T              *) LPC_CCU1_BASE)
+#define LPC_CCU2                  ((LPC_CCU2_T              *) LPC_CCU2_BASE)
+#define LPC_RGU                   ((LPC_RGU_T               *) LPC_RGU_BASE)
+#define LPC_WWDT                  ((LPC_WWDT_T              *) LPC_WWDT_BASE)
+#define LPC_USART0                ((LPC_USART_T             *) LPC_USART0_BASE)
+#define LPC_USART2                ((LPC_USART_T             *) LPC_USART2_BASE)
+#define LPC_USART3                ((LPC_USART_T             *) LPC_USART3_BASE)
+#define LPC_UART1                 ((LPC_USART_T             *) LPC_UART1_BASE)
+#define LPC_SSP0                  ((LPC_SSP_T               *) LPC_SSP0_BASE)
+#define LPC_SSP1                  ((LPC_SSP_T               *) LPC_SSP1_BASE)
+#define LPC_TIMER0                ((LPC_TIMER_T             *) LPC_TIMER0_BASE)
+#define LPC_TIMER1                ((LPC_TIMER_T             *) LPC_TIMER1_BASE)
+#define LPC_TIMER2                ((LPC_TIMER_T             *) LPC_TIMER2_BASE)
+#define LPC_TIMER3                ((LPC_TIMER_T             *) LPC_TIMER3_BASE)
+#define LPC_SCU                   ((LPC_SCU_T               *) LPC_SCU_BASE)
+#define LPC_GPIO_PIN_INT          ((LPC_GPIOPININT_T        *) LPC_GPIO_PIN_INT_BASE)
+#define LPC_GPIO_GROUP_INT0       ((IP_GPIOGROUPINT_T       *) LPC_GPIO_GROUP_INT0_BASE)
+#define LPC_GPIO_GROUP_INT1       ((IP_GPIOGROUPINT_T       *) LPC_GPIO_GROUP_INT1_BASE)
+#define LPC_MCPWM                 ((LPC_MCPWM_T             *) LPC_MCPWM_BASE)
+#define LPC_I2C0                  ((LPC_I2C_T               *) LPC_I2C0_BASE)
+#define LPC_I2C1                  ((LPC_I2C_T               *) LPC_I2C1_BASE)
+#define LPC_I2S0                  ((LPC_I2S_T               *) LPC_I2S0_BASE)
+#define LPC_I2S1                  ((LPC_I2S_T               *) LPC_I2S1_BASE)
+#define LPC_C_CAN1                ((LPC_CCAN_T              *) LPC_C_CAN1_BASE)
+#define LPC_RITIMER               ((LPC_RITIMER_T           *) LPC_RITIMER_BASE)
+#define LPC_QEI                   ((LPC_QEI_T               *) LPC_QEI_BASE)
+#define LPC_GIMA                  ((LPC_GIMA_T              *) LPC_GIMA_BASE)
+#define LPC_DAC                   ((LPC_DAC_T               *) LPC_DAC_BASE)
+#define LPC_C_CAN0                ((LPC_CCAN_T              *) LPC_C_CAN0_BASE)
+#define LPC_ADC0                  ((LPC_ADC_T               *) LPC_ADC0_BASE)
+#define LPC_ADC1                  ((LPC_ADC_T               *) LPC_ADC1_BASE)
+#define LPC_GPIO_PORT             ((LPC_GPIO_T              *) LPC_GPIO_PORT_BASE)
+#define LPC_SPI                   ((LPC_SPI_T               *) LPC_SPI_BASE)
+#define LPC_SGPIO                 ((LPC_SGPIO_T             *) LPC_SGPIO_BASE)
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __LPC43XX_H */

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/TOOLCHAIN_ARM_STD/LPC43xx.sct
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/TOOLCHAIN_ARM_STD/LPC43xx.sct
@@ -1,0 +1,25 @@
+
+LR_IROM1 0x14000000 0x00400000  {    ; load region size_region
+  ER_IROM1 0x14000000 0x00400000  {  ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+  }
+  ; 8_byte_aligned(69 vect * 4 bytes) =  8_byte_aligned(0x0114) = 0x0118
+  ; 128KB - 0x0118 = 0x0001FEE8
+  RW_IRAM1 0x10000118 0x1FEE8  {
+   .ANY (+RW +ZI)
+  }
+  RW_IRAM2 0x10080000 0x12000 {  ; RW data
+   .ANY (IRAM2)
+  }
+  RW_IRAM3 0x20000000 0x8000  {  ; RW data
+   .ANY (AHBSRAM0)
+  }
+  RW_IRAM4 0x20008000 0x4000  {  ; RW data
+   .ANY (AHBSRAM1)
+  }
+  RW_IRAM5 0x2000C000 0x4000  {  ; RW data
+   .ANY (AHBSRAM2)
+  }
+}

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/TOOLCHAIN_ARM_STD/startup_LPC43xx.s
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/TOOLCHAIN_ARM_STD/startup_LPC43xx.s
@@ -1,0 +1,291 @@
+;/***********************************************************************
+; * @brief: LPC18xx/43xx M3/M4 startup code
+; *
+; * @note
+; * Copyright(C) NXP Semiconductors, 2012
+; * All rights reserved.
+; *
+; * @par
+; * Software that is described herein is for illustrative purposes only
+; * which provides customers with programming information regarding the
+; * LPC products.  This software is supplied "AS IS" without any warranties of
+; * any kind, and NXP Semiconductors and its licensor disclaim any and
+; * all warranties, express or implied, including all implied warranties of
+; * merchantability, fitness for a particular purpose and non-infringement of
+; * intellectual property rights.  NXP Semiconductors assumes no responsibility
+; * or liability for the use of the software, conveys no license or rights under any
+; * patent, copyright, mask work right, or any other intellectual property rights in
+; * or to any products. NXP Semiconductors reserves the right to make changes
+; * in the software without notification. NXP Semiconductors also makes no
+; * representation or warranty that such application will be suitable for the
+; * specified use without further testing or modification.
+; *
+; * @par
+; * Permission to use, copy, modify, and distribute this software and its
+; * documentation is hereby granted, under NXP Semiconductors' and its
+; * licensor's relevant copyrights in the software, without fee, provided that it
+; * is used in conjunction with NXP Semiconductors microcontrollers.  This
+; * copyright, permission, and disclaimer notice must appear in all copies of
+; * this code.
+; */
+
+__initial_sp    EQU     0x10020000  ; Top of first RAM segment for LPC43XX
+
+                PRESERVE8
+                THUMB
+
+; Vector Table Mapped to Address 0 at Reset
+
+                AREA    RESET, DATA, READONLY
+                EXPORT  __Vectors
+
+Sign_Value		EQU		0x5A5A5A5A
+
+__Vectors       DCD     __initial_sp              	; 0 Top of Stack
+                DCD     Reset_Handler             	; 1 Reset Handler
+                DCD     NMI_Handler               	; 2 NMI Handler
+                DCD     HardFault_Handler         	; 3 Hard Fault Handler
+                DCD     MemManage_Handler         	; 4 MPU Fault Handler
+                DCD     BusFault_Handler          	; 5 Bus Fault Handler
+                DCD     UsageFault_Handler        	; 6 Usage Fault Handler
+                DCD     Sign_Value                	; 7 Reserved
+                DCD     UnHandled_Vector           	; 8 Reserved
+                DCD     UnHandled_Vector           	; 9 Reserved
+                DCD     UnHandled_Vector          	; 10 Reserved
+                DCD     SVC_Handler               	; 11 SVCall Handler
+                DCD     DebugMon_Handler          	; 12 Debug Monitor Handler
+                DCD     UnHandled_Vector          	; 13 Reserved
+                DCD     PendSV_Handler            	; 14 PendSV Handler
+                DCD     SysTick_Handler           	; 15 SysTick Handler
+
+                ; External Interrupts
+				DCD		DAC_IRQHandler	 			; 16 D/A Converter
+				DCD		MX_CORE_IRQHandler			; 17 M0/M4 IRQ handler (LPC43XX ONLY)
+				DCD		DMA_IRQHandler				; 18 General Purpose DMA
+				DCD		UnHandled_Vector			; 19 Reserved
+				DCD		FLASHEEPROM_IRQHandler		; 20 ORed flash bank A, flash bank B, EEPROM interrupts
+				DCD		ETH_IRQHandler				; 21 Ethernet
+				DCD		SDIO_IRQHandler				; 22 SD/MMC
+				DCD		LCD_IRQHandler				; 23 LCD
+				DCD		USB0_IRQHandler				; 24 USB0
+				DCD		USB1_IRQHandler				; 25 USB1
+				DCD		SCT_IRQHandler				; 26 State Configurable Timer
+				DCD		RIT_IRQHandler				; 27 Repetitive Interrupt Timer
+				DCD		TIMER0_IRQHandler			; 28 Timer0
+				DCD		TIMER1_IRQHandler			; 29 Timer1
+				DCD		TIMER2_IRQHandler			; 30 Timer2
+				DCD		TIMER3_IRQHandler			; 31 Timer3
+				DCD		MCPWM_IRQHandler			; 32 Motor Control PWM
+				DCD		ADC0_IRQHandler				; 33 A/D Converter 0
+				DCD		I2C0_IRQHandler				; 34 I2C0
+				DCD		I2C1_IRQHandler				; 35 I2C1
+				DCD		SPI_IRQHandler				; 36 SPI (LPC43XX ONLY)
+				DCD		ADC1_IRQHandler				; 37 A/D Converter 1
+				DCD		SSP0_IRQHandler				; 38 SSP0
+				DCD		SSP1_IRQHandler				; 39 SSP1
+				DCD		UART0_IRQHandler			; 40 UART0
+				DCD		UART1_IRQHandler			; 41 UART1
+				DCD		UART2_IRQHandler			; 42 UART2
+				DCD		UART3_IRQHandler			; 43 UART3
+				DCD		I2S0_IRQHandler				; 44 I2S0
+				DCD		I2S1_IRQHandler				; 45 I2S1
+				DCD		SPIFI_IRQHandler			; 46 SPI Flash Interface
+				DCD		SGPIO_IRQHandler			; 47 SGPIO (LPC43XX ONLY)
+				DCD		GPIO0_IRQHandler			; 48 GPIO0
+				DCD		GPIO1_IRQHandler			; 49 GPIO1
+				DCD		GPIO2_IRQHandler			; 50 GPIO2
+				DCD		GPIO3_IRQHandler			; 51 GPIO3
+				DCD		GPIO4_IRQHandler			; 52 GPIO4
+				DCD		GPIO5_IRQHandler			; 53 GPIO5
+				DCD		GPIO6_IRQHandler			; 54 GPIO6
+				DCD		GPIO7_IRQHandler			; 55 GPIO7
+				DCD		GINT0_IRQHandler			; 56 GINT0
+				DCD		GINT1_IRQHandler			; 57 GINT1
+				DCD		EVRT_IRQHandler				; 58 Event Router
+				DCD		CAN1_IRQHandler				; 59 C_CAN1
+ 				DCD		UnHandled_Vector			; 60 Reserved
+				DCD		VADC_IRQHandler 			; 61 VADC
+				DCD		ATIMER_IRQHandler			; 62 ATIMER
+				DCD		RTC_IRQHandler				; 63 RTC
+ 				DCD		UnHandled_Vector			; 64 Reserved
+				DCD		WDT_IRQHandler				; 65 WDT
+				DCD		UnHandled_Vector			; 66 M0s
+				DCD		CAN0_IRQHandler				; 67 C_CAN0
+				DCD 	QEI_IRQHandler				; 68 QEI
+
+
+;                IF      :LNOT::DEF:NO_CRP
+;                AREA    |.ARM.__at_0x02FC|, CODE, READONLY
+;CRP_Key         DCD     0xFFFFFFFF
+;                ENDIF
+
+                AREA    |.text|, CODE, READONLY
+
+; Reset Handler
+
+Reset_Handler   PROC
+                EXPORT  Reset_Handler             [WEAK]
+                IMPORT  __main
+				IMPORT  SystemInit
+				LDR		R0, =SystemInit
+				BLX		R0
+                LDR     R0, =__main
+                BX      R0
+                ENDP
+
+; Dummy Exception Handlers (infinite loops which can be modified)
+
+NMI_Handler     PROC
+                EXPORT  NMI_Handler               [WEAK]
+                B       .
+                ENDP
+HardFault_Handler\
+                PROC
+                EXPORT  HardFault_Handler         [WEAK]
+                B       .
+                ENDP
+MemManage_Handler\
+                PROC
+                EXPORT  MemManage_Handler         [WEAK]
+                B       .
+                ENDP
+BusFault_Handler\
+                PROC
+                EXPORT  BusFault_Handler          [WEAK]
+                B       .
+                ENDP
+UsageFault_Handler\
+                PROC
+                EXPORT  UsageFault_Handler        [WEAK]
+                B       .
+                ENDP
+SVC_Handler     PROC
+                EXPORT  SVC_Handler               [WEAK]
+                B       .
+                ENDP
+DebugMon_Handler\
+                PROC
+                EXPORT  DebugMon_Handler          [WEAK]
+                B       .
+                ENDP
+PendSV_Handler  PROC
+                EXPORT  PendSV_Handler            [WEAK]
+                B       .
+                ENDP
+SysTick_Handler PROC
+                EXPORT  SysTick_Handler           [WEAK]
+                B       .
+                ENDP
+UnHandled_Vector	PROC
+                EXPORT  UnHandled_Vector          [WEAK]
+                B       .
+                ENDP
+
+Default_Handler PROC
+
+                EXPORT DAC_IRQHandler 	    	[WEAK]
+                EXPORT MX_CORE_IRQHandler	    [WEAK]
+				EXPORT DMA_IRQHandler		    [WEAK]
+                EXPORT FLASHEEPROM_IRQHandler	[WEAK]
+				EXPORT ETH_IRQHandler	    	[WEAK]
+				EXPORT SDIO_IRQHandler	    	[WEAK]
+				EXPORT LCD_IRQHandler	    	[WEAK]
+				EXPORT USB0_IRQHandler	    	[WEAK]
+				EXPORT USB1_IRQHandler	    	[WEAK]
+				EXPORT SCT_IRQHandler	    	[WEAK]
+				EXPORT RIT_IRQHandler	    	[WEAK]
+				EXPORT TIMER0_IRQHandler    	[WEAK]
+				EXPORT TIMER1_IRQHandler    	[WEAK]
+				EXPORT TIMER2_IRQHandler    	[WEAK]
+				EXPORT TIMER3_IRQHandler    	[WEAK]
+				EXPORT MCPWM_IRQHandler	    	[WEAK]
+				EXPORT ADC0_IRQHandler	    	[WEAK]
+				EXPORT I2C0_IRQHandler	    	[WEAK]
+				EXPORT I2C1_IRQHandler	    	[WEAK]
+                EXPORT SPI_IRQHandler	    	[WEAK]
+				EXPORT ADC1_IRQHandler		    [WEAK]
+				EXPORT SSP0_IRQHandler	    	[WEAK]
+				EXPORT SSP1_IRQHandler	    	[WEAK]
+				EXPORT UART0_IRQHandler	    	[WEAK]
+				EXPORT UART1_IRQHandler	    	[WEAK]
+				EXPORT UART2_IRQHandler	    	[WEAK]
+				EXPORT UART3_IRQHandler	    	[WEAK]
+				EXPORT I2S0_IRQHandler	    	[WEAK]
+				EXPORT I2S1_IRQHandler	    	[WEAK]
+				EXPORT SPIFI_IRQHandler     	[WEAK]
+				EXPORT SGPIO_IRQHandler     	[WEAK]
+				EXPORT GPIO0_IRQHandler	        [WEAK]
+				EXPORT GPIO1_IRQHandler     	[WEAK]
+				EXPORT GPIO2_IRQHandler	        [WEAK]
+				EXPORT GPIO3_IRQHandler     	[WEAK]
+				EXPORT GPIO4_IRQHandler     	[WEAK]
+				EXPORT GPIO5_IRQHandler     	[WEAK]
+				EXPORT GPIO6_IRQHandler	        [WEAK]
+				EXPORT GPIO7_IRQHandler	        [WEAK]
+				EXPORT GINT0_IRQHandler	        [WEAK]
+				EXPORT GINT1_IRQHandler	        [WEAK]
+				EXPORT EVRT_IRQHandler		    [WEAK]
+				EXPORT CAN1_IRQHandler	    	[WEAK]
+				EXPORT VADC_IRQHandler	    	[WEAK]
+				EXPORT ATIMER_IRQHandler    	[WEAK]
+				EXPORT RTC_IRQHandler	    	[WEAK]
+				EXPORT WDT_IRQHandler	    	[WEAK]
+				EXPORT CAN0_IRQHandler	    	[WEAK]
+				EXPORT QEI_IRQHandler	    	[WEAK]
+
+DAC_IRQHandler
+MX_CORE_IRQHandler
+DMA_IRQHandler
+FLASHEEPROM_IRQHandler
+ETH_IRQHandler
+SDIO_IRQHandler
+LCD_IRQHandler
+USB0_IRQHandler
+USB1_IRQHandler
+SCT_IRQHandler
+RIT_IRQHandler
+TIMER0_IRQHandler
+TIMER1_IRQHandler
+TIMER2_IRQHandler
+TIMER3_IRQHandler
+MCPWM_IRQHandler
+ADC0_IRQHandler
+I2C0_IRQHandler
+I2C1_IRQHandler
+SPI_IRQHandler
+ADC1_IRQHandler
+SSP0_IRQHandler
+SSP1_IRQHandler
+UART0_IRQHandler
+UART1_IRQHandler
+UART2_IRQHandler
+UART3_IRQHandler
+I2S0_IRQHandler
+I2S1_IRQHandler
+SPIFI_IRQHandler
+SGPIO_IRQHandler
+GPIO0_IRQHandler
+GPIO1_IRQHandler
+GPIO2_IRQHandler
+GPIO3_IRQHandler
+GPIO4_IRQHandler
+GPIO5_IRQHandler
+GPIO6_IRQHandler
+GPIO7_IRQHandler
+GINT0_IRQHandler
+GINT1_IRQHandler
+EVRT_IRQHandler
+CAN1_IRQHandler
+VADC_IRQHandler
+ATIMER_IRQHandler
+RTC_IRQHandler
+WDT_IRQHandler
+CAN0_IRQHandler
+QEI_IRQHandler
+
+                B       .
+
+                ENDP
+                
+                ALIGN
+                END

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/TOOLCHAIN_ARM_STD/sys.cpp
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/TOOLCHAIN_ARM_STD/sys.cpp
@@ -1,0 +1,31 @@
+/* mbed Microcontroller Library - stackheap
+ * Copyright (C) 2009-2011 ARM Limited. All rights reserved.
+ * 
+ * Setup a fixed single stack/heap memory model, 
+ *  between the top of the RW/ZI region and the stackpointer
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif 
+
+#include <rt_misc.h>
+#include <stdint.h>
+
+extern char Image$$RW_IRAM1$$ZI$$Limit[];
+
+extern __value_in_regs struct __initial_stackheap __user_setup_stackheap(uint32_t R0, uint32_t R1, uint32_t R2, uint32_t R3) {
+    uint32_t zi_limit = (uint32_t)Image$$RW_IRAM1$$ZI$$Limit;
+    uint32_t sp_limit = __current_sp();
+
+    zi_limit = (zi_limit + 7) & ~0x7;    // ensure zi_limit is 8-byte aligned
+
+    struct __initial_stackheap r;
+    r.heap_base = zi_limit;
+    r.heap_limit = sp_limit;
+    return r;
+}
+
+#ifdef __cplusplus
+}
+#endif 

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/TOOLCHAIN_GCC_CR/LPC43xx.ld
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/TOOLCHAIN_GCC_CR/LPC43xx.ld
@@ -1,0 +1,19 @@
+/*
+ * LPC43XX Dual core Blinky stand-alone Cortex-M4 LD script
+*/
+
+MEMORY
+{
+  /* Define each memory region */
+  RO_MEM (rx) : ORIGIN = 0x14000000, LENGTH = 0x40000 /* 256K */
+  RW_MEM (rwx) : ORIGIN = 0x10000000, LENGTH = 0x8000 /* 32k */
+  RW_MEM1 (rwx) : ORIGIN = 0x20004000, LENGTH = 0x4000 /* 16K */
+  SH_MEM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x2000 /* 8k */
+  FAT12_MEM (rwx) : ORIGIN = 0x20002000, LENGTH = 0x2000 /* 8k */
+
+}
+
+  __top_RW_MEM = 0x10000000 + 0x8000;
+
+INCLUDE "lpc43xx_dualcore_lib.ld"
+INCLUDE "lpc43xx_dualcore.ld"

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/TOOLCHAIN_GCC_CR/startup_LPC43xx.cpp
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/TOOLCHAIN_GCC_CR/startup_LPC43xx.cpp
@@ -1,0 +1,445 @@
+// *****************************************************************************
+//   +--+
+//   | ++----+
+//   +-++    |
+//     |     |
+//   +-+--+  |
+//   | +--+--+
+//   +----+    Copyright (c) 2011-12 Code Red Technologies Ltd.
+//
+// LPC43xx Microcontroller Startup code for use with Red Suite
+//
+// Version : 120430
+//
+// Software License Agreement
+//
+// The software is owned by Code Red Technologies and/or its suppliers, and is
+// protected under applicable copyright laws.  All rights are reserved.  Any
+// use in violation of the foregoing restrictions may subject the user to criminal
+// sanctions under applicable laws, as well as to civil liability for the breach
+// of the terms and conditions of this license.
+//
+// THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+// OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
+// USE OF THIS SOFTWARE FOR COMMERCIAL DEVELOPMENT AND/OR EDUCATION IS SUBJECT
+// TO A CURRENT END USER LICENSE AGREEMENT (COMMERCIAL OR EDUCATIONAL) WITH
+// CODE RED TECHNOLOGIES LTD.
+//
+// *****************************************************************************
+#if defined(__cplusplus)
+#ifdef __REDLIB__
+#error Redlib does not support C++
+#else
+// *****************************************************************************
+//
+// The entry point for the C++ library startup
+//
+// *****************************************************************************
+extern "C" {
+extern void __libc_init_array(void);
+
+}
+#endif
+#endif
+
+#define WEAK __attribute__ ((weak))
+#define ALIAS(f) __attribute__ ((weak, alias(# f)))
+
+//#if defined (__USE_CMSIS)
+#include "LPC43xx.h"
+//#endif
+
+#if defined(OS_UCOS_III)
+extern void OS_CPU_PendSVHandler(void);
+extern void OS_CPU_SysTickHandler (void);
+#endif
+
+// *****************************************************************************
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// *****************************************************************************
+//
+// Forward declaration of the default handlers. These are aliased.
+// When the application defines a handler (with the same name), this will
+// automatically take precedence over these weak definitions
+//
+// *****************************************************************************
+void ResetISR(void);
+WEAK void NMI_Handler(void);
+WEAK void HardFault_Handler(void);
+WEAK void MemManage_Handler(void);
+WEAK void BusFault_Handler(void);
+WEAK void UsageFault_Handler(void);
+WEAK void SVC_Handler(void);
+WEAK void DebugMon_Handler(void);
+WEAK void PendSV_Handler(void);
+WEAK void SysTick_Handler(void);
+WEAK void IntDefaultHandler(void);
+
+// *****************************************************************************
+//
+// Forward declaration of the specific IRQ handlers. These are aliased
+// to the IntDefaultHandler, which is a 'forever' loop. When the application
+// defines a handler (with the same name), this will automatically take
+// precedence over these weak definitions
+//
+// *****************************************************************************
+void DAC_IRQHandler(void) ALIAS(IntDefaultHandler);
+void MX_CORE_IRQHandler(void) ALIAS(IntDefaultHandler);
+void DMA_IRQHandler(void) ALIAS(IntDefaultHandler);
+void FLASHEEPROM_IRQHandler(void) ALIAS(IntDefaultHandler);
+void ETH_IRQHandler(void) ALIAS(IntDefaultHandler);
+void SDIO_IRQHandler(void) ALIAS(IntDefaultHandler);
+void LCD_IRQHandler(void) ALIAS(IntDefaultHandler);
+void USB0_IRQHandler(void) ALIAS(IntDefaultHandler);
+void USB1_IRQHandler(void) ALIAS(IntDefaultHandler);
+void SCT_IRQHandler(void) ALIAS(IntDefaultHandler);
+void RIT_IRQHandler(void) ALIAS(IntDefaultHandler);
+void TIMER0_IRQHandler(void) ALIAS(IntDefaultHandler);
+void TIMER1_IRQHandler(void) ALIAS(IntDefaultHandler);
+void TIMER2_IRQHandler(void) ALIAS(IntDefaultHandler);
+void TIMER3_IRQHandler(void) ALIAS(IntDefaultHandler);
+void MCPWM_IRQHandler(void) ALIAS(IntDefaultHandler);
+void ADC0_IRQHandler(void) ALIAS(IntDefaultHandler);
+void I2C0_IRQHandler(void) ALIAS(IntDefaultHandler);
+void I2C1_IRQHandler(void) ALIAS(IntDefaultHandler);
+void SPI_IRQHandler (void) ALIAS(IntDefaultHandler);
+void ADC1_IRQHandler(void) ALIAS(IntDefaultHandler);
+void SSP0_IRQHandler(void) ALIAS(IntDefaultHandler);
+void SSP1_IRQHandler(void) ALIAS(IntDefaultHandler);
+void UART0_IRQHandler(void) ALIAS(IntDefaultHandler);
+void UART1_IRQHandler(void) ALIAS(IntDefaultHandler);
+void UART2_IRQHandler(void) ALIAS(IntDefaultHandler);
+void UART3_IRQHandler(void) ALIAS(IntDefaultHandler);
+void I2S0_IRQHandler(void) ALIAS(IntDefaultHandler);
+void I2S1_IRQHandler(void) ALIAS(IntDefaultHandler);
+void SPIFI_IRQHandler(void) ALIAS(IntDefaultHandler);
+void SGPIO_IRQHandler(void) ALIAS(IntDefaultHandler);
+void GPIO0_IRQHandler(void) ALIAS(IntDefaultHandler);
+void GPIO1_IRQHandler(void) ALIAS(IntDefaultHandler);
+void GPIO2_IRQHandler(void) ALIAS(IntDefaultHandler);
+void GPIO3_IRQHandler(void) ALIAS(IntDefaultHandler);
+void GPIO4_IRQHandler(void) ALIAS(IntDefaultHandler);
+void GPIO5_IRQHandler(void) ALIAS(IntDefaultHandler);
+void GPIO6_IRQHandler(void) ALIAS(IntDefaultHandler);
+void GPIO7_IRQHandler(void) ALIAS(IntDefaultHandler);
+void GINT0_IRQHandler(void) ALIAS(IntDefaultHandler);
+void GINT1_IRQHandler(void) ALIAS(IntDefaultHandler);
+void EVRT_IRQHandler(void) ALIAS(IntDefaultHandler);
+void CAN1_IRQHandler(void) ALIAS(IntDefaultHandler);
+void ATIMER_IRQHandler(void) ALIAS(IntDefaultHandler);
+void RTC_IRQHandler(void) ALIAS(IntDefaultHandler);
+void WDT_IRQHandler(void) ALIAS(IntDefaultHandler);
+void CAN0_IRQHandler(void) ALIAS(IntDefaultHandler);
+void QEI_IRQHandler(void) ALIAS(IntDefaultHandler);
+
+// *****************************************************************************
+//
+// The entry point for the application.
+// __main() is the entry point for Redlib based applications
+// main() is the entry point for Newlib based applications
+//
+// *****************************************************************************
+#if defined(__REDLIB__)
+extern void __main(void);
+
+#endif
+extern int main(void);
+
+// *****************************************************************************
+//
+// External declaration for the pointer to the stack top from the Linker Script
+//
+// *****************************************************************************
+extern void _vStackTop(void);
+
+// *****************************************************************************
+//
+// Application can define Stack size (If not defined, default stack size will
+// used
+//
+// *****************************************************************************
+#ifndef STACK_SIZE
+#define STACK_SIZE  (0x200)
+#endif
+
+// *****************************************************************************
+//
+// Application can define Heap size (If not defined, default Heap size will
+// used
+//
+// *****************************************************************************
+#ifndef HEAP_SIZE
+#define HEAP_SIZE   (0x4000)
+#endif
+
+unsigned int __vStack[STACK_SIZE / sizeof(unsigned int)]  __attribute__((section("STACK,\"aw\",%nobits@")));
+unsigned int __vHeap[HEAP_SIZE / sizeof(unsigned int)]  __attribute__((section("HEAP,\"aw\",%nobits@")));
+
+// *****************************************************************************
+#if defined(__cplusplus)
+}	// extern "C"
+#endif
+// *****************************************************************************
+//
+// The vector table.
+// This relies on the linker script to place at correct location in memory.
+//
+// *****************************************************************************
+extern void(*const g_pfnVectors[]) (void);
+__attribute__ ((section(".isr_vector")))
+void(*const g_pfnVectors[]) (void) = {
+	// Core Level - CM4/CM3
+	&_vStackTop,	                // The initial stack pointer
+	ResetISR,						// The reset handler
+	NMI_Handler,					// The NMI handler
+	HardFault_Handler,				// The hard fault handler
+	MemManage_Handler,				// The MPU fault handler
+	BusFault_Handler,				// The bus fault handler
+	UsageFault_Handler,				// The usage fault handler
+	0,								// Reserved
+	0,								// Reserved
+	0,								// Reserved
+	0,								// Reserved
+	SVC_Handler,					// SVCall handler
+	DebugMon_Handler,				// Debug monitor handler
+	0,								// Reserved
+#if defined(OS_UCOS_III)
+    OS_CPU_PendSVHandler,           // uCOS-III PendSV handler
+    OS_CPU_SysTickHandler,          // uCOS-III SysTick handler
+#else
+	PendSV_Handler,					// The PendSV handler
+	SysTick_Handler,				// The SysTick handler
+#endif
+
+	// Chip Level - LPC18xx/43xx
+	DAC_IRQHandler,					// 16 D/A Converter
+	MX_CORE_IRQHandler,				// 17 CortexM4/M0 (LPC43XX ONLY)
+	DMA_IRQHandler,					// 18 General Purpose DMA
+	0,								// 19 Reserved
+	FLASHEEPROM_IRQHandler,			// 20 ORed flash Bank A, flash Bank B, EEPROM interrupts
+	ETH_IRQHandler,					// 21 Ethernet
+	SDIO_IRQHandler,				// 22 SD/MMC
+	LCD_IRQHandler,					// 23 LCD
+	USB0_IRQHandler,				// 24 USB0
+	USB1_IRQHandler,				// 25 USB1
+	SCT_IRQHandler,					// 26 State Configurable Timer
+	RIT_IRQHandler,					// 27 Repetitive Interrupt Timer
+	TIMER0_IRQHandler,				// 28 Timer0
+	TIMER1_IRQHandler,				// 29 Timer 1
+	TIMER2_IRQHandler,				// 30 Timer 2
+	TIMER3_IRQHandler,				// 31 Timer 3
+	MCPWM_IRQHandler,				// 32 Motor Control PWM
+	ADC0_IRQHandler,				// 33 A/D Converter 0
+	I2C0_IRQHandler,				// 34 I2C0
+	I2C1_IRQHandler,				// 35 I2C1
+	SPI_IRQHandler,					// 36 SPI (LPC43XX ONLY)
+	ADC1_IRQHandler,				// 37 A/D Converter 1
+	SSP0_IRQHandler,				// 38 SSP0 
+	SSP1_IRQHandler,				// 39 SSP1
+	UART0_IRQHandler,				// 40 UART0
+	UART1_IRQHandler,				// 41 UART1
+	UART2_IRQHandler,				// 42 UART2
+	UART3_IRQHandler,				// 43 USRT3
+	I2S0_IRQHandler,				// 44 I2S0
+	I2S1_IRQHandler,				// 45 I2S1
+	SPIFI_IRQHandler,				// 46 SPI Flash Interface
+	SGPIO_IRQHandler,				// 47 SGPIO (LPC43XX ONLY)
+	GPIO0_IRQHandler,				// 48 GPIO0
+	GPIO1_IRQHandler,				// 49 GPIO1
+	GPIO2_IRQHandler,				// 50 GPIO2
+	GPIO3_IRQHandler,				// 51 GPIO3 
+	GPIO4_IRQHandler,				// 52 GPIO4
+	GPIO5_IRQHandler,				// 53 GPIO5
+	GPIO6_IRQHandler,				// 54 GPIO6
+	GPIO7_IRQHandler,				// 55 GPIO7
+	GINT0_IRQHandler,				// 56 GINT0
+	GINT1_IRQHandler,				// 57 GINT1
+	EVRT_IRQHandler,				// 58 Event Router
+	CAN1_IRQHandler,				// 59 C_CAN1
+	0,								// 60 Reserved
+	0,				                // 61 Reserved 
+	ATIMER_IRQHandler,				// 62 ATIMER
+	RTC_IRQHandler,					// 63 RTC
+	0,								// 64 Reserved
+	WDT_IRQHandler,					// 65 WDT
+	0,								// 66 Reserved
+	CAN0_IRQHandler,				// 67 C_CAN0
+	QEI_IRQHandler,					// 68 QEI
+};
+
+// *****************************************************************************
+// Functions to carry out the initialization of RW and BSS data sections. These
+// are written as separate functions rather than being inlined within the
+// ResetISR() function in order to cope with MCUs with multiple banks of
+// memory.
+// *****************************************************************************
+__attribute__ ((section(".after_vectors")))
+void data_init(unsigned int romstart, unsigned int start, unsigned int len) {
+	unsigned int *pulDest = (unsigned int *) start;
+	unsigned int *pulSrc = (unsigned int *) romstart;
+	unsigned int loop;
+	for (loop = 0; loop < len; loop = loop + 4)
+		*pulDest++ = *pulSrc++;
+}
+
+__attribute__ ((section(".after_vectors")))
+void bss_init(unsigned int start, unsigned int len) {
+	unsigned int *pulDest = (unsigned int *) start;
+	unsigned int loop;
+	for (loop = 0; loop < len; loop = loop + 4)
+		*pulDest++ = 0;
+}
+
+// *****************************************************************************
+// The following symbols are constructs generated by the linker, indicating
+// the location of various points in the "Global Section Table". This table is
+// created by the linker via the Code Red managed linker script mechanism. It
+// contains the load address, execution address and length of each RW data
+// section and the execution and length of each BSS (zero initialized) section.
+// *****************************************************************************
+extern unsigned int __data_section_table;
+extern unsigned int __data_section_table_end;
+extern unsigned int __bss_section_table;
+extern unsigned int __bss_section_table_end;
+
+// *****************************************************************************
+// Reset entry point for your code.
+// Sets up a simple runtime environment and initializes the C/C++
+// library.
+//
+// *****************************************************************************
+void
+ResetISR(void) {
+
+	//
+	// Copy the data sections from flash to SRAM.
+	//
+	unsigned int LoadAddr, ExeAddr, SectionLen;
+	unsigned int *SectionTableAddr;
+
+	/* Call SystemInit() for clocking/memory setup prior to scatter load */
+	SystemInit();
+
+	// Load base address of Global Section Table
+	SectionTableAddr = &__data_section_table;
+
+	// Copy the data sections from flash to SRAM.
+	while (SectionTableAddr < &__data_section_table_end) {
+		LoadAddr = *SectionTableAddr++;
+		ExeAddr = *SectionTableAddr++;
+		SectionLen = *SectionTableAddr++;
+		data_init(LoadAddr, ExeAddr, SectionLen);
+	}
+	// At this point, SectionTableAddr = &__bss_section_table;
+	// Zero fill the bss segment
+	while (SectionTableAddr < &__bss_section_table_end) {
+		ExeAddr = *SectionTableAddr++;
+		SectionLen = *SectionTableAddr++;
+		bss_init(ExeAddr, SectionLen);
+	}
+
+	#if defined(__cplusplus)
+	//
+	// Call C++ library initialisation
+	//
+	__libc_init_array();
+	#endif
+
+	#if defined(__REDLIB__)
+	// Call the Redlib library, which in turn calls main()
+	__main();
+	#else
+	main();
+	#endif
+
+	//
+	// main() shouldn't return, but if it does, we'll just enter an infinite loop
+	//
+	while (1) {}
+}
+
+// *****************************************************************************
+// Default exception handlers. Override the ones here by defining your own
+// handler routines in your application code.
+// *****************************************************************************
+__attribute__ ((section(".after_vectors")))
+void NMI_Handler(void)
+{
+	while (1) {}
+}
+
+__attribute__ ((section(".after_vectors")))
+void HardFault_Handler(void)
+{
+	while (1) {}
+}
+
+__attribute__ ((section(".after_vectors")))
+void MemManage_Handler(void)
+{
+	while (1) {}
+}
+
+__attribute__ ((section(".after_vectors")))
+void BusFault_Handler(void)
+{
+	while (1) {}
+}
+
+__attribute__ ((section(".after_vectors")))
+void UsageFault_Handler(void)
+{
+	while (1) {}
+}
+
+__attribute__ ((section(".after_vectors")))
+void SVC_Handler(void)
+{
+	while (1) {}
+}
+
+__attribute__ ((section(".after_vectors")))
+void DebugMon_Handler(void)
+{
+	while (1) {}
+}
+
+__attribute__ ((section(".after_vectors")))
+void PendSV_Handler(void)
+{
+	while (1) {}
+}
+
+__attribute__ ((section(".after_vectors")))
+void SysTick_Handler(void)
+{
+	while (1) {}
+}
+
+// *****************************************************************************
+//
+// Processor ends up here if an unexpected interrupt occurs or a specific
+// handler is not present in the application code.
+//
+// *****************************************************************************
+__attribute__ ((section(".after_vectors")))
+void IntDefaultHandler(void)
+{
+	while (1) {}
+}
+
+// *****************************************************************************
+//
+// Heap overflow check function required by REDLib_V2 library
+//
+// *****************************************************************************
+extern unsigned int *_pvHeapStart;
+unsigned int __check_heap_overflow (void * new_end_of_heap)
+{
+	return (new_end_of_heap >= (void *)&__vHeap[HEAP_SIZE/sizeof(unsigned int)]);
+}
+

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/TOOLCHAIN_IAR/LPC43xx.icf
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/TOOLCHAIN_IAR/LPC43xx.icf
@@ -1,0 +1,35 @@
+/* [ROM] */
+define symbol __intvec_start__     = 0x14000000;
+define symbol __region_ROM_start__ = 0x14000000;
+define symbol __region_ROM_end__   = 0x143FFFFF;
+
+/* [RAM] Vector table dynamic copy: 8_byte_aligned(69 vect * 4 bytes) =  8_byte_aligned(0x0114) = 0x0118*/
+define symbol __NVIC_start__       = 0x10000000;
+define symbol __NVIC_end__         = 0x10000117;
+define symbol __region_RAM_start__ = 0x10000118;
+define symbol __region_RAM_end__   = 0x1001FFDF;
+define symbol _AHB_RAM_start__     = 0x20000000;
+define symbol _AHB_RAM_end__       = 0x20007FFF;
+
+/* Memory regions */
+define memory mem with size = 4G;
+
+define region ROM_region     = mem:[from __region_ROM_start__   to __region_ROM_end__];
+
+define region RAM_region     = mem:[from __region_RAM_start__   to __region_RAM_end__];
+define region AHB_RAM_region = mem:[from _AHB_RAM_start__ to _AHB_RAM_end__];
+
+/* Stack and Heap */
+define symbol __size_cstack__   = 0x800;
+define symbol __size_heap__     = 0x800;
+define block CSTACK    with alignment = 8, size = __size_cstack__   { };
+define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block STACKHEAP with fixed order { block HEAP, block CSTACK };
+
+initialize by copy with packing = zeros { readwrite };
+do not initialize  { section .noinit };
+
+place at address mem:__intvec_start__ { section .intvec };
+place in ROM_region     { readonly };
+place in RAM_region     { readwrite, block STACKHEAP };
+place in AHB_RAM_region { section USB_RAM };

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/TOOLCHAIN_IAR/startup_LPC43xx.s
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/TOOLCHAIN_IAR/startup_LPC43xx.s
@@ -1,0 +1,292 @@
+/**************************************************
+ *
+ * Part one of the system initialization code, contains low-level
+ * initialization, plain thumb variant.
+ *
+ * Copyright 2011 IAR Systems. All rights reserved.
+ *
+ * $Revision: 47876 $
+ *
+ **************************************************/
+
+;
+; The modules in this file are included in the libraries, and may be replaced
+; by any user-defined modules that define the PUBLIC symbol _program_start or
+; a user defined start symbol.
+; To override the cstartup defined in the library, simply add your modified
+; version to the workbench project.
+;
+; The vector table is normally located at address 0.
+; When debugging in RAM, it can be located in RAM, aligned to at least 2^6.
+; The name "__vector_table" has special meaning for C-SPY:
+; it is where the SP start value is found, and the NVIC vector
+; table register (VTOR) is initialized to this address if != 0.
+;
+; Cortex-M version
+;
+
+
+        MODULE  ?cstartup
+
+        ;; Forward declaration of sections.
+        SECTION CSTACK:DATA:NOROOT(3)
+
+        SECTION .intvec:CODE:NOROOT(2)
+
+        EXTERN  __iar_program_start 
+        EXTERN  SystemInit        
+        PUBLIC  __vector_table
+        PUBLIC  __vector_table_0x1c
+        PUBLIC  __Vectors
+        PUBLIC  __Vectors_End
+        PUBLIC  __Vectors_Size
+
+        DATA
+
+__vector_table
+        DCD     sfe(CSTACK)
+        DCD     Reset_Handler
+        DCD     NMI_Handler
+        DCD     HardFault_Handler
+        DCD     MemManage_Handler
+        DCD     BusFault_Handler
+        DCD     UsageFault_Handler
+__vector_table_0x1c
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     0
+        DCD     SVC_Handler
+        DCD     DebugMon_Handler
+        DCD     0
+        DCD     PendSV_Handler
+        DCD     SysTick_Handler
+
+        ; External Interrupts
+        DCD		DAC_IRQHandler	 			; 16 D/A Converter
+        DCD		MX_CORE_IRQHandler          ; 17 CortexM0 (LPC43XX ONLY) 
+        DCD		DMA_IRQHandler				; 18 General Purpose DMA
+        DCD		0				            ; 19 Reserved
+        DCD		FLASHEEPROM_IRQHandler		; 20 ORed flash bank A, flash bank B, EEPROM interrupts
+        DCD		ETH_IRQHandler				; 21 Ethernet
+        DCD		SDIO_IRQHandler				; 22 SD/MMC
+        DCD		LCD_IRQHandler				; 23 LCD
+        DCD		USB0_IRQHandler				; 24 USB0
+        DCD		USB1_IRQHandler				; 25 USB1
+        DCD		SCT_IRQHandler				; 26 State Configurable Timer
+        DCD		RIT_IRQHandler				; 27 Repetitive Interrupt Timer
+        DCD		TIMER0_IRQHandler			; 28 Timer0
+        DCD		TIMER1_IRQHandler			; 29 Timer1
+        DCD		TIMER2_IRQHandler			; 30 Timer2
+        DCD		TIMER3_IRQHandler			; 31 Timer3
+        DCD		MCPWM_IRQHandler			; 32 Motor Control PWM
+        DCD		ADC0_IRQHandler				; 33 A/D Converter 0
+        DCD		I2C0_IRQHandler				; 34 I2C0
+        DCD		I2C1_IRQHandler				; 35 I2C1
+        DCD		SPI_IRQHandler				; 36 SPI (LPC43XX ONLY)
+        DCD		ADC1_IRQHandler				; 37 A/D Converter 1
+        DCD		SSP0_IRQHandler				; 38 SSP0
+        DCD		SSP1_IRQHandler				; 39 SSP1
+        DCD		UART0_IRQHandler			; 40 UART0
+        DCD		UART1_IRQHandler			; 41 UART1
+        DCD		UART2_IRQHandler			; 42 UART2
+        DCD		UART3_IRQHandler			; 43 UART3
+        DCD		I2S0_IRQHandler				; 44 I2S0
+        DCD		I2S1_IRQHandler				; 45 I2S1
+        DCD		SPIFI_IRQHandler			; 46 SPI Flash Interface
+        DCD		SGPIO_IRQHandler			; 47 SGPIO (LPC43XX ONLY)
+        DCD		GPIO0_IRQHandler			; 48 GPIO0
+        DCD		GPIO1_IRQHandler			; 49 GPIO1
+        DCD		GPIO2_IRQHandler			; 50 GPIO2
+        DCD		GPIO3_IRQHandler			; 51 GPIO3
+        DCD		GPIO4_IRQHandler			; 52 GPIO4
+        DCD		GPIO5_IRQHandler			; 53 GPIO5
+        DCD		GPIO6_IRQHandler			; 54 GPIO6
+        DCD		GPIO7_IRQHandler			; 55 GPIO7
+        DCD		GINT0_IRQHandler			; 56 GINT0
+        DCD		GINT1_IRQHandler			; 57 GINT1
+        DCD		EVRT_IRQHandler             ; 58 Event Router
+        DCD		CAN1_IRQHandler             ; 59 C_CAN1
+        DCD		0
+        DCD		0
+        DCD 	ATIMER_IRQHandler           ; 62 ATIMER
+        DCD 	RTC_IRQHandler              ; 63 RTC
+        DCD 	0
+        DCD 	WDT_IRQHandler              ; 65 WDT
+        DCD 	0
+        DCD 	CAN0_IRQHandler             ; 67 C_CAN0
+        DCD 	QEI_IRQHandler              ; 68 QEI
+__Vectors_End
+
+__Vectors       EQU   __vector_table
+__Vectors_Size 	EQU   __Vectors_End - __Vectors
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Default interrupt handlers.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+        THUMB
+
+        PUBWEAK Reset_Handler
+        SECTION .text:CODE:REORDER(2)
+Reset_Handler
+        LDR     R0, =SystemInit
+        BLX     R0
+        LDR     R0, =__iar_program_start
+        BX      R0
+  
+        PUBWEAK NMI_Handler
+        PUBWEAK HardFault_Handler
+        PUBWEAK MemManage_Handler
+        PUBWEAK BusFault_Handler
+        PUBWEAK UsageFault_Handler
+        PUBWEAK SVC_Handler
+        PUBWEAK DebugMon_Handler
+        PUBWEAK PendSV_Handler
+        PUBWEAK SysTick_Handler
+        PUBWEAK DAC_IRQHandler
+        PUBWEAK MX_CORE_IRQHandler
+        PUBWEAK DMA_IRQHandler
+        PUBWEAK FLASHEEPROM_IRQHandler
+        PUBWEAK ETH_IRQHandler
+        PUBWEAK SDIO_IRQHandler
+        PUBWEAK LCD_IRQHandler
+        PUBWEAK USB0_IRQHandler
+        PUBWEAK USB1_IRQHandler
+        PUBWEAK SCT_IRQHandler
+        PUBWEAK RIT_IRQHandler
+        PUBWEAK TIMER0_IRQHandler
+        PUBWEAK TIMER1_IRQHandler
+        PUBWEAK TIMER2_IRQHandler
+        PUBWEAK TIMER3_IRQHandler
+        PUBWEAK MCPWM_IRQHandler
+        PUBWEAK ADC0_IRQHandler
+        PUBWEAK I2C0_IRQHandler
+        PUBWEAK I2C1_IRQHandler
+        PUBWEAK SPI_IRQHandler
+        PUBWEAK ADC1_IRQHandler
+        PUBWEAK SSP0_IRQHandler
+        PUBWEAK SSP1_IRQHandler
+        PUBWEAK UART0_IRQHandler
+        PUBWEAK UART1_IRQHandler
+        PUBWEAK UART2_IRQHandler
+        PUBWEAK UART3_IRQHandler
+        PUBWEAK I2S0_IRQHandler
+        PUBWEAK I2S1_IRQHandler
+        PUBWEAK SPIFI_IRQHandler
+        PUBWEAK SGPIO_IRQHandler
+        PUBWEAK GPIO0_IRQHandler
+        PUBWEAK GPIO1_IRQHandler
+        PUBWEAK GPIO2_IRQHandler
+        PUBWEAK GPIO3_IRQHandler
+        PUBWEAK GPIO4_IRQHandler
+        PUBWEAK GPIO5_IRQHandler
+        PUBWEAK GPIO6_IRQHandler
+        PUBWEAK GPIO7_IRQHandler
+        PUBWEAK GINT0_IRQHandler
+        PUBWEAK GINT1_IRQHandler
+        PUBWEAK EVRT_IRQHandler
+        PUBWEAK CAN1_IRQHandler
+        PUBWEAK ATIMER_IRQHandler
+        PUBWEAK RTC_IRQHandler
+        PUBWEAK WDT_IRQHandler
+        PUBWEAK CAN0_IRQHandler
+        PUBWEAK QEI_IRQHandler
+        SECTION .text:CODE:REORDER(1)
+NMI_Handler
+        B NMI_Handler
+SVC_Handler
+        B SVC_Handler
+DebugMon_Handler
+        B DebugMon_Handler
+PendSV_Handler
+        B PendSV_Handler
+SysTick_Handler
+        B SysTick_Handler
+HardFault_Handler
+        B HardFault_Handler
+MemManage_Handler
+        B MemManage_Handler
+BusFault_Handler
+        B BusFault_Handler
+UsageFault_Handler
+DAC_IRQHandler
+MX_CORE_IRQHandler
+DMA_IRQHandler 
+FLASHEEPROM_IRQHandler
+ETH_IRQHandler
+SDIO_IRQHandler
+LCD_IRQHandler
+USB0_IRQHandler
+USB1_IRQHandler
+SCT_IRQHandler
+RIT_IRQHandler
+TIMER0_IRQHandler
+TIMER1_IRQHandler
+TIMER2_IRQHandler
+TIMER3_IRQHandler
+MCPWM_IRQHandler
+ADC0_IRQHandler
+I2C0_IRQHandler
+I2C1_IRQHandler
+SPI_IRQHandler
+ADC1_IRQHandler
+SSP0_IRQHandler
+SSP1_IRQHandler
+UART0_IRQHandler
+UART1_IRQHandler
+UART2_IRQHandler
+UART3_IRQHandler
+I2S0_IRQHandler
+I2S1_IRQHandler
+SPIFI_IRQHandler
+SGPIO_IRQHandler
+GPIO0_IRQHandler
+GPIO1_IRQHandler
+GPIO2_IRQHandler
+GPIO3_IRQHandler
+GPIO4_IRQHandler
+GPIO5_IRQHandler
+GPIO6_IRQHandler
+GPIO7_IRQHandler
+GINT0_IRQHandler
+GINT1_IRQHandler
+EVRT_IRQHandler
+CAN1_IRQHandler
+ATIMER_IRQHandler
+RTC_IRQHandler
+WDT_IRQHandler
+CAN0_IRQHandler
+QEI_IRQHandler
+Default_IRQHandler
+        B Default_IRQHandler
+
+/* CRP Section - not needed for flashless devices */
+
+;;;        SECTION .crp:CODE:ROOT(2)
+;;;        DATA
+/* Code Read Protection
+NO_ISP  0x4E697370 -  Prevents sampling of pin PIO0_1 for entering ISP mode
+CRP1    0x12345678 - Write to RAM command cannot access RAM below 0x10000300.
+                   - Copy RAM to flash command can not write to Sector 0.
+                   - Erase command can erase Sector 0 only when all sectors
+                     are selected for erase.
+                   - Compare command is disabled.
+                   - Read Memory command is disabled.
+CRP2    0x87654321 - Read Memory is disabled.
+                   - Write to RAM is disabled.
+                   - "Go" command is disabled.
+                   - Copy RAM to flash is disabled.
+                   - Compare is disabled.
+CRP3    0x43218765 - Access to chip via the SWD pins is disabled. ISP entry
+                     by pulling PIO0_1 LOW is disabled if a valid user code is
+                     present in flash sector 0.
+Caution: If CRP3 is selected, no future factory testing can be
+performed on the device.
+*/
+;;;	    DCD	0xFFFFFFFF
+;;;
+
+        END

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/cmsis.h
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/cmsis.h
@@ -1,0 +1,15 @@
+/* mbed Microcontroller Library - CMSIS
+ * Copyright (C) 2009-2011 ARM Limited. All rights reserved.
+ * 
+ * A generic CMSIS include header, pulling in LPC43xx specifics
+ *
+ * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
+ */
+
+#ifndef MBED_CMSIS_H
+#define MBED_CMSIS_H
+
+#include "LPC43xx.h"
+#include "cmsis_nvic.h"
+
+#endif

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/cmsis_nvic.c
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/cmsis_nvic.c
@@ -1,0 +1,30 @@
+/* mbed Microcontroller Library - cmsis_nvic for LCP43xx
+ * Copyright (c) 2009-2011 ARM Limited. All rights reserved.
+ *
+ * CMSIS-style functionality to support dynamic vectors
+ */ 
+#include "cmsis_nvic.h"
+
+#define NVIC_NUM_VECTORS          (16 + 53)     // CORE + MCU Peripherals
+#define NVIC_RAM_VECTOR_ADDRESS   (0x10000000)  // Location of vectors in RAM
+
+void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
+    static volatile uint32_t* vectors = (uint32_t*)NVIC_RAM_VECTOR_ADDRESS;
+    int i;
+    // Copy and switch to dynamic vectors if first time called
+    if (SCB->VTOR != NVIC_RAM_VECTOR_ADDRESS) {
+        uint32_t *old_vectors = (uint32_t*)SCB->VTOR;
+        for (i=0; i<NVIC_NUM_VECTORS; i++) {
+            vectors[i] = old_vectors[i];
+        }
+        SCB->VTOR = (uint32_t)vectors;
+    }
+    
+    vectors[IRQn + 16] = vector;
+}
+
+uint32_t NVIC_GetVector(IRQn_Type IRQn) {
+    uint32_t *vectors = (uint32_t*)SCB->VTOR;
+    return vectors[IRQn + 16];
+}
+

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/cmsis_nvic.h
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/cmsis_nvic.h
@@ -1,0 +1,23 @@
+/* mbed Microcontroller Library - cmsis_nvic
+ * Copyright (c) 2009-2011 ARM Limited. All rights reserved.
+ *
+ * CMSIS-style functionality to support dynamic vectors
+ */ 
+
+#ifndef MBED_CMSIS_NVIC_H
+#define MBED_CMSIS_NVIC_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
+uint32_t NVIC_GetVector(IRQn_Type IRQn);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/core_cm4.c
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/core_cm4.c
@@ -1,0 +1,53 @@
+/**************************************************************************//**
+ * @file     core_cm4.c
+ * @brief    CMSIS Cortex-M3 Core Peripheral Access Layer Source File
+ * @version  V2.01
+ * @date     06. December 2010
+ *
+ * @note
+ * Copyright (C) 2010 ARM Limited. All rights reserved.
+ *
+ * @par
+ * ARM Limited (ARM) is supplying this software for use with Cortex-M 
+ * processor based microcontrollers.  This file can be freely distributed 
+ * within development tools that are supporting such ARM based processors. 
+ *
+ * @par
+ * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
+ * ARM SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR
+ * CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ******************************************************************************/
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+
+#if defined ( __CC_ARM   ) /*------------------ RealView Compiler ----------------*/
+/* ARM armcc specific functions */
+
+
+
+
+#elif (defined (__ICCARM__)) /*------------------ ICC Compiler -------------------*/
+/* IAR iccarm specific functions */
+
+
+
+#elif (defined (__GNUC__)) /*------------------ GNU Compiler ---------------------*/
+/* GNU gcc specific functions */
+
+
+
+
+#elif (defined (__TASKING__)) /*------------------ TASKING Compiler --------------*/
+/* TASKING carm specific functions */
+
+/*
+ * The CMSIS functions have been implemented as intrinsics in the compiler.
+ * Please use "carm -?i" to get an up to date list of all instrinsics,
+ * Including the CMSIS ones.
+ */
+
+#endif

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/core_cm4.h
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/core_cm4.h
@@ -1,0 +1,1772 @@
+/**************************************************************************//**
+ * @file     core_cm4.h
+ * @brief    CMSIS Cortex-M4 Core Peripheral Access Layer Header File
+ * @version  V3.20
+ * @date     25. February 2013
+ *
+ * @note
+ *
+ ******************************************************************************/
+/* Copyright (c) 2009 - 2013 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#if defined ( __ICCARM__ )
+ #pragma system_include  /* treat file as system include file for MISRA check */
+#endif
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#ifndef __CORE_CM4_H_GENERIC
+#define __CORE_CM4_H_GENERIC
+
+/** \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/** \ingroup Cortex_M4
+  @{
+ */
+
+/*  CMSIS CM4 definitions */
+#define __CM4_CMSIS_VERSION_MAIN  (0x03)                                   /*!< [31:16] CMSIS HAL main version   */
+#define __CM4_CMSIS_VERSION_SUB   (0x20)                                   /*!< [15:0]  CMSIS HAL sub version    */
+#define __CM4_CMSIS_VERSION       ((__CM4_CMSIS_VERSION_MAIN << 16) | \
+                                    __CM4_CMSIS_VERSION_SUB          )     /*!< CMSIS HAL version number         */
+
+#define __CORTEX_M                (0x04)                                   /*!< Cortex-M Core                    */
+
+
+#if   defined ( __CC_ARM )
+  #define __ASM            __asm                                      /*!< asm keyword for ARM Compiler          */
+  #define __INLINE         __inline                                   /*!< inline keyword for ARM Compiler       */
+  #define __STATIC_INLINE  static __inline
+
+#elif defined ( __ICCARM__ )
+  #define __ASM            __asm                                      /*!< asm keyword for IAR Compiler          */
+  #define __INLINE         inline                                     /*!< inline keyword for IAR Compiler. Only available in High optimization mode! */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __TMS470__ )
+  #define __ASM            __asm                                      /*!< asm keyword for TI CCS Compiler       */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __GNUC__ )
+  #define __ASM            __asm                                      /*!< asm keyword for GNU Compiler          */
+  #define __INLINE         inline                                     /*!< inline keyword for GNU Compiler       */
+  #define __STATIC_INLINE  static inline
+
+#elif defined ( __TASKING__ )
+  #define __ASM            __asm                                      /*!< asm keyword for TASKING Compiler      */
+  #define __INLINE         inline                                     /*!< inline keyword for TASKING Compiler   */
+  #define __STATIC_INLINE  static inline
+
+#endif
+
+/** __FPU_USED indicates whether an FPU is used or not. For this, __FPU_PRESENT has to be checked prior to making use of FPU specific registers and functions.
+*/
+#if defined ( __CC_ARM )
+  #if defined __TARGET_FPU_VFP
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined __ARMVFP__
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+
+#elif defined ( __TMS470__ )
+  #if defined __TI_VFP_SUPPORT__
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined __FPU_VFP__
+    #if (__FPU_PRESENT == 1)
+      #define __FPU_USED       1
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0
+    #endif
+  #else
+    #define __FPU_USED         0
+  #endif
+#endif
+
+#include <stdint.h>                      /* standard types definitions                      */
+#include <core_cmInstr.h>                /* Core Instruction Access                         */
+#include <core_cmFunc.h>                 /* Core Function Access                            */
+#include <core_cm4_simd.h>               /* Compiler specific SIMD Intrinsics               */
+
+#endif /* __CORE_CM4_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM4_H_DEPENDANT
+#define __CORE_CM4_H_DEPENDANT
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM4_REV
+    #define __CM4_REV               0x0000
+    #warning "__CM4_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          4
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions                 */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions                 */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions                */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions              */
+
+/*@} end of group Cortex_M4 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core MPU Register
+  - Core FPU Register
+ ******************************************************************************/
+/** \defgroup CMSIS_core_register Defines and Type Definitions
+    \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/** \ingroup    CMSIS_core_register
+    \defgroup   CMSIS_CORE  Status and Control Registers
+    \brief  Core Register type definitions.
+  @{
+ */
+
+/** \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+#if (__CORTEX_M != 0x04)
+    uint32_t _reserved0:27;              /*!< bit:  0..26  Reserved                           */
+#else
+    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags        */
+    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved                           */
+#endif
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag          */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag       */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag          */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag           */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag       */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} APSR_Type;
+
+
+/** \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number                   */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved                           */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} IPSR_Type;
+
+
+/** \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number                   */
+#if (__CORTEX_M != 0x04)
+    uint32_t _reserved0:15;              /*!< bit:  9..23  Reserved                           */
+#else
+    uint32_t _reserved0:7;               /*!< bit:  9..15  Reserved                           */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags        */
+    uint32_t _reserved1:4;               /*!< bit: 20..23  Reserved                           */
+#endif
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0)          */
+    uint32_t IT:2;                       /*!< bit: 25..26  saved IT state   (read 0)          */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag          */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag       */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag          */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag           */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag       */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} xPSR_Type;
+
+
+/** \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack to be used                   */
+    uint32_t FPCA:1;                     /*!< bit:      2  FP extension active flag           */
+    uint32_t _reserved0:29;              /*!< bit:  3..31  Reserved                           */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} CONTROL_Type;
+
+/*@} end of group CMSIS_CORE */
+
+
+/** \ingroup    CMSIS_core_register
+    \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+    \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/** \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IO uint32_t ISER[8];                 /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register           */
+       uint32_t RESERVED0[24];
+  __IO uint32_t ICER[8];                 /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register         */
+       uint32_t RSERVED1[24];
+  __IO uint32_t ISPR[8];                 /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register          */
+       uint32_t RESERVED2[24];
+  __IO uint32_t ICPR[8];                 /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register        */
+       uint32_t RESERVED3[24];
+  __IO uint32_t IABR[8];                 /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register           */
+       uint32_t RESERVED4[56];
+  __IO uint8_t  IP[240];                 /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+       uint32_t RESERVED5[644];
+  __O  uint32_t STIR;                    /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register     */
+}  NVIC_Type;
+
+/* Software Triggered Interrupt Register Definitions */
+#define NVIC_STIR_INTID_Pos                 0                                          /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL << NVIC_STIR_INTID_Pos)            /*!< STIR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_NVIC */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_SCB     System Control Block (SCB)
+    \brief      Type definitions for the System Control Block Registers
+  @{
+ */
+
+/** \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __I  uint32_t CPUID;                   /*!< Offset: 0x000 (R/ )  CPUID Base Register                                   */
+  __IO uint32_t ICSR;                    /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register                  */
+  __IO uint32_t VTOR;                    /*!< Offset: 0x008 (R/W)  Vector Table Offset Register                          */
+  __IO uint32_t AIRCR;                   /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register      */
+  __IO uint32_t SCR;                     /*!< Offset: 0x010 (R/W)  System Control Register                               */
+  __IO uint32_t CCR;                     /*!< Offset: 0x014 (R/W)  Configuration Control Register                        */
+  __IO uint8_t  SHP[12];                 /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IO uint32_t SHCSR;                   /*!< Offset: 0x024 (R/W)  System Handler Control and State Register             */
+  __IO uint32_t CFSR;                    /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register                    */
+  __IO uint32_t HFSR;                    /*!< Offset: 0x02C (R/W)  HardFault Status Register                             */
+  __IO uint32_t DFSR;                    /*!< Offset: 0x030 (R/W)  Debug Fault Status Register                           */
+  __IO uint32_t MMFAR;                   /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register                      */
+  __IO uint32_t BFAR;                    /*!< Offset: 0x038 (R/W)  BusFault Address Register                             */
+  __IO uint32_t AFSR;                    /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register                       */
+  __I  uint32_t PFR[2];                  /*!< Offset: 0x040 (R/ )  Processor Feature Register                            */
+  __I  uint32_t DFR;                     /*!< Offset: 0x048 (R/ )  Debug Feature Register                                */
+  __I  uint32_t ADR;                     /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register                            */
+  __I  uint32_t MMFR[4];                 /*!< Offset: 0x050 (R/ )  Memory Model Feature Register                         */
+  __I  uint32_t ISAR[5];                 /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register                   */
+       uint32_t RESERVED0[5];
+  __IO uint32_t CPACR;                   /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register                   */
+} SCB_Type;
+
+/* SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24                                             /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20                                             /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16                                             /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4                                             /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0                                             /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL << SCB_CPUID_REVISION_Pos)              /*!< SCB CPUID: REVISION Mask */
+
+/* SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_NMIPENDSET_Pos            31                                             /*!< SCB ICSR: NMIPENDSET Position */
+#define SCB_ICSR_NMIPENDSET_Msk            (1UL << SCB_ICSR_NMIPENDSET_Pos)               /*!< SCB ICSR: NMIPENDSET Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28                                             /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27                                             /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26                                             /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25                                             /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23                                             /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22                                             /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12                                             /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11                                             /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0                                             /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL << SCB_ICSR_VECTACTIVE_Pos)           /*!< SCB ICSR: VECTACTIVE Mask */
+
+/* SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7                                             /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+
+/* SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16                                             /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16                                             /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15                                             /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8                                             /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2                                             /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1                                             /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+#define SCB_AIRCR_VECTRESET_Pos             0                                             /*!< SCB AIRCR: VECTRESET Position */
+#define SCB_AIRCR_VECTRESET_Msk            (1UL << SCB_AIRCR_VECTRESET_Pos)               /*!< SCB AIRCR: VECTRESET Mask */
+
+/* SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4                                             /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2                                             /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1                                             /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/* SCB Configuration Control Register Definitions */
+#define SCB_CCR_STKALIGN_Pos                9                                             /*!< SCB CCR: STKALIGN Position */
+#define SCB_CCR_STKALIGN_Msk               (1UL << SCB_CCR_STKALIGN_Pos)                  /*!< SCB CCR: STKALIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8                                             /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4                                             /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3                                             /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1                                             /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+#define SCB_CCR_NONBASETHRDENA_Pos          0                                             /*!< SCB CCR: NONBASETHRDENA Position */
+#define SCB_CCR_NONBASETHRDENA_Msk         (1UL << SCB_CCR_NONBASETHRDENA_Pos)            /*!< SCB CCR: NONBASETHRDENA Mask */
+
+/* SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_USGFAULTENA_Pos          18                                             /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17                                             /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16                                             /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15                                             /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14                                             /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13                                             /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12                                             /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11                                             /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10                                             /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8                                             /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7                                             /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3                                             /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1                                             /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0                                             /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL << SCB_SHCSR_MEMFAULTACT_Pos)             /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/* SCB Configurable Fault Status Registers Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16                                             /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8                                             /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0                                             /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL << SCB_CFSR_MEMFAULTSR_Pos)            /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/* SCB Hard Fault Status Registers Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31                                             /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30                                             /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1                                             /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/* SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_EXTERNAL_Pos               4                                             /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3                                             /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2                                             /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1                                             /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0                                             /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL << SCB_DFSR_HALTED_Pos)                   /*!< SCB DFSR: HALTED Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_SCnSCB System Controls not in SCB (SCnSCB)
+    \brief      Type definitions for the System Control and ID Register not in the SCB
+  @{
+ */
+
+/** \brief  Structure type to access the System Control and ID Register not in the SCB.
+ */
+typedef struct
+{
+       uint32_t RESERVED0[1];
+  __I  uint32_t ICTR;                    /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register      */
+  __IO uint32_t ACTLR;                   /*!< Offset: 0x008 (R/W)  Auxiliary Control Register              */
+} SCnSCB_Type;
+
+/* Interrupt Controller Type Register Definitions */
+#define SCnSCB_ICTR_INTLINESNUM_Pos         0                                          /*!< ICTR: INTLINESNUM Position */
+#define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL << SCnSCB_ICTR_INTLINESNUM_Pos)      /*!< ICTR: INTLINESNUM Mask */
+
+/* Auxiliary Control Register Definitions */
+#define SCnSCB_ACTLR_DISOOFP_Pos            9                                          /*!< ACTLR: DISOOFP Position */
+#define SCnSCB_ACTLR_DISOOFP_Msk           (1UL << SCnSCB_ACTLR_DISOOFP_Pos)           /*!< ACTLR: DISOOFP Mask */
+
+#define SCnSCB_ACTLR_DISFPCA_Pos            8                                          /*!< ACTLR: DISFPCA Position */
+#define SCnSCB_ACTLR_DISFPCA_Msk           (1UL << SCnSCB_ACTLR_DISFPCA_Pos)           /*!< ACTLR: DISFPCA Mask */
+
+#define SCnSCB_ACTLR_DISFOLD_Pos            2                                          /*!< ACTLR: DISFOLD Position */
+#define SCnSCB_ACTLR_DISFOLD_Msk           (1UL << SCnSCB_ACTLR_DISFOLD_Pos)           /*!< ACTLR: DISFOLD Mask */
+
+#define SCnSCB_ACTLR_DISDEFWBUF_Pos         1                                          /*!< ACTLR: DISDEFWBUF Position */
+#define SCnSCB_ACTLR_DISDEFWBUF_Msk        (1UL << SCnSCB_ACTLR_DISDEFWBUF_Pos)        /*!< ACTLR: DISDEFWBUF Mask */
+
+#define SCnSCB_ACTLR_DISMCYCINT_Pos         0                                          /*!< ACTLR: DISMCYCINT Position */
+#define SCnSCB_ACTLR_DISMCYCINT_Msk        (1UL << SCnSCB_ACTLR_DISMCYCINT_Pos)        /*!< ACTLR: DISMCYCINT Mask */
+
+/*@} end of group CMSIS_SCnotSCB */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+    \brief      Type definitions for the System Timer Registers.
+  @{
+ */
+
+/** \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IO uint32_t CTRL;                    /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IO uint32_t LOAD;                    /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register       */
+  __IO uint32_t VAL;                     /*!< Offset: 0x008 (R/W)  SysTick Current Value Register      */
+  __I  uint32_t CALIB;                   /*!< Offset: 0x00C (R/ )  SysTick Calibration Register        */
+} SysTick_Type;
+
+/* SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16                                             /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2                                             /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1                                             /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0                                             /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL << SysTick_CTRL_ENABLE_Pos)               /*!< SysTick CTRL: ENABLE Mask */
+
+/* SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0                                             /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL << SysTick_LOAD_RELOAD_Pos)        /*!< SysTick LOAD: RELOAD Mask */
+
+/* SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0                                             /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL << SysTick_VAL_CURRENT_Pos)        /*!< SysTick VAL: CURRENT Mask */
+
+/* SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31                                             /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30                                             /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0                                             /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL << SysTick_VAL_CURRENT_Pos)        /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+    \brief      Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
+ */
+
+/** \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct
+{
+  __O  union
+  {
+    __O  uint8_t    u8;                  /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 8-bit                   */
+    __O  uint16_t   u16;                 /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 16-bit                  */
+    __O  uint32_t   u32;                 /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 32-bit                  */
+  }  PORT [32];                          /*!< Offset: 0x000 ( /W)  ITM Stimulus Port Registers               */
+       uint32_t RESERVED0[864];
+  __IO uint32_t TER;                     /*!< Offset: 0xE00 (R/W)  ITM Trace Enable Register                 */
+       uint32_t RESERVED1[15];
+  __IO uint32_t TPR;                     /*!< Offset: 0xE40 (R/W)  ITM Trace Privilege Register              */
+       uint32_t RESERVED2[15];
+  __IO uint32_t TCR;                     /*!< Offset: 0xE80 (R/W)  ITM Trace Control Register                */
+       uint32_t RESERVED3[29];
+  __O  uint32_t IWR;                     /*!< Offset: 0xEF8 ( /W)  ITM Integration Write Register            */
+  __I  uint32_t IRR;                     /*!< Offset: 0xEFC (R/ )  ITM Integration Read Register             */
+  __IO uint32_t IMCR;                    /*!< Offset: 0xF00 (R/W)  ITM Integration Mode Control Register     */
+       uint32_t RESERVED4[43];
+  __O  uint32_t LAR;                     /*!< Offset: 0xFB0 ( /W)  ITM Lock Access Register                  */
+  __I  uint32_t LSR;                     /*!< Offset: 0xFB4 (R/ )  ITM Lock Status Register                  */
+       uint32_t RESERVED5[6];
+  __I  uint32_t PID4;                    /*!< Offset: 0xFD0 (R/ )  ITM Peripheral Identification Register #4 */
+  __I  uint32_t PID5;                    /*!< Offset: 0xFD4 (R/ )  ITM Peripheral Identification Register #5 */
+  __I  uint32_t PID6;                    /*!< Offset: 0xFD8 (R/ )  ITM Peripheral Identification Register #6 */
+  __I  uint32_t PID7;                    /*!< Offset: 0xFDC (R/ )  ITM Peripheral Identification Register #7 */
+  __I  uint32_t PID0;                    /*!< Offset: 0xFE0 (R/ )  ITM Peripheral Identification Register #0 */
+  __I  uint32_t PID1;                    /*!< Offset: 0xFE4 (R/ )  ITM Peripheral Identification Register #1 */
+  __I  uint32_t PID2;                    /*!< Offset: 0xFE8 (R/ )  ITM Peripheral Identification Register #2 */
+  __I  uint32_t PID3;                    /*!< Offset: 0xFEC (R/ )  ITM Peripheral Identification Register #3 */
+  __I  uint32_t CID0;                    /*!< Offset: 0xFF0 (R/ )  ITM Component  Identification Register #0 */
+  __I  uint32_t CID1;                    /*!< Offset: 0xFF4 (R/ )  ITM Component  Identification Register #1 */
+  __I  uint32_t CID2;                    /*!< Offset: 0xFF8 (R/ )  ITM Component  Identification Register #2 */
+  __I  uint32_t CID3;                    /*!< Offset: 0xFFC (R/ )  ITM Component  Identification Register #3 */
+} ITM_Type;
+
+/* ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0                                             /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFUL << ITM_TPR_PRIVMASK_Pos)                /*!< ITM TPR: PRIVMASK Mask */
+
+/* ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23                                             /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_TraceBusID_Pos             16                                             /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TraceBusID_Msk             (0x7FUL << ITM_TCR_TraceBusID_Pos)             /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_GTSFREQ_Pos                10                                             /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+
+#define ITM_TCR_TSPrescale_Pos              8                                             /*!< ITM TCR: TSPrescale Position */
+#define ITM_TCR_TSPrescale_Msk             (3UL << ITM_TCR_TSPrescale_Pos)                /*!< ITM TCR: TSPrescale Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4                                             /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3                                             /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2                                             /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1                                             /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0                                             /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL << ITM_TCR_ITMENA_Pos)                    /*!< ITM TCR: ITM Enable bit Mask */
+
+/* ITM Integration Write Register Definitions */
+#define ITM_IWR_ATVALIDM_Pos                0                                             /*!< ITM IWR: ATVALIDM Position */
+#define ITM_IWR_ATVALIDM_Msk               (1UL << ITM_IWR_ATVALIDM_Pos)                  /*!< ITM IWR: ATVALIDM Mask */
+
+/* ITM Integration Read Register Definitions */
+#define ITM_IRR_ATREADYM_Pos                0                                             /*!< ITM IRR: ATREADYM Position */
+#define ITM_IRR_ATREADYM_Msk               (1UL << ITM_IRR_ATREADYM_Pos)                  /*!< ITM IRR: ATREADYM Mask */
+
+/* ITM Integration Mode Control Register Definitions */
+#define ITM_IMCR_INTEGRATION_Pos            0                                             /*!< ITM IMCR: INTEGRATION Position */
+#define ITM_IMCR_INTEGRATION_Msk           (1UL << ITM_IMCR_INTEGRATION_Pos)              /*!< ITM IMCR: INTEGRATION Mask */
+
+/* ITM Lock Status Register Definitions */
+#define ITM_LSR_ByteAcc_Pos                 2                                             /*!< ITM LSR: ByteAcc Position */
+#define ITM_LSR_ByteAcc_Msk                (1UL << ITM_LSR_ByteAcc_Pos)                   /*!< ITM LSR: ByteAcc Mask */
+
+#define ITM_LSR_Access_Pos                  1                                             /*!< ITM LSR: Access Position */
+#define ITM_LSR_Access_Msk                 (1UL << ITM_LSR_Access_Pos)                    /*!< ITM LSR: Access Mask */
+
+#define ITM_LSR_Present_Pos                 0                                             /*!< ITM LSR: Present Position */
+#define ITM_LSR_Present_Msk                (1UL << ITM_LSR_Present_Pos)                   /*!< ITM LSR: Present Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+    \brief      Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/** \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IO uint32_t CTRL;                    /*!< Offset: 0x000 (R/W)  Control Register                          */
+  __IO uint32_t CYCCNT;                  /*!< Offset: 0x004 (R/W)  Cycle Count Register                      */
+  __IO uint32_t CPICNT;                  /*!< Offset: 0x008 (R/W)  CPI Count Register                        */
+  __IO uint32_t EXCCNT;                  /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register         */
+  __IO uint32_t SLEEPCNT;                /*!< Offset: 0x010 (R/W)  Sleep Count Register                      */
+  __IO uint32_t LSUCNT;                  /*!< Offset: 0x014 (R/W)  LSU Count Register                        */
+  __IO uint32_t FOLDCNT;                 /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register         */
+  __I  uint32_t PCSR;                    /*!< Offset: 0x01C (R/ )  Program Counter Sample Register           */
+  __IO uint32_t COMP0;                   /*!< Offset: 0x020 (R/W)  Comparator Register 0                     */
+  __IO uint32_t MASK0;                   /*!< Offset: 0x024 (R/W)  Mask Register 0                           */
+  __IO uint32_t FUNCTION0;               /*!< Offset: 0x028 (R/W)  Function Register 0                       */
+       uint32_t RESERVED0[1];
+  __IO uint32_t COMP1;                   /*!< Offset: 0x030 (R/W)  Comparator Register 1                     */
+  __IO uint32_t MASK1;                   /*!< Offset: 0x034 (R/W)  Mask Register 1                           */
+  __IO uint32_t FUNCTION1;               /*!< Offset: 0x038 (R/W)  Function Register 1                       */
+       uint32_t RESERVED1[1];
+  __IO uint32_t COMP2;                   /*!< Offset: 0x040 (R/W)  Comparator Register 2                     */
+  __IO uint32_t MASK2;                   /*!< Offset: 0x044 (R/W)  Mask Register 2                           */
+  __IO uint32_t FUNCTION2;               /*!< Offset: 0x048 (R/W)  Function Register 2                       */
+       uint32_t RESERVED2[1];
+  __IO uint32_t COMP3;                   /*!< Offset: 0x050 (R/W)  Comparator Register 3                     */
+  __IO uint32_t MASK3;                   /*!< Offset: 0x054 (R/W)  Mask Register 3                           */
+  __IO uint32_t FUNCTION3;               /*!< Offset: 0x058 (R/W)  Function Register 3                       */
+} DWT_Type;
+
+/* DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28                                          /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27                                          /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (0x1UL << DWT_CTRL_NOTRCPKT_Pos)            /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26                                          /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (0x1UL << DWT_CTRL_NOEXTTRIG_Pos)           /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25                                          /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (0x1UL << DWT_CTRL_NOCYCCNT_Pos)            /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24                                          /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (0x1UL << DWT_CTRL_NOPRFCNT_Pos)            /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22                                          /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (0x1UL << DWT_CTRL_CYCEVTENA_Pos)           /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21                                          /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (0x1UL << DWT_CTRL_FOLDEVTENA_Pos)          /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20                                          /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (0x1UL << DWT_CTRL_LSUEVTENA_Pos)           /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19                                          /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (0x1UL << DWT_CTRL_SLEEPEVTENA_Pos)         /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18                                          /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (0x1UL << DWT_CTRL_EXCEVTENA_Pos)           /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17                                          /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (0x1UL << DWT_CTRL_CPIEVTENA_Pos)           /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16                                          /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (0x1UL << DWT_CTRL_EXCTRCENA_Pos)           /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12                                          /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (0x1UL << DWT_CTRL_PCSAMPLENA_Pos)          /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10                                          /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9                                          /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (0x1UL << DWT_CTRL_CYCTAP_Pos)              /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5                                          /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1                                          /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0                                          /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (0x1UL << DWT_CTRL_CYCCNTENA_Pos)           /*!< DWT CTRL: CYCCNTENA Mask */
+
+/* DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0                                          /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL << DWT_CPICNT_CPICNT_Pos)           /*!< DWT CPICNT: CPICNT Mask */
+
+/* DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0                                          /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL << DWT_EXCCNT_EXCCNT_Pos)           /*!< DWT EXCCNT: EXCCNT Mask */
+
+/* DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0                                          /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL << DWT_SLEEPCNT_SLEEPCNT_Pos)       /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/* DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0                                          /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL << DWT_LSUCNT_LSUCNT_Pos)           /*!< DWT LSUCNT: LSUCNT Mask */
+
+/* DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0                                          /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL << DWT_FOLDCNT_FOLDCNT_Pos)         /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/* DWT Comparator Mask Register Definitions */
+#define DWT_MASK_MASK_Pos                   0                                          /*!< DWT MASK: MASK Position */
+#define DWT_MASK_MASK_Msk                  (0x1FUL << DWT_MASK_MASK_Pos)               /*!< DWT MASK: MASK Mask */
+
+/* DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_MATCHED_Pos           24                                          /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (0x1UL << DWT_FUNCTION_MATCHED_Pos)         /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVADDR1_Pos        16                                          /*!< DWT FUNCTION: DATAVADDR1 Position */
+#define DWT_FUNCTION_DATAVADDR1_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR1_Pos)      /*!< DWT FUNCTION: DATAVADDR1 Mask */
+
+#define DWT_FUNCTION_DATAVADDR0_Pos        12                                          /*!< DWT FUNCTION: DATAVADDR0 Position */
+#define DWT_FUNCTION_DATAVADDR0_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR0_Pos)      /*!< DWT FUNCTION: DATAVADDR0 Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10                                          /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_LNK1ENA_Pos            9                                          /*!< DWT FUNCTION: LNK1ENA Position */
+#define DWT_FUNCTION_LNK1ENA_Msk           (0x1UL << DWT_FUNCTION_LNK1ENA_Pos)         /*!< DWT FUNCTION: LNK1ENA Mask */
+
+#define DWT_FUNCTION_DATAVMATCH_Pos         8                                          /*!< DWT FUNCTION: DATAVMATCH Position */
+#define DWT_FUNCTION_DATAVMATCH_Msk        (0x1UL << DWT_FUNCTION_DATAVMATCH_Pos)      /*!< DWT FUNCTION: DATAVMATCH Mask */
+
+#define DWT_FUNCTION_CYCMATCH_Pos           7                                          /*!< DWT FUNCTION: CYCMATCH Position */
+#define DWT_FUNCTION_CYCMATCH_Msk          (0x1UL << DWT_FUNCTION_CYCMATCH_Pos)        /*!< DWT FUNCTION: CYCMATCH Mask */
+
+#define DWT_FUNCTION_EMITRANGE_Pos          5                                          /*!< DWT FUNCTION: EMITRANGE Position */
+#define DWT_FUNCTION_EMITRANGE_Msk         (0x1UL << DWT_FUNCTION_EMITRANGE_Pos)       /*!< DWT FUNCTION: EMITRANGE Mask */
+
+#define DWT_FUNCTION_FUNCTION_Pos           0                                          /*!< DWT FUNCTION: FUNCTION Position */
+#define DWT_FUNCTION_FUNCTION_Msk          (0xFUL << DWT_FUNCTION_FUNCTION_Pos)        /*!< DWT FUNCTION: FUNCTION Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_TPI     Trace Port Interface (TPI)
+    \brief      Type definitions for the Trace Port Interface (TPI)
+  @{
+ */
+
+/** \brief  Structure type to access the Trace Port Interface Register (TPI).
+ */
+typedef struct
+{
+  __IO uint32_t SSPSR;                   /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register     */
+  __IO uint32_t CSPSR;                   /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+       uint32_t RESERVED0[2];
+  __IO uint32_t ACPR;                    /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+       uint32_t RESERVED1[55];
+  __IO uint32_t SPPR;                    /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+       uint32_t RESERVED2[131];
+  __I  uint32_t FFSR;                    /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IO uint32_t FFCR;                    /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __I  uint32_t FSCR;                    /*!< Offset: 0x308 (R/ )  Formatter Synchronization Counter Register */
+       uint32_t RESERVED3[759];
+  __I  uint32_t TRIGGER;                 /*!< Offset: 0xEE8 (R/ )  TRIGGER */
+  __I  uint32_t FIFO0;                   /*!< Offset: 0xEEC (R/ )  Integration ETM Data */
+  __I  uint32_t ITATBCTR2;               /*!< Offset: 0xEF0 (R/ )  ITATBCTR2 */
+       uint32_t RESERVED4[1];
+  __I  uint32_t ITATBCTR0;               /*!< Offset: 0xEF8 (R/ )  ITATBCTR0 */
+  __I  uint32_t FIFO1;                   /*!< Offset: 0xEFC (R/ )  Integration ITM Data */
+  __IO uint32_t ITCTRL;                  /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+       uint32_t RESERVED5[39];
+  __IO uint32_t CLAIMSET;                /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IO uint32_t CLAIMCLR;                /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+       uint32_t RESERVED7[8];
+  __I  uint32_t DEVID;                   /*!< Offset: 0xFC8 (R/ )  TPIU_DEVID */
+  __I  uint32_t DEVTYPE;                 /*!< Offset: 0xFCC (R/ )  TPIU_DEVTYPE */
+} TPI_Type;
+
+/* TPI Asynchronous Clock Prescaler Register Definitions */
+#define TPI_ACPR_PRESCALER_Pos              0                                          /*!< TPI ACPR: PRESCALER Position */
+#define TPI_ACPR_PRESCALER_Msk             (0x1FFFUL << TPI_ACPR_PRESCALER_Pos)        /*!< TPI ACPR: PRESCALER Mask */
+
+/* TPI Selected Pin Protocol Register Definitions */
+#define TPI_SPPR_TXMODE_Pos                 0                                          /*!< TPI SPPR: TXMODE Position */
+#define TPI_SPPR_TXMODE_Msk                (0x3UL << TPI_SPPR_TXMODE_Pos)              /*!< TPI SPPR: TXMODE Mask */
+
+/* TPI Formatter and Flush Status Register Definitions */
+#define TPI_FFSR_FtNonStop_Pos              3                                          /*!< TPI FFSR: FtNonStop Position */
+#define TPI_FFSR_FtNonStop_Msk             (0x1UL << TPI_FFSR_FtNonStop_Pos)           /*!< TPI FFSR: FtNonStop Mask */
+
+#define TPI_FFSR_TCPresent_Pos              2                                          /*!< TPI FFSR: TCPresent Position */
+#define TPI_FFSR_TCPresent_Msk             (0x1UL << TPI_FFSR_TCPresent_Pos)           /*!< TPI FFSR: TCPresent Mask */
+
+#define TPI_FFSR_FtStopped_Pos              1                                          /*!< TPI FFSR: FtStopped Position */
+#define TPI_FFSR_FtStopped_Msk             (0x1UL << TPI_FFSR_FtStopped_Pos)           /*!< TPI FFSR: FtStopped Mask */
+
+#define TPI_FFSR_FlInProg_Pos               0                                          /*!< TPI FFSR: FlInProg Position */
+#define TPI_FFSR_FlInProg_Msk              (0x1UL << TPI_FFSR_FlInProg_Pos)            /*!< TPI FFSR: FlInProg Mask */
+
+/* TPI Formatter and Flush Control Register Definitions */
+#define TPI_FFCR_TrigIn_Pos                 8                                          /*!< TPI FFCR: TrigIn Position */
+#define TPI_FFCR_TrigIn_Msk                (0x1UL << TPI_FFCR_TrigIn_Pos)              /*!< TPI FFCR: TrigIn Mask */
+
+#define TPI_FFCR_EnFCont_Pos                1                                          /*!< TPI FFCR: EnFCont Position */
+#define TPI_FFCR_EnFCont_Msk               (0x1UL << TPI_FFCR_EnFCont_Pos)             /*!< TPI FFCR: EnFCont Mask */
+
+/* TPI TRIGGER Register Definitions */
+#define TPI_TRIGGER_TRIGGER_Pos             0                                          /*!< TPI TRIGGER: TRIGGER Position */
+#define TPI_TRIGGER_TRIGGER_Msk            (0x1UL << TPI_TRIGGER_TRIGGER_Pos)          /*!< TPI TRIGGER: TRIGGER Mask */
+
+/* TPI Integration ETM Data Register Definitions (FIFO0) */
+#define TPI_FIFO0_ITM_ATVALID_Pos          29                                          /*!< TPI FIFO0: ITM_ATVALID Position */
+#define TPI_FIFO0_ITM_ATVALID_Msk          (0x3UL << TPI_FIFO0_ITM_ATVALID_Pos)        /*!< TPI FIFO0: ITM_ATVALID Mask */
+
+#define TPI_FIFO0_ITM_bytecount_Pos        27                                          /*!< TPI FIFO0: ITM_bytecount Position */
+#define TPI_FIFO0_ITM_bytecount_Msk        (0x3UL << TPI_FIFO0_ITM_bytecount_Pos)      /*!< TPI FIFO0: ITM_bytecount Mask */
+
+#define TPI_FIFO0_ETM_ATVALID_Pos          26                                          /*!< TPI FIFO0: ETM_ATVALID Position */
+#define TPI_FIFO0_ETM_ATVALID_Msk          (0x3UL << TPI_FIFO0_ETM_ATVALID_Pos)        /*!< TPI FIFO0: ETM_ATVALID Mask */
+
+#define TPI_FIFO0_ETM_bytecount_Pos        24                                          /*!< TPI FIFO0: ETM_bytecount Position */
+#define TPI_FIFO0_ETM_bytecount_Msk        (0x3UL << TPI_FIFO0_ETM_bytecount_Pos)      /*!< TPI FIFO0: ETM_bytecount Mask */
+
+#define TPI_FIFO0_ETM2_Pos                 16                                          /*!< TPI FIFO0: ETM2 Position */
+#define TPI_FIFO0_ETM2_Msk                 (0xFFUL << TPI_FIFO0_ETM2_Pos)              /*!< TPI FIFO0: ETM2 Mask */
+
+#define TPI_FIFO0_ETM1_Pos                  8                                          /*!< TPI FIFO0: ETM1 Position */
+#define TPI_FIFO0_ETM1_Msk                 (0xFFUL << TPI_FIFO0_ETM1_Pos)              /*!< TPI FIFO0: ETM1 Mask */
+
+#define TPI_FIFO0_ETM0_Pos                  0                                          /*!< TPI FIFO0: ETM0 Position */
+#define TPI_FIFO0_ETM0_Msk                 (0xFFUL << TPI_FIFO0_ETM0_Pos)              /*!< TPI FIFO0: ETM0 Mask */
+
+/* TPI ITATBCTR2 Register Definitions */
+#define TPI_ITATBCTR2_ATREADY_Pos           0                                          /*!< TPI ITATBCTR2: ATREADY Position */
+#define TPI_ITATBCTR2_ATREADY_Msk          (0x1UL << TPI_ITATBCTR2_ATREADY_Pos)        /*!< TPI ITATBCTR2: ATREADY Mask */
+
+/* TPI Integration ITM Data Register Definitions (FIFO1) */
+#define TPI_FIFO1_ITM_ATVALID_Pos          29                                          /*!< TPI FIFO1: ITM_ATVALID Position */
+#define TPI_FIFO1_ITM_ATVALID_Msk          (0x3UL << TPI_FIFO1_ITM_ATVALID_Pos)        /*!< TPI FIFO1: ITM_ATVALID Mask */
+
+#define TPI_FIFO1_ITM_bytecount_Pos        27                                          /*!< TPI FIFO1: ITM_bytecount Position */
+#define TPI_FIFO1_ITM_bytecount_Msk        (0x3UL << TPI_FIFO1_ITM_bytecount_Pos)      /*!< TPI FIFO1: ITM_bytecount Mask */
+
+#define TPI_FIFO1_ETM_ATVALID_Pos          26                                          /*!< TPI FIFO1: ETM_ATVALID Position */
+#define TPI_FIFO1_ETM_ATVALID_Msk          (0x3UL << TPI_FIFO1_ETM_ATVALID_Pos)        /*!< TPI FIFO1: ETM_ATVALID Mask */
+
+#define TPI_FIFO1_ETM_bytecount_Pos        24                                          /*!< TPI FIFO1: ETM_bytecount Position */
+#define TPI_FIFO1_ETM_bytecount_Msk        (0x3UL << TPI_FIFO1_ETM_bytecount_Pos)      /*!< TPI FIFO1: ETM_bytecount Mask */
+
+#define TPI_FIFO1_ITM2_Pos                 16                                          /*!< TPI FIFO1: ITM2 Position */
+#define TPI_FIFO1_ITM2_Msk                 (0xFFUL << TPI_FIFO1_ITM2_Pos)              /*!< TPI FIFO1: ITM2 Mask */
+
+#define TPI_FIFO1_ITM1_Pos                  8                                          /*!< TPI FIFO1: ITM1 Position */
+#define TPI_FIFO1_ITM1_Msk                 (0xFFUL << TPI_FIFO1_ITM1_Pos)              /*!< TPI FIFO1: ITM1 Mask */
+
+#define TPI_FIFO1_ITM0_Pos                  0                                          /*!< TPI FIFO1: ITM0 Position */
+#define TPI_FIFO1_ITM0_Msk                 (0xFFUL << TPI_FIFO1_ITM0_Pos)              /*!< TPI FIFO1: ITM0 Mask */
+
+/* TPI ITATBCTR0 Register Definitions */
+#define TPI_ITATBCTR0_ATREADY_Pos           0                                          /*!< TPI ITATBCTR0: ATREADY Position */
+#define TPI_ITATBCTR0_ATREADY_Msk          (0x1UL << TPI_ITATBCTR0_ATREADY_Pos)        /*!< TPI ITATBCTR0: ATREADY Mask */
+
+/* TPI Integration Mode Control Register Definitions */
+#define TPI_ITCTRL_Mode_Pos                 0                                          /*!< TPI ITCTRL: Mode Position */
+#define TPI_ITCTRL_Mode_Msk                (0x1UL << TPI_ITCTRL_Mode_Pos)              /*!< TPI ITCTRL: Mode Mask */
+
+/* TPI DEVID Register Definitions */
+#define TPI_DEVID_NRZVALID_Pos             11                                          /*!< TPI DEVID: NRZVALID Position */
+#define TPI_DEVID_NRZVALID_Msk             (0x1UL << TPI_DEVID_NRZVALID_Pos)           /*!< TPI DEVID: NRZVALID Mask */
+
+#define TPI_DEVID_MANCVALID_Pos            10                                          /*!< TPI DEVID: MANCVALID Position */
+#define TPI_DEVID_MANCVALID_Msk            (0x1UL << TPI_DEVID_MANCVALID_Pos)          /*!< TPI DEVID: MANCVALID Mask */
+
+#define TPI_DEVID_PTINVALID_Pos             9                                          /*!< TPI DEVID: PTINVALID Position */
+#define TPI_DEVID_PTINVALID_Msk            (0x1UL << TPI_DEVID_PTINVALID_Pos)          /*!< TPI DEVID: PTINVALID Mask */
+
+#define TPI_DEVID_MinBufSz_Pos              6                                          /*!< TPI DEVID: MinBufSz Position */
+#define TPI_DEVID_MinBufSz_Msk             (0x7UL << TPI_DEVID_MinBufSz_Pos)           /*!< TPI DEVID: MinBufSz Mask */
+
+#define TPI_DEVID_AsynClkIn_Pos             5                                          /*!< TPI DEVID: AsynClkIn Position */
+#define TPI_DEVID_AsynClkIn_Msk            (0x1UL << TPI_DEVID_AsynClkIn_Pos)          /*!< TPI DEVID: AsynClkIn Mask */
+
+#define TPI_DEVID_NrTraceInput_Pos          0                                          /*!< TPI DEVID: NrTraceInput Position */
+#define TPI_DEVID_NrTraceInput_Msk         (0x1FUL << TPI_DEVID_NrTraceInput_Pos)      /*!< TPI DEVID: NrTraceInput Mask */
+
+/* TPI DEVTYPE Register Definitions */
+#define TPI_DEVTYPE_SubType_Pos             0                                          /*!< TPI DEVTYPE: SubType Position */
+#define TPI_DEVTYPE_SubType_Msk            (0xFUL << TPI_DEVTYPE_SubType_Pos)          /*!< TPI DEVTYPE: SubType Mask */
+
+#define TPI_DEVTYPE_MajorType_Pos           4                                          /*!< TPI DEVTYPE: MajorType Position */
+#define TPI_DEVTYPE_MajorType_Msk          (0xFUL << TPI_DEVTYPE_MajorType_Pos)        /*!< TPI DEVTYPE: MajorType Mask */
+
+/*@}*/ /* end of group CMSIS_TPI */
+
+
+#if (__MPU_PRESENT == 1)
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+    \brief      Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/** \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __I  uint32_t TYPE;                    /*!< Offset: 0x000 (R/ )  MPU Type Register                              */
+  __IO uint32_t CTRL;                    /*!< Offset: 0x004 (R/W)  MPU Control Register                           */
+  __IO uint32_t RNR;                     /*!< Offset: 0x008 (R/W)  MPU Region RNRber Register                     */
+  __IO uint32_t RBAR;                    /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register               */
+  __IO uint32_t RASR;                    /*!< Offset: 0x010 (R/W)  MPU Region Attribute and Size Register         */
+  __IO uint32_t RBAR_A1;                 /*!< Offset: 0x014 (R/W)  MPU Alias 1 Region Base Address Register       */
+  __IO uint32_t RASR_A1;                 /*!< Offset: 0x018 (R/W)  MPU Alias 1 Region Attribute and Size Register */
+  __IO uint32_t RBAR_A2;                 /*!< Offset: 0x01C (R/W)  MPU Alias 2 Region Base Address Register       */
+  __IO uint32_t RASR_A2;                 /*!< Offset: 0x020 (R/W)  MPU Alias 2 Region Attribute and Size Register */
+  __IO uint32_t RBAR_A3;                 /*!< Offset: 0x024 (R/W)  MPU Alias 3 Region Base Address Register       */
+  __IO uint32_t RASR_A3;                 /*!< Offset: 0x028 (R/W)  MPU Alias 3 Region Attribute and Size Register */
+} MPU_Type;
+
+/* MPU Type Register */
+#define MPU_TYPE_IREGION_Pos               16                                             /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8                                             /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0                                             /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL << MPU_TYPE_SEPARATE_Pos)                 /*!< MPU TYPE: SEPARATE Mask */
+
+/* MPU Control Register */
+#define MPU_CTRL_PRIVDEFENA_Pos             2                                             /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1                                             /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0                                             /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL << MPU_CTRL_ENABLE_Pos)                   /*!< MPU CTRL: ENABLE Mask */
+
+/* MPU Region Number Register */
+#define MPU_RNR_REGION_Pos                  0                                             /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL << MPU_RNR_REGION_Pos)                 /*!< MPU RNR: REGION Mask */
+
+/* MPU Region Base Address Register */
+#define MPU_RBAR_ADDR_Pos                   5                                             /*!< MPU RBAR: ADDR Position */
+#define MPU_RBAR_ADDR_Msk                  (0x7FFFFFFUL << MPU_RBAR_ADDR_Pos)             /*!< MPU RBAR: ADDR Mask */
+
+#define MPU_RBAR_VALID_Pos                  4                                             /*!< MPU RBAR: VALID Position */
+#define MPU_RBAR_VALID_Msk                 (1UL << MPU_RBAR_VALID_Pos)                    /*!< MPU RBAR: VALID Mask */
+
+#define MPU_RBAR_REGION_Pos                 0                                             /*!< MPU RBAR: REGION Position */
+#define MPU_RBAR_REGION_Msk                (0xFUL << MPU_RBAR_REGION_Pos)                 /*!< MPU RBAR: REGION Mask */
+
+/* MPU Region Attribute and Size Register */
+#define MPU_RASR_ATTRS_Pos                 16                                             /*!< MPU RASR: MPU Region Attribute field Position */
+#define MPU_RASR_ATTRS_Msk                 (0xFFFFUL << MPU_RASR_ATTRS_Pos)               /*!< MPU RASR: MPU Region Attribute field Mask */
+
+#define MPU_RASR_XN_Pos                    28                                             /*!< MPU RASR: ATTRS.XN Position */
+#define MPU_RASR_XN_Msk                    (1UL << MPU_RASR_XN_Pos)                       /*!< MPU RASR: ATTRS.XN Mask */
+
+#define MPU_RASR_AP_Pos                    24                                             /*!< MPU RASR: ATTRS.AP Position */
+#define MPU_RASR_AP_Msk                    (0x7UL << MPU_RASR_AP_Pos)                     /*!< MPU RASR: ATTRS.AP Mask */
+
+#define MPU_RASR_TEX_Pos                   19                                             /*!< MPU RASR: ATTRS.TEX Position */
+#define MPU_RASR_TEX_Msk                   (0x7UL << MPU_RASR_TEX_Pos)                    /*!< MPU RASR: ATTRS.TEX Mask */
+
+#define MPU_RASR_S_Pos                     18                                             /*!< MPU RASR: ATTRS.S Position */
+#define MPU_RASR_S_Msk                     (1UL << MPU_RASR_S_Pos)                        /*!< MPU RASR: ATTRS.S Mask */
+
+#define MPU_RASR_C_Pos                     17                                             /*!< MPU RASR: ATTRS.C Position */
+#define MPU_RASR_C_Msk                     (1UL << MPU_RASR_C_Pos)                        /*!< MPU RASR: ATTRS.C Mask */
+
+#define MPU_RASR_B_Pos                     16                                             /*!< MPU RASR: ATTRS.B Position */
+#define MPU_RASR_B_Msk                     (1UL << MPU_RASR_B_Pos)                        /*!< MPU RASR: ATTRS.B Mask */
+
+#define MPU_RASR_SRD_Pos                    8                                             /*!< MPU RASR: Sub-Region Disable Position */
+#define MPU_RASR_SRD_Msk                   (0xFFUL << MPU_RASR_SRD_Pos)                   /*!< MPU RASR: Sub-Region Disable Mask */
+
+#define MPU_RASR_SIZE_Pos                   1                                             /*!< MPU RASR: Region Size Field Position */
+#define MPU_RASR_SIZE_Msk                  (0x1FUL << MPU_RASR_SIZE_Pos)                  /*!< MPU RASR: Region Size Field Mask */
+
+#define MPU_RASR_ENABLE_Pos                 0                                             /*!< MPU RASR: Region enable bit Position */
+#define MPU_RASR_ENABLE_Msk                (1UL << MPU_RASR_ENABLE_Pos)                   /*!< MPU RASR: Region enable bit Disable Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+#if (__FPU_PRESENT == 1)
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_FPU     Floating Point Unit (FPU)
+    \brief      Type definitions for the Floating Point Unit (FPU)
+  @{
+ */
+
+/** \brief  Structure type to access the Floating Point Unit (FPU).
+ */
+typedef struct
+{
+       uint32_t RESERVED0[1];
+  __IO uint32_t FPCCR;                   /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register               */
+  __IO uint32_t FPCAR;                   /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register               */
+  __IO uint32_t FPDSCR;                  /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register        */
+  __I  uint32_t MVFR0;                   /*!< Offset: 0x010 (R/ )  Media and FP Feature Register 0                       */
+  __I  uint32_t MVFR1;                   /*!< Offset: 0x014 (R/ )  Media and FP Feature Register 1                       */
+} FPU_Type;
+
+/* Floating-Point Context Control Register */
+#define FPU_FPCCR_ASPEN_Pos                31                                             /*!< FPCCR: ASPEN bit Position */
+#define FPU_FPCCR_ASPEN_Msk                (1UL << FPU_FPCCR_ASPEN_Pos)                   /*!< FPCCR: ASPEN bit Mask */
+
+#define FPU_FPCCR_LSPEN_Pos                30                                             /*!< FPCCR: LSPEN Position */
+#define FPU_FPCCR_LSPEN_Msk                (1UL << FPU_FPCCR_LSPEN_Pos)                   /*!< FPCCR: LSPEN bit Mask */
+
+#define FPU_FPCCR_MONRDY_Pos                8                                             /*!< FPCCR: MONRDY Position */
+#define FPU_FPCCR_MONRDY_Msk               (1UL << FPU_FPCCR_MONRDY_Pos)                  /*!< FPCCR: MONRDY bit Mask */
+
+#define FPU_FPCCR_BFRDY_Pos                 6                                             /*!< FPCCR: BFRDY Position */
+#define FPU_FPCCR_BFRDY_Msk                (1UL << FPU_FPCCR_BFRDY_Pos)                   /*!< FPCCR: BFRDY bit Mask */
+
+#define FPU_FPCCR_MMRDY_Pos                 5                                             /*!< FPCCR: MMRDY Position */
+#define FPU_FPCCR_MMRDY_Msk                (1UL << FPU_FPCCR_MMRDY_Pos)                   /*!< FPCCR: MMRDY bit Mask */
+
+#define FPU_FPCCR_HFRDY_Pos                 4                                             /*!< FPCCR: HFRDY Position */
+#define FPU_FPCCR_HFRDY_Msk                (1UL << FPU_FPCCR_HFRDY_Pos)                   /*!< FPCCR: HFRDY bit Mask */
+
+#define FPU_FPCCR_THREAD_Pos                3                                             /*!< FPCCR: processor mode bit Position */
+#define FPU_FPCCR_THREAD_Msk               (1UL << FPU_FPCCR_THREAD_Pos)                  /*!< FPCCR: processor mode active bit Mask */
+
+#define FPU_FPCCR_USER_Pos                  1                                             /*!< FPCCR: privilege level bit Position */
+#define FPU_FPCCR_USER_Msk                 (1UL << FPU_FPCCR_USER_Pos)                    /*!< FPCCR: privilege level bit Mask */
+
+#define FPU_FPCCR_LSPACT_Pos                0                                             /*!< FPCCR: Lazy state preservation active bit Position */
+#define FPU_FPCCR_LSPACT_Msk               (1UL << FPU_FPCCR_LSPACT_Pos)                  /*!< FPCCR: Lazy state preservation active bit Mask */
+
+/* Floating-Point Context Address Register */
+#define FPU_FPCAR_ADDRESS_Pos               3                                             /*!< FPCAR: ADDRESS bit Position */
+#define FPU_FPCAR_ADDRESS_Msk              (0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos)        /*!< FPCAR: ADDRESS bit Mask */
+
+/* Floating-Point Default Status Control Register */
+#define FPU_FPDSCR_AHP_Pos                 26                                             /*!< FPDSCR: AHP bit Position */
+#define FPU_FPDSCR_AHP_Msk                 (1UL << FPU_FPDSCR_AHP_Pos)                    /*!< FPDSCR: AHP bit Mask */
+
+#define FPU_FPDSCR_DN_Pos                  25                                             /*!< FPDSCR: DN bit Position */
+#define FPU_FPDSCR_DN_Msk                  (1UL << FPU_FPDSCR_DN_Pos)                     /*!< FPDSCR: DN bit Mask */
+
+#define FPU_FPDSCR_FZ_Pos                  24                                             /*!< FPDSCR: FZ bit Position */
+#define FPU_FPDSCR_FZ_Msk                  (1UL << FPU_FPDSCR_FZ_Pos)                     /*!< FPDSCR: FZ bit Mask */
+
+#define FPU_FPDSCR_RMode_Pos               22                                             /*!< FPDSCR: RMode bit Position */
+#define FPU_FPDSCR_RMode_Msk               (3UL << FPU_FPDSCR_RMode_Pos)                  /*!< FPDSCR: RMode bit Mask */
+
+/* Media and FP Feature Register 0 */
+#define FPU_MVFR0_FP_rounding_modes_Pos    28                                             /*!< MVFR0: FP rounding modes bits Position */
+#define FPU_MVFR0_FP_rounding_modes_Msk    (0xFUL << FPU_MVFR0_FP_rounding_modes_Pos)     /*!< MVFR0: FP rounding modes bits Mask */
+
+#define FPU_MVFR0_Short_vectors_Pos        24                                             /*!< MVFR0: Short vectors bits Position */
+#define FPU_MVFR0_Short_vectors_Msk        (0xFUL << FPU_MVFR0_Short_vectors_Pos)         /*!< MVFR0: Short vectors bits Mask */
+
+#define FPU_MVFR0_Square_root_Pos          20                                             /*!< MVFR0: Square root bits Position */
+#define FPU_MVFR0_Square_root_Msk          (0xFUL << FPU_MVFR0_Square_root_Pos)           /*!< MVFR0: Square root bits Mask */
+
+#define FPU_MVFR0_Divide_Pos               16                                             /*!< MVFR0: Divide bits Position */
+#define FPU_MVFR0_Divide_Msk               (0xFUL << FPU_MVFR0_Divide_Pos)                /*!< MVFR0: Divide bits Mask */
+
+#define FPU_MVFR0_FP_excep_trapping_Pos    12                                             /*!< MVFR0: FP exception trapping bits Position */
+#define FPU_MVFR0_FP_excep_trapping_Msk    (0xFUL << FPU_MVFR0_FP_excep_trapping_Pos)     /*!< MVFR0: FP exception trapping bits Mask */
+
+#define FPU_MVFR0_Double_precision_Pos      8                                             /*!< MVFR0: Double-precision bits Position */
+#define FPU_MVFR0_Double_precision_Msk     (0xFUL << FPU_MVFR0_Double_precision_Pos)      /*!< MVFR0: Double-precision bits Mask */
+
+#define FPU_MVFR0_Single_precision_Pos      4                                             /*!< MVFR0: Single-precision bits Position */
+#define FPU_MVFR0_Single_precision_Msk     (0xFUL << FPU_MVFR0_Single_precision_Pos)      /*!< MVFR0: Single-precision bits Mask */
+
+#define FPU_MVFR0_A_SIMD_registers_Pos      0                                             /*!< MVFR0: A_SIMD registers bits Position */
+#define FPU_MVFR0_A_SIMD_registers_Msk     (0xFUL << FPU_MVFR0_A_SIMD_registers_Pos)      /*!< MVFR0: A_SIMD registers bits Mask */
+
+/* Media and FP Feature Register 1 */
+#define FPU_MVFR1_FP_fused_MAC_Pos         28                                             /*!< MVFR1: FP fused MAC bits Position */
+#define FPU_MVFR1_FP_fused_MAC_Msk         (0xFUL << FPU_MVFR1_FP_fused_MAC_Pos)          /*!< MVFR1: FP fused MAC bits Mask */
+
+#define FPU_MVFR1_FP_HPFP_Pos              24                                             /*!< MVFR1: FP HPFP bits Position */
+#define FPU_MVFR1_FP_HPFP_Msk              (0xFUL << FPU_MVFR1_FP_HPFP_Pos)               /*!< MVFR1: FP HPFP bits Mask */
+
+#define FPU_MVFR1_D_NaN_mode_Pos            4                                             /*!< MVFR1: D_NaN mode bits Position */
+#define FPU_MVFR1_D_NaN_mode_Msk           (0xFUL << FPU_MVFR1_D_NaN_mode_Pos)            /*!< MVFR1: D_NaN mode bits Mask */
+
+#define FPU_MVFR1_FtZ_mode_Pos              0                                             /*!< MVFR1: FtZ mode bits Position */
+#define FPU_MVFR1_FtZ_mode_Msk             (0xFUL << FPU_MVFR1_FtZ_mode_Pos)              /*!< MVFR1: FtZ mode bits Mask */
+
+/*@} end of group CMSIS_FPU */
+#endif
+
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_CoreDebug       Core Debug Registers (CoreDebug)
+    \brief      Type definitions for the Core Debug Registers
+  @{
+ */
+
+/** \brief  Structure type to access the Core Debug Register (CoreDebug).
+ */
+typedef struct
+{
+  __IO uint32_t DHCSR;                   /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register    */
+  __O  uint32_t DCRSR;                   /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register        */
+  __IO uint32_t DCRDR;                   /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register            */
+  __IO uint32_t DEMCR;                   /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+} CoreDebug_Type;
+
+/* Debug Halting Control and Status Register */
+#define CoreDebug_DHCSR_DBGKEY_Pos         16                                             /*!< CoreDebug DHCSR: DBGKEY Position */
+#define CoreDebug_DHCSR_DBGKEY_Msk         (0xFFFFUL << CoreDebug_DHCSR_DBGKEY_Pos)       /*!< CoreDebug DHCSR: DBGKEY Mask */
+
+#define CoreDebug_DHCSR_S_RESET_ST_Pos     25                                             /*!< CoreDebug DHCSR: S_RESET_ST Position */
+#define CoreDebug_DHCSR_S_RESET_ST_Msk     (1UL << CoreDebug_DHCSR_S_RESET_ST_Pos)        /*!< CoreDebug DHCSR: S_RESET_ST Mask */
+
+#define CoreDebug_DHCSR_S_RETIRE_ST_Pos    24                                             /*!< CoreDebug DHCSR: S_RETIRE_ST Position */
+#define CoreDebug_DHCSR_S_RETIRE_ST_Msk    (1UL << CoreDebug_DHCSR_S_RETIRE_ST_Pos)       /*!< CoreDebug DHCSR: S_RETIRE_ST Mask */
+
+#define CoreDebug_DHCSR_S_LOCKUP_Pos       19                                             /*!< CoreDebug DHCSR: S_LOCKUP Position */
+#define CoreDebug_DHCSR_S_LOCKUP_Msk       (1UL << CoreDebug_DHCSR_S_LOCKUP_Pos)          /*!< CoreDebug DHCSR: S_LOCKUP Mask */
+
+#define CoreDebug_DHCSR_S_SLEEP_Pos        18                                             /*!< CoreDebug DHCSR: S_SLEEP Position */
+#define CoreDebug_DHCSR_S_SLEEP_Msk        (1UL << CoreDebug_DHCSR_S_SLEEP_Pos)           /*!< CoreDebug DHCSR: S_SLEEP Mask */
+
+#define CoreDebug_DHCSR_S_HALT_Pos         17                                             /*!< CoreDebug DHCSR: S_HALT Position */
+#define CoreDebug_DHCSR_S_HALT_Msk         (1UL << CoreDebug_DHCSR_S_HALT_Pos)            /*!< CoreDebug DHCSR: S_HALT Mask */
+
+#define CoreDebug_DHCSR_S_REGRDY_Pos       16                                             /*!< CoreDebug DHCSR: S_REGRDY Position */
+#define CoreDebug_DHCSR_S_REGRDY_Msk       (1UL << CoreDebug_DHCSR_S_REGRDY_Pos)          /*!< CoreDebug DHCSR: S_REGRDY Mask */
+
+#define CoreDebug_DHCSR_C_SNAPSTALL_Pos     5                                             /*!< CoreDebug DHCSR: C_SNAPSTALL Position */
+#define CoreDebug_DHCSR_C_SNAPSTALL_Msk    (1UL << CoreDebug_DHCSR_C_SNAPSTALL_Pos)       /*!< CoreDebug DHCSR: C_SNAPSTALL Mask */
+
+#define CoreDebug_DHCSR_C_MASKINTS_Pos      3                                             /*!< CoreDebug DHCSR: C_MASKINTS Position */
+#define CoreDebug_DHCSR_C_MASKINTS_Msk     (1UL << CoreDebug_DHCSR_C_MASKINTS_Pos)        /*!< CoreDebug DHCSR: C_MASKINTS Mask */
+
+#define CoreDebug_DHCSR_C_STEP_Pos          2                                             /*!< CoreDebug DHCSR: C_STEP Position */
+#define CoreDebug_DHCSR_C_STEP_Msk         (1UL << CoreDebug_DHCSR_C_STEP_Pos)            /*!< CoreDebug DHCSR: C_STEP Mask */
+
+#define CoreDebug_DHCSR_C_HALT_Pos          1                                             /*!< CoreDebug DHCSR: C_HALT Position */
+#define CoreDebug_DHCSR_C_HALT_Msk         (1UL << CoreDebug_DHCSR_C_HALT_Pos)            /*!< CoreDebug DHCSR: C_HALT Mask */
+
+#define CoreDebug_DHCSR_C_DEBUGEN_Pos       0                                             /*!< CoreDebug DHCSR: C_DEBUGEN Position */
+#define CoreDebug_DHCSR_C_DEBUGEN_Msk      (1UL << CoreDebug_DHCSR_C_DEBUGEN_Pos)         /*!< CoreDebug DHCSR: C_DEBUGEN Mask */
+
+/* Debug Core Register Selector Register */
+#define CoreDebug_DCRSR_REGWnR_Pos         16                                             /*!< CoreDebug DCRSR: REGWnR Position */
+#define CoreDebug_DCRSR_REGWnR_Msk         (1UL << CoreDebug_DCRSR_REGWnR_Pos)            /*!< CoreDebug DCRSR: REGWnR Mask */
+
+#define CoreDebug_DCRSR_REGSEL_Pos          0                                             /*!< CoreDebug DCRSR: REGSEL Position */
+#define CoreDebug_DCRSR_REGSEL_Msk         (0x1FUL << CoreDebug_DCRSR_REGSEL_Pos)         /*!< CoreDebug DCRSR: REGSEL Mask */
+
+/* Debug Exception and Monitor Control Register */
+#define CoreDebug_DEMCR_TRCENA_Pos         24                                             /*!< CoreDebug DEMCR: TRCENA Position */
+#define CoreDebug_DEMCR_TRCENA_Msk         (1UL << CoreDebug_DEMCR_TRCENA_Pos)            /*!< CoreDebug DEMCR: TRCENA Mask */
+
+#define CoreDebug_DEMCR_MON_REQ_Pos        19                                             /*!< CoreDebug DEMCR: MON_REQ Position */
+#define CoreDebug_DEMCR_MON_REQ_Msk        (1UL << CoreDebug_DEMCR_MON_REQ_Pos)           /*!< CoreDebug DEMCR: MON_REQ Mask */
+
+#define CoreDebug_DEMCR_MON_STEP_Pos       18                                             /*!< CoreDebug DEMCR: MON_STEP Position */
+#define CoreDebug_DEMCR_MON_STEP_Msk       (1UL << CoreDebug_DEMCR_MON_STEP_Pos)          /*!< CoreDebug DEMCR: MON_STEP Mask */
+
+#define CoreDebug_DEMCR_MON_PEND_Pos       17                                             /*!< CoreDebug DEMCR: MON_PEND Position */
+#define CoreDebug_DEMCR_MON_PEND_Msk       (1UL << CoreDebug_DEMCR_MON_PEND_Pos)          /*!< CoreDebug DEMCR: MON_PEND Mask */
+
+#define CoreDebug_DEMCR_MON_EN_Pos         16                                             /*!< CoreDebug DEMCR: MON_EN Position */
+#define CoreDebug_DEMCR_MON_EN_Msk         (1UL << CoreDebug_DEMCR_MON_EN_Pos)            /*!< CoreDebug DEMCR: MON_EN Mask */
+
+#define CoreDebug_DEMCR_VC_HARDERR_Pos     10                                             /*!< CoreDebug DEMCR: VC_HARDERR Position */
+#define CoreDebug_DEMCR_VC_HARDERR_Msk     (1UL << CoreDebug_DEMCR_VC_HARDERR_Pos)        /*!< CoreDebug DEMCR: VC_HARDERR Mask */
+
+#define CoreDebug_DEMCR_VC_INTERR_Pos       9                                             /*!< CoreDebug DEMCR: VC_INTERR Position */
+#define CoreDebug_DEMCR_VC_INTERR_Msk      (1UL << CoreDebug_DEMCR_VC_INTERR_Pos)         /*!< CoreDebug DEMCR: VC_INTERR Mask */
+
+#define CoreDebug_DEMCR_VC_BUSERR_Pos       8                                             /*!< CoreDebug DEMCR: VC_BUSERR Position */
+#define CoreDebug_DEMCR_VC_BUSERR_Msk      (1UL << CoreDebug_DEMCR_VC_BUSERR_Pos)         /*!< CoreDebug DEMCR: VC_BUSERR Mask */
+
+#define CoreDebug_DEMCR_VC_STATERR_Pos      7                                             /*!< CoreDebug DEMCR: VC_STATERR Position */
+#define CoreDebug_DEMCR_VC_STATERR_Msk     (1UL << CoreDebug_DEMCR_VC_STATERR_Pos)        /*!< CoreDebug DEMCR: VC_STATERR Mask */
+
+#define CoreDebug_DEMCR_VC_CHKERR_Pos       6                                             /*!< CoreDebug DEMCR: VC_CHKERR Position */
+#define CoreDebug_DEMCR_VC_CHKERR_Msk      (1UL << CoreDebug_DEMCR_VC_CHKERR_Pos)         /*!< CoreDebug DEMCR: VC_CHKERR Mask */
+
+#define CoreDebug_DEMCR_VC_NOCPERR_Pos      5                                             /*!< CoreDebug DEMCR: VC_NOCPERR Position */
+#define CoreDebug_DEMCR_VC_NOCPERR_Msk     (1UL << CoreDebug_DEMCR_VC_NOCPERR_Pos)        /*!< CoreDebug DEMCR: VC_NOCPERR Mask */
+
+#define CoreDebug_DEMCR_VC_MMERR_Pos        4                                             /*!< CoreDebug DEMCR: VC_MMERR Position */
+#define CoreDebug_DEMCR_VC_MMERR_Msk       (1UL << CoreDebug_DEMCR_VC_MMERR_Pos)          /*!< CoreDebug DEMCR: VC_MMERR Mask */
+
+#define CoreDebug_DEMCR_VC_CORERESET_Pos    0                                             /*!< CoreDebug DEMCR: VC_CORERESET Position */
+#define CoreDebug_DEMCR_VC_CORERESET_Msk   (1UL << CoreDebug_DEMCR_VC_CORERESET_Pos)      /*!< CoreDebug DEMCR: VC_CORERESET Mask */
+
+/*@} end of group CMSIS_CoreDebug */
+
+
+/** \ingroup    CMSIS_core_register
+    \defgroup   CMSIS_core_base     Core Definitions
+    \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Cortex-M4 Hardware */
+#define SCS_BASE            (0xE000E000UL)                            /*!< System Control Space Base Address  */
+#define ITM_BASE            (0xE0000000UL)                            /*!< ITM Base Address                   */
+#define DWT_BASE            (0xE0001000UL)                            /*!< DWT Base Address                   */
+#define TPI_BASE            (0xE0040000UL)                            /*!< TPI Base Address                   */
+#define CoreDebug_BASE      (0xE000EDF0UL)                            /*!< Core Debug Base Address            */
+#define SysTick_BASE        (SCS_BASE +  0x0010UL)                    /*!< SysTick Base Address               */
+#define NVIC_BASE           (SCS_BASE +  0x0100UL)                    /*!< NVIC Base Address                  */
+#define SCB_BASE            (SCS_BASE +  0x0D00UL)                    /*!< System Control Block Base Address  */
+
+#define SCnSCB              ((SCnSCB_Type    *)     SCS_BASE      )   /*!< System control Register not in SCB */
+#define SCB                 ((SCB_Type       *)     SCB_BASE      )   /*!< SCB configuration struct           */
+#define SysTick             ((SysTick_Type   *)     SysTick_BASE  )   /*!< SysTick configuration struct       */
+#define NVIC                ((NVIC_Type      *)     NVIC_BASE     )   /*!< NVIC configuration struct          */
+#define ITM                 ((ITM_Type       *)     ITM_BASE      )   /*!< ITM configuration struct           */
+#define DWT                 ((DWT_Type       *)     DWT_BASE      )   /*!< DWT configuration struct           */
+#define TPI                 ((TPI_Type       *)     TPI_BASE      )   /*!< TPI configuration struct           */
+#define CoreDebug           ((CoreDebug_Type *)     CoreDebug_BASE)   /*!< Core Debug configuration struct    */
+
+#if (__MPU_PRESENT == 1)
+  #define MPU_BASE          (SCS_BASE +  0x0D90UL)                    /*!< Memory Protection Unit             */
+  #define MPU               ((MPU_Type       *)     MPU_BASE      )   /*!< Memory Protection Unit             */
+#endif
+
+#if (__FPU_PRESENT == 1)
+  #define FPU_BASE          (SCS_BASE +  0x0F30UL)                    /*!< Floating Point Unit                */
+  #define FPU               ((FPU_Type       *)     FPU_BASE      )   /*!< Floating Point Unit                */
+#endif
+
+/*@} */
+
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/** \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+    \brief      Functions that manage interrupts and exceptions via the NVIC.
+    @{
+ */
+
+/** \brief  Set Priority Grouping
+
+  The function sets the priority grouping field using the required unlock sequence.
+  The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+  Only values from 0..7 are used.
+  In case of a conflict between priority grouping and available
+  priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+
+    \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07);               /* only values 0..7 are used          */
+
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk);             /* clear bits to change               */
+  reg_value  =  (reg_value                                 |
+                ((uint32_t)0x5FA << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << 8));                                     /* Insert write key and priorty group */
+  SCB->AIRCR =  reg_value;
+}
+
+
+/** \brief  Get Priority Grouping
+
+  The function reads the priority grouping field from the NVIC Interrupt Controller.
+
+    \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t NVIC_GetPriorityGrouping(void)
+{
+  return ((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos);   /* read priority grouping field */
+}
+
+
+/** \brief  Enable External Interrupt
+
+    The function enables a device-specific interrupt in the NVIC interrupt controller.
+
+    \param [in]      IRQn  External interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+/*  NVIC->ISER[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));  enable interrupt */
+  NVIC->ISER[(uint32_t)((int32_t)IRQn) >> 5] = (uint32_t)(1 << ((uint32_t)((int32_t)IRQn) & (uint32_t)0x1F)); /* enable interrupt */
+}
+
+
+/** \brief  Disable External Interrupt
+
+    The function disables a device-specific interrupt in the NVIC interrupt controller.
+
+    \param [in]      IRQn  External interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  NVIC->ICER[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F)); /* disable interrupt */
+}
+
+
+/** \brief  Get Pending Interrupt
+
+    The function reads the pending register in the NVIC and returns the pending bit
+    for the specified interrupt.
+
+    \param [in]      IRQn  Interrupt number.
+
+    \return             0  Interrupt status is not pending.
+    \return             1  Interrupt status is pending.
+ */
+__STATIC_INLINE uint32_t NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  return((uint32_t) ((NVIC->ISPR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0)); /* Return 1 if pending else 0 */
+}
+
+
+/** \brief  Set Pending Interrupt
+
+    The function sets the pending bit of an external interrupt.
+
+    \param [in]      IRQn  Interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  NVIC->ISPR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F)); /* set interrupt pending */
+}
+
+
+/** \brief  Clear Pending Interrupt
+
+    The function clears the pending bit of an external interrupt.
+
+    \param [in]      IRQn  External interrupt number. Value cannot be negative.
+ */
+__STATIC_INLINE void NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  NVIC->ICPR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F)); /* Clear pending interrupt */
+}
+
+
+/** \brief  Get Active Interrupt
+
+    The function reads the active register in NVIC and returns the active bit.
+
+    \param [in]      IRQn  Interrupt number.
+
+    \return             0  Interrupt status is not active.
+    \return             1  Interrupt status is active.
+ */
+__STATIC_INLINE uint32_t NVIC_GetActive(IRQn_Type IRQn)
+{
+  return((uint32_t)((NVIC->IABR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F)))?1:0)); /* Return 1 if active else 0 */
+}
+
+
+/** \brief  Set Interrupt Priority
+
+    The function sets the priority of an interrupt.
+
+    \note The priority cannot be set for every core interrupt.
+
+    \param [in]      IRQn  Interrupt number.
+    \param [in]  priority  Priority to set.
+ */
+__STATIC_INLINE void NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if(IRQn < 0) {
+    SCB->SHP[((uint32_t)(IRQn) & 0xF)-4] = ((priority << (8 - __NVIC_PRIO_BITS)) & 0xff); } /* set Priority for Cortex-M  System Interrupts */
+  else {
+    NVIC->IP[(uint32_t)(IRQn)] = ((priority << (8 - __NVIC_PRIO_BITS)) & 0xff);    }        /* set Priority for device specific Interrupts  */
+}
+
+
+/** \brief  Get Interrupt Priority
+
+    The function reads the priority of an interrupt. The interrupt
+    number can be positive to specify an external (device specific)
+    interrupt, or negative to specify an internal (core) interrupt.
+
+
+    \param [in]   IRQn  Interrupt number.
+    \return             Interrupt Priority. Value is aligned automatically to the implemented
+                        priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if(IRQn < 0) {
+    return((uint32_t)(SCB->SHP[((uint32_t)(IRQn) & 0xF)-4] >> (8 - __NVIC_PRIO_BITS)));  } /* get priority for Cortex-M  system interrupts */
+  else {
+    return((uint32_t)(NVIC->IP[(uint32_t)(IRQn)]           >> (8 - __NVIC_PRIO_BITS)));  } /* get priority for device specific interrupts  */
+}
+
+
+/** \brief  Encode Priority
+
+    The function encodes the priority for an interrupt with the given priority group,
+    preemptive priority value, and subpriority value.
+    In case of a conflict between priority grouping and available
+    priority bits (__NVIC_PRIO_BITS), the samllest possible priority group is set.
+
+    \param [in]     PriorityGroup  Used priority group.
+    \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+    \param [in]       SubPriority  Subpriority value (starting from 0).
+    \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & 0x07);          /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7 - PriorityGroupTmp) > __NVIC_PRIO_BITS) ? __NVIC_PRIO_BITS : 7 - PriorityGroupTmp;
+  SubPriorityBits     = ((PriorityGroupTmp + __NVIC_PRIO_BITS) < 7) ? 0 : PriorityGroupTmp - 7 + __NVIC_PRIO_BITS;
+
+  return (
+           ((PreemptPriority & ((1 << (PreemptPriorityBits)) - 1)) << SubPriorityBits) |
+           ((SubPriority     & ((1 << (SubPriorityBits    )) - 1)))
+         );
+}
+
+
+/** \brief  Decode Priority
+
+    The function decodes an interrupt priority value with a given priority group to
+    preemptive priority value and subpriority value.
+    In case of a conflict between priority grouping and available
+    priority bits (__NVIC_PRIO_BITS) the samllest possible priority group is set.
+
+    \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+    \param [in]     PriorityGroup  Used priority group.
+    \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+    \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* pPreemptPriority, uint32_t* pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & 0x07);          /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7 - PriorityGroupTmp) > __NVIC_PRIO_BITS) ? __NVIC_PRIO_BITS : 7 - PriorityGroupTmp;
+  SubPriorityBits     = ((PriorityGroupTmp + __NVIC_PRIO_BITS) < 7) ? 0 : PriorityGroupTmp - 7 + __NVIC_PRIO_BITS;
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & ((1 << (PreemptPriorityBits)) - 1);
+  *pSubPriority     = (Priority                   ) & ((1 << (SubPriorityBits    )) - 1);
+}
+
+
+/** \brief  System Reset
+
+    The function initiates a system reset request to reset the MCU.
+ */
+__STATIC_INLINE void NVIC_SystemReset(void)
+{
+  __DSB();                                                     /* Ensure all outstanding memory accesses included
+                                                                  buffered write are completed before reset */
+  SCB->AIRCR  = ((0x5FA << SCB_AIRCR_VECTKEY_Pos)      |
+                 (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                 SCB_AIRCR_SYSRESETREQ_Msk);                   /* Keep priority group unchanged */
+  __DSB();                                                     /* Ensure completion of memory access */
+  while(1);                                                    /* wait until reset */
+}
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+    \brief      Functions that configure the System.
+  @{
+ */
+
+#if (__Vendor_SysTickConfig == 0)
+
+/** \brief  System Tick Configuration
+
+    The function initializes the System Timer and its interrupt, and starts the System Tick Timer.
+    Counter is in free running mode to generate periodic interrupts.
+
+    \param [in]  ticks  Number of ticks between two interrupts.
+
+    \return          0  Function succeeded.
+    \return          1  Function failed.
+
+    \note     When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+    function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+    must contain a vendor-specific implementation of this function.
+
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1) > SysTick_LOAD_RELOAD_Msk)  return (1);      /* Reload value impossible */
+
+  SysTick->LOAD  = ticks - 1;                                  /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1<<__NVIC_PRIO_BITS) - 1);  /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0;                                          /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                    /* Enable SysTick IRQ and SysTick Timer */
+  return (0);                                                  /* Function successful */
+}
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+/* ##################################### Debug In/Output function ########################################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_core_DebugFunctions ITM Functions
+    \brief   Functions that access the ITM debug interface.
+  @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                    /*!< External variable to receive characters.                         */
+#define                 ITM_RXBUFFER_EMPTY    0x5AA55AA5 /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
+
+
+/** \brief  ITM Send Character
+
+    The function transmits a character via the ITM channel 0, and
+    \li Just returns when no debugger is connected that has booked the output.
+    \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+
+    \param [in]     ch  Character to transmit.
+
+    \returns            Character to transmit.
+ */
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if ((ITM->TCR & ITM_TCR_ITMENA_Msk)                  &&      /* ITM enabled */
+      (ITM->TER & (1UL << 0)        )                    )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0].u32 == 0);
+    ITM->PORT[0].u8 = (uint8_t) ch;
+  }
+  return (ch);
+}
+
+
+/** \brief  ITM Receive Character
+
+    The function inputs a character via the external variable \ref ITM_RxBuffer.
+
+    \return             Received character.
+    \return         -1  No character pending.
+ */
+__STATIC_INLINE int32_t ITM_ReceiveChar (void) {
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY) {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/** \brief  ITM Check Character
+
+    The function checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+
+    \return          0  No character available.
+    \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void) {
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY) {
+    return (0);                                 /* no character available */
+  } else {
+    return (1);                                 /*    character available */
+  }
+}
+
+/*@} end of CMSIS_core_DebugFunctions */
+
+#endif /* __CORE_CM4_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */
+
+#ifdef __cplusplus
+}
+#endif

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/core_cm4_simd.h
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/core_cm4_simd.h
@@ -1,0 +1,673 @@
+/**************************************************************************//**
+ * @file     core_cm4_simd.h
+ * @brief    CMSIS Cortex-M4 SIMD Header File
+ * @version  V3.20
+ * @date     25. February 2013
+ *
+ * @note
+ *
+ ******************************************************************************/
+/* Copyright (c) 2009 - 2013 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#ifndef __CORE_CM4_SIMD_H
+#define __CORE_CM4_SIMD_H
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+ ******************************************************************************/
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+/** \defgroup CMSIS_SIMD_intrinsics CMSIS SIMD Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
+
+#if   defined ( __CC_ARM ) /*------------------RealView Compiler -----------------*/
+/* ARM armcc specific functions */
+
+/*------ CM4 SIMD Intrinsics -----------------------------------------------------*/
+#define __SADD8                           __sadd8
+#define __QADD8                           __qadd8
+#define __SHADD8                          __shadd8
+#define __UADD8                           __uadd8
+#define __UQADD8                          __uqadd8
+#define __UHADD8                          __uhadd8
+#define __SSUB8                           __ssub8
+#define __QSUB8                           __qsub8
+#define __SHSUB8                          __shsub8
+#define __USUB8                           __usub8
+#define __UQSUB8                          __uqsub8
+#define __UHSUB8                          __uhsub8
+#define __SADD16                          __sadd16
+#define __QADD16                          __qadd16
+#define __SHADD16                         __shadd16
+#define __UADD16                          __uadd16
+#define __UQADD16                         __uqadd16
+#define __UHADD16                         __uhadd16
+#define __SSUB16                          __ssub16
+#define __QSUB16                          __qsub16
+#define __SHSUB16                         __shsub16
+#define __USUB16                          __usub16
+#define __UQSUB16                         __uqsub16
+#define __UHSUB16                         __uhsub16
+#define __SASX                            __sasx
+#define __QASX                            __qasx
+#define __SHASX                           __shasx
+#define __UASX                            __uasx
+#define __UQASX                           __uqasx
+#define __UHASX                           __uhasx
+#define __SSAX                            __ssax
+#define __QSAX                            __qsax
+#define __SHSAX                           __shsax
+#define __USAX                            __usax
+#define __UQSAX                           __uqsax
+#define __UHSAX                           __uhsax
+#define __USAD8                           __usad8
+#define __USADA8                          __usada8
+#define __SSAT16                          __ssat16
+#define __USAT16                          __usat16
+#define __UXTB16                          __uxtb16
+#define __UXTAB16                         __uxtab16
+#define __SXTB16                          __sxtb16
+#define __SXTAB16                         __sxtab16
+#define __SMUAD                           __smuad
+#define __SMUADX                          __smuadx
+#define __SMLAD                           __smlad
+#define __SMLADX                          __smladx
+#define __SMLALD                          __smlald
+#define __SMLALDX                         __smlaldx
+#define __SMUSD                           __smusd
+#define __SMUSDX                          __smusdx
+#define __SMLSD                           __smlsd
+#define __SMLSDX                          __smlsdx
+#define __SMLSLD                          __smlsld
+#define __SMLSLDX                         __smlsldx
+#define __SEL                             __sel
+#define __QADD                            __qadd
+#define __QSUB                            __qsub
+
+#define __PKHBT(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0x0000FFFFUL) |  \
+                                           ((((uint32_t)(ARG2)) << (ARG3)) & 0xFFFF0000UL)  )
+
+#define __PKHTB(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0xFFFF0000UL) |  \
+                                           ((((uint32_t)(ARG2)) >> (ARG3)) & 0x0000FFFFUL)  )
+
+#define __SMMLA(ARG1,ARG2,ARG3)          ( (int32_t)((((int64_t)(ARG1) * (ARG2)) + \
+                                                      ((int64_t)(ARG3) << 32)      ) >> 32))
+
+/*-- End CM4 SIMD Intrinsics -----------------------------------------------------*/
+
+
+
+#elif defined ( __ICCARM__ ) /*------------------ ICC Compiler -------------------*/
+/* IAR iccarm specific functions */
+
+/*------ CM4 SIMD Intrinsics -----------------------------------------------------*/
+#include <cmsis_iar.h>
+
+/*-- End CM4 SIMD Intrinsics -----------------------------------------------------*/
+
+
+
+#elif defined ( __TMS470__ ) /*---------------- TI CCS Compiler ------------------*/
+/* TI CCS specific functions */
+
+/*------ CM4 SIMD Intrinsics -----------------------------------------------------*/
+#include <cmsis_ccs.h>
+
+/*-- End CM4 SIMD Intrinsics -----------------------------------------------------*/
+
+
+
+#elif defined ( __GNUC__ ) /*------------------ GNU Compiler ---------------------*/
+/* GNU gcc specific functions */
+
+/*------ CM4 SIMD Intrinsics -----------------------------------------------------*/
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SHSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UQSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UHSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USAD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usad8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __USADA8(uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("usada8 %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+#define __SSAT16(ARG1,ARG2) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("ssat16 %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+#define __USAT16(ARG1,ARG2) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("usat16 %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UXTB16(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("uxtb16 %0, %1" : "=r" (result) : "r" (op1));
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __UXTAB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uxtab16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SXTB16(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtb16 %0, %1" : "=r" (result) : "r" (op1));
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SXTAB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtab16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMUAD  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smuad %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMUADX (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smuadx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMLAD (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlad %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMLADX (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smladx %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+#define __SMLALD(ARG1,ARG2,ARG3) \
+({ \
+  uint32_t __ARG1 = (ARG1), __ARG2 = (ARG2), __ARG3_H = (uint32_t)((uint64_t)(ARG3) >> 32), __ARG3_L = (uint32_t)((uint64_t)(ARG3) & 0xFFFFFFFFUL); \
+  __ASM volatile ("smlald %0, %1, %2, %3" : "=r" (__ARG3_L), "=r" (__ARG3_H) : "r" (__ARG1), "r" (__ARG2), "0" (__ARG3_L), "1" (__ARG3_H) ); \
+  (uint64_t)(((uint64_t)__ARG3_H << 32) | __ARG3_L); \
+ })
+
+#define __SMLALDX(ARG1,ARG2,ARG3) \
+({ \
+  uint32_t __ARG1 = (ARG1), __ARG2 = (ARG2), __ARG3_H = (uint32_t)((uint64_t)(ARG3) >> 32), __ARG3_L = (uint32_t)((uint64_t)(ARG3) & 0xFFFFFFFFUL); \
+  __ASM volatile ("smlaldx %0, %1, %2, %3" : "=r" (__ARG3_L), "=r" (__ARG3_H) : "r" (__ARG1), "r" (__ARG2), "0" (__ARG3_L), "1" (__ARG3_H) ); \
+  (uint64_t)(((uint64_t)__ARG3_H << 32) | __ARG3_L); \
+ })
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMUSD  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smusd %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMUSDX (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smusdx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMLSD (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlsd %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMLSDX (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlsdx %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+#define __SMLSLD(ARG1,ARG2,ARG3) \
+({ \
+  uint32_t __ARG1 = (ARG1), __ARG2 = (ARG2), __ARG3_H = (uint32_t)((ARG3) >> 32), __ARG3_L = (uint32_t)((ARG3) & 0xFFFFFFFFUL); \
+  __ASM volatile ("smlsld %0, %1, %2, %3" : "=r" (__ARG3_L), "=r" (__ARG3_H) : "r" (__ARG1), "r" (__ARG2), "0" (__ARG3_L), "1" (__ARG3_H) ); \
+  (uint64_t)(((uint64_t)__ARG3_H << 32) | __ARG3_L); \
+ })
+
+#define __SMLSLDX(ARG1,ARG2,ARG3) \
+({ \
+  uint32_t __ARG1 = (ARG1), __ARG2 = (ARG2), __ARG3_H = (uint32_t)((ARG3) >> 32), __ARG3_L = (uint32_t)((ARG3) & 0xFFFFFFFFUL); \
+  __ASM volatile ("smlsldx %0, %1, %2, %3" : "=r" (__ARG3_L), "=r" (__ARG3_H) : "r" (__ARG1), "r" (__ARG2), "0" (__ARG3_L), "1" (__ARG3_H) ); \
+  (uint64_t)(((uint64_t)__ARG3_H << 32) | __ARG3_L); \
+ })
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SEL  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sel %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QADD(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qadd %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __QSUB(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsub %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+#define __PKHBT(ARG1,ARG2,ARG3) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  __ASM ("pkhbt %0, %1, %2, lsl %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+#define __PKHTB(ARG1,ARG2,ARG3) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  if (ARG3 == 0) \
+    __ASM ("pkhtb %0, %1, %2" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2)  ); \
+  else \
+    __ASM ("pkhtb %0, %1, %2, asr %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
+{
+ int32_t result;
+
+ __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
+ return(result);
+}
+
+/*-- End CM4 SIMD Intrinsics -----------------------------------------------------*/
+
+
+
+#elif defined ( __TASKING__ ) /*------------------ TASKING Compiler --------------*/
+/* TASKING carm specific functions */
+
+
+/*------ CM4 SIMD Intrinsics -----------------------------------------------------*/
+/* not yet supported */
+/*-- End CM4 SIMD Intrinsics -----------------------------------------------------*/
+
+
+#endif
+
+/*@} end of group CMSIS_SIMD_intrinsics */
+
+
+#endif /* __CORE_CM4_SIMD_H */
+
+#ifdef __cplusplus
+}
+#endif

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/core_cmFunc.h
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/core_cmFunc.h
@@ -1,0 +1,636 @@
+/**************************************************************************//**
+ * @file     core_cmFunc.h
+ * @brief    CMSIS Cortex-M Core Function Access Header File
+ * @version  V3.20
+ * @date     25. February 2013
+ *
+ * @note
+ *
+ ******************************************************************************/
+/* Copyright (c) 2009 - 2013 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#ifndef __CORE_CMFUNC_H
+#define __CORE_CMFUNC_H
+
+
+/* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+  @{
+ */
+
+#if   defined ( __CC_ARM ) /*------------------RealView Compiler -----------------*/
+/* ARM armcc specific functions */
+
+#if (__ARMCC_VERSION < 400677)
+  #error "Please use ARM Compiler Toolchain V4.0.677 or later!"
+#endif
+
+/* intrinsic void __enable_irq();     */
+/* intrinsic void __disable_irq();    */
+
+/** \brief  Get Control Register
+
+    This function returns the content of the Control Register.
+
+    \return               Control Register value
+ */
+__STATIC_INLINE uint32_t __get_CONTROL(void)
+{
+  register uint32_t __regControl         __ASM("control");
+  return(__regControl);
+}
+
+
+/** \brief  Set Control Register
+
+    This function writes the given value to the Control Register.
+
+    \param [in]    control  Control Register value to set
+ */
+__STATIC_INLINE void __set_CONTROL(uint32_t control)
+{
+  register uint32_t __regControl         __ASM("control");
+  __regControl = control;
+}
+
+
+/** \brief  Get IPSR Register
+
+    This function returns the content of the IPSR Register.
+
+    \return               IPSR Register value
+ */
+__STATIC_INLINE uint32_t __get_IPSR(void)
+{
+  register uint32_t __regIPSR          __ASM("ipsr");
+  return(__regIPSR);
+}
+
+
+/** \brief  Get APSR Register
+
+    This function returns the content of the APSR Register.
+
+    \return               APSR Register value
+ */
+__STATIC_INLINE uint32_t __get_APSR(void)
+{
+  register uint32_t __regAPSR          __ASM("apsr");
+  return(__regAPSR);
+}
+
+
+/** \brief  Get xPSR Register
+
+    This function returns the content of the xPSR Register.
+
+    \return               xPSR Register value
+ */
+__STATIC_INLINE uint32_t __get_xPSR(void)
+{
+  register uint32_t __regXPSR          __ASM("xpsr");
+  return(__regXPSR);
+}
+
+
+/** \brief  Get Process Stack Pointer
+
+    This function returns the current value of the Process Stack Pointer (PSP).
+
+    \return               PSP Register value
+ */
+__STATIC_INLINE uint32_t __get_PSP(void)
+{
+  register uint32_t __regProcessStackPointer  __ASM("psp");
+  return(__regProcessStackPointer);
+}
+
+
+/** \brief  Set Process Stack Pointer
+
+    This function assigns the given value to the Process Stack Pointer (PSP).
+
+    \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__STATIC_INLINE void __set_PSP(uint32_t topOfProcStack)
+{
+  register uint32_t __regProcessStackPointer  __ASM("psp");
+  __regProcessStackPointer = topOfProcStack;
+}
+
+
+/** \brief  Get Main Stack Pointer
+
+    This function returns the current value of the Main Stack Pointer (MSP).
+
+    \return               MSP Register value
+ */
+__STATIC_INLINE uint32_t __get_MSP(void)
+{
+  register uint32_t __regMainStackPointer     __ASM("msp");
+  return(__regMainStackPointer);
+}
+
+
+/** \brief  Set Main Stack Pointer
+
+    This function assigns the given value to the Main Stack Pointer (MSP).
+
+    \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__STATIC_INLINE void __set_MSP(uint32_t topOfMainStack)
+{
+  register uint32_t __regMainStackPointer     __ASM("msp");
+  __regMainStackPointer = topOfMainStack;
+}
+
+
+/** \brief  Get Priority Mask
+
+    This function returns the current state of the priority mask bit from the Priority Mask Register.
+
+    \return               Priority Mask value
+ */
+__STATIC_INLINE uint32_t __get_PRIMASK(void)
+{
+  register uint32_t __regPriMask         __ASM("primask");
+  return(__regPriMask);
+}
+
+
+/** \brief  Set Priority Mask
+
+    This function assigns the given value to the Priority Mask Register.
+
+    \param [in]    priMask  Priority Mask
+ */
+__STATIC_INLINE void __set_PRIMASK(uint32_t priMask)
+{
+  register uint32_t __regPriMask         __ASM("primask");
+  __regPriMask = (priMask);
+}
+
+
+#if       (__CORTEX_M >= 0x03)
+
+/** \brief  Enable FIQ
+
+    This function enables FIQ interrupts by clearing the F-bit in the CPSR.
+    Can only be executed in Privileged modes.
+ */
+#define __enable_fault_irq                __enable_fiq
+
+
+/** \brief  Disable FIQ
+
+    This function disables FIQ interrupts by setting the F-bit in the CPSR.
+    Can only be executed in Privileged modes.
+ */
+#define __disable_fault_irq               __disable_fiq
+
+
+/** \brief  Get Base Priority
+
+    This function returns the current value of the Base Priority register.
+
+    \return               Base Priority register value
+ */
+__STATIC_INLINE uint32_t  __get_BASEPRI(void)
+{
+  register uint32_t __regBasePri         __ASM("basepri");
+  return(__regBasePri);
+}
+
+
+/** \brief  Set Base Priority
+
+    This function assigns the given value to the Base Priority register.
+
+    \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_INLINE void __set_BASEPRI(uint32_t basePri)
+{
+  register uint32_t __regBasePri         __ASM("basepri");
+  __regBasePri = (basePri & 0xff);
+}
+
+
+/** \brief  Get Fault Mask
+
+    This function returns the current value of the Fault Mask register.
+
+    \return               Fault Mask register value
+ */
+__STATIC_INLINE uint32_t __get_FAULTMASK(void)
+{
+  register uint32_t __regFaultMask       __ASM("faultmask");
+  return(__regFaultMask);
+}
+
+
+/** \brief  Set Fault Mask
+
+    This function assigns the given value to the Fault Mask register.
+
+    \param [in]    faultMask  Fault Mask value to set
+ */
+__STATIC_INLINE void __set_FAULTMASK(uint32_t faultMask)
+{
+  register uint32_t __regFaultMask       __ASM("faultmask");
+  __regFaultMask = (faultMask & (uint32_t)1);
+}
+
+#endif /* (__CORTEX_M >= 0x03) */
+
+
+#if       (__CORTEX_M == 0x04)
+
+/** \brief  Get FPSCR
+
+    This function returns the current value of the Floating Point Status/Control register.
+
+    \return               Floating Point Status/Control register value
+ */
+__STATIC_INLINE uint32_t __get_FPSCR(void)
+{
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+  register uint32_t __regfpscr         __ASM("fpscr");
+  return(__regfpscr);
+#else
+   return(0);
+#endif
+}
+
+
+/** \brief  Set FPSCR
+
+    This function assigns the given value to the Floating Point Status/Control register.
+
+    \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+  register uint32_t __regfpscr         __ASM("fpscr");
+  __regfpscr = (fpscr);
+#endif
+}
+
+#endif /* (__CORTEX_M == 0x04) */
+
+
+#elif defined ( __ICCARM__ ) /*------------------ ICC Compiler -------------------*/
+/* IAR iccarm specific functions */
+
+#include <cmsis_iar.h>
+
+
+#elif defined ( __TMS470__ ) /*---------------- TI CCS Compiler ------------------*/
+/* TI CCS specific functions */
+
+#include <cmsis_ccs.h>
+
+
+#elif defined ( __GNUC__ ) /*------------------ GNU Compiler ---------------------*/
+/* GNU gcc specific functions */
+
+/** \brief  Enable IRQ Interrupts
+
+  This function enables IRQ interrupts by clearing the I-bit in the CPSR.
+  Can only be executed in Privileged modes.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __enable_irq(void)
+{
+  __ASM volatile ("cpsie i" : : : "memory");
+}
+
+
+/** \brief  Disable IRQ Interrupts
+
+  This function disables IRQ interrupts by setting the I-bit in the CPSR.
+  Can only be executed in Privileged modes.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __disable_irq(void)
+{
+  __ASM volatile ("cpsid i" : : : "memory");
+}
+
+
+/** \brief  Get Control Register
+
+    This function returns the content of the Control Register.
+
+    \return               Control Register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_CONTROL(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Set Control Register
+
+    This function writes the given value to the Control Register.
+
+    \param [in]    control  Control Register value to set
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __set_CONTROL(uint32_t control)
+{
+  __ASM volatile ("MSR control, %0" : : "r" (control) : "memory");
+}
+
+
+/** \brief  Get IPSR Register
+
+    This function returns the content of the IPSR Register.
+
+    \return               IPSR Register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_IPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Get APSR Register
+
+    This function returns the content of the APSR Register.
+
+    \return               APSR Register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_APSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Get xPSR Register
+
+    This function returns the content of the xPSR Register.
+
+    \return               xPSR Register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_xPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Get Process Stack Pointer
+
+    This function returns the current value of the Process Stack Pointer (PSP).
+
+    \return               PSP Register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PSP(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, psp\n"  : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Set Process Stack Pointer
+
+    This function assigns the given value to the Process Stack Pointer (PSP).
+
+    \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __set_PSP(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp, %0\n" : : "r" (topOfProcStack) : "sp");
+}
+
+
+/** \brief  Get Main Stack Pointer
+
+    This function returns the current value of the Main Stack Pointer (MSP).
+
+    \return               MSP Register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_MSP(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, msp\n" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Set Main Stack Pointer
+
+    This function assigns the given value to the Main Stack Pointer (MSP).
+
+    \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __set_MSP(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp, %0\n" : : "r" (topOfMainStack) : "sp");
+}
+
+
+/** \brief  Get Priority Mask
+
+    This function returns the current state of the priority mask bit from the Priority Mask Register.
+
+    \return               Priority Mask value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PRIMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Set Priority Mask
+
+    This function assigns the given value to the Priority Mask Register.
+
+    \param [in]    priMask  Priority Mask
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __set_PRIMASK(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
+}
+
+
+#if       (__CORTEX_M >= 0x03)
+
+/** \brief  Enable FIQ
+
+    This function enables FIQ interrupts by clearing the F-bit in the CPSR.
+    Can only be executed in Privileged modes.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
+
+
+/** \brief  Disable FIQ
+
+    This function disables FIQ interrupts by setting the F-bit in the CPSR.
+    Can only be executed in Privileged modes.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
+
+
+/** \brief  Get Base Priority
+
+    This function returns the current value of the Base Priority register.
+
+    \return               Base Priority register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_BASEPRI(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri_max" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Set Base Priority
+
+    This function assigns the given value to the Base Priority register.
+
+    \param [in]    basePri  Base Priority value to set
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __set_BASEPRI(uint32_t value)
+{
+  __ASM volatile ("MSR basepri, %0" : : "r" (value) : "memory");
+}
+
+
+/** \brief  Get Fault Mask
+
+    This function returns the current value of the Fault Mask register.
+
+    \return               Fault Mask register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_FAULTMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask" : "=r" (result) );
+  return(result);
+}
+
+
+/** \brief  Set Fault Mask
+
+    This function assigns the given value to the Fault Mask register.
+
+    \param [in]    faultMask  Fault Mask value to set
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __set_FAULTMASK(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask, %0" : : "r" (faultMask) : "memory");
+}
+
+#endif /* (__CORTEX_M >= 0x03) */
+
+
+#if       (__CORTEX_M == 0x04)
+
+/** \brief  Get FPSCR
+
+    This function returns the current value of the Floating Point Status/Control register.
+
+    \return               Floating Point Status/Control register value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_FPSCR(void)
+{
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+  uint32_t result;
+
+  /* Empty asm statement works as a scheduling barrier */
+  __ASM volatile ("");
+  __ASM volatile ("VMRS %0, fpscr" : "=r" (result) );
+  __ASM volatile ("");
+  return(result);
+#else
+   return(0);
+#endif
+}
+
+
+/** \brief  Set FPSCR
+
+    This function assigns the given value to the Floating Point Status/Control register.
+
+    \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+  /* Empty asm statement works as a scheduling barrier */
+  __ASM volatile ("");
+  __ASM volatile ("VMSR fpscr, %0" : : "r" (fpscr) : "vfpcc");
+  __ASM volatile ("");
+#endif
+}
+
+#endif /* (__CORTEX_M == 0x04) */
+
+
+#elif defined ( __TASKING__ ) /*------------------ TASKING Compiler --------------*/
+/* TASKING carm specific functions */
+
+/*
+ * The CMSIS functions have been implemented as intrinsics in the compiler.
+ * Please use "carm -?i" to get an up to date list of all instrinsics,
+ * Including the CMSIS ones.
+ */
+
+#endif
+
+/*@} end of CMSIS_Core_RegAccFunctions */
+
+
+#endif /* __CORE_CMFUNC_H */

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/core_cmInstr.h
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/core_cmInstr.h
@@ -1,0 +1,688 @@
+/**************************************************************************//**
+ * @file     core_cmInstr.h
+ * @brief    CMSIS Cortex-M Core Instruction Access Header File
+ * @version  V3.20
+ * @date     05. March 2013
+ *
+ * @note
+ *
+ ******************************************************************************/
+/* Copyright (c) 2009 - 2013 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#ifndef __CORE_CMINSTR_H
+#define __CORE_CMINSTR_H
+
+
+/* ##########################  Core Instruction Access  ######################### */
+/** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
+  Access to dedicated instructions
+  @{
+*/
+
+#if   defined ( __CC_ARM ) /*------------------RealView Compiler -----------------*/
+/* ARM armcc specific functions */
+
+#if (__ARMCC_VERSION < 400677)
+  #error "Please use ARM Compiler Toolchain V4.0.677 or later!"
+#endif
+
+
+/** \brief  No Operation
+
+    No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+#define __NOP                             __nop
+
+
+/** \brief  Wait For Interrupt
+
+    Wait For Interrupt is a hint instruction that suspends execution
+    until one of a number of events occurs.
+ */
+#define __WFI                             __wfi
+
+
+/** \brief  Wait For Event
+
+    Wait For Event is a hint instruction that permits the processor to enter
+    a low-power state until one of a number of events occurs.
+ */
+#define __WFE                             __wfe
+
+
+/** \brief  Send Event
+
+    Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+#define __SEV                             __sev
+
+
+/** \brief  Instruction Synchronization Barrier
+
+    Instruction Synchronization Barrier flushes the pipeline in the processor,
+    so that all instructions following the ISB are fetched from cache or
+    memory, after the instruction has been completed.
+ */
+#define __ISB()                           __isb(0xF)
+
+
+/** \brief  Data Synchronization Barrier
+
+    This function acts as a special kind of Data Memory Barrier.
+    It completes when all explicit memory accesses before this instruction complete.
+ */
+#define __DSB()                           __dsb(0xF)
+
+
+/** \brief  Data Memory Barrier
+
+    This function ensures the apparent order of the explicit memory operations before
+    and after the instruction, without ensuring their completion.
+ */
+#define __DMB()                           __dmb(0xF)
+
+
+/** \brief  Reverse byte order (32 bit)
+
+    This function reverses the byte order in integer value.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+#define __REV                             __rev
+
+
+/** \brief  Reverse byte order (16 bit)
+
+    This function reverses the byte order in two unsigned short values.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+#ifndef __NO_EMBEDDED_ASM
+__attribute__((section(".rev16_text"))) __STATIC_INLINE __ASM uint32_t __REV16(uint32_t value)
+{
+  rev16 r0, r0
+  bx lr
+}
+#endif
+
+/** \brief  Reverse byte order in signed short value
+
+    This function reverses the byte order in a signed short value with sign extension to integer.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+#ifndef __NO_EMBEDDED_ASM
+__attribute__((section(".revsh_text"))) __STATIC_INLINE __ASM int32_t __REVSH(int32_t value)
+{
+  revsh r0, r0
+  bx lr
+}
+#endif
+
+
+/** \brief  Rotate Right in unsigned value (32 bit)
+
+    This function Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+
+    \param [in]    value  Value to rotate
+    \param [in]    value  Number of Bits to rotate
+    \return               Rotated value
+ */
+#define __ROR                             __ror
+
+
+/** \brief  Breakpoint
+
+    This function causes the processor to enter Debug state.
+    Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+
+    \param [in]    value  is ignored by the processor.
+                   If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value)                       __breakpoint(value)
+
+
+#if       (__CORTEX_M >= 0x03)
+
+/** \brief  Reverse bit order of value
+
+    This function reverses the bit order of the given value.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+#define __RBIT                            __rbit
+
+
+/** \brief  LDR Exclusive (8 bit)
+
+    This function performs a exclusive LDR command for 8 bit value.
+
+    \param [in]    ptr  Pointer to data
+    \return             value of type uint8_t at (*ptr)
+ */
+#define __LDREXB(ptr)                     ((uint8_t ) __ldrex(ptr))
+
+
+/** \brief  LDR Exclusive (16 bit)
+
+    This function performs a exclusive LDR command for 16 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint16_t at (*ptr)
+ */
+#define __LDREXH(ptr)                     ((uint16_t) __ldrex(ptr))
+
+
+/** \brief  LDR Exclusive (32 bit)
+
+    This function performs a exclusive LDR command for 32 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint32_t at (*ptr)
+ */
+#define __LDREXW(ptr)                     ((uint32_t ) __ldrex(ptr))
+
+
+/** \brief  STR Exclusive (8 bit)
+
+    This function performs a exclusive STR command for 8 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+#define __STREXB(value, ptr)              __strex(value, ptr)
+
+
+/** \brief  STR Exclusive (16 bit)
+
+    This function performs a exclusive STR command for 16 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+#define __STREXH(value, ptr)              __strex(value, ptr)
+
+
+/** \brief  STR Exclusive (32 bit)
+
+    This function performs a exclusive STR command for 32 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+#define __STREXW(value, ptr)              __strex(value, ptr)
+
+
+/** \brief  Remove the exclusive lock
+
+    This function removes the exclusive lock which is created by LDREX.
+
+ */
+#define __CLREX                           __clrex
+
+
+/** \brief  Signed Saturate
+
+    This function saturates a signed value.
+
+    \param [in]  value  Value to be saturated
+    \param [in]    sat  Bit position to saturate to (1..32)
+    \return             Saturated value
+ */
+#define __SSAT                            __ssat
+
+
+/** \brief  Unsigned Saturate
+
+    This function saturates an unsigned value.
+
+    \param [in]  value  Value to be saturated
+    \param [in]    sat  Bit position to saturate to (0..31)
+    \return             Saturated value
+ */
+#define __USAT                            __usat
+
+
+/** \brief  Count leading zeros
+
+    This function counts the number of leading zeros of a data value.
+
+    \param [in]  value  Value to count the leading zeros
+    \return             number of leading zeros in value
+ */
+#define __CLZ                             __clz
+
+#endif /* (__CORTEX_M >= 0x03) */
+
+
+
+#elif defined ( __ICCARM__ ) /*------------------ ICC Compiler -------------------*/
+/* IAR iccarm specific functions */
+
+#include <cmsis_iar.h>
+
+
+#elif defined ( __TMS470__ ) /*---------------- TI CCS Compiler ------------------*/
+/* TI CCS specific functions */
+
+#include <cmsis_ccs.h>
+
+
+#elif defined ( __GNUC__ ) /*------------------ GNU Compiler ---------------------*/
+/* GNU gcc specific functions */
+
+/* Define macros for porting to both thumb1 and thumb2.
+ * For thumb1, use low register (r0-r7), specified by constrant "l"
+ * Otherwise, use general registers, specified by constrant "r" */
+#if defined (__thumb__) && !defined (__thumb2__)
+#define __CMSIS_GCC_OUT_REG(r) "=l" (r)
+#define __CMSIS_GCC_USE_REG(r) "l" (r)
+#else
+#define __CMSIS_GCC_OUT_REG(r) "=r" (r)
+#define __CMSIS_GCC_USE_REG(r) "r" (r)
+#endif
+
+/** \brief  No Operation
+
+    No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __NOP(void)
+{
+  __ASM volatile ("nop");
+}
+
+
+/** \brief  Wait For Interrupt
+
+    Wait For Interrupt is a hint instruction that suspends execution
+    until one of a number of events occurs.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __WFI(void)
+{
+  __ASM volatile ("wfi");
+}
+
+
+/** \brief  Wait For Event
+
+    Wait For Event is a hint instruction that permits the processor to enter
+    a low-power state until one of a number of events occurs.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __WFE(void)
+{
+  __ASM volatile ("wfe");
+}
+
+
+/** \brief  Send Event
+
+    Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __SEV(void)
+{
+  __ASM volatile ("sev");
+}
+
+
+/** \brief  Instruction Synchronization Barrier
+
+    Instruction Synchronization Barrier flushes the pipeline in the processor,
+    so that all instructions following the ISB are fetched from cache or
+    memory, after the instruction has been completed.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __ISB(void)
+{
+  __ASM volatile ("isb");
+}
+
+
+/** \brief  Data Synchronization Barrier
+
+    This function acts as a special kind of Data Memory Barrier.
+    It completes when all explicit memory accesses before this instruction complete.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __DSB(void)
+{
+  __ASM volatile ("dsb");
+}
+
+
+/** \brief  Data Memory Barrier
+
+    This function ensures the apparent order of the explicit memory operations before
+    and after the instruction, without ensuring their completion.
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __DMB(void)
+{
+  __ASM volatile ("dmb");
+}
+
+
+/** \brief  Reverse byte order (32 bit)
+
+    This function reverses the byte order in integer value.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __REV(uint32_t value)
+{
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
+  return __builtin_bswap32(value);
+#else
+  uint32_t result;
+
+  __ASM volatile ("rev %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return(result);
+#endif
+}
+
+
+/** \brief  Reverse byte order (16 bit)
+
+    This function reverses the byte order in two unsigned short values.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __REV16(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rev16 %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return(result);
+}
+
+
+/** \brief  Reverse byte order in signed short value
+
+    This function reverses the byte order in a signed short value with sign extension to integer.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE int32_t __REVSH(int32_t value)
+{
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+  return (short)__builtin_bswap16(value);
+#else
+  uint32_t result;
+
+  __ASM volatile ("revsh %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return(result);
+#endif
+}
+
+
+/** \brief  Rotate Right in unsigned value (32 bit)
+
+    This function Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+
+    \param [in]    value  Value to rotate
+    \param [in]    value  Number of Bits to rotate
+    \return               Rotated value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
+{
+  return (op1 >> op2) | (op1 << (32 - op2)); 
+}
+
+
+/** \brief  Breakpoint
+
+    This function causes the processor to enter Debug state.
+    Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+
+    \param [in]    value  is ignored by the processor.
+                   If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value)                       __ASM volatile ("bkpt "#value)
+
+
+#if       (__CORTEX_M >= 0x03)
+
+/** \brief  Reverse bit order of value
+
+    This function reverses the bit order of the given value.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __RBIT(uint32_t value)
+{
+  uint32_t result;
+
+   __ASM volatile ("rbit %0, %1" : "=r" (result) : "r" (value) );
+   return(result);
+}
+
+
+/** \brief  LDR Exclusive (8 bit)
+
+    This function performs a exclusive LDR command for 8 bit value.
+
+    \param [in]    ptr  Pointer to data
+    \return             value of type uint8_t at (*ptr)
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint8_t __LDREXB(volatile uint8_t *addr)
+{
+    uint32_t result;
+
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+   __ASM volatile ("ldrexb %0, %1" : "=r" (result) : "Q" (*addr) );
+#else
+    /* Prior to GCC 4.8, "Q" will be expanded to [rx, #0] which is not
+       accepted by assembler. So has to use following less efficient pattern.
+    */
+   __ASM volatile ("ldrexb %0, [%1]" : "=r" (result) : "r" (addr) : "memory" );
+#endif
+   return(result);
+}
+
+
+/** \brief  LDR Exclusive (16 bit)
+
+    This function performs a exclusive LDR command for 16 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint16_t at (*ptr)
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint16_t __LDREXH(volatile uint16_t *addr)
+{
+    uint32_t result;
+
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+   __ASM volatile ("ldrexh %0, %1" : "=r" (result) : "Q" (*addr) );
+#else
+    /* Prior to GCC 4.8, "Q" will be expanded to [rx, #0] which is not
+       accepted by assembler. So has to use following less efficient pattern.
+    */
+   __ASM volatile ("ldrexh %0, [%1]" : "=r" (result) : "r" (addr) : "memory" );
+#endif
+   return(result);
+}
+
+
+/** \brief  LDR Exclusive (32 bit)
+
+    This function performs a exclusive LDR command for 32 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint32_t at (*ptr)
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __LDREXW(volatile uint32_t *addr)
+{
+    uint32_t result;
+
+   __ASM volatile ("ldrex %0, %1" : "=r" (result) : "Q" (*addr) );
+   return(result);
+}
+
+
+/** \brief  STR Exclusive (8 bit)
+
+    This function performs a exclusive STR command for 8 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __STREXB(uint8_t value, volatile uint8_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strexb %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" (value) );
+   return(result);
+}
+
+
+/** \brief  STR Exclusive (16 bit)
+
+    This function performs a exclusive STR command for 16 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __STREXH(uint16_t value, volatile uint16_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strexh %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" (value) );
+   return(result);
+}
+
+
+/** \brief  STR Exclusive (32 bit)
+
+    This function performs a exclusive STR command for 32 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __STREXW(uint32_t value, volatile uint32_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strex %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" (value) );
+   return(result);
+}
+
+
+/** \brief  Remove the exclusive lock
+
+    This function removes the exclusive lock which is created by LDREX.
+
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE void __CLREX(void)
+{
+  __ASM volatile ("clrex" ::: "memory");
+}
+
+
+/** \brief  Signed Saturate
+
+    This function saturates a signed value.
+
+    \param [in]  value  Value to be saturated
+    \param [in]    sat  Bit position to saturate to (1..32)
+    \return             Saturated value
+ */
+#define __SSAT(ARG1,ARG2) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("ssat %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+
+/** \brief  Unsigned Saturate
+
+    This function saturates an unsigned value.
+
+    \param [in]  value  Value to be saturated
+    \param [in]    sat  Bit position to saturate to (0..31)
+    \return             Saturated value
+ */
+#define __USAT(ARG1,ARG2) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("usat %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+
+/** \brief  Count leading zeros
+
+    This function counts the number of leading zeros of a data value.
+
+    \param [in]  value  Value to count the leading zeros
+    \return             number of leading zeros in value
+ */
+__attribute__( ( always_inline ) ) __STATIC_INLINE uint8_t __CLZ(uint32_t value)
+{
+   uint32_t result;
+
+  __ASM volatile ("clz %0, %1" : "=r" (result) : "r" (value) );
+  return(result);
+}
+
+#endif /* (__CORTEX_M >= 0x03) */
+
+
+
+
+#elif defined ( __TASKING__ ) /*------------------ TASKING Compiler --------------*/
+/* TASKING carm specific functions */
+
+/*
+ * The CMSIS functions have been implemented as intrinsics in the compiler.
+ * Please use "carm -?i" to get an up to date list of all intrinsics,
+ * Including the CMSIS ones.
+ */
+
+#endif
+
+/*@}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+#endif /* __CORE_CMINSTR_H */

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/system_LPC43xx.c
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/system_LPC43xx.c
@@ -1,0 +1,229 @@
+/*
+ * @brief LPC43xx System Initialization
+ *
+ * @note
+ * Copyright(C) NXP Semiconductors, 2012
+ * All rights reserved.
+ *
+ * @par
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * LPC products.  This software is supplied "AS IS" without any warranties of
+ * any kind, and NXP Semiconductors and its licensor disclaim any and
+ * all warranties, express or implied, including all implied warranties of
+ * merchantability, fitness for a particular purpose and non-infringement of
+ * intellectual property rights.  NXP Semiconductors assumes no responsibility
+ * or liability for the use of the software, conveys no license or rights under any
+ * patent, copyright, mask work right, or any other intellectual property rights in
+ * or to any products. NXP Semiconductors reserves the right to make changes
+ * in the software without notification. NXP Semiconductors also makes no
+ * representation or warranty that such application will be suitable for the
+ * specified use without further testing or modification.
+ *
+ * @par
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation is hereby granted, under NXP Semiconductors' and its
+ * licensor's relevant copyrights in the software, without fee, provided that it
+ * is used in conjunction with NXP Semiconductors microcontrollers.  This
+ * copyright, permission, and disclaimer notice must appear in all copies of
+ * this code.
+ *
+ * Modified by Micromint USA <support@micromint.com>
+ */
+#include "LPC43xx.h"
+
+#define COUNT_OF(a) (sizeof(a)/sizeof(a[0]))
+
+/* Clock variables */
+//uint32_t SystemCoreClock = CRYSTAL_MAIN_FREQ_IN;		/*!< System Clock Frequency (Core Clock)*/
+uint32_t SystemCoreClock = 204000000;
+
+#if !defined(CORE_M0)
+/* SCU pin definitions for pin muxing */
+typedef struct {
+    __IO uint32_t *reg; /* SCU register address */
+    uint16_t mode;      /* SCU pin mode and function */
+} PINMUX_GRP_T;
+
+/* Local functions */
+static void SystemCoreClockUpdate(void);
+static void SystemSetupClock(void);
+static void SystemSetupPins(const PINMUX_GRP_T *mux, uint32_t n);
+static void SystemSetupMemory(void);
+static void WaitUs(uint32_t us);
+
+/* Pins to initialize before clocks are configured */
+static const PINMUX_GRP_T pre_clock_mux[] = {
+    /* SPIFI pins */
+    {SCU_REG(0x3, 3), (SCU_PINIO_FAST | 0x3)},  // P3_3 SPIFI CLK
+    {SCU_REG(0x3, 4), (SCU_PINIO_FAST | 0x3)},  // P3_4 SPIFI D3
+    {SCU_REG(0x3, 5), (SCU_PINIO_FAST | 0x3)},  // P3_5 SPIFI D2
+    {SCU_REG(0x3, 6), (SCU_PINIO_FAST | 0x3)},  // P3_6 SPIFI D1
+    {SCU_REG(0x3, 7), (SCU_PINIO_FAST | 0x3)},  // P3_7 SPIFI D0
+    {SCU_REG(0x3, 8), (SCU_PINIO_FAST | 0x3)}   // P3_8 SPIFI CS/SSEL
+};
+
+/* Pins to initialize after clocks are configured */
+static const PINMUX_GRP_T post_clock_mux[] = {
+    /* Boot pins */
+    {SCU_REG(0x1, 1), (SCU_PINIO_FAST | 0x0)},  // P1_1  BOOT0
+    {SCU_REG(0x1, 2), (SCU_PINIO_FAST | 0x0)},  // P1_2  BOOT1
+    {SCU_REG(0x2, 8), (SCU_PINIO_FAST | 0x0)},  // P2_8  BOOT2
+    {SCU_REG(0x2, 9), (SCU_PINIO_FAST | 0x0)}   // P2_9  BOOT3
+};
+#endif /* !defined(CORE_M0) */
+
+/*
+ * SystemInit() - Initialize the system
+ */
+void SystemInit(void)
+{
+#if !defined(CORE_M0)
+    unsigned int *pSCB_VTOR = (unsigned int *) 0xE000ED08;
+
+#if defined(__ARMCC_VERSION)
+    extern void *__Vectors;
+
+    *pSCB_VTOR = (unsigned int) &__Vectors;
+#elif defined(__IAR_SYSTEMS_ICC__)
+    extern void *__vector_table;
+
+    *pSCB_VTOR = (unsigned int) &__vector_table;
+#else /* defined(__GNUC__) and others */
+    extern void *g_pfnVectors;
+
+    *pSCB_VTOR = (unsigned int) &g_pfnVectors;
+#endif
+
+#if defined(__FPU_PRESENT) && __FPU_PRESENT == 1
+    /* Initialize floating point */
+    fpuInit();
+#endif
+
+    SystemSetupPins(pre_clock_mux, COUNT_OF(pre_clock_mux)); /* Configure pins */
+
+    SystemSetupClock();   /* Configure processor and peripheral clocks */
+    SystemSetupPins(post_clock_mux, COUNT_OF(post_clock_mux)); /* Configure pins */
+    SystemSetupMemory();  /* Configure external memory */
+#endif /* !defined(CORE_M0) */
+
+    SystemCoreClockUpdate(); /* Update SystemCoreClock variable */
+}
+
+/*
+ * SystemCoreClockUpdate() - Update SystemCoreClock variable
+ */
+void SystemCoreClockUpdate(void)
+{
+}
+
+#if !defined(CORE_M0)
+/*
+ * SystemSetupClock() - Set processor and peripheral clocks
+ */
+void SystemSetupClock(void)
+{
+#if (CLOCK_SETUP)
+    /* Switch main clock to Internal RC (IRC) */
+    LPC_CGU->BASE_CLK[CLK_BASE_MX] = ((1 << 11) | (CLKIN_IRC << 24));
+
+    /* Enable the oscillator and wait 100 us */
+    LPC_CGU->XTAL_OSC_CTRL = 0;
+    WaitUs(100);
+
+#if (SPIFI_INIT)
+    /* Switch IDIVA clock to IRC and connect to SPIFI clock */
+    LPC_CGU->IDIV_CTRL[CLK_IDIV_A] =  ((1 << 11) | (CLKIN_IRC << 24));
+    LPC_CGU->BASE_CLK[CLK_BASE_SPIFI] =  ((1 << 11) | (CLKIN_IDIVA << 24));
+#endif /* SPIFI_INIT */
+
+    /* Power down PLL1 */
+    LPC_CGU->PLL1_CTRL |= 1;
+
+    /* Change PLL1 to 108 Mhz (msel=9, 12 MHz*9=108 MHz) */
+//    LPC_CGU->PLL1_CTRL = (DIRECT << 7) | (PSEL << 8) | (1 << 11) | (P(NSEL-1) << 12)  | ((MSEL-1) << 16) | (CLKIN_PLL1 << 24);
+    LPC_CGU->PLL1_CTRL = (1 << 7) | (0 << 8) | (1 << 11) | (0 << 12) | (8 << 16) | (CLKIN_PLL1 << 24);
+    while (!(LPC_CGU->PLL1_STAT & 1)); /* Wait for PLL1 to lock */
+    WaitUs(100);
+
+    /* Change PLL1 to 204 Mhz (msel=17, 12 MHz*17=204 MHz) */
+    LPC_CGU->PLL1_CTRL = (1 << 7) | (0 << 8) | (1 << 11) | (0 << 12) | (16 << 16) | (CLKIN_PLL1 << 24);
+    while (!(LPC_CGU->PLL1_STAT & 1)); /* Wait for PLL1 to lock */
+
+    /* Switch main clock to PLL1 */
+    LPC_CGU->BASE_CLK[CLK_BASE_MX] = ((1 << 11) | (CLKIN_PLL1 << 24));
+    SystemCoreClock = 204000000;
+#endif /* CLOCK_SETUP */
+}
+
+/*
+ * SystemSetupPins() - Configure MCU pins
+ */
+void SystemSetupPins(const PINMUX_GRP_T *mux, uint32_t n)
+{
+    uint16_t i;
+
+    for (i = 0; i < n; i++) {
+        *(mux[i].reg) = mux[i].mode;
+    }
+}
+
+/*
+ * SystemSetupMemory() - Configure external memory
+ */
+void SystemSetupMemory(void)
+{
+#if (MEMORY_SETUP)
+    /* None required for boards without external memory */
+#endif /* MEMORY_SETUP */
+}
+
+#if defined(__FPU_PRESENT) && __FPU_PRESENT == 1
+/*
+ * fpuInit() - Early initialization of the FPU
+ */
+void fpuInit(void)
+{
+	// from ARM TRM manual:
+	//   ; CPACR is located at address 0xE000ED88
+	//   LDR.W R0, =0xE000ED88
+	//   ; Read CPACR
+	//   LDR R1, [R0]
+	//   ; Set bits 20-23 to enable CP10 and CP11 coprocessors
+	//   ORR R1, R1, #(0xF << 20)
+	//   ; Write back the modified value to the CPACR
+	//   STR R1, [R0]
+
+	volatile uint32_t *regCpacr = (uint32_t *) LPC_CPACR;
+	volatile uint32_t *regMvfr0 = (uint32_t *) SCB_MVFR0;
+	volatile uint32_t *regMvfr1 = (uint32_t *) SCB_MVFR1;
+	volatile uint32_t Cpacr;
+	volatile uint32_t Mvfr0;
+	volatile uint32_t Mvfr1;
+	char vfpPresent = 0;
+
+	Mvfr0 = *regMvfr0;
+	Mvfr1 = *regMvfr1;
+
+	vfpPresent = ((SCB_MVFR0_RESET == Mvfr0) && (SCB_MVFR1_RESET == Mvfr1));
+
+	if (vfpPresent) {
+		Cpacr = *regCpacr;
+		Cpacr |= (0xF << 20);
+		*regCpacr = Cpacr;	// enable CP10 and CP11 for full access
+	}
+
+}
+#endif /* defined(__FPU_PRESENT) && __FPU_PRESENT == 1 */
+
+/* Approximate delay function */
+#define CPU_NANOSEC(x)  (((uint64_t) (x) * SystemCoreClock) / 1000000000)
+
+static void WaitUs(uint32_t us)
+{
+    uint32_t  cyc = us * CPU_NANOSEC(1000) / 4;
+    while (cyc--)
+        ;
+}
+
+#endif /* !defined(CORE_M0) */

--- a/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/system_LPC43xx.h
+++ b/libraries/mbed/targets/cmsis/NXP/TARGET_LPC43XX/system_LPC43xx.h
@@ -1,0 +1,89 @@
+/*
+ * @brief LPC43xx/LPC18xx mcu header
+ *
+ * Copyright(C) NXP Semiconductors, 2012
+ * All rights reserved.
+ *
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * LPC products.  This software is supplied "AS IS" without any warranties of
+ * any kind, and NXP Semiconductors and its licensor disclaim any and
+ * all warranties, express or implied, including all implied warranties of
+ * merchantability, fitness for a particular purpose and non-infringement of
+ * intellectual property rights.  NXP Semiconductors assumes no responsibility
+ * or liability for the use of the software, conveys no license or rights under any
+ * patent, copyright, mask work right, or any other intellectual property rights in
+ * or to any products. NXP Semiconductors reserves the right to make changes
+ * in the software without notification. NXP Semiconductors also makes no
+ * representation or warranty that such application will be suitable for the
+ * specified use without further testing or modification.
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation is hereby granted, under NXP Semiconductors' and its
+ * licensor's relevant copyrights in the software, without fee, provided that it
+ * is used in conjunction with NXP Semiconductors microcontrollers.  This
+ * copyright, permission, and disclaimer notice must appear in all copies of
+ * this code.
+ */
+
+#ifndef __SYSTEM_LPC43XX_H
+#define __SYSTEM_LPC43XX_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* System initialization options */
+#define PIN_SETUP             1 /* Configure pins during initialization */
+#define CLOCK_SETUP           1 /* Configure clocks during initialization */
+#define MEMORY_SETUP          0 /* Configure external memory during init */
+#define SPIFI_INIT            1 /* Initialize SPIFI */
+
+/* Crystal frequency into device */
+#define CRYSTAL_MAIN_FREQ_IN 12000000
+
+/* Crystal frequency into device for RTC/32K input */
+#define CRYSTAL_32K_FREQ_IN 32768
+
+/* Default CPU clock frequency */
+#if defined(CHIP_LPC43XX)
+#define MAX_CLOCK_FREQ (204000000)
+#else
+#define MAX_CLOCK_FREQ (180000000)
+#endif
+
+#if defined(__FPU_PRESENT) && __FPU_PRESENT == 1
+  /* FPU declarations */
+  #define LPC_CPACR	          0xE000ED88
+
+  #define SCB_MVFR0           0xE000EF40
+  #define SCB_MVFR0_RESET     0x10110021
+
+  #define SCB_MVFR1           0xE000EF44
+  #define SCB_MVFR1_RESET     0x11000011
+
+  #if defined(__ARMCC_VERSION)
+    void fpuInit(void) __attribute__ ((section("BOOTSTRAP_CODE")));
+  #else
+    extern void fpuInit(void);
+  #endif
+#endif
+
+extern uint32_t SystemCoreClock;     /*!< System Clock Frequency (Core Clock)  */
+
+/**
+ * Initialize the system
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Setup the microcontroller system.
+ *         Initialize the System and update the SystemCoreClock variable.
+ */
+extern void SystemInit (void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SYSTEM_LPC43XX_H */

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/PeripheralNames.h
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/PeripheralNames.h
@@ -1,0 +1,90 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PERIPHERALNAMES_H
+#define MBED_PERIPHERALNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    UART_0 = (int)LPC_USART0_BASE,
+    UART_1 = (int)LPC_UART1_BASE,
+    UART_2 = (int)LPC_USART2_BASE,
+    UART_3 = (int)LPC_USART3_BASE
+} UARTName;
+
+typedef enum {
+    ADC0_0 = 0,
+    ADC0_1,
+    ADC0_2,
+    ADC0_3,
+    ADC0_4,
+    ADC0_5,
+    ADC0_6,
+    ADC0_7,
+    ADC1_0,
+    ADC1_1,
+    ADC1_2,
+    ADC1_3,
+    ADC1_4,
+    ADC1_5,
+    ADC1_6,
+    ADC1_7
+} ADCName;
+
+typedef enum {
+    DAC_0 = 0
+} DACName;
+
+typedef enum {
+    SPI_0 = (int)LPC_SSP0_BASE,
+    SPI_1 = (int)LPC_SSP1_BASE
+} SPIName;
+
+typedef enum {
+    I2C_0 = (int)LPC_I2C0_BASE,
+    I2C_1 = (int)LPC_I2C1_BASE
+} I2CName;
+
+typedef enum {
+    PWM0_1 = 1,
+    PWM0_2,
+    PWM0_3,
+    PWM1_1,
+    PWM1_2,
+    PWM1_3,
+    PWM2_1,
+    PWM2_2,
+    PWM2_3
+} PWMName;
+
+typedef enum {
+     CAN_0 = (int)LPC_C_CAN0_BASE,
+     CAN_1 = (int)LPC_C_CAN1_BASE
+} CANName;
+
+#define STDIO_UART_TX     UART0_TX
+#define STDIO_UART_RX     UART0_RX
+#define STDIO_UART        UART_0
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/PinNames.h
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/PinNames.h
@@ -1,0 +1,393 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+#define PORT_SHIFT  5
+#define NO_GPIO     15
+
+// On the LPC43xx the hardware pin name and the GPIO pin name are not the same.
+// Encode SCU and GPIO offsets as a pin identifier
+#define MBED_PIN(group, num, port, pin)  ((SCU_OFF(group,num) << 16) + GPIO_OFF(port,pin))
+
+// Decode pin identifier into register, port and pin values
+#define MBED_SCU_REG(MBED_PIN)   (LPC_SCU_BASE + (MBED_PIN >> 16))
+#define MBED_GPIO_REG(MBED_PIN)  (LPC_GPIO_PORT_BASE + 0x2000 + ((MBED_PIN >> (PORT_SHIFT - 2)) & 0x0000003C))
+#define MBED_GPIO_PORT(MBED_PIN) ((MBED_PIN >> PORT_SHIFT) & 0x0000000F)
+#define MBED_GPIO_PIN(MBED_PIN)  (MBED_PIN & 0x0000001F)
+
+typedef enum {
+    // LPC43xx Pin Names
+    // All pins defined. Package determines which are available.
+    //          LBGA256  TFBGA180 TFBGA100 LQFP208  LQFP144
+    // GPIO0    [15:0]   [15:0]   [15:6]   [15:0]   [15:0]
+    //                            [4:0]
+    // GPIO1    [15:0]   [15:0]   [15:0]   [15:0]   [15:0]
+    // GPIO2    [15:0]   [15:0]            [15:0]   [15:0]
+    // GPIO3    [15:0]   [15:0]   [7]      [15:0]   [15:0]
+    //                            [5:3]
+    //                            [1:0]
+    // GPIO4    [15:0]   [15:0]            [15:0]   [11]
+    // GPIO5    [26:0]   [26:0]   [11:0]   [25:0]   [18]
+    //                                              [16:0]
+    // GPIO6    [30:0]   [30:28]           [30:20]
+    //                   [26:25]           [5:0]
+    // GPIO7    [25:0]   [4:0]             [25:23]
+    //                                     [21:17]
+    //          ---      ---      ---      ---      ---
+    // Total    164      117      49       131      83
+
+    // Groups 0x00 - 0x0F : Digital pins
+    // * Digital pins support up to 8 functions
+    //   Use func=0 for GPIO0-GPIO4, func=4 for GPIO5-GPIO7
+    // * High-drive pins default to 4 mA but can support 8, 14, 20 mA
+    P0_0  = MBED_PIN(0x00, 0, 0, 0),    // GPIO0[0]
+    P0_1  = MBED_PIN(0x00, 1, 0, 1),    // GPIO0[1]
+
+    P1_0  = MBED_PIN(0x01, 0, 0, 4),    // GPIO0[4]
+    P1_1  = MBED_PIN(0x01, 1, 0, 8),    // GPIO0[8]
+    P1_2  = MBED_PIN(0x01, 2, 0, 9),    // GPIO0[9]
+    P1_3  = MBED_PIN(0x01, 3, 0, 10),   // GPIO0[10]
+    P1_4  = MBED_PIN(0x01, 4, 0, 11),   // GPIO0[11]
+    P1_5  = MBED_PIN(0x01, 5, 1, 8),    // GPIO1[8]
+    P1_6  = MBED_PIN(0x01, 6, 1, 9),    // GPIO1[9]
+    P1_7  = MBED_PIN(0x01, 7, 1, 10),   // GPIO1[10]
+    P1_8  = MBED_PIN(0x01, 8, 1, 1),    // GPIO1[1]
+    P1_9  = MBED_PIN(0x01, 9, 1, 2),    // GPIO1[2]
+    P1_10 = MBED_PIN(0x01, 10, 1, 3),   // GPIO1[3]
+    P1_11 = MBED_PIN(0x01, 11, 1, 4),   // GPIO1[4]
+    P1_12 = MBED_PIN(0x01, 12, 1, 5),   // GPIO1[5]
+    P1_13 = MBED_PIN(0x01, 13, 1, 6),   // GPIO1[6]
+    P1_14 = MBED_PIN(0x01, 14, 1, 7),   // GPIO1[7]
+    P1_15 = MBED_PIN(0x01, 15, 0, 2),   // GPIO0[2]
+    P1_16 = MBED_PIN(0x01, 16, 0, 3),   // GPIO0[3]
+    P1_17 = MBED_PIN(0x01, 17, 0, 12),  // GPIO0[12] high-drive
+    P1_18 = MBED_PIN(0x01, 18, 0, 13),  // GPIO0[13]
+    P1_19 = MBED_PIN(0x01, 19, NO_GPIO, 0),
+    P1_20 = MBED_PIN(0x01, 20, 0, 15),  // GPIO0[15]
+
+    P2_0  = MBED_PIN(0x02, 0, 5, 0),    // GPIO5[0]
+    P2_1  = MBED_PIN(0x02, 1, 5, 1),    // GPIO5[1]
+    P2_2  = MBED_PIN(0x02, 2, 5, 2),    // GPIO5[2]
+    P2_3  = MBED_PIN(0x02, 3, 5, 3),    // GPIO5[3]  high-drive
+    P2_4  = MBED_PIN(0x02, 4, 5, 4),    // GPIO5[4]  high-drive
+    P2_5  = MBED_PIN(0x02, 5, 5, 5),    // GPIO5[5]  high-drive
+    P2_6  = MBED_PIN(0x02, 6, 5, 6),    // GPIO5[6]
+    P2_7  = MBED_PIN(0x02, 7, 0, 7),    // GPIO0[7]
+    P2_8  = MBED_PIN(0x02, 8, 5, 0),    // GPIO5[7]
+    P2_9  = MBED_PIN(0x02, 9, 1, 10),   // GPIO1[10]
+    P2_10 = MBED_PIN(0x02, 10, 0, 14),  // GPIO0[14]
+    P2_11 = MBED_PIN(0x02, 11, 1, 11),  // GPIO1[11]
+    P2_12 = MBED_PIN(0x02, 12, 1, 12),  // GPIO1[12]
+    P2_13 = MBED_PIN(0x02, 13, 1, 13),  // GPIO1[13]
+
+    P3_0  = MBED_PIN(0x03, 0, NO_GPIO, 0),
+    P3_1  = MBED_PIN(0x03, 1, 5, 8),    // GPIO5[8]
+    P3_2  = MBED_PIN(0x03, 2, 5, 9),    // GPIO5[9]
+    P3_3  = MBED_PIN(0x03, 3, NO_GPIO, 0),
+    P3_4  = MBED_PIN(0x03, 4, 1, 14),   // GPIO1[14]
+    P3_5  = MBED_PIN(0x03, 5, 1, 15),   // GPIO1[15]
+    P3_6  = MBED_PIN(0x03, 6, 0, 6),    // GPIO0[6]
+    P3_7  = MBED_PIN(0x03, 7, 5, 10),   // GPIO5[10]
+    P3_8  = MBED_PIN(0x03, 8, 5, 11),   // GPIO5[11]
+
+    P4_0  = MBED_PIN(0x04, 0, 2, 0),    // GPIO2[0]
+    P4_1  = MBED_PIN(0x04, 1, 2, 1),    // GPIO2[1]
+    P4_2  = MBED_PIN(0x04, 2, 2, 2),    // GPIO2[2]
+    P4_3  = MBED_PIN(0x04, 3, 2, 3),    // GPIO2[3]
+    P4_4  = MBED_PIN(0x04, 4, 2, 4),    // GPIO2[4]
+    P4_5  = MBED_PIN(0x04, 5, 2, 5),    // GPIO2[5]
+    P4_6  = MBED_PIN(0x04, 6, 2, 6),    // GPIO2[6]
+    P4_7  = MBED_PIN(0x04, 7, NO_GPIO, 0),
+    P4_8  = MBED_PIN(0x04, 8, 5, 12),   // GPIO5[12]
+    P4_9  = MBED_PIN(0x04, 9, 5, 13),   // GPIO5[13]
+    P4_10 = MBED_PIN(0x04, 10, 5, 14),  // GPIO5[14]
+
+    P5_0  = MBED_PIN(0x05, 0, 2, 0),    // GPIO2[9]
+    P5_1  = MBED_PIN(0x05, 1, 2, 10),   // GPIO2[10]
+    P5_2  = MBED_PIN(0x05, 2, 2, 11),   // GPIO2[11]
+    P5_3  = MBED_PIN(0x05, 3, 2, 12),   // GPIO2[12]
+    P5_4  = MBED_PIN(0x05, 4, 2, 13),   // GPIO2[13]
+    P5_5  = MBED_PIN(0x05, 5, 2, 14),   // GPIO2[14]
+    P5_6  = MBED_PIN(0x05, 6, 2, 15),   // GPIO2[15]
+    P5_7  = MBED_PIN(0x05, 7, 2, 7),    // GPIO2[7]
+
+    P6_0  = MBED_PIN(0x06, 0, NO_GPIO, 0),
+    P6_1  = MBED_PIN(0x06, 1, 3, 0),    // GPIO3[0]
+    P6_2  = MBED_PIN(0x06, 2, 3, 1),    // GPIO3[1]
+    P6_3  = MBED_PIN(0x06, 3, 3, 2),    // GPIO3[2]
+    P6_4  = MBED_PIN(0x06, 4, 3, 3),    // GPIO3[3]
+    P6_5  = MBED_PIN(0x06, 5, 3, 4),    // GPIO3[4]
+    P6_6  = MBED_PIN(0x06, 6, 0, 5),    // GPIO0[5]
+    P6_7  = MBED_PIN(0x06, 7, 5, 15),   // GPIO5[15]
+    P6_8  = MBED_PIN(0x06, 8, 5, 16),   // GPIO5[16]
+    P6_9  = MBED_PIN(0x06, 9, 3, 5),    // GPIO3[5]
+    P6_10 = MBED_PIN(0x06, 10, 3, 6),   // GPIO3[6]
+    P6_11 = MBED_PIN(0x06, 11, 3, 7),   // GPIO3[7]
+    P6_12 = MBED_PIN(0x06, 12, 2, 8),   // GPIO2[8]
+
+    P7_0  = MBED_PIN(0x07, 0, 3, 8),    // GPIO3[8]
+    P7_1  = MBED_PIN(0x07, 1, 3, 9),    // GPIO3[9]
+    P7_2  = MBED_PIN(0x07, 2, 3, 10),   // GPIO3[10]
+    P7_3  = MBED_PIN(0x07, 3, 3, 11),   // GPIO3[11]
+    P7_4  = MBED_PIN(0x07, 4, 3, 12),   // GPIO3[12]
+    P7_5  = MBED_PIN(0x07, 5, 3, 13),   // GPIO3[13]
+    P7_6  = MBED_PIN(0x07, 6, 3, 14),   // GPIO3[14]
+    P7_7  = MBED_PIN(0x07, 7, 3, 15),   // GPIO3[15]
+
+    P8_0  = MBED_PIN(0x08, 8, 4, 0),    // GPIO4[0]  high-drive
+    P8_1  = MBED_PIN(0x09, 0, 4, 1),    // GPIO4[1]  high-drive
+    P8_2  = MBED_PIN(0x09, 1, 4, 2),    // GPIO4[2]  high-drive
+    P8_3  = MBED_PIN(0x09, 2, 4, 3),    // GPIO4[3]
+    P8_4  = MBED_PIN(0x08, 4, 4, 4),    // GPIO4[4]
+    P8_5  = MBED_PIN(0x08, 5, 4, 5),    // GPIO4[5]
+    P8_6  = MBED_PIN(0x08, 6, 4, 6),    // GPIO4[6]
+    P8_7  = MBED_PIN(0x08, 7, 4, 7),    // GPIO4[7]
+    P8_8  = MBED_PIN(0x08, 8, NO_GPIO, 0),
+
+    P9_0  = MBED_PIN(0x09, 0, 4, 12),   // GPIO4[12]
+    P9_1  = MBED_PIN(0x09, 1, 4, 13),   // GPIO4[13]
+    P9_2  = MBED_PIN(0x09, 2, 4, 14),   // GPIO4[14]
+    P9_3  = MBED_PIN(0x09, 3, 4, 15),   // GPIO4[15]
+    P9_4  = MBED_PIN(0x09, 4, 5, 17),   // GPIO5[17]
+    P9_5  = MBED_PIN(0x09, 5, 5, 18),   // GPIO5[18]
+    P9_6  = MBED_PIN(0x09, 6, 4, 11),   // GPIO4[11]
+
+    PA_0  = MBED_PIN(0x0A, 0, NO_GPIO, 0),
+    PA_1  = MBED_PIN(0x0A, 1, 4, 8),    // GPIO4[8]  high-drive
+    PA_2  = MBED_PIN(0x0A, 2, 4, 9),    // GPIO4[9]  high-drive
+    PA_3  = MBED_PIN(0x0A, 3, 4, 10),   // GPIO4[10] high-drive
+    PA_4  = MBED_PIN(0x0A, 4, 5, 19),   // GPIO5[19]
+
+    PB_0   = MBED_PIN(0x0B, 0, 5, 20),  // GPIO5[20]
+    PB_1   = MBED_PIN(0x0B, 1, 5, 21),  // GPIO5[21]
+    PB_2   = MBED_PIN(0x0B, 2, 5, 22),  // GPIO5[22]
+    PB_3   = MBED_PIN(0x0B, 3, 5, 23),  // GPIO5[23]
+    PB_4   = MBED_PIN(0x0B, 4, 5, 24),  // GPIO5[24]
+    PB_5   = MBED_PIN(0x0B, 5, 5, 25),  // GPIO5[25]
+    PB_6   = MBED_PIN(0x0B, 6, 5, 26),  // GPIO5[26]
+
+    PC_0   = MBED_PIN(0x0C, 0, NO_GPIO, 0),
+    PC_1   = MBED_PIN(0x0C, 1, 6, 0),   // GPIO6[0]
+    PC_2   = MBED_PIN(0x0C, 2, 6, 1),   // GPIO6[1]
+    PC_3   = MBED_PIN(0x0C, 3, 6, 2),   // GPIO6[2]
+    PC_4   = MBED_PIN(0x0C, 4, 6, 3),   // GPIO6[3]
+    PC_5   = MBED_PIN(0x0C, 5, 6, 4),   // GPIO6[4]
+    PC_6   = MBED_PIN(0x0C, 6, 6, 5),   // GPIO6[5]
+    PC_7   = MBED_PIN(0x0C, 7, 6, 6),   // GPIO6[6]
+    PC_8   = MBED_PIN(0x0C, 8, 6, 7),   // GPIO6[7]
+    PC_9   = MBED_PIN(0x0C, 9, 6, 8),   // GPIO6[8]
+    PC_10  = MBED_PIN(0x0C, 10, 6, 9),  // GPIO6[9]
+    PC_11  = MBED_PIN(0x0C, 11, 6, 10), // GPIO6[10]
+    PC_12  = MBED_PIN(0x0C, 12, 6, 11), // GPIO6[11]
+    PC_13  = MBED_PIN(0x0C, 13, 6, 12), // GPIO6[12]
+    PC_14  = MBED_PIN(0x0C, 14, 6, 13), // GPIO6[13]
+
+    PD_0   = MBED_PIN(0x0D, 0, 6, 14),  // GPIO6[14]
+    PD_1   = MBED_PIN(0x0D, 1, 6, 15),  // GPIO6[15]
+    PD_2   = MBED_PIN(0x0D, 2, 6, 16),  // GPIO6[16]
+    PD_3   = MBED_PIN(0x0D, 3, 6, 17),  // GPIO6[17]
+    PD_4   = MBED_PIN(0x0D, 4, 6, 18),  // GPIO6[18]
+    PD_5   = MBED_PIN(0x0D, 5, 6, 19),  // GPIO6[19]
+    PD_6   = MBED_PIN(0x0D, 6, 6, 20),  // GPIO6[20]
+    PD_7   = MBED_PIN(0x0D, 7, 6, 21),  // GPIO6[21]
+    PD_8   = MBED_PIN(0x0D, 8, 6, 22),  // GPIO6[22]
+    PD_9   = MBED_PIN(0x0D, 9, 6, 23),  // GPIO6[23]
+    PD_10  = MBED_PIN(0x0D, 10, 6, 24), // GPIO6[24]
+    PD_11  = MBED_PIN(0x0D, 11, 6, 25), // GPIO6[25]
+    PD_12  = MBED_PIN(0x0D, 12, 6, 26), // GPIO6[26]
+    PD_13  = MBED_PIN(0x0D, 13, 6, 27), // GPIO6[27]
+    PD_14  = MBED_PIN(0x0D, 14, 6, 28), // GPIO6[28]
+    PD_15  = MBED_PIN(0x0D, 15, 6, 29), // GPIO6[29]
+    PD_16  = MBED_PIN(0x0D, 16, 6, 30), // GPIO6[30]
+
+    PE_0   = MBED_PIN(0x0E, 0, 7, 0),   // GPIO7[0]
+    PE_1   = MBED_PIN(0x0E, 1, 7, 1),   // GPIO7[1]
+    PE_2   = MBED_PIN(0x0E, 2, 7, 2),   // GPIO7[2]
+    PE_3   = MBED_PIN(0x0E, 3, 7, 3),   // GPIO7[3]
+    PE_4   = MBED_PIN(0x0E, 4, 7, 4),   // GPIO7[4]
+    PE_5   = MBED_PIN(0x0E, 5, 7, 5),   // GPIO7[5]
+    PE_6   = MBED_PIN(0x0E, 6, 7, 6),   // GPIO7[6]
+    PE_7   = MBED_PIN(0x0E, 7, 7, 7),   // GPIO7[7]
+    PE_8   = MBED_PIN(0x0E, 8, 7, 8),   // GPIO7[8]
+    PE_9   = MBED_PIN(0x0E, 9, 7, 9),   // GPIO7[9]
+    PE_10  = MBED_PIN(0x0E, 10, 7, 10), // GPIO7[10]
+    PE_11  = MBED_PIN(0x0E, 11, 7, 11), // GPIO7[11]
+    PE_12  = MBED_PIN(0x0E, 12, 7, 12), // GPIO7[12]
+    PE_13  = MBED_PIN(0x0E, 13, 7, 13), // GPIO7[13]
+    PE_14  = MBED_PIN(0x0E, 14, 7, 14), // GPIO7[14]
+    PE_15  = MBED_PIN(0x0E, 15, 7, 15), // GPIO7[15]
+
+    PF_0   = MBED_PIN(0x0F, 0, NO_GPIO, 0),
+    PF_1   = MBED_PIN(0x0F, 1, 7, 16),  // GPIO7[16]
+    PF_2   = MBED_PIN(0x0F, 2, 7, 17),  // GPIO7[17]
+    PF_3   = MBED_PIN(0x0F, 3, 7, 18),  // GPIO7[18]
+    PF_4   = MBED_PIN(0x0F, 4, NO_GPIO, 0),
+    PF_5   = MBED_PIN(0x0F, 5, 7, 19),  // GPIO7[19]
+    PF_6   = MBED_PIN(0x0F, 6, 7, 20),  // GPIO7[20]
+    PF_7   = MBED_PIN(0x0F, 7, 7, 21),  // GPIO7[21]
+    PF_8   = MBED_PIN(0x0F, 8, 7, 22),  // GPIO7[22]
+    PF_9   = MBED_PIN(0x0F, 9, 7, 23),  // GPIO7[23]
+    PF_10  = MBED_PIN(0x0F, 10, 7, 24), // GPIO7[24]
+    PF_11  = MBED_PIN(0x0F, 11, 7, 25), // GPIO7[25]
+
+    // Map mbed pin names to LPC43xx board signals
+
+    // Group 0x18 : CLKn pins
+    SFP_CLK0  = MBED_PIN(0x18, 0, 0, 0),
+    SFP_CLK1  = MBED_PIN(0x18, 1, 0, 0),
+    SFP_CLK2  = MBED_PIN(0x18, 2, 0, 0),
+    SFP_CLK3  = MBED_PIN(0x18, 3, 0, 0),
+	
+    // Group 0x19 : USB1, I2C0, ADC0, ADC1
+    SFP_USB1  = MBED_PIN(0x19, 0, 0, 0),
+    SFP_I2C0  = MBED_PIN(0x19, 1, 0, 0),
+    SFP_AIO0  = MBED_PIN(0x19, 2, 0, 0), // ADC0 function select register
+    SFP_AIO1  = MBED_PIN(0x19, 3, 0, 0), // ADC1 function select register
+    SFP_AIO2  = MBED_PIN(0x19, 4, 0, 0), // Analog function select register
+
+    SFP_EMCD  = MBED_PIN(0x1A, 0, 0, 0), // EMC clock delay register
+
+    SFP_INS0  = MBED_PIN(0x1C, 0, 0, 0), // Interrupt select for pin interrupts 0 to 3
+    SFP_INS1  = MBED_PIN(0x1C, 1, 0, 0), // Interrupt select for pin interrupts 4 to 7
+
+#define MBED_ADC_NUM(MBED_PIN)   ((MBED_PIN >> 5) & 0x0000000F)
+#define MBED_ADC_CHAN(MBED_PIN)  (MBED_PIN & 0x0000001F)
+
+    // Use pseudo-pin ID also for ADCs, although with special handling
+    SFP_ADC0_0 = MBED_PIN(0x19, 2, 0, 0), // ADC0_0
+    SFP_ADC0_1 = MBED_PIN(0x19, 2, 0, 1), // ADC0_1
+    SFP_ADC0_2 = MBED_PIN(0x19, 2, 0, 2), // ADC0_2
+    SFP_ADC0_3 = MBED_PIN(0x19, 2, 0, 3), // ADC0_3
+    SFP_ADC0_4 = MBED_PIN(0x19, 2, 0, 4), // ADC0_4
+    SFP_ADC0_5 = MBED_PIN(0x19, 2, 0, 5), // ADC0_5
+    SFP_ADC0_6 = MBED_PIN(0x19, 2, 0, 6), // ADC0_6
+
+    SFP_ADC1_0 = MBED_PIN(0x19, 3, 1, 0), // ADC1_0
+    SFP_ADC1_1 = MBED_PIN(0x19, 3, 1, 1), // ADC1_1
+    SFP_ADC1_2 = MBED_PIN(0x19, 3, 1, 2), // ADC1_2
+    SFP_ADC1_3 = MBED_PIN(0x19, 3, 1, 3), // ADC1_3
+    SFP_ADC1_4 = MBED_PIN(0x19, 3, 1, 4), // ADC1_4
+    SFP_ADC1_5 = MBED_PIN(0x19, 3, 1, 5), // ADC1_5
+    SFP_ADC1_6 = MBED_PIN(0x19, 3, 1, 6), // ADC1_6
+    SFP_ADC1_7 = MBED_PIN(0x19, 3, 1, 7), // ADC1_7
+
+    // ---------- Micromint Bambino 200 ----------
+    // LQFP144
+    // NOTE: Pins marked (*) only available on 200E
+    p5  = P1_2,   // SPI0 mosi
+    p6  = P1_1,   // SPI0 miso
+    p7  = P3_0,   // SPI0 sck
+    p8  = P4_5,
+    p9  = P6_4,   // Serial0 tx, I2C0 sda
+    p10 = P6_5,   // Serial0 rx, I2C0 scl
+    p11 = P1_4,   // SPI1 mosi (*)
+    p12 = P1_3,   // SPI1 miso (*)
+    p13 = PF_4,   // Serial1 tx, SPI1 sck (*)
+    p14 = P1_14,  // Serial1 rx
+    p15 = P4_3,   // ADC0
+    p16 = P4_1,   // ADC1
+    p17 = P7_4,   // ADC2
+    p18 = SFP_ADC0_0, // ADC3, DAC0
+    p19 = P7_5,   // ADC4
+    p20 = P7_7,   // ADC5
+    p21 = P4_0,   // PWM0
+    p22 = P5_5,   // PWM1
+    p23 = P5_7,   // PWM2
+    p24 = P4_8,   // PWM3
+    p25 = P4_9,   // PWM4
+    p26 = P4_10,  // PWM5
+    p27 = P2_4,   // I2C1 scl, Serial2 rx
+    p28 = P2_3,   // I2C1 sda, Serial2 tx
+    p29 = P3_2,   // CAN0 td
+    p30 = P3_1,   // CAN0 rx
+
+    // User interfaces: LEDs, buttons
+    LED_YELLOW = P6_11,
+    LED_GREEN = P2_5,
+    LED_RED = LED_YELLOW,
+    LED_BLUE = LED_GREEN,
+
+    LED1 = LED_YELLOW,
+    LED2 = LED_GREEN,
+    LED3 = LED_GREEN,
+    LED4 = LED_GREEN,
+
+    BTN1 = P2_7,
+
+    // Serial pins
+    UART0_TX = P6_4,
+    UART0_RX = P6_5,
+    UART1_TX = P5_6,
+    UART1_RX = P1_14,
+    UART2_TX = P2_10,
+    UART2_RX = P2_11,
+    UART3_TX = P2_3,
+    UART3_RX = P2_4,
+
+    // Analog pins
+    P_ADC0_0 = P4_3,
+    P_ADC0_1 = P4_1,
+    P_ADC1_0 = SFP_ADC0_0,
+    P_ADC0_4 = P7_4,
+    P_ADC0_3 = P7_5,
+    P_ADC1_6 = P7_7,
+
+    P_ADC0 = P_ADC0_0,
+    P_ADC1 = P_ADC0_1,
+    P_ADC2 = P_ADC1_0,
+    P_ADC3 = P_ADC0_4,
+    P_ADC4 = P_ADC0_3,
+    P_ADC5 = P_ADC1_6,
+
+    P_DAC0 = P4_4,
+
+    // USB pins
+    //P_USB0_TX = SFP_USB1,
+    //P_USB0_RX = SFP_USB1,
+
+    USBTX = UART0_TX,
+    USBRX = UART0_RX,
+    // ---------- End of Micromint Bambino 200 ----------
+
+    // Not connected
+    NC = (int)0xFFFFFFFF
+} PinName;
+
+typedef enum {
+    PullUp = 0,
+    PullDown = 3,
+    PullNone = 2,
+    Repeater = 1,
+    OpenDrain = 4
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/PortNames.h
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/PortNames.h
@@ -1,0 +1,37 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PORTNAMES_H
+#define MBED_PORTNAMES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    Port0 = 0,
+    Port1 = 1,
+    Port2 = 2,
+    Port3 = 3,
+    Port4 = 4,
+    Port5 = 5,
+    Port6 = 6,
+    Port7 = 7
+} PortName;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/README.txt
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/README.txt
@@ -1,0 +1,76 @@
+mbed port to NXP LPC43xx
+========================
+Updated: 06/24/13
+
+The NXP LPC43xx microcontrollers are the first to include multiple Cortex-M
+cores in a single microcontroller package. This port allows mbed developers
+to take advantage of the LPC43xx in their application using APIs that they
+are familiar with. Some of the key features of the LPC43xx include:
+
+* Dual core ARM Cortex-M4/M0 both capable of up to 204 MHz
+* Up to 264 KB SRAM, 1 MB internal flash
+* Two High-speed USB 2.0 interfaces
+* Ethernet MAC
+* LCD interface
+* Quad-SPI Flash Interface (SPIFI)
+* State Configurable Timer (SCT)
+* Serial GPIO (SGPIO)
+* Up to 164 GPIO
+
+The NXP LPC18xx is a single core Cortex-M3 implementation that is compatible
+with the LPC43XX for cost-sensitive applications not requiring multiple cores.
+
+mbed port to the LPC43XX - Micromint USA <support@micromint.com>
+
+Compatibility
+-------------
+* This port has been tested with the following boards:
+    Board                    MCU        RAM/Flash
+    Micromint Bambino 200    LPC4330    264K SRAM/4 MB SPIFI flash
+
+* Ethernet, USB and microSD filesystem drivers will be available when the
+  Bambino 200E is released.
+
+* This port uses offline toolchains. Development and testing has been done
+  mainly with the Keil MDK 4.70. Some testing has been done with IAR 6.5.
+  Eventually Keil, IAR and GCC CodeRed will be supported.
+
+* CMSIS-DAP debugging is not currently implemented. To debug use a JTAG.
+  The NXP DFU tool can be used for flash programming.
+
+* This port should support NXP LPC43XX and LPC18XX variants with a single
+  codebase. The core declaration specifies the binaries to be built:
+    mbed define      CMSIS define  MCU Target
+    __CORTEX_M4      CORE_M4       LPC43xx Cortex-M4
+    __CORTEX_M0      CORE_M0       LPC43xx Cortex-M0
+    __CORTEX_M3      CORE_M3       LPC18xx Cortex-M3
+  These MCUs all share the peripheral IP, common driver code is feasible.
+  Yet each variant can have different memory segments, peripherals, etc.
+  Plus, each board design can integrate different external peripherals
+  or interfaces. A future release of the mbed SDK and its build tools will
+  support specifying the target board when building binaries. At this time
+  building binaries for different targets requires an external project or
+  Makefile.
+
+* No testing has been done with LPC18xx hardware. At the very least supporting
+  the LPC18xx would require different compiler flags, additional CMSIS core_cm3
+  code as well as minor driver code changes.
+
+Notes
+-----
+* On the LPC43xx the hardware pin name and the GPIO pin name are not the same,
+  requiring different offsets for the SCU and GPIO registers. To simplify logic
+  the pin identifier encodes the offsets. Macros are used for decoding.
+  For example, P6_11 corresponds to GPIO3[7] and is encoded/decoded as follows:
+
+    P6_11 = MBED_PIN(0x06, 11, 3, 7) = 0x032C0067
+
+    MBED_SCU_REG(P6_11)  = 0x4008632C      MBED_GPIO_PORT(P6_11) = 3
+    MBED_GPIO_REG(P6_11) = 0x400F4000      MBED_GPIO_PIN(P6_11)  = 7
+
+* The LPC43xx implements GPIO pin and group interrupts. Any pin in the 8 32-bit
+  GPIO ports can interrupt (LPC4350 supports up to 164). On group interrupts a
+  pin can only interrupt on the rising or falling edge, not both as required
+  by the mbed InterruptIn class. Also, group interrupts can't be cleared
+  individually. This implementation uses pin interrupts (8 on M4/M3, 1 on M0).
+  A future implementation may provide group interrupt support.

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/analogin_api.c
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/analogin_api.c
@@ -1,0 +1,129 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
+ */
+#include "analogin_api.h"
+#include "cmsis.h"
+#include "pinmap.h"
+#include "error.h"
+
+#define ANALOGIN_MEDIAN_FILTER      1
+
+static inline int div_round_up(int x, int y) {
+  return (x + (y - 1)) / y;
+}
+
+// ToDo: Add support for ADC1
+static const PinMap PinMap_ADC[] = {
+    {P_ADC0, ADC0_0, 0x08},
+    {P_ADC1, ADC0_1, 0x07},
+    {P_ADC2, ADC0_2, 0x01},
+    {P_ADC3, ADC0_3, 0x08},
+    {P_ADC4, ADC0_4, 0x08},
+    {P_ADC5, ADC0_5, 0x08},
+    {NC   , NC    , 0   }
+};
+
+void analogin_init(analogin_t *obj, PinName pin) {
+    uint8_t num, chan;
+
+    obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
+    if (obj->adc == (uint32_t)NC) {
+        error("ADC pin mapping failed");
+    }
+
+
+    // Configure the pin as GPIO input
+    if (pin < SFP_AIO0) {
+        pin_function(pin, (SCU_PINIO_PULLNONE | 0x0));
+        pin_mode(pin, PullNone);
+        num = (uint8_t)(obj->adc) / 8; // Heuristic?
+        chan = (uint8_t)(obj->adc) % 7;
+    } else {
+        num = MBED_ADC_NUM(pin);
+        chan = MBED_ADC_CHAN(pin);
+    }
+
+    // Calculate minimum clock divider
+    //  clkdiv = divider - 1
+		uint32_t PCLK = SystemCoreClock;
+    uint32_t adcRate = 400000;
+    uint32_t clkdiv = div_round_up(PCLK, adcRate) - 1;
+    
+    // Set the generic software-controlled ADC settings
+    LPC_ADC0->CR = (0 << 0)      // SEL: 0 = no channels selected
+                  | (clkdiv << 8) // CLKDIV:
+                  | (0 << 16)     // BURST: 0 = software control
+                  | (1 << 21)     // PDN: 1 = operational
+                  | (0 << 24)     // START: 0 = no start
+                  | (0 << 27);    // EDGE: not applicable
+
+    // Select ADC on analog function select register in SCU
+    LPC_SCU->ENAIO[num] |= 1UL << chan;
+}
+
+static inline uint32_t adc_read(analogin_t *obj) {
+    // Select the appropriate channel and start conversion
+    LPC_ADC0->CR &= ~0xFF;
+    LPC_ADC0->CR |= 1 << (int)obj->adc;
+    LPC_ADC0->CR |= 1 << 24;
+
+    // Repeatedly get the sample data until DONE bit
+    unsigned int data;
+    do {
+        data = LPC_ADC0->GDR;
+    } while ((data & ((unsigned int)1 << 31)) == 0);
+
+    // Stop conversion
+    LPC_ADC0->CR &= ~(1 << 24);
+
+    return (data >> 6) & ADC_RANGE; // 10 bit
+}
+
+static inline void order(uint32_t *a, uint32_t *b) {
+    if (*a > *b) {
+        uint32_t t = *a;
+        *a = *b;
+        *b = t;
+    }
+}
+
+static inline uint32_t adc_read_u32(analogin_t *obj) {
+    uint32_t value;
+#if ANALOGIN_MEDIAN_FILTER
+    uint32_t v1 = adc_read(obj);
+    uint32_t v2 = adc_read(obj);
+    uint32_t v3 = adc_read(obj);
+    order(&v1, &v2);
+    order(&v2, &v3);
+    order(&v1, &v2);
+    value = v2;
+#else
+    value = adc_read(obj);
+#endif
+    return value;
+}
+
+uint16_t analogin_read_u16(analogin_t *obj) {
+    uint32_t value = adc_read_u32(obj);
+
+    return (value << 6) | ((value >> 4) & 0x003F); // 10 bit
+}
+
+float analogin_read(analogin_t *obj) {
+    uint32_t value = adc_read_u32(obj);
+    return (float)value * (1.0f / (float)ADC_RANGE);
+}

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/analogout_api.c
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/analogout_api.c
@@ -1,0 +1,83 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
+ */
+#include "analogout_api.h"
+#include "cmsis.h"
+#include "pinmap.h"
+#include "error.h"
+
+static const PinMap PinMap_DAC[] = {
+    {P_DAC0 , DAC_0, 0x0},
+    {NC     , NC   , 0}
+};
+
+void analogout_init(dac_t *obj, PinName pin) {
+    obj->dac = (DACName)pinmap_peripheral(pin, PinMap_DAC);
+    if (obj->dac == (DACName)NC) {
+        error("DAC pin mapping failed");
+    }
+
+    // Configure the pin as GPIO input
+    pin_function(pin, (SCU_PINIO_PULLNONE | 0x0));
+    pin_mode(pin, PullNone);
+    // Select DAC on analog function select register in SCU
+    LPC_SCU->ENAIO[2] |= 1; // Sets pin P4_4 as DAC
+
+    // Set Maximum update rate for DAC */
+    LPC_DAC->CR &= ~DAC_BIAS_EN;
+	
+    analogout_write_u16(obj, 0);
+}
+
+void analogout_free(dac_t *obj) {}
+
+static inline void dac_write(int value) {
+    uint32_t tmp;
+    
+    // Set the DAC output
+    tmp = LPC_DAC->CR & DAC_BIAS_EN;
+    tmp |= DAC_VALUE(value);
+    LPC_DAC->CR = tmp;
+}
+
+static inline int dac_read() {
+    return (DAC_VALUE(LPC_DAC->CR));
+}
+
+void analogout_write(dac_t *obj, float value) {
+    if (value < 0.0f) {
+        dac_write(0);
+    } else if (value > 1.0f) {
+        dac_write(DAC_RANGE);
+    } else {
+        dac_write(value * (float)DAC_RANGE);
+    }
+}
+
+void analogout_write_u16(dac_t *obj, uint16_t value) {
+    dac_write(value >> 6); // 10-bit
+}
+
+float analogout_read(dac_t *obj) {
+    uint32_t value = dac_read();
+    return (float)value * (1.0f / (float)DAC_RANGE);
+}
+
+uint16_t analogout_read_u16(dac_t *obj) {
+    uint32_t value = dac_read(); // 10-bit
+    return (value << 6) | ((value >> 4) & 0x003F);
+}

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/device.h
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/device.h
@@ -1,0 +1,59 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+#define DEVICE_PORTIN           1
+#define DEVICE_PORTOUT          1
+#define DEVICE_PORTINOUT        1
+
+#define DEVICE_INTERRUPTIN      1
+
+#define DEVICE_ANALOGIN         1
+#define DEVICE_ANALOGOUT        1
+
+#define DEVICE_SERIAL           1
+
+#define DEVICE_I2C              0
+#define DEVICE_I2CSLAVE         0
+
+#define DEVICE_SPI              1
+#define DEVICE_SPISLAVE         1
+
+#define DEVICE_CAN              0
+
+#define DEVICE_RTC              1
+
+#define DEVICE_ETHERNET         0
+
+#define DEVICE_PWMOUT           0
+
+#define DEVICE_SEMIHOST         0
+#define DEVICE_LOCALFILESYSTEM  0
+#define DEVICE_ID_LENGTH       32
+#define DEVICE_MAC_OFFSET      20
+
+#define DEVICE_SLEEP            1
+
+#define DEVICE_DEBUG_AWARENESS  1
+
+#define DEVICE_STDIO_MESSAGES   1
+
+#define DEVICE_ERROR_RED        1
+
+#include "objects.h"
+
+#endif

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/gpio_api.c
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/gpio_api.c
@@ -1,0 +1,61 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
+ */
+#include "gpio_api.h"
+#include "pinmap.h"
+
+uint32_t gpio_set(PinName pin) {
+    int f = 0;
+    unsigned int port = (unsigned int)MBED_GPIO_PORT(pin);
+
+    f = SCU_PINIO_FAST | ((port > 4) ? (4) : (0));
+    pin_function(pin, f);
+
+    return (1 << ((int)pin & 0x1F));
+}
+
+void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+    if (pin == NC) return;
+    
+    obj->pin = pin;
+    obj->mask = gpio_set(pin);
+
+    LPC_GPIO_T *port_reg = (LPC_GPIO_T *) (LPC_GPIO_PORT_BASE);
+    unsigned int port = (unsigned int)MBED_GPIO_PORT(pin);
+
+    obj->reg_set = &port_reg->SET[port];
+    obj->reg_clr = &port_reg->CLR[port];
+    obj->reg_in  = &port_reg->PIN[port];
+    obj->reg_dir = &port_reg->DIR[port];
+
+    gpio_dir(obj, direction);
+    switch (direction) {
+        case PIN_OUTPUT: pin_mode(pin, PullNone); break;
+        case PIN_INPUT : pin_mode(pin, PullDown); break;
+    }
+}
+
+void gpio_mode(gpio_t *obj, PinMode mode) {
+    pin_mode(obj->pin, mode);
+}
+
+void gpio_dir(gpio_t *obj, PinDirection direction) {
+    switch (direction) {
+        case PIN_INPUT : *obj->reg_dir &= ~obj->mask; break;
+        case PIN_OUTPUT: *obj->reg_dir |=  obj->mask; break;
+    }
+}

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/gpio_irq_api.c
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/gpio_irq_api.c
@@ -1,0 +1,136 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
+ */
+#include <stddef.h>
+#include "gpio_irq_api.h"
+#include "error.h"
+#include "cmsis.h"
+
+/* The LPC43xx implements GPIO pin and group interrupts. Any pin in the
+ * 8 32-bit GPIO ports can interrupt. On group interrupts a pin can
+ * only interrupt on the rising or falling edge, not both as required
+ * by mbed. Also, group interrupts can't be cleared individually.
+ * This implementation uses pin interrupts (8 on M4/M3, 1 on M0).
+ * A future implementation may provide group interrupt support.
+ */
+#if !defined(CORE_M0)
+#define CHANNEL_NUM    8
+#else
+#define CHANNEL_NUM    1
+#endif
+
+static uint32_t channel_ids[CHANNEL_NUM] = {0};
+static uint32_t channel = 0;
+static gpio_irq_handler irq_handler;
+
+static void handle_interrupt_in(void) {
+    uint32_t rise = LPC_GPIO_PIN_INT->RISE;
+    uint32_t fall = LPC_GPIO_PIN_INT->FALL;
+    uint32_t pmask;
+    int i;
+
+    for (i = 0; i < CHANNEL_NUM; i++) {
+        pmask = (1 << i);
+        if (rise & pmask) {
+            /* Rising edge interrupts */
+            if (channel_ids[i] != 0)
+                irq_handler(channel_ids[i], IRQ_RISE);
+            /* Clear rising edge detected */
+            LPC_GPIO_PIN_INT->RISE = pmask;
+        }
+        if (fall & pmask) {
+            /* Falling edge interrupts */
+            if (channel_ids[i] != 0)
+                irq_handler(channel_ids[i], IRQ_FALL);
+            /* Clear falling edge detected */
+            LPC_GPIO_PIN_INT->FALL = pmask;
+        }
+    }
+}
+
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id) {
+    uint32_t portnum, pinnum; //, pmask;
+
+    if (pin == NC) return -1;
+
+    irq_handler = handler;
+
+    /* Set port and pin numbers */
+    obj->port = portnum = MBED_GPIO_PORT(pin);
+    obj->pin = pinnum = MBED_GPIO_PIN(pin);
+
+    /* Add to channel table */
+    channel_ids[channel] = id;
+    obj->ch = channel;
+
+	  /* Clear rising and falling edge detection */
+    //pmask = (1 << channel);
+    //LPC_GPIO_PIN_INT->IST = pmask;
+
+    /* Set SCU */
+    if (channel < 4) {
+        LPC_SCU->PINTSEL0 &= ~(0xFF << (portnum << 3));
+        LPC_SCU->PINTSEL0 |= (((portnum << 5) | pinnum) << (channel << 3));
+    } else {
+        LPC_SCU->PINTSEL1 &= ~(0xFF << ((portnum - 4) << 3));
+        LPC_SCU->PINTSEL1 |= (((portnum << 5) | pinnum) << ((channel - 4) << 3));
+    }
+	
+#if !defined(CORE_M0)
+    NVIC_SetVector((IRQn_Type)(PIN_INT0_IRQn + channel), (uint32_t)handle_interrupt_in);
+    NVIC_EnableIRQ((IRQn_Type)(PIN_INT0_IRQn + channel));
+#else
+    NVIC_SetVector((IRQn_Type)PIN_INT4_IRQn, (uint32_t)handle_interrupt_in);
+    NVIC_EnableIRQ((IRQn_Type)PIN_INT4_IRQn);
+#endif
+
+    // Increment channel number
+    channel++;
+    channel %= CHANNEL_NUM;
+
+    return 0;
+}
+
+void gpio_irq_free(gpio_irq_t *obj) {
+    channel_ids[obj->ch] = 0;
+}
+
+void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable) {
+    uint32_t pmask;
+
+    /* Clear pending interrupts */
+    pmask = (1 << obj->ch);
+    LPC_GPIO_PIN_INT->IST = pmask;
+
+    /* Configure pin interrupt */
+    LPC_GPIO_PIN_INT->ISEL &= ~pmask;
+    if (event == IRQ_RISE) {
+        /* Rising edge interrupts */
+        if (enable) {
+            LPC_GPIO_PIN_INT->SIENR |= pmask;
+        } else {
+            LPC_GPIO_PIN_INT->CIENR |= pmask;
+        }
+    } else {
+        /* Falling edge interrupts */
+        if (enable) {
+            LPC_GPIO_PIN_INT->SIENF |= pmask;
+        } else {
+            LPC_GPIO_PIN_INT->CIENF |= pmask;
+        }
+    }
+}

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/gpio_object.h
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/gpio_object.h
@@ -1,0 +1,48 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_GPIO_OBJECT_H
+#define MBED_GPIO_OBJECT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    PinName  pin;
+    uint32_t mask;
+
+    __IO uint32_t *reg_dir;
+    __IO uint32_t *reg_set;
+    __IO uint32_t *reg_clr;
+    __I  uint32_t *reg_in;
+} gpio_t;
+
+static inline void gpio_write(gpio_t *obj, int value) {
+    if (value)
+        *obj->reg_set = obj->mask;
+    else
+        *obj->reg_clr = obj->mask;
+}
+
+static inline int gpio_read(gpio_t *obj) {
+    return ((*obj->reg_in & obj->mask) ? 1 : 0);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/objects.h
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/objects.h
@@ -1,0 +1,79 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_OBJECTS_H
+#define MBED_OBJECTS_H
+
+#include "cmsis.h"
+#include "PortNames.h"
+#include "PeripheralNames.h"
+#include "PinNames.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct gpio_irq_s {
+    uint32_t port;
+    uint32_t pin;
+    uint32_t ch;
+};
+
+struct port_s {
+    __IO uint32_t *reg_dir;
+    __IO uint32_t *reg_out;
+    __I  uint32_t *reg_in;
+    PortName port;
+    uint32_t mask;
+};
+
+struct pwmout_s {
+    __IO uint32_t *MR;
+    LPC_MCPWM_T *pwm;
+    uint32_t channel;
+};
+
+struct serial_s {
+    LPC_USART_T *uart;
+    int index;
+};
+
+struct analogin_s {
+    ADCName adc;
+};
+
+struct dac_s {
+    DACName dac;
+};
+
+struct can_s {
+    LPC_CCAN_T *dev;
+};
+
+struct i2c_s {
+    LPC_I2C_T *i2c;
+};
+
+struct spi_s {
+    LPC_SSP_T *spi;
+};
+
+#include "gpio_object.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/pinmap.c
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/pinmap.c
@@ -1,0 +1,43 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
+ */
+#include "pinmap.h"
+#include "error.h"
+
+void pin_function(PinName pin, int function) {
+    if (pin == (uint32_t)NC) return;
+
+    __IO uint32_t *reg = (__IO uint32_t*) MBED_SCU_REG(pin);
+
+    // Set pin function
+    *reg = function;
+}
+
+void pin_mode(PinName pin, PinMode mode) {
+    if (pin == (uint32_t)NC) { return; }
+
+    if (mode == OpenDrain) error("OpenDrain not supported on LPC43XX");
+
+    __IO uint32_t *reg = (__IO uint32_t*) MBED_SCU_REG(pin);
+    uint32_t tmp = *reg;
+    
+    // pin mode bits: [4:3] -> 11000 = (0x3 << 3)
+    tmp &= ~(0x3 << 3);
+    tmp |= (mode & 0x3) << 3;
+
+    *reg = tmp;
+}

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/port_api.c
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/port_api.c
@@ -1,0 +1,72 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
+ */
+#include "port_api.h"
+#include "pinmap.h"
+#include "gpio_api.h"
+
+PinName port_pin(PortName port, int pin_n) {
+    return (PinName)(LPC_GPIO_PORT_BASE + ((port << PORT_SHIFT) | pin_n));
+}
+
+void port_init(port_t *obj, PortName port, int mask, PinDirection dir) {
+    obj->port = port;
+    obj->mask = mask;
+    
+    LPC_GPIO_T *port_reg = (LPC_GPIO_T *)(LPC_GPIO_PORT_BASE + ((int)port << PORT_SHIFT));
+    
+    port_reg->MASK[port] = ~mask;
+    
+    obj->reg_out = &port_reg->PIN[port];
+    obj->reg_in  = &port_reg->PIN[port];
+    obj->reg_dir = &port_reg->DIR[port];
+	
+    uint32_t i;
+    // The function is set per pin: reuse gpio logic
+    for (i=0; i<32; i++) {
+        if (obj->mask & (1<<i)) {
+            gpio_set(port_pin(obj->port, i));
+        }
+    }
+    
+    port_dir(obj, dir);
+}
+
+void port_mode(port_t *obj, PinMode mode) {
+    uint32_t i;
+    // The mode is set per pin: reuse pinmap logic
+    for (i=0; i<32; i++) {
+        if (obj->mask & (1<<i)) {
+            pin_mode(port_pin(obj->port, i), mode);
+        }
+    }
+}
+
+void port_dir(port_t *obj, PinDirection dir) {
+    switch (dir) {
+        case PIN_INPUT : *obj->reg_dir &= ~obj->mask; break;
+        case PIN_OUTPUT: *obj->reg_dir |=  obj->mask; break;
+    }
+}
+
+void port_write(port_t *obj, int value) {
+    *obj->reg_out = (*obj->reg_in & ~obj->mask) | (value & obj->mask);
+}
+
+int port_read(port_t *obj) {
+    return (*obj->reg_in & obj->mask);
+}

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/rtc_api.c
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/rtc_api.c
@@ -1,0 +1,118 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
+ */
+#include "rtc_api.h"
+
+// ensure rtc is running (unchanged if already running)
+
+/* Setup the RTC based on a time structure, ensuring RTC is enabled
+ *
+ * Can be clocked by a 32.768KHz oscillator or prescale divider based on the APB clock
+ * - We want to use the 32khz clock, allowing for sleep mode
+ *
+ * Most registers are not changed by a Reset
+ * - We must initialize these registers between power-on and setting the RTC into operation
+
+ * Clock Control Register
+ *  RTC_CCR[0] : Enable - 0 = Disabled, 1 = Enabled
+ *  RTC_CCR[1] : Reset - 0 = Normal, 1 = Reset
+ *  RTC_CCR[4] : Clock Source - 0 = Prescaler, 1 = 32k Xtal
+ *
+ * The RTC may already be running, so we should set it up
+ * without impacting if it is the case
+ */
+void rtc_init(void) {
+    LPC_RTC->CCR = 0x00;
+
+    LPC_RTC->CCR |= 1 << 0; // Ensure the RTC is enabled
+}
+
+void rtc_free(void) {
+    // [TODO]
+}
+
+/*
+ * Little check routine to see if the RTC has been enabled
+ *
+ * Clock Control Register
+ *  RTC_CCR[0] : 0 = Disabled, 1 = Enabled
+ *
+ */
+int rtc_isenabled(void) {
+    return(((LPC_RTC->CCR) & 0x01) != 0);
+}
+
+/*
+ * RTC Registers
+ *  RTC_SEC        Seconds 0-59
+ *  RTC_MIN        Minutes 0-59
+ *  RTC_HOUR    Hour 0-23
+ *  RTC_DOM        Day of Month 1-28..31
+ *  RTC_DOW        Day of Week 0-6
+ *  RTC_DOY        Day of Year 1-365
+ *  RTC_MONTH    Month 1-12
+ *  RTC_YEAR    Year 0-4095
+ *
+ * struct tm
+ *  tm_sec        seconds after the minute 0-61
+ *  tm_min        minutes after the hour 0-59
+ *  tm_hour        hours since midnight 0-23
+ *  tm_mday        day of the month 1-31
+ *  tm_mon        months since January 0-11
+ *  tm_year        years since 1900
+ *  tm_wday        days since Sunday 0-6
+ *  tm_yday        days since January 1 0-365
+ *  tm_isdst    Daylight Saving Time flag
+ */
+time_t rtc_read(void) {
+    // Setup a tm structure based on the RTC
+    struct tm timeinfo;
+    timeinfo.tm_sec = LPC_RTC->TIME[RTC_TIMETYPE_SECOND];
+    timeinfo.tm_min = LPC_RTC->TIME[RTC_TIMETYPE_MINUTE];
+    timeinfo.tm_hour = LPC_RTC->TIME[RTC_TIMETYPE_HOUR];
+    timeinfo.tm_mday = LPC_RTC->TIME[RTC_TIMETYPE_DAYOFMONTH];
+    timeinfo.tm_wday = LPC_RTC->TIME[RTC_TIMETYPE_DAYOFWEEK];
+    timeinfo.tm_yday = LPC_RTC->TIME[RTC_TIMETYPE_DAYOFYEAR];
+    timeinfo.tm_mon = LPC_RTC->TIME[RTC_TIMETYPE_MONTH] - 1;
+    timeinfo.tm_year = LPC_RTC->TIME[RTC_TIMETYPE_YEAR] - 1900;
+    
+    // Convert to timestamp
+    time_t t = mktime(&timeinfo);
+    
+    return t;
+}
+
+void rtc_write(time_t t) {
+    // Convert the time in to a tm
+    struct tm *timeinfo = localtime(&t);
+    
+    // Pause clock, and clear counter register (clears us count)
+    LPC_RTC->CCR |= 2;
+    
+    // Set the RTC
+    LPC_RTC->TIME[RTC_TIMETYPE_SECOND] = timeinfo->tm_sec;
+    LPC_RTC->TIME[RTC_TIMETYPE_MINUTE] = timeinfo->tm_min;
+    LPC_RTC->TIME[RTC_TIMETYPE_HOUR] = timeinfo->tm_hour;
+    LPC_RTC->TIME[RTC_TIMETYPE_DAYOFMONTH] = timeinfo->tm_mday;
+    LPC_RTC->TIME[RTC_TIMETYPE_DAYOFWEEK] = timeinfo->tm_wday;
+    LPC_RTC->TIME[RTC_TIMETYPE_DAYOFYEAR] = timeinfo->tm_yday;
+    LPC_RTC->TIME[RTC_TIMETYPE_MONTH] = timeinfo->tm_mon + 1;
+    LPC_RTC->TIME[RTC_TIMETYPE_YEAR] = timeinfo->tm_year + 1900;
+    
+    // Restart clock
+    LPC_RTC->CCR &= ~((uint32_t)2);
+}

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/serial_api.c
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/serial_api.c
@@ -1,0 +1,283 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
+ */
+// math.h required for floating point operations for baud rate calculation
+#include <math.h>
+#include <string.h>
+
+#include "serial_api.h"
+#include "cmsis.h"
+#include "pinmap.h"
+#include "error.h"
+
+/******************************************************************************
+ * INITIALIZATION
+ ******************************************************************************/
+static const PinMap PinMap_UART_TX[] = {
+    {UART0_TX, UART_0, (SCU_PINIO_PULLDOWN | 2)},
+    {UART1_TX, UART_1, (SCU_PINIO_PULLDOWN | 4)},
+    {UART2_TX, UART_2, (SCU_PINIO_PULLDOWN | 2)},
+    {UART3_TX, UART_3, (SCU_PINIO_PULLDOWN | 2)},
+    {NC        , NC    , 0}
+};
+
+static const PinMap PinMap_UART_RX[] = {
+    {UART0_RX, UART_0, (SCU_PINIO_PULLDOWN | 2)},
+    {UART1_RX, UART_1, (SCU_PINIO_PULLDOWN | 1)},
+    {UART2_RX, UART_2, (SCU_PINIO_PULLDOWN | 2)},
+    {UART3_RX, UART_3, (SCU_PINIO_PULLDOWN | 2)},
+    {NC        , NC    , 0}
+};
+
+#define UART_NUM    4
+
+static uint32_t serial_irq_ids[UART_NUM] = {0};
+static uart_irq_handler irq_handler;
+
+int stdio_uart_inited = 0;
+serial_t stdio_uart;
+
+void serial_init(serial_t *obj, PinName tx, PinName rx) {
+    int is_stdio_uart = 0;
+    
+    // determine the UART to use
+    UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
+    UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
+    UARTName uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
+    if ((int)uart == NC) {
+        error("Serial pinout mapping failed");
+    }
+
+    obj->uart = (LPC_USART_T *)uart;
+
+    // enable fifos and default rx trigger level
+    obj->uart->FCR = 1 << 0  // FIFO Enable - 0 = Disables, 1 = Enabled
+                   | 0 << 1  // Rx Fifo Reset
+                   | 0 << 2  // Tx Fifo Reset
+                   | 0 << 6; // Rx irq trigger level - 0 = 1 char, 1 = 4 chars, 2 = 8 chars, 3 = 14 chars
+
+    // disable irqs
+    obj->uart->IER = 0 << 0  // Rx Data available irq enable
+                   | 0 << 1  // Tx Fifo empty irq enable
+                   | 0 << 2; // Rx Line Status irq enable
+    
+    // set default baud rate and format
+    serial_baud  (obj, 9600);
+    serial_format(obj, 8, ParityNone, 1);
+    
+    // pinout the chosen uart
+    pinmap_pinout(tx, PinMap_UART_TX);
+    pinmap_pinout(rx, PinMap_UART_RX);
+    
+    // set rx/tx pins in PullUp mode
+    pin_mode(tx, PullUp);
+    pin_mode(rx, PullUp);
+    
+    switch (uart) {
+        case UART_0: obj->index = 0; break;
+        case UART_1: obj->index = 1; break;
+        case UART_2: obj->index = 2; break;
+#if (UART_NUM > 3)
+        case UART_3: obj->index = 3; break;
+#endif
+#if (UART_NUM > 4)
+        case UART_4: obj->index = 4; break;
+#endif
+    }
+    
+    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
+    
+    if (is_stdio_uart) {
+        stdio_uart_inited = 1;
+        memcpy(&stdio_uart, obj, sizeof(serial_t));
+    }
+}
+
+void serial_free(serial_t *obj) {
+    serial_irq_ids[obj->index] = 0;
+}
+
+// serial_baud
+// set the baud rate, taking in to account the current SystemFrequency
+void serial_baud(serial_t *obj, int baudrate) {
+    uint32_t PCLK = SystemCoreClock;
+
+    // First we check to see if the basic divide with no DivAddVal/MulVal
+    // ratio gives us an integer result. If it does, we set DivAddVal = 0,
+    // MulVal = 1. Otherwise, we search the valid ratio value range to find
+    // the closest match. This could be more elegant, using search methods
+    // and/or lookup tables, but the brute force method is not that much
+    // slower, and is more maintainable.
+    uint16_t DL = PCLK / (16 * baudrate);
+
+    uint8_t DivAddVal = 0;
+    uint8_t MulVal = 1;
+    int hit = 0;
+    uint16_t dlv;
+    uint8_t mv, dav;
+    if ((PCLK % (16 * baudrate)) != 0) {     // Checking for zero remainder
+        float err_best = (float) baudrate;
+        uint16_t dlmax = DL;
+        for ( dlv = (dlmax/2); (dlv <= dlmax) && !hit; dlv++) {
+            for ( mv = 1; mv <= 15; mv++) {
+                for ( dav = 1; dav < mv; dav++) {
+                    float ratio = 1.0f + ((float) dav / (float) mv);
+                    float calcbaud = (float)PCLK / (16.0f * (float) dlv * ratio);
+                    float err = fabs(((float) baudrate - calcbaud) / (float) baudrate);
+                    if (err < err_best) {
+                        DL = dlv;
+                        DivAddVal = dav;
+                        MulVal = mv;
+                        err_best = err;
+                        if (err < 0.001f) {
+                            hit = 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    // set LCR[DLAB] to enable writing to divider registers
+    obj->uart->LCR |= (1 << 7);
+    
+    // set divider values
+    obj->uart->DLM = (DL >> 8) & 0xFF;
+    obj->uart->DLL = (DL >> 0) & 0xFF;
+    obj->uart->FDR = (uint32_t) DivAddVal << 0
+                   | (uint32_t) MulVal    << 4;
+    
+    // clear LCR[DLAB]
+    obj->uart->LCR &= ~(1 << 7);
+}
+
+void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits) {
+    // 0: 1 stop bits, 1: 2 stop bits
+    if (stop_bits != 1 && stop_bits != 2) {
+        error("Invalid stop bits specified");
+    }
+    stop_bits -= 1;
+    
+    // 0: 5 data bits ... 3: 8 data bits
+    if (data_bits < 5 || data_bits > 8) {
+        error("Invalid number of bits (%d) in serial format, should be 5..8", data_bits);
+    }
+    data_bits -= 5;
+
+    int parity_enable, parity_select;
+    switch (parity) {
+        case ParityNone: parity_enable = 0; parity_select = 0; break;
+        case ParityOdd : parity_enable = 1; parity_select = 0; break;
+        case ParityEven: parity_enable = 1; parity_select = 1; break;
+        case ParityForced1: parity_enable = 1; parity_select = 2; break;
+        case ParityForced0: parity_enable = 1; parity_select = 3; break;
+        default:
+            error("Invalid serial parity setting");
+            return;
+    }
+    
+    obj->uart->LCR = data_bits            << 0
+                   | stop_bits            << 2
+                   | parity_enable        << 3
+                   | parity_select        << 4;
+}
+
+/******************************************************************************
+ * INTERRUPTS HANDLING
+ ******************************************************************************/
+static inline void uart_irq(uint32_t iir, uint32_t index) {
+    // [Chapter 14] LPC17xx UART0/2/3: UARTn Interrupt Handling
+    SerialIrq irq_type;
+    switch (iir) {
+        case 1: irq_type = TxIrq; break;
+        case 2: irq_type = RxIrq; break;
+        default: return;
+    }
+    
+    if (serial_irq_ids[index] != 0)
+        irq_handler(serial_irq_ids[index], irq_type);
+}
+
+void uart0_irq() {uart_irq((LPC_USART0->IIR >> 1) & 0x7, 0);}
+void uart1_irq() {uart_irq((LPC_UART1->IIR >> 1) & 0x7, 1);}
+void uart2_irq() {uart_irq((LPC_USART2->IIR >> 1) & 0x7, 2);}
+void uart3_irq() {uart_irq((LPC_USART3->IIR >> 1) & 0x7, 3);}
+
+void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id) {
+    irq_handler = handler;
+    serial_irq_ids[obj->index] = id;
+}
+
+void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable) {
+    IRQn_Type irq_n = (IRQn_Type)0;
+    uint32_t vector = 0;
+    switch ((int)obj->uart) {
+        case UART_0: irq_n=USART0_IRQn; vector = (uint32_t)&uart0_irq; break;
+        case UART_1: irq_n=UART1_IRQn; vector = (uint32_t)&uart1_irq; break;
+        case UART_2: irq_n=USART2_IRQn; vector = (uint32_t)&uart2_irq; break;
+        case UART_3: irq_n=USART3_IRQn; vector = (uint32_t)&uart3_irq; break;
+    }
+    
+    if (enable) {
+        obj->uart->IER |= 1 << irq;
+        NVIC_SetVector(irq_n, vector);
+        NVIC_EnableIRQ(irq_n);
+    } else { // disable
+        int all_disabled = 0;
+        SerialIrq other_irq = (irq == RxIrq) ? (TxIrq) : (RxIrq);
+        obj->uart->IER &= ~(1 << irq);
+        all_disabled = (obj->uart->IER & (1 << other_irq)) == 0;
+        if (all_disabled)
+            NVIC_DisableIRQ(irq_n);
+    }
+}
+
+/******************************************************************************
+ * READ/WRITE
+ ******************************************************************************/
+int serial_getc(serial_t *obj) {
+    while (!serial_readable(obj));
+    return obj->uart->RBR;
+}
+
+void serial_putc(serial_t *obj, int c) {
+    while (!serial_writable(obj));
+    obj->uart->THR = c;
+    
+    uint32_t lsr = obj->uart->LSR;
+    lsr = lsr;
+    uint32_t thr = obj->uart->THR;
+    thr = thr;
+}
+
+int serial_readable(serial_t *obj) {
+    return obj->uart->LSR & 0x01;
+}
+
+int serial_writable(serial_t *obj) {
+    return obj->uart->LSR & 0x20;
+}
+
+void serial_clear(serial_t *obj) {
+    obj->uart->FCR = 1 << 1  // rx FIFO reset
+                   | 1 << 2  // tx FIFO reset
+                   | 0 << 6; // interrupt depth
+}
+
+void serial_pinout_tx(PinName tx) {
+    pinmap_pinout(tx, PinMap_UART_TX);
+}

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/sleep.c
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/sleep.c
@@ -1,0 +1,36 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
+ */
+#include "sleep_api.h"
+#include "cmsis.h"
+#include "mbed_interface.h"
+
+void sleep(void) {
+    
+    // SRC[SLEEPDEEP] set to 0 = sleep
+    SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
+    
+    // wait for interrupt
+    __WFI();
+}
+
+/*
+ *  ToDo: Implement deepsleep()
+ */
+void deepsleep(void) {
+    sleep();
+}

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/spi_api.c
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/spi_api.c
@@ -1,0 +1,199 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
+ */
+#include <math.h>
+
+#include "spi_api.h"
+#include "cmsis.h"
+#include "pinmap.h"
+#include "error.h"
+
+static const PinMap PinMap_SPI_SCLK[] = {
+    {P3_0 , SPI_0, (SCU_PINIO_FAST | 2)},
+    {PF_4 , SPI_1, (SCU_PINIO_FAST | 2)},
+    {NC   , NC   , 0}
+};
+
+static const PinMap PinMap_SPI_MOSI[] = {
+    {P1_2 , SPI_0, (SCU_PINIO_FAST | 2)},
+    {P1_4 , SPI_1, (SCU_PINIO_FAST | 2)},
+    {NC   , NC   , 0}
+};
+
+static const PinMap PinMap_SPI_MISO[] = {
+    {P1_1 , SPI_0, (SCU_PINIO_FAST | 2)},
+    {P1_3 , SPI_1, (SCU_PINIO_FAST | 2)},
+    {NC   , NC   , 0}
+};
+
+static const PinMap PinMap_SPI_SSEL[] = {
+    {P1_0 , SPI_0, (SCU_PINIO_FAST | 2)},
+    {P1_5 , SPI_1, (SCU_PINIO_FAST | 2)},
+    {NC   , NC   , 0}
+};
+
+static inline int ssp_disable(spi_t *obj);
+static inline int ssp_enable(spi_t *obj);
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
+    // determine the SPI to use
+    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
+    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
+    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
+
+    obj->spi = (LPC_SSP_T*)pinmap_merge(spi_data, spi_cntl);
+    if ((int)obj->spi == NC) {
+        error("SPI pinout mapping failed");
+    }
+
+    // set default format and frequency
+    if (ssel == NC) {
+        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
+    } else {
+        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
+    }
+    spi_frequency(obj, 1000000);
+    
+    // enable the ssp channel
+    ssp_enable(obj);
+    
+    // pin out the spi pins
+    pinmap_pinout(mosi, PinMap_SPI_MOSI);
+    pinmap_pinout(miso, PinMap_SPI_MISO);
+    pinmap_pinout(sclk, PinMap_SPI_SCLK);
+    if (ssel != NC) {
+        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    }
+}
+
+void spi_free(spi_t *obj) {}
+
+void spi_format(spi_t *obj, int bits, int mode, int slave) {
+    ssp_disable(obj);
+    
+    if (!(bits >= 4 && bits <= 16) || !(mode >= 0 && mode <= 3)) {
+        error("SPI format error");
+    }
+    
+    int polarity = (mode & 0x2) ? 1 : 0;
+    int phase = (mode & 0x1) ? 1 : 0;
+    
+    // set it up
+    int DSS = bits - 1;            // DSS (data select size)
+    int SPO = (polarity) ? 1 : 0;  // SPO - clock out polarity
+    int SPH = (phase) ? 1 : 0;     // SPH - clock out phase
+    
+    int FRF = 0;                   // FRF (frame format) = SPI
+    uint32_t tmp = obj->spi->CR0;
+    tmp &= ~(0xFFFF);
+    tmp |= DSS << 0
+        | FRF << 4
+        | SPO << 6
+        | SPH << 7;
+    obj->spi->CR0 = tmp;
+    
+    tmp = obj->spi->CR1;
+    tmp &= ~(0xD);
+    tmp |= 0 << 0                   // LBM - loop back mode - off
+        | ((slave) ? 1 : 0) << 2   // MS - master slave mode, 1 = slave
+        | 0 << 3;                  // SOD - slave output disable - na
+    obj->spi->CR1 = tmp;
+    ssp_enable(obj);
+}
+
+void spi_frequency(spi_t *obj, int hz) {
+    ssp_disable(obj);
+    
+    uint32_t PCLK = SystemCoreClock;
+    
+    int prescaler;
+    
+    for (prescaler = 2; prescaler <= 254; prescaler += 2) {
+        int prescale_hz = PCLK / prescaler;
+        
+        // calculate the divider
+        int divider = floor(((float)prescale_hz / (float)hz) + 0.5f);
+        
+        // check we can support the divider
+        if (divider < 256) {
+            // prescaler
+            obj->spi->CPSR = prescaler;
+            
+            // divider
+            obj->spi->CR0 &= ~(0xFFFF << 8);
+            obj->spi->CR0 |= (divider - 1) << 8;
+            ssp_enable(obj);
+            return;
+        }
+    }
+    error("Couldn't setup requested SPI frequency");
+}
+
+static inline int ssp_disable(spi_t *obj) {
+    return obj->spi->CR1 &= ~(1 << 1);
+}
+
+static inline int ssp_enable(spi_t *obj) {
+    return obj->spi->CR1 |= (1 << 1);
+}
+
+static inline int ssp_readable(spi_t *obj) {
+    return obj->spi->SR & (1 << 2);
+}
+
+static inline int ssp_writeable(spi_t *obj) {
+    return obj->spi->SR & (1 << 1);
+}
+
+static inline void ssp_write(spi_t *obj, int value) {
+    while (!ssp_writeable(obj));
+    obj->spi->DR = value;
+}
+
+static inline int ssp_read(spi_t *obj) {
+    while (!ssp_readable(obj));
+    return obj->spi->DR;
+}
+
+static inline int ssp_busy(spi_t *obj) {
+    return (obj->spi->SR & (1 << 4)) ? (1) : (0);
+}
+
+int spi_master_write(spi_t *obj, int value) {
+    ssp_write(obj, value);
+    return ssp_read(obj);
+}
+
+int spi_slave_receive(spi_t *obj) {
+    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+};
+
+int spi_slave_read(spi_t *obj) {
+    return obj->spi->DR;
+}
+
+void spi_slave_write(spi_t *obj, int value) {
+    while (ssp_writeable(obj) == 0) ;
+    obj->spi->DR = value;
+}
+
+int spi_busy(spi_t *obj) {
+    return ssp_busy(obj);
+}

--- a/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/us_ticker.c
+++ b/libraries/mbed/targets/hal/NXP/TARGET_LPC43XX/us_ticker.c
@@ -1,0 +1,64 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
+ */
+#include <stddef.h>
+#include "us_ticker_api.h"
+#include "PeripheralNames.h"
+
+#define US_TICKER_TIMER      ((LPC_TIMER_T *)LPC_TIMER3_BASE)
+#define US_TICKER_TIMER_IRQn TIMER3_IRQn
+
+int us_ticker_inited = 0;
+
+void us_ticker_init(void) {
+    if (us_ticker_inited) return;
+    us_ticker_inited = 1;
+    
+    US_TICKER_TIMER->CTCR = 0x0; // timer mode
+    uint32_t PCLK = SystemCoreClock;
+
+    US_TICKER_TIMER->TCR = 0x2;  // reset
+    
+    uint32_t prescale = PCLK / 1000000; // default to 1MHz (1 us ticks)
+    US_TICKER_TIMER->PR = prescale - 1;
+    US_TICKER_TIMER->TCR = 1; // enable = 1, reset = 0
+    
+    NVIC_SetVector(US_TICKER_TIMER_IRQn, (uint32_t)us_ticker_irq_handler);
+    NVIC_EnableIRQ(US_TICKER_TIMER_IRQn);
+}
+
+uint32_t us_ticker_read() {
+    if (!us_ticker_inited)
+        us_ticker_init();
+    
+    return US_TICKER_TIMER->TC;
+}
+
+void us_ticker_set_interrupt(unsigned int timestamp) {
+    // set match value
+    US_TICKER_TIMER->MR[3] = timestamp;
+    // enable match interrupt
+    US_TICKER_TIMER->MCR |= 1;
+}
+
+void us_ticker_disable_interrupt(void) {
+    US_TICKER_TIMER->MCR &= ~1;
+}
+
+void us_ticker_clear_interrupt(void) {
+    US_TICKER_TIMER->IR = 1;
+}

--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -96,6 +96,17 @@ class LPC4088(Target):
         self.supported_toolchains = ["ARM", "GCC_CR"]
 
 
+class LPC4330(Target):
+    def __init__(self):
+        Target.__init__(self)
+        
+        self.core = "Cortex-M4"
+        
+        self.extra_labels = ['LPC43XX']
+        
+        self.supported_toolchains = ["ARM", "GCC_CR", "IAR"]
+
+
 class MBED_MCU(Target):
     def __init__(self):
         Target.__init__(self)
@@ -113,6 +124,7 @@ TARGETS = [
     KL25Z(),
     LPC812(),
     LPC4088(),
+    LPC4330(),
     MBED_MCU()
 ]
 

--- a/workspace_tools/toolchains/gcc.py
+++ b/workspace_tools/toolchains/gcc.py
@@ -2,7 +2,7 @@ import re
 from os.path import join, basename, splitext
 
 from workspace_tools.toolchains import mbedToolchain
-from workspace_tools.settings import GCC_ARM_PATH, GCC_CR_PATH, GCC_CS_PATH, CW_EWL_PATH, CW_GCC_PATH, GCC_CW_PATH
+from workspace_tools.settings import GCC_ARM_PATH, GCC_CR_PATH, GCC_CS_PATH, EWL_LIB_PATH, GCC_CW_PATH, GCC_CW_PATH
 
 
 class GCC(mbedToolchain):


### PR DESCRIPTION
This is an mbed port to the LPC43xx tested with the Micromint Bambino 200. Some details are available in the README file

mbed/libraries/mbed/vendor/NXP/LPC43XX/README.txt

This port is still in development. Besides bug fixes there are two major changes planned for the next few weeks:
1. Support for Ethernet, USB and microSD filesystems when the Bambino 200E is shipping.
2. Use the mbed SDK with the slave M0 core.We can build mbed M0 binaries (using an external project file) but some changes are required in the startup so they can be started from the master M4 core.

Regards,
Jesus Alvarez
