### PR TITLE
add D0-D13 and A0-A5 for Arch V1.1 and Arch Pro

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/TARGET_LPC11U24_401/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/TARGET_LPC11U24_401/PinNames.h
@@ -135,6 +135,29 @@ typedef enum {
     USBTX = P0_19,
     USBRX = P0_18,
 
+    // for Arch V1.1
+    D0 = P0_18,
+    D1 = P0_19,
+    D2 = P0_17,
+    D3 = P1_17,
+    D4 = P1_18,
+    D5 = P1_24,
+    D6 = P1_25,
+    D7 = P1_5,
+    D8 = P1_26,
+    D9 = P1_27,
+    D10 = P0_2,
+    D11 = P0_9,  // P1_29 for Arch V1.0
+    D12 = P0_8,
+    D13 = P1_29, // P0_9 for Arch V1.0
+
+    A0 = P0_11,
+    A1 = P0_12,
+    A2 = P0_13,
+    A3 = P0_14,
+    A4 = P0_16,
+    A5 = P0_22,
+
     // Not connected
     NC = (int)0xFFFFFFFF,
 } PinName;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/TARGET_MBED_LPC1768/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/TARGET_MBED_LPC1768/PinNames.h
@@ -81,6 +81,29 @@ typedef enum {
     USBTX = P0_2,
     USBRX = P0_3,
 
+    // Arch Pro Pin Names
+    D0 = P4_29,
+    D1 = P4_28,
+    D2 = P0_4,
+    D3 = P0_5,
+    D4 = P2_2,
+    D5 = P2_3,
+    D6 = P2_4,
+    D7 = P2_5,
+    D8 = P0_0,
+    D9 = P0_1,
+    D10 = P0_6,
+    D11 = P0_9,
+    D12 = P0_8,
+    D13 = P0_7,
+
+    A0 = P0_23,
+    A1 = P0_24,
+    A2 = P0_25,
+    A3 = P0_26,
+    A4 = P1_30,
+    A5 = P1_31,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;


### PR DESCRIPTION
add pin names D0-D13 and A0-A5 to target LPC11U24(Arch) and LPC1768(Arch Pro)
