### PR TITLE
HAL : [LPC824] Fix I2C return value

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/i2c_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/i2c_api.c
@@ -228,7 +228,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
     memcpy(data, buf + 1, i2c_result.n_bytes_recd);
     free(buf);
     if (err == 0)
-        return i2c_result.n_bytes_recd;
+        return i2c_result.n_bytes_recd - 1;
     else
         return -1;
 }
@@ -248,7 +248,7 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
     err = LPC_I2CD_API->i2c_master_transmit_poll(obj->handler, &i2c_param, &i2c_result);
     free(buf);
     if (err == 0)
-        return i2c_result.n_bytes_sent;
+        return i2c_result.n_bytes_sent - 1;
     else
         return -1;
 }
@@ -282,7 +282,7 @@ int i2c_byte_write(i2c_t *obj, int data)
 
 #if DEVICE_I2CSLAVE
 
-	void i2c_slave_mode(i2c_t *obj, int enable_slave)
+void i2c_slave_mode(i2c_t *obj, int enable_slave)
 {
     obj->handler = LPC_I2CD_API->i2c_setup((uint32_t)(obj->i2c), i2c_buffer);
     if (enable_slave != 0) {

--- a/libraries/tests/mbed/i2c_TMP102/main.cpp
+++ b/libraries/tests/mbed/i2c_TMP102/main.cpp
@@ -23,7 +23,8 @@ TMP102 temperature(p28, p27, 0x90);
       defined(TARGET_NUCLEO_F401RE) || \
       defined(TARGET_NUCLEO_F411RE) || \
       defined(TARGET_NUCLEO_L053R8) || \
-      defined(TARGET_NUCLEO_L152RE)
+      defined(TARGET_NUCLEO_L152RE) || \
+      defined(TARGET_LPC824)
 TMP102 temperature(I2C_SDA, I2C_SCL, 0x90);
 
 #else

--- a/libraries/tests/mbed/i2c_mma7660/main.cpp
+++ b/libraries/tests/mbed/i2c_mma7660/main.cpp
@@ -2,7 +2,11 @@
 #include "test_env.h"
 #include "MMA7660.h"
 
+#if defined(TARGET_FF_ARDUINO)
+MMA7660 MMA(I2C_SDA, I2C_SCL);
+#else
 MMA7660 MMA(p28, p27);
+#endif
 
 int main() {
     if (!MMA.testConnection())


### PR DESCRIPTION
- Add LPC824 target for I2C test cases
- Fix I2C read/write return value bug, detected by I2C_MMA7660 test case
