### PR TITLE
add errors in case some target defines were not set properly

### DIFF
--- a/libraries/net/lwip/lwip/core/memp.c
+++ b/libraries/net/lwip/lwip/core/memp.c
@@ -168,7 +168,7 @@ static u8_t *const memp_bases[] = {
 
 #if defined(TARGET_LPC1768)
 #  define ETHMEM_SECTION __attribute((section("AHBSRAM1")))
-#elif defined(TARGET_LPC4088)
+#else
 #  define ETHMEM_SECTION 
 #endif
 

--- a/libraries/rtos/rtx/RTX_CM_lib.h
+++ b/libraries/rtos/rtx/RTX_CM_lib.h
@@ -229,6 +229,9 @@ osThreadDef_t os_thread_def_main = {(os_pthread)main, osPriorityNormal, 0, NULL}
 #elif defined(TARGET_STM32F100RB)
 #define INITIAL_SP            (0x20002000UL)
 
+#else
+#error "no target defined"
+
 #endif
 
 #ifdef __CC_ARM

--- a/libraries/rtos/rtx/RTX_Conf_CM.c
+++ b/libraries/rtos/rtx/RTX_Conf_CM.c
@@ -53,6 +53,8 @@
 #    define OS_TASKCNT         14
 #  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPC1114) || defined(TARGET_LPC812) || defined(TARGET_KL25Z) || defined(TARGET_STM32F100RB)
 #    define OS_TASKCNT         6
+#  else
+#    error "no target defined"
 #  endif
 #endif
 
@@ -62,6 +64,8 @@
 #      define OS_SCHEDULERSTKSIZE    256
 #  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPC1114) || defined(TARGET_LPC812) || defined(TARGET_KL25Z) || defined(TARGET_STM32F100RB)
 #      define OS_SCHEDULERSTKSIZE    128
+#  else
+#    error "no target defined"
 #  endif
 #endif
 
@@ -118,6 +122,9 @@
 
 #  elif defined(TARGET_LPC4088)
 #    define OS_CLOCK       120000000
+
+#  else
+#    error "no target defined"
 #  endif
 #endif
 


### PR DESCRIPTION
- make lwip compile on any targets (not just LPC1768 and 4088)
- added erros to better detect misconfiguration of build system (missing TARGET defines)
