### PR TITLE
Fix MASKED_ACCESS bug in gpio_init

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11CXX/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11CXX/gpio_api.c
@@ -28,7 +28,7 @@ uint32_t gpio_set(PinName pin) {
              (1) : (0);
     
     pin_function(pin, f);
-    return ((pin & 0x0F00) >> 8);
+    return ((pin & 0x0F00) >> PIN_SHIFT);
 }
 
 void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
@@ -36,8 +36,8 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
 
     obj->pin = pin;
     LPC_GPIO_TypeDef *port_reg = ((LPC_GPIO_TypeDef *) (LPC_GPIO0_BASE + (((pin & 0xF000) >> PORT_SHIFT) * 0x10000)));
-
-    obj->reg_mask_read = &port_reg->MASKED_ACCESS[gpio_set(pin) + 1];
+    
+    obj->reg_mask_read = &port_reg->MASKED_ACCESS[1 << gpio_set(pin)];
     obj->reg_dir       = &port_reg->DIR;
     obj->reg_write     = &port_reg->DATA;
     


### PR DESCRIPTION
Now same as LPC11xx (Also use PIN_SHIFT instead of magic number 8 in gpio_set)
