### PR TITLE
Fix opendir for multiple FAT volumes

### DIFF
--- a/libraries/fs/fat/FATFileSystem.cpp
+++ b/libraries/fs/fat/FATFileSystem.cpp
@@ -127,8 +127,8 @@ int FATFileSystem::format() {
 }
 
 DirHandle *FATFileSystem::opendir(const char *name) {
-	char n[64];
-	sprintf(n, "%d:/%s", _fsid, name);
+    char n[64];
+    sprintf(n, "%d:/%s", _fsid, name);
     FATFS_DIR dir;
     FRESULT res = f_opendir(&dir, n);
     if (res != 0) {


### PR DESCRIPTION
This fixes a bug which exhibits itself if you have multiple FAT volumes mounted. Whereas open() takes the volumes into account opendir() did not.
