### PR TITLE
[NUCLEO_F401RE] Update STM32Cube driver

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/TOOLCHAIN_ARM_MICRO/startup_stm32f401xe.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/TOOLCHAIN_ARM_MICRO/startup_stm32f401xe.s
@@ -1,8 +1,8 @@
 ;******************** (C) COPYRIGHT 2014 STMicroelectronics ********************
 ;* File Name          : startup_stm32f401xe.s
 ;* Author             : MCD Application Team
-;* Version            : V2.1.0RC2
-;* Date               : 14-May-2014
+;* Version            : V2.1.0
+;* Date               : 19-June-2014
 ;* Description        : STM32F401xe devices vector table for MDK-ARM_MICRO toolchain. 
 ;*                      This module performs:
 ;*                      - Set the initial SP

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/TOOLCHAIN_ARM_STD/startup_stm32f401xe.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/TOOLCHAIN_ARM_STD/startup_stm32f401xe.s
@@ -1,8 +1,8 @@
 ;******************** (C) COPYRIGHT 2014 STMicroelectronics ********************
 ;* File Name          : startup_stm32f401xe.s
 ;* Author             : MCD Application Team
-;* Version            : V2.1.0RC2
-;* Date               : 14-May-2014
+;* Version            : V2.1.0
+;* Date               : 19-June-2014
 ;* Description        : STM32F401xe devices vector table for MDK-ARM_STD toolchain. 
 ;*                      This module performs:
 ;*                      - Set the initial SP

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/hal_tick.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/hal_tick.c
@@ -71,7 +71,10 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Reset timer
     TIM_MST_RESET_ON;
     TIM_MST_RESET_OFF;
-  
+
+    // Update the SystemCoreClock variable
+    SystemCoreClockUpdate();
+
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f401xe.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f401xe.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f401xe.h
   * @author  MCD Application Team
-  * @version V2.1.0RC2
-  * @date    14-May-2014
+  * @version V2.1.0
+  * @date    19-June-2014
   * @brief   CMSIS STM32F401xExx Device Peripheral Access Layer Header File. 
   *
   *          This file contains:
@@ -675,6 +675,7 @@ USB_OTG_HostChannelTypeDef;
 #define SRAM3_BB_BASE         ((uint32_t)0x22020000) /*!< SRAM3(64 KB) base address in the bit-band region                              */
 #define PERIPH_BB_BASE        ((uint32_t)0x42000000) /*!< Peripheral base address in the bit-band region                                */
 #define BKPSRAM_BB_BASE       ((uint32_t)0x42024000) /*!< Backup SRAM(4 KB) base address in the bit-band region                         */
+#define FLASH_END             ((uint32_t)0x0807FFFF) /*!< FLASH end address */
 
 /* Legacy defines */
 #define SRAM_BASE             SRAM1_BASE

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx.h
   * @author  MCD Application Team
-  * @version V2.1.0RC2
-  * @date    14-May-2014
+  * @version V2.1.0
+  * @date    19-June-2014
   * @brief   CMSIS STM32F4xx Device Peripheral Access Layer Header File.           
   *            
   *          The file is the unique include file that the application programmer
@@ -99,16 +99,16 @@
 #endif /* USE_HAL_DRIVER */
 
 /**
-  * @brief CMSIS Device version number V2.1.0RC2
+  * @brief CMSIS Device version number V2.1.0
   */
 #define __STM32F4xx_CMSIS_DEVICE_VERSION_MAIN   (0x02) /*!< [31:24] main version */                                  
 #define __STM32F4xx_CMSIS_DEVICE_VERSION_SUB1   (0x01) /*!< [23:16] sub1 version */
 #define __STM32F4xx_CMSIS_DEVICE_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
-#define __STM32F4xx_CMSIS_DEVICE_VERSION_RC     (0x02) /*!< [7:0]  release candidate */ 
-#define __STM32F4xx_CMSIS_DEVICE_VERSION        ((__CMSIS_DEVICE_VERSION_MAIN     << 24)\
-                                      |(__CMSIS_DEVICE_HAL_VERSION_SUB1 << 16)\
-                                      |(__CMSIS_DEVICE_HAL_VERSION_SUB2 << 8 )\
-                                      |(__CMSIS_DEVICE_HAL_VERSION_RC))
+#define __STM32F4xx_CMSIS_DEVICE_VERSION_RC     (0x00) /*!< [7:0]  release candidate */ 
+#define __STM32F4xx_CMSIS_DEVICE_VERSION        ((__STM32F4xx_CMSIS_DEVICE_VERSION_MAIN << 24)\
+                                                |(__STM32F4xx_CMSIS_DEVICE_VERSION_SUB1 << 16)\
+                                                |(__STM32F4xx_CMSIS_DEVICE_VERSION_SUB2 << 8 )\
+                                                |(__STM32F4xx_CMSIS_DEVICE_VERSION))
                                              
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   HAL module driver.
   *          This is the common part of the HAL initialization
   *
@@ -65,12 +65,12 @@
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /**
- * @brief STM32F4xx HAL Driver version number V1.1.0RC2
+ * @brief STM32F4xx HAL Driver version number V1.1.0
    */
 #define __STM32F4xx_HAL_VERSION_MAIN   (0x01) /*!< [31:24] main version */
 #define __STM32F4xx_HAL_VERSION_SUB1   (0x01) /*!< [23:16] sub1 version */
 #define __STM32F4xx_HAL_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
-#define __STM32F4xx_HAL_VERSION_RC     (0x02) /*!< [7:0]  release candidate */ 
+#define __STM32F4xx_HAL_VERSION_RC     (0x00) /*!< [7:0]  release candidate */ 
 #define __STM32F4xx_HAL_VERSION         ((__STM32F4xx_HAL_VERSION_MAIN << 24)\
                                         |(__STM32F4xx_HAL_VERSION_SUB1 << 16)\
                                         |(__STM32F4xx_HAL_VERSION_SUB2 << 8 )\

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   This file contains all the functions prototypes for the HAL 
   *          module driver.
   ******************************************************************************

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_adc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_adc.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_adc.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   This file provides firmware functions to manage the following 
   *          functionalities of the Analog to Digital Convertor (ADC) peripheral:
   *           + Initialization and de-initialization functions
@@ -206,7 +206,7 @@ static void ADC_DMAHalfConvCplt(DMA_HandleTypeDef *hdma);
 HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
 {
   /* Check ADC handle */
-  if(hadc == NULL)
+  if(hadc == HAL_NULL)
   {
      return HAL_ERROR;
   }
@@ -259,7 +259,7 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
 HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
 {
   /* Check ADC handle */
-  if(hadc == NULL)
+  if(hadc == HAL_NULL)
   {
      return HAL_ERROR;
   } 
@@ -434,10 +434,10 @@ HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef* hadc)
   */
 HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout)
 {
-  uint32_t timeout;
+  uint32_t tickstart = 0;
  
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;  
+  /* Get tick */ 
+  tickstart = HAL_GetTick();
 
   /* Check End of conversion flag */
   while(!(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOC)))
@@ -445,7 +445,7 @@ HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Ti
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         hadc->State= HAL_ADC_STATE_TIMEOUT;
         /* Process unlocked */
@@ -484,13 +484,13 @@ HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Ti
   */
 HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventType, uint32_t Timeout)
 {
+  uint32_t tickstart = 0;
+  
   /* Check the parameters */
   assert_param(IS_ADC_EVENT_TYPE(EventType));
-  
-  uint32_t timeout; 
 
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;   
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   /* Check selected event flag */
   while(!(__HAL_ADC_GET_FLAG(hadc,EventType)))
@@ -498,7 +498,7 @@ HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventTy
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         hadc->State= HAL_ADC_STATE_TIMEOUT;
         /* Process unlocked */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_adc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_adc.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_adc.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of ADC HAL extension module.
   ******************************************************************************
   * @attention
@@ -198,6 +198,46 @@ typedef struct
                                               ((ADC_CLOCK) == ADC_CLOCKPRESCALER_PCLK_DIV4) || \
                                               ((ADC_CLOCK) == ADC_CLOCKPRESCALER_PCLK_DIV6) || \
                                               ((ADC_CLOCK) == ADC_CLOCKPRESCALER_PCLK_DIV8))
+/**
+  * @}
+  */ 
+
+/** @defgroup ADC_delay_between_2_sampling_phases 
+  * @{
+  */ 
+#define ADC_TWOSAMPLINGDELAY_5CYCLES    ((uint32_t)0x00000000)
+#define ADC_TWOSAMPLINGDELAY_6CYCLES    ((uint32_t)ADC_CCR_DELAY_0)
+#define ADC_TWOSAMPLINGDELAY_7CYCLES    ((uint32_t)ADC_CCR_DELAY_1)
+#define ADC_TWOSAMPLINGDELAY_8CYCLES    ((uint32_t)(ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_9CYCLES    ((uint32_t)ADC_CCR_DELAY_2)
+#define ADC_TWOSAMPLINGDELAY_10CYCLES   ((uint32_t)(ADC_CCR_DELAY_2 | ADC_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_11CYCLES   ((uint32_t)(ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1))
+#define ADC_TWOSAMPLINGDELAY_12CYCLES   ((uint32_t)(ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_13CYCLES   ((uint32_t)ADC_CCR_DELAY_3)
+#define ADC_TWOSAMPLINGDELAY_14CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_15CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_1))
+#define ADC_TWOSAMPLINGDELAY_16CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_17CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_2))
+#define ADC_TWOSAMPLINGDELAY_18CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_2 | ADC_CCR_DELAY_0))
+#define ADC_TWOSAMPLINGDELAY_19CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1))
+#define ADC_TWOSAMPLINGDELAY_20CYCLES   ((uint32_t)ADC_CCR_DELAY)
+
+#define IS_ADC_SAMPLING_DELAY(DELAY) (((DELAY) == ADC_TWOSAMPLINGDELAY_5CYCLES)  || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_6CYCLES)  || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_7CYCLES)  || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_8CYCLES)  || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_9CYCLES)  || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_10CYCLES) || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_11CYCLES) || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_12CYCLES) || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_13CYCLES) || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_14CYCLES) || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_15CYCLES) || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_16CYCLES) || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_17CYCLES) || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_18CYCLES) || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_19CYCLES) || \
+                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_20CYCLES))
 /**
   * @}
   */ 
@@ -630,7 +670,7 @@ typedef struct
   * @param  __FLAG__: ADC flag.
   * @retval None
   */
-#define __HAL_ADC_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) &= ~(__FLAG__))
+#define __HAL_ADC_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) = ~(__FLAG__))
 
 /**
   * @brief  Get the selected ADC's flag status.

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_adc_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_adc_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_adc_ex.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   This file provides firmware functions to manage the following 
   *          functionalities of the ADC extension peripheral:
   *           + Extended features functions
@@ -338,10 +338,10 @@ HAL_StatusTypeDef HAL_ADCEx_InjectedStop(ADC_HandleTypeDef* hadc)
   */
 HAL_StatusTypeDef HAL_ADCEx_InjectedPollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout)
 {
-  uint32_t timeout;
- 
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;  
+  uint32_t tickstart = 0;
+
+  /* Get tick */ 
+  tickstart = HAL_GetTick();
 
   /* Check End of conversion flag */
   while(!(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JEOC)))
@@ -349,7 +349,7 @@ HAL_StatusTypeDef HAL_ADCEx_InjectedPollForConversion(ADC_HandleTypeDef* hadc, u
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         hadc->State= HAL_ADC_STATE_TIMEOUT;
         /* Process unlocked */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_adc_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_adc_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_adc.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of ADC HAL module.
   ******************************************************************************
   * @attention
@@ -92,7 +92,7 @@ typedef struct
   uint32_t DMAAccessMode;     /*!< Configures the Direct memory access mode for multi ADC mode.
                                    This parameter can be a value of @ref ADCEx_Direct_memory_access_mode_for_multi_mode */
   uint32_t TwoSamplingDelay;  /*!< Configures the Delay between 2 sampling phases.
-                                   This parameter can be a value of @ref ADCEx_delay_between_2_sampling_phases */
+                                   This parameter can be a value of @ref ADC_delay_between_2_sampling_phases */
 }ADC_MultiModeTypeDef;
 
 /* Exported constants --------------------------------------------------------*/
@@ -151,46 +151,6 @@ typedef struct
 /**
   * @}
   */ 
-
-  /** @defgroup ADCEx_delay_between_2_sampling_phases 
-  * @{
-  */ 
-#define ADC_TWOSAMPLINGDELAY_5CYCLES    ((uint32_t)0x00000000)
-#define ADC_TWOSAMPLINGDELAY_6CYCLES    ((uint32_t)ADC_CCR_DELAY_0)
-#define ADC_TWOSAMPLINGDELAY_7CYCLES    ((uint32_t)ADC_CCR_DELAY_1)
-#define ADC_TWOSAMPLINGDELAY_8CYCLES    ((uint32_t)(ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0))
-#define ADC_TWOSAMPLINGDELAY_9CYCLES    ((uint32_t)ADC_CCR_DELAY_2)
-#define ADC_TWOSAMPLINGDELAY_10CYCLES   ((uint32_t)(ADC_CCR_DELAY_2 | ADC_CCR_DELAY_0))
-#define ADC_TWOSAMPLINGDELAY_11CYCLES   ((uint32_t)(ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1))
-#define ADC_TWOSAMPLINGDELAY_12CYCLES   ((uint32_t)(ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0))
-#define ADC_TWOSAMPLINGDELAY_13CYCLES   ((uint32_t)ADC_CCR_DELAY_3)
-#define ADC_TWOSAMPLINGDELAY_14CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_0))
-#define ADC_TWOSAMPLINGDELAY_15CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_1))
-#define ADC_TWOSAMPLINGDELAY_16CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0))
-#define ADC_TWOSAMPLINGDELAY_17CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_2))
-#define ADC_TWOSAMPLINGDELAY_18CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_2 | ADC_CCR_DELAY_0))
-#define ADC_TWOSAMPLINGDELAY_19CYCLES   ((uint32_t)(ADC_CCR_DELAY_3 | ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1))
-#define ADC_TWOSAMPLINGDELAY_20CYCLES   ((uint32_t)ADC_CCR_DELAY)
-
-#define IS_ADC_SAMPLING_DELAY(DELAY) (((DELAY) == ADC_TWOSAMPLINGDELAY_5CYCLES)  || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_6CYCLES)  || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_7CYCLES)  || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_8CYCLES)  || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_9CYCLES)  || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_10CYCLES) || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_11CYCLES) || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_12CYCLES) || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_13CYCLES) || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_14CYCLES) || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_15CYCLES) || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_16CYCLES) || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_17CYCLES) || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_18CYCLES) || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_19CYCLES) || \
-                                      ((DELAY) == ADC_TWOSAMPLINGDELAY_20CYCLES))
-/**
-  * @}
-  */
 
 /** @defgroup ADCEx_External_trigger_edge_Injected 
   * @{

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_can.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_can.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_can.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of CAN HAL module.
   ******************************************************************************
   * @attention
@@ -673,11 +673,11 @@ typedef struct
   * @retval The new state of __FLAG__ (TRUE or FALSE).
   */
 #define __HAL_CAN_CLEAR_FLAG(__HANDLE__, __FLAG__) \
-((((__FLAG__) >> 8) == 5)? (((__HANDLE__)->Instance->TSR) &= ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))): \
- (((__FLAG__) >> 8) == 2)? (((__HANDLE__)->Instance->RF0R) &= ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))): \
- (((__FLAG__) >> 8) == 4)? (((__HANDLE__)->Instance->RF1R) &= ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))): \
- (((__FLAG__) >> 8) == 1)? (((__HANDLE__)->Instance->MSR) &= ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))): \
- (((__HANDLE__)->Instance->ESR) &= ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))))
+((((__FLAG__) >> 8) == 5)? (((__HANDLE__)->Instance->TSR) = ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8) == 2)? (((__HANDLE__)->Instance->RF0R) = ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8) == 4)? (((__HANDLE__)->Instance->RF1R) = ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__FLAG__) >> 8) == 1)? (((__HANDLE__)->Instance->MSR) = ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))): \
+ (((__HANDLE__)->Instance->ESR) = ~((uint32_t)1 << ((__FLAG__) & CAN_FLAG_MASK))))
 
 /** @brief  Check if the specified CAN interrupt source is enabled or disabled.
   * @param  __HANDLE__: CAN Handle

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_conf.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_conf.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_conf_template.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   HAL configuration template file. 
   *          This file should be copied to the application folder and renamed
   *          to stm32f4xx_hal_conf.h.
@@ -76,7 +76,7 @@
 #define HAL_LTDC_MODULE_ENABLED 
 #define HAL_PWR_MODULE_ENABLED   
 #define HAL_RCC_MODULE_ENABLED 
-//#define HAL_RNG_MODULE_ENABLED   
+#define HAL_RNG_MODULE_ENABLED   
 #define HAL_RTC_MODULE_ENABLED
 #define HAL_SAI_MODULE_ENABLED   
 #define HAL_SD_MODULE_ENABLED  
@@ -103,7 +103,7 @@
 #endif /* HSE_VALUE */
 
 #if !defined  (HSE_STARTUP_TIMEOUT)
-  #define HSE_STARTUP_TIMEOUT    ((uint32_t)100)   /*!< Time out for HSE start up, in ms */
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)500)   /*!< Time out for HSE start up, in ms */
 #endif /* HSE_STARTUP_TIMEOUT */
 
 /**
@@ -116,11 +116,18 @@
 #endif /* HSI_VALUE */
 
 /**
+  * @brief Internal Low Speed oscillator (LSI) value.
+  */
+#if !defined  (LSI_VALUE) 
+ #define LSI_VALUE  ((uint32_t)40000)    
+#endif /* LSI_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
+                                             The real value may vary depending on the variations
+                                             in voltage and temperature.  */
+/**
   * @brief External Low Speed oscillator (LSE) value.
-  *        This value is used by the UART, RTC HAL module to compute the system frequency
   */
 #if !defined  (LSE_VALUE)
-  #define LSE_VALUE    ((uint32_t)32768) /*!< Value of the External oscillator in Hz*/
+ #define LSE_VALUE  ((uint32_t)32768)    /*!< Value of the External Low Speed oscillator in Hz */
 #endif /* LSE_VALUE */
 
 /**
@@ -129,7 +136,7 @@
   *        frequency, this source is inserted directly through I2S_CKIN pad. 
   */
 #if !defined  (EXTERNAL_CLOCK_VALUE)
-  #define EXTERNAL_CLOCK_VALUE    ((uint32_t)12288000) /*!< Value of the external oscillator in Hz*/
+  #define EXTERNAL_CLOCK_VALUE    ((uint32_t)12288000) /*!< Value of the Internal oscillator in Hz*/
 #endif /* EXTERNAL_CLOCK_VALUE */
 
 /* Tip: To avoid modifying this file each time you need to use different HSE,

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_cortex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_cortex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_cortex.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   CORTEX HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the CORTEX:

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_cortex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_cortex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_cortex.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of CORTEX HAL module.
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_crc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_crc.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_crc.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   CRC HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Cyclic Redundancy Check (CRC) peripheral:
@@ -112,7 +112,7 @@
 HAL_StatusTypeDef HAL_CRC_Init(CRC_HandleTypeDef *hcrc)
 {
   /* Check the CRC handle allocation */
-  if(hcrc == NULL)
+  if(hcrc == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -145,7 +145,7 @@ HAL_StatusTypeDef HAL_CRC_Init(CRC_HandleTypeDef *hcrc)
 HAL_StatusTypeDef HAL_CRC_DeInit(CRC_HandleTypeDef *hcrc)
 {
   /* Check the CRC handle allocation */
-  if(hcrc == NULL)
+  if(hcrc == HAL_NULL)
   {
     return HAL_ERROR;
   }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_crc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_crc.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_crc.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of CRC HAL module.
   ******************************************************************************
   * @attention
@@ -97,6 +97,21 @@ typedef struct
   * @retval None
   */
 #define __HAL_CRC_DR_RESET(__HANDLE__) ((__HANDLE__)->Instance->CR |= CRC_CR_RESET)
+
+/**
+  * @brief Stores a 8-bit data in the Independent Data(ID) register.
+  * @param __HANDLE__: CRC handle
+  * @param __VALUE: 8-bit value to be stored in the ID register
+  * @retval None
+  */
+#define __HAL_CRC_SET_IDR(__HANDLE__, __VALUE__) (MODIFY_REG((__HANDLE__)->Instance->IDR, CRC_IDR_IDR, (__VALUE__))
+
+/**
+  * @brief Returns the 8-bit data stored in the Independent Data(ID) register.
+  * @param __HANDLE__: CRC handle
+  * @retval 8-bit value of the ID register 
+  */
+#define __HAL_CRC_GET_IDR(__HANDLE__) (((__HANDLE__)->Instance->IDR) & CRC_IDR_IDR)
 
 /* Exported functions --------------------------------------------------------*/
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_cryp.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_cryp.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_cryp.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   CRYP HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Cryptography (CRYP) peripheral:
@@ -115,6 +115,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+#define CRYP_TIMEOUT_VALUE  1
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
@@ -472,7 +473,7 @@ HAL_StatusTypeDef HAL_CRYP_AESCTR_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pP
   */
 HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData, uint32_t Timeout)
 {
-   uint32_t timeout = 0;
+   uint32_t tickstart = 0;
   
   /* Process Locked */
   __HAL_LOCK(hcryp);
@@ -492,15 +493,15 @@ HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pC
     /* Enable CRYP */
     __HAL_CRYP_ENABLE();
     
-    /* Get timeout */
-    timeout = HAL_GetTick() + Timeout;
+    /* Get tick */ 
+    tickstart = HAL_GetTick();
 
     while(HAL_IS_BIT_SET(CRYP->SR, CRYP_FLAG_BUSY))
     {
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
@@ -560,7 +561,7 @@ HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pC
   */
 HAL_StatusTypeDef HAL_CRYP_AESCBC_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData, uint32_t Timeout)
 {
-   uint32_t timeout = 0;   
+  uint32_t tickstart = 0;
   
   /* Process Locked */
   __HAL_LOCK(hcryp);
@@ -580,20 +581,20 @@ HAL_StatusTypeDef HAL_CRYP_AESCBC_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pC
     /* Enable CRYP */
     __HAL_CRYP_ENABLE();
     
-    /* Get Timeout */
-    timeout = HAL_GetTick() + Timeout;
+    /* Get tick */ 
+    tickstart = HAL_GetTick();
 
     while(HAL_IS_BIT_SET(CRYP->SR, CRYP_FLAG_BUSY))
     {
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;
@@ -1012,7 +1013,7 @@ HAL_StatusTypeDef HAL_CRYP_AESCTR_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t 
   */
 HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;
 
   uint32_t inputaddr;
   uint32_t outputaddr;
@@ -1041,13 +1042,13 @@ HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t 
     /* Enable CRYP */
     __HAL_CRYP_ENABLE();
     
-    /* Get timeout */
-    timeout = HAL_GetTick() + 1;
+    /* Get tick */ 
+    tickstart = HAL_GetTick();
 
     while(HAL_IS_BIT_SET(CRYP->SR, CRYP_FLAG_BUSY))
     {
       /* Check for the Timeout */
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > CRYP_TIMEOUT_VALUE)
       {
         /* Change state */
         hcryp->State = HAL_CRYP_STATE_TIMEOUT;
@@ -1142,7 +1143,7 @@ HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t 
 HAL_StatusTypeDef HAL_CRYP_AESCBC_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData)
 {
 
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   uint32_t inputaddr;
   uint32_t outputaddr;
   
@@ -1172,18 +1173,18 @@ HAL_StatusTypeDef HAL_CRYP_AESCBC_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t 
       /* Enable CRYP */
       __HAL_CRYP_ENABLE();
       
-    /* Get timeout */
-    timeout = HAL_GetTick() + 1;
+    /* Get tick */
+    tickstart = HAL_GetTick();
 
     while(HAL_IS_BIT_SET(CRYP->SR, CRYP_FLAG_BUSY))
     {
       /* Check for the Timeout */
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > CRYP_TIMEOUT_VALUE)
       {
         /* Change state */
         hcryp->State = HAL_CRYP_STATE_TIMEOUT;
         
-        /* Process Unlocked */          
+        /* Process Unlocked */
         __HAL_UNLOCK(hcryp);
         
         return HAL_TIMEOUT;
@@ -1555,7 +1556,7 @@ HAL_StatusTypeDef HAL_CRYP_AESCTR_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t
   */
 HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   uint32_t inputaddr;
   uint32_t outputaddr;
   
@@ -1582,18 +1583,18 @@ HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t
     /* Enable CRYP */
     __HAL_CRYP_ENABLE();
     
-    /* Get timeout */
-    timeout = HAL_GetTick() + 1;
+    /* Get tick */
+    tickstart = HAL_GetTick();
     
     while(HAL_IS_BIT_SET(CRYP->SR, CRYP_FLAG_BUSY))
     {
       /* Check for the Timeout */
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > CRYP_TIMEOUT_VALUE)
       {
         /* Change state */
         hcryp->State = HAL_CRYP_STATE_TIMEOUT;
         
-        /* Process Unlocked */          
+        /* Process Unlocked */
         __HAL_UNLOCK(hcryp);
         
         return HAL_TIMEOUT;
@@ -1639,7 +1640,7 @@ HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t
   */
 HAL_StatusTypeDef HAL_CRYP_AESCBC_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   uint32_t inputaddr;
   uint32_t outputaddr;
   
@@ -1666,18 +1667,18 @@ HAL_StatusTypeDef HAL_CRYP_AESCBC_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t
       /* Enable CRYP */
       __HAL_CRYP_ENABLE();
       
-      /* Get timeout */
-      timeout = HAL_GetTick() + 1;
+      /* Get tick */
+      tickstart = HAL_GetTick();
 
       while(HAL_IS_BIT_SET(CRYP->SR, CRYP_FLAG_BUSY))
       {
         /* Check for the Timeout */
-        if(HAL_GetTick() >= timeout)
+        if((HAL_GetTick() - tickstart ) > CRYP_TIMEOUT_VALUE)
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;
@@ -3507,7 +3508,7 @@ static void CRYP_SetInitVector(CRYP_HandleTypeDef *hcryp, uint8_t *InitVector, u
   */
 static HAL_StatusTypeDef CRYP_ProcessData(CRYP_HandleTypeDef *hcryp, uint8_t* Input, uint16_t Ilength, uint8_t* Output, uint32_t Timeout)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
   
   uint32_t i = 0;
   uint32_t inputaddr  = (uint32_t)Input;
@@ -3525,20 +3526,20 @@ static HAL_StatusTypeDef CRYP_ProcessData(CRYP_HandleTypeDef *hcryp, uint8_t* In
     CRYP->DR = *(uint32_t*)(inputaddr);
     inputaddr+=4;
     
-    /* Get timeout */
-    timeout = HAL_GetTick() + Timeout;
+    /* Get tick */
+    tickstart = HAL_GetTick();
 
     while(HAL_IS_BIT_CLR(CRYP->SR, CRYP_FLAG_OFNE))
     {    
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
         
           return HAL_TIMEOUT;
@@ -3571,7 +3572,7 @@ static HAL_StatusTypeDef CRYP_ProcessData(CRYP_HandleTypeDef *hcryp, uint8_t* In
   */
 static HAL_StatusTypeDef CRYP_ProcessData2Words(CRYP_HandleTypeDef *hcryp, uint8_t* Input, uint16_t Ilength, uint8_t* Output, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   
   uint32_t i = 0;
   uint32_t inputaddr  = (uint32_t)Input;
@@ -3585,15 +3586,15 @@ static HAL_StatusTypeDef CRYP_ProcessData2Words(CRYP_HandleTypeDef *hcryp, uint8
     CRYP->DR = *(uint32_t*)(inputaddr);
     inputaddr+=4;
     
-    /* Get timeout */
-    timeout = HAL_GetTick() + Timeout;
+    /* Get tick */
+    tickstart = HAL_GetTick();
     
     while(HAL_IS_BIT_CLR(CRYP->SR, CRYP_FLAG_OFNE))
     {
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_cryp.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_cryp.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_cryp.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of CRYP HAL module.
   ******************************************************************************
   * @attention
@@ -255,7 +255,7 @@ typedef struct
 #define __HAL_CRYP_FIFO_FLUSH() (CRYP->CR |=  CRYP_CR_FFLUSH)
 
 /**
-  * @brief  Set the algorithm mode: AES-ECB, AES-CBC, AES-CTR, DES-ECB, DES-CBC,
+  * @brief  Set the algorithm mode: AES-ECB, AES-CBC, AES-CTR, DES-ECB, DES-CBC.
   * @param  MODE: The algorithm mode.
   * @retval None
   */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_cryp_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_cryp_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_cryp_ex.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Extended CRYP HAL module driver
   *          This file provides firmware functions to manage the following 
   *          functionalities of CRYP extension peripheral:
@@ -111,6 +111,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+#define CRYPEx_TIMEOUT_VALUE  1
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
@@ -163,7 +164,7 @@ static void CRYPEx_GCMCCM_SetDMAConfig(CRYP_HandleTypeDef *hcryp, uint32_t input
   */
 HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;
   uint32_t headersize = hcryp->Init.HeaderSize;
   uint32_t headeraddr = (uint32_t)hcryp->Init.Header;
   uint32_t loopcounter = 0;
@@ -284,20 +285,20 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *
     /* Enable the CRYP peripheral */
     __HAL_CRYP_ENABLE();
     
-    /* Get timeout */
-    timeout = HAL_GetTick() + Timeout;
+    /* Get tick */
+    tickstart = HAL_GetTick();
 
     while((CRYP->CR & CRYP_CR_CRYPEN) == CRYP_CR_CRYPEN)
     {
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
         
           return HAL_TIMEOUT;
@@ -315,20 +316,21 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *
       
       for(loopcounter = 0; (loopcounter < headersize); loopcounter+=16)
       {
-        /* Get timeout */
-        timeout = HAL_GetTick() + Timeout;
+        /* Get tick */
+        tickstart = HAL_GetTick();
+
         while(HAL_IS_BIT_CLR(CRYP->SR, CRYP_FLAG_IFEM))
         {
           {
             /* Check for the Timeout */
             if(Timeout != HAL_MAX_DELAY)
             {
-              if(HAL_GetTick() >= timeout)
+              if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
               {
                 /* Change state */
                 hcryp->State = HAL_CRYP_STATE_TIMEOUT;
                 
-                /* Process Unlocked */          
+                /* Process Unlocked */
                 __HAL_UNLOCK(hcryp);
                 
                 return HAL_TIMEOUT;
@@ -347,20 +349,20 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *
         headeraddr+=4;
       }
       
-      /* Get timeout */
-      timeout = HAL_GetTick() + Timeout;
+      /* Get tick */
+      tickstart = HAL_GetTick();
 
       while((CRYP->SR & CRYP_FLAG_BUSY) == CRYP_FLAG_BUSY)
       {
         /* Check for the Timeout */
         if(Timeout != HAL_MAX_DELAY)
         {
-          if(HAL_GetTick() >= timeout)
+          if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
           {
             /* Change state */
             hcryp->State = HAL_CRYP_STATE_TIMEOUT;
             
-            /* Process Unlocked */          
+            /* Process Unlocked */
             __HAL_UNLOCK(hcryp);
             
             return HAL_TIMEOUT;
@@ -418,7 +420,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *
   */
 HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;
   
   /* Process Locked */
   __HAL_LOCK(hcryp);
@@ -444,20 +446,20 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *
     /* Enable the CRYP peripheral */
     __HAL_CRYP_ENABLE();
     
-    /* Get timeout */
-    timeout = HAL_GetTick() + Timeout;
+    /* Get tick */
+    tickstart = HAL_GetTick();
 
     while((CRYP->CR & CRYP_CR_CRYPEN) == CRYP_CR_CRYPEN)
     {
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;
@@ -516,7 +518,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *
   */
 HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   
   /* Process Locked */
   __HAL_LOCK(hcryp);
@@ -542,20 +544,20 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *
     /* Enable the CRYP peripheral */
     __HAL_CRYP_ENABLE();
     
-    /* Get the timeout */
-    timeout = HAL_GetTick() + Timeout;
+    /* Get tick */
+    tickstart = HAL_GetTick();
 
     while((CRYP->CR & CRYP_CR_CRYPEN) == CRYP_CR_CRYPEN)
     {
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;
@@ -608,7 +610,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *
   */
 HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Finish(CRYP_HandleTypeDef *hcryp, uint16_t Size, uint8_t *AuthTag, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   uint32_t headerlength = hcryp->Init.HeaderSize * 8; /* Header length in bits */
   uint32_t inputlength = Size * 8; /* input length in bits */
   uint32_t tagaddr = (uint32_t)AuthTag;
@@ -664,20 +666,20 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Finish(CRYP_HandleTypeDef *hcryp, uint16_t S
       CRYP->DR = 0;
       CRYP->DR = (uint32_t)(inputlength);
     }
-    /* Get timeout */
-    timeout = HAL_GetTick() + Timeout;
+    /* Get tick */
+    tickstart = HAL_GetTick();
 
     while(HAL_IS_BIT_CLR(CRYP->SR, CRYP_FLAG_OFNE))
     {
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
         
           return HAL_TIMEOUT;
@@ -716,7 +718,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Finish(CRYP_HandleTypeDef *hcryp, uint16_t S
   */
 HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Finish(CRYP_HandleTypeDef *hcryp, uint8_t *AuthTag, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   uint32_t tagaddr = (uint32_t)AuthTag;
   uint32_t ctraddr = (uint32_t)hcryp->Init.pScratch;
   uint32_t temptag[4] = {0}; /* Temporary TAG (MAC) */
@@ -752,20 +754,20 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Finish(CRYP_HandleTypeDef *hcryp, uint8_t *A
     ctraddr+=4;
     CRYP->DR = *(uint32_t*)ctraddr;
     
-    /* Get timeout */
-    timeout = HAL_GetTick() + Timeout;
+    /* Get tick */
+    tickstart = HAL_GetTick();
 
     while(HAL_IS_BIT_CLR(CRYP->SR, CRYP_FLAG_OFNE))
     {
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;
@@ -810,7 +812,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Finish(CRYP_HandleTypeDef *hcryp, uint8_t *A
   */
 HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   uint32_t headersize = hcryp->Init.HeaderSize;
   uint32_t headeraddr = (uint32_t)hcryp->Init.Header;
   uint32_t loopcounter = 0;
@@ -931,20 +933,20 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *
     /* Enable the CRYP peripheral */
     __HAL_CRYP_ENABLE();
     
-    /* Get timeout */
-    timeout = HAL_GetTick() + Timeout;
+    /* Get tick */
+    tickstart = HAL_GetTick();
  
     while((CRYP->CR & CRYP_CR_CRYPEN) == CRYP_CR_CRYPEN)
     {
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
         
           return HAL_TIMEOUT;
@@ -962,20 +964,20 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *
       
       for(loopcounter = 0; (loopcounter < headersize); loopcounter+=16)
       {
-        /* Get timeout */
-        timeout = HAL_GetTick() + Timeout;
+        /* Get tick */
+        tickstart = HAL_GetTick();
 
         while(HAL_IS_BIT_CLR(CRYP->SR, CRYP_FLAG_IFEM))
         {
           /* Check for the Timeout */
           if(Timeout != HAL_MAX_DELAY)
           {
-            if(HAL_GetTick() >= timeout)
+            if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
             {
               /* Change state */
               hcryp->State = HAL_CRYP_STATE_TIMEOUT;
               
-              /* Process Unlocked */          
+              /* Process Unlocked */
               __HAL_UNLOCK(hcryp);
               
               return HAL_TIMEOUT;
@@ -993,20 +995,20 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *
         headeraddr+=4;
       }
       
-      /* Get timeout */
-      timeout = HAL_GetTick() + Timeout;
+      /* Get tick */
+      tickstart = HAL_GetTick();
 
       while((CRYP->SR & CRYP_FLAG_BUSY) == CRYP_FLAG_BUSY)
       {
       /* Check for the Timeout */
         if(Timeout != HAL_MAX_DELAY)
         {
-          if(HAL_GetTick() >= timeout)
+          if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
           {
             /* Change state */
             hcryp->State = HAL_CRYP_STATE_TIMEOUT;
             
-            /* Process Unlocked */          
+            /* Process Unlocked */
             __HAL_UNLOCK(hcryp);
             
             return HAL_TIMEOUT;
@@ -1061,7 +1063,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *
   */
 HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   uint32_t inputaddr;
   uint32_t outputaddr;
   
@@ -1097,19 +1099,19 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_
       /* Enable CRYP to start the init phase */
       __HAL_CRYP_ENABLE();
       
-      /* Get timeout */
-      timeout = HAL_GetTick() + 1;
+     /* Get tick */
+     tickstart = HAL_GetTick();
 
       while((CRYP->CR & CRYP_CR_CRYPEN) == CRYP_CR_CRYPEN)
       {
         /* Check for the Timeout */
         
-        if(HAL_GetTick() >= timeout)
+        if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;
@@ -1212,7 +1214,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_
   */
 HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   uint32_t inputaddr;
   uint32_t outputaddr;
   
@@ -1343,18 +1345,18 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_
       /* Enable the CRYP peripheral */
       __HAL_CRYP_ENABLE();
       
-      /* Get timeout */
-      timeout = HAL_GetTick() + 1;
+     /* Get tick */
+     tickstart = HAL_GetTick();
 
       while((CRYP->CR & CRYP_CR_CRYPEN) == CRYP_CR_CRYPEN)
       {
         /* Check for the Timeout */
-        if(HAL_GetTick() >= timeout)
+        if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;
@@ -1371,18 +1373,18 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_
         
         for(loopcounter = 0; (loopcounter < headersize); loopcounter+=16)
         {
-          /* Get timeout */
-          timeout = HAL_GetTick() + 1;
+         /* Get tick */
+         tickstart = HAL_GetTick();
 
           while(HAL_IS_BIT_CLR(CRYP->SR, CRYP_FLAG_IFEM))
           {
             /* Check for the Timeout */
-            if(HAL_GetTick() >= timeout)
+            if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
             {
               /* Change state */
               hcryp->State = HAL_CRYP_STATE_TIMEOUT;
               
-              /* Process Unlocked */          
+              /* Process Unlocked */
               __HAL_UNLOCK(hcryp);
               
               return HAL_TIMEOUT;
@@ -1398,19 +1400,19 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_
           CRYP->DR = *(uint32_t*)(headeraddr);
           headeraddr+=4;
         }
-        
-        /* Get timeout */
-        timeout = HAL_GetTick() + 1;
+
+        /* Get tick */
+        tickstart = HAL_GetTick();
 
         while((CRYP->SR & CRYP_FLAG_BUSY) == CRYP_FLAG_BUSY)
         {
           /* Check for the Timeout */
-          if(HAL_GetTick() >= timeout)
+          if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
           {
             /* Change state */
             hcryp->State = HAL_CRYP_STATE_TIMEOUT;
             
-            /* Process Unlocked */          
+            /* Process Unlocked */
             __HAL_UNLOCK(hcryp);
             
             return HAL_TIMEOUT;
@@ -1511,7 +1513,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_
   */
 HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   uint32_t inputaddr;
   uint32_t outputaddr;
   
@@ -1546,19 +1548,19 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_
       
       /* Enable CRYP to start the init phase */
       __HAL_CRYP_ENABLE();
-      
-      /* Get timeout */
-      timeout = HAL_GetTick() + 1;
-      
+
+        /* Get tick */
+        tickstart = HAL_GetTick();
+
       while((CRYP->CR & CRYP_CR_CRYPEN) == CRYP_CR_CRYPEN)
       {
         /* Check for the Timeout */
-        if(HAL_GetTick() >= timeout)
+        if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;
@@ -1661,7 +1663,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_
 {
   uint32_t inputaddr;
   uint32_t outputaddr;
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
   uint32_t headersize = hcryp->Init.HeaderSize;
   uint32_t headeraddr = (uint32_t)hcryp->Init.Header;
   uint32_t loopcounter = 0;
@@ -1788,19 +1790,19 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_
       
       /* Enable the CRYP peripheral */
       __HAL_CRYP_ENABLE();
-      
-      /* Get timeout */
-      timeout = HAL_GetTick() + 1;
+
+      /* Get tick */
+      tickstart = HAL_GetTick();
 
       while((CRYP->CR & CRYP_CR_CRYPEN) == CRYP_CR_CRYPEN)
       {
         /* Check for the Timeout */
-        if(HAL_GetTick() >= timeout)
+        if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;
@@ -1817,18 +1819,18 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_
         
         for(loopcounter = 0; (loopcounter < headersize); loopcounter+=16)
         {
-          /* Get timeout */
-          timeout = HAL_GetTick() + 1;
+         /* Get tick */
+         tickstart = HAL_GetTick();
 
           while(HAL_IS_BIT_CLR(CRYP->SR, CRYP_FLAG_IFEM))
           {
             /* Check for the Timeout */
-            if(HAL_GetTick() >= timeout)
+            if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
             {
               /* Change state */
               hcryp->State = HAL_CRYP_STATE_TIMEOUT;
               
-              /* Process Unlocked */          
+              /* Process Unlocked */
               __HAL_UNLOCK(hcryp);
               
               return HAL_TIMEOUT;
@@ -1844,19 +1846,19 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_
           CRYP->DR = *(uint32_t*)(headeraddr);
           headeraddr+=4;
         }
-        
-        /* Get timeout */
-        timeout = HAL_GetTick() + 1;
+
+        /* Get tick */
+        tickstart = HAL_GetTick();
 
         while((CRYP->SR & CRYP_FLAG_BUSY) == CRYP_FLAG_BUSY)
         {
           /* Check for the Timeout */
-          if(HAL_GetTick() >= timeout)
+          if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
           {
             /* Change state */
             hcryp->State = HAL_CRYP_STATE_TIMEOUT;
             
-            /* Process Unlocked */          
+            /* Process Unlocked */
             __HAL_UNLOCK(hcryp);
             
             return HAL_TIMEOUT;
@@ -1949,7 +1951,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_
   */
 HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
   uint32_t inputaddr;
   uint32_t outputaddr;
   
@@ -1982,18 +1984,18 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8
       /* Enable CRYP to start the init phase */
       __HAL_CRYP_ENABLE();
       
-      /* Get timeout */
-      timeout = HAL_GetTick() + 1;
+      /* Get tick */
+      tickstart = HAL_GetTick();
 
       while((CRYP->CR & CRYP_CR_CRYPEN) == CRYP_CR_CRYPEN)
       {
         /* Check for the Timeout */
-        if(HAL_GetTick() >= timeout)
+        if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;
@@ -2046,7 +2048,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8
   */
 HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   uint32_t inputaddr;
   uint32_t outputaddr;
   uint32_t headersize;
@@ -2182,18 +2184,18 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8
       /* Enable the CRYP peripheral */
       __HAL_CRYP_ENABLE();
       
-      /* Get timeout */
-      timeout = HAL_GetTick() + 1;
+      /* Get tick */
+      tickstart = HAL_GetTick();
  
       while((CRYP->CR & CRYP_CR_CRYPEN) == CRYP_CR_CRYPEN)
       {
         /* Check for the Timeout */
-        if(HAL_GetTick() >= timeout)
+        if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;
@@ -2210,18 +2212,18 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8
         
         for(loopcounter = 0; (loopcounter < headersize); loopcounter+=16)
         {
-          /* Get timeout */
-          timeout = HAL_GetTick() + 1;
-          
+         /* Get tick */
+         tickstart = HAL_GetTick();
+
           while(HAL_IS_BIT_CLR(CRYP->SR, CRYP_FLAG_IFEM))
           {
             /* Check for the Timeout */
-            if(HAL_GetTick() >= timeout)
+            if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
             {
               /* Change state */
               hcryp->State = HAL_CRYP_STATE_TIMEOUT;
               
-              /* Process Unlocked */          
+              /* Process Unlocked */
               __HAL_UNLOCK(hcryp);
               
               return HAL_TIMEOUT;
@@ -2238,18 +2240,18 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8
           headeraddr+=4;
         }
         
-        /* Get timeout */
-        timeout = HAL_GetTick() + 1;
+        /* Get tick */
+        tickstart = HAL_GetTick();
 
         while((CRYP->SR & CRYP_FLAG_BUSY) == CRYP_FLAG_BUSY)
         {
           /* Check for the Timeout */
-          if(HAL_GetTick() >= timeout)
+          if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
           {
             /* Change state */
             hcryp->State = HAL_CRYP_STATE_TIMEOUT;
             
-            /* Process Unlocked */          
+            /* Process Unlocked */
             __HAL_UNLOCK(hcryp);
             
             return HAL_TIMEOUT;
@@ -2300,7 +2302,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8
   */
 HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   uint32_t inputaddr;
   uint32_t outputaddr;
   
@@ -2330,18 +2332,18 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8
       /* Enable CRYP to start the init phase */
       __HAL_CRYP_ENABLE();
       
-      /* Get timeout */
-      timeout = HAL_GetTick() + 1;
+      /* Get tick */
+      tickstart = HAL_GetTick();
 
       while((CRYP->CR & CRYP_CR_CRYPEN) == CRYP_CR_CRYPEN)
       {
         /* Check for the Timeout */
-        if(HAL_GetTick() >= timeout)
+        if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;
@@ -2390,7 +2392,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8
   */
 HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   uint32_t inputaddr;
   uint32_t outputaddr;
   uint32_t headersize;
@@ -2526,19 +2528,19 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8
       /* Enable the CRYP peripheral */
       __HAL_CRYP_ENABLE();
       
-      /* Get timeout */
-      timeout = HAL_GetTick() + 1;
+      /* Get tick */
+      tickstart = HAL_GetTick();
  
       while((CRYP->CR & CRYP_CR_CRYPEN) == CRYP_CR_CRYPEN)
       {
         /* Check for the Timeout */
         
-        if(HAL_GetTick() >= timeout)
+        if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;
@@ -2556,18 +2558,18 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8
         
         for(loopcounter = 0; (loopcounter < headersize); loopcounter+=16)
         {
-          /* Get timeout */
-          timeout = HAL_GetTick() + 1;
+         /* Get tick */
+         tickstart = HAL_GetTick();
  
           while(HAL_IS_BIT_CLR(CRYP->SR, CRYP_FLAG_IFEM))
           {
             /* Check for the Timeout */
-            if(HAL_GetTick() >= timeout)
+            if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
             {
               /* Change state */
               hcryp->State = HAL_CRYP_STATE_TIMEOUT;
               
-              /* Process Unlocked */          
+              /* Process Unlocked */
               __HAL_UNLOCK(hcryp);
               
               return HAL_TIMEOUT;
@@ -2584,18 +2586,18 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8
           headeraddr+=4;
         }
         
-/* Get timeout */
-        timeout = HAL_GetTick() + 1;
+        /* Get tick */
+        tickstart = HAL_GetTick();
 
         while((CRYP->SR & CRYP_FLAG_BUSY) == CRYP_FLAG_BUSY)
         {
           /* Check for the Timeout */
-          if(HAL_GetTick() >= timeout)
+          if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
           {
             /* Change state */
             hcryp->State = HAL_CRYP_STATE_TIMEOUT;
             
-            /* Process Unlocked */          
+            /* Process Unlocked */
             __HAL_UNLOCK(hcryp);
             
             return HAL_TIMEOUT;
@@ -2830,7 +2832,7 @@ static void CRYPEx_GCMCCM_SetInitVector(CRYP_HandleTypeDef *hcryp, uint8_t *Init
   */
 static HAL_StatusTypeDef CRYPEx_GCMCCM_ProcessData(CRYP_HandleTypeDef *hcryp, uint8_t *Input, uint16_t Ilength, uint8_t *Output, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   uint32_t i = 0;
   uint32_t inputaddr  = (uint32_t)Input;
   uint32_t outputaddr = (uint32_t)Output;
@@ -2847,20 +2849,20 @@ static HAL_StatusTypeDef CRYPEx_GCMCCM_ProcessData(CRYP_HandleTypeDef *hcryp, ui
     CRYP->DR = *(uint32_t*)(inputaddr);
     inputaddr+=4;
     
-    /* Get timeout */
-    timeout = HAL_GetTick() + Timeout;
+    /* Get tick */
+    tickstart = HAL_GetTick();
  
     while(HAL_IS_BIT_CLR(CRYP->SR, CRYP_FLAG_OFNE))
     {
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((HAL_GetTick() - tickstart ) > CRYPEx_TIMEOUT_VALUE)
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;
@@ -2892,7 +2894,7 @@ static HAL_StatusTypeDef CRYPEx_GCMCCM_ProcessData(CRYP_HandleTypeDef *hcryp, ui
   */
 static HAL_StatusTypeDef CRYPEx_GCMCCM_SetHeaderPhase(CRYP_HandleTypeDef *hcryp, uint8_t* Input, uint16_t Ilength, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   uint32_t loopcounter = 0;
   uint32_t headeraddr = (uint32_t)Input;
   
@@ -2906,20 +2908,20 @@ static HAL_StatusTypeDef CRYPEx_GCMCCM_SetHeaderPhase(CRYP_HandleTypeDef *hcryp,
     
     for(loopcounter = 0; (loopcounter < hcryp->Init.HeaderSize); loopcounter+=16)
     {
-      /* Get timeout */
-      timeout = HAL_GetTick() + Timeout;
+      /* Get tick */
+      tickstart = HAL_GetTick();
       
       while(HAL_IS_BIT_CLR(CRYP->SR, CRYP_FLAG_IFEM))
       {
         /* Check for the Timeout */
         if(Timeout != HAL_MAX_DELAY)
         {
-          if(HAL_GetTick() >= timeout)
+          if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
           {
             /* Change state */
             hcryp->State = HAL_CRYP_STATE_TIMEOUT;
             
-            /* Process Unlocked */          
+            /* Process Unlocked */
             __HAL_UNLOCK(hcryp);
             
             return HAL_TIMEOUT;
@@ -2939,20 +2941,20 @@ static HAL_StatusTypeDef CRYPEx_GCMCCM_SetHeaderPhase(CRYP_HandleTypeDef *hcryp,
     
     /* Wait until the complete message has been processed */
 
-    /* Get timeout */
-    timeout = HAL_GetTick() + Timeout;
+    /* Get tick */
+    tickstart = HAL_GetTick();
 
     while((CRYP->SR & CRYP_FLAG_BUSY) == CRYP_FLAG_BUSY)
     {
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Change state */
           hcryp->State = HAL_CRYP_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hcryp);
           
           return HAL_TIMEOUT;

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_cryp_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_cryp_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_cryp_ex.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of CRYP HAL Extension module.
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dac.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dac.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_dac.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   DAC HAL module driver.
   *         This file provides firmware functions to manage the following 
   *         functionalities of the Digital to Analog Converter (DAC) peripheral:

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dac.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dac.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_dac.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of DAC HAL module.
   ******************************************************************************
   * @attention
@@ -279,7 +279,7 @@ typedef struct
   * @param  __HANDLE__: specifies the DAC handle.
   * @retval None
   */
-#define __HAL_DAC_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) |= (__FLAG__))
+#define __HAL_DAC_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) = (__FLAG__))
 
 /* Include DAC HAL Extension module */
 #include "stm32f4xx_hal_dac_ex.h"

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dac_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dac_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_dac_ex.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   DAC HAL module driver.
   *         This file provides firmware functions to manage the following 
   *         functionalities of DAC extension peripheral:

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dac_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dac_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_dac.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of DAC HAL Extension module.
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dcmi.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dcmi.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_dcmi.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   DCMI HAL module driver
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Digital Camera Interface (DCMI) peripheral:
@@ -367,7 +367,7 @@ HAL_StatusTypeDef HAL_DCMI_Start_DMA(DCMI_HandleTypeDef* hdcmi, uint32_t DCMI_Mo
   */
 HAL_StatusTypeDef HAL_DCMI_Stop(DCMI_HandleTypeDef* hdcmi)
 {
-  uint32_t timeout = 0x00;
+  uint32_t tickstart = 0;
 
   /* Lock the DCMI peripheral state */
   hdcmi->State = HAL_DCMI_STATE_BUSY;
@@ -377,13 +377,13 @@ HAL_StatusTypeDef HAL_DCMI_Stop(DCMI_HandleTypeDef* hdcmi)
   /* Disable Capture */
   DCMI->CR &= ~(DCMI_CR_CAPTURE);
 
-  /* Get timeout */
-  timeout = HAL_GetTick() + HAL_TIMEOUT_DCMI_STOP;
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   /* Check if the DCMI capture effectively disabled */
   while((hdcmi->Instance->CR & DCMI_CR_CAPTURE) != 0)
   {
-    if(HAL_GetTick() >= timeout)
+    if((HAL_GetTick() - tickstart ) > HAL_TIMEOUT_DCMI_STOP)
     {
       /* Process Unlocked */
       __HAL_UNLOCK(hdcmi);

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dcmi.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dcmi.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_dcmi.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of DCMI HAL module.
   ******************************************************************************
   * @attention
@@ -410,7 +410,7 @@ typedef struct
   *            @arg DCMI_FLAG_LINERI: Line flag mask
   * @retval None
   */
-#define __HAL_DCMI_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ICR |= (__FLAG__))
+#define __HAL_DCMI_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ICR = (__FLAG__))
 
 /**
   * @brief  Enable the specified DCMI interrupts.

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_def.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_def.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_def.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   This file contains HAL common defines, enumeration, macros and 
   *          structures definitions. 
   ******************************************************************************
@@ -71,7 +71,7 @@ typedef enum
 
 /* Exported macro ------------------------------------------------------------*/
 #ifndef NULL
-  #define NULL      (void *) 0
+  #define HAL_NULL      (void *) 0
 #endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFF
@@ -85,8 +85,26 @@ typedef enum
                               (__DMA_HANDLE__).Parent = (__HANDLE__);             \
                           } while(0)
 
+/** @brief Reset the Handle's State field.
+  * @param __HANDLE__: specifies the Peripheral Handle.
+  * @note  This macro can be used for the following purpose: 
+  *          - When the Handle is declared as local variable; before passing it as parameter
+  *            to HAL_PPP_Init() for the first time, it is mandatory to use this macro 
+  *            to set to 0 the Handle's "State" field.
+  *            Otherwise, "State" field may have any random value and the first time the function 
+  *            HAL_PPP_Init() is called, the low level hardware initialization will be missed
+  *            (i.e. HAL_PPP_MspInit() will not be executed).
+  *          - When there is a need to reconfigure the low level hardware: instead of calling
+  *            HAL_PPP_DeInit() then HAL_PPP_Init(), user can make a call to this macro then HAL_PPP_Init().
+  *            In this later function, when the Handle's "State" field is set to 0, it will execute the function
+  *            HAL_PPP_MspInit() which will reconfigure the low level hardware.
+  * @retval None
+  */
+#define __HAL_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = 0)
+
 #if (USE_RTOS == 1)
   /* Reserved for future use */
+  #error “USE_RTOS should be 0 in the current HAL release”
 #else
   #define __HAL_LOCK(__HANDLE__)                                           \
                                 do{                                        \
@@ -133,11 +151,43 @@ typedef enum
       #define __ALIGN_BEGIN    __align(4)  
     #elif defined (__ICCARM__)    /* IAR Compiler */
       #define __ALIGN_BEGIN 
-    #elif defined  (__TASKING__)  /* TASKING Compiler */
-      #define __ALIGN_BEGIN    __align(4) 
     #endif /* __CC_ARM */
   #endif /* __ALIGN_BEGIN */
 #endif /* __GNUC__ */
+
+
+/** 
+  * @brief  __RAM_FUNC definition
+  */ 
+#if defined ( __CC_ARM   )
+/* ARM Compiler
+   ------------
+   RAM functions are defined using the toolchain options. 
+   Functions that are executed in RAM should reside in a separate source module.
+   Using the 'Options for File' dialog you can simply change the 'Code / Const' 
+   area of a module to a memory space in physical RAM.
+   Available memory areas are declared in the 'Target' tab of the 'Options for Target'
+   dialog. 
+*/
+#define __RAM_FUNC HAL_StatusTypeDef 
+
+#elif defined ( __ICCARM__ )
+/* ICCARM Compiler
+   ---------------
+   RAM functions are defined using a specific toolchain keyword "__ramfunc". 
+*/
+#define __RAM_FUNC __ramfunc HAL_StatusTypeDef
+
+#elif defined   (  __GNUC__  )
+/* GNU Compiler
+   ------------
+  RAM functions are defined using a specific toolchain attribute 
+   "__attribute__((section(".RamFunc")))".
+*/
+#define __RAM_FUNC HAL_StatusTypeDef  __attribute__((section(".RamFunc")))
+
+#endif
+
 
 #ifdef __cplusplus
 }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dma.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dma.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_dma.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   DMA HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -172,7 +172,7 @@ HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma)
   uint32_t tmp = 0;
   
   /* Check the DMA peripheral state */
-  if(hdma == NULL)
+  if(hdma == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -261,6 +261,12 @@ HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma)
   */
 HAL_StatusTypeDef HAL_DMA_DeInit(DMA_HandleTypeDef *hdma)
 {
+  /* Check the DMA peripheral state */
+  if(hdma == HAL_NULL)
+  {
+    return HAL_ERROR;
+  }
+  
   /* Check the DMA peripheral state */
   if(hdma->State == HAL_DMA_STATE_BUSY)
   {
@@ -423,19 +429,19 @@ HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress,
   */
 HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma)
 {
-  uint32_t timeout = 0x00;
+  uint32_t tickstart = 0;
 
   /* Disable the stream */
   __HAL_DMA_DISABLE(hdma);
 
-  /* Get timeout */
-  timeout = HAL_GetTick() + HAL_TIMEOUT_DMA_ABORT;
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   /* Check if the DMA Stream is effectively disabled */
   while((hdma->Instance->CR & DMA_SxCR_EN) != 0)
   {
     /* Check for the Timeout */
-    if(HAL_GetTick() >= timeout)
+    if((HAL_GetTick() - tickstart ) > HAL_TIMEOUT_DMA_ABORT)
     {
       /* Update error code */
       hdma->ErrorCode |= HAL_DMA_ERROR_TIMEOUT;
@@ -469,7 +475,7 @@ HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma)
 HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, uint32_t CompleteLevel, uint32_t Timeout)
 {
   uint32_t temp, tmp, tmp1, tmp2;
-  uint32_t timeout = 0x00; 
+  uint32_t tickstart = 0; 
 
   /* Get the level transfer complete flag */
   if(CompleteLevel == HAL_DMA_FULL_TRANSFER)
@@ -483,8 +489,8 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, uint32_t Comp
     temp = __HAL_DMA_GET_HT_FLAG_INDEX(hdma);
   }
 
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   while(__HAL_DMA_GET_FLAG(hdma, temp) == RESET)
   {
@@ -493,13 +499,30 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, uint32_t Comp
     tmp2 = __HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_DME_FLAG_INDEX(hdma));
     if((tmp != RESET) || (tmp1 != RESET) || (tmp2 != RESET))
     {
-      /* Clear the transfer error flag */
-      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma));
-      /* Clear the FIFO error flag */
-      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_FE_FLAG_INDEX(hdma));
-      /* Clear the DIrect Mode error flag */
-      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_DME_FLAG_INDEX(hdma));
+      if(tmp != RESET)
+      {
+        /* Update error code */
+        hdma->ErrorCode |= HAL_DMA_ERROR_TE;
 
+        /* Clear the transfer error flag */
+        __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma));
+      }
+      if(tmp1 != RESET)
+      {
+        /* Update error code */
+        hdma->ErrorCode |= HAL_DMA_ERROR_FE;
+ 
+        /* Clear the FIFO error flag */
+        __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_FE_FLAG_INDEX(hdma));
+      }
+      if(tmp2 != RESET)
+      {
+        /* Update error code */
+        hdma->ErrorCode |= HAL_DMA_ERROR_DME;
+
+        /* Clear the Direct Mode error flag */
+        __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_DME_FLAG_INDEX(hdma));
+      }
       /* Change the DMA state */
       hdma->State= HAL_DMA_STATE_ERROR;
       
@@ -511,32 +534,29 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, uint32_t Comp
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         /* Update error code */
         hdma->ErrorCode |= HAL_DMA_ERROR_TIMEOUT;
 
-        /* Process Unlocked */
-        __HAL_UNLOCK(hdma);
-
         /* Change the DMA state */
         hdma->State = HAL_DMA_STATE_TIMEOUT;
 
+        /* Process Unlocked */
+        __HAL_UNLOCK(hdma);
+        
         return HAL_TIMEOUT;
       }
     }
   }
-  /* Clear the half transfer complete flag */
-  __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
-
-  /* Change DMA peripheral state */
-  hdma->State = HAL_DMA_STATE_READY_HALF_MEM0;
 
   if(CompleteLevel == HAL_DMA_FULL_TRANSFER)
   {
     /* Multi_Buffering mode enabled */
     if(((hdma->Instance->CR) & (uint32_t)(DMA_SxCR_DBM)) != 0)
     {
+      /* Clear the half transfer complete flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
       /* Clear the transfer complete flag */
       __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma));
 
@@ -555,6 +575,8 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, uint32_t Comp
     }
     else
     {
+      /* Clear the half transfer complete flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
       /* Clear the transfer complete flag */
       __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma)); 
 
@@ -626,7 +648,7 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
       /* Process Unlocked */
       __HAL_UNLOCK(hdma); 
 
-      if(hdma->XferErrorCallback != NULL)
+      if(hdma->XferErrorCallback != HAL_NULL)
       {
         /* Transfer error callback */
         hdma->XferErrorCallback(hdma);
@@ -653,7 +675,7 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
       /* Process Unlocked */
       __HAL_UNLOCK(hdma);
 
-      if(hdma->XferErrorCallback != NULL)
+      if(hdma->XferErrorCallback != HAL_NULL)
       {
         /* Transfer error callback */
         hdma->XferErrorCallback(hdma);
@@ -680,7 +702,7 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
       /* Process Unlocked */
       __HAL_UNLOCK(hdma);
 
-      if(hdma->XferErrorCallback != NULL)
+      if(hdma->XferErrorCallback != HAL_NULL)
       {
         /* Transfer error callback */
         hdma->XferErrorCallback(hdma);
@@ -726,7 +748,7 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
         hdma->State = HAL_DMA_STATE_READY_HALF_MEM0;
       }
 
-      if(hdma->XferHalfCpltCallback != NULL)
+      if(hdma->XferHalfCpltCallback != HAL_NULL)
       {
         /* Half transfer callback */
         hdma->XferHalfCpltCallback(hdma);
@@ -746,7 +768,7 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
         /* Current memory buffer used is Memory 1 */
         if((hdma->Instance->CR & DMA_SxCR_CT) == 0)
         {
-          if(hdma->XferM1CpltCallback != NULL)
+          if(hdma->XferM1CpltCallback != HAL_NULL)
           {
             /* Transfer complete Callback for memory1 */
             hdma->XferM1CpltCallback(hdma);
@@ -755,7 +777,7 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
         /* Current memory buffer used is Memory 0 */
         else if((hdma->Instance->CR & DMA_SxCR_CT) != 0) 
         {
-          if(hdma->XferCpltCallback != NULL)
+          if(hdma->XferCpltCallback != HAL_NULL)
           {
             /* Transfer complete Callback for memory0 */
             hdma->XferCpltCallback(hdma);
@@ -782,7 +804,7 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
         /* Process Unlocked */
         __HAL_UNLOCK(hdma);      
 
-        if(hdma->XferCpltCallback != NULL)
+        if(hdma->XferCpltCallback != HAL_NULL)
         {
           /* Transfer complete callback */
           hdma->XferCpltCallback(hdma);

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dma.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dma.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_dma.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of DMA HAL module.
   ******************************************************************************
   * @attention
@@ -582,9 +582,9 @@ typedef struct __DMA_HandleTypeDef
   * @retval None
   */
 #define __HAL_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__) \
-(((uint32_t)((__HANDLE__)->Instance) > (uint32_t)DMA2_Stream3)? (DMA2->HIFCR |= (__FLAG__)) :\
- ((uint32_t)((__HANDLE__)->Instance) > (uint32_t)DMA1_Stream7)? (DMA2->LIFCR |= (__FLAG__)) :\
- ((uint32_t)((__HANDLE__)->Instance) > (uint32_t)DMA1_Stream3)? (DMA1->HIFCR |= (__FLAG__)) : (DMA1->LIFCR |= (__FLAG__)))
+(((uint32_t)((__HANDLE__)->Instance) > (uint32_t)DMA2_Stream3)? (DMA2->HIFCR = (__FLAG__)) :\
+ ((uint32_t)((__HANDLE__)->Instance) > (uint32_t)DMA1_Stream7)? (DMA2->LIFCR = (__FLAG__)) :\
+ ((uint32_t)((__HANDLE__)->Instance) > (uint32_t)DMA1_Stream3)? (DMA1->HIFCR = (__FLAG__)) : (DMA1->LIFCR = (__FLAG__)))
 
 /**
   * @brief  Enable the specified DMA Stream interrupts.

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dma2d.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dma2d.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_dma2d.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   DMA2D HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the DMA2D peripheral:
@@ -46,8 +46,7 @@
 
          -@-   In Register-to-Memory transfer mode, the pdata parameter is the register
                color, in Memory-to-memory or memory-to-memory with pixel format
-               conversion the pdata is the source address and it is the color value 
-               for the A4 or A8 mode.
+               conversion the pdata is the source address.
 
          -@-   Configure the foreground source address, the background source address, 
                the Destination and data length and Enable the transfer using 
@@ -334,8 +333,7 @@ __weak void HAL_DMA2D_MspDeInit(DMA2D_HandleTypeDef* hdma2d)
   * @param  pdata:      Configure the source memory Buffer address if 
   *                     the memory to memory or memory to memory with pixel format 
   *                     conversion DMA2D mode is selected, and configure 
-  *                     the color value if register to memory DMA2D mode is selected
-  *                     or the color value for the A4 or A8 mode.
+  *                     the color value if register to memory DMA2D mode is selected.
   * @param  DstAddress: The destination memory Buffer address.
   * @param  Width:      The width of data to be transferred from source to destination.
   * @param  Heigh:      The heigh of data to be transferred from source to destination.
@@ -372,8 +370,7 @@ HAL_StatusTypeDef HAL_DMA2D_Start(DMA2D_HandleTypeDef *hdma2d, uint32_t pdata, u
   * @param  pdata:      Configure the source memory Buffer address if 
   *                     the memory to memory or memory to memory with pixel format 
   *                     conversion DMA2D mode is selected, and configure 
-  *                     the color value if register to memory DMA2D mode is selected
-  *                     or the color value for the A4 or A8 mode.
+  *                     the color value if register to memory DMA2D mode is selected.
   * @param  DstAddress: The destination memory Buffer address.
   * @param  Width:      The width of data to be transferred from source to destination.
   * @param  Heigh:      The heigh of data to be transferred from source to destination.
@@ -417,8 +414,7 @@ HAL_StatusTypeDef HAL_DMA2D_Start_IT(DMA2D_HandleTypeDef *hdma2d, uint32_t pdata
   * @param  hdma2d:      pointer to a DMA2D_HandleTypeDef structure that contains
   *                      the configuration information for the DMA2D.  
   * @param  SrcAddress1: The source memory Buffer address of the foreground layer.
-  * @param  SrcAddress2: The source memory Buffer address of the background layer
-  *                      or the color value for the A4 or A8 mode.
+  * @param  SrcAddress2: The source memory Buffer address of the background layer.
   * @param  DstAddress:  The destination memory Buffer address
   * @param  Width:       The width of data to be transferred from source to destination.
   * @param  Heigh:       The heigh of data to be transferred from source to destination.
@@ -439,15 +435,8 @@ HAL_StatusTypeDef HAL_DMA2D_BlendingStart(DMA2D_HandleTypeDef *hdma2d, uint32_t 
   /* Disable the Peripheral */
   __HAL_DMA2D_DISABLE(hdma2d);
 
-  if((hdma2d->LayerCfg[0].InputColorMode == CM_A4) || (hdma2d->LayerCfg[0].InputColorMode == CM_A8))
-  {
-    hdma2d->Instance->BGCOLR = SrcAddress2;
-  }
-  else
-  {
   /* Configure DMA2D Stream source2 address */
   hdma2d->Instance->BGMAR = SrcAddress2;
-  }
 
   /* Configure the source, destination address and the data size */
   DMA2D_SetConfig(hdma2d, SrcAddress1, DstAddress, Width, Heigh);
@@ -463,8 +452,7 @@ HAL_StatusTypeDef HAL_DMA2D_BlendingStart(DMA2D_HandleTypeDef *hdma2d, uint32_t 
   * @param  hdma2d:     pointer to a DMA2D_HandleTypeDef structure that contains
   *                     the configuration information for the DMA2D.  
   * @param  SrcAddress1: The source memory Buffer address of the foreground layer.
-  * @param  SrcAddress2: The source memory Buffer address of the background layer
-  *                      or the color value for the A4 or A8 mode.
+  * @param  SrcAddress2: The source memory Buffer address of the background layer.
   * @param  DstAddress:  The destination memory Buffer address.
   * @param  Width:       The width of data to be transferred from source to destination.
   * @param  Heigh:       The heigh of data to be transferred from source to destination.
@@ -484,16 +472,9 @@ HAL_StatusTypeDef HAL_DMA2D_BlendingStart_IT(DMA2D_HandleTypeDef *hdma2d, uint32
 
   /* Disable the Peripheral */
   __HAL_DMA2D_DISABLE(hdma2d);
-
-  if ((hdma2d->LayerCfg[0].InputColorMode == CM_A4) || (hdma2d->LayerCfg[0].InputColorMode == CM_A8))
-  {
-    hdma2d->Instance->BGCOLR = SrcAddress2;
-  }
-  else
-  {  
-    /* Configure DMA2D Stream source2 address */
-    hdma2d->Instance->BGMAR = SrcAddress2;
-  }
+ 
+  /* Configure DMA2D Stream source2 address */
+  hdma2d->Instance->BGMAR = SrcAddress2;
 
   /* Configure the source, destination address and the data size */
   DMA2D_SetConfig(hdma2d, SrcAddress1, DstAddress, Width, Heigh);
@@ -521,18 +502,18 @@ HAL_StatusTypeDef HAL_DMA2D_BlendingStart_IT(DMA2D_HandleTypeDef *hdma2d, uint32
   */
 HAL_StatusTypeDef HAL_DMA2D_Abort(DMA2D_HandleTypeDef *hdma2d)
 {
-  uint32_t timeout = 0x00;
+  uint32_t tickstart = 0;
 
   /* Disable the DMA2D */
   __HAL_DMA2D_DISABLE(hdma2d);
 
-  /* Get timeout */
-  timeout = HAL_GetTick() + HAL_TIMEOUT_DMA2D_ABORT;
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   /* Check if the DMA2D is effectively disabled */
   while((hdma2d->Instance->CR & DMA2D_CR_START) != 0)
   {
-    if(HAL_GetTick() >= timeout)
+    if((HAL_GetTick() - tickstart ) > HAL_TIMEOUT_DMA2D_ABORT)
     {
       /* Update error code */
       hdma2d->ErrorCode |= HAL_DMA2D_ERROR_TIMEOUT;
@@ -563,18 +544,18 @@ HAL_StatusTypeDef HAL_DMA2D_Abort(DMA2D_HandleTypeDef *hdma2d)
   */
 HAL_StatusTypeDef HAL_DMA2D_Suspend(DMA2D_HandleTypeDef *hdma2d)
 {
-  uint32_t timeout = 0x00;
+  uint32_t tickstart = 0;
 
   /* Suspend the DMA2D transfer */
   hdma2d->Instance->CR |= DMA2D_CR_SUSP;
 
-  /* Get timeout */
-  timeout = HAL_GetTick() + HAL_TIMEOUT_DMA2D_SUSPEND;
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   /* Check if the DMA2D is effectively suspended */
   while((hdma2d->Instance->CR & DMA2D_CR_SUSP) != DMA2D_CR_SUSP)
   {
-    if(HAL_GetTick() >= timeout)
+    if((HAL_GetTick() - tickstart ) > HAL_TIMEOUT_DMA2D_SUSPEND)
     {
       /* Update error code */
       hdma2d->ErrorCode |= HAL_DMA2D_ERROR_TIMEOUT;
@@ -618,13 +599,13 @@ HAL_StatusTypeDef HAL_DMA2D_Resume(DMA2D_HandleTypeDef *hdma2d)
 HAL_StatusTypeDef HAL_DMA2D_PollForTransfer(DMA2D_HandleTypeDef *hdma2d, uint32_t Timeout)
 {
   uint32_t tmp, tmp1;
-  uint32_t timeout = 0x00;
+  uint32_t tickstart = 0;
 
   /* Polling for DMA2D transfer */
   if((hdma2d->Instance->CR & DMA2D_CR_START) != 0)
   {
-    /* Get timeout */
-    timeout = HAL_GetTick() + Timeout;
+   /* Get tick */
+   tickstart = HAL_GetTick();
 
     while(__HAL_DMA2D_GET_FLAG(hdma2d, DMA2D_FLAG_TC) == RESET)
     {
@@ -648,7 +629,7 @@ HAL_StatusTypeDef HAL_DMA2D_PollForTransfer(DMA2D_HandleTypeDef *hdma2d, uint32_
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Process unlocked */
           __HAL_UNLOCK(hdma2d);
@@ -667,8 +648,8 @@ HAL_StatusTypeDef HAL_DMA2D_PollForTransfer(DMA2D_HandleTypeDef *hdma2d, uint32_
   /* Polling for CLUT loading */
   if((hdma2d->Instance->FGPFCCR & DMA2D_FGPFCCR_START) != 0)
   {
-    /* Get timeout */
-    timeout = HAL_GetTick() + Timeout;
+    /* Get tick */
+    tickstart = HAL_GetTick();
    
     while(__HAL_DMA2D_GET_FLAG(hdma2d, DMA2D_FLAG_CTC) == RESET)
     {
@@ -685,7 +666,7 @@ HAL_StatusTypeDef HAL_DMA2D_PollForTransfer(DMA2D_HandleTypeDef *hdma2d, uint32_
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Update error code */
           hdma2d->ErrorCode |= HAL_DMA2D_ERROR_TIMEOUT;
@@ -855,7 +836,6 @@ HAL_StatusTypeDef HAL_DMA2D_ConfigLayer(DMA2D_HandleTypeDef *hdma2d, uint32_t La
     if(hdma2d->Init.Mode != DMA2D_M2M)
     {
       assert_param(IS_DMA2D_ALPHA_MODE(pLayerCfg->AlphaMode));
-      assert_param(IS_DMA2D_ALPHA_VALUE(pLayerCfg->InputAlpha));
     }
   }
   
@@ -869,8 +849,16 @@ HAL_StatusTypeDef HAL_DMA2D_ConfigLayer(DMA2D_HandleTypeDef *hdma2d, uint32_t La
     /* Clear Input color mode, alpha value and alpha mode bits */
     tmp &= (uint32_t)~(DMA2D_BGPFCCR_CM | DMA2D_BGPFCCR_AM | DMA2D_BGPFCCR_ALPHA); 
     
-    /* Prepare the value to be wrote to the BGPFCCR register */
-    tmp |= (pLayerCfg->InputColorMode | (pLayerCfg->AlphaMode << 16) | (pLayerCfg->InputAlpha << 24));
+    if ((pLayerCfg->InputColorMode == CM_A4) || (pLayerCfg->InputColorMode == CM_A8))
+    {
+      /* Prepare the value to be wrote to the BGPFCCR register */
+      tmp |= (pLayerCfg->InputColorMode | (pLayerCfg->AlphaMode << 16) | ((pLayerCfg->InputAlpha) & 0xFF000000));
+    }
+    else
+    {
+      /* Prepare the value to be wrote to the BGPFCCR register */
+      tmp |= (pLayerCfg->InputColorMode | (pLayerCfg->AlphaMode << 16) | (pLayerCfg->InputAlpha << 24));
+    }
     
     /* Write to DMA2D BGPFCCR register */
     hdma2d->Instance->BGPFCCR = tmp; 
@@ -887,6 +875,15 @@ HAL_StatusTypeDef HAL_DMA2D_ConfigLayer(DMA2D_HandleTypeDef *hdma2d, uint32_t La
     
     /* Write to DMA2D BGOR register */
     hdma2d->Instance->BGOR = tmp;
+    
+    if ((pLayerCfg->InputColorMode == CM_A4) || (pLayerCfg->InputColorMode == CM_A8))
+    {
+      /* Prepare the value to be wrote to the BGCOLR register */
+      tmp |= ((pLayerCfg->InputAlpha) & 0x00FFFFFF);
+    
+      /* Write to DMA2D BGCOLR register */
+      hdma2d->Instance->BGCOLR = tmp;
+    }    
   }
   /* Configure the foreground DMA2D layer */
   else
@@ -898,8 +895,16 @@ HAL_StatusTypeDef HAL_DMA2D_ConfigLayer(DMA2D_HandleTypeDef *hdma2d, uint32_t La
     /* Clear Input color mode, alpha value and alpha mode bits */
     tmp &= (uint32_t)~(DMA2D_FGPFCCR_CM | DMA2D_FGPFCCR_AM | DMA2D_FGPFCCR_ALPHA); 
     
-    /* Prepare the value to be wrote to the FGPFCCR register */
-    tmp |= (pLayerCfg->InputColorMode | (pLayerCfg->AlphaMode << 16) | (pLayerCfg->InputAlpha << 24));
+    if ((pLayerCfg->InputColorMode == CM_A4) || (pLayerCfg->InputColorMode == CM_A8))
+    {
+      /* Prepare the value to be wrote to the FGPFCCR register */
+      tmp |= (pLayerCfg->InputColorMode | (pLayerCfg->AlphaMode << 16) | ((pLayerCfg->InputAlpha) & 0xFF000000));
+    }
+    else
+    {
+      /* Prepare the value to be wrote to the FGPFCCR register */
+      tmp |= (pLayerCfg->InputColorMode | (pLayerCfg->AlphaMode << 16) | (pLayerCfg->InputAlpha << 24));
+    }
     
     /* Write to DMA2D FGPFCCR register */
     hdma2d->Instance->FGPFCCR = tmp; 
@@ -916,6 +921,15 @@ HAL_StatusTypeDef HAL_DMA2D_ConfigLayer(DMA2D_HandleTypeDef *hdma2d, uint32_t La
     
     /* Write to DMA2D FGOR register */
     hdma2d->Instance->FGOR = tmp;
+   
+    if ((pLayerCfg->InputColorMode == CM_A4) || (pLayerCfg->InputColorMode == CM_A8))
+    {
+      /* Prepare the value to be wrote to the FGCOLR register */
+      tmp |= ((pLayerCfg->InputAlpha) & 0x00FFFFFF);
+    
+      /* Write to DMA2D FGCOLR register */
+      hdma2d->Instance->FGCOLR = tmp;
+    }   
   }    
   /* Initialize the DMA2D state*/
   hdma2d->State  = HAL_DMA2D_STATE_READY;
@@ -1212,11 +1226,7 @@ static void DMA2D_SetConfig(DMA2D_HandleTypeDef *hdma2d, uint32_t pdata, uint32_
     }    
     /* Write to DMA2D OCOLR register */
     hdma2d->Instance->OCOLR = tmp;
-  }
-  else if ((hdma2d->LayerCfg[1].InputColorMode == CM_A4) || (hdma2d->LayerCfg[1].InputColorMode == CM_A8))
-  {
-    hdma2d->Instance->FGCOLR = pdata;
-  }  
+  } 
   else /* M2M, M2M_PFC or M2M_Blending DMA2D Mode */
   {
     /* Configure DMA2D source address */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dma2d.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dma2d.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_dma2d.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of DMA2D HAL module.
   ******************************************************************************
   * @attention
@@ -117,8 +117,10 @@ typedef struct
   uint32_t             AlphaMode;         /*!< configures the DMA2D foreground alpha mode. 
                                                This parameter can be one value of @ref DMA2D_ALPHA_MODE */
 
-  uint32_t             InputAlpha;        /*!< Specifies the DMA2D foreground alpha value. 
-                                               This parameter must be a number between Min_Data = 0x00 and Max_Data = 0xFF. */
+  uint32_t             InputAlpha;        /*!< Specifies the DMA2D foreground alpha value and color value in case of A8 or A4 color mode. 
+                                               This parameter must be a number between Min_Data = 0x00000000 and Max_Data = 0xFFFFFFFF 
+                                               in case of A8 or A4 color mode (ARGB). 
+                                               Otherwise, This parameter must be a number between Min_Data = 0x00 and Max_Data = 0xFF.*/
 
 } DMA2D_LayerCfgTypeDef;
 
@@ -219,7 +221,6 @@ typedef struct __DMA2D_HandleTypeDef
 
 #define COLOR_VALUE             ((uint32_t)0x000000FF)                          /*!< color value mask */
 
-#define IS_DMA2D_ALPHA_VALUE(ALPHA_VALUE) ((ALPHA_VALUE) <= COLOR_VALUE)
 #define IS_DMA2D_COLOR(COLOR) ((COLOR) <= COLOR_VALUE)
 /**
   * @}
@@ -406,7 +407,7 @@ typedef struct __DMA2D_HandleTypeDef
   *            @arg DMA2D_FLAG_TE:  Transfer error flag    
   * @retval None
   */
-#define __HAL_DMA2D_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->IFCR |= (__FLAG__))
+#define __HAL_DMA2D_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->IFCR = (__FLAG__))
 
 /**
   * @brief  Enables the specified DMA2D interrupts.

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dma_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dma_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_dma_ex.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   DMA Extension HAL module driver
   *         This file provides firmware functions to manage the following 
   *         functionalities of the DMA Extension peripheral:

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dma_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_dma_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_dma_ex.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of DMA HAL extension module.
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_eth.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_eth.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_eth.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of ETH HAL module.
   ******************************************************************************
   * @attention
@@ -1878,20 +1878,6 @@ typedef struct
   */
 #define __HAL_ETH_MAC_GET_FLAG(__HANDLE__, __FLAG__)                   (((__HANDLE__)->Instance->MACSR &( __FLAG__)) == ( __FLAG__))
 
-/**
-  * @brief  Clears the specified ETHERNET MAC flag.
-  * @param  __HANDLE__: ETH Handle
-  * @param  __FLAG__: specifies the flag to clear.
-  *   This parameter can be one of the following values:
-  *     @arg ETH_MAC_FLAG_TST  : Time stamp trigger flag   
-  *     @arg ETH_MAC_FLAG_MMCT : MMC transmit flag  
-  *     @arg ETH_MAC_FLAG_MMCR : MMC receive flag   
-  *     @arg ETH_MAC_FLAG_MMC  : MMC flag  
-  *     @arg ETH_MAC_FLAG_PMT  : PMT flag  
-  * @retval None.
-  */
-#define __HAL_ETH_MAC_CLEAR_FLAG(__HANDLE__, __FLAG__)                 ((__HANDLE__)->Instance->MACSR &= ~(__FLAG__))
-
 /** 
   * @brief  Enables the specified ETHERNET DMA interrupts.
   * @param  __HANDLE__   : ETH Handle
@@ -1921,7 +1907,7 @@ typedef struct
 /**
   * @brief  Checks whether the specified ETHERNET DMA flag is set or not.
 * @param  __HANDLE__: ETH Handle
-  * @param  __FLAG__: specifies the flag to check.
+  * @param  __FLAG__: specifies the flag to check. @defgroup ETH_DMA_Flags
   * @retval The new state of ETH_DMA_FLAG (SET or RESET).
   */
 #define __HAL_ETH_DMA_GET_FLAG(__HANDLE__, __FLAG__)                   (((__HANDLE__)->Instance->DMASR &( __FLAG__)) == ( __FLAG__))
@@ -1929,10 +1915,10 @@ typedef struct
 /**
   * @brief  Checks whether the specified ETHERNET DMA flag is set or not.
   * @param  __HANDLE__: ETH Handle
-  * @param  __FLAG__: specifies the flag to clear.
+  * @param  __FLAG__: specifies the flag to clear. @defgroup ETH_DMA_Flags
   * @retval The new state of ETH_DMA_FLAG (SET or RESET).
   */
-#define __HAL_ETH_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__)                 ((__HANDLE__)->Instance->DMASR &= ~(__FLAG__))
+#define __HAL_ETH_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__)                 ((__HANDLE__)->Instance->DMASR = (__FLAG__))
 
 /**
   * @brief  Checks whether the specified ETHERNET DMA overflow flag is set or not.
@@ -2133,7 +2119,68 @@ typedef struct
   */
 #define __HAL_ETH_MMC_TX_IT_DISABLE(__HANDLE__, __INTERRUPT__)           ((__HANDLE__)->Instance->MMCRIMR |= (__INTERRUPT__))                                             
 
+/** @defgroup ETH_EXTI_LINE_WAKEUP 
+  * @{
+  */ 
+#define ETH_EXTI_LINE_WAKEUP              ((uint32_t)0x00080000)  /*!< External interrupt line 19 Connected to the ETH EXTI Line */
 
+/**
+  * @}
+  */
+
+/**
+  * @brief  Enables the ETH External interrupt line.
+  * @param  None
+  * @retval None
+  */
+#define __HAL_ETH_EXTI_ENABLE_IT()    EXTI->IMR |= (ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief  Disables the ETH External interrupt line.
+  * @param  None
+  * @retval None
+  */
+#define __HAL_ETH_EXTI_DISABLE_IT()   EXTI->IMR &= ~(ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief  Get flag of the ETH External interrupt line.
+  * @param  None
+  * @retval None
+  */
+#define __HAL_ETH_EXTI_GET_FLAG()     EXTI->PR & (ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief  Clear flag of the ETH External interrupt line.
+  * @param  None
+  * @retval None
+  */
+#define __HAL_ETH_EXTI_CLEAR_FLAG()   EXTI->PR = (ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief  Sets rising edge trigger to the ETH External interrupt line.
+  * @param  None
+  * @retval None
+  */
+#define __HAL_ETH_EXTI_SET_RISING_EGDE_TRIGGER()  EXTI->FTSR &= ~(ETH_EXTI_LINE_WAKEUP);\
+                                                  EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP
+
+/**
+  * @brief  Sets falling edge trigger to the ETH External interrupt line.
+  * @param  None
+  * @retval None
+  */                                                      
+#define __HAL_ETH_EXTI_SET_FALLING_EGDE_TRIGGER()  EXTI->FTSR |= (ETH_EXTI_LINE_WAKEUP);\
+                                                   EXTI->RTSR &= ~(ETH_EXTI_LINE_WAKEUP)
+
+/**
+  * @brief  Sets rising/falling edge trigger to the ETH External interrupt line.
+  * @param  None
+  * @retval None
+  */
+#define __HAL_ETH_EXTI_SET_FALLINGRISING_TRIGGER()   EXTI->RTSR &= ~(ETH_EXTI_LINE_WAKEUP);\
+                                                     EXTI->FTSR &= ~(ETH_EXTI_LINE_WAKEUP);\
+                                                     EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP;\
+                                                     EXTI->FTSR |= ETH_EXTI_LINE_WAKEUP
 
 /* Exported functions --------------------------------------------------------*/
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_flash.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_flash.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_flash.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   FLASH HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the internal FLASH memory:
@@ -562,17 +562,18 @@ FLASH_ErrorTypeDef HAL_FLASH_GetError(void)
   */
 HAL_StatusTypeDef FLASH_WaitForLastOperation(uint32_t Timeout)
 { 
+  uint32_t tickstart = 0;
   /* Wait for the FLASH operation to complete by polling on BUSY flag to be reset.
      Even if the FLASH operation fails, the BUSY flag will be reset and an error
      flag will be set */
-    
-  uint32_t timeout = HAL_GetTick() + Timeout;
-     
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
   while(__HAL_FLASH_GET_FLAG(FLASH_FLAG_BSY) != RESET) 
   { 
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         return HAL_TIMEOUT;
       }
@@ -707,7 +708,7 @@ static void FLASH_SetErrorCode(void)
   
   if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_PGAERR) != RESET)
   {
-   pFlash.ErrorCode |= FLASH_ERROR_PGA;
+   pFlash.ErrorCode |= (FLASH_ErrorTypeDef)FLASH_ERROR_PGA;
   }
   
   if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_PGPERR) != RESET)

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_flash.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_flash.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_flash.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of FLASH HAL module.
   ******************************************************************************
   * @attention
@@ -321,6 +321,7 @@ typedef struct
 
 /* Include FLASH HAL Extension module */
 #include "stm32f4xx_hal_flash_ex.h"
+#include "stm32f4xx_hal_flash_ramfunc.h"
 
 /* Exported functions --------------------------------------------------------*/
 /* Program operation functions  ***********************************************/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_flash_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_flash_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_flash_ex.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Extended FLASH HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the FLASH extension peripheral:
@@ -113,10 +113,10 @@ static uint16_t           FLASH_OB_GetWRP(void);
 static FlagStatus         FLASH_OB_GetRDP(void);
 static uint8_t            FLASH_OB_GetBOR(void);
 
-#if defined(STM32F401xC) || defined(STM32F401xE)
+#if defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 static HAL_StatusTypeDef  FLASH_OB_EnablePCROP(uint32_t Sector);
 static HAL_StatusTypeDef  FLASH_OB_DisablePCROP(uint32_t Sector);
-#endif /* STM32F401xC || STM32F401xE */
+#endif /* STM32F401xC || STM32F401xE || STM32F411xE */
 
 #if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) 
 static HAL_StatusTypeDef FLASH_OB_EnablePCROP(uint32_t SectorBank1, uint32_t SectorBank2, uint32_t Banks);
@@ -355,7 +355,8 @@ void HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit)
   pOBInit->BORLevel = FLASH_OB_GetBOR();
 }
 
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) || defined(STM32F401xC) || defined(STM32F401xE)
+#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) ||\
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 /**
   * @brief   Program option bytes
   * @param  pAdvOBInit: pointer to an FLASH_AdvOBProgramInitTypeDef structure that
@@ -378,20 +379,20 @@ HAL_StatusTypeDef HAL_FLASHEx_AdvOBProgram (FLASH_AdvOBProgramInitTypeDef *pAdvO
     if ((pAdvOBInit->PCROPState) == PCROPSTATE_ENABLE)
     {
       /*Enable of Write protection on the selected Sector*/
-#if defined(STM32F401xC) || defined(STM32F401xE) 
+#if defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE) 
       status = FLASH_OB_EnablePCROP(pAdvOBInit->Sectors);
 #else  /* STM32F427xx || STM32F437xx || STM32F429xx|| STM32F439xx */
       status = FLASH_OB_EnablePCROP(pAdvOBInit->SectorsBank1, pAdvOBInit->SectorsBank2, pAdvOBInit->Banks);
-#endif /* STM32F401xC || STM32F401xE */
+#endif /* STM32F401xC || STM32F401xE || STM32F411xE */
     }
     else
     {
       /*Disable of Write protection on the selected Sector*/
-#if defined(STM32F401xC) || defined(STM32F401xE) 
+#if defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE) 
       status = FLASH_OB_DisablePCROP(pAdvOBInit->Sectors);
 #else /* STM32F427xx || STM32F437xx || STM32F429xx|| STM32F439xx */
       status = FLASH_OB_DisablePCROP(pAdvOBInit->SectorsBank1, pAdvOBInit->SectorsBank2, pAdvOBInit->Banks);
-#endif /* STM32F401xC || STM32F401xE */
+#endif /* STM32F401xC || STM32F401xE || STM32F411xE */
     }
   }
    
@@ -415,7 +416,7 @@ HAL_StatusTypeDef HAL_FLASHEx_AdvOBProgram (FLASH_AdvOBProgramInitTypeDef *pAdvO
   */
 void HAL_FLASHEx_AdvOBGetConfig(FLASH_AdvOBProgramInitTypeDef *pAdvOBInit)
 {
-#if defined(STM32F401xC) || defined(STM32F401xE)
+#if defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
   /*Get Sector*/
   pAdvOBInit->Sectors = (*(__IO uint16_t *)(OPTCR_BYTE2_ADDRESS));
 #else  /* STM32F427xx || STM32F437xx || STM32F429xx|| STM32F439xx */
@@ -427,7 +428,7 @@ void HAL_FLASHEx_AdvOBGetConfig(FLASH_AdvOBProgramInitTypeDef *pAdvOBInit)
 
   /*Get Boot config OB*/
   pAdvOBInit->BootConfig = *(__IO uint8_t *)OPTCR_BYTE0_ADDRESS;
-#endif /* STM32F401xC || STM32F401xE */
+#endif /* STM32F401xC || STM32F401xE || STM32F411xE */
 }
 
 /**
@@ -481,7 +482,7 @@ HAL_StatusTypeDef HAL_FLASHEx_OB_DeSelectPCROP(void)
   return HAL_OK;
 }
 
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx || STM32F401xC || STM32F401xE */
+#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx || STM32F401xC || STM32F401xE || STM32F411xE */
 
 #if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx)
 
@@ -914,7 +915,8 @@ static HAL_StatusTypeDef FLASH_OB_DisablePCROP(uint32_t SectorBank1, uint32_t Se
 
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 
-#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx)|| defined(STM32F417xx) || defined(STM32F401xC) || defined(STM32F401xE) 
+#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx)|| defined(STM32F417xx) ||\
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 /**
   * @brief  Mass erase of FLASH memory
   * @param  VoltageRange: The device voltage range which defines the erase parallelism.  
@@ -1070,9 +1072,9 @@ static HAL_StatusTypeDef FLASH_OB_DisableWRP(uint32_t WRPSector, uint32_t Banks)
   
   return status;
 }
-#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F401xC || STM32F401xE */
+#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F401xC || STM32F401xE || STM32F411xE */
 
-#if defined(STM32F401xC) || defined(STM32F401xE)
+#if defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 /**
   * @brief  Enable the read/write protection (PCROP) of the desired sectors.
   * @note   This function can be used only for STM32F401xx devices.
@@ -1128,7 +1130,7 @@ static HAL_StatusTypeDef FLASH_OB_DisablePCROP(uint32_t Sector)
   return status;
 
 }
-#endif /* STM32F401xC || STM32F401xE */
+#endif /* STM32F401xC || STM32F401xE || STM32F411xE */
 
 /**
   * @brief  Set the read protection level.

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_flash_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_flash_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_flash_ex.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of FLASH HAL Extension module.
   ******************************************************************************
   * @attention
@@ -108,7 +108,8 @@ typedef struct
 /**
   * @brief  FLASH Advanced Option Bytes Program structure definition
   */
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx) || defined(STM32F401xC) || defined(STM32F401xE)
+#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx) || \
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 typedef struct
 {
   uint32_t OptionType;     /*!< Option byte to be configured for extension.
@@ -117,10 +118,11 @@ typedef struct
   uint32_t PCROPState;     /*!< PCROP activation or deactivation.
                                 This parameter can be a value of @ref FLASHEx_PCROP_State */
 
-#if defined (STM32F401xC) || defined (STM32F401xE)
+#if defined (STM32F401xC) || defined (STM32F401xE) || defined (STM32F411xE)
   uint16_t Sectors;        /*!< specifies the sector(s) set for PCROP.
                                 This parameter can be a value of @ref FLASHEx_Option_Bytes_PC_ReadWrite_Protection */
-#endif /* STM32F401xC || STM32F401xE */
+#endif /* STM32F401xC || STM32F401xE || STM32F411xE */
+
 #if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
   uint32_t Banks;          /*!< Select banks for PCROP activation/deactivation of all sectors.
                                 This parameter must be a value of @ref FLASHEx_Banks */
@@ -136,11 +138,11 @@ typedef struct
   
 #endif /*STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 } FLASH_AdvOBProgramInitTypeDef;
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx || STM32F401xC || STM32F401xE */
+#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx || STM32F401xC || STM32F401xE || STM32F411xE */
 
 /* Exported constants --------------------------------------------------------*/
 
-/** @defgroup FLASH_Exported_Constants FLASH Exported Constants
+/** @defgroup FLASHEx_Exported_Constants FLASH Exported Constants
   * @{
   */
 
@@ -259,7 +261,8 @@ typedef struct
   * @}
   */
 
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx) || defined(STM32F401xC) || defined(STM32F401xE)
+#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx) ||\
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 /** @defgroup FLASHEx_PCROP_State FLASH PCROP State
   * @{
   */ 
@@ -272,7 +275,7 @@ typedef struct
 /**
   * @}
   */
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx || STM32F401xC || STM32F401xE */
+#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx || STM32F401xC || STM32F401xE || STM32F411xE */
 
 /** @defgroup FLASHEx_Advanced_Option_Type FLASH Advanced Option Type
   * @{
@@ -286,12 +289,12 @@ typedef struct
   
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 
-#if defined(STM32F401xC) || defined(STM32F401xE)
+#if defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 #define OBEX_PCROP        ((uint32_t)0x01)  /*!<PCROP option byte configuration */
 
 #define IS_OBEX(VALUE)(((VALUE) == OBEX_PCROP))  
   
-#endif /* STM32F401xC || STM32F401xE */
+#endif /* STM32F401xC || STM32F401xE || STM32F411xE */
 /**
   * @}
   */
@@ -299,6 +302,7 @@ typedef struct
 /** @defgroup FLASH_Latency FLASH Latency
   * @{
   */
+/*------------------------------------------- STM32F42xxx/STM32F43xxx------------------------------------------*/  
 #if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx)
 #define FLASH_LATENCY_0                FLASH_ACR_LATENCY_0WS   /*!< FLASH Zero Latency cycle      */
 #define FLASH_LATENCY_1                FLASH_ACR_LATENCY_1WS   /*!< FLASH One Latency cycle       */
@@ -335,8 +339,12 @@ typedef struct
                                    ((LATENCY) == FLASH_LATENCY_14) || \
                                    ((LATENCY) == FLASH_LATENCY_15))
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx|| STM32F439xx */
+/*--------------------------------------------------------------------------------------------------------------*/
 
-#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx) || defined(STM32F401xC) || defined(STM32F401xE)
+/*-------------------------- STM32F40xxx/STM32F41xxx/STM32F401xx/STM32F411xx -----------------------------------*/ 
+#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx) || \
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
+     
 #define FLASH_LATENCY_0                FLASH_ACR_LATENCY_0WS   /*!< FLASH Zero Latency cycle      */
 #define FLASH_LATENCY_1                FLASH_ACR_LATENCY_1WS   /*!< FLASH One Latency cycle       */
 #define FLASH_LATENCY_2                FLASH_ACR_LATENCY_2WS   /*!< FLASH Two Latency cycles      */
@@ -355,7 +363,8 @@ typedef struct
                                    ((LATENCY) == FLASH_LATENCY_5)  || \
                                    ((LATENCY) == FLASH_LATENCY_6)  || \
                                    ((LATENCY) == FLASH_LATENCY_7))
-#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F401xC || STM32F401xE */
+#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F401xC || STM32F401xE || STM32F411xE */
+/*--------------------------------------------------------------------------------------------------------------*/
 
 /**
   * @}
@@ -375,11 +384,12 @@ typedef struct
                              ((BANK) == FLASH_BANK_BOTH))
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx|| STM32F439xx */
 
-#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx) || defined(STM32F401xC) || defined(STM32F401xE)
+#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx) ||\
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 #define FLASH_BANK_1     ((uint32_t)1) /*!< Bank 1   */
 
 #define IS_FLASH_BANK(BANK) (((BANK) == FLASH_BANK_1))
-#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F401xC || STM32F401xE */
+#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F401xC || STM32F401xE || STM32F411xE */
 /**
   * @}
   */ 
@@ -391,9 +401,10 @@ typedef struct
 #define FLASH_MER_BIT     (FLASH_CR_MER1 | FLASH_CR_MER2) /*!< 2 MER bits here to clear */
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx|| STM32F439xx */
 
-#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx) || defined(STM32F401xC) || defined(STM32F401xE)
+#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx) ||\
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 #define FLASH_MER_BIT     (FLASH_CR_MER) /*!< only 1 MER Bit */
-#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F401xC || STM32F401xE */
+#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F401xC || STM32F401xE || STM32F411xE */
 /**
   * @}
   */ 
@@ -401,6 +412,7 @@ typedef struct
 /** @defgroup FLASHEx_Sectors FLASH Sectors
   * @{
   */
+/*------------------------------------------ STM32F42xxx/STM32F43xxx--------------------------------------*/   
 #if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx)
 #define FLASH_SECTOR_0     ((uint32_t)0)  /*!< Sector Number 0   */
 #define FLASH_SECTOR_1     ((uint32_t)1)  /*!< Sector Number 1   */
@@ -441,11 +453,10 @@ typedef struct
                                   ((SECTOR) == FLASH_SECTOR_18)  || ((SECTOR) == FLASH_SECTOR_19)  ||\
                                   ((SECTOR) == FLASH_SECTOR_20)  || ((SECTOR) == FLASH_SECTOR_21)  ||\
                                   ((SECTOR) == FLASH_SECTOR_22)  || ((SECTOR) == FLASH_SECTOR_23))
-
-#define IS_FLASH_ADDRESS(ADDRESS) ((((ADDRESS) >= 0x08000000) && ((ADDRESS) < 0x081FFFFF)) ||\
-                                   (((ADDRESS) >= 0x1FFF7800) && ((ADDRESS) < 0x1FFF7A0F)))  
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx|| STM32F439xx */
+/*-----------------------------------------------------------------------------------------------------*/  
 
+/*--------------------------------------- STM32F40xxx/STM32F41xxx -------------------------------------*/ 
 #if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx)
 #define FLASH_SECTOR_0     ((uint32_t)0)  /*!< Sector Number 0   */
 #define FLASH_SECTOR_1     ((uint32_t)1)  /*!< Sector Number 1   */
@@ -468,11 +479,10 @@ typedef struct
                                  ((SECTOR) == FLASH_SECTOR_6)   || ((SECTOR) == FLASH_SECTOR_7)   ||\
                                  ((SECTOR) == FLASH_SECTOR_8)   || ((SECTOR) == FLASH_SECTOR_9)   ||\
                                  ((SECTOR) == FLASH_SECTOR_10)  || ((SECTOR) == FLASH_SECTOR_11))
-
-#define IS_FLASH_ADDRESS(ADDRESS) ((((ADDRESS) >= 0x08000000) && ((ADDRESS) < 0x080FFFFF)) ||\
-                                   (((ADDRESS) >= 0x1FFF7800) && ((ADDRESS) < 0x1FFF7A0F)))
 #endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx */
+/*-----------------------------------------------------------------------------------------------------*/
 
+/*--------------------------------------------- STM32F401xC -------------------------------------------*/ 
 #if defined(STM32F401xC)
 #define FLASH_SECTOR_0     ((uint32_t)0) /*!< Sector Number 0   */
 #define FLASH_SECTOR_1     ((uint32_t)1) /*!< Sector Number 1   */
@@ -486,12 +496,11 @@ typedef struct
 #define IS_FLASH_SECTOR(SECTOR) (((SECTOR) == FLASH_SECTOR_0)   || ((SECTOR) == FLASH_SECTOR_1)   ||\
                                  ((SECTOR) == FLASH_SECTOR_2)   || ((SECTOR) == FLASH_SECTOR_3)   ||\
                                  ((SECTOR) == FLASH_SECTOR_4)   || ((SECTOR) == FLASH_SECTOR_5))
-
-#define IS_FLASH_ADDRESS(ADDRESS) ((((ADDRESS) >= 0x08000000) && ((ADDRESS) < 0x0803FFFF)) ||\
-                                   (((ADDRESS) >= 0x1FFF7800) && ((ADDRESS) < 0x1FFF7A0F)))
 #endif /* STM32F401xC */
+/*-----------------------------------------------------------------------------------------------------*/
 
-#if defined(STM32F401xE)
+/*--------------------------------------- STM32F401xE/STM32F411xE -------------------------------------*/
+#if defined(STM32F401xE) || defined(STM32F411xE)
 #define FLASH_SECTOR_0     ((uint32_t)0) /*!< Sector Number 0   */
 #define FLASH_SECTOR_1     ((uint32_t)1) /*!< Sector Number 1   */
 #define FLASH_SECTOR_2     ((uint32_t)2) /*!< Sector Number 2   */
@@ -507,11 +516,9 @@ typedef struct
                                  ((SECTOR) == FLASH_SECTOR_2)   || ((SECTOR) == FLASH_SECTOR_3)   ||\
                                  ((SECTOR) == FLASH_SECTOR_4)   || ((SECTOR) == FLASH_SECTOR_5)   ||\
                                  ((SECTOR) == FLASH_SECTOR_6)   || ((SECTOR) == FLASH_SECTOR_7))
-
-#define IS_FLASH_ADDRESS(ADDRESS) ((((ADDRESS) >= 0x08000000) && ((ADDRESS) < 0x0807FFFF)) ||\
-                                   (((ADDRESS) >= 0x1FFF7800) && ((ADDRESS) < 0x1FFF7A0F)))
-#endif /* STM32F401xE */
-
+#endif /* STM32F401xE || STM32F411xE */
+/*-----------------------------------------------------------------------------------------------------*/
+#define IS_FLASH_ADDRESS(ADDRESS) (((ADDRESS) >= FLASH_BASE) && ((ADDRESS) < FLASH_END))
 #define IS_NBSECTORS(NBSECTORS) (((NBSECTORS) != 0) && ((NBSECTORS) <= FLASH_SECTOR_TOTAL))
 
 /**
@@ -521,6 +528,7 @@ typedef struct
 /** @defgroup FLASHEx_Option_Bytes_Write_Protection FLASH Option Bytes Write Protection
   * @{
   */
+/*----------------------------------------- STM32F42xxx/STM32F43xxx-------------------------------------*/  
 #if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) 
 #define OB_WRP_SECTOR_0       ((uint32_t)0x00000001) /*!< Write protection of Sector0     */
 #define OB_WRP_SECTOR_1       ((uint32_t)0x00000002) /*!< Write protection of Sector1     */
@@ -550,7 +558,9 @@ typedef struct
 
 #define IS_OB_WRP_SECTOR(SECTOR)((((SECTOR) & (uint32_t)0xFF000000) == 0x00000000) && ((SECTOR) != 0x00000000))
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx|| STM32F439xx */
+/*-----------------------------------------------------------------------------------------------------*/
 
+/*--------------------------------------- STM32F40xxx/STM32F41xxx -------------------------------------*/ 
 #if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx)
 #define OB_WRP_SECTOR_0       ((uint32_t)0x00000001) /*!< Write protection of Sector0     */
 #define OB_WRP_SECTOR_1       ((uint32_t)0x00000002) /*!< Write protection of Sector1     */
@@ -568,7 +578,9 @@ typedef struct
 
 #define IS_OB_WRP_SECTOR(SECTOR)((((SECTOR) & (uint32_t)0xFFFFF000) == 0x00000000) && ((SECTOR) != 0x00000000))
 #endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx */
+/*-----------------------------------------------------------------------------------------------------*/
 
+/*--------------------------------------------- STM32F401xC -------------------------------------------*/
 #if defined(STM32F401xC)
 #define OB_WRP_SECTOR_0       ((uint32_t)0x00000001) /*!< Write protection of Sector0     */
 #define OB_WRP_SECTOR_1       ((uint32_t)0x00000002) /*!< Write protection of Sector1     */
@@ -580,8 +592,10 @@ typedef struct
 
 #define IS_OB_WRP_SECTOR(SECTOR)((((SECTOR) & (uint32_t)0xFFFFF000) == 0x00000000) && ((SECTOR) != 0x00000000))
 #endif /* STM32F401xC */
+/*-----------------------------------------------------------------------------------------------------*/
 
-#if defined(STM32F401xE)
+/*--------------------------------------- STM32F401xE/STM32F411xE -------------------------------------*/
+#if defined(STM32F401xE) || defined(STM32F411xE)
 #define OB_WRP_SECTOR_0       ((uint32_t)0x00000001) /*!< Write protection of Sector0     */
 #define OB_WRP_SECTOR_1       ((uint32_t)0x00000002) /*!< Write protection of Sector1     */
 #define OB_WRP_SECTOR_2       ((uint32_t)0x00000004) /*!< Write protection of Sector2     */
@@ -593,7 +607,8 @@ typedef struct
 #define OB_WRP_SECTOR_All     ((uint32_t)0x00000FFF) /*!< Write protection of all Sectors */
 
 #define IS_OB_WRP_SECTOR(SECTOR)((((SECTOR) & (uint32_t)0xFFFFF000) == 0x00000000) && ((SECTOR) != 0x00000000))
-#endif /* STM32F401xE */
+#endif /* STM32F401xE || STM32F411xE */
+/*-----------------------------------------------------------------------------------------------------*/
 /**
   * @}
   */
@@ -601,6 +616,7 @@ typedef struct
 /** @defgroup FLASHEx_Option_Bytes_PC_ReadWrite_Protection FLASH Option Bytes PC ReadWrite Protection
   * @{
   */
+/*----------------------------------------- STM32F42xxx/STM32F43xxx-------------------------------------*/   
 #if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) 
 #define OB_PCROP_SECTOR_0        ((uint32_t)0x00000001) /*!< PC Read/Write protection of Sector0      */
 #define OB_PCROP_SECTOR_1        ((uint32_t)0x00000002) /*!< PC Read/Write protection of Sector1      */
@@ -630,7 +646,9 @@ typedef struct
 
 #define IS_OB_PCROP(SECTOR)((((SECTOR) & (uint32_t)0xFFFFF000) == 0x00000000) && ((SECTOR) != 0x00000000))
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx|| STM32F439xx */
+/*-----------------------------------------------------------------------------------------------------*/
 
+/*--------------------------------------------- STM32F401xC -------------------------------------------*/
 #if defined(STM32F401xC)
 #define OB_PCROP_SECTOR_0        ((uint32_t)0x00000001) /*!< PC Read/Write protection of Sector0      */
 #define OB_PCROP_SECTOR_1        ((uint32_t)0x00000002) /*!< PC Read/Write protection of Sector1      */
@@ -642,8 +660,10 @@ typedef struct
 
 #define IS_OB_PCROP(SECTOR)((((SECTOR) & (uint32_t)0xFFFFF000) == 0x00000000) && ((SECTOR) != 0x00000000))
 #endif /* STM32F401xC */
+/*-----------------------------------------------------------------------------------------------------*/
 
-#if defined(STM32F401xE)
+/*--------------------------------------- STM32F401xE/STM32F411xE -------------------------------------*/
+#if defined(STM32F401xE) || defined(STM32F411xE)
 #define OB_PCROP_SECTOR_0        ((uint32_t)0x00000001) /*!< PC Read/Write protection of Sector0      */
 #define OB_PCROP_SECTOR_1        ((uint32_t)0x00000002) /*!< PC Read/Write protection of Sector1      */
 #define OB_PCROP_SECTOR_2        ((uint32_t)0x00000004) /*!< PC Read/Write protection of Sector2      */
@@ -655,7 +675,8 @@ typedef struct
 #define OB_PCROP_SECTOR_All      ((uint32_t)0x00000FFF) /*!< PC Read/Write protection of all Sectors  */
 
 #define IS_OB_PCROP(SECTOR)((((SECTOR) & (uint32_t)0xFFFFF000) == 0x00000000) && ((SECTOR) != 0x00000000))
-#endif /* STM32F401xE */
+#endif /* STM32F401xE || STM32F411xE */
+/*-----------------------------------------------------------------------------------------------------*/
 
 /**
   * @}
@@ -676,11 +697,12 @@ typedef struct
 /** @defgroup  FLASHEx_Selection_Protection_Mode FLASH Selection Protection Mode
   * @{
   */
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx) || defined(STM32F401xC) || defined(STM32F401xE)
+#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx) ||\
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 #define OB_PCROP_DESELECTED     ((uint8_t)0x00) /*!< Disabled PcROP, nWPRi bits used for Write Protection on sector i */
 #define OB_PCROP_SELECTED       ((uint8_t)0x80) /*!< Enable PcROP, nWPRi bits used for PCRoP Protection on sector i   */
 #define IS_OB_PCROP_SELECT(PCROP) (((PCROP) == OB_PCROP_SELECTED) || ((PCROP) == OB_PCROP_DESELECTED))
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx || STM32F401xC || STM32F401xE */
+#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx || STM32F401xC || STM32F401xE || STM32F411xE */
 /**
   * @}
   */
@@ -705,12 +727,14 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t
 HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit);
 HAL_StatusTypeDef HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit);
 void              HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit);
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx) || defined(STM32F401xC) || defined(STM32F401xE) 
+
+#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx) ||\
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 HAL_StatusTypeDef HAL_FLASHEx_AdvOBProgram (FLASH_AdvOBProgramInitTypeDef *pAdvOBInit);
 void              HAL_FLASHEx_AdvOBGetConfig(FLASH_AdvOBProgramInitTypeDef *pAdvOBInit);
 HAL_StatusTypeDef HAL_FLASHEx_OB_SelectPCROP(void);
 HAL_StatusTypeDef HAL_FLASHEx_OB_DeSelectPCROP(void);
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx || STM32F401xC || STM32F401xE */
+#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx || STM32F401xC || STM32F401xE || STM32F411xE */
 
 #if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx)
 uint16_t          HAL_FLASHEx_OB_GetBank2WRP(void);

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_gpio.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_gpio.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_gpio.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   GPIO HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the General Purpose Input/Output (GPIO) peripheral:
@@ -135,7 +135,7 @@
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
-#define __HAL_GET_GPIO_SOURCE(__GPIOx__) \
+#define GET_GPIO_SOURCE(__GPIOx__) \
 (((uint32_t)(__GPIOx__) == ((uint32_t)GPIOA_BASE))? (uint32_t)0 :\
  ((uint32_t)(__GPIOx__) == ((uint32_t)(GPIOA_BASE + 0x0400)))? (uint32_t)1 :\
  ((uint32_t)(__GPIOx__) == ((uint32_t)(GPIOA_BASE + 0x0800)))? (uint32_t)2 :\
@@ -259,7 +259,7 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
 
         temp = SYSCFG->EXTICR[position >> 2];
         temp &= ~(((uint32_t)0x0F) << (4 * (position & 0x03)));
-        temp |= ((uint32_t)(__HAL_GET_GPIO_SOURCE(GPIOx)) << (4 * (position & 0x03)));
+        temp |= ((uint32_t)(GET_GPIO_SOURCE(GPIOx)) << (4 * (position & 0x03)));
         SYSCFG->EXTICR[position >> 2] = temp;
 
         /* Clear EXTI line configuration */
@@ -386,7 +386,7 @@ GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
   GPIO_PinState bitstatus;
 
   /* Check the parameters */
-  assert_param(IS_GET_GPIO_PIN(GPIO_Pin));
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
 
   if((GPIOx->IDR & GPIO_Pin) != (uint32_t)GPIO_PIN_RESET)
   {
@@ -419,7 +419,7 @@ GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
 void HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState)
 {
   /* Check the parameters */
-  assert_param(IS_GET_GPIO_PIN(GPIO_Pin));
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
   assert_param(IS_GPIO_PIN_ACTION(PinState));
 
   if(PinState != GPIO_PIN_RESET)
@@ -442,7 +442,7 @@ void HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState Pin
 void HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
 {
   /* Check the parameters */
-  assert_param(IS_GET_GPIO_PIN(GPIO_Pin));
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
 
   GPIOx->ODR ^= GPIO_Pin;
 }
@@ -476,7 +476,7 @@ HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
   /* Read LCKK bit*/
   tmp = GPIOx->LCKR;
 
-  if(GPIOx->LCKR & GPIO_LCKR_LCKK)
+ if((GPIOx->LCKR & GPIO_LCKR_LCKK) != RESET)
   {
     return HAL_OK;
   }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_gpio.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_gpio.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_gpio.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of GPIO HAL module.
   ******************************************************************************
   * @attention
@@ -114,23 +114,9 @@ typedef enum
 #define GPIO_PIN_15                ((uint16_t)0x8000)  /* Pin 15 selected   */
 #define GPIO_PIN_All               ((uint16_t)0xFFFF)  /* All pins selected */
 
-#define IS_GPIO_PIN(PIN) ((((PIN) & (uint32_t)0x00) == 0x00) && ((PIN) != (uint32_t)0x00))
-#define IS_GET_GPIO_PIN(PIN) (((PIN) == GPIO_PIN_0)  || \
-                              ((PIN) == GPIO_PIN_1)  || \
-                              ((PIN) == GPIO_PIN_2)  || \
-                              ((PIN) == GPIO_PIN_3)  || \
-                              ((PIN) == GPIO_PIN_4)  || \
-                              ((PIN) == GPIO_PIN_5)  || \
-                              ((PIN) == GPIO_PIN_6)  || \
-                              ((PIN) == GPIO_PIN_7)  || \
-                              ((PIN) == GPIO_PIN_8)  || \
-                              ((PIN) == GPIO_PIN_9)  || \
-                              ((PIN) == GPIO_PIN_10) || \
-                              ((PIN) == GPIO_PIN_11) || \
-                              ((PIN) == GPIO_PIN_12) || \
-                              ((PIN) == GPIO_PIN_13) || \
-                              ((PIN) == GPIO_PIN_14) || \
-                              ((PIN) == GPIO_PIN_15))
+#define GPIO_PIN_MASK              ((uint32_t)0x0000FFFF) /* PIN mask for assert test */
+#define IS_GPIO_PIN(PIN)           (((PIN) & GPIO_PIN_MASK ) != (uint32_t)0x00)
+
 /**
   * @}
   */
@@ -243,6 +229,14 @@ typedef enum
   * @retval None
   */
 #define __HAL_GPIO_EXTI_CLEAR_IT(__EXTI_LINE__) (EXTI->PR = (__EXTI_LINE__))
+
+/**
+  * @brief  Generates a Software interrupt on selected EXTI line.
+  * @param  __EXTI_LINE__: specifies the EXTI line to check.
+  *          This parameter can be GPIO_PIN_x where x can be(0..15)
+  * @retval None
+  */
+#define __HAL_GPIO_EXTI_GENERATE_SWIT(__EXTI_LINE__) (EXTI->SWIER |= (__EXTI_LINE__))
 
 /* Include GPIO HAL Extension module */
 #include "stm32f4xx_hal_gpio_ex.h"

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_gpio_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_gpio_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_gpio_ex.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of GPIO HAL Extension module.
   ******************************************************************************
   * @attention
@@ -687,6 +687,116 @@
                           ((AF) == GPIO_AF12_SDIO)      || ((AF) == GPIO_AF15_EVENTOUT))
 
 #endif /* STM32F401xC || STM32F401xE */
+/*------------------------------------------------------------------------------------------*/
+
+/*---------------------------------------- STM32F411xx--------------------------------------*/
+#if defined(STM32F411xE) 
+/** 
+  * @brief   AF 0 selection  
+  */ 
+#define GPIO_AF0_RTC_50Hz      ((uint8_t)0x00)  /* RTC_50Hz Alternate Function mapping                       */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /* MCO (MCO1 and MCO2) Alternate Function mapping            */
+#define GPIO_AF0_TAMPER        ((uint8_t)0x00)  /* TAMPER (TAMPER_1 and TAMPER_2) Alternate Function mapping */
+#define GPIO_AF0_SWJ           ((uint8_t)0x00)  /* SWJ (SWD and JTAG) Alternate Function mapping             */
+#define GPIO_AF0_TRACE         ((uint8_t)0x00)  /* TRACE Alternate Function mapping                          */
+
+/** 
+  * @brief   AF 1 selection  
+  */ 
+#define GPIO_AF1_TIM1          ((uint8_t)0x01)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF1_TIM2          ((uint8_t)0x01)  /* TIM2 Alternate Function mapping */
+
+/** 
+  * @brief   AF 2 selection  
+  */ 
+#define GPIO_AF2_TIM3          ((uint8_t)0x02)  /* TIM3 Alternate Function mapping */
+#define GPIO_AF2_TIM4          ((uint8_t)0x02)  /* TIM4 Alternate Function mapping */
+#define GPIO_AF2_TIM5          ((uint8_t)0x02)  /* TIM5 Alternate Function mapping */
+
+/** 
+  * @brief   AF 3 selection  
+  */ 
+#define GPIO_AF3_TIM9          ((uint8_t)0x03)  /* TIM9 Alternate Function mapping  */
+#define GPIO_AF3_TIM10         ((uint8_t)0x03)  /* TIM10 Alternate Function mapping */
+#define GPIO_AF3_TIM11         ((uint8_t)0x03)  /* TIM11 Alternate Function mapping */
+
+/** 
+  * @brief   AF 4 selection  
+  */ 
+#define GPIO_AF4_I2C1          ((uint8_t)0x04)  /* I2C1 Alternate Function mapping */
+#define GPIO_AF4_I2C2          ((uint8_t)0x04)  /* I2C2 Alternate Function mapping */
+#define GPIO_AF4_I2C3          ((uint8_t)0x04)  /* I2C3 Alternate Function mapping */
+
+/** 
+  * @brief   AF 5 selection  
+  */ 
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /* SPI1/I2S1 Alternate Function mapping   */
+#define GPIO_AF5_SPI2          ((uint8_t)0x05)  /* SPI2/I2S2 Alternate Function mapping   */
+#define GPIO_AF5_SPI3          ((uint8_t)0x05)  /* SPI3/I2S3 Alternate Function mapping   */
+#define GPIO_AF5_SPI4          ((uint8_t)0x05)  /* SPI4 Alternate Function mapping        */
+#define GPIO_AF5_I2S3ext       ((uint8_t)0x05)  /* I2S3ext_SD Alternate Function mapping  */
+
+/** 
+  * @brief   AF 6 selection  
+  */
+#define GPIO_AF6_SPI2          ((uint8_t)0x06)  /* I2S2 Alternate Function mapping       */ 
+#define GPIO_AF6_SPI3          ((uint8_t)0x06)  /* SPI3/I2S3 Alternate Function mapping  */
+#define GPIO_AF6_SPI4          ((uint8_t)0x06)  /* SPI4/I2S4 Alternate Function mapping  */
+#define GPIO_AF6_SPI5          ((uint8_t)0x06)  /* SPI5/I2S5 Alternate Function mapping  */
+#define GPIO_AF6_I2S2ext       ((uint8_t)0x06)  /* I2S2ext_SD Alternate Function mapping */
+/** 
+  * @brief   AF 7 selection  
+  */ 
+#define GPIO_AF7_SPI3          ((uint8_t)0x07)  /* SPI3/I2S3 Alternate Function mapping  */
+#define GPIO_AF7_USART1        ((uint8_t)0x07)  /* USART1 Alternate Function mapping     */
+#define GPIO_AF7_USART2        ((uint8_t)0x07)  /* USART2 Alternate Function mapping     */
+#define GPIO_AF7_I2S3ext       ((uint8_t)0x07)  /* I2S3ext_SD Alternate Function mapping */
+
+/** 
+  * @brief   AF 8 selection  
+  */ 
+#define GPIO_AF8_USART6        ((uint8_t)0x08)  /* USART6 Alternate Function mapping */
+
+/** 
+  * @brief   AF 9 selection 
+  */ 
+#define GPIO_AF9_TIM14         ((uint8_t)0x09)  /* TIM14 Alternate Function mapping */
+#define GPIO_AF9_I2C2          ((uint8_t)0x09)  /* I2C2 Alternate Function mapping  */
+#define GPIO_AF9_I2C3          ((uint8_t)0x09)  /* I2C3 Alternate Function mapping  */
+
+
+/** 
+  * @brief   AF 10 selection  
+  */ 
+#define GPIO_AF10_OTG_FS        ((uint8_t)0xA)  /* OTG_FS Alternate Function mapping */
+
+/** 
+  * @brief   AF 12 selection  
+  */ 
+#define GPIO_AF12_SDIO          ((uint8_t)0xC)  /* SDIO Alternate Function mapping  */
+
+/** 
+  * @brief   AF 15 selection  
+  */ 
+#define GPIO_AF15_EVENTOUT      ((uint8_t)0x0F)  /* EVENTOUT Alternate Function mapping */
+
+#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_RTC_50Hz)   || ((AF) == GPIO_AF9_TIM14)      || \
+                          ((AF) == GPIO_AF0_MCO)        || ((AF) == GPIO_AF0_TAMPER)     || \
+                          ((AF) == GPIO_AF0_SWJ)        || ((AF) == GPIO_AF0_TRACE)      || \
+                          ((AF) == GPIO_AF1_TIM1)       || ((AF) == GPIO_AF1_TIM2)       || \
+                          ((AF) == GPIO_AF2_TIM3)       || ((AF) == GPIO_AF2_TIM4)       || \
+                          ((AF) == GPIO_AF2_TIM5)       || ((AF) == GPIO_AF4_I2C1)       || \
+                          ((AF) == GPIO_AF4_I2C2)       || ((AF) == GPIO_AF4_I2C3)       || \
+                          ((AF) == GPIO_AF5_SPI1)       || ((AF) == GPIO_AF5_SPI2)       || \
+                          ((AF) == GPIO_AF5_SPI3)       || ((AF) == GPIO_AF6_SPI4)       || \
+                          ((AF) == GPIO_AF6_SPI3)       || ((AF) == GPIO_AF5_SPI4)       || \
+                          ((AF) == GPIO_AF6_SPI5)       || ((AF) == GPIO_AF7_SPI3)       || \
+                          ((AF) == GPIO_AF7_USART1)     || ((AF) == GPIO_AF7_USART2)     || \
+                          ((AF) == GPIO_AF8_USART6)     || ((AF) == GPIO_AF10_OTG_FS)    || \
+                          ((AF) == GPIO_AF9_I2C2)       || ((AF) == GPIO_AF9_I2C3)       || \
+                          ((AF) == GPIO_AF12_SDIO)      || ((AF) == GPIO_AF15_EVENTOUT))
+
+#endif /* STM32F411xE */
 /**
   * @}
   */ 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_hash.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_hash.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_hash.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   HASH HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the HASH peripheral:
@@ -331,7 +331,7 @@ __weak void HAL_HASH_MspDeInit(HASH_HandleTypeDef *hhash)
   */
 HAL_StatusTypeDef HAL_HASH_MD5_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuffer, uint32_t Size, uint8_t* pOutBuffer, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;
   
   /* Process Locked */
   __HAL_LOCK(hhash);
@@ -359,20 +359,20 @@ HAL_StatusTypeDef HAL_HASH_MD5_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuff
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while(HAL_IS_BIT_SET(HASH->SR, HASH_FLAG_BUSY))
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
         
-        /* Process Unlocked */          
+        /* Process Unlocked */
         __HAL_UNLOCK(hhash);
         
         return HAL_TIMEOUT;
@@ -453,7 +453,7 @@ HAL_StatusTypeDef HAL_HASH_MD5_Accumulate(HASH_HandleTypeDef *hhash, uint8_t *pI
   */
 HAL_StatusTypeDef HAL_HASH_SHA1_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuffer, uint32_t Size, uint8_t* pOutBuffer, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
 
   /* Process Locked */
   __HAL_LOCK(hhash);
@@ -481,20 +481,20 @@ HAL_StatusTypeDef HAL_HASH_SHA1_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuf
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-    timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   while(HAL_IS_BIT_SET(HASH->SR, HASH_FLAG_BUSY))
     {
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Change state */
           hhash->State = HAL_HASH_STATE_TIMEOUT;
           
-          /* Process Unlocked */          
+          /* Process Unlocked */
           __HAL_UNLOCK(hhash);
           
           return HAL_TIMEOUT;
@@ -992,7 +992,7 @@ HAL_StatusTypeDef HAL_HASH_MD5_Start_DMA(HASH_HandleTypeDef *hhash, uint8_t *pIn
   */
 HAL_StatusTypeDef HAL_HASH_MD5_Finish(HASH_HandleTypeDef *hhash, uint8_t* pOutBuffer, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   
    /* Process Locked */
   __HAL_LOCK(hhash);
@@ -1000,20 +1000,20 @@ HAL_StatusTypeDef HAL_HASH_MD5_Finish(HASH_HandleTypeDef *hhash, uint8_t* pOutBu
   /* Change HASH peripheral state */
   hhash->State = HAL_HASH_STATE_BUSY;
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   while(HAL_IS_BIT_CLR(HASH->SR, HASH_FLAG_DCIS))
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
         
-        /* Process Unlocked */          
+        /* Process Unlocked */
         __HAL_UNLOCK(hhash);
         
         return HAL_TIMEOUT;
@@ -1097,7 +1097,7 @@ HAL_StatusTypeDef HAL_HASH_SHA1_Start_DMA(HASH_HandleTypeDef *hhash, uint8_t *pI
   */
 HAL_StatusTypeDef HAL_HASH_SHA1_Finish(HASH_HandleTypeDef *hhash, uint8_t* pOutBuffer, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   
    /* Process Locked */
   __HAL_LOCK(hhash);
@@ -1105,19 +1105,19 @@ HAL_StatusTypeDef HAL_HASH_SHA1_Finish(HASH_HandleTypeDef *hhash, uint8_t* pOutB
   /* Change HASH peripheral state */
   hhash->State = HAL_HASH_STATE_BUSY;
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   while(HAL_IS_BIT_CLR(HASH->SR, HASH_FLAG_DCIS))
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
         
-        /* Process Unlocked */          
+        /* Process Unlocked */
         __HAL_UNLOCK(hhash);
         
         return HAL_TIMEOUT;
@@ -1173,7 +1173,7 @@ HAL_StatusTypeDef HAL_HASH_SHA1_Finish(HASH_HandleTypeDef *hhash, uint8_t* pOutB
   */
 HAL_StatusTypeDef HAL_HMAC_MD5_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuffer, uint32_t Size, uint8_t* pOutBuffer, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   
    /* Process Locked */
   __HAL_LOCK(hhash);
@@ -1210,20 +1210,20 @@ HAL_StatusTypeDef HAL_HMAC_MD5_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuff
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   while(HAL_IS_BIT_SET(HASH->SR, HASH_FLAG_BUSY))
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
         
-        /* Process Unlocked */          
+        /* Process Unlocked */
         __HAL_UNLOCK(hhash);
         
         return HAL_TIMEOUT;
@@ -1240,20 +1240,20 @@ HAL_StatusTypeDef HAL_HMAC_MD5_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuff
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while(HAL_IS_BIT_SET(HASH->SR, HASH_FLAG_BUSY))
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > Timeout)
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
         
-        /* Process Unlocked */          
+        /* Process Unlocked */
         __HAL_UNLOCK(hhash);
         
         return HAL_TIMEOUT;
@@ -1270,20 +1270,20 @@ HAL_StatusTypeDef HAL_HMAC_MD5_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuff
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while(HAL_IS_BIT_SET(HASH->SR, HASH_FLAG_BUSY))
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > Timeout)
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
         
-        /* Process Unlocked */          
+        /* Process Unlocked */
         __HAL_UNLOCK(hhash);
         
         return HAL_TIMEOUT;
@@ -1318,7 +1318,7 @@ HAL_StatusTypeDef HAL_HMAC_MD5_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuff
   */
 HAL_StatusTypeDef HAL_HMAC_SHA1_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuffer, uint32_t Size, uint8_t* pOutBuffer, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   
   /* Process Locked */
   __HAL_LOCK(hhash);
@@ -1355,20 +1355,20 @@ HAL_StatusTypeDef HAL_HMAC_SHA1_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuf
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while(HAL_IS_BIT_SET(HASH->SR, HASH_FLAG_BUSY))
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
         
-        /* Process Unlocked */          
+        /* Process Unlocked */
         __HAL_UNLOCK(hhash);
         
         return HAL_TIMEOUT;
@@ -1385,20 +1385,20 @@ HAL_StatusTypeDef HAL_HMAC_SHA1_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuf
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while(HAL_IS_BIT_SET(HASH->SR, HASH_FLAG_BUSY))
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > Timeout)
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
         
-        /* Process Unlocked */          
+        /* Process Unlocked */
         __HAL_UNLOCK(hhash);
         
         return HAL_TIMEOUT;
@@ -1415,20 +1415,20 @@ HAL_StatusTypeDef HAL_HMAC_SHA1_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuf
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   while(HAL_IS_BIT_SET(HASH->SR, HASH_FLAG_BUSY))
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > Timeout)
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
         
-        /* Process Unlocked */          
+        /* Process Unlocked */
         __HAL_UNLOCK(hhash);
         
         return HAL_TIMEOUT;
@@ -1447,9 +1447,6 @@ HAL_StatusTypeDef HAL_HMAC_SHA1_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuf
   /* Return function status */
   return HAL_OK;
 }
-
-
-
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_hash.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_hash.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_hash.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of HASH HAL module.
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_hash_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_hash_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_hash_ex.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   HASH HAL Extension module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of HASH peripheral:
@@ -154,7 +154,7 @@ static void HASHEx_DMAError(DMA_HandleTypeDef *hdma);
   */
 HAL_StatusTypeDef HAL_HASHEx_SHA224_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuffer, uint32_t Size, uint8_t* pOutBuffer, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   
   /* Process Locked */
   __HAL_LOCK(hhash);
@@ -182,15 +182,15 @@ HAL_StatusTypeDef HAL_HASHEx_SHA224_Start(HASH_HandleTypeDef *hhash, uint8_t *pI
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while((HASH->SR & HASH_FLAG_BUSY) == HASH_FLAG_BUSY)
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
@@ -230,7 +230,7 @@ HAL_StatusTypeDef HAL_HASHEx_SHA224_Start(HASH_HandleTypeDef *hhash, uint8_t *pI
   */
 HAL_StatusTypeDef HAL_HASHEx_SHA256_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuffer, uint32_t Size, uint8_t* pOutBuffer, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   
   /* Process Locked */
   __HAL_LOCK(hhash);
@@ -258,15 +258,15 @@ HAL_StatusTypeDef HAL_HASHEx_SHA256_Start(HASH_HandleTypeDef *hhash, uint8_t *pI
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while((HASH->SR & HASH_FLAG_BUSY) == HASH_FLAG_BUSY)
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
@@ -418,7 +418,7 @@ HAL_StatusTypeDef HAL_HASHEx_SHA256_Accumulate(HASH_HandleTypeDef *hhash, uint8_
   */
 HAL_StatusTypeDef HAL_HMACEx_SHA224_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuffer, uint32_t Size, uint8_t* pOutBuffer, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
 
    /* Process Locked */
   __HAL_LOCK(hhash);
@@ -455,15 +455,15 @@ HAL_StatusTypeDef HAL_HMACEx_SHA224_Start(HASH_HandleTypeDef *hhash, uint8_t *pI
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while((HASH->SR & HASH_FLAG_BUSY) == HASH_FLAG_BUSY)
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
@@ -485,15 +485,15 @@ HAL_StatusTypeDef HAL_HMACEx_SHA224_Start(HASH_HandleTypeDef *hhash, uint8_t *pI
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while((HASH->SR & HASH_FLAG_BUSY) == HASH_FLAG_BUSY)
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > Timeout)
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
@@ -515,15 +515,15 @@ HAL_StatusTypeDef HAL_HMACEx_SHA224_Start(HASH_HandleTypeDef *hhash, uint8_t *pI
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while((HASH->SR & HASH_FLAG_BUSY) == HASH_FLAG_BUSY)
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > Timeout)
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
@@ -561,7 +561,7 @@ HAL_StatusTypeDef HAL_HMACEx_SHA224_Start(HASH_HandleTypeDef *hhash, uint8_t *pI
   */
 HAL_StatusTypeDef HAL_HMACEx_SHA256_Start(HASH_HandleTypeDef *hhash, uint8_t *pInBuffer, uint32_t Size, uint8_t* pOutBuffer, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   
   /* Process Locked */
   __HAL_LOCK(hhash);
@@ -601,15 +601,15 @@ HAL_StatusTypeDef HAL_HMACEx_SHA256_Start(HASH_HandleTypeDef *hhash, uint8_t *pI
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while((HASH->SR & HASH_FLAG_BUSY) == HASH_FLAG_BUSY)
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
@@ -631,15 +631,15 @@ HAL_StatusTypeDef HAL_HMACEx_SHA256_Start(HASH_HandleTypeDef *hhash, uint8_t *pI
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while((HASH->SR & HASH_FLAG_BUSY) == HASH_FLAG_BUSY)
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > Timeout)
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
@@ -661,15 +661,15 @@ HAL_StatusTypeDef HAL_HMACEx_SHA256_Start(HASH_HandleTypeDef *hhash, uint8_t *pI
   /* Start the digest calculation */
   __HAL_HASH_START_DIGEST();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while((HASH->SR & HASH_FLAG_BUSY) == HASH_FLAG_BUSY)
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > Timeout)
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
@@ -1109,7 +1109,7 @@ HAL_StatusTypeDef HAL_HASHEx_SHA224_Start_DMA(HASH_HandleTypeDef *hhash, uint8_t
   */
 HAL_StatusTypeDef HAL_HASHEx_SHA224_Finish(HASH_HandleTypeDef *hhash, uint8_t* pOutBuffer, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   
   /* Process Locked */
   __HAL_LOCK(hhash);
@@ -1117,15 +1117,15 @@ HAL_StatusTypeDef HAL_HASHEx_SHA224_Finish(HASH_HandleTypeDef *hhash, uint8_t* p
   /* Change HASH peripheral state */
   hhash->State = HAL_HASH_STATE_BUSY;
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while(HAL_IS_BIT_CLR(HASH->SR, HASH_FLAG_DCIS))
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;
@@ -1213,7 +1213,7 @@ HAL_StatusTypeDef HAL_HASHEx_SHA256_Start_DMA(HASH_HandleTypeDef *hhash, uint8_t
   */
 HAL_StatusTypeDef HAL_HASHEx_SHA256_Finish(HASH_HandleTypeDef *hhash, uint8_t* pOutBuffer, uint32_t Timeout)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;   
   
    /* Process Locked */
   __HAL_LOCK(hhash);
@@ -1221,15 +1221,15 @@ HAL_StatusTypeDef HAL_HASHEx_SHA256_Finish(HASH_HandleTypeDef *hhash, uint8_t* p
   /* Change HASH peripheral state */
   hhash->State = HAL_HASH_STATE_BUSY;
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   while(HAL_IS_BIT_CLR(HASH->SR, HASH_FLAG_DCIS))
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         /* Change state */
         hhash->State = HAL_HASH_STATE_TIMEOUT;

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_hash_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_hash_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_hash_ex.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of HASH HAL Extension module.
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_hcd.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_hcd.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_hcd.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   HCD HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the USB Peripheral Controller:
@@ -119,7 +119,7 @@ static void HCD_Port_IRQHandler(HCD_HandleTypeDef *hhcd);
 HAL_StatusTypeDef HAL_HCD_Init(HCD_HandleTypeDef *hhcd)
 { 
   /* Check the HCD handle allocation */
-  if(hhcd == NULL)
+  if(hhcd == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -127,7 +127,7 @@ HAL_StatusTypeDef HAL_HCD_Init(HCD_HandleTypeDef *hhcd)
   /* Check the parameters */
   assert_param(IS_HCD_ALL_INSTANCE(hhcd->Instance));
 
-  hhcd->State = HCD_BUSY;
+  hhcd->State = HAL_HCD_STATE_BUSY;
   
   /* Init the low level hardware : GPIO, CLOCK, NVIC... */
   HAL_HCD_MspInit(hhcd);
@@ -144,7 +144,7 @@ HAL_StatusTypeDef HAL_HCD_Init(HCD_HandleTypeDef *hhcd)
  /* Init Host */
  USB_HostInit(hhcd->Instance, hhcd->Init);
  
- hhcd->State= HCD_READY;
+ hhcd->State= HAL_HCD_STATE_READY;
  
  return HAL_OK;
 }
@@ -233,19 +233,19 @@ HAL_StatusTypeDef HAL_HCD_HC_Halt(HCD_HandleTypeDef *hhcd,
 HAL_StatusTypeDef HAL_HCD_DeInit(HCD_HandleTypeDef *hhcd)
 {
   /* Check the HCD handle allocation */
-  if(hhcd == NULL)
+  if(hhcd == HAL_NULL)
   {
     return HAL_ERROR;
   }
   
-  hhcd->State = HCD_BUSY;
+  hhcd->State = HAL_HCD_STATE_BUSY;
   
   /* DeInit the low level hardware */
   HAL_HCD_MspDeInit(hhcd);
   
    __HAL_HCD_DISABLE(hhcd);
   
-  hhcd->State = HCD_READY; 
+  hhcd->State = HAL_HCD_STATE_RESET; 
   
   return HAL_OK;
 }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_hcd.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_hcd.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_hcd.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of HCD HAL module.
   ******************************************************************************
   * @attention
@@ -61,10 +61,11 @@
   */  
 typedef enum 
 {
-  HCD_READY    = 0x00,
-  HCD_ERROR    = 0x01,
-  HCD_BUSY     = 0x02,
-  HCD_TIMEOUT  = 0x03
+  HAL_HCD_STATE_RESET    = 0x00,
+  HAL_HCD_STATE_READY    = 0x01,
+  HAL_HCD_STATE_ERROR    = 0x02,
+  HAL_HCD_STATE_BUSY     = 0x03,
+  HAL_HCD_STATE_TIMEOUT  = 0x04
 } HCD_StateTypeDef;
 
 typedef USB_OTG_GlobalTypeDef   HCD_TypeDef;
@@ -95,16 +96,11 @@ typedef struct
 /** @defgroup HCD_Instance_definition 
   * @{
   */ 
-   
-#define __HAL_HCD_GET_FLAG(__HANDLE__, __INTERRUPT__)      ((USB_ReadInterrupts((__HANDLE__)->Instance) & (__INTERRUPT__)) == (__INTERRUPT__))
-#define __HAL_HCD_CLEAR_FLAG(__HANDLE__, __INTERRUPT__)    (((__HANDLE__)->Instance->GINTSTS) |= (__INTERRUPT__))
-#define __HAL_HCD_IS_INVALID_INTERRUPT(__HANDLE__)         (USB_ReadInterrupts((__HANDLE__)->Instance) == 0)   
-
 
 #if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx) || defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
  #define IS_HCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_OTG_FS) || \
                                         ((INSTANCE) == USB_OTG_HS))
-#elif defined(STM32F401xC) || defined(STM32F401xE)
+#elif defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
  #define IS_HCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_OTG_FS))
 #endif
 
@@ -144,9 +140,10 @@ typedef struct
 #define __HAL_HCD_ENABLE(__HANDLE__)                   USB_EnableGlobalInt ((__HANDLE__)->Instance)
 #define __HAL_HCD_DISABLE(__HANDLE__)                  USB_DisableGlobalInt ((__HANDLE__)->Instance)
    
-#define __HAL_GET_FLAG(__HANDLE__, __INTERRUPT__)      ((USB_ReadInterrupts((__HANDLE__)->Instance) & (__INTERRUPT__)) == (__INTERRUPT__))
-#define __HAL_CLEAR_FLAG(__HANDLE__, __INTERRUPT__)    (((__HANDLE__)->Instance->GINTSTS) |= (__INTERRUPT__))
-#define __HAL_IS_INVALID_INTERRUPT(__HANDLE__)         (USB_ReadInterrupts((__HANDLE__)->Instance) == 0)   
+   
+#define __HAL_HCD_GET_FLAG(__HANDLE__, __INTERRUPT__)      ((USB_ReadInterrupts((__HANDLE__)->Instance) & (__INTERRUPT__)) == (__INTERRUPT__))
+#define __HAL_HCD_CLEAR_FLAG(__HANDLE__, __INTERRUPT__)    (((__HANDLE__)->Instance->GINTSTS) = (__INTERRUPT__))
+#define __HAL_HCD_IS_INVALID_INTERRUPT(__HANDLE__)         (USB_ReadInterrupts((__HANDLE__)->Instance) == 0)    
    
    
 #define __HAL_HCD_CLEAR_HC_INT(chnum, __INTERRUPT__)  (USBx_HC(chnum)->HCINT = (__INTERRUPT__)) 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2c.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2c.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_i2c.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   I2C HAL module driver.
   *          This file provides firmware functions to manage the following
   *          functionalities of the Inter Integrated Circuit (I2C) peripheral:
@@ -280,7 +280,7 @@ HAL_StatusTypeDef HAL_I2C_Init(I2C_HandleTypeDef *hi2c)
   uint32_t pclk1 = 0;
 
   /* Check the I2C handle allocation */
-  if(hi2c == NULL)
+  if(hi2c == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -355,7 +355,7 @@ HAL_StatusTypeDef HAL_I2C_Init(I2C_HandleTypeDef *hi2c)
 HAL_StatusTypeDef HAL_I2C_DeInit(I2C_HandleTypeDef *hi2c)
 {
   /* Check the I2C handle allocation */
-  if(hi2c == NULL)
+  if(hi2c == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -484,7 +484,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevA
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -582,7 +582,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAd
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -773,7 +773,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -878,7 +878,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData,
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -970,7 +970,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t D
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -1041,7 +1041,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t De
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -1139,7 +1139,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pD
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -1192,7 +1192,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pDa
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -1246,7 +1246,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t 
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -1322,7 +1322,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t D
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -1408,7 +1408,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *p
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -1493,7 +1493,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pD
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -1566,7 +1566,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress
 
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -1666,7 +1666,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
 
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -1858,7 +1858,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
 
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -1931,7 +1931,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddre
 
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -2034,7 +2034,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
 
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -2112,7 +2112,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
 
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     {
       return  HAL_ERROR;
     }
@@ -2198,7 +2198,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
   */
 HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout)
 {
-  uint32_t timeout = 0, tmp1 = 0, tmp2 = 0, tmp3 = 0, I2C_Trials = 1;
+  uint32_t tickstart = 0, tmp1 = 0, tmp2 = 0, tmp3 = 0, I2C_Trials = 1;
 
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
@@ -2228,14 +2228,15 @@ HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
       hi2c->Instance->DR = __HAL_I2C_7BIT_ADD_WRITE(DevAddress);
 
       /* Wait until ADDR or AF flag are set */
-      timeout = HAL_GetTick() + Timeout;
+      /* Get tick */
+      tickstart = HAL_GetTick();
 
       tmp1 = __HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ADDR);
       tmp2 = __HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF);
       tmp3 = hi2c->State;
       while((tmp1 == RESET) && (tmp2 == RESET) && (tmp3 != HAL_I2C_STATE_TIMEOUT))
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           hi2c->State = HAL_I2C_STATE_TIMEOUT;
         }
@@ -2615,9 +2616,6 @@ uint32_t HAL_I2C_GetError(I2C_HandleTypeDef *hi2c)
   */
 static HAL_StatusTypeDef I2C_MasterTransmit_TXE(I2C_HandleTypeDef *hi2c)
 {
-  /* Process Locked */
-  __HAL_LOCK(hi2c);
-
   /* Write data to DR */
   hi2c->Instance->DR = (*hi2c->pBuffPtr++);
   hi2c->XferCount--;
@@ -2627,9 +2625,6 @@ static HAL_StatusTypeDef I2C_MasterTransmit_TXE(I2C_HandleTypeDef *hi2c)
     /* Disable BUF interrupt */
     __HAL_I2C_DISABLE_IT(hi2c, I2C_IT_BUF);
   }
-
-  /* Process Unlocked */
-  __HAL_UNLOCK(hi2c);
 
   return HAL_OK;
 }
@@ -2642,17 +2637,11 @@ static HAL_StatusTypeDef I2C_MasterTransmit_TXE(I2C_HandleTypeDef *hi2c)
   */
 static HAL_StatusTypeDef I2C_MasterTransmit_BTF(I2C_HandleTypeDef *hi2c)
 {
-  /* Process Locked */
-  __HAL_LOCK(hi2c);
-
   if(hi2c->XferCount != 0)
   {
     /* Write data to DR */
     hi2c->Instance->DR = (*hi2c->pBuffPtr++);
     hi2c->XferCount--;
-
-    /* Process Unlocked */
-    __HAL_UNLOCK(hi2c);
   }
   else
   {
@@ -2672,17 +2661,11 @@ static HAL_StatusTypeDef I2C_MasterTransmit_BTF(I2C_HandleTypeDef *hi2c)
     {
       hi2c->State = HAL_I2C_STATE_READY;
 
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
-
       HAL_I2C_MemTxCpltCallback(hi2c);
     }
     else
     {
       hi2c->State = HAL_I2C_STATE_READY;
-
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
 
       HAL_I2C_MasterTxCpltCallback(hi2c);
     }
@@ -2700,26 +2683,17 @@ static HAL_StatusTypeDef I2C_MasterReceive_RXNE(I2C_HandleTypeDef *hi2c)
 {
   uint32_t tmp = 0;
 
-  /* Process Locked */
-  __HAL_LOCK(hi2c);
-
   tmp = hi2c->XferCount;
   if(tmp > 3)
   {
     /* Read data from DR */
     (*hi2c->pBuffPtr++) = hi2c->Instance->DR;
     hi2c->XferCount--;
-
-    /* Process Unlocked */
-    __HAL_UNLOCK(hi2c);
   }
   else if((tmp == 2) || (tmp == 3))
   {
     /* Disable BUF interrupt */
     __HAL_I2C_DISABLE_IT(hi2c, I2C_IT_BUF);
-
-    /* Process Unlocked */
-    __HAL_UNLOCK(hi2c);
   }
   else
   {
@@ -2740,17 +2714,11 @@ static HAL_StatusTypeDef I2C_MasterReceive_RXNE(I2C_HandleTypeDef *hi2c)
     {
       hi2c->State = HAL_I2C_STATE_READY;
 
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
-
       HAL_I2C_MemRxCpltCallback(hi2c);
     }
     else
     {
       hi2c->State = HAL_I2C_STATE_READY;
-
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
 
       HAL_I2C_MasterRxCpltCallback(hi2c);
     }
@@ -2766,9 +2734,6 @@ static HAL_StatusTypeDef I2C_MasterReceive_RXNE(I2C_HandleTypeDef *hi2c)
   */
 static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
 {
-  /* Process Locked */
-  __HAL_LOCK(hi2c);
-
   if(hi2c->XferCount == 3)
   {
     /* Disable Acknowledge */
@@ -2777,9 +2742,6 @@ static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
     /* Read data from DR */
     (*hi2c->pBuffPtr++) = hi2c->Instance->DR;
     hi2c->XferCount--;
-
-    /* Process Unlocked */
-    __HAL_UNLOCK(hi2c);
   }
   else if(hi2c->XferCount == 2)
   {
@@ -2807,17 +2769,11 @@ static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
     {
       hi2c->State = HAL_I2C_STATE_READY;
 
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
-
       HAL_I2C_MemRxCpltCallback(hi2c);
     }
     else
     {
       hi2c->State = HAL_I2C_STATE_READY;
-
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
 
       HAL_I2C_MasterRxCpltCallback(hi2c);
     }
@@ -2827,9 +2783,6 @@ static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
     /* Read data from DR */
     (*hi2c->pBuffPtr++) = hi2c->Instance->DR;
     hi2c->XferCount--;
-
-    /* Process Unlocked */
-    __HAL_UNLOCK(hi2c);
   }
   return HAL_OK;
 }
@@ -2842,18 +2795,12 @@ static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
   */
 static HAL_StatusTypeDef I2C_SlaveTransmit_TXE(I2C_HandleTypeDef *hi2c)
 {
-  /* Process Locked */
-  __HAL_LOCK(hi2c);
-
-    if(hi2c->XferCount != 0)
+  if(hi2c->XferCount != 0)
   {
     /* Write data to DR */
     hi2c->Instance->DR = (*hi2c->pBuffPtr++);
     hi2c->XferCount--;
   }
-
-  /* Process Unlocked */
-  __HAL_UNLOCK(hi2c);
   return HAL_OK;
 }
 
@@ -2865,18 +2812,12 @@ static HAL_StatusTypeDef I2C_SlaveTransmit_TXE(I2C_HandleTypeDef *hi2c)
   */
 static HAL_StatusTypeDef I2C_SlaveTransmit_BTF(I2C_HandleTypeDef *hi2c)
 {
-  /* Process Locked */
-  __HAL_LOCK(hi2c);
-
-    if(hi2c->XferCount != 0)
+  if(hi2c->XferCount != 0)
   {
     /* Write data to DR */
     hi2c->Instance->DR = (*hi2c->pBuffPtr++);
     hi2c->XferCount--;
   }
-
-  /* Process Unlocked */
-  __HAL_UNLOCK(hi2c);
   return HAL_OK;
 }
 
@@ -2888,18 +2829,12 @@ static HAL_StatusTypeDef I2C_SlaveTransmit_BTF(I2C_HandleTypeDef *hi2c)
   */
 static HAL_StatusTypeDef I2C_SlaveReceive_RXNE(I2C_HandleTypeDef *hi2c)
 {
-  /* Process Locked */
-  __HAL_LOCK(hi2c);
-
-    if(hi2c->XferCount != 0)
+  if(hi2c->XferCount != 0)
   {
     /* Read data from DR */
     (*hi2c->pBuffPtr++) = hi2c->Instance->DR;
     hi2c->XferCount--;
   }
-
-  /* Process Unlocked */
-  __HAL_UNLOCK(hi2c);
   return HAL_OK;
 }
 
@@ -2911,18 +2846,12 @@ static HAL_StatusTypeDef I2C_SlaveReceive_RXNE(I2C_HandleTypeDef *hi2c)
   */
 static HAL_StatusTypeDef I2C_SlaveReceive_BTF(I2C_HandleTypeDef *hi2c)
 {
-  /* Process Locked */
-  __HAL_LOCK(hi2c);
-
-    if(hi2c->XferCount != 0)
+  if(hi2c->XferCount != 0)
   {
     /* Read data from DR */
     (*hi2c->pBuffPtr++) = hi2c->Instance->DR;
     hi2c->XferCount--;
   }
-
-  /* Process Unlocked */
-  __HAL_UNLOCK(hi2c);
   return HAL_OK;
 }
 
@@ -2934,14 +2863,9 @@ static HAL_StatusTypeDef I2C_SlaveReceive_BTF(I2C_HandleTypeDef *hi2c)
   */
 static HAL_StatusTypeDef I2C_Slave_ADDR(I2C_HandleTypeDef *hi2c)
 {
-  /* Process Locked */
-  __HAL_LOCK(hi2c);
-
   /* Clear ADDR flag */
   __HAL_I2C_CLEAR_ADDRFLAG(hi2c);
 
-  /* Process Unlocked */
-  __HAL_UNLOCK(hi2c);
   return HAL_OK;
 }
 
@@ -2953,9 +2877,6 @@ static HAL_StatusTypeDef I2C_Slave_ADDR(I2C_HandleTypeDef *hi2c)
   */
 static HAL_StatusTypeDef I2C_Slave_STOPF(I2C_HandleTypeDef *hi2c)
 {
-  /* Process Locked */
-  __HAL_LOCK(hi2c);
-
   /* Disable EVT, BUF and ERR interrupt */
   __HAL_I2C_DISABLE_IT(hi2c, I2C_IT_EVT | I2C_IT_BUF | I2C_IT_ERR);
 
@@ -2973,9 +2894,6 @@ static HAL_StatusTypeDef I2C_Slave_STOPF(I2C_HandleTypeDef *hi2c)
 
   hi2c->State = HAL_I2C_STATE_READY;
 
-  /* Process Unlocked */
-  __HAL_UNLOCK(hi2c);
-
   HAL_I2C_SlaveRxCpltCallback(hi2c);
 
   return HAL_OK;
@@ -2988,9 +2906,6 @@ static HAL_StatusTypeDef I2C_Slave_STOPF(I2C_HandleTypeDef *hi2c)
   */
 static HAL_StatusTypeDef I2C_Slave_AF(I2C_HandleTypeDef *hi2c)
 {
-  /* Process Locked */
-  __HAL_LOCK(hi2c);
-
   /* Disable EVT, BUF and ERR interrupt */
   __HAL_I2C_DISABLE_IT(hi2c, I2C_IT_EVT | I2C_IT_BUF | I2C_IT_ERR);
 
@@ -3007,9 +2922,6 @@ static HAL_StatusTypeDef I2C_Slave_AF(I2C_HandleTypeDef *hi2c)
   }
 
   hi2c->State = HAL_I2C_STATE_READY;
-
-  /* Process Unlocked */
-  __HAL_UNLOCK(hi2c);
 
   HAL_I2C_SlaveTxCpltCallback(hi2c);
 
@@ -3632,9 +3544,10 @@ static void I2C_DMAError(DMA_HandleTypeDef *hdma)
   */
 static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Flag, FlagStatus Status, uint32_t Timeout)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
 
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   /* Wait until flag is set */
   if(Status == RESET)
@@ -3644,7 +3557,7 @@ static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uin
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           hi2c->State= HAL_I2C_STATE_READY;
 
@@ -3663,7 +3576,7 @@ static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uin
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           hi2c->State= HAL_I2C_STATE_READY;
 
@@ -3688,9 +3601,10 @@ static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uin
   */
 static HAL_StatusTypeDef I2C_WaitOnMasterAddressFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Flag, uint32_t Timeout)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
 
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   while(__HAL_I2C_GET_FLAG(hi2c, Flag) == RESET)
   {
@@ -3714,7 +3628,7 @@ static HAL_StatusTypeDef I2C_WaitOnMasterAddressFlagUntilTimeout(I2C_HandleTypeD
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         hi2c->State= HAL_I2C_STATE_READY;
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2c.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2c.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_i2c.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of I2C HAL module.
   ******************************************************************************
   * @attention
@@ -348,7 +348,7 @@ typedef struct
   *            @arg I2C_FLAG_BERR: Bus error flag
   * @retval None
   */
-#define __HAL_I2C_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->SR1 &= ~((__FLAG__) & I2C_FLAG_MASK))
+#define __HAL_I2C_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->SR1 = ~((__FLAG__) & I2C_FLAG_MASK))
 
 /** @brief  Clears the I2C ADDR pending flag.
   * @param  __HANDLE__: specifies the I2C Handle.

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2c_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2c_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_i2c_ex.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   I2C Extension HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of I2C extension peripheral:
@@ -71,7 +71,8 @@
 
 #ifdef HAL_I2C_MODULE_ENABLED
 
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) || defined(STM32F401xC) || defined(STM32F401xE)
+#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) ||\
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2c_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2c_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_i2c_ex.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of I2C HAL Extension module.
   ******************************************************************************
   * @attention
@@ -43,7 +43,8 @@
  extern "C" {
 #endif
 
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) || defined(STM32F401xC) || defined(STM32F401xE)
+#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) ||\
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f4xx_hal_def.h"  
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2s.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2s.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_i2s.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   I2S HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Integrated Interchip Sound (I2S) peripheral:
@@ -205,7 +205,7 @@ HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s)
   uint32_t tmp = 0, i2sclk = 0;
   
   /* Check the I2S handle allocation */
-  if(hi2s == NULL)
+  if(hi2s == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -383,7 +383,7 @@ HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s)
 HAL_StatusTypeDef HAL_I2S_DeInit(I2S_HandleTypeDef *hi2s)
 {
   /* Check the I2S handle allocation */
-  if(hi2s == NULL)
+  if(hi2s == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -492,7 +492,7 @@ HAL_StatusTypeDef HAL_I2S_DeInit(I2S_HandleTypeDef *hi2s)
 HAL_StatusTypeDef HAL_I2S_Transmit(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size, uint32_t Timeout)
 {
   uint32_t tmp1 = 0, tmp2 = 0;  
-  if((pData == NULL ) || (Size == 0)) 
+  if((pData == HAL_NULL ) || (Size == 0)) 
   {
     return  HAL_ERROR;
   }
@@ -574,7 +574,7 @@ HAL_StatusTypeDef HAL_I2S_Transmit(I2S_HandleTypeDef *hi2s, uint16_t *pData, uin
 HAL_StatusTypeDef HAL_I2S_Receive(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size, uint32_t Timeout)
 {
   uint32_t tmp1 = 0, tmp2 = 0;   
-  if((pData == NULL ) || (Size == 0)) 
+  if((pData == HAL_NULL ) || (Size == 0)) 
   {
     return  HAL_ERROR;
   }
@@ -659,7 +659,7 @@ HAL_StatusTypeDef HAL_I2S_Transmit_IT(I2S_HandleTypeDef *hi2s, uint16_t *pData, 
   uint32_t tmp1 = 0, tmp2 = 0;     
   if(hi2s->State == HAL_I2S_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;
     }
@@ -727,7 +727,7 @@ HAL_StatusTypeDef HAL_I2S_Receive_IT(I2S_HandleTypeDef *hi2s, uint16_t *pData, u
   uint32_t tmp1 = 0, tmp2 = 0;     
   if(hi2s->State == HAL_I2S_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;
     }
@@ -793,7 +793,7 @@ HAL_StatusTypeDef HAL_I2S_Transmit_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData,
   uint32_t *tmp;
   uint32_t tmp1 = 0, tmp2 = 0;     
   
-  if((pData == NULL) || (Size == 0)) 
+  if((pData == HAL_NULL) || (Size == 0)) 
   {
     return  HAL_ERROR;
   }
@@ -878,7 +878,7 @@ HAL_StatusTypeDef HAL_I2S_Receive_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData, 
   uint32_t *tmp;
   uint32_t tmp1 = 0, tmp2 = 0;  
   
-  if((pData == NULL) || (Size == 0))
+  if((pData == HAL_NULL) || (Size == 0))
   {
     return  HAL_ERROR;
   }
@@ -1071,12 +1071,12 @@ HAL_StatusTypeDef HAL_I2S_DMAStop(I2S_HandleTypeDef *hi2s)
   }
   
   /* Abort the I2S DMA Stream tx */
-  if(hi2s->hdmatx != NULL)
+  if(hi2s->hdmatx != HAL_NULL)
   {
     HAL_DMA_Abort(hi2s->hdmatx);
   }
   /* Abort the I2S DMA Stream rx */
-  if(hi2s->hdmarx != NULL)
+  if(hi2s->hdmarx != HAL_NULL)
   {
     HAL_DMA_Abort(hi2s->hdmarx);
   }
@@ -1606,9 +1606,10 @@ static HAL_StatusTypeDef I2S_Receive_IT(I2S_HandleTypeDef *hi2s)
   */
 HAL_StatusTypeDef I2S_WaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, uint32_t Flag, uint32_t Status, uint32_t Timeout)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
   
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   /* Wait until flag is set */
   if(Status == RESET)
@@ -1617,7 +1618,7 @@ HAL_StatusTypeDef I2S_WaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, uint32_
     {
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Set the I2S State ready */
           hi2s->State= HAL_I2S_STATE_READY;
@@ -1636,7 +1637,7 @@ HAL_StatusTypeDef I2S_WaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, uint32_
     {
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Set the I2S State ready */
           hi2s->State= HAL_I2S_STATE_READY;

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2s.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2s.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_i2s.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of I2S HAL module.
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2s_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2s_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_i2s_ex.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   I2S HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of I2S extension peripheral:
@@ -183,10 +183,10 @@
   */
 HAL_StatusTypeDef HAL_I2SEx_TransmitReceive(I2S_HandleTypeDef *hi2s, uint16_t *pTxData, uint16_t *pRxData, uint16_t Size, uint32_t Timeout)
 {
-  uint32_t timeout = 0;
-  uint32_t tmp1 = 0, tmp2 = 0;   
+  uint32_t tickstart = 0;
+  uint32_t tmp1 = 0, tmp2 = 0;
  
-  if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0)) 
+  if((pTxData == HAL_NULL ) || (pRxData == HAL_NULL ) || (Size == 0)) 
   {
     return  HAL_ERROR;
   }
@@ -247,14 +247,15 @@ HAL_StatusTypeDef HAL_I2SEx_TransmitReceive(I2S_HandleTypeDef *hi2s, uint16_t *p
         }
         hi2s->Instance->DR = (*pTxData++);
 
-        /* Wait until RXNE flag is set */
-        timeout = HAL_GetTick() + Timeout;
+        /* Get tick */
+        tickstart = HAL_GetTick();
 
+        /* Wait until RXNE flag is set */
         while((I2SxEXT(hi2s->Instance)->SR & SPI_SR_RXNE) != SPI_SR_RXNE)
         {
           if(Timeout != HAL_MAX_DELAY)
           {
-            if(HAL_GetTick() >= timeout)
+            if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
             {
               /* Process Unlocked */
               __HAL_UNLOCK(hi2s);
@@ -293,14 +294,15 @@ HAL_StatusTypeDef HAL_I2SEx_TransmitReceive(I2S_HandleTypeDef *hi2s, uint16_t *p
       }
       while(hi2s->TxXferCount > 0)
       {
-        /* Wait until TXE flag is set */
-        timeout = HAL_GetTick() + Timeout;
+        /* Get tick */
+        tickstart = HAL_GetTick();
 
+        /* Wait until TXE flag is set */
         while((I2SxEXT(hi2s->Instance)->SR & SPI_SR_TXE) != SPI_SR_TXE)
         {
           if(Timeout != HAL_MAX_DELAY)
           {
-            if(HAL_GetTick() >= timeout)
+            if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
             {
               /* Process Unlocked */
               __HAL_UNLOCK(hi2s);
@@ -358,7 +360,7 @@ HAL_StatusTypeDef HAL_I2SEx_TransmitReceive_IT(I2S_HandleTypeDef *hi2s, uint16_t
   
   if(hi2s->State == HAL_I2S_STATE_READY)
   {
-    if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0)) 
+    if((pTxData == HAL_NULL ) || (pRxData == HAL_NULL ) || (Size == 0)) 
     {
       return  HAL_ERROR;
     }
@@ -483,7 +485,7 @@ HAL_StatusTypeDef HAL_I2SEx_TransmitReceive_DMA(I2S_HandleTypeDef *hi2s, uint16_
   uint32_t *tmp;
   uint32_t tmp1 = 0, tmp2 = 0;
     
-  if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0)) 
+  if((pTxData == HAL_NULL ) || (pRxData == HAL_NULL ) || (Size == 0)) 
   {
     return  HAL_ERROR;
   }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2s_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_i2s_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_i2s_ex.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of I2S HAL module.
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_irda.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_irda.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_irda.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of IRDA HAL module.
   ******************************************************************************
   * @attention
@@ -250,13 +250,17 @@ typedef struct
 /* Exported macro ------------------------------------------------------------*/
 
 /** @brief Reset IRDA handle state
-  * @param  __HANDLE__: specifies the IRDA Handle.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
   * @retval None
   */
 #define __HAL_IRDA_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_IRDA_STATE_RESET)
 
 /** @brief  Flushs the IRDA DR register 
-  * @param  __HANDLE__: specifies the IRDA Handle.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
   */
 #define __HAL_IRDA_FLUSH_DRREGISTER(__HANDLE__) ((__HANDLE__)->Instance->DR)
 
@@ -298,8 +302,47 @@ typedef struct
   *   
   * @retval None
   */
-#define __HAL_IRDA_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->SR &= ~(__FLAG__))
+#define __HAL_IRDA_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->SR = ~(__FLAG__))
 
+/** @brief  Clear the IRDA PE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_IRDA_CLEAR_PEFLAG(__HANDLE__) do{(__HANDLE__)->Instance->SR;\
+                                               (__HANDLE__)->Instance->DR;}while(0)
+/** @brief  Clear the IRDA FE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_IRDA_CLEAR_FEFLAG(__HANDLE__) __HAL_IRDA_CLEAR_PEFLAG(__HANDLE__)
+
+/** @brief  Clear the IRDA NE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_IRDA_CLEAR_NEFLAG(__HANDLE__) __HAL_IRDA_CLEAR_PEFLAG(__HANDLE__)
+
+/** @brief  Clear the IRDA ORE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_IRDA_CLEAR_OREFLAG(__HANDLE__) __HAL_IRDA_CLEAR_PEFLAG(__HANDLE__)
+
+/** @brief  Clear the IRDA IDLE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_IRDA_CLEAR_IDLEFLAG(__HANDLE__) __HAL_IRDA_CLEAR_PEFLAG(__HANDLE__)
 
 /** @brief  Enables or disables the specified IRDA interrupt.
   * @param  __HANDLE__: specifies the USART Handle.
@@ -369,9 +412,14 @@ HAL_StatusTypeDef HAL_IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData
 HAL_StatusTypeDef HAL_IRDA_Receive_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_IRDA_Transmit_DMA(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_IRDA_Receive_DMA(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_IRDA_DMAPause(IRDA_HandleTypeDef *hirda);
+HAL_StatusTypeDef HAL_IRDA_DMAResume(IRDA_HandleTypeDef *hirda);
+HAL_StatusTypeDef HAL_IRDA_DMAStop(IRDA_HandleTypeDef *hirda);
 void HAL_IRDA_IRQHandler(IRDA_HandleTypeDef *hirda);
 void HAL_IRDA_TxCpltCallback(IRDA_HandleTypeDef *hirda);
 void HAL_IRDA_RxCpltCallback(IRDA_HandleTypeDef *hirda);
+void HAL_IRDA_TxHalfCpltCallback(IRDA_HandleTypeDef *hirda);
+void HAL_IRDA_RxHalfCpltCallback(IRDA_HandleTypeDef *hirda);
 void HAL_IRDA_ErrorCallback(IRDA_HandleTypeDef *hirda);
 
 /* Peripheral State functions  **************************************************/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_iwdg.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_iwdg.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_iwdg.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   IWDG HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Independent Watchdog (IWDG) peripheral:
@@ -44,12 +44,27 @@
                      ##### How to use this driver #####
   ==============================================================================
     [..]
+    If Window option is disabled
+      (+) Use IWDG using HAL_IWDG_Init() function to :
+         (++) Enable write access to IWDG_PR, IWDG_RLR.
+         (++) Configure the IWDG prescaler, counter reload value.
+              This reload value will be loaded in the IWDG counter each time the counter
+              is reloaded, then the IWDG will start counting down from this value.
+    [..]
       (+) Use IWDG using HAL_IWDG_Start() function to:
-          (++) Enable write access to IWDG_PR and IWDG_RLR registers.   
-          (++) Configure the IWDG prescaler and counter reload values.
           (++) Reload IWDG counter with value defined in the IWDG_RLR register.
           (++) Start the IWDG, when the IWDG is used in software mode (no need 
                to enable the LSI, it will be enabled by hardware).
+      (+) Then the application program must refresh the IWDG counter at regular
+          intervals during normal operation to prevent an MCU reset, using
+          HAL_IWDG_Refresh() function.
+    [..] 
+    if Window option is enabled:
+      
+      (+) Use IWDG using HAL_IWDG_Start() function to enable IWDG downcounter
+      (+) Use IWDG using HAL_IWDG_Init() function to :
+         (++) Enable write access to IWDG_PR, IWDG_RLR and IWDG_WINR registers.
+         (++) Configure the IWDG prescaler, reload value and window value.
       (+) Then the application program must refresh the IWDG counter at regular
           intervals during normal operation to prevent an MCU reset, using
           HAL_IWDG_Refresh() function.  
@@ -64,8 +79,7 @@
       (+) __HAL_IWDG_ENABLE_WRITE_ACCESS : Enable write access to IWDG_PR and IWDG_RLR registers
       (+) __HAL_IWDG_DISABLE_WRITE_ACCESS : Disable write access to IWDG_PR and IWDG_RLR registers
       (+) __HAL_IWDG_GET_FLAG: Get the selected IWDG's flag status
-      (+) __HAL_IWDG_CLEAR_FLAG: Clear the IWDG's pending flags      
-            
+
   @endverbatim
   ******************************************************************************
   * @attention
@@ -113,6 +127,7 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+#define IWDG_TIMEOUT_FLAG          ((uint32_t)1000)     /* 1 s */
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
@@ -148,15 +163,14 @@
   */
 HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg)
 {
-  uint32_t tmp;
-  
   /* Check the IWDG handle allocation */
-  if(hiwdg == NULL)
+  if(hiwdg == HAL_NULL)
   {
     return HAL_ERROR;
   }
 
   /* Check the parameters */
+  assert_param(IS_IWDG_ALL_INSTANCE(hiwdg->Instance));
   assert_param(IS_IWDG_PRESCALER(hiwdg->Init.Prescaler));
   assert_param(IS_IWDG_RELOAD(hiwdg->Init.Reload)); 
   
@@ -169,34 +183,12 @@ HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg)
   /* Change IWDG peripheral state */
   hiwdg->State = HAL_IWDG_STATE_BUSY;  
   
-  /* Set IWDG counter clock prescaler */  
-  /* Get the PR register value */
-  tmp = hiwdg->Instance->PR;
-  
-  /* Clear PR[2:0] bits */
-  tmp &= ((uint32_t)~(IWDG_PR_PR));
-  
-  /* Prepare the IWDG Prescaler parameter */
-  tmp |= hiwdg->Init.Prescaler;
-  
   /* Enable write access to IWDG_PR and IWDG_RLR registers */  
   __HAL_IWDG_ENABLE_WRITE_ACCESS(hiwdg);
   
-  /* Write to IWDG PR */
-  hiwdg->Instance->PR = tmp;
-  
-  /* Set IWDG counter reload value */  
-  /* Get the RLR register value */
-  tmp = hiwdg->Instance->RLR;
-  
-  /* Clear RL[11:0] bits */
-  tmp &= ((uint32_t)~(IWDG_RLR_RL));
-  
-  /* Prepare the IWDG Prescaler parameter */
-  tmp |= hiwdg->Init.Reload;
-  
-  /* Write to IWDG RLR */
-  hiwdg->Instance->RLR = tmp;
+  /* Write to IWDG registers the IWDG_Prescaler & IWDG_Reload values to work with */
+  MODIFY_REG(hiwdg->Instance->PR, IWDG_PR_PR, hiwdg->Init.Prescaler);
+  MODIFY_REG(hiwdg->Instance->RLR, IWDG_RLR_RL, hiwdg->Init.Reload);
  
   /* Change IWDG peripheral state */
   hiwdg->State = HAL_IWDG_STATE_READY;
@@ -275,14 +267,30 @@ HAL_StatusTypeDef HAL_IWDG_Start(IWDG_HandleTypeDef *hiwdg)
   */
 HAL_StatusTypeDef HAL_IWDG_Refresh(IWDG_HandleTypeDef *hiwdg)
 {
+  uint32_t tickstart = 0;
+
   /* Process Locked */
-  __HAL_LOCK(hiwdg); 
-  
+  __HAL_LOCK(hiwdg);
+
     /* Change IWDG peripheral state */
   hiwdg->State = HAL_IWDG_STATE_BUSY;
-  
-  /* Clear the RVU flag */  
-  __HAL_IWDG_CLEAR_FLAG(hiwdg, IWDG_FLAG_RVU);
+
+  tickstart = HAL_GetTick();
+
+  /* Wait until RVU flag is RESET */
+  while(__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_RVU) != RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > IWDG_TIMEOUT_FLAG)
+    {
+      /* Set IWDG state */
+      hiwdg->State = HAL_IWDG_STATE_TIMEOUT;
+
+       /* Process unlocked */
+      __HAL_UNLOCK(hiwdg);
+
+      return HAL_TIMEOUT;
+    }
+  }
   
   /* Reload IWDG counter with value defined in the reload register */
   __HAL_IWDG_RELOAD_COUNTER(hiwdg);

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_iwdg.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_iwdg.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_iwdg.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of IWDG HAL module.
   ******************************************************************************
   * @attention
@@ -112,6 +112,10 @@ typedef struct
 #define KR_KEY_EWA      ((uint32_t)0x5555)  /*!< IWDG KR write Access enable  */
 #define KR_KEY_DWA      ((uint32_t)0x0000)  /*!< IWDG KR write Access disable */
 
+#define IS_IWDG_KR(__KR__) (((__KR__) == KR_KEY_RELOAD) || \
+                            ((__KR__) == KR_KEY_ENABLE))|| \
+                            ((__KR__) == KR_KEY_EWA))   || \
+                            ((__KR__) == KR_KEY_DWA))
 /**
   * @}
   */
@@ -133,12 +137,13 @@ typedef struct
   * @{
   */ 
 #define IWDG_PRESCALER_4     ((uint8_t)0x00)  /*!< IWDG prescaler set to 4   */
-#define IWDG_PRESCALER_8     ((uint8_t)0x01)  /*!< IWDG prescaler set to 8   */
-#define IWDG_PRESCALER_16    ((uint8_t)0x02)  /*!< IWDG prescaler set to 16  */
-#define IWDG_PRESCALER_32    ((uint8_t)0x03)  /*!< IWDG prescaler set to 32  */
-#define IWDG_PRESCALER_64    ((uint8_t)0x04)  /*!< IWDG prescaler set to 64  */
-#define IWDG_PRESCALER_128   ((uint8_t)0x05)  /*!< IWDG prescaler set to 128 */
-#define IWDG_PRESCALER_256   ((uint8_t)0x06)  /*!< IWDG prescaler set to 256 */
+#define IWDG_PRESCALER_8     ((uint8_t)(IWDG_PR_PR_0))                  /*!< IWDG prescaler set to 8   */
+#define IWDG_PRESCALER_16    ((uint8_t)(IWDG_PR_PR_1))                  /*!< IWDG prescaler set to 16  */
+#define IWDG_PRESCALER_32    ((uint8_t)(IWDG_PR_PR_1 | IWDG_PR_PR_0))   /*!< IWDG prescaler set to 32  */
+#define IWDG_PRESCALER_64    ((uint8_t)(IWDG_PR_PR_2))                  /*!< IWDG prescaler set to 64  */
+#define IWDG_PRESCALER_128   ((uint8_t)(IWDG_PR_PR_2 | IWDG_PR_PR_0))   /*!< IWDG prescaler set to 128 */
+#define IWDG_PRESCALER_256   ((uint8_t)(IWDG_PR_PR_2 | IWDG_PR_PR_1))   /*!< IWDG prescaler set to 256 */
+
 
 #define IS_IWDG_PRESCALER(PRESCALER) (((PRESCALER) == IWDG_PRESCALER_4)  || \
                                       ((PRESCALER) == IWDG_PRESCALER_8)  || \
@@ -178,7 +183,7 @@ typedef struct
   * @param  __HANDLE__: IWDG handle
   * @retval None
   */
-#define __HAL_IWDG_START(__HANDLE__) ((__HANDLE__)->Instance->KR |=  KR_KEY_ENABLE)
+#define __HAL_IWDG_START(__HANDLE__) WRITE_REG((__HANDLE__)->Instance->KR, KR_KEY_ENABLE)
 
 /**
   * @brief  Reloads IWDG counter with value defined in the reload register
@@ -186,21 +191,21 @@ typedef struct
   * @param  __HANDLE__: IWDG handle
   * @retval None
   */
-#define __HAL_IWDG_RELOAD_COUNTER(__HANDLE__) (((__HANDLE__)->Instance->KR) |= KR_KEY_RELOAD)
+#define __HAL_IWDG_RELOAD_COUNTER(__HANDLE__) WRITE_REG((__HANDLE__)->Instance->KR, KR_KEY_RELOAD)
 
 /**
   * @brief  Enables write access to IWDG_PR and IWDG_RLR registers.
   * @param  __HANDLE__: IWDG handle
   * @retval None
   */
-#define __HAL_IWDG_ENABLE_WRITE_ACCESS(__HANDLE__) (((__HANDLE__)->Instance->KR) |= KR_KEY_EWA)
+#define __HAL_IWDG_ENABLE_WRITE_ACCESS(__HANDLE__) WRITE_REG((__HANDLE__)->Instance->KR, KR_KEY_EWA)
 
 /**
   * @brief  Disables write access to IWDG_PR and IWDG_RLR registers.
   * @param  __HANDLE__: IWDG handle
   * @retval None
   */
-#define __HAL_IWDG_DISABLE_WRITE_ACCESS(__HANDLE__) (((__HANDLE__)->Instance->KR) |= KR_KEY_DWA)
+#define __HAL_IWDG_DISABLE_WRITE_ACCESS(__HANDLE__) WRITE_REG((__HANDLE__)->Instance->KR, KR_KEY_DWA)
 
 /**
   * @brief  Gets the selected IWDG's flag status.
@@ -212,18 +217,6 @@ typedef struct
   * @retval The new state of __FLAG__ (TRUE or FALSE).
   */
 #define __HAL_IWDG_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR & (__FLAG__)) == (__FLAG__))
-
-/**
-  * @brief  Clears the IWDG's pending flags.
-  * @param  __HANDLE__: IWDG handle
-  * @param  __FLAG__: specifies the flag to clear.
-  *         This parameter can be one of the following values:
-  *            @arg IWDG_FLAG_PVU: Watchdog counter reload value update flag
-  *            @arg IWDG_FLAG_RVU: Watchdog counter prescaler value flag
-  * @retval None
-  */
-#define __HAL_IWDG_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->SR &= ~(__FLAG__))
-
 
 /* Exported functions --------------------------------------------------------*/
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_ltdc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_ltdc.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_ltdc.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   LTDC HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the LTDC peripheral:
@@ -13,7 +13,7 @@
   *           + Peripheral State and Errors functions
   *           
   @verbatim      
-  ==============================================================================      
+  ==============================================================================
                         ##### How to use this driver #####
   ==============================================================================
     [..]

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_ltdc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_ltdc.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_ltdc.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of LTDC HAL module.
   ******************************************************************************
   * @attention
@@ -488,7 +488,7 @@ typedef struct
   *            @arg LTDC_FLAG_RR: Register Reload Interrupt Flag 
   * @retval None
   */
-#define __HAL_LTDC_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ICR |= (__FLAG__))
+#define __HAL_LTDC_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ICR = (__FLAG__))
 
 /**
   * @brief  Enables the specified LTDC interrupts.

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_nand.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_nand.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_nand.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of NAND HAL module.
   ******************************************************************************
   * @attention
@@ -152,6 +152,16 @@ typedef struct
 #define	NAND_CMD_AREA_A            ((uint8_t)0x00)
 #define	NAND_CMD_AREA_B            ((uint8_t)0x01)
 #define NAND_CMD_AREA_C            ((uint8_t)0x50)
+#define NAND_CMD_AREA_TRUE1        ((uint8_t)0x30)
+
+#define NAND_CMD_WRITE0            ((uint8_t)0x80)
+#define NAND_CMD_WRITE_TRUE1       ((uint8_t)0x10)	
+#define NAND_CMD_ERASE0            ((uint8_t)0x60)
+#define NAND_CMD_ERASE1            ((uint8_t)0xD0)  
+#define NAND_CMD_READID            ((uint8_t)0x90)	
+#define NAND_CMD_STATUS            ((uint8_t)0x70)
+#define NAND_CMD_LOCK_STATUS       ((uint8_t)0x7A)
+#define NAND_CMD_RESET             ((uint8_t)0xFF)
 
 /* NAND memory status */
 #define NAND_VALID_ADDRESS         ((uint32_t)0x00000100)
@@ -179,17 +189,18 @@ typedef struct
   * @param  __HANDLE__ : NAND handle.
   * @retval NAND Raw address value
   */
-#define ARRAY_ADDRESS(__ADDRESS__ , __HANDLE__) ((__ADDRESS__)->Page + (((__ADDRESS__)->Block + (((__ADDRESS__)->Zone) * ((__HANDLE__)->Info.BlockSize)))* ((__HANDLE__)->Info.ZoneSize)))
-
+#define __ARRAY_ADDRESS(__ADDRESS__ , __HANDLE__) ((__ADDRESS__)->Page + \
+                         (((__ADDRESS__)->Block + (((__ADDRESS__)->Zone) * ((__HANDLE__)->Info.ZoneSize)))* ((__HANDLE__)->Info.BlockSize)))
+        
 /**
   * @brief  NAND memory address cycling.
   * @param  __ADDRESS__: NAND memory address.
   * @retval NAND address cycling value.
   */
-#define ADDR_1st_CYCLE(__ADDRESS__)       (uint8_t)((__ADDRESS__)& 0xFF)               /* 1st addressing cycle */
-#define ADDR_2nd_CYCLE(__ADDRESS__)       (uint8_t)(((__ADDRESS__)& 0xFF00) >> 8)      /* 2nd addressing cycle */
-#define ADDR_3rd_CYCLE(__ADDRESS__)       (uint8_t)(((__ADDRESS__)& 0xFF0000) >> 16)   /* 3rd addressing cycle */
-#define ADDR_4th_CYCLE(__ADDRESS__)       (uint8_t)(((__ADDRESS__)& 0xFF000000) >> 24) /* 4th addressing cycle */
+#define __ADDR_1st_CYCLE(__ADDRESS__)       (uint8_t)(__ADDRESS__)              /* 1st addressing cycle */
+#define __ADDR_2nd_CYCLE(__ADDRESS__)       (uint8_t)((__ADDRESS__) >> 8)       /* 2nd addressing cycle */
+#define __ADDR_3rd_CYCLE(__ADDRESS__)       (uint8_t)((__ADDRESS__) >> 16)      /* 3rd addressing cycle */
+#define __ADDR_4th_CYCLE(__ADDRESS__)       (uint8_t)((__ADDRESS__) >> 24)      /* 4th addressing cycle */
 
 /* Exported functions --------------------------------------------------------*/
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_nor.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_nor.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_nor.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of NOR HAL module.
   ******************************************************************************
   * @attention
@@ -157,11 +157,15 @@ typedef struct
 /* NOR operation wait timeout */
 #define NOR_TMEOUT               ((uint16_t)0xFFFF)
    
-/* #define NOR_MEMORY_16B */
-#define NOR_MEMORY_8B
+/* NOR memory data width */
+#define NOR_MEMORY_8B            ((uint8_t)0x0)
+#define NOR_MEMORY_16B           ((uint8_t)0x1)
 
 /* NOR memory device read/write start address */
-#define NOR_MEMORY_ADRESS        ((uint32_t)0x60000000)
+#define NOR_MEMORY_ADRESS1       ((uint32_t)0x60000000)
+#define NOR_MEMORY_ADRESS2       ((uint32_t)0x64000000)
+#define NOR_MEMORY_ADRESS3       ((uint32_t)0x68000000)
+#define NOR_MEMORY_ADRESS4       ((uint32_t)0x6C000000)
 
 /**
   * @}
@@ -180,11 +184,8 @@ typedef struct
   * @param  __ADDRESS__: NOR memory address 
   * @retval NOR shifted address value
   */
-#ifdef  NOR_MEMORY_8B
- #define __NOR_ADDR_SHIFT(__ADDRESS__) (uint32_t)(NOR_MEMORY_ADRESS + (2 * (__ADDRESS__)))
-#else /* NOR_MEMORY_16B */
- #define __NOR_ADDR_SHIFT(__ADDRESS__) (uint32_t)(NOR_MEMORY_ADRESS + (__ADDRESS__))
-#endif /* NOR_MEMORY_8B */ 
+#define __NOR_ADDR_SHIFT(__NOR_ADDRESS, __NOR_MEMORY_WIDTH_, __ADDRESS__) (((__NOR_MEMORY_WIDTH_) == NOR_MEMORY_8B)? ((uint32_t)((__NOR_ADDRESS) + (2 * (__ADDRESS__)))):\
+                         ((uint32_t)((__NOR_ADDRESS) + (__ADDRESS__))))
  
 /**
   * @brief  NOR memory write data to specified address.

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pccard.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pccard.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_pccard.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   PCCARD HAL module driver.
   *          This file provides a generic firmware to drive PCCARD memories mounted 
   *          as external device.

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pccard.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pccard.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_pccard.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of PCCARD HAL module.
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pcd.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pcd.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_pcd.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   PCD HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the USB Peripheral Controller:
@@ -124,7 +124,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
   uint32_t i = 0;
   
   /* Check the PCD handle allocation */
-  if(hpcd == NULL)
+  if(hpcd == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -132,7 +132,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
   /* Check the parameters */
   assert_param(IS_PCD_ALL_INSTANCE(hpcd->Instance));
 
-  hpcd->State = PCD_BUSY;
+  hpcd->State = HAL_PCD_STATE_BUSY;
   
   /* Init the low level hardware : GPIO, CLOCK, NVIC... */
   HAL_PCD_MspInit(hpcd);
@@ -177,7 +177,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
  /* Init Device */
  USB_DevInit(hpcd->Instance, hpcd->Init);
  
- hpcd->State= PCD_READY;
+ hpcd->State= HAL_PCD_STATE_READY;
  
  USB_DevDisconnect (hpcd->Instance);  
  return HAL_OK;
@@ -191,12 +191,12 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
 HAL_StatusTypeDef HAL_PCD_DeInit(PCD_HandleTypeDef *hpcd)
 {
   /* Check the PCD handle allocation */
-  if(hpcd == NULL)
+  if(hpcd == HAL_NULL)
   {
     return HAL_ERROR;
   }
 
-  hpcd->State = PCD_BUSY;
+  hpcd->State = HAL_PCD_STATE_BUSY;
   
   /* Stop Device */
   HAL_PCD_Stop(hpcd);
@@ -204,7 +204,7 @@ HAL_StatusTypeDef HAL_PCD_DeInit(PCD_HandleTypeDef *hpcd)
   /* DeInit the low level hardware */
   HAL_PCD_MspDeInit(hpcd);
   
-  hpcd->State = PCD_READY; 
+  hpcd->State = HAL_PCD_STATE_RESET; 
   
   return HAL_OK;
 }
@@ -297,18 +297,18 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
   if (USB_GetMode(hpcd->Instance) == USB_OTG_MODE_DEVICE)
   {
     /* avoid spurious interrupt */
-    if(__HAL_IS_INVALID_INTERRUPT(hpcd)) 
+    if(__HAL_PCD_IS_INVALID_INTERRUPT(hpcd)) 
     {
       return;
     }
     
-    if(__HAL_GET_FLAG(hpcd, USB_OTG_GINTSTS_MMIS))
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_MMIS))
     {
      /* incorrect mode, acknowledge the interrupt */
-      __HAL_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_MMIS);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_MMIS);
     }
     
-    if(__HAL_GET_FLAG(hpcd, USB_OTG_GINTSTS_OEPINT))
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_OEPINT))
     {
       epnum = 0;
       
@@ -359,7 +359,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
       }
     }
     
-    if(__HAL_GET_FLAG(hpcd, USB_OTG_GINTSTS_IEPINT))
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_IEPINT))
     {
       /* Read in the device interrupt bits */
       ep_intr = USB_ReadDevAllInEpInterrupt(hpcd->Instance);
@@ -375,7 +375,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
            if(( epint & USB_OTG_DIEPINT_XFRC) == USB_OTG_DIEPINT_XFRC)
           {
             fifoemptymsk = 0x1 << epnum;
-            USBx_DEVICE->DIEPEMPMSK = ~fifoemptymsk;
+            USBx_DEVICE->DIEPEMPMSK &= ~fifoemptymsk;
             
             CLEAR_IN_EP_INTR(epnum, USB_OTG_DIEPINT_XFRC);
             
@@ -423,18 +423,18 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
     }
     
     /* Handle Resume Interrupt */
-    if(__HAL_GET_FLAG(hpcd, USB_OTG_GINTSTS_WKUINT))
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_WKUINT))
     {    
      /* Clear the Remote Wake-up Signaling */
       USBx_DEVICE->DCTL &= ~USB_OTG_DCTL_RWUSIG;
      
      HAL_PCD_ResumeCallback(hpcd);
 
-     __HAL_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_WKUINT);
+     __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_WKUINT);
     }
     
     /* Handle Suspend Interrupt */
-    if(__HAL_GET_FLAG(hpcd, USB_OTG_GINTSTS_USBSUSP))
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_USBSUSP))
     {
 
       if((USBx_DEVICE->DSTS & USB_OTG_DSTS_SUSPSTS) == USB_OTG_DSTS_SUSPSTS)
@@ -442,13 +442,13 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
         
         HAL_PCD_SuspendCallback(hpcd);
       }
-      __HAL_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_USBSUSP);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_USBSUSP);
     }
     
 
 
     /* Handle Reset Interrupt */
-    if(__HAL_GET_FLAG(hpcd, USB_OTG_GINTSTS_USBRST))
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_USBRST))
     {
       USBx_DEVICE->DCTL &= ~USB_OTG_DCTL_RWUSIG; 
       USB_FlushTxFifo(hpcd->Instance ,  0 );
@@ -478,11 +478,11 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
       /* setup EP0 to receive SETUP packets */
       USB_EP0_OutStart(hpcd->Instance, hpcd->Init.dma_enable, (uint8_t *)hpcd->Setup);
         
-      __HAL_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_USBRST);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_USBRST);
     }
     
     /* Handle Enumeration done Interrupt */
-    if(__HAL_GET_FLAG(hpcd, USB_OTG_GINTSTS_ENUMDNE))
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_ENUMDNE))
     {
       USB_ActivateSetup(hpcd->Instance);
       hpcd->Instance->GUSBCFG &= ~USB_OTG_GUSBCFG_TRDT;
@@ -502,12 +502,12 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
       
       HAL_PCD_ResetCallback(hpcd);
       
-      __HAL_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_ENUMDNE);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_ENUMDNE);
     }
     
      
     /* Handle RxQLevel Interrupt */
-    if(__HAL_GET_FLAG(hpcd, USB_OTG_GINTSTS_RXFLVL))
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_RXFLVL))
     {
       USB_MASK_INTERRUPT(hpcd->Instance, USB_OTG_GINTSTS_RXFLVL);
       temp = USBx->GRXSTSP;
@@ -531,35 +531,35 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
     }
     
     /* Handle SOF Interrupt */
-    if(__HAL_GET_FLAG(hpcd, USB_OTG_GINTSTS_SOF))
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_SOF))
     {
       HAL_PCD_SOFCallback(hpcd);
-      __HAL_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_SOF);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_SOF);
     }
     
     /* Handle Incomplete ISO IN Interrupt */
-    if(__HAL_GET_FLAG(hpcd, USB_OTG_GINTSTS_IISOIXFR))
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_IISOIXFR))
     {
       HAL_PCD_ISOINIncompleteCallback(hpcd, epnum);
-      __HAL_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_IISOIXFR);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_IISOIXFR);
     } 
     
     /* Handle Incomplete ISO OUT Interrupt */
-    if(__HAL_GET_FLAG(hpcd, USB_OTG_GINTSTS_PXFR_INCOMPISOOUT))
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_PXFR_INCOMPISOOUT))
     {
       HAL_PCD_ISOOUTIncompleteCallback(hpcd, epnum);
-      __HAL_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_PXFR_INCOMPISOOUT);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_PXFR_INCOMPISOOUT);
     } 
     
     /* Handle Connection event Interrupt */
-    if(__HAL_GET_FLAG(hpcd, USB_OTG_GINTSTS_SRQINT))
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_SRQINT))
     {
       HAL_PCD_ConnectCallback(hpcd);
-      __HAL_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_SRQINT);
+      __HAL_PCD_CLEAR_FLAG(hpcd, USB_OTG_GINTSTS_SRQINT);
     } 
     
     /* Handle Disconnection event Interrupt */
-    if(__HAL_GET_FLAG(hpcd, USB_OTG_GINTSTS_OTGINT))
+    if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_OTGINT))
     {
       temp = hpcd->Instance->GOTGINT;
       
@@ -1017,64 +1017,6 @@ HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
     
   return HAL_OK;
 }
-
-/**
-  * @brief  Update FIFO configuration
-  * @param  hpcd: PCD handle
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_PCD_SetTxFiFo(PCD_HandleTypeDef *hpcd, uint8_t fifo, uint16_t size)
-{
-  uint8_t i = 0;
-  uint32_t Tx_Offset = 0;
-  
-  
-  /*  TXn min size = 16 words. (n  : Transmit FIFO index)
-  *   When a TxFIFO is not used, the Configuration should be as follows: 
-  *       case 1 :  n > m    and Txn is not used    (n,m  : Transmit FIFO indexes)
-  *       --> Txm can use the space allocated for Txn.
-  *       case2  :  n < m    and Txn is not used    (n,m  : Transmit FIFO indexes)
-  *       --> Txn should be configured with the minimum space of 16 words
-  *  The FIFO is used optimally when used TxFIFOs are allocated in the top 
-  *       of the FIFO.Ex: use EP1 and EP2 as IN instead of EP1 and EP3 as IN ones.
-  *   When DMA is used 3n * FIFO locations should be reserved for internal DMA registers */
-  
-  Tx_Offset = hpcd->Instance->GRXFSIZ;
-  
-  if(fifo == 0)
-  {
-    hpcd->Instance->DIEPTXF0_HNPTXFSIZ = (size << 16) | Tx_Offset;
-  }
-  else
-  {
-    Tx_Offset += (hpcd->Instance->DIEPTXF0_HNPTXFSIZ) >> 16;
-    for (i = 0; i < (fifo - 1); i++)
-    {
-      Tx_Offset += (hpcd->Instance->DIEPTXF[i] >> 16);
-    }
-    
-    /* Multiply Tx_Size by 2 to get higher performance */
-    hpcd->Instance->DIEPTXF[fifo - 1] = (size << 16) | Tx_Offset;
-    
-  }
-  
-  return HAL_OK;
-}
-
-
-/**
-  * @brief  Update FIFO configuration
-  * @param  hpcd: PCD handle
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_PCD_SetRxFiFo(PCD_HandleTypeDef *hpcd, uint16_t size)
-{
-  
-  hpcd->Instance->GRXFSIZ = size;
-  
-  return HAL_OK;
-}
-
 
 /**
   * @brief  HAL_PCD_ActiveRemoteWakeup : active remote wakeup signalling

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pcd.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pcd.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_pcd.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of PCD HAL module.
   ******************************************************************************
   * @attention
@@ -61,10 +61,11 @@
   */  
 typedef enum 
 {
-  PCD_READY    = 0x00,
-  PCD_ERROR    = 0x01,
-  PCD_BUSY     = 0x02,
-  PCD_TIMEOUT  = 0x03
+  HAL_PCD_STATE_RESET   = 0x00,
+  HAL_PCD_STATE_READY   = 0x01,
+  HAL_PCD_STATE_ERROR   = 0x02,
+  HAL_PCD_STATE_BUSY    = 0x03,
+  HAL_PCD_STATE_TIMEOUT = 0x04
 } PCD_StateTypeDef;
 
 
@@ -118,7 +119,7 @@ typedef struct
 #if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx) || defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
  #define IS_PCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_OTG_FS) || \
                                         ((INSTANCE) == USB_OTG_HS))
-#elif defined(STM32F401xC) || defined(STM32F401xE)
+#elif defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
  #define IS_PCD_ALL_INSTANCE(INSTANCE) (((INSTANCE) == USB_OTG_FS))
 #endif
 
@@ -139,9 +140,9 @@ typedef struct
 #define __HAL_PCD_ENABLE(__HANDLE__)                   USB_EnableGlobalInt ((__HANDLE__)->Instance)
 #define __HAL_PCD_DISABLE(__HANDLE__)                  USB_DisableGlobalInt ((__HANDLE__)->Instance)
    
-#define __HAL_GET_FLAG(__HANDLE__, __INTERRUPT__)      ((USB_ReadInterrupts((__HANDLE__)->Instance) & (__INTERRUPT__)) == (__INTERRUPT__))
-#define __HAL_CLEAR_FLAG(__HANDLE__, __INTERRUPT__)    (((__HANDLE__)->Instance->GINTSTS) |= (__INTERRUPT__))
-#define __HAL_IS_INVALID_INTERRUPT(__HANDLE__)         (USB_ReadInterrupts((__HANDLE__)->Instance) == 0)
+#define __HAL_PCD_GET_FLAG(__HANDLE__, __INTERRUPT__)      ((USB_ReadInterrupts((__HANDLE__)->Instance) & (__INTERRUPT__)) == (__INTERRUPT__))
+#define __HAL_PCD_CLEAR_FLAG(__HANDLE__, __INTERRUPT__)    (((__HANDLE__)->Instance->GINTSTS) = (__INTERRUPT__))
+#define __HAL_PCD_IS_INVALID_INTERRUPT(__HANDLE__)         (USB_ReadInterrupts((__HANDLE__)->Instance) == 0)
 
 
 #define __HAL_PCD_UNGATE_PHYCLOCK(__HANDLE__)             *(__IO uint32_t *)((uint32_t)((__HANDLE__)->Instance) + USB_OTG_PCGCCTL_BASE) &= \
@@ -184,7 +185,9 @@ typedef struct
                                                         EXTI->RTSR |= USB_HS_EXTI_LINE_WAKEUP;\
                                                         EXTI->FTSR |= USB_HS_EXTI_LINE_WAKEUP
 
-
+#define __HAL_USB_HS_EXTI_GENERATE_SWIT()             (EXTI->SWIER |= USB_FS_EXTI_LINE_WAKEUP) 
+                                                          
+                                                          
 #define __HAL_USB_FS_EXTI_ENABLE_IT()    EXTI->IMR |= USB_FS_EXTI_LINE_WAKEUP
 #define __HAL_USB_FS_EXTI_DISABLE_IT()   EXTI->IMR &= ~(USB_FS_EXTI_LINE_WAKEUP)
 #define __HAL_USB_FS_EXTI_GET_FLAG()     EXTI->PR & (USB_FS_EXTI_LINE_WAKEUP)
@@ -201,11 +204,16 @@ typedef struct
 #define __HAL_USB_FS_EXTI_SET_FALLINGRISING_TRIGGER()  EXTI->RTSR &= ~(USB_FS_EXTI_LINE_WAKEUP);\
                                                        EXTI->FTSR &= ~(USB_FS_EXTI_LINE_WAKEUP);\
                                                        EXTI->RTSR |= USB_FS_EXTI_LINE_WAKEUP;\
-                                                       EXTI->FTSR |= USB_FS_EXTI_LINE_WAKEUP  
+                                                       EXTI->FTSR |= USB_FS_EXTI_LINE_WAKEUP 
+                                                         
+#define __HAL_USB_FS_EXTI_GENERATE_SWIT()             (EXTI->SWIER |= USB_FS_EXTI_LINE_WAKEUP)                                                          
 
 /**
   * @}
   */
+
+/* Include PCD HAL Extension module */
+#include "stm32f4xx_hal_pcd_ex.h"
 
 /* Exported functions --------------------------------------------------------*/
 
@@ -233,8 +241,6 @@ void HAL_PCD_ISOINIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
 void HAL_PCD_ConnectCallback(PCD_HandleTypeDef *hpcd);
 void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd);
 
-
-
 /* Peripheral Control functions  ************************************************/
 HAL_StatusTypeDef HAL_PCD_DevConnect(PCD_HandleTypeDef *hpcd);
 HAL_StatusTypeDef HAL_PCD_DevDisconnect(PCD_HandleTypeDef *hpcd);
@@ -247,10 +253,13 @@ uint16_t          HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef *hpcd, uint8_t ep_addr
 HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
-HAL_StatusTypeDef HAL_PCD_SetTxFiFo(PCD_HandleTypeDef *hpcd, uint8_t fifo, uint16_t size);
-HAL_StatusTypeDef HAL_PCD_SetRxFiFo(PCD_HandleTypeDef *hpcd, uint16_t size);
 HAL_StatusTypeDef HAL_PCD_ActiveRemoteWakeup(PCD_HandleTypeDef *hpcd);
 HAL_StatusTypeDef HAL_PCD_DeActiveRemoteWakeup(PCD_HandleTypeDef *hpcd);
+
+/* Create an alias to keep compatibility with the old name */ 
+#define HAL_PCD_SetTxFiFo    HAL_PCDEx_SetTxFiFo
+#define HAL_PCD_SetRxFiFo    HAL_PCDEx_SetRxFiFo
+
 /* Peripheral State functions  **************************************************/
 PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pwr.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pwr.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_pwr.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   PWR HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Power Controller (PWR) peripheral:
@@ -451,9 +451,6 @@ void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry)
   */
 void HAL_PWR_EnterSTANDBYMode(void)
 {
-  /* Clear Wakeup flag */
-  PWR->CR |= PWR_CR_CWUF;
-  
   /* Select Standby mode */
   PWR->CR |= PWR_CR_PDDS;
   

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pwr.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pwr.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_pwr.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of PWR HAL module.
   ******************************************************************************
   * @attention
@@ -81,10 +81,6 @@ typedef struct
 #define PVDE_BitNumber  0x04
 #define CR_PVDE_BB      (PERIPH_BB_BASE + (CR_OFFSET * 32) + (PVDE_BitNumber * 4))
 
-/* Alias word address of FPDS bit */
-#define FPDS_BitNumber  0x09
-#define CR_FPDS_BB      (PERIPH_BB_BASE + (CR_OFFSET * 32) + (FPDS_BitNumber * 4))
-
 /* Alias word address of PMODE bit */
 #define PMODE_BitNumber 0x0E
 #define CR_PMODE_BB     (PERIPH_BB_BASE + (CR_OFFSET * 32) + (PMODE_BitNumber * 4))
@@ -94,10 +90,6 @@ typedef struct
 #define CSR_OFFSET      (PWR_OFFSET + 0x04)
 #define EWUP_BitNumber  0x08
 #define CSR_EWUP_BB     (PERIPH_BB_BASE + (CSR_OFFSET * 32) + (EWUP_BitNumber * 4))
-
-/* Alias word address of BRE bit */
-#define BRE_BitNumber   0x09
-#define CSR_BRE_BB      (PERIPH_BB_BASE + (CSR_OFFSET * 32) + (BRE_BitNumber * 4))
    
 /** @defgroup PWR_Exported_Constants
   * @{
@@ -289,29 +281,41 @@ typedef struct
   */
 #define __HAL_PVD_EXTI_CLEAR_FLAG(__EXTILINE__)  (EXTI->PR = (__EXTILINE__))
 
+/**
+  * @brief  Generates a Software interrupt on selected EXTI line.
+  * @param  __EXTILINE__: specifies the PVD EXTI sources to be disabled.
+  * This parameter can be:
+  *  @arg PWR_EXTI_LINE_PVD
+  * @retval None
+  */
+#define __HAL_PVD_EXTI_GENERATE_SWIT(__EXTI_LINE__) (EXTI->SWIER |= (__EXTI_LINE__))
 
 /* Include PWR HAL Extension module */
 #include "stm32f4xx_hal_pwr_ex.h"
 
 /* Exported functions --------------------------------------------------------*/
 
-/* Initialization and de-initialization functions *******************************/
-void        HAL_PWR_DeInit(void);
-void        HAL_PWR_EnableBkUpAccess(void);
-void        HAL_PWR_DisableBkUpAccess(void);
+/* Initialization and de-initialization functions *****************************/
+void HAL_PWR_DeInit(void);
+void HAL_PWR_EnableBkUpAccess(void);
+void HAL_PWR_DisableBkUpAccess(void);
 
-/* Peripheral Control functions  ************************************************/
-void        HAL_PWR_PVDConfig(PWR_PVDTypeDef *sConfigPVD);
-void        HAL_PWR_EnablePVD(void);
-void        HAL_PWR_DisablePVD(void);
-void        HAL_PWR_EnableWakeUpPin(uint32_t WakeUpPinx);
-void        HAL_PWR_DisableWakeUpPin(uint32_t WakeUpPinx);
+/* Peripheral Control functions  **********************************************/
+/* PVD configuration */
+void HAL_PWR_PVDConfig(PWR_PVDTypeDef *sConfigPVD);
+void HAL_PWR_EnablePVD(void);
+void HAL_PWR_DisablePVD(void);
 
-void        HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry);
-void        HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry);
-void        HAL_PWR_EnterSTANDBYMode(void);
+/* WakeUp pins configuration */
+void HAL_PWR_EnableWakeUpPin(uint32_t WakeUpPinx);
+void HAL_PWR_DisableWakeUpPin(uint32_t WakeUpPinx);
 
-void        HAL_PWR_PVD_IRQHandler(void);
+/* Low Power modes entry */
+void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry);
+void HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry);
+void HAL_PWR_EnterSTANDBYMode(void);
+
+void HAL_PWR_PVD_IRQHandler(void);
 void HAL_PWR_PVDCallback(void);
 
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pwr_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pwr_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_pwr_ex.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Extended PWR HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of PWR extension peripheral:           
@@ -56,6 +56,7 @@
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 #define PWR_OVERDRIVE_TIMEOUT_VALUE  1000
+#define PWR_UDERDRIVE_TIMEOUT_VALUE  1000
 #define PWR_BKPREG_TIMEOUT_VALUE     1000
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
@@ -152,16 +153,17 @@
   */
 HAL_StatusTypeDef HAL_PWREx_EnableBkUpReg(void)
 {
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;
 
   *(__IO uint32_t *) CSR_BRE_BB = (uint32_t)ENABLE;
 
-  /* Get timeout */
-  timeout = HAL_GetTick() + PWR_BKPREG_TIMEOUT_VALUE;
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
   /* Wait till Backup regulator ready flag is set */  
   while(__HAL_PWR_GET_FLAG(PWR_FLAG_BRR) == RESET)
   {
-    if(HAL_GetTick() >= timeout)
+    if((HAL_GetTick() - tickstart ) > PWR_BKPREG_TIMEOUT_VALUE)
     {
       return HAL_TIMEOUT;
     } 
@@ -176,16 +178,17 @@ HAL_StatusTypeDef HAL_PWREx_EnableBkUpReg(void)
   */
 HAL_StatusTypeDef HAL_PWREx_DisableBkUpReg(void)
 {
-  uint32_t timeout = 0; 
+  uint32_t tickstart = 0;
 
   *(__IO uint32_t *) CSR_BRE_BB = (uint32_t)DISABLE;
 
-  /* Get timeout */
-  timeout = HAL_GetTick() + PWR_BKPREG_TIMEOUT_VALUE;
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
   /* Wait till Backup regulator ready flag is set */  
   while(__HAL_PWR_GET_FLAG(PWR_FLAG_BRR) != RESET)
   {
-    if(HAL_GetTick() >= timeout)
+    if((HAL_GetTick() - tickstart ) > PWR_BKPREG_TIMEOUT_VALUE)
     {
       return HAL_TIMEOUT;
     } 
@@ -213,10 +216,57 @@ void HAL_PWREx_DisableFlashPowerDown(void)
   *(__IO uint32_t *) CR_FPDS_BB = (uint32_t)DISABLE;
 }
 
+#if defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
+/**
+  * @brief Enables Main Regulator low voltage mode.
+  * @note  This mode is only available for STM32F401xx/STM32F411xx devices.   
+  * @param None
+  * @retval None
+  */
+void HAL_PWREx_EnableMainRegulatorLowVoltage(void)
+{
+  *(__IO uint32_t *) CR_MRLVDS_BB = (uint32_t)ENABLE;
+}
+
+/**
+  * @brief Disables Main Regulator low voltage mode.
+  * @note  This mode is only available for STM32F401xx/STM32F411xx devices. 
+  * @param None
+  * @retval None
+  */
+void HAL_PWREx_DisableMainRegulatorLowVoltage(void)
+{
+  *(__IO uint32_t *) CR_MRLVDS_BB = (uint32_t)DISABLE;
+}
+
+/**
+  * @brief Enables Low Power Regulator low voltage mode.
+  * @note  This mode is only available for STM32F401xx/STM32F411xx devices.   
+  * @param None
+  * @retval None
+  */
+void HAL_PWREx_EnableLowRegulatorLowVoltage(void)
+{
+  *(__IO uint32_t *) CR_LPLVDS_BB = (uint32_t)ENABLE;
+}
+
+/**
+  * @brief Disables Low Power Regulator low voltage mode.
+  * @note  This mode is only available for STM32F401xx/STM32F411xx devices.   
+  * @param None
+  * @retval None
+  */
+void HAL_PWREx_DisableLowRegulatorLowVoltage(void)
+{
+  *(__IO uint32_t *) CR_LPLVDS_BB = (uint32_t)DISABLE;
+}
+
+#endif /* STM32F401xC || STM32F401xE || STM32F411xE */
+
 #if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
 /**
   * @brief  Activates the Over-Drive mode.
-  * @note   These macros can be used only for STM32F42xx/STM32F43xx devices.
+  * @note   This function can be used only for STM32F42xx/STM32F43xx devices.
   *         This mode allows the CPU and the core logic to operate at a higher frequency
   *         than the normal mode for a given voltage scaling (scale 1, scale 2 or scale 3).   
   * @note   It is recommended to enter or exit Over-drive mode when the application is not running 
@@ -228,18 +278,19 @@ void HAL_PWREx_DisableFlashPowerDown(void)
   */
 HAL_StatusTypeDef HAL_PWREx_ActivateOverDrive(void)
 {
-  uint32_t timeout = 0;
-  
+  uint32_t tickstart = 0;
+
   __PWR_CLK_ENABLE();
   
   /* Enable the Over-drive to extend the clock frequency to 180 Mhz */
   __HAL_PWR_OVERDRIVE_ENABLE();
-  
-  /* Get timeout */
-  timeout = HAL_GetTick() + PWR_OVERDRIVE_TIMEOUT_VALUE;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
   while(!__HAL_PWR_GET_FLAG(PWR_FLAG_ODRDY))
   {
-    if(HAL_GetTick() >= timeout)
+    if((HAL_GetTick() - tickstart ) > PWR_OVERDRIVE_TIMEOUT_VALUE)
     {
       return HAL_TIMEOUT;
     }
@@ -247,12 +298,13 @@ HAL_StatusTypeDef HAL_PWREx_ActivateOverDrive(void)
   
   /* Enable the Over-drive switch */
   __HAL_PWR_OVERDRIVESWITCHING_ENABLE();
-  
-  /* Get timeout */
-  timeout = HAL_GetTick() + PWR_OVERDRIVE_TIMEOUT_VALUE;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
   while(!__HAL_PWR_GET_FLAG(PWR_FLAG_ODSWRDY))
   {
-    if(HAL_GetTick() >= timeout)
+    if((HAL_GetTick() - tickstart ) > PWR_OVERDRIVE_TIMEOUT_VALUE)
     {
       return HAL_TIMEOUT;
     }
@@ -262,7 +314,7 @@ HAL_StatusTypeDef HAL_PWREx_ActivateOverDrive(void)
 
 /**
   * @brief  Deactivates the Over-Drive mode.
-  * @note   These macros can be used only for STM32F42xx/STM32F43xx devices.
+  * @note   This function can be used only for STM32F42xx/STM32F43xx devices.
   *         This mode allows the CPU and the core logic to operate at a higher frequency
   *         than the normal mode for a given voltage scaling (scale 1, scale 2 or scale 3).    
   * @note   It is recommended to enter or exit Over-drive mode when the application is not running 
@@ -274,19 +326,19 @@ HAL_StatusTypeDef HAL_PWREx_ActivateOverDrive(void)
   */
 HAL_StatusTypeDef HAL_PWREx_DeactivateOverDrive(void)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
   
   __PWR_CLK_ENABLE();
     
   /* Disable the Over-drive switch */
   __HAL_PWR_OVERDRIVESWITCHING_DISABLE();
   
-  /* Get timeout */
-  timeout = HAL_GetTick() + PWR_OVERDRIVE_TIMEOUT_VALUE;
+  /* Get tick */
+  tickstart = HAL_GetTick();
  
   while(__HAL_PWR_GET_FLAG(PWR_FLAG_ODSWRDY))
   {
-    if(HAL_GetTick() >= timeout)
+    if((HAL_GetTick() - tickstart ) > PWR_OVERDRIVE_TIMEOUT_VALUE)
     {
       return HAL_TIMEOUT;
     }
@@ -295,12 +347,12 @@ HAL_StatusTypeDef HAL_PWREx_DeactivateOverDrive(void)
   /* Disable the Over-drive */
   __HAL_PWR_OVERDRIVE_DISABLE();
 
-  /* Get timeout */
-  timeout = HAL_GetTick() + PWR_OVERDRIVE_TIMEOUT_VALUE;  
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   while(__HAL_PWR_GET_FLAG(PWR_FLAG_ODRDY))
   {
-    if(HAL_GetTick() >= timeout)
+    if((HAL_GetTick() - tickstart ) > PWR_OVERDRIVE_TIMEOUT_VALUE)
     {
       return HAL_TIMEOUT;
     }
@@ -308,6 +360,107 @@ HAL_StatusTypeDef HAL_PWREx_DeactivateOverDrive(void)
   
   return HAL_OK;
 }
+
+/**
+  * @brief  Enters in Under-Drive STOP mode.
+  *  
+  * @note   This mode is only available for STM32F42xxx/STM324F3xxx devices. 
+  * 
+  * @note    This mode can be selected only when the Under-Drive is already active 
+  *   
+  * @note    This mode is enabled only with STOP low power mode.
+  *          In this mode, the 1.2V domain is preserved in reduced leakage mode. This 
+  *          mode is only available when the main regulator or the low power regulator 
+  *          is in low voltage mode
+  *        
+  * @note   If the Under-drive mode was enabled, it is automatically disabled after 
+  *         exiting Stop mode. 
+  *         When the voltage regulator operates in Under-drive mode, an additional  
+  *         startup delay is induced when waking up from Stop mode.
+  *                    
+  * @note   In Stop mode, all I/O pins keep the same state as in Run mode.
+  *   
+  * @note   When exiting Stop mode by issuing an interrupt or a wakeup event, 
+  *         the HSI RC oscillator is selected as system clock.
+  *           
+  * @note   When the voltage regulator operates in low power mode, an additional 
+  *         startup delay is incurred when waking up from Stop mode. 
+  *         By keeping the internal regulator ON during Stop mode, the consumption 
+  *         is higher although the startup time is reduced.
+  *     
+  * @param  Regulator: specifies the regulator state in STOP mode.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_MAINREGULATOR_UNDERDRIVE_ON:  Main Regulator in under-drive mode 
+  *                 and Flash memory in power-down when the device is in Stop under-drive mode
+  *            @arg PWR_LOWPOWERREGULATOR_UNDERDRIVE_ON:  Low Power Regulator in under-drive mode 
+  *                and Flash memory in power-down when the device is in Stop under-drive mode
+  * @param  STOPEntry: specifies if STOP mode in entered with WFI or WFE instruction.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_SLEEPENTRY_WFI: enter STOP mode with WFI instruction
+  *            @arg PWR_SLEEPENTRY_WFE: enter STOP mode with WFE instruction
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_PWREx_EnterUnderDriveSTOPMode(uint32_t Regulator, uint8_t STOPEntry)
+{
+  uint32_t tmpreg = 0;
+  uint32_t tickstart = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_PWR_REGULATOR_UNDERDRIVE(Regulator));
+  assert_param(IS_PWR_STOP_ENTRY(STOPEntry));
+  
+  /* Enable Power ctrl clock */
+  __PWR_CLK_ENABLE();
+  /* Enable the Under-drive Mode ---------------------------------------------*/
+  /* Clear Under-drive flag */
+  __HAL_PWR_CLEAR_ODRUDR_FLAG();
+  
+  /* Enable the Under-drive */ 
+  __HAL_PWR_UNDERDRIVE_ENABLE();
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait for UnderDrive mode is ready */
+  while(__HAL_PWR_GET_FLAG(PWR_FLAG_UDRDY))
+  {
+    if((HAL_GetTick() - tickstart ) > PWR_UDERDRIVE_TIMEOUT_VALUE)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  
+  /* Select the regulator state in STOP mode ---------------------------------*/
+  tmpreg = PWR->CR;
+  /* Clear PDDS, LPDS, MRLUDS and LPLUDS bits */
+  tmpreg &= (uint32_t)~(PWR_CR_PDDS | PWR_CR_LPDS | PWR_CR_LPUDS | PWR_CR_MRUDS);
+  
+  /* Set LPDS, MRLUDS and LPLUDS bits according to PWR_Regulator value */
+  tmpreg |= Regulator;
+  
+  /* Store the new value */
+  PWR->CR = tmpreg;
+  
+  /* Set SLEEPDEEP bit of Cortex System Control Register */
+  SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+  
+  /* Select STOP mode entry --------------------------------------------------*/
+  if(STOPEntry == PWR_SLEEPENTRY_WFI)
+  {   
+    /* Request Wait For Interrupt */
+    __WFI();
+  }
+  else
+  {
+    /* Request Wait For Event */
+    __WFE();
+  }
+  /* Reset SLEEPDEEP bit of Cortex System Control Register */
+  SCB->SCR &= (uint32_t)~((uint32_t)SCB_SCR_SLEEPDEEP_Msk);
+
+  return HAL_OK;  
+}
+
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pwr_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_pwr_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_pwr_ex.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of PWR HAL Extension module.
   ******************************************************************************
   * @attention
@@ -54,12 +54,13 @@
   * @{
   */ 
 
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
-
 /* Exported types ------------------------------------------------------------*/ 
 /* Exported constants --------------------------------------------------------*/
 /* ------------- PWR registers bit address in the alias region ---------------*/
 /* --- CR Register ---*/
+/* Alias word address of FPDS bit */
+#define FPDS_BitNumber  0x09
+#define CR_FPDS_BB      (PERIPH_BB_BASE + (CR_OFFSET * 32) + (FPDS_BitNumber * 4))
 
 /* Alias word address of ODEN bit   */
 #define ODEN_BitNumber           0x10
@@ -69,7 +70,33 @@
 #define ODSWEN_BitNumber         0x11
 #define CR_ODSWEN_BB             (PERIPH_BB_BASE + (CR_OFFSET * 32) + (ODSWEN_BitNumber * 4))
     
+/* Alias word address of MRLVDS bit */
+#define MRLVDS_BitNumber         0x0B
+#define CR_MRLVDS_BB             (PERIPH_BB_BASE + (CR_OFFSET * 32) + (MRLVDS_BitNumber * 4))
 
+/* Alias word address of LPLVDS bit */
+#define LPLVDS_BitNumber         0x0A
+#define CR_LPLVDS_BB             (PERIPH_BB_BASE + (CR_OFFSET * 32) + (LPLVDS_BitNumber * 4))
+
+/* --- CSR Register ---*/
+/* Alias word address of BRE bit */
+#define BRE_BitNumber   0x09
+#define CSR_BRE_BB      (PERIPH_BB_BASE + (CSR_OFFSET * 32) + (BRE_BitNumber * 4))    
+
+#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
+   
+/** @defgroup PWREx_Regulator_state_in_UnderDrive_mode 
+  * @{
+  */
+#define PWR_MAINREGULATOR_UNDERDRIVE_ON                       PWR_CR_MRUDS
+#define PWR_LOWPOWERREGULATOR_UNDERDRIVE_ON                   ((uint32_t)(PWR_CR_LPDS | PWR_CR_LPUDS))
+
+#define IS_PWR_REGULATOR_UNDERDRIVE(REGULATOR) (((REGULATOR) == PWR_MAINREGULATOR_UNDERDRIVE_ON) || \
+                                                ((REGULATOR) == PWR_LOWPOWERREGULATOR_UNDERDRIVE_ON))
+/**
+  * @}
+  */ 
+  
 /** @defgroup PWREx_Over_Under_Drive_Flag 
   * @{
   */
@@ -79,13 +106,14 @@
 /**
   * @}
   */
-
+#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 /**
   * @}
   */ 
   
 /* Exported macro ------------------------------------------------------------*/
   
+#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
 /** @brief Macros to enable or disable the Over drive mode.
   * @note  These macros can be used only for STM32F42xx/STM3243xx devices.
   */
@@ -138,9 +166,17 @@ void              HAL_PWREx_DisableFlashPowerDown(void);
 HAL_StatusTypeDef HAL_PWREx_EnableBkUpReg(void);
 HAL_StatusTypeDef HAL_PWREx_DisableBkUpReg(void); 
 
+#if defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
+void HAL_PWREx_EnableMainRegulatorLowVoltage(void);
+void HAL_PWREx_DisableMainRegulatorLowVoltage(void);
+void HAL_PWREx_EnableLowRegulatorLowVoltage(void);
+void HAL_PWREx_DisableLowRegulatorLowVoltage(void);
+#endif /* STM32F401xC || STM32F401xE || STM32F411xE */
+
 #if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
 HAL_StatusTypeDef HAL_PWREx_ActivateOverDrive(void);
 HAL_StatusTypeDef HAL_PWREx_DeactivateOverDrive(void);
+HAL_StatusTypeDef HAL_PWREx_EnterUnderDriveSTOPMode(uint32_t Regulator, uint8_t STOPEntry);
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 
 /**

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rcc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rcc.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_rcc.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   RCC HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Reset and Clock Control (RCC) peripheral:
@@ -269,7 +269,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
       /* Wait till HSE is disabled */  
       while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != RESET)
       {
-        if((int32_t) (HAL_GetTick() - tickstart ) > HSE_TIMEOUT_VALUE)
+        if((HAL_GetTick() - tickstart ) > HSE_TIMEOUT_VALUE)
         {
           return HAL_TIMEOUT;
         }       
@@ -287,7 +287,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
         /* Wait till HSE is ready */  
         while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) == RESET)
         {
-          if((int32_t) (HAL_GetTick() - tickstart ) > HSE_TIMEOUT_VALUE)
+          if((HAL_GetTick() - tickstart ) > HSE_TIMEOUT_VALUE)
           {
             return HAL_TIMEOUT;
           } 
@@ -301,7 +301,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
         /* Wait till HSE is bypassed or disabled */
         while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != RESET)
         {
-          if((int32_t) (HAL_GetTick() - tickstart ) > HSE_TIMEOUT_VALUE)
+          if((HAL_GetTick() - tickstart ) > HSE_TIMEOUT_VALUE)
           {
             return HAL_TIMEOUT;
           } 
@@ -316,12 +316,19 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     assert_param(IS_RCC_HSI(RCC_OscInitStruct->HSIState));
     assert_param(IS_RCC_CALIBRATION_VALUE(RCC_OscInitStruct->HSICalibrationValue));
     
-    /* When the HSI is used as system clock it will not disabled */
+    /* Check if HSI is used as system clock or as PLL source when PLL is selected as system clock */ 
     if((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_HSI) || ((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_PLL) && ((RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC) == RCC_PLLCFGR_PLLSRC_HSI)))
     {
+      /* When HSI is used as system clock it will not disabled */
       if((__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) != RESET) && (RCC_OscInitStruct->HSIState != RCC_HSI_ON))
       {
         return HAL_ERROR;
+      }
+      /* Otherwise, just the calibration is allowed */
+      else
+      {
+        /* Adjusts the Internal High Speed oscillator (HSI) calibration value.*/
+        __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->HSICalibrationValue);
       }
     }
     else
@@ -338,7 +345,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
         /* Wait till HSI is ready */  
         while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) == RESET)
         {
-          if((int32_t) (HAL_GetTick() - tickstart ) > HSI_TIMEOUT_VALUE)
+          if((HAL_GetTick() - tickstart ) > HSI_TIMEOUT_VALUE)
           {
             return HAL_TIMEOUT;
           }       
@@ -358,7 +365,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
         /* Wait till HSI is ready */  
         while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) != RESET)
         {
-          if((int32_t) (HAL_GetTick() - tickstart ) > HSI_TIMEOUT_VALUE)
+          if((HAL_GetTick() - tickstart ) > HSI_TIMEOUT_VALUE)
           {
             return HAL_TIMEOUT;
           } 
@@ -384,7 +391,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
       /* Wait till LSI is ready */
       while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY) == RESET)
       {
-        if((int32_t) (HAL_GetTick() - tickstart ) > LSI_TIMEOUT_VALUE)
+        if((HAL_GetTick() - tickstart ) > LSI_TIMEOUT_VALUE)
         {
           return HAL_TIMEOUT;
         } 
@@ -401,7 +408,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
       /* Wait till LSI is ready */  
       while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY) != RESET)
       {
-        if((int32_t) (HAL_GetTick() - tickstart ) > LSI_TIMEOUT_VALUE)
+        if((HAL_GetTick() - tickstart ) > LSI_TIMEOUT_VALUE)
         {
           return HAL_TIMEOUT;
         }       
@@ -425,7 +432,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     
     while((PWR->CR & PWR_CR_DBP) == RESET)
     {
-      if((int32_t) (HAL_GetTick() - tickstart ) > DBP_TIMEOUT_VALUE)
+      if((HAL_GetTick() - tickstart ) > DBP_TIMEOUT_VALUE)
       {
         return HAL_TIMEOUT;
       }      
@@ -440,7 +447,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     /* Wait till LSE is ready */  
     while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) != RESET)
     {
-      if((int32_t) (HAL_GetTick() - tickstart ) > LSE_TIMEOUT_VALUE)
+      if((HAL_GetTick() - tickstart ) > LSE_TIMEOUT_VALUE)
       {
         return HAL_TIMEOUT;
       }    
@@ -457,7 +464,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
       /* Wait till LSE is ready */  
       while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) == RESET)
       {
-        if((int32_t) (HAL_GetTick() - tickstart ) > LSE_TIMEOUT_VALUE)
+        if((HAL_GetTick() - tickstart ) > LSE_TIMEOUT_VALUE)
         {
           return HAL_TIMEOUT;
         }       
@@ -471,7 +478,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
       /* Wait till LSE is ready */  
       while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) != RESET)
       {
-        if((int32_t) (HAL_GetTick() - tickstart ) > LSE_TIMEOUT_VALUE)
+        if((HAL_GetTick() - tickstart ) > LSE_TIMEOUT_VALUE)
         {
           return HAL_TIMEOUT;
         }       
@@ -504,7 +511,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
         /* Wait till PLL is ready */  
         while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) != RESET)
         {
-          if((int32_t) (HAL_GetTick() - tickstart ) > PLL_TIMEOUT_VALUE)
+          if((HAL_GetTick() - tickstart ) > PLL_TIMEOUT_VALUE)
           {
             return HAL_TIMEOUT;
           }
@@ -525,7 +532,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
         /* Wait till PLL is ready */  
         while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) == RESET)
         {
-          if((int32_t) (HAL_GetTick() - tickstart ) > PLL_TIMEOUT_VALUE)
+          if((HAL_GetTick() - tickstart ) > PLL_TIMEOUT_VALUE)
           {
             return HAL_TIMEOUT;
           } 
@@ -542,7 +549,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
         /* Wait till PLL is ready */  
         while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) != RESET)
         {
-          if((int32_t) (HAL_GetTick() - tickstart ) > PLL_TIMEOUT_VALUE)
+          if((HAL_GetTick() - tickstart ) > PLL_TIMEOUT_VALUE)
           {
             return HAL_TIMEOUT;
           }
@@ -655,7 +662,7 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
       {
         while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_HSE)
         {
-          if((int32_t) (HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
           {
             return HAL_TIMEOUT;
           }
@@ -665,7 +672,7 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
       {
         while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_PLL)
         {
-          if((int32_t) (HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
           {
             return HAL_TIMEOUT;
           }
@@ -675,7 +682,7 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
       {
         while(__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_HSI)
         {
-          if((int32_t) (HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
           {
             return HAL_TIMEOUT;
           }
@@ -734,7 +741,7 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
       {
         while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_HSE)
         {
-          if((int32_t) (HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
           {
             return HAL_TIMEOUT;
           } 
@@ -744,7 +751,7 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
       {
         while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_PLL)
         {
-          if((int32_t) (HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
           {
             return HAL_TIMEOUT;
           } 
@@ -754,7 +761,7 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
       {
         while(__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_HSI)
         {
-          if((int32_t) (HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
           {
             return HAL_TIMEOUT;
           }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rcc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rcc.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_rcc.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of RCC HAL module.
   ******************************************************************************
   * @attention
@@ -190,7 +190,7 @@ typedef struct
 
 
 #define DBP_TIMEOUT_VALUE          ((uint32_t)100)
-#define LSE_TIMEOUT_VALUE          ((uint32_t)500)
+#define LSE_TIMEOUT_VALUE          ((uint32_t)600)
 /**
   * @}
   */
@@ -655,11 +655,15 @@ typedef struct
 /** @brief  Force or release AHB2 peripheral reset.
   */
 #define __AHB2_FORCE_RESET()    (RCC->AHB2RSTR = 0xFFFFFFFF) 
-#define __OTGFS_FORCE_RESET()   (RCC->AHB2RSTR |= (RCC_AHB2RSTR_OTGFSRST))
+#define __USB_OTG_FS_FORCE_RESET()   (RCC->AHB2RSTR |= (RCC_AHB2RSTR_OTGFSRST))
 
 #define __AHB2_RELEASE_RESET()  (RCC->AHB2RSTR = 0x00)
-#define __OTGFS_RELEASE_RESET() (RCC->AHB2RSTR &= ~(RCC_AHB2RSTR_OTGFSRST))
+#define __USB_OTG_FS_RELEASE_RESET() (RCC->AHB2RSTR &= ~(RCC_AHB2RSTR_OTGFSRST))
 
+/* alias define maintained for legacy */
+#define __OTGFS_FORCE_RESET    __USB_OTG_FS_FORCE_RESET
+#define __OTGFS_RELEASE_RESET  __USB_OTG_FS_RELEASE_RESET                                      
+                                      
 #define __RNG_FORCE_RESET()    (RCC->AHB2RSTR |= (RCC_AHB2RSTR_RNGRST))
 #define __RNG_RELEASE_RESET()  (RCC->AHB2RSTR &= ~(RCC_AHB2RSTR_RNGRST))
 
@@ -764,9 +768,13 @@ typedef struct
   * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
   * @note   By default, all peripheral clocks are enabled during SLEEP mode.
   */
-#define __OTGFS_CLK_SLEEP_ENABLE()  (RCC->AHB2LPENR |= (RCC_AHB2LPENR_OTGFSLPEN))
+#define __USB_OTG_FS_CLK_SLEEP_ENABLE()  (RCC->AHB2LPENR |= (RCC_AHB2LPENR_OTGFSLPEN))
 
-#define __OTGFS_CLK_SLEEP_DISABLE() (RCC->AHB2LPENR &= ~(RCC_AHB2LPENR_OTGFSLPEN))
+#define __USB_OTG_FS_CLK_SLEEP_DISABLE()   (RCC->AHB2LPENR &= ~(RCC_AHB2LPENR_OTGFSLPEN))
+
+/* alias define maintained for legacy */
+#define __OTGFS_CLK_SLEEP_ENABLE    __USB_OTG_FS_CLK_SLEEP_ENABLE
+#define __OTGFS_CLK_SLEEP_DISABLE   __USB_OTG_FS_CLK_SLEEP_DISABLE
 
 #define __RNG_CLK_SLEEP_ENABLE()   (RCC->AHB2LPENR |= (RCC_AHB2LPENR_RNGLPEN))
 #define __RNG_CLK_SLEEP_DISABLE()  (RCC->AHB2LPENR &= ~(RCC_AHB2LPENR_RNGLPEN))

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rcc_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rcc_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_rcc_ex.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Extension RCC HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities RCC extension peripheral:
@@ -102,7 +102,7 @@
   */
 HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
   uint32_t tmpreg = 0;
     
   /* Check the parameters */
@@ -121,14 +121,14 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
         
     /* Disable the PLLI2S */
     __HAL_RCC_PLLI2S_DISABLE();    
-    /* Get new Timeout value */
-    timeout = HAL_GetTick() + PLLI2S_TIMEOUT_VALUE;
+    /* Get tick */
+    tickstart = HAL_GetTick();
     /* Wait till PLLI2S is disabled */
     while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLI2SRDY)  != RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > PLLI2S_TIMEOUT_VALUE)
       {
-        /* return in case of Timeout detected */         
+        /* return in case of Timeout detected */
         return HAL_TIMEOUT;
       }
     }
@@ -168,23 +168,23 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     
     /* Enable the PLLI2S */
     __HAL_RCC_PLLI2S_ENABLE();
-    /* Get new Timeout value */
-    timeout = HAL_GetTick() + PLLI2S_TIMEOUT_VALUE;
+    /* Get tick */
+    tickstart = HAL_GetTick();
     /* Wait till PLLI2S is ready */
     while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLI2SRDY)  == RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > PLLI2S_TIMEOUT_VALUE)
       {
-        /* return in case of Timeout detected */         
+        /* return in case of Timeout detected */
         return HAL_TIMEOUT;
       }
     }
   }
   
-  /*----------------------- SAI/LTDC Configuration (PLLSAI) -------------------------*/
+  /*----------------------- SAI/LTDC Configuration (PLLSAI) ------------------*/
   
-  /*----------------------- Common configuration SAI/LTDC ---------------------------*/ 
-  /* In Case of SAI or LTDC Clock Configuration through PLLSAI, PLLSAIN division   
+  /*----------------------- Common configuration SAI/LTDC --------------------*/
+  /* In Case of SAI or LTDC Clock Configuration through PLLSAI, PLLSAIN division
      factor is common parameters for both peripherals */ 
   if((((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SAI_PLLSAI) == RCC_PERIPHCLK_SAI_PLLSAI) || 
      (((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_LTDC) == RCC_PERIPHCLK_LTDC))
@@ -194,19 +194,19 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
  
     /* Disable PLLSAI Clock */
     __HAL_RCC_PLLSAI_DISABLE(); 
-    /* Get new Timeout value */    
-    timeout = HAL_GetTick() + PLLSAI_TIMEOUT_VALUE;
+    /* Get tick */
+    tickstart = HAL_GetTick();
     /* Wait till PLLSAI is disabled */
     while(__HAL_RCC_PLLSAI_GET_FLAG() != RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > PLLSAI_TIMEOUT_VALUE)
       { 
-        /* return in case of Timeout detected */        
+        /* return in case of Timeout detected */
         return HAL_TIMEOUT;
       }
     }
     
-    /*---------------------------- SAI configuration -------------------------------*/
+    /*---------------------------- SAI configuration -------------------------*/
     /* In Case of SAI Clock Configuration through PLLSAI, PLLSAIQ and PLLSAI_DIVQ must  
        be added only for SAI configuration */     
     if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_SAI_PLLSAI) == (RCC_PERIPHCLK_SAI_PLLSAI))
@@ -224,7 +224,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
       __HAL_RCC_PLLSAI_PLLSAICLKDIVQ_CONFIG(PeriphClkInit->PLLSAIDivQ);
     }
     
-    /*---------------------------- LTDC configuration -------------------------------*/
+    /*---------------------------- LTDC configuration ------------------------*/
     if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_LTDC) == (RCC_PERIPHCLK_LTDC))
     {
       assert_param(IS_RCC_PLLSAIR_VALUE(PeriphClkInit->PLLSAI.PLLSAIR));
@@ -241,21 +241,21 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     }    
     /* Enable PLLSAI Clock */
     __HAL_RCC_PLLSAI_ENABLE();
-    /* Get new Timeout value */    
-    timeout = HAL_GetTick() + PLLSAI_TIMEOUT_VALUE;
+    /* Get tick */
+    tickstart = HAL_GetTick();
     /* Wait till PLLSAI is ready */
     while(__HAL_RCC_PLLSAI_GET_FLAG() == RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > PLLSAI_TIMEOUT_VALUE)
       { 
-        /* return in case of Timeout detected */        
+        /* return in case of Timeout detected */
         return HAL_TIMEOUT;
       }
     }  
   }
 
    
-  /*---------------------------- RTC configuration -------------------------------*/
+  /*---------------------------- RTC configuration ---------------------------*/
   if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_RTC) == (RCC_PERIPHCLK_RTC))
   {
     /* Enable Power Clock*/
@@ -264,12 +264,12 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     /* Enable write access to Backup domain */
     PWR->CR |= PWR_CR_DBP;
     
-    /* Wait for Backup domain Write protection disable */
-    timeout = HAL_GetTick() + DBP_TIMEOUT_VALUE;
+    /* Get tick */
+    tickstart = HAL_GetTick();
     
     while((PWR->CR & PWR_CR_DBP) == RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > DBP_TIMEOUT_VALUE)
       {
         return HAL_TIMEOUT;
       }      
@@ -290,13 +290,13 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     /* If LSE is selected as RTC clock source, wait for LSE reactivation */
     if(PeriphClkInit->RTCClockSelection == RCC_RTCCLKSOURCE_LSE)
     {
-      /* Get timeout */
-      timeout = HAL_GetTick() + LSE_TIMEOUT_VALUE;
+      /* Get tick */
+      tickstart = HAL_GetTick();
       
       /* Wait till LSE is ready */  
       while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) == RESET)
       {
-        if(HAL_GetTick() >= timeout)
+        if((HAL_GetTick() - tickstart ) > LSE_TIMEOUT_VALUE)
         {
           return HAL_TIMEOUT;
         }      
@@ -305,7 +305,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     __HAL_RCC_RTC_CONFIG(PeriphClkInit->RTCClockSelection); 
   }
   
-  /*---------------------------- TIM configuration -------------------------------*/
+  /*---------------------------- TIM configuration ---------------------------*/
   if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_TIM) == (RCC_PERIPHCLK_TIM))
   {
     __HAL_RCC_TIMCLKPRESCALER(PeriphClkInit->TIMPresSelection);
@@ -354,7 +354,8 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
 }
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 
-#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx)|| defined(STM32F417xx) || defined(STM32F401xC) || defined(STM32F401xE) 
+#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx)|| defined(STM32F417xx) ||\
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 /**
   * @brief  Initializes the RCC extended peripherals clocks according to the specified parameters in the
   *         RCC_PeriphCLKInitTypeDef.
@@ -369,53 +370,63 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
   */
 HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
   uint32_t tmpreg = 0;
     
   /* Check the parameters */
   assert_param(IS_RCC_PERIPHCLOCK(PeriphClkInit->PeriphClockSelection));
   
-  /*---------------------------- I2S configuration -------------------------------*/      
+  /*---------------------------- I2S configuration ---------------------------*/
   if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2S) == (RCC_PERIPHCLK_I2S))
   {
     /* check for Parameters */
     assert_param(IS_RCC_PLLI2SR_VALUE(PeriphClkInit->PLLI2S.PLLI2SR));
     assert_param(IS_RCC_PLLI2SN_VALUE(PeriphClkInit->PLLI2S.PLLI2SN));
-      
+#if defined(STM32F411xE)    
+    assert_param(IS_RCC_PLLI2SM_VALUE(PeriphClkInit->PLLI2S.PLLI2SM));
+#endif /* STM32F411xE */
     /* Disable the PLLI2S */
-    __HAL_RCC_PLLI2S_DISABLE();    
-    /* Get new Timeout value */
-    timeout = HAL_GetTick() + PLLI2S_TIMEOUT_VALUE;
+    __HAL_RCC_PLLI2S_DISABLE();
+    /* Get tick */
+    tickstart = HAL_GetTick();
     /* Wait till PLLI2S is disabled */
     while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLI2SRDY)  != RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > PLLI2S_TIMEOUT_VALUE)
       {
-        /* return in case of Timeout detected */         
+        /* return in case of Timeout detected */
         return HAL_TIMEOUT;
       } 
     }
+
+#if defined(STM32F411xE)
+    /* Configure the PLLI2S division factors */
+    /* PLLI2S_VCO = f(VCO clock) = f(PLLI2S clock input) × (PLLI2SN/PLLI2SM) */
+    /* I2SCLK = f(PLLI2S clock output) = f(VCO clock) / PLLI2SR */    
+    __HAL_RCC_PLLI2S_I2SCLK_CONFIG(PeriphClkInit->PLLI2S.PLLI2SM, PeriphClkInit->PLLI2S.PLLI2SN, PeriphClkInit->PLLI2S.PLLI2SR);
+#else
     /* Configure the PLLI2S division factors */
     /* PLLI2S_VCO = f(VCO clock) = f(PLLI2S clock input) × (PLLI2SN/PLLM) */
     /* I2SCLK = f(PLLI2S clock output) = f(VCO clock) / PLLI2SR */
     __HAL_RCC_PLLI2S_CONFIG(PeriphClkInit->PLLI2S.PLLI2SN , PeriphClkInit->PLLI2S.PLLI2SR);
+#endif /* STM32F411xE */
     
     /* Enable the PLLI2S */
     __HAL_RCC_PLLI2S_ENABLE();
-    /* Get new Timeout value */
-    timeout = HAL_GetTick() + PLLI2S_TIMEOUT_VALUE;
+    /* Get tick */
+    tickstart = HAL_GetTick();
     /* Wait till PLLI2S is ready */
     while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLI2SRDY)  == RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > PLLI2S_TIMEOUT_VALUE)
       {
-        /* return in case of Timeout detected */         
+        /* return in case of Timeout detected */
         return HAL_TIMEOUT;
       }
     }
   }
   
-  /*---------------------------- RTC configuration -------------------------------*/
+  /*---------------------------- RTC configuration ---------------------------*/
   if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_RTC) == (RCC_PERIPHCLK_RTC))
   {
     /* Enable Power Clock*/
@@ -423,13 +434,13 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     
     /* Enable write access to Backup domain */
     PWR->CR |= PWR_CR_DBP;
-    
-    /* Wait for Backup domain Write protection disable */
-    timeout = HAL_GetTick() + DBP_TIMEOUT_VALUE;
-    
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
     while((PWR->CR & PWR_CR_DBP) == RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > DBP_TIMEOUT_VALUE)
       {
         return HAL_TIMEOUT;
       }      
@@ -450,16 +461,16 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     /* If LSE is selected as RTC clock source, wait for LSE reactivation */
     if(PeriphClkInit->RTCClockSelection == RCC_RTCCLKSOURCE_LSE)
     {
-      /* Get timeout */
-      timeout = HAL_GetTick() + LSE_TIMEOUT_VALUE;
-      
+      /* Get tick */
+      tickstart = HAL_GetTick();
+
       /* Wait till LSE is ready */  
       while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) == RESET)
       {
-        if(HAL_GetTick() >= timeout)
+        if((HAL_GetTick() - tickstart ) > LSE_TIMEOUT_VALUE)
         {
           return HAL_TIMEOUT;
-        }      
+        }
       }  
     }
     __HAL_RCC_RTC_CONFIG(PeriphClkInit->RTCClockSelection); 
@@ -485,13 +496,44 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
   /* Get the PLLI2S Clock configuration -----------------------------------------------*/
   PeriphClkInit->PLLI2S.PLLI2SN = (uint32_t)((RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SN) >> POSITION_VAL(RCC_PLLI2SCFGR_PLLI2SN));
   PeriphClkInit->PLLI2S.PLLI2SR = (uint32_t)((RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SR) >> POSITION_VAL(RCC_PLLI2SCFGR_PLLI2SR));
-  
+#if defined(STM32F411xE)
+  PeriphClkInit->PLLI2S.PLLI2SM = (uint32_t)(RCC->PLLI2SCFGR & RCC_PLLI2SCFGR_PLLI2SM);
+#endif /* STM32F411xE */  
   /* Get the RTC Clock configuration -----------------------------------------------*/
   tempreg = (RCC->CFGR & RCC_CFGR_RTCPRE);
   PeriphClkInit->RTCClockSelection = (uint32_t)((tempreg) | (RCC->BDCR & RCC_BDCR_RTCSEL));
   
 }
-#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F401xC || STM32F401xE */
+#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F401xC || STM32F401xE || STM32F411xE */
+
+#if defined(STM32F411xE)
+/**
+  * @brief  Select LSE mode
+  *   
+  * @note   This mode is only available for STM32F411xx devices.
+  *     
+  * @param  Mode: specifies the LSE mode.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_LSE_LOWPOWER_MODE:  LSE oscillator in low power mode selection
+  *            @arg RCC_LSE_HIGHDRIVE_MODE: LSE oscillator in High Drive mode selection
+  * @retval None
+  */
+void HAL_RCCEx_SelectLSEMode(uint8_t Mode)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_LSE_MODE(Mode));
+  if(Mode == RCC_LSE_HIGHDRIVE_MODE)
+  {
+    SET_BIT(RCC->BDCR, RCC_BDCR_LSEMOD);
+  }
+  else
+  {
+    CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSEMOD);
+  }
+}
+
+#endif /* STM32F411xE */
+
 /**
   * @}
   */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rcc_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rcc_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_rcc_ex.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of RCC HAL Extension module.
   ******************************************************************************
   * @attention
@@ -126,12 +126,18 @@ typedef struct
 }RCC_PeriphCLKInitTypeDef;
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 
-#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx)|| defined(STM32F417xx) || defined(STM32F401xC) || defined(STM32F401xE)
+#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx)|| defined(STM32F417xx) ||\
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
 /** 
   * @brief  PLLI2S Clock structure definition  
   */
 typedef struct
 {
+#if defined(STM32F411xE) 
+  uint32_t PLLI2SM;    /*!< PLLM: Division factor for PLLI2S VCO input clock.
+                            This parameter must be a number between Min_Data = 2 and Max_Data = 62  */
+#endif /* STM32F411xE */
+                                
   uint32_t PLLI2SN;    /*!< Specifies the multiplication factor for PLLI2S VCO output clock.
                             This parameter must be a number between Min_Data = 192 and Max_Data = 432
                             This parameter will be used only when PLLI2S is selected as Clock Source I2S or SAI */
@@ -155,10 +161,10 @@ typedef struct
                                       This parameter will be used only when PLLI2S is selected as Clock Source I2S or SAI */
 
   uint32_t RTCClockSelection;      /*!< Specifies RTC Clock Prescalers Selection.
-                                      This parameter can be a value of @ref RCC_RTC_Clock_Source */
+                                       This parameter can be a value of @ref RCC_RTC_Clock_Source */                                   
 
 }RCC_PeriphCLKInitTypeDef;
-#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F401xC || STM32F401xE */
+#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F401xC || STM32F401xE || STM32F411xE */
 /* Exported constants --------------------------------------------------------*/
 /** @defgroup RCCEx_Exported_Constants
   * @{
@@ -177,11 +183,12 @@ typedef struct
 #define IS_RCC_PERIPHCLOCK(SELECTION) ((1 <= (SELECTION)) && ((SELECTION) <= 0x0000002F))
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 
-#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx)|| defined(STM32F417xx) || defined(STM32F401xC) || defined(STM32F401xE) 
+#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx)|| defined(STM32F417xx) ||\
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE) 
 #define RCC_PERIPHCLK_I2S             ((uint32_t)0x00000001)
 #define RCC_PERIPHCLK_RTC             ((uint32_t)0x00000002)
 #define IS_RCC_PERIPHCLOCK(SELECTION) ((1 <= (SELECTION)) && ((SELECTION) <= 0x00000003))
-#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F401xC || STM32F401xE */
+#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F401xC || STM32F401xE || STM32F411xE */
 
 /**
   * @}
@@ -286,58 +293,404 @@ typedef struct
   * @}
   */
 #endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
+
+#if defined(STM32F411xE) 
+/** @defgroup RCCEx_PLLI2S_PLLI2SM 
+  * @{
+  */
+#define IS_RCC_PLLI2SM_VALUE(VALUE) ((VALUE) <= 63)  
 /**
   * @}
   */
 
+/** @defgroup RCCEx_LSE_Dual_Mode_Selection
+  * @{
+  */
+#define RCC_LSE_LOWPOWER_MODE           ((uint8_t)0x00)
+#define RCC_LSE_HIGHDRIVE_MODE          ((uint8_t)0x01)
+#define IS_RCC_LSE_MODE(MODE)           (((MODE) == RCC_LSE_LOWPOWER_MODE) ||\
+                                         ((MODE) == RCC_LSE_HIGHDRIVE_MODE))
+/**
+  * @}
+  */
+  
+#endif /* STM32F411xE */
 /**
   * @}
   */
      
 /* Exported macro ------------------------------------------------------------*/
 
+/*----------------------------------- STM32F42xxx/STM32F43xxx----------------------------------*/
+#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx)
 /** @brief  Enables or disables the AHB1 peripheral clock.
   * @note   After reset, the peripheral clock (used for registers read/write access)
   *         is disabled and the application software has to enable this clock before 
   *         using it.
   */
-
-#if !defined(STM32F401xC) && !defined(STM32F401xE)
-#define __GPIOI_CLK_ENABLE()      (RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOIEN))
-#define __GPIOF_CLK_ENABLE()      (RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOFEN))
-#define __GPIOG_CLK_ENABLE()      (RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOGEN))
-#define __ETHMAC_CLK_ENABLE()     (RCC->AHB1ENR |= (RCC_AHB1ENR_ETHMACEN))
-#define __ETHMACTX_CLK_ENABLE()   (RCC->AHB1ENR |= (RCC_AHB1ENR_ETHMACTXEN))
-#define __ETHMACRX_CLK_ENABLE()   (RCC->AHB1ENR |= (RCC_AHB1ENR_ETHMACRXEN))
-#define __ETHMACPTP_CLK_ENABLE()  (RCC->AHB1ENR |= (RCC_AHB1ENR_ETHMACPTPEN))
-#define __USB_OTG_HS_CLK_ENABLE()      (RCC->AHB1ENR |= (RCC_AHB1ENR_OTGHSEN))
+#define __GPIOI_CLK_ENABLE()            (RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOIEN))
+#define __GPIOF_CLK_ENABLE()            (RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOFEN))
+#define __GPIOG_CLK_ENABLE()            (RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOGEN))
+#define __GPIOJ_CLK_ENABLE()            (RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOJEN))
+#define __GPIOK_CLK_ENABLE()            (RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOKEN))
+#define __DMA2D_CLK_ENABLE()            (RCC->AHB1ENR |= (RCC_AHB1ENR_DMA2DEN))
+#define __ETHMAC_CLK_ENABLE()           (RCC->AHB1ENR |= (RCC_AHB1ENR_ETHMACEN))
+#define __ETHMACTX_CLK_ENABLE()         (RCC->AHB1ENR |= (RCC_AHB1ENR_ETHMACTXEN))
+#define __ETHMACRX_CLK_ENABLE()         (RCC->AHB1ENR |= (RCC_AHB1ENR_ETHMACRXEN))
+#define __ETHMACPTP_CLK_ENABLE()        (RCC->AHB1ENR |= (RCC_AHB1ENR_ETHMACPTPEN))
+#define __USB_OTG_HS_CLK_ENABLE()       (RCC->AHB1ENR |= (RCC_AHB1ENR_OTGHSEN))
 #define __USB_OTG_HS_ULPI_CLK_ENABLE()  (RCC->AHB1ENR |= (RCC_AHB1ENR_OTGHSULPIEN))
 
-#define __GPIOF_CLK_DISABLE()     (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOFEN))
-#define __GPIOG_CLK_DISABLE()     (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOGEN))
-#define __GPIOI_CLK_DISABLE()     (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOIEN))
-#define __ETHMAC_CLK_DISABLE()    (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACEN))
-#define __ETHMACTX_CLK_DISABLE()  (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACTXEN))
-#define __ETHMACRX_CLK_DISABLE()  (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACRXEN))
-#define __ETHMACPTP_CLK_DISABLE() (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACPTPEN))
-#define __USB_OTG_HS_CLK_DISABLE()     (RCC->AHB1ENR &= ~(RCC_AHB1ENR_OTGHSEN))
+#define __GPIOF_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOFEN))
+#define __GPIOG_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOGEN))
+#define __GPIOI_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOIEN))
+#define __GPIOJ_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOJEN))
+#define __GPIOK_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOKEN))
+#define __DMA2D_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_DMA2DEN))
+#define __ETHMAC_CLK_DISABLE()          (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACEN))
+#define __ETHMACTX_CLK_DISABLE()        (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACTXEN))
+#define __ETHMACRX_CLK_DISABLE()        (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACRXEN))
+#define __ETHMACPTP_CLK_DISABLE()       (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACPTPEN))
+#define __USB_OTG_HS_CLK_DISABLE()      (RCC->AHB1ENR &= ~(RCC_AHB1ENR_OTGHSEN))
 #define __USB_OTG_HS_ULPI_CLK_DISABLE() (RCC->AHB1ENR &= ~(RCC_AHB1ENR_OTGHSULPIEN))
-#endif /* !(STM32F401xC && STM32F401xE) */
 
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) 
-#define __GPIOJ_CLK_ENABLE()      (RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOJEN))
-#define __GPIOK_CLK_ENABLE()      (RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOKEN))
-#define __DMA2D_CLK_ENABLE()      (RCC->AHB1ENR |= (RCC_AHB1ENR_DMA2DEN))
-
-#define __GPIOJ_CLK_DISABLE()     (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOJEN))
-#define __GPIOK_CLK_DISABLE()     (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOKEN))
-#define __DMA2D_CLK_DISABLE()     (RCC->AHB1ENR &= ~(RCC_AHB1ENR_DMA2DEN))
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx|| STM32F439xx */
-
-#if !defined(STM32F401xC) && !defined(STM32F401xE)
 /**
   * @brief  Enable ETHERNET clock.
   */
+#define __ETH_CLK_ENABLE()       do {                            \
+                                     __ETHMAC_CLK_ENABLE();      \
+                                     __ETHMACTX_CLK_ENABLE();    \
+                                     __ETHMACRX_CLK_ENABLE();    \
+                                    } while(0)
+/**
+  * @brief  Disable ETHERNET clock.
+  */
+#define __ETH_CLK_DISABLE()       do {                             \
+                                      __ETHMACTX_CLK_DISABLE();    \
+                                      __ETHMACRX_CLK_DISABLE();    \
+                                      __ETHMAC_CLK_DISABLE();      \
+                                     } while(0)
+                                     
+/** @brief  Enable or disable the AHB2 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it.
+  */
+ 
+#define __DCMI_CLK_ENABLE()   (RCC->AHB2ENR |= (RCC_AHB2ENR_DCMIEN))
+#define __DCMI_CLK_DISABLE()  (RCC->AHB2ENR &= ~(RCC_AHB2ENR_DCMIEN))
+
+#if defined(STM32F437xx)|| defined(STM32F439xx)
+#define __CRYP_CLK_ENABLE()   (RCC->AHB2ENR |= (RCC_AHB2ENR_CRYPEN))
+#define __HASH_CLK_ENABLE()   (RCC->AHB2ENR |= (RCC_AHB2ENR_HASHEN))
+
+#define __CRYP_CLK_DISABLE()  (RCC->AHB2ENR &= ~(RCC_AHB2ENR_CRYPEN))
+#define __HASH_CLK_DISABLE()  (RCC->AHB2ENR &= ~(RCC_AHB2ENR_HASHEN))
+#endif /* STM32F437xx || STM32F439xx */
+
+/** @brief  Enables or disables the AHB3 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it. 
+  */
+#define __FMC_CLK_ENABLE()   (RCC->AHB3ENR |= (RCC_AHB3ENR_FMCEN))
+#define __FMC_CLK_DISABLE()  (RCC->AHB3ENR &= ~(RCC_AHB3ENR_FMCEN))
+
+/** @brief  Enable or disable the Low Speed APB (APB1) peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it. 
+  */
+#define __TIM6_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_TIM6EN))
+#define __TIM7_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_TIM7EN))
+#define __TIM12_CLK_ENABLE()   (RCC->APB1ENR |= (RCC_APB1ENR_TIM12EN))
+#define __TIM13_CLK_ENABLE()   (RCC->APB1ENR |= (RCC_APB1ENR_TIM13EN))
+#define __TIM14_CLK_ENABLE()   (RCC->APB1ENR |= (RCC_APB1ENR_TIM14EN))
+#define __WWDG_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_WWDGEN))
+#define __USART3_CLK_ENABLE()  (RCC->APB1ENR |= (RCC_APB1ENR_USART3EN))
+#define __UART4_CLK_ENABLE()   (RCC->APB1ENR |= (RCC_APB1ENR_UART4EN))
+#define __UART5_CLK_ENABLE()   (RCC->APB1ENR |= (RCC_APB1ENR_UART5EN))
+#define __CAN1_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_CAN1EN))
+#define __CAN2_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_CAN2EN))
+#define __DAC_CLK_ENABLE()     (RCC->APB1ENR |= (RCC_APB1ENR_DACEN))
+#define __UART7_CLK_ENABLE()   (RCC->APB1ENR |= (RCC_APB1ENR_UART7EN))
+#define __UART8_CLK_ENABLE()   (RCC->APB1ENR |= (RCC_APB1ENR_UART8EN))
+
+#define __TIM6_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM6EN))
+#define __TIM7_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM7EN))
+#define __TIM12_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM12EN))
+#define __TIM13_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM13EN))
+#define __TIM14_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM14EN))
+#define __WWDG_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_WWDGEN))
+#define __USART3_CLK_DISABLE() (RCC->APB1ENR &= ~(RCC_APB1ENR_USART3EN))
+#define __UART4_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_UART4EN))
+#define __UART5_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_UART5EN))
+#define __CAN1_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_CAN1EN))
+#define __CAN2_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_CAN2EN))
+#define __DAC_CLK_DISABLE()    (RCC->APB1ENR &= ~(RCC_APB1ENR_DACEN))
+#define __UART7_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_UART7EN))
+#define __UART8_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_UART8EN))
+
+/** @brief  Enable or disable the High Speed APB (APB2) peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it.
+  */
+#define __TIM8_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_TIM8EN))
+#define __ADC2_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_ADC2EN))
+#define __ADC3_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_ADC3EN))
+#define __SPI5_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_SPI5EN))
+#define __SPI6_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_SPI6EN))
+#define __SAI1_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_SAI1EN))
+
+#define __TIM8_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM8EN))
+#define __ADC2_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_ADC2EN))
+#define __ADC3_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_ADC3EN))
+#define __SPI5_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI5EN))
+#define __SPI6_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI6EN))
+#define __SAI1_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_SAI1EN))
+
+#if defined(STM32F429xx)|| defined(STM32F439xx)
+#define __LTDC_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_LTDCEN))
+
+#define __LTDC_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_LTDCEN))
+#endif /* STM32F429xx || STM32F439xx */
+
+/** @brief  Force or release AHB1 peripheral reset.
+  */  
+#define __GPIOF_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOFRST))
+#define __GPIOG_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOGRST))
+#define __GPIOI_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOIRST))
+#define __ETHMAC_FORCE_RESET()   (RCC->AHB1RSTR |= (RCC_AHB1RSTR_ETHMACRST))
+#define __OTGHS_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_OTGHRST))
+#define __GPIOJ_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOJRST))
+#define __GPIOK_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOKRST))
+#define __DMA2D_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_DMA2DRST))
+
+#define __GPIOF_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOFRST))
+#define __GPIOG_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOGRST))
+#define __GPIOI_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOIRST))
+#define __ETHMAC_RELEASE_RESET() (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_ETHMACRST))
+#define __OTGHS_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_OTGHRST))
+#define __GPIOJ_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOJRST))
+#define __GPIOK_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOKRST))
+#define __DMA2D_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_DMA2DRST))
+ 
+/** @brief  Force or release AHB2 peripheral reset.
+  */
+#define __DCMI_FORCE_RESET()   (RCC->AHB2RSTR |= (RCC_AHB2RSTR_DCMIRST))
+#define __DCMI_RELEASE_RESET() (RCC->AHB2RSTR &= ~(RCC_AHB2RSTR_DCMIRST))
+
+#if defined(STM32F437xx)|| defined(STM32F439xx) 
+#define __CRYP_FORCE_RESET()   (RCC->AHB2RSTR |= (RCC_AHB2RSTR_CRYPRST))
+#define __HASH_FORCE_RESET()   (RCC->AHB2RSTR |= (RCC_AHB2RSTR_HASHRST))
+
+#define __CRYP_RELEASE_RESET() (RCC->AHB2RSTR &= ~(RCC_AHB2RSTR_CRYPRST))
+#define __HASH_RELEASE_RESET() (RCC->AHB2RSTR &= ~(RCC_AHB2RSTR_HASHRST))
+#endif /* STM32F437xx || STM32F439xx */
+
+/** @brief  Force or release AHB3 peripheral reset
+  */ 
+#define __FMC_FORCE_RESET()    (RCC->AHB3RSTR |= (RCC_AHB3RSTR_FMCRST))
+#define __FMC_RELEASE_RESET()  (RCC->AHB3RSTR &= ~(RCC_AHB3RSTR_FMCRST))
+ 
+/** @brief  Force or release APB1 peripheral reset.
+  */ 
+#define __TIM6_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM6RST))
+#define __TIM7_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM7RST))
+#define __TIM12_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM12RST))
+#define __TIM13_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM13RST))
+#define __TIM14_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM14RST))
+#define __USART3_FORCE_RESET()   (RCC->APB1RSTR |= (RCC_APB1RSTR_USART3RST))
+#define __UART4_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_UART4RST))
+#define __UART5_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_UART5RST))
+#define __CAN1_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_CAN1RST))
+#define __CAN2_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_CAN2RST))
+#define __DAC_FORCE_RESET()      (RCC->APB1RSTR |= (RCC_APB1RSTR_DACRST))
+#define __UART7_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_UART7RST))
+#define __UART8_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_UART8RST))
+
+#define __TIM6_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM6RST))
+#define __TIM7_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM7RST))
+#define __TIM12_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM12RST))
+#define __TIM13_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM13RST))
+#define __TIM14_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM14RST))
+#define __USART3_RELEASE_RESET() (RCC->APB1RSTR &= ~(RCC_APB1RSTR_USART3RST))
+#define __UART4_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_UART4RST))
+#define __UART5_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_UART5RST))
+#define __CAN1_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_CAN1RST))
+#define __CAN2_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_CAN2RST))
+#define __DAC_RELEASE_RESET()    (RCC->APB1RSTR &= ~(RCC_APB1RSTR_DACRST))
+#define __UART7_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_UART7RST))
+#define __UART8_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_UART8RST))
+
+/** @brief  Force or release APB2 peripheral reset.
+  */
+#define __TIM8_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_TIM8RST))
+#define __SPI5_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI5RST))
+#define __SPI6_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI6RST))
+#define __SAI1_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_SAI1RST))
+
+#define __TIM8_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_TIM8RST))
+#define __SPI5_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SPI5RST))
+#define __SPI6_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SPI6RST))
+#define __SAI1_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SAI1RST))
+
+#if defined(STM32F429xx)|| defined(STM32F439xx)
+#define __LTDC_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_LTDCRST))
+#define __LTDC_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_LTDCRST))
+#endif /* STM32F429xx|| STM32F439xx */
+
+/** @brief  Enable or disable the AHB1 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */ 
+#define __GPIOF_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOFLPEN))
+#define __GPIOG_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOGLPEN))
+#define __GPIOI_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOILPEN))
+#define __SRAM2_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_SRAM2LPEN))
+#define __ETHMAC_CLK_SLEEP_ENABLE()     (RCC->AHB1LPENR |= (RCC_AHB1LPENR_ETHMACLPEN))
+#define __ETHMACTX_CLK_SLEEP_ENABLE()   (RCC->AHB1LPENR |= (RCC_AHB1LPENR_ETHMACTXLPEN))
+#define __ETHMACRX_CLK_SLEEP_ENABLE()   (RCC->AHB1LPENR |= (RCC_AHB1LPENR_ETHMACRXLPEN))
+#define __ETHMACPTP_CLK_SLEEP_ENABLE()  (RCC->AHB1LPENR |= (RCC_AHB1LPENR_ETHMACPTPLPEN))
+#define __OTGHS_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_OTGHSLPEN))
+#define __OTGHSULPI_CLK_SLEEP_ENABLE()  (RCC->AHB1LPENR |= (RCC_AHB1LPENR_OTGHSULPILPEN))
+#define __GPIOJ_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOJLPEN))
+#define __GPIOK_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOKLPEN))
+#define __SRAM3_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_SRAM3LPEN))
+#define __DMA2D_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_DMA2DLPEN))
+
+#define __GPIOF_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOFLPEN))
+#define __GPIOG_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOGLPEN))
+#define __GPIOI_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOILPEN))
+#define __SRAM2_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_SRAM2LPEN))
+#define __ETHMAC_CLK_SLEEP_DISABLE()    (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_ETHMACLPEN))
+#define __ETHMACTX_CLK_SLEEP_DISABLE()  (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_ETHMACTXLPEN))
+#define __ETHMACRX_CLK_SLEEP_DISABLE()  (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_ETHMACRXLPEN))
+#define __ETHMACPTP_CLK_SLEEP_DISABLE() (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_ETHMACPTPLPEN))
+#define __OTGHS_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_OTGHSLPEN))
+#define __OTGHSULPI_CLK_SLEEP_DISABLE() (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_OTGHSULPILPEN))
+#define __GPIOJ_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOJLPEN))
+#define __GPIOK_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOKLPEN))
+#define __DMA2D_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_DMA2DLPEN))
+
+/** @brief  Enable or disable the AHB2 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __DCMI_CLK_SLEEP_ENABLE()  (RCC->AHB2LPENR |= (RCC_AHB2LPENR_DCMILPEN))
+#define __DCMI_CLK_SLEEP_DISABLE() (RCC->AHB2LPENR &= ~(RCC_AHB2LPENR_DCMILPEN))
+
+#if defined(STM32F437xx)|| defined(STM32F439xx) 
+#define __CRYP_CLK_SLEEP_ENABLE()  (RCC->AHB2LPENR |= (RCC_AHB2LPENR_CRYPLPEN))
+#define __HASH_CLK_SLEEP_ENABLE()  (RCC->AHB2LPENR |= (RCC_AHB2LPENR_HASHLPEN))
+
+#define __CRYP_CLK_SLEEP_DISABLE() (RCC->AHB2LPENR &= ~(RCC_AHB2LPENR_CRYPLPEN))
+#define __HASH_CLK_SLEEP_DISABLE() (RCC->AHB2LPENR &= ~(RCC_AHB2LPENR_HASHLPEN))
+#endif /* STM32F437xx || STM32F439xx */
+
+/** @brief  Enable or disable the AHB3 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __FMC_CLK_SLEEP_ENABLE()  (RCC->AHB3LPENR |= (RCC_AHB3LPENR_FMCLPEN))
+#define __FMC_CLK_SLEEP_DISABLE() (RCC->AHB3LPENR &= ~(RCC_AHB3LPENR_FMCLPEN))
+
+/** @brief  Enable or disable the APB1 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */  
+#define __TIM6_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM6LPEN))
+#define __TIM7_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM7LPEN))
+#define __TIM12_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM12LPEN))
+#define __TIM13_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM13LPEN))
+#define __TIM14_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM14LPEN))
+#define __USART3_CLK_SLEEP_ENABLE()  (RCC->APB1LPENR |= (RCC_APB1LPENR_USART3LPEN))
+#define __UART4_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_UART4LPEN))
+#define __UART5_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_UART5LPEN))
+#define __CAN1_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_CAN1LPEN))
+#define __CAN2_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_CAN2LPEN))
+#define __DAC_CLK_SLEEP_ENABLE()     (RCC->APB1LPENR |= (RCC_APB1LPENR_DACLPEN))
+#define __UART7_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_UART7LPEN))
+#define __UART8_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_UART8LPEN))
+
+#define __TIM6_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_TIM6LPEN))
+#define __TIM7_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_TIM7LPEN))
+#define __TIM12_CLK_SLEEP_DISABLE()  (RCC->APB1LPENR &= ~(RCC_APB1LPENR_TIM12LPEN))
+#define __TIM13_CLK_SLEEP_DISABLE()  (RCC->APB1LPENR &= ~(RCC_APB1LPENR_TIM13LPEN))
+#define __TIM14_CLK_SLEEP_DISABLE()  (RCC->APB1LPENR &= ~(RCC_APB1LPENR_TIM14LPEN))
+#define __USART3_CLK_SLEEP_DISABLE() (RCC->APB1LPENR &= ~(RCC_APB1LPENR_USART3LPEN))
+#define __UART4_CLK_SLEEP_DISABLE()  (RCC->APB1LPENR &= ~(RCC_APB1LPENR_UART4LPEN))
+#define __UART5_CLK_SLEEP_DISABLE()  (RCC->APB1LPENR &= ~(RCC_APB1LPENR_UART5LPEN))
+#define __CAN1_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_CAN1LPEN))
+#define __CAN2_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_CAN2LPEN))
+#define __DAC_CLK_SLEEP_DISABLE()    (RCC->APB1LPENR &= ~(RCC_APB1LPENR_DACLPEN))
+#define __UART7_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_UART7LPEN))
+#define __UART8_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_UART8LPEN))
+
+/** @brief  Enable or disable the APB2 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */ 
+#define __TIM8_CLK_SLEEP_ENABLE() (RCC->APB2LPENR |= (RCC_APB2LPENR_TIM8LPEN))
+#define __ADC2_CLK_SLEEP_ENABLE() (RCC->APB2LPENR |= (RCC_APB2LPENR_ADC2LPEN))
+#define __ADC3_CLK_SLEEP_ENABLE() (RCC->APB2LPENR |= (RCC_APB2LPENR_ADC3LPEN))
+#define __SPI5_CLK_SLEEP_ENABLE() (RCC->APB2LPENR |= (RCC_APB2LPENR_SPI5LPEN))
+#define __SPI6_CLK_SLEEP_ENABLE() (RCC->APB2LPENR |= (RCC_APB2LPENR_SPI6LPEN))
+#define __SAI1_CLK_SLEEP_ENABLE() (RCC->APB2LPENR |= (RCC_APB2LPENR_SAI1LPEN))
+
+#define __TIM8_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_TIM8LPEN))
+#define __ADC2_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_ADC2LPEN))
+#define __ADC3_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_ADC3LPEN))
+#define __SPI5_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_SPI5LPEN))
+#define __SPI6_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_SPI6LPEN))
+#define __SAI1_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_SAI1LPEN))
+
+#if defined(STM32F429xx)|| defined(STM32F439xx)
+#define __LTDC_CLK_SLEEP_ENABLE() (RCC->APB2LPENR |= (RCC_APB2LPENR_LTDCLPEN))
+
+#define __LTDC_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_LTDCLPEN))
+#endif /* STM32F429xx || STM32F439xx */
+#endif /* STM32F427xx || STM32F437xx || STM32F429xx|| STM32F439xx */
+/*---------------------------------------------------------------------------------------------*/
+
+/*----------------------------------- STM32F40xxx/STM32F41xxx----------------------------------*/
+#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx)|| defined(STM32F417xx)
+/** @brief  Enables or disables the AHB1 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it.
+  */
+#define __GPIOI_CLK_ENABLE()            (RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOIEN))
+#define __GPIOF_CLK_ENABLE()            (RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOFEN))
+#define __GPIOG_CLK_ENABLE()            (RCC->AHB1ENR |= (RCC_AHB1ENR_GPIOGEN))
+#define __USB_OTG_HS_CLK_ENABLE()       (RCC->AHB1ENR |= (RCC_AHB1ENR_OTGHSEN))
+#define __USB_OTG_HS_ULPI_CLK_ENABLE()  (RCC->AHB1ENR |= (RCC_AHB1ENR_OTGHSULPIEN))
+
+#define __GPIOF_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOFEN))
+#define __GPIOG_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOGEN))
+#define __GPIOI_CLK_DISABLE()           (RCC->AHB1ENR &= ~(RCC_AHB1ENR_GPIOIEN))
+#define __USB_OTG_HS_CLK_DISABLE()      (RCC->AHB1ENR &= ~(RCC_AHB1ENR_OTGHSEN))
+#define __USB_OTG_HS_ULPI_CLK_DISABLE() (RCC->AHB1ENR &= ~(RCC_AHB1ENR_OTGHSULPIEN))
+
+#if defined(STM32F407xx)|| defined(STM32F417xx)
+/**
+  * @brief  Enable ETHERNET clock.
+  */
+#define __ETHMAC_CLK_ENABLE()     (RCC->AHB1ENR |= (RCC_AHB1ENR_ETHMACEN))
+#define __ETHMACTX_CLK_ENABLE()   (RCC->AHB1ENR |= (RCC_AHB1ENR_ETHMACTXEN))
+#define __ETHMACRX_CLK_ENABLE()   (RCC->AHB1ENR |= (RCC_AHB1ENR_ETHMACRXEN))
+#define __ETHMACPTP_CLK_ENABLE()  (RCC->AHB1ENR |= (RCC_AHB1ENR_ETHMACPTPEN))  
 #define __ETH_CLK_ENABLE()       do {                            \
                                      __ETHMAC_CLK_ENABLE();      \
                                      __ETHMACTX_CLK_ENABLE();    \
@@ -347,54 +700,48 @@ typedef struct
 /**
   * @brief  Disable ETHERNET clock.
   */
+#define __ETHMAC_CLK_DISABLE()    (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACEN))
+#define __ETHMACTX_CLK_DISABLE()  (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACTXEN))
+#define __ETHMACRX_CLK_DISABLE()  (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACRXEN))
+#define __ETHMACPTP_CLK_DISABLE() (RCC->AHB1ENR &= ~(RCC_AHB1ENR_ETHMACPTPEN))  
 #define __ETH_CLK_DISABLE()       do {                             \
                                       __ETHMACTX_CLK_DISABLE();    \
                                       __ETHMACRX_CLK_DISABLE();    \
                                       __ETHMAC_CLK_DISABLE();      \
                                      } while(0)
-#endif /* !(STM32F401xC && STM32F401xE) */
+#endif /* STM32F407xx || STM32F417xx */
  
 /** @brief  Enable or disable the AHB2 peripheral clock.
   * @note   After reset, the peripheral clock (used for registers read/write access)
   *         is disabled and the application software has to enable this clock before 
   *         using it.
   */
-#if !defined(STM32F401xC) && !defined(STM32F401xE)  
+#if defined(STM32F407xx)|| defined(STM32F417xx) 
 #define __DCMI_CLK_ENABLE()   (RCC->AHB2ENR |= (RCC_AHB2ENR_DCMIEN))
 #define __DCMI_CLK_DISABLE()  (RCC->AHB2ENR &= ~(RCC_AHB2ENR_DCMIEN))
-#endif /* !(STM32F401xC && STM32F401xE) */
+#endif /* STM32F407xx || STM32F417xx */
 
-#if defined(STM32F415xx) || defined(STM32F417xx) || defined(STM32F437xx)|| defined(STM32F439xx)
+#if defined(STM32F415xx) || defined(STM32F417xx)
 #define __CRYP_CLK_ENABLE()   (RCC->AHB2ENR |= (RCC_AHB2ENR_CRYPEN))
 #define __HASH_CLK_ENABLE()   (RCC->AHB2ENR |= (RCC_AHB2ENR_HASHEN))
 
 #define __CRYP_CLK_DISABLE()  (RCC->AHB2ENR &= ~(RCC_AHB2ENR_CRYPEN))
 #define __HASH_CLK_DISABLE()  (RCC->AHB2ENR &= ~(RCC_AHB2ENR_HASHEN))
-
-#endif /* STM32F415xx || STM32F417xx || STM32F437xx || STM32F439xx */
+#endif /* STM32F415xx || STM32F417xx */
 
 /** @brief  Enables or disables the AHB3 peripheral clock.
   * @note   After reset, the peripheral clock (used for registers read/write access)
   *         is disabled and the application software has to enable this clock before 
   *         using it. 
   */
-#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx)|| defined(STM32F417xx)
 #define __FSMC_CLK_ENABLE()  (RCC->AHB3ENR |= (RCC_AHB3ENR_FSMCEN))
 #define __FSMC_CLK_DISABLE() (RCC->AHB3ENR &= ~(RCC_AHB3ENR_FSMCEN))
-#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx */
-
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx)
-#define __FMC_CLK_ENABLE()   (RCC->AHB3ENR |= (RCC_AHB3ENR_FMCEN))
-#define __FMC_CLK_DISABLE()  (RCC->AHB3ENR &= ~(RCC_AHB3ENR_FMCEN))
-#endif /* STM32F415xx || STM32F417xx || STM32F437xx || STM32F439xx */
-
 
 /** @brief  Enable or disable the Low Speed APB (APB1) peripheral clock.
   * @note   After reset, the peripheral clock (used for registers read/write access)
   *         is disabled and the application software has to enable this clock before 
   *         using it. 
   */
-#if !defined(STM32F401xC) && !defined(STM32F401xE)
 #define __TIM6_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_TIM6EN))
 #define __TIM7_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_TIM7EN))
 #define __TIM12_CLK_ENABLE()   (RCC->APB1ENR |= (RCC_APB1ENR_TIM12EN))
@@ -420,22 +767,12 @@ typedef struct
 #define __CAN1_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_CAN1EN))
 #define __CAN2_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_CAN2EN))
 #define __DAC_CLK_DISABLE()    (RCC->APB1ENR &= ~(RCC_APB1ENR_DACEN))
-#endif /* !(STM32F401xC && STM32F401xE) */
-
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx)
-#define __UART7_CLK_ENABLE()   (RCC->APB1ENR |= (RCC_APB1ENR_UART7EN))
-#define __UART8_CLK_ENABLE()   (RCC->APB1ENR |= (RCC_APB1ENR_UART8EN))
-
-#define __UART7_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_UART7EN))
-#define __UART8_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_UART8EN))
-#endif /* STM32F415xx || STM32F417xx || STM32F437xx || STM32F439xx */
 
 /** @brief  Enable or disable the High Speed APB (APB2) peripheral clock.
   * @note   After reset, the peripheral clock (used for registers read/write access)
   *         is disabled and the application software has to enable this clock before 
   *         using it.
   */
-#if !defined(STM32F401xC) && !defined(STM32F401xE)  
 #define __TIM8_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_TIM8EN))
 #define __ADC2_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_ADC2EN))
 #define __ADC3_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_ADC3EN))
@@ -443,23 +780,9 @@ typedef struct
 #define __TIM8_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM8EN))
 #define __ADC2_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_ADC2EN))
 #define __ADC3_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_ADC3EN))
-#endif /* !(STM32F401xC && STM32F401xE) */
-
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx)
-#define __SPI5_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_SPI5EN))
-#define __SPI6_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_SPI6EN))
-#define __SAI1_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_SAI1EN))
-#define __LTDC_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_LTDCEN))
-
-#define __SPI5_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI5EN))
-#define __SPI6_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI6EN))
-#define __SAI1_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_SAI1EN))
-#define __LTDC_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_LTDCEN))
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 
 /** @brief  Force or release AHB1 peripheral reset.
   */  
-#if !defined(STM32F401xC) && !defined(STM32F401xE)
 #define __GPIOF_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOFRST))
 #define __GPIOG_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOGRST))
 #define __GPIOI_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOIRST))
@@ -471,49 +794,30 @@ typedef struct
 #define __GPIOI_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOIRST))
 #define __ETHMAC_RELEASE_RESET() (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_ETHMACRST))
 #define __OTGHS_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_OTGHRST))
-#endif /* !STM32F401xC && STM32F401xE */
 
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) 
-#define __GPIOJ_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOJRST))
-#define __GPIOK_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_GPIOKRST))
-#define __DMA2D_FORCE_RESET()    (RCC->AHB1RSTR |= (RCC_AHB1RSTR_DMA2DRST))
-
-#define __GPIOJ_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOJRST))
-#define __GPIOK_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_GPIOKRST))
-#define __DMA2D_RELEASE_RESET()  (RCC->AHB1RSTR &= ~(RCC_AHB1RSTR_DMA2DRST))
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
- 
 /** @brief  Force or release AHB2 peripheral reset.
   */
-#if !defined(STM32F401xC) && !defined(STM32F401xE) 
+#if defined(STM32F407xx)|| defined(STM32F417xx)  
 #define __DCMI_FORCE_RESET()   (RCC->AHB2RSTR |= (RCC_AHB2RSTR_DCMIRST))
 #define __DCMI_RELEASE_RESET() (RCC->AHB2RSTR &= ~(RCC_AHB2RSTR_DCMIRST))
-#endif /* !STM32F401xC && STM32F401xE */
+#endif /* STM32F407xx || STM32F417xx */
 
-#if defined(STM32F415xx) || defined(STM32F417xx) || defined(STM32F437xx)|| defined(STM32F439xx) 
+#if defined(STM32F415xx) || defined(STM32F417xx) 
 #define __CRYP_FORCE_RESET()   (RCC->AHB2RSTR |= (RCC_AHB2RSTR_CRYPRST))
 #define __HASH_FORCE_RESET()   (RCC->AHB2RSTR |= (RCC_AHB2RSTR_HASHRST))
 
 #define __CRYP_RELEASE_RESET() (RCC->AHB2RSTR &= ~(RCC_AHB2RSTR_CRYPRST))
 #define __HASH_RELEASE_RESET() (RCC->AHB2RSTR &= ~(RCC_AHB2RSTR_HASHRST))
 
-#endif /* STM32F415xx || STM32F417xx || STM32F437xx || STM32F439xx */
+#endif /* STM32F415xx || STM32F417xx */
 
 /** @brief  Force or release AHB3 peripheral reset
   */
-#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx)|| defined(STM32F417xx)
 #define __FSMC_FORCE_RESET()   (RCC->AHB3RSTR |= (RCC_AHB3RSTR_FSMCRST))
 #define __FSMC_RELEASE_RESET() (RCC->AHB3RSTR &= ~(RCC_AHB3RSTR_FSMCRST))
-#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx */
 
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) 
-#define __FMC_FORCE_RESET()    (RCC->AHB3RSTR |= (RCC_AHB3RSTR_FMCRST))
-#define __FMC_RELEASE_RESET()  (RCC->AHB3RSTR &= ~(RCC_AHB3RSTR_FMCRST))
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
- 
 /** @brief  Force or release APB1 peripheral reset.
-  */
-#if !defined(STM32F401xC) && !defined(STM32F401xE)  
+  */ 
 #define __TIM6_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM6RST))
 #define __TIM7_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM7RST))
 #define __TIM12_FORCE_RESET()    (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM12RST))
@@ -537,43 +841,18 @@ typedef struct
 #define __CAN1_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_CAN1RST))
 #define __CAN2_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_CAN2RST))
 #define __DAC_RELEASE_RESET()    (RCC->APB1RSTR &= ~(RCC_APB1RSTR_DACRST))
-#endif /* !STM32F401xC && STM32F401xE */
-
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx)
-#define __UART7_FORCE_RESET()   (RCC->APB1RSTR |= (RCC_APB1RSTR_UART7RST))
-#define __UART8_FORCE_RESET()   (RCC->APB1RSTR |= (RCC_APB1RSTR_UART8RST))
-
-#define __UART7_RELEASE_RESET() (RCC->APB1RSTR &= ~(RCC_APB1RSTR_UART7RST))
-#define __UART8_RELEASE_RESET() (RCC->APB1RSTR &= ~(RCC_APB1RSTR_UART8RST))
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 
 /** @brief  Force or release APB2 peripheral reset.
   */
-#if !defined(STM32F401xC) && !defined(STM32F401xE) 
 #define __TIM8_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_TIM8RST))
 #define __TIM8_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_TIM8RST))
-#endif /* !STM32F401xC && STM32F401xE */
-
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx)
-#define __SPI5_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI5RST))
-#define __SPI6_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI6RST))
-#define __SAI1_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_SAI1RST))
-#define __LTDC_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_LTDCRST))
-
-#define __SPI5_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SPI5RST))
-#define __SPI6_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SPI6RST))
-#define __SAI1_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SAI1RST))
-#define __LTDC_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_LTDCRST))
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
-
 
 /** @brief  Enable or disable the AHB1 peripheral clock during Low Power (Sleep) mode.
   * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
   *         power consumption.
   * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
   * @note   By default, all peripheral clocks are enabled during SLEEP mode.
-  */
-#if !defined(STM32F401xC) && !defined(STM32F401xE)  
+  */   
 #define __GPIOF_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOFLPEN))
 #define __GPIOG_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOGLPEN))
 #define __GPIOI_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOILPEN))
@@ -595,18 +874,6 @@ typedef struct
 #define __ETHMACPTP_CLK_SLEEP_DISABLE() (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_ETHMACPTPLPEN))
 #define __OTGHS_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_OTGHSLPEN))
 #define __OTGHSULPI_CLK_SLEEP_DISABLE() (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_OTGHSULPILPEN))
-#endif /* !STM32F401xC && STM32F401xE */
-
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx)
-#define __GPIOJ_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOJLPEN))
-#define __GPIOK_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_GPIOKLPEN))
-#define __SRAM3_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_SRAM3LPEN))
-#define __DMA2D_CLK_SLEEP_ENABLE()      (RCC->AHB1LPENR |= (RCC_AHB1LPENR_DMA2DLPEN))
-
-#define __GPIOJ_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOJLPEN))
-#define __GPIOK_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_GPIOKLPEN))
-#define __DMA2D_CLK_SLEEP_DISABLE()     (RCC->AHB1LPENR &= ~(RCC_AHB1LPENR_DMA2DLPEN))
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 
 /** @brief  Enable or disable the AHB2 peripheral clock during Low Power (Sleep) mode.
   * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
@@ -614,19 +881,18 @@ typedef struct
   * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
   * @note   By default, all peripheral clocks are enabled during SLEEP mode.
   */
-#if !defined(STM32F401xC) && !defined(STM32F401xE)
+#if defined(STM32F407xx)|| defined(STM32F417xx) 
 #define __DCMI_CLK_SLEEP_ENABLE()  (RCC->AHB2LPENR |= (RCC_AHB2LPENR_DCMILPEN))
 #define __DCMI_CLK_SLEEP_DISABLE() (RCC->AHB2LPENR &= ~(RCC_AHB2LPENR_DCMILPEN))
-#endif /* !STM32F401xC && STM32F401xE */
+#endif /* STM32F407xx || STM32F417xx */
 
-#if defined(STM32F415xx) || defined(STM32F417xx) || defined(STM32F437xx)|| defined(STM32F439xx) 
+#if defined(STM32F415xx) || defined(STM32F417xx) 
 #define __CRYP_CLK_SLEEP_ENABLE()  (RCC->AHB2LPENR |= (RCC_AHB2LPENR_CRYPLPEN))
 #define __HASH_CLK_SLEEP_ENABLE()  (RCC->AHB2LPENR |= (RCC_AHB2LPENR_HASHLPEN))
 
 #define __CRYP_CLK_SLEEP_DISABLE() (RCC->AHB2LPENR &= ~(RCC_AHB2LPENR_CRYPLPEN))
 #define __HASH_CLK_SLEEP_DISABLE() (RCC->AHB2LPENR &= ~(RCC_AHB2LPENR_HASHLPEN))
-
-#endif /* STM32F415xx || STM32F417xx || STM32F437xx || STM32F439xx */
+#endif /* STM32F415xx || STM32F417xx */
 
 /** @brief  Enable or disable the AHB3 peripheral clock during Low Power (Sleep) mode.
   * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
@@ -634,15 +900,8 @@ typedef struct
   * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
   * @note   By default, all peripheral clocks are enabled during SLEEP mode.
   */
-#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx)|| defined(STM32F417xx)
 #define __FSMC_CLK_SLEEP_ENABLE()  (RCC->AHB3LPENR |= (RCC_AHB3LPENR_FSMCLPEN))
 #define __FSMC_CLK_SLEEP_DISABLE() (RCC->AHB3LPENR &= ~(RCC_AHB3LPENR_FSMCLPEN))
-#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx */
-
-#if defined(STM32F415xx) || defined(STM32F417xx) || defined(STM32F437xx)|| defined(STM32F439xx) 
-#define __FMC_CLK_SLEEP_ENABLE()  (RCC->AHB3LPENR |= (RCC_AHB3LPENR_FMCLPEN))
-#define __FMC_CLK_SLEEP_DISABLE() (RCC->AHB3LPENR &= ~(RCC_AHB3LPENR_FMCLPEN))
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 
 /** @brief  Enable or disable the APB1 peripheral clock during Low Power (Sleep) mode.
   * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
@@ -650,7 +909,6 @@ typedef struct
   * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
   * @note   By default, all peripheral clocks are enabled during SLEEP mode.
   */
-#if !defined(STM32F401xC) && !defined(STM32F401xE)  
 #define __TIM6_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM6LPEN))
 #define __TIM7_CLK_SLEEP_ENABLE()    (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM7LPEN))
 #define __TIM12_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_TIM12LPEN))
@@ -674,23 +932,13 @@ typedef struct
 #define __CAN1_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_CAN1LPEN))
 #define __CAN2_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_CAN2LPEN))
 #define __DAC_CLK_SLEEP_DISABLE()    (RCC->APB1LPENR &= ~(RCC_APB1LPENR_DACLPEN))
-#endif /* !STM32F401xC && STM32F401xE */
-
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx)
-#define __UART7_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_UART7LPEN))
-#define __UART8_CLK_SLEEP_ENABLE()   (RCC->APB1LPENR |= (RCC_APB1LPENR_UART8LPEN))
-
-#define __UART7_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_UART7LPEN))
-#define __UART8_CLK_SLEEP_DISABLE()   (RCC->APB1LPENR &= ~(RCC_APB1LPENR_UART8LPEN))
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 
 /** @brief  Enable or disable the APB2 peripheral clock during Low Power (Sleep) mode.
   * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
   *         power consumption.
   * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
   * @note   By default, all peripheral clocks are enabled during SLEEP mode.
-  */
-#if !defined(STM32F401xC) && !defined(STM32F401xE)  
+  */ 
 #define __TIM8_CLK_SLEEP_ENABLE() (RCC->APB2LPENR |= (RCC_APB2LPENR_TIM8LPEN))
 #define __ADC2_CLK_SLEEP_ENABLE() (RCC->APB2LPENR |= (RCC_APB2LPENR_ADC2LPEN))
 #define __ADC3_CLK_SLEEP_ENABLE() (RCC->APB2LPENR |= (RCC_APB2LPENR_ADC3LPEN))
@@ -698,21 +946,31 @@ typedef struct
 #define __TIM8_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_TIM8LPEN))
 #define __ADC2_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_ADC2LPEN))
 #define __ADC3_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_ADC3LPEN))
-#endif /* !STM32F401xC && STM32F401xE */
+#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx */
+/*---------------------------------------------------------------------------------------------*/
 
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx)
+/*------------------------------------------ STM32F411xx --------------------------------------*/
+#if defined(STM32F411xE)
+/** @brief  Enable or disable the High Speed APB (APB2) peripheral clock.
+  */
+#define __SPI5_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_SPI5EN))
+#define __SPI5_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI5EN))
+                                       
+/** @brief  Force or release APB2 peripheral reset.
+  */
+#define __SPI5_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI5RST))
+#define __SPI5_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SPI5RST))                                    
+
+/** @brief  Enable or disable the APB2 peripheral clock during Low Power (Sleep) mode.
+  */ 
 #define __SPI5_CLK_SLEEP_ENABLE() (RCC->APB2LPENR |= (RCC_APB2LPENR_SPI5LPEN))
-#define __SPI6_CLK_SLEEP_ENABLE() (RCC->APB2LPENR |= (RCC_APB2LPENR_SPI6LPEN))
-#define __SAI1_CLK_SLEEP_ENABLE() (RCC->APB2LPENR |= (RCC_APB2LPENR_SAI1LPEN))
-#define __LTDC_CLK_SLEEP_ENABLE() (RCC->APB2LPENR |= (RCC_APB2LPENR_LTDCLPEN))
-
 #define __SPI5_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_SPI5LPEN))
-#define __SPI6_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_SPI6LPEN))
-#define __SAI1_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_SAI1LPEN))
-#define __LTDC_CLK_SLEEP_DISABLE() (RCC->APB2LPENR &= ~(RCC_APB2LPENR_LTDCLPEN))
-#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 
-#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx)
+#endif /* STM32F411xE */
+/*---------------------------------------------------------------------------------------------*/
+
+#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx)|| defined(STM32F439xx) ||\
+    defined(STM32F401xC) || defined(STM32F401xE) || defined(STM32F411xE)
                            
 /** @brief  Macro to configure the Timers clocks prescalers 
   * @note   This feature is only available with STM32F429x/439x Devices.  
@@ -729,6 +987,36 @@ typedef struct
   */     
 #define __HAL_RCC_TIMCLKPRESCALER(__PRESC__) (*(__IO uint32_t *) DCKCFGR_TIMPRE_BB = (__PRESC__))
 
+#endif /* STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx) || STM32F401xC || STM32F401xE || STM32F411xE */
+
+#if defined(STM32F411xE)
+                           
+/** @brief  Macro to configure the PLLI2S clock multiplication and division factors .
+  * @note   This macro must be used only when the PLLI2S is disabled.
+  * @note   This macro must be used only when the PLLI2S is disabled.
+  * @note   PLLI2S clock source is common with the main PLL (configured in 
+  *         HAL_RCC_ClockConfig() API).
+  * @param  __PLLI2SM__: specifies the division factor for PLLI2S VCO input clock
+  *         This parameter must be a number between Min_Data = 2 and Max_Data = 63.
+  * @note   You have to set the PLLI2SM parameter correctly to ensure that the VCO input
+  *         frequency ranges from 1 to 2 MHz. It is recommended to select a frequency
+  *         of 2 MHz to limit PLLI2S jitter.    
+  * @param  __PLLI2SN__: specifies the multiplication factor for PLLI2S VCO output clock
+  *         This parameter must be a number between Min_Data = 192 and Max_Data = 432.
+  * @note   You have to set the PLLI2SN parameter correctly to ensure that the VCO 
+  *         output frequency is between Min_Data = 192 and Max_Data = 432 MHz.
+  * @param  __PLLI2SR__: specifies the division factor for I2S clock
+  *         This parameter must be a number between Min_Data = 2 and Max_Data = 7.
+  * @note   You have to set the PLLI2SR parameter correctly to not exceed 192 MHz
+  *         on the I2S clock frequency.
+  */
+#define __HAL_RCC_PLLI2S_I2SCLK_CONFIG(__PLLI2SM__, __PLLI2SN__, __PLLI2SR__) (RCC->PLLI2SCFGR = ((__PLLI2SN__) << POSITION_VAL(RCC_PLLI2SCFGR_PLLI2SN)) |\
+                                                                                    ((__PLLI2SR__) << POSITION_VAL(RCC_PLLI2SCFGR_PLLI2SR)) | (__PLLI2SM__))
+#endif /* STM32F411xE */
+
+
+#if defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
+     
 /** @brief Macros to Enable or Disable the PLLISAI. 
   * @note  The PLLSAI is only available with STM32F429x/439x Devices.     
   * @note  The PLLSAI is disabled by hardware when entering STOP and STANDBY modes. 
@@ -857,6 +1145,9 @@ typedef struct
 HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit);
 void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit);
 
+#if defined(STM32F411xE)
+void HAL_RCCEx_SelectLSEMode(uint8_t Mode);
+#endif /* STM32F411xE */
 /**
   * @}
   */ 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rng.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rng.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_rng.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   RNG HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Random Number Generator (RNG) peripheral:
@@ -68,6 +68,9 @@
   */
 
 #ifdef HAL_RNG_MODULE_ENABLED
+
+#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx) ||\
+    defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
@@ -228,17 +231,18 @@ __weak void HAL_RNG_MspDeInit(RNG_HandleTypeDef *hrng)
 uint32_t HAL_RNG_GetRandomNumber(RNG_HandleTypeDef *hrng)
 {
   uint32_t random32bit = 0;
-  uint32_t timeout = 0;   
+  uint32_t tickstart = 0;    
   
   /* Process Locked */
   __HAL_LOCK(hrng); 
   
-  timeout = HAL_GetTick() + RNG_TIMEOUT_VALUE;
+  /* Get tick */
+  tickstart = HAL_GetTick();
   
   /* Check if data register contains valid random data */
   while(__HAL_RNG_GET_FLAG(hrng, RNG_FLAG_DRDY) == RESET)
   {
-    if(HAL_GetTick() >= timeout)
+    if((HAL_GetTick() - tickstart ) > RNG_TIMEOUT_VALUE)
     {    
       return HAL_TIMEOUT;
     } 
@@ -413,6 +417,8 @@ HAL_RNG_StateTypeDef HAL_RNG_GetState(RNG_HandleTypeDef *hrng)
   * @}
   */
 
+#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
+
 #endif /* HAL_RNG_MODULE_ENABLED */
 /**
   * @}
@@ -423,4 +429,3 @@ HAL_RNG_StateTypeDef HAL_RNG_GetState(RNG_HandleTypeDef *hrng)
   */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
-                  

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rng.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rng.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_rng.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of RNG HAL module.
   ******************************************************************************
   * @attention
@@ -43,6 +43,8 @@
  extern "C" {
 #endif
 
+#if defined(STM32F405xx) || defined(STM32F415xx) || defined(STM32F407xx) || defined(STM32F417xx) ||\
+    defined(STM32F427xx) || defined(STM32F437xx) || defined(STM32F429xx) || defined(STM32F439xx)
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f4xx_hal_def.h"
 
@@ -155,7 +157,7 @@ typedef struct
   * @param  __FLAG__: RNG flag
   * @retval None
   */
-#define __HAL_RNG_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) &= ~(__FLAG__))
+#define __HAL_RNG_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) = ~(__FLAG__))
     
 /**
   * @brief  Enables the RNG interrupts.
@@ -200,6 +202,8 @@ void HAL_RNG_ErrorCallback(RNG_HandleTypeDef *hrng);
 
 /* Peripheral State functions  **************************************************/
 HAL_RNG_StateTypeDef HAL_RNG_GetState(RNG_HandleTypeDef *hrng);
+
+#endif /* STM32F405xx || STM32F415xx || STM32F407xx || STM32F417xx || STM32F427xx || STM32F437xx || STM32F429xx || STM32F439xx */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rtc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rtc.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_rtc.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   RTC HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Real Time Clock (RTC) peripheral:
@@ -203,7 +203,7 @@
 HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc)
 {
   /* Check the RTC peripheral state */
-  if(hrtc == NULL)
+  if(hrtc == HAL_NULL)
   {
      return HAL_ERROR;
   }
@@ -275,7 +275,7 @@ HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc)
   */
 HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
 
   /* Set RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY; 
@@ -301,13 +301,14 @@ HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc)
     hrtc->Instance->DR = (uint32_t)0x00002101;
     /* Reset All CR bits except CR[2:0] */
     hrtc->Instance->CR &= (uint32_t)0x00000007;
-       
-    timeout = HAL_GetTick() + RTC_TIMEOUT_VALUE;
-    
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
     /* Wait till WUTWF flag is set and if Time out is reached exit */
     while(((hrtc->Instance->ISR) & RTC_ISR_WUTWF) == (uint32_t)RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
       { 
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc); 
@@ -756,7 +757,7 @@ HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDat
   */
 HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
   uint32_t tmpreg = 0, subsecondtmpreg = 0;
   
   /* Check the parameters */
@@ -855,12 +856,14 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
     
     /* In case of interrupt mode is used, the interrupt source must disabled */ 
     __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRA);
-         
-    timeout = HAL_GetTick() + RTC_TIMEOUT_VALUE;
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
     /* Wait till RTC ALRAWF flag is set and if Time out is reached exit */
     while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
       {
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -887,12 +890,14 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
     
     /* In case of interrupt mode is used, the interrupt source must disabled */ 
     __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRB);
-       
-    timeout = HAL_GetTick() + RTC_TIMEOUT_VALUE;
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
     /* Wait till RTC ALRBWF flag is set and if Time out is reached exit */
     while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
       {
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -938,7 +943,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
   */
 HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
   uint32_t tmpreg = 0, subsecondtmpreg = 0;
   
   /* Check the parameters */
@@ -1035,11 +1040,13 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
     /* Clear flag alarm A */
     __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
 
-    timeout = HAL_GetTick() + RTC_TIMEOUT_VALUE;
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
     /* Wait till RTC ALRAWF flag is set and if Time out is reached exit */
     while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
       {
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1069,11 +1076,13 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
     /* Clear flag alarm B */
     __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
 
-    timeout = HAL_GetTick() + RTC_TIMEOUT_VALUE;
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
     /* Wait till RTC ALRBWF flag is set and if Time out is reached exit */
     while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
       {
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1097,7 +1106,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
   }
 
   /* RTC Alarm Interrupt Configuration: EXTI configuration */
-  __HAL_RTC_ENABLE_IT(RTC_EXTI_LINE_ALARM_EVENT);
+  __HAL_RTC_EXTI_ENABLE_IT(RTC_EXTI_LINE_ALARM_EVENT);
   
   EXTI->RTSR |= RTC_EXTI_LINE_ALARM_EVENT;
   
@@ -1124,7 +1133,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
   */
 HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alarm)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
   
   /* Check the parameters */
   assert_param(IS_ALARM(Alarm));
@@ -1144,13 +1153,14 @@ HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alar
     
     /* In case of interrupt mode is used, the interrupt source must disabled */ 
     __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRA);
-    
-    timeout = HAL_GetTick() + RTC_TIMEOUT_VALUE;
-    
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
     /* Wait till RTC ALRxWF flag is set and if Time out is reached exit */
     while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
       { 
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1171,13 +1181,14 @@ HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alar
     
     /* In case of interrupt mode is used, the interrupt source must disabled */ 
     __HAL_RTC_ALARM_DISABLE_IT(hrtc,RTC_IT_ALRB);
-    
-    timeout = HAL_GetTick() + RTC_TIMEOUT_VALUE;
-    
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
     /* Wait till RTC ALRxWF flag is set and if Time out is reached exit */
     while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
       {
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1297,7 +1308,7 @@ void HAL_RTC_AlarmIRQHandler(RTC_HandleTypeDef* hrtc)
   }
   
   /* Clear the EXTI's line Flag for RTC Alarm */
-  __HAL_RTC_CLEAR_FLAG(RTC_EXTI_LINE_ALARM_EVENT);
+  __HAL_RTC_EXTI_CLEAR_FLAG(RTC_EXTI_LINE_ALARM_EVENT);
   
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY; 
@@ -1324,18 +1335,17 @@ __weak void HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc)
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
-{  
+{
+  uint32_t tickstart = 0; 
 
-  uint32_t timeout = 0; 
+    /* Get tick */
+    tickstart = HAL_GetTick();
 
-  /* Get Timeout value */
-  timeout = HAL_GetTick() + Timeout;   
-  
   while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAF) == RESET)
   {
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         hrtc->State = HAL_RTC_STATE_TIMEOUT;
         return HAL_TIMEOUT;
@@ -1388,17 +1398,18 @@ HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t T
   */
 HAL_StatusTypeDef HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
 
   /* Clear RSF flag */
   hrtc->Instance->ISR &= (uint32_t)RTC_RSF_MASK;
-  
-  timeout = HAL_GetTick() + RTC_TIMEOUT_VALUE;
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
 
   /* Wait the registers to be synchronised */
   while((hrtc->Instance->ISR & RTC_ISR_RSF) == (uint32_t)RESET)
   {
-    if(HAL_GetTick() >= timeout)
+    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
     {       
       return HAL_TIMEOUT;
     } 
@@ -1446,19 +1457,21 @@ HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef* hrtc)
   */
 HAL_StatusTypeDef RTC_EnterInitMode(RTC_HandleTypeDef* hrtc)
 {
-  uint32_t timeout = 0; 
+  uint32_t tickstart = 0; 
   
   /* Check if the Initialization mode is set */
   if((hrtc->Instance->ISR & RTC_ISR_INITF) == (uint32_t)RESET)
   {
     /* Set the Initialization mode */
     hrtc->Instance->ISR = (uint32_t)RTC_INIT_MASK;
-    
-    timeout = HAL_GetTick() + RTC_TIMEOUT_VALUE;
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
     /* Wait till RTC is in INIT state and if Time out is reached exit */
     while((hrtc->Instance->ISR & RTC_ISR_INITF) == (uint32_t)RESET)
     {
-      if(HAL_GetTick() >= timeout)
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
       {       
         return HAL_TIMEOUT;
       } 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rtc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rtc.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_rtc.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of RTC HAL module.
   ******************************************************************************
   * @attention
@@ -663,34 +663,55 @@ typedef struct
   * @brief  Enable the RTC Exti line.
   * @param  __EXTILINE__: specifies the RTC Exti sources to be enabled or disabled.
   *         This parameter can be:
-  *            @arg RTC_EXTI_LINE_ALARM_EVENT   
-  *            @arg RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT 
-  *            @arg RTC_EXTI_LINE_WAKEUPTIMER_EVENT      
+  *            @arg RTC_EXTI_LINE_ALARM_EVENT
+  *            @arg RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT
+  *            @arg RTC_EXTI_LINE_WAKEUPTIMER_EVENT
   * @retval None
-  */                                         
-#define __HAL_RTC_ENABLE_IT(__EXTILINE__)   (EXTI->IMR |= (__EXTILINE__))
+  */
+#define __HAL_RTC_EXTI_ENABLE_IT(__EXTILINE__)   (EXTI->IMR |= (__EXTILINE__))
+
+/* alias define maintained for legacy */
+#define __HAL_RTC_ENABLE_IT   __HAL_RTC_EXTI_ENABLE_IT
 
 /**
   * @brief  Disable the RTC Exti line.
   * @param  __EXTILINE__: specifies the RTC Exti sources to be enabled or disabled.
   *         This parameter can be:
-  *            @arg RTC_EXTI_LINE_ALARM_EVENT   
-  *            @arg RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT 
-  *            @arg RTC_EXTI_LINE_WAKEUPTIMER_EVENT     
+  *            @arg RTC_EXTI_LINE_ALARM_EVENT
+  *            @arg RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT
+  *            @arg RTC_EXTI_LINE_WAKEUPTIMER_EVENT
   * @retval None
   */
-#define __HAL_RTC_DISABLE_IT(__EXTILINE__)  (EXTI->IMR &= ~(__EXTILINE__))
+#define __HAL_RTC_EXTI_DISABLE_IT(__EXTILINE__)  (EXTI->IMR &= ~(__EXTILINE__))
+
+/* alias define maintained for legacy */
+#define __HAL_RTC_DISABLE_IT   __HAL_RTC_EXTI_DISABLE_IT
+
+/**
+  * @brief  Generates a Software interrupt on selected EXTI line.
+  * @param  __EXTILINE__: specifies the RTC Exti sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_EXTI_LINE_ALARM_EVENT
+  *            @arg RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT
+  *            @arg RTC_EXTI_LINE_WAKEUPTIMER_EVENT
+  * @retval None
+  */
+#define __HAL_RTC_EXTI_GENERATE_SWIT(__EXTI_LINE__) (EXTI->SWIER |= (__EXTI_LINE__))
 
 /**
   * @brief  Clear the RTC Exti flags.
   * @param  __FLAG__: specifies the RTC Exti sources to be enabled or disabled.
   *         This parameter can be:
-  *            @arg RTC_EXTI_LINE_ALARM_EVENT   
-  *            @arg RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT 
-  *            @arg RTC_EXTI_LINE_WAKEUPTIMER_EVENT      
+  *            @arg RTC_EXTI_LINE_ALARM_EVENT
+  *            @arg RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT
+  *            @arg RTC_EXTI_LINE_WAKEUPTIMER_EVENT
   * @retval None
   */
-#define __HAL_RTC_CLEAR_FLAG(__FLAG__)  (EXTI->PR = (__FLAG__))
+#define __HAL_RTC_EXTI_CLEAR_FLAG(__FLAG__)  (EXTI->PR = (__FLAG__))
+
+/* alias define maintained for legacy */
+#define __HAL_RTC_CLEAR_FLAG   __HAL_RTC_EXTI_CLEAR_FLAG
+
 
 /* Include RTC HAL Extension module */
 #include "stm32f4xx_hal_rtc_ex.h"

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rtc_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_rtc_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_rtc_ex.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of RTC HAL Extension module.
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_sai.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_sai.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_sai.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of SAI HAL module.
   ******************************************************************************
   * @attention
@@ -708,7 +708,7 @@ typedef struct
   *   
   * @retval None
   */
-#define __HAL_SAI_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->CLRFR |= (__FLAG__))                                        
+#define __HAL_SAI_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->CLRFR = (__FLAG__))                                        
 
 #define __HAL_SAI_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR1 |=  SAI_xCR1_SAIEN)
 #define __HAL_SAI_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR1 &=  ~SAI_xCR1_SAIEN)

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_sd.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_sd.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_sd.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   SD card HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Secure Digital (SD) peripheral:
@@ -76,10 +76,6 @@
     (#) Configure the SD Card Data transfer frequency. By Default, the card transfer 
         frequency is set to 24MHz. You can change or adapt this frequency by adjusting 
         the "ClockDiv" field.
-        The SD Card frequency (SDIO_CK) is computed as follows:
-
-           SDIO_CK = SDIOCLK / (ClockDiv + 2) 
-
         In transfer mode and according to the SD Card standard, make sure that the 
         SDIO_CK frequency doesn't exceed 25MHz and 50MHz in High-speed mode switch.
         To be able to use a frequency higher than 24MHz, you should use the SDIO 
@@ -196,11 +192,18 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
-
+/** @defgroup SD_Private_Define
+  * @{
+  */
+  
 /** 
   * @brief  SDIO Static flags, TimeOut, FIFO Address  
   */
-#define SDIO_STATIC_FLAGS               ((uint32_t)0x000005FF)
+#define SDIO_STATIC_FLAGS               ((uint32_t)(SDIO_FLAG_CCRCFAIL | SDIO_FLAG_DCRCFAIL | SDIO_FLAG_CTIMEOUT |\
+                                                    SDIO_FLAG_DTIMEOUT | SDIO_FLAG_TXUNDERR | SDIO_FLAG_RXOVERR  |\
+                                                    SDIO_FLAG_CMDREND  | SDIO_FLAG_CMDSENT  | SDIO_FLAG_DATAEND  |\
+                                                    SDIO_FLAG_DBCKEND))  
+
 #define SDIO_CMD0TIMEOUT                ((uint32_t)0x00010000)
 
 /** 
@@ -268,12 +271,17 @@
   *         SDIO_APP_CMD should be sent before sending these commands. 
   */
 #define SD_SDIO_SEND_IF_COND            ((uint32_t)SD_CMD_HS_SEND_EXT_CSD)
-
+/**
+  * @}
+  */
   
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 /* Private functions ---------------------------------------------------------*/
+/** @defgroup SD_Private_Functions SD Private Functions
+  * @{
+  */
 static HAL_SD_ErrorTypedef SD_Initialize_Cards(SD_HandleTypeDef *hsd);
 static HAL_SD_ErrorTypedef SD_Select_Deselect(SD_HandleTypeDef *hsd, uint64_t addr);
 static HAL_SD_ErrorTypedef SD_PowerON(SD_HandleTypeDef *hsd); 
@@ -294,7 +302,10 @@ static void SD_DMA_RxCplt(DMA_HandleTypeDef *hdma);
 static void SD_DMA_RxError(DMA_HandleTypeDef *hdma);
 static void SD_DMA_TxCplt(DMA_HandleTypeDef *hdma);
 static void SD_DMA_TxError(DMA_HandleTypeDef *hdma);
-
+/**
+  * @}
+  */
+  
 /** @defgroup SD_Private_Functions
   * @{
   */
@@ -324,52 +335,52 @@ static void SD_DMA_TxError(DMA_HandleTypeDef *hdma);
   */
 HAL_SD_ErrorTypedef HAL_SD_Init(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTypedef *SDCardInfo)
 { 
-  __IO HAL_SD_ErrorTypedef errorState = SD_OK;
-  SD_InitTypeDef tmpInit;
+  __IO HAL_SD_ErrorTypedef errorstate = SD_OK;
+  SD_InitTypeDef tmpinit;
   
   /* Initialize the low level hardware (MSP) */
   HAL_SD_MspInit(hsd);
   
   /* Default SDIO peripheral configuration for SD card initialization */
-  tmpInit.ClockEdge           = SDIO_CLOCK_EDGE_RISING;
-  tmpInit.ClockBypass         = SDIO_CLOCK_BYPASS_DISABLE;
-  tmpInit.ClockPowerSave      = SDIO_CLOCK_POWER_SAVE_DISABLE;
-  tmpInit.BusWide             = SDIO_BUS_WIDE_1B;
-  tmpInit.HardwareFlowControl = SDIO_HARDWARE_FLOW_CONTROL_DISABLE;
-  tmpInit.ClockDiv            = SDIO_INIT_CLK_DIV;
+  tmpinit.ClockEdge           = SDIO_CLOCK_EDGE_RISING;
+  tmpinit.ClockBypass         = SDIO_CLOCK_BYPASS_DISABLE;
+  tmpinit.ClockPowerSave      = SDIO_CLOCK_POWER_SAVE_DISABLE;
+  tmpinit.BusWide             = SDIO_BUS_WIDE_1B;
+  tmpinit.HardwareFlowControl = SDIO_HARDWARE_FLOW_CONTROL_DISABLE;
+  tmpinit.ClockDiv            = SDIO_INIT_CLK_DIV;
   
   /* Initialize SDIO peripheral interface with default configuration */
-  SDIO_Init(hsd->Instance, tmpInit);
+  SDIO_Init(hsd->Instance, tmpinit);
   
   /* Identify card operating voltage */
-  errorState = SD_PowerON(hsd); 
+  errorstate = SD_PowerON(hsd); 
   
-  if(errorState != SD_OK)     
+  if(errorstate != SD_OK)     
   {
-    return errorState;
+    return errorstate;
   }
   
   /* Initialize the present SDIO card(s) and put them in idle state */
-  errorState = SD_Initialize_Cards(hsd);
+  errorstate = SD_Initialize_Cards(hsd);
   
-  if (errorState != SD_OK)
+  if (errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* Read CSD/CID MSD registers */
-  errorState = HAL_SD_Get_CardInfo(hsd, SDCardInfo);
+  errorstate = HAL_SD_Get_CardInfo(hsd, SDCardInfo);
   
-  if (errorState == SD_OK)
+  if (errorstate == SD_OK)
   {
     /* Select the Card */
-    errorState = SD_Select_Deselect(hsd, (uint32_t)(((uint32_t)SDCardInfo->RCA) << 16));
+    errorstate = SD_Select_Deselect(hsd, (uint32_t)(((uint32_t)SDCardInfo->RCA) << 16));
   }
   
   /* Configure SDIO peripheral interface */
   SDIO_Init(hsd->Instance, hsd->Init);   
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -446,9 +457,9 @@ __weak void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd)
   */
 HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
 {
-  SDIO_CmdInitTypeDef  SDIO_CmdInitStructure;
-  SDIO_DataInitTypeDef SDIO_DataInitStructure;
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  SDIO_CmdInitTypeDef  sdio_cmdinitstructure;
+  SDIO_DataInitTypeDef sdio_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   uint32_t count = 0, *tempbuff = (uint32_t *)pReadBuffer;
   
   /* Initialize data control register */
@@ -461,53 +472,53 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuff
   }
   
   /* Set Block Size for Card */ 
-  SDIO_CmdInitStructure.Argument         = (uint32_t) BlockSize;
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
-  SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-  SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-  SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = (uint32_t) BlockSize;
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+  sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+  sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
   
-  if (errorState != SD_OK)
+  if (errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* Configure the SD DPSM (Data Path State Machine) */
-  SDIO_DataInitStructure.DataTimeOut   = SD_DATATIMEOUT;
-  SDIO_DataInitStructure.DataLength    = NumberOfBlocks * BlockSize;
-  SDIO_DataInitStructure.DataBlockSize = (uint32_t)(9 << 4);
-  SDIO_DataInitStructure.TransferDir   = SDIO_TRANSFER_DIR_TO_SDIO;
-  SDIO_DataInitStructure.TransferMode  = SDIO_TRANSFER_MODE_BLOCK;
-  SDIO_DataInitStructure.DPSM          = SDIO_DPSM_ENABLE;
-  SDIO_DataConfig(hsd->Instance, &SDIO_DataInitStructure);
+  sdio_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdio_datainitstructure.DataLength    = NumberOfBlocks * BlockSize;
+  sdio_datainitstructure.DataBlockSize = (uint32_t)(9 << 4);
+  sdio_datainitstructure.TransferDir   = SDIO_TRANSFER_DIR_TO_SDIO;
+  sdio_datainitstructure.TransferMode  = SDIO_TRANSFER_MODE_BLOCK;
+  sdio_datainitstructure.DPSM          = SDIO_DPSM_ENABLE;
+  SDIO_DataConfig(hsd->Instance, &sdio_datainitstructure);
   
   if(NumberOfBlocks > 1)
   {
     /* Send CMD18 READ_MULT_BLOCK with argument data address */
-    SDIO_CmdInitStructure.CmdIndex = SD_CMD_READ_MULT_BLOCK;
+    sdio_cmdinitstructure.CmdIndex = SD_CMD_READ_MULT_BLOCK;
   }
   else
   {
     /* Send CMD17 READ_SINGLE_BLOCK */
-    SDIO_CmdInitStructure.CmdIndex = SD_CMD_READ_SINGLE_BLOCK;    
+    sdio_cmdinitstructure.CmdIndex = SD_CMD_READ_SINGLE_BLOCK;    
   }
   
-  SDIO_CmdInitStructure.Argument         = (uint32_t)ReadAddr;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = (uint32_t)ReadAddr;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Read block(s) in polling mode */
   if(NumberOfBlocks > 1)
   {
     /* Check for error conditions */
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_READ_MULT_BLOCK);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_READ_MULT_BLOCK);
     
-    if (errorState != SD_OK)
+    if (errorstate != SD_OK)
     {
-      return errorState;
+      return errorstate;
     }
     
     /* Poll on SDIO flags */
@@ -528,11 +539,11 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuff
   else
   {
     /* Check for error conditions */
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_READ_SINGLE_BLOCK); 
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_READ_SINGLE_BLOCK); 
     
-    if (errorState != SD_OK)
+    if (errorstate != SD_OK)
     {
-      return errorState;
+      return errorstate;
     }    
     
     /* In case of single block transfer, no need of stop transfer at all */
@@ -559,7 +570,7 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuff
         (hsd->CardType == HIGH_CAPACITY_SD_CARD))
     {
       /* Send stop transmission command */
-      errorState = HAL_SD_StopTransfer(hsd);
+      errorstate = HAL_SD_StopTransfer(hsd);
     }
   }
   
@@ -568,33 +579,37 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuff
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_DTIMEOUT);
     
-    errorState = SD_DATA_TIMEOUT;
+    errorstate = SD_DATA_TIMEOUT;
     
-    return errorState;
+    return errorstate;
   }
   else if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_DCRCFAIL))
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_DCRCFAIL);
     
-    errorState = SD_DATA_CRC_FAIL;
+    errorstate = SD_DATA_CRC_FAIL;
     
-    return errorState;
+    return errorstate;
   }
   else if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_RXOVERR))
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_RXOVERR);
     
-    errorState = SD_RX_OVERRUN;
+    errorstate = SD_RX_OVERRUN;
     
-    return errorState;
+    return errorstate;
   }
   else if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_STBITERR))
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_STBITERR);
     
-    errorState = SD_START_BIT_ERR;
+    errorstate = SD_START_BIT_ERR;
     
-    return errorState;
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
   }
   
   count = SD_DATATIMEOUT;
@@ -610,7 +625,7 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuff
   /* Clear all the static flags */
   __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_STATIC_FLAGS);
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -626,10 +641,10 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuff
   */
 HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
 {
-  SDIO_CmdInitTypeDef SDIO_CmdInitStructure;
-  SDIO_DataInitTypeDef SDIO_DataInitStructure;
-  HAL_SD_ErrorTypedef errorState = SD_OK;
-  uint32_t TotalNumberOfBytes = 0, bytestransferred = 0, count = 0, restwords = 0;
+  SDIO_CmdInitTypeDef sdio_cmdinitstructure;
+  SDIO_DataInitTypeDef sdio_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t totalnumberofbytes = 0, bytestransferred = 0, count = 0, restwords = 0;
   uint32_t *tempbuff = (uint32_t *)pWriteBuffer;
   uint8_t cardstate  = 0;
   
@@ -643,61 +658,61 @@ HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBu
   }
   
   /* Set Block Size for Card */ 
-  SDIO_CmdInitStructure.Argument         = (uint32_t)BlockSize;
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
-  SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-  SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-  SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = (uint32_t)BlockSize;
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+  sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+  sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
   
-  if (errorState != SD_OK)
+  if (errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   if(NumberOfBlocks > 1)
   {
     /* Send CMD25 WRITE_MULT_BLOCK with argument data address */
-    SDIO_CmdInitStructure.CmdIndex = SD_CMD_WRITE_MULT_BLOCK;
+    sdio_cmdinitstructure.CmdIndex = SD_CMD_WRITE_MULT_BLOCK;
   }
   else
   {
     /* Send CMD24 WRITE_SINGLE_BLOCK */
-    SDIO_CmdInitStructure.CmdIndex = SD_CMD_WRITE_SINGLE_BLOCK;
+    sdio_cmdinitstructure.CmdIndex = SD_CMD_WRITE_SINGLE_BLOCK;
   }
   
-  SDIO_CmdInitStructure.Argument         = (uint32_t)WriteAddr;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = (uint32_t)WriteAddr;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
   if(NumberOfBlocks > 1)
   {
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_WRITE_MULT_BLOCK);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_WRITE_MULT_BLOCK);
   }
   else
   {
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_WRITE_SINGLE_BLOCK);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_WRITE_SINGLE_BLOCK);
   }  
   
-  if (errorState != SD_OK)
+  if (errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* Set total number of bytes to write */
-  TotalNumberOfBytes = NumberOfBlocks * BlockSize;
+  totalnumberofbytes = NumberOfBlocks * BlockSize;
   
   /* Configure the SD DPSM (Data Path State Machine) */ 
-  SDIO_DataInitStructure.DataTimeOut   = SD_DATATIMEOUT;
-  SDIO_DataInitStructure.DataLength    = NumberOfBlocks * BlockSize;
-  SDIO_DataInitStructure.DataBlockSize = SDIO_DATABLOCK_SIZE_512B;
-  SDIO_DataInitStructure.TransferDir   = SDIO_TRANSFER_DIR_TO_CARD;
-  SDIO_DataInitStructure.TransferMode  = SDIO_TRANSFER_MODE_BLOCK;
-  SDIO_DataInitStructure.DPSM          = SDIO_DPSM_ENABLE;
-  SDIO_DataConfig(hsd->Instance, &SDIO_DataInitStructure);
+  sdio_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdio_datainitstructure.DataLength    = NumberOfBlocks * BlockSize;
+  sdio_datainitstructure.DataBlockSize = SDIO_DATABLOCK_SIZE_512B;
+  sdio_datainitstructure.TransferDir   = SDIO_TRANSFER_DIR_TO_CARD;
+  sdio_datainitstructure.TransferMode  = SDIO_TRANSFER_MODE_BLOCK;
+  sdio_datainitstructure.DPSM          = SDIO_DPSM_ENABLE;
+  SDIO_DataConfig(hsd->Instance, &sdio_datainitstructure);
   
   /* Write block(s) in polling mode */
   if(NumberOfBlocks > 1)
@@ -706,9 +721,9 @@ HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBu
     {
       if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_TXFIFOHE))
       {
-        if ((TotalNumberOfBytes - bytestransferred) < 32)
+        if ((totalnumberofbytes - bytestransferred) < 32)
         {
-          restwords = ((TotalNumberOfBytes - bytestransferred) % 4 == 0) ? ((TotalNumberOfBytes - bytestransferred) / 4) : (( TotalNumberOfBytes -  bytestransferred) / 4 + 1);
+          restwords = ((totalnumberofbytes - bytestransferred) % 4 == 0) ? ((totalnumberofbytes - bytestransferred) / 4) : (( totalnumberofbytes -  bytestransferred) / 4 + 1);
           
           /* Write data to SDIO Tx FIFO */
           for (count = 0; count < restwords; count++)
@@ -739,9 +754,9 @@ HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBu
     {
       if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_TXFIFOHE))
       {
-        if ((TotalNumberOfBytes - bytestransferred) < 32)
+        if ((totalnumberofbytes - bytestransferred) < 32)
         {
-          restwords = ((TotalNumberOfBytes - bytestransferred) % 4 == 0) ? ((TotalNumberOfBytes - bytestransferred) / 4) : (( TotalNumberOfBytes -  bytestransferred) / 4 + 1);
+          restwords = ((totalnumberofbytes - bytestransferred) % 4 == 0) ? ((totalnumberofbytes - bytestransferred) / 4) : (( totalnumberofbytes -  bytestransferred) / 4 + 1);
           
           /* Write data to SDIO Tx FIFO */
           for (count = 0; count < restwords; count++)
@@ -773,7 +788,7 @@ HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBu
       (hsd->CardType == HIGH_CAPACITY_SD_CARD))
     {
       /* Send stop transmission command */
-      errorState = HAL_SD_StopTransfer(hsd);
+      errorstate = HAL_SD_StopTransfer(hsd);
     }
   }
   
@@ -782,47 +797,51 @@ HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBu
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_DTIMEOUT);
     
-    errorState = SD_DATA_TIMEOUT;
+    errorstate = SD_DATA_TIMEOUT;
     
-    return errorState;
+    return errorstate;
   }
   else if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_DCRCFAIL))
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_DCRCFAIL);
     
-    errorState = SD_DATA_CRC_FAIL;
+    errorstate = SD_DATA_CRC_FAIL;
     
-    return errorState;
+    return errorstate;
   }
   else if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_TXUNDERR))
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_TXUNDERR);
     
-    errorState = SD_TX_UNDERRUN;
+    errorstate = SD_TX_UNDERRUN;
     
-    return errorState;
+    return errorstate;
   }
   else if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_STBITERR))
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_STBITERR);
     
-    errorState = SD_START_BIT_ERR;
+    errorstate = SD_START_BIT_ERR;
     
-    return errorState;
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
   }
   
   /* Clear all the static flags */
   __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_STATIC_FLAGS);
   
   /* Wait till the card is in programming state */
-  errorState = SD_IsCardProgramming(hsd, &cardstate);
+  errorstate = SD_IsCardProgramming(hsd, &cardstate);
   
-  while ((errorState == SD_OK) && ((cardstate == SD_CARD_PROGRAMMING) || (cardstate == SD_CARD_RECEIVING)))
+  while ((errorstate == SD_OK) && ((cardstate == SD_CARD_PROGRAMMING) || (cardstate == SD_CARD_RECEIVING)))
   {
-    errorState = SD_IsCardProgramming(hsd, &cardstate);
+    errorstate = SD_IsCardProgramming(hsd, &cardstate);
   }
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -840,9 +859,9 @@ HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBu
   */
 HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
 {
-  SDIO_CmdInitTypeDef SDIO_CmdInitStructure;
-  SDIO_DataInitTypeDef SDIO_DataInitStructure;
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  SDIO_CmdInitTypeDef sdio_cmdinitstructure;
+  SDIO_DataInitTypeDef sdio_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   
   /* Initialize data control register */
   hsd->Instance->DCTRL = 0;
@@ -877,7 +896,7 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pRead
   hsd->hdmarx->XferErrorCallback = SD_DMA_RxError;
   
   /* Enable the DMA Stream */
-  HAL_DMA_Start_IT(hsd->hdmarx, (uint32_t)SDIO_FIFO_ADDRESS, (uint32_t)pReadBuffer, (uint32_t)(BlockSize * NumberOfBlocks));
+  HAL_DMA_Start_IT(hsd->hdmarx, (uint32_t)&hsd->Instance->FIFO, (uint32_t)pReadBuffer, (uint32_t)(BlockSize * NumberOfBlocks));
   
   if (hsd->CardType == HIGH_CAPACITY_SD_CARD)
   {
@@ -886,59 +905,59 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pRead
   }
   
   /* Set Block Size for Card */ 
-  SDIO_CmdInitStructure.Argument         = (uint32_t)BlockSize;
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
-  SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-  SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-  SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = (uint32_t)BlockSize;
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+  sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+  sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
   
-  if (errorState != SD_OK)
+  if (errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* Configure the SD DPSM (Data Path State Machine) */ 
-  SDIO_DataInitStructure.DataTimeOut   = SD_DATATIMEOUT;
-  SDIO_DataInitStructure.DataLength    = BlockSize * NumberOfBlocks;
-  SDIO_DataInitStructure.DataBlockSize = SDIO_DATABLOCK_SIZE_512B;
-  SDIO_DataInitStructure.TransferDir   = SDIO_TRANSFER_DIR_TO_SDIO;
-  SDIO_DataInitStructure.TransferMode  = SDIO_TRANSFER_MODE_BLOCK;
-  SDIO_DataInitStructure.DPSM          = SDIO_DPSM_ENABLE;
-  SDIO_DataConfig(hsd->Instance, &SDIO_DataInitStructure);
+  sdio_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdio_datainitstructure.DataLength    = BlockSize * NumberOfBlocks;
+  sdio_datainitstructure.DataBlockSize = SDIO_DATABLOCK_SIZE_512B;
+  sdio_datainitstructure.TransferDir   = SDIO_TRANSFER_DIR_TO_SDIO;
+  sdio_datainitstructure.TransferMode  = SDIO_TRANSFER_MODE_BLOCK;
+  sdio_datainitstructure.DPSM          = SDIO_DPSM_ENABLE;
+  SDIO_DataConfig(hsd->Instance, &sdio_datainitstructure);
   
   /* Check number of blocks command */
   if(NumberOfBlocks > 1)
   {
     /* Send CMD18 READ_MULT_BLOCK with argument data address */
-    SDIO_CmdInitStructure.CmdIndex = SD_CMD_READ_MULT_BLOCK;
+    sdio_cmdinitstructure.CmdIndex = SD_CMD_READ_MULT_BLOCK;
   }
   else
   {
     /* Send CMD17 READ_SINGLE_BLOCK */
-    SDIO_CmdInitStructure.CmdIndex = SD_CMD_READ_SINGLE_BLOCK;
+    sdio_cmdinitstructure.CmdIndex = SD_CMD_READ_SINGLE_BLOCK;
   }
   
-  SDIO_CmdInitStructure.Argument         = (uint32_t)ReadAddr;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = (uint32_t)ReadAddr;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
   if(NumberOfBlocks > 1)
   {
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_READ_MULT_BLOCK);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_READ_MULT_BLOCK);
   }
   else
   {
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_READ_SINGLE_BLOCK);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_READ_SINGLE_BLOCK);
   }
   
   /* Update the SD transfer error in SD handle */
-  hsd->SdTransferErr = errorState;
+  hsd->SdTransferErr = errorstate;
   
-  return errorState;
+  return errorstate;
 }
 
 
@@ -957,9 +976,9 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pRead
   */
 HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks)
 {
-  SDIO_CmdInitTypeDef SDIO_CmdInitStructure;
-  SDIO_DataInitTypeDef SDIO_DataInitStructure;
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  SDIO_CmdInitTypeDef sdio_cmdinitstructure;
+  SDIO_DataInitTypeDef sdio_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   
   /* Initialize data control register */
   hsd->Instance->DCTRL = 0;
@@ -991,7 +1010,7 @@ HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pWri
   hsd->hdmatx->XferErrorCallback = SD_DMA_TxError;
   
   /* Enable the DMA Stream */
-  HAL_DMA_Start_IT(hsd->hdmatx, (uint32_t)pWriteBuffer, (uint32_t)SDIO_FIFO_ADDRESS, (uint32_t)(BlockSize * NumberOfBlocks));
+  HAL_DMA_Start_IT(hsd->hdmatx, (uint32_t)pWriteBuffer, (uint32_t)&hsd->Instance->FIFO, (uint32_t)(BlockSize * NumberOfBlocks));
 
   /* Enable SDIO DMA transfer */
   __HAL_SD_SDIO_DMA_ENABLE();
@@ -1003,63 +1022,63 @@ HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pWri
   }
 
   /* Set Block Size for Card */ 
-  SDIO_CmdInitStructure.Argument         = (uint32_t)BlockSize;
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
-  SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-  SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-  SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = (uint32_t)BlockSize;
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+  sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+  sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
 
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
 
-  if (errorState != SD_OK)
+  if (errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* Check number of blocks command */
   if(NumberOfBlocks <= 1)
   {
     /* Send CMD24 WRITE_SINGLE_BLOCK */
-    SDIO_CmdInitStructure.CmdIndex = SD_CMD_WRITE_SINGLE_BLOCK;
+    sdio_cmdinitstructure.CmdIndex = SD_CMD_WRITE_SINGLE_BLOCK;
   }
   else
   {
     /* Send CMD25 WRITE_MULT_BLOCK with argument data address */
-    SDIO_CmdInitStructure.CmdIndex = SD_CMD_WRITE_MULT_BLOCK;
+    sdio_cmdinitstructure.CmdIndex = SD_CMD_WRITE_MULT_BLOCK;
   }
   
-  SDIO_CmdInitStructure.Argument         = (uint32_t)WriteAddr;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = (uint32_t)WriteAddr;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
 
   /* Check for error conditions */
   if(NumberOfBlocks > 1)
   {
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_WRITE_MULT_BLOCK);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_WRITE_MULT_BLOCK);
   }
   else
   {
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_WRITE_SINGLE_BLOCK);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_WRITE_SINGLE_BLOCK);
   }
   
-  if (errorState != SD_OK)
+  if (errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* Configure the SD DPSM (Data Path State Machine) */ 
-  SDIO_DataInitStructure.DataTimeOut   = SD_DATATIMEOUT;
-  SDIO_DataInitStructure.DataLength    = BlockSize * NumberOfBlocks;
-  SDIO_DataInitStructure.DataBlockSize = SDIO_DATABLOCK_SIZE_512B;
-  SDIO_DataInitStructure.TransferDir   = SDIO_TRANSFER_DIR_TO_CARD;
-  SDIO_DataInitStructure.TransferMode  = SDIO_TRANSFER_MODE_BLOCK;
-  SDIO_DataInitStructure.DPSM          = SDIO_DPSM_ENABLE;
-  SDIO_DataConfig(hsd->Instance, &SDIO_DataInitStructure);
+  sdio_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdio_datainitstructure.DataLength    = BlockSize * NumberOfBlocks;
+  sdio_datainitstructure.DataBlockSize = SDIO_DATABLOCK_SIZE_512B;
+  sdio_datainitstructure.TransferDir   = SDIO_TRANSFER_DIR_TO_CARD;
+  sdio_datainitstructure.TransferMode  = SDIO_TRANSFER_MODE_BLOCK;
+  sdio_datainitstructure.DPSM          = SDIO_DPSM_ENABLE;
+  SDIO_DataConfig(hsd->Instance, &sdio_datainitstructure);
   
-  hsd->SdTransferErr = errorState;
+  hsd->SdTransferErr = errorstate;
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -1073,7 +1092,7 @@ HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pWri
   */
 HAL_SD_ErrorTypedef HAL_SD_CheckReadOperation(SD_HandleTypeDef *hsd, uint32_t Timeout)
 {
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   uint32_t timeout = Timeout;
   uint32_t tmp1, tmp2;
   HAL_SD_ErrorTypedef tmp3;
@@ -1102,12 +1121,12 @@ HAL_SD_ErrorTypedef HAL_SD_CheckReadOperation(SD_HandleTypeDef *hsd, uint32_t Ti
   /* Send stop command in multiblock read */
   if (hsd->SdOperation == SD_READ_MULTIPLE_BLOCK)
   {
-    errorState = HAL_SD_StopTransfer(hsd);
+    errorstate = HAL_SD_StopTransfer(hsd);
   }
   
-  if ((timeout == 0) && (errorState == SD_OK))
+  if ((timeout == 0) && (errorstate == SD_OK))
   {
-    errorState = SD_DATA_TIMEOUT;
+    errorstate = SD_DATA_TIMEOUT;
   }
   
   /* Clear all the static flags */
@@ -1119,7 +1138,7 @@ HAL_SD_ErrorTypedef HAL_SD_CheckReadOperation(SD_HandleTypeDef *hsd, uint32_t Ti
     return (HAL_SD_ErrorTypedef)(hsd->SdTransferErr);
   }
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -1133,7 +1152,7 @@ HAL_SD_ErrorTypedef HAL_SD_CheckReadOperation(SD_HandleTypeDef *hsd, uint32_t Ti
   */
 HAL_SD_ErrorTypedef HAL_SD_CheckWriteOperation(SD_HandleTypeDef *hsd, uint32_t Timeout)
 {
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   uint32_t timeout = Timeout;
   uint32_t tmp1, tmp2;
   HAL_SD_ErrorTypedef tmp3;
@@ -1162,12 +1181,12 @@ HAL_SD_ErrorTypedef HAL_SD_CheckWriteOperation(SD_HandleTypeDef *hsd, uint32_t T
   /* Send stop command in multiblock write */
   if (hsd->SdOperation == SD_WRITE_MULTIPLE_BLOCK)
   {
-    errorState = HAL_SD_StopTransfer(hsd);
+    errorstate = HAL_SD_StopTransfer(hsd);
   }
   
-  if ((timeout == 0) && (errorState == SD_OK))
+  if ((timeout == 0) && (errorstate == SD_OK))
   {
-    errorState = SD_DATA_TIMEOUT;
+    errorstate = SD_DATA_TIMEOUT;
   }
   
   /* Clear all the static flags */
@@ -1184,7 +1203,7 @@ HAL_SD_ErrorTypedef HAL_SD_CheckWriteOperation(SD_HandleTypeDef *hsd, uint32_t T
   {    
   }
 
-  return errorState; 
+  return errorstate; 
 }
 
 /**
@@ -1196,8 +1215,8 @@ HAL_SD_ErrorTypedef HAL_SD_CheckWriteOperation(SD_HandleTypeDef *hsd, uint32_t T
   */
 HAL_SD_ErrorTypedef HAL_SD_Erase(SD_HandleTypeDef *hsd, uint64_t startaddr, uint64_t endaddr)
 {
-  HAL_SD_ErrorTypedef errorState = SD_OK;
-  SDIO_CmdInitTypeDef SDIO_CmdInitStructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  SDIO_CmdInitTypeDef sdio_cmdinitstructure;
   
   uint32_t delay         = 0;
   __IO uint32_t maxdelay = 0;
@@ -1206,9 +1225,9 @@ HAL_SD_ErrorTypedef HAL_SD_Erase(SD_HandleTypeDef *hsd, uint64_t startaddr, uint
   /* Check if the card command class supports erase command */
   if (((hsd->CSD[1] >> 20) & SD_CCCC_ERASE) == 0)
   {
-    errorState = SD_REQUEST_NOT_APPLICABLE;
+    errorstate = SD_REQUEST_NOT_APPLICABLE;
     
-    return errorState;
+    return errorstate;
   }
   
   /* Get max delay value */
@@ -1216,9 +1235,9 @@ HAL_SD_ErrorTypedef HAL_SD_Erase(SD_HandleTypeDef *hsd, uint64_t startaddr, uint
   
   if((SDIO_GetResponse(SDIO_RESP1) & SD_CARD_LOCKED) == SD_CARD_LOCKED)
   {
-    errorState = SD_LOCK_UNLOCK_FAILED;
+    errorstate = SD_LOCK_UNLOCK_FAILED;
     
-    return errorState;
+    return errorstate;
   }
   
   /* Get start and end block for high capacity cards */
@@ -1233,46 +1252,46 @@ HAL_SD_ErrorTypedef HAL_SD_Erase(SD_HandleTypeDef *hsd, uint64_t startaddr, uint
     (hsd->CardType == HIGH_CAPACITY_SD_CARD))
   {
     /* Send CMD32 SD_ERASE_GRP_START with argument as addr  */
-    SDIO_CmdInitStructure.Argument         =(uint32_t)startaddr;
-    SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SD_ERASE_GRP_START;
-    SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-    SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-    SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-    SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+    sdio_cmdinitstructure.Argument         =(uint32_t)startaddr;
+    sdio_cmdinitstructure.CmdIndex         = SD_CMD_SD_ERASE_GRP_START;
+    sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+    sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+    sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+    SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
     
     /* Check for error conditions */
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_SD_ERASE_GRP_START);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_SD_ERASE_GRP_START);
     
-    if (errorState != SD_OK)
+    if (errorstate != SD_OK)
     {
-      return errorState;
+      return errorstate;
     }
     
     /* Send CMD33 SD_ERASE_GRP_END with argument as addr  */
-    SDIO_CmdInitStructure.Argument         = (uint32_t)endaddr;
-    SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SD_ERASE_GRP_END;
-    SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+    sdio_cmdinitstructure.Argument         = (uint32_t)endaddr;
+    sdio_cmdinitstructure.CmdIndex         = SD_CMD_SD_ERASE_GRP_END;
+    SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
     
     /* Check for error conditions */
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_SD_ERASE_GRP_END);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_SD_ERASE_GRP_END);
     
-    if (errorState != SD_OK)
+    if (errorstate != SD_OK)
     {
-      return errorState;
+      return errorstate;
     }
   }
   
   /* Send CMD38 ERASE */
-  SDIO_CmdInitStructure.Argument         = 0;
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_ERASE;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = 0;
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_ERASE;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_ERASE);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_ERASE);
   
-  if (errorState != SD_OK)
+  if (errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   for (; delay < maxdelay; delay++)
@@ -1280,17 +1299,17 @@ HAL_SD_ErrorTypedef HAL_SD_Erase(SD_HandleTypeDef *hsd, uint64_t startaddr, uint
   }
   
   /* Wait untill the card is in programming state */
-  errorState = SD_IsCardProgramming(hsd, &cardstate);
+  errorstate = SD_IsCardProgramming(hsd, &cardstate);
   
   delay = SD_DATATIMEOUT;
   
-  while ((delay > 0) && (errorState == SD_OK) && ((cardstate == SD_CARD_PROGRAMMING) || (cardstate == SD_CARD_RECEIVING)))
+  while ((delay > 0) && (errorstate == SD_OK) && ((cardstate == SD_CARD_PROGRAMMING) || (cardstate == SD_CARD_RECEIVING)))
   {
-    errorState = SD_IsCardProgramming(hsd, &cardstate);
+    errorstate = SD_IsCardProgramming(hsd, &cardstate);
     delay--;
   }
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -1354,6 +1373,10 @@ void HAL_SD_IRQHandler(SD_HandleTypeDef *hsd)
     
     HAL_SD_XferErrorCallback(hsd);
   }
+  else
+  {
+    /* No error flag set */
+  }  
 
   /* Disable all SDIO peripheral interrupt sources */
   __HAL_SD_SDIO_DISABLE_IT(hsd, SDIO_IT_DCRCFAIL | SDIO_IT_DTIMEOUT | SDIO_IT_DATAEND  |\
@@ -1466,7 +1489,7 @@ __weak void HAL_SD_DMA_TxErrorCallback(DMA_HandleTypeDef *hdma)
   */
 HAL_SD_ErrorTypedef HAL_SD_Get_CardInfo(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTypedef *pCardInfo)
 {
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   uint32_t tmp = 0;
   
   pCardInfo->CardType = (uint8_t)(hsd->CardType);
@@ -1558,7 +1581,12 @@ HAL_SD_ErrorTypedef HAL_SD_Get_CardInfo(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTy
     pCardInfo->CardCapacity  = ((pCardInfo->SD_csd.DeviceSize + 1)) * 512 * 1024;
     pCardInfo->CardBlockSize = 512;    
   }
-    
+  else
+  {
+    /* Not supported card type */
+    errorstate = SD_ERROR;
+  }
+      
   pCardInfo->SD_csd.EraseGrSize = (tmp & 0x40) >> 6;
   pCardInfo->SD_csd.EraseGrMul  = (tmp & 0x3F) << 1;
   
@@ -1661,7 +1689,7 @@ HAL_SD_ErrorTypedef HAL_SD_Get_CardInfo(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTy
   pCardInfo->SD_cid.CID_CRC   = (tmp & 0xFE) >> 1;
   pCardInfo->SD_cid.Reserved2 = 1;
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -1677,64 +1705,51 @@ HAL_SD_ErrorTypedef HAL_SD_Get_CardInfo(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTy
   */
 HAL_SD_ErrorTypedef HAL_SD_WideBusOperation_Config(SD_HandleTypeDef *hsd, uint32_t WideMode)
 {
-  HAL_SD_ErrorTypedef errorState = SD_OK;
-  SDIO_InitTypeDef Init;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  SDIO_InitTypeDef tmpinit;
   
   /* MMC Card does not support this feature */
   if (hsd->CardType == MULTIMEDIA_CARD)
   {
-    errorState = SD_UNSUPPORTED_FEATURE;
+    errorstate = SD_UNSUPPORTED_FEATURE;
     
-    return errorState;
+    return errorstate;
   }
   else if ((hsd->CardType == STD_CAPACITY_SD_CARD_V1_1) || (hsd->CardType == STD_CAPACITY_SD_CARD_V2_0) ||\
     (hsd->CardType == HIGH_CAPACITY_SD_CARD))
   {
     if (WideMode == SDIO_BUS_WIDE_8B)
     {
-      errorState = SD_UNSUPPORTED_FEATURE;
-      
-      return errorState;
+      errorstate = SD_UNSUPPORTED_FEATURE;
     }
     else if (WideMode == SDIO_BUS_WIDE_4B)
     {
-      errorState = SD_WideBus_Enable(hsd);
-      
-      if (errorState == SD_OK)
-      {
-        /* Configure the SDIO peripheral */
-        Init.ClockEdge           = SDIO_CLOCK_EDGE_RISING;
-        Init.ClockBypass         = SDIO_CLOCK_BYPASS_DISABLE;
-        Init.ClockPowerSave      = SDIO_CLOCK_POWER_SAVE_DISABLE;
-        Init.BusWide             = SDIO_BUS_WIDE_4B;
-        Init.HardwareFlowControl = SDIO_HARDWARE_FLOW_CONTROL_DISABLE;
-        Init.ClockDiv            = SDIO_TRANSFER_CLK_DIV;
-        
-        /* Configure SDIO peripheral interface */
-        SDIO_Init(hsd->Instance, Init);
-      }
+      errorstate = SD_WideBus_Enable(hsd);
+    }
+    else if (WideMode == SDIO_BUS_WIDE_1B)
+    {
+      errorstate = SD_WideBus_Disable(hsd);
     }
     else
     {
-      errorState = SD_WideBus_Disable(hsd);
+      /* WideMode is not a valid argument*/
+      errorstate = SD_INVALID_PARAMETER;
+    }
       
-      if (errorState == SD_OK)
-      {
-        /* Configure the SDIO peripheral */
-        Init.ClockEdge           = SDIO_CLOCK_EDGE_RISING;
-        Init.ClockBypass         = SDIO_CLOCK_BYPASS_DISABLE;
-        Init.ClockPowerSave      = SDIO_CLOCK_POWER_SAVE_DISABLE;
-        Init.BusWide             = SDIO_BUS_WIDE_1B;
-        Init.HardwareFlowControl = SDIO_HARDWARE_FLOW_CONTROL_DISABLE;
-        Init.ClockDiv            = SDIO_TRANSFER_CLK_DIV;
-        
-        /* Configure SDIO peripheral interface */
-        SDIO_Init(hsd->Instance, Init);
-      }
+    if (errorstate == SD_OK)
+    {
+      /* Configure the SDIO peripheral */
+      tmpinit.ClockEdge           = hsd->Init.ClockEdge;
+      tmpinit.ClockBypass         = hsd->Init.ClockBypass;
+      tmpinit.ClockPowerSave      = hsd->Init.ClockPowerSave;
+      tmpinit.BusWide             = WideMode;
+      tmpinit.HardwareFlowControl = hsd->Init.HardwareFlowControl;
+      tmpinit.ClockDiv            = hsd->Init.ClockDiv;
+      SDIO_Init(hsd->Instance, tmpinit);
     }
   }
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -1744,21 +1759,21 @@ HAL_SD_ErrorTypedef HAL_SD_WideBusOperation_Config(SD_HandleTypeDef *hsd, uint32
   */
 HAL_SD_ErrorTypedef HAL_SD_StopTransfer(SD_HandleTypeDef *hsd)
 {
-  SDIO_CmdInitTypeDef SDIO_CmdInitStructure;
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  SDIO_CmdInitTypeDef sdio_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   
   /* Send CMD12 STOP_TRANSMISSION  */
-  SDIO_CmdInitStructure.Argument         = 0;
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_STOP_TRANSMISSION;
-  SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-  SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-  SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = 0;
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_STOP_TRANSMISSION;
+  sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+  sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+  sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_STOP_TRANSMISSION);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_STOP_TRANSMISSION);
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -1771,9 +1786,9 @@ HAL_SD_ErrorTypedef HAL_SD_StopTransfer(SD_HandleTypeDef *hsd)
   */
 HAL_SD_ErrorTypedef HAL_SD_HighSpeed (SD_HandleTypeDef *hsd)
 {
-  HAL_SD_ErrorTypedef errorState = SD_OK;
-  SDIO_CmdInitTypeDef SDIO_CmdInitStructure;
-  SDIO_DataInitTypeDef SDIO_DataInitStructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  SDIO_CmdInitTypeDef sdio_cmdinitstructure;
+  SDIO_DataInitTypeDef sdio_datainitstructure;
   
   uint8_t SD_hs[64]  = {0};
   uint32_t SD_scr[2] = {0, 0};
@@ -1784,11 +1799,11 @@ HAL_SD_ErrorTypedef HAL_SD_HighSpeed (SD_HandleTypeDef *hsd)
   hsd->Instance->DCTRL = 0;
   
   /* Get SCR Register */
-  errorState = SD_FindSCR(hsd, SD_scr);
+  errorstate = SD_FindSCR(hsd, SD_scr);
   
-  if (errorState != SD_OK)
+  if (errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* Test the Version supported by the card*/ 
@@ -1797,41 +1812,41 @@ HAL_SD_ErrorTypedef HAL_SD_HighSpeed (SD_HandleTypeDef *hsd)
   if (SD_SPEC != SD_ALLZERO)
   {
     /* Set Block Size for Card */
-    SDIO_CmdInitStructure.Argument         = (uint32_t)64;
-    SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
-    SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-    SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-    SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-    SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+    sdio_cmdinitstructure.Argument         = (uint32_t)64;
+    sdio_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+    sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+    sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+    sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+    SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
     
     /* Check for error conditions */
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
     
-    if (errorState != SD_OK)
+    if (errorstate != SD_OK)
     {
-      return errorState;
+      return errorstate;
     }
     
     /* Configure the SD DPSM (Data Path State Machine) */
-    SDIO_DataInitStructure.DataTimeOut   = SD_DATATIMEOUT;
-    SDIO_DataInitStructure.DataLength    = 64;
-    SDIO_DataInitStructure.DataBlockSize = SDIO_DATABLOCK_SIZE_64B ;
-    SDIO_DataInitStructure.TransferDir   = SDIO_TRANSFER_DIR_TO_SDIO;
-    SDIO_DataInitStructure.TransferMode  = SDIO_TRANSFER_MODE_BLOCK;
-    SDIO_DataInitStructure.DPSM          = SDIO_DPSM_ENABLE;
-    SDIO_DataConfig(hsd->Instance, &SDIO_DataInitStructure);
+    sdio_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+    sdio_datainitstructure.DataLength    = 64;
+    sdio_datainitstructure.DataBlockSize = SDIO_DATABLOCK_SIZE_64B ;
+    sdio_datainitstructure.TransferDir   = SDIO_TRANSFER_DIR_TO_SDIO;
+    sdio_datainitstructure.TransferMode  = SDIO_TRANSFER_MODE_BLOCK;
+    sdio_datainitstructure.DPSM          = SDIO_DPSM_ENABLE;
+    SDIO_DataConfig(hsd->Instance, &sdio_datainitstructure);
     
     /* Send CMD6 switch mode */
-    SDIO_CmdInitStructure.Argument         = 0x80FFFF01;
-    SDIO_CmdInitStructure.CmdIndex         = SD_CMD_HS_SWITCH;
-    SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure); 
+    sdio_cmdinitstructure.Argument         = 0x80FFFF01;
+    sdio_cmdinitstructure.CmdIndex         = SD_CMD_HS_SWITCH;
+    SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure); 
     
     /* Check for error conditions */
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_HS_SWITCH);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_HS_SWITCH);
     
-    if (errorState != SD_OK)
+    if (errorstate != SD_OK)
     {
-      return errorState;
+      return errorstate;
     }
         
     while(!__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_RXOVERR | SDIO_FLAG_DCRCFAIL | SDIO_FLAG_DTIMEOUT | SDIO_FLAG_DBCKEND | SDIO_FLAG_STBITERR))
@@ -1851,35 +1866,39 @@ HAL_SD_ErrorTypedef HAL_SD_HighSpeed (SD_HandleTypeDef *hsd)
     {
       __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_DTIMEOUT);
       
-      errorState = SD_DATA_TIMEOUT;
+      errorstate = SD_DATA_TIMEOUT;
       
-      return errorState;
+      return errorstate;
     }
     else if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_DCRCFAIL))
     {
       __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_DCRCFAIL);
       
-      errorState = SD_DATA_CRC_FAIL;
+      errorstate = SD_DATA_CRC_FAIL;
       
-      return errorState;
+      return errorstate;
     }
     else if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_RXOVERR))
     {
       __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_RXOVERR);
       
-      errorState = SD_RX_OVERRUN;
+      errorstate = SD_RX_OVERRUN;
       
-      return errorState;
+      return errorstate;
     }
     else if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_STBITERR))
     {
       __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_STBITERR);
       
-      errorState = SD_START_BIT_ERR;
+      errorstate = SD_START_BIT_ERR;
       
-      return errorState;
+      return errorstate;
     }
-    
+    else
+    {
+      /* No error flag set */
+    }
+        
     count = SD_DATATIMEOUT;
     
     while ((__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_RXDAVL)) && (count > 0))
@@ -1895,11 +1914,11 @@ HAL_SD_ErrorTypedef HAL_SD_HighSpeed (SD_HandleTypeDef *hsd)
     /* Test if the switch mode HS is ok */
     if ((SD_hs[13]& 2) != 2)
     {
-      errorState = SD_UNSUPPORTED_FEATURE;
+      errorstate = SD_UNSUPPORTED_FEATURE;
     } 
   }
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -1930,68 +1949,68 @@ HAL_SD_ErrorTypedef HAL_SD_HighSpeed (SD_HandleTypeDef *hsd)
   */
 HAL_SD_ErrorTypedef HAL_SD_SendSDStatus(SD_HandleTypeDef *hsd, uint32_t *pSDstatus)
 {
-  SDIO_CmdInitTypeDef  SDIO_CmdInitStructure;
-  SDIO_DataInitTypeDef SDIO_DataInitStructure;
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  SDIO_CmdInitTypeDef  sdio_cmdinitstructure;
+  SDIO_DataInitTypeDef sdio_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   uint32_t count = 0;
   
   /* Check SD response */
   if ((SDIO_GetResponse(SDIO_RESP1) & SD_CARD_LOCKED) == SD_CARD_LOCKED)
   {
-    errorState = SD_LOCK_UNLOCK_FAILED;
+    errorstate = SD_LOCK_UNLOCK_FAILED;
     
-    return errorState;
+    return errorstate;
   }
   
   /* Set block size for card if it is not equal to current block size for card */
-  SDIO_CmdInitStructure.Argument         = 64;
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
-  SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-  SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-  SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = 64;
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+  sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+  sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
   
-  if (errorState != SD_OK)
+  if (errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* Send CMD55 */
-  SDIO_CmdInitStructure.Argument         = (uint32_t)(hsd->RCA << 16);
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_APP_CMD;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
   
-  if (errorState != SD_OK)
+  if (errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* Configure the SD DPSM (Data Path State Machine) */ 
-  SDIO_DataInitStructure.DataTimeOut   = SD_DATATIMEOUT;
-  SDIO_DataInitStructure.DataLength    = 64;
-  SDIO_DataInitStructure.DataBlockSize = SDIO_DATABLOCK_SIZE_64B;
-  SDIO_DataInitStructure.TransferDir   = SDIO_TRANSFER_DIR_TO_SDIO;
-  SDIO_DataInitStructure.TransferMode  = SDIO_TRANSFER_MODE_BLOCK;
-  SDIO_DataInitStructure.DPSM          = SDIO_DPSM_ENABLE;
-  SDIO_DataConfig(hsd->Instance, &SDIO_DataInitStructure);
+  sdio_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdio_datainitstructure.DataLength    = 64;
+  sdio_datainitstructure.DataBlockSize = SDIO_DATABLOCK_SIZE_64B;
+  sdio_datainitstructure.TransferDir   = SDIO_TRANSFER_DIR_TO_SDIO;
+  sdio_datainitstructure.TransferMode  = SDIO_TRANSFER_MODE_BLOCK;
+  sdio_datainitstructure.DPSM          = SDIO_DPSM_ENABLE;
+  SDIO_DataConfig(hsd->Instance, &sdio_datainitstructure);
   
   /* Send ACMD13 (SD_APP_STAUS)  with argument as card's RCA */
-  SDIO_CmdInitStructure.Argument         = 0;
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SD_APP_STAUS;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = 0;
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_SD_APP_STAUS;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_SD_APP_STAUS);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SD_APP_STAUS);
   
-  if (errorState != SD_OK)
+  if (errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* Get status data */
@@ -2012,34 +2031,38 @@ HAL_SD_ErrorTypedef HAL_SD_SendSDStatus(SD_HandleTypeDef *hsd, uint32_t *pSDstat
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_DTIMEOUT);
     
-    errorState = SD_DATA_TIMEOUT;
+    errorstate = SD_DATA_TIMEOUT;
     
-    return errorState;
+    return errorstate;
   }
   else if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_DCRCFAIL))
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_DCRCFAIL);
     
-    errorState = SD_DATA_CRC_FAIL;
+    errorstate = SD_DATA_CRC_FAIL;
     
-    return errorState;
+    return errorstate;
   }
   else if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_RXOVERR))
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_RXOVERR);
     
-    errorState = SD_RX_OVERRUN;
+    errorstate = SD_RX_OVERRUN;
     
-    return errorState;
+    return errorstate;
   }
   else if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_STBITERR))
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_STBITERR);
     
-    errorState = SD_START_BIT_ERR;
+    errorstate = SD_START_BIT_ERR;
     
-    return errorState;
+    return errorstate;
   }
+  else
+  {
+    /* No error flag set */
+  }  
   
   count = SD_DATATIMEOUT;
   while ((__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_RXDAVL)) && (count > 0))
@@ -2052,7 +2075,7 @@ HAL_SD_ErrorTypedef HAL_SD_SendSDStatus(SD_HandleTypeDef *hsd, uint32_t *pSDstat
   /* Clear all the static status flags*/
   __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_STATIC_FLAGS);
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -2091,84 +2114,92 @@ HAL_SD_TransferStateTypedef HAL_SD_GetStatus(SD_HandleTypeDef *hsd)
   */
 HAL_SD_ErrorTypedef HAL_SD_GetCardStatus(SD_HandleTypeDef *hsd, HAL_SD_CardStatusTypedef *pCardStatus)
 {
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   uint32_t tmp = 0;
-  uint32_t SD_STATUS[16];
+  uint32_t sd_status[16];
   
-  errorState = HAL_SD_SendSDStatus(hsd, SD_STATUS);
+  errorstate = HAL_SD_SendSDStatus(hsd, sd_status);
   
-  if (errorState  != SD_OK)
+  if (errorstate  != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* Byte 0 */
-  tmp = (SD_STATUS[0] & 0xC0) >> 6;
+  tmp = (sd_status[0] & 0xC0) >> 6;
   pCardStatus->DAT_BUS_WIDTH = (uint8_t)tmp;
   
   /* Byte 0 */
-  tmp = (SD_STATUS[0] & 0x20) >> 5;
+  tmp = (sd_status[0] & 0x20) >> 5;
   pCardStatus->SECURED_MODE = (uint8_t)tmp;
   
   /* Byte 2 */
-  tmp = (SD_STATUS[2] & 0xFF);
+  tmp = (sd_status[2] & 0xFF);
   pCardStatus->SD_CARD_TYPE = (uint8_t)(tmp << 8);
   
   /* Byte 3 */
-  tmp = (SD_STATUS[3] & 0xFF);
+  tmp = (sd_status[3] & 0xFF);
   pCardStatus->SD_CARD_TYPE |= (uint8_t)tmp;
   
   /* Byte 4 */
-  tmp = (SD_STATUS[4] & 0xFF);
+  tmp = (sd_status[4] & 0xFF);
   pCardStatus->SIZE_OF_PROTECTED_AREA = (uint8_t)(tmp << 24);
   
   /* Byte 5 */
-  tmp = (SD_STATUS[5] & 0xFF);
+  tmp = (sd_status[5] & 0xFF);
   pCardStatus->SIZE_OF_PROTECTED_AREA |= (uint8_t)(tmp << 16);
   
   /* Byte 6 */
-  tmp = (SD_STATUS[6] & 0xFF);
+  tmp = (sd_status[6] & 0xFF);
   pCardStatus->SIZE_OF_PROTECTED_AREA |= (uint8_t)(tmp << 8);
   
   /* Byte 7 */
-  tmp = (SD_STATUS[7] & 0xFF);
+  tmp = (sd_status[7] & 0xFF);
   pCardStatus->SIZE_OF_PROTECTED_AREA |= (uint8_t)tmp;
   
   /* Byte 8 */
-  tmp = (SD_STATUS[8] & 0xFF);
+  tmp = (sd_status[8] & 0xFF);
   pCardStatus->SPEED_CLASS = (uint8_t)tmp;
   
   /* Byte 9 */
-  tmp = (SD_STATUS[9] & 0xFF);
+  tmp = (sd_status[9] & 0xFF);
   pCardStatus->PERFORMANCE_MOVE = (uint8_t)tmp;
   
   /* Byte 10 */
-  tmp = (SD_STATUS[10] & 0xF0) >> 4;
+  tmp = (sd_status[10] & 0xF0) >> 4;
   pCardStatus->AU_SIZE = (uint8_t)tmp;
   
   /* Byte 11 */
-  tmp = (SD_STATUS[11] & 0xFF);
+  tmp = (sd_status[11] & 0xFF);
   pCardStatus->ERASE_SIZE = (uint8_t)(tmp << 8);
   
   /* Byte 12 */
-  tmp = (SD_STATUS[12] & 0xFF);
+  tmp = (sd_status[12] & 0xFF);
   pCardStatus->ERASE_SIZE |= (uint8_t)tmp;
   
   /* Byte 13 */
-  tmp = (SD_STATUS[13] & 0xFC) >> 2;
+  tmp = (sd_status[13] & 0xFC) >> 2;
   pCardStatus->ERASE_TIMEOUT = (uint8_t)tmp;
   
   /* Byte 13 */
-  tmp = (SD_STATUS[13] & 0x3);
+  tmp = (sd_status[13] & 0x3);
   pCardStatus->ERASE_OFFSET = (uint8_t)tmp;
   
-  return errorState;
+  return errorstate;
 }
          
 /**
   * @}
   */
-
+  
+/**
+  * @}
+  */
+  
+/** @addtogroup SD_Private_Functions
+  * @{
+  */
+  
 /**
   * @brief  SD DMA transfer complete Rx callback.
   * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
@@ -2268,33 +2299,33 @@ static HAL_SD_CardStateTypedef SD_GetState(SD_HandleTypeDef *hsd)
   */
 static HAL_SD_ErrorTypedef SD_Initialize_Cards(SD_HandleTypeDef *hsd)
 {
-  SDIO_CmdInitTypeDef SDIO_CmdInitStructure; 
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  SDIO_CmdInitTypeDef sdio_cmdinitstructure; 
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   uint16_t sd_rca = 1;
   
   if(SDIO_GetPowerState(hsd->Instance) == 0) /* Power off */
   {
-    errorState = SD_REQUEST_NOT_APPLICABLE;
+    errorstate = SD_REQUEST_NOT_APPLICABLE;
     
-    return errorState;
+    return errorstate;
   }
   
   if(hsd->CardType != SECURE_DIGITAL_IO_CARD)
   {
     /* Send CMD2 ALL_SEND_CID */
-    SDIO_CmdInitStructure.Argument         = 0;
-    SDIO_CmdInitStructure.CmdIndex         = SD_CMD_ALL_SEND_CID;
-    SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_LONG;
-    SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-    SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-    SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+    sdio_cmdinitstructure.Argument         = 0;
+    sdio_cmdinitstructure.CmdIndex         = SD_CMD_ALL_SEND_CID;
+    sdio_cmdinitstructure.Response         = SDIO_RESPONSE_LONG;
+    sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+    sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+    SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
     
     /* Check for error conditions */
-    errorState = SD_CmdResp2Error(hsd);
+    errorstate = SD_CmdResp2Error(hsd);
     
-    if(errorState != SD_OK)
+    if(errorstate != SD_OK)
     {
-      return errorState;
+      return errorstate;
     }
     
     /* Get Card identification number data */
@@ -2309,16 +2340,16 @@ static HAL_SD_ErrorTypedef SD_Initialize_Cards(SD_HandleTypeDef *hsd)
   {
     /* Send CMD3 SET_REL_ADDR with argument 0 */
     /* SD Card publishes its RCA. */
-    SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SET_REL_ADDR;
-    SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-    SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+    sdio_cmdinitstructure.CmdIndex         = SD_CMD_SET_REL_ADDR;
+    sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+    SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
     
     /* Check for error conditions */
-    errorState = SD_CmdResp6Error(hsd, SD_CMD_SET_REL_ADDR, &sd_rca);
+    errorstate = SD_CmdResp6Error(hsd, SD_CMD_SET_REL_ADDR, &sd_rca);
     
-    if(errorState != SD_OK)
+    if(errorstate != SD_OK)
     {
-      return errorState;
+      return errorstate;
     }
   }
   
@@ -2328,17 +2359,17 @@ static HAL_SD_ErrorTypedef SD_Initialize_Cards(SD_HandleTypeDef *hsd)
     hsd->RCA = sd_rca;
     
     /* Send CMD9 SEND_CSD with argument as card's RCA */
-    SDIO_CmdInitStructure.Argument         = (uint32_t)(hsd->RCA << 16);
-    SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SEND_CSD;
-    SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_LONG;
-    SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+    sdio_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+    sdio_cmdinitstructure.CmdIndex         = SD_CMD_SEND_CSD;
+    sdio_cmdinitstructure.Response         = SDIO_RESPONSE_LONG;
+    SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
     
     /* Check for error conditions */
-    errorState = SD_CmdResp2Error(hsd);
+    errorstate = SD_CmdResp2Error(hsd);
     
-    if(errorState != SD_OK)
+    if(errorstate != SD_OK)
     {
-      return errorState;
+      return errorstate;
     }
     
     /* Get Card Specific Data */
@@ -2349,7 +2380,7 @@ static HAL_SD_ErrorTypedef SD_Initialize_Cards(SD_HandleTypeDef *hsd)
   }
   
   /* All cards are initialized */
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -2360,21 +2391,21 @@ static HAL_SD_ErrorTypedef SD_Initialize_Cards(SD_HandleTypeDef *hsd)
   */
 static HAL_SD_ErrorTypedef SD_Select_Deselect(SD_HandleTypeDef *hsd, uint64_t addr)
 {
-  SDIO_CmdInitTypeDef SDIO_CmdInitStructure;
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  SDIO_CmdInitTypeDef sdio_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   
   /* Send CMD7 SDIO_SEL_DESEL_CARD */
-  SDIO_CmdInitStructure.Argument         = (uint32_t)addr;
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SEL_DESEL_CARD;
-  SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-  SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-  SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = (uint32_t)addr;
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_SEL_DESEL_CARD;
+  sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+  sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+  sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_SEL_DESEL_CARD);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SEL_DESEL_CARD);
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -2386,10 +2417,10 @@ static HAL_SD_ErrorTypedef SD_Select_Deselect(SD_HandleTypeDef *hsd, uint64_t ad
   */
 static HAL_SD_ErrorTypedef SD_PowerON(SD_HandleTypeDef *hsd)
 {
-  SDIO_CmdInitTypeDef SDIO_CmdInitStructure; 
-  __IO HAL_SD_ErrorTypedef errorState = SD_OK; 
+  SDIO_CmdInitTypeDef sdio_cmdinitstructure; 
+  __IO HAL_SD_ErrorTypedef errorstate = SD_OK; 
   uint32_t response = 0, count = 0, validvoltage = 0;
-  uint32_t SDType = SD_STD_CAPACITY;
+  uint32_t sdtype = SD_STD_CAPACITY;
   
   /* Power ON Sequence -------------------------------------------------------*/
   /* Disable SDIO Clock */
@@ -2403,20 +2434,20 @@ static HAL_SD_ErrorTypedef SD_PowerON(SD_HandleTypeDef *hsd)
   
   /* CMD0: GO_IDLE_STATE -----------------------------------------------------*/
   /* No CMD response required */
-  SDIO_CmdInitStructure.Argument         = 0;
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_GO_IDLE_STATE;
-  SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_NO;
-  SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-  SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = 0;
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_GO_IDLE_STATE;
+  sdio_cmdinitstructure.Response         = SDIO_RESPONSE_NO;
+  sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+  sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdError(hsd);
+  errorstate = SD_CmdError(hsd);
   
-  if(errorState != SD_OK)
+  if(errorstate != SD_OK)
   {
     /* CMD Response TimeOut (wait for CMDSENT flag) */
-    return errorState;
+    return errorstate;
   }
   
   /* CMD8: SEND_IF_COND ------------------------------------------------------*/
@@ -2425,33 +2456,33 @@ static HAL_SD_ErrorTypedef SD_PowerON(SD_HandleTypeDef *hsd)
   - [11:8]: Supply Voltage (VHS) 0x1 (Range: 2.7-3.6 V)
   - [7:0]: Check Pattern (recommended 0xAA) */
   /* CMD Response: R7 */
-  SDIO_CmdInitStructure.Argument         = SD_CHECK_PATTERN;
-  SDIO_CmdInitStructure.CmdIndex         = SD_SDIO_SEND_IF_COND;
-  SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = SD_CHECK_PATTERN;
+  sdio_cmdinitstructure.CmdIndex         = SD_SDIO_SEND_IF_COND;
+  sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */ 
-  errorState = SD_CmdResp7Error(hsd);
+  errorstate = SD_CmdResp7Error(hsd);
   
-  if (errorState == SD_OK)
+  if (errorstate == SD_OK)
   {
     /* SD Card 2.0 */
     hsd->CardType = STD_CAPACITY_SD_CARD_V2_0; 
-    SDType        = SD_HIGH_CAPACITY;
+    sdtype        = SD_HIGH_CAPACITY;
   }
   
   /* Send CMD55 */
-  SDIO_CmdInitStructure.Argument         = 0;
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_APP_CMD;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = 0;
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
   
-  /* If errorState is Command TimeOut, it is a MMC card */
-  /* If errorState is SD_OK it is a SD card: SD card 2.0 (voltage range mismatch)
+  /* If errorstate is Command TimeOut, it is a MMC card */
+  /* If errorstate is SD_OK it is a SD card: SD card 2.0 (voltage range mismatch)
      or SD card 1.x */
-  if(errorState == SD_OK)
+  if(errorstate == SD_OK)
   {
     /* SD CARD */
     /* Send ACMD41 SD_APP_OP_COND with Argument 0x80100000 */
@@ -2459,35 +2490,35 @@ static HAL_SD_ErrorTypedef SD_PowerON(SD_HandleTypeDef *hsd)
     {
       
       /* SEND CMD55 APP_CMD with RCA as 0 */
-      SDIO_CmdInitStructure.Argument         = 0;
-      SDIO_CmdInitStructure.CmdIndex         = SD_CMD_APP_CMD;
-      SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-      SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-      SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-      SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+      sdio_cmdinitstructure.Argument         = 0;
+      sdio_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+      sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+      sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+      sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+      SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
       
       /* Check for error conditions */
-      errorState = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+      errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
       
-      if(errorState != SD_OK)
+      if(errorstate != SD_OK)
       {
-        return errorState;
+        return errorstate;
       }
       
       /* Send CMD41 */
-      SDIO_CmdInitStructure.Argument         = SD_VOLTAGE_WINDOW_SD | SDType;
-      SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SD_APP_OP_COND;
-      SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-      SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-      SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-      SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+      sdio_cmdinitstructure.Argument         = SD_VOLTAGE_WINDOW_SD | sdtype;
+      sdio_cmdinitstructure.CmdIndex         = SD_CMD_SD_APP_OP_COND;
+      sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+      sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+      sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+      SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
       
       /* Check for error conditions */
-      errorState = SD_CmdResp3Error(hsd);
+      errorstate = SD_CmdResp3Error(hsd);
       
-      if(errorState != SD_OK)
+      if(errorstate != SD_OK)
       {
-        return errorState;
+        return errorstate;
       }
       
       /* Get command response */
@@ -2501,9 +2532,9 @@ static HAL_SD_ErrorTypedef SD_PowerON(SD_HandleTypeDef *hsd)
     
     if(count >= SD_MAX_VOLT_TRIAL)
     {
-      errorState = SD_INVALID_VOLTRANGE;
+      errorstate = SD_INVALID_VOLTRANGE;
       
-      return errorState;
+      return errorstate;
     }
     
     if((response & SD_HIGH_CAPACITY) == SD_HIGH_CAPACITY) /* (response &= SD_HIGH_CAPACITY) */
@@ -2513,7 +2544,7 @@ static HAL_SD_ErrorTypedef SD_PowerON(SD_HandleTypeDef *hsd)
     
   } /* else MMC Card */
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -2523,12 +2554,12 @@ static HAL_SD_ErrorTypedef SD_PowerON(SD_HandleTypeDef *hsd)
   */
 static HAL_SD_ErrorTypedef SD_PowerOFF(SD_HandleTypeDef *hsd)
 {
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   
   /* Set Power State to OFF */
   SDIO_PowerState_OFF(hsd->Instance);
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -2540,36 +2571,36 @@ static HAL_SD_ErrorTypedef SD_PowerOFF(SD_HandleTypeDef *hsd)
   */
 static HAL_SD_ErrorTypedef SD_SendStatus(SD_HandleTypeDef *hsd, uint32_t *pCardStatus)
 {
-  SDIO_CmdInitTypeDef SDIO_CmdInitStructure;
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  SDIO_CmdInitTypeDef sdio_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   
-  if(pCardStatus == NULL)
+  if(pCardStatus == HAL_NULL)
   {
-    errorState = SD_INVALID_PARAMETER;
+    errorstate = SD_INVALID_PARAMETER;
     
-    return errorState;
+    return errorstate;
   }
   
   /* Send Status command */
-  SDIO_CmdInitStructure.Argument         = (uint32_t)(hsd->RCA << 16);
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SEND_STATUS;
-  SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-  SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-  SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_SEND_STATUS;
+  sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+  sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+  sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_SEND_STATUS);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SEND_STATUS);
   
-  if(errorState != SD_OK)
+  if(errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* Get SD card status */
   *pCardStatus = SDIO_GetResponse(SDIO_RESP1);
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -2579,7 +2610,7 @@ static HAL_SD_ErrorTypedef SD_SendStatus(SD_HandleTypeDef *hsd, uint32_t *pCardS
   */
 static HAL_SD_ErrorTypedef SD_CmdError(SD_HandleTypeDef *hsd)
 {
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   uint32_t timeout, tmp;
   
   timeout = SDIO_CMD0TIMEOUT;
@@ -2594,14 +2625,14 @@ static HAL_SD_ErrorTypedef SD_CmdError(SD_HandleTypeDef *hsd)
   
   if(timeout == 0)
   {
-    errorState = SD_CMD_RSP_TIMEOUT;
-    return errorState;
+    errorstate = SD_CMD_RSP_TIMEOUT;
+    return errorstate;
   }
   
   /* Clear all the static flags */
   __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_STATIC_FLAGS);
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -2611,7 +2642,7 @@ static HAL_SD_ErrorTypedef SD_CmdError(SD_HandleTypeDef *hsd)
   */
 static HAL_SD_ErrorTypedef SD_CmdResp7Error(SD_HandleTypeDef *hsd)
 {
-  HAL_SD_ErrorTypedef errorState = SD_ERROR;
+  HAL_SD_ErrorTypedef errorstate = SD_ERROR;
   uint32_t timeout = SDIO_CMD0TIMEOUT, tmp;
   
   tmp = __HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CCRCFAIL | SDIO_FLAG_CMDREND | SDIO_FLAG_CTIMEOUT); 
@@ -2627,24 +2658,24 @@ static HAL_SD_ErrorTypedef SD_CmdResp7Error(SD_HandleTypeDef *hsd)
   if((timeout == 0) || tmp)
   {
     /* Card is not V2.0 compliant or card does not support the set voltage range */
-    errorState = SD_CMD_RSP_TIMEOUT;
+    errorstate = SD_CMD_RSP_TIMEOUT;
     
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_CTIMEOUT);
     
-    return errorState;
+    return errorstate;
   }
   
   if(__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CMDREND))
   {
     /* Card is SD V2.0 compliant */
-    errorState = SD_OK;
+    errorstate = SD_OK;
     
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_CMDREND);
     
-    return errorState;
+    return errorstate;
   }
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -2655,8 +2686,8 @@ static HAL_SD_ErrorTypedef SD_CmdResp7Error(SD_HandleTypeDef *hsd)
   */
 static HAL_SD_ErrorTypedef SD_CmdResp1Error(SD_HandleTypeDef *hsd, uint8_t SD_CMD)
 {
-  HAL_SD_ErrorTypedef errorState = SD_OK;
-  uint32_t response_R1;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t response_r1;
   
   while(!__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CCRCFAIL | SDIO_FLAG_CMDREND | SDIO_FLAG_CTIMEOUT))
   {
@@ -2664,136 +2695,136 @@ static HAL_SD_ErrorTypedef SD_CmdResp1Error(SD_HandleTypeDef *hsd, uint8_t SD_CM
   
   if(__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CTIMEOUT))
   {
-    errorState = SD_CMD_RSP_TIMEOUT;
+    errorstate = SD_CMD_RSP_TIMEOUT;
     
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_CTIMEOUT);
     
-    return errorState;
+    return errorstate;
   }
   else if(__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CCRCFAIL))
   {
-    errorState = SD_CMD_CRC_FAIL;
+    errorstate = SD_CMD_CRC_FAIL;
     
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_CCRCFAIL);
     
-    return errorState;
+    return errorstate;
   }
   
   /* Check response received is of desired command */
   if(SDIO_GetCommandResponse(hsd->Instance) != SD_CMD)
   {
-    errorState = SD_ILLEGAL_CMD;
+    errorstate = SD_ILLEGAL_CMD;
     
-    return errorState;
+    return errorstate;
   }
   
   /* Clear all the static flags */
   __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_STATIC_FLAGS);
   
   /* We have received response, retrieve it for analysis  */
-  response_R1 = SDIO_GetResponse(SDIO_RESP1);
+  response_r1 = SDIO_GetResponse(SDIO_RESP1);
   
-  if((response_R1 & SD_OCR_ERRORBITS) == SD_ALLZERO)
+  if((response_r1 & SD_OCR_ERRORBITS) == SD_ALLZERO)
   {
-    return errorState;
+    return errorstate;
   }
   
-  if((response_R1 & SD_OCR_ADDR_OUT_OF_RANGE) == SD_OCR_ADDR_OUT_OF_RANGE)
+  if((response_r1 & SD_OCR_ADDR_OUT_OF_RANGE) == SD_OCR_ADDR_OUT_OF_RANGE)
   {
     return(SD_ADDR_OUT_OF_RANGE);
   }
   
-  if((response_R1 & SD_OCR_ADDR_MISALIGNED) == SD_OCR_ADDR_MISALIGNED)
+  if((response_r1 & SD_OCR_ADDR_MISALIGNED) == SD_OCR_ADDR_MISALIGNED)
   {
     return(SD_ADDR_MISALIGNED);
   }
   
-  if((response_R1 & SD_OCR_BLOCK_LEN_ERR) == SD_OCR_BLOCK_LEN_ERR)
+  if((response_r1 & SD_OCR_BLOCK_LEN_ERR) == SD_OCR_BLOCK_LEN_ERR)
   {
     return(SD_BLOCK_LEN_ERR);
   }
   
-  if((response_R1 & SD_OCR_ERASE_SEQ_ERR) == SD_OCR_ERASE_SEQ_ERR)
+  if((response_r1 & SD_OCR_ERASE_SEQ_ERR) == SD_OCR_ERASE_SEQ_ERR)
   {
     return(SD_ERASE_SEQ_ERR);
   }
   
-  if((response_R1 & SD_OCR_BAD_ERASE_PARAM) == SD_OCR_BAD_ERASE_PARAM)
+  if((response_r1 & SD_OCR_BAD_ERASE_PARAM) == SD_OCR_BAD_ERASE_PARAM)
   {
     return(SD_BAD_ERASE_PARAM);
   }
   
-  if((response_R1 & SD_OCR_WRITE_PROT_VIOLATION) == SD_OCR_WRITE_PROT_VIOLATION)
+  if((response_r1 & SD_OCR_WRITE_PROT_VIOLATION) == SD_OCR_WRITE_PROT_VIOLATION)
   {
     return(SD_WRITE_PROT_VIOLATION);
   }
   
-  if((response_R1 & SD_OCR_LOCK_UNLOCK_FAILED) == SD_OCR_LOCK_UNLOCK_FAILED)
+  if((response_r1 & SD_OCR_LOCK_UNLOCK_FAILED) == SD_OCR_LOCK_UNLOCK_FAILED)
   {
     return(SD_LOCK_UNLOCK_FAILED);
   }
   
-  if((response_R1 & SD_OCR_COM_CRC_FAILED) == SD_OCR_COM_CRC_FAILED)
+  if((response_r1 & SD_OCR_COM_CRC_FAILED) == SD_OCR_COM_CRC_FAILED)
   {
     return(SD_COM_CRC_FAILED);
   }
   
-  if((response_R1 & SD_OCR_ILLEGAL_CMD) == SD_OCR_ILLEGAL_CMD)
+  if((response_r1 & SD_OCR_ILLEGAL_CMD) == SD_OCR_ILLEGAL_CMD)
   {
     return(SD_ILLEGAL_CMD);
   }
   
-  if((response_R1 & SD_OCR_CARD_ECC_FAILED) == SD_OCR_CARD_ECC_FAILED)
+  if((response_r1 & SD_OCR_CARD_ECC_FAILED) == SD_OCR_CARD_ECC_FAILED)
   {
     return(SD_CARD_ECC_FAILED);
   }
   
-  if((response_R1 & SD_OCR_CC_ERROR) == SD_OCR_CC_ERROR)
+  if((response_r1 & SD_OCR_CC_ERROR) == SD_OCR_CC_ERROR)
   {
     return(SD_CC_ERROR);
   }
   
-  if((response_R1 & SD_OCR_GENERAL_UNKNOWN_ERROR) == SD_OCR_GENERAL_UNKNOWN_ERROR)
+  if((response_r1 & SD_OCR_GENERAL_UNKNOWN_ERROR) == SD_OCR_GENERAL_UNKNOWN_ERROR)
   {
     return(SD_GENERAL_UNKNOWN_ERROR);
   }
   
-  if((response_R1 & SD_OCR_STREAM_READ_UNDERRUN) == SD_OCR_STREAM_READ_UNDERRUN)
+  if((response_r1 & SD_OCR_STREAM_READ_UNDERRUN) == SD_OCR_STREAM_READ_UNDERRUN)
   {
     return(SD_STREAM_READ_UNDERRUN);
   }
   
-  if((response_R1 & SD_OCR_STREAM_WRITE_OVERRUN) == SD_OCR_STREAM_WRITE_OVERRUN)
+  if((response_r1 & SD_OCR_STREAM_WRITE_OVERRUN) == SD_OCR_STREAM_WRITE_OVERRUN)
   {
     return(SD_STREAM_WRITE_OVERRUN);
   }
   
-  if((response_R1 & SD_OCR_CID_CSD_OVERWRIETE) == SD_OCR_CID_CSD_OVERWRIETE)
+  if((response_r1 & SD_OCR_CID_CSD_OVERWRIETE) == SD_OCR_CID_CSD_OVERWRIETE)
   {
     return(SD_CID_CSD_OVERWRITE);
   }
   
-  if((response_R1 & SD_OCR_WP_ERASE_SKIP) == SD_OCR_WP_ERASE_SKIP)
+  if((response_r1 & SD_OCR_WP_ERASE_SKIP) == SD_OCR_WP_ERASE_SKIP)
   {
     return(SD_WP_ERASE_SKIP);
   }
   
-  if((response_R1 & SD_OCR_CARD_ECC_DISABLED) == SD_OCR_CARD_ECC_DISABLED)
+  if((response_r1 & SD_OCR_CARD_ECC_DISABLED) == SD_OCR_CARD_ECC_DISABLED)
   {
     return(SD_CARD_ECC_DISABLED);
   }
   
-  if((response_R1 & SD_OCR_ERASE_RESET) == SD_OCR_ERASE_RESET)
+  if((response_r1 & SD_OCR_ERASE_RESET) == SD_OCR_ERASE_RESET)
   {
     return(SD_ERASE_RESET);
   }
   
-  if((response_R1 & SD_OCR_AKE_SEQ_ERROR) == SD_OCR_AKE_SEQ_ERROR)
+  if((response_r1 & SD_OCR_AKE_SEQ_ERROR) == SD_OCR_AKE_SEQ_ERROR)
   {
     return(SD_AKE_SEQ_ERROR);
   }
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -2803,7 +2834,7 @@ static HAL_SD_ErrorTypedef SD_CmdResp1Error(SD_HandleTypeDef *hsd, uint8_t SD_CM
   */
 static HAL_SD_ErrorTypedef SD_CmdResp3Error(SD_HandleTypeDef *hsd)
 {
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   
   while (!__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CCRCFAIL | SDIO_FLAG_CMDREND | SDIO_FLAG_CTIMEOUT))
   {
@@ -2811,17 +2842,17 @@ static HAL_SD_ErrorTypedef SD_CmdResp3Error(SD_HandleTypeDef *hsd)
   
   if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CTIMEOUT))
   {
-    errorState = SD_CMD_RSP_TIMEOUT;
+    errorstate = SD_CMD_RSP_TIMEOUT;
     
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_CTIMEOUT);
     
-    return errorState;
+    return errorstate;
   }
   
   /* Clear all the static flags */
   __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_STATIC_FLAGS);
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -2831,7 +2862,7 @@ static HAL_SD_ErrorTypedef SD_CmdResp3Error(SD_HandleTypeDef *hsd)
   */
 static HAL_SD_ErrorTypedef SD_CmdResp2Error(SD_HandleTypeDef *hsd)
 {
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   
   while (!__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CCRCFAIL | SDIO_FLAG_CMDREND | SDIO_FLAG_CTIMEOUT))
   {
@@ -2839,25 +2870,29 @@ static HAL_SD_ErrorTypedef SD_CmdResp2Error(SD_HandleTypeDef *hsd)
     
   if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CTIMEOUT))
   {
-    errorState = SD_CMD_RSP_TIMEOUT;
+    errorstate = SD_CMD_RSP_TIMEOUT;
     
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_CTIMEOUT);
     
-    return errorState;
+    return errorstate;
   }
   else if (__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CCRCFAIL))
   {
-    errorState = SD_CMD_CRC_FAIL;
+    errorstate = SD_CMD_CRC_FAIL;
     
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_CCRCFAIL);
     
-    return errorState;
+    return errorstate;
   }
+  else
+  {
+    /* No error flag set */
+  }  
   
   /* Clear all the static flags */
   __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_STATIC_FLAGS);
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -2870,8 +2905,8 @@ static HAL_SD_ErrorTypedef SD_CmdResp2Error(SD_HandleTypeDef *hsd)
   */
 static HAL_SD_ErrorTypedef SD_CmdResp6Error(SD_HandleTypeDef *hsd, uint8_t SD_CMD, uint16_t *pRCA)
 {
-  HAL_SD_ErrorTypedef errorState = SD_OK;
-  uint32_t response_R1;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
+  uint32_t response_r1;
   
   while(!__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CCRCFAIL | SDIO_FLAG_CMDREND | SDIO_FLAG_CTIMEOUT))
   {
@@ -2879,58 +2914,62 @@ static HAL_SD_ErrorTypedef SD_CmdResp6Error(SD_HandleTypeDef *hsd, uint8_t SD_CM
   
   if(__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CTIMEOUT))
   {
-    errorState = SD_CMD_RSP_TIMEOUT;
+    errorstate = SD_CMD_RSP_TIMEOUT;
     
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_CTIMEOUT);
     
-    return errorState;
+    return errorstate;
   }
   else if(__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CCRCFAIL))
   {
-    errorState = SD_CMD_CRC_FAIL;
+    errorstate = SD_CMD_CRC_FAIL;
     
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_CCRCFAIL);
     
-    return errorState;
+    return errorstate;
   }
+  else
+  {
+    /* No error flag set */
+  }  
   
   /* Check response received is of desired command */
   if(SDIO_GetCommandResponse(hsd->Instance) != SD_CMD)
   {
-    errorState = SD_ILLEGAL_CMD;
+    errorstate = SD_ILLEGAL_CMD;
     
-    return errorState;
+    return errorstate;
   }
   
   /* Clear all the static flags */
   __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_STATIC_FLAGS);
   
   /* We have received response, retrieve it.  */
-  response_R1 = SDIO_GetResponse(SDIO_RESP1);
+  response_r1 = SDIO_GetResponse(SDIO_RESP1);
   
-  if((response_R1 & (SD_R6_GENERAL_UNKNOWN_ERROR | SD_R6_ILLEGAL_CMD | SD_R6_COM_CRC_FAILED)) == SD_ALLZERO)
+  if((response_r1 & (SD_R6_GENERAL_UNKNOWN_ERROR | SD_R6_ILLEGAL_CMD | SD_R6_COM_CRC_FAILED)) == SD_ALLZERO)
   {
-    *pRCA = (uint16_t) (response_R1 >> 16);
+    *pRCA = (uint16_t) (response_r1 >> 16);
     
-    return errorState;
+    return errorstate;
   }
   
-  if((response_R1 & SD_R6_GENERAL_UNKNOWN_ERROR) == SD_R6_GENERAL_UNKNOWN_ERROR)
+  if((response_r1 & SD_R6_GENERAL_UNKNOWN_ERROR) == SD_R6_GENERAL_UNKNOWN_ERROR)
   {
     return(SD_GENERAL_UNKNOWN_ERROR);
   }
   
-  if((response_R1 & SD_R6_ILLEGAL_CMD) == SD_R6_ILLEGAL_CMD)
+  if((response_r1 & SD_R6_ILLEGAL_CMD) == SD_R6_ILLEGAL_CMD)
   {
     return(SD_ILLEGAL_CMD);
   }
   
-  if((response_R1 & SD_R6_COM_CRC_FAILED) == SD_R6_COM_CRC_FAILED)
+  if((response_r1 & SD_R6_COM_CRC_FAILED) == SD_R6_COM_CRC_FAILED)
   {
     return(SD_COM_CRC_FAILED);
   }
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -2940,65 +2979,65 @@ static HAL_SD_ErrorTypedef SD_CmdResp6Error(SD_HandleTypeDef *hsd, uint8_t SD_CM
   */
 static HAL_SD_ErrorTypedef SD_WideBus_Enable(SD_HandleTypeDef *hsd)
 {
-  SDIO_CmdInitTypeDef SDIO_CmdInitStructure;
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  SDIO_CmdInitTypeDef sdio_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   
   uint32_t scr[2] = {0, 0};
   
   if((SDIO_GetResponse(SDIO_RESP1) & SD_CARD_LOCKED) == SD_CARD_LOCKED)
   {
-    errorState = SD_LOCK_UNLOCK_FAILED;
+    errorstate = SD_LOCK_UNLOCK_FAILED;
     
-    return errorState;
+    return errorstate;
   }
   
   /* Get SCR Register */
-  errorState = SD_FindSCR(hsd, scr);
+  errorstate = SD_FindSCR(hsd, scr);
   
-  if(errorState != SD_OK)
+  if(errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* If requested card supports wide bus operation */
   if((scr[1] & SD_WIDE_BUS_SUPPORT) != SD_ALLZERO)
   {
     /* Send CMD55 APP_CMD with argument as card's RCA.*/
-    SDIO_CmdInitStructure.Argument         = (uint32_t)(hsd->RCA << 16);
-    SDIO_CmdInitStructure.CmdIndex         = SD_CMD_APP_CMD;
-    SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-    SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-    SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-    SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+    sdio_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+    sdio_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+    sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+    sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+    sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+    SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
     
     /* Check for error conditions */
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
     
-    if(errorState != SD_OK)
+    if(errorstate != SD_OK)
     {
-      return errorState;
+      return errorstate;
     }
     
     /* Send ACMD6 APP_CMD with argument as 2 for wide bus mode */
-    SDIO_CmdInitStructure.Argument         = 2;
-    SDIO_CmdInitStructure.CmdIndex         = SD_CMD_APP_SD_SET_BUSWIDTH;
-    SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+    sdio_cmdinitstructure.Argument         = 2;
+    sdio_cmdinitstructure.CmdIndex         = SD_CMD_APP_SD_SET_BUSWIDTH;
+    SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
     
     /* Check for error conditions */
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_APP_SD_SET_BUSWIDTH);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_SD_SET_BUSWIDTH);
     
-    if(errorState != SD_OK)
+    if(errorstate != SD_OK)
     {
-      return errorState;
+      return errorstate;
     }
     
-    return errorState;
+    return errorstate;
   }
   else
   {
-    errorState = SD_REQUEST_NOT_APPLICABLE;
+    errorstate = SD_REQUEST_NOT_APPLICABLE;
     
-    return errorState;
+    return errorstate;
   }
 }   
 
@@ -3009,65 +3048,65 @@ static HAL_SD_ErrorTypedef SD_WideBus_Enable(SD_HandleTypeDef *hsd)
   */
 static HAL_SD_ErrorTypedef SD_WideBus_Disable(SD_HandleTypeDef *hsd)
 {
-  SDIO_CmdInitTypeDef SDIO_CmdInitStructure;
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  SDIO_CmdInitTypeDef sdio_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   
   uint32_t scr[2] = {0, 0};
   
   if((SDIO_GetResponse(SDIO_RESP1) & SD_CARD_LOCKED) == SD_CARD_LOCKED)
   {
-    errorState = SD_LOCK_UNLOCK_FAILED;
+    errorstate = SD_LOCK_UNLOCK_FAILED;
     
-    return errorState;
+    return errorstate;
   }
   
   /* Get SCR Register */
-  errorState = SD_FindSCR(hsd, scr);
+  errorstate = SD_FindSCR(hsd, scr);
   
-  if(errorState != SD_OK)
+  if(errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* If requested card supports 1 bit mode operation */
   if((scr[1] & SD_SINGLE_BUS_SUPPORT) != SD_ALLZERO)
   {
     /* Send CMD55 APP_CMD with argument as card's RCA */
-    SDIO_CmdInitStructure.Argument         = (uint32_t)(hsd->RCA << 16);
-    SDIO_CmdInitStructure.CmdIndex         = SD_CMD_APP_CMD;
-    SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-    SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-    SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-    SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+    sdio_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+    sdio_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+    sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+    sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+    sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+    SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
     
     /* Check for error conditions */
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
     
-    if(errorState != SD_OK)
+    if(errorstate != SD_OK)
     {
-      return errorState;
+      return errorstate;
     }
     
     /* Send ACMD6 APP_CMD with argument as 0 for single bus mode */
-    SDIO_CmdInitStructure.Argument         = 0;
-    SDIO_CmdInitStructure.CmdIndex         = SD_CMD_APP_SD_SET_BUSWIDTH;
-    SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+    sdio_cmdinitstructure.Argument         = 0;
+    sdio_cmdinitstructure.CmdIndex         = SD_CMD_APP_SD_SET_BUSWIDTH;
+    SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
     
     /* Check for error conditions */
-    errorState = SD_CmdResp1Error(hsd, SD_CMD_APP_SD_SET_BUSWIDTH);
+    errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_SD_SET_BUSWIDTH);
     
-    if(errorState != SD_OK)
+    if(errorstate != SD_OK)
     {
-      return errorState;
+      return errorstate;
     }
     
-    return errorState;
+    return errorstate;
   }
   else
   {
-    errorState = SD_REQUEST_NOT_APPLICABLE;
+    errorstate = SD_REQUEST_NOT_APPLICABLE;
     
-    return errorState;
+    return errorstate;
   }
 }
   
@@ -3080,60 +3119,60 @@ static HAL_SD_ErrorTypedef SD_WideBus_Disable(SD_HandleTypeDef *hsd)
   */
 static HAL_SD_ErrorTypedef SD_FindSCR(SD_HandleTypeDef *hsd, uint32_t *pSCR)
 {
-  SDIO_CmdInitTypeDef  SDIO_CmdInitStructure;
-  SDIO_DataInitTypeDef SDIO_DataInitStructure;
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  SDIO_CmdInitTypeDef  sdio_cmdinitstructure;
+  SDIO_DataInitTypeDef sdio_datainitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   uint32_t index = 0;
   uint32_t tempscr[2] = {0, 0};
   
   /* Set Block Size To 8 Bytes */
   /* Send CMD55 APP_CMD with argument as card's RCA */
-  SDIO_CmdInitStructure.Argument         = (uint32_t)8;
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
-  SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-  SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-  SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = (uint32_t)8;
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
+  sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+  sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+  sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SET_BLOCKLEN);
   
-  if(errorState != SD_OK)
+  if(errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   /* Send CMD55 APP_CMD with argument as card's RCA */
-  SDIO_CmdInitStructure.Argument         = (uint32_t)((hsd->RCA) << 16);
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_APP_CMD;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = (uint32_t)((hsd->RCA) << 16);
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_APP_CMD;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_APP_CMD);
   
-  if(errorState != SD_OK)
+  if(errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
-  SDIO_DataInitStructure.DataTimeOut   = SD_DATATIMEOUT;
-  SDIO_DataInitStructure.DataLength    = 8;
-  SDIO_DataInitStructure.DataBlockSize = SDIO_DATABLOCK_SIZE_8B;
-  SDIO_DataInitStructure.TransferDir   = SDIO_TRANSFER_DIR_TO_SDIO;
-  SDIO_DataInitStructure.TransferMode  = SDIO_TRANSFER_MODE_BLOCK;
-  SDIO_DataInitStructure.DPSM          = SDIO_DPSM_ENABLE;
-  SDIO_DataConfig(hsd->Instance, &SDIO_DataInitStructure);
+  sdio_datainitstructure.DataTimeOut   = SD_DATATIMEOUT;
+  sdio_datainitstructure.DataLength    = 8;
+  sdio_datainitstructure.DataBlockSize = SDIO_DATABLOCK_SIZE_8B;
+  sdio_datainitstructure.TransferDir   = SDIO_TRANSFER_DIR_TO_SDIO;
+  sdio_datainitstructure.TransferMode  = SDIO_TRANSFER_MODE_BLOCK;
+  sdio_datainitstructure.DPSM          = SDIO_DPSM_ENABLE;
+  SDIO_DataConfig(hsd->Instance, &sdio_datainitstructure);
   
   /* Send ACMD51 SD_APP_SEND_SCR with argument as 0 */
-  SDIO_CmdInitStructure.Argument         = 0;
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SD_APP_SEND_SCR;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = 0;
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_SD_APP_SEND_SCR;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   /* Check for error conditions */
-  errorState = SD_CmdResp1Error(hsd, SD_CMD_SD_APP_SEND_SCR);
+  errorstate = SD_CmdResp1Error(hsd, SD_CMD_SD_APP_SEND_SCR);
   
-  if(errorState != SD_OK)
+  if(errorstate != SD_OK)
   {
-    return errorState;
+    return errorstate;
   }
   
   while(!__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_RXOVERR | SDIO_FLAG_DCRCFAIL | SDIO_FLAG_DTIMEOUT | SDIO_FLAG_DBCKEND | SDIO_FLAG_STBITERR))
@@ -3149,33 +3188,37 @@ static HAL_SD_ErrorTypedef SD_FindSCR(SD_HandleTypeDef *hsd, uint32_t *pSCR)
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_DTIMEOUT);
     
-    errorState = SD_DATA_TIMEOUT;
+    errorstate = SD_DATA_TIMEOUT;
     
-    return errorState;
+    return errorstate;
   }
   else if(__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_DCRCFAIL))
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_DCRCFAIL);
     
-    errorState = SD_DATA_CRC_FAIL;
+    errorstate = SD_DATA_CRC_FAIL;
     
-    return errorState;
+    return errorstate;
   }
   else if(__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_RXOVERR))
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_RXOVERR);
     
-    errorState = SD_RX_OVERRUN;
+    errorstate = SD_RX_OVERRUN;
     
-    return errorState;
+    return errorstate;
   }
   else if(__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_STBITERR))
   {
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_STBITERR);
     
-    errorState = SD_START_BIT_ERR;
+    errorstate = SD_START_BIT_ERR;
     
-    return errorState;
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
   }
   
   /* Clear all the static flags */
@@ -3187,7 +3230,7 @@ static HAL_SD_ErrorTypedef SD_FindSCR(SD_HandleTypeDef *hsd, uint32_t *pSCR)
   *(pSCR) = ((tempscr[1] & SD_0TO7BITS) << 24)  | ((tempscr[1] & SD_8TO15BITS) << 8) |\
     ((tempscr[1] & SD_16TO23BITS) >> 8) | ((tempscr[1] & SD_24TO31BITS) >> 24);
   
-  return errorState;
+  return errorstate;
 }
 
 /**
@@ -3198,16 +3241,16 @@ static HAL_SD_ErrorTypedef SD_FindSCR(SD_HandleTypeDef *hsd, uint32_t *pSCR)
   */
 static HAL_SD_ErrorTypedef SD_IsCardProgramming(SD_HandleTypeDef *hsd, uint8_t *pStatus)
 {
-  SDIO_CmdInitTypeDef SDIO_CmdInitStructure;
-  HAL_SD_ErrorTypedef errorState = SD_OK;
+  SDIO_CmdInitTypeDef sdio_cmdinitstructure;
+  HAL_SD_ErrorTypedef errorstate = SD_OK;
   __IO uint32_t responseR1 = 0;
   
-  SDIO_CmdInitStructure.Argument         = (uint32_t)(hsd->RCA << 16);
-  SDIO_CmdInitStructure.CmdIndex         = SD_CMD_SEND_STATUS;
-  SDIO_CmdInitStructure.Response         = SDIO_RESPONSE_SHORT;
-  SDIO_CmdInitStructure.WaitForInterrupt = SDIO_WAIT_NO;
-  SDIO_CmdInitStructure.CPSM             = SDIO_CPSM_ENABLE;
-  SDIO_SendCommand(hsd->Instance, &SDIO_CmdInitStructure);
+  sdio_cmdinitstructure.Argument         = (uint32_t)(hsd->RCA << 16);
+  sdio_cmdinitstructure.CmdIndex         = SD_CMD_SEND_STATUS;
+  sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
+  sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
+  sdio_cmdinitstructure.CPSM             = SDIO_CPSM_ENABLE;
+  SDIO_SendCommand(hsd->Instance, &sdio_cmdinitstructure);
   
   while(!__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CCRCFAIL | SDIO_FLAG_CMDREND | SDIO_FLAG_CTIMEOUT))
   {
@@ -3215,27 +3258,31 @@ static HAL_SD_ErrorTypedef SD_IsCardProgramming(SD_HandleTypeDef *hsd, uint8_t *
   
   if(__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CTIMEOUT))
   {
-    errorState = SD_CMD_RSP_TIMEOUT;
+    errorstate = SD_CMD_RSP_TIMEOUT;
     
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_CTIMEOUT);
     
-    return errorState;
+    return errorstate;
   }
   else if(__HAL_SD_SDIO_GET_FLAG(hsd, SDIO_FLAG_CCRCFAIL))
   {
-    errorState = SD_CMD_CRC_FAIL;
+    errorstate = SD_CMD_CRC_FAIL;
     
     __HAL_SD_SDIO_CLEAR_FLAG(hsd, SDIO_FLAG_CCRCFAIL);
     
-    return errorState;
+    return errorstate;
+  }
+  else
+  {
+    /* No error flag set */
   }
   
   /* Check response received is of desired command */
   if((uint32_t)SDIO_GetCommandResponse(hsd->Instance) != SD_CMD_SEND_STATUS)
   {
-    errorState = SD_ILLEGAL_CMD;
+    errorstate = SD_ILLEGAL_CMD;
     
-    return errorState;
+    return errorstate;
   }
   
   /* Clear all the static flags */
@@ -3250,7 +3297,7 @@ static HAL_SD_ErrorTypedef SD_IsCardProgramming(SD_HandleTypeDef *hsd, uint8_t *
   
   if((responseR1 & SD_OCR_ERRORBITS) == SD_ALLZERO)
   {
-    return errorState;
+    return errorstate;
   }
   
   if((responseR1 & SD_OCR_ADDR_OUT_OF_RANGE) == SD_OCR_ADDR_OUT_OF_RANGE)
@@ -3348,7 +3395,7 @@ static HAL_SD_ErrorTypedef SD_IsCardProgramming(SD_HandleTypeDef *hsd, uint8_t *
     return(SD_AKE_SEQ_ERROR);
   }
   
-  return errorState;
+  return errorstate;
 }   
 
 /**

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_sd.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_sd.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_sd.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of SD HAL module.
   ******************************************************************************
   * @attention
@@ -55,6 +55,9 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup SD_Exported_Types
+  * @{
+  */
 #define SD_InitTypeDef      SDIO_InitTypeDef 
 #define SD_TypeDef          SDIO_TypeDef
 
@@ -394,7 +397,7 @@ typedef enum
   
 /* Exported macro ------------------------------------------------------------*/
 
-/** @defgroup SD_Interrupt_Clock
+/** @defgroup SD_Exported_macros
  *  @brief macros to handle interrupts and specific clock configurations
  * @{
  */
@@ -606,14 +609,26 @@ typedef enum
   */
   
 /* Exported functions --------------------------------------------------------*/
-
-/* Initialization/de-initialization functions  **********************************/
+/** @addtogroup SD_Exported_Functions
+  * @{
+  */
+  
+/* Initialization/de-initialization functions  ********************************/
+/** @addtogroup SD_Group1
+  * @{
+  */
 HAL_SD_ErrorTypedef HAL_SD_Init(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTypedef *SDCardInfo);
 HAL_StatusTypeDef   HAL_SD_DeInit (SD_HandleTypeDef *hsd);
 void HAL_SD_MspInit(SD_HandleTypeDef *hsd);
 void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd);
-
-/* I/O operation functions  *****************************************************/
+/**
+  * @}
+  */
+  
+/* I/O operation functions  ***************************************************/
+/** @addtogroup SD_Group2
+  * @{
+  */
 /* Blocking mode: Polling */
 HAL_SD_ErrorTypedef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint32_t *pReadBuffer, uint64_t ReadAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
 HAL_SD_ErrorTypedef HAL_SD_WriteBlocks(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
@@ -635,18 +650,37 @@ HAL_SD_ErrorTypedef HAL_SD_ReadBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pRead
 HAL_SD_ErrorTypedef HAL_SD_WriteBlocks_DMA(SD_HandleTypeDef *hsd, uint32_t *pWriteBuffer, uint64_t WriteAddr, uint32_t BlockSize, uint32_t NumberOfBlocks);
 HAL_SD_ErrorTypedef HAL_SD_CheckWriteOperation(SD_HandleTypeDef *hsd, uint32_t Timeout);
 HAL_SD_ErrorTypedef HAL_SD_CheckReadOperation(SD_HandleTypeDef *hsd, uint32_t Timeout);
-
-/* Peripheral Control functions  ************************************************/
+/**
+  * @}
+  */
+  
+/* Peripheral Control functions  **********************************************/
+/** @addtogroup SD_Group3
+  * @{
+  */
 HAL_SD_ErrorTypedef HAL_SD_Get_CardInfo(SD_HandleTypeDef *hsd, HAL_SD_CardInfoTypedef *pCardInfo);
 HAL_SD_ErrorTypedef HAL_SD_WideBusOperation_Config(SD_HandleTypeDef *hsd, uint32_t WideMode);
 HAL_SD_ErrorTypedef HAL_SD_StopTransfer(SD_HandleTypeDef *hsd);
 HAL_SD_ErrorTypedef HAL_SD_HighSpeed (SD_HandleTypeDef *hsd);
-
-/* Peripheral State functions  **************************************************/
+/**
+  * @}
+  */
+  
+/* Peripheral State functions  ************************************************/
+/** @addtogroup SD_Group4
+  * @{
+  */
 HAL_SD_ErrorTypedef HAL_SD_SendSDStatus(SD_HandleTypeDef *hsd, uint32_t *pSDstatus);
 HAL_SD_ErrorTypedef HAL_SD_GetCardStatus(SD_HandleTypeDef *hsd, HAL_SD_CardStatusTypedef *pCardStatus);
 HAL_SD_TransferStateTypedef HAL_SD_GetStatus(SD_HandleTypeDef *hsd);
-
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */
+    
 /**
   * @}
   */ 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_sdram.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_sdram.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_sdram.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   SDRAM HAL module driver.
   *          This file provides a generic firmware to drive SDRAM memories mounted 
   *          as external device.

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_sdram.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_sdram.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_sdram.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of SDRAM HAL module.
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_smartcard.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_smartcard.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_smartcard.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   SMARTCARD HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the SMARTCARD peripheral:
@@ -222,7 +222,7 @@ static HAL_StatusTypeDef SMARTCARD_WaitOnFlagUntilTimeout(SMARTCARD_HandleTypeDe
 HAL_StatusTypeDef HAL_SMARTCARD_Init(SMARTCARD_HandleTypeDef *hsc)
 {
   /* Check the SMARTCARD handle allocation */
-  if(hsc == NULL)
+  if(hsc == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -285,7 +285,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Init(SMARTCARD_HandleTypeDef *hsc)
 HAL_StatusTypeDef HAL_SMARTCARD_DeInit(SMARTCARD_HandleTypeDef *hsc)
 {
   /* Check the SMARTCARD handle allocation */
-  if(hsc == NULL)
+  if(hsc == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -404,7 +404,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsc, uint8_t *
   tmp1 = hsc->State;
   if((tmp1 == HAL_SMARTCARD_STATE_READY) || (tmp1 == HAL_SMARTCARD_STATE_BUSY_RX))
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;
     }
@@ -497,7 +497,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Receive(SMARTCARD_HandleTypeDef *hsc, uint8_t *p
   tmp1 = hsc->State;
   if((tmp1 == HAL_SMARTCARD_STATE_READY) || (tmp1 == HAL_SMARTCARD_STATE_BUSY_TX))
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;
     }
@@ -594,7 +594,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsc, uint8_
   tmp1 = hsc->State;
   if((tmp1 == HAL_SMARTCARD_STATE_READY) || (tmp1 == HAL_SMARTCARD_STATE_BUSY_RX))
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;
     }
@@ -626,8 +626,8 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsc, uint8_
     /* Process Unlocked */
     __HAL_UNLOCK(hsc);
 
-    /* Enable the SMARTCARD Transmit Complete Interrupt */
-    __SMARTCARD_ENABLE_IT(hsc, SMARTCARD_IT_TC);
+    /* Enable the SMARTCARD Transmit data register empty Interrupt */
+    __SMARTCARD_ENABLE_IT(hsc, SMARTCARD_IT_TXE);
 
     return HAL_OK;
   }
@@ -652,7 +652,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Receive_IT(SMARTCARD_HandleTypeDef *hsc, uint8_t
   tmp1 = hsc->State;
   if((tmp1 == HAL_SMARTCARD_STATE_READY) || (tmp1 == HAL_SMARTCARD_STATE_BUSY_TX))
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;
     }
@@ -711,7 +711,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit_DMA(SMARTCARD_HandleTypeDef *hsc, uint8
   tmp1 = hsc->State;
   if((tmp1 == HAL_SMARTCARD_STATE_READY) || (tmp1 == HAL_SMARTCARD_STATE_BUSY_RX))
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;
     }
@@ -776,7 +776,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Receive_DMA(SMARTCARD_HandleTypeDef *hsc, uint8_
   tmp1 = hsc->State;
   if((tmp1 == HAL_SMARTCARD_STATE_READY) || (tmp1 == HAL_SMARTCARD_STATE_BUSY_TX))
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;
     }
@@ -839,7 +839,7 @@ void HAL_SMARTCARD_IRQHandler(SMARTCARD_HandleTypeDef *hsc)
   /* SMARTCARD parity error interrupt occured --------------------------------*/
   if(((tmp1 & SMARTCARD_FLAG_PE) != RESET) && (tmp2 != RESET))
   { 
-    __HAL_SMARTCARD_CLEAR_FLAG(hsc, SMARTCARD_FLAG_PE);
+    __HAL_SMARTCARD_CLEAR_PEFLAG(hsc);
     hsc->ErrorCode |= HAL_SMARTCARD_ERROR_PE;
   }
   
@@ -847,7 +847,7 @@ void HAL_SMARTCARD_IRQHandler(SMARTCARD_HandleTypeDef *hsc)
   /* SMARTCARD frame error interrupt occured ---------------------------------*/
   if(((tmp1 & SMARTCARD_FLAG_FE) != RESET) && (tmp2 != RESET))
   { 
-    __HAL_SMARTCARD_CLEAR_FLAG(hsc, SMARTCARD_FLAG_FE);
+    __HAL_SMARTCARD_CLEAR_FEFLAG(hsc);
     hsc->ErrorCode |= HAL_SMARTCARD_ERROR_FE;
   }
   
@@ -855,7 +855,7 @@ void HAL_SMARTCARD_IRQHandler(SMARTCARD_HandleTypeDef *hsc)
   /* SMARTCARD noise error interrupt occured ---------------------------------*/
   if(((tmp1 & SMARTCARD_FLAG_NE) != RESET) && (tmp2 != RESET))
   { 
-    __HAL_SMARTCARD_CLEAR_FLAG(hsc, SMARTCARD_FLAG_NE);
+    __HAL_SMARTCARD_CLEAR_NEFLAG(hsc);
     hsc->ErrorCode |= HAL_SMARTCARD_ERROR_NE;
   }
 
@@ -863,7 +863,7 @@ void HAL_SMARTCARD_IRQHandler(SMARTCARD_HandleTypeDef *hsc)
   /* SMARTCARD Over-Run interrupt occured ------------------------------------*/
   if(((tmp1 & SMARTCARD_FLAG_ORE) != RESET) && (tmp2 != RESET))
   { 
-    __HAL_SMARTCARD_CLEAR_FLAG(hsc, SMARTCARD_FLAG_ORE);
+    __HAL_SMARTCARD_CLEAR_OREFLAG(hsc);
     hsc->ErrorCode |= HAL_SMARTCARD_ERROR_ORE;
   }
   
@@ -872,15 +872,13 @@ void HAL_SMARTCARD_IRQHandler(SMARTCARD_HandleTypeDef *hsc)
   if(((tmp1 & SMARTCARD_FLAG_RXNE) != RESET) && (tmp2 != RESET))
   { 
     SMARTCARD_Receive_IT(hsc);
-    __HAL_SMARTCARD_CLEAR_FLAG(hsc, SMARTCARD_FLAG_RXNE);
   }
 
-  tmp2 = __HAL_SMARTCARD_GET_IT_SOURCE(hsc, SMARTCARD_IT_TC);
+  tmp2 = __HAL_SMARTCARD_GET_IT_SOURCE(hsc, SMARTCARD_IT_TXE);
   /* SMARTCARD in mode Transmitter -------------------------------------------*/
-  if(((tmp1 & SMARTCARD_FLAG_TC) != RESET) && (tmp2 != RESET))
+  if(((tmp1 & SMARTCARD_FLAG_TXE) != RESET) && (tmp2 != RESET))
   {
     SMARTCARD_Transmit_IT(hsc);
-    __HAL_SMARTCARD_CLEAR_FLAG(hsc, SMARTCARD_FLAG_TC);
   }
   
   /* Call the Error call Back in case of Errors */
@@ -1072,10 +1070,11 @@ static void SMARTCARD_DMAError(DMA_HandleTypeDef *hdma)
   */
 static HAL_StatusTypeDef SMARTCARD_WaitOnFlagUntilTimeout(SMARTCARD_HandleTypeDef *hsc, uint32_t Flag, FlagStatus Status, uint32_t Timeout)
 {
-  uint32_t timeout = 0;
-  
-  timeout = HAL_GetTick() + Timeout;
-  
+  uint32_t tickstart = 0;
+
+  /* Get tick */ 
+  tickstart = HAL_GetTick();
+
   /* Wait until flag is set */
   if(Status == RESET)
   {    
@@ -1084,7 +1083,7 @@ static HAL_StatusTypeDef SMARTCARD_WaitOnFlagUntilTimeout(SMARTCARD_HandleTypeDe
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Disable TXE and RXNE interrupts for the interrupt process */
           __SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_TXE);
@@ -1107,7 +1106,7 @@ static HAL_StatusTypeDef SMARTCARD_WaitOnFlagUntilTimeout(SMARTCARD_HandleTypeDe
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Disable TXE and RXNE interrupts for the interrupt process */
           __SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_TXE);
@@ -1160,8 +1159,8 @@ static HAL_StatusTypeDef SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsc)
     
     if(--hsc->TxXferCount == 0)
     {
-      /* Disable the SMARTCARD Transmit Complete Interrupt */
-      __SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_TC);
+      /* Disable the SMARTCARD Transmit data register empty Interrupt */
+      __SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_TXE);
       
       /* Disable the SMARTCARD Parity Error Interrupt */
       __SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_PE);
@@ -1169,6 +1168,11 @@ static HAL_StatusTypeDef SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsc)
       /* Disable the SMARTCARD Error Interrupt: (Frame error, noise error, overrun error) */
       __SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_ERR);
       
+      if(SMARTCARD_WaitOnFlagUntilTimeout(hsc, SMARTCARD_FLAG_TC, RESET, SMARTCARD_TIMEOUT_VALUE) != HAL_OK)
+      {
+        return HAL_TIMEOUT;
+      }
+            
       /* Check if a non-blocking receive process is ongoing or not */
       if(hsc->State == HAL_SMARTCARD_STATE_BUSY_TX_RX) 
       {
@@ -1178,7 +1182,7 @@ static HAL_StatusTypeDef SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsc)
       {
         hsc->State = HAL_SMARTCARD_STATE_READY;
       }
-      
+
       HAL_SMARTCARD_TxCpltCallback(hsc);
       
       return HAL_OK;
@@ -1234,9 +1238,6 @@ static HAL_StatusTypeDef SMARTCARD_Receive_IT(SMARTCARD_HandleTypeDef *hsc)
     
     if(--hsc->RxXferCount == 0)
     {
-      while(HAL_IS_BIT_SET(hsc->Instance->SR, SMARTCARD_FLAG_RXNE))
-      {
-      }
       __SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_RXNE);
       
       /* Disable the SMARTCARD Parity Error Interrupt */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_smartcard.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_smartcard.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_smartcard.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of SMARTCARD HAL module.
   ******************************************************************************
   * @attention
@@ -356,7 +356,48 @@ typedef struct
   *          USART_SR register followed by a write operation to USART_DR register.
   * @note   TXE flag is cleared only by a write to the USART_DR register.
   */
-#define __HAL_SMARTCARD_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->SR &= ~(__FLAG__))
+#define __HAL_SMARTCARD_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->SR = ~(__FLAG__))
+
+/** @brief  Clear the SMARTCARD PE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_SMARTCARD_CLEAR_PEFLAG(__HANDLE__) do{(__HANDLE__)->Instance->SR;\
+                                               (__HANDLE__)->Instance->DR;}while(0)
+/** @brief  Clear the SMARTCARD FE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_SMARTCARD_CLEAR_FEFLAG(__HANDLE__) __HAL_SMARTCARD_CLEAR_PEFLAG(__HANDLE__)
+
+/** @brief  Clear the SMARTCARD NE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_SMARTCARD_CLEAR_NEFLAG(__HANDLE__) __HAL_SMARTCARD_CLEAR_PEFLAG(__HANDLE__)
+
+/** @brief  Clear the SMARTCARD ORE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_SMARTCARD_CLEAR_OREFLAG(__HANDLE__) __HAL_SMARTCARD_CLEAR_PEFLAG(__HANDLE__)
+
+/** @brief  Clear the SMARTCARD IDLE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_SMARTCARD_CLEAR_IDLEFLAG(__HANDLE__) __HAL_SMARTCARD_CLEAR_PEFLAG(__HANDLE__)
+
 
 /** @brief  Enables or disables the specified SmartCard interrupts.
   * @param  __HANDLE__: specifies the SMARTCARD Handle.

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_spi.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_spi.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_spi.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of SPI HAL module.
   ******************************************************************************
   * @attention
@@ -399,7 +399,7 @@ typedef struct __SPI_HandleTypeDef
   *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
   * @retval None
   */
-#define __HAL_SPI_CLEAR_CRCERRFLAG(__HANDLE__) ((__HANDLE__)->Instance->SR &= ~(SPI_FLAG_CRCERR))
+#define __HAL_SPI_CLEAR_CRCERRFLAG(__HANDLE__) ((__HANDLE__)->Instance->SR = ~(SPI_FLAG_CRCERR))
 
 /** @brief  Clear the SPI MODF pending flag.
   * @param  __HANDLE__: specifies the SPI handle.
@@ -454,11 +454,18 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *p
 HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_DMAPause(SPI_HandleTypeDef *hspi);
+HAL_StatusTypeDef HAL_SPI_DMAResume(SPI_HandleTypeDef *hspi);
+HAL_StatusTypeDef HAL_SPI_DMAStop(SPI_HandleTypeDef *hspi);
+
 void HAL_SPI_IRQHandler(SPI_HandleTypeDef *hspi);
 void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi);
 void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi);
 void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi);
 void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_TxHalfCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_RxHalfCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_TxRxHalfCpltCallback(SPI_HandleTypeDef *hspi);
 
 /* Peripheral State and Control functions  **************************************/
 HAL_SPI_StateTypeDef HAL_SPI_GetState(SPI_HandleTypeDef *hspi);

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_sram.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_sram.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_sram.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   SRAM HAL module driver.
   *          This file provides a generic firmware to drive SRAM memories  
   *          mounted as external device.

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_sram.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_sram.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_sram.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of SRAM HAL module.
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_tim.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_tim.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_tim.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   TIM HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Timer (TIM) peripheral:
@@ -200,7 +200,7 @@ static void TIM_DMATriggerCplt(DMA_HandleTypeDef *hdma);
 HAL_StatusTypeDef HAL_TIM_Base_Init(TIM_HandleTypeDef *htim)
 { 
   /* Check the TIM handle allocation */
-  if(htim == NULL)
+  if(htim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -477,7 +477,7 @@ HAL_StatusTypeDef HAL_TIM_Base_Stop_DMA(TIM_HandleTypeDef *htim)
 HAL_StatusTypeDef HAL_TIM_OC_Init(TIM_HandleTypeDef* htim)
 {
   /* Check the TIM handle allocation */
-  if(htim == NULL)
+  if(htim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -984,7 +984,7 @@ HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
 HAL_StatusTypeDef HAL_TIM_PWM_Init(TIM_HandleTypeDef *htim)
 {
   /* Check the TIM handle allocation */
-  if(htim == NULL)
+  if(htim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -1494,7 +1494,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
 HAL_StatusTypeDef HAL_TIM_IC_Init(TIM_HandleTypeDef *htim)
 {
   /* Check the TIM handle allocation */
-  if(htim == NULL)
+  if(htim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -1970,7 +1970,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
 HAL_StatusTypeDef HAL_TIM_OnePulse_Init(TIM_HandleTypeDef *htim, uint32_t OnePulseMode)
 {
   /* Check the TIM handle allocation */
-  if(htim == NULL)
+  if(htim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -2245,7 +2245,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_Ini
   uint32_t tmpccer = 0;
   
   /* Check the TIM handle allocation */
-  if(htim == NULL)
+  if(htim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -2805,7 +2805,7 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
       __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC3);
       htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
       /* Input capture event */
-      if((htim->Instance->CCMR1 & TIM_CCMR2_CC3S) != 0x00)
+      if((htim->Instance->CCMR2 & TIM_CCMR2_CC3S) != 0x00)
       {          
         HAL_TIM_IC_CaptureCallback(htim);
       }
@@ -2826,7 +2826,7 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
       __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC4);
       htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
       /* Input capture event */
-      if((htim->Instance->CCMR1 & TIM_CCMR2_CC4S) != 0x00)
+      if((htim->Instance->CCMR2 & TIM_CCMR2_CC4S) != 0x00)
       {          
         HAL_TIM_IC_CaptureCallback(htim);
       }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_tim.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_tim.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_tim.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of TIM HAL module.
   ******************************************************************************
   * @attention
@@ -591,6 +591,8 @@ typedef struct
 /**
   * @}
   */
+#define TIM_COMMUTATION_TRGI              (TIM_CR2_CCUS)
+#define TIM_COMMUTATION_SOFTWARE          ((uint32_t)0x0000)
 
 /** @defgroup TIM_DMA_sources 
   * @{
@@ -771,6 +773,103 @@ typedef struct
   * @}
   */
 
+/** @defgroup TIM_OSSR_Off_State_Selection_for_Run_mode_state
+  * @{
+  */  
+#define TIM_OSSR_ENABLE 	      (TIM_BDTR_OSSR)
+#define TIM_OSSR_DISABLE              ((uint32_t)0x0000)
+
+#define IS_TIM_OSSR_STATE(STATE) (((STATE) == TIM_OSSR_ENABLE) || \
+                                  ((STATE) == TIM_OSSR_DISABLE))
+/**
+  * @}
+  */
+  
+/** @defgroup TIM_OSSI_Off_State_Selection_for_Idle_mode_state 
+  * @{
+  */
+#define TIM_OSSI_ENABLE	 	    (TIM_BDTR_OSSI)
+#define TIM_OSSI_DISABLE            ((uint32_t)0x0000)
+
+#define IS_TIM_OSSI_STATE(STATE) (((STATE) == TIM_OSSI_ENABLE) || \
+                                  ((STATE) == TIM_OSSI_DISABLE))
+/**
+  * @}
+  */
+/** @defgroup TIM_Lock_level 
+  * @{
+  */
+#define TIM_LOCKLEVEL_OFF	   ((uint32_t)0x0000)
+#define TIM_LOCKLEVEL_1            (TIM_BDTR_LOCK_0)
+#define TIM_LOCKLEVEL_2            (TIM_BDTR_LOCK_1)
+#define TIM_LOCKLEVEL_3            (TIM_BDTR_LOCK)
+
+#define IS_TIM_LOCK_LEVEL(LEVEL) (((LEVEL) == TIM_LOCKLEVEL_OFF) || \
+                                  ((LEVEL) == TIM_LOCKLEVEL_1) || \
+                                  ((LEVEL) == TIM_LOCKLEVEL_2) || \
+                                  ((LEVEL) == TIM_LOCKLEVEL_3)) 
+/**
+  * @}
+  */  
+/** @defgroup TIM_Break_Input_enable_disable 
+  * @{
+  */                         
+#define TIM_BREAK_ENABLE          (TIM_BDTR_BKE)
+#define TIM_BREAK_DISABLE         ((uint32_t)0x0000)
+
+#define IS_TIM_BREAK_STATE(STATE) (((STATE) == TIM_BREAK_ENABLE) || \
+                                   ((STATE) == TIM_BREAK_DISABLE))
+/**
+  * @}
+  */
+/** @defgroup TIM_Break_Polarity 
+  * @{
+  */
+#define TIM_BREAKPOLARITY_LOW        ((uint32_t)0x0000)
+#define TIM_BREAKPOLARITY_HIGH       (TIM_BDTR_BKP)
+
+#define IS_TIM_BREAK_POLARITY(POLARITY) (((POLARITY) == TIM_BREAKPOLARITY_LOW) || \
+                                         ((POLARITY) == TIM_BREAKPOLARITY_HIGH))
+/**
+  * @}
+  */
+/** @defgroup TIM_AOE_Bit_Set_Reset 
+  * @{
+  */
+#define TIM_AUTOMATICOUTPUT_ENABLE           (TIM_BDTR_AOE)
+#define	TIM_AUTOMATICOUTPUT_DISABLE          ((uint32_t)0x0000)
+
+#define IS_TIM_AUTOMATIC_OUTPUT_STATE(STATE) (((STATE) == TIM_AUTOMATICOUTPUT_ENABLE) || \
+                                              ((STATE) == TIM_AUTOMATICOUTPUT_DISABLE))
+/**
+  * @}
+  */  
+  
+/** @defgroup TIM_Master_Mode_Selection
+  * @{
+  */  
+#define	TIM_TRGO_RESET            ((uint32_t)0x0000)             
+#define	TIM_TRGO_ENABLE           (TIM_CR2_MMS_0)           
+#define	TIM_TRGO_UPDATE           (TIM_CR2_MMS_1)             
+#define	TIM_TRGO_OC1              ((TIM_CR2_MMS_1 | TIM_CR2_MMS_0))    
+#define	TIM_TRGO_OC1REF           (TIM_CR2_MMS_2)           
+#define	TIM_TRGO_OC2REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_0))          
+#define	TIM_TRGO_OC3REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_1))           
+#define	TIM_TRGO_OC4REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_1 | TIM_CR2_MMS_0))   
+
+#define IS_TIM_TRGO_SOURCE(SOURCE) (((SOURCE) == TIM_TRGO_RESET) || \
+                                    ((SOURCE) == TIM_TRGO_ENABLE) || \
+                                    ((SOURCE) == TIM_TRGO_UPDATE) || \
+                                    ((SOURCE) == TIM_TRGO_OC1) || \
+                                    ((SOURCE) == TIM_TRGO_OC1REF) || \
+                                    ((SOURCE) == TIM_TRGO_OC2REF) || \
+                                    ((SOURCE) == TIM_TRGO_OC3REF) || \
+                                    ((SOURCE) == TIM_TRGO_OC4REF))
+      
+
+/**
+  * @}
+  */ 
 /** @defgroup TIM_Slave_Mode 
   * @{
   */
@@ -789,6 +888,17 @@ typedef struct
   * @}
   */
 
+/** @defgroup TIM_Master_Slave_Mode 
+  * @{
+  */
+
+#define TIM_MASTERSLAVEMODE_ENABLE          ((uint32_t)0x0080)
+#define TIM_MASTERSLAVEMODE_DISABLE         ((uint32_t)0x0000)
+#define IS_TIM_MSM_STATE(STATE) (((STATE) == TIM_MASTERSLAVEMODE_ENABLE) || \
+                                 ((STATE) == TIM_MASTERSLAVEMODE_DISABLE))
+/**
+  * @}
+  */ 
 /** @defgroup TIM_Trigger_Selection 
   * @{
   */
@@ -1070,13 +1180,13 @@ typedef struct
 #define __HAL_TIM_DISABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->DIER &= ~(__INTERRUPT__))
 #define __HAL_TIM_DISABLE_DMA(__HANDLE__, __DMA__)        ((__HANDLE__)->Instance->DIER &= ~(__DMA__))
 #define __HAL_TIM_GET_FLAG(__HANDLE__, __FLAG__)          (((__HANDLE__)->Instance->SR &(__FLAG__)) == (__FLAG__))
-#define __HAL_TIM_CLEAR_FLAG(__HANDLE__, __FLAG__)        ((__HANDLE__)->Instance->SR &= ~(__FLAG__))
+#define __HAL_TIM_CLEAR_FLAG(__HANDLE__, __FLAG__)        ((__HANDLE__)->Instance->SR = ~(__FLAG__))
 
 #define __HAL_TIM_GET_ITSTATUS(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->DIER & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
-#define __HAL_TIM_CLEAR_IT(__HANDLE__, __INTERRUPT__)     ((__HANDLE__)->Instance->SR &= ~(__INTERRUPT__))
+#define __HAL_TIM_CLEAR_IT(__HANDLE__, __INTERRUPT__)     ((__HANDLE__)->Instance->SR = ~(__INTERRUPT__))
 
 #define __HAL_TIM_DIRECTION_STATUS(__HANDLE__)            (((__HANDLE__)->Instance->CR1 &(TIM_CR1_DIR)) == (TIM_CR1_DIR))
-#define __HAL_TIM_PRESCALER (__HANDLE__, __PRESC__)       ((__HANDLE__)->Instance->PSC |= (__PRESC__))
+#define __HAL_TIM_PRESCALER (__HANDLE__, __PRESC__)       ((__HANDLE__)->Instance->PSC = (__PRESC__))
 
 #define __HAL_TIM_SetICPrescalerValue(__HANDLE__, __CHANNEL__, __ICPSC__) \
 (((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCMR1 |= (__ICPSC__)) :\

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_tim_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_tim_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_tim_ex.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   TIM HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Timer extension peripheral:
@@ -155,7 +155,7 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Init(TIM_HandleTypeDef *htim, TIM_HallSen
   TIM_OC_InitTypeDef OC_Config;
     
   /* Check the TIM handle allocation */
-  if(htim == NULL)
+  if(htim == HAL_NULL)
   {
     return HAL_ERROR;
   }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_tim_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_tim_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_tim_ex.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of TIM HAL Extension module.
   ******************************************************************************
   * @attention
@@ -80,9 +80,9 @@ typedef struct
   */ 
 typedef struct {
   uint32_t  MasterOutputTrigger;   /*!< Trigger output (TRGO) selection. 
-                                      This parameter can be a value of @ref TIMEx_Master_Mode_Selection */ 
+                                      This parameter can be a value of @ref TIM_Master_Mode_Selection */ 
   uint32_t  MasterSlaveMode;       /*!< Master/slave mode selection. 
-                                      This parameter can be a value of @ref TIMEx_Master_Slave_Mode */
+                                      This parameter can be a value of @ref TIM_Master_Slave_Mode */
 }TIM_MasterConfigTypeDef;
 
 /** 
@@ -91,142 +91,24 @@ typedef struct {
 typedef struct
 {
   uint32_t OffStateRunMode;	        /*!< TIM off state in run mode.
-                                         This parameter can be a value of @ref TIMEx_OSSR_Off_State_Selection_for_Run_mode_state */
+                                         This parameter can be a value of @ref TIM_OSSR_Off_State_Selection_for_Run_mode_state */
   uint32_t OffStateIDLEMode;	      /*!< TIM off state in IDLE mode.
-                                         This parameter can be a value of @ref TIMEx_OSSI_Off_State_Selection_for_Idle_mode_state */
+                                         This parameter can be a value of @ref TIM_OSSI_Off_State_Selection_for_Idle_mode_state */
   uint32_t LockLevel;	 	            /*!< TIM Lock level.
-                                         This parameter can be a value of @ref TIMEx_Lock_level */                             
+                                         This parameter can be a value of @ref TIM_Lock_level */                             
   uint32_t DeadTime;	 	            /*!< TIM dead Time. 
                                          This parameter can be a number between Min_Data = 0x00 and Max_Data = 0xFF */
   uint32_t BreakState;	 	          /*!< TIM Break State. 
-                                         This parameter can be a value of @ref TIMEx_Break_Input_enable_disable */
+                                         This parameter can be a value of @ref TIM_Break_Input_enable_disable */
   uint32_t BreakPolarity;	 	        /*!< TIM Break input polarity. 
-                                         This parameter can be a value of @ref TIMEx_Break_Polarity */
+                                         This parameter can be a value of @ref TIM_Break_Polarity */
   uint32_t AutomaticOutput;	 	      /*!< TIM Automatic Output Enable state. 
-                                         This parameter can be a value of @ref TIMEx_AOE_Bit_Set_Reset */           
+                                         This parameter can be a value of @ref TIM_AOE_Bit_Set_Reset */           
 }TIM_BreakDeadTimeConfigTypeDef;
 
 /* Exported constants --------------------------------------------------------*/
 /** @defgroup TIMEx_Exported_Constants
   * @{
-  */
-/** @defgroup TIMEx_OSSR_Off_State_Selection_for_Run_mode_state
-  * @{
-  */  
-#define TIM_OSSR_ENABLE 	      (TIM_BDTR_OSSR)
-#define TIM_OSSR_DISABLE              ((uint32_t)0x0000)
-
-#define IS_TIM_OSSR_STATE(STATE) (((STATE) == TIM_OSSR_ENABLE) || \
-                                  ((STATE) == TIM_OSSR_DISABLE))
-/**
-  * @}
-  */
-  
-/** @defgroup TIMEx_OSSI_Off_State_Selection_for_Idle_mode_state 
-  * @{
-  */
-#define TIM_OSSI_ENABLE	 	    (TIM_BDTR_OSSI)
-#define TIM_OSSI_DISABLE            ((uint32_t)0x0000)
-
-#define IS_TIM_OSSI_STATE(STATE) (((STATE) == TIM_OSSI_ENABLE) || \
-                                  ((STATE) == TIM_OSSI_DISABLE))
-/**
-  * @}
-  */
-/** @defgroup TIMEx_Lock_level 
-  * @{
-  */
-#define TIM_LOCKLEVEL_OFF	   ((uint32_t)0x0000)
-#define TIM_LOCKLEVEL_1            (TIM_BDTR_LOCK_0)
-#define TIM_LOCKLEVEL_2            (TIM_BDTR_LOCK_1)
-#define TIM_LOCKLEVEL_3            (TIM_BDTR_LOCK)
-
-#define IS_TIM_LOCK_LEVEL(LEVEL) (((LEVEL) == TIM_LOCKLEVEL_OFF) || \
-                                  ((LEVEL) == TIM_LOCKLEVEL_1) || \
-                                  ((LEVEL) == TIM_LOCKLEVEL_2) || \
-                                  ((LEVEL) == TIM_LOCKLEVEL_3)) 
-/**
-  * @}
-  */  
-/** @defgroup TIMEx_Break_Input_enable_disable 
-  * @{
-  */                         
-#define TIM_BREAK_ENABLE          (TIM_BDTR_BKE)
-#define TIM_BREAK_DISABLE         ((uint32_t)0x0000)
-
-#define IS_TIM_BREAK_STATE(STATE) (((STATE) == TIM_BREAK_ENABLE) || \
-                                   ((STATE) == TIM_BREAK_DISABLE))
-/**
-  * @}
-  */
-/** @defgroup TIMEx_Break_Polarity 
-  * @{
-  */
-#define TIM_BREAKPOLARITY_LOW        ((uint32_t)0x0000)
-#define TIM_BREAKPOLARITY_HIGH       (TIM_BDTR_BKP)
-
-#define IS_TIM_BREAK_POLARITY(POLARITY) (((POLARITY) == TIM_BREAKPOLARITY_LOW) || \
-                                         ((POLARITY) == TIM_BREAKPOLARITY_HIGH))
-/**
-  * @}
-  */
-/** @defgroup TIMEx_AOE_Bit_Set_Reset 
-  * @{
-  */
-#define TIM_AUTOMATICOUTPUT_ENABLE           (TIM_BDTR_AOE)
-#define	TIM_AUTOMATICOUTPUT_DISABLE          ((uint32_t)0x0000)
-
-#define IS_TIM_AUTOMATIC_OUTPUT_STATE(STATE) (((STATE) == TIM_AUTOMATICOUTPUT_ENABLE) || \
-                                              ((STATE) == TIM_AUTOMATICOUTPUT_DISABLE))
-/**
-  * @}
-  */  
-  
-/** @defgroup TIMEx_Master_Mode_Selection
-  * @{
-  */  
-#define	TIM_TRGO_RESET            ((uint32_t)0x0000)             
-#define	TIM_TRGO_ENABLE           (TIM_CR2_MMS_0)           
-#define	TIM_TRGO_UPDATE           (TIM_CR2_MMS_1)             
-#define	TIM_TRGO_OC1              ((TIM_CR2_MMS_1 | TIM_CR2_MMS_0))    
-#define	TIM_TRGO_OC1REF           (TIM_CR2_MMS_2)           
-#define	TIM_TRGO_OC2REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_0))          
-#define	TIM_TRGO_OC3REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_1))           
-#define	TIM_TRGO_OC4REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_1 | TIM_CR2_MMS_0))   
-
-#define IS_TIM_TRGO_SOURCE(SOURCE) (((SOURCE) == TIM_TRGO_RESET) || \
-                                    ((SOURCE) == TIM_TRGO_ENABLE) || \
-                                    ((SOURCE) == TIM_TRGO_UPDATE) || \
-                                    ((SOURCE) == TIM_TRGO_OC1) || \
-                                    ((SOURCE) == TIM_TRGO_OC1REF) || \
-                                    ((SOURCE) == TIM_TRGO_OC2REF) || \
-                                    ((SOURCE) == TIM_TRGO_OC3REF) || \
-                                    ((SOURCE) == TIM_TRGO_OC4REF))
-      
-   
-/**
-  * @}
-  */ 
-
-/** @defgroup TIMEx_Master_Slave_Mode 
-  * @{
-  */
-
-#define TIM_MASTERSLAVEMODE_ENABLE          ((uint32_t)0x0080)
-#define TIM_MASTERSLAVEMODE_DISABLE         ((uint32_t)0x0000)
-#define IS_TIM_MSM_STATE(STATE) (((STATE) == TIM_MASTERSLAVEMODE_ENABLE) || \
-                                 ((STATE) == TIM_MASTERSLAVEMODE_DISABLE))
-/**
-  * @}
-  */ 
-
-/** @defgroup TIMEx_Commutation_Mode 
-  * @{
-  */
-#define TIM_COMMUTATION_TRGI              (TIM_CR2_CCUS)
-#define TIM_COMMUTATION_SOFTWARE          ((uint32_t)0x0000)
-/**
-  * @}
   */
   
 /** @defgroup TIMEx_Remap 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_uart.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_uart.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_uart.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   UART HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Universal Asynchronous Receiver Transmitter (UART) peripheral:
@@ -87,7 +87,7 @@
        (+) At reception end of half transfer HAL_UART_RxHalfCpltCallback is executed and user can 
             add his own code by customization of function pointer HAL_UART_RxHalfCpltCallback 
        (+) At reception end of transfer HAL_UART_RxCpltCallback is executed and user can 
-            add his own code by customization of function pointer HAL_UART_RxCpltCallback                                      
+            add his own code by customization of function pointer HAL_UART_RxCpltCallback
        (+) In case of transfer Error, HAL_UART_ErrorCallback() function is executed and user can 
             add his own code by customization of function pointer HAL_UART_ErrorCallback
 
@@ -103,7 +103,7 @@
        (+) At reception end of half transfer HAL_UART_RxHalfCpltCallback is executed and user can 
             add his own code by customization of function pointer HAL_UART_RxHalfCpltCallback 
        (+) At reception end of transfer HAL_UART_RxCpltCallback is executed and user can 
-            add his own code by customization of function pointer HAL_UART_RxCpltCallback                                      
+            add his own code by customization of function pointer HAL_UART_RxCpltCallback
        (+) In case of transfer Error, HAL_UART_ErrorCallback() function is executed and user can 
             add his own code by customization of function pointer HAL_UART_ErrorCallback
        (+) Pause the DMA Transfer using HAL_UART_DMAPause()      
@@ -231,7 +231,7 @@ static HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, 
 HAL_StatusTypeDef HAL_UART_Init(UART_HandleTypeDef *huart)
 {
   /* Check the UART handle allocation */
-  if(huart == NULL)
+  if(huart == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -287,7 +287,7 @@ HAL_StatusTypeDef HAL_UART_Init(UART_HandleTypeDef *huart)
 HAL_StatusTypeDef HAL_HalfDuplex_Init(UART_HandleTypeDef *huart)
 {
   /* Check the UART handle allocation */
-  if(huart == NULL)
+  if(huart == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -339,7 +339,7 @@ HAL_StatusTypeDef HAL_HalfDuplex_Init(UART_HandleTypeDef *huart)
 HAL_StatusTypeDef HAL_LIN_Init(UART_HandleTypeDef *huart, uint32_t BreakDetectLength)
 {
   /* Check the UART handle allocation */
-  if(huart == NULL)
+  if(huart == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -398,7 +398,7 @@ HAL_StatusTypeDef HAL_LIN_Init(UART_HandleTypeDef *huart, uint32_t BreakDetectLe
 HAL_StatusTypeDef HAL_MultiProcessor_Init(UART_HandleTypeDef *huart, uint8_t Address, uint32_t WakeUpMethode)
 {
   /* Check the UART handle allocation */
-  if(huart == NULL)
+  if(huart == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -455,7 +455,7 @@ HAL_StatusTypeDef HAL_MultiProcessor_Init(UART_HandleTypeDef *huart, uint8_t Add
 HAL_StatusTypeDef HAL_UART_DeInit(UART_HandleTypeDef *huart)
 {
   /* Check the UART handle allocation */
-  if(huart == NULL)
+  if(huart == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -576,7 +576,7 @@ HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, u
   tmp1 = huart->State;
   if((tmp1 == HAL_UART_STATE_READY) || (tmp1 == HAL_UART_STATE_BUSY_RX))
   {
-    if((pData == NULL ) || (Size == 0)) 
+    if((pData == HAL_NULL ) || (Size == 0)) 
     {
       return  HAL_ERROR;
     }
@@ -670,7 +670,7 @@ HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, ui
   tmp1 = huart->State;
   if((tmp1 == HAL_UART_STATE_READY) || (tmp1 == HAL_UART_STATE_BUSY_TX))
   { 
-    if((pData == NULL ) || (Size == 0)) 
+    if((pData == HAL_NULL ) || (Size == 0)) 
     {
       return  HAL_ERROR;
     }
@@ -768,7 +768,7 @@ HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData
   tmp = huart->State;
   if((tmp == HAL_UART_STATE_READY) || (tmp == HAL_UART_STATE_BUSY_RX))
   {
-    if((pData == NULL ) || (Size == 0)) 
+    if((pData == HAL_NULL ) || (Size == 0)) 
     {
       return HAL_ERROR;
     }
@@ -800,8 +800,8 @@ HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData
     /* Process Unlocked */
     __HAL_UNLOCK(huart);
 
-    /* Enable the UART Transmit Complete Interrupt */
-    __HAL_UART_ENABLE_IT(huart, UART_IT_TC);
+    /* Enable the UART Transmit data register empty Interrupt */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
     
     return HAL_OK;
   }
@@ -826,7 +826,7 @@ HAL_StatusTypeDef HAL_UART_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData,
   tmp = huart->State;  
   if((tmp == HAL_UART_STATE_READY) || (tmp == HAL_UART_STATE_BUSY_TX))
   {
-    if((pData == NULL ) || (Size == 0)) 
+    if((pData == HAL_NULL ) || (Size == 0)) 
     {
       return HAL_ERROR;
     }
@@ -885,7 +885,7 @@ HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, uint8_t *pDat
   tmp1 = huart->State;  
   if((tmp1 == HAL_UART_STATE_READY) || (tmp1 == HAL_UART_STATE_BUSY_RX))
   {
-    if((pData == NULL ) || (Size == 0)) 
+    if((pData == HAL_NULL ) || (Size == 0)) 
     {
       return HAL_ERROR;
     }
@@ -953,7 +953,7 @@ HAL_StatusTypeDef HAL_UART_Receive_DMA(UART_HandleTypeDef *huart, uint8_t *pData
   tmp1 = huart->State;    
   if((tmp1 == HAL_UART_STATE_READY) || (tmp1 == HAL_UART_STATE_BUSY_TX))
   {
-    if((pData == NULL ) || (Size == 0)) 
+    if((pData == HAL_NULL ) || (Size == 0)) 
     {
       return HAL_ERROR;
     }
@@ -1055,21 +1055,18 @@ HAL_StatusTypeDef HAL_UART_DMAResume(UART_HandleTypeDef *huart)
   }
   else if(huart->State == HAL_UART_STATE_BUSY_RX)
   {
+    /* Clear the Overrun flag before resumming the Rx transfer*/
+    __HAL_UART_CLEAR_OREFLAG(huart);
     /* Enable the UART DMA Rx request */
     huart->Instance->CR3 |= USART_CR3_DMAR;
   }
   else if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
   {
+    /* Clear the Overrun flag before resumming the Rx transfer*/
+    __HAL_UART_CLEAR_OREFLAG(huart);
     /* Enable the UART DMA Tx & Rx request */
     huart->Instance->CR3 |= USART_CR3_DMAT;
     huart->Instance->CR3 |= USART_CR3_DMAR;
-  }
-
-  /* If the UART peripheral is still not enabled, enable it */
-  if ((huart->Instance->CR1 & USART_CR1_UE) == 0)
-  {
-    /* Enable UART peripheral */    
-    __HAL_UART_ENABLE(huart);
   }
   
   /* Process Unlocked */
@@ -1086,30 +1083,28 @@ HAL_StatusTypeDef HAL_UART_DMAResume(UART_HandleTypeDef *huart)
   */
 HAL_StatusTypeDef HAL_UART_DMAStop(UART_HandleTypeDef *huart)
 {
-  /* Process Locked */
-  __HAL_LOCK(huart);
+  /* The Lock is not implemented on this API to allow the user application
+     to call the HAL UART API under callbacks HAL_UART_TxCpltCallback() / HAL_UART_RxCpltCallback():
+     when calling HAL_DMA_Abort() API the DMA TX/RX Transfer complete interrupt is generated
+     and the correspond call back is executed HAL_UART_TxCpltCallback() / HAL_UART_RxCpltCallback()
+     */
   
   /* Disable the UART Tx/Rx DMA requests */
   huart->Instance->CR3 &= ~USART_CR3_DMAT;
   huart->Instance->CR3 &= ~USART_CR3_DMAR;
   
   /* Abort the UART DMA tx Stream */
-  if(huart->hdmatx != NULL)
+  if(huart->hdmatx != HAL_NULL)
   {
     HAL_DMA_Abort(huart->hdmatx);
   }
   /* Abort the UART DMA rx Stream */
-  if(huart->hdmarx != NULL)
+  if(huart->hdmarx != HAL_NULL)
   {
     HAL_DMA_Abort(huart->hdmarx);
   }
-  /* Disable UART peripheral */
-  __HAL_UART_DISABLE(huart);
   
   huart->State = HAL_UART_STATE_READY;
-  
-  /* Process Unlocked */
-  __HAL_UNLOCK(huart);
   
   return HAL_OK;
 }
@@ -1129,7 +1124,7 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
   /* UART parity error interrupt occurred ------------------------------------*/
   if((tmp1 != RESET) && (tmp2 != RESET))
   { 
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_PE);
+    __HAL_UART_CLEAR_PEFLAG(huart);
     
     huart->ErrorCode |= HAL_UART_ERROR_PE;
   }
@@ -1139,7 +1134,7 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
   /* UART frame error interrupt occurred -------------------------------------*/
   if((tmp1 != RESET) && (tmp2 != RESET))
   { 
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_FE);
+    __HAL_UART_CLEAR_FEFLAG(huart);
     
     huart->ErrorCode |= HAL_UART_ERROR_FE;
   }
@@ -1149,7 +1144,7 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
   /* UART noise error interrupt occurred -------------------------------------*/
   if((tmp1 != RESET) && (tmp2 != RESET))
   { 
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_NE);
+    __HAL_UART_CLEAR_NEFLAG(huart);
     
     huart->ErrorCode |= HAL_UART_ERROR_NE;
   }
@@ -1159,7 +1154,7 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
   /* UART Over-Run interrupt occurred ----------------------------------------*/
   if((tmp1 != RESET) && (tmp2 != RESET))
   { 
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_ORE);
+    __HAL_UART_CLEAR_OREFLAG(huart);
     
     huart->ErrorCode |= HAL_UART_ERROR_ORE;
   }
@@ -1170,16 +1165,14 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
   if((tmp1 != RESET) && (tmp2 != RESET))
   { 
     UART_Receive_IT(huart);
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
   }
   
-  tmp1 = __HAL_UART_GET_FLAG(huart, UART_FLAG_TC);
-  tmp2 = __HAL_UART_GET_IT_SOURCE(huart, UART_IT_TC);
+  tmp1 = __HAL_UART_GET_FLAG(huart, UART_FLAG_TXE);
+  tmp2 = __HAL_UART_GET_IT_SOURCE(huart, UART_IT_TXE);
   /* UART in mode Transmitter ------------------------------------------------*/
   if((tmp1 != RESET) && (tmp2 != RESET))
   {
     UART_Transmit_IT(huart);
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
   }
   
   if(huart->ErrorCode != HAL_UART_ERROR_NONE)
@@ -1481,34 +1474,43 @@ uint32_t HAL_UART_GetError(UART_HandleTypeDef *huart)
   * @param  hdma: DMA handle
   * @retval None
   */
-static void UART_DMATransmitCplt(DMA_HandleTypeDef *hdma)     
+static void UART_DMATransmitCplt(DMA_HandleTypeDef *hdma)
 {
   UART_HandleTypeDef* huart = ( UART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
-  huart->TxXferCount = 0;
-  
-  /* Disable the DMA transfer for transmit request by setting the DMAT bit
-     in the UART CR3 register */
-  huart->Instance->CR3 &= (uint32_t)~((uint32_t)USART_CR3_DMAT);
+  /* DMA Normal mode*/
+  if((hdma->Instance->CR & DMA_SxCR_CIRC) == 0)
+  {
+    huart->TxXferCount = 0;
 
-  /* Wait for UART TC Flag */
-  if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_TC, RESET, UART_TIMEOUT_VALUE) != HAL_OK)
-  {
-    /* Timeout occurred */ 
-    huart->State = HAL_UART_STATE_TIMEOUT;
-    HAL_UART_ErrorCallback(huart);
-  }
-  else
-  {
-    /* No Timeout */
-    /* Check if a receive process is ongoing or not */
-    if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+    /* Disable the DMA transfer for transmit request by setting the DMAT bit
+       in the UART CR3 register */
+    huart->Instance->CR3 &= (uint32_t)~((uint32_t)USART_CR3_DMAT);
+
+    /* Wait for UART TC Flag */
+    if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_TC, RESET, UART_TIMEOUT_VALUE) != HAL_OK)
     {
-      huart->State = HAL_UART_STATE_BUSY_RX;
+      /* Timeout occurred */ 
+      huart->State = HAL_UART_STATE_TIMEOUT;
+      HAL_UART_ErrorCallback(huart);
     }
     else
     {
-      huart->State = HAL_UART_STATE_READY;
+      /* No Timeout */
+      /* Check if a receive process is ongoing or not */
+      if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+      {
+        huart->State = HAL_UART_STATE_BUSY_RX;
+      }
+      else
+      {
+        huart->State = HAL_UART_STATE_READY;
+      }
+      HAL_UART_TxCpltCallback(huart);
     }
+  }
+  /* DMA Circular mode */
+  else
+  {
     HAL_UART_TxCpltCallback(huart);
   }
 }
@@ -1534,20 +1536,24 @@ static void UART_DMATxHalfCplt(DMA_HandleTypeDef *hdma)
 static void UART_DMAReceiveCplt(DMA_HandleTypeDef *hdma)  
 {
   UART_HandleTypeDef* huart = ( UART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
-  huart->RxXferCount = 0;
+  /* DMA Normal mode*/
+  if((hdma->Instance->CR & DMA_SxCR_CIRC) == 0)
+  {
+    huart->RxXferCount = 0;
   
-  /* Disable the DMA transfer for the receiver request by setting the DMAR bit 
-     in the UART CR3 register */
-  huart->Instance->CR3 &= (uint32_t)~((uint32_t)USART_CR3_DMAR);
+    /* Disable the DMA transfer for the receiver request by setting the DMAR bit 
+       in the UART CR3 register */
+    huart->Instance->CR3 &= (uint32_t)~((uint32_t)USART_CR3_DMAR);
 
-  /* Check if a transmit process is ongoing or not */
-  if(huart->State == HAL_UART_STATE_BUSY_TX_RX) 
-  {
-    huart->State = HAL_UART_STATE_BUSY_TX;
-  }
-  else
-  {
-    huart->State = HAL_UART_STATE_READY;
+    /* Check if a transmit process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX_RX) 
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_READY;
+    }
   }
   HAL_UART_RxCpltCallback(huart);
 }
@@ -1591,10 +1597,11 @@ static void UART_DMAError(DMA_HandleTypeDef *hdma)
   */
 static HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_t Flag, FlagStatus Status, uint32_t Timeout)
 {
-  uint32_t timeout = 0;
-  
-  timeout = HAL_GetTick() + Timeout;
-  
+  uint32_t tickstart = 0;
+
+  /* Get tick */ 
+  tickstart = HAL_GetTick();
+
   /* Wait until flag is set */
   if(Status == RESET)
   {
@@ -1603,7 +1610,7 @@ static HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, 
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
           __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
@@ -1628,7 +1635,7 @@ static HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, 
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
           __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
@@ -1646,7 +1653,7 @@ static HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, 
       }
     }
   }
-  return HAL_OK;      
+  return HAL_OK;
 }
 
 /**
@@ -1684,8 +1691,8 @@ static HAL_StatusTypeDef UART_Transmit_IT(UART_HandleTypeDef *huart)
     if(--huart->TxXferCount == 0)
     {
       /* Disable the UART Transmit Complete Interrupt */
-      __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
-      
+      __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
+
       /* Check if a receive process is ongoing or not */
       if(huart->State == HAL_UART_STATE_BUSY_TX_RX) 
       {
@@ -1695,12 +1702,19 @@ static HAL_StatusTypeDef UART_Transmit_IT(UART_HandleTypeDef *huart)
       {
         /* Disable the UART Parity Error Interrupt */
         __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
-        
+
         /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) */
         __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
-        
+
         huart->State = HAL_UART_STATE_READY;
       }
+      
+      /* Wait on TC flag to be able to start a second transfer */
+      if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_TC, RESET, UART_TIMEOUT_VALUE) != HAL_OK)
+      { 
+        return HAL_TIMEOUT;
+      }
+      
       HAL_UART_TxCpltCallback(huart);
       
       return HAL_OK;
@@ -1712,6 +1726,7 @@ static HAL_StatusTypeDef UART_Transmit_IT(UART_HandleTypeDef *huart)
     return HAL_BUSY;
   }
 }
+
 /**
   * @brief  Receives an amount of data in non blocking mode 
   * @param  huart: pointer to a UART_HandleTypeDef structure that contains
@@ -1751,15 +1766,11 @@ static HAL_StatusTypeDef UART_Receive_IT(UART_HandleTypeDef *huart)
         *huart->pRxBuffPtr++ = (uint8_t)(huart->Instance->DR & (uint8_t)0x007F);
       }
     }
-    
+
     if(--huart->RxXferCount == 0)
     {
-      if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_RXNE, SET, UART_TIMEOUT_VALUE) != HAL_OK)
-      { 
-        return HAL_TIMEOUT;
-      }
       __HAL_UART_DISABLE_IT(huart, UART_IT_RXNE);
-      
+
       /* Check if a transmit process is ongoing or not */
       if(huart->State == HAL_UART_STATE_BUSY_TX_RX) 
       {
@@ -1769,14 +1780,14 @@ static HAL_StatusTypeDef UART_Receive_IT(UART_HandleTypeDef *huart)
       {
         /* Disable the UART Parity Error Interrupt */
         __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
-        
+
         /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) */
         __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
-        
+
         huart->State = HAL_UART_STATE_READY;
       }
       HAL_UART_RxCpltCallback(huart);
-      
+
       return HAL_OK;
     }
     return HAL_OK;

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_uart.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_uart.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_uart.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of UART HAL module.
   ******************************************************************************
   * @attention
@@ -369,8 +369,48 @@ typedef struct
   *   
   * @retval None
   */
-#define __HAL_UART_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->SR &= ~(__FLAG__))
+#define __HAL_UART_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->SR = ~(__FLAG__))
 
+/** @brief  Clear the UART PE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         This parameter can be UARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_PEFLAG(__HANDLE__) do{(__HANDLE__)->Instance->SR;\
+                                               (__HANDLE__)->Instance->DR;}while(0)
+/** @brief  Clear the UART FE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         This parameter can be UARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_FEFLAG(__HANDLE__) __HAL_UART_CLEAR_PEFLAG(__HANDLE__)
+
+/** @brief  Clear the UART NE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         This parameter can be UARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_NEFLAG(__HANDLE__) __HAL_UART_CLEAR_PEFLAG(__HANDLE__)
+
+/** @brief  Clear the UART ORE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         This parameter can be UARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_OREFLAG(__HANDLE__) __HAL_UART_CLEAR_PEFLAG(__HANDLE__)
+
+/** @brief  Clear the UART IDLE pending flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         This parameter can be UARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
+  *         UART peripheral.
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_IDLEFLAG(__HANDLE__) __HAL_UART_CLEAR_PEFLAG(__HANDLE__)
+                                                 
 /** @brief  Enables or disables the specified UART interrupt.
   * @param  __HANDLE__: specifies the UART Handle.
   *         This parameter can be UARTx where x: 1, 2, 3, 4, 5, 6, 7 or 8 to select the USART or 
@@ -414,6 +454,82 @@ typedef struct
   */
 #define __HAL_UART_GET_IT_SOURCE(__HANDLE__, __IT__) (((((__IT__) >> 28) == 1)? (__HANDLE__)->Instance->CR1:(((((uint32_t)(__IT__)) >> 28) == 2)? \
                                                       (__HANDLE__)->Instance->CR2 : (__HANDLE__)->Instance->CR3)) & (((uint32_t)(__IT__)) & UART_IT_MASK))
+
+/** @brief  Enable CTS flow control 
+  *         This macro allows to enable CTS hardware flow control for a given UART instance, 
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying CTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e __HAL_UART_ENABLE(__HANDLE__)).                                                                                                                  
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance can be USART1, USART2 or LPUART.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_CTS_ENABLE(__HANDLE__)        \
+  do{                                                      \
+    SET_BIT((__HANDLE__)->Instance->CR3, USART_CR3_CTSE);  \
+    (__HANDLE__)->Init.HwFlowCtl |= USART_CR3_CTSE;        \
+  } while(0)
+
+/** @brief  Disable CTS flow control 
+  *         This macro allows to disable CTS hardware flow control for a given UART instance, 
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying CTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e __HAL_UART_ENABLE(__HANDLE__)). 
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance can be USART1, USART2 or LPUART.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_CTS_DISABLE(__HANDLE__)        \
+  do{                                                       \
+    CLEAR_BIT((__HANDLE__)->Instance->CR3, USART_CR3_CTSE); \
+    (__HANDLE__)->Init.HwFlowCtl &= ~(USART_CR3_CTSE);      \
+  } while(0)
+
+/** @brief  Enable RTS flow control 
+  *         This macro allows to enable RTS hardware flow control for a given UART instance, 
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying RTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e __HAL_UART_ENABLE(__HANDLE__)). 
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance can be USART1, USART2 or LPUART.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_RTS_ENABLE(__HANDLE__)       \
+  do{                                                     \
+    SET_BIT((__HANDLE__)->Instance->CR3, USART_CR3_RTSE); \
+    (__HANDLE__)->Init.HwFlowCtl |= USART_CR3_RTSE;       \
+  } while(0)
+
+/** @brief  Disable RTS flow control 
+  *         This macro allows to disable RTS hardware flow control for a given UART instance, 
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying RTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e __HAL_UART_ENABLE(__HANDLE__)). 
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance can be USART1, USART2 or LPUART.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_RTS_DISABLE(__HANDLE__)       \
+  do{                                                      \
+    CLEAR_BIT((__HANDLE__)->Instance->CR3, USART_CR3_RTSE);\
+    (__HANDLE__)->Init.HwFlowCtl &= ~(USART_CR3_RTSE);     \
+  } while(0)
 
 /** @brief  macros to enables or disables the UART's one bit sampling method
   * @param  __HANDLE__: specifies the UART Handle.  

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_usart.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_usart.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_usart.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   USART HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Universal Synchronous Asynchronous Receiver Transmitter (USART) peripheral:
@@ -213,7 +213,7 @@ static HAL_StatusTypeDef USART_WaitOnFlagUntilTimeout(USART_HandleTypeDef *husar
 HAL_StatusTypeDef HAL_USART_Init(USART_HandleTypeDef *husart)
 {
   /* Check the USART handle allocation */
-  if(husart == NULL)
+  if(husart == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -257,7 +257,7 @@ HAL_StatusTypeDef HAL_USART_Init(USART_HandleTypeDef *husart)
 HAL_StatusTypeDef HAL_USART_DeInit(USART_HandleTypeDef *husart)
 {
    /* Check the USART handle allocation */
-  if(husart == NULL)
+  if(husart == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -380,7 +380,7 @@ HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, uint8_t *pTxDa
 
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pTxData == NULL) || (Size == 0)) 
+    if((pTxData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;
     }
@@ -399,7 +399,7 @@ HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, uint8_t *pTxDa
       if(husart->Init.WordLength == USART_WORDLENGTH_9B)
       {
         /* Wait for TC flag in order to write data in DR */
-        if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TC, RESET, Timeout) != HAL_OK)
+        if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TXE, RESET, Timeout) != HAL_OK)
         {
           return HAL_TIMEOUT;
         }
@@ -457,7 +457,7 @@ HAL_StatusTypeDef HAL_USART_Receive(USART_HandleTypeDef *husart, uint8_t *pRxDat
 
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pRxData == NULL) || (Size == 0)) 
+    if((pRxData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;
     }
@@ -475,8 +475,8 @@ HAL_StatusTypeDef HAL_USART_Receive(USART_HandleTypeDef *husart, uint8_t *pRxDat
       husart->RxXferCount--;
       if(husart->Init.WordLength == USART_WORDLENGTH_9B)
       {
-        /* Wait until TC flag is set to send dummy byte in order to generate the clock for the slave to send data */
-        if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TC, RESET, Timeout) != HAL_OK)
+        /* Wait until TXE flag is set to send dummy byte in order to generate the clock for the slave to send data */
+        if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TXE, RESET, Timeout) != HAL_OK)
         { 
           return HAL_TIMEOUT;
         }
@@ -502,8 +502,8 @@ HAL_StatusTypeDef HAL_USART_Receive(USART_HandleTypeDef *husart, uint8_t *pRxDat
       }
       else
       {
-        /* Wait until TC flag is set to send dummy byte in order to generate the clock for the slave to send data */
-        if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TC, RESET, Timeout) != HAL_OK)
+        /* Wait until TXE flag is set to send dummy byte in order to generate the clock for the slave to send data */
+        if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TXE, RESET, Timeout) != HAL_OK)
         { 
           return HAL_TIMEOUT;
         }
@@ -559,7 +559,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, uint8_t
 
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pTxData == NULL) || (pRxData == NULL) || (Size == 0)) 
+    if((pTxData == HAL_NULL) || (pRxData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;
     }
@@ -582,7 +582,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, uint8_t
       if(husart->Init.WordLength == USART_WORDLENGTH_9B)
       {
         /* Wait for TC flag in order to write data in DR */
-        if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TC, RESET, Timeout) != HAL_OK)
+        if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TXE, RESET, Timeout) != HAL_OK)
         {
           return HAL_TIMEOUT;
         }
@@ -617,7 +617,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, uint8_t
       else
       {
         /* Wait for TC flag in order to write data in DR */
-        if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TC, RESET, Timeout) != HAL_OK)
+        if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TXE, RESET, Timeout) != HAL_OK)
         {
           return HAL_TIMEOUT;
         }
@@ -667,7 +667,7 @@ HAL_StatusTypeDef HAL_USART_Transmit_IT(USART_HandleTypeDef *husart, uint8_t *pT
 {
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pTxData == NULL) || (Size == 0)) 
+    if((pTxData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;
     }
@@ -693,8 +693,8 @@ HAL_StatusTypeDef HAL_USART_Transmit_IT(USART_HandleTypeDef *husart, uint8_t *pT
     /* Process Unlocked */
     __HAL_UNLOCK(husart);
 
-    /* Enable the USART Transmit Complete Interrupt */
-    __USART_ENABLE_IT(husart, USART_IT_TC);
+    /* Enable the USART Transmit Data Register Empty Interrupt */
+    __USART_ENABLE_IT(husart, USART_IT_TXE);
 
     return HAL_OK;
   }
@@ -716,7 +716,7 @@ HAL_StatusTypeDef HAL_USART_Receive_IT(USART_HandleTypeDef *husart, uint8_t *pRx
 {
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pRxData == NULL) || (Size == 0)) 
+    if((pRxData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;
     }
@@ -766,7 +766,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, uint
 {
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pTxData == NULL) || (pRxData == NULL) || (Size == 0)) 
+    if((pTxData == HAL_NULL) || (pRxData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;
     }
@@ -795,8 +795,8 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, uint
     /* Process Unlocked */
     __HAL_UNLOCK(husart);
 
-    /* Enable the USART Transmit Complete Interrupt */
-    __USART_ENABLE_IT(husart, USART_IT_TC);
+    /* Enable the USART Transmit Data Register Empty Interrupt */
+    __USART_ENABLE_IT(husart, USART_IT_TXE);
 
     return HAL_OK;
   }
@@ -820,7 +820,7 @@ HAL_StatusTypeDef HAL_USART_Transmit_DMA(USART_HandleTypeDef *husart, uint8_t *p
   
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pTxData == NULL) || (Size == 0)) 
+    if((pTxData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;
     }
@@ -878,7 +878,7 @@ HAL_StatusTypeDef HAL_USART_Receive_DMA(USART_HandleTypeDef *husart, uint8_t *pR
   
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pRxData == NULL) || (Size == 0)) 
+    if((pRxData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;
     }
@@ -912,6 +912,10 @@ HAL_StatusTypeDef HAL_USART_Receive_DMA(USART_HandleTypeDef *husart, uint8_t *pR
        this mode isn't a simplex receive mode but a full-duplex receive one */
     HAL_DMA_Start_IT(husart->hdmatx, *(uint32_t*)tmp, (uint32_t)&husart->Instance->DR, Size);
 
+    /* Clear the Overrun flag just before enabling the DMA Rx request: mandatory for the second transfer
+       when using the USART in circular mode */
+    __HAL_USART_CLEAR_OREFLAG(husart);
+    
     /* Enable the DMA transfer for the receiver request by setting the DMAR bit 
        in the USART CR3 register */
     husart->Instance->CR3 |= USART_CR3_DMAR;
@@ -947,7 +951,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_DMA(USART_HandleTypeDef *husart, uin
   
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pTxData == NULL) || (pRxData == NULL) || (Size == 0)) 
+    if((pTxData == HAL_NULL) || (pRxData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;
     }
@@ -987,7 +991,10 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_DMA(USART_HandleTypeDef *husart, uin
     /* Enable the USART transmit DMA Stream */
     tmp = (uint32_t*)&pTxData;
     HAL_DMA_Start_IT(husart->hdmatx, *(uint32_t*)tmp, (uint32_t)&husart->Instance->DR, Size);
-
+    
+    /* Clear the Overrun flag: mandatory for the second transfer in circular mode */
+    __HAL_USART_CLEAR_OREFLAG(husart);
+    
     /* Enable the DMA transfer for the receiver request by setting the DMAR bit 
        in the USART CR3 register */
     husart->Instance->CR3 |= USART_CR3_DMAR;
@@ -1017,28 +1024,13 @@ HAL_StatusTypeDef HAL_USART_DMAPause(USART_HandleTypeDef *husart)
 {
   /* Process Locked */
   __HAL_LOCK(husart);
-
-  if(husart->State == HAL_USART_STATE_BUSY_TX)
-  {
-    /* Disable the USART DMA Tx request */
-    husart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAT);
-  }
-  else if(husart->State == HAL_USART_STATE_BUSY_RX)
-  {
-    /* Disable the USART DMA Rx request */
-    husart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAR);
-  }
-  else if(husart->State == HAL_USART_STATE_BUSY_TX_RX)
-  {
-    /* Disable the USART DMA Tx request */
-    husart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAT);
-    /* Disable the USART DMA Rx request */
-    husart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAR);
-  }
-
+  
+  /* Disable the USART DMA Tx request */
+  husart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAT);
+  
   /* Process Unlocked */
   __HAL_UNLOCK(husart);
-
+  
   return HAL_OK; 
 }
 
@@ -1052,35 +1044,13 @@ HAL_StatusTypeDef HAL_USART_DMAResume(USART_HandleTypeDef *husart)
 {
   /* Process Locked */
   __HAL_LOCK(husart);
-
-  if(husart->State == HAL_USART_STATE_BUSY_TX)
-  {
-    /* Enable the USART DMA Tx request */
-    husart->Instance->CR3 |= USART_CR3_DMAT;
-  }
-  else if(husart->State == HAL_USART_STATE_BUSY_RX)
-  {
-    /* Enable the USART DMA Rx request */
-    husart->Instance->CR3 |= USART_CR3_DMAR;
-  }
-  else if(husart->State == HAL_USART_STATE_BUSY_TX_RX)
-  {
-    /* Enable the USART DMA Rx request  before the DMA Tx request */
-    husart->Instance->CR3 |= USART_CR3_DMAR;
-    /* Enable the USART DMA Tx request */
-    husart->Instance->CR3 |= USART_CR3_DMAT;
-  }
-
-  /* If the USART peripheral is still not enabled, enable it */
-  if ((husart->Instance->CR1 & USART_CR1_UE) == 0)
-  {
-    /* Enable USART peripheral */
-    __USART_ENABLE(husart);
-  }
-
+  
+  /* Enable the USART DMA Tx request */
+  husart->Instance->CR3 |= USART_CR3_DMAT;
+  
   /* Process Unlocked */
   __HAL_UNLOCK(husart);
-
+  
   return HAL_OK;
 }
 
@@ -1092,30 +1062,28 @@ HAL_StatusTypeDef HAL_USART_DMAResume(USART_HandleTypeDef *husart)
   */
 HAL_StatusTypeDef HAL_USART_DMAStop(USART_HandleTypeDef *husart)
 {
-  /* Process Locked */
-  __HAL_LOCK(husart);
-
-  /* Disable the USART Tx/Rx DMA requests */
-  husart->Instance->CR3 &= ~USART_CR3_DMAT;
-  husart->Instance->CR3 &= ~USART_CR3_DMAR;
+  /* The Lock is not implemented on this API to allow the user application
+     to call the HAL USART API under callbacks HAL_USART_TxCpltCallback() / HAL_USART_RxCpltCallback():
+     when calling HAL_DMA_Abort() API the DMA TX/RX Transfer complete interrupt is generated
+     and the correspond call back is executed HAL_USART_TxCpltCallback() / HAL_USART_RxCpltCallback()
+     */
 
   /* Abort the USART DMA Tx Stream */
-  if(husart->hdmatx != NULL)
+  if(husart->hdmatx != HAL_NULL)
   {
     HAL_DMA_Abort(husart->hdmatx);
   }
   /* Abort the USART DMA Rx Stream */
-  if(husart->hdmarx != NULL)
+  if(husart->hdmarx != HAL_NULL)
   {  
     HAL_DMA_Abort(husart->hdmarx);
   }
-  /* Disable USART peripheral */
-  __USART_DISABLE(husart);
-
+  
+  /* Disable the USART Tx/Rx DMA requests */
+  husart->Instance->CR3 &= ~USART_CR3_DMAT;
+  husart->Instance->CR3 &= ~USART_CR3_DMAR;
+  
   husart->State = HAL_USART_STATE_READY;
-
-  /* Process Unlocked */
-  __HAL_UNLOCK(husart);
 
   return HAL_OK;
 }
@@ -1135,7 +1103,7 @@ void HAL_USART_IRQHandler(USART_HandleTypeDef *husart)
   /* USART parity error interrupt occurred -----------------------------------*/
   if((tmp1 != RESET) && (tmp2 != RESET))
   {
-    __HAL_USART_CLEAR_FLAG(husart, USART_FLAG_PE);
+    __HAL_USART_CLEAR_PEFLAG(husart);
     husart->ErrorCode |= HAL_USART_ERROR_PE;
   }
 
@@ -1144,7 +1112,7 @@ void HAL_USART_IRQHandler(USART_HandleTypeDef *husart)
   /* USART frame error interrupt occurred ------------------------------------*/
   if((tmp1 != RESET) && (tmp2 != RESET))
   {
-    __HAL_USART_CLEAR_FLAG(husart, USART_FLAG_FE);
+    __HAL_USART_CLEAR_FEFLAG(husart);
     husart->ErrorCode |= HAL_USART_ERROR_FE;
   }
 
@@ -1153,7 +1121,7 @@ void HAL_USART_IRQHandler(USART_HandleTypeDef *husart)
   /* USART noise error interrupt occurred ------------------------------------*/
   if((tmp1 != RESET) && (tmp2 != RESET))
   {
-    __HAL_USART_CLEAR_FLAG(husart, USART_FLAG_NE);
+    __HAL_USART_CLEAR_NEFLAG(husart);
     husart->ErrorCode |= HAL_USART_ERROR_NE;
   }
 
@@ -1162,7 +1130,7 @@ void HAL_USART_IRQHandler(USART_HandleTypeDef *husart)
   /* USART Over-Run interrupt occurred ---------------------------------------*/
   if((tmp1 != RESET) && (tmp2 != RESET))
   {
-    __HAL_USART_CLEAR_FLAG(husart, USART_FLAG_ORE);
+    __HAL_USART_CLEAR_OREFLAG(husart);
     husart->ErrorCode |= HAL_USART_ERROR_ORE;
   }
 
@@ -1189,8 +1157,8 @@ void HAL_USART_IRQHandler(USART_HandleTypeDef *husart)
     }
   }
 
-  tmp1 = __HAL_USART_GET_FLAG(husart, USART_FLAG_TC);
-  tmp2 = __HAL_USART_GET_IT_SOURCE(husart, USART_IT_TC);
+  tmp1 = __HAL_USART_GET_FLAG(husart, USART_FLAG_TXE);
+  tmp2 = __HAL_USART_GET_IT_SOURCE(husart, USART_IT_TXE);
   /* USART in mode Transmitter -----------------------------------------------*/
   if((tmp1 != RESET) && (tmp2 != RESET))
   {
@@ -1341,31 +1309,37 @@ uint32_t HAL_USART_GetError(USART_HandleTypeDef *husart)
 static void USART_DMATransmitCplt(DMA_HandleTypeDef *hdma)
 {
   USART_HandleTypeDef* husart = ( USART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
-
-  husart->TxXferCount = 0;
-  if(husart->State == HAL_USART_STATE_BUSY_TX)
+  /* DMA Normal mode */
+  if((hdma->Instance->CR & DMA_SxCR_CIRC) == 0)
   {
-    /* Wait for USART TC Flag */
-    if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TC, RESET, USART_TIMEOUT_VALUE) != HAL_OK)
+    husart->TxXferCount = 0;
+    if(husart->State == HAL_USART_STATE_BUSY_TX)
     {
-      /* Timeout occurred */ 
-      husart->State = HAL_USART_STATE_TIMEOUT;
-      HAL_USART_ErrorCallback(husart);
-    }
-    else
-    {
-      /* No Timeout */
-      /* Disable the DMA transfer for transmit request by setting the DMAT bit
-       in the USART CR3 register */
-      husart->Instance->CR3 &= ~(USART_CR3_DMAT);
-      husart->State= HAL_USART_STATE_READY;
+      /* Wait for USART TC Flag */
+      if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TC, RESET, USART_TIMEOUT_VALUE) != HAL_OK)
+      {
+        /* Timeout occurred */ 
+        husart->State = HAL_USART_STATE_TIMEOUT;
+        HAL_USART_ErrorCallback(husart);
+      }
+      else
+      {
+        /* No Timeout */
+        /* Disable the DMA transfer for transmit request by setting the DMAT bit
+         in the USART CR3 register */
+        husart->Instance->CR3 &= ~(USART_CR3_DMAT);
+        husart->State= HAL_USART_STATE_READY;
+        HAL_USART_TxCpltCallback(husart);
+      }
     }
   }
-  /* the usart state is HAL_USART_STATE_BUSY_TX_RX*/
+  /* DMA Circular mode */
   else
   {
-    husart->State= HAL_USART_STATE_BUSY_RX;
-    HAL_USART_TxCpltCallback(husart);
+    if(husart->State == HAL_USART_STATE_BUSY_TX)
+    {
+      HAL_USART_TxCpltCallback(husart);
+    }
   }
 }
 
@@ -1387,20 +1361,46 @@ static void USART_DMATxHalfCplt(DMA_HandleTypeDef *hdma)
   * @param  hdma: DMA handle
   * @retval None
   */
-static void USART_DMAReceiveCplt(DMA_HandleTypeDef *hdma)   
+static void USART_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
 {
   USART_HandleTypeDef* husart = ( USART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  /* DMA Normal mode */
+  if((hdma->Instance->CR & DMA_SxCR_CIRC) == 0)
+  {
+    husart->RxXferCount = 0;
+    husart->State= HAL_USART_STATE_READY;
+    if(husart->State == HAL_USART_STATE_BUSY_RX)
+    {
+      /* Disable the DMA transfer for the Transmit/receiver requests by setting the DMAT/DMAR bit 
+         in the USART CR3 register */
+      husart->Instance->CR3 &= ~(USART_CR3_DMAR);
 
-  husart->RxXferCount = 0;
+      HAL_USART_RxCpltCallback(husart);
+    }
+    /* the usart state is HAL_USART_STATE_BUSY_TX_RX*/
+    else
+    {
+      /* Disable the DMA transfer for the Transmit/receiver requests by setting the DMAT/DMAR bit 
+         in the USART CR3 register */
+      husart->Instance->CR3 &= ~(USART_CR3_DMAR);
+      husart->Instance->CR3 &= ~(USART_CR3_DMAT);
 
-  /* Disable the DMA transfer for the Transmit/receiver requests by setting the DMAT/DMAR bit 
-  in the USART CR3 register */
-  husart->Instance->CR3 &= ~(USART_CR3_DMAR);
-  husart->Instance->CR3 &= ~(USART_CR3_DMAT);
-
-  husart->State= HAL_USART_STATE_READY;
-  
-  HAL_USART_RxCpltCallback(husart);
+      HAL_USART_TxRxCpltCallback(husart);
+    }
+  }
+  /* DMA circular mode */
+  else
+  {
+    if(husart->State == HAL_USART_STATE_BUSY_RX)
+    {
+      HAL_USART_RxCpltCallback(husart);
+    }
+    /* the usart state is HAL_USART_STATE_BUSY_TX_RX*/
+    else
+    {
+      HAL_USART_TxRxCpltCallback(husart);
+    }
+  }
 }
 
 /**
@@ -1421,7 +1421,7 @@ static void USART_DMARxHalfCplt(DMA_HandleTypeDef *hdma)
   * @param  hdma: DMA handle
   * @retval None
   */
-static void USART_DMAError(DMA_HandleTypeDef *hdma)   
+static void USART_DMAError(DMA_HandleTypeDef *hdma)
 {
   USART_HandleTypeDef* husart = ( USART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
 
@@ -1444,9 +1444,10 @@ static void USART_DMAError(DMA_HandleTypeDef *hdma)
   */
 static HAL_StatusTypeDef USART_WaitOnFlagUntilTimeout(USART_HandleTypeDef *husart, uint32_t Flag, FlagStatus Status, uint32_t Timeout)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
 
-  timeout = HAL_GetTick() + Timeout;
+  /* Get tick */ 
+  tickstart = HAL_GetTick();
 
   /* Wait until flag is set */
   if(Status == RESET)
@@ -1456,7 +1457,7 @@ static HAL_StatusTypeDef USART_WaitOnFlagUntilTimeout(USART_HandleTypeDef *husar
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
           __USART_DISABLE_IT(husart, USART_IT_TXE);
@@ -1481,7 +1482,7 @@ static HAL_StatusTypeDef USART_WaitOnFlagUntilTimeout(USART_HandleTypeDef *husar
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        if(HAL_GetTick() >= timeout)
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
         {
           /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
           __USART_DISABLE_IT(husart, USART_IT_TXE);
@@ -1536,14 +1537,19 @@ static HAL_StatusTypeDef USART_Transmit_IT(USART_HandleTypeDef *husart)
     
     if(--husart->TxXferCount == 0)
     {
-      /* Disable the USART Transmit Complete Interrupt */
-      __USART_DISABLE_IT(husart, USART_IT_TC);
+      /* Disable the USART Transmit data register empty Interrupt */
+      __USART_DISABLE_IT(husart, USART_IT_TXE);
 
       /* Disable the USART Error Interrupt: (Frame error, noise error, overrun error) */
       __USART_DISABLE_IT(husart, USART_IT_ERR);
 
-      husart->State = HAL_USART_STATE_READY;
 
+      if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TC, RESET, USART_TIMEOUT_VALUE) != HAL_OK)
+      { 
+        return HAL_TIMEOUT;
+      }
+      husart->State = HAL_USART_STATE_READY;
+      
       HAL_USART_TxCpltCallback(husart);
 
       return HAL_OK;
@@ -1640,8 +1646,6 @@ static HAL_StatusTypeDef USART_TransmitReceive_IT(USART_HandleTypeDef *husart)
 
   if(husart->State == HAL_USART_STATE_BUSY_TX_RX)
   {
-    /* Process Locked */
-    __HAL_LOCK(husart);
     if(husart->TxXferCount != 0x00)
     {
       if(__HAL_USART_GET_FLAG(husart, USART_FLAG_TXE) != RESET)
@@ -1668,7 +1672,7 @@ static HAL_StatusTypeDef USART_TransmitReceive_IT(USART_HandleTypeDef *husart)
         /* Check the latest data transmitted */
         if(husart->TxXferCount == 0)
         {
-           __USART_DISABLE_IT(husart, USART_IT_TC);
+           __USART_DISABLE_IT(husart, USART_IT_TXE);
         }
       }
     }
@@ -1716,20 +1720,13 @@ static HAL_StatusTypeDef USART_TransmitReceive_IT(USART_HandleTypeDef *husart)
 
       /* Disable the USART Error Interrupt: (Frame error, noise error, overrun error) */
       __USART_DISABLE_IT(husart, USART_IT_ERR);
-
+      
       husart->State = HAL_USART_STATE_READY;
-
-      /* Call the Process Unlocked before calling the Tx\Rx callback API to give the possibility to
-         start again the Transmission\Reception under the Tx\Rx callback API */
-      __HAL_UNLOCK(husart);
 
       HAL_USART_TxRxCpltCallback(husart);
 
       return HAL_OK;
     }
-
-    /* Process Unlocked */
-    __HAL_UNLOCK(husart);
 
     return HAL_OK;
   }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_usart.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_usart.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_usart.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of USART HAL module.
   ******************************************************************************
   * @attention
@@ -355,8 +355,42 @@ typedef struct
   *   
   * @retval None
   */
-#define __HAL_USART_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->SR &= ~(__FLAG__))
+#define __HAL_USART_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->SR = ~(__FLAG__))
 
+/** @brief  Clear the USART PE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3 or 6 to select the USART peripheral.
+  * @retval None
+  */
+#define __HAL_USART_CLEAR_PEFLAG(__HANDLE__) do{(__HANDLE__)->Instance->SR;\
+                                                (__HANDLE__)->Instance->DR;}while(0)
+/** @brief  Clear the USART FE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3 or 6 to select the USART peripheral.
+  * @retval None
+  */
+#define __HAL_USART_CLEAR_FEFLAG(__HANDLE__) __HAL_USART_CLEAR_PEFLAG(__HANDLE__)
+
+/** @brief  Clear the USART NE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3 or 6 to select the USART peripheral.
+  * @retval None
+  */
+#define __HAL_USART_CLEAR_NEFLAG(__HANDLE__) __HAL_USART_CLEAR_PEFLAG(__HANDLE__)
+
+/** @brief  Clear the UART ORE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3 or 6 to select the USART peripheral.
+  * @retval None
+  */
+#define __HAL_USART_CLEAR_OREFLAG(__HANDLE__) __HAL_USART_CLEAR_PEFLAG(__HANDLE__)
+
+/** @brief  Clear the USART IDLE pending flag.
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         This parameter can be USARTx where x: 1, 2, 3 or 6 to select the USART peripheral.
+  * @retval None
+  */
+#define __HAL_USART_CLEAR_IDLEFLAG(__HANDLE__) __HAL_USART_CLEAR_PEFLAG(__HANDLE__)
 
 /** @brief  Enables or disables the specified Usart interrupts.
   * @param  __HANDLE__: specifies the USART Handle.

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_wwdg.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_wwdg.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_wwdg.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   WWDG HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Window Watchdog (WWDG) peripheral:
@@ -62,9 +62,9 @@
        Below the list of most used macros in WWDG HAL driver.
        
       (+) __HAL_WWDG_ENABLE: Enable the WWDG peripheral 
-      (+) __HAL_IWDG_GET_FLAG: Get the selected WWDG's flag status
-      (+) __HAL_IWDG_CLEAR_FLAG: Clear the WWDG's pending flags 
-      (+) __HAL_IWDG_RELOAD_COUNTER: Enables the WWDG early wakeup interrupt  
+      (+) __HAL_WWDG_GET_FLAG: Get the selected WWDG's flag status
+      (+) __HAL_WWDG_CLEAR_FLAG: Clear the WWDG's pending flags 
+      (+) __HAL_WWDG_ENABLE_IT:  Enables the WWDG early wakeup interrupt 
 
   @endverbatim
   ******************************************************************************
@@ -150,15 +150,14 @@
   */
 HAL_StatusTypeDef HAL_WWDG_Init(WWDG_HandleTypeDef *hwwdg)
 {
-  uint32_t tmp = 0;
-  
   /* Check the WWDG handle allocation */
-  if(hwwdg == NULL)
+  if(hwwdg == HAL_NULL)
   {
     return HAL_ERROR;
   }
-  
+
   /* Check the parameters */
+  assert_param(IS_WWDG_ALL_INSTANCE(hwwdg->Instance));
   assert_param(IS_WWDG_PRESCALER(hwwdg->Init.Prescaler));
   assert_param(IS_WWDG_WINDOW(hwwdg->Init.Window)); 
   assert_param(IS_WWDG_COUNTER(hwwdg->Init.Counter)); 
@@ -173,31 +172,10 @@ HAL_StatusTypeDef HAL_WWDG_Init(WWDG_HandleTypeDef *hwwdg)
   hwwdg->State = HAL_WWDG_STATE_BUSY;
 
   /* Set WWDG Prescaler and Window */
-  /* Get the CFR register value */
-  tmp = hwwdg->Instance->CFR;
-  
-  /* Clear WDGTB[1:0] and W[6:0] bits */
-  tmp &= ((uint32_t)~(WWDG_CFR_WDGTB | WWDG_CFR_W));
-  
-  /* Prepare the WWDG Prescaler and Window parameters */
-  tmp |= hwwdg->Init.Prescaler | hwwdg->Init.Window;
-  
-  /* Write to WWDG CFR */
-  hwwdg->Instance->CFR = tmp;   
- 
+  MODIFY_REG(hwwdg->Instance->CFR, (WWDG_CFR_WDGTB | WWDG_CFR_W), (hwwdg->Init.Prescaler | hwwdg->Init.Window));
   /* Set WWDG Counter */
-  /* Get the CR register value */
-  tmp = hwwdg->Instance->CR;
-  
-  /* Clear T[6:0] bits */
-  tmp &= ((uint32_t)~(WWDG_CR_T));
-  
-  /* Prepare the WWDG Counter parameter */
-  tmp |= (hwwdg->Init.Counter);  
-  
-  /* Write to WWDG CR */
-  hwwdg->Instance->CR = tmp;  
-   
+  MODIFY_REG(hwwdg->Instance->CR, WWDG_CR_T, hwwdg->Init.Counter);
+
   /* Change WWDG peripheral state */
   hwwdg->State = HAL_WWDG_STATE_READY;
   
@@ -212,7 +190,16 @@ HAL_StatusTypeDef HAL_WWDG_Init(WWDG_HandleTypeDef *hwwdg)
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_WWDG_DeInit(WWDG_HandleTypeDef *hwwdg)
-{   
+{ 
+  /* Check the WWDG handle allocation */
+  if(hwwdg == HAL_NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_WWDG_ALL_INSTANCE(hwwdg->Instance));
+
   /* Change WWDG peripheral state */  
   hwwdg->State = HAL_WWDG_STATE_BUSY;
   
@@ -319,19 +306,19 @@ HAL_StatusTypeDef HAL_WWDG_Start(WWDG_HandleTypeDef *hwwdg)
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_WWDG_Start_IT(WWDG_HandleTypeDef *hwwdg)
-{   
+{
   /* Process Locked */
   __HAL_LOCK(hwwdg); 
-  
+
   /* Change WWDG peripheral state */  
   hwwdg->State = HAL_WWDG_STATE_BUSY;
-  
+
   /* Enable the Early Wakeup Interrupt */ 
   __HAL_WWDG_ENABLE_IT(WWDG_IT_EWI);
 
   /* Enable the peripheral */
   __HAL_WWDG_ENABLE(hwwdg);  
-  
+
   /* Return function status */
   return HAL_OK;
 }
@@ -340,6 +327,7 @@ HAL_StatusTypeDef HAL_WWDG_Start_IT(WWDG_HandleTypeDef *hwwdg)
   * @brief  Refreshes the WWDG.
   * @param  hwwdg: pointer to a WWDG_HandleTypeDef structure that contains
   *              the configuration information for the specified WWDG module.
+  * @param  Counter: value of counter to put in WWDG counter
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_WWDG_Refresh(WWDG_HandleTypeDef *hwwdg, uint32_t Counter)
@@ -354,7 +342,7 @@ HAL_StatusTypeDef HAL_WWDG_Refresh(WWDG_HandleTypeDef *hwwdg, uint32_t Counter)
   assert_param(IS_WWDG_COUNTER(Counter));
   
   /* Write to WWDG CR the WWDG Counter value to refresh with */
-  MODIFY_REG(hwwdg->Instance->CR, WWDG_CR_T, Counter);
+  MODIFY_REG(hwwdg->Instance->CR, (uint32_t)WWDG_CR_T, Counter);
   
   /* Change WWDG peripheral state */    
   hwwdg->State = HAL_WWDG_STATE_READY; 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_wwdg.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_hal_wwdg.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_hal_wwdg.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of WWDG HAL module.
   ******************************************************************************
   * @attention
@@ -54,19 +54,18 @@
   * @{
   */ 
 
-/* Exported types ------------------------------------------------------------*/ 
+/* Exported types ------------------------------------------------------------*/
 
-/** 
-  * @brief  WWDG HAL State Structure definition  
-  */ 
+/**
+  * @brief  WWDG HAL State Structure definition
+  */
 typedef enum
 {
   HAL_WWDG_STATE_RESET     = 0x00,  /*!< WWDG not yet initialized or disabled */
   HAL_WWDG_STATE_READY     = 0x01,  /*!< WWDG initialized and ready for use   */
-  HAL_WWDG_STATE_BUSY      = 0x02,  /*!< WWDG internal process is ongoing     */ 
+  HAL_WWDG_STATE_BUSY      = 0x02,  /*!< WWDG internal process is ongoing     */
   HAL_WWDG_STATE_TIMEOUT   = 0x03,  /*!< WWDG timeout state                   */
   HAL_WWDG_STATE_ERROR     = 0x04   /*!< WWDG error state                     */
-    
 }HAL_WWDG_StateTypeDef;
 
 /** 
@@ -74,14 +73,14 @@ typedef enum
   */ 
 typedef struct
 {
-  uint32_t Prescaler;  /*!< Specifies the prescaler.  
+  uint32_t Prescaler;  /*!< Specifies the prescaler value of the WWDG.
                             This parameter can be a value of @ref WWDG_Prescaler */
   
   uint32_t Window;     /*!< Specifies the WWDG window value to be compared to the downcounter.
                             This parameter must be a number lower than Max_Data = 0x80 */ 
   
   uint32_t Counter;    /*!< Specifies the WWDG free-running downcounter value.
-                            This parameter must be a number between Min_Data = 0x40 and Max_Data = 0x7F */                                    
+                            This parameter must be a number between Min_Data = 0x40 and Max_Data = 0x7F */
 
 }WWDG_InitTypeDef;
 
@@ -90,7 +89,7 @@ typedef struct
   */ 
 typedef struct
 {
-  WWDG_TypeDef                 *Instance;  /*!< Register base address    */ 
+  WWDG_TypeDef                 *Instance;  /*!< Register base address    */
   
   WWDG_InitTypeDef             Init;       /*!< WWDG required parameters */
   
@@ -102,7 +101,12 @@ typedef struct
 
 /* Exported constants --------------------------------------------------------*/
 
+/** @defgroup WWDG_Exported_Constants
+  * @{
+  */
+
 /** @defgroup WWDG_BitAddress_AliasRegion
+  * @brief WWDG registers bit address in the alias region
   * @{
   */
 
@@ -119,7 +123,7 @@ typedef struct
   */ 
 #define WWDG_IT_EWI   ((uint32_t)WWDG_CFR_EWI)  
 
-#define IS_WWDG_IT(IT) ((IT) == WWDG_IT_EWI)
+#define IS_WWDG_IT(__IT__) ((__IT__) == WWDG_IT_EWI)
 
 /**
   * @}
@@ -129,9 +133,9 @@ typedef struct
   * @brief WWDG Flag definition
   * @{
   */ 
-#define WWDG_FLAG_EWIF   ((uint32_t)0x0001)  /*!< Early wakeup interrupt flag */
+#define WWDG_FLAG_EWIF   ((uint32_t)WWDG_SR_EWIF)  /*!< Early wakeup interrupt flag */
+#define IS_WWDG_FLAG(__FLAG__) ((__FLAG__) == WWDG_FLAG_EWIF)) 
 
-#define IS_WWDG_FLAG(FLAG) ((FLAG) == WWDG_FLAG_EWIF)) 
 
 /**
   * @}
@@ -141,14 +145,14 @@ typedef struct
   * @{
   */ 
 #define WWDG_PRESCALER_1   ((uint32_t)0x00000000)  /*!< WWDG counter clock = (PCLK1/4096)/1 */
-#define WWDG_PRESCALER_2   ((uint32_t)0x00000080)  /*!< WWDG counter clock = (PCLK1/4096)/2 */
-#define WWDG_PRESCALER_4   ((uint32_t)0x00000100)  /*!< WWDG counter clock = (PCLK1/4096)/4 */
-#define WWDG_PRESCALER_8   ((uint32_t)0x00000180)  /*!< WWDG counter clock = (PCLK1/4096)/8 */
+#define WWDG_PRESCALER_2   ((uint32_t)WWDG_CFR_WDGTB0)  /*!< WWDG counter clock = (PCLK1/4096)/2 */
+#define WWDG_PRESCALER_4   ((uint32_t)WWDG_CFR_WDGTB1)  /*!< WWDG counter clock = (PCLK1/4096)/4 */
+#define WWDG_PRESCALER_8   ((uint32_t)WWDG_CFR_WDGTB)  /*!< WWDG counter clock = (PCLK1/4096)/8 */
 
-#define IS_WWDG_PRESCALER(PRESCALER) (((PRESCALER) == WWDG_PRESCALER_1) || \
-                                      ((PRESCALER) == WWDG_PRESCALER_2) || \
-                                      ((PRESCALER) == WWDG_PRESCALER_4) || \
-                                      ((PRESCALER) == WWDG_PRESCALER_8))
+#define IS_WWDG_PRESCALER(__PRESCALER__) (((__PRESCALER__) == WWDG_PRESCALER_1) || \
+                                          ((__PRESCALER__) == WWDG_PRESCALER_2) || \
+                                          ((__PRESCALER__) == WWDG_PRESCALER_4) || \
+                                          ((__PRESCALER__) == WWDG_PRESCALER_8))
 
 /**
   * @}
@@ -157,7 +161,7 @@ typedef struct
 /** @defgroup WWDG_Window 
   * @{
   */ 
-#define IS_WWDG_WINDOW(WINDOW) ((WINDOW) <= 0x7F)
+#define IS_WWDG_WINDOW(__WINDOW__) ((__WINDOW__) <= 0x7F)
 
 /**
   * @}
@@ -166,7 +170,11 @@ typedef struct
 /** @defgroup WWDG_Counter 
   * @{
   */ 
-#define IS_WWDG_COUNTER(COUNTER) (((COUNTER) >= 0x40) && ((COUNTER) <= 0x7F))
+#define IS_WWDG_COUNTER(__COUNTER__) (((__COUNTER__) >= 0x40) && ((__COUNTER__) <= 0x7F))
+
+/**
+  * @}
+  */
 
 /**
   * @}
@@ -185,7 +193,7 @@ typedef struct
   * @param  __HANDLE__: WWDG handle
   * @retval None
   */
-#define __HAL_WWDG_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR |=  WWDG_CR_WDGA)
+#define __HAL_WWDG_ENABLE(__HANDLE__) SET_BIT((__HANDLE__)->Instance->CR, WWDG_CR_WDGA)
 
 /**
   * @brief  Gets the selected WWDG's flag status.
@@ -205,15 +213,26 @@ typedef struct
   *            @arg WWDG_FLAG_EWIF: Early wakeup interrupt flag
   * @retval None
   */
-#define __HAL_WWDG_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) &= ~(__FLAG__))
+#define __HAL_WWDG_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) = ~(__FLAG__))
 
 /**
   * @brief  Enables the WWDG early wakeup interrupt.
+  * @param  __INTERRUPT__: specifies the interrupt to enable.
+  *         This parameter can be one of the following values:
+  *            @arg WWDG_IT_EWI: Early wakeup interrupt
   * @note   Once enabled this interrupt cannot be disabled except by a system reset.
   * @retval None
   */
 #define __HAL_WWDG_ENABLE_IT(__INTERRUPT__) (*(__IO uint32_t *) CFR_BASE |= (__INTERRUPT__))
 
+/** @brief  Clear the WWDG's interrupt pending bits
+  *         bits to clear the selected interrupt pending bits.
+  * @param  __HANDLE__: WWDG handle
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear.
+  *         This parameter can be one of the following values:
+  *            @arg WWDG_FLAG_EWIF: Early wakeup interrupt flag
+  */
+#define __HAL_WWDG_CLEAR_IT(__HANDLE__, __INTERRUPT__) __HAL_WWDG_CLEAR_FLAG((__HANDLE__), (__INTERRUPT__))
 /* Exported functions --------------------------------------------------------*/
 
 /* Initialization/de-initialization functions  **********************************/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_fmc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_fmc.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_ll_fmc.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   FMC Low Layer HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -685,21 +685,22 @@ HAL_StatusTypeDef FMC_NAND_ECC_Disable(FMC_NAND_TypeDef *Device, uint32_t Bank)
   */
 HAL_StatusTypeDef FMC_NAND_GetECC(FMC_NAND_TypeDef *Device, uint32_t *ECCval, uint32_t Bank, uint32_t Timeout)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
 
   /* Check the parameters */ 
   assert_param(IS_FMC_NAND_DEVICE(Device)); 
   assert_param(IS_FMC_NAND_BANK(Bank));
-      
-  timeout = HAL_GetTick() + Timeout;
-  
+
+  /* Get tick */ 
+  tickstart = HAL_GetTick();
+
   /* Wait untill FIFO is empty */
   while(__FMC_NAND_GET_FLAG(Device, Bank, FMC_FLAG_FEMPT))
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         return HAL_TIMEOUT;
       }
@@ -1145,7 +1146,7 @@ HAL_StatusTypeDef FMC_SDRAM_WriteProtection_Disable(FMC_SDRAM_TypeDef *Device, u
 HAL_StatusTypeDef FMC_SDRAM_SendCommand(FMC_SDRAM_TypeDef *Device, FMC_SDRAM_CommandTypeDef *Command, uint32_t Timeout)
 {
   __IO uint32_t tmpr = 0;
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
   
   /* Check the parameters */
   assert_param(IS_FMC_SDRAM_DEVICE(Device));
@@ -1158,12 +1159,13 @@ HAL_StatusTypeDef FMC_SDRAM_SendCommand(FMC_SDRAM_TypeDef *Device, FMC_SDRAM_Com
   tmpr = (uint32_t)((Command->CommandMode)                  |\
                     (Command->CommandTarget)                |\
                     (((Command->AutoRefreshNumber)-1) << 5) |\
-                    ((Command->ModeRegisterDefinition) << 9)     
+                    ((Command->ModeRegisterDefinition) << 9)
                     );
     
   Device->SDCMR = tmpr;
-   
-  timeout = HAL_GetTick() + Timeout;
+
+  /* Get tick */ 
+  tickstart = HAL_GetTick();
 
   /* wait until command is send */
   while(HAL_IS_BIT_SET(Device->SDSR, FMC_SDSR_BUSY))
@@ -1171,7 +1173,7 @@ HAL_StatusTypeDef FMC_SDRAM_SendCommand(FMC_SDRAM_TypeDef *Device, FMC_SDRAM_Com
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         return HAL_TIMEOUT;
       }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_fmc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_fmc.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_ll_fmc.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of FMC HAL module.
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_fsmc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_fsmc.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_ll_fsmc.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   FSMC Low Layer HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -630,21 +630,22 @@ HAL_StatusTypeDef FSMC_NAND_ECC_Disable(FSMC_NAND_TypeDef *Device, uint32_t Bank
   */
 HAL_StatusTypeDef FSMC_NAND_GetECC(FSMC_NAND_TypeDef *Device, uint32_t *ECCval, uint32_t Bank, uint32_t Timeout)
 {
-  uint32_t timeout = 0;
+  uint32_t tickstart = 0;
   
   /* Check the parameters */ 
   assert_param(IS_FSMC_NAND_DEVICE(Device)); 
   assert_param(IS_FSMC_NAND_BANK(Bank));
-    
-  timeout = HAL_GetTick() + Timeout;
-  
+
+  /* Get tick */ 
+  tickstart = HAL_GetTick();
+
   /* Wait untill FIFO is empty */
   while(__FSMC_NAND_GET_FLAG(Device, Bank, FSMC_FLAG_FEMPT))
   {
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-      if(HAL_GetTick() >= timeout)
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
       {
         return HAL_TIMEOUT;
       }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_fsmc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_fsmc.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_ll_fsmc.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of FSMC HAL module.
   ******************************************************************************
   * @attention
@@ -1014,6 +1014,10 @@ HAL_StatusTypeDef  FSMC_PCCARD_DeInit(FSMC_PCCARD_TypeDef *Device);
 #define FMC_PCCARD_DEVICE                     FSMC_PCCARD_DEVICE 
 
 #define FMC_NAND_BANK2                        FSMC_NAND_BANK2
+
+#define FMC_NORSRAM_BANK1                     FSMC_NORSRAM_BANK1    
+#define FMC_NORSRAM_BANK2                     FSMC_NORSRAM_BANK2    
+#define FMC_NORSRAM_BANK3                     FSMC_NORSRAM_BANK3
 
 #define FMC_IT_RISING_EDGE                    FSMC_IT_RISING_EDGE
 #define FMC_IT_LEVEL                          FSMC_IT_LEVEL

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_sdmmc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_sdmmc.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_ll_sdmmc.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   SDMMC Low Layer HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -66,8 +66,8 @@
       (+) Enable/Disable peripheral clock using RCC peripheral macros related to SDIO
           peripheral.
 
-      (+) Enable the Power ON State using the HAL_SDIO_PowerState_ON(hsdio) 
-          function and disable it using the function HAL_SDIO_PowerState_OFF(hsdio).
+      (+) Enable the Power ON State using the SDIO_PowerState_ON(SDIOx) 
+          function and disable it using the function HAL_SDIO_PowerState_OFF(SDIOx).
                 
       (+) Enable/Disable the clock using the __SDIO_ENABLE()/__SDIO_DISABLE() macros.
   
@@ -81,8 +81,8 @@
                __SDIO_DMA_DISABLE().
   
       (+) To control the CPSM (Command Path State Machine) and send 
-          commands to the card use the HAL_SDIO_SendCommand(), 
-          HAL_SDIO_GetCommandResponse() and HAL_SDIO_GetResponse() functions. First, user has
+          commands to the card use the SDIO_SendCommand(SDIOx), 
+          SDIO_GetCommandResponse() and SDIO_GetResponse() functions. First, user has
           to fill the command structure (pointer to SDIO_CmdInitTypeDef) according 
           to the selected command to be sent.
           The parameters that should be filled are:
@@ -93,13 +93,13 @@
            (++) CPSM Status (Enable or Disable).
   
           -@@- To check if the command is well received, read the SDIO_CMDRESP
-              register using the HAL_SDIO_GetCommandResponse().
+              register using the SDIO_GetCommandResponse().
               The SDIO responses registers (SDIO_RESP1 to SDIO_RESP2), use the
-              HAL_SDIO_GetResponse() function.
+              SDIO_GetResponse() function.
   
       (+) To control the DPSM (Data Path State Machine) and send/receive 
-           data to/from the card use the HAL_SDIO_DataConfig(), HAL_SDIO_GetDataCounter(), 
-          HAL_SDIO_ReadFIFO(), HAL_SDIO_WriteFIFO() and HAL_SDIO_GetFIFOCount() functions.
+           data to/from the card use the SDIO_DataConfig(), SDIO_GetDataCounter(), 
+          SDIO_ReadFIFO(), DIO_WriteFIFO() and SDIO_GetFIFOCount() functions.
   
     *** Read Operations ***
     =======================
@@ -135,9 +135,9 @@
           (++) DPSM Status (Enable or Disable)
   
      (#) Configure the SDIO resources to send the data to the card according to 
-         selected transfer mode (Refer to Step 8, 9 and 10).
+         selected transfer mode.
                      
-     (#) Send the selected Write command (refer to step 11).
+     (#) Send the selected Write command.
                     
      (#) Use the SDIO flags/interrupts to check the transfer status.
   
@@ -219,7 +219,7 @@
   */
 HAL_StatusTypeDef SDIO_Init(SDIO_TypeDef *SDIOx, SDIO_InitTypeDef Init)
 {
-  __IO uint32_t tmpreg = 0; 
+  uint32_t tmpreg = 0; 
 
   /* Check the parameters */
   assert_param(IS_SDIO_ALL_INSTANCE(SDIOx));
@@ -229,12 +229,6 @@ HAL_StatusTypeDef SDIO_Init(SDIO_TypeDef *SDIOx, SDIO_InitTypeDef Init)
   assert_param(IS_SDIO_BUS_WIDE(Init.BusWide));
   assert_param(IS_SDIO_HARDWARE_FLOW_CONTROL(Init.HardwareFlowControl));
   assert_param(IS_SDIO_CLKDIV(Init.ClockDiv));
-  
-  /* Get the SDIO CLKCR value */
-  tmpreg = SDIOx->CLKCR;
-  
-  /* Clear CLKDIV, PWRSAV, BYPASS, WIDBUS, NEGEDGE, HWFC_EN bits */
-  tmpreg &= CLKCR_CLEAR_MASK;
   
   /* Set SDIO configuration parameters */
   tmpreg |= (Init.ClockEdge           |\
@@ -246,7 +240,7 @@ HAL_StatusTypeDef SDIO_Init(SDIO_TypeDef *SDIOx, SDIO_InitTypeDef Init)
              ); 
   
   /* Write to SDIO CLKCR */
-  SDIOx->CLKCR = tmpreg;  
+  MODIFY_REG(SDIOx->CLKCR, CLKCR_CLEAR_MASK, tmpreg);  
 
   return HAL_OK;
 }
@@ -275,7 +269,6 @@ HAL_StatusTypeDef SDIO_Init(SDIO_TypeDef *SDIOx, SDIO_InitTypeDef Init)
 /**
   * @brief  Read data (word) from Rx FIFO in blocking mode (polling) 
   * @param  SDIOx: Pointer to SDIO register base
-  * @param  ReadData: Data to read
   * @retval HAL status
   */
 uint32_t SDIO_ReadFIFO(SDIO_TypeDef *SDIOx)
@@ -325,7 +318,7 @@ HAL_StatusTypeDef SDIO_WriteFIFO(SDIO_TypeDef *SDIOx, uint32_t *pWriteData)
 HAL_StatusTypeDef SDIO_PowerState_ON(SDIO_TypeDef *SDIOx)
 {  
   /* Set power state to ON */ 
-  SDIOx->POWER = (uint32_t)0x00000003;
+  SDIOx->POWER = SDIO_POWER_PWRCTRL;
   
   return HAL_OK; 
 }
@@ -354,7 +347,7 @@ HAL_StatusTypeDef SDIO_PowerState_OFF(SDIO_TypeDef *SDIOx)
   */
 uint32_t SDIO_GetPowerState(SDIO_TypeDef *SDIOx)  
 {
-  return (SDIOx->POWER & (~PWR_PWRCTRL_MASK));
+  return (SDIOx->POWER & SDIO_POWER_PWRCTRL);
 }
 
 /**
@@ -377,14 +370,7 @@ HAL_StatusTypeDef SDIO_SendCommand(SDIO_TypeDef *SDIOx, SDIO_CmdInitTypeDef *SDI
 
   /* Set the SDIO Argument value */
   SDIOx->ARG = SDIO_CmdInitStruct->Argument;
-  
-  /* SDIO CMD Configuration */  
-  /* Get the SDIO CMD value */
-  tmpreg = SDIOx->CMD;
-  
-  /* Clear CMDINDEX, WAITRESP, WAITINT, WAITPEND, CPSMEN bits */
-  tmpreg &= CMD_CLEAR_MASK;
-  
+
   /* Set SDIO command parameters */
   tmpreg |= (uint32_t)(SDIO_CmdInitStruct->CmdIndex         |\
                        SDIO_CmdInitStruct->Response         |\
@@ -392,7 +378,7 @@ HAL_StatusTypeDef SDIO_SendCommand(SDIO_TypeDef *SDIOx, SDIO_CmdInitTypeDef *SDI
                        SDIO_CmdInitStruct->CPSM);
   
   /* Write to SDIO CMD register */
-  SDIOx->CMD = tmpreg;
+  MODIFY_REG(SDIOx->CMD, CMD_CLEAR_MASK, tmpreg); 
   
   return HAL_OK;  
 }
@@ -456,21 +442,14 @@ HAL_StatusTypeDef SDIO_DataConfig(SDIO_TypeDef *SDIOx, SDIO_DataInitTypeDef* SDI
   /* Set the SDIO DataLength value */
   SDIOx->DLEN = SDIO_DataInitStruct->DataLength;
 
-/* SDIO DCTRL Configuration */  
-  /* Get the SDIO DCTRL value */
-  tmpreg = SDIOx->DCTRL;
-  
-  /* Clear DEN, DTMODE, DTDIR and DBCKSIZE bits */
-  tmpreg &= DCTRL_CLEAR_MASK;
-  
   /* Set the SDIO data configuration parameters */
   tmpreg |= (uint32_t)(SDIO_DataInitStruct->DataBlockSize |\
                        SDIO_DataInitStruct->TransferDir   |\
                        SDIO_DataInitStruct->TransferMode  |\
                        SDIO_DataInitStruct->DPSM);
-
+  
   /* Write to SDIO DCTRL */
-  SDIOx->DCTRL = tmpreg;
+  MODIFY_REG(SDIOx->DCTRL, DCTRL_CLEAR_MASK, tmpreg);
 
   return HAL_OK;
 
@@ -488,7 +467,7 @@ uint32_t SDIO_GetDataCounter(SDIO_TypeDef *SDIOx)
 
 /**
   * @brief  Get the FIFO data
-  * @param  hsdio: SDIO handle
+  * @param  SDIOx: Pointer to SDIO register base 
   * @retval Data received
   */
 uint32_t SDIO_GetFIFOCount(SDIO_TypeDef *SDIOx)
@@ -514,26 +493,6 @@ HAL_StatusTypeDef SDIO_SetSDIOReadWaitMode(uint32_t SDIO_ReadWaitMode)
   
   return HAL_OK;  
 }
-
-
-/**
-  * @}
-  */
-
-/** @defgroup HAL_SDIO_Group3 Peripheral State functions 
- *  @brief   Peripheral State functions 
- *
-@verbatim   
- ===============================================================================
-                      ##### Peripheral State functions #####
- ===============================================================================  
-    [..]
-    This subsection permit to get in runtime the status of the SDIO peripheral 
-    and the data flow.
-
-@endverbatim
-  * @{
-  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_sdmmc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_sdmmc.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_ll_sdmmc.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of SDMMC HAL module.
   ******************************************************************************
   * @attention
@@ -56,6 +56,10 @@
 
 /* Exported types ------------------------------------------------------------*/ 
 
+/** @defgroup SDIO_Exported_Types SDIO Exported Types
+  * @{
+  */
+  
 /** 
   * @brief  SDMMC Configuration Structure definition  
   */
@@ -134,6 +138,10 @@ typedef struct
                                      This parameter can be a value of @ref SDIO_DPSM_State         */
 }SDIO_DataInitTypeDef;
 
+/**
+  * @}
+  */
+  
 /* Exported constants --------------------------------------------------------*/
 
 /** @defgroup SDIO_Exported_Constants
@@ -144,7 +152,7 @@ typedef struct
   * @{
   */
 #define SDIO_CLOCK_EDGE_RISING               ((uint32_t)0x00000000)
-#define SDIO_CLOCK_EDGE_FALLING              ((uint32_t)0x00002000)
+#define SDIO_CLOCK_EDGE_FALLING              SDIO_CLKCR_NEGEDGE
 
 #define IS_SDIO_CLOCK_EDGE(EDGE) (((EDGE) == SDIO_CLOCK_EDGE_RISING) || \
                                   ((EDGE) == SDIO_CLOCK_EDGE_FALLING))
@@ -156,7 +164,7 @@ typedef struct
   * @{
   */
 #define SDIO_CLOCK_BYPASS_DISABLE             ((uint32_t)0x00000000)
-#define SDIO_CLOCK_BYPASS_ENABLE              ((uint32_t)0x00000400)    
+#define SDIO_CLOCK_BYPASS_ENABLE              SDIO_CLKCR_BYPASS   
 
 #define IS_SDIO_CLOCK_BYPASS(BYPASS) (((BYPASS) == SDIO_CLOCK_BYPASS_DISABLE) || \
                                       ((BYPASS) == SDIO_CLOCK_BYPASS_ENABLE))
@@ -168,7 +176,7 @@ typedef struct
   * @{
   */
 #define SDIO_CLOCK_POWER_SAVE_DISABLE         ((uint32_t)0x00000000)
-#define SDIO_CLOCK_POWER_SAVE_ENABLE          ((uint32_t)0x00000200) 
+#define SDIO_CLOCK_POWER_SAVE_ENABLE          SDIO_CLKCR_PWRSAV
 
 #define IS_SDIO_CLOCK_POWER_SAVE(SAVE) (((SAVE) == SDIO_CLOCK_POWER_SAVE_DISABLE) || \
                                         ((SAVE) == SDIO_CLOCK_POWER_SAVE_ENABLE))
@@ -180,8 +188,8 @@ typedef struct
   * @{
   */
 #define SDIO_BUS_WIDE_1B                      ((uint32_t)0x00000000)
-#define SDIO_BUS_WIDE_4B                      ((uint32_t)0x00000800)
-#define SDIO_BUS_WIDE_8B                      ((uint32_t)0x00001000)
+#define SDIO_BUS_WIDE_4B                      SDIO_CLKCR_WIDBUS_0
+#define SDIO_BUS_WIDE_8B                      SDIO_CLKCR_WIDBUS_1
 
 #define IS_SDIO_BUS_WIDE(WIDE) (((WIDE) == SDIO_BUS_WIDE_1B) || \
                                 ((WIDE) == SDIO_BUS_WIDE_4B) || \
@@ -194,7 +202,7 @@ typedef struct
   * @{
   */
 #define SDIO_HARDWARE_FLOW_CONTROL_DISABLE    ((uint32_t)0x00000000)
-#define SDIO_HARDWARE_FLOW_CONTROL_ENABLE     ((uint32_t)0x00004000)
+#define SDIO_HARDWARE_FLOW_CONTROL_ENABLE     SDIO_CLKCR_HWFC_EN
 
 #define IS_SDIO_HARDWARE_FLOW_CONTROL(CONTROL) (((CONTROL) == SDIO_HARDWARE_FLOW_CONTROL_DISABLE) || \
                                                 ((CONTROL) == SDIO_HARDWARE_FLOW_CONTROL_ENABLE))
@@ -209,10 +217,6 @@ typedef struct
 /**
   * @}
   */  
-  
-/**
-  * @}
-  */ 
     
 /** @defgroup SDIO_Command_Index
   * @{
@@ -226,8 +230,8 @@ typedef struct
   * @{
   */
 #define SDIO_RESPONSE_NO                    ((uint32_t)0x00000000)
-#define SDIO_RESPONSE_SHORT                 ((uint32_t)0x00000040)
-#define SDIO_RESPONSE_LONG                  ((uint32_t)0x000000C0)
+#define SDIO_RESPONSE_SHORT                 SDIO_CMD_WAITRESP_0
+#define SDIO_RESPONSE_LONG                  SDIO_CMD_WAITRESP
 
 #define IS_SDIO_RESPONSE(RESPONSE) (((RESPONSE) == SDIO_RESPONSE_NO)    || \
                                     ((RESPONSE) == SDIO_RESPONSE_SHORT) || \
@@ -240,8 +244,8 @@ typedef struct
   * @{
   */
 #define SDIO_WAIT_NO                        ((uint32_t)0x00000000)
-#define SDIO_WAIT_IT                        ((uint32_t)0x00000100) 
-#define SDIO_WAIT_PEND                      ((uint32_t)0x00000200) 
+#define SDIO_WAIT_IT                        SDIO_CMD_WAITINT 
+#define SDIO_WAIT_PEND                      SDIO_CMD_WAITPEND
 
 #define IS_SDIO_WAIT(WAIT) (((WAIT) == SDIO_WAIT_NO) || \
                             ((WAIT) == SDIO_WAIT_IT) || \
@@ -254,7 +258,7 @@ typedef struct
   * @{
   */
 #define SDIO_CPSM_DISABLE                   ((uint32_t)0x00000000)
-#define SDIO_CPSM_ENABLE                    ((uint32_t)0x00000400)
+#define SDIO_CPSM_ENABLE                    SDIO_CMD_CPSMEN
 
 #define IS_SDIO_CPSM(CPSM) (((CPSM) == SDIO_CPSM_DISABLE) || \
                             ((CPSM) == SDIO_CPSM_ENABLE))
@@ -290,14 +294,14 @@ typedef struct
   * @{
   */
 #define SDIO_DATABLOCK_SIZE_1B               ((uint32_t)0x00000000)
-#define SDIO_DATABLOCK_SIZE_2B               ((uint32_t)0x00000010)
-#define SDIO_DATABLOCK_SIZE_4B               ((uint32_t)0x00000020)
+#define SDIO_DATABLOCK_SIZE_2B               SDIO_DCTRL_DBLOCKSIZE_0
+#define SDIO_DATABLOCK_SIZE_4B               SDIO_DCTRL_DBLOCKSIZE_1
 #define SDIO_DATABLOCK_SIZE_8B               ((uint32_t)0x00000030)
-#define SDIO_DATABLOCK_SIZE_16B              ((uint32_t)0x00000040)
+#define SDIO_DATABLOCK_SIZE_16B              SDIO_DCTRL_DBLOCKSIZE_2
 #define SDIO_DATABLOCK_SIZE_32B              ((uint32_t)0x00000050)
 #define SDIO_DATABLOCK_SIZE_64B              ((uint32_t)0x00000060)
 #define SDIO_DATABLOCK_SIZE_128B             ((uint32_t)0x00000070)
-#define SDIO_DATABLOCK_SIZE_256B             ((uint32_t)0x00000080)
+#define SDIO_DATABLOCK_SIZE_256B             SDIO_DCTRL_DBLOCKSIZE_3
 #define SDIO_DATABLOCK_SIZE_512B             ((uint32_t)0x00000090)
 #define SDIO_DATABLOCK_SIZE_1024B            ((uint32_t)0x000000A0)
 #define SDIO_DATABLOCK_SIZE_2048B            ((uint32_t)0x000000B0)
@@ -328,7 +332,7 @@ typedef struct
   * @{
   */
 #define SDIO_TRANSFER_DIR_TO_CARD            ((uint32_t)0x00000000)
-#define SDIO_TRANSFER_DIR_TO_SDIO             ((uint32_t)0x00000002)
+#define SDIO_TRANSFER_DIR_TO_SDIO            SDIO_DCTRL_DTDIR
 
 #define IS_SDIO_TRANSFER_DIR(DIR) (((DIR) == SDIO_TRANSFER_DIR_TO_CARD) || \
                                    ((DIR) == SDIO_TRANSFER_DIR_TO_SDIO))
@@ -340,7 +344,7 @@ typedef struct
   * @{
   */
 #define SDIO_TRANSFER_MODE_BLOCK             ((uint32_t)0x00000000)
-#define SDIO_TRANSFER_MODE_STREAM            ((uint32_t)0x00000004)
+#define SDIO_TRANSFER_MODE_STREAM            SDIO_DCTRL_DTMODE
 
 #define IS_SDIO_TRANSFER_MODE(MODE) (((MODE) == SDIO_TRANSFER_MODE_BLOCK) || \
                                      ((MODE) == SDIO_TRANSFER_MODE_STREAM))
@@ -352,7 +356,7 @@ typedef struct
   * @{
   */
 #define SDIO_DPSM_DISABLE                    ((uint32_t)0x00000000)
-#define SDIO_DPSM_ENABLE                     ((uint32_t)0x00000001)
+#define SDIO_DPSM_ENABLE                     SDIO_DCTRL_DTEN
 
 #define IS_SDIO_DPSM(DPSM) (((DPSM) == SDIO_DPSM_DISABLE) ||\
                             ((DPSM) == SDIO_DPSM_ENABLE))
@@ -375,30 +379,30 @@ typedef struct
 /** @defgroup SDIO_Interrupt_sources
   * @{
   */
-#define SDIO_IT_CCRCFAIL                    ((uint32_t)0x00000001)
-#define SDIO_IT_DCRCFAIL                    ((uint32_t)0x00000002)
-#define SDIO_IT_CTIMEOUT                    ((uint32_t)0x00000004)
-#define SDIO_IT_DTIMEOUT                    ((uint32_t)0x00000008)
-#define SDIO_IT_TXUNDERR                    ((uint32_t)0x00000010)
-#define SDIO_IT_RXOVERR                     ((uint32_t)0x00000020)
-#define SDIO_IT_CMDREND                     ((uint32_t)0x00000040)
-#define SDIO_IT_CMDSENT                     ((uint32_t)0x00000080)
-#define SDIO_IT_DATAEND                     ((uint32_t)0x00000100)
-#define SDIO_IT_STBITERR                    ((uint32_t)0x00000200)
-#define SDIO_IT_DBCKEND                     ((uint32_t)0x00000400)
-#define SDIO_IT_CMDACT                      ((uint32_t)0x00000800)
-#define SDIO_IT_TXACT                       ((uint32_t)0x00001000)
-#define SDIO_IT_RXACT                       ((uint32_t)0x00002000)
-#define SDIO_IT_TXFIFOHE                    ((uint32_t)0x00004000)
-#define SDIO_IT_RXFIFOHF                    ((uint32_t)0x00008000)
-#define SDIO_IT_TXFIFOF                     ((uint32_t)0x00010000)
-#define SDIO_IT_RXFIFOF                     ((uint32_t)0x00020000)
-#define SDIO_IT_TXFIFOE                     ((uint32_t)0x00040000)
-#define SDIO_IT_RXFIFOE                     ((uint32_t)0x00080000)
-#define SDIO_IT_TXDAVL                      ((uint32_t)0x00100000)
-#define SDIO_IT_RXDAVL                      ((uint32_t)0x00200000)
-#define SDIO_IT_SDIOIT                      ((uint32_t)0x00400000)
-#define SDIO_IT_CEATAEND                    ((uint32_t)0x00800000)
+#define SDIO_IT_CCRCFAIL                    SDIO_STA_CCRCFAIL
+#define SDIO_IT_DCRCFAIL                    SDIO_STA_DCRCFAIL
+#define SDIO_IT_CTIMEOUT                    SDIO_STA_CTIMEOUT
+#define SDIO_IT_DTIMEOUT                    SDIO_STA_DTIMEOUT
+#define SDIO_IT_TXUNDERR                    SDIO_STA_TXUNDERR
+#define SDIO_IT_RXOVERR                     SDIO_STA_RXOVERR
+#define SDIO_IT_CMDREND                     SDIO_STA_CMDREND
+#define SDIO_IT_CMDSENT                     SDIO_STA_CMDSENT
+#define SDIO_IT_DATAEND                     SDIO_STA_DATAEND
+#define SDIO_IT_STBITERR                    SDIO_STA_STBITERR
+#define SDIO_IT_DBCKEND                     SDIO_STA_DBCKEND
+#define SDIO_IT_CMDACT                      SDIO_STA_CMDACT
+#define SDIO_IT_TXACT                       SDIO_STA_TXACT
+#define SDIO_IT_RXACT                       SDIO_STA_RXACT
+#define SDIO_IT_TXFIFOHE                    SDIO_STA_TXFIFOHE
+#define SDIO_IT_RXFIFOHF                    SDIO_STA_RXFIFOHF
+#define SDIO_IT_TXFIFOF                     SDIO_STA_TXFIFOF
+#define SDIO_IT_RXFIFOF                     SDIO_STA_RXFIFOF
+#define SDIO_IT_TXFIFOE                     SDIO_STA_TXFIFOE
+#define SDIO_IT_RXFIFOE                     SDIO_STA_RXFIFOE
+#define SDIO_IT_TXDAVL                      SDIO_STA_TXDAVL
+#define SDIO_IT_RXDAVL                      SDIO_STA_RXDAVL
+#define SDIO_IT_SDIOIT                      SDIO_STA_SDIOIT
+#define SDIO_IT_CEATAEND                    SDIO_STA_CEATAEND
 
 #define IS_SDIO_IT(IT) ((((IT) & (uint32_t)0xFF000000) == 0x00) && ((IT) != (uint32_t)0x00))
 /**
@@ -408,30 +412,30 @@ typedef struct
 /** @defgroup SDIO_Flags 
   * @{
   */
-#define SDIO_FLAG_CCRCFAIL                  ((uint32_t)0x00000001)
-#define SDIO_FLAG_DCRCFAIL                  ((uint32_t)0x00000002)
-#define SDIO_FLAG_CTIMEOUT                  ((uint32_t)0x00000004)
-#define SDIO_FLAG_DTIMEOUT                  ((uint32_t)0x00000008)
-#define SDIO_FLAG_TXUNDERR                  ((uint32_t)0x00000010)
-#define SDIO_FLAG_RXOVERR                   ((uint32_t)0x00000020)
-#define SDIO_FLAG_CMDREND                   ((uint32_t)0x00000040)
-#define SDIO_FLAG_CMDSENT                   ((uint32_t)0x00000080)
-#define SDIO_FLAG_DATAEND                   ((uint32_t)0x00000100)
-#define SDIO_FLAG_STBITERR                  ((uint32_t)0x00000200)
-#define SDIO_FLAG_DBCKEND                   ((uint32_t)0x00000400)
-#define SDIO_FLAG_CMDACT                    ((uint32_t)0x00000800)
-#define SDIO_FLAG_TXACT                     ((uint32_t)0x00001000)
-#define SDIO_FLAG_RXACT                     ((uint32_t)0x00002000)
-#define SDIO_FLAG_TXFIFOHE                  ((uint32_t)0x00004000)
-#define SDIO_FLAG_RXFIFOHF                  ((uint32_t)0x00008000)
-#define SDIO_FLAG_TXFIFOF                   ((uint32_t)0x00010000)
-#define SDIO_FLAG_RXFIFOF                   ((uint32_t)0x00020000)
-#define SDIO_FLAG_TXFIFOE                   ((uint32_t)0x00040000)
-#define SDIO_FLAG_RXFIFOE                   ((uint32_t)0x00080000)
-#define SDIO_FLAG_TXDAVL                    ((uint32_t)0x00100000)
-#define SDIO_FLAG_RXDAVL                    ((uint32_t)0x00200000)
-#define SDIO_FLAG_SDIOIT                    ((uint32_t)0x00400000)
-#define SDIO_FLAG_CEATAEND                  ((uint32_t)0x00800000)
+#define SDIO_FLAG_CCRCFAIL                  SDIO_STA_CCRCFAIL
+#define SDIO_FLAG_DCRCFAIL                  SDIO_STA_DCRCFAIL
+#define SDIO_FLAG_CTIMEOUT                  SDIO_STA_CTIMEOUT
+#define SDIO_FLAG_DTIMEOUT                  SDIO_STA_DTIMEOUT
+#define SDIO_FLAG_TXUNDERR                  SDIO_STA_TXUNDERR
+#define SDIO_FLAG_RXOVERR                   SDIO_STA_RXOVERR
+#define SDIO_FLAG_CMDREND                   SDIO_STA_CMDREND
+#define SDIO_FLAG_CMDSENT                   SDIO_STA_CMDSENT
+#define SDIO_FLAG_DATAEND                   SDIO_STA_DATAEND
+#define SDIO_FLAG_STBITERR                  SDIO_STA_STBITERR
+#define SDIO_FLAG_DBCKEND                   SDIO_STA_DBCKEND
+#define SDIO_FLAG_CMDACT                    SDIO_STA_CMDACT
+#define SDIO_FLAG_TXACT                     SDIO_STA_TXACT
+#define SDIO_FLAG_RXACT                     SDIO_STA_RXACT
+#define SDIO_FLAG_TXFIFOHE                  SDIO_STA_TXFIFOHE
+#define SDIO_FLAG_RXFIFOHF                  SDIO_STA_RXFIFOHF
+#define SDIO_FLAG_TXFIFOF                   SDIO_STA_TXFIFOF
+#define SDIO_FLAG_RXFIFOF                   SDIO_STA_RXFIFOF
+#define SDIO_FLAG_TXFIFOE                   SDIO_STA_TXFIFOE
+#define SDIO_FLAG_RXFIFOE                   SDIO_STA_RXFIFOE
+#define SDIO_FLAG_TXDAVL                    SDIO_STA_TXDAVL
+#define SDIO_FLAG_RXDAVL                    SDIO_STA_RXDAVL
+#define SDIO_FLAG_SDIOIT                    SDIO_STA_SDIOIT
+#define SDIO_FLAG_CEATAEND                  SDIO_STA_CEATAEND
 
 #define IS_SDIO_FLAG(FLAG) (((FLAG)  == SDIO_FLAG_CCRCFAIL) || \
                             ((FLAG)  == SDIO_FLAG_DCRCFAIL) || \
@@ -553,26 +557,25 @@ typedef struct
 
 /* ---------------------- SDIO registers bit mask --------------------------- */
 /* --- CLKCR Register ---*/
-/* CLKCR register clear mask */
-#define CLKCR_CLEAR_MASK         ((uint32_t)0xFFFF8100) 
+/* CLKCR register clear mask */ 
+#define CLKCR_CLEAR_MASK         ((uint32_t)(SDIO_CLKCR_CLKDIV  | SDIO_CLKCR_PWRSAV |\
+                                             SDIO_CLKCR_BYPASS  | SDIO_CLKCR_WIDBUS |\
+                                             SDIO_CLKCR_NEGEDGE | SDIO_CLKCR_HWFC_EN))
 
 /* --- PWRCTRL Register ---*/
-/* SDIO PWRCTRL Mask */
-#define PWR_PWRCTRL_MASK         ((uint32_t)0xFFFFFFFC)
-
 /* --- DCTRL Register ---*/
 /* SDIO DCTRL Clear Mask */
-#define DCTRL_CLEAR_MASK         ((uint32_t)0xFFFFFF08)
+#define DCTRL_CLEAR_MASK         ((uint32_t)(SDIO_DCTRL_DTEN    | SDIO_DCTRL_DTDIR |\
+                                             SDIO_DCTRL_DTMODE  | SDIO_DCTRL_DBLOCKSIZE))
 
 /* --- CMD Register ---*/
 /* CMD Register clear mask */
-#define CMD_CLEAR_MASK           ((uint32_t)0xFFFFF800)
+#define CMD_CLEAR_MASK           ((uint32_t)(SDIO_CMD_CMDINDEX | SDIO_CMD_WAITRESP |\
+                                             SDIO_CMD_WAITINT  | SDIO_CMD_WAITPEND |\
+                                             SDIO_CMD_CPSMEN   | SDIO_CMD_SDIOSUSPEND))
 
 /* SDIO RESP Registers Address */
 #define SDIO_RESP_ADDR           ((uint32_t)(SDIO_BASE + 0x14))
-
-/* SD FLASH SDIO Interface */
-#define SDIO_FIFO_ADDRESS ((uint32_t)0x40012C80)
 
 /* SDIO Intialization Frequency (400KHz max) */
 #define SDIO_INIT_CLK_DIV ((uint8_t)0x76)
@@ -716,7 +719,7 @@ typedef struct
 
 
 /**
-  * @brief  Clears the SDIO's pending flags.
+  * @brief  Clears the SDIO pending flags.
   * @param  __INSTANCE__ : Pointer to SDIO register base  
   * @param  __FLAG__: specifies the flag to clear.  
   *          This parameter can be one or a combination of the following values:
@@ -895,17 +898,39 @@ typedef struct
   * @}
   */
 
+/**
+  * @}
+  */  
+
 /* Exported functions --------------------------------------------------------*/
-
+/** @addtogroup SDIO_Exported_Functions
+  * @{
+  */
+  
 /* Initialization/de-initialization functions  **********************************/
+/** @addtogroup HAL_SDIO_Group1
+  * @{
+  */
 HAL_StatusTypeDef SDIO_Init(SDIO_TypeDef *SDIOx, SDIO_InitTypeDef Init);
-
+/**
+  * @}
+  */
+  
 /* I/O operation functions  *****************************************************/
+/** @addtogroup HAL_SDIO_Group2
+  * @{
+  */
 /* Blocking mode: Polling */
 uint32_t          SDIO_ReadFIFO(SDIO_TypeDef *SDIOx);
 HAL_StatusTypeDef SDIO_WriteFIFO(SDIO_TypeDef *SDIOx, uint32_t *pWriteData);
-
+/**
+  * @}
+  */
+  
 /* Peripheral Control functions  ************************************************/
+/** @addtogroup HAL_SDIO_Group3
+  * @{
+  */
 HAL_StatusTypeDef SDIO_PowerState_ON(SDIO_TypeDef *SDIOx);
 HAL_StatusTypeDef SDIO_PowerState_OFF(SDIO_TypeDef *SDIOx);
 uint32_t          SDIO_GetPowerState(SDIO_TypeDef *SDIOx);
@@ -923,18 +948,26 @@ uint32_t          SDIO_GetFIFOCount(SDIO_TypeDef *SDIOx);
 /* SDIO IO Cards mode management functions */
 HAL_StatusTypeDef SDIO_SetSDIOReadWaitMode(uint32_t SDIO_ReadWaitMode);
 
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* __STM32F4xx_LL_SDMMC_H */
-
-/**
-  * @}
-  */ 
-
-/**
-  * @}
-  */ 
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_usb.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_usb.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_ll_usb.c
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   USB Low Layer HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -1420,8 +1420,6 @@ HAL_StatusTypeDef USB_HC_Init(USB_OTG_GlobalTypeDef *USBx,
 #pragma O0
 #elif defined (__GNUC__) /*!< GNU Compiler */
 #pragma GCC optimize ("O0")
-#elif defined  (__TASKING__) /*!< TASKING Compiler */ 
-#pragma optimize=0                          
 #endif /* __CC_ARM */
 HAL_StatusTypeDef USB_HC_StartXfer(USB_OTG_GlobalTypeDef *USBx, USB_OTG_HCTypeDef *hc, uint8_t dma)
 {
@@ -1436,6 +1434,11 @@ HAL_StatusTypeDef USB_HC_StartXfer(USB_OTG_GlobalTypeDef *USBx, USB_OTG_HCTypeDe
     {
       USB_DoPing(USBx, hc->ch_num);
       return HAL_OK;
+    }
+    else if(dma == 1)
+    {
+      USBx_HC(hc->ch_num)->HCINTMSK &= ~(USB_OTG_HCINTMSK_NYET | USB_OTG_HCINTMSK_ACKM);
+      hc->do_ping = 0;
     }
   }
   
@@ -1463,15 +1466,15 @@ HAL_StatusTypeDef USB_HC_StartXfer(USB_OTG_GlobalTypeDef *USBx, USB_OTG_HCTypeDe
   
   /* Initialize the HCTSIZn register */
   USBx_HC(hc->ch_num)->HCTSIZ = (((hc->xfer_len) & USB_OTG_HCTSIZ_XFRSIZ)) |\
-                                ((num_packets << 19) & USB_OTG_HCTSIZ_PKTCNT) |\
-                                (((hc->data_pid) << 29) & USB_OTG_HCTSIZ_DPID);
+    ((num_packets << 19) & USB_OTG_HCTSIZ_PKTCNT) |\
+      (((hc->data_pid) << 29) & USB_OTG_HCTSIZ_DPID);
   
   if (dma)
   {
     /* xfer_buff MUST be 32-bits aligned */
     USBx_HC(hc->ch_num)->HCDMA = (uint32_t)hc->xfer_buff;
   }
-
+  
   is_oddframe = (USBx_HOST->HFNUM & 0x01) ? 0 : 1;
   USBx_HC(hc->ch_num)->HCCHAR &= ~USB_OTG_HCCHAR_ODDFRM;
   USBx_HC(hc->ch_num)->HCCHAR |= (is_oddframe << 29);
@@ -1479,7 +1482,7 @@ HAL_StatusTypeDef USB_HC_StartXfer(USB_OTG_GlobalTypeDef *USBx, USB_OTG_HCTypeDe
   /* Set host channel enable */
   USBx_HC(hc->ch_num)->HCCHAR &= ~USB_OTG_HCCHAR_CHDIS;
   USBx_HC(hc->ch_num)->HCCHAR |= USB_OTG_HCCHAR_CHENA;
-
+  
   if (dma == 0) /* Slave mode */
   {  
     if((hc->ep_is_in == 0) && (hc->xfer_len > 0))

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_usb.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/stm32f4xx_ll_usb.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f4xx_ll_usb.h
   * @author  MCD Application Team
-  * @version V1.1.0RC2
-  * @date    14-May-2014
+  * @version V1.1.0
+  * @date    19-June-2014
   * @brief   Header file of USB Core HAL module.
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/system_stm32f4xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/system_stm32f4xx.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    system_stm32f4xx.c
   * @author  MCD Application Team
-  * @version V2.1.0RC2
-  * @date    14-May-2014
+  * @version V2.1.0
+  * @date    19-June-2014
   * @brief   CMSIS Cortex-M4 Device Peripheral Access Layer System Source File.
   *
   *   This file provides two functions and one global variable to be called from 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/system_stm32f4xx.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F401RE/system_stm32f4xx.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    system_stm32f4xx.h
   * @author  MCD Application Team
-  * @version V2.1.0RC2
-  * @date    14-May-2014
+  * @version V2.1.0
+  * @date    19-June-2014
   * @brief   CMSIS Cortex-M4 Device System Source File for STM32F4xx devices.       
   ******************************************************************************  
   * @attention


### PR DESCRIPTION
- Same version as in NUCLEO_F411RE.
- This change is mandatory to be able to compile with IAR (issue #482)
