### PR TITLE
LPC11U35 support for USBDevice and mbed-rtos

### DIFF
--- a/libraries/USBDevice/USBDevice/USBDevice.cpp
+++ b/libraries/USBDevice/USBDevice/USBDevice.cpp
@@ -926,7 +926,7 @@ uint8_t * USBDevice::stringLangidDesc() {
     static uint8_t stringLangidDescriptor[] = {
         0x04,               /*bLength*/
         STRING_DESCRIPTOR,  /*bDescriptorType 0x03*/
-        0x09,0x00,          /*bString Lang ID - 0x009 - English*/
+        0x09,0x04,          /*bString Lang ID - 0x0409 - English*/
     };
     return stringLangidDescriptor;
 }

--- a/libraries/USBDevice/USBDevice/USBDevice_Types.h
+++ b/libraries/USBDevice/USBDevice/USBDevice_Types.h
@@ -49,7 +49,7 @@
 
 /* Descriptors */
 #define DESCRIPTOR_TYPE(wValue)  (wValue >> 8)
-#define DESCRIPTOR_INDEX(wValue) (wValue & 0xf)
+#define DESCRIPTOR_INDEX(wValue) (wValue & 0xff)
 
 typedef struct {
     struct {

--- a/libraries/USBDevice/USBDevice/USBHAL_LPC11U.cpp
+++ b/libraries/USBDevice/USBDevice/USBHAL_LPC11U.cpp
@@ -16,11 +16,11 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#if defined(TARGET_LPC11U24) || defined(TARGET_LPC1347)
+#if defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401) || defined(TARGET_LPC1347)
 
 #if defined(TARGET_LPC1347)
 #define USB_IRQ USB_IRQ_IRQn
-#elif defined(TARGET_LPC11U24)
+#elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)
 #define USB_IRQ USB_IRQn
 #endif
 
@@ -145,6 +145,11 @@ USBHAL::USBHAL(void) {
     epCallback[6] = &USBHAL::EP4_OUT_callback;
     epCallback[7] = &USBHAL::EP4_IN_callback;
 
+    #if defined(TARGET_LPC11U35_401)
+    // USB_VBUS input with pull-down
+    LPC_IOCON->PIO0_3 = 0x00000009;
+    #endif
+    
     // nUSB_CONNECT output
     LPC_IOCON->PIO0_6 = 0x00000001;
 

--- a/libraries/rtos/rtx/RTX_CM_lib.h
+++ b/libraries/rtos/rtx/RTX_CM_lib.h
@@ -205,6 +205,9 @@ osThreadDef_t os_thread_def_main = {(os_pthread)main, osPriorityNormal, 0, NULL}
 #elif TARGET_LPC11U24
 #define INITIAL_SP            (0x10002000UL)
 
+#elif TARGET_LPC11U35_401
+#define INITIAL_SP            (0x10002000UL)
+
 #elif TARGET_LPC1114
 #define INITIAL_SP            (0x10001000UL)
 

--- a/libraries/rtos/rtx/RTX_Conf_CM.c
+++ b/libraries/rtos/rtx/RTX_Conf_CM.c
@@ -51,7 +51,7 @@
 #ifndef OS_TASKCNT
 #  if defined(TARGET_LPC1768) || defined(TARGET_LPC2368) || defined(TARGET_LPC4088) || defined(TARGET_LPC1347)
 #    define OS_TASKCNT         14
-#  elif defined(TARGET_LPC11U24) || (TARGET_LPC1114) || (TARGET_LPC812) || defined(TARGET_KL25Z)
+#  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401) || (TARGET_LPC1114) || (TARGET_LPC812) || defined(TARGET_KL25Z)
 #    define OS_TASKCNT         6
 #  endif
 #endif
@@ -60,7 +60,7 @@
 #ifndef OS_SCHEDULERSTKSIZE
 #  if defined(TARGET_LPC1768) || defined(TARGET_LPC2368) || defined(TARGET_LPC4088) || defined(TARGET_LPC1347)
 #      define OS_SCHEDULERSTKSIZE    256
-#  elif defined(TARGET_LPC11U24) || (TARGET_LPC1114) || (TARGET_LPC812) || defined(TARGET_KL25Z)
+#  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401) || (TARGET_LPC1114) || (TARGET_LPC812) || defined(TARGET_KL25Z)
 #      define OS_SCHEDULERSTKSIZE    128
 #  endif
 #endif
@@ -107,7 +107,7 @@
 #  elif defined(TARGET_LPC1347)
 #    define OS_CLOCK       72000000
 
-#  elif defined(TARGET_LPC11U24) || (TARGET_LPC1114) || defined(TARGET_KL25Z)
+#  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401) || (TARGET_LPC1114) || defined(TARGET_KL25Z)
 #    define OS_CLOCK       48000000
 #
 #  elif defined(TARGET_LPC812)


### PR DESCRIPTION
I've added support for the EA LPC11U35 QuickStart Board to USBDevice and mbed-rtos. I also fixed several string-related bugs in USBDevice. This pull request is identical to the following two pull requests on the mbed site:
- https://mbed.org/users/mbed_official/code/mbed-rtos/pull-request/2
- https://mbed.org/users/mbed_official/code/USBDevice/pull-request/3

...and is in response to my [conversation with Erik Olieman](http://mbed.org/forum/bugs-suggestions/post/23285/).
