### PR TITLE
Added count argument to disk read/write

### DIFF
--- a/libraries/USBDevice/USBMSD/USBMSD.cpp
+++ b/libraries/USBDevice/USBMSD/USBMSD.cpp
@@ -232,7 +232,7 @@ void USBMSD::memoryWrite (uint8_t * buf, uint16_t size) {
     // if the array is filled, write it in memory
     if (!((addr + size)%BlockSize)) {
         if (!(disk_status() & WRITE_PROTECT)) {
-            disk_write(page, addr/BlockSize);
+            disk_write(page, addr/BlockSize, 1);
         }
     }
 
@@ -257,7 +257,7 @@ void USBMSD::memoryVerify (uint8_t * buf, uint16_t size) {
 
     // beginning of a new block -> load a whole block in RAM
     if (!(addr%BlockSize))
-        disk_read(page, addr/BlockSize);
+        disk_read(page, addr/BlockSize, 1);
 
     // info are in RAM -> no need to re-read memory
     for (n = 0; n < size; n++) {
@@ -505,7 +505,7 @@ void USBMSD::memoryRead (void) {
 
     // we read an entire block
     if (!(addr%BlockSize))
-        disk_read(page, addr/BlockSize);
+        disk_read(page, addr/BlockSize, 1);
 
     // write data which are in RAM
     writeNB(EPBULK_IN, &page[addr%BlockSize], n, MAX_PACKET_SIZE_EPBULK);

--- a/libraries/USBDevice/USBMSD/USBMSD.h
+++ b/libraries/USBDevice/USBMSD/USBMSD.h
@@ -88,22 +88,24 @@ public:
 protected:
 
     /*
-    * read a block on a storage chip
+    * read one or more blocks on a storage chip
     *
     * @param data pointer where will be stored read data
-    * @param block block number
+    * @param block starting block number
+    * @param count number of blocks to read
     * @returns 0 if successful
     */
-    virtual int disk_read(uint8_t * data, uint64_t block) = 0;
+    virtual int disk_read(uint8_t* data, uint64_t block, uint8_t count) = 0;
 
     /*
-    * write a block on a storage chip
+    * write one or more blocks on a storage chip
     *
     * @param data data to write
-    * @param block block number
+    * @param block starting block number
+    * @param count number of blocks to write
     * @returns 0 if successful
     */
-    virtual int disk_write(const uint8_t * data, uint64_t block) = 0;
+    virtual int disk_write(const uint8_t* data, uint64_t block, uint8_t count) = 0;
 
     /*
     * Disk initilization

--- a/libraries/USBHost/USBHostMSD/USBHostMSD.h
+++ b/libraries/USBHost/USBHostMSD/USBHostMSD.h
@@ -59,8 +59,8 @@ protected:
     // From FATFileSystem
     virtual int disk_initialize();
     virtual int disk_status() {return 0;};
-    virtual int disk_read(uint8_t * buffer, uint64_t sector);
-    virtual int disk_write(const uint8_t * buffer, uint64_t sector);
+    virtual int disk_read(uint8_t* buffer, uint64_t sector, uint8_t count);
+    virtual int disk_write(const uint8_t* buffer, uint64_t sector, uint8_t count);
     virtual int disk_sync() {return 0;};
     virtual uint64_t disk_sectors();
 

--- a/libraries/fs/fat/ChaN/diskio.cpp
+++ b/libraries/fs/fat/ChaN/diskio.cpp
@@ -36,15 +36,10 @@ DRESULT disk_read (
 )
 {
     debug_if(FFS_DBG, "disk_read(sector %d, count %d) on drv [%d]\n", sector, count, drv);
-    for(DWORD s=sector; s<sector+count; s++) {
-        debug_if(FFS_DBG, " disk_read(sector %d)\n", s);
-        int res = FATFileSystem::_ffs[drv]->disk_read((uint8_t*)buff, s);
-        if(res) {
-            return RES_PARERR;
-        }
-        buff += 512;
-    }
-    return RES_OK;
+    if (FATFileSystem::_ffs[drv]->disk_read((uint8_t*)buff, sector, count))
+        return RES_PARERR;
+    else
+        return RES_OK;
 }
 
 #if _READONLY == 0
@@ -56,15 +51,10 @@ DRESULT disk_write (
 )
 {
     debug_if(FFS_DBG, "disk_write(sector %d, count %d) on drv [%d]\n", sector, count, drv);
-    for(DWORD s = sector; s < sector + count; s++) {
-        debug_if(FFS_DBG, " disk_write(sector %d)\n", s);
-        int res = FATFileSystem::_ffs[drv]->disk_write((uint8_t*)buff, s);
-        if(res) {
-            return RES_PARERR;
-        }
-        buff += 512;
-    }
-    return RES_OK;
+    if (FATFileSystem::_ffs[drv]->disk_write((uint8_t*)buff, sector, count))
+        return RES_PARERR;
+    else
+        return RES_OK;
 }
 #endif /* _READONLY */
 

--- a/libraries/fs/fat/FATFileSystem.h
+++ b/libraries/fs/fat/FATFileSystem.h
@@ -29,6 +29,9 @@
 
 using namespace mbed;
 
+/**
+ * FATFileSystem based on ChaN's Fat Filesystem library v0.8 
+ */
 class FATFileSystem : public FileSystemLike {
 public:
 
@@ -39,19 +42,50 @@ public:
     FATFS _fs;                               // Work area (file system object) for logical drive
     int _fsid;
 
+    /**
+     * Opens a file on the filesystem
+     */
     virtual FileHandle *open(const char* name, int flags);
+    
+    /**
+     * Removes a file path
+     */
     virtual int remove(const char *filename);
+    
+    /**
+     * Renames a file
+     */
     virtual int rename(const char *oldname, const char *newname);
+    
+    /**
+     * Formats a logical drive, FDISK artitioning rule, 512 bytes per cluster
+     */
     virtual int format();
+    
+    /**
+     * Opens a directory on the filesystem
+     */
     virtual DirHandle *opendir(const char *name);
+    
+    /**
+     * Creates a directory path
+     */
     virtual int mkdir(const char *name, mode_t mode);
+    
+    /**
+     * Mounts the filesystem
+     */
     virtual int mount();
+    
+    /**
+     * Unmounts the filesystem
+     */
     virtual int unmount();
 
     virtual int disk_initialize() { return 0; }
     virtual int disk_status() { return 0; }
-    virtual int disk_read(uint8_t * buffer, uint64_t sector) = 0;
-    virtual int disk_write(const uint8_t * buffer, uint64_t sector) = 0;
+    virtual int disk_read(uint8_t * buffer, uint64_t sector, uint8_t count) = 0;
+    virtual int disk_write(const uint8_t * buffer, uint64_t sector, uint8_t count) = 0;
     virtual int disk_sync() { return 0; }
     virtual uint64_t disk_sectors() = 0;
 

--- a/libraries/fs/sd/SDFileSystem.cpp
+++ b/libraries/fs/sd/SDFileSystem.cpp
@@ -223,33 +223,41 @@ int SDFileSystem::disk_initialize() {
     return 0;
 }
 
-int SDFileSystem::disk_write(const uint8_t *buffer, uint64_t block_number) {
+int SDFileSystem::disk_write(const uint8_t* buffer, uint64_t block_number, uint8_t count) {
     if (!_is_initialized) {
         return -1;
     }
-
-    // set write address for single block (CMD24)
-    if (_cmd(24, block_number * cdv) != 0) {
-        return 1;
+    
+    for (uint64_t b = block_number; b < block_number + count; b++) {
+        // set write address for single block (CMD24)
+        if (_cmd(24, b * cdv) != 0) {
+            return 1;
+        }
+        
+        // send the data block
+        _write(buffer, 512);
+        buffer += 512;
     }
-
-    // send the data block
-    _write(buffer, 512);
+    
     return 0;
 }
 
-int SDFileSystem::disk_read(uint8_t *buffer, uint64_t block_number) {
+int SDFileSystem::disk_read(uint8_t* buffer, uint64_t block_number, uint8_t count) {
     if (!_is_initialized) {
         return -1;
     }
-
-    // set read address for single block (CMD17)
-    if (_cmd(17, block_number * cdv) != 0) {
-        return 1;
+    
+    for (uint64_t b = block_number; b < block_number + count; b++) {
+        // set read address for single block (CMD17)
+        if (_cmd(17, b * cdv) != 0) {
+            return 1;
+        }
+        
+        // receive the data
+        _read(buffer, 512);
+        buffer += 512;
     }
 
-    // receive the data
-    _read(buffer, 512);
     return 0;
 }
 

--- a/libraries/fs/sd/SDFileSystem.h
+++ b/libraries/fs/sd/SDFileSystem.h
@@ -54,8 +54,8 @@ public:
     SDFileSystem(PinName mosi, PinName miso, PinName sclk, PinName cs, const char* name);
     virtual int disk_initialize();
     virtual int disk_status();
-    virtual int disk_read(uint8_t * buffer, uint64_t block_number);
-    virtual int disk_write(const uint8_t * buffer, uint64_t block_number);
+    virtual int disk_read(uint8_t* buffer, uint64_t block_number, uint8_t count);
+    virtual int disk_write(const uint8_t* buffer, uint64_t block_number, uint8_t count);
     virtual int disk_sync();
     virtual uint64_t disk_sectors();
 


### PR DESCRIPTION
The count argument in disk_read() and disk_write() is now passed to the FATFileSystem instance. This allows more efficient disk drivers to be written that can read and write multiple sectors at a time.
