### PR TITLE
libraries/sd: Fixed SDFileSystem when no card present

### DIFF
--- a/libraries/fs/sd/SDFileSystem.h
+++ b/libraries/fs/sd/SDFileSystem.h
@@ -77,6 +77,7 @@ protected:
     SPI _spi;
     DigitalOut _cs;
     int cdv;
+    int _is_initialized;
 };
 
 #endif


### PR DESCRIPTION
It might also happen when the card is corrupted.
This patch prevent the instantiation of the SDFileSystem class to be blocking.
