### PR TITLE
Change F411 to Cortex-M4F instead of Cortex-M4

### DIFF
--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -301,7 +301,7 @@ class NUCLEO_F401RE(Target):
 class NUCLEO_F411RE(Target):
     def __init__(self):
         Target.__init__(self)
-        self.core = "Cortex-M4"
+        self.core = "Cortex-M4F"
         self.extra_labels = ['STM', 'STM32F4', 'STM32F411RE']
         self.supported_toolchains = ["ARM", "uARM"]
         self.default_toolchain = "uARM"


### PR DESCRIPTION
Straightforward. Without this, the mbed-RTOS doesn't work for the F411.
