### PR TITLE
[LPC4088]: Networking was broking when splitting peripheral RAM into two...

### DIFF
--- a/libraries/net/lwip/lwip/lwipopts.h
+++ b/libraries/net/lwip/lwip/lwipopts.h
@@ -50,7 +50,7 @@
 
 #if defined(TARGET_LPC4088)
 #define MEM_SIZE                    15360
-#elif
+#else
 #define MEM_SIZE                    16362
 #endif
 


### PR DESCRIPTION
When the peripheral RAM was split into two 16 KB sections (AHBSRAM0 and AHBSRAM1) networking stopped to work. The reason is that section AHBSRAM1 is used at two locations in the networking code.

lwip/core/mem.c: allocates a ram heap of size MEM_SIZE (about 16KB aligned)
lwip-eth/arch/lpc17_emac.c: driver data lpc_enetdata is put in AHBSRAM1

When splitting peripheral RAM the total size of AHBSRAM1 is 16KB. This forced lpc_enetdata to be put in main SRAM. Since the Ethernet block in LPC4088 doesn't have access to main SRAM ethernet stopped working. 

The fix was to reduce the size of the ram heap used by lwip. In the long run it would be better to avoid defining memory regions at several locations in the code.  
