### PR TITLE
[DISCO_F407VG]: Change default FPU option to "softfp" from "hard".

### DIFF
--- a/workspace_tools/export/gcc_arm_disco_f407vg.tmpl
+++ b/workspace_tools/export/gcc_arm_disco_f407vg.tmpl
@@ -28,10 +28,10 @@ LD_FLAGS = $(CPU) -Wl,--gc-sections --specs=nano.specs -u _printf_float -u _scan
 LD_FLAGS += -Wl,-Map=$(PROJECT).map,--cref
 LD_SYS_LIBS = -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys
 
-ifeq ($(SOFTFP),1)
-	FLOAT_ABI = softfp
-else
+ifeq ($(HARDFP),1)
 	FLOAT_ABI = hard
+else
+	FLOAT_ABI = softfp
 endif
 
 ifeq ($(DEBUG), 1)


### PR DESCRIPTION
This commit changes the defalt compile option in relation to FPU from "hard" to "softfp" in
Makefile template, because it would be better to maintain the consistency with "build.py" and "make.py"
that have the default option, "softfp".
If the "hard" option is needed, execute "make HARDFP=1" on command line.
