### PR TITLE
[DISCO_F429ZI] correction of RAM memory layout in linker script and stdio_uart config

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_F429ZI/TOOLCHAIN_GCC_ARM/STM32F429ZI.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_F429ZI/TOOLCHAIN_GCC_ARM/STM32F429ZI.ld
@@ -5,7 +5,7 @@ MEMORY
 { 
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 2048k
   CCM (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
-  RAM (rwx) : ORIGIN = 0x20000188, LENGTH = 192k - 0x188 
+  RAM (rwx) : ORIGIN = 0x200001AC, LENGTH = 192k - 0x1AC 
 }
 
 /* Linker script to place sections and symbol values. Should be used together

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F429ZI/PeripheralNames.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F429ZI/PeripheralNames.h
@@ -60,7 +60,7 @@ typedef enum {
 
 #define STDIO_UART_TX  PA_9
 #define STDIO_UART_RX  PA_10
-#define STDIO_UART     UART_2
+#define STDIO_UART     UART_1
 
 typedef enum {
     SPI_1 = (int)SPI1_BASE,


### PR DESCRIPTION
All test without any peripherals ("peripherals": []) are OK with these two corrections.
- RAM start address was wrong - overlaped with interrupt vector table
- wrong uart config (pins and uart number) for stdio uart
