### PR TITLE
[NUCLEOs] SPI corrections

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/spi_api.c
@@ -59,9 +59,9 @@ static const PinMap PinMap_SPI_SCLK[] = {
 
 // Only used in Slave mode
 static const PinMap PinMap_SPI_SSEL[] = {
-    {PA_4,  SPI_1, STM_PIN_DATA(GPIO_Mode_IN, GPIO_OType_PP, GPIO_PuPd_NOPULL, 0)},
-    {PA_15, SPI_1, STM_PIN_DATA(GPIO_Mode_IN, GPIO_OType_PP, GPIO_PuPd_NOPULL, 0)},
-    {PB_12, SPI_2, STM_PIN_DATA(GPIO_Mode_IN, GPIO_OType_PP, GPIO_PuPd_NOPULL, 0)},
+    {PA_4,  SPI_1, STM_PIN_DATA(GPIO_Mode_AF, GPIO_OType_PP, GPIO_PuPd_NOPULL, 0)},
+    {PA_15, SPI_1, STM_PIN_DATA(GPIO_Mode_AF, GPIO_OType_PP, GPIO_PuPd_NOPULL, 0)},
+    {PB_12, SPI_2, STM_PIN_DATA(GPIO_Mode_AF, GPIO_OType_PP, GPIO_PuPd_NOPULL, 0)},
     {NC,    NC,    0}
 };
 
@@ -159,10 +159,10 @@ void spi_free(spi_t *obj) {
 
 void spi_format(spi_t *obj, int bits, int mode, int slave) {
     // Save new values
-    if (bits == 8) {
-        obj->bits = SPI_DataSize_8b;
-    } else {
+    if (bits == 16) {
         obj->bits = SPI_DataSize_16b;
+    } else {
+        obj->bits = SPI_DataSize_8b;
     }
 
     switch (mode) {
@@ -266,7 +266,7 @@ int spi_master_write(spi_t *obj, int value) {
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ((ssp_readable(obj) && !ssp_busy(obj)) ? 1 : 0);
 };
 
 int spi_slave_read(spi_t *obj) {

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F072RB/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F072RB/spi_api.c
@@ -282,7 +282,7 @@ int spi_master_write(spi_t *obj, int value) {
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ((ssp_readable(obj) && !ssp_busy(obj)) ? 1 : 0);
 };
 
 int spi_slave_read(spi_t *obj) {

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F103RB/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F103RB/spi_api.c
@@ -156,10 +156,10 @@ void spi_free(spi_t *obj) {
 
 void spi_format(spi_t *obj, int bits, int mode, int slave) {
     // Save new values
-    if (bits == 8) {
-        obj->bits = SPI_DataSize_8b;
-    } else {
+    if (bits == 16) {
         obj->bits = SPI_DataSize_16b;
+    } else {
+        obj->bits = SPI_DataSize_8b;
     }
 
     switch (mode) {
@@ -279,7 +279,7 @@ int spi_master_write(spi_t *obj, int value) {
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ((ssp_readable(obj) && !ssp_busy(obj)) ? 1 : 0);
 };
 
 int spi_slave_read(spi_t *obj) {

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F302R8/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F302R8/spi_api.c
@@ -161,10 +161,10 @@ void spi_free(spi_t *obj) {
 
 void spi_format(spi_t *obj, int bits, int mode, int slave) {
     // Save new values
-    if (bits == 8) {
-        obj->bits = SPI_DataSize_8b;
-    } else {
+    if (bits == 16) {
         obj->bits = SPI_DataSize_16b;
+    } else {
+        obj->bits = SPI_DataSize_8b;
     }
 
     switch (mode) {
@@ -268,7 +268,7 @@ int spi_master_write(spi_t *obj, int value) {
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ((ssp_readable(obj) && !ssp_busy(obj)) ? 1 : 0);
 };
 
 int spi_slave_read(spi_t *obj) {

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F401RE/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F401RE/spi_api.c
@@ -67,12 +67,12 @@ static const PinMap PinMap_SPI_SCLK[] = {
 };
 
 static const PinMap PinMap_SPI_SSEL[] = {
-    {PA_4,  SPI_1, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, GPIO_AF5_SPI1)},
-//  {PA_4,  SPI_3, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, GPIO_AF6_SPI3)},
-    {PA_15, SPI_1, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, GPIO_AF5_SPI1)},
-//  {PA_15, SPI_3, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, GPIO_AF6_SPI3)},
-    {PB_9,  SPI_2, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, GPIO_AF5_SPI2)},
-    {PB_12, SPI_2, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, GPIO_AF5_SPI2)},
+    {PA_4,  SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI1)},
+//  {PA_4,  SPI_3, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF6_SPI3)},
+    {PA_15, SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI1)},
+//  {PA_15, SPI_3, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF6_SPI3)},
+    {PB_9,  SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)},
+    {PB_12, SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF5_SPI2)},
     {NC,    NC,    0}
 };
 
@@ -181,10 +181,10 @@ void spi_free(spi_t *obj) {
 
 void spi_format(spi_t *obj, int bits, int mode, int slave) {
     // Save new values
-    if (bits == 8) {
-        obj->bits = SPI_DATASIZE_8BIT;
-    } else {
+    if (bits == 16) {
         obj->bits = SPI_DATASIZE_16BIT;
+    } else {
+        obj->bits = SPI_DATASIZE_8BIT;
     }
 
     switch (mode) {
@@ -280,7 +280,7 @@ int spi_master_write(spi_t *obj, int value) {
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ((ssp_readable(obj) && !ssp_busy(obj)) ? 1 : 0);
 };
 
 int spi_slave_read(spi_t *obj) {

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L053R8/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L053R8/spi_api.c
@@ -166,10 +166,10 @@ void spi_free(spi_t *obj) {
 
 void spi_format(spi_t *obj, int bits, int mode, int slave) {
     // Save new values
-    if (bits == 8) {
-        obj->bits = SPI_DATASIZE_8BIT;
-    } else {
+    if (bits == 16) {
         obj->bits = SPI_DATASIZE_16BIT;
+    } else {
+        obj->bits = SPI_DATASIZE_8BIT;
     }
 
     switch (mode) {
@@ -265,7 +265,7 @@ int spi_master_write(spi_t *obj, int value) {
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj)) ? (1) : (0);
+    return (ssp_readable(obj) ? 1 : 0);
 };
 
 int spi_slave_read(spi_t *obj) {

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/spi_api.c
@@ -175,10 +175,10 @@ void spi_free(spi_t *obj) {
 
 void spi_format(spi_t *obj, int bits, int mode, int slave) {
     // Save new values
-    if (bits == 8) {
-        obj->bits = SPI_DataSize_8b;
-    } else {
+    if (bits == 16) {
         obj->bits = SPI_DataSize_16b;
+    } else {
+        obj->bits = SPI_DataSize_8b;
     }
 
     switch (mode) {
@@ -294,8 +294,7 @@ int spi_master_write(spi_t *obj, int value) {
 }
 
 int spi_slave_receive(spi_t *obj) {
-    //return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0); // initial code
-    return (ssp_readable(obj)) ? (1) : (0); // works better like this
+    return (ssp_readable(obj) ? 1 : 0);
 };
 
 int spi_slave_read(spi_t *obj) {


### PR DESCRIPTION
- Correct wrong NSS pin configuration on F030R8 and F401RE
- Set the default data size to 8 bits
- Typo corrections
