### PR TITLE
[HAL]Allow Serial pin to be NC on Freescale/NXP devices

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_K20D50M/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_K20D50M/serial_api.c
@@ -98,10 +98,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     pinmap_pinout(rx, PinMap_UART_RX);
 
     // set rx/tx pins in PullUp mode
-    if (tx != NC)
+    if (tx != NC) {
         pin_mode(tx, PullUp);
-    if (rx != NC)
+    }
+    if (rx != NC) {
         pin_mode(rx, PullUp);
+    }
 
     obj->uart->C2 |= (UART_C2_RE_MASK | UART_C2_TE_MASK);
 

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/serial_api.c
@@ -96,10 +96,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     pinmap_pinout(rx, PinMap_UART_RX);
 
     // set rx/tx pins in PullUp mode
-    if (tx != NC)
+    if (tx != NC) {
         pin_mode(tx, PullUp);
-    if (rx != NC)
+    }
+    if (rx != NC) {
         pin_mode(rx, PullUp);
+    }
 
     obj->uart->C2 |= (UARTLP_C2_RE_MASK | UARTLP_C2_TE_MASK);
 

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/serial_api.c
@@ -68,10 +68,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
 
-    if (tx != NC)
+    if (tx != NC) {
         pin_mode(tx, PullUp);
-    if (rx != NC)
+    }
+    if (rx != NC) {
         pin_mode(rx, PullUp);
+    }
 
     if (obj->index == STDIO_UART) {
         stdio_uart_inited = 1;

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
@@ -85,8 +85,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     obj->index = 0;
 
     // set rx/tx pins in PullUp mode
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
 
     if (uart == STDIO_UART) {
         stdio_uart_inited = 1;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11U6X/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11U6X/serial_api.c
@@ -142,10 +142,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     pinmap_pinout(rx, PinMap_UART_RX);
     
     // set rx/tx pins in PullUp mode
-    if (tx != NC)
+    if (tx != NC) {
         pin_mode(tx, PullUp);
-    if (rx != NC)
+    }
+    if (rx != NC) {
         pin_mode(rx, PullUp);
+    }
     
     is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
     

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/serial_api.c
@@ -73,10 +73,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     pinmap_pinout(rx, PinMap_UART_RX);
     
     // set rx/tx pins in PullUp mode
-    if (tx != NC)
+    if (tx != NC) {
         pin_mode(tx, PullUp);
-    if (rx != NC)
+    }
+    if (rx != NC) {
         pin_mode(rx, PullUp);
+    }
     
     switch (uart) {
         case UART_0: obj->index = 0; break;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/serial_api.c
@@ -82,10 +82,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     pinmap_pinout(rx, PinMap_UART_RX);
     
     // set rx/tx pins in PullUp mode
-    if (tx != NC)
+    if (tx != NC) {
         pin_mode(tx, PullUp);
-    if (rx != NC)
+    }
+    if (rx != NC) {
         pin_mode(rx, PullUp);
+    }
     
     switch (uart) {
         case UART_0: obj->index = 0; break;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/serial_api.c
@@ -85,10 +85,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     pinmap_pinout(rx, PinMap_UART_RX);
     
     // set rx/tx pins in PullUp mode
-    if (tx != NC)
+    if (tx != NC) {
         pin_mode(tx, PullUp);
-    if (rx != NC)
+    }
+    if (rx != NC) {
         pin_mode(rx, PullUp);
+    }
     
     switch (uart) {
         case UART_0: obj->index = 0; break;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/serial_api.c
@@ -120,10 +120,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     pinmap_pinout(rx, PinMap_UART_RX);
 
     // set rx/tx pins in PullUp mode
-    if (tx != NC)
+    if (tx != NC) {
         pin_mode(tx, PullUp);
-    if (rx != NC)
+    }
+    if (rx != NC) {
         pin_mode(rx, PullUp);
+    }
 
     switch (uart) {
         case UART_0: obj->index = 0; break;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/serial_api.c
@@ -96,10 +96,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     pinmap_pinout(rx, PinMap_UART_RX);
     
     // set rx/tx pins in PullUp mode
-    if (tx != NC)
+    if (tx != NC) {
         pin_mode(tx, PullUp);
-    if (rx != NC)
+    }
+    if (rx != NC) {
         pin_mode(rx, PullUp);
+    }
     
     switch (uart) {
         case UART_0: obj->index = 0; break;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/serial_api.c
@@ -104,10 +104,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     pinmap_pinout(rx, PinMap_UART_RX);
     
     // set rx/tx pins in PullUp mode
-    if (tx != NC)
+    if (tx != NC) {
         pin_mode(tx, PullUp);
-    if (rx != NC)
+    }
+    if (rx != NC) {
         pin_mode(rx, PullUp);
+    }
     
     switch (uart) {
         case UART_0: obj->index = 0; break;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/serial_api.c
@@ -139,14 +139,16 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     serial_format(obj, 8, ParityNone, 1);
     
     // pinout the chosen uart
-    if (tx != NC)
-        pin_mode(tx, PullUp);
-    if (rx != NC)
-        pin_mode(rx, PullUp);
+    pinmap_pinout(tx, PinMap_UART_TX);
+    pinmap_pinout(rx, PinMap_UART_RX);
     
     // set rx/tx pins in PullUp mode
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
     
     switch (uart) {
         case UART_0: obj->index = 0; break;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F051R8/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F051R8/serial_api.c
@@ -99,8 +99,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
 
     // Configure UART
     obj->baudrate = 9600;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F303VC/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F303VC/serial_api.c
@@ -114,8 +114,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
 
     // Configure UART
     obj->baudrate = 9600;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/serial_api.c
@@ -107,8 +107,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
 
     // Configure UART
     obj->baudrate = 9600;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F072RB/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F072RB/serial_api.c
@@ -128,8 +128,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
 
     // Configure UART
     obj->baudrate = 9600;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F302R8/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F302R8/serial_api.c
@@ -122,8 +122,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
 
     // Configure UART
     obj->baudrate = 9600;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F334R8/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F334R8/serial_api.c
@@ -125,8 +125,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
 
     // Configure UART
     obj->baudrate = 9600;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F401RE/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F401RE/serial_api.c
@@ -111,8 +111,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
 
     // Configure UART
     obj->baudrate = 9600;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F411RE/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F411RE/serial_api.c
@@ -115,8 +115,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
 
     // Configure UART
     obj->baudrate = 9600;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L053R8/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L053R8/serial_api.c
@@ -126,8 +126,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
 
     // Configure UART
     obj->baudrate = 9600;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/serial_api.c
@@ -126,8 +126,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
 
     // Configure UART
     obj->baudrate = 9600;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F3XX/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F3XX/serial_api.c
@@ -108,8 +108,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
 
     // Configure UART
     obj->baudrate = 9600;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F407VG/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F407VG/serial_api.c
@@ -104,8 +104,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
     
     // Configure UART
     obj->baudrate = 9600;


### PR DESCRIPTION
Nordic(?)/STM should also be done, but I don't know if they do their own
stuff.

Issue is that since the mbed-assert implementation, calling pin_mode
causes an assert when a pin is NC. Since defining a serial object with
only TX or RX is a valid use case, this should be handled.

pinmap_pinout does accept NC pins, so there no guards are needed (person
who adds asserts there may also fix it in all other code).

On a related note: Does anyone have a clue why the serial_pinout_tx function exists?
