### PR TITLE
Clean up GCC_ARM startup code

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KL25Z/TOOLCHAIN_GCC_ARM/startup_MKL25Z4.s
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KL25Z/TOOLCHAIN_GCC_ARM/startup_MKL25Z4.s
@@ -150,16 +150,16 @@ Reset_Handler:
     ldr    r3, =__data_end__
 
     subs    r3, r2
-    ble    .flash_to_ram_loop_end
+    ble    .Lflash_to_ram_loop_end
 
     movs    r4, 0
-.flash_to_ram_loop:
+.Lflash_to_ram_loop:
     ldr    r0, [r1,r4]
     str    r0, [r2,r4]
     adds    r4, 4
     cmp    r4, r3
-    blt    .flash_to_ram_loop
-.flash_to_ram_loop_end:
+    blt    .Lflash_to_ram_loop
+.Lflash_to_ram_loop_end:
 
     ldr    r0, =SystemInit
     blx    r0
@@ -189,38 +189,41 @@ Reset_Handler:
     def_default_handler     SysTick_Handler
     def_default_handler     Default_Handler
 
-    def_default_handler     DMA0_IRQHandler
-    def_default_handler     DMA1_IRQHandler
-    def_default_handler     DMA2_IRQHandler
-    def_default_handler     DMA3_IRQHandler
-    def_default_handler     FTFA_IRQHandler
-    def_default_handler     LVD_LVW_IRQHandler
-    def_default_handler     LLW_IRQHandler
-    def_default_handler     I2C0_IRQHandler
-    def_default_handler     I2C1_IRQHandler
-    def_default_handler     SPI0_IRQHandler
-    def_default_handler     SPI1_IRQHandler
-    def_default_handler     UART0_IRQHandler
-    def_default_handler     UART1_IRQHandler
-    def_default_handler     UART2_IRQHandler
-    def_default_handler     ADC0_IRQHandler
-    def_default_handler     CMP0_IRQHandler
-    def_default_handler     TPM0_IRQHandler
-    def_default_handler     TPM1_IRQHandler
-    def_default_handler     TPM2_IRQHandler
-    def_default_handler     RTC_IRQHandler
-    def_default_handler     RTC_Seconds_IRQHandler
-    def_default_handler     PIT_IRQHandler
-    def_default_handler     USB0_IRQHandler
-    def_default_handler     DAC0_IRQHandler
-    def_default_handler     TSI0_IRQHandler
-    def_default_handler     MCG_IRQHandler
-    def_default_handler     LPTimer_IRQHandler
-    def_default_handler     PORTA_IRQHandler
-    def_default_handler     PORTD_IRQHandler
+    .macro    def_irq_default_handler    handler_name
+    .weak     \handler_name
+    .set      \handler_name, Default_Handler
+    .endm
 
-    .weak   DEF_IRQHandler
-    .set    DEF_IRQHandler, Default_Handler
+    def_irq_default_handler     DMA0_IRQHandler
+    def_irq_default_handler     DMA1_IRQHandler
+    def_irq_default_handler     DMA2_IRQHandler
+    def_irq_default_handler     DMA3_IRQHandler
+    def_irq_default_handler     FTFA_IRQHandler
+    def_irq_default_handler     LVD_LVW_IRQHandler
+    def_irq_default_handler     LLW_IRQHandler
+    def_irq_default_handler     I2C0_IRQHandler
+    def_irq_default_handler     I2C1_IRQHandler
+    def_irq_default_handler     SPI0_IRQHandler
+    def_irq_default_handler     SPI1_IRQHandler
+    def_irq_default_handler     UART0_IRQHandler
+    def_irq_default_handler     UART1_IRQHandler
+    def_irq_default_handler     UART2_IRQHandler
+    def_irq_default_handler     ADC0_IRQHandler
+    def_irq_default_handler     CMP0_IRQHandler
+    def_irq_default_handler     TPM0_IRQHandler
+    def_irq_default_handler     TPM1_IRQHandler
+    def_irq_default_handler     TPM2_IRQHandler
+    def_irq_default_handler     RTC_IRQHandler
+    def_irq_default_handler     RTC_Seconds_IRQHandler
+    def_irq_default_handler     PIT_IRQHandler
+    def_irq_default_handler     USB0_IRQHandler
+    def_irq_default_handler     DAC0_IRQHandler
+    def_irq_default_handler     TSI0_IRQHandler
+    def_irq_default_handler     MCG_IRQHandler
+    def_irq_default_handler     LPTimer_IRQHandler
+    def_irq_default_handler     PORTA_IRQHandler
+    def_irq_default_handler     PORTD_IRQHandler
+    def_irq_default_handler     DEF_IRQHandler
 
 /* Flash protection region, placed at 0x400 */
     .text

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KL46Z/TOOLCHAIN_GCC_ARM/startup_MKL46Z4.s
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KL46Z/TOOLCHAIN_GCC_ARM/startup_MKL46Z4.s
@@ -150,16 +150,16 @@ Reset_Handler:
     ldr    r3, =__data_end__
 
     subs    r3, r2
-    ble    .flash_to_ram_loop_end
+    ble    .Lflash_to_ram_loop_end
 
     movs    r4, 0
-.flash_to_ram_loop:
+.Lflash_to_ram_loop:
     ldr    r0, [r1,r4]
     str    r0, [r2,r4]
     adds    r4, 4
     cmp    r4, r3
-    blt    .flash_to_ram_loop
-.flash_to_ram_loop_end:
+    blt    .Lflash_to_ram_loop
+.Lflash_to_ram_loop_end:
 
     ldr    r0, =SystemInit
     blx    r0
@@ -187,44 +187,45 @@ Reset_Handler:
     def_default_handler     SVC_Handler
     def_default_handler     PendSV_Handler
     def_default_handler     SysTick_Handler
-    def_default_handler     Default_Handler
+    def_default_handler     Default_Handler    
 
-    def_default_handler     DMA0_IRQHandler
-    def_default_handler     DMA1_IRQHandler
-    def_default_handler     DMA2_IRQHandler
-    def_default_handler     DMA3_IRQHandler
-    def_default_handler     FTFA_IRQHandler
-    def_default_handler     LVD_LVW_IRQHandler
-    def_default_handler     LLW_IRQHandler
-    def_default_handler     I2C0_IRQHandler
-    def_default_handler     I2C1_IRQHandler
-    def_default_handler     SPI0_IRQHandler
-    def_default_handler     SPI1_IRQHandler
-    def_default_handler     UART0_IRQHandler
-    def_default_handler     UART1_IRQHandler
-    def_default_handler     UART2_IRQHandler
-    def_default_handler     ADC0_IRQHandler
-    def_default_handler     CMP0_IRQHandler
-    def_default_handler     TPM0_IRQHandler
-    def_default_handler     TPM1_IRQHandler
-    def_default_handler     TPM2_IRQHandler
-    def_default_handler     RTC_IRQHandler
-    def_default_handler     RTC_Seconds_IRQHandler
-    def_default_handler     PIT_IRQHandler
-    def_default_handler     I2S_IRQHandler
-    def_default_handler     USB0_IRQHandler
-    def_default_handler     DAC0_IRQHandler
-    def_default_handler     TSI0_IRQHandler
-    def_default_handler     MCG_IRQHandler
-    def_default_handler     LPTimer_IRQHandler
-    def_default_handler     LCD_IRQHandler
-    def_default_handler     PORTA_IRQHandler
-    def_default_handler     PORTD_IRQHandler
-   
+    .macro    def_irq_default_handler    handler_name
+    .weak     \handler_name
+    .set      \handler_name, Default_Handler
+    .endm
 
