### PR TITLE
Detection of modem when using serial port, CDMA version of linkmonitor

### DIFF
--- a/libraries/net/cellular/CellularModem/link/LinkMonitor.h
+++ b/libraries/net/cellular/CellularModem/link/LinkMonitor.h
@@ -39,7 +39,7 @@ public:
 
   /** Initialize monitor
    */
-  int init();
+  int init(bool gsm = true);
 
   /** Registration State
   */  
@@ -82,6 +82,7 @@ private:
   ATCommandsInterface* m_pIf;
   
   int m_rssi;
+  bool m_gsm;
   REGISTRATION_STATE m_registrationState;
   BEARER m_bearer;
 


### PR DESCRIPTION
Add detection of LISA-C to select CDMA protocol when using serial port.
Make link monitor compatible with CDMA (no AT+COPS).
