### PR TITLE
LPC4330_M4 port_api, us_ticker update

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC43XX/LPC43xx.h
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC43XX/LPC43xx.h
@@ -1204,10 +1204,10 @@ typedef enum CCU_CLK {
 /*
  * Audio or USB PLL selection
  */
-typedef enum CHIP_CGU_USB_AUDIO_PLL {
+typedef enum CGU_USB_AUDIO_PLL {
     CGU_USB_PLL,
     CGU_AUDIO_PLL
-} CHIP_CGU_USB_AUDIO_PLL_T;
+} CGU_USB_AUDIO_PLL_T;
 
 /*
  * PLL register block
@@ -1264,7 +1264,7 @@ typedef struct {                        /* (@ 0x40052000) CCU2 Structure        
  */
 #define LPC_RGU_BASE              0x40053000
 
-typedef enum CHIP_RGU_RST {
+typedef enum RGU_RST {
     RGU_CORE_RST,
     RGU_PERIPH_RST,
     RGU_MASTER_RST,
@@ -1313,7 +1313,7 @@ typedef enum CHIP_RGU_RST {
     RGU_SPI_RST,
 #endif
     RGU_LAST_RST = 63,
-} CHIP_RGU_RST_T;
+} RGU_RST_T;
 
 typedef struct {                        /* RGU Structure          */
     __I  uint32_t  RESERVED0[64];
@@ -1498,7 +1498,7 @@ typedef struct {
 #define SCU_PINIO_PULLNONE         (SCU_MODE_INACT | SCU_MODE_INBUFF_EN)
 
 /* Calculate SCU offset and register address from group and pin number */
-#define SCU_OFF(group, num)        ((0x80 * group) + (0x04 * num))
+#define SCU_OFF(group, num)        ((group << 7) + (num << 2))
 #define SCU_REG(group, num)        ((__IO uint32_t *)(LPC_SCU_BASE + SCU_OFF(group, num)))
 
 /**

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC43XX/system_LPC43xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC43XX/system_LPC43xx.c
@@ -98,8 +98,8 @@ static const struct CLK_BASE_STATES clock_states[] = {
     {CLK_BASE_PHY_RX, CLKIN_ENET_RX, 0},
 #endif
     {CLK_BASE_SDIO, CLKIN_MAINPLL, 0},
-    {CLK_BASE_SSP0, CLKIN_MAINPLL, 0},
-    {CLK_BASE_SSP1, CLKIN_MAINPLL, 0},
+    {CLK_BASE_SSP0, CLKIN_IDIVC, 0},
+    {CLK_BASE_SSP1, CLKIN_IDIVC, 0},
     {CLK_BASE_UART0, CLKIN_MAINPLL, 0},
     {CLK_BASE_UART1, CLKIN_MAINPLL, 0},
     {CLK_BASE_UART2, CLKIN_MAINPLL, 0},
@@ -237,6 +237,11 @@ void SystemSetupClock(void)
 
     /* Switch main clock to Internal RC (IRC) while setting up PLL1 */
     LPC_CGU->BASE_CLK[CLK_BASE_MX] = (1 << 11) | (CLKIN_IRC << 24);
+    /* Set prescaler/divider on SSP1 assuming 204 MHz clock */
+    LPC_SSP1->CR1 &= ~(1 << 1);
+    LPC_SSP1->CPSR = 0x0002;
+    LPC_SSP1->CR0 = 0x00006507;
+    LPC_SSP1->CR1 |= (1 << 1);
 
     /* Enable the oscillator and wait 100 us */
     LPC_CGU->XTAL_OSC_CTRL = 0;
@@ -291,6 +296,9 @@ void SystemSetupClock(void)
                          | (1 << 11) | (clock_states[i].clkin << 24);
     }
 #endif /* CLOCK_SETUP */
+    /* Reset peripherals */
+    LPC_RGU->RESET_CTRL0 = 0x105F0000;
+    LPC_RGU->RESET_CTRL1 = 0x01DFF7FF;
 }
 
 /*

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/gpio_api.c
@@ -37,7 +37,7 @@ void gpio_init(gpio_t *obj, PinName pin) {
 
     obj->mask = gpio_set(pin);
 
-    LPC_GPIO_T *port_reg = (LPC_GPIO_T *) (LPC_GPIO_PORT_BASE);
+    LPC_GPIO_T *port_reg = (LPC_GPIO_T *)(LPC_GPIO_PORT_BASE);
     unsigned int port = (unsigned int)MBED_GPIO_PORT(pin);
 
     obj->reg_set = &port_reg->SET[port];
@@ -57,7 +57,7 @@ void gpio_dir(gpio_t *obj, PinDirection direction) {
             *obj->reg_dir &= ~obj->mask;
             break;
         case PIN_OUTPUT:
-            *obj->reg_dir |=  obj->mask;
+            *obj->reg_dir |= obj->mask;
             break;
     }
 }

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/port_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/port_api.c
@@ -15,21 +15,95 @@
  *
  * Ported to NXP LPC43XX by Micromint USA <support@micromint.com>
  */
+#include "mbed_assert.h"
 #include "port_api.h"
 #include "pinmap.h"
 #include "gpio_api.h"
 
+// Lookup table to determine SCU offset for GPIO [port][pin]
+// Supports eight 16-bit ports to limit table size
+#define _SO(MBED_PIN)            (MBED_PIN >> 18)
+
+static const uint8_t _scu_off[][16] =
+{   // GPIO0 to GPIO3
+    { _SO(GPIO0_0),  _SO(GPIO0_1),  _SO(GPIO0_2),  _SO(GPIO0_3),
+      _SO(GPIO0_4),  _SO(GPIO0_5),  _SO(GPIO0_6),  _SO(GPIO0_7),
+      _SO(GPIO0_8),  _SO(GPIO0_9),  _SO(GPIO0_10), _SO(GPIO0_11),
+      _SO(GPIO0_12), _SO(GPIO0_13), _SO(GPIO0_14), _SO(GPIO0_15)
+    },
+    { _SO(GPIO1_0),  _SO(GPIO1_1),  _SO(GPIO1_2),  _SO(GPIO1_3),
+      _SO(GPIO1_4),  _SO(GPIO1_5),  _SO(GPIO1_6),  _SO(GPIO1_7),
+      _SO(GPIO1_8),  _SO(GPIO1_9),  _SO(GPIO1_10), _SO(GPIO1_11),
+      _SO(GPIO1_12), _SO(GPIO1_13), _SO(GPIO1_14), _SO(GPIO1_15)
+    },
+    { _SO(GPIO2_0),  _SO(GPIO2_1),  _SO(GPIO2_2),  _SO(GPIO2_3),
+      _SO(GPIO2_4),  _SO(GPIO2_5),  _SO(GPIO2_6),  _SO(GPIO2_7),
+      _SO(GPIO2_8),  _SO(GPIO2_9),  _SO(GPIO2_10), _SO(GPIO2_11),
+      _SO(GPIO2_12), _SO(GPIO2_13), _SO(GPIO2_14), _SO(GPIO2_15)
+    },
+    { _SO(GPIO3_0),  _SO(GPIO3_1),  _SO(GPIO3_2),  _SO(GPIO3_3),
+      _SO(GPIO3_4),  _SO(GPIO3_5),  _SO(GPIO3_6),  _SO(GPIO3_7),
+      _SO(GPIO3_8),  _SO(GPIO3_9),  _SO(GPIO3_10), _SO(GPIO3_11),
+      _SO(GPIO3_12), _SO(GPIO3_13), _SO(GPIO3_14), _SO(GPIO3_15)
+    },
+};
+
+// Use alternate encoding for ports 4 to 7 so lookup stays within uint8
+#define _S2(MBED_PIN)            (((MBED_PIN >> 19) & 0xf0) | ((MBED_PIN >> 18) & 0x0f))
+
+static const uint8_t _scu_off2[][16] = 
+{   // GPIO4 to GPIO7
+    { _S2(GPIO4_0),  _S2(GPIO4_1),  _S2(GPIO4_2),  _S2(GPIO4_3),
+      _S2(GPIO4_4),  _S2(GPIO4_5),  _S2(GPIO4_6),  _S2(GPIO4_7),
+      _S2(GPIO4_8),  _S2(GPIO4_9),  _S2(GPIO4_10), _S2(GPIO4_11),
+      _S2(GPIO4_12), _S2(GPIO4_13), _S2(GPIO4_14), _S2(GPIO4_15)
+    },
+    { _S2(GPIO5_0),  _S2(GPIO5_1),  _S2(GPIO5_2),  _S2(GPIO5_3),
+      _S2(GPIO5_4),  _S2(GPIO5_5),  _S2(GPIO5_6),  _S2(GPIO5_7),
+      _S2(GPIO5_8),  _S2(GPIO5_9),  _S2(GPIO5_10), _S2(GPIO5_11),
+      _S2(GPIO5_12), _S2(GPIO5_13), _S2(GPIO5_14), _S2(GPIO5_15)
+    },
+    { _S2(GPIO6_0),  _S2(GPIO6_1),  _S2(GPIO6_2),  _S2(GPIO6_3),
+      _S2(GPIO6_4),  _S2(GPIO6_5),  _S2(GPIO6_6),  _S2(GPIO6_7),
+      _S2(GPIO6_8),  _S2(GPIO6_9),  _S2(GPIO6_10), _S2(GPIO6_11),
+      _S2(GPIO6_12), _S2(GPIO6_13), _S2(GPIO6_14), _S2(GPIO6_15)
+    },
+    { _S2(GPIO7_0),  _S2(GPIO7_1),  _S2(GPIO7_2),  _S2(GPIO7_3),
+      _S2(GPIO7_4),  _S2(GPIO7_5),  _S2(GPIO7_6),  _S2(GPIO7_7),
+      _S2(GPIO7_8),  _S2(GPIO7_9),  _S2(GPIO7_10), _S2(GPIO7_11),
+      _S2(GPIO7_12), _S2(GPIO7_13), _S2(GPIO7_14), _S2(GPIO7_15)
+    },
+};
+
 PinName port_pin(PortName port, int pin_n) {
-    return (PinName)(LPC_GPIO_PORT_BASE + ((port << PORT_SHIFT) | pin_n));
+    MBED_ASSERT((port <= Port7) && (pin_n < 32));
+    int offset = 0;
+
+    // Lookup table only maps pins 0 to 15
+    if (pin_n > 15) {
+        return NC;
+    }
+
+    // Lookup SCU offset
+    if (port < Port4) {
+        offset = _scu_off[port][pin_n];
+    } else {
+        offset = _scu_off2[port - Port4][pin_n];
+        offset = ((offset & 0xf0) << 1) | (offset & 0x0f);
+    }
+
+    // Return pin name
+    return (PinName)((offset << 18) | GPIO_OFF(port, pin_n));
 }
 
 void port_init(port_t *obj, PortName port, int mask, PinDirection dir) {
     obj->port = port;
     obj->mask = mask;
     
-    LPC_GPIO_T *port_reg = (LPC_GPIO_T *)(LPC_GPIO_PORT_BASE + ((int)port << PORT_SHIFT));
+    LPC_GPIO_T *port_reg = (LPC_GPIO_T *)(LPC_GPIO_PORT_BASE);
     
-    port_reg->MASK[port] = ~mask;
+    // Do not use masking, because it prevents the use of the unmasked pins
+    // obj->MASK[port] = ~mask;
     
     obj->reg_out = &port_reg->PIN[port];
     obj->reg_in  = &port_reg->PIN[port];
@@ -42,7 +116,7 @@ void port_init(port_t *obj, PortName port, int mask, PinDirection dir) {
             gpio_set(port_pin(obj->port, i));
         }
     }
-    
+
     port_dir(obj, dir);
 }
 

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/us_ticker.c
@@ -50,7 +50,7 @@ uint32_t us_ticker_read() {
 
 void us_ticker_set_interrupt(unsigned int timestamp) {
     // set match value
-    US_TICKER_TIMER->MR[3] = timestamp;
+    US_TICKER_TIMER->MR[0] = timestamp;
     // enable match interrupt
     US_TICKER_TIMER->MCR |= 1;
 }


### PR DESCRIPTION
Corrects reported issues with port_api and us_ticker HAL drivers on LPC4330_M4 platform. A lookup table was implemented to support the port_pin() API. This mapping is required since the LPC43xx GPIO pin name is not the same as the MCU pin name. For example, GPIO3[7] uses pin P6_11, not P3_7.