-
-    .weak   DEF_IRQHandler
-    .set    DEF_IRQHandler, Default_Handler
+    def_irq_default_handler     DMA0_IRQHandler
+    def_irq_default_handler     DMA1_IRQHandler
+    def_irq_default_handler     DMA2_IRQHandler
+    def_irq_default_handler     DMA3_IRQHandler
+    def_irq_default_handler     FTFA_IRQHandler
+    def_irq_default_handler     LVD_LVW_IRQHandler
+    def_irq_default_handler     LLW_IRQHandler
+    def_irq_default_handler     I2C0_IRQHandler
+    def_irq_default_handler     I2C1_IRQHandler
+    def_irq_default_handler     SPI0_IRQHandler
+    def_irq_default_handler     SPI1_IRQHandler
+    def_irq_default_handler     UART0_IRQHandler
+    def_irq_default_handler     UART1_IRQHandler
+    def_irq_default_handler     UART2_IRQHandler
+    def_irq_default_handler     ADC0_IRQHandler
+    def_irq_default_handler     CMP0_IRQHandler
+    def_irq_default_handler     TPM0_IRQHandler
+    def_irq_default_handler     TPM1_IRQHandler
+    def_irq_default_handler     TPM2_IRQHandler
+    def_irq_default_handler     RTC_IRQHandler
+    def_irq_default_handler     RTC_Seconds_IRQHandler
+    def_irq_default_handler     PIT_IRQHandler
+    def_irq_default_handler     I2S_IRQHandler
+    def_irq_default_handler     USB0_IRQHandler
+    def_irq_default_handler     DAC0_IRQHandler
+    def_irq_default_handler     TSI0_IRQHandler
+    def_irq_default_handler     MCG_IRQHandler
+    def_irq_default_handler     LPTimer_IRQHandler
+    def_irq_default_handler     LCD_IRQHandler
+    def_irq_default_handler     PORTA_IRQHandler
+    def_irq_default_handler     PORTD_IRQHandler
+    def_irq_default_handler     DEF_IRQHandler
 
 /* Flash protection region, placed at 0x400 */
     .text

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC11UXX/TOOLCHAIN_GCC_ARM/startup_LPC11xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC11UXX/TOOLCHAIN_GCC_ARM/startup_LPC11xx.s
@@ -150,16 +150,16 @@ Reset_Handler:
     ldr    r3, =__data_end__
 
     subs    r3, r2
-    ble    .flash_to_ram_loop_end
+    ble    .Lflash_to_ram_loop_end
 
     movs    r4, 0
-.flash_to_ram_loop:
+.Lflash_to_ram_loop:
     ldr    r0, [r1,r4]
     str    r0, [r2,r4]
     adds    r4, 4
     cmp    r4, r3
-    blt    .flash_to_ram_loop
-.flash_to_ram_loop_end:
+    blt    .Lflash_to_ram_loop
+.Lflash_to_ram_loop_end:
 
     ldr    r0, =SystemInit
     blx    r0
@@ -181,33 +181,36 @@ Reset_Handler:
     b    .
     .size    \handler_name, . - \handler_name
     .endm
-    
-    def_default_handler    NMI_Handler
-    def_default_handler    HardFault_Handler
-    def_default_handler    SVC_Handler
-    def_default_handler    PendSV_Handler
-    def_default_handler    SysTick_Handler
-    def_default_handler    Default_Handler
-    
-    def_default_handler    WAKEUP_IRQHandler
-    def_default_handler    SSP1_IRQHandler
-    def_default_handler    I2C_IRQHandler
-    def_default_handler    TIMER16_0_IRQHandler
-    def_default_handler    TIMER16_1_IRQHandler
-    def_default_handler    TIMER32_0_IRQHandler
-    def_default_handler    TIMER32_1_IRQHandler
-    def_default_handler    SSP0_IRQHandler
-    def_default_handler    UART_IRQHandler
-    def_default_handler    ADC_IRQHandler
-    def_default_handler    WDT_IRQHandler
-    def_default_handler    BOD_IRQHandler
-    def_default_handler    PIOINT3_IRQHandler
-    def_default_handler    PIOINT2_IRQHandler
-    def_default_handler    PIOINT1_IRQHandler
-    def_default_handler    PIOINT0_IRQHandler
 
-    .weak    DEF_IRQHandler
-    .set    DEF_IRQHandler, Default_Handler
+    def_default_handler     NMI_Handler
+    def_default_handler     HardFault_Handler
+    def_default_handler     SVC_Handler
+    def_default_handler     PendSV_Handler
+    def_default_handler     SysTick_Handler
+    def_default_handler     Default_Handler
+
+    .macro    def_irq_default_handler    handler_name
+    .weak     \handler_name
+    .set      \handler_name, Default_Handler
+    .endm
+    
+    def_irq_default_handler    WAKEUP_IRQHandler
+    def_irq_default_handler    SSP1_IRQHandler
+    def_irq_default_handler    I2C_IRQHandler
+    def_irq_default_handler    TIMER16_0_IRQHandler
+    def_irq_default_handler    TIMER16_1_IRQHandler
+    def_irq_default_handler    TIMER32_0_IRQHandler
+    def_irq_default_handler    TIMER32_1_IRQHandler
+    def_irq_default_handler    SSP0_IRQHandler
+    def_irq_default_handler    UART_IRQHandler
+    def_irq_default_handler    ADC_IRQHandler
+    def_irq_default_handler    WDT_IRQHandler
+    def_irq_default_handler    BOD_IRQHandler
+    def_irq_default_handler    PIOINT3_IRQHandler
+    def_irq_default_handler    PIOINT2_IRQHandler
+    def_irq_default_handler    PIOINT1_IRQHandler
+    def_irq_default_handler    PIOINT0_IRQHandler
+    def_irq_default_handler    DEF_IRQHandler
 
     .end
 

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC11XX_11CXX/TOOLCHAIN_GCC_ARM/startup_LPC11xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC11XX_11CXX/TOOLCHAIN_GCC_ARM/startup_LPC11xx.s
@@ -150,16 +150,16 @@ Reset_Handler:
     ldr    r3, =__data_end__
 
     subs    r3, r2
-    ble    .flash_to_ram_loop_end
+    ble    .Lflash_to_ram_loop_end
 
     movs    r4, 0
