### PR TITLE
[K64F] ARM GCC startup fix - watchdog, linker correction and NVIC number of ...

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_K64F/TOOLCHAIN_GCC_ARM/K64FN1M0xxx12.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_K64F/TOOLCHAIN_GCC_ARM/K64FN1M0xxx12.ld
@@ -7,7 +7,7 @@ MEMORY
   VECTORS (rx)          : ORIGIN = 0x00000000, LENGTH = 0x00000400
   FLASH_PROTECTION (rx) : ORIGIN = 0x00000400, LENGTH = 0x00000010
   FLASH (rx)            : ORIGIN = 0x00000410, LENGTH = 0x00100000 - 0x00000410
-  RAM (rwx)             : ORIGIN = 0x1FFF0400, LENGTH = 0x00040000 - 0x00000400
+  RAM (rwx)             : ORIGIN = 0x1FFF0198, LENGTH = 0x00040000 - 0x00000198
 }
 
 /* Linker script to place sections and symbol values. Should be used together

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_K64F/TOOLCHAIN_GCC_ARM/startup_MK64F12.s
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_K64F/TOOLCHAIN_GCC_ARM/startup_MK64F12.s
@@ -49,7 +49,7 @@
 #ifdef __STACK_SIZE
     .equ    Stack_Size, __STACK_SIZE
 #else
-    .equ    Stack_Size, 0x400
+    .equ    Stack_Size, 0xC00
 #endif
     .globl    __StackTop
     .globl    __StackLimit
@@ -64,7 +64,7 @@ __StackTop:
 #ifdef __HEAP_SIZE
     .equ    Heap_Size, __HEAP_SIZE
 #else
-    .equ    Heap_Size, 0x80
+    .equ    Heap_Size, 0x400
 #endif
     .globl    __HeapBase
     .globl    __HeapLimit
@@ -198,6 +198,18 @@ Reset_Handler:
  *      __etext: End of code section, i.e., begin of data sections to copy from.
  *      __data_start__/__data_end__: RAM address range that data should be
  *      copied to. Both must be aligned to 4 bytes boundary.  */
+
+disable_watchdog:
+    /* unlock */
+    ldr r1, =0x4005200e
+    ldr r0, =0xc520
+    strh r0, [r1]
+    ldr r0, =0xd928
+    strh r0, [r1]
+    /* disable */
+    ldr r1, =0x40052000
+    ldr r0, =0x01d2
+    strh r0, [r1]
 
     ldr    r1, =__etext
     ldr    r2, =__data_start__

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_K64F/cmsis_nvic.h
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_K64F/cmsis_nvic.h
@@ -7,7 +7,7 @@
 #ifndef MBED_CMSIS_NVIC_H
 #define MBED_CMSIS_NVIC_H
 
-#define NVIC_NUM_VECTORS      (16 + 85)   // CORE + MCU Peripherals
+#define NVIC_NUM_VECTORS      (16 + 86)   // CORE + MCU Peripherals
 #define NVIC_USER_IRQ_OFFSET  16
 
 #include "cmsis.h"


### PR DESCRIPTION
This commit fixes issue with GCC startup - disabling watchdog as the very first thing in the reset handler, plus some small changes.

I'll add that disabling watchdog to other kinetis targets which supports GCC.

Regards,
0xc0170
