### PR TITLE
Split up source files in groups

### DIFF
--- a/workspace_tools/export/uvision4.py
+++ b/workspace_tools/export/uvision4.py
@@ -31,18 +31,27 @@ class Uvision4(Exporter):
     # 'headers':'5',
     
     def generate(self):
-        source_files = []
+        source_files = {
+            'mbed': [],
+            'hal': [],
+            'src': []
+        }
         for r_type, n in Uvision4.FILE_TYPES.iteritems():
             for file in getattr(self.resources, r_type):
-                source_files.append({
-                    'name': basename(file), 'type': n, 'path': file
-                })
+                f = {'name': basename(file), 'type': n, 'path': file}
+                if file.startswith("mbed\\common"):
+                    source_files['mbed'].append(f)
+                elif file.startswith("mbed\\targets"):
+                    source_files['hal'].append(f)
+                else:
+                    source_files['src'].append(f)
+        
         ctx = {
             'name': self.program_name,
             'include_paths': self.resources.inc_dirs,
             'scatter_file': self.resources.linker_script,
             'object_files': self.resources.objects + self.resources.libraries,
-            'source_files': source_files,
+            'source_files': source_files.items(),
             'symbols': self.toolchain.get_symbols()
         }
         target = self.target.lower()

--- a/workspace_tools/export/uvision4_kl25z.uvproj.tmpl
+++ b/workspace_tools/export/uvision4_kl25z.uvproj.tmpl
@@ -391,30 +391,31 @@
         </TargetArmAds>
       </TargetOption>
       <Groups>
+        {% for group,files in source_files %}
         <Group>
-          <GroupName>src</GroupName>
+          <GroupName>{{group}}</GroupName>
           <Files>
-               {% for file in source_files %}
-               <File>
-                        <FileName>{{file.name}}</FileName>
-                        <FileType>{{file.type}}</FileType>
-                        <FilePath>{{file.path}}</FilePath>
-                        {%if file.type == "1" %}
-                        <FileOption>
-                            <FileArmAds>
-                              <Cads>
-                                <VariousControls>
-                                  <MiscControls>--c99</MiscControls>
-                                </VariousControls>
-                              </Cads>
-                            </FileArmAds>
-                        </FileOption>
-                        {% endif %}
-                </File>
-               {% endfor %}
-
+            {% for file in files %}
+            <File>
+              <FileName>{{file.name}}</FileName>
+              <FileType>{{file.type}}</FileType>
+              <FilePath>{{file.path}}</FilePath>
+              {%if file.type == "1" %}
+              <FileOption>
+                  <FileArmAds>
+                    <Cads>
+                      <VariousControls>
+                        <MiscControls>--c99</MiscControls>
+                      </VariousControls>
+                    </Cads>
+                  </FileArmAds>
+              </FileOption>
+              {% endif %}
+            </File>
+            {% endfor %}
           </Files>
         </Group>
+        {% endfor %}
       </Groups>
     </Target>
   </Targets>

--- a/workspace_tools/export/uvision4_lpc1114.uvopt.tmpl
+++ b/workspace_tools/export/uvision4_lpc1114.uvopt.tmpl
@@ -43,7 +43,7 @@
         <PageWidth>79</PageWidth>
         <PageLength>66</PageLength>
         <TabStop>8</TabStop>
-        <ListingPath>.\</ListingPath>
+        <ListingPath>.\build\</ListingPath>
       </OPTLEX>
       <ListingPage>
         <CreateCListing>1</CreateCListing>

--- a/workspace_tools/export/uvision4_lpc1114.uvproj.tmpl
+++ b/workspace_tools/export/uvision4_lpc1114.uvproj.tmpl
@@ -43,14 +43,14 @@
             <NotGenerated>0</NotGenerated>
             <InvalidFlash>1</InvalidFlash>
           </TargetStatus>
-          <OutputDirectory>.\</OutputDirectory>
-          <OutputName>lpc1114_test</OutputName>
+          <OutputDirectory>.\build\</OutputDirectory>
+          <OutputName>{{name}}</OutputName>
           <CreateExecutable>1</CreateExecutable>
           <CreateLib>0</CreateLib>
           <CreateHexFile>0</CreateHexFile>
           <DebugInformation>1</DebugInformation>
           <BrowseInformation>1</BrowseInformation>
