### PR TITLE
[NUCLEO_F401RE] Fix issue with sleep and ST HAL tick timer

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F401RE/sleep.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F401RE/sleep.c
@@ -36,8 +36,16 @@
 static TIM_HandleTypeDef TimMasterHandle;
 
 void sleep(void) {
+    TimMasterHandle.Instance = TIM5;
+
+    // Disable HAL tick interrupt
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+
     // Request to enter SLEEP mode
     HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
+
+    // Enable HAL tick interrupt
+    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
 }
 
 void deepsleep(void) {


### PR DESCRIPTION
The timer used for the ST HAL tick must be disabled before entering in
sleep mode.
