### PR TITLE
fix for the case where there are multiple tickers firing at nearly the s...

### DIFF
--- a/libraries/mbed/common/us_ticker_api.c
+++ b/libraries/mbed/common/us_ticker_api.c
@@ -37,7 +37,7 @@ void us_ticker_irq_handler(void) {
             return;
         }
 
-        if ((int)(head->timestamp - us_ticker_read()) <= 0) {
+        if ((int64_t)(head->timestamp - us_ticker_read()) <= 0) {
             // This event was in the past:
             //      point to the following one and execute its handler
             ticker_event_t *p = head;
@@ -70,7 +70,7 @@ void us_ticker_insert_event(ticker_event_t *obj, timestamp_t timestamp, uint32_t
     ticker_event_t *prev = NULL, *p = head;
     while (p != NULL) {
         /* check if we come before p */
-        if ((int)(timestamp - p->timestamp) <= 0) {
+        if ((int64_t)(timestamp - p->timestamp) < 0) {
             break;
         }
         /* go to the next element */


### PR DESCRIPTION
...ame time

Here's the main fix:
- if (ticksToCount < APP_TIMER_MIN_TIMEOUT_TICKS) { /\* Honour the minimum value of the timeout_ticks parameter of app_timer_start() */
- ticksToCount = APP_TIMER_MIN_TIMEOUT_TICKS;
- }

There is a limit on how close app_timers can be setup to fire one after another; and I was not respect these thresholds. This would get exposed when users would setup tickers to fire at nearly the same time.
