### PR TITLE
GCC: conflicting types for 'can_filter' params

### DIFF
--- a/libraries/mbed/hal/can_api.h
+++ b/libraries/mbed/hal/can_api.h
@@ -65,7 +65,7 @@ void          can_irq_set  (can_t *obj, CanIrqType irq, uint32_t enable);
 int           can_write    (can_t *obj, CAN_Message, int cc);
 int           can_read     (can_t *obj, CAN_Message *msg, int handle);
 int           can_mode     (can_t *obj, CanMode mode);
-int           can_filter   (can_t *obj, unsigned int id, unsigned int mask, CANFormat format, int handle);
+int           can_filter   (can_t *obj, uint32_t id, uint32_t mask, CANFormat format, int32_t handle);
 void          can_reset    (can_t *obj);
 unsigned char can_rderror  (can_t *obj);
 unsigned char can_tderror  (can_t *obj);


### PR DESCRIPTION
Definition was previously updated to use uint32_t and int_t types for
the can_filter() function parameters but the declaration in the header
file didn't contain the same updates.  On GCC, this resulted in the
following error:

.../can_api.c:85:5: error: conflicting types for 'can_filter'
In file included from .../can_api.c:16:0:
.../can_api.h:68:15: note: previous declaration of 'can_filter' was here
