### PR TITLE
[NUCLEOs] Call SystemCoreClockUpdate() before SystemCoreClock is used.

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/pwmout_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/pwmout_api.c
@@ -188,6 +188,9 @@ void pwmout_period_us(pwmout_t* obj, int us) {
 
     obj->period = us;
 
+    // Update the SystemCoreClock variable.
+    SystemCoreClockUpdate();
+
     TIM_TimeBaseStructure.TIM_Period = obj->period - 1;
     TIM_TimeBaseStructure.TIM_Prescaler = (uint16_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
     TIM_TimeBaseStructure.TIM_ClockDivision = 0;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/us_ticker.c
@@ -87,6 +87,9 @@ void us_ticker_init(void) {
     // Enable Timer clock
     TIM_MST_RCC;
 
+    // Update the SystemCoreClock variable.
+    SystemCoreClockUpdate();
+
     // Configure time base
     TIM_TimeBaseStructInit(&TIM_TimeBaseStructure);
     TIM_TimeBaseStructure.TIM_Period = 0xFFFF;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F072RB/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F072RB/us_ticker.c
@@ -41,11 +41,11 @@ void us_ticker_init(void) {
     if (us_ticker_inited) return;
     us_ticker_inited = 1;
 
-    // Update the SystemCoreClock variable
-    SystemCoreClockUpdate();
-
     // Enable timer clock
     TIM_MST_RCC;
+
+    // Update the SystemCoreClock variable
+    SystemCoreClockUpdate();
 
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F103RB/pwmout_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F103RB/pwmout_api.c
@@ -221,6 +221,9 @@ void pwmout_period_us(pwmout_t* obj, int us) {
 
     obj->period = us;
 
+    // Update the SystemCoreClock variable.
+    SystemCoreClockUpdate();
+
     TIM_TimeBaseStructure.TIM_Period        = obj->period - 1;
     TIM_TimeBaseStructure.TIM_Prescaler     = (uint16_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
     TIM_TimeBaseStructure.TIM_ClockDivision = 0;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F103RB/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F103RB/us_ticker.c
@@ -80,6 +80,9 @@ void us_ticker_init(void) {
     // Enable timer clock
     TIM_MST_RCC;
 
+    // Update the SystemCoreClock variable.
+    SystemCoreClockUpdate();
+
     // Configure time base
     TIM_TimeBaseStructInit(&TIM_TimeBaseStructure);
     TIM_TimeBaseStructure.TIM_Period = 0xFFFF;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F302R8/i2c_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F302R8/i2c_api.c
@@ -108,6 +108,9 @@ void i2c_frequency(i2c_t *obj, int hz) {
     SYSCFG_I2CFastModePlusConfig(SYSCFG_I2CFastModePlus_I2C1, DISABLE);
     SYSCFG_I2CFastModePlusConfig(SYSCFG_I2CFastModePlus_I2C2, DISABLE);
 
+    // Update the SystemCoreClock variable.
+    SystemCoreClockUpdate();
+
     /*
        Values calculated with I2C_Timing_Configuration_V1.0.1.xls file (see AN4235)
        * Standard mode (up to 100 kHz)

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F302R8/pwmout_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F302R8/pwmout_api.c
@@ -245,6 +245,9 @@ void pwmout_period_us(pwmout_t* obj, int us) {
 
     obj->period = us;
 
+    // Update the SystemCoreClock variable.
+    SystemCoreClockUpdate();
+
     TIM_TimeBaseStructInit(&TIM_TimeBaseStructure);
     TIM_TimeBaseStructure.TIM_Period = obj->period - 1;
     TIM_TimeBaseStructure.TIM_Prescaler = (uint16_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F302R8/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F302R8/us_ticker.c
@@ -45,6 +45,9 @@ void us_ticker_init(void) {
     // Enable timer clock
     TIM_MST_RCC;
 
+    // Update the SystemCoreClock variable.
+    SystemCoreClockUpdate();
+
     // Configure time base
     TIM_TimeBaseStructInit(&TIM_TimeBaseStructure);
     TIM_TimeBaseStructure.TIM_Period        = 0xFFFFFFFF;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L053R8/pwmout_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L053R8/pwmout_api.c
@@ -172,6 +172,9 @@ void pwmout_period_us(pwmout_t* obj, int us) {
 
     __HAL_TIM_DISABLE(&TimHandle);
 
+    // Update the SystemCoreClock variable.
+    SystemCoreClockUpdate();
+
     TimHandle.Init.Period        = us - 1;
     TimHandle.Init.Prescaler     = (uint16_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
     TimHandle.Init.ClockDivision = 0;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L053R8/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L053R8/us_ticker.c
@@ -82,6 +82,9 @@ void us_ticker_init(void) {
     // Enable timer clock
     TIM_MST_RCC;
 
+    // Update the SystemCoreClock variable.
+    SystemCoreClockUpdate();
+
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period        = 0xFFFF;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/pwmout_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/pwmout_api.c
@@ -202,6 +202,9 @@ void pwmout_period_us(pwmout_t* obj, int us) {
 
     obj->period = us;
 
+    // Update the SystemCoreClock variable.
+    SystemCoreClockUpdate();
+
     TIM_TimeBaseStructure.TIM_Period        = obj->period - 1;
     TIM_TimeBaseStructure.TIM_Prescaler     = (uint16_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
     TIM_TimeBaseStructure.TIM_ClockDivision = 0;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/spi_api.c
@@ -215,6 +215,9 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
 }
 
 void spi_frequency(spi_t *obj, int hz) {
+    // Update the SystemCoreClock variable.
+    SystemCoreClockUpdate();
+
     // Values depend of PCLK1 and PCLK2: 32 MHz if HSI is used, 24 MHz if HSE is used
     if (SystemCoreClock == 32000000) { // HSI
         if (hz < 250000) {

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/us_ticker.c
@@ -45,6 +45,9 @@ void us_ticker_init(void) {
     // Enable timer clock
     TIM_MST_RCC;
 
+    // Update the SystemCoreClock variable.
+    SystemCoreClockUpdate();
+
     // Configure time base
     TIM_TimeBaseStructInit(&TIM_TimeBaseStructure);
     TIM_TimeBaseStructure.TIM_Period = 0xFFFFFFFF;


### PR DESCRIPTION
This solves the issue with Ticker class (wrong timing).
