### PR TITLE
USBDevice: Silence GCC warning

### DIFF
--- a/libraries/USBDevice/USBDevice/USBHAL_KL25Z.cpp
+++ b/libraries/USBDevice/USBDevice/USBHAL_KL25Z.cpp
@@ -75,7 +75,7 @@ static uint8_t addr = 0;
 static uint32_t Data1  = 0x55555555;
 
 static uint32_t frameNumber() {
-    return((USB0->FRMNUML | (USB0->FRMNUMH << 8) & 0x07FF));
+    return((USB0->FRMNUML | (USB0->FRMNUMH << 8)) & 0x07FF);
 }
 
 uint32_t USBHAL::endpointReadcore(uint8_t endpoint, uint8_t *buffer) {


### PR DESCRIPTION
The following line in USBHAL_KL25Z.cpp would generate a warning in GCC
because of a potential operator precendence issue:
    return((USB0->FRMNUML | (USB0->FRMNUMH << 8) & 0x07FF));

This would have been interpreted as:
    return((USB0->FRMNUML | ((USB0->FRMNUMH << 8) & 0x07FF)));
since & has higher precedence than |

I switched it to be:
    return((USB0->FRMNUML | (USB0->FRMNUMH << 8)) & 0x07FF);
Since it makes more sense to & with 0x7FF after having merged the lower
and upper bytes together rather than just the upper byte.  It should
have resulted in the same value either way.
