### PR TITLE
[LPC4088] GCC: corrected alignment problem when setting up memory region...

### DIFF
--- a/libraries/net/eth/lwip-eth/arch/TARGET_NXP/lpc17_emac.c
+++ b/libraries/net/eth/lwip-eth/arch/TARGET_NXP/lpc17_emac.c
@@ -138,7 +138,7 @@ struct lpc_enetdata {
 #  if defined (__ICCARM__)
 #     define ETHMEM_SECTION
 #  elif defined(TOOLCHAIN_GCC_CR)
-#     define ETHMEM_SECTION __attribute__((section(".data.$RamPeriph32")))
+#     define ETHMEM_SECTION __attribute__((section(".data.$RamPeriph32"), aligned))
 #  else
 #     define ETHMEM_SECTION __attribute__((section("AHBSRAM1"),aligned))
 #  endif


### PR DESCRIPTION
... for Ethernet driver
