### PR TITLE
Enable exporters for LPC4330_M4

### DIFF
--- a/workspace_tools/export/codered.py
+++ b/workspace_tools/export/codered.py
@@ -25,6 +25,7 @@ class CodeRed(Exporter):
     TARGETS = [
         'LPC1768',
         'LPC4088',
+        'LPC4330_M4',
         'LPC1114',
         'LPC11U35_401',
         'LPC11U35_501',

--- a/workspace_tools/export/gccarm.py
+++ b/workspace_tools/export/gccarm.py
@@ -30,6 +30,7 @@ class GccArm(Exporter):
         'K64F',
         'K20D50M',
         'LPC4088',
+        'LPC4330_M4',
         'LPC11U24',
         'LPC1114',
         'LPC11U35_401',

--- a/workspace_tools/export/uvision4.py
+++ b/workspace_tools/export/uvision4.py
@@ -33,6 +33,7 @@ class Uvision4(Exporter):
         'LPC1114',
         'LPC11C24',
         'LPC4088',
+        'LPC4330_M4',
         'LPC812',
         'NUCLEO_F030R8',
         'NUCLEO_F072RB',


### PR DESCRIPTION
Enable export templates for LPC4330_M4 port: ARM_STD (Keil), GCC_CR (Codered) and GCC_ARM (GCC ARM Embedded).
