### PR TITLE
Fixed: The issue of interrupt vector remapping for GCC_ARM LPC1114

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC11XX/TOOLCHAIN_GCC_ARM/LPC1114.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC11XX/TOOLCHAIN_GCC_ARM/LPC1114.ld
@@ -40,6 +40,8 @@ SECTIONS
     .text :
     {
         KEEP(*(.isr_vector))
+		*(.text.Reset_Handler)
+        *(.text.SystemInit)
 		. = 0x200;
         *(.text*)
 


### PR DESCRIPTION
Fixed: The issue of interrupt vector remapping for GCC_ARM LPC1114
