### PR TITLE
[K64F] enet - IRQ handlers are in the emac (eth) layer

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/TARGET_KPSDK_CODE/drivers/enet/src/fsl_enet_irq.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/TARGET_KPSDK_CODE/drivers/enet/src/fsl_enet_irq.c
@@ -33,7 +33,7 @@
 /*******************************************************************************
  * Variables
  ******************************************************************************/
-extern void *enetIfHandle;
+
 
 /* Internal irq number*/
 typedef enum _enet_irq_number
@@ -81,24 +81,7 @@ uint8_t enetIntMap[kEnetIntNum] =
 /*******************************************************************************
  * Code
  ******************************************************************************/
-#if defined (K64F12_SERIES) || defined (K70F12_SERIES) 
-void ENET_Transmit_IRQHandler(void)
-{
-     enet_mac_tx_isr(enetIfHandle);
-}
-
-void ENET_Receive_IRQHandler(void)
-{
-     enet_mac_rx_isr(enetIfHandle);
-}
-
-#if FSL_FEATURE_ENET_SUPPORT_PTP
-void ENET_1588_Timer_IRQHandler(void)
-{
-     enet_mac_ts_isr(enetIfHandle);
-}
-#endif
-#endif
+/* The code was moved to k64f mac file (eth) */
 
 /*******************************************************************************
  * EOF

--- a/libraries/net/eth/lwip-eth/arch/TARGET_K64F/k64f_emac.c
+++ b/libraries/net/eth/lwip-eth/arch/TARGET_K64F/k64f_emac.c
@@ -27,6 +27,7 @@
 
 extern IRQn_Type enet_irq_ids[HW_ENET_INSTANCE_COUNT][FSL_FEATURE_ENET_INTERRUPT_COUNT];
 extern uint8_t enetIntMap[kEnetIntNum];
+extern void *enetIfHandle;
 
 /********************************************************************************
  * Internal data
@@ -855,6 +856,22 @@ void eth_arch_disable_interrupts(void) {
   interrupt_disable(enet_irq_ids[BOARD_DEBUG_ENET_INSTANCE][enetIntMap[kEnetTxfInt]]);  
 }
 
+void ENET_Transmit_IRQHandler(void)
+{
+     enet_mac_tx_isr(enetIfHandle);
+}
+
+void ENET_Receive_IRQHandler(void)
+{
+     enet_mac_rx_isr(enetIfHandle);
+}
+
+#if FSL_FEATURE_ENET_SUPPORT_PTP
+void ENET_1588_Timer_IRQHandler(void)
+{
+     enet_mac_ts_isr(enetIfHandle);
+}
+#endif
 /**
  * @}
  */


### PR DESCRIPTION
This commit fixes an issue with mbed-src and not defined some symbols in the enet KSDK layer, if ethernet lib is not used.

Regards,
0xc0170
