### PR TITLE
Fix USB serial RX bug

### DIFF
--- a/libraries/USBDevice/USBSerial/USBSerial.cpp
+++ b/libraries/USBDevice/USBSerial/USBSerial.cpp
@@ -59,8 +59,6 @@ bool USBSerial::EP2_OUT_callback() {
     //call a potential handler
     rx.call();
 
-    // We reactivate the endpoint to receive next characters
-    readStart(EPBULK_OUT, MAX_PACKET_SIZE_EPBULK);
     return true;
 }
 


### PR DESCRIPTION
USBCDC::readEP already already called readStart, so we should not call
it from USBDevice.  Calling readStart twice can cause data corruption if a packet arrives in between the two calls.

Tested on KL25Z.