-          <ListingPath>.\</ListingPath>
+          <ListingPath>.\build\</ListingPath>
           <HexFormatSelection>1</HexFormatSelection>
           <Merge32K>0</Merge32K>
           <CreateBatchFile>0</CreateBatchFile>
@@ -393,10 +393,11 @@
         </TargetArmAds>
       </TargetOption>
       <Groups>
+        {% for group,files in source_files %}
         <Group>
-          <GroupName>src</GroupName>
+          <GroupName>{{group}}</GroupName>
           <Files>
-            {% for file in source_files %}
+            {% for file in files %}
             <File>
               <FileName>{{file.name}}</FileName>
               <FileType>{{file.type}}</FileType>
@@ -416,6 +417,7 @@
             {% endfor %}
           </Files>
         </Group>
+        {% endfor %}
       </Groups>
     </Target>
   </Targets>

--- a/workspace_tools/export/uvision4_lpc11c24.uvopt.tmpl
+++ b/workspace_tools/export/uvision4_lpc11c24.uvopt.tmpl
@@ -43,7 +43,7 @@
         <PageWidth>79</PageWidth>
         <PageLength>66</PageLength>
         <TabStop>8</TabStop>
-        <ListingPath>.\</ListingPath>
+        <ListingPath>.\build\</ListingPath>
       </OPTLEX>
       <ListingPage>
         <CreateCListing>1</CreateCListing>

--- a/workspace_tools/export/uvision4_lpc11c24.uvproj.tmpl
+++ b/workspace_tools/export/uvision4_lpc11c24.uvproj.tmpl
@@ -43,14 +43,14 @@
             <NotGenerated>0</NotGenerated>
             <InvalidFlash>1</InvalidFlash>
           </TargetStatus>
-          <OutputDirectory>.\</OutputDirectory>
-          <OutputName>lpc1114_test</OutputName>
+          <OutputDirectory>.\build\</OutputDirectory>
+          <OutputName>{{name}}</OutputName>
           <CreateExecutable>1</CreateExecutable>
           <CreateLib>0</CreateLib>
           <CreateHexFile>0</CreateHexFile>
           <DebugInformation>1</DebugInformation>
           <BrowseInformation>1</BrowseInformation>
-          <ListingPath>.\</ListingPath>
+          <ListingPath>.\build\</ListingPath>
           <HexFormatSelection>1</HexFormatSelection>
           <Merge32K>0</Merge32K>
           <CreateBatchFile>0</CreateBatchFile>
@@ -393,10 +393,11 @@
         </TargetArmAds>
       </TargetOption>
       <Groups>
+        {% for group,files in source_files %}
         <Group>
-          <GroupName>src</GroupName>
+          <GroupName>{{group}}</GroupName>
           <Files>
-            {% for file in source_files %}
+            {% for file in files %}
             <File>
               <FileName>{{file.name}}</FileName>
               <FileType>{{file.type}}</FileType>
@@ -416,6 +417,7 @@
             {% endfor %}
           </Files>
         </Group>
+        {% endfor %}
       </Groups>
     </Target>
   </Targets>

--- a/workspace_tools/export/uvision4_lpc11u24.uvproj.tmpl
+++ b/workspace_tools/export/uvision4_lpc11u24.uvproj.tmpl
@@ -387,19 +387,31 @@
         </TargetArmAds>
       </TargetOption>
       <Groups>
+        {% for group,files in source_files %}
         <Group>
-          <GroupName>src</GroupName>
+          <GroupName>{{group}}</GroupName>
           <Files>
