### PR TITLE
Fixed TARGET STM32F4XX spi_api.c syntax error

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4XX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4XX/spi_api.c
@@ -75,7 +75,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
     SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
     obj->spi = (SPI_TypeDef*)pinmap_merge(spi_data, spi_cntl);
-    MBED_ASSERT((int)obj->spi != NC)
+    MBED_ASSERT((int)obj->spi != NC);
 
     // enable power and clocking
     switch ((int)obj->spi) {


### PR DESCRIPTION
mbed library fails to build for stm32f4xx target due to syntax error in spi_api.c. I've checked other targets for similar error, but it turns out the code is OK.
