### PR TITLE
Create a platform specific file to override WEAK Handlers and pre-main hook mbed_sdk_init

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/gpio_irq_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/gpio_irq_api.c
@@ -173,12 +173,3 @@ void gpio_irq_disable(gpio_irq_t *obj) {
         NVIC_DisableIRQ(PORTB_IRQn);
     }
 }
-
-// Change the NMI pin to an input. This allows NMI pin to 
-//  be used as a low power mode wakeup.  The application will
-//  need to change the pin back to NMI_b or wakeup only occurs once!
-void NMI_Handler(void)
-{
-    gpio_t gpio;
-    gpio_init_in(&gpio, PTA4);
-}

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/platform_init.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/platform_init.c
@@ -1,0 +1,32 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "gpio_api.h"
+
+// called before main - implement here if board needs it ortherwise, let
+//  the application override this if necessary
+//void mbed_sdk_init()
+//{
+//
+//}
+
+// Change the NMI pin to an input. This allows NMI pin to 
+//  be used as a low power mode wakeup.  The application will
+//  need to change the pin back to NMI_b or wakeup only occurs once!
+void NMI_Handler(void)
+{
+    gpio_t gpio;
+    gpio_init_in(&gpio, PTB5);
+}

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/gpio_irq_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/gpio_irq_api.c
@@ -163,12 +163,3 @@ void gpio_irq_disable(gpio_irq_t *obj) {
         NVIC_DisableIRQ(PORTD_IRQn);
     }
 }
-
-// Change the NMI pin to an input. This allows NMI pin to 
-//  be used as a low power mode wakeup.  The application will
-//  need to change the pin back to NMI_b or wakeup only occurs once!
-void NMI_Handler(void)
-{
-    gpio_t gpio;
-    gpio_init_in(&gpio, PTA4);
-}

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/platform_init.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/platform_init.c
@@ -1,0 +1,32 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "gpio_api.h"
+
+// called before main - implement here if board needs it ortherwise, let
+//  the application override this if necessary
+//void mbed_sdk_init()
+//{
+//
+//}
+
+// Change the NMI pin to an input. This allows NMI pin to 
+//  be used as a low power mode wakeup.  The application will
+//  need to change the pin back to NMI_b or wakeup only occurs once!
+void NMI_Handler(void)
+{
+    gpio_t gpio;
+    gpio_init_in(&gpio, PTA4);
+}

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/gpio_irq_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/gpio_irq_api.c
@@ -183,12 +183,3 @@ void gpio_irq_disable(gpio_irq_t *obj) {
         NVIC_DisableIRQ(PORTC_PORTD_IRQn);
     }
 }
-
-// Change the NMI pin to an input. This allows NMI pin to 
-//  be used as a low power mode wakeup.  The application will
-//  need to change the pin back to NMI_b or wakeup only occurs once!
-void NMI_Handler(void)
-{
-    gpio_t gpio;
-    gpio_init_in(&gpio, PTA4);
-}

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/platform_init.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/platform_init.c
@@ -1,0 +1,32 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "gpio_api.h"
+
+// called before main - implement here if board needs it ortherwise, let
+//  the application override this if necessary
+//void mbed_sdk_init()
+//{
+//
+//}
+
+// Change the NMI pin to an input. This allows NMI pin to 
+//  be used as a low power mode wakeup.  The application will
+//  need to change the pin back to NMI_b or wakeup only occurs once!
+void NMI_Handler(void)
+{
+    gpio_t gpio;
+    gpio_init_in(&gpio, PTA4);
+}

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/platform_init.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/platform_init.c
@@ -1,8 +1,22 @@
-
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "gpio_api.h"
 #include "wait_api.h"
 
- // called before main
+// called before main
 void mbed_sdk_init()
 {
     gpio_t modemEn, modemRst, modemPwrOn, modemLvlOe, modemILvlOe, modemUsbDet;

--- a/workspace_tools/build_api.py
+++ b/workspace_tools/build_api.py
@@ -189,6 +189,15 @@ def build_mbed_libs(target, toolchain_name, options=None, verbose=False, clean=F
         if o.endswith('retarget.o'):
             retargeting = o
     objects.remove(retargeting)
+    # We need to have a file that overrides weak delcatations on a per board basis and the
+    #   lesser evil is to pull in this file if it extist rather than add board specific 
+    #   startup code in the /targets/cmsis directory
+    platform_initialize = None
+    for p in objects:
+        if p.endswith('platform_init.o'):
+            platform_initialize = p
+            objects.remove(platform_initialize)
     toolchain.build_library(objects, BUILD_TOOLCHAIN, "mbed")
     toolchain.copy_files(retargeting, BUILD_TOOLCHAIN)
+    toolchain.copy_files(platform_initialize, BUILD_TOOLCHAIN)
 


### PR DESCRIPTION
I think this is an cleaner change than adding code to CMSIS files or creating a platform specific directory in /targets/cmsis. All other .o files are from /targets/cmsis except for retarget.o and that was the model for this change. Now each platform can create a platform_init.c file and use it to override default handlers or hook before main is called with mbed_sdk_init.

Tested with KL05Z, KL46Z, KL25Z and UBLOX_C027.
