### PR TITLE
Retarget STDIO to other than UART_2 without the need to patch the mbed source code

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F407VG/TARGET_DISCO_F407VG/PeripheralNames.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F407VG/TARGET_DISCO_F407VG/PeripheralNames.h
@@ -51,9 +51,17 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
+#ifndef STDIO_UART_TX
 #define STDIO_UART_TX  PA_2
+#endif
+
+#ifndef STDIO_UART_RX
 #define STDIO_UART_RX  PA_3
+#endif
+
+#ifndef STDIO_UART
 #define STDIO_UART     UART_2
+#endif
 
 typedef enum {
     SPI_1 = (int)SPI1_BASE,


### PR DESCRIPTION
I have added ifndef directives to be able to override the default STDIO_UART\* macro values at build time. This enables overrides without the need to patch the mbed source code (after this pull request is accepted).

I need such an override to retarget STDIO to other than the default UART_2 device, when using STM32F4-Discovery with STM32F4-BaseBoard. The latter has the RS-232 interface routed to the UART_6 device.

I provide a [project example](https://github.com/istarc/stm32/tree/master/examples/BaseBoardUART.mbed-RetargetSTDIO) with an appropriate [Makefile](https://github.com/istarc/stm32/blob/master/examples/BaseBoardUART.mbed-RetargetSTDIO/Makefile) (see DEFS variable) to demonstrate this pull request, 

This pull request updates only the STM32F407VG code. Other targets may need this update as well.