-.flash_to_ram_loop:
+.Lflash_to_ram_loop:
     ldr    r0, [r1,r4]
     str    r0, [r2,r4]
     adds    r4, 4
     cmp    r4, r3
-    blt    .flash_to_ram_loop
-.flash_to_ram_loop_end:
+    blt    .Lflash_to_ram_loop
+.Lflash_to_ram_loop_end:
 
     ldr    r0, =SystemInit
     blx    r0
@@ -181,33 +181,36 @@ Reset_Handler:
     b    .
     .size    \handler_name, . - \handler_name
     .endm
-    
-    def_default_handler    NMI_Handler
-    def_default_handler    HardFault_Handler
-    def_default_handler    SVC_Handler
-    def_default_handler    PendSV_Handler
-    def_default_handler    SysTick_Handler
-    def_default_handler    Default_Handler
-    
-    def_default_handler    WAKEUP_IRQHandler
-    def_default_handler    SSP1_IRQHandler
-    def_default_handler    I2C_IRQHandler
-    def_default_handler    TIMER16_0_IRQHandler
-    def_default_handler    TIMER16_1_IRQHandler
-    def_default_handler    TIMER32_0_IRQHandler
-    def_default_handler    TIMER32_1_IRQHandler
-    def_default_handler    SSP0_IRQHandler
-    def_default_handler    UART_IRQHandler
-    def_default_handler    ADC_IRQHandler
-    def_default_handler    WDT_IRQHandler
-    def_default_handler    BOD_IRQHandler
-    def_default_handler    PIOINT3_IRQHandler
-    def_default_handler    PIOINT2_IRQHandler
-    def_default_handler    PIOINT1_IRQHandler
-    def_default_handler    PIOINT0_IRQHandler
 
-    .weak    DEF_IRQHandler
-    .set    DEF_IRQHandler, Default_Handler
+    def_default_handler     NMI_Handler
+    def_default_handler     HardFault_Handler
+    def_default_handler     SVC_Handler
+    def_default_handler     PendSV_Handler
+    def_default_handler     SysTick_Handler
+    def_default_handler     Default_Handler
+
+    .macro    def_irq_default_handler    handler_name
+    .weak     \handler_name
+    .set      \handler_name, Default_Handler
+    .endm
+    
+    def_irq_default_handler    WAKEUP_IRQHandler
+    def_irq_default_handler    SSP1_IRQHandler
+    def_irq_default_handler    I2C_IRQHandler
+    def_irq_default_handler    TIMER16_0_IRQHandler
+    def_irq_default_handler    TIMER16_1_IRQHandler
+    def_irq_default_handler    TIMER32_0_IRQHandler
+    def_irq_default_handler    TIMER32_1_IRQHandler
+    def_irq_default_handler    SSP0_IRQHandler
+    def_irq_default_handler    UART_IRQHandler
+    def_irq_default_handler    ADC_IRQHandler
+    def_irq_default_handler    WDT_IRQHandler
+    def_irq_default_handler    BOD_IRQHandler
+    def_irq_default_handler    PIOINT3_IRQHandler
+    def_irq_default_handler    PIOINT2_IRQHandler
+    def_irq_default_handler    PIOINT1_IRQHandler
+    def_irq_default_handler    PIOINT0_IRQHandler
+    def_irq_default_handler    DEF_IRQHandler
 
     .end
 

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC13XX/TOOLCHAIN_GCC_ARM/startup_LPC13xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC13XX/TOOLCHAIN_GCC_ARM/startup_LPC13xx.s
@@ -135,12 +135,12 @@ Reset_Handler:
     ldr    r2, =__data_start__
     ldr    r3, =__data_end__
 
-.flash_to_ram_loop:
+.Lflash_to_ram_loop:
     cmp     r2, r3
     ittt    lt
     ldrlt   r0, [r1], #4
     strlt   r0, [r2], #4
-    blt    .flash_to_ram_loop
+    blt    .Lflash_to_ram_loop
 
     ldr    r0, =SystemInit
     blx    r0
@@ -149,6 +149,7 @@ Reset_Handler:
     .pool
     .size Reset_Handler, . - Reset_Handler
     
+    .text
 /*    Macro to define default handlers. Default handler
  *    will be weak symbol and just dead loops. They can be
  *    overwritten by other handlers */
@@ -161,7 +162,7 @@ Reset_Handler:
     b    .
     .size    \handler_name, . - \handler_name
     .endm
-    
+
     def_default_handler    NMI_Handler
     def_default_handler    HardFault_Handler
     def_default_handler    MemManage_Handler
@@ -173,37 +174,40 @@ Reset_Handler:
     def_default_handler    SysTick_Handler
     def_default_handler    Default_Handler
 
-    def_default_handler    PIN_INT0_Handler
-    def_default_handler    PIN_INT1_Handler
-    def_default_handler    PIN_INT2_Handler
-    def_default_handler    PIN_INT3_Handler
-    def_default_handler    PIN_INT4_Handler
-    def_default_handler    PIN_INT5_Handler
-    def_default_handler    PIN_INT6_Handler
-    def_default_handler    PIN_INT7_Handler
-    def_default_handler    GINT0_Handler
-    def_default_handler    GINT1_Handler
-    def_default_handler    OSTIMER_Handler
-    def_default_handler    SSP1_Handler
-    def_default_handler    I2C_Handler
-    def_default_handler    CT16B0_Handler
-    def_default_handler    CT16B1_Handler
-    def_default_handler    CT32B0_Handler
-    def_default_handler    CT32B1_Handler
-    def_default_handler    SSP0_Handler
-    def_default_handler    USART_Handler
-    def_default_handler    USB_Handler
-    def_default_handler    USB_FIQHandler
-    def_default_handler    ADC_Handler
-    def_default_handler    WDT_Handler
-    def_default_handler    BOD_Handler
-    def_default_handler    FMC_Handler
-    def_default_handler    OSCFAIL_Handler
-    def_default_handler    PVTCIRCUIT_Handler
-    def_default_handler    USBWakeup_Handler
+    .macro    def_irq_default_handler    handler_name
+    .weak     \handler_name
+    .set      \handler_name, Default_Handler
+    .endm
 
