### PR TITLE
Replace #ifdef with #if DEVICE_STDIO_MESSAGES

### DIFF
--- a/libraries/mbed/api/error.h
+++ b/libraries/mbed/api/error.h
@@ -56,7 +56,7 @@
 #include <stdlib.h>
 #include "device.h"
 
-#ifdef DEVICE_STDIO_MESSAGES
+#if DEVICE_STDIO_MESSAGES
     #include <stdio.h>
     #define error(...) (fprintf(stderr, __VA_ARGS__), exit(1))
 #else

--- a/libraries/mbed/api/mbed_debug.h
+++ b/libraries/mbed/api/mbed_debug.h
@@ -21,7 +21,7 @@
 extern "C" {
 #endif
 
-#ifdef DEVICE_STDIO_MESSAGES
+#if DEVICE_STDIO_MESSAGES
 #include <stdio.h>
 #include <stdarg.h>
 


### PR DESCRIPTION
DEVICE_STDIO_MESSAGES is the only #define in device.h that is being used in the library as #ifdef rather than #if. This is misleading since setting it to 0 will not disable including the <stdio.h> libraries.
