### PR TITLE
serial_putc() can cause rx bytes to be dropped

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11CXX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11CXX/serial_api.c
@@ -249,12 +249,6 @@ int serial_getc(serial_t *obj) {
 void serial_putc(serial_t *obj, int c) {
     while (!serial_writable(obj));
     obj->uart->THR = c;
-    
-#warning TODO(@toyowata): need to fix a full-duplex bug? https://mbed.org/forum/bugs-suggestions/topic/4473/
-    uint32_t lsr = obj->uart->LSR;
-    lsr = lsr;
-    uint32_t thr = obj->uart->THR;
-    thr = thr;
 }
 
 int serial_readable(serial_t *obj) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/serial_api.c
@@ -247,11 +247,6 @@ int serial_getc(serial_t *obj) {
 void serial_putc(serial_t *obj, int c) {
     while (!serial_writable(obj));
     obj->uart->THR = c;
-    
-    uint32_t lsr = obj->uart->LSR;
-    lsr = lsr;
-    uint32_t thr = obj->uart->THR;
-    thr = thr;
 }
 
 int serial_readable(serial_t *obj) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/serial_api.c
@@ -247,11 +247,6 @@ int serial_getc(serial_t *obj) {
 void serial_putc(serial_t *obj, int c) {
     while (!serial_writable(obj));
     obj->uart->THR = c;
-    
-    uint32_t lsr = obj->uart->LSR;
-    lsr = lsr;
-    uint32_t thr = obj->uart->THR;
-    thr = thr;
 }
 
 int serial_readable(serial_t *obj) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/serial_api.c
@@ -283,11 +283,6 @@ int serial_getc(serial_t *obj) {
 void serial_putc(serial_t *obj, int c) {
     while (!serial_writable(obj));
     obj->uart->THR = c;
-    
-    uint32_t lsr = obj->uart->LSR;
-    lsr = lsr;
-    uint32_t thr = obj->uart->THR;
-    thr = thr;
 }
 
 int serial_readable(serial_t *obj) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/serial_api.c
@@ -283,11 +283,6 @@ int serial_getc(serial_t *obj) {
 void serial_putc(serial_t *obj, int c) {
     while (!serial_writable(obj));
     obj->uart->THR = c;
-    
-    uint32_t lsr = obj->uart->LSR;
-    lsr = lsr;
-    uint32_t thr = obj->uart->THR;
-    thr = thr;
 }
 
 int serial_readable(serial_t *obj) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/serial_api.c
@@ -276,11 +276,6 @@ int serial_getc(serial_t *obj) {
 void serial_putc(serial_t *obj, int c) {
     while (!serial_writable(obj));
     obj->uart->THR = c;
-    
-    uint32_t lsr = obj->uart->LSR;
-    lsr = lsr;
-    uint32_t thr = obj->uart->THR;
-    thr = thr;
 }
 
 int serial_readable(serial_t *obj) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/serial_api.c
@@ -257,11 +257,6 @@ int serial_getc(serial_t *obj) {
 void serial_putc(serial_t *obj, int c) {
     while (!serial_writable(obj));
     obj->uart->THR = c;
-    
-    uint32_t lsr = obj->uart->LSR;
-    lsr = lsr;
-    uint32_t thr = obj->uart->THR;
-    thr = thr;
 }
 
 int serial_readable(serial_t *obj) {


### PR DESCRIPTION
While fixing this issue in the various LPC\* ports, I noticed a comment
pointing to this mbed forum post which summarizes this bug quite well:
  https://mbed.org/forum/bugs-suggestions/topic/4473/

This bug was introduced in the following commit:
https://github.com/mbedmicro/mbed/commit/2662e105c43c93986d52713234375b7910acf297

The following code was added to serial_putc() as part of this commit:
    uint32_t lsr = obj->uart->LSR;
    lsr = lsr;
    uint32_t thr = obj->uart->THR;
    thr = thr;

As the forum post indicates, this causes the serial_putc() routine to
actually eat an inbound received byte if it exists since reading THR is
really reading the RBR, the Receiver Buffer Register.  This code looks
like code that was probably added so that the developer could take a
snapshot of these registers and look at them in the debugger.  It
probably got committed in error.