-    .weak    DEF_IRQHandler
-    .set    DEF_IRQHandler, Default_Handler
+    def_irq_default_handler    PIN_INT0_Handler
+    def_irq_default_handler    PIN_INT1_Handler
+    def_irq_default_handler    PIN_INT2_Handler
+    def_irq_default_handler    PIN_INT3_Handler
+    def_irq_default_handler    PIN_INT4_Handler
+    def_irq_default_handler    PIN_INT5_Handler
+    def_irq_default_handler    PIN_INT6_Handler
+    def_irq_default_handler    PIN_INT7_Handler
+    def_irq_default_handler    GINT0_Handler
+    def_irq_default_handler    GINT1_Handler
+    def_irq_default_handler    OSTIMER_Handler
+    def_irq_default_handler    SSP1_Handler
+    def_irq_default_handler    I2C_Handler
+    def_irq_default_handler    CT16B0_Handler
+    def_irq_default_handler    CT16B1_Handler
+    def_irq_default_handler    CT32B0_Handler
+    def_irq_default_handler    CT32B1_Handler
+    def_irq_default_handler    SSP0_Handler
+    def_irq_default_handler    USART_Handler
+    def_irq_default_handler    USB_Handler
+    def_irq_default_handler    USB_FIQHandler
+    def_irq_default_handler    ADC_Handler
+    def_irq_default_handler    WDT_Handler
+    def_irq_default_handler    BOD_Handler
+    def_irq_default_handler    FMC_Handler
+    def_irq_default_handler    OSCFAIL_Handler
+    def_irq_default_handler    PVTCIRCUIT_Handler
+    def_irq_default_handler    USBWakeup_Handler
+    def_irq_default_handler    DEF_IRQHandler
 
     .end
 

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X/TOOLCHAIN_GCC_ARM/startup_LPC17xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X/TOOLCHAIN_GCC_ARM/startup_LPC17xx.s
@@ -138,12 +138,12 @@ Reset_Handler:
     ldr    r2, =__data_start__
     ldr    r3, =__data_end__
 
-.flash_to_ram_loop:
+.Lflash_to_ram_loop:
     cmp     r2, r3
     ittt    lt
     ldrlt   r0, [r1], #4
     strlt   r0, [r2], #4
-    blt    .flash_to_ram_loop
+    blt    .Lflash_to_ram_loop
 
     ldr    r0, =SystemInit
     blx    r0
@@ -152,6 +152,7 @@ Reset_Handler:
     .pool
     .size Reset_Handler, . - Reset_Handler
     
+    .text
 /*    Macro to define default handlers. Default handler
  *    will be weak symbol and just dead loops. They can be
  *    overwritten by other handlers */
@@ -164,7 +165,7 @@ Reset_Handler:
     b    .
     .size    \handler_name, . - \handler_name
     .endm
-    
+
     def_default_handler    NMI_Handler
     def_default_handler    HardFault_Handler
     def_default_handler    MemManage_Handler
@@ -175,45 +176,48 @@ Reset_Handler:
     def_default_handler    PendSV_Handler
     def_default_handler    SysTick_Handler
     def_default_handler    Default_Handler
-    
-    def_default_handler     WDT_IRQHandler
-    def_default_handler     TIMER0_IRQHandler
-    def_default_handler     TIMER1_IRQHandler
-    def_default_handler     TIMER2_IRQHandler
-    def_default_handler     TIMER3_IRQHandler
-    def_default_handler     UART0_IRQHandler
-    def_default_handler     UART1_IRQHandler
-    def_default_handler     UART2_IRQHandler
-    def_default_handler     UART3_IRQHandler
-    def_default_handler     PWM1_IRQHandler
-    def_default_handler     I2C0_IRQHandler
-    def_default_handler     I2C1_IRQHandler
-    def_default_handler     I2C2_IRQHandler
-    def_default_handler     SPI_IRQHandler
-    def_default_handler     SSP0_IRQHandler
-    def_default_handler     SSP1_IRQHandler
-    def_default_handler     PLL0_IRQHandler
-    def_default_handler     RTC_IRQHandler
-    def_default_handler     EINT0_IRQHandler
-    def_default_handler     EINT1_IRQHandler
-    def_default_handler     EINT2_IRQHandler
-    def_default_handler     EINT3_IRQHandler
-    def_default_handler     ADC_IRQHandler
-    def_default_handler     BOD_IRQHandler
-    def_default_handler     USB_IRQHandler
-    def_default_handler     CAN_IRQHandler
-    def_default_handler     DMA_IRQHandler
-    def_default_handler     I2S_IRQHandler
-    def_default_handler     ENET_IRQHandler
-    def_default_handler     RIT_IRQHandler
-    def_default_handler     MCPWM_IRQHandler
-    def_default_handler     QEI_IRQHandler
-    def_default_handler     PLL1_IRQHandler
-    def_default_handler     USBActivity_IRQHandler
-    def_default_handler     CANActivity_IRQHandler
 
-    .weak    DEF_IRQHandler
-    .set    DEF_IRQHandler, Default_Handler
+    .macro    def_irq_default_handler    handler_name
+    .weak     \handler_name
+    .set      \handler_name, Default_Handler
+    .endm
+ 
+    def_irq_default_handler     WDT_IRQHandler
+    def_irq_default_handler     TIMER0_IRQHandler
+    def_irq_default_handler     TIMER1_IRQHandler
+    def_irq_default_handler     TIMER2_IRQHandler
+    def_irq_default_handler     TIMER3_IRQHandler
+    def_irq_default_handler     UART0_IRQHandler
+    def_irq_default_handler     UART1_IRQHandler
+    def_irq_default_handler     UART2_IRQHandler
+    def_irq_default_handler     UART3_IRQHandler
+    def_irq_default_handler     PWM1_IRQHandler
+    def_irq_default_handler     I2C0_IRQHandler
+    def_irq_default_handler     I2C1_IRQHandler
+    def_irq_default_handler     I2C2_IRQHandler
+    def_irq_default_handler     SPI_IRQHandler
+    def_irq_default_handler     SSP0_IRQHandler
+    def_irq_default_handler     SSP1_IRQHandler
+    def_irq_default_handler     PLL0_IRQHandler
+    def_irq_default_handler     RTC_IRQHandler
+    def_irq_default_handler     EINT0_IRQHandler
+    def_irq_default_handler     EINT1_IRQHandler
+    def_irq_default_handler     EINT2_IRQHandler
+    def_irq_default_handler     EINT3_IRQHandler
+    def_irq_default_handler     ADC_IRQHandler
+    def_irq_default_handler     BOD_IRQHandler
+    def_irq_default_handler     USB_IRQHandler
+    def_irq_default_handler     CAN_IRQHandler
+    def_irq_default_handler     DMA_IRQHandler
+    def_irq_default_handler     I2S_IRQHandler
+    def_irq_default_handler     ENET_IRQHandler
+    def_irq_default_handler     RIT_IRQHandler
+    def_irq_default_handler     MCPWM_IRQHandler
+    def_irq_default_handler     QEI_IRQHandler
+    def_irq_default_handler     PLL1_IRQHandler
+    def_irq_default_handler     USBActivity_IRQHandler
+    def_irq_default_handler     CANActivity_IRQHandler
+    def_irq_default_handler     DEF_IRQHandler
 
     .end
 

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC408X/TOOLCHAIN_GCC_ARM/startup_LPC408x.s
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC408X/TOOLCHAIN_GCC_ARM/startup_LPC408x.s
@@ -144,12 +144,12 @@ Reset_Handler:
     ldr    r2, =__data_start__
     ldr    r3, =__data_end__
 
