### PR TITLE
add readable(), writeable() and settings changed callback to USBSerial

### DIFF
--- a/libraries/USBDevice/USBSerial/USBCDC.h
+++ b/libraries/USBDevice/USBSerial/USBCDC.h
@@ -99,9 +99,21 @@ protected:
     * @returns true if successful
     */
     bool readEP_NB(uint8_t * buffer, uint32_t * size);
+
+    /*
+    * Called by USBCallback_requestCompleted when CDC line coding is changed
+    * Warning: Called in ISR
+    *
+    * @param baud The baud rate
+    * @param bits The number of bits in a word (5-8)
+    * @param parity The parity
+    * @param stop The number of stop bits (1 or 2)
+    */
+    virtual void lineCodingChanged(int baud, int bits, int parity, int stop) {};
     
 protected:
     virtual bool USBCallback_request();
+    virtual void USBCallback_requestCompleted(uint8_t *buf, uint32_t length);
     virtual bool USBCallback_setConfiguration(uint8_t configuration);
     volatile bool terminal_connected;
 


### PR DESCRIPTION
For class Serial has readable() and writeable(), add them to class USBSerial,  switch between Serial and USBSerial easily.
Add settings changed callback to USBSerial to implement a USB to UART bridge.

```
#include "mbed.h"
#include "USBSerial.h"

Serial uart(USBTX, USBRX);
USBSerial pc;

void settingsChanged(int baud, int bits, int parity, int stop)                // Called by ISR
{
    const Serial::Parity parityTable[] = {Serial::None, Serial::Odd, Serial::Even, Serial::Forced0, Serial::Forced1};
    if (stop != 2) {
        stop = 1;   // stop bit(s) = 1 or 1.5
    }
    uart.baud(baud);
    uart.format(bits, parityTable[parity], stop);
}

int main()
{
    pc.attach(settingsChanged);
    while (1) {
        while (uart.readable()) {
           pc.putc(uart.getc());
        }     
        while (pc.readable()) {
            uart.putc(pc.getc());
        }
    }
}
```
