### PR TITLE
Updates to GCC warning level flags

### DIFF
--- a/workspace_tools/toolchains/gcc.py
+++ b/workspace_tools/toolchains/gcc.py
@@ -47,7 +47,8 @@ class GCC(mbedToolchain):
         
         # Note: We are using "-O2" instead of "-Os" to avoid this known GCC bug:
         # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=46762
-        common_flags = ["-c", "-O2", "-Wall",
+        common_flags = ["-c", "-O2", "-Wall", "-Wextra",
+            "-Wno-unused-parameter", "-Wno-missing-field-initializers",
             "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
             "-ffunction-sections", "-fdata-sections",
             "-MMD", "-fno-delete-null-pointer-checks",


### PR DESCRIPTION
In gcc4mbed, I have been running with "-Wall -Wextra" and then
disabling a couple of noisy warnings that result.  In particular, I
disable the unused-parameter and missing-field-initializers warnings.
The first commonly goes off for implementation of virtual methods or
other overridable functions where not all parameters are required for
every override.  I don't find the second warning to be all that useful
anyway since missing structure field initializers will be set to 0
according to the C language specification.  The RTOS code uses this
language feature and I see no reason that it shouldn't :)