-.flash_to_ram_loop:
+.Lflash_to_ram_loop:
     cmp     r2, r3
     ittt    lt
     ldrlt   r0, [r1], #4
     strlt   r0, [r2], #4
-    blt    .flash_to_ram_loop
+    blt    .Lflash_to_ram_loop
 
     ldr    r0, =SystemInit
     blx    r0
@@ -158,6 +158,7 @@ Reset_Handler:
     .pool
     .size Reset_Handler, . - Reset_Handler
     
+    .text
 /*    Macro to define default handlers. Default handler
  *    will be weak symbol and just dead loops. They can be
  *    overwritten by other handlers */
@@ -170,7 +171,7 @@ Reset_Handler:
     b    .
     .size    \handler_name, . - \handler_name
     .endm
-    
+
     def_default_handler    NMI_Handler
     def_default_handler    HardFault_Handler
     def_default_handler    MemManage_Handler
@@ -181,51 +182,54 @@ Reset_Handler:
     def_default_handler    PendSV_Handler
     def_default_handler    SysTick_Handler
     def_default_handler    Default_Handler
-    
-    def_default_handler     WDT_IRQHandler
-    def_default_handler     TIMER0_IRQHandler
-    def_default_handler     TIMER1_IRQHandler
-    def_default_handler     TIMER2_IRQHandler
-    def_default_handler     TIMER3_IRQHandler
-    def_default_handler     UART0_IRQHandler
-    def_default_handler     UART1_IRQHandler
-    def_default_handler     UART2_IRQHandler
-    def_default_handler     UART3_IRQHandler
-    def_default_handler     PWM1_IRQHandler
-    def_default_handler     I2C0_IRQHandler
-    def_default_handler     I2C1_IRQHandler
-    def_default_handler     I2C2_IRQHandler
-/*    def_default_handler     SPI_IRQHandler */
-    def_default_handler     SSP0_IRQHandler
-    def_default_handler     SSP1_IRQHandler
-    def_default_handler     PLL0_IRQHandler
-    def_default_handler     RTC_IRQHandler
-    def_default_handler     EINT0_IRQHandler
-    def_default_handler     EINT1_IRQHandler
-    def_default_handler     EINT2_IRQHandler
-    def_default_handler     EINT3_IRQHandler
-    def_default_handler     ADC_IRQHandler
-    def_default_handler     BOD_IRQHandler
-    def_default_handler     USB_IRQHandler
-    def_default_handler     CAN_IRQHandler
-    def_default_handler     DMA_IRQHandler
-    def_default_handler     I2S_IRQHandler
-    def_default_handler     ENET_IRQHandler
-    def_default_handler     MCI_IRQHandler
-    def_default_handler     MCPWM_IRQHandler
-    def_default_handler     QEI_IRQHandler
-    def_default_handler     PLL1_IRQHandler
-    def_default_handler     USBActivity_IRQHandler
-    def_default_handler     CANActivity_IRQHandler
-    def_default_handler     UART4_IRQHandler
-    def_default_handler     SSP2_IRQHandler
-    def_default_handler     LCD_IRQHandler
-    def_default_handler     GPIO_IRQHandler
-    def_default_handler     PWM0_IRQHandler
-    def_default_handler     EEPROM_IRQHandler    
 
-    .weak    DEF_IRQHandler
-    .set    DEF_IRQHandler, Default_Handler
+    .macro    def_irq_default_handler    handler_name
+    .weak     \handler_name
+    .set      \handler_name, Default_Handler
+    .endm
+    
+    def_irq_default_handler     WDT_IRQHandler
+    def_irq_default_handler     TIMER0_IRQHandler
+    def_irq_default_handler     TIMER1_IRQHandler
+    def_irq_default_handler     TIMER2_IRQHandler
+    def_irq_default_handler     TIMER3_IRQHandler
+    def_irq_default_handler     UART0_IRQHandler
+    def_irq_default_handler     UART1_IRQHandler
+    def_irq_default_handler     UART2_IRQHandler
+    def_irq_default_handler     UART3_IRQHandler
+    def_irq_default_handler     PWM1_IRQHandler
+    def_irq_default_handler     I2C0_IRQHandler
+    def_irq_default_handler     I2C1_IRQHandler
+    def_irq_default_handler     I2C2_IRQHandler
+/*    def_irq_default_handler     SPI_IRQHandler */
+    def_irq_default_handler     SSP0_IRQHandler
+    def_irq_default_handler     SSP1_IRQHandler
+    def_irq_default_handler     PLL0_IRQHandler
+    def_irq_default_handler     RTC_IRQHandler
+    def_irq_default_handler     EINT0_IRQHandler
+    def_irq_default_handler     EINT1_IRQHandler
+    def_irq_default_handler     EINT2_IRQHandler
+    def_irq_default_handler     EINT3_IRQHandler
+    def_irq_default_handler     ADC_IRQHandler
+    def_irq_default_handler     BOD_IRQHandler
+    def_irq_default_handler     USB_IRQHandler
+    def_irq_default_handler     CAN_IRQHandler
+    def_irq_default_handler     DMA_IRQHandler
+    def_irq_default_handler     I2S_IRQHandler
+    def_irq_default_handler     ENET_IRQHandler
+    def_irq_default_handler     MCI_IRQHandler
+    def_irq_default_handler     MCPWM_IRQHandler
+    def_irq_default_handler     QEI_IRQHandler
+    def_irq_default_handler     PLL1_IRQHandler
+    def_irq_default_handler     USBActivity_IRQHandler
+    def_irq_default_handler     CANActivity_IRQHandler
+    def_irq_default_handler     UART4_IRQHandler
+    def_irq_default_handler     SSP2_IRQHandler
+    def_irq_default_handler     LCD_IRQHandler
+    def_irq_default_handler     GPIO_IRQHandler
+    def_irq_default_handler     PWM0_IRQHandler
+    def_irq_default_handler     EEPROM_IRQHandler    
+    def_irq_default_handler     DEF_IRQHandler
 
     .end
 

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC43XX/TOOLCHAIN_GCC_ARM/startup_LPC43xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC43XX/TOOLCHAIN_GCC_ARM/startup_LPC43xx.s
@@ -164,62 +164,25 @@ Reset_Handler:
     ldr    r2, =__data_start__
     ldr    r3, =__data_end__
 
-.if 1
-/* Here are two copies of loop implemenations. First one favors code size
- * and the second one favors performance. Default uses the first one.
- * Change to "#if 0" to use the second one */
 .LC0:
     cmp     r2, r3
     ittt    lt
     ldrlt   r0, [r1], #4
     strlt   r0, [r2], #4
     blt    .LC0
-.else
-    subs    r3, r2
-    ble    .LC1
-.LC0:
-    subs    r3, #4
-    ldr    r0, [r1, r3]
-    str    r0, [r2, r3]
-    bgt    .LC0
-.LC1:
-.endif
 
