### PR TITLE
[HAL][K22F] Added final UART pinnames

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/TARGET_K22F/PeripheralPins.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/TARGET_K22F/PeripheralPins.c
@@ -76,17 +76,25 @@ const PinMap PinMap_I2C_SCL[] = {
 
 /************UART***************/
 const PinMap PinMap_UART_TX[] = {
-    {PTA2, UART_0, 2},
-    {PTE0, UART_1, 3},
-    {PTD3, UART_2, 3},
-    {NC  ,  NC    , 0}
+    {PTA2 , UART_0, 2},
+    {PTA14, UART_0, 3},
+    {PTB17, UART_0, 3},
+    {PTD7 , UART_0, 3},
+    {PTC4 , UART_1, 3},
+    {PTE0 , UART_1, 3},
+    {PTD3 , UART_2, 3},
+    {NC   ,  NC   , 0}
 };
 
 const PinMap PinMap_UART_RX[] = {
-    {PTA1, UART_0, 2},
-    {PTE1, UART_1, 3},
-    {PTD2, UART_2, 3},
-    {NC  ,  NC    , 0}
+    {PTA1 , UART_0, 2},
+    {PTA15, UART_0, 3},
+    {PTB16, UART_0, 3},
+    {PTD6 , UART_0, 3},
+    {PTC3 , UART_1, 3},
+    {PTE1 , UART_1, 3},
+    {PTD2 , UART_2, 3},
+    {NC   ,  NC    , 0}
 };
 
 /************SPI***************/


### PR DESCRIPTION
Should be complete new regarding PeripheralPins. Adding the LPUART is a thing to do, but not a matter of only adding some pins.
