### PR TITLE
[EXPORT] commandline options for export_test.py similar to build.py

### DIFF
--- a/workspace_tools/export_test.py
+++ b/workspace_tools/export_test.py
@@ -24,22 +24,95 @@ from shutil import move
 from workspace_tools.paths import *
 from workspace_tools.utils import mkdir, cmd
 from workspace_tools.export import export, setup_user_prj
+from optparse import OptionParser
 
+
+# List of project which can be exported
+USER_PROJECTS = {
+    'RTOS_MBED_BASIC' : (join(TEST_DIR, "rtos", "mbed", "basic"), [join(LIB_DIR, "rtos")]),
+    'MBED_BLINKY' : (join(TEST_DIR, "mbed", "blinky"), [])
+}
+
+# Tuple of toolchain and target with possible export projects
+EXPORTS = (
+    ('coide', 'KL05Z', ['RTOS_MBED_BASIC']),
+    ('coide', 'KL25Z', ['RTOS_MBED_BASIC']),
+    ('coide', 'LPC1768', ['RTOS_MBED_BASIC']),
+    ('coide', 'ARCH_PRO', ['RTOS_MBED_BASIC']),
+    ('coide', 'DISCO_F407VG', ['RTOS_MBED_BASIC', 'MBED_BLINKY']),
+    ('coide', 'NUCLEO_F401RE', ['RTOS_MBED_BASIC']),
+    ('coide', 'NUCLEO_F411RE', ['RTOS_MBED_BASIC']),
+    # ('coide', 'NUCLEO_F334R8', ['MBED_BLINKY']),
+
+    ('uvision', 'LPC1768', ['RTOS_MBED_BASIC']),
+    ('uvision', 'LPC11U24', ['RTOS_MBED_BASIC']),
+    ('uvision', 'KL25Z', ['RTOS_MBED_BASIC']),
+    ('uvision', 'LPC1347', ['RTOS_MBED_BASIC']),
+    ('uvision', 'LPC1114', ['RTOS_MBED_BASIC']),
+    ('uvision', 'LPC4088', ['RTOS_MBED_BASIC']),
+    ('uvision', 'LPC4337', ['RTOS_MBED_BASIC']),
+
+    ('uvision', 'NUCLEO_F030R8', ['RTOS_MBED_BASIC']),
+    ('uvision', 'NUCLEO_F072RB', ['RTOS_MBED_BASIC']),
+    ('uvision', 'NUCLEO_F103RB', ['RTOS_MBED_BASIC']),
+    ('uvision', 'NUCLEO_F302R8', ['RTOS_MBED_BASIC']),
+    ('uvision', 'NUCLEO_F334R8', ['RTOS_MBED_BASIC']),
+    ('uvision', 'NUCLEO_F401RE', ['RTOS_MBED_BASIC']),
+    ('uvision', 'NUCLEO_F411RE', ['RTOS_MBED_BASIC']),
+    ('uvision', 'NUCLEO_L053R8', ['RTOS_MBED_BASIC']),
+    ('uvision', 'NUCLEO_L152RE', ['RTOS_MBED_BASIC']),
+
+    ('lpcxpresso', 'LPC1768', ['RTOS_MBED_BASIC']),
+    ('lpcxpresso', 'LPC4088', ['RTOS_MBED_BASIC']),
+    ('lpcxpresso', 'LPC1114', ['RTOS_MBED_BASIC']),
+    ('lpcxpresso', 'LPC11U35_401', ['RTOS_MBED_BASIC']),
+    ('lpcxpresso', 'LPC11U35_501', ['RTOS_MBED_BASIC']),
+    ('lpcxpresso', 'LPCCAPPUCCINO', ['RTOS_MBED_BASIC']),
+    ('lpcxpresso', 'LPC1549', ['RTOS_MBED_BASIC']),
+    ('lpcxpresso', 'LPC11U68', ['RTOS_MBED_BASIC']),
+    ('codesourcery', 'LPC1768', ['RTOS_MBED_BASIC']),
+
+    ('gcc_arm', 'LPC1768', ['RTOS_MBED_BASIC']),
+    ('gcc_arm', 'LPC1549', ['RTOS_MBED_BASIC']),
+    ('gcc_arm', 'LPC1114', ['RTOS_MBED_BASIC']),
+    ('gcc_arm', 'LPC11U35_401', ['RTOS_MBED_BASIC']),
+    ('gcc_arm', 'LPC11U35_501', ['RTOS_MBED_BASIC']),
+    ('gcc_arm', 'LPCCAPPUCCINO', ['RTOS_MBED_BASIC']),
+    ('gcc_arm', 'LPC2368', ['RTOS_MBED_BASIC']),
+
+    ('gcc_arm', 'STM32F407', ['RTOS_MBED_BASIC']),
+    ('gcc_arm', 'DISCO_F100RB', ['RTOS_MBED_BASIC']),
+    ('gcc_arm', 'DISCO_F051R8', ['RTOS_MBED_BASIC']),
+    ('gcc_arm', 'DISCO_F407VG', ['RTOS_MBED_BASIC']),
+    ('gcc_arm', 'DISCO_F303VC', ['RTOS_MBED_BASIC']),
+    ('gcc_arm', 'NRF51822', ['RTOS_MBED_BASIC']),
+    ('gcc_arm', 'NUCLEO_F401RE', ['RTOS_MBED_BASIC']),
+    ('gcc_arm', 'NUCLEO_F411RE', ['RTOS_MBED_BASIC']),
+    # ('gcc_arm', 'NUCLEO_F334R8', ['MBED_BLINKY']),
+
+
+    ('ds5_5', 'LPC1768', ['RTOS_MBED_BASIC']), 
+    ('ds5_5', 'LPC11U24', ['RTOS_MBED_BASIC']),
+
+    ('iar', 'LPC1768', ['RTOS_MBED_BASIC'])
+)
 
 USR_PRJ_NAME = "usr_prj"
