### PR TITLE
Changes to LPC11uXX sleep behavior

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/sleep.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/sleep.c
@@ -29,6 +29,11 @@ void sleep(void) {
 }
 
 void deepsleep(void) {
+    // ensure debug is disconnected
+    #if DEVICE_SEMIHOST
+    mbed_interface_disconnect();
+    #endif
+
     // PCON[PD] set to powerdown
     LPC_PMU->PCON = 0x2;
     


### PR DESCRIPTION
See: https://github.com/mbedmicro/mbed/issues/143
- Removed interface disconnect for reasons in that issue
- Removed incorrect comments copy pasted from LPC1768
- Switched from deepsleep to power down (see that issue also)
- Only enable components after wakeup when they are currently running
- Only keep watchdog and brownout running when they are currently running