-.ifdef __STARTUP_CLEAR_BSS
-/*     This part of work usually is done in C library startup code. Otherwise,
- *     define this macro to enable it in this startup.
- *
- *     Loop to zero out BSS section, which uses following symbols
- *     in linker script:
- *      __bss_start__: start of BSS section. Must align to 4
- *      __bss_end__: end of BSS section. Must align to 4
- */
-    ldr r1, =__bss_start__
-    ldr r2, =__bss_end__
-
-    movs    r0, 0
-.LC2:
-    cmp     r1, r2
-    itt    lt
-    strlt   r0, [r1], #4
-    blt    .LC2
-.endif /* __STARTUP_CLEAR_BSS */
-
-.ifndef __NO_SYSTEM_INIT
-    bl    SystemInit
-.endif
-
-.ifndef __START
-.set __START,_start
-.endif
-    bl    __START
+    ldr    r0, =SystemInit
+    blx    r0
+    ldr    r0, =_start
+    bx     r0
     .pool
     .size Reset_Handler, . - Reset_Handler
 
+    .text
 /*    Macro to define default handlers. Default handler
  *    will be weak symbol and just dead loops. They can be
  *    overwritten by other handlers */
-    .macro    def_irq_handler    handler_name
+    .macro    def_default_handler    handler_name
     .align 1
     .thumb_func
     .weak    \handler_name
@@ -229,64 +192,69 @@ Reset_Handler:
     .size    \handler_name, . - \handler_name
     .endm
 
-    def_irq_handler    NMI_Handler
-    def_irq_handler    HardFault_Handler
-    def_irq_handler    MemManage_Handler
-    def_irq_handler    BusFault_Handler
-    def_irq_handler    UsageFault_Handler
-    def_irq_handler    SVC_Handler
-    def_irq_handler    DebugMon_Handler
-    def_irq_handler    PendSV_Handler
-    def_irq_handler    SysTick_Handler
-    def_irq_handler    Default_Handler
+    def_default_handler    NMI_Handler
+    def_default_handler    HardFault_Handler
+    def_default_handler    MemManage_Handler
+    def_default_handler    BusFault_Handler
+    def_default_handler    UsageFault_Handler
+    def_default_handler    SVC_Handler
+    def_default_handler    DebugMon_Handler
+    def_default_handler    PendSV_Handler
+    def_default_handler    SysTick_Handler
+    def_default_handler    Default_Handler
 
-    def_irq_handler    DAC_IRQHandler
-    def_irq_handler    M0CORE_IRQHandler
-    def_irq_handler    DMA_IRQHandler
-    def_irq_handler    FLASHEEPROM_IRQHandler
-    def_irq_handler    ETHERNET_IRQHandler
-    def_irq_handler    SDIO_IRQHandler
-    def_irq_handler    LCD_IRQHandler
-    def_irq_handler    USB0_IRQHandler
-    def_irq_handler    USB1_IRQHandler
-    def_irq_handler    SCT_IRQHandler
-    def_irq_handler    RITIMER_IRQHandler
-    def_irq_handler    TIMER0_IRQHandler
-    def_irq_handler    TIMER1_IRQHandler
-    def_irq_handler    TIMER2_IRQHandler
-    def_irq_handler    TIMER3_IRQHandler
-    def_irq_handler    MCPWM_IRQHandler
-    def_irq_handler    ADC0_IRQHandler
-    def_irq_handler    I2C0_IRQHandler
-    def_irq_handler    I2C1_IRQHandler
-    def_irq_handler    SPI_IRQHandler
-    def_irq_handler    ADC1_IRQHandler
-    def_irq_handler    SSP0_IRQHandler
-    def_irq_handler    SSP1_IRQHandler
-    def_irq_handler    USART0_IRQHandler
-    def_irq_handler    UART1_IRQHandler
-    def_irq_handler    USART2_IRQHandler
-    def_irq_handler    USART3_IRQHandler
-    def_irq_handler    I2S0_IRQHandler
-    def_irq_handler    I2S1_IRQHandler
-    def_irq_handler    SPIFI_IRQHandler
-    def_irq_handler    SGPIO_IRQHandler
-    def_irq_handler    PIN_INT0_IRQHandler
-    def_irq_handler    PIN_INT1_IRQHandler
-    def_irq_handler    PIN_INT2_IRQHandler
-    def_irq_handler    PIN_INT3_IRQHandler
-    def_irq_handler    PIN_INT4_IRQHandler
-    def_irq_handler    PIN_INT5_IRQHandler
-    def_irq_handler    PIN_INT6_IRQHandler
-    def_irq_handler    PIN_INT7_IRQHandler
-    def_irq_handler    GINT0_IRQHandler
-    def_irq_handler    GINT1_IRQHandler
-    def_irq_handler    EVENTROUTER_IRQHandler
-    def_irq_handler    C_CAN1_IRQHandler
-    def_irq_handler    ATIMER_IRQHandler
-    def_irq_handler    RTC_IRQHandler
-    def_irq_handler    WWDT_IRQHandler
-    def_irq_handler    C_CAN0_IRQHandler
-    def_irq_handler    QEI_IRQHandler
+    .macro    def_irq_default_handler    handler_name
+    .weak     \handler_name
+    .set      \handler_name, Default_Handler
+    .endm
+
+    def_irq_default_handler    DAC_IRQHandler
+    def_irq_default_handler    M0CORE_IRQHandler
+    def_irq_default_handler    DMA_IRQHandler
+    def_irq_default_handler    FLASHEEPROM_IRQHandler
+    def_irq_default_handler    ETHERNET_IRQHandler
+    def_irq_default_handler    SDIO_IRQHandler
+    def_irq_default_handler    LCD_IRQHandler
+    def_irq_default_handler    USB0_IRQHandler
+    def_irq_default_handler    USB1_IRQHandler
+    def_irq_default_handler    SCT_IRQHandler
+    def_irq_default_handler    RITIMER_IRQHandler
+    def_irq_default_handler    TIMER0_IRQHandler
+    def_irq_default_handler    TIMER1_IRQHandler
+    def_irq_default_handler    TIMER2_IRQHandler
+    def_irq_default_handler    TIMER3_IRQHandler
+    def_irq_default_handler    MCPWM_IRQHandler
+    def_irq_default_handler    ADC0_IRQHandler
+    def_irq_default_handler    I2C0_IRQHandler
+    def_irq_default_handler    I2C1_IRQHandler
+    def_irq_default_handler    SPI_IRQHandler
+    def_irq_default_handler    ADC1_IRQHandler
+    def_irq_default_handler    SSP0_IRQHandler
+    def_irq_default_handler    SSP1_IRQHandler
+    def_irq_default_handler    USART0_IRQHandler
+    def_irq_default_handler    UART1_IRQHandler
+    def_irq_default_handler    USART2_IRQHandler
+    def_irq_default_handler    USART3_IRQHandler
+    def_irq_default_handler    I2S0_IRQHandler
+    def_irq_default_handler    I2S1_IRQHandler
+    def_irq_default_handler    SPIFI_IRQHandler
+    def_irq_default_handler    SGPIO_IRQHandler
+    def_irq_default_handler    PIN_INT0_IRQHandler
+    def_irq_default_handler    PIN_INT1_IRQHandler
+    def_irq_default_handler    PIN_INT2_IRQHandler
+    def_irq_default_handler    PIN_INT3_IRQHandler
+    def_irq_default_handler    PIN_INT4_IRQHandler
+    def_irq_default_handler    PIN_INT5_IRQHandler
+    def_irq_default_handler    PIN_INT6_IRQHandler
+    def_irq_default_handler    PIN_INT7_IRQHandler
+    def_irq_default_handler    GINT0_IRQHandler
+    def_irq_default_handler    GINT1_IRQHandler
+    def_irq_default_handler    EVENTROUTER_IRQHandler
+    def_irq_default_handler    C_CAN1_IRQHandler
+    def_irq_default_handler    ATIMER_IRQHandler
+    def_irq_default_handler    RTC_IRQHandler
+    def_irq_default_handler    WWDT_IRQHandler
+    def_irq_default_handler    C_CAN0_IRQHandler
+    def_irq_default_handler    QEI_IRQHandler
 
     .end

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4XX/TOOLCHAIN_GCC_ARM/startup_STM32F40x.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4XX/TOOLCHAIN_GCC_ARM/startup_STM32F40x.s
@@ -196,27 +196,6 @@ Reset_Handler:
     strlt   r0, [r2], #4
     blt    .LC0
 
