### PR TITLE
Fixed readNB() bug

### DIFF
--- a/libraries/USBDevice/USBHID/USBHID.cpp
+++ b/libraries/USBDevice/USBHID/USBHID.cpp
@@ -59,6 +59,9 @@ bool USBHID::readNB(HID_REPORT *report)
     uint32_t bytesRead = 0;
     bool result;
     result = USBDevice::readEP_NB(EPINT_OUT, report->data, &bytesRead, MAX_HID_REPORT_SIZE);
+    // if readEP_NB did not succeed, does not issue a readStart
+    if (!result)
+        return false;
     report->length = bytesRead;
     if(!readStart(EPINT_OUT, MAX_HID_REPORT_SIZE))
         return false;


### PR DESCRIPTION
Fixed a race condition with readNB() in USBHID that caused reports to be
periodically returned empty. The discussion regarding this can be found at https://mbed.org/forum/bugs-suggestions/topic/4806/
