### PR TITLE
- Add Nucleo F401RE Support

### DIFF
--- a/libraries/rtos/rtx/RTX_CM_lib.h
+++ b/libraries/rtos/rtx/RTX_CM_lib.h
@@ -238,7 +238,7 @@ osThreadDef_t os_thread_def_main = {(os_pthread)main, osPriorityNormal, 0, NULL}
 #elif defined(TARGET_DISCO_F303VC)
 #define INITIAL_SP            (0x2000A000UL)
 
-#elif defined(TARGET_STM32F407) || defined(TARGET_F407VG)
+#elif defined(TARGET_STM32F407) || defined(TARGET_F407VG)  || defined(TARGET_STM32F401RE)
 #define INITIAL_SP            (0x20020000UL)
 
 #elif defined(TARGET_LPC1549)

--- a/libraries/rtos/rtx/RTX_Conf_CM.c
+++ b/libraries/rtos/rtx/RTX_Conf_CM.c
@@ -49,7 +49,7 @@
 //       counting "main", but not counting "osTimerThread"
 //   <i> Default: 6
 #ifndef OS_TASKCNT
-#  if   defined(TARGET_LPC1768) || defined(TARGET_LPC2368)   || defined(TARGET_LPC4088) || defined(TARGET_LPC1347) || defined(TARGET_K64F) \
+#  if   defined(TARGET_LPC1768) || defined(TARGET_LPC2368)   || defined(TARGET_LPC4088) || defined(TARGET_LPC1347) || defined(TARGET_K64F) || defined(TARGET_STM32F401RE)\
 	 || defined(TARGET_KL46Z)   || defined(TARGET_STM32F407) || defined(TARGET_F407VG)  || defined(TARGET_STM32F303VC) || defined(TARGET_LPC1549) || defined(TARGET_LPC11U68) || defined(TARGET_NRF51822)
 #    define OS_TASKCNT         14
 #  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPCCAPPUCCINO) || defined(TARGET_LPC1114) \
@@ -62,7 +62,7 @@
 
 //   <o>Scheduler (+ interrupts) stack size [bytes] <64-4096:8><#/4>
 #ifndef OS_SCHEDULERSTKSIZE
-#  if   defined(TARGET_LPC1768) || defined(TARGET_LPC2368)   || defined(TARGET_LPC4088) || defined(TARGET_LPC1347)  || defined(TARGET_K64F) \
+#  if   defined(TARGET_LPC1768) || defined(TARGET_LPC2368)   || defined(TARGET_LPC4088) || defined(TARGET_LPC1347)  || defined(TARGET_K64F) || defined(TARGET_STM32F401RE)\
 	 || defined(TARGET_KL46Z)   || defined(TARGET_STM32F407) || defined(TARGET_F407VG)  || defined(TARGET_STM32F303VC) || defined(TARGET_LPC1549) || defined(TARGET_LPC11U68) || defined(TARGET_NRF51822)
 #      define OS_SCHEDULERSTKSIZE    256
 #  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPCCAPPUCCINO)  || defined(TARGET_LPC1114) \
@@ -132,7 +132,8 @@
 
 #  elif defined(TARGET_NRF51822)
 #    define OS_CLOCK       16000000
-
+#  elif defined(TARGET_STM32F401RE)
+#    define OS_CLOCK       84000000
 #  else
 #    error "no target defined"
 #  endif


### PR DESCRIPTION
Just few lines of macro added it's based on assumption that F401RE is fully compatible to F407V in kernel dependency (mostly arm v7m dependent part)
