### PR TITLE
Update GNU Makefiles to generate DEBUG binaries

### DIFF
--- a/workspace_tools/export/codesourcery_lpc1768.tmpl
+++ b/workspace_tools/export/codesourcery_lpc1768.tmpl
@@ -13,7 +13,7 @@ LINKER_SCRIPT = {{linker_script}}
 ############################################################################### 
 CC = $(GCC_BIN)arm-none-eabi-gcc
 CPP = $(GCC_BIN)arm-none-eabi-g++
-CC_FLAGS = -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -mcpu=cortex-m3 -mthumb -ffunction-sections -fdata-sections 
+CC_FLAGS = -c -g -fno-common -fmessage-length=0 -Wall -fno-exceptions -mcpu=cortex-m3 -mthumb -ffunction-sections -fdata-sections 
 ONLY_C_FLAGS = -std=gnu99
 ONLY_CPP_FLAGS = -std=gnu++98
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
@@ -26,6 +26,12 @@ LD_FLAGS = -mcpu=cortex-m3 -mthumb -Wl,--gc-sections
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc
 
 OBJCOPY = $(GCC_BIN)arm-none-eabi-objcopy
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin
 

--- a/workspace_tools/export/gcc_arm_disco_f051r8.tmpl
+++ b/workspace_tools/export/gcc_arm_disco_f051r8.tmpl
@@ -20,13 +20,19 @@ OBJDUMP = $(GCC_BIN)arm-none-eabi-objdump
 SIZE 	= $(GCC_BIN)arm-none-eabi-size
 
 CPU = -mcpu=cortex-m0 -mthumb
-CC_FLAGS = $(CPU) -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections -g
+CC_FLAGS = $(CPU) -c -g -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
 
 LD_FLAGS = -mcpu=cortex-m0 -mthumb -Wl,--gc-sections --specs=nano.specs
 #LD_FLAGS += -u _printf_float -u _scanf_float
 LD_FLAGS += -Wl,-Map=$(PROJECT).map,--cref
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin $(PROJECT).hex size
 

--- a/workspace_tools/export/gcc_arm_disco_f100rb.tmpl
+++ b/workspace_tools/export/gcc_arm_disco_f100rb.tmpl
@@ -20,12 +20,18 @@ OBJDUMP = $(GCC_BIN)arm-none-eabi-objdump
 SIZE 	= $(GCC_BIN)arm-none-eabi-size
 
 CPU = -mcpu=cortex-m3 -mthumb
-CC_FLAGS = $(CPU) -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
+CC_FLAGS = $(CPU) -c -g -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
 
 LD_FLAGS = -mcpu=cortex-m3 -mthumb -Wl,--gc-sections --specs=nano.specs
 LD_FLAGS += -Wl,-Map=$(PROJECT).map,--cref
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin $(PROJECT).hex size
 

--- a/workspace_tools/export/gcc_arm_disco_f407vg.tmpl
+++ b/workspace_tools/export/gcc_arm_disco_f407vg.tmpl
@@ -20,12 +20,18 @@ OBJDUMP = $(GCC_BIN)arm-none-eabi-objdump
 SIZE 	= $(GCC_BIN)arm-none-eabi-size
 
 CPU = -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp
-CC_FLAGS = $(CPU) -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections -g3
+CC_FLAGS = $(CPU) -c -g3 -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
 
 LD_FLAGS = -mcpu=cortex-m4 -mthumb -Wl,--gc-sections --specs=nano.specs -u _printf_float -u _scanf_float
 LD_FLAGS += -Wl,-Map=$(PROJECT).map,--cref
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin $(PROJECT).hex size
 

--- a/workspace_tools/export/gcc_arm_k20d5m.tmpl
+++ b/workspace_tools/export/gcc_arm_k20d5m.tmpl
@@ -18,11 +18,17 @@ LD      = $(GCC_BIN)arm-none-eabi-gcc
 OBJCOPY = $(GCC_BIN)arm-none-eabi-objcopy
 
 CPU = -mcpu=cortex-m4 -mthumb
