### PR TITLE
[LPC1114] Sleep fix + some device.h settings

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11CXX/device.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11CXX/device.h
@@ -41,8 +41,8 @@
 
 #define DEVICE_PWMOUT           1
 
-#define DEVICE_SEMIHOST         1
-#define DEVICE_LOCALFILESYSTEM  1
+#define DEVICE_SEMIHOST         0
+#define DEVICE_LOCALFILESYSTEM  0
 #define DEVICE_ID_LENGTH       32
 #define DEVICE_MAC_OFFSET      20
 

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11XX/device.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11XX/device.h
@@ -41,8 +41,8 @@
 
 #define DEVICE_PWMOUT           1
 
-#define DEVICE_SEMIHOST         1
-#define DEVICE_LOCALFILESYSTEM  1
+#define DEVICE_SEMIHOST         0
+#define DEVICE_LOCALFILESYSTEM  0
 #define DEVICE_ID_LENGTH       32
 #define DEVICE_MAC_OFFSET      20
 


### PR DESCRIPTION
LPC1114 has no semihosting and also no localfilesystem. I took the
liberty of guessing the LPC11Cxx also don't have those.

Sleep code did nothing outside of locking up the microcontroller
(because semihosting was enabled). Code seems to be copied from
LPC11u24, but the LPC1114 is fundamentally different. (For example
deep-sleep bit is now the deep-powerdown bit, which you dont want).

Aditionally it keeps current peripheral state during deepsleep and when
waking up. Datasheet rates LPC1114 at 6uA in deepsleep, I measured it at
3.7uA (WDOSC + BOD disabled). That makes me a happy panda.
