### PR TITLE
Remove unnecessary semicolons.

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
@@ -202,7 +202,7 @@ int spi_master_write(spi_t *obj, int value) {
 
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
-};
+}
 
 int spi_slave_read(spi_t *obj) {
     return obj->spi->DR;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
@@ -198,7 +198,7 @@ int spi_master_write(spi_t *obj, int value) {
 
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
-};
+}
 
 int spi_slave_read(spi_t *obj) {
     return obj->spi->DR;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/spi_api.c
@@ -202,7 +202,7 @@ int spi_master_write(spi_t *obj, int value) {
 
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
-};
+}
 
 int spi_slave_read(spi_t *obj) {
     return obj->spi->DR;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/spi_api.c
@@ -206,7 +206,7 @@ int spi_master_write(spi_t *obj, int value) {
 
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
-};
+}
 
 int spi_slave_read(spi_t *obj) {
     return obj->spi->DR;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/spi_api.c
@@ -208,7 +208,7 @@ int spi_master_write(spi_t *obj, int value) {
 
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
-};
+}
 
 int spi_slave_read(spi_t *obj) {
     return obj->spi->DR;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/spi_api.c
@@ -215,7 +215,7 @@ int spi_master_write(spi_t *obj, int value) {
 
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
-};
+}
 
 int spi_slave_read(spi_t *obj) {
     return obj->spi->DR;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/spi_api.c
@@ -183,7 +183,7 @@ int spi_master_write(spi_t *obj, int value) {
 
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
-};
+}
 
 int spi_slave_read(spi_t *obj) {
     return obj->spi->DR;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/spi_api.c
@@ -194,7 +194,7 @@ int spi_master_write(spi_t *obj, int value) {
 
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
-};
+}
 
 int spi_slave_read(spi_t *obj) {
     return obj->spi->RXDAT;


### PR DESCRIPTION
Remove unnecessary semicolon that was placed in all SPI drivers for NXP
targets.
