### PR TITLE
[K64F] Add mbed_mac_address implementation

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/TARGET_MCU_K64F/TARGET_FRDM/mbed_overrides.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/TARGET_MCU_K64F/TARGET_FRDM/mbed_overrides.c
@@ -30,3 +30,25 @@ void NMI_Handler(void)
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
 }
+
+// Provide ethernet devices with a semi-unique MAC address from the UUID
+void mbed_mac_address(char *mac)
+{
+    // Fetch word 0
+    uint32_t word0 = *(uint32_t *)0x40048060;
+    // Fetch word 1
+    // we only want bottom 16 bits of word1 (MAC bits 32-47)
+    // and bit 9 forced to 1, bit 8 forced to 0
+    // Locally administered MAC, reduced conflicts
+    // http://en.wikipedia.org/wiki/MAC_address
+    uint32_t word1 = *(uint32_t *)0x4004805C;
+    word1 |= 0x00000200;
+    word1 &= 0x0000FEFF;
+    
+    mac[0] = (word1 & 0x000000ff);
+    mac[1] = (word1 & 0x0000ff00) >> 8;
+    mac[2] = (word0 & 0xff000000) >> 24;
+    mac[3] = (word0 & 0x00ff0000) >> 16;
+    mac[4] = (word0 & 0x0000ff00) >> 8;
+    mac[5] = (word0 & 0x000000ff);
+}


### PR DESCRIPTION
Currently the MAC for K64 is hardcoded and causes conflicts when multiple devices are on the same network. Downside is that to override this from an application $Sub$$ and $Super$$ need to be used but this seems reasonable. Seems like mbed_mac_address should be weakly defined for all SDK ports rather than in the mbed_common
