### PR TITLE
Don't dereference NULL ipaddr in netif_set_ipaddr()

### DIFF
--- a/libraries/net/lwip/lwip/core/netif.c
+++ b/libraries/net/lwip/lwip/core/netif.c
@@ -318,6 +318,12 @@ netif_find(char *name)
 void
 netif_set_ipaddr(struct netif *netif, ip_addr_t *ipaddr)
 {
+  /* Protect against dereferencing NULL pointers by
+     treating like ANY, as does ip_addr_set() */
+  if (!ipaddr) {
+    ipaddr = IP_ADDR_ANY;
+  }
+  
   /* TODO: Handling of obsolete pcbs */
   /* See:  http://mail.gnu.org/archive/html/lwip-users/2003-03/msg00118.html */
 #if LWIP_TCP


### PR DESCRIPTION
The code in netif_set_ipaddr would read the memory pointed to by its
ipaddr parameter, even if it was NULL on this line:
  if ((ip_addr_cmp(ipaddr, &(netif->ip_addr))) == 0) {
On the Cortex-M3, it is typically OK to read from address 0 so this
code will actually compare the reset stack pointer value to the
current value in netif->ip_addr.

Later in the code, this same pointer will be used for a second read:
  ip_addr_set(&(netif->ip_addr), ipaddr);

The ip_addr_set call will first check to see if the ipaddr is NULL and
if so, treats it like IP_ADDR_ANY (4 bytes of 0).
    /*\* Safely copy one IP address to another (src may be NULL) */
    #define ip_addr_set(dest, src) ((dest)->addr = \
                                        ((src) == NULL ? 0 : \
                                        (src)->addr))

The issue here is that when GCC optimizes this code, it assumes that
the first dereference of ipaddr would have thrown an invalid memory
access exception and execution would never make it to this second
dereference.  Therefore it optimizes out the NULL check in ip_addr_set.

The -fno-delete-null-pointer-checks will disable this optimization and
is a good thing to use with GCC in general on Cortex-M parts.  I will
let the mbed guys make that change to their build system.

I have however corrected the code so that the intent of how to handle a
NULL ipaddr is more obvious and gets rid of the potential NULL
dereference.

By the way, this bug caused connect() to fail in obtaining an
address from DHCP.  If I recall correctly from when I first debugged
this issue (late last year), I actually saw the initial value of the
stack pointer being used in the DHCP request as an IP address which
caused it to be rejected.
