### PR TITLE
Avoid hardfault when CAN object is destructed.

### DIFF
--- a/libraries/mbed/common/CAN.cpp
+++ b/libraries/mbed/common/CAN.cpp
@@ -27,8 +27,8 @@ CAN::CAN(PinName rd, PinName td) {
 }
 
 CAN::~CAN() {
-    can_free(&_can);
     can_irq_free(&_can);
+    can_free(&_can);
 }
 
 int CAN::frequency(int f) {


### PR DESCRIPTION
interrupts have to be disabled(can_irq_free) before we turn off(can_free) the peripheral