-/*     This part of work usually is done in C library startup code. Otherwise,
- *     define this macro to enable it in this startup.
- *
- *     Loop to zero out BSS section, which uses following symbols
- *     in linker script:
- *      __bss_start__: start of BSS section. Must align to 4
- *      __bss_end__: end of BSS section. Must align to 4
- *
- *      Question - Why is this not in the mbed version?
- */
-    ldr r1, =__bss_start__
-    ldr r2, =__bss_end__
-
-    movs    r0, 0
-.LC2:
-    cmp     r1, r2
-    itt    lt
-    strlt   r0, [r1], #4
-    blt    .LC2
-# End clearing the BSS section
-
     ldr    r0, =SystemInit
     blx    r0
     ldr    r0, =_start
@@ -224,6 +203,7 @@ Reset_Handler:
     .pool
     .size Reset_Handler, . - Reset_Handler
 
+    .text
 /*    Macro to define default handlers. Default handler
  *    will be weak symbol and just dead loops. They can be
  *    overwritten by other handlers */
@@ -248,91 +228,93 @@ Reset_Handler:
     def_default_handler    SysTick_Handler
     def_default_handler    Default_Handler
 
-    def_default_handler     WWDG_IRQHandler
-    def_default_handler     PVD_IRQHandler
-    def_default_handler     TAMP_STAMP_IRQHandler
-    def_default_handler     RTC_WKUP_IRQHandler
-    def_default_handler     FLASH_IRQHandler
-    def_default_handler     RCC_IRQHandler
-    def_default_handler     EXTI0_IRQHandler
-    def_default_handler     EXTI1_IRQHandler
-    def_default_handler     EXTI2_IRQHandler
-    def_default_handler     EXTI3_IRQHandler
-    def_default_handler     EXTI4_IRQHandler
-    def_default_handler     DMA1_Stream0_IRQHandler
-    def_default_handler     DMA1_Stream1_IRQHandler
-    def_default_handler     DMA1_Stream2_IRQHandler
-    def_default_handler     DMA1_Stream3_IRQHandler
-    def_default_handler     DMA1_Stream4_IRQHandler
-    def_default_handler     DMA1_Stream5_IRQHandler
-    def_default_handler     DMA1_Stream6_IRQHandler
-    def_default_handler     ADC_IRQHandler
-    def_default_handler     CAN1_TX_IRQHandler
-    def_default_handler     CAN1_RX0_IRQHandler
-    def_default_handler     CAN1_RX1_IRQHandler
-    def_default_handler     CAN1_SCE_IRQHandler
-    def_default_handler     EXTI9_5_IRQHandler
-    def_default_handler     TIM1_BRK_TIM9_IRQHandler
-    def_default_handler     TIM1_UP_TIM10_IRQHandler
-    def_default_handler     TIM1_TRG_COM_TIM11_IRQHandler
-    def_default_handler     TIM1_CC_IRQHandler
-    def_default_handler     TIM2_IRQHandler
-    def_default_handler     TIM3_IRQHandler
-    def_default_handler     TIM4_IRQHandler
-    def_default_handler     I2C1_EV_IRQHandler
-    def_default_handler     I2C1_ER_IRQHandler
-    def_default_handler     I2C2_EV_IRQHandler
-    def_default_handler     I2C2_ER_IRQHandler
-    def_default_handler     SPI1_IRQHandler
-    def_default_handler     SPI2_IRQHandler
-    def_default_handler     USART1_IRQHandler
-    def_default_handler     USART2_IRQHandler
-    def_default_handler     USART3_IRQHandler
-    def_default_handler     EXTI15_10_IRQHandler
-    def_default_handler     RTC_Alarm_IRQHandler
-    def_default_handler     OTG_FS_WKUP_IRQHandler
-    def_default_handler     TIM8_BRK_TIM12_IRQHandler
-    def_default_handler     TIM8_UP_TIM13_IRQHandler
-    def_default_handler     TIM8_TRG_COM_TIM14_IRQHandler
-    def_default_handler     TIM8_CC_IRQHandler
-    def_default_handler     DMA1_Stream7_IRQHandler
-    def_default_handler     FSMC_IRQHandler
-    def_default_handler     SDIO_IRQHandler
-    def_default_handler     TIM5_IRQHandler
-    def_default_handler     SPI3_IRQHandler
-    def_default_handler     UART4_IRQHandler
-    def_default_handler     UART5_IRQHandler
-    def_default_handler     TIM6_DAC_IRQHandler
-    def_default_handler     TIM7_IRQHandler
-    def_default_handler     DMA2_Stream0_IRQHandler
-    def_default_handler     DMA2_Stream1_IRQHandler
-    def_default_handler     DMA2_Stream2_IRQHandler
-    def_default_handler     DMA2_Stream3_IRQHandler
-    def_default_handler     DMA2_Stream4_IRQHandler
-    def_default_handler     ETH_IRQHandler
-    def_default_handler     ETH_WKUP_IRQHandler
-    def_default_handler     CAN2_TX_IRQHandler
-    def_default_handler     CAN2_RX0_IRQHandler
-    def_default_handler     CAN2_RX1_IRQHandler
-    def_default_handler     CAN2_SCE_IRQHandler
-    def_default_handler     OTG_FS_IRQHandler
-    def_default_handler     DMA2_Stream5_IRQHandler
-    def_default_handler     DMA2_Stream6_IRQHandler
-    def_default_handler     DMA2_Stream7_IRQHandler
-    def_default_handler     USART6_IRQHandler
-    def_default_handler     I2C3_EV_IRQHandler
-    def_default_handler     I2C3_ER_IRQHandler
-    def_default_handler     OTG_HS_EP1_OUT_IRQHandler
-    def_default_handler     OTG_HS_EP1_IN_IRQHandler
-    def_default_handler     OTG_HS_WKUP_IRQHandler
-    def_default_handler     OTG_HS_IRQHandler
-    def_default_handler     DCMI_IRQHandler
-    def_default_handler     CRYP_IRQHandler
-    def_default_handler     HASH_RNG_IRQHandler
-    def_default_handler     FPU_IRQHandler
+    .macro    def_irq_default_handler    handler_name
+    .weak     \handler_name
+    .set      \handler_name, Default_Handler
+    .endm
 
