### PR TITLE
[LPC11U35][GCC_ARM][GCC_CR]: Modificatins for build.

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC11UXX/TOOLCHAIN_GCC_ARM/TARGET_LPC11U35_501/LPC11U35.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC11UXX/TOOLCHAIN_GCC_ARM/TARGET_LPC11U35_501/LPC11U35.ld
@@ -1,0 +1,152 @@
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 64K
+  RAM (rwx) : ORIGIN = 0x100000C0, LENGTH = 0x1F40
+  USB_RAM (rwx): ORIGIN = 0x20004000, LENGTH = 0x800
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ * 
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .text :
+    {
+        KEEP(*(.isr_vector))
+        *(.text.Reset_Handler)
+        *(.text.SystemInit)
+        
+        /* Only vectors and code running at reset are safe to be in first 512
+           bytes since RAM can be mapped into this area for RAM based interrupt
+           vectors. */
+        . = 0x00000200;
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        KEEP(*(.eh_frame*))
+    } > FLASH
+
+    .ARM.extab : 
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
+
+    __etext = .;
+        
+    .data : AT (__etext)
+    {
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE (__fini_array_end = .);
+
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+
+    } > RAM
+
+    .bss :
+    {
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        __bss_end__ = .;
+    } > RAM
+    
+    .heap :
+    {
+        __end__ = .;
+        end = __end__;
+        *(.heap*)
+        __HeapLimit = .;
+    } > RAM
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy :
+    {
+        *(.stack)
+    } > RAM
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+    
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/libraries/rtos/rtx/RTX_CM_lib.h
+++ b/libraries/rtos/rtx/RTX_CM_lib.h
@@ -205,7 +205,7 @@ osThreadDef_t os_thread_def_main = {(os_pthread)main, osPriorityNormal, 0, NULL}
 #elif defined(TARGET_LPC11U24)
 #define INITIAL_SP            (0x10002000UL)
 
-#elif defined(TARGET_LPC11U35_401)
+#elif defined(TARGET_LPC11U35_401) || defined(TARGET_LPC11U35_501)
 #define INITIAL_SP            (0x10002000UL)
 
 #elif defined(TARGET_LPC1114)

--- a/libraries/rtos/rtx/RTX_Conf_CM.c
+++ b/libraries/rtos/rtx/RTX_Conf_CM.c
@@ -51,7 +51,7 @@
 #ifndef OS_TASKCNT
 #  if defined(TARGET_LPC1768) || defined(TARGET_LPC2368) || defined(TARGET_LPC4088) || defined(TARGET_LPC1347)
 #    define OS_TASKCNT         14
-#  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401) || defined(TARGET_LPC1114) || defined(TARGET_LPC812) || defined(TARGET_KL25Z)
+#  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPC1114) || defined(TARGET_LPC812) || defined(TARGET_KL25Z)
 #    define OS_TASKCNT         6
 #  endif
 #endif
@@ -60,7 +60,7 @@
 #ifndef OS_SCHEDULERSTKSIZE
 #  if defined(TARGET_LPC1768) || defined(TARGET_LPC2368) || defined(TARGET_LPC4088) || defined(TARGET_LPC1347)
 #      define OS_SCHEDULERSTKSIZE    256
-#  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401) || defined(TARGET_LPC1114) || defined(TARGET_LPC812) || defined(TARGET_KL25Z)
+#  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPC1114) || defined(TARGET_LPC812) || defined(TARGET_KL25Z)
 #      define OS_SCHEDULERSTKSIZE    128
 #  endif
 #endif
@@ -107,7 +107,7 @@
 #  elif defined(TARGET_LPC1347)
 #    define OS_CLOCK       72000000
 
-#  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401) || defined(TARGET_LPC1114) || defined(TARGET_KL25Z)
+#  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPC1114) || defined(TARGET_KL25Z)
 #    define OS_CLOCK       48000000
 #
 #  elif defined(TARGET_LPC812)

--- a/workspace_tools/build_release.py
+++ b/workspace_tools/build_release.py
@@ -34,8 +34,8 @@ OFFICIAL_MBED_LIBRARY_BUILD = (
     ('LPC1347',      ('ARM',)),
     ('LPC4088',      ('ARM', 'GCC_ARM', 'GCC_CR')),
     ('LPC1114',      ('uARM','GCC_ARM')),
-    ('LPC11U35_401', ('ARM', 'uARM')),
-    ('LPC11U35_501', ('ARM', 'uARM')),
+    ('LPC11U35_401', ('ARM', 'uARM','GCC_ARM','GCC_CR')),
+    ('LPC11U35_501', ('ARM', 'uARM','GCC_ARM','GCC_CR')),
     ('LPC1549',      ('uARM',)),
     
     ('KL05Z',        ('ARM', 'uARM', 'GCC_ARM')),

--- a/workspace_tools/export/gccarm.py
+++ b/workspace_tools/export/gccarm.py
@@ -21,7 +21,7 @@ from os.path import splitext, basename
 class GccArm(Exporter):
     NAME = 'GccArm'
     TOOLCHAIN = 'GCC_ARM'
-    TARGETS = ['LPC1768','KL05Z','KL25Z','KL46Z','K20D5M','LPC4088','LPC11U24','LPC1114']
+    TARGETS = ['LPC1768','KL05Z','KL25Z','KL46Z','K20D5M','LPC4088','LPC11U24','LPC1114','LPC11U35_401','LPC11U35_501']
     DOT_IN_RELATIVE_PATH = True
     
     def generate(self):

--- a/workspace_tools/export_test.py
+++ b/workspace_tools/export_test.py
@@ -90,6 +90,9 @@ if __name__ == '__main__':
             # Windows path: C:/arm-none-eabi-gcc-4_7/bin/
             ('gcc_arm', 'LPC1768'),
             ('gcc_arm', 'LPC1114'),
+            ('gcc_arm', 'LPC11U35_401'),
+            ('gcc_arm', 'LPC11U35_501'),
+
             
             ('ds5_5', 'LPC1768'), ('ds5_5', 'LPC11U24'),
             

--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -387,7 +387,7 @@ class LPC11U35_501(Target):
         
         self.extra_labels = ['NXP', 'LPC11UXX']
         
-        self.supported_toolchains = ["ARM", "uARM","GCC_CR"]
+        self.supported_toolchains = ["ARM", "uARM","GCC_ARM","GCC_CR"]
 
 
 class UBLOX_C027(Target):


### PR DESCRIPTION
1. Added to the export table in export_test.py.
2. Added to the build table in build_release.py
3. Added the compilation directives to RTX os files.

Notice:
 It would be better to change WORDS_STACK_SIZE definition in libraries/rtos/rtx/cmsis_os.h
 from 512 to 128 for LPC11U35 and LPC1114 micros compiled by GCC toolchain with newlib-nano,
 but I don't know the good way at this moment.
