### PR TITLE
Reset device to initial state in disconnect()

### DIFF
--- a/libraries/USBDevice/USBDevice/USBDevice.cpp
+++ b/libraries/USBDevice/USBDevice/USBDevice.cpp
@@ -718,6 +718,11 @@ void USBDevice::disconnect(void)
 {
     /* Disconnect device */
     USBHAL::disconnect();
+    
+    /* Set initial device state */
+    device.state = POWERED;
+    device.configuration = 0;
+    device.suspended = false;
 }
 
 CONTROL_TRANSFER * USBDevice::getTransferPtr(void)


### PR DESCRIPTION
Added code to reset the device to the initial state when disconnect() is called. This prevents calls to configured() from returning true when the device has been disconnected.
