### PR TITLE
Fix bug in gpio_set not setting reserved pins correctly

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/gpio_api.c
@@ -24,7 +24,7 @@ uint32_t gpio_set(PinName pin) {
     unsigned i;
     int f = 0;
 
-    for (i = 0; i < sizeof(reserved_pins) / sizeof(int); i ++)
+    for (i = 0; i < sizeof(reserved_pins) / sizeof(PinName); i ++)
         if (pin == reserved_pins[i]) {
             f = 1;
             break;


### PR DESCRIPTION
Loop going over reserved pins was not going over all entries as result of incorrect sizeof
