### PR TITLE
Fix _sbrk() implementation for Cortex-M parts.

### DIFF
--- a/libraries/mbed/common/retarget.cpp
+++ b/libraries/mbed/common/retarget.cpp
@@ -448,10 +448,10 @@ extern "C" caddr_t _sbrk(int incr) {
     unsigned char*        prev_heap = heap;
     unsigned char*        new_heap = heap + incr;
 
-#ifdef __get_MSP
-    if (new_heap >= (unsigned char*)__get_MSP()) {
-#else
+#if defined(TARGET_ARM7)
     if (new_heap >= stack_ptr) {
+#else
+    if (new_heap >= (unsigned char*)__get_MSP()) {
 #endif
         errno = ENOMEM;
         return (caddr_t)-1;


### PR DESCRIPTION
A recent commit, 43acaa4166, to get _sbrk() to build successfully for
LPC2368 broke the Cortex-M implementation.  __get_MSP() isn't ever
defined as a macro, it is an inline function.  This means that the
code would always be compiled to use SP instead of MSP on Cortex-M
parts.  I switched the code to instead use the TARGET_ARM7 define
to choose which stack pointer to utilize.

I tested this fix by making sure that the LPC2368 version of the mbed
SDK would still build successfully with the Python scripts and that the
NET1 test still built and ran successfully on my mbed-LPC1768 device.
