### PR TITLE
NXP targets: Improved baudrate calculation function

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/serial_api.c
@@ -124,22 +124,47 @@ void serial_baud(serial_t *obj, int baudrate) {
     uint16_t dlv;
     uint8_t mv, dav;
     if ((PCLK % (16 * baudrate)) != 0) {     // Checking for zero remainder
-        float err_best = (float) baudrate;
-        uint16_t dlmax = DL;
-        for ( dlv = (dlmax/2); (dlv <= dlmax) && !hit; dlv++) {
-            for ( mv = 1; mv <= 15; mv++) {
-                for ( dav = 1; dav < mv; dav++) {
-                    float ratio = 1.0f + ((float) dav / (float) mv);
-                    float calcbaud = (float)PCLK / (16.0f * (float) dlv * ratio);
-                    float err = fabs(((float) baudrate - calcbaud) / (float) baudrate);
-                    if (err < err_best) {
-                        DL = dlv;
-                        DivAddVal = dav;
-                        MulVal = mv;
-                        err_best = err;
-                        if (err < 0.001f) {
-                            hit = 1;
-                        }
+        int err_best = baudrate, b;
+        for (mv = 1; mv < 16 && !hit; mv++)
+        {
+            for (dav = 0; dav < mv; dav++)
+            {
+                // baudrate = PCLK / (16 * dlv * (1 + (DivAdd / Mul))
+                // solving for dlv, we get dlv = mul * PCLK / (16 * baudrate * (divadd + mul))
+                // mul has 4 bits, PCLK has 27 so we have 1 bit headroom which can be used for rounding
+                // for many values of mul and PCLK we have 2 or more bits of headroom which can be used to improve precision
+                // note: X / 32 doesn't round correctly. Instead, we use ((X / 16) + 1) / 2 for correct rounding
+
+                if ((mv * PCLK * 2) & 0x80000000) // 1 bit headroom
+                    dlv = ((((2 * mv * PCLK) / (baudrate * (dav + mv))) / 16) + 1) / 2;
+                else // 2 bits headroom, use more precision
+                    dlv = ((((4 * mv * PCLK) / (baudrate * (dav + mv))) / 32) + 1) / 2;
+
+                // datasheet says if DLL==DLM==0, then 1 is used instead since divide by zero is ungood
+                if (dlv == 0)
+                    dlv = 1;
+
+                // datasheet says if dav > 0 then DL must be >= 2
+                if ((dav > 0) && (dlv < 2))
+                    dlv = 2;
+
+                // integer rearrangement of the baudrate equation (with rounding)
+                b = ((PCLK * mv / (dlv * (dav + mv) * 8)) + 1) / 2;
+
+                // check to see how we went
+                b = abs(b - baudrate);
+                if (b < err_best)
+                {
+                    err_best  = b;
+
+                    DL        = dlv;
+                    MulVal    = mv;
+                    DivAddVal = dav;
+
+                    if (b == baudrate)
+                    {
+                        hit = 1;
+                        break;
                     }
                 }
             }

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/serial_api.c
@@ -121,22 +121,47 @@ void serial_baud(serial_t *obj, int baudrate) {
     uint16_t dlv;
     uint8_t mv, dav;
     if ((PCLK % (16 * baudrate)) != 0) {     // Checking for zero remainder
-        float err_best = (float) baudrate;
-        uint16_t dlmax = DL;
-        for ( dlv = (dlmax/2); (dlv <= dlmax) && !hit; dlv++) {
-            for ( mv = 1; mv <= 15; mv++) {
-                for ( dav = 1; dav < mv; dav++) {
-                    float ratio = 1.0f + ((float) dav / (float) mv);
-                    float calcbaud = (float)PCLK / (16.0f * (float) dlv * ratio);
-                    float err = fabs(((float) baudrate - calcbaud) / (float) baudrate);
-                    if (err < err_best) {
-                        DL = dlv;
-                        DivAddVal = dav;
-                        MulVal = mv;
-                        err_best = err;
-                        if (err < 0.001f) {
-                            hit = 1;
-                        }
+        int err_best = baudrate, b;
+        for (mv = 1; mv < 16 && !hit; mv++)
+        {
+            for (dav = 0; dav < mv; dav++)
+            {
+                // baudrate = PCLK / (16 * dlv * (1 + (DivAdd / Mul))
+                // solving for dlv, we get dlv = mul * PCLK / (16 * baudrate * (divadd + mul))
+                // mul has 4 bits, PCLK has 27 so we have 1 bit headroom which can be used for rounding
+                // for many values of mul and PCLK we have 2 or more bits of headroom which can be used to improve precision
+                // note: X / 32 doesn't round correctly. Instead, we use ((X / 16) + 1) / 2 for correct rounding
+
+                if ((mv * PCLK * 2) & 0x80000000) // 1 bit headroom
+                    dlv = ((((2 * mv * PCLK) / (baudrate * (dav + mv))) / 16) + 1) / 2;
+                else // 2 bits headroom, use more precision
+                    dlv = ((((4 * mv * PCLK) / (baudrate * (dav + mv))) / 32) + 1) / 2;
+
+                // datasheet says if DLL==DLM==0, then 1 is used instead since divide by zero is ungood
+                if (dlv == 0)
+                    dlv = 1;
+
+                // datasheet says if dav > 0 then DL must be >= 2
+                if ((dav > 0) && (dlv < 2))
+                    dlv = 2;
+
+                // integer rearrangement of the baudrate equation (with rounding)
+                b = ((PCLK * mv / (dlv * (dav + mv) * 8)) + 1) / 2;
+
+                // check to see how we went
+                b = abs(b - baudrate);
+                if (b < err_best)
+                {
+                    err_best  = b;
+
+                    DL        = dlv;
+                    MulVal    = mv;
+                    DivAddVal = dav;
+
+                    if (b == baudrate)
+                    {
+                        hit = 1;
+                        break;
                     }
                 }
             }

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/serial_api.c
@@ -124,22 +124,47 @@ void serial_baud(serial_t *obj, int baudrate) {
     uint16_t dlv;
     uint8_t mv, dav;
     if ((PCLK % (16 * baudrate)) != 0) {     // Checking for zero remainder
-        float err_best = (float) baudrate;
-        uint16_t dlmax = DL;
-        for ( dlv = (dlmax/2); (dlv <= dlmax) && !hit; dlv++) {
-            for ( mv = 1; mv <= 15; mv++) {
-                for ( dav = 1; dav < mv; dav++) {
-                    float ratio = 1.0f + ((float) dav / (float) mv);
-                    float calcbaud = (float)PCLK / (16.0f * (float) dlv * ratio);
-                    float err = fabs(((float) baudrate - calcbaud) / (float) baudrate);
-                    if (err < err_best) {
-                        DL = dlv;
-                        DivAddVal = dav;
-                        MulVal = mv;
-                        err_best = err;
-                        if (err < 0.001f) {
-                            hit = 1;
-                        }
+        int err_best = baudrate, b;
+        for (mv = 1; mv < 16 && !hit; mv++)
+        {
+            for (dav = 0; dav < mv; dav++)
+            {
+                // baudrate = PCLK / (16 * dlv * (1 + (DivAdd / Mul))
+                // solving for dlv, we get dlv = mul * PCLK / (16 * baudrate * (divadd + mul))
+                // mul has 4 bits, PCLK has 27 so we have 1 bit headroom which can be used for rounding
+                // for many values of mul and PCLK we have 2 or more bits of headroom which can be used to improve precision
+                // note: X / 32 doesn't round correctly. Instead, we use ((X / 16) + 1) / 2 for correct rounding
+
+                if ((mv * PCLK * 2) & 0x80000000) // 1 bit headroom
+                    dlv = ((((2 * mv * PCLK) / (baudrate * (dav + mv))) / 16) + 1) / 2;
+                else // 2 bits headroom, use more precision
+                    dlv = ((((4 * mv * PCLK) / (baudrate * (dav + mv))) / 32) + 1) / 2;
+
+                // datasheet says if DLL==DLM==0, then 1 is used instead since divide by zero is ungood
+                if (dlv == 0)
+                    dlv = 1;
+
+                // datasheet says if dav > 0 then DL must be >= 2
+                if ((dav > 0) && (dlv < 2))
+                    dlv = 2;
+
+                // integer rearrangement of the baudrate equation (with rounding)
+                b = ((PCLK * mv / (dlv * (dav + mv) * 8)) + 1) / 2;
+
+                // check to see how we went
+                b = abs(b - baudrate);
+                if (b < err_best)
+                {
+                    err_best  = b;
+
+                    DL        = dlv;
+                    MulVal    = mv;
+                    DivAddVal = dav;
+
+                    if (b == baudrate)
+                    {
+                        hit = 1;
+                        break;
                     }
                 }
             }

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/serial_api.c
@@ -157,22 +157,47 @@ void serial_baud(serial_t *obj, int baudrate) {
     uint16_t dlv;
     uint8_t mv, dav;
     if ((PCLK % (16 * baudrate)) != 0) {     // Checking for zero remainder
-        float err_best = (float) baudrate;
-        uint16_t dlmax = DL;
-        for ( dlv = (dlmax/2); (dlv <= dlmax) && !hit; dlv++) {
-            for ( mv = 1; mv <= 15; mv++) {
-                for ( dav = 1; dav < mv; dav++) {
-                    float ratio = 1.0f + ((float) dav / (float) mv);
-                    float calcbaud = (float)PCLK / (16.0f * (float) dlv * ratio);
-                    float err = fabs(((float) baudrate - calcbaud) / (float) baudrate);
-                    if (err < err_best) {
-                        DL = dlv;
-                        DivAddVal = dav;
-                        MulVal = mv;
-                        err_best = err;
-                        if (err < 0.001f) {
-                            hit = 1;
-                        }
+        int err_best = baudrate, b;
+        for (mv = 1; mv < 16 && !hit; mv++)
+        {
+            for (dav = 0; dav < mv; dav++)
+            {
+                // baudrate = PCLK / (16 * dlv * (1 + (DivAdd / Mul))
+                // solving for dlv, we get dlv = mul * PCLK / (16 * baudrate * (divadd + mul))
+                // mul has 4 bits, PCLK has 27 so we have 1 bit headroom which can be used for rounding
+                // for many values of mul and PCLK we have 2 or more bits of headroom which can be used to improve precision
+                // note: X / 32 doesn't round correctly. Instead, we use ((X / 16) + 1) / 2 for correct rounding
+
+                if ((mv * PCLK * 2) & 0x80000000) // 1 bit headroom
+                    dlv = ((((2 * mv * PCLK) / (baudrate * (dav + mv))) / 16) + 1) / 2;
+                else // 2 bits headroom, use more precision
+                    dlv = ((((4 * mv * PCLK) / (baudrate * (dav + mv))) / 32) + 1) / 2;
+
+                // datasheet says if DLL==DLM==0, then 1 is used instead since divide by zero is ungood
+                if (dlv == 0)
+                    dlv = 1;
+
+                // datasheet says if dav > 0 then DL must be >= 2
+                if ((dav > 0) && (dlv < 2))
+                    dlv = 2;
+
+                // integer rearrangement of the baudrate equation (with rounding)
+                b = ((PCLK * mv / (dlv * (dav + mv) * 8)) + 1) / 2;
+
+                // check to see how we went
+                b = abs(b - baudrate);
+                if (b < err_best)
+                {
+                    err_best  = b;
+
+                    DL        = dlv;
+                    MulVal    = mv;
+                    DivAddVal = dav;
+
+                    if (b == baudrate)
+                    {
+                        hit = 1;
+                        break;
                     }
                 }
             }

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/serial_api.c
@@ -156,22 +156,47 @@ void serial_baud(serial_t *obj, int baudrate) {
     uint16_t dlv;
     uint8_t mv, dav;
     if ((PCLK % (16 * baudrate)) != 0) {     // Checking for zero remainder
-        float err_best = (float) baudrate;
-        uint16_t dlmax = DL;
-        for ( dlv = (dlmax/2); (dlv <= dlmax) && !hit; dlv++) {
-            for ( mv = 1; mv <= 15; mv++) {
-                for ( dav = 1; dav < mv; dav++) {
-                    float ratio = 1.0f + ((float) dav / (float) mv);
-                    float calcbaud = (float)PCLK / (16.0f * (float) dlv * ratio);
-                    float err = fabs(((float) baudrate - calcbaud) / (float) baudrate);
-                    if (err < err_best) {
-                        DL = dlv;
-                        DivAddVal = dav;
-                        MulVal = mv;
-                        err_best = err;
-                        if (err < 0.001f) {
-                            hit = 1;
-                        }
+        int err_best = baudrate, b;
+        for (mv = 1; mv < 16 && !hit; mv++)
+        {
+            for (dav = 0; dav < mv; dav++)
+            {
+                // baudrate = PCLK / (16 * dlv * (1 + (DivAdd / Mul))
+                // solving for dlv, we get dlv = mul * PCLK / (16 * baudrate * (divadd + mul))
+                // mul has 4 bits, PCLK has 27 so we have 1 bit headroom which can be used for rounding
+                // for many values of mul and PCLK we have 2 or more bits of headroom which can be used to improve precision
+                // note: X / 32 doesn't round correctly. Instead, we use ((X / 16) + 1) / 2 for correct rounding
+
+                if ((mv * PCLK * 2) & 0x80000000) // 1 bit headroom
+                    dlv = ((((2 * mv * PCLK) / (baudrate * (dav + mv))) / 16) + 1) / 2;
+                else // 2 bits headroom, use more precision
+                    dlv = ((((4 * mv * PCLK) / (baudrate * (dav + mv))) / 32) + 1) / 2;
+
+                // datasheet says if DLL==DLM==0, then 1 is used instead since divide by zero is ungood
+                if (dlv == 0)
+                    dlv = 1;
+
+                // datasheet says if dav > 0 then DL must be >= 2
+                if ((dav > 0) && (dlv < 2))
+                    dlv = 2;
+
+                // integer rearrangement of the baudrate equation (with rounding)
+                b = ((PCLK * mv / (dlv * (dav + mv) * 8)) + 1) / 2;
+
+                // check to see how we went
+                b = abs(b - baudrate);
+                if (b < err_best)
+                {
+                    err_best  = b;
+
+                    DL        = dlv;
+                    MulVal    = mv;
+                    DivAddVal = dav;
+
+                    if (b == baudrate)
+                    {
+                        hit = 1;
+                        break;
                     }
                 }
             }

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/serial_api.c
@@ -147,22 +147,47 @@ void serial_baud(serial_t *obj, int baudrate) {
     uint16_t dlv;
     uint8_t mv, dav;
     if ((PCLK % (16 * baudrate)) != 0) {     // Checking for zero remainder
-        float err_best = (float) baudrate;
-        uint16_t dlmax = DL;
-        for ( dlv = (dlmax/2); (dlv <= dlmax) && !hit; dlv++) {
-            for ( mv = 1; mv <= 15; mv++) {
-                for ( dav = 1; dav < mv; dav++) {
-                    float ratio = 1.0f + ((float) dav / (float) mv);
-                    float calcbaud = (float)PCLK / (16.0f * (float) dlv * ratio);
-                    float err = fabs(((float) baudrate - calcbaud) / (float) baudrate);
-                    if (err < err_best) {
-                        DL = dlv;
-                        DivAddVal = dav;
-                        MulVal = mv;
-                        err_best = err;
-                        if (err < 0.001f) {
-                            hit = 1;
-                        }
+        int err_best = baudrate, b;
+        for (mv = 1; mv < 16 && !hit; mv++)
+        {
+            for (dav = 0; dav < mv; dav++)
+            {
+                // baudrate = PCLK / (16 * dlv * (1 + (DivAdd / Mul))
+                // solving for dlv, we get dlv = mul * PCLK / (16 * baudrate * (divadd + mul))
+                // mul has 4 bits, PCLK has 27 so we have 1 bit headroom which can be used for rounding
+                // for many values of mul and PCLK we have 2 or more bits of headroom which can be used to improve precision
+                // note: X / 32 doesn't round correctly. Instead, we use ((X / 16) + 1) / 2 for correct rounding
+
+                if ((mv * PCLK * 2) & 0x80000000) // 1 bit headroom
+                    dlv = ((((2 * mv * PCLK) / (baudrate * (dav + mv))) / 16) + 1) / 2;
+                else // 2 bits headroom, use more precision
+                    dlv = ((((4 * mv * PCLK) / (baudrate * (dav + mv))) / 32) + 1) / 2;
+
+                // datasheet says if DLL==DLM==0, then 1 is used instead since divide by zero is ungood
+                if (dlv == 0)
+                    dlv = 1;
+
+                // datasheet says if dav > 0 then DL must be >= 2
+                if ((dav > 0) && (dlv < 2))
+                    dlv = 2;
+
+                // integer rearrangement of the baudrate equation (with rounding)
+                b = ((PCLK * mv / (dlv * (dav + mv) * 8)) + 1) / 2;
+
+                // check to see how we went
+                b = abs(b - baudrate);
+                if (b < err_best)
+                {
+                    err_best  = b;
+
+                    DL        = dlv;
+                    MulVal    = mv;
+                    DivAddVal = dav;
+
+                    if (b == baudrate)
+                    {
+                        hit = 1;
+                        break;
                     }
                 }
             }

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/serial_api.c
@@ -130,22 +130,47 @@ void serial_baud(serial_t *obj, int baudrate) {
     uint16_t dlv;
     uint8_t mv, dav;
     if ((PCLK % (16 * baudrate)) != 0) {     // Checking for zero remainder
-        float err_best = (float) baudrate;
-        uint16_t dlmax = DL;
-        for ( dlv = (dlmax/2); (dlv <= dlmax) && !hit; dlv++) {
-            for ( mv = 1; mv <= 15; mv++) {
-                for ( dav = 1; dav < mv; dav++) {
-                    float ratio = 1.0f + ((float) dav / (float) mv);
-                    float calcbaud = (float)PCLK / (16.0f * (float) dlv * ratio);
-                    float err = fabs(((float) baudrate - calcbaud) / (float) baudrate);
-                    if (err < err_best) {
-                        DL = dlv;
-                        DivAddVal = dav;
-                        MulVal = mv;
-                        err_best = err;
-                        if (err < 0.001f) {
-                            hit = 1;
-                        }
+        int err_best = baudrate, b;
+        for (mv = 1; mv < 16 && !hit; mv++)
+        {
+            for (dav = 0; dav < mv; dav++)
+            {
+                // baudrate = PCLK / (16 * dlv * (1 + (DivAdd / Mul))
+                // solving for dlv, we get dlv = mul * PCLK / (16 * baudrate * (divadd + mul))
+                // mul has 4 bits, PCLK has 27 so we have 1 bit headroom which can be used for rounding
+                // for many values of mul and PCLK we have 2 or more bits of headroom which can be used to improve precision
+                // note: X / 32 doesn't round correctly. Instead, we use ((X / 16) + 1) / 2 for correct rounding
+
+                if ((mv * PCLK * 2) & 0x80000000) // 1 bit headroom
+                    dlv = ((((2 * mv * PCLK) / (baudrate * (dav + mv))) / 16) + 1) / 2;
+                else // 2 bits headroom, use more precision
+                    dlv = ((((4 * mv * PCLK) / (baudrate * (dav + mv))) / 32) + 1) / 2;
+
+                // datasheet says if DLL==DLM==0, then 1 is used instead since divide by zero is ungood
+                if (dlv == 0)
+                    dlv = 1;
+
+                // datasheet says if dav > 0 then DL must be >= 2
+                if ((dav > 0) && (dlv < 2))
+                    dlv = 2;
+
+                // integer rearrangement of the baudrate equation (with rounding)
+                b = ((PCLK * mv / (dlv * (dav + mv) * 8)) + 1) / 2;
+
+                // check to see how we went
+                b = abs(b - baudrate);
+                if (b < err_best)
+                {
+                    err_best  = b;
+
+                    DL        = dlv;
+                    MulVal    = mv;
+                    DivAddVal = dav;
+
+                    if (b == baudrate)
+                    {
+                        hit = 1;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Uses 100% integer math, delivers more accurate results with fewer iterations in less time.

Since it seems most of the NXP chips use identical math, I have also altered the other targets in this commit.

If there are non-NXP chips which use a similar serial block, consider porting to those as well

Comparison:

```
     BAUD   DL MUL DIV  CPU_CLOCK
  -------  --- --- --- ----------
```

new: {   9600, 625,  1,  0,  96000000}, // Actual baud:    9600, error =0.00%,    1 iterations
old: {   9600, 625,  1,  0,  96000000}, // Actual baud:    9600, error =0.00%,    0 iterations

new: {  38400, 125,  4,  1,  96000000}, // Actual baud:   38400, error =0.00%,    8 iterations
old: {  38400,  81, 14, 13,  96000000}, // Actual baud:   38409, error +0.02%,  420 iterations

new: {  57600,  81,  7,  2,  96000000}, // Actual baud:   57613, error +0.02%,  120 iterations
old: {  57600,  54, 14, 13,  96000000}, // Actual baud:   57613, error +0.02%,  315 iterations

new: { 115200,  27, 14, 13,  96000000}, // Actual baud:  115226, error +0.02%,  120 iterations
old: { 115200,  27, 14, 13,  96000000}, // Actual baud:  115226, error +0.02%,  210 iterations

new: { 230400,  23, 15,  2,  96000000}, // Actual baud:  230179, error -0.10%,  120 iterations
old: { 230400,  17, 15,  8,  96000000}, // Actual baud:  230179, error -0.10%,  525 iterations

new: { 250000,  24,  1,  0,  96000000}, // Actual baud:  250000, error =0.00%,    1 iterations
old: { 250000,  24,  1,  0,  96000000}, // Actual baud:  250000, error =0.00%,    0 iterations

new: {1000000,   6,  1,  0,  96000000}, // Actual baud: 1000000, error =0.00%,    1 iterations
old: {1000000,   6,  1,  0,  96000000}, // Actual baud: 1000000, error =0.00%,    0 iterations

new: {2000000,   3,  1,  0,  96000000}, // Actual baud: 2000000, error =0.00%,    1 iterations
old: {2000000,   3,  1,  0,  96000000}, // Actual baud: 2000000, error =0.00%,    0 iterations

new: {   9600, 514, 15,  4, 100000000}, // Actual baud:    9600, error =0.00%,  110 iterations
old: {   9600, 337, 15, 14, 100000000}, // Actual baud:    9593, error -0.07%, 1365 iterations

new: {  38400,  93,  4,  3, 100000000}, // Actual baud:   38402, error +0.01%,  120 iterations
old: {  38400,  85, 12, 11, 100000000}, // Actual baud:   38363, error -0.10%,  525 iterations

new: {  57600,  62,  4,  3, 100000000}, // Actual baud:   57604, error +0.01%,  120 iterations
old: {  57600,  61,  9,  7, 100000000}, // Actual baud:   57633, error +0.06%,  840 iterations

new: { 115200,  31,  4,  3, 100000000}, // Actual baud:  115207, error +0.01%,  120 iterations
old: { 115200,  31,  4,  3, 100000000}, // Actual baud:  115207, error +0.01%,  525 iterations

new: { 230400,  19,  7,  3, 100000000}, // Actual baud:  230263, error -0.06%,  120 iterations
old: { 230400,  19,  7,  3, 100000000}, // Actual baud:  230263, error -0.06%,  735 iterations

new: { 250000,  25,  1,  0, 100000000}, // Actual baud:  250000, error =0.00%,    1 iterations
old: { 250000,  25,  1,  0, 100000000}, // Actual baud:  250000, error =0.00%,    0 iterations

new: {1000000,   5,  4,  1, 100000000}, // Actual baud: 1000000, error =0.00%,    8 iterations
old: {1000000,   5,  4,  1, 100000000}, // Actual baud: 1000000, error =0.00%,  315 iterations

new: {2000000,   2,  9,  5, 100000000}, // Actual baud: 2008929, error +0.45%,  120 iterations
old: {2000000,   2,  9,  5, 100000000}, // Actual baud: 2008929, error +0.45%,  315 iterations

new: {   9600, 625,  4,  1, 120000000}, // Actual baud:    9600, error =0.00%,    8 iterations
old: {   9600, 404, 15, 14, 120000000}, // Actual baud:    9602, error +0.02%, 1575 iterations

new: {  38400, 179, 11,  1, 120000000}, // Actual baud:   38408, error +0.02%,  120 iterations
old: {  38400, 101, 15, 14, 120000000}, // Actual baud:   38409, error +0.02%,  525 iterations

new: {  57600,  93,  5,  2, 120000000}, // Actual baud:   57604, error +0.01%,  120 iterations
old: {  57600,  68, 12, 11, 120000000}, // Actual baud:   57545, error -0.10%,  420 iterations

new: { 115200,  47, 13,  5, 120000000}, // Actual baud:  115248, error +0.04%,  120 iterations
old: { 115200,  34, 12, 11, 120000000}, // Actual baud:  115090, error -0.10%,  315 iterations

new: { 230400,  19,  7,  5, 120000000}, // Actual baud:  230263, error -0.06%,  120 iterations
old: { 230400,  17, 12, 11, 120000000}, // Actual baud:  230179, error -0.10%,  210 iterations

new: { 250000,  30,  1,  0, 120000000}, // Actual baud:  250000, error =0.00%,    1 iterations
old: { 250000,  30,  1,  0, 120000000}, // Actual baud:  250000, error =0.00%,    0 iterations

new: {1000000,   5,  2,  1, 120000000}, // Actual baud: 1000000, error =0.00%,    3 iterations
old: {1000000,   4,  8,  7, 120000000}, // Actual baud: 1000000, error =0.00%,  210 iterations

new: {2000000,   3,  4,  1, 120000000}, // Actual baud: 2000000, error =0.00%,    8 iterations
old: {2000000,   2,  8,  7, 120000000}, // Actual baud: 2000000, error =0.00%,  210 iterations
