### PR TITLE
KL25Z - pyOCD locking

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KL25Z/TOOLCHAIN_GCC_ARM/MKL25Z4.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KL25Z/TOOLCHAIN_GCC_ARM/MKL25Z4.ld
@@ -4,8 +4,7 @@
 
 MEMORY
 {
-  VECTORS (rx) : ORIGIN = 0x00000000, LENGTH = 0x00000400
-  FLASH_PROTECTION	(rx) : ORIGIN = 0x00000400, LENGTH = 0x00000010
+  VECTORS	(rx) : ORIGIN = 0x00000000, LENGTH = 0x00000410
   FLASH (rx) : ORIGIN = 0x00000410, LENGTH = 128K - 0x00000410
   RAM (rwx) : ORIGIN = 0x1FFFF0C0, LENGTH = 16K - 0xC0
 }
@@ -44,16 +43,8 @@ SECTIONS
     {
         __vector_table = .;
         KEEP(*(.vector_table))
-        *(.text.Reset_Handler)
-        *(.text.System_Init)
          . = ALIGN(4);
     } > VECTORS
-
-    .flash_protect :
-    {
-        KEEP(*(.kinetis_flash_config_field))
-         . = ALIGN(4);
-    } > FLASH_PROTECTION
 
     .text :
     {

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KL25Z/TOOLCHAIN_GCC_ARM/startup_MKL25Z4.s
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KL25Z/TOOLCHAIN_GCC_ARM/startup_MKL25Z4.s
@@ -131,6 +131,13 @@ __isr_vector:
 
     .size    __isr_vector, . - __isr_vector
 
+/* Flash Configuration */
+    .org    0x400, 0xFF
+    .long   0xFFFFFFFF
+    .long   0xFFFFFFFF
+    .long   0xFFFFFFFF
+    .long   0xFFFFFFFE
+
     .section .text.Reset_Handler
     .thumb
     .thumb_func
@@ -221,16 +228,5 @@ Reset_Handler:
 
     .weak   DEF_IRQHandler
     .set    DEF_IRQHandler, Default_Handler
-
-/* Flash protection region, placed at 0x400 */
-    .text
-    .thumb
-    .align 2
-    .section .kinetis_flash_config_field,"a",%progbits
-kinetis_flash_config:
-    .long 0xffffffff
-    .long 0xffffffff
-    .long 0xffffffff
-    .long 0xfffffffe
 
     .end


### PR DESCRIPTION
I found out that the previous setup of KL25Z, caused locking of a chip. 

The log from gdb command line is at http://pastebin.com/zLCAkTh8. Line 144 (vectors section). With this fix, I was able to load an image to KL25Z, locking did not happen.

Regards,
0xc0170
