### PR TITLE
Fixups to network code after recent merges.

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X/TOOLCHAIN_GCC_ARM/LPC1768.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X/TOOLCHAIN_GCC_ARM/LPC1768.ld
@@ -116,25 +116,6 @@ SECTIONS
     } > RAM
 
     
-    /* Code can explicitly ask for data to be
-       placed in these higher RAM banks where
-       they will be left uninitialized.
-    */
-    .AHBSRAM0 (NOLOAD):
-    {
-        Image$$RW_IRAM2$$Base = . ;
-        *(AHBSRAM0)
-        Image$$RW_IRAM2$$ZI$$Limit = .;
-    } > USB_RAM
-
-    .AHBSRAM1 (NOLOAD):
-    {
-        Image$$RW_IRAM3$$Base = . ;
-        *(AHBSRAM1)
-        Image$$RW_IRAM3$$ZI$$Limit = .;
-    } > ETH_RAM
-    
-    
     .bss :
     {
         __bss_start__ = .;

--- a/libraries/net/eth/lwip-eth/arch/lpc17_emac.c
+++ b/libraries/net/eth/lwip-eth/arch/lpc17_emac.c
@@ -139,11 +139,11 @@ struct lpc_enetdata {
 #     define ETHMEM_SECTION __attribute__((section("AHBSRAM1"),aligned))
 #  endif
 #else
-#   define ETHMEM_SECTION ALIGNED(8)
-#endif
-
 #if defined(TARGET_LPC1768) && defined(TOOLCHAIN_GCC_ARM)
-#define ETHMEM_SECTION __attribute__((section("AHBSRAM1"),aligned))
+#     define ETHMEM_SECTION __attribute__((section("AHBSRAM1"),aligned))
+#else
+#     define ETHMEM_SECTION ALIGNED(8)
+#endif
 #endif
 
 /** \brief  LPC EMAC driver work data


### PR DESCRIPTION
Peter's and my changes to LPC1768.ld ended up adding the same AHBSRAM0
and AHBSRAM1 section clauses to the script twice.  I removed one copy.

I also pulled Peter's define of the ETHMEM_SECTION macro up into the
previous nested #if so that the preprocessor wouldn't spit out a
redefined macro warning.

I verified that building the code clean before and after these changes
still results in the same .bin file but now without warnings and/or
duplicate code.