-CC_FLAGS = $(CPU) -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections
+CC_FLAGS = $(CPU) -c -g -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
 
 LD_FLAGS = -mcpu=cortex-m4 -mthumb -Wl,--gc-sections --specs=nano.specs -u _printf_float -u _scanf_float
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin
 

--- a/workspace_tools/export/gcc_arm_kl05z.tmpl
+++ b/workspace_tools/export/gcc_arm_kl05z.tmpl
@@ -18,11 +18,17 @@ LD      = $(GCC_BIN)arm-none-eabi-gcc
 OBJCOPY = $(GCC_BIN)arm-none-eabi-objcopy
 
 CPU = -mcpu=cortex-m0plus -mthumb
-CC_FLAGS = $(CPU) -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections
+CC_FLAGS = $(CPU) -c -g -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
 
 LD_FLAGS = -mcpu=cortex-m0plus -mthumb -Wl,--gc-sections --specs=nano.specs -u _printf_float -u _scanf_float
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin
 

--- a/workspace_tools/export/gcc_arm_kl25z.tmpl
+++ b/workspace_tools/export/gcc_arm_kl25z.tmpl
@@ -18,11 +18,17 @@ LD      = $(GCC_BIN)arm-none-eabi-gcc
 OBJCOPY = $(GCC_BIN)arm-none-eabi-objcopy
 
 CPU = -mcpu=cortex-m0plus -mthumb
-CC_FLAGS = $(CPU) -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections
+CC_FLAGS = $(CPU) -c -g -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
 
 LD_FLAGS = -mcpu=cortex-m0plus -mthumb -Wl,--gc-sections --specs=nano.specs -u _printf_float -u _scanf_float
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin
 

--- a/workspace_tools/export/gcc_arm_kl46z.tmpl
+++ b/workspace_tools/export/gcc_arm_kl46z.tmpl
@@ -18,11 +18,17 @@ LD      = $(GCC_BIN)arm-none-eabi-gcc
 OBJCOPY = $(GCC_BIN)arm-none-eabi-objcopy
 
 CPU = -mcpu=cortex-m0plus -mthumb
-CC_FLAGS = $(CPU) -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections
+CC_FLAGS = $(CPU) -c -g -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
 
 LD_FLAGS = -mcpu=cortex-m0plus -mthumb -Wl,--gc-sections --specs=nano.specs -u _printf_float -u _scanf_float
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin
 

--- a/workspace_tools/export/gcc_arm_lpc1114.tmpl
+++ b/workspace_tools/export/gcc_arm_lpc1114.tmpl
@@ -20,12 +20,18 @@ OBJDUMP = $(GCC_BIN)arm-none-eabi-objdump
 SIZE 	= $(GCC_BIN)arm-none-eabi-size
 
 CPU = -mcpu=cortex-m0 -mthumb
-CC_FLAGS = $(CPU) -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
+CC_FLAGS = $(CPU) -c -g -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
 
 LD_FLAGS = -mcpu=cortex-m0 -mthumb -Wl,--gc-sections --specs=nano.specs
 LD_FLAGS += -Wl,-Map=$(PROJECT).map,--cref
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin $(PROJECT).hex size
 

--- a/workspace_tools/export/gcc_arm_lpc11u24.tmpl
+++ b/workspace_tools/export/gcc_arm_lpc11u24.tmpl
@@ -18,11 +18,17 @@ LD      = $(GCC_BIN)arm-none-eabi-gcc
 OBJCOPY = $(GCC_BIN)arm-none-eabi-objcopy
 
 CPU = -mcpu=cortex-m0 -mthumb
-CC_FLAGS = $(CPU) -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
+CC_FLAGS = $(CPU) -c -g -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
 
 LD_FLAGS = -mcpu=cortex-m0 -mthumb -Wl,--gc-sections --specs=nano.specs
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin
 

--- a/workspace_tools/export/gcc_arm_lpc11u35_401.tmpl
+++ b/workspace_tools/export/gcc_arm_lpc11u35_401.tmpl
@@ -20,12 +20,18 @@ OBJDUMP = $(GCC_BIN)arm-none-eabi-objdump
 SIZE 	= $(GCC_BIN)arm-none-eabi-size
 
 CPU = -mcpu=cortex-m0 -mthumb
