### PR TITLE
[NUCLEO_F091RC] pin_mode for Serial only if the pin is present

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F091RC/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F091RC/serial_api.c
@@ -168,8 +168,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
-    pin_mode(tx, PullUp);
-    pin_mode(rx, PullUp);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
 
     // Configure UART
     obj->baudrate = 9600;


### PR DESCRIPTION
Same as all other targets.
