### PR TITLE
[PROJECT.py] some additions and minor changes to cmdline options

### DIFF
--- a/workspace_tools/project.py
+++ b/workspace_tools/project.py
@@ -56,13 +56,11 @@ if __name__ == '__main__':
     if options.list_tests is True:
         print '\n'.join(map(str, sorted(TEST_MAP.values())))
         sys.exit()
-        
+
     # Clean Export Directory
     if options.clean:
         if exists(EXPORT_DIR):
             rmtree(EXPORT_DIR)
-        sys.exit()
-
 
     # Target
     if options.mcu is None :


### PR DESCRIPTION
- new option (-L) to list all buildable programs (same option as in make.py)
- new option (-n xxx) to chose a program name instead only program id (-p yyy) as before  (same option as in make.py)
- new option (-c) to clean the export folder (similar to options in build.py and make.py which clean build folder)
- reorder the options similar to build.py and make.py when printing the help text
- order the entries in mcu and ide lists when printing the help text - perhaps the same can be done in the other tools?
