### PR TITLE
Macros are not passed down to toolchain for compilation

### DIFF
--- a/workspace_tools/toolchains/__init__.py
+++ b/workspace_tools/toolchains/__init__.py
@@ -32,7 +32,7 @@ import workspace_tools.hooks as hooks
 import re
 
 #Disables multiprocessing if set to higher number than the host machine CPUs
-CPU_COUNT_MIN = 1 
+CPU_COUNT_MIN = 1
 
 def print_notify(event):
     # Default command line notification
@@ -74,7 +74,7 @@ def compile_worker(job):
             'output': stderr,
             'command': command
         })
-    
+
     return {
         'source': job['source'],
         'object': job['object'],
@@ -235,11 +235,11 @@ class mbedToolchain:
         self.build_all = False
         self.timestamp = time()
         self.jobs = 1
-        
+
         self.CHROOT = None
-        
+
         self.mp_pool = None
-        
+
     def __exit__(self):
         if self.mp_pool is not None:
             self.mp_pool.terminate()
@@ -271,8 +271,9 @@ class mbedToolchain:
                 self.symbols.append('MBED_USERNAME=' + MBED_ORG_USER)
 
             # Add target's symbols
-            for macro in self.target.macros:
-                self.symbols.append(macro)
+            self.symbols += self.target.macros
+            # Add extra symbols passed via 'macros' parameter
+            self.symbols += self.macros
 
             # Form factor variables
             if hasattr(self.target, 'supported_form_factors'):
@@ -310,7 +311,7 @@ class mbedToolchain:
                 return True
 
         return False
-        
+
     def scan_resources(self, path):
         labels = self.get_labels()
         resources = Resources(path)
@@ -426,38 +427,38 @@ class mbedToolchain:
         obj_dir = join(build_path, relpath(source_dir, base_dir))
         mkdir(obj_dir)
         return join(obj_dir, name + '.o')
-        
+
     def compile_sources(self, resources, build_path, inc_dirs=None):
         # Web IDE progress bar for project build
         files_to_compile = resources.s_sources + resources.c_sources + resources.cpp_sources
         self.to_be_compiled = len(files_to_compile)
         self.compiled = 0
-        
+
         #for i in self.build_params:
         #    self.debug(i)
         #    self.debug("%s" % self.build_params[i])
-        
+
         inc_paths = resources.inc_dirs
         if inc_dirs is not None:
             inc_paths.extend(inc_dirs)
-        
+
         objects = []
         queue = []
         prev_dir = None
-        
+
         # The dependency checking for C/C++ is delegated to the compiler
         base_path = resources.base_path
         files_to_compile.sort()
         for source in files_to_compile:
             _, name, _ = split_path(source)
             object = self.relative_object_path(build_path, base_path, source)
-            
+
             # Avoid multiple mkdir() calls on same work directory
             work_dir = dirname(object)
             if work_dir is not prev_dir:
                 prev_dir = work_dir
                 mkdir(work_dir)
-            
+
             # Queue mode (multiprocessing)
             commands = self.compile_command(source, object, inc_paths)
             if commands is not None:
@@ -481,7 +482,7 @@ class mbedToolchain:
     def compile_seq(self, queue, objects):
         for item in queue:
             result = compile_worker(item)
-            
+
             self.compiled += 1
             self.progress("compile", item['source'], build_update=True)
             for res in result['results']:
@@ -497,7 +498,7 @@ class mbedToolchain:
     def compile_queue(self, queue, objects):
         jobs_count = int(self.jobs if self.jobs else cpu_count())
         p = Pool(processes=jobs_count)
-        
+
         results = []
         for i in range(len(queue)):
             results.append(p.apply_async(compile_worker, [queue[i]]))
@@ -509,7 +510,7 @@ class mbedToolchain:
                 p.terminate()
                 p.join()
                 raise ToolException("Compile did not finish in 5 minutes")
-            
+
             pending = 0
             for r in results:
                 if r._ready is True:
@@ -535,7 +536,7 @@ class mbedToolchain:
                     pending += 1
                     if pending > jobs_count:
                         break
-                    
+
 
             if len(results) == 0:
                 break
@@ -544,15 +545,15 @@ class mbedToolchain:
 
         results = None
         p.terminate()
-        p.join()        
-        
+        p.join()
+
         return objects
 
     def compile_command(self, source, object, includes):
         # Check dependencies
         _, ext = splitext(source)
         ext = ext.lower()
-        
+
         if ext == '.c' or  ext == '.cpp':
             base, _ = splitext(object)
             dep_path = base + '.d'
@@ -568,19 +569,19 @@ class mbedToolchain:
                 return self.assemble(source, object, includes)
         else:
             return False
-        
+
         return None
-        
+
     def compile_output(self, output=[]):
         rc = output[0]
         stderr = output[1]
         command = output[2]
-        
+
         # Parse output for Warnings and Errors
         self.parse_output(stderr)
         self.debug("Return: %s" % rc)
         self.debug("Output: %s" % stderr)
-        
+
         # Check return code
         if rc != 0:
             raise ToolException(stderr)
@@ -588,17 +589,17 @@ class mbedToolchain:
     def compile(self, cc, source, object, includes):
         _, ext = splitext(source)
         ext = ext.lower()
-        
+
         command = cc + ['-D%s' % s for s in self.get_symbols()] + ["-I%s" % i for i in includes] + ["-o", object, source]
-        
+
         if hasattr(self, "get_dep_opt"):
             base, _ = splitext(object)
             dep_path = base + '.d'
             command.extend(self.get_dep_opt(dep_path))
-        
+
         if hasattr(self, "cc_extra"):
             command.extend(self.cc_extra(base))
-            
+
         return [command]
 
     def compile_c(self, source, object, includes):
@@ -650,7 +651,7 @@ class mbedToolchain:
         stdout, stderr, rc = run_cmd(command)
         self.debug("Return: %s" % rc)
         self.debug("Output: %s" % ' '.join(stdout))
-        
+
         if rc != 0:
             for line in stderr.splitlines():
                 self.tool_error(line)


### PR DESCRIPTION
# Problem:
- After last compilation improvement macros passed to toolchain object for compilation were not added to compilation symbols' list. 
- macros and inc_dirs are used to change the way build scripts compile libraries. In case of cpputest library additional macros are in order (e.g. to remove some memory management etc.). Because macros were not included cpputest library and related tests failed to compile.
  # Changes:
- added self.macros to self.symbols list/
- changed way self.symbols is updated with target symbols.
- removed trailing spaces from code (sorry for that, it makes this pull not so clear to read).
# Issue Traceback:

``` python
Compile: MemoryLeakWarningPlugin.cpp
[Warning] Utest.h@200:  #1300-D: testBody inherits implicit virtual
[Warning] Utest.h@221:  #1300-D: createTest inherits implicit virtual
[Warning] TestOutput.h@145:  #1300-D: printBuffer inherits implicit virtual
[Warning] TestOutput.h@150:  #1300-D: flush inherits implicit virtual
[Error] MemoryLeakWarningPlugin.cpp@110:  #540: support for exception handling is disabled; use --exceptions to enable
[Error] MemoryLeakWarningPlugin.cpp@122:  #540: support for exception handling is disabled; use --exceptions to enable
[Error] MemoryLeakWarningPlugin.cpp@129:  #540: support for exception handling is disabled; use --exceptions to enable
[Error] MemoryLeakWarningPlugin.cpp@141:  #540: support for exception handling is disabled; use --exceptions to enable
[Error] MemoryLeakWarningPlugin.cpp@160:  #540: support for exception handling is disabled; use --exceptions to enable
[Error] MemoryLeakWarningPlugin.cpp@172:  #540: support for exception handling is disabled; use --exceptions to enable
[Error] MemoryLeakWarningPlugin.cpp@179:  #540: support for exception handling is disabled; use --exceptions to enable
[Error] MemoryLeakWarningPlugin.cpp@191:  #540: support for exception handling is disabled; use --exceptions to enable
Traceback (most recent call last):
  File "C:\Work\winbb\slave\BuildRelease\build\workspace_tools\singletest.py", line 194, in <module>
    singletest_in_cli_mode(single_test)
  File "C:\Work\winbb\slave\BuildRelease\build\workspace_tools\test_api.py", line 1119, in singletest_in_cli_mode
    test_summary, shuffle_seed = single_test.execute()
  File "C:\Work\winbb\slave\BuildRelease\build\workspace_tools\test_api.py", line 352, in execute
    jobs=self.opts_jobs)
  File "C:\Work\winbb\slave\BuildRelease\build\workspace_tools\build_api.py", line 170, in build_lib
    verbose=verbose, clean=clean, macros=MACROS, notify=notify, inc_dirs=lib.inc_dirs, jobs=jobs)
  File "C:\Work\winbb\slave\BuildRelease\build\workspace_tools\build_api.py", line 155, in build_library
    objects.extend(toolchain.compile_sources(resource, tmp_path, dependencies_include_dir))
  File "C:\Work\winbb\slave\BuildRelease\build\workspace_tools\toolchains\__init__.py", line 479, in compile_sources
    return self.compile_seq(queue, objects)
  File "C:\Work\winbb\slave\BuildRelease\build\workspace_tools\toolchains\__init__.py", line 492, in compile_seq
    res['command']
  File "C:\Work\winbb\slave\BuildRelease\build\workspace_tools\toolchains\__init__.py", line 586, in compile_output
    raise ToolException(stderr)
workspace_tools.utils.ToolException: "no source": Warning:  #3036-D: "C:/Work/toolchains/ARMCompiler_5.03_117_Windows\include" was specified as both a system and non-system include directory -- the non-system entry will be ignored
```
