### PR TITLE
Adds standard DONT_CARE pin name for specifying that any pin will work

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
@@ -27,16 +27,6 @@
  ******************************************************************************/
 #define UART_NUM    1
 
-static const PinMap PinMap_UART_TX[] = {
-    {TX_PIN_NUMBER, UART_0, 1},
-    { NC  , NC    , 0}
-};
-
-static const PinMap PinMap_UART_RX[] = {
-    {RX_PIN_NUMBER, UART_0, 1},
-    {NC   , NC    , 0}
-};
-
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 static uint32_t acceptedSpeeds[16][2] = {{1200,UART_BAUDRATE_BAUDRATE_Baud1200},
@@ -61,10 +51,7 @@ serial_t stdio_uart;
 
 
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
-    // determine the UART to use -- for mcu's with multiple uart connections
-    UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
-    UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
-    UARTName uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
+    UARTName uart = UART_0;
     
     MBED_ASSERT((int)uart != NC);
     


### PR DESCRIPTION
This patch dds a standard DONT_CARE pin name that allows specifying that any pin will work in a pin map.  This is currently used in the nRF51822 serial API to allow specifying any pins as a UART.

On a chip like the nRF51822 that supports mapping functions to any arbitrary pin, it seems overly restrictive to limit a user to only use a set of pin mappings.

In my case I built a custom board that has a USB to UART and another port that could either be a UART or a number of other functions.  I need to be able to map the UART to one of two different pin sets.  This isn't supported by the PinMap in the nRF51822 serial_api.c.

I"m open to suggestions if someone has a better way of implementing this.
