### PR TITLE
[Kinetis K] K64F and K20D50M - SPI Slave read bug fix

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_K20D50M/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_K20D50M/spi_api.c
@@ -165,6 +165,7 @@ int spi_slave_receive(spi_t *obj) {
 }
 
 int spi_slave_read(spi_t *obj) {
+    obj->spi->SR |= SPI_SR_RFDF_MASK;
     return obj->spi->POPR;
 }
 

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/TARGET_K64F/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/TARGET_K64F/spi_api.c
@@ -133,6 +133,7 @@ int spi_slave_receive(spi_t *obj) {
 }
 
 int spi_slave_read(spi_t *obj) {
+    dspi_hal_clear_status_flag(obj->instance, kDspiRxFifoDrainRequest);
     return dspi_hal_read_data(obj->instance);
 }
 


### PR DESCRIPTION
Thanks to Donald Potter for raising this issue.

Spi slave read() needs to clear Drain Request flag for Kinetis K platforms.
