### PR TITLE
[API] Timer-start behavior (bug)fix

### DIFF
--- a/libraries/mbed/common/Timer.cpp
+++ b/libraries/mbed/common/Timer.cpp
@@ -23,8 +23,10 @@ Timer::Timer() : _running(), _start(), _time() {
 }
 
 void Timer::start() {
-    _start = us_ticker_read();
-    _running = 1;
+    if (!_running) {
+        _start = us_ticker_read();
+        _running = 1;
+    }
 }
 
 void Timer::stop() {


### PR DESCRIPTION
Only start the timer when it is not running currently. In old behavior
the current slice-time was discarded, now multiple starts have no
effect.

The total time of a timer consists of two parts: The current time, and the stored time from the last time stop() was called. Right now the start command sets the starting point of now running time to the current time. This means if you call start twice, effectively the last one overrides the first one. However the stored time from the last stop() command does stay correct. Effectively this means that the current time is reset, but the stored time is not. To me this looks like unintended behavior, and if a timer is already running and the start function is used, it should just continue running.
