### PR TITLE
Mode added to BusIn + allow creation of NC pins

### DIFF
--- a/libraries/mbed/api/BusIn.h
+++ b/libraries/mbed/api/BusIn.h
@@ -51,7 +51,13 @@ public:
      *   An integer with each bit corresponding to the value read from the associated DigitalIn pin
      */
     int read();
-
+    
+    /** Set the input pin mode
+     *
+     *  @param mode PullUp, PullDown, PullNone
+     */
+    void mode(PinMode pull);
+	
 #ifdef MBED_OPERATORS
     /** A shorthand for read()
      */

--- a/libraries/mbed/common/BusIn.cpp
+++ b/libraries/mbed/common/BusIn.cpp
@@ -49,6 +49,14 @@ int BusIn::read() {
     return v;
 }
 
+void BusIn::mode(PinMode pull) {
+    for (int i=0; i<16; i++) {
+        if (_pin[i] != 0) {
+            _pin[i]->mode(pull);
+        }
+    }
+}
+
 #ifdef MBED_OPERATORS
 BusIn::operator int() {
     return read();

--- a/libraries/mbed/common/gpio.c
+++ b/libraries/mbed/common/gpio.c
@@ -18,16 +18,20 @@
 static inline void _gpio_init_in(gpio_t* gpio, PinName pin, PinMode mode)
 {
     gpio_init(gpio, pin);    
-    gpio_dir(gpio, PIN_INPUT);
-    gpio_mode(gpio, mode);
+    if (pin != NC) {    
+        gpio_dir(gpio, PIN_INPUT);
+        gpio_mode(gpio, mode);
+    }
 }
     
 static inline void _gpio_init_out(gpio_t* gpio, PinName pin, PinMode mode, int value)
 {
     gpio_init(gpio, pin);
-    gpio_write(gpio, value);
-    gpio_dir(gpio, PIN_OUTPUT);
-    gpio_mode(gpio, mode);
+    if (pin != NC) {
+        gpio_write(gpio, value);
+        gpio_dir(gpio, PIN_OUTPUT);
+        gpio_mode(gpio, mode);
+    }
 }
 
 void gpio_init_in(gpio_t* gpio, PinName pin) {
@@ -49,7 +53,8 @@ void gpio_init_out_ex(gpio_t* gpio, PinName pin, int value) {
 void gpio_init_inout(gpio_t* gpio, PinName pin, PinDirection direction, PinMode mode, int value) {
     if (direction == PIN_INPUT) {
         _gpio_init_in(gpio, pin, mode);
-        gpio_write(gpio, value); // we prepare the value in case it is switched later
+        if (pin != NC)
+            gpio_write(gpio, value); // we prepare the value in case it is switched later
     } else {
         _gpio_init_out(gpio, pin, mode, value);
     }


### PR DESCRIPTION
Now BusIn can also use PullUp, etc, instead of only BusInOut.

If the pin is NC, it does get to the init, but all write/mode functions
are disabled. This is how it used to be in the old gpio version. Quite
some libraries allow users to make pins NC, and they are all locking up
with the current mbed version. This is far from a perfect solution, but
more a temporary fix.
