### PR TITLE
Issue #84 - Added command line source/build directory option

### DIFF
--- a/workspace_tools/settings.py
+++ b/workspace_tools/settings.py
@@ -53,7 +53,7 @@ ARM_CPPLIB = join(ARM_LIB, "cpplib")
 MY_ARM_CLIB = join(ARM_PATH, "lib", "microlib")
 
 # GCC ARM
-GCC_ARM_PATH = "/opt/gcc4mbed/gcc-arm-none-eabi/bin"
+GCC_ARM_PATH = "C:/arm-none-eabi-gcc-4_7/bin"
 
 # GCC CodeSourcery
 GCC_CS_PATH = "C:/Program Files (x86)/CodeSourcery/Sourcery_CodeBench_Lite_for_ARM_EABI/bin"


### PR DESCRIPTION
Basic command line option for source and build path. Todo: Need to include other parameters, like dependencies etc.
