### PR TITLE
Allow USBDevice::connect() to be non-blocking

### DIFF
--- a/libraries/USBDevice/USBDevice/USBDevice.cpp
+++ b/libraries/USBDevice/USBDevice/USBDevice.cpp
@@ -703,12 +703,15 @@ bool USBDevice::configured(void)
     return (device.state == CONFIGURED);
 }
 
-void USBDevice::connect(void)
+void USBDevice::connect(bool blocking)
 {
     /* Connect device */
     USBHAL::connect();
-    /* Block if not configured */
-    while (!configured());
+    
+    if (blocking) {
+        /* Block if not configured */
+        while (!configured());
+    }
 }
 
 void USBDevice::disconnect(void)

--- a/libraries/USBDevice/USBDevice/USBDevice.h
+++ b/libraries/USBDevice/USBDevice/USBDevice.h
@@ -37,8 +37,10 @@ public:
     
     /*
     * Connect a device
+    * 
+    * @param blocking: block if not configured
     */
-    void connect(void);
+    void connect(bool blocking = true);
     
     /*
     * Disconnect a device

--- a/libraries/USBDevice/USBMSD/USBMSD.cpp
+++ b/libraries/USBDevice/USBMSD/USBMSD.cpp
@@ -103,8 +103,7 @@ bool USBMSD::USBCallback_request(void) {
 }
 
 
-bool USBMSD::connect() {
-
+bool USBMSD::connect(bool blocking) {
     //disk initialization
     if (disk_status() & NO_INIT) {
         if (disk_initialize()) {
@@ -131,7 +130,7 @@ bool USBMSD::connect() {
     }
 
     //connect the device
-    USBDevice::connect();
+    USBDevice::connect(blocking);
     return true;
 }
 

--- a/libraries/USBDevice/USBMSD/USBMSD.h
+++ b/libraries/USBDevice/USBMSD/USBMSD.h
@@ -70,9 +70,10 @@ public:
     /**
     * Connect the USB MSD device. Establish disk initialization before really connect the device.
     *
+    * @param blocking if not configured
     * @returns true if successful
     */
-    bool connect();
+    bool connect(bool blocking = true);
 
     /**
     * Disconnect the USB MSD device.


### PR DESCRIPTION
It is required if USB is not the primary use of the device (eg: use
of USB mass storage to transfer pictures from the camera (the
device) to the host once in a while).
