### PR TITLE
for nRF51822 MCU, enable I/O mapping for I2C, SPI and UART when pinmap doesn't match

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/i2c_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/i2c_api.c
@@ -56,13 +56,17 @@ void twi_master_init(i2c_t *obj, PinName sda, PinName scl, int frequency) {
     i2c_interface_enable(obj);
 }
 void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
-    // determine the SPI to use
+    // determine the I2C to use
     I2CName i2c_sda = (I2CName)pinmap_peripheral(sda, PinMap_I2C_SDA);
     I2CName i2c_scl = (I2CName)pinmap_peripheral(scl, PinMap_I2C_SCL);
     I2CName i2c     = (I2CName)pinmap_merge(i2c_sda,i2c_scl);
+
+    if ((int)i2c == NC) {
+        // pinmap doesn't match, use I2C_0, for I2C_1 (SPI_1) is reserved for SPI
+        i2c = (I2CName)I2C_0; 
+    }
+
     obj->i2c        = (NRF_TWI_Type            *)i2c;
-    
-    MBED_ASSERT((int)obj->i2c != NC);
 
     obj->scl=scl;
     obj->sda=sda;

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
@@ -66,8 +66,10 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
     UARTName uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
     
-    MBED_ASSERT((int)uart != NC);
-    
+    if ((int)uart == NC) {
+        uart = (UARTName)UART_0;
+    }
+
     obj->uart = (NRF_UART_Type *)uart;
     
     //pin configurations --

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/spi_api.c
@@ -60,6 +60,11 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
     SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
     SPIName spi = (SPIName)pinmap_merge(spi_data, spi_cntl);
+
+    if ((int)spi == NC) {
+        spi = SPI_1;    // pinmap doesn't match, use SPI_1, for only SPI_1 supports SPI slave
+    }
+
     //SPIName
     if(ssel==NC){
         obj->spi = (NRF_SPI_Type*)spi;
@@ -69,9 +74,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         obj->spi = (NRF_SPI_Type*)NC;
         obj->spis = (NRF_SPIS_Type*)spi;
     }
-    MBED_ASSERT((int)obj->spi != NC || (int)obj->spis != NC);
 
-      // pin out the spi pins
+    // pin out the spi pins
     if (ssel != NC) {//slave
         obj->spis->POWER=0;
         obj->spis->POWER=1;


### PR DESCRIPTION
1. enable nRF51822 I/O mapping for I2C, SPI and UART
2. make I2C use I2C0 and SPI use SPI1, as I2C0 & SPI0 (or I2C1 & SPI1) share the same address and can't be used at the same time

The change only affects target Arch BLE