-               {% for file in source_files %}
-               <File>
-                        <FileName>{{file.name}}</FileName>
-                        <FileType>{{file.type}}</FileType>
-                        <FilePath>{{file.path}}</FilePath>
-                </File>
-               {% endfor %}
-
+            {% for file in files %}
+            <File>
+              <FileName>{{file.name}}</FileName>
+              <FileType>{{file.type}}</FileType>
+              <FilePath>{{file.path}}</FilePath>
+              {%if file.type == "1" %}
+              <FileOption>
+                  <FileArmAds>
+                    <Cads>
+                      <VariousControls>
+                        <MiscControls>--c99</MiscControls>
+                      </VariousControls>
+                    </Cads>
+                  </FileArmAds>
+              </FileOption>
+              {% endif %}
+            </File>
+            {% endfor %}
           </Files>
         </Group>
+        {% endfor %}
       </Groups>
     </Target>
   </Targets>

--- a/workspace_tools/export/uvision4_lpc1347.uvproj.tmpl
+++ b/workspace_tools/export/uvision4_lpc1347.uvproj.tmpl
@@ -388,19 +388,31 @@
         </TargetArmAds>
       </TargetOption>
       <Groups>
+        {% for group,files in source_files %}
         <Group>
-          <GroupName>src</GroupName>
+          <GroupName>{{group}}</GroupName>
           <Files>
-               {% for file in source_files %}
-               <File>
-                        <FileName>{{file.name}}</FileName>
-                        <FileType>{{file.type}}</FileType>
-                        <FilePath>{{file.path}}</FilePath>
-                </File>
-               {% endfor %}
-
+            {% for file in files %}
+            <File>
+              <FileName>{{file.name}}</FileName>
+              <FileType>{{file.type}}</FileType>
+              <FilePath>{{file.path}}</FilePath>
+              {%if file.type == "1" %}
+              <FileOption>
+                  <FileArmAds>
+                    <Cads>
+                      <VariousControls>
+                        <MiscControls>--c99</MiscControls>
+                      </VariousControls>
+                    </Cads>
+                  </FileArmAds>
+              </FileOption>
+              {% endif %}
+            </File>
+            {% endfor %}
           </Files>
         </Group>
+        {% endfor %}
       </Groups>
     </Target>
   </Targets>

--- a/workspace_tools/export/uvision4_lpc1768.uvproj.tmpl
+++ b/workspace_tools/export/uvision4_lpc1768.uvproj.tmpl
@@ -392,29 +392,31 @@
         </TargetArmAds>
       </TargetOption>
       <Groups>
+        {% for group,files in source_files %}
         <Group>
-          <GroupName>src</GroupName>
+          <GroupName>{{group}}</GroupName>
           <Files>
-               {% for file in source_files %}
-               <File>
-                        <FileName>{{file.name}}</FileName>
-                        <FileType>{{file.type}}</FileType>
-                        <FilePath>{{file.path}}</FilePath>
-                        {%if file.type == "1" %}
-                        <FileOption>
-                            <FileArmAds>
-                              <Cads>
-                                <VariousControls>
-                                  <MiscControls>--c99</MiscControls>
-                                </VariousControls>
-                              </Cads>
-                            </FileArmAds>
-                        </FileOption>
-                        {% endif %}
-                </File>
-               {% endfor %}
+            {% for file in files %}
+            <File>
+              <FileName>{{file.name}}</FileName>
+              <FileType>{{file.type}}</FileType>
+              <FilePath>{{file.path}}</FilePath>
+              {%if file.type == "1" %}
+              <FileOption>
+                  <FileArmAds>
+                    <Cads>
+                      <VariousControls>
+                        <MiscControls>--c99</MiscControls>
+                      </VariousControls>
+                    </Cads>
+                  </FileArmAds>
+              </FileOption>
+              {% endif %}
+            </File>
+            {% endfor %}
           </Files>
         </Group>
+        {% endfor %}
       </Groups>
     </Target>
   </Targets>


### PR DESCRIPTION
**Note: Do not merge**

Split up source files in three groups to make projects more friendly to use.
![tree](https://f.cloud.github.com/assets/5098411/1162494/c56b48b2-2015-11e3-8b90-eea4e336b29c.png)

If this is considered an improvement I will do a proper pull request to master.
Note that the KL25Z, LPC11U24 and LPC1347 did not have the --c99 setting for c files before, please verify if this is intended or not.
