### PR TITLE
Added MCGPLLFLL clock function, squished some 'bugs'

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KL25Z/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KL25Z/us_ticker.c
@@ -102,10 +102,22 @@ static void lptmr_init(void) {
             }
         }
     }
-    //No suitable external oscillator clock -> Use fast internal oscillator (4MHz)
+    //No suitable external oscillator clock -> Use fast internal oscillator (4MHz / divider)
     MCG->C1 |= MCG_C1_IRCLKEN_MASK;
     MCG->C2 |= MCG_C2_IRCS_MASK;
-    LPTMR0->PSR = LPTMR_PSR_PCS(0) | LPTMR_PSR_PRESCALE(1);
+    LPTMR0->PSR =  LPTMR_PSR_PCS(0);
+    switch (MCG->SC & MCG_SC_FCRDIV_MASK) {
+        case MCG_SC_FCRDIV(0):                  //4MHz
+            LPTMR0->PSR |= LPTMR_PSR_PRESCALE(1);
+            break;
+        case MCG_SC_FCRDIV(1):                  //2MHz
+            LPTMR0->PSR |= LPTMR_PSR_PRESCALE(0);
+            break;
+        default:                                //1MHz or anything else, in which case we put it on 1MHz
+            MCG->SC &= ~MCG_SC_FCRDIV_MASK;
+            MCG->SC |= MCG_SC_FCRDIV(2);
+            LPTMR0->PSR |= LPTMR_PSR_PBYP_MASK;
+    }
     
 }
 


### PR DESCRIPTION
PWM bug mentioned here:
https://mbed.org/questions/2315/BUG-Exporting-to-ARM-GCC-does-not-work-n/

Fast internal osc prescaler wasn't taken into account at us_ticker
interrupt clock source, now it is.

And the MCGPLLFLL output for peripherals is now properly calculated for UART0 and PWM.
