### PR TITLE
Changed "Cortex-M4" to "Cortex-M4F"

### DIFF
--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -315,7 +315,7 @@ class NUCLEO_F401RE(Target):
 class NUCLEO_F411RE(Target):
     def __init__(self):
         Target.__init__(self)
-        self.core = "Cortex-M4"
+        self.core = "Cortex-M4F"
         self.extra_labels = ['STM', 'STM32F4', 'STM32F411RE']
         self.supported_toolchains = ["ARM", "uARM"]
         self.default_toolchain = "uARM"


### PR DESCRIPTION
This got reverted but wasn't added back in the last SDK build. Would appreciate if the online compiler would include this.
