### PR TITLE
serial_putc() to make better use of Tx FIFO

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/objects.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/objects.h
@@ -47,6 +47,7 @@ struct pwmout_s {
 struct serial_s {
     LPC_UART_TypeDef *uart;
     int index;
+    uint8_t count;
 };
 
 struct analogin_s {


### PR DESCRIPTION
If don't know if this is an issue that anyone cares about.  I am also
not sure what the best way to solve it is either.  I just thought I
would issue a pull request with this commit to bring the issue to light
and show a possible solution that I have tested on my mbed-1768 device.

Previously the serial_putc() API didn't make any use of the Tx FIFO
since the serial_writable() API it utilizes only returns true when the
FIFO is completely empty.  This is due to the fact that the THRE bit of
the UART's LSR (Line Status Register) only goes high when the whole
FIFO is empty.

I noticed this when doing some performance testing with the network
stack.  I went from calling printf() to output 3 bytes every 10 seconds
(with packet drop stats) to instead output 4 bytes every 10 seconds.
I thought these should easily fit in the 16 byte FIFO but outputting
one extra byte caused an additional three 550 byte UDP packets to be
dropped.  This should only happen if the additional character being
sent to the UART was taking away extra CPU cycles from the network
stack.

My solution is to keep track of the number of bytes that have been
placed in the Tx FIFO since it was last detected as being completely
empty (via the THRE bit).  Only once this count hits 16 does the code
then block, waiting for the THRE bit to go high.  Each time the THRE
bit does go high, the count is reset to 0 again and it is incremented
for each byte that is loaded into the THR.
