### PR TITLE
add RTOS support for Nucleo STM32F302R8

### DIFF
--- a/libraries/rtos/rtx/RTX_CM_lib.h
+++ b/libraries/rtos/rtx/RTX_CM_lib.h
@@ -268,6 +268,9 @@ osThreadDef_t os_thread_def_main = {(os_pthread)main, osPriorityNormal, 0, NULL}
 #elif defined(TARGET_STM32F103RB)
 #define INITIAL_SP            (0x20005000UL)
 
+#elif defined(TARGET_STM32F302R8)
+#define INITIAL_SP            (0x20004000UL)
+
 #else
 #error "no target defined"
 

--- a/libraries/rtos/rtx/RTX_Conf_CM.c
+++ b/libraries/rtos/rtx/RTX_Conf_CM.c
@@ -54,7 +54,7 @@
 #    define OS_TASKCNT         14
 #  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPCCAPPUCCINO) || defined(TARGET_LPC1114) \
 	 || defined(TARGET_LPC812)   || defined(TARGET_KL25Z)         || defined(TARGET_KL05Z)        || defined(TARGET_STM32F100RB)  || defined(TARGET_STM32F051R8) \
-	 || defined(TARGET_STM32F103RB) || defined(TARGET_LPC824)
+	 || defined(TARGET_STM32F103RB) || defined(TARGET_LPC824) || defined(TARGET_STM32F302R8)
 #    define OS_TASKCNT         6
 #  else
 #    error "no target defined"
@@ -68,7 +68,7 @@
 #      define OS_SCHEDULERSTKSIZE    256
 #  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPCCAPPUCCINO)  || defined(TARGET_LPC1114) \
 	 || defined(TARGET_LPC812)   || defined(TARGET_KL25Z)         || defined(TARGET_KL05Z)        || defined(TARGET_STM32F100RB)  || defined(TARGET_STM32F051R8) \
-	 || defined(TARGET_STM32F103RB) || defined(TARGET_LPC824)
+	 || defined(TARGET_STM32F103RB) || defined(TARGET_LPC824) || defined(TARGET_STM32F302R8)
 #      define OS_SCHEDULERSTKSIZE    128
 #  else
 #    error "no target defined"
@@ -114,7 +114,7 @@
 #  if defined(TARGET_LPC1768) || defined(TARGET_LPC2368)
 #    define OS_CLOCK       96000000
 
-#  elif defined(TARGET_LPC1347) || defined(TARGET_STM32F303VC) || defined(TARGET_LPC1549)
+#  elif defined(TARGET_LPC1347) || defined(TARGET_STM32F303VC) || defined(TARGET_LPC1549) || defined(TARGET_STM32F302R8)
 #    define OS_CLOCK       72000000
 
 #  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPCCAPPUCCINO)  || defined(TARGET_LPC1114) || defined(TARGET_KL25Z) || defined(TARGET_KL05Z) || defined(TARGET_KL46Z) || defined(TARGET_KL43Z) || defined(TARGET_STM32F051R8) || defined(TARGET_LPC11U68)


### PR DESCRIPTION
This works with the rtos_basic project.

Initial SP from
mbed/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F302R8/TOOLCHAIN_ARM_MICRO/startup_stm32f302x8.s

Please review the other values (task count, stack size, clock).

Thanks,
Lawrence