-USER_PRJ = join(EXPORT_WORKSPACE, USR_PRJ_NAME)
-USER_SRC = join(USER_PRJ, "src")
 
 
 def setup_test_user_prj():
-    if exists(USER_PRJ):
-        print 'Test user project already generated...'
-        return
+    for project_name in USER_PROJECTS:
+        (source_dir, libraries) = USER_PROJECTS[project_name]
+        user_project_name = USR_PRJ_NAME + '_' + project_name
+        user_project = join(EXPORT_WORKSPACE, user_project_name)
+        if exists(user_project):
+            print 'Test user project ' + user_project_name + 'already generated...'
+            continue
 
-    setup_user_prj(USER_PRJ, join(TEST_DIR, "rtos", "mbed", "basic"), [join(LIB_DIR, "rtos")])
+        setup_user_prj(user_project, source_dir, libraries)
 
-    # FAKE BUILD URL
-    open(join(USER_SRC, "mbed.bld"), 'w').write("http://mbed.org/users/mbed_official/code/mbed/builds/976df7c37ad5\n")
+        # FAKE BUILD URL
+        open(join(join(user_project, "src"), "mbed.bld"), 'w').write("http://mbed.org/users/mbed_official/code/mbed/builds/976df7c37ad5\n")
 
 
 def fake_build_url_resolver(url):
@@ -47,18 +120,21 @@ def fake_build_url_resolver(url):
     return {'path':MBED_LIBRARIES, 'name':'mbed'}
 
 
-def test_export(toolchain, target, expected_error=None):
-    if toolchain is None and target is None:
+def test_export(toolchain, target, project, expected_error=None):
+    if toolchain is None and target is None and project is None:
         base_dir = join(EXPORT_TMP, "zip")
     else:
-        base_dir = join(EXPORT_TMP, toolchain, target)
+        base_dir = join(EXPORT_TMP, toolchain, target, project)
     temp_dir = join(base_dir, "temp")
     mkdir(temp_dir)
 
-    zip_path, report = export(USER_PRJ, USR_PRJ_NAME, toolchain, target, base_dir, temp_dir, False, fake_build_url_resolver)
+    (source_dir, libraries) = USER_PROJECTS[project]
+    user_project_name = USR_PRJ_NAME + '_' + project
+    user_project = join(EXPORT_WORKSPACE, user_project_name)
+    zip_path, report = export(user_project, user_project_name, toolchain, target, base_dir, temp_dir, False, fake_build_url_resolver)
 
     if report['success']:
