### PR TITLE
[NUCLEO_F030R8] Change PWM_OUT label

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/PinNames.h
@@ -158,7 +158,7 @@ typedef enum {
     SPI_MISO    = PA_6,
     SPI_SCK     = PA_5,
     SPI_CS      = PB_6,
-    PWM_OUT     = PB_3,
+    PWM_OUT     = PC_7,
 
     // Not connected
     NC = (int)0xFFFFFFFF


### PR DESCRIPTION
PB_3 does not support pwm out.
