### PR TITLE
Properly round non integer bus-frequencies in MHz

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/us_ticker.c
@@ -44,7 +44,7 @@ static void pit_init(void) {
     PIT->CHANNEL[1].TCTRL |= PIT_TCTRL_TEN_MASK;   // Start timer 1
     
     // Use channel 0 as a prescaler for channel 1
-    PIT->CHANNEL[0].LDVAL = bus_frequency() / 1000000 - 1;
+    PIT->CHANNEL[0].LDVAL = (bus_frequency() + 500000) / 1000000 - 1;
     PIT->CHANNEL[0].TCTRL = PIT_TCTRL_TEN_MASK;    // Start timer 0, disable interrupts
 }
 


### PR DESCRIPTION
PIT prescaler now rounds to nearest instead of down. Since when FLL is
used (default on KL05Z, but also possible on others), the bus
frequencies is 23.986MHz, rounding down is bad.