-CC_FLAGS = $(CPU) -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
+CC_FLAGS = $(CPU) -c -g -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
 
 LD_FLAGS = -mcpu=cortex-m0 -mthumb -Wl,--gc-sections --specs=nano.specs
 LD_FLAGS += -Wl,-Map=$(PROJECT).map,--cref
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin $(PROJECT).hex size
 

--- a/workspace_tools/export/gcc_arm_lpc11u35_501.tmpl
+++ b/workspace_tools/export/gcc_arm_lpc11u35_501.tmpl
@@ -20,12 +20,18 @@ OBJDUMP = $(GCC_BIN)arm-none-eabi-objdump
 SIZE 	= $(GCC_BIN)arm-none-eabi-size
 
 CPU = -mcpu=cortex-m0 -mthumb
-CC_FLAGS = $(CPU) -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
+CC_FLAGS = $(CPU) -c -g -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
 
 LD_FLAGS = -mcpu=cortex-m0 -mthumb -Wl,--gc-sections --specs=nano.specs
 LD_FLAGS += -Wl,-Map=$(PROJECT).map,--cref
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin $(PROJECT).hex size
 

--- a/workspace_tools/export/gcc_arm_lpc1768.tmpl
+++ b/workspace_tools/export/gcc_arm_lpc1768.tmpl
@@ -18,11 +18,17 @@ LD      = $(GCC_BIN)arm-none-eabi-gcc
 OBJCOPY = $(GCC_BIN)arm-none-eabi-objcopy
 
 CPU = -mcpu=cortex-m3 -mthumb
-CC_FLAGS = $(CPU) -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
+CC_FLAGS = $(CPU) -c -g -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
 
 LD_FLAGS = -mcpu=cortex-m3 -mthumb -Wl,--gc-sections --specs=nano.specs -u _printf_float -u _scanf_float
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin
 

--- a/workspace_tools/export/gcc_arm_lpc4088.tmpl
+++ b/workspace_tools/export/gcc_arm_lpc4088.tmpl
@@ -18,11 +18,17 @@ LD      = $(GCC_BIN)arm-none-eabi-gcc
 OBJCOPY = $(GCC_BIN)arm-none-eabi-objcopy
 
 CPU = -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp
-CC_FLAGS = $(CPU) -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
+CC_FLAGS = $(CPU) -c -g -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
 
 LD_FLAGS = -mcpu=cortex-m4 -mthumb -Wl,--gc-sections --specs=nano.specs -u _printf_float -u _scanf_float
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin
 

--- a/workspace_tools/export/gcc_arm_stm32f407.tmpl
+++ b/workspace_tools/export/gcc_arm_stm32f407.tmpl
@@ -20,12 +20,18 @@ OBJDUMP = $(GCC_BIN)arm-none-eabi-objdump
 SIZE 	= $(GCC_BIN)arm-none-eabi-size
 
 CPU = -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp
-CC_FLAGS = $(CPU) -c -Os -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
+CC_FLAGS = $(CPU) -c -g -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections 
 CC_SYMBOLS = {% for s in symbols %}-D{{s}} {% endfor %}
 
 LD_FLAGS  = -mcpu=cortex-m4 -mthumb -Wl,--gc-sections --specs=nano.specs -u _printf_float -u _scanf_float
 LD_FLAGS += -Wl,-Map=$(PROJECT).map,--cref
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
+
+ifeq ($(DEBUG), 1)
+  CC_FLAGS += -DDEBUG -O0
+else
+  CC_FLAGS += -DNDEBUG -Os
+endif
 
 all: $(PROJECT).bin $(PROJECT).hex size
 


### PR DESCRIPTION
- '-g' has been added for all the build to produce debugging information. '-g' allows to get the symbols when debugging with GDB.
- introduce the macro 'DEBUG' to enable/disable build optimization.

Limitations:
- Support in non-Makefile projects has been added.
