### PR TITLE
Removed direct use of r7 in inline asm, which caused GCC to abort as it is used as a frame pointer.

### DIFF
--- a/libraries/rtos/rtx/rt_CMSIS.c
+++ b/libraries/rtos/rtx/rt_CMSIS.c
@@ -195,16 +195,18 @@ typedef uint32_t __attribute__((vector_size(16))) ret128;
   SVC_ArgR(3,t4,a4)
 
 #if (defined (__CORTEX_M0)) || defined (__CORTEX_M0PLUS)
-#define SVC_Call(f)                                                            \
-  __asm volatile                                                                 \
+#define SVC_Call(f) do {                                                       \
+  register int tmp;                                                            \
+  __asm volatile                                                               \
   (                                                                            \
-    "ldr r7,="#f"\n\t"                                                         \
-    "mov r12,r7\n\t"                                                           \
+    "ldr %[tmp],="#f"\n\t"                                                     \
+    "mov r12,%[tmp]\n\t"                                                       \
     "svc 0"                                                                    \
-    :               "=r" (__r0), "=r" (__r1), "=r" (__r2), "=r" (__r3)         \
-    :                "r" (__r0),  "r" (__r1),  "r" (__r2),  "r" (__r3)         \
-    : "r7", "r12", "lr", "cc"                                                  \
-  );
+    : [tmp] "=r" (tmp), "=r" (__r0), "=r" (__r1), "=r" (__r2), "=r" (__r3)     \
+    :                    "r" (__r0),  "r" (__r1),  "r" (__r2),  "r" (__r3)     \
+    : "r12", "lr", "cc"                                                        \
+  );                                                                           \
+} while (0)
 #else
 #define SVC_Call(f)                                                            \
   __asm volatile                                                                 \


### PR DESCRIPTION
I initially reported this on mbed.org forum (http://mbed.org/forum/bugs-suggestions/topic/5112/), and was instructed to re-send it as a pull request. So, here it is.
# Patch Description

I'm currently doing offline development with the mbed SDK, and noticed it fails to build under certain condition with a following error:

```
# python build.py -t GCC_ARM -m LPC1114 -o debug-info -r
...
Building library RTX (LPC1114, GCC_ARM)
Compile: rt_CMSIS.c
[Error] rt_CMSIS.c@588: In function 'osKernelInitialize': r7 cannot be used in asm here
c:\src\mbed\libraries\rtos\rtx\rt_CMSIS.c: In function 'osKernelInitialize':
c:\src\mbed\libraries\rtos\rtx\rt_CMSIS.c:588:1: error: r7 cannot be used in asm here
 }
 ^
```

Culpit is the following code in rt_CMSIS.c:

``` c
#if (defined (__CORTEX_M0)) || defined (__CORTEX_M0PLUS)
#define SVC_Call(f)                                                            \
  __asm volatile                                                                 \
  (                                                                            \
    "ldr r7,="#f"\n\t"                                                         \
    "mov r12,r7\n\t"                                                           \
    "svc 0"                                                                    \
    :               "=r" (__r0), "=r" (__r1), "=r" (__r2), "=r" (__r3)         \
    :                "r" (__r0),  "r" (__r1),  "r" (__r2),  "r" (__r3)         \
    : "r7", "r12", "lr", "cc"                                                  \
  );
#else
```

Cortex-M0 LDR has a limitation that it cannot directly load value into upper register (r12), and that's why r7 is being used as a temporary register. However, that breaks GCC on debug build since GCC is also using r7 as frame pointer.

An easy fix would be to change r7 into something else in lower register, say r6. However, to avoid writing temporary register name in asm, my patch allows compiler to allocate available register.
