### PR TITLE
Ensure the NVIC table gets copied to RAM even when it is not at 0x0000

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X/cmsis_nvic.c
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X/cmsis_nvic.c
@@ -13,7 +13,7 @@ void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     uint32_t i;
 
     // Copy and switch to dynamic vectors if the first time called
-    if (SCB->VTOR == NVIC_FLASH_VECTOR_ADDRESS) {
+    if (SCB->VTOR < NVIC_RAM_VECTOR_ADDRESS) {
         uint32_t *old_vectors = vectors;
         vectors = (uint32_t*)NVIC_RAM_VECTOR_ADDRESS;
         for (i=0; i<NVIC_NUM_VECTORS; i++) {


### PR DESCRIPTION
When using user application code on an actual mbed the original code runs fine. 

However, when migrating from a prototype to a bare metal controller that is running on a circuit designed from scratch you typically implement a secondary boot loader that enables updating the flash from USB or from an SD card. This secondary bootloader requires that you compile the mbed-based application code with an offset. Before jumping to the application the SCB->VTOR register is set to the correct offset for the vector table in the application code (in flash).

Here lies the catch: the mbed startup code checks if the SCB->VTOR == 0x0000 and if it is not the case it does not copy the vector table to RAM. It also tries to adapt the table, which is not possible (the application cannot write to the flash memory).

With the proposed fix the code runs fine with or without a bootloader.
