### PR TITLE
Added fat library (switch --fat) to Travis libs build

### DIFF
--- a/workspace_tools/build_travis.py
+++ b/workspace_tools/build_travis.py
@@ -27,28 +27,28 @@ import sys
 # "libs" can contain "dsp", "rtos", "eth", "usb_host", "usb", "ublox", "fat"
 
 build_list = (
-    { "target": "LPC1768",       "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "eth", "usb_host", "usb", "ublox"] },
-    { "target": "LPC2368",       "toolchains": "GCC_ARM" },
-    { "target": "LPC11U24",      "toolchains": "GCC_ARM", "libs": ["dsp", "rtos"]},
-    { "target": "GHI_MBUINO",    "toolchains": "GCC_ARM"},
+    { "target": "LPC1768",       "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "eth", "usb_host", "usb", "ublox", "fat"] },
+    { "target": "LPC2368",       "toolchains": "GCC_ARM", "libs": ["fat"]  },
+    { "target": "LPC11U24",      "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
+    { "target": "GHI_MBUINO",    "toolchains": "GCC_ARM", "libs": ["fat"]  },
 
-    { "target": "LPC11U24_301",  "toolchains": "GCC_ARM" },
-    { "target": "NUCLEO_F103RB", "toolchains": "GCC_ARM"},
+    { "target": "LPC11U24_301",  "toolchains": "GCC_ARM", "libs": ["fat"] },
+    { "target": "NUCLEO_F103RB", "toolchains": "GCC_ARM", "libs": ["fat"] },
 
-    { "target": "NUCLEO_F401RE", "toolchains": "GCC_ARM", "libs": ["dsp", "rtos"]},
-    { "target": "LPC1114",       "toolchains": "GCC_ARM", "libs": ["dsp", "rtos"] },
-    { "target": "LPC11U35_401",  "toolchains": "GCC_ARM", "libs": ["dsp", "rtos"] },
-    { "target": "UBLOX_C027",    "toolchains": "GCC_ARM", "libs": ["dsp", "rtos"] },
-    { "target": "LPC11U35_501",  "toolchains": "GCC_ARM", "libs": ["dsp"] },
-    { "target": "LPC11U68",      "toolchains": "GCC_ARM", "libs": ["dsp", "rtos"] },
+    { "target": "NUCLEO_F401RE", "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
+    { "target": "LPC1114",       "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
+    { "target": "LPC11U35_401",  "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
+    { "target": "UBLOX_C027",    "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
+    { "target": "LPC11U35_501",  "toolchains": "GCC_ARM", "libs": ["dsp", "fat"] },
+    { "target": "LPC11U68",      "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
 
-    { "target": "KL05Z",         "toolchains": "GCC_ARM", "libs": ["dsp", "rtos"] },
-    { "target": "KL25Z",         "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "usb"] },
-    { "target": "KL46Z",         "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "usb"] },
-    { "target": "K20D50M",       "toolchains": "GCC_ARM", "libs": ["dsp"] },
-    { "target": "K64F",          "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "usb"] },
-    { "target": "LPC4088",       "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "usb"] },
-    { "target": "ARCH_PRO",      "toolchains": "GCC_ARM", "libs": ["dsp", "rtos"] },
+    { "target": "KL05Z",         "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
+    { "target": "KL25Z",         "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "usb", "fat"] },
+    { "target": "KL46Z",         "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "usb", "fat"] },
+    { "target": "K20D50M",       "toolchains": "GCC_ARM", "libs": ["dsp", "fat"] },
+    { "target": "K64F",          "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "usb", "fat"] },
+    { "target": "LPC4088",       "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "usb", "fat"] },
+    { "target": "ARCH_PRO",      "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
 )
 
 ################################################################################


### PR DESCRIPTION
# Description

Due to recent changes we can now use witch --fat to build library 'fat' which will build FAT FS and SDFileSystem into separate library.

Now we can add 'fat' library to targets built when build_travis.py script is launched to cover more libraries.
# Solution test

Checked 'fat' library builds with build_travis.py targets on devbox:

[git:master*] c:\Work\winbb\slave\BuildRelease\build\workspace_tools> build.py -m LPC1768,LPC2368,KL46Z,K20D50M,K64F,LPC4088,ARCH_PRO,LPC11U24,GHI_MBUINO,LPC11U24_301,NUCLEO_F103RB,NUCLEO_F401RE,LPC11
14,LPC11U35_401,UBLOX_C027,LPC11U35_501,LPC11U68,KL05Z,KL25Z,KL46Z -t GCC_ARM --fat
Building library CMSIS (LPC1768, GCC_ARM)
Building library MBED (LPC1768, GCC_ARM)
Building library FAT (LPC1768, GCC_ARM)
Building library CMSIS (LPC2368, GCC_ARM)
Building library MBED (LPC2368, GCC_ARM)
Building library FAT (LPC2368, GCC_ARM)
Building library CMSIS (KL46Z, GCC_ARM)
Building library MBED (KL46Z, GCC_ARM)
Building library FAT (KL46Z, GCC_ARM)
Building library CMSIS (K20D50M, GCC_ARM)
Building library MBED (K20D50M, GCC_ARM)
Building library FAT (K20D50M, GCC_ARM)
Building library CMSIS (K64F, GCC_ARM)
Building library MBED (K64F, GCC_ARM)
Building library FAT (K64F, GCC_ARM)
Building library CMSIS (LPC4088, GCC_ARM)
Building library MBED (LPC4088, GCC_ARM)
Building library FAT (LPC4088, GCC_ARM)
Building library CMSIS (ARCH_PRO, GCC_ARM)
Building library MBED (ARCH_PRO, GCC_ARM)
Building library FAT (ARCH_PRO, GCC_ARM)
Building library CMSIS (LPC11U24, GCC_ARM)
Building library MBED (LPC11U24, GCC_ARM)
Building library FAT (LPC11U24, GCC_ARM)
Building library CMSIS (GHI_MBUINO, GCC_ARM)
Building library MBED (GHI_MBUINO, GCC_ARM)
Building library FAT (GHI_MBUINO, GCC_ARM)
Building library CMSIS (LPC11U24_301, GCC_ARM)
Building library MBED (LPC11U24_301, GCC_ARM)
Building library FAT (LPC11U24_301, GCC_ARM)
Building library CMSIS (NUCLEO_F103RB, GCC_ARM)
Building library MBED (NUCLEO_F103RB, GCC_ARM)
Building library FAT (NUCLEO_F103RB, GCC_ARM)
Building library CMSIS (NUCLEO_F401RE, GCC_ARM)
Building library MBED (NUCLEO_F401RE, GCC_ARM)
Building library FAT (NUCLEO_F401RE, GCC_ARM)
Building library CMSIS (LPC1114, GCC_ARM)
Building library MBED (LPC1114, GCC_ARM)
Building library FAT (LPC1114, GCC_ARM)
Building library CMSIS (LPC11U35_401, GCC_ARM)
Building library MBED (LPC11U35_401, GCC_ARM)
Building library FAT (LPC11U35_401, GCC_ARM)
Building library CMSIS (UBLOX_C027, GCC_ARM)
Building library MBED (UBLOX_C027, GCC_ARM)
Building library FAT (UBLOX_C027, GCC_ARM)
Building library CMSIS (LPC11U35_501, GCC_ARM)
Building library MBED (LPC11U35_501, GCC_ARM)
Building library FAT (LPC11U35_501, GCC_ARM)
Building library CMSIS (LPC11U68, GCC_ARM)
Building library MBED (LPC11U68, GCC_ARM)
Building library FAT (LPC11U68, GCC_ARM)
Building library CMSIS (KL05Z, GCC_ARM)
Building library MBED (KL05Z, GCC_ARM)
Building library FAT (KL05Z, GCC_ARM)
Building library CMSIS (KL25Z, GCC_ARM)
Building library MBED (KL25Z, GCC_ARM)
Building library FAT (KL25Z, GCC_ARM)
Building library CMSIS (KL46Z, GCC_ARM)
Building library MBED (KL46Z, GCC_ARM)
Building library FAT (KL46Z, GCC_ARM)
Completed in: (7.31)s

Build successes:
- GCC_ARM::LPC1768
- GCC_ARM::LPC2368
- GCC_ARM::KL46Z
- GCC_ARM::K20D50M
- GCC_ARM::K64F
- GCC_ARM::LPC4088
- GCC_ARM::ARCH_PRO
- GCC_ARM::LPC11U24
- GCC_ARM::GHI_MBUINO
- GCC_ARM::LPC11U24_301
- GCC_ARM::NUCLEO_F103RB
- GCC_ARM::NUCLEO_F401RE
- GCC_ARM::LPC1114
- GCC_ARM::LPC11U35_401
- GCC_ARM::UBLOX_C027
- GCC_ARM::LPC11U35_501
- GCC_ARM::LPC11U68
- GCC_ARM::KL05Z
- GCC_ARM::KL25Z
- GCC_ARM::KL46Z
