### PR TITLE
[HAL][KSDK] Use PIT timer for ticker/timeout

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/us_ticker.c
@@ -20,9 +20,6 @@
 #include "fsl_sim_hal.h"
 #include "fsl_clock_manager.h"
 
-static void pit_init(void);
-static void lptmr_init(void);
-
 static int us_ticker_inited = 0;
 
 void us_ticker_init(void) {
@@ -30,9 +27,25 @@ void us_ticker_init(void) {
         return;
     }
     us_ticker_inited = 1;
-
-    pit_init();
-    lptmr_init();
+    
+    //Common for ticker/timer
+    uint32_t busClock;
+    CLOCK_SYS_EnablePitClock(0);
+    PIT_HAL_Enable(PIT_BASE);
+    CLOCK_SYS_GetFreq(kBusClock, &busClock);
+    
+    //Timer
+    PIT_HAL_SetTimerPeriodByCount(PIT_BASE, 0, busClock / 1000000 - 1);
+    PIT_HAL_SetTimerPeriodByCount(PIT_BASE, 1, 0xFFFFFFFF);
+    PIT_HAL_SetTimerChainCmd(PIT_BASE, 1, true);
+    PIT_HAL_StartTimer(PIT_BASE, 0);
+    PIT_HAL_StartTimer(PIT_BASE, 1);
+    
+    //Ticker
+    PIT_HAL_SetTimerPeriodByCount(PIT_BASE, 2, busClock / 1000000 - 1);
+    PIT_HAL_SetTimerChainCmd(PIT_BASE, 3, true);
+    NVIC_SetVector(PIT3_IRQn, (uint32_t)us_ticker_irq_handler);
+    NVIC_EnableIRQ(PIT3_IRQn);
 }
 
 
@@ -43,93 +56,13 @@ uint32_t us_ticker_read() {
 
     return ~(PIT_HAL_ReadTimerCount(PIT_BASE, 1));
 }
-/******************************************************************************
- * Timer for us timing.
- ******************************************************************************/
-static void pit_init(void) {
-    uint32_t busClock;
-
-    CLOCK_SYS_EnablePitClock(0);
-    PIT_HAL_Enable(PIT_BASE);
-    CLOCK_SYS_GetFreq(kBusClock, &busClock);
-    PIT_HAL_SetTimerPeriodByCount(PIT_BASE, 0, busClock / 1000000 - 1);
-    PIT_HAL_SetTimerPeriodByCount(PIT_BASE, 1, 0xFFFFFFFF);
-    PIT_HAL_SetTimerChainCmd(PIT_BASE, 1, true);
-
-    PIT_HAL_StartTimer(PIT_BASE, 0);
-    PIT_HAL_StartTimer(PIT_BASE, 1);
-}
-
-/******************************************************************************
- * Timer Event
- *
- * It schedules interrupts at given (32bit)us interval of time.
- * It is implemented used the 16bit Low Power Timer that remains powered in all
- * power modes.
- ******************************************************************************/
-static void lptmr_isr(void);
-
-static void lptmr_init(void) {
-    CLOCK_SYS_EnableLptimerClock(0);
-
-    /* Set interrupt handler */
-    NVIC_SetVector(LPTimer_IRQn, (uint32_t)lptmr_isr);
-    NVIC_EnableIRQ(LPTimer_IRQn);
-
-    /* TODO: check clock manager, due to nonstandard 50 MHz */
-    //No suitable external oscillator clock -> Use fast internal oscillator (4MHz / divider)
-    MCG->C1 |= MCG_C1_IRCLKEN_MASK;
-    MCG->C2 |= MCG_C2_IRCS_MASK;
-    LPTMR0->PSR =  LPTMR_PSR_PCS(0);
-    switch (MCG->SC & MCG_SC_FCRDIV_MASK) {
-        case MCG_SC_FCRDIV(0):                  //4MHz
-            LPTMR0->PSR |= LPTMR_PSR_PRESCALE(1);
-            break;
-        case MCG_SC_FCRDIV(1):                  //2MHz
-            LPTMR0->PSR |= LPTMR_PSR_PRESCALE(0);
-            break;
-        default:                                //1MHz or anything else, in which case we put it on 1MHz
-            MCG->SC &= ~MCG_SC_FCRDIV_MASK;
-            MCG->SC |= MCG_SC_FCRDIV(2);
-            LPTMR0->PSR |= LPTMR_PSR_PBYP_MASK;
-    }
-}
 
 void us_ticker_disable_interrupt(void) {
-    BW_LPTMR_CSR_TIE(LPTMR0_BASE, 0);
+    PIT_HAL_SetIntCmd(PIT_BASE, 3, false);
 }
 
 void us_ticker_clear_interrupt(void) {
-    // we already clear interrupt in lptmr_isr
-}
-
-static uint32_t us_ticker_int_counter = 0;
-static uint16_t us_ticker_int_remainder = 0;
-
-static void lptmr_set(unsigned short count) {
-    HW_LPTMR_CSR_WR(LPTMR0_BASE, 0);
-    BW_LPTMR_CMR_COMPARE(LPTMR0_BASE, count);
-    BW_LPTMR_CSR_TIE(LPTMR0_BASE, 1);
-    BW_LPTMR_CSR_TEN(LPTMR0_BASE, 1);
-}
-
-static void lptmr_isr(void) {
-    // write 1 to TCF to clear the LPT timer compare flag
-    BW_LPTMR_CSR_TCF(LPTMR0_BASE, 1);
-
-    if (us_ticker_int_counter > 0) {
-        lptmr_set(0xFFFF);
-        us_ticker_int_counter--;
-    } else {
-        if (us_ticker_int_remainder > 0) {
-            lptmr_set(us_ticker_int_remainder);
-            us_ticker_int_remainder = 0;
-        } else {
-            // This function is going to disable the interrupts if there are
-            // no other events in the queue
-            us_ticker_irq_handler();
-        }
-    }
+    PIT_HAL_ClearIntFlag(PIT_BASE, 3);
 }
 
 void us_ticker_set_interrupt(timestamp_t timestamp) {
@@ -139,14 +72,11 @@ void us_ticker_set_interrupt(timestamp_t timestamp) {
         us_ticker_irq_handler();
         return;
     }
-
-    us_ticker_int_counter   = (uint32_t)(delta >> 16);
-    us_ticker_int_remainder = (uint16_t)(0xFFFF & delta);
-    if (us_ticker_int_counter > 0) {
-        lptmr_set(0xFFFF);
-        us_ticker_int_counter--;
-    } else {
-        lptmr_set(us_ticker_int_remainder);
-        us_ticker_int_remainder = 0;
-    }
+ 
+    PIT_HAL_StopTimer(PIT_BASE, 3);
+    PIT_HAL_StopTimer(PIT_BASE, 2);
+    PIT_HAL_SetTimerPeriodByCount(PIT_BASE, 3, (uint32_t)delta);
+    PIT_HAL_SetIntCmd(PIT_BASE, 3, true);
+    PIT_HAL_StartTimer(PIT_BASE, 3);
+    PIT_HAL_StartTimer(PIT_BASE, 2);
 }


### PR DESCRIPTION
Previously in the KLXX devices the LPTMR was used for ticker/timeout,
since they only have 2 PIT channels which are required for regular
timer. The KSDK targets have 4 PIT channels, which allows for two 32-bit
timers running at 1 MHz.

Since PIT timers are 32-bit, and LPTMR 16-bit, this both simplifies it
and makes it more efficient. It does cost the remaining 2 PIT channels,
but on the other hand leaves the LPTMR free.
