### PR TITLE
Recover from exception in serial.sendBreak() in linux.

### DIFF
--- a/workspace_tools/make.py
+++ b/workspace_tools/make.py
@@ -186,7 +186,15 @@ if __name__ == '__main__':
             serial.flushInput()
             serial.flushOutput()
 
-            serial.sendBreak()
+            try:
+                serial.sendBreak()
+            except:
+                # In linux a termios.error is raised in sendBreak and in setBreak.
+                # The following setBreak() is needed to release the reset signal on the target mcu.
+                try:
+                    serial.setBreak(False)
+                except:
+                    pass
 
             while True:
                 c = serial.read(512)


### PR DESCRIPTION
When i execute the script workspace_tools/make.py to execute a test on my lpcxpresso1549 board, an exception is raised on line https://github.com/mbedmicro/mbed/blob/master/workspace_tools/make.py#L189 in serial.sendBreak().

Linux: Fedora 20 kernel 3.14.7-200.fc20.x86_64
Python: 2.7.5

Currently this is only tested in fedora 20 and with the lpcxpresso1549.
I can test it in a week on the LPC1768 board.

See mbedmicro/mbed#362
