### PR TITLE
[fix] nucleo targets - gcc arm removal from targets.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-mbed SDK 
-======== 
+mbed SDK
+========
 
 [![Build Status](https://travis-ci.org/mbedmicro/mbed.png)](https://travis-ci.org/mbedmicro/mbed/builds)
 
@@ -38,6 +38,7 @@ NXP:
 * [LPC1549](https://mbed.org/platforms/LPCXpresso1549/) (Cortex-M3)
 
 Freescale:
+* FRDM-K20D50M
 * [FRDM-KL05Z](https://mbed.org/platforms/FRDM-KL05Z/) (Cortex-M0+)
 * [FRDM-KL25Z](http://mbed.org/platforms/KL25Z/) (Cortex-M0+)
 * [FRDM-KL46Z](https://mbed.org/platforms/FRDM-KL46Z/) (Cortex-M0+)

--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -284,7 +284,7 @@ class NUCLEO_F103RB(Target):
         
         self.extra_labels = ['STM', 'STM32F1', 'STM32F103RB']
         
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
+        self.supported_toolchains = ["ARM", "uARM"]
 
 
 class NUCLEO_L152RE(Target):
@@ -298,7 +298,7 @@ class NUCLEO_L152RE(Target):
         
         self.extra_labels = ['STM', 'STM32L1', 'STM32L152RE']
         
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
+        self.supported_toolchains = ["ARM", "uARM"]
 
 
 class NUCLEO_F401RE(Target):
@@ -312,7 +312,7 @@ class NUCLEO_F401RE(Target):
         
         self.extra_labels = ['STM', 'STM32F4', 'STM32F401RE']
         
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
+        self.supported_toolchains = ["ARM", "uARM"]
 
 
 class NUCLEO_F030R8(Target):
@@ -326,7 +326,7 @@ class NUCLEO_F030R8(Target):
         
         self.extra_labels = ['STM', 'STM32F0', 'STM32F030R8']
         
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
+        self.supported_toolchains = ["ARM", "uARM"]
 
 
 class LPC1347(Target):


### PR DESCRIPTION
Reported by a user on mbed site. There's no files for GCC ARM in cmsis for nucleo targets, thus I believe it should not be yet defined in targets.py.

Regards,
0xc0170