-
-    .weak    DEF_IRQHandler
-    .set    DEF_IRQHandler, Default_Handler
+    def_irq_default_handler     WWDG_IRQHandler
+    def_irq_default_handler     PVD_IRQHandler
+    def_irq_default_handler     TAMP_STAMP_IRQHandler
+    def_irq_default_handler     RTC_WKUP_IRQHandler
+    def_irq_default_handler     FLASH_IRQHandler
+    def_irq_default_handler     RCC_IRQHandler
+    def_irq_default_handler     EXTI0_IRQHandler
+    def_irq_default_handler     EXTI1_IRQHandler
+    def_irq_default_handler     EXTI2_IRQHandler
+    def_irq_default_handler     EXTI3_IRQHandler
+    def_irq_default_handler     EXTI4_IRQHandler
+    def_irq_default_handler     DMA1_Stream0_IRQHandler
+    def_irq_default_handler     DMA1_Stream1_IRQHandler
+    def_irq_default_handler     DMA1_Stream2_IRQHandler
+    def_irq_default_handler     DMA1_Stream3_IRQHandler
+    def_irq_default_handler     DMA1_Stream4_IRQHandler
+    def_irq_default_handler     DMA1_Stream5_IRQHandler
+    def_irq_default_handler     DMA1_Stream6_IRQHandler
+    def_irq_default_handler     ADC_IRQHandler
+    def_irq_default_handler     CAN1_TX_IRQHandler
+    def_irq_default_handler     CAN1_RX0_IRQHandler
+    def_irq_default_handler     CAN1_RX1_IRQHandler
+    def_irq_default_handler     CAN1_SCE_IRQHandler
+    def_irq_default_handler     EXTI9_5_IRQHandler
+    def_irq_default_handler     TIM1_BRK_TIM9_IRQHandler
+    def_irq_default_handler     TIM1_UP_TIM10_IRQHandler
+    def_irq_default_handler     TIM1_TRG_COM_TIM11_IRQHandler
+    def_irq_default_handler     TIM1_CC_IRQHandler
+    def_irq_default_handler     TIM2_IRQHandler
+    def_irq_default_handler     TIM3_IRQHandler
+    def_irq_default_handler     TIM4_IRQHandler
+    def_irq_default_handler     I2C1_EV_IRQHandler
+    def_irq_default_handler     I2C1_ER_IRQHandler
+    def_irq_default_handler     I2C2_EV_IRQHandler
+    def_irq_default_handler     I2C2_ER_IRQHandler
+    def_irq_default_handler     SPI1_IRQHandler
+    def_irq_default_handler     SPI2_IRQHandler
+    def_irq_default_handler     USART1_IRQHandler
+    def_irq_default_handler     USART2_IRQHandler
+    def_irq_default_handler     USART3_IRQHandler
+    def_irq_default_handler     EXTI15_10_IRQHandler
+    def_irq_default_handler     RTC_Alarm_IRQHandler
+    def_irq_default_handler     OTG_FS_WKUP_IRQHandler
+    def_irq_default_handler     TIM8_BRK_TIM12_IRQHandler
+    def_irq_default_handler     TIM8_UP_TIM13_IRQHandler
+    def_irq_default_handler     TIM8_TRG_COM_TIM14_IRQHandler
+    def_irq_default_handler     TIM8_CC_IRQHandler
+    def_irq_default_handler     DMA1_Stream7_IRQHandler
+    def_irq_default_handler     FSMC_IRQHandler
+    def_irq_default_handler     SDIO_IRQHandler
+    def_irq_default_handler     TIM5_IRQHandler
+    def_irq_default_handler     SPI3_IRQHandler
+    def_irq_default_handler     UART4_IRQHandler
+    def_irq_default_handler     UART5_IRQHandler
+    def_irq_default_handler     TIM6_DAC_IRQHandler
+    def_irq_default_handler     TIM7_IRQHandler
+    def_irq_default_handler     DMA2_Stream0_IRQHandler
+    def_irq_default_handler     DMA2_Stream1_IRQHandler
+    def_irq_default_handler     DMA2_Stream2_IRQHandler
+    def_irq_default_handler     DMA2_Stream3_IRQHandler
+    def_irq_default_handler     DMA2_Stream4_IRQHandler
+    def_irq_default_handler     ETH_IRQHandler
+    def_irq_default_handler     ETH_WKUP_IRQHandler
+    def_irq_default_handler     CAN2_TX_IRQHandler
+    def_irq_default_handler     CAN2_RX0_IRQHandler
+    def_irq_default_handler     CAN2_RX1_IRQHandler
+    def_irq_default_handler     CAN2_SCE_IRQHandler
+    def_irq_default_handler     OTG_FS_IRQHandler
+    def_irq_default_handler     DMA2_Stream5_IRQHandler
+    def_irq_default_handler     DMA2_Stream6_IRQHandler
+    def_irq_default_handler     DMA2_Stream7_IRQHandler
+    def_irq_default_handler     USART6_IRQHandler
+    def_irq_default_handler     I2C3_EV_IRQHandler
+    def_irq_default_handler     I2C3_ER_IRQHandler
+    def_irq_default_handler     OTG_HS_EP1_OUT_IRQHandler
+    def_irq_default_handler     OTG_HS_EP1_IN_IRQHandler
+    def_irq_default_handler     OTG_HS_WKUP_IRQHandler
+    def_irq_default_handler     OTG_HS_IRQHandler
+    def_irq_default_handler     DCMI_IRQHandler
+    def_irq_default_handler     CRYP_IRQHandler
+    def_irq_default_handler     HASH_RNG_IRQHandler
+    def_irq_default_handler     FPU_IRQHandler
+    def_irq_default_handler     DEF_IRQHandler
 
     .end


### PR DESCRIPTION
This pull request cleans up startup code for GCC_ARM in following ways:
1. Prefixing internal labels with .L to avoid making them external symbols. Making dissemble version more friendly
2. Reuse the single irq default handler for all irq handlers, to avoid code size waste from replicating all irq handlers.
3. For STM32F407, needn't clear BSS region as it will be cleared in startup code of C library (_start)

Tested all board with GCC_ARM with no more build failure. 
Tested with LPC1768.
It doesn't impact any tools other than GCC_ARM.
