### PR TITLE
test [MBED_A7] extension

### DIFF
--- a/libraries/tests/mbed/interruptin/main.cpp
+++ b/libraries/tests/mbed/interruptin/main.cpp
@@ -47,6 +47,10 @@ void in_handler() {
 #define PIN_IN      PB_8
 #define PIN_OUT     PC_6
 
+#elif defined(TARGET_DISCO_F407VG)
+#define PIN_OUT    PC_12
+#define PIN_IN     PD_0
+
 #elif defined(TARGET_FF_ARDUINO)
 #define PIN_OUT    D0
 #define PIN_IN     D7
@@ -90,13 +94,23 @@ int main() {
         notify_completion(false);
     }
 
+    //Now test switch off edge detection
+    in.rise(NULL);
+    in.fall(NULL);
+    flipper();
+
+    if (checks != 10) {
+        printf("edge detection switch off test failed: %d\n",checks);
+        notify_completion(false);
+    }
+
     //Finally test both
     in.rise(in_handler);
     in.fall(in_handler);
     flipper();
 
     if (checks != 20) {
-        printf("Simultaneous rising and falling edges failed\n");
+        printf("Simultaneous rising and falling edges failed: %d\n",checks);
         notify_completion(false);
     }
 


### PR DESCRIPTION
The test MBED_A7 is missing one functionality. It tests switch on an edge detection, change the detected edge and switching on both. The complete switch off is not tested.
