### PR TITLE
Fix hardfault when attaching callback to CAN2 when CAN1 is not defined

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/can_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/can_api.c
@@ -164,7 +164,7 @@ void can_irq_set(can_t *obj, CanIrqType type, uint32_t enable) {
     obj->dev->MOD &= ~(1);
     
     // Enable NVIC if at least 1 interrupt is active
-    if(LPC_CAN1->IER | LPC_CAN2->IER) {
+    if(((LPC_SC->PCONP & (1 << 13)) && LPC_CAN1->IER) || ((LPC_SC->PCONP & (1 << 14)) && LPC_CAN2->IER)) {
         NVIC_SetVector(CAN_IRQn, (uint32_t) &can_irq_n);
         NVIC_EnableIRQ(CAN_IRQn);
     }


### PR DESCRIPTION
Fault is triggered by trying to read LPC_CAN1->IER when the peripheral is powered off. Fixed by checking the power control register before checking the IER register.
