### PR TITLE
[MAKE.py] additional error handling when missing an option in private_setttings.py

### DIFF
--- a/workspace_tools/make.py
+++ b/workspace_tools/make.py
@@ -114,6 +114,8 @@ if __name__ == '__main__':
                     args_error(parser, "[ERROR] Program with name '%s' not found" % n)
                 else:
                     n = alias
+            else:
+                args_error(parser, "[ERROR] Program with name '%s' not found" % n)
         p = TEST_MAP[n].n
     if p is None or (p < 0) or (p > (len(TESTS)-1)):
         message = "[ERROR] You have to specify one of the following tests:\n"


### PR DESCRIPTION
Adding an error handling.

make.py with the option -n PROGRAM_NAME wants to have a test_alias
variable in private_settings.py. Without this alias and with a wrong
PROGRAM_NAME an error message is generated because of a missing else
branch.