-        move(zip_path, join(EXPORT_DIR, "export_%s_%s.zip" % (toolchain, target)))
+        move(zip_path, join(EXPORT_DIR, "export_%s_%s_%s.zip" % (toolchain, target, project)))
         print "[OK]"
     else:
         if expected_error is None:
@@ -73,75 +149,92 @@ def test_export(toolchain, target, expected_error=None):
 
 
 if __name__ == '__main__':
+    toolchainlist = []
+    targetlist = []
+    projectlist = []
+    for toolchain, target, projects in EXPORTS:
+        if not toolchainlist.__contains__(toolchain):
+            toolchainlist.append(toolchain)
+        if not targetlist.__contains__(target):
+            targetlist.append(target)
+        for project in projects:
+            if not projectlist.__contains__(project):
+                projectlist.append(project)
+
+    targetlist.sort()
+    toolchainlist.sort()
+    projectlist.sort()
+
+    # Parse Options
+    parser = OptionParser()
+
+    # Default option: with this option or without any option all possible exports are generated
+    parser.add_option("-a", "--all",
+                  action="store_true",
+                  default=False,
+                  help="export all projects and MCU to all toolchains",
+                  metavar="ALL")
+
+    parser.add_option("-m", "--mcu",
+                  help="export for the given MCU (%s)" % ', '.join(targetlist),
+                  metavar="MCU")
+
+    parser.add_option("-t", "--tool",
+                  help="export to the given TOOLCHAIN (%s)" % ', '.join(toolchainlist),
+                  metavar="TOOLCHAIN")
+
+    parser.add_option("-p", "--project",
+                  help="export the given PROJECT (%s)" % ', '.join(projectlist),
+                  metavar="PROJECT")
+
+    (options, args) = parser.parse_args()
+
+    # Get target list
+    if options.mcu:
+        mcu_list = (options.mcu).split(",")
+        for mcu in mcu_list:
+            if mcu not in targetlist:
+                print "Given MCU '%s' not into the supported list:\n%s" % (mcu, targetlist)
+                sys.exit(1)
+        targets = mcu_list
+    else:
+        targets = targetlist
+
+    # Get toolchains list
+    if options.tool:
+        toolchain_list = (options.tool).split(",")
+        for tc in toolchain_list:
+            if tc not in toolchainlist:
+                print "Given toolchain '%s' not into the supported list:\n%s" % (tc, toolchainlist)
+                sys.exit(1)
+        toolchains = toolchain_list
+    else:
+        toolchains = toolchainlist
+
+    # Get projects list
+    if options.project:
+        project_list = (options.project).split(",")
+        for prj in project_list:
+            if prj not in projectlist:
+                print "Given project '%s' not into the configured list:\n%s" % (prj, projectlist)
+                sys.exit(1)
+        projects = project_list
+    else:
+        projects = projectlist
+        
+    # Generates all possible exports
+    if options.all:
+        targets = targetlist
+        toolchains = toolchainlist
+        projects = projectlist
+
     setup_test_user_prj()
 
