### PR TITLE
STMs: Microlib heap fix for new, malloc and friends

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F030R8/TOOLCHAIN_ARM_MICRO/startup_stm32f030.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F030R8/TOOLCHAIN_ARM_MICRO/startup_stm32f030.s
@@ -54,7 +54,7 @@ Heap_Size       EQU     0x00000400
                 
 __heap_base
 Heap_Mem        SPACE   Heap_Size
-__heap_limit
+__heap_limit    EQU (__initial_sp - Stack_Size)
 
                 PRESERVE8
                 THUMB

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F072RB/TOOLCHAIN_ARM_MICRO/startup_stm32f072xb.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F072RB/TOOLCHAIN_ARM_MICRO/startup_stm32f072xb.s
@@ -66,7 +66,7 @@ Heap_Size       EQU     0x00000400
                 
 __heap_base
 Heap_Mem        SPACE   Heap_Size
-__heap_limit
+__heap_limit    EQU (__initial_sp - Stack_Size)
 
                 PRESERVE8
                 THUMB

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F103RB/TOOLCHAIN_ARM_MICRO/startup_stm32f10x_md.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F103RB/TOOLCHAIN_ARM_MICRO/startup_stm32f10x_md.s
@@ -54,7 +54,7 @@ Heap_Size       EQU     0x00000400
                 
 __heap_base
 Heap_Mem        SPACE   Heap_Size
-__heap_limit
+__heap_limit    EQU (__initial_sp - Stack_Size)
 
                 PRESERVE8
                 THUMB

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F302R8/TOOLCHAIN_ARM_MICRO/startup_stm32f302x8.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F302R8/TOOLCHAIN_ARM_MICRO/startup_stm32f302x8.s
@@ -56,7 +56,7 @@ Heap_Size       EQU     0x00000400
                 
 __heap_base
 Heap_Mem        SPACE   Heap_Size
-__heap_limit
+__heap_limit    EQU (__initial_sp - Stack_Size)
 
                 PRESERVE8
                 THUMB

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/TOOLCHAIN_ARM_MICRO/startup_stm32f334x8.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/TOOLCHAIN_ARM_MICRO/startup_stm32f334x8.s
@@ -66,7 +66,7 @@ Heap_Size       EQU     0x00000400
                 
 __heap_base
 Heap_Mem        SPACE   Heap_Size
-__heap_limit
+__heap_limit    EQU (__initial_sp - Stack_Size)
 
                 PRESERVE8
                 THUMB

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/TOOLCHAIN_ARM_MICRO/startup_stm32f401xe.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/TOOLCHAIN_ARM_MICRO/startup_stm32f401xe.s
@@ -66,7 +66,7 @@ Heap_Size       EQU     0x00000400
                 
 __heap_base
 Heap_Mem        SPACE   Heap_Size
-__heap_limit
+__heap_limit    EQU (__initial_sp - Stack_Size)
 
                 PRESERVE8
                 THUMB

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F411RE/TOOLCHAIN_ARM_MICRO/startup_stm32f411xe.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F411RE/TOOLCHAIN_ARM_MICRO/startup_stm32f411xe.s
@@ -66,7 +66,7 @@ Heap_Size       EQU     0x00000400
                 
 __heap_base
 Heap_Mem        SPACE   Heap_Size
-__heap_limit
+__heap_limit    EQU (__initial_sp - Stack_Size)
 
                 PRESERVE8
                 THUMB

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_L053R8/TOOLCHAIN_ARM_MICRO/startup_stm32l053xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_L053R8/TOOLCHAIN_ARM_MICRO/startup_stm32l053xx.s
@@ -66,7 +66,7 @@ Heap_Size       EQU     0x00000400
                 
 __heap_base
 Heap_Mem        SPACE   Heap_Size
-__heap_limit
+__heap_limit    EQU (__initial_sp - Stack_Size)
 
                 PRESERVE8
                 THUMB

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_L152RE/TOOLCHAIN_ARM_MICRO/startup_stm32l1xx_hd.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_L152RE/TOOLCHAIN_ARM_MICRO/startup_stm32l1xx_hd.s
@@ -54,7 +54,7 @@ Heap_Size       EQU     0x00000400
                 
 __heap_base
 Heap_Mem        SPACE   Heap_Size
-__heap_limit
+__heap_limit    EQU (__initial_sp - Stack_Size)
 
                 PRESERVE8
                 THUMB

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F3XX/TOOLCHAIN_ARM_MICRO/startup_stm32f302x8.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F3XX/TOOLCHAIN_ARM_MICRO/startup_stm32f302x8.s
@@ -48,7 +48,7 @@ __initial_sp    EQU     0x20004000 ; Top of RAM
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
 ; </h>
 
-Heap_Size       EQU     0x00000000
+Heap_Size       EQU     0x00000400
 
                 AREA    HEAP, NOINIT, READWRITE, ALIGN=3
                 EXPORT  __heap_base
@@ -56,7 +56,7 @@ Heap_Size       EQU     0x00000000
                 
 __heap_base
 Heap_Mem        SPACE   Heap_Size
-__heap_limit
+__heap_limit    EQU (__initial_sp - Stack_Size)
 
                 PRESERVE8
                 THUMB


### PR DESCRIPTION
heap can grow outside 0x400 default size and does not overlap stack area.
I checked on F401 board, the only one i've actually, but isue should be reflected to all other stm32 whith arm micro toolchain.
I really don't know about rtos, i never used so far, i just looked at src and seems it uses new for creating thread stacks, so probably it could fix something there also....or break it:)
