### PR TITLE
[NUCLEO_F091RC] Minor change in pinname definitions

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F091RC/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F091RC/PinNames.h
@@ -164,7 +164,7 @@ typedef enum {
     SPI_MISO    = PA_6,
     SPI_SCK     = PA_5,
     SPI_CS      = PB_6,
-    PWM_OUT     = PB_3,
+    PWM_OUT     = PB_4,
 
     // Not connected
     NC = (int)0xFFFFFFFF


### PR DESCRIPTION
There is no PWM on PB_3 for this device.