-    for toolchain, target in [
-            ('coide', 'KL05Z'),
-            ('coide', 'KL25Z'),
-            ('coide', 'LPC1768'),
-            ('coide', 'ARCH_PRO'),
-            ('coide', 'DISCO_F407VG'),
-            ('coide', 'NUCLEO_F401RE'),
-            ('coide', 'NUCLEO_F411RE'),
+    for toolchain, target, project in EXPORTS:
+        for prj in project:
+            if toolchains.__contains__(toolchain) and targets.__contains__(target) and projects.__contains__(prj):
+                print '\n=== Exporting to "%s::%s::%s" ===' % (toolchain, target, prj)
+                test_export(toolchain, target, prj)
 
-            ('uvision', 'LPC1768'),
-            ('uvision', 'LPC11U24'),
-            ('uvision', 'KL25Z'),
-            ('uvision', 'LPC1347'),
-            ('uvision', 'LPC1114'),
-            ('uvision', 'LPC4088'),
-            ('uvision', 'LPC4337'),
-
-            ('uvision', 'NUCLEO_F030R8'),
-            ('uvision', 'NUCLEO_F072RB'),
-            ('uvision', 'NUCLEO_F103RB'),
-            ('uvision', 'NUCLEO_F302R8'),
-            ('uvision', 'NUCLEO_F334R8'),
-            ('uvision', 'NUCLEO_F401RE'),
-            ('uvision', 'NUCLEO_F411RE'),
-            ('uvision', 'NUCLEO_L053R8'),
-            ('uvision', 'NUCLEO_L152RE'),
-
-            ('lpcxpresso', 'LPC1768'),
-            ('lpcxpresso', 'LPC4088'),
-            ('lpcxpresso', 'LPC1114'),
-            ('lpcxpresso', 'LPC11U35_401'),
-            ('lpcxpresso', 'LPC11U35_501'),
-            ('lpcxpresso', 'LPCCAPPUCCINO'),
-            ('lpcxpresso', 'LPC1549'),
-            ('lpcxpresso', 'LPC11U68'),
-            # Linux path: /home/emimon01/bin/gcc-cs/bin/
-            # Windows path: "C:/Program Files (x86)/CodeSourcery/Sourcery_CodeBench_Lite_for_ARM_EABI/bin/"
-            ('codesourcery', 'LPC1768'),
-
-            # Linux path: /home/emimon01/bin/gcc-arm/bin/
-            # Windows path: C:/arm-none-eabi-gcc-4_7/bin/
-            ('gcc_arm', 'LPC1768'),
-            ('gcc_arm', 'LPC1549'),
-            ('gcc_arm', 'LPC1114'),
-            ('gcc_arm', 'LPC11U35_401'),
-            ('gcc_arm', 'LPC11U35_501'),
-            ('gcc_arm', 'LPCCAPPUCCINO'),
-            ('gcc_arm', 'LPC2368'),
-
-            ('gcc_arm', 'STM32F407'),
-            ('gcc_arm', 'DISCO_F100RB'),
-            ('gcc_arm', 'DISCO_F051R8'),
-            ('gcc_arm', 'DISCO_F407VG'),
-            ('gcc_arm', 'DISCO_F303VC'),
-            ('gcc_arm', 'NRF51822'),
-            ('gcc_arm', 'NUCLEO_F401RE'),
-            ('gcc_arm', 'NUCLEO_F411RE'),
-
-
-            ('ds5_5', 'LPC1768'), ('ds5_5', 'LPC11U24'),
-
-            ('iar', 'LPC1768'),
-
-            (None, None),
-        ]:
-        print '\n=== Exporting to "%s::%s" ===' % (toolchain, target)
-        test_export(toolchain, target)
-
-    print "\n=== Test error messages ==="
-    test_export('lpcxpresso', 'LPC11U24', expected_error='lpcxpresso')
+    # print "\n=== Test error messages ==="
+    # test_export('lpcxpresso', 'LPC11U24', 'RTOS_MBED_BASIC', expected_error='lpcxpresso')


### PR DESCRIPTION
This is a suggestion to use the tool export_test.py in a similar way like e.g. build.py. The reason to change the behaviour was the development of an gcc_arm toolchain/exporter for Nucleo_F334. The hal of this board currently does not allow to link with the rtos library. Both define a SysTick_Handler. 
With command line options, similar to build.py, the export can be limited now to specific toolchains, targets and/or export projects.
Without a command line option the behaviour is the same as before.

Here are the options:

Usage: export_test.py [options]

Options:
-h, --help            show this help message and exit
-a, --all             export all projects and MCU to all toolchains
-m MCU, --mcu=MCU
     export for the given MCU (ARCH_PRO, DISCO_F051R8, ... STM32F407)
-t TOOLCHAIN, --tool=TOOLCHAIN
     export to the given TOOLCHAIN (codesourcery, coide, ... uvision)
-p PROJECT, --project=PROJECT
     export the given PROJECT (MBED_BLINKY, RTOS_MBED_BASIC)
