### PR TITLE
Increase available RAM for RTX on LPC11U24

### DIFF
--- a/libraries/rtos/rtx/RTX_CM_lib.h
+++ b/libraries/rtos/rtx/RTX_CM_lib.h
@@ -203,7 +203,7 @@ osThreadDef_t os_thread_def_main = {(os_pthread)main, osPriorityNormal, 0, NULL}
 #define INITIAL_SP            (0x10008000UL)
 
 #elif TARGET_LPC11U24
-#define INITIAL_SP            (0x10001000UL)
+#define INITIAL_SP            (0x10002000UL)
 
 #elif TARGET_LPC1114
 #define INITIAL_SP            (0x10001000UL)
@@ -226,8 +226,8 @@ osThreadDef_t os_thread_def_main = {(os_pthread)main, osPriorityNormal, 0, NULL}
 extern unsigned char     Image$$RW_IRAM1$$ZI$$Limit[];
 #define HEAP_START      (Image$$RW_IRAM1$$ZI$$Limit)
 #elif defined(__GNUC__)
-extern unsigned char     __HeapLimit[];
-#define HEAP_START      (__HeapLimit)
+extern unsigned char     __end__[];
+#define HEAP_START      (__end__)
 #endif
 
 void set_main_stack(void) {


### PR DESCRIPTION
The INITIAL_SP value used by RTX was originally at the 4k limit instead
of at the 8k limit.  The HEAP_START macro was defined to **HeapLimit
but the heap really starts at __end**.  __HeapLimit is just used for
some link time sanity checks to verify that the heap and stack can
grow a bit without colliding.

See https://mbed.org/questions/2065/RTOS-Memory-Usage-Confusion/ for Neil Thiessen's encountering of the LPC11U24 issue as well.
