### PR TITLE
[FRDM-K64F] Fix FOPT EzPort bit documentation and set it to disable at s...

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_MCU_K64F/TOOLCHAIN_ARM_STD/startup_MK64F12.s
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_MCU_K64F/TOOLCHAIN_ARM_STD/startup_MK64F12.s
@@ -402,9 +402,9 @@ FEPROT          EQU     nFEPROT:EOR:0xFF
 ;       <0=> Low-power boot
 ;       <1=> normal boot
 ;     <o.1>  EZPORT_DIS
-;       <0=> EzPort operation is enabled
-;       <1=> EzPort operation is disabled
-FOPT            EQU     0xFF
+;       <0=> EzPort operation is disabled
+;       <1=> EzPort operation is enabled
+FOPT            EQU     0xFD
 ;   </h>
 ;   <h> Flash security byte (FSEC)
 ;     <i> WARNING: If SEC field is configured as "MCU security status is secure" and MEEN field is configured as "Mass erase is disabled",

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_MCU_K64F/TOOLCHAIN_GCC_ARM/startup_MK64F12.S
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_MCU_K64F/TOOLCHAIN_GCC_ARM/startup_MK64F12.S
@@ -364,6 +364,6 @@ kinetis_flash_config:
     .long 0xffffffff
     .long 0xffffffff
     .long 0xffffffff
-    .long 0xfffffffe
+    .long 0xfffffdfe
 
     .end


### PR DESCRIPTION
...tart-up to

allow proper booting when powered from the K64F USB port. Refer to issue (#569).
