### PR TITLE
Added (deep)sleep to KL25Z

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KL25Z/device.h
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KL25Z/device.h
@@ -45,7 +45,7 @@
 #define DEVICE_LOCALFILESYSTEM  0
 #define DEVICE_ID_LENGTH       24
 
-#define DEVICE_SLEEP            0
+#define DEVICE_SLEEP            1
 
 #define DEVICE_DEBUG_AWARENESS  0
 

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KL25Z/sleep.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KL25Z/sleep.c
@@ -1,0 +1,51 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sleep_api.h"
+#include "cmsis.h"
+
+//Normal wait mode
+void sleep(void)
+{
+    SMC->PMPROT = SMC_PMPROT_AVLLS_MASK | SMC_PMPROT_ALLS_MASK | SMC_PMPROT_AVLP_MASK;
+
+    //Normal sleep mode for ARM core:
+    SCB->SCR = 0;
+    __WFI();
+}
+
+//Very low-power stop mode
+void deepsleep(void)
+{
+    //Check if PLL/FLL is enabled:
+    uint32_t PLL_FLL_en = (MCG->C1 & MCG_C1_CLKS_MASK) == MCG_C1_CLKS(0);
+    
+    SMC->PMPROT = SMC_PMPROT_AVLLS_MASK | SMC_PMPROT_ALLS_MASK | SMC_PMPROT_AVLP_MASK;
+    SMC->PMCTRL = SMC_PMCTRL_STOPM(2);
+
+    //Deep sleep for ARM core:
+    SCB->SCR = 1<<SCB_SCR_SLEEPDEEP_Pos;
+
+    __WFI();
+
+    //Switch back to PLL as clock source if needed
+    //The interrupt that woke up the device will run at reduced speed
+    if (PLL_FLL_en) {
+        if (MCG->C6 & (1<<MCG_C6_PLLS_SHIFT) != 0) /* If PLL */
+            while((MCG->S & MCG_S_LOCK0_MASK) == 0x00U); /* Wait until locked */
+        MCG->C1 &= ~MCG_C1_CLKS_MASK;
+    }
+
+}


### PR DESCRIPTION
Sleep is wait mode

Deepsleep is very low power stop mode

During the interrupt that removes it from deepsleep it will run at low
speed until the PLL is automatically re-enabled after the interrupt.

For proper testing completely remove power and enable it again to disable debug mode, otherwise power usage will be too high.
