### PR TITLE
[NUCLEO_F302R8] Fix issue with SystemCoreClock variable update.

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F302R8/TOOLCHAIN_ARM_MICRO/stm32f302x8.sct
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F302R8/TOOLCHAIN_ARM_MICRO/stm32f302x8.sct
@@ -37,7 +37,8 @@ LR_IROM1 0x08000000 0x10000  {    ; load region size_region
   }
 
   ; 98 vectors (16 core + 82 peripheral) * 4 bytes = 392 bytes to reserve (0x188)
-  RW_IRAM1 (0x20000000+0x188) (0x4000-0x188)  {  ; RW data
+  ; + 4 more bytes reserved for the SystemCoreClock variable
+  RW_IRAM1 (0x20000000+(0x188+4)) (0x4000-(0x188+4))  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F302R8/TOOLCHAIN_ARM_STD/stm32f302x8.sct
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F302R8/TOOLCHAIN_ARM_STD/stm32f302x8.sct
@@ -37,7 +37,8 @@ LR_IROM1 0x08000000 0x10000  {    ; load region size_region
   }
 
   ; 98 vectors (16 core + 82 peripheral) * 4 bytes = 392 bytes to reserve (0x188)
-  RW_IRAM1 (0x20000000+0x188) (0x4000-0x188)  {  ; RW data
+  ; + 4 more bytes reserved for the SystemCoreClock variable
+  RW_IRAM1 (0x20000000+(0x188+4)) (0x4000-(0x188+4))  {  ; RW data
    .ANY (+RW +ZI)
   }
 


### PR DESCRIPTION
This variable must be placed outside the RAM initialization section.
