### PR TITLE
proposed change of gpio_api

### DIFF
--- a/libraries/mbed/api/DigitalIn.h
+++ b/libraries/mbed/api/DigitalIn.h
@@ -49,10 +49,10 @@ public:
     /** Create a DigitalIn connected to the specified pin
      *
      *  @param pin DigitalIn pin to connect to
-     *  @param name (optional) A string to identify the object
+     *  @param mode the initial mode of the pin
      */
-    DigitalIn(PinName pin) {
-        gpio_init(&gpio, pin, PIN_INPUT);
+    DigitalIn(PinName pin, PinMode mode = PullDefault) {
+        GPIO_INIT_IN(&gpio, pin, mode);
     }
 
     /** Read the input, represented as 0 or 1 (int)

--- a/libraries/mbed/api/DigitalInOut.h
+++ b/libraries/mbed/api/DigitalInOut.h
@@ -30,9 +30,17 @@ public:
     /** Create a DigitalInOut connected to the specified pin
      *
      *  @param pin DigitalInOut pin to connect to
+     *  @param direction the initial direction of the pin
+     *  @param mode the initial mode of the pin
+     *  @param value the initial value of the pin if is an output
      */
-    DigitalInOut(PinName pin) {
-        gpio_init(&gpio, pin, PIN_INPUT);
+    DigitalInOut(PinName pin, PinDirection direction = PIN_INPUT, PinMode mode = PullDefault, int value = 0) {
+        if (direction == PIN_INPUT) {
+            GPIO_INIT_IN(&gpio, pin, mode);
+            gpio_write(&gpio, value); // we prepare the value in case it is switched later
+        } else {
+            GPIO_INIT_OUT(&gpio, pin, mode, value);
+        }
     }
 
     /** Set the output, specified as 0 or 1 (int)

--- a/libraries/mbed/api/DigitalOut.h
+++ b/libraries/mbed/api/DigitalOut.h
@@ -44,9 +44,10 @@ public:
     /** Create a DigitalOut connected to the specified pin
      *
      *  @param pin DigitalOut pin to connect to
+     *  @param value the initial pin value
      */
-    DigitalOut(PinName pin) {
-        gpio_init(&gpio, pin, PIN_OUTPUT);
+    DigitalOut(PinName pin, int value = 0) {
+        GPIO_INIT_OUT(&gpio, pin, PullNone, value);
     }
 
     /** Set the output, specified as 0 or 1 (int)

--- a/libraries/mbed/common/InterruptIn.cpp
+++ b/libraries/mbed/common/InterruptIn.cpp
@@ -21,7 +21,7 @@ namespace mbed {
 
 InterruptIn::InterruptIn(PinName pin) {
     gpio_irq_init(&gpio_irq, pin, (&InterruptIn::_irq_handler), (uint32_t)this);
-    gpio_init(&gpio, pin, PIN_INPUT);
+    GPIO_INIT_IN(&gpio, pin, PullDefault);
 }
 
 InterruptIn::~InterruptIn() {

--- a/libraries/mbed/common/board.c
+++ b/libraries/mbed/common/board.c
@@ -20,15 +20,15 @@
 WEAK void mbed_die(void);
 WEAK void mbed_die(void) {
 	__disable_irq();	// dont allow interrupts to disturb the flash pattern
-	
-#if   (DEVICE_ERROR_RED == 1)
-    gpio_t led_red; gpio_init(&led_red, LED_RED, PIN_OUTPUT);
 
+#if   (DEVICE_ERROR_RED == 1)
+    gpio_t led_red; GPIO_INIT_OUT(&led_red, LED_RED, PullNone, 0);
+    
 #elif (DEVICE_ERROR_PATTERN == 1)
-    gpio_t led_1; gpio_init(&led_1, LED1, PIN_OUTPUT);
-    gpio_t led_2; gpio_init(&led_2, LED2, PIN_OUTPUT);
-    gpio_t led_3; gpio_init(&led_3, LED3, PIN_OUTPUT);
-    gpio_t led_4; gpio_init(&led_4, LED4, PIN_OUTPUT);
+    gpio_t led_1; GPIO_INIT_OUT(&led_1, LED1, PullNone, 0);
+    gpio_t led_2; GPIO_INIT_OUT(&led_2, LED2, PullNone, 0);
+    gpio_t led_3; GPIO_INIT_OUT(&led_3, LED3, PullNone, 0);
+    gpio_t led_4; GPIO_INIT_OUT(&led_4, LED4, PullNone, 0);
 #endif
     
     while (1) {

--- a/libraries/mbed/hal/gpio_api.h
+++ b/libraries/mbed/hal/gpio_api.h
@@ -29,13 +29,24 @@ extern "C" {
 uint32_t gpio_set(PinName pin);
 
 /* GPIO object */
-void gpio_init (gpio_t *obj, PinName pin, PinDirection direction);
+void gpio_init(gpio_t *obj, PinName pin);
 
 void gpio_mode (gpio_t *obj, PinMode mode);
 void gpio_dir  (gpio_t *obj, PinDirection direction);
 
 void gpio_write(gpio_t *obj, int value);
 int  gpio_read (gpio_t *obj);
+
+#define GPIO_INIT_IN(obj, pin, mode) \
+    gpio_init(obj, pin), \
+    gpio_mode(obj, mode), \
+    gpio_dir(obj, PIN_INPUT)
+    
+#define GPIO_INIT_OUT(obj, pin, mode, value) \
+    gpio_init(obj, pin), \
+    gpio_write(obj, value), \
+    gpio_dir(obj, PIN_OUTPUT), \
+    gpio_mode(obj, mode)
 
 #ifdef __cplusplus
 }

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_K20D5M/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_K20D5M/PinNames.h
@@ -240,6 +240,7 @@ typedef enum {
     PullNone = 0,
     PullDown = 2,
     PullUp   = 3,
+    PullDefault = PullUp
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_K20D5M/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_K20D5M/gpio_api.c
@@ -21,7 +21,7 @@ uint32_t gpio_set(PinName pin) {
     return 1 << ((pin & 0x7F) >> 2);
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if(pin == NC)
         return;
 
@@ -35,16 +35,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_clr = &reg->PCOR;
     obj->reg_in  = &reg->PDIR;
     obj->reg_dir = &reg->PDDR;
-
-    gpio_dir(obj, direction);
-    switch (direction) {
-        case PIN_OUTPUT:
-            pin_mode(pin, PullNone);
-            break;
-        case PIN_INPUT :
-            pin_mode(pin, PullUp);
-            break;
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/PinNames.h
@@ -126,6 +126,7 @@ typedef enum {
 typedef enum {
     PullNone = 0,
     PullUp   = 2,
+    PullDefault = PullUp
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/gpio_irq_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/gpio_irq_api.c
@@ -17,6 +17,7 @@
 #include "cmsis.h"
 
 #include "gpio_irq_api.h"
+#include "gpio_api.h"
 #include "error.h"
 
 #define CHANNEL_NUM    64   // 31 pins on 2 ports
@@ -176,9 +177,8 @@ void gpio_irq_disable(gpio_irq_t *obj) {
 // Change the NMI pin to an input. This allows NMI pin to 
 //  be used as a low power mode wakeup.  The application will
 //  need to change the pin back to NMI_b or wakeup only occurs once!
-extern void gpio_init(gpio_t *obj, PinName pin, PinDirection direction);
 void NMI_Handler(void)
 {
     gpio_t gpio;
-    gpio_init(&gpio, PTB5, PIN_INPUT);
+    GPIO_INIT_IN(&gpio, PTA4, PIN_INPUT, PullDefault);
 }

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/PinNames.h
@@ -244,6 +244,7 @@ typedef enum {
 typedef enum {
     PullNone = 0,
     PullUp = 2,
+    PullDefault = PullUp
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/gpio_irq_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/gpio_irq_api.c
@@ -17,6 +17,7 @@
 #include "cmsis.h"
 
 #include "gpio_irq_api.h"
+#include "gpio_api.h"
 #include "error.h"
 
 #define CHANNEL_NUM    64
@@ -166,9 +167,8 @@ void gpio_irq_disable(gpio_irq_t *obj) {
 // Change the NMI pin to an input. This allows NMI pin to 
 //  be used as a low power mode wakeup.  The application will
 //  need to change the pin back to NMI_b or wakeup only occurs once!
-extern void gpio_init(gpio_t *obj, PinName pin, PinDirection direction);
 void NMI_Handler(void)
 {
     gpio_t gpio;
-    gpio_init(&gpio, PTA4, PIN_INPUT);
+    GPIO_INIT_IN(&gpio, PTA4, PullDefault);
 }

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/PinNames.h
@@ -247,7 +247,8 @@ typedef enum {
 typedef enum {
     PullNone = 0,
     PullDown = 2,
-    PullUp = 3
+    PullUp = 3,
+    PullDefault = PullUp
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/gpio_irq_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/gpio_irq_api.c
@@ -17,6 +17,7 @@
 #include "cmsis.h"
 
 #include "gpio_irq_api.h"
+#include "gpio_api.h"
 #include "error.h"
 
 #define CHANNEL_NUM    96
@@ -186,9 +187,8 @@ void gpio_irq_disable(gpio_irq_t *obj) {
 // Change the NMI pin to an input. This allows NMI pin to 
 //  be used as a low power mode wakeup.  The application will
 //  need to change the pin back to NMI_b or wakeup only occurs once!
-extern void gpio_init(gpio_t *obj, PinName pin, PinDirection direction);
 void NMI_Handler(void)
 {
     gpio_t gpio;
-    gpio_init(&gpio, PTA4, PIN_INPUT);
+    GPIO_INIT_IN(&gpio, PTA4, PIN_INPUT, PullDefault);
 }

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/gpio_api.c
@@ -21,7 +21,7 @@ uint32_t gpio_set(PinName pin) {
     return 1 << ((pin & 0x7F) >> 2);
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if(pin == (PinName)NC) return;
 
     obj->pin = pin;
@@ -34,12 +34,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_clr = &reg->PCOR;
     obj->reg_in  = &reg->PDIR;
     obj->reg_dir = &reg->PDDR;
-
-    gpio_dir(obj, direction);
-    switch (direction) {
-        case PIN_OUTPUT: pin_mode(pin, PullNone); break;
-        case PIN_INPUT : pin_mode(pin, PullUp); break;
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_NRF51822/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_NRF51822/PinNames.h
@@ -142,7 +142,8 @@ typedef enum {
 typedef enum {
     PullNone = 0,
     PullDown = 1,
-    PullUp = 3
+    PullUp = 3,
+    PullDefault = PullUp
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_NRF51822/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_NRF51822/gpio_api.c
@@ -16,7 +16,7 @@
 #include "gpio_api.h"
 #include "pinmap.h"
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if(pin == NC) return;
 
     obj->pin = pin;
@@ -26,12 +26,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_clr = &NRF_GPIO->OUTCLR;
     obj->reg_in  = &NRF_GPIO->IN;
     obj->reg_dir = &NRF_GPIO->DIR;
-
-    gpio_dir(obj, direction);
-    switch (direction) {
-        case PIN_OUTPUT: pin_mode(pin, PullNone); break;
-        case PIN_INPUT : pin_mode(pin, PullUp); break;
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/TARGET_LPC11U24_301/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/TARGET_LPC11U24_301/PinNames.h
@@ -155,7 +155,8 @@ typedef enum {
     PullDown = 1,
     PullNone = 0,
     Repeater = 3,
-    OpenDrain = 4
+    OpenDrain = 4,
+    PullDefault = PullDown
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/TARGET_LPC11U24_401/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/TARGET_LPC11U24_401/PinNames.h
@@ -178,7 +178,8 @@ typedef enum {
     PullDown = 1,
     PullNone = 0,
     Repeater = 3,
-    OpenDrain = 4
+    OpenDrain = 4,
+    PullDefault = PullDown
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/TARGET_LPC11U35_401/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/TARGET_LPC11U35_401/PinNames.h
@@ -150,7 +150,8 @@ typedef enum {
     PullDown = 1,
     PullNone = 0,
     Repeater = 3,
-    OpenDrain = 4
+    OpenDrain = 4,
+    PullDefault = PullDown
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/gpio_api.c
@@ -27,7 +27,7 @@ uint32_t gpio_set(PinName pin) {
     return (1 << ((int)pin & 0x1F));
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if(pin == NC) return;
 
     obj->pin = pin;
@@ -39,12 +39,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_clr = &LPC_GPIO->CLR[port];
     obj->reg_in  = &LPC_GPIO->PIN[port];
     obj->reg_dir = &LPC_GPIO->DIR[port];
-    
-    gpio_dir(obj, direction);
-    switch (direction) {
-        case PIN_OUTPUT: pin_mode(pin, PullNone); break;
-        case PIN_INPUT : pin_mode(pin, PullDown); break;
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11CXX/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11CXX/PinNames.h
@@ -208,7 +208,8 @@ typedef enum {
     PullDown = 1,
     PullNone = 0,
     Repeater = 3,
-    OpenDrain = 4
+    OpenDrain = 4,
+    PullDefault = PullDown
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11XX/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11XX/PinNames.h
@@ -223,7 +223,8 @@ typedef enum {
     PullDown = 1,
     PullNone = 0,
     Repeater = 3,
-    OpenDrain = 4
+    OpenDrain = 4,
+    PullDefault = PullDown
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/gpio_api.c
@@ -34,7 +34,7 @@ uint32_t gpio_set(PinName pin) {
     return ((pin & 0x0F00) >> 8);
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if(pin == NC) return;
 
     obj->pin = pin;
@@ -43,13 +43,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_mask_read = &port_reg->MASKED_ACCESS[1 << gpio_set(pin)];
     obj->reg_dir       = &port_reg->DIR;
     obj->reg_write     = &port_reg->DATA;
-    
-    gpio_dir(obj, direction);
-    
-    switch (direction) {
-        case PIN_OUTPUT: pin_mode(pin, PullNone); break;
-        case PIN_INPUT : pin_mode(pin, PullDown); break;
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/PinNames.h
@@ -140,7 +140,8 @@ typedef enum {
     PullDown = 1,
     PullNone = 0,
     Repeater = 3,
-    OpenDrain = 4
+    OpenDrain = 4,
+    PullDefault = PullDown
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/gpio_api.c
@@ -27,7 +27,7 @@ uint32_t gpio_set(PinName pin) {
     return (1 << ((int)pin & 0x1F));
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if(pin == NC) return;
 
     obj->pin = pin;
@@ -39,12 +39,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_clr = &LPC_GPIO->CLR[port];
     obj->reg_in  = &LPC_GPIO->PIN[port];
     obj->reg_dir = &LPC_GPIO->DIR[port];
-    
-    gpio_dir(obj, direction);
-    switch (direction) {
-        case PIN_OUTPUT: pin_mode(pin, PullNone); break;
-        case PIN_INPUT : pin_mode(pin, PullDown); break;
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC15XX/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC15XX/PinNames.h
@@ -81,7 +81,8 @@ typedef enum {
     PullDown = 1,
     PullNone = 0,
     Repeater = 3,
-    OpenDrain = 4
+    OpenDrain = 4,
+    PullDefault = PullDown
 } PinMode;
 
 #define STDIO_UART_TX     USBTX

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC15XX/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC15XX/gpio_api.c
@@ -33,7 +33,7 @@ uint32_t gpio_set(PinName pin) {
     return (1UL << ((int)pin & 0x1f));
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if(pin == NC) return;
     
     obj->pin = pin;
@@ -45,12 +45,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_clr = &LPC_GPIO_PORT->CLR[port];
     obj->reg_in  = &LPC_GPIO_PORT->PIN[port];
     obj->reg_dir = &LPC_GPIO_PORT->DIR[port];
-    
-    gpio_dir(obj, direction);
-    switch (direction) {
-        case PIN_OUTPUT: pin_mode(pin, PullNone); break;
-        case PIN_INPUT : pin_mode(pin, PullDown); break;
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/TARGET_MBED_LPC1768/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/TARGET_MBED_LPC1768/PinNames.h
@@ -112,7 +112,8 @@ typedef enum {
     PullUp = 0,
     PullDown = 3,
     PullNone = 2,
-    OpenDrain = 4
+    OpenDrain = 4,
+    PullDefault = PullDown
 } PinMode;
 
 // version of PINCON_TypeDef using register arrays

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/platform_init.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/platform_init.c
@@ -8,29 +8,19 @@ void mbed_sdk_init()
     gpio_t modemEn, modemRst, modemPwrOn, modemLvlOe, modemILvlOe, modemUsbDet;
     gpio_t gpsEn, gpsRst, led, modemRts;
     
-    gpio_init(&modemEn, MDMEN, PIN_OUTPUT);
-    gpio_init(&modemRst, MDMRST, PIN_OUTPUT);
-    gpio_init(&modemPwrOn, MDMPWRON, PIN_OUTPUT);
-    gpio_init(&modemLvlOe, MDMLVLOE, PIN_OUTPUT);
-    gpio_init(&modemILvlOe, MDMILVLOE, PIN_OUTPUT);
-    gpio_init(&modemUsbDet, MDMUSBDET, PIN_OUTPUT);
-    gpio_init(&gpsEn, GPSEN, PIN_OUTPUT);
-    gpio_init(&gpsRst, GPSRST, PIN_OUTPUT);
-    gpio_init(&led, LED, PIN_OUTPUT);
-    gpio_init(&modemRts, MDMRTS, PIN_OUTPUT);
-    
-    gpio_write(&led, 0);  			// LED1:   0=off
-    gpio_write(&modemRts, 0);		// RTS:    0=ready to send 
-    // we start with the gps disabled
-    gpio_write(&gpsEn, 0);  		// LDOEN:  1=on,0=off
-    gpio_write(&gpsRst, 0); 		// RESET:  0=reset,1=operating
-    // we start with the modem disabled
-    gpio_write(&modemLvlOe, 1);		// LVLEN:  1=disabled (uart/gpio)
-    gpio_write(&modemILvlOe, 0);  	// ILVLEN: 0=disabled (i2c)
-    gpio_write(&modemUsbDet, 0); 	// USBDET: 0=disabled
-    gpio_write(&modemPwrOn, 1);		// PWRON:  1=idle, 0=action
-    gpio_write(&modemEn, 0);  		// LDOEN:  1=on, 0=off
-    gpio_write(&modemRst, 0);  		// RESET:  0=reset, 1=operating
+    // start with modem disabled 
+    GPIO_INIT_OUT(&modemEn,     MDMEN,      PullNone, 0);
+    GPIO_INIT_OUT(&modemRst,    MDMRST,     PullNone, 1);
+    GPIO_INIT_OUT(&modemPwrOn,  MDMPWRON,   PullNone, 1);
+    GPIO_INIT_OUT(&modemLvlOe,  MDMLVLOE,   PullNone, 1);
+    GPIO_INIT_OUT(&modemILvlOe, MDMILVLOE,  PullNone, 0);
+    GPIO_INIT_OUT(&modemUsbDet, MDMUSBDET,  PullNone, 0);
+    GPIO_INIT_OUT(&modemRts,    MDMRTS,     PullNone, 0);
+    // start with gps disabled 
+    GPIO_INIT_OUT(&gpsEn,       GPSEN,      PullNone, 0);
+    GPIO_INIT_OUT(&gpsRst,      GPSRST,     PullNone, 1);
+    // led should be off
+    GPIO_INIT_OUT(&led,         LED,        PullNone, 0);
     
     wait_ms(50); // when USB cable is inserted the interface chip issues 
     // multiple resets to the target CPU We wait here for a short period to 

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/gpio_api.c
@@ -21,7 +21,7 @@ uint32_t gpio_set(PinName pin) {
     return (1 << ((int)pin & 0x1F));
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if(pin == NC) return;
     
     obj->pin = pin;
@@ -32,12 +32,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_clr = &port_reg->FIOCLR;
     obj->reg_in  = &port_reg->FIOPIN;
     obj->reg_dir = &port_reg->FIODIR;
-    
-    gpio_dir(obj, direction);
-    switch (direction) {
-        case PIN_OUTPUT: pin_mode(pin, PullNone); break;
-        case PIN_INPUT : pin_mode(pin, PullDown); break;
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/serial_api.c
@@ -76,7 +76,7 @@ serial_t stdio_uart;
 struct serial_global_data_s {
     uint32_t serial_irq_id;
     gpio_t sw_rts, sw_cts;
-    uint8_t count, rx_irq_set_flow, rx_irq_set_api;
+    uint8_t rx_irq_set_flow, rx_irq_set_api;
 };
 
 static struct serial_global_data_s uart_data[UART_NUM];
@@ -357,7 +357,6 @@ int serial_getc(serial_t *obj) {
 void serial_putc(serial_t *obj, int c) {
     while (!serial_writable(obj));
     obj->uart->THR = c;
-    uart_data[obj->index].count++;    
 }
 
 int serial_readable(serial_t *obj) {
@@ -365,16 +364,10 @@ int serial_readable(serial_t *obj) {
 }
 
 int serial_writable(serial_t *obj) {
-    int isWritable = 1;
     if (NC != uart_data[obj->index].sw_cts.pin)
-        isWritable = (gpio_read(&uart_data[obj->index].sw_cts) == 0) && (obj->uart->LSR & 0x40);
-    else {
-        if (obj->uart->LSR & 0x20)
-            uart_data[obj->index].count = 0;
-        else if (uart_data[obj->index].count >= 16)
-            isWritable = 0;
-    }
-    return isWritable;
+        return (gpio_read(&uart_data[obj->index].sw_cts) == 0) && (obj->uart->LSR & 0x40);  //If flow control: writable if CTS low + UART done
+    else
+        return obj->uart->LSR & 0x20;                                                       //No flow control: writable if space in holding register
 }
 
 void serial_clear(serial_t *obj) {
@@ -419,7 +412,7 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
             pinmap_pinout(txflow, PinMap_UART_CTS);
         } else {
             // Can't enable in hardware, use software emulation
-            gpio_init(&uart_data[index].sw_cts, txflow, PIN_INPUT);
+            GPIO_INIT_IN(&uart_data[index].sw_cts, txflow, PullDown);
         }
     }
     if (((FlowControlRTS == type) || (FlowControlRTSCTS == type)) && (NC != rxflow)) {
@@ -434,8 +427,7 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
             uart1->MCR |= UART_MCR_RTSEN_MASK;
             pinmap_pinout(rxflow, PinMap_UART_RTS);
         } else { // can't enable in hardware, use software emulation
-            gpio_init(&uart_data[index].sw_rts, rxflow, PIN_OUTPUT);
-            gpio_write(&uart_data[index].sw_rts, 0);
+            GPIO_INIT_OUT(&uart_data[index].sw_rts, rxflow, PullNone, 0);
             // Enable RX interrupt
             serial_flow_irq_set(obj, 1);
         }

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/PinNames.h
@@ -84,7 +84,8 @@ typedef enum {
     PullUp = 0,
     PullDown = 3,
     PullNone = 2,
-    OpenDrain = 4
+    OpenDrain = 4,
+    PullDefault = PullDown
 } PinMode;
 
 // version of PINCON_TypeDef using register arrays

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/gpio_api.c
@@ -24,7 +24,7 @@ uint32_t gpio_set(PinName pin) {
     return (1 << ((int)pin & 0x1F));
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if (pin == NC) return;
     
     obj->pin = pin;
@@ -36,12 +36,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_clr = &port_reg->FIOCLR;
     obj->reg_in  = &port_reg->FIOPIN;
     obj->reg_dir = &port_reg->FIODIR;
-    
-    gpio_dir(obj, direction);
-    switch (direction) {
-        case PIN_OUTPUT: pin_mode(pin, PullNone); break;
-        case PIN_INPUT : pin_mode(pin, PullDown); break;
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/PinNames.h
@@ -91,7 +91,8 @@ typedef enum {
     PullUp = 2,
     PullDown = 1,
     PullNone = 0,
-    OpenDrain = 4
+    OpenDrain = 4,
+    PullDefault = PullDown
 } PinMode;
 
 

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/gpio_api.c
@@ -21,7 +21,7 @@ uint32_t gpio_set(PinName pin) {
     return (1 << ((int)pin & 0x1F));
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if (pin == NC) return;
     
     obj->pin = pin;
@@ -33,12 +33,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_clr = &port_reg->CLR;
     obj->reg_in  = &port_reg->PIN;
     obj->reg_dir = &port_reg->DIR;
-    
-    gpio_dir(obj, direction);
-    switch (direction) {
-        case PIN_OUTPUT: pin_mode(pin, PullNone); break;
-        case PIN_INPUT : pin_mode(pin, PullDown); break;
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/PinNames.h
@@ -556,7 +556,8 @@ typedef enum {
     PullDown = 3,
     PullNone = 2,
     Repeater = 1,
-    OpenDrain = 4
+    OpenDrain = 4,
+    PullDefault = PullDown
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/gpio_api.c
@@ -28,7 +28,7 @@ uint32_t gpio_set(PinName pin) {
     return (1 << ((int)pin & 0x1F));
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if (pin == NC) return;
     
     obj->pin = pin;
@@ -41,12 +41,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_clr = &port_reg->CLR[port];
     obj->reg_in  = &port_reg->PIN[port];
     obj->reg_dir = &port_reg->DIR[port];
-
-    gpio_dir(obj, direction);
-    switch (direction) {
-        case PIN_OUTPUT: pin_mode(pin, PullNone); break;
-        case PIN_INPUT : pin_mode(pin, PullDown); break;
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/TARGET_LPC810/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/TARGET_LPC810/PinNames.h
@@ -62,7 +62,8 @@ typedef enum {
     PullDown = 1,
     PullNone = 0,
     Repeater = 3,
-    OpenDrain = 4
+    OpenDrain = 4,
+    PullDefault = PullDown
 } PinMode;
 
 #define STDIO_UART_TX     USBTX

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/TARGET_LPC812/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/TARGET_LPC812/PinNames.h
@@ -88,7 +88,8 @@ typedef enum {
     PullDown = 1,
     PullNone = 0,
     Repeater = 3,
-    OpenDrain = 4
+    OpenDrain = 4,
+    PullDefault = PullDown
 } PinMode;
 
 #define STDIO_UART_TX     USBTX

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/gpio_api.c
@@ -39,7 +39,7 @@ uint32_t gpio_set(PinName pin) {
     return (1 << ((int)pin & 0x1F));
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if(pin == NC) return;
     
     obj->pin = pin;
@@ -49,12 +49,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_clr = &LPC_GPIO_PORT->CLR0;
     obj->reg_in  = &LPC_GPIO_PORT->PIN0;
     obj->reg_dir = &LPC_GPIO_PORT->DIR0;
-    
-    gpio_dir(obj, direction);
-    switch (direction) {
-        case PIN_OUTPUT: pin_mode(pin, PullNone); break;
-        case PIN_INPUT : pin_mode(pin, PullDown); break;
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/PinNames.h
@@ -166,7 +166,8 @@ typedef enum {
     PullNone  = 0,
     PullUp    = 1,
     PullDown  = 2,
-    OpenDrain = 3
+    OpenDrain = 3,
+    PullDefault = PullNone
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/gpio_api.c
@@ -41,7 +41,7 @@ uint32_t gpio_set(PinName pin) {
     return (uint32_t)(1 << ((uint32_t)pin & 0xF)); // Return the pin mask
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if (pin == NC) return;
 
     uint32_t port_index = STM_PORT(pin);
@@ -56,14 +56,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_in  = &gpio->IDR;
     obj->reg_set = &gpio->BSRR;
     obj->reg_clr = &gpio->BRR;
-  
-    // Configure GPIO
-    if (direction == PIN_OUTPUT) {
-        pin_function(pin, STM_PIN_DATA(GPIO_Mode_OUT, GPIO_OType_PP, GPIO_PuPd_NOPULL, 0xFF));
-    }
-    else { // PIN_INPUT
-        pin_function(pin, STM_PIN_DATA(GPIO_Mode_IN, 0, GPIO_PuPd_NOPULL, 0xFF));
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F103RB/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F103RB/PinNames.h
@@ -156,7 +156,8 @@ typedef enum {
     PullNone  = 0,
     PullUp    = 1,
     PullDown  = 2,
-    OpenDrain = 3
+    OpenDrain = 3,
+    PullDefault = PullNone
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F103RB/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F103RB/gpio_api.c
@@ -41,7 +41,7 @@ uint32_t gpio_set(PinName pin) {
     return (uint32_t)(1 << ((uint32_t)pin & 0xF)); // Return the pin mask
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if (pin == NC) return;
 
     uint32_t port_index = STM_PORT(pin);
@@ -56,14 +56,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_in  = &gpio->IDR;
     obj->reg_set = &gpio->BSRR;
     obj->reg_clr = &gpio->BRR;
-  
-    // Configure GPIO
-    if (direction == PIN_OUTPUT) {
-        pin_function(pin, STM_PIN_DATA(GPIO_Mode_Out_PP, 0));
-    }
-    else { // PIN_INPUT
-        pin_function(pin, STM_PIN_DATA(GPIO_Mode_IN_FLOATING, 0));
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F401RE/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F401RE/PinNames.h
@@ -168,7 +168,8 @@ typedef enum {
     PullNone  = 0,
     PullUp    = 1,
     PullDown  = 2,
-    OpenDrain = 3
+    OpenDrain = 3,
+    PullDefault = PullNone
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F401RE/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F401RE/gpio_api.c
@@ -42,7 +42,7 @@ uint32_t gpio_set(PinName pin) {
     return (uint32_t)(1 << ((uint32_t)pin & 0xF)); // Return the pin mask
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if (pin == NC) return;
 
     uint32_t port_index = STM_PORT(pin);
@@ -57,14 +57,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_in  = &gpio->IDR;
     obj->reg_set = &gpio->BSRRL;
     obj->reg_clr = &gpio->BSRRH;
-  
-    // Configure GPIO
-    if (direction == PIN_OUTPUT) {
-        pin_function(pin, STM_PIN_DATA(STM_MODE_OUTPUT_PP, GPIO_NOPULL, 0));
-    }
-    else { // PIN_INPUT
-        pin_function(pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/PinNames.h
@@ -161,7 +161,8 @@ typedef enum {
     PullNone  = 0,
     PullUp    = 1,
     PullDown  = 2,
-    OpenDrain = 3
+    OpenDrain = 3,
+    PullDefault = PullNone
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/gpio_api.c
@@ -41,7 +41,7 @@ uint32_t gpio_set(PinName pin) {
     return (uint32_t)(1 << ((uint32_t)pin & 0xF)); // Return the pin mask
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if (pin == NC) return;
 
     uint32_t port_index = STM_PORT(pin);
@@ -56,14 +56,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_in  = &gpio->IDR;
     obj->reg_set = &gpio->BSRRL;
     obj->reg_clr = &gpio->BSRRH;
-  
-    // Configure GPIO
-    if (direction == PIN_OUTPUT) {
-        pin_function(pin, STM_PIN_DATA(GPIO_Mode_OUT, GPIO_OType_PP, GPIO_PuPd_NOPULL, 0xFF));
-    }
-    else { // PIN_INPUT
-        pin_function(pin, STM_PIN_DATA(GPIO_Mode_IN, 0, GPIO_PuPd_NOPULL, 0xFF));
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4XX/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4XX/PinNames.h
@@ -51,7 +51,8 @@ typedef enum {
     PullNone = 0,
     PullUp = 1,
     PullDown = 2,
-    OpenDrain = 3
+    OpenDrain = 3,
+    PullDefault = PullDown
 } PinMode;
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4XX/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4XX/gpio_api.c
@@ -26,7 +26,7 @@ uint32_t gpio_set(PinName pin) {
     return 1 << ((uint32_t) pin & 0xF);
 }
 
-void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
+void gpio_init(gpio_t *obj, PinName pin) {
     if(pin == NC) return;
 
     obj->pin = pin;
@@ -39,14 +39,6 @@ void gpio_init(gpio_t *obj, PinName pin, PinDirection direction) {
     obj->reg_set = &port_reg->BSRRL;
     obj->reg_clr = &port_reg->BSRRH;
     obj->reg_in  = &port_reg->IDR;
-
-
-    gpio_dir(obj, direction);
-
-    switch (direction) {
-        case PIN_OUTPUT: pin_mode(pin, PullNone); break;
-        case PIN_INPUT : pin_mode(pin, PullDown); break;
-    }
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {


### PR DESCRIPTION
Currently the gpio_init function is configuring a gpio either to pull low or to output low. This can be a problem if you need to respect timing of a pin or only set the pin low only when it should be. An example could be initializing multiple chip selects on an SPI bus. There is no way to init a pin as "input pull none" or "output high" or "input pull high". Therefore I am proposing a change to the gpio api.

The function gpio_init should only create the gpio object and not apply any changes to the hardware.

Unfortunately this change affects all targets. And I am not able to test them.
