### PR TITLE
Fix KL25Z connect problem with some USB 3.0 hosts

### DIFF
--- a/libraries/USBDevice/USBDevice/USBDevice.cpp
+++ b/libraries/USBDevice/USBDevice/USBDevice.cpp
@@ -187,7 +187,27 @@ bool USBDevice::controlOut(void)
     /* Check we should be transferring data OUT */
     if (transfer.direction != HOST_TO_DEVICE)
     {
-        return false;
+#if defined(TARGET_KL25Z) | defined(TARGET_KL46Z) | defined(TARGET_K20D5M) | defined(TARGET_K64F)
+        /*
+         * We seem to have a pending device-to-host transfer.  The host must have
+         * sent a new control request without waiting for us to finish processing
+         * the previous one.  This appears to happen when we're connected to certain 
+         * USB 3.0 host chip set. Do a zeor-length send to tell the host we're not
+         * ready for the new request - that'll make it resend - and then just
+         * pretend we were successful here so that the pending transfer can finish.
+         */
+         uint8_t buf[1] = { 0 };
+         EP0write(buf, 0);
+         
+         /* execute our pending ttransfer */
+         controlIn();
+         
+         /* indicate success */
+         return true;
+ #else
+         /* for other platforms, count on the HAL to handle this case */
+         return false;
+ #endif
     }
 
     /* Read from endpoint */


### PR DESCRIPTION
This change fixes a problem I've encountered using the Freescale KL25Z as a USB client device when attaching to a USB 3.0 port on a host PC.  I've personally observed the problem on two PCs, one a Dell running Windows 8.1 and the other a custom-built Windows 7 machine with a Gigabyte mobo.  Several other people on the Web have reported what appears to be the same problem.  It even appears to happen with some Macs - so it's apparently not Windows-specific or Windows-version-specific.  But it does seem to be USB 3.0 specific, and one report speculated that the common element is the Intel Haswell chip set on the host side.

The problem can be worked around by using USB 2.1 ports (many PCs have a mix of 2.1 and 3.0 port hardware) or by connecting a USB 2.1 hub between the device and host.  I have USB 2.1 ports on both of my testing machines, and this solution does work for me.  But I wanted to fix it at the software level if possible, so that my project would work for people who might only have USB 3.0 ports available.

I tracked down the problem to a timing issue that seems to cause the device and host to get out of sync with respect to flow direction on the USB connection during the initial handshake. It seems that the host can issue a CONTROL OUT token at a point where the client is trying to send the response for a previous CONTROL IN token. I found a note in some USB 3.0 reference material that this situation can occur, and that the client can resolve it by sending a zero-length ACK, which tells the host that the client isn't ready and that the host request should be repeated. 

My fix sends a zero-length reply in USBDevice::controlOut() when the control flow error is detected, and also explicitly sends the pending CONTROL_IN packet.  This appears to fix it reliably on my machine.  I'm not entirely confident about the fix, though, since I don't feel I understand the USB protocol or the mbed code in enough depth.  I'm submitting the change here in the hope that someone with a deeper knowledge of the mbed code can determine if this is a good fix, and if not can hopefully use it as the starting point for a better solution.  

Note that I submitted the same pull request via the mbed source control system, but I was advised by another mbed user that I should also submit it directly on github.  Apologies for any confusion caused by the redundant submissions.
