### PR TITLE
NUCLEO_F401RE and NUCLEO_F302R8 - FPU enabled

### DIFF
--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -340,7 +340,7 @@ class NUCLEO_F401RE(Target):
     def __init__(self):
         Target.__init__(self)
         
-        self.core = "Cortex-M4"
+        self.core = "Cortex-M4F"
         
         self.extra_labels = ['STM', 'STM32F4', 'STM32F401RE']
         
@@ -372,7 +372,7 @@ class NUCLEO_F302R8(Target):
     def __init__(self):
         Target.__init__(self)
         
-        self.core = "Cortex-M4"
+        self.core = "Cortex-M4F"
         
         self.extra_labels = ['STM', 'STM32F3', 'STM32F302R8']
         


### PR DESCRIPTION
Enable FPU for 2 nucleo targets which contain FPU. 
I currently don't have these 2 boards at my disposal, please test the simple program with wait() to verify. With the current settings (targets are defined as M4 core), the simple program with wait() halts because project templates have FPU enabled and the mbed lib is compiled as without FPU. 

Thanks!
