### PR TITLE
Changed LED mapping to RGB

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11U6X/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11U6X/PinNames.h
@@ -121,10 +121,10 @@ typedef enum {
     LED_BLUE  = P2_18,
     
     // mbed original LED naming
-    LED1 = LED_BLUE,
+    LED1 = LED_RED,
     LED2 = LED_GREEN,
-    LED3 = LED_RED,
-    LED4 = LED_RED,
+    LED3 = LED_BLUE,
+    LED4 = LED_BLUE,
     
     // Serial to USB pins
     USBTX = P0_19,


### PR DESCRIPTION
Changed the pin mapping for LED1, LED2, and LED3, to Red, Green, and Blue respectively. This matches the KL25Z, and makes more sense in my opinion.
