### PR TITLE
libraries/USBSerial: Allow the USB connection to be non-blocking

### DIFF
--- a/libraries/USBDevice/USBSerial/USBCDC.cpp
+++ b/libraries/USBDevice/USBSerial/USBCDC.cpp
@@ -29,9 +29,9 @@ static uint8_t cdc_line_coding[7]= {0x80, 0x25, 0x00, 0x00, 0x00, 0x00, 0x08};
 
 #define MAX_CDC_REPORT_SIZE MAX_PACKET_SIZE_EPBULK
 
-USBCDC::USBCDC(uint16_t vendor_id, uint16_t product_id, uint16_t product_release): USBDevice(vendor_id, product_id, product_release) {
+USBCDC::USBCDC(uint16_t vendor_id, uint16_t product_id, uint16_t product_release, bool connect_blocking): USBDevice(vendor_id, product_id, product_release) {
     terminal_connected = false;
-    USBDevice::connect();
+    USBDevice::connect(connect_blocking);
 }
 
 bool USBCDC::USBCallback_request(void) {

--- a/libraries/USBDevice/USBSerial/USBCDC.h
+++ b/libraries/USBDevice/USBSerial/USBCDC.h
@@ -35,8 +35,9 @@ public:
     * @param vendor_id Your vendor_id
     * @param product_id Your product_id
     * @param product_release Your preoduct_release
+    * @param connect_blocking define if the connection must be blocked if USB not plugged in
     */
-    USBCDC(uint16_t vendor_id, uint16_t product_id, uint16_t product_release);
+    USBCDC(uint16_t vendor_id, uint16_t product_id, uint16_t product_release, bool connect_blocking);
 
 protected:
     

--- a/libraries/USBDevice/USBSerial/USBSerial.h
+++ b/libraries/USBDevice/USBSerial/USBSerial.h
@@ -53,9 +53,10 @@ public:
     * @param vendor_id Your vendor_id (default: 0x1f00)
     * @param product_id Your product_id (default: 0x2012)
     * @param product_release Your preoduct_release (default: 0x0001)
+    * @param connect_blocking define if the connection must be blocked if USB not plugged in
     *
     */
-    USBSerial(uint16_t vendor_id = 0x1f00, uint16_t product_id = 0x2012, uint16_t product_release = 0x0001): USBCDC(vendor_id, product_id, product_release), buf(128){
+    USBSerial(uint16_t vendor_id = 0x1f00, uint16_t product_id = 0x2012, uint16_t product_release = 0x0001, bool connect_blocking = true): USBCDC(vendor_id, product_id, product_release, connect_blocking), buf(128){
         settingsChangedCallback = 0;
     };
 


### PR DESCRIPTION
Prior to this change the connection was waiting for a USB cable to be plugged in.

Note: The default behaviour is still with the connection blocking.
