### PR TITLE
[DISCO_L053C8] Added support for the STM32L0 Discovery board

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ STMicroelectronics:
 * STM32F3-Discovery (Cortex-M4F)
 * STM32F4-Discovery (Cortex-M4F)
 * STM32F429-Discovery (Cortex-M4F)
+* STM32L0-Discovery (Cortex-M0+)
 * [Arch Max](https://developer.mbed.org/platforms/Seeed-Arch-Max/) (Cortex-M4F)
 
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_ARM_MICRO/startup_stm32l053xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_ARM_MICRO/startup_stm32l053xx.s
@@ -1,0 +1,266 @@
+;******************** (C) COPYRIGHT 2014 STMicroelectronics ********************
+;* File Name          : startup_stm32l053xx.s
+;* Author             : MCD Application Team
+;* Version            : V1.1.0
+;* Date               : 18-June-2014
+;* Description        : STM32l053xx Devices vector table for MDK-ARM toolchain.
+;*                      This module performs:
+;*                      - Set the initial SP
+;*                      - Set the initial PC == Reset_Handler
+;*                      - Set the vector table entries with the exceptions ISR address
+;*                      - Branches to __main in the C library (which eventually
+;*                        calls main()).
+;*                      After Reset the Cortex-M0+ processor is in Thread mode,
+;*                      priority is Privileged, and the Stack is set to Main.
+;* <<< Use Configuration Wizard in Context Menu >>>
+;*******************************************************************************
+;*
+;* Redistribution and use in source and binary forms, with or without modification,
+;* are permitted provided that the following conditions are met:
+;*   1. Redistributions of source code must retain the above copyright notice,
+;*      this list of conditions and the following disclaimer.
+;*   2. Redistributions in binary form must reproduce the above copyright notice,
+;*      this list of conditions and the following disclaimer in the documentation
+;*      and/or other materials provided with the distribution.
+;*   3. Neither the name of STMicroelectronics nor the names of its contributors
+;*      may be used to endorse or promote products derived from this software
+;*      without specific prior written permission.
+;*
+;* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+;* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+;* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+;* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+;* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+;* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;*
+;*******************************************************************************
+;
+; Amount of memory (in bytes) allocated for Stack
+; Tailor this value to your application needs
+; <h> Stack Configuration
+;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Stack_Size      EQU     0x00000400
+
+                AREA    STACK, NOINIT, READWRITE, ALIGN=3
+Stack_Mem       SPACE   Stack_Size
+__initial_sp
+
+
+; <h> Heap Configuration
+;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Heap_Size       EQU     0x00000200
+
+                AREA    HEAP, NOINIT, READWRITE, ALIGN=3
+__heap_base
+Heap_Mem        SPACE   Heap_Size
+__heap_limit
+
+                PRESERVE8
+                THUMB
+
+
+; Vector Table Mapped to Address 0 at Reset
+                AREA    RESET, DATA, READONLY
+                EXPORT  __Vectors
+                EXPORT  __Vectors_End
+                EXPORT  __Vectors_Size
+
+__Vectors       DCD     __initial_sp              ; Top of Stack
+                DCD     Reset_Handler             ; Reset Handler
+                DCD     NMI_Handler               ; NMI Handler
+                DCD     HardFault_Handler         ; Hard Fault Handler
+                DCD     0                         ; Reserved
+                DCD     0                         ; Reserved
+                DCD     0                         ; Reserved
+                DCD     0                         ; Reserved
+                DCD     0                         ; Reserved
+                DCD     0                         ; Reserved
+                DCD     0                         ; Reserved
+                DCD     SVC_Handler               ; SVCall Handler
+                DCD     DebugMon_Handler          ; Debug Monitor Handler
+                DCD     0                         ; Reserved
+                DCD     PendSV_Handler            ; PendSV Handler
+                DCD     SysTick_Handler           ; SysTick Handler
+
+                ; External Interrupts
+                DCD     WWDG_IRQHandler                ; Window Watchdog
+                DCD     PVD_IRQHandler                 ; PVD through EXTI Line detect
+                DCD     RTC_IRQHandler                 ; RTC through EXTI Line
+                DCD     FLASH_IRQHandler               ; FLASH
+                DCD     RCC_CRS_IRQHandler             ; RCC and CRS
+                DCD     EXTI0_1_IRQHandler             ; EXTI Line 0 and 1
+                DCD     EXTI2_3_IRQHandler             ; EXTI Line 2 and 3
+                DCD     EXTI4_15_IRQHandler            ; EXTI Line 4 to 15
+                DCD     TSC_IRQHandler                 ; TSC
+                DCD     DMA1_Channel1_IRQHandler       ; DMA1 Channel 1
+                DCD     DMA1_Channel2_3_IRQHandler     ; DMA1 Channel 2 and Channel 3
+                DCD     DMA1_Channel4_5_6_7_IRQHandler ; DMA1 Channel 4, Channel 5, Channel 6 and Channel 7
+                DCD     ADC1_COMP_IRQHandler           ; ADC1, COMP1 and COMP2
+                DCD     LPTIM1_IRQHandler              ; LPTIM1
+                DCD     0                              ; Reserved
+                DCD     TIM2_IRQHandler                ; TIM2
+                DCD     0                              ; Reserved
+                DCD     TIM6_DAC_IRQHandler            ; TIM6 and DAC
+                DCD     0                              ; Reserved
+                DCD     0                              ; Reserved
+                DCD     TIM21_IRQHandler               ; TIM21
+                DCD     0                              ; Reserved
+                DCD     TIM22_IRQHandler               ; TIM22
+                DCD     I2C1_IRQHandler                ; I2C1
+                DCD     I2C2_IRQHandler                ; I2C2
+                DCD     SPI1_IRQHandler                ; SPI1
+                DCD     SPI2_IRQHandler                ; SPI2
+                DCD     USART1_IRQHandler              ; USART1
+                DCD     USART2_IRQHandler              ; USART2
+                DCD     RNG_LPUART1_IRQHandler         ; RNG and LPUART1
+                DCD     LCD_IRQHandler                 ; LCD
+                DCD     USB_IRQHandler                 ; USB
+
+__Vectors_End
+
+__Vectors_Size  EQU  __Vectors_End - __Vectors
+
+                AREA    |.text|, CODE, READONLY
+
+; Reset handler routine
+Reset_Handler    PROC
+                 EXPORT  Reset_Handler                 [WEAK]
+        IMPORT  __main
+        IMPORT  SystemInit
+                 LDR     R0, =SystemInit
+                 BLX     R0
+                 LDR     R0, =__main
+                 BX      R0
+                 ENDP
+
+; Dummy Exception Handlers (infinite loops which can be modified)
+
+NMI_Handler     PROC
+                EXPORT  NMI_Handler                    [WEAK]
+                B       .
+                ENDP
+HardFault_Handler\
+                PROC
+                EXPORT  HardFault_Handler              [WEAK]
+                B       .
+                ENDP
+SVC_Handler     PROC
+                EXPORT  SVC_Handler                    [WEAK]
+                B       .
+                ENDP
+DebugMon_Handler\
+                PROC
+                EXPORT  DebugMon_Handler               [WEAK]
+                B       .
+                ENDP
+PendSV_Handler  PROC
+                EXPORT  PendSV_Handler                 [WEAK]
+                B       .
+                ENDP
+SysTick_Handler PROC
+                EXPORT  SysTick_Handler                [WEAK]
+                B       .
+                ENDP
+
+Default_Handler PROC
+
+                EXPORT  WWDG_IRQHandler                [WEAK]
+                EXPORT  PVD_IRQHandler                 [WEAK]
+                EXPORT  RTC_IRQHandler                 [WEAK]
+                EXPORT  FLASH_IRQHandler               [WEAK]
+                EXPORT  RCC_CRS_IRQHandler             [WEAK]
+                EXPORT  EXTI0_1_IRQHandler             [WEAK]
+                EXPORT  EXTI2_3_IRQHandler             [WEAK]
+                EXPORT  EXTI4_15_IRQHandler            [WEAK]
+                EXPORT  TSC_IRQHandler                  [WEAK]
+                EXPORT  DMA1_Channel1_IRQHandler       [WEAK]
+                EXPORT  DMA1_Channel2_3_IRQHandler     [WEAK]
+                EXPORT  DMA1_Channel4_5_6_7_IRQHandler [WEAK]
+                EXPORT  ADC1_COMP_IRQHandler           [WEAK]
+                EXPORT  LPTIM1_IRQHandler              [WEAK]
+                EXPORT  TIM2_IRQHandler                [WEAK]
+                EXPORT  TIM6_DAC_IRQHandler            [WEAK]
+                EXPORT  TIM21_IRQHandler               [WEAK]
+                EXPORT  TIM22_IRQHandler               [WEAK]
+                EXPORT  I2C1_IRQHandler                [WEAK]
+                EXPORT  I2C2_IRQHandler                [WEAK]
+                EXPORT  SPI1_IRQHandler                [WEAK]
+                EXPORT  SPI2_IRQHandler                [WEAK]
+                EXPORT  USART1_IRQHandler              [WEAK]
+                EXPORT  USART2_IRQHandler              [WEAK]
+                EXPORT  RNG_LPUART1_IRQHandler         [WEAK]
+                EXPORT  LCD_IRQHandler                 [WEAK]
+                EXPORT  USB_IRQHandler                 [WEAK]
+
+
+WWDG_IRQHandler
+PVD_IRQHandler
+RTC_IRQHandler
+FLASH_IRQHandler
+RCC_CRS_IRQHandler
+EXTI0_1_IRQHandler
+EXTI2_3_IRQHandler
+EXTI4_15_IRQHandler
+TSC_IRQHandler
+DMA1_Channel1_IRQHandler
+DMA1_Channel2_3_IRQHandler
+DMA1_Channel4_5_6_7_IRQHandler
+ADC1_COMP_IRQHandler
+LPTIM1_IRQHandler
+TIM2_IRQHandler
+TIM6_DAC_IRQHandler
+TIM21_IRQHandler
+TIM22_IRQHandler
+I2C1_IRQHandler
+I2C2_IRQHandler
+SPI1_IRQHandler
+SPI2_IRQHandler
+USART1_IRQHandler
+USART2_IRQHandler
+RNG_LPUART1_IRQHandler
+LCD_IRQHandler
+USB_IRQHandler
+
+                B       .
+
+                ENDP
+
+                ALIGN
+
+;*******************************************************************************
+; User Stack and Heap initialization
+;*******************************************************************************
+                 IF      :DEF:__MICROLIB
+
+                 EXPORT  __initial_sp
+                 EXPORT  __heap_base
+                 EXPORT  __heap_limit
+
+                 ELSE
+
+                 IMPORT  __use_two_region_memory
+                 EXPORT  __user_initial_stackheap
+
+__user_initial_stackheap
+
+                 LDR     R0, =  Heap_Mem
+                 LDR     R1, =(Stack_Mem + Stack_Size)
+                 LDR     R2, = (Heap_Mem +  Heap_Size)
+                 LDR     R3, = Stack_Mem
+                 BX      LR
+
+                 ALIGN
+
+                 ENDIF
+
+                 END
+
+;************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE*****

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_ARM_MICRO/stm32l053c8.sct
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_ARM_MICRO/stm32l053c8.sct
@@ -1,0 +1,44 @@
+; Scatter-Loading Description File
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Copyright (c) 2014, STMicroelectronics
+; All rights reserved.
+;
+; Redistribution and use in source and binary forms, with or without
+; modification, are permitted provided that the following conditions are met:
+;
+; 1. Redistributions of source code must retain the above copyright notice,
+;     this list of conditions and the following disclaimer.
+; 2. Redistributions in binary form must reproduce the above copyright notice,
+;    this list of conditions and the following disclaimer in the documentation
+;    and/or other materials provided with the distribution.
+; 3. Neither the name of STMicroelectronics nor the names of its contributors
+;    may be used to endorse or promote products derived from this software
+;    without specific prior written permission.
+;
+; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; STM32L053C8: 64KB FLASH (0x10000) + 8KB RAM (0x2000)
+LR_IROM1 0x08000000 0x10000  {    ; load region size_region
+
+  ER_IROM1 0x08000000 0x10000  {  ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+  }
+
+  ; Total: 48 vectors = 192 bytes (0xC0) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0xC0) (0x2000-0xC0)  {  ; RW data
+   .ANY (+RW +ZI)
+  }
+
+}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_ARM_MICRO/sys.cpp
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_ARM_MICRO/sys.cpp
@@ -1,0 +1,56 @@
+/* mbed Microcontroller Library - stackheap
+ * Setup a fixed single stack/heap memory model, 
+ * between the top of the RW/ZI region and the stackpointer
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ *******************************************************************************
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif 
+
+#include <rt_misc.h>
+#include <stdint.h>
+
+extern char Image$$RW_IRAM1$$ZI$$Limit[];
+
+extern __value_in_regs struct __initial_stackheap __user_setup_stackheap(uint32_t R0, uint32_t R1, uint32_t R2, uint32_t R3) {
+    uint32_t zi_limit = (uint32_t)Image$$RW_IRAM1$$ZI$$Limit;
+    uint32_t sp_limit = __current_sp();
+
+    zi_limit = (zi_limit + 7) & ~0x7;    // ensure zi_limit is 8-byte aligned
+
+    struct __initial_stackheap r;
+    r.heap_base = zi_limit;
+    r.heap_limit = sp_limit;
+    return r;
+}
+
+#ifdef __cplusplus
+}
+#endif 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_ARM_STD/startup_stm32l053xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_ARM_STD/startup_stm32l053xx.s
@@ -1,0 +1,266 @@
+;******************** (C) COPYRIGHT 2014 STMicroelectronics ********************
+;* File Name          : startup_stm32l053xx.s
+;* Author             : MCD Application Team
+;* Version            : V1.1.0
+;* Date               : 18-June-2014
+;* Description        : STM32l053xx Devices vector table for MDK-ARM toolchain.
+;*                      This module performs:
+;*                      - Set the initial SP
+;*                      - Set the initial PC == Reset_Handler
+;*                      - Set the vector table entries with the exceptions ISR address
+;*                      - Branches to __main in the C library (which eventually
+;*                        calls main()).
+;*                      After Reset the Cortex-M0+ processor is in Thread mode,
+;*                      priority is Privileged, and the Stack is set to Main.
+;* <<< Use Configuration Wizard in Context Menu >>>
+;*******************************************************************************
+;*
+;* Redistribution and use in source and binary forms, with or without modification,
+;* are permitted provided that the following conditions are met:
+;*   1. Redistributions of source code must retain the above copyright notice,
+;*      this list of conditions and the following disclaimer.
+;*   2. Redistributions in binary form must reproduce the above copyright notice,
+;*      this list of conditions and the following disclaimer in the documentation
+;*      and/or other materials provided with the distribution.
+;*   3. Neither the name of STMicroelectronics nor the names of its contributors
+;*      may be used to endorse or promote products derived from this software
+;*      without specific prior written permission.
+;*
+;* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+;* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+;* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+;* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+;* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+;* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;*
+;*******************************************************************************
+;
+; Amount of memory (in bytes) allocated for Stack
+; Tailor this value to your application needs
+; <h> Stack Configuration
+;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Stack_Size      EQU     0x00000400
+
+                AREA    STACK, NOINIT, READWRITE, ALIGN=3
+Stack_Mem       SPACE   Stack_Size
+__initial_sp
+
+
+; <h> Heap Configuration
+;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Heap_Size       EQU     0x00000200
+
+                AREA    HEAP, NOINIT, READWRITE, ALIGN=3
+__heap_base
+Heap_Mem        SPACE   Heap_Size
+__heap_limit
+
+                PRESERVE8
+                THUMB
+
+
+; Vector Table Mapped to Address 0 at Reset
+                AREA    RESET, DATA, READONLY
+                EXPORT  __Vectors
+                EXPORT  __Vectors_End
+                EXPORT  __Vectors_Size
+
+__Vectors       DCD     __initial_sp              ; Top of Stack
+                DCD     Reset_Handler             ; Reset Handler
+                DCD     NMI_Handler               ; NMI Handler
+                DCD     HardFault_Handler         ; Hard Fault Handler
+                DCD     0                         ; Reserved
+                DCD     0                         ; Reserved
+                DCD     0                         ; Reserved
+                DCD     0                         ; Reserved
+                DCD     0                         ; Reserved
+                DCD     0                         ; Reserved
+                DCD     0                         ; Reserved
+                DCD     SVC_Handler               ; SVCall Handler
+                DCD     DebugMon_Handler          ; Debug Monitor Handler
+                DCD     0                         ; Reserved
+                DCD     PendSV_Handler            ; PendSV Handler
+                DCD     SysTick_Handler           ; SysTick Handler
+
+                ; External Interrupts
+                DCD     WWDG_IRQHandler                ; Window Watchdog
+                DCD     PVD_IRQHandler                 ; PVD through EXTI Line detect
+                DCD     RTC_IRQHandler                 ; RTC through EXTI Line
+                DCD     FLASH_IRQHandler               ; FLASH
+                DCD     RCC_CRS_IRQHandler             ; RCC and CRS
+                DCD     EXTI0_1_IRQHandler             ; EXTI Line 0 and 1
+                DCD     EXTI2_3_IRQHandler             ; EXTI Line 2 and 3
+                DCD     EXTI4_15_IRQHandler            ; EXTI Line 4 to 15
+                DCD     TSC_IRQHandler                 ; TSC
+                DCD     DMA1_Channel1_IRQHandler       ; DMA1 Channel 1
+                DCD     DMA1_Channel2_3_IRQHandler     ; DMA1 Channel 2 and Channel 3
+                DCD     DMA1_Channel4_5_6_7_IRQHandler ; DMA1 Channel 4, Channel 5, Channel 6 and Channel 7
+                DCD     ADC1_COMP_IRQHandler           ; ADC1, COMP1 and COMP2 
+                DCD     LPTIM1_IRQHandler              ; LPTIM1
+                DCD     0                              ; Reserved
+                DCD     TIM2_IRQHandler                ; TIM2
+                DCD     0                              ; Reserved
+                DCD     TIM6_DAC_IRQHandler            ; TIM6 and DAC
+                DCD     0                              ; Reserved
+                DCD     0                              ; Reserved
+                DCD     TIM21_IRQHandler               ; TIM21
+                DCD     0                              ; Reserved
+                DCD     TIM22_IRQHandler               ; TIM22
+                DCD     I2C1_IRQHandler                ; I2C1
+                DCD     I2C2_IRQHandler                ; I2C2
+                DCD     SPI1_IRQHandler                ; SPI1
+                DCD     SPI2_IRQHandler                ; SPI2
+                DCD     USART1_IRQHandler              ; USART1
+                DCD     USART2_IRQHandler              ; USART2
+                DCD     RNG_LPUART1_IRQHandler         ; RNG and LPUART1
+                DCD     LCD_IRQHandler                 ; LCD
+                DCD     USB_IRQHandler                 ; USB
+
+__Vectors_End
+
+__Vectors_Size  EQU  __Vectors_End - __Vectors
+
+                AREA    |.text|, CODE, READONLY
+
+; Reset handler routine
+Reset_Handler    PROC
+                 EXPORT  Reset_Handler                 [WEAK]
+        IMPORT  __main
+        IMPORT  SystemInit
+                 LDR     R0, =SystemInit
+                 BLX     R0
+                 LDR     R0, =__main
+                 BX      R0
+                 ENDP
+
+; Dummy Exception Handlers (infinite loops which can be modified)
+
+NMI_Handler     PROC
+                EXPORT  NMI_Handler                    [WEAK]
+                B       .
+                ENDP
+HardFault_Handler\
+                PROC
+                EXPORT  HardFault_Handler              [WEAK]
+                B       .
+                ENDP
+SVC_Handler     PROC
+                EXPORT  SVC_Handler                    [WEAK]
+                B       .
+                ENDP
+DebugMon_Handler\
+                PROC
+                EXPORT  DebugMon_Handler               [WEAK]
+                B       .
+                ENDP
+PendSV_Handler  PROC
+                EXPORT  PendSV_Handler                 [WEAK]
+                B       .
+                ENDP
+SysTick_Handler PROC
+                EXPORT  SysTick_Handler                [WEAK]
+                B       .
+                ENDP
+
+Default_Handler PROC
+
+                EXPORT  WWDG_IRQHandler                [WEAK]
+                EXPORT  PVD_IRQHandler                 [WEAK]
+                EXPORT  RTC_IRQHandler                 [WEAK]
+                EXPORT  FLASH_IRQHandler               [WEAK]
+                EXPORT  RCC_CRS_IRQHandler             [WEAK]
+                EXPORT  EXTI0_1_IRQHandler             [WEAK]
+                EXPORT  EXTI2_3_IRQHandler             [WEAK]
+                EXPORT  EXTI4_15_IRQHandler            [WEAK]
+                EXPORT  TSC_IRQHandler                  [WEAK]
+                EXPORT  DMA1_Channel1_IRQHandler       [WEAK]
+                EXPORT  DMA1_Channel2_3_IRQHandler     [WEAK]
+                EXPORT  DMA1_Channel4_5_6_7_IRQHandler [WEAK]
+                EXPORT  ADC1_COMP_IRQHandler           [WEAK]
+                EXPORT  LPTIM1_IRQHandler              [WEAK]
+                EXPORT  TIM2_IRQHandler                [WEAK]
+                EXPORT  TIM6_DAC_IRQHandler            [WEAK]
+                EXPORT  TIM21_IRQHandler               [WEAK]
+                EXPORT  TIM22_IRQHandler               [WEAK]
+                EXPORT  I2C1_IRQHandler                [WEAK]
+                EXPORT  I2C2_IRQHandler                [WEAK]
+                EXPORT  SPI1_IRQHandler                [WEAK]
+                EXPORT  SPI2_IRQHandler                [WEAK]
+                EXPORT  USART1_IRQHandler              [WEAK]
+                EXPORT  USART2_IRQHandler              [WEAK]
+                EXPORT  RNG_LPUART1_IRQHandler         [WEAK]
+                EXPORT  LCD_IRQHandler                 [WEAK]
+                EXPORT  USB_IRQHandler                 [WEAK]
+
+
+WWDG_IRQHandler
+PVD_IRQHandler
+RTC_IRQHandler
+FLASH_IRQHandler
+RCC_CRS_IRQHandler
+EXTI0_1_IRQHandler
+EXTI2_3_IRQHandler
+EXTI4_15_IRQHandler
+TSC_IRQHandler
+DMA1_Channel1_IRQHandler
+DMA1_Channel2_3_IRQHandler
+DMA1_Channel4_5_6_7_IRQHandler
+ADC1_COMP_IRQHandler
+LPTIM1_IRQHandler
+TIM2_IRQHandler
+TIM6_DAC_IRQHandler
+TIM21_IRQHandler
+TIM22_IRQHandler
+I2C1_IRQHandler
+I2C2_IRQHandler
+SPI1_IRQHandler
+SPI2_IRQHandler
+USART1_IRQHandler
+USART2_IRQHandler
+RNG_LPUART1_IRQHandler
+LCD_IRQHandler
+USB_IRQHandler
+
+                B       .
+
+                ENDP
+
+                ALIGN
+
+;*******************************************************************************
+; User Stack and Heap initialization
+;*******************************************************************************
+                 IF      :DEF:__MICROLIB
+
+                 EXPORT  __initial_sp
+                 EXPORT  __heap_base
+                 EXPORT  __heap_limit
+
+                 ELSE
+
+                 IMPORT  __use_two_region_memory
+                 EXPORT  __user_initial_stackheap
+
+__user_initial_stackheap
+
+                 LDR     R0, =  Heap_Mem
+                 LDR     R1, =(Stack_Mem + Stack_Size)
+                 LDR     R2, = (Heap_Mem +  Heap_Size)
+                 LDR     R3, = Stack_Mem
+                 BX      LR
+
+                 ALIGN
+
+                 ENDIF
+
+                 END
+
+;************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE*****

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_ARM_STD/stm32l053c8.sct
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_ARM_STD/stm32l053c8.sct
@@ -1,0 +1,44 @@
+; Scatter-Loading Description File
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Copyright (c) 2014, STMicroelectronics
+; All rights reserved.
+;
+; Redistribution and use in source and binary forms, with or without
+; modification, are permitted provided that the following conditions are met:
+;
+; 1. Redistributions of source code must retain the above copyright notice,
+;     this list of conditions and the following disclaimer.
+; 2. Redistributions in binary form must reproduce the above copyright notice,
+;    this list of conditions and the following disclaimer in the documentation
+;    and/or other materials provided with the distribution.
+; 3. Neither the name of STMicroelectronics nor the names of its contributors
+;    may be used to endorse or promote products derived from this software
+;    without specific prior written permission.
+;
+; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; STM32L053C8: 64KB FLASH (0x10000) + 8KB RAM (0x2000)
+LR_IROM1 0x08000000 0x10000  {    ; load region size_region
+
+  ER_IROM1 0x08000000 0x10000  {  ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+  }
+
+  ; Total: 48 vectors = 192 bytes (0xC0) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0xC0) (0x2000-0xC0)  {  ; RW data
+   .ANY (+RW +ZI)
+  }
+
+}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_ARM_STD/sys.cpp
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_ARM_STD/sys.cpp
@@ -1,0 +1,56 @@
+/* mbed Microcontroller Library - stackheap
+ * Setup a fixed single stack/heap memory model, 
+ * between the top of the RW/ZI region and the stackpointer
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ *******************************************************************************
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif 
+
+#include <rt_misc.h>
+#include <stdint.h>
+
+extern char Image$$RW_IRAM1$$ZI$$Limit[];
+
+extern __value_in_regs struct __initial_stackheap __user_setup_stackheap(uint32_t R0, uint32_t R1, uint32_t R2, uint32_t R3) {
+    uint32_t zi_limit = (uint32_t)Image$$RW_IRAM1$$ZI$$Limit;
+    uint32_t sp_limit = __current_sp();
+
+    zi_limit = (zi_limit + 7) & ~0x7;    // ensure zi_limit is 8-byte aligned
+
+    struct __initial_stackheap r;
+    r.heap_base = zi_limit;
+    r.heap_limit = sp_limit;
+    return r;
+}
+
+#ifdef __cplusplus
+}
+#endif 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_GCC_ARM/STM32L0xx.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_GCC_ARM/STM32L0xx.ld
@@ -1,0 +1,155 @@
+/* Linker script for STM32L0 */
+
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 64k
+  RAM (rwx) : ORIGIN = 0x200000C0, LENGTH = 0x2000-0xC0
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .text :
+    {
+        KEEP(*(.isr_vector))
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        KEEP(*(.eh_frame*))
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
+
+    __etext = .;
+    _sidata = .;
+
+    .data : AT (__etext)
+    {
+        __data_start__ = .;
+        _sdata = .;
+        *(vtable)
+        *(.data*)
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        KEEP(*(.jcr*))
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+        _edata = .;
+
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        _sbss = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+        _ebss = .;
+    } > RAM
+
+    .heap (COPY):
+    {
+        __end__ = .;
+        end = __end__;
+        *(.heap*)
+        __HeapLimit = .;
+    } > RAM
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > RAM
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    _estack = __StackTop;
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_GCC_ARM/startup_stm32l053xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/TOOLCHAIN_GCC_ARM/startup_stm32l053xx.s
@@ -1,0 +1,298 @@
+/**
+  ******************************************************************************
+  * @file      startup_stm32l053xx.s
+  * @author    MCD Application Team
+  * @version   V1.1.0
+  * @date      18-June-2014
+  * @brief     STM32L053xx Devices vector table for Atollic TrueSTUDIO toolchain.
+  *            This module performs:
+  *                - Set the initial SP
+  *                - Set the initial PC == Reset_Handler,
+  *                - Set the vector table entries with the exceptions ISR address
+  *                - Branches to main in the C library (which eventually
+  *                  calls main()).
+  *            After Reset the Cortex-M0+ processor is in Thread mode,
+  *            priority is Privileged, and the Stack is set to Main.
+  ******************************************************************************
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+  .syntax unified
+  .cpu cortex-m0plus
+  .fpu softvfp
+  .thumb
+
+.global  g_pfnVectors
+.global  Default_Handler
+
+/* start address for the initialization values of the .data section.
+defined in linker script */
+.word  _sidata
+/* start address for the .data section. defined in linker script */
+.word  _sdata
+/* end address for the .data section. defined in linker script */
+.word  _edata
+/* start address for the .bss section. defined in linker script */
+.word  _sbss
+/* end address for the .bss section. defined in linker script */
+.word  _ebss
+
+    .section  .text.Reset_Handler
+  .weak  Reset_Handler
+  .type  Reset_Handler, %function
+Reset_Handler:
+  ldr   r0, =_estack
+  mov   sp, r0          /* set stack pointer */
+
+/* Copy the data segment initializers from flash to SRAM */
+  movs  r1, #0
+  b  LoopCopyDataInit
+
+CopyDataInit:
+  ldr  r3, =_sidata
+  ldr  r3, [r3, r1]
+  str  r3, [r0, r1]
+  adds  r1, r1, #4
+
+LoopCopyDataInit:
+  ldr  r0, =_sdata
+  ldr  r3, =_edata
+  adds  r2, r0, r1
+  cmp  r2, r3
+  bcc  CopyDataInit
+  ldr  r2, =_sbss
+  b  LoopFillZerobss
+/* Zero fill the bss segment. */
+FillZerobss:
+  movs  r3, #0
+  str  r3, [r2]
+  adds r2, r2, #4
+
+
+LoopFillZerobss:
+  ldr  r3, = _ebss
+  cmp  r2, r3
+  bcc  FillZerobss
+
+/* Call the clock system intitialization function.*/
+  bl  SystemInit
+/* Call static constructors */
+    bl __libc_init_array
+/* Call the application's entry point.*/
+  bl  main
+
+LoopForever:
+    b LoopForever
+
+
+.size  Reset_Handler, .-Reset_Handler
+
+/**
+ * @brief  This is the code that gets called when the processor receives an
+ *         unexpected interrupt.  This simply enters an infinite loop, preserving
+ *         the system state for examination by a debugger.
+ *
+ * @param  None
+ * @retval : None
+*/
+    .section  .text.Default_Handler,"ax",%progbits
+Default_Handler:
+Infinite_Loop:
+  b  Infinite_Loop
+  .size  Default_Handler, .-Default_Handler
+/******************************************************************************
+*
+* The minimal vector table for a Cortex M0.  Note that the proper constructs
+* must be placed on this to ensure that it ends up at physical address
+* 0x0000.0000.
+*
+******************************************************************************/
+   .section  .isr_vector,"a",%progbits
+  .type  g_pfnVectors, %object
+  .size  g_pfnVectors, .-g_pfnVectors
+
+
+g_pfnVectors:
+  .word  _estack
+  .word  Reset_Handler
+  .word  NMI_Handler
+  .word  HardFault_Handler
+  .word  0
+  .word  0
+  .word  0
+  .word  0
+  .word  0
+  .word  0
+  .word  0
+  .word  SVC_Handler
+  .word  DebugMon_Handler
+  .word  0
+  .word  PendSV_Handler
+  .word  SysTick_Handler
+  .word     WWDG_IRQHandler                   /* Window WatchDog              */
+  .word     PVD_IRQHandler                    /* PVD through EXTI Line detection */
+  .word     RTC_IRQHandler                    /* RTC through the EXTI line     */
+  .word     FLASH_IRQHandler                  /* FLASH                        */
+  .word     RCC_CRS_IRQHandler                /* RCC and CRS                  */
+  .word     EXTI0_1_IRQHandler                /* EXTI Line 0 and 1            */
+  .word     EXTI2_3_IRQHandler                /* EXTI Line 2 and 3            */
+  .word     EXTI4_15_IRQHandler               /* EXTI Line 4 to 15            */
+  .word     TSC_IRQHandler                     /* TSC                           */
+  .word     DMA1_Channel1_IRQHandler          /* DMA1 Channel 1               */
+  .word     DMA1_Channel2_3_IRQHandler        /* DMA1 Channel 2 and Channel 3 */
+  .word     DMA1_Channel4_5_6_7_IRQHandler    /* DMA1 Channel 4, Channel 5, Channel 6 and Channel 7*/
+  .word     ADC1_COMP_IRQHandler              /* ADC1, COMP1 and COMP2        */
+  .word     LPTIM1_IRQHandler                 /* LPTIM1                       */
+  .word     0                                 /* Reserved                     */
+  .word     TIM2_IRQHandler                   /* TIM2                         */
+  .word     0                                 /* Reserved                     */
+  .word     TIM6_DAC_IRQHandler               /* TIM6 and DAC                 */
+  .word     0               				          /* Reserved                     */
+  .word     0              					          /* Reserved                     */
+  .word     TIM21_IRQHandler                  /* TIM21                        */
+  .word     0                                 /* Reserved                     */
+  .word     TIM22_IRQHandler                  /* TIM22                        */
+  .word     I2C1_IRQHandler                   /* I2C1                         */
+  .word     I2C2_IRQHandler                   /* I2C2                         */
+  .word     SPI1_IRQHandler                   /* SPI1                         */
+  .word     SPI2_IRQHandler                   /* SPI2                         */
+  .word     USART1_IRQHandler                 /* USART1                       */
+  .word     USART2_IRQHandler                 /* USART2                       */
+  .word     RNG_LPUART1_IRQHandler            /* RNG and LPUART1              */
+  .word     LCD_IRQHandler                    /* LCD                          */
+  .word     USB_IRQHandler                    /* USB                          */
+
+/*******************************************************************************
+*
+* Provide weak aliases for each Exception handler to the Default_Handler.
+* As they are weak aliases, any function with the same name will override
+* this definition.
+*
+*******************************************************************************/
+
+   .weak      NMI_Handler
+   .thumb_set NMI_Handler,Default_Handler
+
+   .weak      HardFault_Handler
+   .thumb_set HardFault_Handler,Default_Handler
+
+   .weak      SVC_Handler
+   .thumb_set SVC_Handler,Default_Handler
+
+   .weak      DebugMon_Handler
+   .thumb_set DebugMon_Handler,Default_Handler
+
+   .weak      PendSV_Handler
+   .thumb_set PendSV_Handler,Default_Handler
+
+   .weak      SysTick_Handler
+   .thumb_set SysTick_Handler,Default_Handler
+
+   .weak      WWDG_IRQHandler
+   .thumb_set WWDG_IRQHandler,Default_Handler
+
+   .weak      PVD_IRQHandler
+   .thumb_set PVD_IRQHandler,Default_Handler
+
+   .weak      RTC_IRQHandler
+   .thumb_set RTC_IRQHandler,Default_Handler
+
+   .weak      FLASH_IRQHandler
+   .thumb_set FLASH_IRQHandler,Default_Handler
+
+   .weak      RCC_CRS_IRQHandler
+   .thumb_set RCC_CRS_IRQHandler,Default_Handler
+
+   .weak      EXTI0_1_IRQHandler
+   .thumb_set EXTI0_1_IRQHandler,Default_Handler
+
+   .weak      EXTI2_3_IRQHandler
+   .thumb_set EXTI2_3_IRQHandler,Default_Handler
+
+   .weak      EXTI4_15_IRQHandler
+   .thumb_set EXTI4_15_IRQHandler,Default_Handler
+
+   .weak      TSC_IRQHandler
+   .thumb_set TSC_IRQHandler,Default_Handler
+
+   .weak      DMA1_Channel1_IRQHandler
+   .thumb_set DMA1_Channel1_IRQHandler,Default_Handler
+
+   .weak      DMA1_Channel2_3_IRQHandler
+   .thumb_set DMA1_Channel2_3_IRQHandler,Default_Handler
+
+   .weak      DMA1_Channel4_5_6_7_IRQHandler
+   .thumb_set DMA1_Channel4_5_6_7_IRQHandler,Default_Handler
+
+   .weak      ADC1_COMP_IRQHandler
+   .thumb_set ADC1_COMP_IRQHandler,Default_Handler
+
+   .weak      LPTIM1_IRQHandler
+   .thumb_set LPTIM1_IRQHandler,Default_Handler
+
+   .weak      TIM2_IRQHandler
+   .thumb_set TIM2_IRQHandler,Default_Handler
+
+   .weak      TIM6_DAC_IRQHandler
+   .thumb_set TIM6_DAC_IRQHandler,Default_Handler
+
+   .weak      TIM21_IRQHandler
+   .thumb_set TIM21_IRQHandler,Default_Handler
+
+   .weak      TIM22_IRQHandler
+   .thumb_set TIM22_IRQHandler,Default_Handler
+
+   .weak      I2C1_IRQHandler
+   .thumb_set I2C1_IRQHandler,Default_Handler
+
+   .weak      I2C2_IRQHandler
+   .thumb_set I2C2_IRQHandler,Default_Handler
+
+   .weak      SPI1_IRQHandler
+   .thumb_set SPI1_IRQHandler,Default_Handler
+
+   .weak      SPI2_IRQHandler
+   .thumb_set SPI2_IRQHandler,Default_Handler
+
+   .weak      USART1_IRQHandler
+   .thumb_set USART1_IRQHandler,Default_Handler
+
+   .weak      USART2_IRQHandler
+   .thumb_set USART2_IRQHandler,Default_Handler
+
+   .weak      RNG_LPUART1_IRQHandler
+   .thumb_set RNG_LPUART1_IRQHandler,Default_Handler
+
+   .weak      LCD_IRQHandler
+   .thumb_set LCD_IRQHandler,Default_Handler
+
+   .weak      USB_IRQHandler
+   .thumb_set USB_IRQHandler,Default_Handler
+
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/cmsis.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/cmsis.h
@@ -1,0 +1,38 @@
+/* mbed Microcontroller Library
+ * A generic CMSIS include header
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+
+#ifndef MBED_CMSIS_H
+#define MBED_CMSIS_H
+
+#include "stm32l0xx.h"
+#include "cmsis_nvic.h"
+
+#endif

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/cmsis_nvic.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/cmsis_nvic.c
@@ -1,0 +1,55 @@
+/* mbed Microcontroller Library
+ * CMSIS-style functionality to support dynamic vectors
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */ 
+#include "cmsis_nvic.h"
+
+#define NVIC_RAM_VECTOR_ADDRESS   (0x20000000)  // Vectors positioned at start of RAM
+#define NVIC_FLASH_VECTOR_ADDRESS (0x08000000)  // Initial vector position in flash
+
+void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
+    uint32_t *vectors = (uint32_t *)SCB->VTOR;
+    uint32_t i;
+
+    // Copy and switch to dynamic vectors if the first time called
+    if (SCB->VTOR == NVIC_FLASH_VECTOR_ADDRESS) {
+        uint32_t *old_vectors = vectors;
+        vectors = (uint32_t*)NVIC_RAM_VECTOR_ADDRESS;
+        for (i=0; i<NVIC_NUM_VECTORS; i++) {
+            vectors[i] = old_vectors[i];
+        }
+        SCB->VTOR = (uint32_t)NVIC_RAM_VECTOR_ADDRESS;
+    }
+    vectors[IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+}
+
+uint32_t NVIC_GetVector(IRQn_Type IRQn) {
+    uint32_t *vectors = (uint32_t*)SCB->VTOR;
+    return vectors[IRQn + NVIC_USER_IRQ_OFFSET];
+}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/cmsis_nvic.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/cmsis_nvic.h
@@ -1,0 +1,55 @@
+/* mbed Microcontroller Library
+ * CMSIS-style functionality to support dynamic vectors
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */ 
+
+#ifndef MBED_CMSIS_NVIC_H
+#define MBED_CMSIS_NVIC_H
+
+// STM32L053R8
+// CORE: 16 vectors = 64 bytes from 0x00 to 0x3F
+// MCU Peripherals: 32 vectors = 128 bytes from 0x40 to 0xBF
+// Total: 48 vectors = 192 bytes (0xC0) to be reserved in RAM
+#define NVIC_NUM_VECTORS      48
+#define NVIC_USER_IRQ_OFFSET  16
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
+uint32_t NVIC_GetVector(IRQn_Type IRQn);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l053xx.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l053xx.h
@@ -1,0 +1,4169 @@
+/**
+  ******************************************************************************
+  * @file    stm32l053xx.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   CMSIS Cortex-M0+ Device Peripheral Access Layer Header File. 
+  *          This file contains all the peripheral register's definitions, bits 
+  *          definitions and memory mapping for STM32L0xx devices.  
+  *          
+  *          This file contains:
+  *           - Data structures and the address mapping for all peripherals
+  *           - Peripheral's registers declarations and bits definition
+  *           - Macros to access peripheral’s registers hardware
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32l053xx
+  * @{
+  */
+    
+#ifndef __STM32L053xx_H
+#define __STM32L053xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif 
+  
+
+/** @addtogroup Configuration_section_for_CMSIS
+  * @{
+  */
+/**
+  * @brief Configuration of the Cortex-M0+ Processor and Core Peripherals 
+  */
+#define __CM0PLUS_REV             0 /*!< Core Revision r0p0                            */
+#define __MPU_PRESENT             1 /*!< STM32L0xx  provides an MPU                    */
+#define __VTOR_PRESENT            1 /*!< Vector  Table  Register supported             */
+#define __NVIC_PRIO_BITS          2 /*!< STM32L0xx uses 2 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0 /*!< Set to 1 if different SysTick Config is used  */
+
+
+/**
+  * @}
+  */
+   
+/** @addtogroup Peripheral_interrupt_number_definition
+  * @{
+  */
+   
+/**
+ * @brief STM32L0xx Interrupt Number Definition, according to the selected device 
+ *        in @ref Library_configuration_section 
+ */
+
+/*!< Interrupt Number Definition */
+typedef enum
+{
+/******  Cortex-M0 Processor Exceptions Numbers ******************************************************/
+  NonMaskableInt_IRQn         = -14,    /*!< 2 Non Maskable Interrupt                                */
+  HardFault_IRQn              = -13,    /*!< 3 Cortex-M0+ Hard Fault Interrupt                        */
+  SVC_IRQn                    = -5,     /*!< 11 Cortex-M0+ SV Call Interrupt                          */
+  PendSV_IRQn                 = -2,     /*!< 14 Cortex-M0+ Pend SV Interrupt                          */
+  SysTick_IRQn                = -1,     /*!< 15 Cortex-M0+ System Tick Interrupt                      */
+
+/******  STM32L-0 specific Interrupt Numbers *********************************************************/
+  WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                     */
+  PVD_IRQn                    = 1,      /*!< PVD through EXTI Line detect Interrupt                        */
+  RTC_IRQn                    = 2,      /*!< RTC through EXTI Line Interrupt                               */
+  FLASH_IRQn                  = 3,      /*!< FLASH Interrupt                                               */
+  RCC_CRS_IRQn                = 4,      /*!< RCC and CRS Interrupts                                        */
+  EXTI0_1_IRQn                = 5,      /*!< EXTI Line 0 and 1 Interrupts                                  */
+  EXTI2_3_IRQn                = 6,      /*!< EXTI Line 2 and 3 Interrupts                                  */
+  EXTI4_15_IRQn               = 7,      /*!< EXTI Line 4 to 15 Interrupts                                  */
+  TSC_IRQn                    = 8,      /*!< TSC Interrupt                                                  */
+  DMA1_Channel1_IRQn          = 9,      /*!< DMA1 Channel 1 Interrupt                                      */
+  DMA1_Channel2_3_IRQn        = 10,     /*!< DMA1 Channel 2 and Channel 3 Interrupts                       */
+  DMA1_Channel4_5_6_7_IRQn    = 11,     /*!< DMA1 Channel 4, Channel 5, Channel 6 and Channel 7 Interrupts */
+  ADC1_COMP_IRQn              = 12,     /*!< ADC1, COMP1 and COMP2 Interrupts                              */
+  LPTIM1_IRQn                 = 13,     /*!< LPTIM1 Interrupt                                              */
+  TIM2_IRQn                   = 15,     /*!< TIM2 Interrupt                                                */
+  TIM6_DAC_IRQn               = 17,     /*!< TIM6 and DAC Interrupts                                       */
+  TIM21_IRQn                  = 20,     /*!< TIM21 Interrupt                                               */
+  TIM22_IRQn                  = 22,     /*!< TIM22 Interrupt                                               */
+  I2C1_IRQn                   = 23,     /*!< I2C1 Interrupt                                                */
+  I2C2_IRQn                   = 24,     /*!< I2C2 Interrupt                                                */
+  SPI1_IRQn                   = 25,     /*!< SPI1 Interrupt                                                */
+  SPI2_IRQn                   = 26,     /*!< SPI2 Interrupt                                                */
+  USART1_IRQn                 = 27,     /*!< USART1 Interrupt                                              */
+  USART2_IRQn                 = 28,     /*!< USART2 Interrupt                                              */
+  RNG_LPUART1_IRQn            = 29,     /*!< RNG and LPUART1 Interrupts                                    */
+  LCD_IRQn                    = 30,     /*!< LCD Interrupts                                                */
+  USB_IRQn                    = 31      /*!< USB global Interrupt                                          */
+} IRQn_Type;
+
+/**
+  * @}
+  */
+
+#include "core_cm0plus.h"
+#include "system_stm32l0xx.h"
+#include <stdint.h>
+
+/** @addtogroup Peripheral_registers_structures
+  * @{
+  */   
+
+/** 
+  * @brief Analog to Digital Converter  
+  */
+
+typedef struct
+{
+  __IO uint32_t ISR;          /*!< ADC Interrupt and Status register,                          Address offset:0x00 */
+  __IO uint32_t IER;          /*!< ADC Interrupt Enable register,                              Address offset:0x04 */
+  __IO uint32_t CR;           /*!< ADC Control register,                                       Address offset:0x08 */
+  __IO uint32_t CFGR1;        /*!< ADC Configuration register 1,                               Address offset:0x0C */
+  __IO uint32_t CFGR2;        /*!< ADC Configuration register 2,                               Address offset:0x10 */
+  __IO uint32_t SMPR;         /*!< ADC Sampling time register,                                 Address offset:0x14 */
+  uint32_t   RESERVED1;       /*!< Reserved,                                                                  0x18 */
+  uint32_t   RESERVED2;       /*!< Reserved,                                                                  0x1C */
+  __IO uint32_t TR;           /*!< ADC watchdog threshold register,                            Address offset:0x20 */
+  uint32_t   RESERVED3;       /*!< Reserved,                                                                  0x24 */
+  __IO uint32_t CHSELR;       /*!< ADC channel selection register,                             Address offset:0x28 */
+  uint32_t   RESERVED4[5];    /*!< Reserved,                                                                  0x2C */
+  __IO uint32_t DR;           /*!< ADC data register,                                          Address offset:0x40 */
+  uint32_t   RESERVED5[28];    /*!< Reserved,                                                          0x44 - 0xB0 */
+  __IO uint32_t CALFACT;      /*!< ADC data register,                                          Address offset:0xB4 */
+} ADC_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CCR;
+} ADC_Common_TypeDef;
+
+
+/**
+  * @brief Comparator 
+  */
+
+typedef struct
+{
+  __IO uint32_t CSR;     /*!< COMP comparator control and status register, Address offset: 0x18 */
+} COMP_TypeDef;
+
+
+/** 
+  * @brief CRC calculation unit 
+  */
+
+typedef struct
+{
+  __IO uint32_t DR;          /*!< CRC Data register,                           Address offset: 0x00 */
+  __IO uint32_t  IDR;         /*!< CRC Independent data register,               Address offset: 0x04 */
+  __IO uint32_t CR;          /*!< CRC Control register,                        Address offset: 0x08 */
+  uint32_t      RESERVED2;   /*!< Reserved,                                                    0x0C */
+  __IO uint32_t INIT;        /*!< Initial CRC value register,                  Address offset: 0x10 */
+  __IO uint32_t POL;         /*!< CRC polynomial register,                     Address offset: 0x14 */
+} CRC_TypeDef;
+
+/**
+  * @brief Clock Recovery System 
+  */
+typedef struct 
+{
+__IO uint32_t CR;     /*!< CRS ccontrol register,              Address offset: 0x00 */
+__IO uint32_t CFGR;   /*!< CRS configuration register,         Address offset: 0x04 */
+__IO uint32_t ISR;    /*!< CRS interrupt and status register,  Address offset: 0x08 */
+__IO uint32_t ICR;    /*!< CRS interrupt flag clear register,  Address offset: 0x0C */
+} CRS_TypeDef;
+
+/** 
+  * @brief Digital to Analog Converter
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;            /*!< DAC control register,                                    Address offset: 0x00 */
+  __IO uint32_t SWTRIGR;       /*!< DAC software trigger register,                           Address offset: 0x04 */
+  __IO uint32_t DHR12R1;       /*!< DAC channel1 12-bit right-aligned data holding register, Address offset: 0x08 */
+  __IO uint32_t DHR12L1;       /*!< DAC channel1 12-bit left aligned data holding register,  Address offset: 0x0C */
+  __IO uint32_t DHR8R1;        /*!< DAC channel1 8-bit right aligned data holding register,  Address offset: 0x10 */
+  uint32_t      RESERVED0[6];  /*!<                                                                     0x14-0x28 */
+  __IO uint32_t DOR1;          /*!< DAC channel1 data output register,                       Address offset: 0x2C */
+  uint32_t      RESERVED1;     /*!<                                                                          0x30 */
+  __IO uint32_t SR;            /*!< DAC status register,                                     Address offset: 0x34 */
+} DAC_TypeDef;
+
+/** 
+  * @brief Debug MCU
+  */
+
+typedef struct
+{
+  __IO uint32_t IDCODE;       /*!< MCU device ID code,                          Address offset: 0x00 */
+  __IO uint32_t CR;           /*!< Debug MCU configuration register,            Address offset: 0x04 */
+  __IO uint32_t APB1FZ;       /*!< Debug MCU APB1 freeze register,              Address offset: 0x08 */
+  __IO uint32_t APB2FZ;       /*!< Debug MCU APB2 freeze register,              Address offset: 0x0C */
+}DBGMCU_TypeDef;
+
+/** 
+  * @brief DMA Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t CCR;          /*!< DMA channel x configuration register                                           */
+  __IO uint32_t CNDTR;        /*!< DMA channel x number of data register                                          */
+  __IO uint32_t CPAR;         /*!< DMA channel x peripheral address register                                      */
+  __IO uint32_t CMAR;         /*!< DMA channel x memory address register                                          */
+} DMA_Channel_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t ISR;          /*!< DMA interrupt status register,                            Address offset: 0x00 */
+  __IO uint32_t IFCR;         /*!< DMA interrupt flag clear register,                        Address offset: 0x04 */
+} DMA_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CSELR;           /*!< DMA channel selection register,                  Address offset: 0xA8 */
+} DMA_Request_TypeDef;
+
+/** 
+  * @brief External Interrupt/Event Controller
+  */
+
+typedef struct
+{
+  __IO uint32_t IMR;          /*!<EXTI Interrupt mask register,                             Address offset: 0x00 */
+  __IO uint32_t EMR;          /*!<EXTI Event mask register,                                 Address offset: 0x04 */
+  __IO uint32_t RTSR;         /*!<EXTI Rising trigger selection register ,                  Address offset: 0x08 */
+  __IO uint32_t FTSR;         /*!<EXTI Falling trigger selection register,                  Address offset: 0x0C */
+  __IO uint32_t SWIER;        /*!<EXTI Software interrupt event register,                   Address offset: 0x10 */
+  __IO uint32_t PR;           /*!<EXTI Pending register,                                    Address offset: 0x14 */
+}EXTI_TypeDef;
+
+/** 
+  * @brief FLASH Registers
+  */
+typedef struct
+{
+  __IO uint32_t ACR;          /*!< Access control register,                     Address offset: 0x00 */
+  __IO uint32_t PECR;         /*!< Program/erase control register,              Address offset: 0x04 */
+  __IO uint32_t PDKEYR;       /*!< Power down key register,                     Address offset: 0x08 */
+  __IO uint32_t PEKEYR;       /*!< Program/erase key register,                  Address offset: 0x0c */
+  __IO uint32_t PRGKEYR;      /*!< Program memory key register,                 Address offset: 0x10 */
+  __IO uint32_t OPTKEYR;      /*!< Option byte key register,                    Address offset: 0x14 */
+  __IO uint32_t SR;           /*!< Status register,                             Address offset: 0x18 */
+  __IO uint32_t OBR;          /*!< Option byte register,                        Address offset: 0x1c */
+  __IO uint32_t WRPR;         /*!< Write protection register,                   Address offset: 0x20 */
+} FLASH_TypeDef;
+
+
+/** 
+  * @brief Option Bytes Registers
+  */
+typedef struct
+{
+  __IO uint32_t RDP;               /*!< Read protection register,               Address offset: 0x00 */
+  __IO uint32_t USER;              /*!< user register,                          Address offset: 0x04 */
+  __IO uint32_t WRP01;             /*!< write protection register 0 1,          Address offset: 0x08 */
+} OB_TypeDef;
+  
+
+/** 
+  * @brief General Purpose IO
+  */
+
+typedef struct
+{
+  __IO uint32_t MODER;        /*!< GPIO port mode register,                                  Address offset: 0x00 */
+  __IO uint32_t OTYPER;       /*!< GPIO port output type register,                           Address offset: 0x04 */
+  __IO uint32_t OSPEEDR;      /*!< GPIO port output speed register,                          Address offset: 0x08 */
+  __IO uint32_t PUPDR;        /*!< GPIO port pull-up/pull-down register,                     Address offset: 0x0C */
+  __IO uint32_t IDR;          /*!< GPIO port input data register,                            Address offset: 0x10 */
+  __IO uint32_t ODR;          /*!< GPIO port output data register,                           Address offset: 0x14 */
+  __IO uint32_t BSRR;         /*!< GPIO port bit set/reset registerBSRR,                     Address offset: 0x18 */
+  __IO uint32_t LCKR;         /*!< GPIO port configuration lock register,                    Address offset: 0x1C */
+  __IO uint32_t AFR[2];       /*!< GPIO alternate function register,                    Address offset: 0x20-0x24 */
+  __IO uint32_t BRR;          /*!< GPIO bit reset register,                                  Address offset: 0x28 */
+}GPIO_TypeDef;
+
+/** 
+  * @brief LPTIMIMER
+  */
+typedef struct
+{
+  __IO uint32_t ISR;      /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
+  __IO uint32_t ICR;      /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
+  __IO uint32_t IER;      /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
+  __IO uint32_t CFGR;     /*!< LPTIM Configuration register,                       Address offset: 0x0C */
+  __IO uint32_t CR;       /*!< LPTIM Control register,                             Address offset: 0x10 */
+  __IO uint32_t CMP;      /*!< LPTIM Compare register,                             Address offset: 0x14 */
+  __IO uint32_t ARR;      /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
+  __IO uint32_t CNT;      /*!< LPTIM Counter register,                             Address offset: 0x1C */
+} LPTIM_TypeDef;
+
+/** 
+  * @brief SysTem Configuration
+  */
+
+typedef struct
+{
+  __IO uint32_t CFGR1;         /*!< SYSCFG configuration register 1,                           Address offset: 0x00 */
+  __IO uint32_t CFGR2;         /*!< SYSCFG configuration register 2,                           Address offset: 0x04 */
+  __IO uint32_t EXTICR[4];     /*!< SYSCFG external interrupt configuration register,          Address offset: 0x14-0x08 */
+       uint32_t RESERVED[2];   /*!< Reserved,                                                  0x18-0x1C */
+  __IO uint32_t CFGR3;         /*!< SYSCFG configuration register 3,                           Address offset: 0x20 */       
+} SYSCFG_TypeDef;
+
+
+
+/** 
+  * @brief Inter-integrated Circuit Interface
+  */
+
+typedef struct
+{
+  __IO uint32_t CR1;      /*!< I2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;      /*!< I2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;     /*!< I2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;     /*!< I2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;  /*!< I2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR; /*!< I2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;      /*!< I2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;      /*!< I2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;     /*!< I2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;     /*!< I2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;     /*!< I2C Transmit data register,        Address offset: 0x28 */
+}I2C_TypeDef;
+
+
+/** 
+  * @brief Independent WATCHDOG
+  */
+typedef struct
+{
+  __IO uint32_t KR;   /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;   /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;  /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;   /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t WINR; /*!< IWDG Window register,    Address offset: 0x10 */
+} IWDG_TypeDef;
+
+/** 
+  * @brief LCD
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;        /*!< LCD control register,              Address offset: 0x00 */
+  __IO uint32_t FCR;       /*!< LCD frame control register,        Address offset: 0x04 */
+  __IO uint32_t SR;        /*!< LCD status register,               Address offset: 0x08 */
+  __IO uint32_t CLR;       /*!< LCD clear register,                Address offset: 0x0C */
+  uint32_t RESERVED;       /*!< Reserved,                          Address offset: 0x10 */
+  __IO uint32_t RAM[16];   /*!< LCD display memory,           Address offset: 0x14-0x50 */
+} LCD_TypeDef;
+
+/** 
+  * @brief MIFARE Firewall
+  */
+
+typedef struct
+{
+  __IO uint32_t CSSA;     /*!< Code Segment Start Address register,              Address offset: 0x00 */
+  __IO uint32_t CSL;      /*!< Code Segment Length register,                      Address offset: 0x04 */
+  __IO uint32_t NVDSSA;   /*!< NON volatile data Segment Start Address register,  Address offset: 0x08 */
+  __IO uint32_t NVDSL;    /*!< NON volatile data Segment Length register,         Address offset: 0x0C */
+  __IO uint32_t VDSSA ;   /*!< Volatile data Segment Start Address register,      Address offset: 0x10 */
+  __IO uint32_t VDSL ;    /*!< Volatile data Segment Length register,             Address offset: 0x14 */
+  __IO uint32_t LSSA ;    /*!< Library Segment Start Address register,            Address offset: 0x18 */
+  __IO uint32_t LSL ;     /*!< Library Segment Length register,                   Address offset: 0x1C */
+  __IO uint32_t CR ;      /*!< Configuration  register,                           Address offset: 0x20 */
+ 
+} FW_TypeDef;
+
+/** 
+  * @brief Power Control
+  */
+
+typedef struct
+{
+  __IO uint32_t CR;   /*!< PWR power control register,        Address offset: 0x00 */
+  __IO uint32_t CSR;  /*!< PWR power control/status register, Address offset: 0x04 */
+} PWR_TypeDef;
+
+/** 
+  * @brief Reset and Clock Control
+  */
+typedef struct
+{
+  __IO uint32_t CR;            /*!< RCC clock control register,                                   Address offset: 0x00 */
+  __IO uint32_t ICSCR;         /*!< RCC Internal clock sources calibration register,              Address offset: 0x04 */
+  __IO uint32_t CRRCR;        /*!< RCC Clock recovery RC register,                               Address offset: 0x08 */
+  __IO uint32_t CFGR;          /*!< RCC Clock configuration register,                             Address offset: 0x0C */
+  __IO uint32_t CIER;          /*!< RCC Clock interrupt enable register,                          Address offset: 0x10 */
+  __IO uint32_t CIFR;          /*!< RCC Clock interrupt flag register,                            Address offset: 0x14 */
+  __IO uint32_t CICR;          /*!< RCC Clock interrupt clear register,                           Address offset: 0x18 */
+  __IO uint32_t IOPRSTR;       /*!< RCC IO port reset register,                                   Address offset: 0x1C */
+  __IO uint32_t AHBRSTR;       /*!< RCC AHB peripheral reset register,                            Address offset: 0x20 */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                           Address offset: 0x24 */
+  __IO uint32_t APB1RSTR;      /*!< RCC APB1 peripheral reset register,                           Address offset: 0x28 */
+  __IO uint32_t IOPENR;        /*!< RCC Clock IO port enable register,                            Address offset: 0x2C */
+  __IO uint32_t AHBENR;        /*!< RCC AHB peripheral clock enable register,                     Address offset: 0x30 */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral enable register,                          Address offset: 0x34 */
+  __IO uint32_t APB1ENR;       /*!< RCC APB1 peripheral enable register,                          Address offset: 0x38 */
+  __IO uint32_t IOPSMENR;      /*!< RCC IO port clock enable in sleep mode register,              Address offset: 0x3C */
+  __IO uint32_t AHBSMENR;      /*!< RCC AHB peripheral clock enable in sleep mode register,       Address offset: 0x40 */
+  __IO uint32_t APB2SMENR;     /*!< RCC APB2 peripheral clock enable in sleep mode register,      Address offset: 0x44 */
+  __IO uint32_t APB1SMENR;     /*!< RCC APB1 peripheral clock enable in sleep mode register,      Address offset: 0x48 */
+  __IO uint32_t CCIPR;         /*!< RCC clock configuration register,                             Address offset: 0x4C */
+  __IO uint32_t CSR;           /*!< RCC Control/status register,                                  Address offset: 0x50 */
+} RCC_TypeDef;
+
+
+/** 
+  * @brief Random numbers generator
+  */
+typedef struct 
+{
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+} RNG_TypeDef;
+
+
+/** 
+  * @brief Real-Time Clock
+  */
+typedef struct
+{
+  __IO uint32_t TR;         /*!< RTC time register,                                         Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< RTC date register,                                         Address offset: 0x04 */
+  __IO uint32_t CR;         /*!< RTC control register,                                      Address offset: 0x08 */                                                                                            
+  __IO uint32_t ISR;        /*!< RTC initialization and status register,                    Address offset: 0x0C */
+  __IO uint32_t PRER;       /*!< RTC prescaler register,                                    Address offset: 0x10 */
+  __IO uint32_t WUTR;       /*!< RTC wakeup timer register,                                 Address offset: 0x14 */
+       uint32_t RESERVED;   /*!< Reserved,                                                  Address offset: 0x18 */
+  __IO uint32_t ALRMAR;     /*!< RTC alarm A register,                                      Address offset: 0x1C */
+  __IO uint32_t ALRMBR;     /*!< RTC alarm B register,                                      Address offset: 0x20 */
+  __IO uint32_t WPR;        /*!< RTC write protection register,                             Address offset: 0x24 */
+  __IO uint32_t SSR;        /*!< RTC sub second register,                                   Address offset: 0x28 */
+  __IO uint32_t SHIFTR;     /*!< RTC shift control register,                                Address offset: 0x2C */
+  __IO uint32_t TSTR;       /*!< RTC time stamp time register,                              Address offset: 0x30 */
+  __IO uint32_t TSDR;       /*!< RTC time stamp date register,                              Address offset: 0x34 */
+  __IO uint32_t TSSSR;      /*!< RTC time-stamp sub second register,                        Address offset: 0x38 */
+  __IO uint32_t CALR;       /*!< RTC calibration register,                                  Address offset: 0x3C */
+  __IO uint32_t TAMPCR;     /*!< RTC tamper configuration register,                         Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;   /*!< RTC alarm A sub second register,                           Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;   /*!< RTC alarm B sub second register,                           Address offset: 0x48 */
+  __IO uint32_t OR;         /*!< RTC option register,                                       Address offset  0x4C */
+  __IO uint32_t BKP0R;      /*!< RTC backup register 0,                                     Address offset: 0x50 */
+  __IO uint32_t BKP1R;      /*!< RTC backup register 1,                                     Address offset: 0x54 */
+  __IO uint32_t BKP2R;      /*!< RTC backup register 2,                                     Address offset: 0x58 */
+  __IO uint32_t BKP3R;      /*!< RTC backup register 3,                                     Address offset: 0x5C */
+  __IO uint32_t BKP4R;      /*!< RTC backup register 4,                                     Address offset: 0x60 */
+} RTC_TypeDef;
+
+
+/** 
+  * @brief Serial Peripheral Interface
+  */
+  
+typedef struct
+{
+  __IO uint32_t CR1;      /*!< SPI Control register 1 (not used in I2S mode),       Address offset: 0x00 */
+  __IO uint32_t CR2;      /*!< SPI Control register 2,                              Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< SPI Status register,                                 Address offset: 0x08 */
+  __IO uint32_t DR;       /*!< SPI data register,                                   Address offset: 0x0C */
+  __IO uint32_t CRCPR;    /*!< SPI CRC polynomial register (not used in I2S mode),  Address offset: 0x10 */
+  __IO uint32_t RXCRCR;   /*!< SPI Rx CRC register (not used in I2S mode),          Address offset: 0x14 */
+  __IO uint32_t TXCRCR;   /*!< SPI Tx CRC register (not used in I2S mode),          Address offset: 0x18 */
+  __IO uint32_t I2SCFGR;  /*!< SPI_I2S configuration register,                      Address offset: 0x1C */
+  __IO uint32_t I2SPR;    /*!< SPI_I2S prescaler register,                          Address offset: 0x20 */
+} SPI_TypeDef;
+
+/** 
+  * @brief TIM
+  */
+typedef struct
+{
+  __IO uint32_t CR1;             /*!< TIM control register 1,                      Address offset: 0x00 */
+  __IO uint32_t CR2;             /*!< TIM control register 2,                      Address offset: 0x04 */
+  __IO uint32_t SMCR;            /*!< TIM slave Mode Control register,             Address offset: 0x08 */
+  __IO uint32_t DIER;            /*!< TIM DMA/interrupt enable register,           Address offset: 0x0C */
+  __IO uint32_t SR;              /*!< TIM status register,                         Address offset: 0x10 */
+  __IO uint32_t EGR;             /*!< TIM event generation register,               Address offset: 0x14 */
+  __IO uint32_t CCMR1;           /*!< TIM  capture/compare mode register 1,        Address offset: 0x18 */
+  __IO uint32_t CCMR2;           /*!< TIM  capture/compare mode register 2,        Address offset: 0x1C */
+  __IO uint32_t CCER;            /*!< TIM capture/compare enable register,         Address offset: 0x20 */
+  __IO uint32_t CNT;             /*!< TIM counter register,                        Address offset: 0x24 */
+  __IO uint32_t PSC;             /*!< TIM prescaler register,                      Address offset: 0x28 */
+  __IO uint32_t ARR;             /*!< TIM auto-reload register,                    Address offset: 0x2C */
+  __IO uint32_t RCR;             /*!< TIM  repetition counter register,            Address offset: 0x30 */
+  __IO uint32_t CCR1;            /*!< TIM capture/compare register 1,              Address offset: 0x34 */
+  __IO uint32_t CCR2;            /*!< TIM capture/compare register 2,              Address offset: 0x38 */
+  __IO uint32_t CCR3;            /*!< TIM capture/compare register 3,              Address offset: 0x3C */
+  __IO uint32_t CCR4;            /*!< TIM capture/compare register 4,              Address offset: 0x40 */
+  __IO uint32_t BDTR;            /*!< TIM break and dead-time register,            Address offset: 0x44 */
+  __IO uint32_t DCR;             /*!< TIM DMA control register,                    Address offset: 0x48 */
+  __IO uint32_t DMAR;            /*!< TIM DMA address for full transfer register,  Address offset: 0x4C */
+  __IO uint32_t OR;              /*!< TIM option register,                         Address offset: 0x50 */
+} TIM_TypeDef;
+
+/**
+  * @brief Touch Sensing Controller (TSC)
+  */
+typedef struct
+{
+  __IO uint32_t CR;            /*!< TSC control register,                                     Address offset: 0x00 */
+  __IO uint32_t IER;           /*!< TSC interrupt enable register,                            Address offset: 0x04 */
+  __IO uint32_t ICR;           /*!< TSC interrupt clear register,                             Address offset: 0x08 */
+  __IO uint32_t ISR;           /*!< TSC interrupt status register,                            Address offset: 0x0C */
+  __IO uint32_t IOHCR;         /*!< TSC I/O hysteresis control register,                      Address offset: 0x10 */
+  uint32_t      RESERVED1;     /*!< Reserved,                                                 Address offset: 0x14 */
+  __IO uint32_t IOASCR;        /*!< TSC I/O analog switch control register,                   Address offset: 0x18 */
+  uint32_t      RESERVED2;     /*!< Reserved,                                                 Address offset: 0x1C */
+  __IO uint32_t IOSCR;         /*!< TSC I/O sampling control register,                        Address offset: 0x20 */
+  uint32_t      RESERVED3;     /*!< Reserved,                                                 Address offset: 0x24 */
+  __IO uint32_t IOCCR;         /*!< TSC I/O channel control register,                         Address offset: 0x28 */
+  uint32_t      RESERVED4;     /*!< Reserved,                                                 Address offset: 0x2C */
+  __IO uint32_t IOGCSR;        /*!< TSC I/O group control status register,                    Address offset: 0x30 */
+  __IO uint32_t IOGXCR[8];     /*!< TSC I/O group x counter register,                         Address offset: 0x34-50 */
+} TSC_TypeDef;
+
+/** 
+  * @brief Universal Synchronous Asynchronous Receiver Transmitter
+  */
+  
+typedef struct
+{
+  __IO uint32_t CR1;    /*!< USART Control register 1,                 Address offset: 0x00 */ 
+  __IO uint32_t CR2;    /*!< USART Control register 2,                 Address offset: 0x04 */ 
+  __IO uint32_t CR3;    /*!< USART Control register 3,                 Address offset: 0x08 */
+  __IO uint32_t BRR;    /*!< USART Baud rate register,                 Address offset: 0x0C */  
+  __IO uint32_t GTPR;   /*!< USART Guard time and prescaler register,  Address offset: 0x10 */
+  __IO uint32_t RTOR;   /*!< USART Receiver Time Out register,         Address offset: 0x14 */  
+  __IO uint32_t RQR;    /*!< USART Request register,                   Address offset: 0x18 */
+  __IO uint32_t ISR;    /*!< USART Interrupt and status register,      Address offset: 0x1C */
+  __IO uint32_t ICR;    /*!< USART Interrupt flag Clear register,      Address offset: 0x20 */
+  __IO uint32_t RDR;    /*!< USART Receive Data register,              Address offset: 0x24 */
+  __IO uint32_t TDR;    /*!< USART Transmit Data register,             Address offset: 0x28 */
+} USART_TypeDef;
+
+/** 
+  * @brief Window WATCHDOG
+  */
+typedef struct
+{
+  __IO uint32_t CR;   /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;  /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;   /*!< WWDG Status register,        Address offset: 0x08 */
+} WWDG_TypeDef;
+
+/** 
+  * @brief Universal Serial Bus Full Speed Device
+  */
+  
+typedef struct
+{
+  __IO uint16_t EP0R;            /*!< USB Endpoint 0 register,                Address offset: 0x00 */ 
+  __IO uint16_t RESERVED0;       /*!< Reserved */     
+  __IO uint16_t EP1R;            /*!< USB Endpoint 1 register,                Address offset: 0x04 */
+  __IO uint16_t RESERVED1;       /*!< Reserved */       
+  __IO uint16_t EP2R;            /*!< USB Endpoint 2 register,                Address offset: 0x08 */
+  __IO uint16_t RESERVED2;       /*!< Reserved */       
+  __IO uint16_t EP3R;            /*!< USB Endpoint 3 register,                Address offset: 0x0C */ 
+  __IO uint16_t RESERVED3;       /*!< Reserved */       
+  __IO uint16_t EP4R;            /*!< USB Endpoint 4 register,                Address offset: 0x10 */
+  __IO uint16_t RESERVED4;       /*!< Reserved */       
+  __IO uint16_t EP5R;            /*!< USB Endpoint 5 register,                Address offset: 0x14 */
+  __IO uint16_t RESERVED5;       /*!< Reserved */       
+  __IO uint16_t EP6R;            /*!< USB Endpoint 6 register,                Address offset: 0x18 */
+  __IO uint16_t RESERVED6;       /*!< Reserved */       
+  __IO uint16_t EP7R;            /*!< USB Endpoint 7 register,                Address offset: 0x1C */
+  __IO uint16_t RESERVED7[17];   /*!< Reserved */     
+  __IO uint16_t CNTR;            /*!< Control register,                       Address offset: 0x40 */
+  __IO uint16_t RESERVED8;       /*!< Reserved */       
+  __IO uint16_t ISTR;            /*!< Interrupt status register,              Address offset: 0x44 */
+  __IO uint16_t RESERVED9;       /*!< Reserved */       
+  __IO uint16_t FNR;             /*!< Frame number register,                  Address offset: 0x48 */
+  __IO uint16_t RESERVEDA;       /*!< Reserved */       
+  __IO uint16_t DADDR;           /*!< Device address register,                Address offset: 0x4C */
+  __IO uint16_t RESERVEDB;       /*!< Reserved */       
+  __IO uint16_t BTABLE;          /*!< Buffer Table address register,          Address offset: 0x50 */
+  __IO uint16_t RESERVEDC;       /*!< Reserved */       
+  __IO uint16_t LPMCSR;          /*!< LPM Control and Status register,        Address offset: 0x54 */
+  __IO uint16_t RESERVEDD;       /*!< Reserved */       
+  __IO uint16_t BCDR;            /*!< Battery Charging detector register,     Address offset: 0x58 */
+  __IO uint16_t RESERVEDE;       /*!< Reserved */       
+} USB_TypeDef;
+
+
+/**
+  * @}
+  */
+  
+/** @addtogroup Peripheral_memory_map
+  * @{
+  */
+
+#define FLASH_BASE            ((uint32_t)0x08000000) /*!< FLASH base address in the alias region */
+#define FLASH_END             ((uint32_t)0x0800FFFF) /*!< FLASH end address in the alias region */
+#define DATA_EEPROM_BASE      ((uint32_t)0x08080000) /*!<DATA_EEPROM base address in the alias region */
+#define DATA_EEPROM_END       ((uint32_t)0x080807FF) /*!<DATA_EEPROM end address in the alias region */
+#define SRAM_BASE             ((uint32_t)0x20000000) /*!< SRAM base address in the alias region */
+#define PERIPH_BASE           ((uint32_t)0x40000000) /*!< Peripheral base address in the alias region */
+
+/*!< Peripheral memory map */
+#define APBPERIPH_BASE        PERIPH_BASE
+#define AHBPERIPH_BASE        (PERIPH_BASE + 0x00020000)
+#define IOPPERIPH_BASE       (PERIPH_BASE + 0x10000000)
+
+#define TIM2_BASE             (APBPERIPH_BASE + 0x00000000)
+#define TIM6_BASE             (APBPERIPH_BASE + 0x00001000)
+#define LCD_BASE              (APBPERIPH_BASE + 0x00002400)
+#define RTC_BASE              (APBPERIPH_BASE + 0x00002800)
+#define WWDG_BASE             (APBPERIPH_BASE + 0x00002C00)
+#define IWDG_BASE             (APBPERIPH_BASE + 0x00003000)
+#define SPI2_BASE             (APBPERIPH_BASE + 0x00003800)
+#define USART2_BASE           (APBPERIPH_BASE + 0x00004400)
+#define LPUART1_BASE          (APBPERIPH_BASE + 0x00004800)
+#define I2C1_BASE             (APBPERIPH_BASE + 0x00005400)
+#define I2C2_BASE             (APBPERIPH_BASE + 0x00005800)
+#define CRS_BASE              (APBPERIPH_BASE + 0x00006C00)
+#define PWR_BASE              (APBPERIPH_BASE + 0x00007000)
+#define DAC_BASE              (APBPERIPH_BASE + 0x00007400)
+#define LPTIM1_BASE           (APBPERIPH_BASE + 0x00007C00)
+
+#define SYSCFG_BASE           (APBPERIPH_BASE + 0x00010000)
+#define COMP1_BASE            (APBPERIPH_BASE + 0x00010018)
+#define COMP2_BASE            (APBPERIPH_BASE + 0x0001001C)
+#define EXTI_BASE             (APBPERIPH_BASE + 0x00010400)
+#define TIM21_BASE            (APBPERIPH_BASE + 0x00010800)
+#define TIM22_BASE            (APBPERIPH_BASE + 0x00011400)
+#define FW_BASE         (APBPERIPH_BASE + 0x00011C00)
+#define ADC1_BASE             (APBPERIPH_BASE + 0x00012400)
+#define ADC_BASE              (APBPERIPH_BASE + 0x00012708)
+#define SPI1_BASE             (APBPERIPH_BASE + 0x00013000)
+#define USART1_BASE           (APBPERIPH_BASE + 0x00013800)
+#define DBGMCU_BASE           (APBPERIPH_BASE + 0x00015800)
+
+#define DMA1_BASE             (AHBPERIPH_BASE + 0x00000000)
+#define DMA1_Channel1_BASE    (DMA1_BASE + 0x00000008)
+#define DMA1_Channel2_BASE    (DMA1_BASE + 0x0000001C)
+#define DMA1_Channel3_BASE    (DMA1_BASE + 0x00000030)
+#define DMA1_Channel4_BASE    (DMA1_BASE + 0x00000044)
+#define DMA1_Channel5_BASE    (DMA1_BASE + 0x00000058)
+#define DMA1_Channel6_BASE    (DMA1_BASE + 0x0000006C)
+#define DMA1_Channel7_BASE    (DMA1_BASE + 0x00000080)
+#define DMA1_CSELR_BASE       (DMA1_BASE + 0x000000A8)
+
+
+#define RCC_BASE              (AHBPERIPH_BASE + 0x00001000)
+#define FLASH_R_BASE          (AHBPERIPH_BASE + 0x00002000) /*!< FLASH registers base address */
+#define OB_BASE               ((uint32_t)0x1FF80000)        /*!< FLASH Option Bytes base address */
+#define CRC_BASE              (AHBPERIPH_BASE + 0x00003000)
+#define TSC_BASE              (AHBPERIPH_BASE + 0x00004000)
+#define RNG_BASE              (AHBPERIPH_BASE + 0x00005000)
+
+#define GPIOA_BASE            (IOPPERIPH_BASE + 0x00000000)
+#define GPIOB_BASE            (IOPPERIPH_BASE + 0x00000400)
+#define GPIOC_BASE            (IOPPERIPH_BASE + 0x00000800)
+#define GPIOD_BASE            (IOPPERIPH_BASE + 0x00000C00)
+#define GPIOH_BASE            (IOPPERIPH_BASE + 0x00001C00)
+
+/**
+  * @}
+  */
+  
+/** @addtogroup Peripheral_declaration
+  * @{
+  */  
+
+#define TIM2                ((TIM_TypeDef *) TIM2_BASE)
+#define TIM6                ((TIM_TypeDef *) TIM6_BASE)
+#define RTC                 ((RTC_TypeDef *) RTC_BASE)
+#define WWDG                ((WWDG_TypeDef *) WWDG_BASE)
+#define IWDG                ((IWDG_TypeDef *) IWDG_BASE)
+#define SPI2                ((SPI_TypeDef *) SPI2_BASE)
+#define USART2              ((USART_TypeDef *) USART2_BASE)
+#define LPUART1             ((USART_TypeDef *) LPUART1_BASE)
+#define I2C1                ((I2C_TypeDef *) I2C1_BASE)
+#define I2C2                ((I2C_TypeDef *) I2C2_BASE)
+#define CRS                 ((CRS_TypeDef *) CRS_BASE)
+#define PWR                 ((PWR_TypeDef *) PWR_BASE)
+#define DAC                 ((DAC_TypeDef *) DAC_BASE)
+#define LPTIM1              ((LPTIM_TypeDef *) LPTIM1_BASE)
+#define LCD                 ((LCD_TypeDef *) LCD_BASE)
+
+#define SYSCFG              ((SYSCFG_TypeDef *) SYSCFG_BASE)
+#define COMP1               ((COMP_TypeDef *) COMP1_BASE)
+#define COMP2               ((COMP_TypeDef *) COMP2_BASE)
+#define EXTI                ((EXTI_TypeDef *) EXTI_BASE)
+#define TIM21                ((TIM_TypeDef *) TIM21_BASE)
+#define TIM22               ((TIM_TypeDef *) TIM22_BASE)
+#define FW                ((FW_TypeDef *) FW_BASE)
+#define ADC1                ((ADC_TypeDef *) ADC1_BASE)
+#define ADC                 ((ADC_Common_TypeDef *) ADC_BASE)
+#define SPI1                ((SPI_TypeDef *) SPI1_BASE)
+#define USART1              ((USART_TypeDef *) USART1_BASE)
+#define DBGMCU              ((DBGMCU_TypeDef *) DBGMCU_BASE)
+
+#define DMA1                ((DMA_TypeDef *) DMA1_BASE)
+#define DMA1_Channel1       ((DMA_Channel_TypeDef *) DMA1_Channel1_BASE)
+#define DMA1_Channel2       ((DMA_Channel_TypeDef *) DMA1_Channel2_BASE)
+#define DMA1_Channel3       ((DMA_Channel_TypeDef *) DMA1_Channel3_BASE)
+#define DMA1_Channel4       ((DMA_Channel_TypeDef *) DMA1_Channel4_BASE)
+#define DMA1_Channel5       ((DMA_Channel_TypeDef *) DMA1_Channel5_BASE)
+#define DMA1_Channel6       ((DMA_Channel_TypeDef *) DMA1_Channel6_BASE)
+#define DMA1_Channel7       ((DMA_Channel_TypeDef *) DMA1_Channel7_BASE)
+#define DMA1_CSELR          ((DMA_Request_TypeDef *) DMA1_CSELR_BASE)
+
+
+#define FLASH               ((FLASH_TypeDef *) FLASH_R_BASE)
+#define OB                  ((OB_TypeDef *) OB_BASE) 
+#define RCC                 ((RCC_TypeDef *) RCC_BASE)
+#define CRC                 ((CRC_TypeDef *) CRC_BASE)
+#define TSC                 ((TSC_TypeDef *) TSC_BASE)
+#define RNG                 ((RNG_TypeDef *) RNG_BASE)
+
+#define GPIOA               ((GPIO_TypeDef *) GPIOA_BASE)
+#define GPIOB               ((GPIO_TypeDef *) GPIOB_BASE)
+#define GPIOC               ((GPIO_TypeDef *) GPIOC_BASE)
+#define GPIOD               ((GPIO_TypeDef *) GPIOD_BASE)
+#define GPIOH               ((GPIO_TypeDef *) GPIOH_BASE)
+
+#define USB              ((USB_TypeDef *) USB_BASE)
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_constants
+  * @{
+  */
+  
+  /** @addtogroup Peripheral_Registers_Bits_Definition
+  * @{
+  */
+    
+/******************************************************************************/
+/*                         Peripheral Registers Bits Definition               */
+/******************************************************************************/
+/******************************************************************************/
+/*                                                                            */
+/*                      Analog to Digital Converter (ADC)                     */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for ADC_ISR register  ******************/
+#define ADC_ISR_EOCAL                        ((uint32_t)0x00000800)        /*!< End of calibration flag */
+#define ADC_ISR_AWD                          ((uint32_t)0x00000080)        /*!< Analog watchdog flag */
+#define ADC_ISR_OVR                          ((uint32_t)0x00000010)        /*!< Overrun flag */
+#define ADC_ISR_EOSEQ                        ((uint32_t)0x00000008)        /*!< End of Sequence flag */
+#define ADC_ISR_EOC                          ((uint32_t)0x00000004)        /*!< End of Conversion */
+#define ADC_ISR_EOSMP                        ((uint32_t)0x00000002)        /*!< End of sampling flag */
+#define ADC_ISR_ADRDY                        ((uint32_t)0x00000001)        /*!< ADC Ready */
+
+/* Old EOSEQ bit definition, maintained for legacy purpose */
+#define ADC_ISR_EOS                          ADC_ISR_EOSEQ
+
+/********************  Bits definition for ADC_IER register  ******************/
+#define ADC_IER_EOCALIE                      ((uint32_t)0x00000800)        /*!< Enf Of Calibration interrupt enable */
+#define ADC_IER_AWDIE                        ((uint32_t)0x00000080)        /*!< Analog Watchdog interrupt enable */
+#define ADC_IER_OVRIE                        ((uint32_t)0x00000010)        /*!< Overrun interrupt enable */
+#define ADC_IER_EOSEQIE                      ((uint32_t)0x00000008)        /*!< End of Sequence of conversion interrupt enable */
+#define ADC_IER_EOCIE                        ((uint32_t)0x00000004)        /*!< End of Conversion interrupt enable */
+#define ADC_IER_EOSMPIE                      ((uint32_t)0x00000002)        /*!< End of sampling interrupt enable */
+#define ADC_IER_ADRDYIE                      ((uint32_t)0x00000001)        /*!< ADC Ready interrupt enable */
+
+/* Old EOSEQIE bit definition, maintained for legacy purpose */
+#define ADC_IER_EOSIE                        ADC_IER_EOSEQIE
+
+/********************  Bits definition for ADC_CR register  *******************/
+#define ADC_CR_ADCAL                         ((uint32_t)0x80000000)        /*!< ADC calibration */
+#define ADC_CR_ADVREGEN                      ((uint32_t)0x10000000)        /*!< ADC Voltage Regulator Enable */
+#define ADC_CR_ADSTP                         ((uint32_t)0x00000010)        /*!< ADC stop of conversion command */
+#define ADC_CR_ADSTART                       ((uint32_t)0x00000004)        /*!< ADC start of conversion */
+#define ADC_CR_ADDIS                         ((uint32_t)0x00000002)        /*!< ADC disable command */
+#define ADC_CR_ADEN                          ((uint32_t)0x00000001)        /*!< ADC enable control */ /*####   TBV  */
+
+/*******************  Bits definition for ADC_CFGR1 register  *****************/
+#define  ADC_CFGR1_AWDCH                      ((uint32_t)0x7C000000)       /*!< AWDCH[4:0] bits (Analog watchdog channel select bits) */
+#define  ADC_CFGR1_AWDCH_0                    ((uint32_t)0x04000000)       /*!< Bit 0 */
+#define  ADC_CFGR1_AWDCH_1                    ((uint32_t)0x08000000)       /*!< Bit 1 */
+#define  ADC_CFGR1_AWDCH_2                    ((uint32_t)0x10000000)       /*!< Bit 2 */
+#define  ADC_CFGR1_AWDCH_3                    ((uint32_t)0x20000000)       /*!< Bit 3 */
+#define  ADC_CFGR1_AWDCH_4                    ((uint32_t)0x40000000)       /*!< Bit 4 */
+#define  ADC_CFGR1_AWDEN                      ((uint32_t)0x00800000)       /*!< Analog watchdog enable on regular channels */
+#define  ADC_CFGR1_AWDSGL                     ((uint32_t)0x00400000)       /*!< Enable the watchdog on a single channel or on all channels  */
+#define  ADC_CFGR1_DISCEN                     ((uint32_t)0x00010000)       /*!< Discontinuous mode on regular channels */
+#define  ADC_CFGR1_AUTOFF                     ((uint32_t)0x00008000)       /*!< ADC auto power off */
+#define  ADC_CFGR1_WAIT                       ((uint32_t)0x00004000)       /*!< ADC wait conversion mode */
+#define  ADC_CFGR1_CONT                       ((uint32_t)0x00002000)       /*!< Continuous Conversion */
+#define  ADC_CFGR1_OVRMOD                     ((uint32_t)0x00001000)       /*!< Overrun mode */
+#define  ADC_CFGR1_EXTEN                      ((uint32_t)0x00000C00)       /*!< EXTEN[1:0] bits (External Trigger Conversion mode for regular channels) */
+#define  ADC_CFGR1_EXTEN_0                    ((uint32_t)0x00000400)       /*!< Bit 0 */
+#define  ADC_CFGR1_EXTEN_1                    ((uint32_t)0x00000800)       /*!< Bit 1 */
+#define  ADC_CFGR1_EXTSEL                     ((uint32_t)0x000001C0)       /*!< EXTSEL[2:0] bits (External Event Select for regular group) */
+#define  ADC_CFGR1_EXTSEL_0                   ((uint32_t)0x00000040)       /*!< Bit 0 */
+#define  ADC_CFGR1_EXTSEL_1                   ((uint32_t)0x00000080)       /*!< Bit 1 */
+#define  ADC_CFGR1_EXTSEL_2                   ((uint32_t)0x00000100)       /*!< Bit 2 */
+#define  ADC_CFGR1_ALIGN                      ((uint32_t)0x00000020)       /*!< Data Alignment */
+#define  ADC_CFGR1_RES                        ((uint32_t)0x00000018)       /*!< RES[1:0] bits (Resolution) */
+#define  ADC_CFGR1_RES_0                      ((uint32_t)0x00000008)       /*!< Bit 0 */
+#define  ADC_CFGR1_RES_1                      ((uint32_t)0x00000010)       /*!< Bit 1 */
+#define  ADC_CFGR1_SCANDIR                    ((uint32_t)0x00000004)       /*!< Sequence scan direction */
+#define  ADC_CFGR1_DMACFG                     ((uint32_t)0x00000002)       /*!< Direct memory access configuration */
+#define  ADC_CFGR1_DMAEN                      ((uint32_t)0x00000001)       /*!< Direct memory access enable */
+
+/* Old WAIT bit definition, maintained for legacy purpose */
+#define  ADC_CFGR1_AUTDLY                     ADC_CFGR1_WAIT
+
+/*******************  Bits definition for ADC_CFGR2 register  *****************/
+#define  ADC_CFGR2_TOVS                       ((uint32_t)0x80000200)        /*!< Triggered Oversampling */
+#define  ADC_CFGR2_OVSS                       ((uint32_t)0x000001E0)        /*!< OVSS [3:0] bits (Oversampling shift) */
+#define  ADC_CFGR2_OVSS_0                     ((uint32_t)0x00000020)        /*!< Bit 0 */
+#define  ADC_CFGR2_OVSS_1                     ((uint32_t)0x00000040)        /*!< Bit 1 */
+#define  ADC_CFGR2_OVSS_2                     ((uint32_t)0x00000080)        /*!< Bit 2 */
+#define  ADC_CFGR2_OVSS_3                     ((uint32_t)0x00000100)        /*!< Bit 3 */
+#define  ADC_CFGR2_OVSR                       ((uint32_t)0x0000001C)        /*!< OVSR  [2:0] bits (Oversampling ratio) */
+#define  ADC_CFGR2_OVSR_0                     ((uint32_t)0x00000004)        /*!< Bit 0 */
+#define  ADC_CFGR2_OVSR_1                     ((uint32_t)0x00000008)        /*!< Bit 1 */
+#define  ADC_CFGR2_OVSR_2                     ((uint32_t)0x00000010)        /*!< Bit 2 */
+#define  ADC_CFGR2_OVSE                       ((uint32_t)0x00000001)        /*!< Oversampler Enable */
+#define  ADC_CFGR2_CKMODE                     ((uint32_t)0xC0000000)        /*!< CKMODE [1:0] bits (ADC clock mode) */
+#define  ADC_CFGR2_CKMODE_0                   ((uint32_t)0x40000000)        /*!< Bit 0 */
+#define  ADC_CFGR2_CKMODE_1                   ((uint32_t)0x80000000)        /*!< Bit 1 */
+
+
+/******************  Bit definition for ADC_SMPR register  ********************/
+#define  ADC_SMPR_SMP                      ((uint32_t)0x00000007)        /*!< SMPR[2:0] bits (Sampling time selection) */
+#define  ADC_SMPR_SMP_0                    ((uint32_t)0x00000001)        /*!< Bit 0 */
+#define  ADC_SMPR_SMP_1                    ((uint32_t)0x00000002)        /*!< Bit 1 */
+#define  ADC_SMPR_SMP_2                    ((uint32_t)0x00000004)        /*!< Bit 2 */
+
+/* Bit names aliases maintained for legacy */
+#define  ADC_SMPR_SMPR                      ADC_SMPR_SMP
+#define  ADC_SMPR_SMPR_0                    ADC_SMPR_SMP_0
+#define  ADC_SMPR_SMPR_1                    ADC_SMPR_SMP_1
+#define  ADC_SMPR_SMPR_2                    ADC_SMPR_SMP_2
+
+/*******************  Bit definition for ADC_TR register  ********************/
+#define  ADC_TR_HT                          ((uint32_t)0x0FFF0000)        /*!< Analog watchdog high threshold */
+#define  ADC_TR_LT                          ((uint32_t)0x00000FFF)        /*!< Analog watchdog low threshold */
+
+/******************  Bit definition for ADC_CHSELR register  ******************/
+#define  ADC_CHSELR_CHSEL18                   ((uint32_t)0x00040000)        /*!< Channel 18 selection */
+#define  ADC_CHSELR_CHSEL17                   ((uint32_t)0x00020000)        /*!< Channel 17 selection */
+#define  ADC_CHSELR_CHSEL16                   ((uint32_t)0x00010000)        /*!< Channel 16 selection */
+#define  ADC_CHSELR_CHSEL15                   ((uint32_t)0x00008000)        /*!< Channel 15 selection */
+#define  ADC_CHSELR_CHSEL14                   ((uint32_t)0x00004000)        /*!< Channel 14 selection */
+#define  ADC_CHSELR_CHSEL13                   ((uint32_t)0x00002000)        /*!< Channel 13 selection */
+#define  ADC_CHSELR_CHSEL12                   ((uint32_t)0x00001000)        /*!< Channel 12 selection */
+#define  ADC_CHSELR_CHSEL11                   ((uint32_t)0x00000800)        /*!< Channel 11 selection */
+#define  ADC_CHSELR_CHSEL10                   ((uint32_t)0x00000400)        /*!< Channel 10 selection */
+#define  ADC_CHSELR_CHSEL9                    ((uint32_t)0x00000200)        /*!< Channel 9 selection */
+#define  ADC_CHSELR_CHSEL8                    ((uint32_t)0x00000100)        /*!< Channel 8 selection */
+#define  ADC_CHSELR_CHSEL7                    ((uint32_t)0x00000080)        /*!< Channel 7 selection */
+#define  ADC_CHSELR_CHSEL6                    ((uint32_t)0x00000040)        /*!< Channel 6 selection */
+#define  ADC_CHSELR_CHSEL5                    ((uint32_t)0x00000020)        /*!< Channel 5 selection */
+#define  ADC_CHSELR_CHSEL4                    ((uint32_t)0x00000010)        /*!< Channel 4 selection */
+#define  ADC_CHSELR_CHSEL3                    ((uint32_t)0x00000008)        /*!< Channel 3 selection */
+#define  ADC_CHSELR_CHSEL2                    ((uint32_t)0x00000004)        /*!< Channel 2 selection */
+#define  ADC_CHSELR_CHSEL1                    ((uint32_t)0x00000002)        /*!< Channel 1 selection */
+#define  ADC_CHSELR_CHSEL0                    ((uint32_t)0x00000001)        /*!< Channel 0 selection */
+
+/********************  Bit definition for ADC_DR register  ********************/
+#define  ADC_DR_DATA                         ((uint32_t)0x0000FFFF)        /*!< Regular data */
+
+/********************  Bit definition for ADC_CALFACT register  ********************/
+#define  ADC_CALFACT_CALFACT       ((uint32_t)0x0000007F)                  /*!< Calibration factor */
+
+/*******************  Bit definition for ADC_CCR register  ********************/
+#define  ADC_CCR_LFMEN                        ((uint32_t)0x02000000)       /*!< Low Frequency Mode enable */
+#define  ADC_CCR_VLCDEN                       ((uint32_t)0x01000000)       /*!< Voltage battery enable */
+#define  ADC_CCR_TSEN                         ((uint32_t)0x00800000)       /*!< Temperature sensore enable */
+#define  ADC_CCR_VREFEN                       ((uint32_t)0x00400000)       /*!< Vrefint enable */
+#define  ADC_CCR_PRESC                        ((uint32_t)0x003C0000)       /*!< PRESC  [3:0] bits (ADC prescaler) */
+#define  ADC_CCR_PRESC_0                      ((uint32_t)0x00040000)       /*!< Bit 0 */
+#define  ADC_CCR_PRESC_1                      ((uint32_t)0x00080000)       /*!< Bit 1 */
+#define  ADC_CCR_PRESC_2                      ((uint32_t)0x00100000)       /*!< Bit 2 */
+#define  ADC_CCR_PRESC_3                      ((uint32_t)0x00200000)       /*!< Bit 3 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Analog Comparators (COMP)                             */
+/*                                                                            */
+/******************************************************************************/
+/*************  Bit definition for COMP_CSR register (COMP1 and COMP2)  **************/
+/* COMP1 bits definition */
+#define COMP_CSR_COMP1EN                ((uint32_t)0x00000001) /*!< COMP1 enable */
+#define COMP_CSR_COMP1INNSEL            ((uint32_t)0x00000030) /*!< COMP1 inverting input select */
+#define COMP_CSR_COMP1INNSEL_0          ((uint32_t)0x00000010) /*!< COMP1 inverting input select bit 0 */
+#define COMP_CSR_COMP1INNSEL_1          ((uint32_t)0x00000020) /*!< COMP1 inverting input select bit 1 */
+#define COMP_CSR_COMP1WM                ((uint32_t)0x00000100) /*!< Comparators window mode enable */
+#define COMP_CSR_COMP1LPTIM1IN1         ((uint32_t)0x00001000) /*!< COMP1 LPTIM1 IN1 connection */
+#define COMP_CSR_COMP1POLARITY          ((uint32_t)0x00008000) /*!< COMP1 output polarity */
+#define COMP_CSR_COMP1VALUE             ((uint32_t)0x40000000) /*!< COMP1 output level */
+#define COMP_CSR_COMP1LOCK              ((uint32_t)0x80000000) /*!< COMP1 lock */
+/* COMP2 bits definition */
+#define COMP_CSR_COMP2EN                ((uint32_t)0x00000001) /*!< COMP2 enable */
+#define COMP_CSR_COMP2SPEED             ((uint32_t)0x000C0008) /*!< COMP2 power mode */
+#define COMP_CSR_COMP2INNSEL            ((uint32_t)0x00100070) /*!< COMP2 inverting input select */
+#define COMP_CSR_COMP2INNSEL_0          ((uint32_t)0x00100010) /*!< COMP2 inverting input select bit 0 */
+#define COMP_CSR_COMP2INNSEL_1          ((uint32_t)0x00200020) /*!< COMP2 inverting input select bit 1 */
+#define COMP_CSR_COMP2INNSEL_2          ((uint32_t)0x00400040) /*!< COMP2 inverting input select bit 2 */
+#define COMP_CSR_COMP2INPSEL            ((uint32_t)0x00000700) /*!< COMPx non inverting input select */
+#define COMP_CSR_COMP2INPSEL_0          ((uint32_t)0x00000100) /*!< COMPx non inverting input select */
+#define COMP_CSR_COMP2INPSEL_1          ((uint32_t)0x00000200) /*!< COMPx non inverting input select */
+#define COMP_CSR_COMP2INPSEL_2          ((uint32_t)0x00000400) /*!< COMPx non inverting input select */
+#define COMP_CSR_COMP2LPTIM1IN2         ((uint32_t)0x00001000) /*!< COMP2 LPTIM1 IN2 connection */
+#define COMP_CSR_COMP2POLARITY          ((uint32_t)0x00008000) /*!< COMP2 output polarity */
+#define COMP_CSR_COMP2VALUE             ((uint32_t)0x40000000) /*!< COMP2 output level */
+#define COMP_CSR_COMP2LOCK              ((uint32_t)0x80000000) /*!< COMP2 lock */
+
+/**********************  Bit definition for COMP_CSR register common  ****************/
+#define COMP_CSR_COMPxEN               ((uint32_t)0x00000001) /*!< COMPx enable */
+#define COMP_CSR_COMPxPOLARITY         ((uint32_t)0x00008000) /*!< COMPx output polarity */
+#define COMP_CSR_COMPxOUTVALUE         ((uint32_t)0x40000000) /*!< COMPx output level */
+#define COMP_CSR_COMPxLOCK             ((uint32_t)0x80000000) /*!< COMPx lock */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                       CRC calculation unit (CRC)                           */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for CRC_DR register  *********************/
+#define  CRC_DR_DR                           ((uint32_t)0xFFFFFFFF) /*!< Data register bits */
+
+/*******************  Bit definition for CRC_IDR register  ********************/
+#define  CRC_IDR_IDR                         ((uint32_t)0x000000FF)        /*!< General-purpose 8-bit data register bits */
+
+/********************  Bit definition for CRC_CR register  ********************/
+#define  CRC_CR_RESET                        ((uint32_t)0x00000001) /*!< RESET the CRC computation unit bit */
+#define  CRC_CR_POLYSIZE                     ((uint32_t)0x00000018) /*!< Polynomial size bits */
+#define  CRC_CR_POLYSIZE_0                   ((uint32_t)0x00000008) /*!< Polynomial size bit 0 */
+#define  CRC_CR_POLYSIZE_1                   ((uint32_t)0x00000010) /*!< Polynomial size bit 1 */
+#define  CRC_CR_REV_IN                       ((uint32_t)0x00000060) /*!< REV_IN Reverse Input Data bits */
+#define  CRC_CR_REV_IN_0                     ((uint32_t)0x00000020) /*!< Bit 0 */
+#define  CRC_CR_REV_IN_1                     ((uint32_t)0x00000040) /*!< Bit 1 */
+#define  CRC_CR_REV_OUT                      ((uint32_t)0x00000080) /*!< REV_OUT Reverse Output Data bits */
+
+/*******************  Bit definition for CRC_INIT register  *******************/
+#define  CRC_INIT_INIT                       ((uint32_t)0xFFFFFFFF) /*!< Initial CRC value bits */
+
+/*******************  Bit definition for CRC_POL register  ********************/
+#define  CRC_POL_POL                         ((uint32_t)0xFFFFFFFF) /*!< Coefficients of the polynomial */
+
+/******************************************************************************/
+/*                                                                            */
+/*                          CRS Clock Recovery System                         */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for CRS_CR register  *********************/
+#define  CRS_CR_SYNCOKIE                     ((uint32_t)0x00000001) /* SYNC event OK interrupt enable        */
+#define  CRS_CR_SYNCWARNIE                   ((uint32_t)0x00000002) /* SYNC warning interrupt enable         */
+#define  CRS_CR_ERRIE                        ((uint32_t)0x00000004) /* SYNC error interrupt enable           */
+#define  CRS_CR_ESYNCIE                      ((uint32_t)0x00000008) /* Expected SYNC(ESYNCF) interrupt Enable*/
+#define  CRS_CR_CEN                          ((uint32_t)0x00000020) /* Frequency error counter enable        */
+#define  CRS_CR_AUTOTRIMEN                   ((uint32_t)0x00000040) /* Automatic trimming enable             */
+#define  CRS_CR_SWSYNC                       ((uint32_t)0x00000080) /* A Software SYNC event is generated    */
+#define  CRS_CR_TRIM                         ((uint32_t)0x00003F00) /* HSI48 oscillator smooth trimming      */
+
+/*******************  Bit definition for CRS_CFGR register  *********************/
+#define  CRS_CFGR_RELOAD                     ((uint32_t)0x0000FFFF) /* Counter reload value               */
+#define  CRS_CFGR_FELIM                      ((uint32_t)0x00FF0000) /* Frequency error limit              */
+
+#define  CRS_CFGR_SYNCDIV                    ((uint32_t)0x07000000) /* SYNC divider                       */
+#define  CRS_CFGR_SYNCDIV_0                  ((uint32_t)0x01000000) /* Bit 0                              */
+#define  CRS_CFGR_SYNCDIV_1                  ((uint32_t)0x02000000) /* Bit 1                              */
+#define  CRS_CFGR_SYNCDIV_2                  ((uint32_t)0x04000000) /* Bit 2                              */
+
+#define  CRS_CFGR_SYNCSRC                    ((uint32_t)0x30000000) /* SYNC signal source selection       */
+#define  CRS_CFGR_SYNCSRC_0                  ((uint32_t)0x10000000) /* Bit 0                              */
+#define  CRS_CFGR_SYNCSRC_1                  ((uint32_t)0x20000000) /* Bit 1                              */
+
+#define  CRS_CFGR_SYNCPOL                    ((uint32_t)0x80000000) /* SYNC polarity selection            */
+  
+/*******************  Bit definition for CRS_ISR register  *********************/
+#define  CRS_ISR_SYNCOKF                     ((uint32_t)0x00000001) /* SYNC event OK flag             */
+#define  CRS_ISR_SYNCWARNF                   ((uint32_t)0x00000002) /* SYNC warning                   */
+#define  CRS_ISR_ERRF                        ((uint32_t)0x00000004) /* SYNC error flag                */
+#define  CRS_ISR_ESYNCF                      ((uint32_t)0x00000008) /* Expected SYNC flag             */
+#define  CRS_ISR_SYNCERR                     ((uint32_t)0x00000100) /* SYNC error                     */
+#define  CRS_ISR_SYNCMISS                    ((uint32_t)0x00000200) /* SYNC missed                    */
+#define  CRS_ISR_TRIMOVF                     ((uint32_t)0x00000400) /* Trimming overflow or underflow */
+#define  CRS_ISR_FEDIR                       ((uint32_t)0x00008000) /* Frequency error direction      */
+#define  CRS_ISR_FECAP                       ((uint32_t)0xFFFF0000) /* Frequency error capture        */
+
+/*******************  Bit definition for CRS_ICR register  *********************/
+#define  CRS_ICR_SYNCOKC                     ((uint32_t)0x00000001) /* SYNC event OK clear flag     */
+#define  CRS_ICR_SYNCWARNC                   ((uint32_t)0x00000002) /* SYNC warning clear flag      */
+#define  CRS_ICR_ERRC                        ((uint32_t)0x00000004) /* Error clear flag             */
+#define  CRS_ICR_ESYNCC                      ((uint32_t)0x00000008) /* Expected SYNC clear flag     */
+
+/******************************************************************************/
+/*                                                                            */
+/*                 Digital to Analog Converter (DAC)                          */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for DAC_CR register  ********************/
+#define  DAC_CR_EN1                          ((uint32_t)0x00000001)        /*!< DAC channel1 enable */
+#define  DAC_CR_BOFF1                        ((uint32_t)0x00000002)        /*!< DAC channel1 output buffer disable */
+#define  DAC_CR_TEN1                         ((uint32_t)0x00000004)        /*!< DAC channel1 Trigger enable */
+
+#define  DAC_CR_TSEL1                        ((uint32_t)0x00000038)        /*!< TSEL1[2:0] (DAC channel1 Trigger selection) */
+#define  DAC_CR_TSEL1_0                      ((uint32_t)0x00000008)        /*!< Bit 0 */
+#define  DAC_CR_TSEL1_1                      ((uint32_t)0x00000010)        /*!< Bit 1 */
+#define  DAC_CR_TSEL1_2                      ((uint32_t)0x00000020)        /*!< Bit 2 */
+
+#define  DAC_CR_WAVE1                        ((uint32_t)0x000000C0)        /*!< WAVE1[1:0] (DAC channel1 noise/triangle wave generation enable) */
+#define  DAC_CR_WAVE1_0                      ((uint32_t)0x00000040)        /*!< Bit 0 */
+#define  DAC_CR_WAVE1_1                      ((uint32_t)0x00000080)        /*!< Bit 1 */
+
+#define  DAC_CR_MAMP1                        ((uint32_t)0x00000F00)        /*!< MAMP1[3:0] (DAC channel1 Mask/Amplitude selector) */
+#define  DAC_CR_MAMP1_0                      ((uint32_t)0x00000100)        /*!< Bit 0 */
+#define  DAC_CR_MAMP1_1                      ((uint32_t)0x00000200)        /*!< Bit 1 */
+#define  DAC_CR_MAMP1_2                      ((uint32_t)0x00000400)        /*!< Bit 2 */
+#define  DAC_CR_MAMP1_3                      ((uint32_t)0x00000800)        /*!< Bit 3 */
+
+#define  DAC_CR_DMAEN1                       ((uint32_t)0x00001000)        /*!< DAC channel1 DMA enable */
+#define  DAC_CR_DMAUDRIE1                    ((uint32_t)0x00002000)        /*!< DAC channel1 DMA Interrupt enable */
+
+/*****************  Bit definition for DAC_SWTRIGR register  ******************/
+#define  DAC_SWTRIGR_SWTRIG1                 ((uint8_t)0x01)               /*!< DAC channel1 software trigger */
+
+/*****************  Bit definition for DAC_DHR12R1 register  ******************/
+#define  DAC_DHR12R1_DACC1DHR                ((uint16_t)0x0FFF)            /*!< DAC channel1 12-bit Right aligned data */
+
+/*****************  Bit definition for DAC_DHR12L1 register  ******************/
+#define  DAC_DHR12L1_DACC1DHR                ((uint16_t)0xFFF0)            /*!< DAC channel1 12-bit Left aligned data */
+
+/******************  Bit definition for DAC_DHR8R1 register  ******************/
+#define  DAC_DHR8R1_DACC1DHR                 ((uint8_t)0xFF)               /*!< DAC channel1 8-bit Right aligned data */
+
+/*******************  Bit definition for DAC_DOR1 register  *******************/
+#define  DAC_DOR1_DACC1DOR                   ((uint16_t)0x0FFF)            /*!< DAC channel1 data output */
+
+/********************  Bit definition for DAC_SR register  ********************/
+#define  DAC_SR_DMAUDR1                      ((uint32_t)0x00002000)        /*!< DAC channel1 DMA underrun flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Debug MCU (DBGMCU)                               */
+/*                                                                            */
+/******************************************************************************/
+
+/****************  Bit definition for DBGMCU_IDCODE register  *****************/
+#define  DBGMCU_IDCODE_DEV_ID                ((uint32_t)0x00000FFF)        /*!< Device Identifier */
+
+#define  DBGMCU_IDCODE_REV_ID                ((uint32_t)0xFFFF0000)        /*!< REV_ID[15:0] bits (Revision Identifier) */
+#define  DBGMCU_IDCODE_REV_ID_0              ((uint32_t)0x00010000)        /*!< Bit 0 */
+#define  DBGMCU_IDCODE_REV_ID_1              ((uint32_t)0x00020000)        /*!< Bit 1 */
+#define  DBGMCU_IDCODE_REV_ID_2              ((uint32_t)0x00040000)        /*!< Bit 2 */
+#define  DBGMCU_IDCODE_REV_ID_3              ((uint32_t)0x00080000)        /*!< Bit 3 */
+#define  DBGMCU_IDCODE_REV_ID_4              ((uint32_t)0x00100000)        /*!< Bit 4 */
+#define  DBGMCU_IDCODE_REV_ID_5              ((uint32_t)0x00200000)        /*!< Bit 5 */
+#define  DBGMCU_IDCODE_REV_ID_6              ((uint32_t)0x00400000)        /*!< Bit 6 */
+#define  DBGMCU_IDCODE_REV_ID_7              ((uint32_t)0x00800000)        /*!< Bit 7 */
+#define  DBGMCU_IDCODE_REV_ID_8              ((uint32_t)0x01000000)        /*!< Bit 8 */
+#define  DBGMCU_IDCODE_REV_ID_9              ((uint32_t)0x02000000)        /*!< Bit 9 */
+#define  DBGMCU_IDCODE_REV_ID_10             ((uint32_t)0x04000000)        /*!< Bit 10 */
+#define  DBGMCU_IDCODE_REV_ID_11             ((uint32_t)0x08000000)        /*!< Bit 11 */
+#define  DBGMCU_IDCODE_REV_ID_12             ((uint32_t)0x10000000)        /*!< Bit 12 */
+#define  DBGMCU_IDCODE_REV_ID_13             ((uint32_t)0x20000000)        /*!< Bit 13 */
+#define  DBGMCU_IDCODE_REV_ID_14             ((uint32_t)0x40000000)        /*!< Bit 14 */
+#define  DBGMCU_IDCODE_REV_ID_15             ((uint32_t)0x80000000)        /*!< Bit 15 */
+
+/******************  Bit definition for DBGMCU_CR register  *******************/
+#define  DBGMCU_CR_DBG_SLEEP                 ((uint32_t)0x00000001)        /*!< Debug Sleep Mode */
+#define  DBGMCU_CR_DBG_STOP                  ((uint32_t)0x00000002)        /*!< Debug Stop Mode */
+#define  DBGMCU_CR_DBG_STANDBY               ((uint32_t)0x00000004)        /*!< Debug Standby mode */
+
+/******************  Bit definition for DBGMCU_APB1_FZ register  **************/
+#define  DBGMCU_APB1_FZ_DBG_TIM2_STOP        ((uint32_t)0x00000001)        /*!< TIM2 counter stopped when core is halted */
+#define  DBGMCU_APB1_FZ_DBG_TIM6_STOP        ((uint32_t)0x00000010)        /*!< TIM6 counter stopped when core is halted */
+#define  DBGMCU_APB1_FZ_DBG_RTC_STOP         ((uint32_t)0x00000400)        /*!< RTC Calendar frozen when core is halted */
+#define  DBGMCU_APB1_FZ_DBG_WWDG_STOP        ((uint32_t)0x00000800)        /*!< Debug Window Watchdog stopped when Core is halted */
+#define  DBGMCU_APB1_FZ_DBG_IWDG_STOP        ((uint32_t)0x00001000)        /*!< Debug Independent Watchdog stopped when Core is halted */
+#define  DBGMCU_APB1_FZ_DBG_I2C1_STOP        ((uint32_t)0x00200000)   /*!< I2C1 SMBUS timeout mode stopped when Core is halted */
+#define  DBGMCU_APB1_FZ_DBG_I2C2_STOP        ((uint32_t)0x00400000)   /*!< I2C2 SMBUS timeout mode stopped when Core is halted */
+#define  DBGMCU_APB1_FZ_DBG_LPTIMER_STOP     ((uint32_t)0x80000000)   /*!< LPTIM1 counter stopped when core is halted */
+/******************  Bit definition for DBGMCU_APB2_FZ register  **************/
+#define  DBGMCU_APB2_FZ_DBG_TIM22_STOP       ((uint32_t)0x00000020)        /*!< TIM22 counter stopped when core is halted */
+#define  DBGMCU_APB2_FZ_DBG_TIM21_STOP        ((uint32_t)0x00000004)        /*!< TIM21 counter stopped when core is halted */
+
+/******************************************************************************/
+/*                                                                            */
+/*                           DMA Controller (DMA)                             */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for DMA_ISR register  ********************/
+#define  DMA_ISR_GIF1                        ((uint32_t)0x00000001)        /*!< Channel 1 Global interrupt flag    */
+#define  DMA_ISR_TCIF1                       ((uint32_t)0x00000002)        /*!< Channel 1 Transfer Complete flag   */
+#define  DMA_ISR_HTIF1                       ((uint32_t)0x00000004)        /*!< Channel 1 Half Transfer flag       */
+#define  DMA_ISR_TEIF1                       ((uint32_t)0x00000008)        /*!< Channel 1 Transfer Error flag      */
+#define  DMA_ISR_GIF2                        ((uint32_t)0x00000010)        /*!< Channel 2 Global interrupt flag    */
+#define  DMA_ISR_TCIF2                       ((uint32_t)0x00000020)        /*!< Channel 2 Transfer Complete flag   */
+#define  DMA_ISR_HTIF2                       ((uint32_t)0x00000040)        /*!< Channel 2 Half Transfer flag       */
+#define  DMA_ISR_TEIF2                       ((uint32_t)0x00000080)        /*!< Channel 2 Transfer Error flag      */
+#define  DMA_ISR_GIF3                        ((uint32_t)0x00000100)        /*!< Channel 3 Global interrupt flag    */
+#define  DMA_ISR_TCIF3                       ((uint32_t)0x00000200)        /*!< Channel 3 Transfer Complete flag   */
+#define  DMA_ISR_HTIF3                       ((uint32_t)0x00000400)        /*!< Channel 3 Half Transfer flag       */
+#define  DMA_ISR_TEIF3                       ((uint32_t)0x00000800)        /*!< Channel 3 Transfer Error flag      */
+#define  DMA_ISR_GIF4                        ((uint32_t)0x00001000)        /*!< Channel 4 Global interrupt flag    */
+#define  DMA_ISR_TCIF4                       ((uint32_t)0x00002000)        /*!< Channel 4 Transfer Complete flag   */
+#define  DMA_ISR_HTIF4                       ((uint32_t)0x00004000)        /*!< Channel 4 Half Transfer flag       */
+#define  DMA_ISR_TEIF4                       ((uint32_t)0x00008000)        /*!< Channel 4 Transfer Error flag      */
+#define  DMA_ISR_GIF5                        ((uint32_t)0x00010000)        /*!< Channel 5 Global interrupt flag    */
+#define  DMA_ISR_TCIF5                       ((uint32_t)0x00020000)        /*!< Channel 5 Transfer Complete flag   */
+#define  DMA_ISR_HTIF5                       ((uint32_t)0x00040000)        /*!< Channel 5 Half Transfer flag       */
+#define  DMA_ISR_TEIF5                       ((uint32_t)0x00080000)        /*!< Channel 5 Transfer Error flag      */
+#define  DMA_ISR_GIF6                        ((uint32_t)0x00100000)        /*!< Channel 6 Global interrupt flag */
+#define  DMA_ISR_TCIF6                       ((uint32_t)0x00200000)        /*!< Channel 6 Transfer Complete flag */
+#define  DMA_ISR_HTIF6                       ((uint32_t)0x00400000)        /*!< Channel 6 Half Transfer flag */
+#define  DMA_ISR_TEIF6                       ((uint32_t)0x00800000)        /*!< Channel 6 Transfer Error flag */
+#define  DMA_ISR_GIF7                        ((uint32_t)0x01000000)        /*!< Channel 7 Global interrupt flag */
+#define  DMA_ISR_TCIF7                       ((uint32_t)0x02000000)        /*!< Channel 7 Transfer Complete flag */
+#define  DMA_ISR_HTIF7                       ((uint32_t)0x04000000)        /*!< Channel 7 Half Transfer flag */
+#define  DMA_ISR_TEIF7                       ((uint32_t)0x08000000)        /*!< Channel 7 Transfer Error flag */
+
+/*******************  Bit definition for DMA_IFCR register  *******************/
+#define  DMA_IFCR_CGIF1                      ((uint32_t)0x00000001)        /*!< Channel 1 Global interrupt clear    */
+#define  DMA_IFCR_CTCIF1                     ((uint32_t)0x00000002)        /*!< Channel 1 Transfer Complete clear   */
+#define  DMA_IFCR_CHTIF1                     ((uint32_t)0x00000004)        /*!< Channel 1 Half Transfer clear       */
+#define  DMA_IFCR_CTEIF1                     ((uint32_t)0x00000008)        /*!< Channel 1 Transfer Error clear      */
+#define  DMA_IFCR_CGIF2                      ((uint32_t)0x00000010)        /*!< Channel 2 Global interrupt clear    */
+#define  DMA_IFCR_CTCIF2                     ((uint32_t)0x00000020)        /*!< Channel 2 Transfer Complete clear   */
+#define  DMA_IFCR_CHTIF2                     ((uint32_t)0x00000040)        /*!< Channel 2 Half Transfer clear       */
+#define  DMA_IFCR_CTEIF2                     ((uint32_t)0x00000080)        /*!< Channel 2 Transfer Error clear      */
+#define  DMA_IFCR_CGIF3                      ((uint32_t)0x00000100)        /*!< Channel 3 Global interrupt clear    */
+#define  DMA_IFCR_CTCIF3                     ((uint32_t)0x00000200)        /*!< Channel 3 Transfer Complete clear   */
+#define  DMA_IFCR_CHTIF3                     ((uint32_t)0x00000400)        /*!< Channel 3 Half Transfer clear       */
+#define  DMA_IFCR_CTEIF3                     ((uint32_t)0x00000800)        /*!< Channel 3 Transfer Error clear      */
+#define  DMA_IFCR_CGIF4                      ((uint32_t)0x00001000)        /*!< Channel 4 Global interrupt clear    */
+#define  DMA_IFCR_CTCIF4                     ((uint32_t)0x00002000)        /*!< Channel 4 Transfer Complete clear   */
+#define  DMA_IFCR_CHTIF4                     ((uint32_t)0x00004000)        /*!< Channel 4 Half Transfer clear       */
+#define  DMA_IFCR_CTEIF4                     ((uint32_t)0x00008000)        /*!< Channel 4 Transfer Error clear      */
+#define  DMA_IFCR_CGIF5                      ((uint32_t)0x00010000)        /*!< Channel 5 Global interrupt clear    */
+#define  DMA_IFCR_CTCIF5                     ((uint32_t)0x00020000)        /*!< Channel 5 Transfer Complete clear   */
+#define  DMA_IFCR_CHTIF5                     ((uint32_t)0x00040000)        /*!< Channel 5 Half Transfer clear       */
+#define  DMA_IFCR_CTEIF5                     ((uint32_t)0x00080000)        /*!< Channel 5 Transfer Error clear      */
+#define  DMA_IFCR_CGIF6                      ((uint32_t)0x00100000)        /*!< Channel 6 Global interrupt clear */
+#define  DMA_IFCR_CTCIF6                     ((uint32_t)0x00200000)        /*!< Channel 6 Transfer Complete clear */
+#define  DMA_IFCR_CHTIF6                     ((uint32_t)0x00400000)        /*!< Channel 6 Half Transfer clear */
+#define  DMA_IFCR_CTEIF6                     ((uint32_t)0x00800000)        /*!< Channel 6 Transfer Error clear */
+#define  DMA_IFCR_CGIF7                      ((uint32_t)0x01000000)        /*!< Channel 7 Global interrupt clear */
+#define  DMA_IFCR_CTCIF7                     ((uint32_t)0x02000000)        /*!< Channel 7 Transfer Complete clear */
+#define  DMA_IFCR_CHTIF7                     ((uint32_t)0x04000000)        /*!< Channel 7 Half Transfer clear */
+#define  DMA_IFCR_CTEIF7                     ((uint32_t)0x08000000)        /*!< Channel 7 Transfer Error clear */
+
+/*******************  Bit definition for DMA_CCR register  ********************/
+#define  DMA_CCR_EN                          ((uint32_t)0x00000001)        /*!< Channel enable                      */
+#define  DMA_CCR_TCIE                        ((uint32_t)0x00000002)        /*!< Transfer complete interrupt enable  */
+#define  DMA_CCR_HTIE                        ((uint32_t)0x00000004)        /*!< Half Transfer interrupt enable      */
+#define  DMA_CCR_TEIE                        ((uint32_t)0x00000008)        /*!< Transfer error interrupt enable     */
+#define  DMA_CCR_DIR                         ((uint32_t)0x00000010)        /*!< Data transfer direction             */
+#define  DMA_CCR_CIRC                        ((uint32_t)0x00000020)        /*!< Circular mode                       */
+#define  DMA_CCR_PINC                        ((uint32_t)0x00000040)        /*!< Peripheral increment mode           */
+#define  DMA_CCR_MINC                        ((uint32_t)0x00000080)        /*!< Memory increment mode               */
+
+#define  DMA_CCR_PSIZE                       ((uint32_t)0x00000300)        /*!< PSIZE[1:0] bits (Peripheral size)   */
+#define  DMA_CCR_PSIZE_0                     ((uint32_t)0x00000100)        /*!< Bit 0                               */
+#define  DMA_CCR_PSIZE_1                     ((uint32_t)0x00000200)        /*!< Bit 1                               */
+
+#define  DMA_CCR_MSIZE                       ((uint32_t)0x00000C00)        /*!< MSIZE[1:0] bits (Memory size)       */
+#define  DMA_CCR_MSIZE_0                     ((uint32_t)0x00000400)        /*!< Bit 0                               */
+#define  DMA_CCR_MSIZE_1                     ((uint32_t)0x00000800)        /*!< Bit 1                               */
+
+#define  DMA_CCR_PL                          ((uint32_t)0x00003000)        /*!< PL[1:0] bits(Channel Priority level)*/
+#define  DMA_CCR_PL_0                        ((uint32_t)0x00001000)        /*!< Bit 0                               */
+#define  DMA_CCR_PL_1                        ((uint32_t)0x00002000)        /*!< Bit 1                               */
+
+#define  DMA_CCR_MEM2MEM                     ((uint32_t)0x00004000)        /*!< Memory to memory mode               */
+
+/******************  Bit definition for DMA_CNDTR register  *******************/
+#define  DMA_CNDTR_NDT                       ((uint32_t)0x0000FFFF)        /*!< Number of data to Transfer          */
+
+/******************  Bit definition for DMA_CPAR register  ********************/
+#define  DMA_CPAR_PA                         ((uint32_t)0xFFFFFFFF)        /*!< Peripheral Address                  */
+
+/******************  Bit definition for DMA_CMAR register  ********************/
+#define  DMA_CMAR_MA                         ((uint32_t)0xFFFFFFFF)        /*!< Memory Address                      */
+
+
+/*******************  Bit definition for DMA_CSELR register  *******************/
+#define  DMA_CSELR_C1S                          ((uint32_t)0x0000000F)          /*!< Channel 1 Selection */ 
+#define  DMA_CSELR_C2S                          ((uint32_t)0x000000F0)          /*!< Channel 2 Selection */ 
+#define  DMA_CSELR_C3S                          ((uint32_t)0x00000F00)          /*!< Channel 3 Selection */ 
+#define  DMA_CSELR_C4S                          ((uint32_t)0x0000F000)          /*!< Channel 4 Selection */ 
+#define  DMA_CSELR_C5S                          ((uint32_t)0x000F0000)          /*!< Channel 5 Selection */ 
+#define  DMA_CSELR_C6S                          ((uint32_t)0x00F00000)          /*!< Channel 6 Selection */ 
+#define  DMA_CSELR_C7S                          ((uint32_t)0x0F000000)          /*!< Channel 7 Selection */
+
+
+/******************************************************************************/
+/*                                                                            */
+/*                 External Interrupt/Event Controller (EXTI)                 */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for EXTI_IMR register  *******************/
+#define  EXTI_IMR_IM0                        ((uint32_t)0x00000001)        /*!< Interrupt Mask on line 0  */
+#define  EXTI_IMR_IM1                        ((uint32_t)0x00000002)        /*!< Interrupt Mask on line 1  */
+#define  EXTI_IMR_IM2                        ((uint32_t)0x00000004)        /*!< Interrupt Mask on line 2  */
+#define  EXTI_IMR_IM3                        ((uint32_t)0x00000008)        /*!< Interrupt Mask on line 3  */
+#define  EXTI_IMR_IM4                        ((uint32_t)0x00000010)        /*!< Interrupt Mask on line 4  */
+#define  EXTI_IMR_IM5                        ((uint32_t)0x00000020)        /*!< Interrupt Mask on line 5  */
+#define  EXTI_IMR_IM6                        ((uint32_t)0x00000040)        /*!< Interrupt Mask on line 6  */
+#define  EXTI_IMR_IM7                        ((uint32_t)0x00000080)        /*!< Interrupt Mask on line 7  */
+#define  EXTI_IMR_IM8                        ((uint32_t)0x00000100)        /*!< Interrupt Mask on line 8  */
+#define  EXTI_IMR_IM9                        ((uint32_t)0x00000200)        /*!< Interrupt Mask on line 9  */
+#define  EXTI_IMR_IM10                       ((uint32_t)0x00000400)        /*!< Interrupt Mask on line 10 */
+#define  EXTI_IMR_IM11                       ((uint32_t)0x00000800)        /*!< Interrupt Mask on line 11 */
+#define  EXTI_IMR_IM12                       ((uint32_t)0x00001000)        /*!< Interrupt Mask on line 12 */
+#define  EXTI_IMR_IM13                       ((uint32_t)0x00002000)        /*!< Interrupt Mask on line 13 */
+#define  EXTI_IMR_IM14                       ((uint32_t)0x00004000)        /*!< Interrupt Mask on line 14 */
+#define  EXTI_IMR_IM15                       ((uint32_t)0x00008000)        /*!< Interrupt Mask on line 15 */
+#define  EXTI_IMR_IM16                       ((uint32_t)0x00010000)        /*!< Interrupt Mask on line 16 */
+#define  EXTI_IMR_IM17                       ((uint32_t)0x00020000)        /*!< Interrupt Mask on line 17 */
+#define  EXTI_IMR_IM18                       ((uint32_t)0x00040000)        /*!< Interrupt Mask on line 18 */
+#define  EXTI_IMR_IM19                       ((uint32_t)0x00080000)        /*!< Interrupt Mask on line 19 */
+#define  EXTI_IMR_IM20                       ((uint32_t)0x00100000)        /*!< Interrupt Mask on line 20 */
+#define  EXTI_IMR_IM21                       ((uint32_t)0x00200000)        /*!< Interrupt Mask on line 21 */
+#define  EXTI_IMR_IM22                       ((uint32_t)0x00400000)        /*!< Interrupt Mask on line 22 */
+#define  EXTI_IMR_IM23                       ((uint32_t)0x00800000)        /*!< Interrupt Mask on line 23 */
+#define  EXTI_IMR_IM25                       ((uint32_t)0x02000000)        /*!< Interrupt Mask on line 25 */
+#define  EXTI_IMR_IM26                       ((uint32_t)0x04000000)        /*!< Interrupt Mask on line 26 */
+#define  EXTI_IMR_IM28                       ((uint32_t)0x10000000)        /*!< Interrupt Mask on line 28 */
+#define  EXTI_IMR_IM29                       ((uint32_t)0x20000000)        /*!< Interrupt Mask on line 29 */
+
+/******************  Bit definition for EXTI_EMR register  ********************/
+#define  EXTI_EMR_EM0                        ((uint32_t)0x00000001)        /*!< Event Mask on line 0  */
+#define  EXTI_EMR_EM1                        ((uint32_t)0x00000002)        /*!< Event Mask on line 1  */
+#define  EXTI_EMR_EM2                        ((uint32_t)0x00000004)        /*!< Event Mask on line 2  */
+#define  EXTI_EMR_EM3                        ((uint32_t)0x00000008)        /*!< Event Mask on line 3  */
+#define  EXTI_EMR_EM4                        ((uint32_t)0x00000010)        /*!< Event Mask on line 4  */
+#define  EXTI_EMR_EM5                        ((uint32_t)0x00000020)        /*!< Event Mask on line 5  */
+#define  EXTI_EMR_EM6                        ((uint32_t)0x00000040)        /*!< Event Mask on line 6  */
+#define  EXTI_EMR_EM7                        ((uint32_t)0x00000080)        /*!< Event Mask on line 7  */
+#define  EXTI_EMR_EM8                        ((uint32_t)0x00000100)        /*!< Event Mask on line 8  */
+#define  EXTI_EMR_EM9                        ((uint32_t)0x00000200)        /*!< Event Mask on line 9  */
+#define  EXTI_EMR_EM10                       ((uint32_t)0x00000400)        /*!< Event Mask on line 10 */
+#define  EXTI_EMR_EM11                       ((uint32_t)0x00000800)        /*!< Event Mask on line 11 */
+#define  EXTI_EMR_EM12                       ((uint32_t)0x00001000)        /*!< Event Mask on line 12 */
+#define  EXTI_EMR_EM13                       ((uint32_t)0x00002000)        /*!< Event Mask on line 13 */
+#define  EXTI_EMR_EM14                       ((uint32_t)0x00004000)        /*!< Event Mask on line 14 */
+#define  EXTI_EMR_EM15                       ((uint32_t)0x00008000)        /*!< Event Mask on line 15 */
+#define  EXTI_EMR_EM16                       ((uint32_t)0x00010000)        /*!< Event Mask on line 16 */
+#define  EXTI_EMR_EM17                       ((uint32_t)0x00020000)        /*!< Event Mask on line 17 */
+#define  EXTI_EMR_EM18                       ((uint32_t)0x00040000)        /*!< Event Mask on line 18 */
+#define  EXTI_EMR_EM19                       ((uint32_t)0x00080000)        /*!< Event Mask on line 19 */
+#define  EXTI_EMR_EM20                       ((uint32_t)0x00100000)        /*!< Event Mask on line 20 */
+#define  EXTI_EMR_EM21                       ((uint32_t)0x00200000)        /*!< Event Mask on line 21 */
+#define  EXTI_EMR_EM22                       ((uint32_t)0x00400000)        /*!< Event Mask on line 22 */
+#define  EXTI_EMR_EM23                       ((uint32_t)0x00800000)        /*!< Event Mask on line 23 */
+#define  EXTI_EMR_EM25                       ((uint32_t)0x02000000)        /*!< Event Mask on line 25 */
+#define  EXTI_EMR_EM26                       ((uint32_t)0x04000000)        /*!< Event Mask on line 26 */
+#define  EXTI_EMR_EM28                       ((uint32_t)0x10000000)        /*!< Event Mask on line 28 */
+#define  EXTI_EMR_EM29                       ((uint32_t)0x20000000)        /*!< Event Mask on line 29 */
+
+/*******************  Bit definition for EXTI_RTSR register  ******************/
+#define  EXTI_RTSR_TR0                       ((uint32_t)0x00000001)        /*!< Rising trigger event configuration bit of line 0 */
+#define  EXTI_RTSR_TR1                       ((uint32_t)0x00000002)        /*!< Rising trigger event configuration bit of line 1 */
+#define  EXTI_RTSR_TR2                       ((uint32_t)0x00000004)        /*!< Rising trigger event configuration bit of line 2 */
+#define  EXTI_RTSR_TR3                       ((uint32_t)0x00000008)        /*!< Rising trigger event configuration bit of line 3 */
+#define  EXTI_RTSR_TR4                       ((uint32_t)0x00000010)        /*!< Rising trigger event configuration bit of line 4 */
+#define  EXTI_RTSR_TR5                       ((uint32_t)0x00000020)        /*!< Rising trigger event configuration bit of line 5 */
+#define  EXTI_RTSR_TR6                       ((uint32_t)0x00000040)        /*!< Rising trigger event configuration bit of line 6 */
+#define  EXTI_RTSR_TR7                       ((uint32_t)0x00000080)        /*!< Rising trigger event configuration bit of line 7 */
+#define  EXTI_RTSR_TR8                       ((uint32_t)0x00000100)        /*!< Rising trigger event configuration bit of line 8 */
+#define  EXTI_RTSR_TR9                       ((uint32_t)0x00000200)        /*!< Rising trigger event configuration bit of line 9 */
+#define  EXTI_RTSR_TR10                      ((uint32_t)0x00000400)        /*!< Rising trigger event configuration bit of line 10 */
+#define  EXTI_RTSR_TR11                      ((uint32_t)0x00000800)        /*!< Rising trigger event configuration bit of line 11 */
+#define  EXTI_RTSR_TR12                      ((uint32_t)0x00001000)        /*!< Rising trigger event configuration bit of line 12 */
+#define  EXTI_RTSR_TR13                      ((uint32_t)0x00002000)        /*!< Rising trigger event configuration bit of line 13 */
+#define  EXTI_RTSR_TR14                      ((uint32_t)0x00004000)        /*!< Rising trigger event configuration bit of line 14 */
+#define  EXTI_RTSR_TR15                      ((uint32_t)0x00008000)        /*!< Rising trigger event configuration bit of line 15 */
+#define  EXTI_RTSR_TR16                      ((uint32_t)0x00010000)        /*!< Rising trigger event configuration bit of line 16 */
+#define  EXTI_RTSR_TR17                      ((uint32_t)0x00020000)        /*!< Rising trigger event configuration bit of line 17 */
+#define  EXTI_RTSR_TR19                      ((uint32_t)0x00080000)        /*!< Rising trigger event configuration bit of line 19 */
+#define  EXTI_RTSR_TR20                      ((uint32_t)0x00100000)        /*!< Rising trigger event configuration bit of line 20 */
+#define  EXTI_RTSR_TR21                      ((uint32_t)0x00200000)        /*!< Rising trigger event configuration bit of line 21 */
+#define  EXTI_RTSR_TR22                      ((uint32_t)0x00400000)        /*!< Rising trigger event configuration bit of line 22 */
+
+/*******************  Bit definition for EXTI_FTSR register *******************/
+#define  EXTI_FTSR_TR0                       ((uint32_t)0x00000001)        /*!< Falling trigger event configuration bit of line 0 */
+#define  EXTI_FTSR_TR1                       ((uint32_t)0x00000002)        /*!< Falling trigger event configuration bit of line 1 */
+#define  EXTI_FTSR_TR2                       ((uint32_t)0x00000004)        /*!< Falling trigger event configuration bit of line 2 */
+#define  EXTI_FTSR_TR3                       ((uint32_t)0x00000008)        /*!< Falling trigger event configuration bit of line 3 */
+#define  EXTI_FTSR_TR4                       ((uint32_t)0x00000010)        /*!< Falling trigger event configuration bit of line 4 */
+#define  EXTI_FTSR_TR5                       ((uint32_t)0x00000020)        /*!< Falling trigger event configuration bit of line 5 */
+#define  EXTI_FTSR_TR6                       ((uint32_t)0x00000040)        /*!< Falling trigger event configuration bit of line 6 */
+#define  EXTI_FTSR_TR7                       ((uint32_t)0x00000080)        /*!< Falling trigger event configuration bit of line 7 */
+#define  EXTI_FTSR_TR8                       ((uint32_t)0x00000100)        /*!< Falling trigger event configuration bit of line 8 */
+#define  EXTI_FTSR_TR9                       ((uint32_t)0x00000200)        /*!< Falling trigger event configuration bit of line 9 */
+#define  EXTI_FTSR_TR10                      ((uint32_t)0x00000400)        /*!< Falling trigger event configuration bit of line 10 */
+#define  EXTI_FTSR_TR11                      ((uint32_t)0x00000800)        /*!< Falling trigger event configuration bit of line 11 */
+#define  EXTI_FTSR_TR12                      ((uint32_t)0x00001000)        /*!< Falling trigger event configuration bit of line 12 */
+#define  EXTI_FTSR_TR13                      ((uint32_t)0x00002000)        /*!< Falling trigger event configuration bit of line 13 */
+#define  EXTI_FTSR_TR14                      ((uint32_t)0x00004000)        /*!< Falling trigger event configuration bit of line 14 */
+#define  EXTI_FTSR_TR15                      ((uint32_t)0x00008000)        /*!< Falling trigger event configuration bit of line 15 */
+#define  EXTI_FTSR_TR16                      ((uint32_t)0x00010000)        /*!< Falling trigger event configuration bit of line 16 */
+#define  EXTI_FTSR_TR17                      ((uint32_t)0x00020000)        /*!< Falling trigger event configuration bit of line 17 */
+#define  EXTI_FTSR_TR19                      ((uint32_t)0x00080000)        /*!< Falling trigger event configuration bit of line 19 */
+#define  EXTI_FTSR_TR20                      ((uint32_t)0x00100000)        /*!< Falling trigger event configuration bit of line 20 */
+#define  EXTI_FTSR_TR21                      ((uint32_t)0x00200000)        /*!< Falling trigger event configuration bit of line 21 */
+#define  EXTI_FTSR_TR22                      ((uint32_t)0x00400000)        /*!< Falling trigger event configuration bit of line 22 */
+
+/******************* Bit definition for EXTI_SWIER register *******************/
+#define  EXTI_SWIER_SWIER0                   ((uint32_t)0x00000001)        /*!< Software Interrupt on line 0  */
+#define  EXTI_SWIER_SWIER1                   ((uint32_t)0x00000002)        /*!< Software Interrupt on line 1  */
+#define  EXTI_SWIER_SWIER2                   ((uint32_t)0x00000004)        /*!< Software Interrupt on line 2  */
+#define  EXTI_SWIER_SWIER3                   ((uint32_t)0x00000008)        /*!< Software Interrupt on line 3  */
+#define  EXTI_SWIER_SWIER4                   ((uint32_t)0x00000010)        /*!< Software Interrupt on line 4  */
+#define  EXTI_SWIER_SWIER5                   ((uint32_t)0x00000020)        /*!< Software Interrupt on line 5  */
+#define  EXTI_SWIER_SWIER6                   ((uint32_t)0x00000040)        /*!< Software Interrupt on line 6  */
+#define  EXTI_SWIER_SWIER7                   ((uint32_t)0x00000080)        /*!< Software Interrupt on line 7  */
+#define  EXTI_SWIER_SWIER8                   ((uint32_t)0x00000100)        /*!< Software Interrupt on line 8  */
+#define  EXTI_SWIER_SWIER9                   ((uint32_t)0x00000200)        /*!< Software Interrupt on line 9  */
+#define  EXTI_SWIER_SWIER10                  ((uint32_t)0x00000400)        /*!< Software Interrupt on line 10 */
+#define  EXTI_SWIER_SWIER11                  ((uint32_t)0x00000800)        /*!< Software Interrupt on line 11 */
+#define  EXTI_SWIER_SWIER12                  ((uint32_t)0x00001000)        /*!< Software Interrupt on line 12 */
+#define  EXTI_SWIER_SWIER13                  ((uint32_t)0x00002000)        /*!< Software Interrupt on line 13 */
+#define  EXTI_SWIER_SWIER14                  ((uint32_t)0x00004000)        /*!< Software Interrupt on line 14 */
+#define  EXTI_SWIER_SWIER15                  ((uint32_t)0x00008000)        /*!< Software Interrupt on line 15 */
+#define  EXTI_SWIER_SWIER16                  ((uint32_t)0x00010000)        /*!< Software Interrupt on line 16 */
+#define  EXTI_SWIER_SWIER17                  ((uint32_t)0x00020000)        /*!< Software Interrupt on line 17 */
+#define  EXTI_SWIER_SWIER19                  ((uint32_t)0x00080000)        /*!< Software Interrupt on line 19 */
+#define  EXTI_SWIER_SWIER20                  ((uint32_t)0x00100000)        /*!< Software Interrupt on line 20 */
+#define  EXTI_SWIER_SWIER21                  ((uint32_t)0x00200000)        /*!< Software Interrupt on line 21 */
+#define  EXTI_SWIER_SWIER22                  ((uint32_t)0x00400000)        /*!< Software Interrupt on line 22 */
+/******************  Bit definition for EXTI_PR register  *********************/
+#define  EXTI_PR_PR0                         ((uint32_t)0x00000001)        /*!< Pending bit 0  */
+#define  EXTI_PR_PR1                         ((uint32_t)0x00000002)        /*!< Pending bit 1  */
+#define  EXTI_PR_PR2                         ((uint32_t)0x00000004)        /*!< Pending bit 2  */
+#define  EXTI_PR_PR3                         ((uint32_t)0x00000008)        /*!< Pending bit 3  */
+#define  EXTI_PR_PR4                         ((uint32_t)0x00000010)        /*!< Pending bit 4  */
+#define  EXTI_PR_PR5                         ((uint32_t)0x00000020)        /*!< Pending bit 5  */
+#define  EXTI_PR_PR6                         ((uint32_t)0x00000040)        /*!< Pending bit 6  */
+#define  EXTI_PR_PR7                         ((uint32_t)0x00000080)        /*!< Pending bit 7  */
+#define  EXTI_PR_PR8                         ((uint32_t)0x00000100)        /*!< Pending bit 8  */
+#define  EXTI_PR_PR9                         ((uint32_t)0x00000200)        /*!< Pending bit 9  */
+#define  EXTI_PR_PR10                        ((uint32_t)0x00000400)        /*!< Pending bit 10 */
+#define  EXTI_PR_PR11                        ((uint32_t)0x00000800)        /*!< Pending bit 11 */
+#define  EXTI_PR_PR12                        ((uint32_t)0x00001000)        /*!< Pending bit 12 */
+#define  EXTI_PR_PR13                        ((uint32_t)0x00002000)        /*!< Pending bit 13 */
+#define  EXTI_PR_PR14                        ((uint32_t)0x00004000)        /*!< Pending bit 14 */
+#define  EXTI_PR_PR15                        ((uint32_t)0x00008000)        /*!< Pending bit 15 */
+#define  EXTI_PR_PR16                        ((uint32_t)0x00010000)        /*!< Pending bit 16 */
+#define  EXTI_PR_PR17                        ((uint32_t)0x00020000)        /*!< Pending bit 17 */
+#define  EXTI_PR_PR19                        ((uint32_t)0x00080000)        /*!< Pending bit 19 */
+#define  EXTI_PR_PR20                        ((uint32_t)0x00100000)        /*!< Pending bit 20 */
+#define  EXTI_PR_PR21                        ((uint32_t)0x00200000)        /*!< Pending bit 21 */
+#define  EXTI_PR_PR22                        ((uint32_t)0x00400000)        /*!< Pending bit 22 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                      FLASH and Option Bytes Registers                      */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for FLASH_ACR register  ******************/
+#define  FLASH_ACR_LATENCY                   ((uint32_t)0x00000001)        /*!< LATENCY bit (Latency) */
+#define  FLASH_ACR_PRFTEN                    ((uint32_t)0x00000002)        /*!< Prefetch Buffer Enable */
+#define  FLASH_ACR_SLEEP_PD                  ((uint32_t)0x00000008)        /*!< Flash mode during sleep mode */
+#define  FLASH_ACR_RUN_PD                    ((uint32_t)0x00000010)        /*!< Flash mode during RUN mode */
+#define  FLASH_ACR_DISAB_BUF                 ((uint32_t)0x00000020)        /*!< Disable Buffer */
+#define  FLASH_ACR_PRE_READ                  ((uint32_t)0x00000040)        /*!< Pre-read data address */
+
+/*******************  Bit definition for FLASH_PECR register  ******************/
+#define FLASH_PECR_PELOCK                    ((uint32_t)0x00000001)        /*!< FLASH_PECR and Flash data Lock */
+#define FLASH_PECR_PRGLOCK                   ((uint32_t)0x00000002)        /*!< Program matrix Lock */
+#define FLASH_PECR_OPTLOCK                   ((uint32_t)0x00000004)        /*!< Option byte matrix Lock */
+#define FLASH_PECR_PROG                      ((uint32_t)0x00000008)        /*!< Program matrix selection */
+#define FLASH_PECR_DATA                      ((uint32_t)0x00000010)        /*!< Data matrix selection */
+#define FLASH_PECR_FTDW                      ((uint32_t)0x00000100)        /*!< Fixed Time Data write for Word/Half Word/Byte programming */
+#define FLASH_PECR_ERASE                     ((uint32_t)0x00000200)        /*!< Page erasing mode */
+#define FLASH_PECR_FPRG                      ((uint32_t)0x00000400)        /*!< Fast Page/Half Page programming mode */
+#define FLASH_PECR_EOPIE                     ((uint32_t)0x00010000)        /*!< End of programming interrupt */ 
+#define FLASH_PECR_ERRIE                     ((uint32_t)0x00020000)        /*!< Error interrupt */ 
+#define FLASH_PECR_OBL_LAUNCH                ((uint32_t)0x00040000)        /*!< Launch the option byte loading */
+#define FLASH_PECR_HALF_ARRAY                ((uint32_t)0x00080000)        /*!< Half array mode */
+
+/******************  Bit definition for FLASH_PDKEYR register  ******************/
+#define  FLASH_PDKEYR_PDKEYR                 ((uint32_t)0xFFFFFFFF)       /*!< FLASH_PEC and data matrix Key */
+
+/******************  Bit definition for FLASH_PEKEYR register  ******************/
+#define  FLASH_PEKEYR_PEKEYR                 ((uint32_t)0xFFFFFFFF)       /*!< FLASH_PEC and data matrix Key */
+
+/******************  Bit definition for FLASH_PRGKEYR register  ******************/
+#define  FLASH_PRGKEYR_PRGKEYR               ((uint32_t)0xFFFFFFFF)        /*!< Program matrix Key */
+
+/******************  Bit definition for FLASH_OPTKEYR register  ******************/
+#define  FLASH_OPTKEYR_OPTKEYR               ((uint32_t)0xFFFFFFFF)        /*!< Option bytes matrix Key */
+
+/******************  Bit definition for FLASH_SR register  *******************/
+#define  FLASH_SR_BSY                        ((uint32_t)0x00000001)        /*!< Busy */
+#define  FLASH_SR_EOP                        ((uint32_t)0x00000002)        /*!< End Of Programming*/
+#define  FLASH_SR_ENDHV                      ((uint32_t)0x00000004)        /*!< End of high voltage */
+#define  FLASH_SR_READY                      ((uint32_t)0x00000008)        /*!< Flash ready after low power mode */
+
+#define  FLASH_SR_WRPERR                     ((uint32_t)0x00000100)        /*!< Write protection error */
+#define  FLASH_SR_PGAERR                     ((uint32_t)0x00000200)        /*!< Programming Alignment Error */
+#define  FLASH_SR_SIZERR                     ((uint32_t)0x00000400)        /*!< Size error */
+#define  FLASH_SR_OPTVERR                    ((uint32_t)0x00000800)        /*!< Option Valid error */
+#define  FLASH_SR_RDERR                      ((uint32_t)0x00002000)        /*!< Read protected error */
+#define  FLASH_SR_NOTZEROERR                 ((uint32_t)0x00010000)        /*!< Not Zero error */
+#define  FLASH_SR_FWWERR                     ((uint32_t)0x00020000)        /*!< Write/Errase operation aborted */
+
+/* alias maintained for legacy */
+#define  FLASH_SR_FWWER                      FLASH_SR_FWWERR
+#define  FLASH_SR_ENHV                       FLASH_SR_ENDHV
+
+/******************  Bit definition for FLASH_OBR register  *******************/
+#define  FLASH_OBR_RDPRT                     ((uint32_t)0x000000AA)        /*!< Read Protection */
+#define  FLASH_OBR_SPRMOD                    ((uint32_t)0x00000100)        /*!< Selection of protection mode of WPR bits */
+#define  FLASH_OBR_BOR_LEV                   ((uint32_t)0x000F0000)        /*!< BOR_LEV[3:0] Brown Out Reset Threshold Level*/
+
+/******************  Bit definition for FLASH_WRPR register  ******************/
+#define  FLASH_WRPR_WRP                      ((uint32_t)0x0000FFFF)        /*!< Write Protection bits */
+
+/******************************************************************************/
+/*                                                                            */
+/*                       General Purpose IOs (GPIO)                           */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for GPIO_MODER register  *****************/
+#define GPIO_MODER_MODE0          ((uint32_t)0x00000003)
+#define GPIO_MODER_MODE0_0        ((uint32_t)0x00000001)
+#define GPIO_MODER_MODE0_1        ((uint32_t)0x00000002)
+#define GPIO_MODER_MODE1          ((uint32_t)0x0000000C)
+#define GPIO_MODER_MODE1_0        ((uint32_t)0x00000004)
+#define GPIO_MODER_MODE1_1        ((uint32_t)0x00000008)
+#define GPIO_MODER_MODE2          ((uint32_t)0x00000030)
+#define GPIO_MODER_MODE2_0        ((uint32_t)0x00000010)
+#define GPIO_MODER_MODE2_1        ((uint32_t)0x00000020)
+#define GPIO_MODER_MODE3          ((uint32_t)0x000000C0)
+#define GPIO_MODER_MODE3_0        ((uint32_t)0x00000040)
+#define GPIO_MODER_MODE3_1        ((uint32_t)0x00000080)
+#define GPIO_MODER_MODE4          ((uint32_t)0x00000300)
+#define GPIO_MODER_MODE4_0        ((uint32_t)0x00000100)
+#define GPIO_MODER_MODE4_1        ((uint32_t)0x00000200)
+#define GPIO_MODER_MODE5          ((uint32_t)0x00000C00)
+#define GPIO_MODER_MODE5_0        ((uint32_t)0x00000400)
+#define GPIO_MODER_MODE5_1        ((uint32_t)0x00000800)
+#define GPIO_MODER_MODE6          ((uint32_t)0x00003000)
+#define GPIO_MODER_MODE6_0        ((uint32_t)0x00001000)
+#define GPIO_MODER_MODE6_1        ((uint32_t)0x00002000)
+#define GPIO_MODER_MODE7          ((uint32_t)0x0000C000)
+#define GPIO_MODER_MODE7_0        ((uint32_t)0x00004000)
+#define GPIO_MODER_MODE7_1        ((uint32_t)0x00008000)
+#define GPIO_MODER_MODE8          ((uint32_t)0x00030000)
+#define GPIO_MODER_MODE8_0        ((uint32_t)0x00010000)
+#define GPIO_MODER_MODE8_1        ((uint32_t)0x00020000)
+#define GPIO_MODER_MODE9          ((uint32_t)0x000C0000)
+#define GPIO_MODER_MODE9_0        ((uint32_t)0x00040000)
+#define GPIO_MODER_MODE9_1        ((uint32_t)0x00080000)
+#define GPIO_MODER_MODE10         ((uint32_t)0x00300000)
+#define GPIO_MODER_MODE10_0       ((uint32_t)0x00100000)
+#define GPIO_MODER_MODE10_1       ((uint32_t)0x00200000)
+#define GPIO_MODER_MODE11         ((uint32_t)0x00C00000)
+#define GPIO_MODER_MODE11_0       ((uint32_t)0x00400000)
+#define GPIO_MODER_MODE11_1       ((uint32_t)0x00800000)
+#define GPIO_MODER_MODE12         ((uint32_t)0x03000000)
+#define GPIO_MODER_MODE12_0       ((uint32_t)0x01000000)
+#define GPIO_MODER_MODE12_1       ((uint32_t)0x02000000)
+#define GPIO_MODER_MODE13         ((uint32_t)0x0C000000)
+#define GPIO_MODER_MODE13_0       ((uint32_t)0x04000000)
+#define GPIO_MODER_MODE13_1       ((uint32_t)0x08000000)
+#define GPIO_MODER_MODE14         ((uint32_t)0x30000000)
+#define GPIO_MODER_MODE14_0       ((uint32_t)0x10000000)
+#define GPIO_MODER_MODE14_1       ((uint32_t)0x20000000)
+#define GPIO_MODER_MODE15         ((uint32_t)0xC0000000)
+#define GPIO_MODER_MODE15_0       ((uint32_t)0x40000000)
+#define GPIO_MODER_MODE15_1       ((uint32_t)0x80000000)
+
+/******************  Bit definition for GPIO_OTYPER register  *****************/
+#define GPIO_OTYPER_OT_0           ((uint32_t)0x00000001)
+#define GPIO_OTYPER_OT_1           ((uint32_t)0x00000002)
+#define GPIO_OTYPER_OT_2           ((uint32_t)0x00000004)
+#define GPIO_OTYPER_OT_3           ((uint32_t)0x00000008)
+#define GPIO_OTYPER_OT_4           ((uint32_t)0x00000010)
+#define GPIO_OTYPER_OT_5           ((uint32_t)0x00000020)
+#define GPIO_OTYPER_OT_6           ((uint32_t)0x00000040)
+#define GPIO_OTYPER_OT_7           ((uint32_t)0x00000080)
+#define GPIO_OTYPER_OT_8           ((uint32_t)0x00000100)
+#define GPIO_OTYPER_OT_9           ((uint32_t)0x00000200)
+#define GPIO_OTYPER_OT_10          ((uint32_t)0x00000400)
+#define GPIO_OTYPER_OT_11          ((uint32_t)0x00000800)
+#define GPIO_OTYPER_OT_12          ((uint32_t)0x00001000)
+#define GPIO_OTYPER_OT_13          ((uint32_t)0x00002000)
+#define GPIO_OTYPER_OT_14          ((uint32_t)0x00004000)
+#define GPIO_OTYPER_OT_15          ((uint32_t)0x00008000)
+
+/****************  Bit definition for GPIO_OSPEEDR register  ******************/
+#define GPIO_OSPEEDER_OSPEED0     ((uint32_t)0x00000003)
+#define GPIO_OSPEEDER_OSPEED0_0   ((uint32_t)0x00000001)
+#define GPIO_OSPEEDER_OSPEED0_1   ((uint32_t)0x00000002)
+#define GPIO_OSPEEDER_OSPEED1     ((uint32_t)0x0000000C)
+#define GPIO_OSPEEDER_OSPEED1_0   ((uint32_t)0x00000004)
+#define GPIO_OSPEEDER_OSPEED1_1   ((uint32_t)0x00000008)
+#define GPIO_OSPEEDER_OSPEED2     ((uint32_t)0x00000030)
+#define GPIO_OSPEEDER_OSPEED2_0   ((uint32_t)0x00000010)
+#define GPIO_OSPEEDER_OSPEED2_1   ((uint32_t)0x00000020)
+#define GPIO_OSPEEDER_OSPEED3     ((uint32_t)0x000000C0)
+#define GPIO_OSPEEDER_OSPEED3_0   ((uint32_t)0x00000040)
+#define GPIO_OSPEEDER_OSPEED3_1   ((uint32_t)0x00000080)
+#define GPIO_OSPEEDER_OSPEED4     ((uint32_t)0x00000300)
+#define GPIO_OSPEEDER_OSPEED4_0   ((uint32_t)0x00000100)
+#define GPIO_OSPEEDER_OSPEED4_1   ((uint32_t)0x00000200)
+#define GPIO_OSPEEDER_OSPEED5     ((uint32_t)0x00000C00)
+#define GPIO_OSPEEDER_OSPEED5_0   ((uint32_t)0x00000400)
+#define GPIO_OSPEEDER_OSPEED5_1   ((uint32_t)0x00000800)
+#define GPIO_OSPEEDER_OSPEED6     ((uint32_t)0x00003000)
+#define GPIO_OSPEEDER_OSPEED6_0   ((uint32_t)0x00001000)
+#define GPIO_OSPEEDER_OSPEED6_1   ((uint32_t)0x00002000)
+#define GPIO_OSPEEDER_OSPEED7     ((uint32_t)0x0000C000)
+#define GPIO_OSPEEDER_OSPEED7_0   ((uint32_t)0x00004000)
+#define GPIO_OSPEEDER_OSPEED7_1   ((uint32_t)0x00008000)
+#define GPIO_OSPEEDER_OSPEED8     ((uint32_t)0x00030000)
+#define GPIO_OSPEEDER_OSPEED8_0   ((uint32_t)0x00010000)
+#define GPIO_OSPEEDER_OSPEED8_1   ((uint32_t)0x00020000)
+#define GPIO_OSPEEDER_OSPEED9     ((uint32_t)0x000C0000)
+#define GPIO_OSPEEDER_OSPEED9_0   ((uint32_t)0x00040000)
+#define GPIO_OSPEEDER_OSPEED9_1   ((uint32_t)0x00080000)
+#define GPIO_OSPEEDER_OSPEED10    ((uint32_t)0x00300000)
+#define GPIO_OSPEEDER_OSPEED10_0  ((uint32_t)0x00100000)
+#define GPIO_OSPEEDER_OSPEED10_1  ((uint32_t)0x00200000)
+#define GPIO_OSPEEDER_OSPEED11    ((uint32_t)0x00C00000)
+#define GPIO_OSPEEDER_OSPEED11_0  ((uint32_t)0x00400000)
+#define GPIO_OSPEEDER_OSPEED11_1  ((uint32_t)0x00800000)
+#define GPIO_OSPEEDER_OSPEED12    ((uint32_t)0x03000000)
+#define GPIO_OSPEEDER_OSPEED12_0  ((uint32_t)0x01000000)
+#define GPIO_OSPEEDER_OSPEED12_1  ((uint32_t)0x02000000)
+#define GPIO_OSPEEDER_OSPEED13    ((uint32_t)0x0C000000)
+#define GPIO_OSPEEDER_OSPEED13_0  ((uint32_t)0x04000000)
+#define GPIO_OSPEEDER_OSPEED13_1  ((uint32_t)0x08000000)
+#define GPIO_OSPEEDER_OSPEED14    ((uint32_t)0x30000000)
+#define GPIO_OSPEEDER_OSPEED14_0  ((uint32_t)0x10000000)
+#define GPIO_OSPEEDER_OSPEED14_1  ((uint32_t)0x20000000)
+#define GPIO_OSPEEDER_OSPEED15    ((uint32_t)0xC0000000)
+#define GPIO_OSPEEDER_OSPEED15_0  ((uint32_t)0x40000000)
+#define GPIO_OSPEEDER_OSPEED15_1  ((uint32_t)0x80000000)
+
+/*******************  Bit definition for GPIO_PUPDR register ******************/
+#define GPIO_PUPDR_PUPD0          ((uint32_t)0x00000003)
+#define GPIO_PUPDR_PUPD0_0        ((uint32_t)0x00000001)
+#define GPIO_PUPDR_PUPD0_1        ((uint32_t)0x00000002)
+#define GPIO_PUPDR_PUPD1          ((uint32_t)0x0000000C)
+#define GPIO_PUPDR_PUPD1_0        ((uint32_t)0x00000004)
+#define GPIO_PUPDR_PUPD1_1        ((uint32_t)0x00000008)
+#define GPIO_PUPDR_PUPD2          ((uint32_t)0x00000030)
+#define GPIO_PUPDR_PUPD2_0        ((uint32_t)0x00000010)
+#define GPIO_PUPDR_PUPD2_1        ((uint32_t)0x00000020)
+#define GPIO_PUPDR_PUPD3          ((uint32_t)0x000000C0)
+#define GPIO_PUPDR_PUPD3_0        ((uint32_t)0x00000040)
+#define GPIO_PUPDR_PUPD3_1        ((uint32_t)0x00000080)
+#define GPIO_PUPDR_PUPD4          ((uint32_t)0x00000300)
+#define GPIO_PUPDR_PUPD4_0        ((uint32_t)0x00000100)
+#define GPIO_PUPDR_PUPD4_1        ((uint32_t)0x00000200)
+#define GPIO_PUPDR_PUPD5          ((uint32_t)0x00000C00)
+#define GPIO_PUPDR_PUPD5_0        ((uint32_t)0x00000400)
+#define GPIO_PUPDR_PUPD5_1        ((uint32_t)0x00000800)
+#define GPIO_PUPDR_PUPD6          ((uint32_t)0x00003000)
+#define GPIO_PUPDR_PUPD6_0        ((uint32_t)0x00001000)
+#define GPIO_PUPDR_PUPD6_1        ((uint32_t)0x00002000)
+#define GPIO_PUPDR_PUPD7          ((uint32_t)0x0000C000)
+#define GPIO_PUPDR_PUPD7_0        ((uint32_t)0x00004000)
+#define GPIO_PUPDR_PUPD7_1        ((uint32_t)0x00008000)
+#define GPIO_PUPDR_PUPD8          ((uint32_t)0x00030000)
+#define GPIO_PUPDR_PUPD8_0        ((uint32_t)0x00010000)
+#define GPIO_PUPDR_PUPD8_1        ((uint32_t)0x00020000)
+#define GPIO_PUPDR_PUPD9          ((uint32_t)0x000C0000)
+#define GPIO_PUPDR_PUPD9_0        ((uint32_t)0x00040000)
+#define GPIO_PUPDR_PUPD9_1        ((uint32_t)0x00080000)
+#define GPIO_PUPDR_PUPD10         ((uint32_t)0x00300000)
+#define GPIO_PUPDR_PUPD10_0       ((uint32_t)0x00100000)
+#define GPIO_PUPDR_PUPD10_1       ((uint32_t)0x00200000)
+#define GPIO_PUPDR_PUPD11         ((uint32_t)0x00C00000)
+#define GPIO_PUPDR_PUPD11_0       ((uint32_t)0x00400000)
+#define GPIO_PUPDR_PUPD11_1       ((uint32_t)0x00800000)
+#define GPIO_PUPDR_PUPD12         ((uint32_t)0x03000000)
+#define GPIO_PUPDR_PUPD12_0       ((uint32_t)0x01000000)
+#define GPIO_PUPDR_PUPD12_1       ((uint32_t)0x02000000)
+#define GPIO_PUPDR_PUPD13         ((uint32_t)0x0C000000)
+#define GPIO_PUPDR_PUPD13_0       ((uint32_t)0x04000000)
+#define GPIO_PUPDR_PUPD13_1       ((uint32_t)0x08000000)
+#define GPIO_PUPDR_PUPD14         ((uint32_t)0x30000000)
+#define GPIO_PUPDR_PUPD14_0       ((uint32_t)0x10000000)
+#define GPIO_PUPDR_PUPD14_1       ((uint32_t)0x20000000)
+#define GPIO_PUPDR_PUPD15         ((uint32_t)0xC0000000)
+#define GPIO_PUPDR_PUPD15_0       ((uint32_t)0x40000000)
+#define GPIO_PUPDR_PUPD15_1       ((uint32_t)0x80000000)
+
+/*******************  Bit definition for GPIO_IDR register  *******************/
+#define GPIO_IDR_ID0                 ((uint32_t)0x00000001)
+#define GPIO_IDR_ID1                 ((uint32_t)0x00000002)
+#define GPIO_IDR_ID2                 ((uint32_t)0x00000004)
+#define GPIO_IDR_ID3                 ((uint32_t)0x00000008)
+#define GPIO_IDR_ID4                 ((uint32_t)0x00000010)
+#define GPIO_IDR_ID5                 ((uint32_t)0x00000020)
+#define GPIO_IDR_ID6                 ((uint32_t)0x00000040)
+#define GPIO_IDR_ID7                 ((uint32_t)0x00000080)
+#define GPIO_IDR_ID8                 ((uint32_t)0x00000100)
+#define GPIO_IDR_ID9                 ((uint32_t)0x00000200)
+#define GPIO_IDR_ID10                ((uint32_t)0x00000400)
+#define GPIO_IDR_ID11                ((uint32_t)0x00000800)
+#define GPIO_IDR_ID12                ((uint32_t)0x00001000)
+#define GPIO_IDR_ID13                ((uint32_t)0x00002000)
+#define GPIO_IDR_ID14                ((uint32_t)0x00004000)
+#define GPIO_IDR_ID15                ((uint32_t)0x00008000)
+
+/******************  Bit definition for GPIO_ODR register  ********************/
+#define GPIO_ODR_OD0                 ((uint32_t)0x00000001)
+#define GPIO_ODR_OD1                 ((uint32_t)0x00000002)
+#define GPIO_ODR_OD2                 ((uint32_t)0x00000004)
+#define GPIO_ODR_OD3                 ((uint32_t)0x00000008)
+#define GPIO_ODR_OD4                 ((uint32_t)0x00000010)
+#define GPIO_ODR_OD5                 ((uint32_t)0x00000020)
+#define GPIO_ODR_OD6                 ((uint32_t)0x00000040)
+#define GPIO_ODR_OD7                 ((uint32_t)0x00000080)
+#define GPIO_ODR_OD8                 ((uint32_t)0x00000100)
+#define GPIO_ODR_OD9                 ((uint32_t)0x00000200)
+#define GPIO_ODR_OD10                ((uint32_t)0x00000400)
+#define GPIO_ODR_OD11                ((uint32_t)0x00000800)
+#define GPIO_ODR_OD12                ((uint32_t)0x00001000)
+#define GPIO_ODR_OD13                ((uint32_t)0x00002000)
+#define GPIO_ODR_OD14                ((uint32_t)0x00004000)
+#define GPIO_ODR_OD15                ((uint32_t)0x00008000)
+
+/****************** Bit definition for GPIO_BSRR register  ********************/
+#define GPIO_BSRR_BS_0             ((uint32_t)0x00000001)
+#define GPIO_BSRR_BS_1             ((uint32_t)0x00000002)
+#define GPIO_BSRR_BS_2             ((uint32_t)0x00000004)
+#define GPIO_BSRR_BS_3             ((uint32_t)0x00000008)
+#define GPIO_BSRR_BS_4             ((uint32_t)0x00000010)
+#define GPIO_BSRR_BS_5             ((uint32_t)0x00000020)
+#define GPIO_BSRR_BS_6             ((uint32_t)0x00000040)
+#define GPIO_BSRR_BS_7             ((uint32_t)0x00000080)
+#define GPIO_BSRR_BS_8             ((uint32_t)0x00000100)
+#define GPIO_BSRR_BS_9             ((uint32_t)0x00000200)
+#define GPIO_BSRR_BS_10            ((uint32_t)0x00000400)
+#define GPIO_BSRR_BS_11            ((uint32_t)0x00000800)
+#define GPIO_BSRR_BS_12            ((uint32_t)0x00001000)
+#define GPIO_BSRR_BS_13            ((uint32_t)0x00002000)
+#define GPIO_BSRR_BS_14            ((uint32_t)0x00004000)
+#define GPIO_BSRR_BS_15            ((uint32_t)0x00008000)
+#define GPIO_BSRR_BR_0             ((uint32_t)0x00010000)
+#define GPIO_BSRR_BR_1             ((uint32_t)0x00020000)
+#define GPIO_BSRR_BR_2             ((uint32_t)0x00040000)
+#define GPIO_BSRR_BR_3             ((uint32_t)0x00080000)
+#define GPIO_BSRR_BR_4             ((uint32_t)0x00100000)
+#define GPIO_BSRR_BR_5             ((uint32_t)0x00200000)
+#define GPIO_BSRR_BR_6             ((uint32_t)0x00400000)
+#define GPIO_BSRR_BR_7             ((uint32_t)0x00800000)
+#define GPIO_BSRR_BR_8             ((uint32_t)0x01000000)
+#define GPIO_BSRR_BR_9             ((uint32_t)0x02000000)
+#define GPIO_BSRR_BR_10            ((uint32_t)0x04000000)
+#define GPIO_BSRR_BR_11            ((uint32_t)0x08000000)
+#define GPIO_BSRR_BR_12            ((uint32_t)0x10000000)
+#define GPIO_BSRR_BR_13            ((uint32_t)0x20000000)
+#define GPIO_BSRR_BR_14            ((uint32_t)0x40000000)
+#define GPIO_BSRR_BR_15            ((uint32_t)0x80000000)
+
+/****************** Bit definition for GPIO_LCKR register  ********************/
+#define GPIO_LCKR_LCK0             ((uint32_t)0x00000001)
+#define GPIO_LCKR_LCK1             ((uint32_t)0x00000002)
+#define GPIO_LCKR_LCK2             ((uint32_t)0x00000004)
+#define GPIO_LCKR_LCK3             ((uint32_t)0x00000008)
+#define GPIO_LCKR_LCK4             ((uint32_t)0x00000010)
+#define GPIO_LCKR_LCK5             ((uint32_t)0x00000020)
+#define GPIO_LCKR_LCK6             ((uint32_t)0x00000040)
+#define GPIO_LCKR_LCK7             ((uint32_t)0x00000080)
+#define GPIO_LCKR_LCK8             ((uint32_t)0x00000100)
+#define GPIO_LCKR_LCK9             ((uint32_t)0x00000200)
+#define GPIO_LCKR_LCK10            ((uint32_t)0x00000400)
+#define GPIO_LCKR_LCK11            ((uint32_t)0x00000800)
+#define GPIO_LCKR_LCK12            ((uint32_t)0x00001000)
+#define GPIO_LCKR_LCK13            ((uint32_t)0x00002000)
+#define GPIO_LCKR_LCK14            ((uint32_t)0x00004000)
+#define GPIO_LCKR_LCK15            ((uint32_t)0x00008000)
+#define GPIO_LCKR_LCKK             ((uint32_t)0x00010000)
+
+/****************** Bit definition for GPIO_BRR register  *********************/
+#define GPIO_BRR_BR_0              ((uint32_t)0x00000001)
+#define GPIO_BRR_BR_1              ((uint32_t)0x00000002)
+#define GPIO_BRR_BR_2              ((uint32_t)0x00000004)
+#define GPIO_BRR_BR_3              ((uint32_t)0x00000008)
+#define GPIO_BRR_BR_4              ((uint32_t)0x00000010)
+#define GPIO_BRR_BR_5              ((uint32_t)0x00000020)
+#define GPIO_BRR_BR_6              ((uint32_t)0x00000040)
+#define GPIO_BRR_BR_7              ((uint32_t)0x00000080)
+#define GPIO_BRR_BR_8              ((uint32_t)0x00000100)
+#define GPIO_BRR_BR_9              ((uint32_t)0x00000200)
+#define GPIO_BRR_BR_10             ((uint32_t)0x00000400)
+#define GPIO_BRR_BR_11             ((uint32_t)0x00000800)
+#define GPIO_BRR_BR_12             ((uint32_t)0x00001000)
+#define GPIO_BRR_BR_13             ((uint32_t)0x00002000)
+#define GPIO_BRR_BR_14             ((uint32_t)0x00004000)
+#define GPIO_BRR_BR_15             ((uint32_t)0x00008000)
+
+/******************************************************************************/
+/*                                                                            */
+/*                   Inter-integrated Circuit Interface (I2C)                 */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for I2C_CR1 register  *******************/
+#define  I2C_CR1_PE                          ((uint32_t)0x00000001)        /*!< Peripheral enable */
+#define  I2C_CR1_TXIE                        ((uint32_t)0x00000002)        /*!< TX interrupt enable */
+#define  I2C_CR1_RXIE                        ((uint32_t)0x00000004)        /*!< RX interrupt enable */
+#define  I2C_CR1_ADDRIE                      ((uint32_t)0x00000008)        /*!< Address match interrupt enable */
+#define  I2C_CR1_NACKIE                      ((uint32_t)0x00000010)        /*!< NACK received interrupt enable */
+#define  I2C_CR1_STOPIE                      ((uint32_t)0x00000020)        /*!< STOP detection interrupt enable */
+#define  I2C_CR1_TCIE                        ((uint32_t)0x00000040)        /*!< Transfer complete interrupt enable */
+#define  I2C_CR1_ERRIE                       ((uint32_t)0x00000080)        /*!< Errors interrupt enable */
+#define  I2C_CR1_DFN                         ((uint32_t)0x00000F00)        /*!< Digital noise filter */
+#define  I2C_CR1_ANFOFF                      ((uint32_t)0x00001000)        /*!< Analog noise filter OFF */
+#define  I2C_CR1_TXDMAEN                     ((uint32_t)0x00004000)        /*!< DMA transmission requests enable */
+#define  I2C_CR1_RXDMAEN                     ((uint32_t)0x00008000)        /*!< DMA reception requests enable */
+#define  I2C_CR1_SBC                         ((uint32_t)0x00010000)        /*!< Slave byte control */
+#define  I2C_CR1_NOSTRETCH                   ((uint32_t)0x00020000)        /*!< Clock stretching disable */
+#define  I2C_CR1_WUPEN                       ((uint32_t)0x00040000)        /*!< Wakeup from STOP enable */
+#define  I2C_CR1_GCEN                        ((uint32_t)0x00080000)        /*!< General call enable */
+#define  I2C_CR1_SMBHEN                      ((uint32_t)0x00100000)        /*!< SMBus host address enable */
+#define  I2C_CR1_SMBDEN                      ((uint32_t)0x00200000)        /*!< SMBus device default address enable */
+#define  I2C_CR1_ALERTEN                     ((uint32_t)0x00400000)        /*!< SMBus alert enable */
+#define  I2C_CR1_PECEN                       ((uint32_t)0x00800000)        /*!< PEC enable */
+
+/******************  Bit definition for I2C_CR2 register  ********************/
+#define  I2C_CR2_SADD                        ((uint32_t)0x000003FF)        /*!< Slave address (master mode) */
+#define  I2C_CR2_RD_WRN                      ((uint32_t)0x00000400)        /*!< Transfer direction (master mode) */
+#define  I2C_CR2_ADD10                       ((uint32_t)0x00000800)        /*!< 10-bit addressing mode (master mode) */
+#define  I2C_CR2_HEAD10R                     ((uint32_t)0x00001000)        /*!< 10-bit address header only read direction (master mode) */
+#define  I2C_CR2_START                       ((uint32_t)0x00002000)        /*!< START generation */
+#define  I2C_CR2_STOP                        ((uint32_t)0x00004000)        /*!< STOP generation (master mode) */
+#define  I2C_CR2_NACK                        ((uint32_t)0x00008000)        /*!< NACK generation (slave mode) */
+#define  I2C_CR2_NBYTES                      ((uint32_t)0x00FF0000)        /*!< Number of bytes */
+#define  I2C_CR2_RELOAD                      ((uint32_t)0x01000000)        /*!< NBYTES reload mode */
+#define  I2C_CR2_AUTOEND                     ((uint32_t)0x02000000)        /*!< Automatic end mode (master mode) */
+#define  I2C_CR2_PECBYTE                     ((uint32_t)0x04000000)        /*!< Packet error checking byte */
+
+/*******************  Bit definition for I2C_OAR1 register  ******************/
+#define  I2C_OAR1_OA1                        ((uint32_t)0x000003FF)        /*!< Interface own address 1 */
+#define  I2C_OAR1_OA1MODE                    ((uint32_t)0x00000400)        /*!< Own address 1 10-bit mode */
+#define  I2C_OAR1_OA1EN                      ((uint32_t)0x00008000)        /*!< Own address 1 enable */
+
+/*******************  Bit definition for I2C_OAR2 register  ******************/
+#define  I2C_OAR2_OA2                        ((uint32_t)0x000000FE)        /*!< Interface own address 2 */
+#define  I2C_OAR2_OA2MSK                     ((uint32_t)0x00000700)        /*!< Own address 2 masks */
+#define  I2C_OAR2_OA2EN                      ((uint32_t)0x00008000)        /*!< Own address 2 enable */
+
+/*******************  Bit definition for I2C_TIMINGR register *******************/
+#define  I2C_TIMINGR_SCLL                    ((uint32_t)0x000000FF)        /*!< SCL low period (master mode) */
+#define  I2C_TIMINGR_SCLH                    ((uint32_t)0x0000FF00)        /*!< SCL high period (master mode) */
+#define  I2C_TIMINGR_SDADEL                  ((uint32_t)0x000F0000)        /*!< Data hold time */
+#define  I2C_TIMINGR_SCLDEL                  ((uint32_t)0x00F00000)        /*!< Data setup time */
+#define  I2C_TIMINGR_PRESC                   ((uint32_t)0xF0000000)        /*!< Timings prescaler */
+
+/******************* Bit definition for I2C_TIMEOUTR register *******************/
+#define  I2C_TIMEOUTR_TIMEOUTA               ((uint32_t)0x00000FFF)        /*!< Bus timeout A */
+#define  I2C_TIMEOUTR_TIDLE                  ((uint32_t)0x00001000)        /*!< Idle clock timeout detection */
+#define  I2C_TIMEOUTR_TIMOUTEN               ((uint32_t)0x00008000)        /*!< Clock timeout enable */
+#define  I2C_TIMEOUTR_TIMEOUTB               ((uint32_t)0x0FFF0000)        /*!< Bus timeout B*/
+#define  I2C_TIMEOUTR_TEXTEN                 ((uint32_t)0x80000000)        /*!< Extended clock timeout enable */
+
+/******************  Bit definition for I2C_ISR register  *********************/
+#define  I2C_ISR_TXE                         ((uint32_t)0x00000001)        /*!< Transmit data register empty */
+#define  I2C_ISR_TXIS                        ((uint32_t)0x00000002)        /*!< Transmit interrupt status */
+#define  I2C_ISR_RXNE                        ((uint32_t)0x00000004)        /*!< Receive data register not empty */
+#define  I2C_ISR_ADDR                        ((uint32_t)0x00000008)        /*!< Address matched (slave mode)*/
+#define  I2C_ISR_NACKF                       ((uint32_t)0x00000010)        /*!< NACK received flag */
+#define  I2C_ISR_STOPF                       ((uint32_t)0x00000020)        /*!< STOP detection flag */
+#define  I2C_ISR_TC                          ((uint32_t)0x00000040)        /*!< Transfer complete (master mode) */
+#define  I2C_ISR_TCR                         ((uint32_t)0x00000080)        /*!< Transfer complete reload */
+#define  I2C_ISR_BERR                        ((uint32_t)0x00000100)        /*!< Bus error */
+#define  I2C_ISR_ARLO                        ((uint32_t)0x00000200)        /*!< Arbitration lost */
+#define  I2C_ISR_OVR                         ((uint32_t)0x00000400)        /*!< Overrun/Underrun */
+#define  I2C_ISR_PECERR                      ((uint32_t)0x00000800)        /*!< PEC error in reception */
+#define  I2C_ISR_TIMEOUT                     ((uint32_t)0x00001000)        /*!< Timeout or Tlow detection flag */
+#define  I2C_ISR_ALERT                       ((uint32_t)0x00002000)        /*!< SMBus alert */
+#define  I2C_ISR_BUSY                        ((uint32_t)0x00008000)        /*!< Bus busy */
+#define  I2C_ISR_DIR                         ((uint32_t)0x00010000)        /*!< Transfer direction (slave mode) */
+#define  I2C_ISR_ADDCODE                     ((uint32_t)0x00FE0000)        /*!< Address match code (slave mode) */
+
+/******************  Bit definition for I2C_ICR register  *********************/
+#define  I2C_ICR_ADDRCF                      ((uint32_t)0x00000008)        /*!< Address matched clear flag */
+#define  I2C_ICR_NACKCF                      ((uint32_t)0x00000010)        /*!< NACK clear flag */
+#define  I2C_ICR_STOPCF                      ((uint32_t)0x00000020)        /*!< STOP detection clear flag */
+#define  I2C_ICR_BERRCF                      ((uint32_t)0x00000100)        /*!< Bus error clear flag */
+#define  I2C_ICR_ARLOCF                      ((uint32_t)0x00000200)        /*!< Arbitration lost clear flag */
+#define  I2C_ICR_OVRCF                       ((uint32_t)0x00000400)        /*!< Overrun/Underrun clear flag */
+#define  I2C_ICR_PECCF                       ((uint32_t)0x00000800)        /*!< PAC error clear flag */
+#define  I2C_ICR_TIMOUTCF                    ((uint32_t)0x00001000)        /*!< Timeout clear flag */
+#define  I2C_ICR_ALERTCF                     ((uint32_t)0x00002000)        /*!< Alert clear flag */
+
+/******************  Bit definition for I2C_PECR register  *********************/
+#define  I2C_PECR_PEC                        ((uint32_t)0x000000FF)       /*!< PEC register */
+
+/******************  Bit definition for I2C_RXDR register  *********************/
+#define  I2C_RXDR_RXDATA                     ((uint32_t)0x000000FF)        /*!< 8-bit receive data */
+
+/******************  Bit definition for I2C_TXDR register  *********************/
+#define  I2C_TXDR_TXDATA                     ((uint32_t)0x000000FF)        /*!< 8-bit transmit data */
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Independent WATCHDOG (IWDG)                         */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define  IWDG_KR_KEY                         ((uint32_t)0x0000FFFF)            /*!< Key value (write only, read 0000h) */
+
+/*******************  Bit definition for IWDG_PR register  ********************/
+#define  IWDG_PR_PR                          ((uint32_t)0x00000007)               /*!< PR[2:0] (Prescaler divider) */
+#define  IWDG_PR_PR_0                        ((uint32_t)0x00000001)               /*!< Bit 0 */
+#define  IWDG_PR_PR_1                        ((uint32_t)0x00000002)               /*!< Bit 1 */
+#define  IWDG_PR_PR_2                        ((uint32_t)0x00000004)               /*!< Bit 2 */
+
+/*******************  Bit definition for IWDG_RLR register  *******************/
+#define  IWDG_RLR_RL                         ((uint32_t)0x00000FFF)            /*!< Watchdog counter reload value */
+
+/*******************  Bit definition for IWDG_SR register  ********************/
+#define  IWDG_SR_PVU                         ((uint32_t)0x00000001)               /*!< Watchdog prescaler value update */
+#define  IWDG_SR_RVU                         ((uint32_t)0x00000002)               /*!< Watchdog counter reload value update */
+#define  IWDG_SR_WVU                         ((uint32_t)0x00000004)               /*!< Watchdog counter window value update */
+
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define  IWDG_WINR_WIN                       ((uint32_t)0x00000FFF)            /*!< Watchdog counter window value */
+
+/******************************************************************************/
+/*                                                                            */
+/*                          LCD Controller (LCD)                              */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for LCD_CR register  *********************/
+#define LCD_CR_LCDEN               ((uint32_t)0x00000001)     /*!< LCD Enable Bit */
+#define LCD_CR_VSEL                ((uint32_t)0x00000002)     /*!< Voltage source selector Bit */
+
+#define LCD_CR_DUTY                ((uint32_t)0x0000001C)     /*!< DUTY[2:0] bits (Duty selector) */
+#define LCD_CR_DUTY_0              ((uint32_t)0x00000004)     /*!< Duty selector Bit 0 */
+#define LCD_CR_DUTY_1              ((uint32_t)0x00000008)     /*!< Duty selector Bit 1 */
+#define LCD_CR_DUTY_2              ((uint32_t)0x00000010)     /*!< Duty selector Bit 2 */
+
+#define LCD_CR_BIAS                ((uint32_t)0x00000060)     /*!< BIAS[1:0] bits (Bias selector) */
+#define LCD_CR_BIAS_0              ((uint32_t)0x00000020)     /*!< Bias selector Bit 0 */
+#define LCD_CR_BIAS_1              ((uint32_t)0x00000040)     /*!< Bias selector Bit 1 */
+
+#define LCD_CR_MUX_SEG             ((uint32_t)0x00000080)     /*!< Mux Segment Enable Bit */
+
+/*******************  Bit definition for LCD_FCR register  ********************/
+#define LCD_FCR_HD                 ((uint32_t)0x00000001)     /*!< High Drive Enable Bit */
+#define LCD_FCR_SOFIE              ((uint32_t)0x00000002)     /*!< Start of Frame Interrupt Enable Bit */
+#define LCD_FCR_UDDIE              ((uint32_t)0x00000008)     /*!< Update Display Done Interrupt Enable Bit */
+
+#define LCD_FCR_PON                ((uint32_t)0x00000070)     /*!< PON[2:0] bits (Puls ON Duration) */
+#define LCD_FCR_PON_0              ((uint32_t)0x00000010)     /*!< Bit 0 */
+#define LCD_FCR_PON_1              ((uint32_t)0x00000020)     /*!< Bit 1 */
+#define LCD_FCR_PON_2              ((uint32_t)0x00000040)     /*!< Bit 2 */
+
+#define LCD_FCR_DEAD               ((uint32_t)0x00000380)     /*!< DEAD[2:0] bits (DEAD Time) */
+#define LCD_FCR_DEAD_0             ((uint32_t)0x00000080)     /*!< Bit 0 */
+#define LCD_FCR_DEAD_1             ((uint32_t)0x00000100)     /*!< Bit 1 */
+#define LCD_FCR_DEAD_2             ((uint32_t)0x00000200)     /*!< Bit 2 */
+
+#define LCD_FCR_CC                 ((uint32_t)0x00001C00)     /*!< CC[2:0] bits (Contrast Control) */
+#define LCD_FCR_CC_0               ((uint32_t)0x00000400)     /*!< Bit 0 */
+#define LCD_FCR_CC_1               ((uint32_t)0x00000800)     /*!< Bit 1 */
+#define LCD_FCR_CC_2               ((uint32_t)0x00001000)     /*!< Bit 2 */
+
+#define LCD_FCR_BLINKF             ((uint32_t)0x0000E000)     /*!< BLINKF[2:0] bits (Blink Frequency) */
+#define LCD_FCR_BLINKF_0           ((uint32_t)0x00002000)     /*!< Bit 0 */
+#define LCD_FCR_BLINKF_1           ((uint32_t)0x00004000)     /*!< Bit 1 */
+#define LCD_FCR_BLINKF_2           ((uint32_t)0x00008000)     /*!< Bit 2 */
+
+#define LCD_FCR_BLINK              ((uint32_t)0x00030000)     /*!< BLINK[1:0] bits (Blink Enable) */
+#define LCD_FCR_BLINK_0            ((uint32_t)0x00010000)     /*!< Bit 0 */
+#define LCD_FCR_BLINK_1            ((uint32_t)0x00020000)     /*!< Bit 1 */
+
+#define LCD_FCR_DIV                ((uint32_t)0x003C0000)     /*!< DIV[3:0] bits (Divider) */
+#define LCD_FCR_PS                 ((uint32_t)0x03C00000)     /*!< PS[3:0] bits (Prescaler) */
+
+/*******************  Bit definition for LCD_SR register  *********************/
+#define LCD_SR_ENS                 ((uint32_t)0x00000001)     /*!< LCD Enabled Bit */
+#define LCD_SR_SOF                 ((uint32_t)0x00000002)     /*!< Start Of Frame Flag Bit */
+#define LCD_SR_UDR                 ((uint32_t)0x00000004)     /*!< Update Display Request Bit */
+#define LCD_SR_UDD                 ((uint32_t)0x00000008)     /*!< Update Display Done Flag Bit */
+#define LCD_SR_RDY                 ((uint32_t)0x00000010)     /*!< Ready Flag Bit */
+#define LCD_SR_FCRSR               ((uint32_t)0x00000020)     /*!< LCD FCR Register Synchronization Flag Bit */
+
+/*******************  Bit definition for LCD_CLR register  ********************/
+#define LCD_CLR_SOFC               ((uint32_t)0x00000002)     /*!< Start Of Frame Flag Clear Bit */
+#define LCD_CLR_UDDC               ((uint32_t)0x00000008)     /*!< Update Display Done Flag Clear Bit */
+
+/*******************  Bit definition for LCD_RAM register  ********************/
+#define LCD_RAM_SEGMENT_DATA       ((uint32_t)0xFFFFFFFF)     /*!< Segment Data Bits */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Low Power Timer (LPTTIM)                           */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for LPTIM_ISR register  *******************/
+#define  LPTIM_ISR_CMPM                         ((uint32_t)0x00000001)            /*!< Compare match */
+#define  LPTIM_ISR_ARRM                         ((uint32_t)0x00000002)            /*!< Autoreload match */
+#define  LPTIM_ISR_EXTTRIG                      ((uint32_t)0x00000004)            /*!< External trigger edge event */
+#define  LPTIM_ISR_CMPOK                        ((uint32_t)0x00000008)            /*!< Compare register update OK */
+#define  LPTIM_ISR_ARROK                        ((uint32_t)0x00000010)            /*!< Autoreload register update OK */
+#define  LPTIM_ISR_UP                           ((uint32_t)0x00000020)            /*!< Counter direction change down to up */
+#define  LPTIM_ISR_DOWN                         ((uint32_t)0x00000040)            /*!< Counter direction change up to down */
+
+/******************  Bit definition for LPTIM_ICR register  *******************/
+#define  LPTIM_ICR_CMPMCF                       ((uint32_t)0x00000001)            /*!< Compare match Clear Flag */
+#define  LPTIM_ICR_ARRMCF                       ((uint32_t)0x00000002)            /*!< Autoreload match Clear Flag */
+#define  LPTIM_ICR_EXTTRIGCF                    ((uint32_t)0x00000004)            /*!< External trigger edge event Clear Flag */
+#define  LPTIM_ICR_CMPOKCF                      ((uint32_t)0x00000008)            /*!< Compare register update OK Clear Flag */
+#define  LPTIM_ICR_ARROKCF                      ((uint32_t)0x00000010)            /*!< Autoreload register update OK Clear Flag */
+#define  LPTIM_ICR_UPCF                         ((uint32_t)0x00000020)            /*!< Counter direction change down to up Clear Flag */
+#define  LPTIM_ICR_DOWNCF                       ((uint32_t)0x00000040)            /*!< Counter direction change up to down Clear Flag */
+
+/******************  Bit definition for LPTIM_IER register ********************/
+#define  LPTIM_IER_CMPMIE                       ((uint32_t)0x00000001)            /*!< Compare match Interrupt Enable */
+#define  LPTIM_IER_ARRMIE                       ((uint32_t)0x00000002)            /*!< Autoreload match Interrupt Enable */
+#define  LPTIM_IER_EXTTRIGIE                    ((uint32_t)0x00000004)            /*!< External trigger edge event Interrupt Enable */
+#define  LPTIM_IER_CMPOKIE                      ((uint32_t)0x00000008)            /*!< Compare register update OK Interrupt Enable */
+#define  LPTIM_IER_ARROKIE                      ((uint32_t)0x00000010)            /*!< Autoreload register update OK Interrupt Enable */
+#define  LPTIM_IER_UPIE                         ((uint32_t)0x00000020)            /*!< Counter direction change down to up Interrupt Enable */
+#define  LPTIM_IER_DOWNIE                       ((uint32_t)0x00000040)            /*!< Counter direction change up to down Interrupt Enable */
+
+/******************  Bit definition for LPTIM_CFGR register *******************/
+#define  LPTIM_CFGR_CKSEL                       ((uint32_t)0x00000001)             /*!< Clock selector */
+
+#define  LPTIM_CFGR_CKPOL                       ((uint32_t)0x00000006)             /*!< CKPOL[1:0] bits (Clock polarity) */
+#define  LPTIM_CFGR_CKPOL_0                     ((uint32_t)0x00000002)             /*!< Bit 0 */
+#define  LPTIM_CFGR_CKPOL_1                     ((uint32_t)0x00000004)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_CKFLT                       ((uint32_t)0x00000018)             /*!< CKFLT[1:0] bits (Configurable digital filter for external clock) */
+#define  LPTIM_CFGR_CKFLT_0                     ((uint32_t)0x00000008)             /*!< Bit 0 */
+#define  LPTIM_CFGR_CKFLT_1                     ((uint32_t)0x00000010)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_TRGFLT                      ((uint32_t)0x000000C0)             /*!< TRGFLT[1:0] bits (Configurable digital filter for trigger) */
+#define  LPTIM_CFGR_TRGFLT_0                    ((uint32_t)0x00000040)             /*!< Bit 0 */
+#define  LPTIM_CFGR_TRGFLT_1                    ((uint32_t)0x00000080)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_PRESC                       ((uint32_t)0x00000E00)             /*!< PRESC[2:0] bits (Clock prescaler) */
+#define  LPTIM_CFGR_PRESC_0                     ((uint32_t)0x00000200)             /*!< Bit 0 */
+#define  LPTIM_CFGR_PRESC_1                     ((uint32_t)0x00000400)             /*!< Bit 1 */
+#define  LPTIM_CFGR_PRESC_2                     ((uint32_t)0x00000800)             /*!< Bit 2 */
+
+#define  LPTIM_CFGR_TRIGSEL                     ((uint32_t)0x0000E000)             /*!< TRIGSEL[2:0]] bits (Trigger selector) */
+#define  LPTIM_CFGR_TRIGSEL_0                   ((uint32_t)0x00002000)             /*!< Bit 0 */
+#define  LPTIM_CFGR_TRIGSEL_1                   ((uint32_t)0x00004000)             /*!< Bit 1 */
+#define  LPTIM_CFGR_TRIGSEL_2                   ((uint32_t)0x00008000)             /*!< Bit 2 */
+
+#define  LPTIM_CFGR_TRIGEN                      ((uint32_t)0x00060000)             /*!< TRIGEN[1:0] bits (Trigger enable and polarity) */
+#define  LPTIM_CFGR_TRIGEN_0                    ((uint32_t)0x00020000)             /*!< Bit 0 */
+#define  LPTIM_CFGR_TRIGEN_1                    ((uint32_t)0x00040000)             /*!< Bit 1 */
+
+#define  LPTIM_CFGR_TIMOUT                      ((uint32_t)0x00080000)             /*!< Timout enable */
+#define  LPTIM_CFGR_WAVE                        ((uint32_t)0x00100000)             /*!< Waveform shape */
+#define  LPTIM_CFGR_WAVPOL                      ((uint32_t)0x00200000)             /*!< Waveform shape polarity */
+#define  LPTIM_CFGR_PRELOAD                     ((uint32_t)0x00400000)             /*!< Reg update mode */
+#define  LPTIM_CFGR_COUNTMODE                   ((uint32_t)0x00800000)             /*!< Counter mode enable */
+#define  LPTIM_CFGR_ENC                         ((uint32_t)0x01000000)             /*!< Encoder mode enable */
+
+/******************  Bit definition for LPTIM_CR register  ********************/
+#define  LPTIM_CR_ENABLE                        ((uint32_t)0x00000001)             /*!< LPTIMer enable */
+#define  LPTIM_CR_SNGSTRT                       ((uint32_t)0x00000002)             /*!< Timer start in single mode */
+#define  LPTIM_CR_CNTSTRT                       ((uint32_t)0x00000004)             /*!< Timer start in continuous mode */
+
+/******************  Bit definition for LPTIM_CMP register  *******************/
+#define  LPTIM_CMP_CMP                          ((uint32_t)0x0000FFFF)             /*!< Compare register */
+
+/******************  Bit definition for LPTIM_ARR register  *******************/
+#define  LPTIM_ARR_ARR                          ((uint32_t)0x0000FFFF)             /*!< Auto reload register */
+
+/******************  Bit definition for LPTIM_CNT register  *******************/
+#define  LPTIM_CNT_CNT                          ((uint32_t)0x0000FFFF)             /*!< Counter register */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            MIFARE   Firewall                               */
+/*                                                                            */
+/******************************************************************************/
+
+/*******Bit definition for CSSA;CSL;NVDSSA;NVDSL;VDSSA;VDSL register */
+#define  FW_CSSA_ADD                        ((uint32_t)0x00FFFF00)        /*!< Code Segment Start Address */ 
+#define  FW_CSL_LENG                        ((uint32_t)0x003FFF00)        /*!< Code Segment Length        */  
+#define  FW_NVDSSA_ADD                      ((uint32_t)0x00FFFF00)        /*!< Non Volatile Dat Segment Start Address */ 
+#define  FW_NVDSL_LENG                      ((uint32_t)0x003FFF00)        /*!< Non Volatile Data Segment Length */ 
+#define  FW_VDSSA_ADD                       ((uint32_t)0x0000FFC0)        /*!< Volatile Data Segment Start Address */ 
+#define  FW_VDSL_LENG                       ((uint32_t)0x0000FFC0)        /*!< Volatile Data Segment Length */ 
+
+/**************************Bit definition for CR register *********************/
+#define  FW_CR_FPA                          ((uint32_t)0x00000001)         /*!< Firewall Pre Arm*/ 
+#define  FW_CR_VDS                          ((uint32_t)0x00000002)         /*!< Volatile Data Sharing*/ 
+#define  FW_CR_VDE                          ((uint32_t)0x00000004)         /*!< Volatile Data Execution*/ 
+
+/******************************************************************************/
+/*                                                                            */
+/*                          Power Control (PWR)                               */
+/*                                                                            */
+/******************************************************************************/
+
+/********************  Bit definition for PWR_CR register  ********************/
+#define  PWR_CR_LPSDSR                       ((uint32_t)0x00000001)     /*!< Low-power deepsleep/sleep/low power run */
+#define  PWR_CR_PDDS                         ((uint32_t)0x00000002)     /*!< Power Down Deepsleep */
+#define  PWR_CR_CWUF                         ((uint32_t)0x00000004)     /*!< Clear Wakeup Flag */
+#define  PWR_CR_CSBF                         ((uint32_t)0x00000008)     /*!< Clear Standby Flag */
+#define  PWR_CR_PVDE                         ((uint32_t)0x00000010)     /*!< Power Voltage Detector Enable */
+
+#define  PWR_CR_PLS                          ((uint32_t)0x000000E0)     /*!< PLS[2:0] bits (PVD Level Selection) */
+#define  PWR_CR_PLS_0                        ((uint32_t)0x00000020)     /*!< Bit 0 */
+#define  PWR_CR_PLS_1                        ((uint32_t)0x00000040)     /*!< Bit 1 */
+#define  PWR_CR_PLS_2                        ((uint32_t)0x00000080)     /*!< Bit 2 */
+
+/*!< PVD level configuration */
+#define  PWR_CR_PLS_LEV0                     ((uint32_t)0x00000000)     /*!< PVD level 0 */
+#define  PWR_CR_PLS_LEV1                     ((uint32_t)0x00000020)     /*!< PVD level 1 */
+#define  PWR_CR_PLS_LEV2                     ((uint32_t)0x00000040)     /*!< PVD level 2 */
+#define  PWR_CR_PLS_LEV3                     ((uint32_t)0x00000060)     /*!< PVD level 3 */
+#define  PWR_CR_PLS_LEV4                     ((uint32_t)0x00000080)     /*!< PVD level 4 */
+#define  PWR_CR_PLS_LEV5                     ((uint32_t)0x000000A0)     /*!< PVD level 5 */
+#define  PWR_CR_PLS_LEV6                     ((uint32_t)0x000000C0)     /*!< PVD level 6 */
+#define  PWR_CR_PLS_LEV7                     ((uint32_t)0x000000E0)     /*!< PVD level 7 */
+
+#define  PWR_CR_DBP                          ((uint32_t)0x00000100)     /*!< Disable Backup Domain write protection */
+#define  PWR_CR_ULP                          ((uint32_t)0x00000200)     /*!< Ultra Low Power mode */
+#define  PWR_CR_FWU                          ((uint32_t)0x00000400)     /*!< Fast wakeup */
+
+#define  PWR_CR_VOS                          ((uint32_t)0x00001800)     /*!< VOS[1:0] bits (Voltage scaling range selection) */
+#define  PWR_CR_VOS_0                        ((uint32_t)0x00000800)     /*!< Bit 0 */
+#define  PWR_CR_VOS_1                        ((uint32_t)0x00001000)     /*!< Bit 1 */
+#define  PWR_CR_DSEEKOFF                     ((uint32_t)0x00002000)     /*!< Deep Sleep mode with EEPROM kept Off */
+#define  PWR_CR_LPRUN                        ((uint32_t)0x00004000)     /*!< Low power run mode */
+
+/*******************  Bit definition for PWR_CSR register  ********************/
+#define  PWR_CSR_WUF                         ((uint32_t)0x00000001)     /*!< Wakeup Flag */
+#define  PWR_CSR_SBF                         ((uint32_t)0x00000002)     /*!< Standby Flag */
+#define  PWR_CSR_PVDO                        ((uint32_t)0x00000004)     /*!< PVD Output */
+#define  PWR_CSR_VREFINTRDYF                 ((uint32_t)0x00000008)     /*!< Internal voltage reference (VREFINT) ready flag */
+#define  PWR_CSR_VOSF                        ((uint32_t)0x00000010)     /*!< Voltage Scaling select flag */
+#define  PWR_CSR_REGLPF                      ((uint32_t)0x00000020)     /*!< Regulator LP flag */
+
+#define  PWR_CSR_EWUP1                       ((uint32_t)0x00000100)     /*!< Enable WKUP pin 1 */
+#define  PWR_CSR_EWUP2                       ((uint32_t)0x00000200)     /*!< Enable WKUP pin 2 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Reset and Clock Control                            */
+/*                                                                            */
+/******************************************************************************/
+
+/********************  Bit definition for RCC_CR register  ********************/
+#define  RCC_CR_HSION                        ((uint32_t)0x00000001)        /*!< Internal High Speed clock enable */
+#define  RCC_CR_HSIKERON                     ((uint32_t)0x00000002)        /*!< Internal High Speed clock enable for some IPs Kernel */
+#define  RCC_CR_HSIRDY                       ((uint32_t)0x00000004)        /*!< Internal High Speed clock ready flag */
+#define  RCC_CR_HSIDIVEN                     ((uint32_t)0x00000008)        /*!< Internal High Speed clock divider enable */
+#define  RCC_CR_HSIDIVF                      ((uint32_t)0x00000010)        /*!< Internal High Speed clock divider flag */
+#define  RCC_CR_MSION                        ((uint32_t)0x00000100)        /*!< Internal Multi Speed clock enable */
+#define  RCC_CR_MSIRDY                       ((uint32_t)0x00000200)        /*!< Internal Multi Speed clock ready flag */
+#define  RCC_CR_HSEON                        ((uint32_t)0x00010000)        /*!< External High Speed clock enable */
+#define  RCC_CR_HSERDY                       ((uint32_t)0x00020000)        /*!< External High Speed clock ready flag */
+#define  RCC_CR_HSEBYP                       ((uint32_t)0x00040000)        /*!< External High Speed clock Bypass */
+#define  RCC_CR_CSSHSEON                     ((uint32_t)0x00080000)        /*!< HSE Clock Security System enable */
+#define  RCC_CR_RTCPRE                       ((uint32_t)0x00300000)        /*!< RTC/LCD prescaler [1:0] bits */
+#define  RCC_CR_RTCPRE_0                     ((uint32_t)0x00100000)        /*!< RTC/LCD prescaler Bit 0 */
+#define  RCC_CR_RTCPRE_1                     ((uint32_t)0x00200000)        /*!< RTC/LCD prescaler Bit 1 */
+#define  RCC_CR_PLLON                        ((uint32_t)0x01000000)        /*!< PLL enable */
+#define  RCC_CR_PLLRDY                       ((uint32_t)0x02000000)        /*!< PLL clock ready flag */
+
+/********************  Bit definition for RCC_ICSCR register  *****************/
+#define  RCC_ICSCR_HSICAL                    ((uint32_t)0x000000FF)        /*!< Internal High Speed clock Calibration */
+#define  RCC_ICSCR_HSITRIM                   ((uint32_t)0x00001F00)        /*!< Internal High Speed clock trimming */
+
+#define  RCC_ICSCR_MSIRANGE                  ((uint32_t)0x0000E000)        /*!< Internal Multi Speed clock Range */
+#define  RCC_ICSCR_MSIRANGE_0                ((uint32_t)0x00000000)        /*!< Internal Multi Speed clock Range 65.536 KHz */
+#define  RCC_ICSCR_MSIRANGE_1                ((uint32_t)0x00002000)        /*!< Internal Multi Speed clock Range 131.072 KHz */
+#define  RCC_ICSCR_MSIRANGE_2                ((uint32_t)0x00004000)        /*!< Internal Multi Speed clock Range 262.144 KHz */
+#define  RCC_ICSCR_MSIRANGE_3                ((uint32_t)0x00006000)        /*!< Internal Multi Speed clock Range 524.288 KHz */
+#define  RCC_ICSCR_MSIRANGE_4                ((uint32_t)0x00008000)        /*!< Internal Multi Speed clock Range 1.048 MHz */
+#define  RCC_ICSCR_MSIRANGE_5                ((uint32_t)0x0000A000)        /*!< Internal Multi Speed clock Range 2.097 MHz */
+#define  RCC_ICSCR_MSIRANGE_6                ((uint32_t)0x0000C000)        /*!< Internal Multi Speed clock Range 4.194 MHz */
+#define  RCC_ICSCR_MSICAL                    ((uint32_t)0x00FF0000)        /*!< Internal Multi Speed clock Calibration */
+#define  RCC_ICSCR_MSITRIM                   ((uint32_t)0xFF000000)        /*!< Internal Multi Speed clock trimming */
+
+/********************  Bit definition for RCC_CRRCR register  *****************/
+#define  RCC_CRRCR_HSI48ON                    ((uint32_t)0x00000001)        /*!< HSI 48MHz clock enable */
+#define  RCC_CRRCR_HSI48RDY                   ((uint32_t)0x00000002)        /*!< HSI 48MHz clock ready flag */
+#define  RCC_CRRCR_HSI48CAL                   ((uint32_t)0x0000FF00)        /*!< HSI 48MHz clock Calibration */
+
+/*******************  Bit definition for RCC_CFGR register  *******************/
+/*!< SW configuration */
+#define  RCC_CFGR_SW                         ((uint32_t)0x00000003)        /*!< SW[1:0] bits (System clock Switch) */
+#define  RCC_CFGR_SW_0                       ((uint32_t)0x00000001)        /*!< Bit 0 */
+#define  RCC_CFGR_SW_1                       ((uint32_t)0x00000002)        /*!< Bit 1 */
+
+#define  RCC_CFGR_SW_MSI                     ((uint32_t)0x00000000)        /*!< MSI selected as system clock */
+#define  RCC_CFGR_SW_HSI                     ((uint32_t)0x00000001)        /*!< HSI selected as system clock */
+#define  RCC_CFGR_SW_HSE                     ((uint32_t)0x00000002)        /*!< HSE selected as system clock */
+#define  RCC_CFGR_SW_PLL                     ((uint32_t)0x00000003)        /*!< PLL selected as system clock */
+
+/*!< SWS configuration */
+#define  RCC_CFGR_SWS                        ((uint32_t)0x0000000C)        /*!< SWS[1:0] bits (System Clock Switch Status) */
+#define  RCC_CFGR_SWS_0                      ((uint32_t)0x00000004)        /*!< Bit 0 */
+#define  RCC_CFGR_SWS_1                      ((uint32_t)0x00000008)        /*!< Bit 1 */
+
+#define  RCC_CFGR_SWS_MSI                    ((uint32_t)0x00000000)        /*!< MSI oscillator used as system clock */
+#define  RCC_CFGR_SWS_HSI                    ((uint32_t)0x00000004)        /*!< HSI oscillator used as system clock */
+#define  RCC_CFGR_SWS_HSE                    ((uint32_t)0x00000008)        /*!< HSE oscillator used as system clock */
+#define  RCC_CFGR_SWS_PLL                    ((uint32_t)0x0000000C)        /*!< PLL used as system clock */
+
+/*!< HPRE configuration */
+#define  RCC_CFGR_HPRE                       ((uint32_t)0x000000F0)        /*!< HPRE[3:0] bits (AHB prescaler) */
+#define  RCC_CFGR_HPRE_0                     ((uint32_t)0x00000010)        /*!< Bit 0 */
+#define  RCC_CFGR_HPRE_1                     ((uint32_t)0x00000020)        /*!< Bit 1 */
+#define  RCC_CFGR_HPRE_2                     ((uint32_t)0x00000040)        /*!< Bit 2 */
+#define  RCC_CFGR_HPRE_3                     ((uint32_t)0x00000080)        /*!< Bit 3 */
+
+#define  RCC_CFGR_HPRE_DIV1                  ((uint32_t)0x00000000)        /*!< SYSCLK not divided */
+#define  RCC_CFGR_HPRE_DIV2                  ((uint32_t)0x00000080)        /*!< SYSCLK divided by 2 */
+#define  RCC_CFGR_HPRE_DIV4                  ((uint32_t)0x00000090)        /*!< SYSCLK divided by 4 */
+#define  RCC_CFGR_HPRE_DIV8                  ((uint32_t)0x000000A0)        /*!< SYSCLK divided by 8 */
+#define  RCC_CFGR_HPRE_DIV16                 ((uint32_t)0x000000B0)        /*!< SYSCLK divided by 16 */
+#define  RCC_CFGR_HPRE_DIV64                 ((uint32_t)0x000000C0)        /*!< SYSCLK divided by 64 */
+#define  RCC_CFGR_HPRE_DIV128                ((uint32_t)0x000000D0)        /*!< SYSCLK divided by 128 */
+#define  RCC_CFGR_HPRE_DIV256                ((uint32_t)0x000000E0)        /*!< SYSCLK divided by 256 */
+#define  RCC_CFGR_HPRE_DIV512                ((uint32_t)0x000000F0)        /*!< SYSCLK divided by 512 */
+
+/*!< PPRE1 configuration */
+#define  RCC_CFGR_PPRE1                      ((uint32_t)0x00000700)        /*!< PRE1[2:0] bits (APB1 prescaler) */
+#define  RCC_CFGR_PPRE1_0                    ((uint32_t)0x00000100)        /*!< Bit 0 */
+#define  RCC_CFGR_PPRE1_1                    ((uint32_t)0x00000200)        /*!< Bit 1 */
+#define  RCC_CFGR_PPRE1_2                    ((uint32_t)0x00000400)        /*!< Bit 2 */
+
+#define  RCC_CFGR_PPRE1_DIV1                 ((uint32_t)0x00000000)        /*!< HCLK not divided */
+#define  RCC_CFGR_PPRE1_DIV2                 ((uint32_t)0x00000400)        /*!< HCLK divided by 2 */
+#define  RCC_CFGR_PPRE1_DIV4                 ((uint32_t)0x00000500)        /*!< HCLK divided by 4 */
+#define  RCC_CFGR_PPRE1_DIV8                 ((uint32_t)0x00000600)        /*!< HCLK divided by 8 */
+#define  RCC_CFGR_PPRE1_DIV16                ((uint32_t)0x00000700)        /*!< HCLK divided by 16 */
+
+/*!< PPRE2 configuration */
+#define  RCC_CFGR_PPRE2                      ((uint32_t)0x00003800)        /*!< PRE2[2:0] bits (APB2 prescaler) */
+#define  RCC_CFGR_PPRE2_0                    ((uint32_t)0x00000800)        /*!< Bit 0 */
+#define  RCC_CFGR_PPRE2_1                    ((uint32_t)0x00001000)        /*!< Bit 1 */
+#define  RCC_CFGR_PPRE2_2                    ((uint32_t)0x00002000)        /*!< Bit 2 */
+
+#define  RCC_CFGR_PPRE2_DIV1                 ((uint32_t)0x00000000)        /*!< HCLK not divided */
+#define  RCC_CFGR_PPRE2_DIV2                 ((uint32_t)0x00002000)        /*!< HCLK divided by 2 */
+#define  RCC_CFGR_PPRE2_DIV4                 ((uint32_t)0x00002800)        /*!< HCLK divided by 4 */
+#define  RCC_CFGR_PPRE2_DIV8                 ((uint32_t)0x00003000)        /*!< HCLK divided by 8 */
+#define  RCC_CFGR_PPRE2_DIV16                ((uint32_t)0x00003800)        /*!< HCLK divided by 16 */
+
+#define  RCC_CFGR_STOPWUCK                   ((uint32_t)0x00008000)        /*!< Wake Up from Stop Clock selection */
+
+/*!< PLL entry clock source*/
+#define  RCC_CFGR_PLLSRC                     ((uint32_t)0x00010000)        /*!< PLL entry clock source */
+
+#define  RCC_CFGR_PLLSRC_HSI                 ((uint32_t)0x00000000)        /*!< HSI as PLL entry clock source */
+#define  RCC_CFGR_PLLSRC_HSE                 ((uint32_t)0x00010000)        /*!< HSE as PLL entry clock source */
+
+
+/*!< PLLMUL configuration */
+#define  RCC_CFGR_PLLMUL                     ((uint32_t)0x003C0000)        /*!< PLLMUL[3:0] bits (PLL multiplication factor) */
+#define  RCC_CFGR_PLLMUL_0                   ((uint32_t)0x00040000)        /*!< Bit 0 */
+#define  RCC_CFGR_PLLMUL_1                   ((uint32_t)0x00080000)        /*!< Bit 1 */
+#define  RCC_CFGR_PLLMUL_2                   ((uint32_t)0x00100000)        /*!< Bit 2 */
+#define  RCC_CFGR_PLLMUL_3                   ((uint32_t)0x00200000)        /*!< Bit 3 */
+
+#define  RCC_CFGR_PLLMUL3                    ((uint32_t)0x00000000)        /*!< PLL input clock * 3 */
+#define  RCC_CFGR_PLLMUL4                    ((uint32_t)0x00040000)        /*!< PLL input clock * 4 */
+#define  RCC_CFGR_PLLMUL6                    ((uint32_t)0x00080000)        /*!< PLL input clock * 6 */
+#define  RCC_CFGR_PLLMUL8                    ((uint32_t)0x000C0000)        /*!< PLL input clock * 8 */
+#define  RCC_CFGR_PLLMUL12                   ((uint32_t)0x00100000)        /*!< PLL input clock * 12 */
+#define  RCC_CFGR_PLLMUL16                   ((uint32_t)0x00140000)        /*!< PLL input clock * 16 */
+#define  RCC_CFGR_PLLMUL24                   ((uint32_t)0x00180000)        /*!< PLL input clock * 24 */
+#define  RCC_CFGR_PLLMUL32                   ((uint32_t)0x001C0000)        /*!< PLL input clock * 32 */
+#define  RCC_CFGR_PLLMUL48                   ((uint32_t)0x00200000)        /*!< PLL input clock * 48 */
+
+/*!< PLLDIV configuration */
+#define  RCC_CFGR_PLLDIV                     ((uint32_t)0x00C00000)        /*!< PLLDIV[1:0] bits (PLL Output Division) */
+#define  RCC_CFGR_PLLDIV_0                   ((uint32_t)0x00400000)        /*!< Bit0 */
+#define  RCC_CFGR_PLLDIV_1                   ((uint32_t)0x00800000)        /*!< Bit1 */
+
+#define  RCC_CFGR_PLLDIV2                    ((uint32_t)0x00400000)        /*!< PLL clock output = CKVCO / 2 */
+#define  RCC_CFGR_PLLDIV3                    ((uint32_t)0x00800000)        /*!< PLL clock output = CKVCO / 3 */
+#define  RCC_CFGR_PLLDIV4                    ((uint32_t)0x00C00000)        /*!< PLL clock output = CKVCO / 4 */
+
+/*!< MCO configuration */
+#define  RCC_CFGR_MCOSEL                        ((uint32_t)0x0F000000)        /*!< MCO[3:0] bits (Microcontroller Clock Output) */
+#define  RCC_CFGR_MCOSEL_0                      ((uint32_t)0x01000000)        /*!< Bit 0 */
+#define  RCC_CFGR_MCOSEL_1                      ((uint32_t)0x02000000)        /*!< Bit 1 */
+#define  RCC_CFGR_MCOSEL_2                      ((uint32_t)0x04000000)        /*!< Bit 2 */
+#define  RCC_CFGR_MCOSEL_3                      ((uint32_t)0x08000000)        /*!< Bit 3 */
+
+#define  RCC_CFGR_MCO_NOCLOCK                ((uint32_t)0x00000000)        /*!< No clock */
+#define  RCC_CFGR_MCO_SYSCLK                 ((uint32_t)0x01000000)        /*!< System clock selected as MCO source */
+#define  RCC_CFGR_MCO_HSI                    ((uint32_t)0x02000000)        /*!< Internal 16 MHz RC oscillator clock selected */
+#define  RCC_CFGR_MCO_MSI                    ((uint32_t)0x03000000)        /*!< Internal Medium Speed RC oscillator clock selected */
+#define  RCC_CFGR_MCO_HSE                    ((uint32_t)0x04000000)        /*!< External 1-25 MHz oscillator clock selected */
+#define  RCC_CFGR_MCO_PLL                    ((uint32_t)0x05000000)        /*!< PLL clock divided */
+#define  RCC_CFGR_MCO_LSI                    ((uint32_t)0x06000000)        /*!< LSI selected */
+#define  RCC_CFGR_MCO_LSE                    ((uint32_t)0x07000000)        /*!< LSE selected */
+#define  RCC_CFGR_MCO_HSI48                  ((uint32_t)0x08000000)        /*!< HSI48 clock selected as MCO source */
+
+#define  RCC_CFGR_MCO_PRE                    ((uint32_t)0x70000000)        /*!< MCO prescaler */
+#define  RCC_CFGR_MCO_PRE_1                  ((uint32_t)0x00000000)        /*!< MCO is divided by 1 */
+#define  RCC_CFGR_MCO_PRE_2                  ((uint32_t)0x10000000)        /*!< MCO is divided by 2 */
+#define  RCC_CFGR_MCO_PRE_4                  ((uint32_t)0x20000000)        /*!< MCO is divided by 4 */
+#define  RCC_CFGR_MCO_PRE_8                  ((uint32_t)0x30000000)        /*!< MCO is divided by 8 */
+#define  RCC_CFGR_MCO_PRE_16                 ((uint32_t)0x40000000)        /*!< MCO is divided by 16 */
+
+/*!<******************  Bit definition for RCC_CIER register  ********************/
+#define  RCC_CIER_LSIRDYIE                    ((uint32_t)0x00000001)        /*!< LSI Ready Interrupt Enable */
+#define  RCC_CIER_LSERDYIE                    ((uint32_t)0x00000002)        /*!< LSE Ready Interrupt Enable */
+#define  RCC_CIER_HSIRDYIE                    ((uint32_t)0x00000004)        /*!< HSI Ready Interrupt Enable */
+#define  RCC_CIER_HSERDYIE                    ((uint32_t)0x00000008)        /*!< HSE Ready Interrupt Enable */
+#define  RCC_CIER_PLLRDYIE                    ((uint32_t)0x00000010)        /*!< PLL Ready Interrupt Enable */
+#define  RCC_CIER_MSIRDYIE                    ((uint32_t)0x00000020)        /*!< MSI Ready Interrupt Enable */
+#define  RCC_CIER_HSI48RDYIE                  ((uint32_t)0x00000040)        /*!< HSI48 Ready Interrupt Enable */
+#define  RCC_CIER_LSECSSIE                    ((uint32_t)0x00000080)        /*!< LSE CSS Interrupt Enable */
+
+/*!<******************  Bit definition for RCC_CIFR register  ********************/
+#define  RCC_CIFR_LSIRDYF                     ((uint32_t)0x00000001)        /*!< LSI Ready Interrupt flag */
+#define  RCC_CIFR_LSERDYF                     ((uint32_t)0x00000002)        /*!< LSE Ready Interrupt flag */
+#define  RCC_CIFR_HSIRDYF                     ((uint32_t)0x00000004)        /*!< HSI Ready Interrupt flag */
+#define  RCC_CIFR_HSERDYF                     ((uint32_t)0x00000008)        /*!< HSE Ready Interrupt flag */
+#define  RCC_CIFR_PLLRDYF                     ((uint32_t)0x00000010)        /*!< PLL Ready Interrupt flag */
+#define  RCC_CIFR_MSIRDYF                     ((uint32_t)0x00000020)        /*!< MSI Ready Interrupt flag */
+#define  RCC_CIFR_HSI48RDYF                   ((uint32_t)0x00000040)        /*!< HSI48 Ready Interrupt flag */
+#define  RCC_CIFR_LSECSSF                     ((uint32_t)0x00000080)        /*!< LSE Clock Security System Interrupt flag */
+#define  RCC_CIFR_CSSF                        ((uint32_t)0x00000100)        /*!< Clock Security System Interrupt flag */
+
+/*!<******************  Bit definition for RCC_CICR register  ********************/
+#define  RCC_CICR_LSIRDYC                     ((uint32_t)0x00000001)        /*!< LSI Ready Interrupt Clear */
+#define  RCC_CICR_LSERDYC                     ((uint32_t)0x00000002)        /*!< LSE Ready Interrupt Clear */
+#define  RCC_CICR_HSIRDYC                     ((uint32_t)0x00000004)        /*!< HSI Ready Interrupt Clear */
+#define  RCC_CICR_HSERDYC                     ((uint32_t)0x00000008)        /*!< HSE Ready Interrupt Clear */
+#define  RCC_CICR_PLLRDYC                     ((uint32_t)0x00000010)        /*!< PLL Ready Interrupt Clear */
+#define  RCC_CICR_MSIRDYC                     ((uint32_t)0x00000020)        /*!< MSI Ready Interrupt Clear */
+#define  RCC_CICR_HSI48RDYC                   ((uint32_t)0x00000040)        /*!< HSI48 Ready Interrupt Clear */
+#define  RCC_CICR_LSECSSC                     ((uint32_t)0x00000080)        /*!< LSE Clock Security System Interrupt Clear */
+#define  RCC_CICR_CSSC                        ((uint32_t)0x00000100)        /*!< Clock Security System Interrupt Clear */
+
+/*****************  Bit definition for RCC_IOPRSTR register  ******************/
+#define  RCC_IOPRSTR_GPIOARST                ((uint32_t)0x00000001)        /*!< GPIO port A reset */
+#define  RCC_IOPRSTR_GPIOBRST                ((uint32_t)0x00000002)        /*!< GPIO port B reset */
+#define  RCC_IOPRSTR_GPIOCRST                ((uint32_t)0x00000004)        /*!< GPIO port C reset */
+#define  RCC_IOPRSTR_GPIODRST                ((uint32_t)0x00000008)        /*!< GPIO port D reset */
+#define  RCC_IOPRSTR_GPIOHRST                ((uint32_t)0x00000080)        /*!< GPIO port H reset */
+
+/******************  Bit definition for RCC_AHBRST register  ******************/
+#define  RCC_AHBRSTR_DMA1RST                 ((uint32_t)0x00000001)        /*!< DMA1 reset */
+#define  RCC_AHBRSTR_MIFRST                  ((uint32_t)0x00000100)        /*!< Memory interface reset reset */
+#define  RCC_AHBRSTR_CRCRST                  ((uint32_t)0x00001000)        /*!< CRC reset */
+#define  RCC_AHBRSTR_TSCRST                   ((uint32_t)0x00010000)        /*!< TSC reset */
+#define  RCC_AHBRSTR_RNGRST                  ((uint32_t)0x00100000)        /*!< RNG reset */
+
+/*****************  Bit definition for RCC_APB2RSTR register  *****************/
+#define  RCC_APB2RSTR_SYSCFGRST              ((uint32_t)0x00000001)        /*!< SYSCFG clock reset */
+#define  RCC_APB2RSTR_TIM21RST                ((uint32_t)0x00000004)        /*!< TIM21 clock reset */
+#define  RCC_APB2RSTR_TIM22RST               ((uint32_t)0x00000020)        /*!< TIM22 clock reset */
+#define  RCC_APB2RSTR_ADC1RST                ((uint32_t)0x00000200)        /*!< ADC1 clock reset */
+#define  RCC_APB2RSTR_SPI1RST                ((uint32_t)0x00001000)        /*!< SPI1 clock reset */
+#define  RCC_APB2RSTR_USART1RST              ((uint32_t)0x00004000)        /*!< USART1 clock reset */
+#define  RCC_APB2RSTR_DBGMCURST              ((uint32_t)0x00400000)        /*!< DBGMCU clock reset */
+
+/*****************  Bit definition for RCC_APB1RSTR register  *****************/
+#define  RCC_APB1RSTR_TIM2RST                ((uint32_t)0x00000001)        /*!< Timer 2 clock reset */
+#define  RCC_APB1RSTR_TIM6RST                ((uint32_t)0x00000010)        /*!< Timer 6 clock reset */
+#define  RCC_APB1RSTR_LCDRST                 ((uint32_t)0x00000200)        /*!< LCD clock reset */
+#define  RCC_APB1RSTR_WWDGRST                ((uint32_t)0x00000800)        /*!< Window Watchdog clock reset */
+#define  RCC_APB1RSTR_SPI2RST                ((uint32_t)0x00004000)        /*!< SPI2 clock reset */
+#define  RCC_APB1RSTR_USART2RST              ((uint32_t)0x00020000)        /*!< USART 2 clock reset */
+#define  RCC_APB1RSTR_LPUART1RST             ((uint32_t)0x00040000)        /*!< LPUART1 clock reset */
+#define  RCC_APB1RSTR_I2C1RST                ((uint32_t)0x00200000)        /*!< I2C 1 clock reset */
+#define  RCC_APB1RSTR_I2C2RST                ((uint32_t)0x00400000)        /*!< I2C 2 clock reset */
+#define  RCC_APB1RSTR_USBRST                 ((uint32_t)0x00800000)        /*!< USB clock reset */
+#define  RCC_APB1RSTR_CRSRST                 ((uint32_t)0x08000000)        /*!< CRS clock reset */
+#define  RCC_APB1RSTR_PWRRST                 ((uint32_t)0x10000000)        /*!< PWR clock reset */
+#define  RCC_APB1RSTR_DACRST                 ((uint32_t)0x20000000)        /*!< DAC clock reset */
+#define  RCC_APB1RSTR_LPTIM1RST              ((uint32_t)0x80000000)        /*!< LPTIM1 clock reset */
+
+/*****************  Bit definition for RCC_IOPENR register  ******************/
+#define  RCC_IOPENR_GPIOAEN                ((uint32_t)0x00000001)        /*!< GPIO port A clock enable */
+#define  RCC_IOPENR_GPIOBEN                ((uint32_t)0x00000002)        /*!< GPIO port B clock enable */
+#define  RCC_IOPENR_GPIOCEN                ((uint32_t)0x00000004)        /*!< GPIO port C clock enable */
+#define  RCC_IOPENR_GPIODEN                ((uint32_t)0x00000008)        /*!< GPIO port D clock enable */
+#define  RCC_IOPENR_GPIOHEN                ((uint32_t)0x00000080)        /*!< GPIO port H clock enable */
+
+/*****************  Bit definition for RCC_AHBENR register  ******************/
+#define  RCC_AHBENR_DMA1EN                   ((uint32_t)0x00000001)        /*!< DMA1 clock enable */
+#define  RCC_AHBENR_MIFEN                    ((uint32_t)0x00000100)        /*!< NVM interface clock enable bit */
+#define  RCC_AHBENR_CRCEN                    ((uint32_t)0x00001000)        /*!< CRC clock enable */
+#define  RCC_AHBENR_TSCEN                     ((uint32_t)0x00010000)        /*!< TSC clock enable */
+#define  RCC_AHBENR_RNGEN                    ((uint32_t)0x00100000)        /*!< RNG clock enable */
+
+/*****************  Bit definition for RCC_APB2ENR register  ******************/
+#define  RCC_APB2ENR_SYSCFGEN                ((uint32_t)0x00000001)        /*!< SYSCFG clock enable */
+#define  RCC_APB2ENR_TIM21EN                  ((uint32_t)0x00000004)        /*!< TIM21 clock enable */
+#define  RCC_APB2ENR_TIM22EN                 ((uint32_t)0x00000020)        /*!< TIM22 clock enable */
+#define  RCC_APB2ENR_MIFIEN                  ((uint32_t)0x00000080)        /*!< MiFare Firewall clock enable */
+#define  RCC_APB2ENR_ADC1EN                  ((uint32_t)0x00000200)        /*!< ADC1 clock enable */
+#define  RCC_APB2ENR_SPI1EN                  ((uint32_t)0x00001000)        /*!< SPI1 clock enable */
+#define  RCC_APB2ENR_USART1EN                ((uint32_t)0x00004000)        /*!< USART1 clock enable */
+#define  RCC_APB2ENR_DBGMCUEN                ((uint32_t)0x00400000)        /*!< DBGMCU clock enable */
+
+/*****************  Bit definition for RCC_APB1ENR register  ******************/
+#define  RCC_APB1ENR_TIM2EN                  ((uint32_t)0x00000001)        /*!< Timer 2 clock enable */
+#define  RCC_APB1ENR_TIM6EN                  ((uint32_t)0x00000010)        /*!< Timer 6 clock enable */
+#define  RCC_APB1ENR_LCDEN                   ((uint32_t)0x00000200)        /*!< LCD clock enable */
+#define  RCC_APB1ENR_WWDGEN                  ((uint32_t)0x00000800)        /*!< Window Watchdog clock enable */
+#define  RCC_APB1ENR_SPI2EN                  ((uint32_t)0x00004000)        /*!< SPI2 clock enable */
+#define  RCC_APB1ENR_USART2EN                ((uint32_t)0x00020000)        /*!< USART2 clock enable */
+#define  RCC_APB1ENR_LPUART1EN               ((uint32_t)0x00040000)        /*!< LPUART1 clock enable */
+#define  RCC_APB1ENR_I2C1EN                  ((uint32_t)0x00200000)        /*!< I2C1 clock enable */
+#define  RCC_APB1ENR_I2C2EN                  ((uint32_t)0x00400000)        /*!< I2C2 clock enable */
+#define  RCC_APB1ENR_USBEN                   ((uint32_t)0x00800000)        /*!< USB clock enable */
+#define  RCC_APB1ENR_CRSEN                   ((uint32_t)0x08000000)        /*!< CRS clock enable */
+#define  RCC_APB1ENR_PWREN                   ((uint32_t)0x10000000)        /*!< PWR clock enable */
+#define  RCC_APB1ENR_DACEN                   ((uint32_t)0x20000000)        /*!< DAC clock enable */
+#define  RCC_APB1ENR_LPTIM1EN                ((uint32_t)0x80000000)        /*!< LPTIM1 clock enable */
+
+/******************  Bit definition for RCC_IOPSMENR register  ****************/
+#define  RCC_IOPSMENR_GPIOASMEN              ((uint32_t)0x00000001)        /*!< GPIO port A clock enabled in sleep mode */
+#define  RCC_IOPSMENR_GPIOBSMEN              ((uint32_t)0x00000002)        /*!< GPIO port B clock enabled in sleep mode */
+#define  RCC_IOPSMENR_GPIOCSMEN              ((uint32_t)0x00000004)        /*!< GPIO port C clock enabled in sleep mode */
+#define  RCC_IOPSMENR_GPIODSMEN              ((uint32_t)0x00000008)        /*!< GPIO port D clock enabled in sleep mode */
+#define  RCC_IOPSMENR_GPIOHSMEN              ((uint32_t)0x00000080)        /*!< GPIO port H clock enabled in sleep mode */
+
+/*****************  Bit definition for RCC_AHBSMENR register  ******************/
+#define  RCC_AHBSMENR_DMA1SMEN                 ((uint32_t)0x00000001)        /*!< DMA1 clock enabled in sleep mode */
+#define  RCC_AHBSMENR_MIFSMEN                  ((uint32_t)0x00000100)        /*!< NVM interface clock enable during sleep mode */
+#define  RCC_AHBSMENR_SRAMSMEN                 ((uint32_t)0x00000200)        /*!< SRAM clock enabled in sleep mode */
+#define  RCC_AHBSMENR_CRCSMEN                  ((uint32_t)0x00001000)        /*!< CRC clock enabled in sleep mode */
+#define  RCC_AHBSMENR_TSCSMEN                   ((uint32_t)0x00010000)        /*!< TSC clock enabled in sleep mode */
+#define  RCC_AHBSMENR_RNGSMEN                  ((uint32_t)0x00100000)        /*!< RNG clock enabled in sleep mode */
+
+/*****************  Bit definition for RCC_APB2SMENR register  ******************/
+#define  RCC_APB2SMENR_SYSCFGSMEN              ((uint32_t)0x00000001)        /*!< SYSCFG clock enabled in sleep mode */
+#define  RCC_APB2SMENR_TIM21SMEN                ((uint32_t)0x00000004)        /*!< TIM21 clock enabled in sleep mode */
+#define  RCC_APB2SMENR_TIM22SMEN               ((uint32_t)0x00000020)        /*!< TIM22 clock enabled in sleep mode */
+#define  RCC_APB2SMENR_ADC1SMEN                ((uint32_t)0x00000200)        /*!< ADC1 clock enabled in sleep mode */
+#define  RCC_APB2SMENR_SPI1SMEN                ((uint32_t)0x00001000)        /*!< SPI1 clock enabled in sleep mode */
+#define  RCC_APB2SMENR_USART1SMEN              ((uint32_t)0x00004000)        /*!< USART1 clock enabled in sleep mode */
+#define  RCC_APB2SMENR_DBGMCUSMEN              ((uint32_t)0x00400000)        /*!< DBGMCU clock enabled in sleep mode */
+
+/*****************  Bit definition for RCC_APB1SMENR register  ******************/
+#define  RCC_APB1SMENR_TIM2SMEN                ((uint32_t)0x00000001)        /*!< Timer 2 clock enabled in sleep mode */
+#define  RCC_APB1SMENR_TIM6SMEN                ((uint32_t)0x00000010)        /*!< Timer 6 clock enabled in sleep mode */
+#define  RCC_APB1SMENR_LCDSMEN                 ((uint32_t)0x00000200)        /*!< LCD clock enabled in sleep mode */
+#define  RCC_APB1SMENR_WWDGSMEN                ((uint32_t)0x00000800)        /*!< Window Watchdog clock enabled in sleep mode */
+#define  RCC_APB1SMENR_SPI2SMEN                ((uint32_t)0x00004000)        /*!< SPI2 clock enabled in sleep mode */
+#define  RCC_APB1SMENR_USART2SMEN              ((uint32_t)0x00020000)        /*!< USART2 clock enabled in sleep mode */
+#define  RCC_APB1SMENR_LPUART1SMEN             ((uint32_t)0x00040000)        /*!< LPUART1 clock enabled in sleep mode */
+#define  RCC_APB1SMENR_I2C1SMEN                ((uint32_t)0x00200000)        /*!< I2C1 clock enabled in sleep mode */
+#define  RCC_APB1SMENR_I2C2SMEN                ((uint32_t)0x00400000)        /*!< I2C2 clock enabled in sleep mode */
+#define  RCC_APB1SMENR_USBSMEN                 ((uint32_t)0x00800000)        /*!< USB clock enabled in sleep mode */
+#define  RCC_APB1SMENR_CRSSMEN                 ((uint32_t)0x08000000)        /*!< CRS clock enabled in sleep mode */
+#define  RCC_APB1SMENR_PWRSMEN                 ((uint32_t)0x10000000)        /*!< PWR clock enabled in sleep mode */
+#define  RCC_APB1SMENR_DACSMEN                 ((uint32_t)0x20000000)        /*!< DAC clock enabled in sleep mode */
+#define  RCC_APB1SMENR_LPTIM1SMEN              ((uint32_t)0x80000000)        /*!< LPTIM1 clock enabled in sleep mode */
+
+/*******************  Bit definition for RCC_CCIPR register  *******************/
+/*!< USART1 Clock source selection */
+#define  RCC_CCIPR_USART1SEL                  ((uint32_t)0x00000003)        /*!< USART1SEL[1:0] bits */
+#define  RCC_CCIPR_USART1SEL_0                ((uint32_t)0x00000001)        /*!< Bit 0 */
+#define  RCC_CCIPR_USART1SEL_1                ((uint32_t)0x00000002)        /*!< Bit 1 */
+
+/*!< USART2 Clock source selection */
+#define  RCC_CCIPR_USART2SEL                  ((uint32_t)0x0000000C)        /*!< USART2SEL[1:0] bits */
+#define  RCC_CCIPR_USART2SEL_0                ((uint32_t)0x00000004)        /*!< Bit 0 */
+#define  RCC_CCIPR_USART2SEL_1                ((uint32_t)0x00000008)        /*!< Bit 1 */
+
+/*!< LPUART1 Clock source selection */ 
+#define  RCC_CCIPR_LPUART1SEL                  ((uint32_t)0x0000C00)        /*!< LPUART1SEL[1:0] bits */
+#define  RCC_CCIPR_LPUART1SEL_0                ((uint32_t)0x0000400)        /*!< Bit 0 */
+#define  RCC_CCIPR_LPUART1SEL_1                ((uint32_t)0x0000800)        /*!< Bit 1 */
+
+/*!< I2C2 Clock source selection */
+#define  RCC_CCIPR_I2C1SEL                    ((uint32_t)0x00003000)        /*!< I2C1SEL [1:0] bits */
+#define  RCC_CCIPR_I2C1SEL_0                  ((uint32_t)0x00001000)        /*!< Bit 0 */
+#define  RCC_CCIPR_I2C1SEL_1                  ((uint32_t)0x00002000)        /*!< Bit 1 */
+
+/*!< LPTIM1 Clock source selection */ 
+#define  RCC_CCIPR_LPTIM1SEL                  ((uint32_t)0x000C0000)        /*!< LPTIM1SEL [1:0] bits */
+#define  RCC_CCIPR_LPTIM1SEL_0                ((uint32_t)0x00040000)        /*!< Bit 0 */
+#define  RCC_CCIPR_LPTIM1SEL_1                ((uint32_t)0x00080000)        /*!< Bit 1 */
+
+/*!< HSI48 Clock source selection */ 
+#define  RCC_CCIPR_HSI48SEL                  ((uint32_t)0x04000000)        /*!< HSI48 RC clock source selection bit for USB and RNG*/
+
+/* Bit name alias maintained for legacy */
+#define  RCC_CCIPR_HSI48MSEL                  RCC_CCIPR_HSI48SEL
+
+/*******************  Bit definition for RCC_CSR register  *******************/
+#define  RCC_CSR_LSION                       ((uint32_t)0x00000001)        /*!< Internal Low Speed oscillator enable */
+#define  RCC_CSR_LSIRDY                      ((uint32_t)0x00000002)        /*!< Internal Low Speed oscillator Ready */
+
+#define  RCC_CSR_LSEON                      ((uint32_t)0x00000100)        /*!< External Low Speed oscillator enable */
+#define  RCC_CSR_LSERDY                     ((uint32_t)0x00000200)        /*!< External Low Speed oscillator Ready */
+#define  RCC_CSR_LSEBYP                     ((uint32_t)0x00000400)        /*!< External Low Speed oscillator Bypass */
+
+#define  RCC_CSR_LSEDRV                     ((uint32_t)0x00001800)        /*!< LSEDRV[1:0] bits (LSE Osc. drive capability) */
+#define  RCC_CSR_LSEDRV_0                   ((uint32_t)0x00000800)        /*!< Bit 0 */
+#define  RCC_CSR_LSEDRV_1                   ((uint32_t)0x00001000)        /*!< Bit 1 */
+
+#define  RCC_CSR_LSECSSON                   ((uint32_t)0x00002000)        /*!< External Low Speed oscillator CSS Enable */
+#define  RCC_CSR_LSECSSD                    ((uint32_t)0x00004000)        /*!< External Low Speed oscillator CSS Detected */
+
+/*!< RTC congiguration */
+#define  RCC_CSR_RTCSEL                     ((uint32_t)0x00030000)        /*!< RTCSEL[1:0] bits (RTC clock source selection) */
+#define  RCC_CSR_RTCSEL_0                   ((uint32_t)0x00010000)        /*!< Bit 0 */
+#define  RCC_CSR_RTCSEL_1                   ((uint32_t)0x00020000)        /*!< Bit 1 */
+
+#define  RCC_CSR_RTCSEL_NOCLOCK             ((uint32_t)0x00000000)        /*!< No clock */
+#define  RCC_CSR_RTCSEL_LSE                 ((uint32_t)0x00010000)        /*!< LSE oscillator clock used as RTC clock */
+#define  RCC_CSR_RTCSEL_LSI                 ((uint32_t)0x00020000)        /*!< LSI oscillator clock used as RTC clock */
+#define  RCC_CSR_RTCSEL_HSE                 ((uint32_t)0x00030000)        /*!< HSE oscillator clock used as RTC clock */
+
+#define  RCC_CSR_RTCEN                      ((uint32_t)0x00040000)        /*!< RTC clock enable */
+#define  RCC_CSR_RTCRST                     ((uint32_t)0x00080000)        /*!< RTC software reset  */
+
+#define  RCC_CSR_RMVF                       ((uint32_t)0x00800000)        /*!< Remove reset flag */
+#define  RCC_CSR_FWRSTF                   ((uint32_t)0x01000000)        /*!< Mifare Firewall reset flag */
+#define  RCC_CSR_OBL                        ((uint32_t)0x02000000)        /*!< OBL reset flag */
+#define  RCC_CSR_PINRSTF                    ((uint32_t)0x04000000)        /*!< PIN reset flag */
+#define  RCC_CSR_PORRSTF                    ((uint32_t)0x08000000)        /*!< POR/PDR reset flag */
+#define  RCC_CSR_SFTRSTF                    ((uint32_t)0x10000000)        /*!< Software Reset flag */
+#define  RCC_CSR_IWDGRSTF                   ((uint32_t)0x20000000)        /*!< Independent Watchdog reset flag */
+#define  RCC_CSR_WWDGRSTF                   ((uint32_t)0x40000000)        /*!< Window watchdog reset flag */
+#define  RCC_CSR_LPWRRSTF                   ((uint32_t)0x80000000)        /*!< Low-Power reset flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    RNG                                     */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for RNG_CR register  *******************/
+#define RNG_CR_RNGEN                         ((uint32_t)0x00000004)
+#define RNG_CR_IE                            ((uint32_t)0x00000008)
+
+/********************  Bits definition for RNG_SR register  *******************/
+#define RNG_SR_DRDY                          ((uint32_t)0x00000001)
+#define RNG_SR_CECS                          ((uint32_t)0x00000002)
+#define RNG_SR_SECS                          ((uint32_t)0x00000004)
+#define RNG_SR_CEIS                          ((uint32_t)0x00000020)
+#define RNG_SR_SEIS                          ((uint32_t)0x00000040)
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Real-Time Clock (RTC)                            */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for RTC_TR register  *******************/
+#define RTC_TR_PM                            ((uint32_t)0x00400000)        /*!<  */
+#define RTC_TR_HT                            ((uint32_t)0x00300000)        /*!<  */
+#define RTC_TR_HT_0                          ((uint32_t)0x00100000)        /*!<  */
+#define RTC_TR_HT_1                          ((uint32_t)0x00200000)        /*!<  */
+#define RTC_TR_HU                            ((uint32_t)0x000F0000)        /*!<  */
+#define RTC_TR_HU_0                          ((uint32_t)0x00010000)        /*!<  */
+#define RTC_TR_HU_1                          ((uint32_t)0x00020000)        /*!<  */
+#define RTC_TR_HU_2                          ((uint32_t)0x00040000)        /*!<  */
+#define RTC_TR_HU_3                          ((uint32_t)0x00080000)        /*!<  */
+#define RTC_TR_MNT                           ((uint32_t)0x00007000)        /*!<  */
+#define RTC_TR_MNT_0                         ((uint32_t)0x00001000)        /*!<  */
+#define RTC_TR_MNT_1                         ((uint32_t)0x00002000)        /*!<  */
+#define RTC_TR_MNT_2                         ((uint32_t)0x00004000)        /*!<  */
+#define RTC_TR_MNU                           ((uint32_t)0x00000F00)        /*!<  */
+#define RTC_TR_MNU_0                         ((uint32_t)0x00000100)        /*!<  */
+#define RTC_TR_MNU_1                         ((uint32_t)0x00000200)        /*!<  */
+#define RTC_TR_MNU_2                         ((uint32_t)0x00000400)        /*!<  */
+#define RTC_TR_MNU_3                         ((uint32_t)0x00000800)        /*!<  */
+#define RTC_TR_ST                            ((uint32_t)0x00000070)        /*!<  */
+#define RTC_TR_ST_0                          ((uint32_t)0x00000010)        /*!<  */
+#define RTC_TR_ST_1                          ((uint32_t)0x00000020)        /*!<  */
+#define RTC_TR_ST_2                          ((uint32_t)0x00000040)        /*!<  */
+#define RTC_TR_SU                            ((uint32_t)0x0000000F)        /*!<  */
+#define RTC_TR_SU_0                          ((uint32_t)0x00000001)        /*!<  */
+#define RTC_TR_SU_1                          ((uint32_t)0x00000002)        /*!<  */
+#define RTC_TR_SU_2                          ((uint32_t)0x00000004)        /*!<  */
+#define RTC_TR_SU_3                          ((uint32_t)0x00000008)        /*!<  */
+
+/********************  Bits definition for RTC_DR register  *******************/
+#define RTC_DR_YT                            ((uint32_t)0x00F00000)        /*!<  */
+#define RTC_DR_YT_0                          ((uint32_t)0x00100000)        /*!<  */
+#define RTC_DR_YT_1                          ((uint32_t)0x00200000)        /*!<  */
+#define RTC_DR_YT_2                          ((uint32_t)0x00400000)        /*!<  */
+#define RTC_DR_YT_3                          ((uint32_t)0x00800000)        /*!<  */
+#define RTC_DR_YU                            ((uint32_t)0x000F0000)        /*!<  */
+#define RTC_DR_YU_0                          ((uint32_t)0x00010000)        /*!<  */
+#define RTC_DR_YU_1                          ((uint32_t)0x00020000)        /*!<  */
+#define RTC_DR_YU_2                          ((uint32_t)0x00040000)        /*!<  */
+#define RTC_DR_YU_3                          ((uint32_t)0x00080000)        /*!<  */
+#define RTC_DR_WDU                           ((uint32_t)0x0000E000)        /*!<  */
+#define RTC_DR_WDU_0                         ((uint32_t)0x00002000)        /*!<  */
+#define RTC_DR_WDU_1                         ((uint32_t)0x00004000)        /*!<  */
+#define RTC_DR_WDU_2                         ((uint32_t)0x00008000)        /*!<  */
+#define RTC_DR_MT                            ((uint32_t)0x00001000)        /*!<  */
+#define RTC_DR_MU                            ((uint32_t)0x00000F00)        /*!<  */
+#define RTC_DR_MU_0                          ((uint32_t)0x00000100)        /*!<  */
+#define RTC_DR_MU_1                          ((uint32_t)0x00000200)        /*!<  */
+#define RTC_DR_MU_2                          ((uint32_t)0x00000400)        /*!<  */
+#define RTC_DR_MU_3                          ((uint32_t)0x00000800)        /*!<  */
+#define RTC_DR_DT                            ((uint32_t)0x00000030)        /*!<  */
+#define RTC_DR_DT_0                          ((uint32_t)0x00000010)        /*!<  */
+#define RTC_DR_DT_1                          ((uint32_t)0x00000020)        /*!<  */
+#define RTC_DR_DU                            ((uint32_t)0x0000000F)        /*!<  */
+#define RTC_DR_DU_0                          ((uint32_t)0x00000001)        /*!<  */
+#define RTC_DR_DU_1                          ((uint32_t)0x00000002)        /*!<  */
+#define RTC_DR_DU_2                          ((uint32_t)0x00000004)        /*!<  */
+#define RTC_DR_DU_3                          ((uint32_t)0x00000008)        /*!<  */
+
+/********************  Bits definition for RTC_CR register  *******************/
+#define RTC_CR_COE                           ((uint32_t)0x00800000)        /*!<  */
+#define RTC_CR_OSEL                          ((uint32_t)0x00600000)        /*!<  */
+#define RTC_CR_OSEL_0                        ((uint32_t)0x00200000)        /*!<  */
+#define RTC_CR_OSEL_1                        ((uint32_t)0x00400000)        /*!<  */
+#define RTC_CR_POL                           ((uint32_t)0x00100000)        /*!<  */
+#define RTC_CR_COSEL                        ((uint32_t)0x00080000)        /*!<  */
+#define RTC_CR_BCK                           ((uint32_t)0x00040000)        /*!<  */
+#define RTC_CR_SUB1H                         ((uint32_t)0x00020000)        /*!<  */
+#define RTC_CR_ADD1H                         ((uint32_t)0x00010000)        /*!<  */
+#define RTC_CR_TSIE                          ((uint32_t)0x00008000)        /*!<  */
+#define RTC_CR_WUTIE                         ((uint32_t)0x00004000)        /*!<  */
+#define RTC_CR_ALRBIE                        ((uint32_t)0x00002000)        /*!<  */
+#define RTC_CR_ALRAIE                        ((uint32_t)0x00001000)        /*!<  */
+#define RTC_CR_TSE                           ((uint32_t)0x00000800)        /*!<  */
+#define RTC_CR_WUTE                          ((uint32_t)0x00000400)        /*!<  */
+#define RTC_CR_ALRBE                         ((uint32_t)0x00000200)        /*!<  */
+#define RTC_CR_ALRAE                         ((uint32_t)0x00000100)        /*!<  */
+#define RTC_CR_FMT                           ((uint32_t)0x00000040)        /*!<  */
+#define RTC_CR_BYPSHAD                       ((uint32_t)0x00000020)        /*!<  */
+#define RTC_CR_REFCKON                       ((uint32_t)0x00000010)        /*!<  */
+#define RTC_CR_TSEDGE                        ((uint32_t)0x00000008)        /*!<  */
+#define RTC_CR_WUCKSEL                       ((uint32_t)0x00000007)        /*!<  */
+#define RTC_CR_WUCKSEL_0                     ((uint32_t)0x00000001)        /*!<  */
+#define RTC_CR_WUCKSEL_1                     ((uint32_t)0x00000002)        /*!<  */
+#define RTC_CR_WUCKSEL_2                     ((uint32_t)0x00000004)        /*!<  */
+
+/********************  Bits definition for RTC_ISR register  ******************/
+#define RTC_ISR_RECALPF                      ((uint32_t)0x00010000)        /*!<  */
+#define RTC_ISR_TAMP2F                       ((uint32_t)0x00004000)        /*!<  */
+#define RTC_ISR_TAMP1F                       ((uint32_t)0x00002000)        /*!<  */
+#define RTC_ISR_TSOVF                        ((uint32_t)0x00001000)        /*!<  */
+#define RTC_ISR_TSF                          ((uint32_t)0x00000800)        /*!<  */
+#define RTC_ISR_WUTF                         ((uint32_t)0x00000400)        /*!<  */
+#define RTC_ISR_ALRBF                        ((uint32_t)0x00000200)        /*!<  */
+#define RTC_ISR_ALRAF                        ((uint32_t)0x00000100)        /*!<  */
+#define RTC_ISR_INIT                         ((uint32_t)0x00000080)        /*!<  */
+#define RTC_ISR_INITF                        ((uint32_t)0x00000040)        /*!<  */
+#define RTC_ISR_RSF                          ((uint32_t)0x00000020)        /*!<  */
+#define RTC_ISR_INITS                        ((uint32_t)0x00000010)        /*!<  */
+#define RTC_ISR_SHPF                         ((uint32_t)0x00000008)        /*!<  */
+#define RTC_ISR_WUTWF                        ((uint32_t)0x00000004)        /*!<  */
+#define RTC_ISR_ALRBWF                       ((uint32_t)0x00000002)        /*!<  */
+#define RTC_ISR_ALRAWF                       ((uint32_t)0x00000001)        /*!<  */
+
+/********************  Bits definition for RTC_PRER register  *****************/
+#define RTC_PRER_PREDIV_A                    ((uint32_t)0x007F0000)        /*!<  */
+#define RTC_PRER_PREDIV_S                    ((uint32_t)0x00007FFF)        /*!<  */
+
+/********************  Bits definition for RTC_WUTR register  *****************/
+#define RTC_WUTR_WUT                         ((uint32_t)0x0000FFFF)
+
+/********************  Bits definition for RTC_ALRMAR register  ***************/
+#define RTC_ALRMAR_MSK4                      ((uint32_t)0x80000000)        /*!<  */
+#define RTC_ALRMAR_WDSEL                     ((uint32_t)0x40000000)        /*!<  */
+#define RTC_ALRMAR_DT                        ((uint32_t)0x30000000)        /*!<  */
+#define RTC_ALRMAR_DT_0                      ((uint32_t)0x10000000)        /*!<  */
+#define RTC_ALRMAR_DT_1                      ((uint32_t)0x20000000)        /*!<  */
+#define RTC_ALRMAR_DU                        ((uint32_t)0x0F000000)        /*!<  */
+#define RTC_ALRMAR_DU_0                      ((uint32_t)0x01000000)        /*!<  */
+#define RTC_ALRMAR_DU_1                      ((uint32_t)0x02000000)        /*!<  */
+#define RTC_ALRMAR_DU_2                      ((uint32_t)0x04000000)        /*!<  */
+#define RTC_ALRMAR_DU_3                      ((uint32_t)0x08000000)        /*!<  */
+#define RTC_ALRMAR_MSK3                      ((uint32_t)0x00800000)        /*!<  */
+#define RTC_ALRMAR_PM                        ((uint32_t)0x00400000)        /*!<  */
+#define RTC_ALRMAR_HT                        ((uint32_t)0x00300000)        /*!<  */
+#define RTC_ALRMAR_HT_0                      ((uint32_t)0x00100000)        /*!<  */
+#define RTC_ALRMAR_HT_1                      ((uint32_t)0x00200000)        /*!<  */
+#define RTC_ALRMAR_HU                        ((uint32_t)0x000F0000)        /*!<  */
+#define RTC_ALRMAR_HU_0                      ((uint32_t)0x00010000)        /*!<  */
+#define RTC_ALRMAR_HU_1                      ((uint32_t)0x00020000)        /*!<  */
+#define RTC_ALRMAR_HU_2                      ((uint32_t)0x00040000)        /*!<  */
+#define RTC_ALRMAR_HU_3                      ((uint32_t)0x00080000)        /*!<  */
+#define RTC_ALRMAR_MSK2                      ((uint32_t)0x00008000)        /*!<  */
+#define RTC_ALRMAR_MNT                       ((uint32_t)0x00007000)        /*!<  */
+#define RTC_ALRMAR_MNT_0                     ((uint32_t)0x00001000)        /*!<  */
+#define RTC_ALRMAR_MNT_1                     ((uint32_t)0x00002000)        /*!<  */
+#define RTC_ALRMAR_MNT_2                     ((uint32_t)0x00004000)        /*!<  */
+#define RTC_ALRMAR_MNU                       ((uint32_t)0x00000F00)        /*!<  */
+#define RTC_ALRMAR_MNU_0                     ((uint32_t)0x00000100)        /*!<  */
+#define RTC_ALRMAR_MNU_1                     ((uint32_t)0x00000200)        /*!<  */
+#define RTC_ALRMAR_MNU_2                     ((uint32_t)0x00000400)        /*!<  */
+#define RTC_ALRMAR_MNU_3                     ((uint32_t)0x00000800)        /*!<  */
+#define RTC_ALRMAR_MSK1                      ((uint32_t)0x00000080)        /*!<  */
+#define RTC_ALRMAR_ST                        ((uint32_t)0x00000070)        /*!<  */
+#define RTC_ALRMAR_ST_0                      ((uint32_t)0x00000010)        /*!<  */
+#define RTC_ALRMAR_ST_1                      ((uint32_t)0x00000020)        /*!<  */
+#define RTC_ALRMAR_ST_2                      ((uint32_t)0x00000040)        /*!<  */
+#define RTC_ALRMAR_SU                        ((uint32_t)0x0000000F)        /*!<  */
+#define RTC_ALRMAR_SU_0                      ((uint32_t)0x00000001)        /*!<  */
+#define RTC_ALRMAR_SU_1                      ((uint32_t)0x00000002)        /*!<  */
+#define RTC_ALRMAR_SU_2                      ((uint32_t)0x00000004)        /*!<  */
+#define RTC_ALRMAR_SU_3                      ((uint32_t)0x00000008)        /*!<  */
+
+/********************  Bits definition for RTC_ALRMBR register  ***************/
+#define RTC_ALRMBR_MSK4                      ((uint32_t)0x80000000)        /*!<  */
+#define RTC_ALRMBR_WDSEL                     ((uint32_t)0x40000000)        /*!<  */
+#define RTC_ALRMBR_DT                        ((uint32_t)0x30000000)        /*!<  */
+#define RTC_ALRMBR_DT_0                      ((uint32_t)0x10000000)        /*!<  */
+#define RTC_ALRMBR_DT_1                      ((uint32_t)0x20000000)        /*!<  */
+#define RTC_ALRMBR_DU                        ((uint32_t)0x0F000000)        /*!<  */
+#define RTC_ALRMBR_DU_0                      ((uint32_t)0x01000000)        /*!<  */
+#define RTC_ALRMBR_DU_1                      ((uint32_t)0x02000000)        /*!<  */
+#define RTC_ALRMBR_DU_2                      ((uint32_t)0x04000000)        /*!<  */
+#define RTC_ALRMBR_DU_3                      ((uint32_t)0x08000000)        /*!<  */
+#define RTC_ALRMBR_MSK3                      ((uint32_t)0x00800000)        /*!<  */
+#define RTC_ALRMBR_PM                        ((uint32_t)0x00400000)        /*!<  */
+#define RTC_ALRMBR_HT                        ((uint32_t)0x00300000)        /*!<  */
+#define RTC_ALRMBR_HT_0                      ((uint32_t)0x00100000)        /*!<  */
+#define RTC_ALRMBR_HT_1                      ((uint32_t)0x00200000)        /*!<  */
+#define RTC_ALRMBR_HU                        ((uint32_t)0x000F0000)        /*!<  */
+#define RTC_ALRMBR_HU_0                      ((uint32_t)0x00010000)        /*!<  */
+#define RTC_ALRMBR_HU_1                      ((uint32_t)0x00020000)        /*!<  */
+#define RTC_ALRMBR_HU_2                      ((uint32_t)0x00040000)        /*!<  */
+#define RTC_ALRMBR_HU_3                      ((uint32_t)0x00080000)        /*!<  */
+#define RTC_ALRMBR_MSK2                      ((uint32_t)0x00008000)        /*!<  */
+#define RTC_ALRMBR_MNT                       ((uint32_t)0x00007000)        /*!<  */
+#define RTC_ALRMBR_MNT_0                     ((uint32_t)0x00001000)        /*!<  */
+#define RTC_ALRMBR_MNT_1                     ((uint32_t)0x00002000)        /*!<  */
+#define RTC_ALRMBR_MNT_2                     ((uint32_t)0x00004000)        /*!<  */
+#define RTC_ALRMBR_MNU                       ((uint32_t)0x00000F00)        /*!<  */
+#define RTC_ALRMBR_MNU_0                     ((uint32_t)0x00000100)        /*!<  */
+#define RTC_ALRMBR_MNU_1                     ((uint32_t)0x00000200)        /*!<  */
+#define RTC_ALRMBR_MNU_2                     ((uint32_t)0x00000400)        /*!<  */
+#define RTC_ALRMBR_MNU_3                     ((uint32_t)0x00000800)        /*!<  */
+#define RTC_ALRMBR_MSK1                      ((uint32_t)0x00000080)        /*!<  */
+#define RTC_ALRMBR_ST                        ((uint32_t)0x00000070)        /*!<  */
+#define RTC_ALRMBR_ST_0                      ((uint32_t)0x00000010)        /*!<  */
+#define RTC_ALRMBR_ST_1                      ((uint32_t)0x00000020)        /*!<  */
+#define RTC_ALRMBR_ST_2                      ((uint32_t)0x00000040)        /*!<  */
+#define RTC_ALRMBR_SU                        ((uint32_t)0x0000000F)        /*!<  */
+#define RTC_ALRMBR_SU_0                      ((uint32_t)0x00000001)        /*!<  */
+#define RTC_ALRMBR_SU_1                      ((uint32_t)0x00000002)        /*!<  */
+#define RTC_ALRMBR_SU_2                      ((uint32_t)0x00000004)        /*!<  */
+#define RTC_ALRMBR_SU_3                      ((uint32_t)0x00000008)        /*!<  */
+
+/********************  Bits definition for RTC_WPR register  ******************/
+#define RTC_WPR_KEY                          ((uint32_t)0x000000FF)        /*!<  */
+
+/********************  Bits definition for RTC_SSR register  ******************/
+#define RTC_SSR_SS                           ((uint32_t)0x0000FFFF)        /*!<  */
+
+/********************  Bits definition for RTC_SHIFTR register  ***************/
+#define RTC_SHIFTR_SUBFS                     ((uint32_t)0x00007FFF)        /*!<  */
+#define RTC_SHIFTR_ADD1S                     ((uint32_t)0x80000000)        /*!<  */
+
+/********************  Bits definition for RTC_TSTR register  *****************/
+#define RTC_TSTR_PM                          ((uint32_t)0x00400000)        /*!<  */
+#define RTC_TSTR_HT                          ((uint32_t)0x00300000)        /*!<  */
+#define RTC_TSTR_HT_0                        ((uint32_t)0x00100000)        /*!<  */
+#define RTC_TSTR_HT_1                        ((uint32_t)0x00200000)        /*!<  */
+#define RTC_TSTR_HU                          ((uint32_t)0x000F0000)        /*!<  */
+#define RTC_TSTR_HU_0                        ((uint32_t)0x00010000)        /*!<  */
+#define RTC_TSTR_HU_1                        ((uint32_t)0x00020000)        /*!<  */
+#define RTC_TSTR_HU_2                        ((uint32_t)0x00040000)        /*!<  */
+#define RTC_TSTR_HU_3                        ((uint32_t)0x00080000)        /*!<  */
+#define RTC_TSTR_MNT                         ((uint32_t)0x00007000)        /*!<  */
+#define RTC_TSTR_MNT_0                       ((uint32_t)0x00001000)        /*!<  */
+#define RTC_TSTR_MNT_1                       ((uint32_t)0x00002000)        /*!<  */
+#define RTC_TSTR_MNT_2                       ((uint32_t)0x00004000)        /*!<  */
+#define RTC_TSTR_MNU                         ((uint32_t)0x00000F00)        /*!<  */
+#define RTC_TSTR_MNU_0                       ((uint32_t)0x00000100)        /*!<  */
+#define RTC_TSTR_MNU_1                       ((uint32_t)0x00000200)        /*!<  */
+#define RTC_TSTR_MNU_2                       ((uint32_t)0x00000400)        /*!<  */
+#define RTC_TSTR_MNU_3                       ((uint32_t)0x00000800)        /*!<  */
+#define RTC_TSTR_ST                          ((uint32_t)0x00000070)        /*!<  */
+#define RTC_TSTR_ST_0                        ((uint32_t)0x00000010)        /*!<  */
+#define RTC_TSTR_ST_1                        ((uint32_t)0x00000020)        /*!<  */
+#define RTC_TSTR_ST_2                        ((uint32_t)0x00000040)        /*!<  */
+#define RTC_TSTR_SU                          ((uint32_t)0x0000000F)        /*!<  */
+#define RTC_TSTR_SU_0                        ((uint32_t)0x00000001)        /*!<  */
+#define RTC_TSTR_SU_1                        ((uint32_t)0x00000002)        /*!<  */
+#define RTC_TSTR_SU_2                        ((uint32_t)0x00000004)        /*!<  */
+#define RTC_TSTR_SU_3                        ((uint32_t)0x00000008)        /*!<  */
+
+/********************  Bits definition for RTC_TSDR register  *****************/
+#define RTC_TSDR_WDU                         ((uint32_t)0x0000E000)        /*!<  */
+#define RTC_TSDR_WDU_0                       ((uint32_t)0x00002000)        /*!<  */
+#define RTC_TSDR_WDU_1                       ((uint32_t)0x00004000)        /*!<  */
+#define RTC_TSDR_WDU_2                       ((uint32_t)0x00008000)        /*!<  */
+#define RTC_TSDR_MT                          ((uint32_t)0x00001000)        /*!<  */
+#define RTC_TSDR_MU                          ((uint32_t)0x00000F00)        /*!<  */
+#define RTC_TSDR_MU_0                        ((uint32_t)0x00000100)        /*!<  */
+#define RTC_TSDR_MU_1                        ((uint32_t)0x00000200)        /*!<  */
+#define RTC_TSDR_MU_2                        ((uint32_t)0x00000400)        /*!<  */
+#define RTC_TSDR_MU_3                        ((uint32_t)0x00000800)        /*!<  */
+#define RTC_TSDR_DT                          ((uint32_t)0x00000030)        /*!<  */
+#define RTC_TSDR_DT_0                        ((uint32_t)0x00000010)        /*!<  */
+#define RTC_TSDR_DT_1                        ((uint32_t)0x00000020)        /*!<  */
+#define RTC_TSDR_DU                          ((uint32_t)0x0000000F)        /*!<  */
+#define RTC_TSDR_DU_0                        ((uint32_t)0x00000001)        /*!<  */
+#define RTC_TSDR_DU_1                        ((uint32_t)0x00000002)        /*!<  */
+#define RTC_TSDR_DU_2                        ((uint32_t)0x00000004)        /*!<  */
+#define RTC_TSDR_DU_3                        ((uint32_t)0x00000008)        /*!<  */
+
+/********************  Bits definition for RTC_TSSSR register  ****************/
+#define RTC_TSSSR_SS                         ((uint32_t)0x0000FFFF)
+
+/********************  Bits definition for RTC_CAL register  *****************/
+#define RTC_CAL_CALP                         ((uint32_t)0x00008000)        /*!<  */
+#define RTC_CAL_CALW8                        ((uint32_t)0x00004000)        /*!<  */
+#define RTC_CAL_CALW16                       ((uint32_t)0x00002000)        /*!<  */
+#define RTC_CAL_CALM                         ((uint32_t)0x000001FF)        /*!<  */
+#define RTC_CAL_CALM_0                       ((uint32_t)0x00000001)        /*!<  */
+#define RTC_CAL_CALM_1                       ((uint32_t)0x00000002)        /*!<  */
+#define RTC_CAL_CALM_2                       ((uint32_t)0x00000004)        /*!<  */
+#define RTC_CAL_CALM_3                       ((uint32_t)0x00000008)        /*!<  */
+#define RTC_CAL_CALM_4                       ((uint32_t)0x00000010)        /*!<  */
+#define RTC_CAL_CALM_5                       ((uint32_t)0x00000020)        /*!<  */
+#define RTC_CAL_CALM_6                       ((uint32_t)0x00000040)        /*!<  */
+#define RTC_CAL_CALM_7                       ((uint32_t)0x00000080)        /*!<  */
+#define RTC_CAL_CALM_8                       ((uint32_t)0x00000100)        /*!<  */
+
+/********************  Bits definition for RTC_TAMPCR register  ****************/
+#define RTC_TAMPCR_TAMP2MF                   ((uint32_t)0x00200000)        /*!<  */
+#define RTC_TAMPCR_TAMP2NOERASE              ((uint32_t)0x00100000)        /*!<  */
+#define RTC_TAMPCR_TAMP2IE                   ((uint32_t)0x00080000)        /*!<  */
+#define RTC_TAMPCR_TAMP1MF                   ((uint32_t)0x00040000)        /*!<  */
+#define RTC_TAMPCR_TAMP1NOERASE              ((uint32_t)0x00020000)        /*!<  */
+#define RTC_TAMPCR_TAMP1IE                   ((uint32_t)0x00010000)        /*!<  */
+#define RTC_TAMPCR_TAMPPUDIS                 ((uint32_t)0x00008000)        /*!<  */
+#define RTC_TAMPCR_TAMPPRCH                  ((uint32_t)0x00006000)        /*!<  */
+#define RTC_TAMPCR_TAMPPRCH_0                ((uint32_t)0x00002000)        /*!<  */
+#define RTC_TAMPCR_TAMPPRCH_1                ((uint32_t)0x00004000)        /*!<  */
+#define RTC_TAMPCR_TAMPFLT                   ((uint32_t)0x00001800)        /*!<  */
+#define RTC_TAMPCR_TAMPFLT_0                 ((uint32_t)0x00000800)        /*!<  */
+#define RTC_TAMPCR_TAMPFLT_1                 ((uint32_t)0x00001000)        /*!<  */
+#define RTC_TAMPCR_TAMPFREQ                  ((uint32_t)0x00000700)        /*!<  */
+#define RTC_TAMPCR_TAMPFREQ_0                ((uint32_t)0x00000100)        /*!<  */
+#define RTC_TAMPCR_TAMPFREQ_1                ((uint32_t)0x00000200)        /*!<  */
+#define RTC_TAMPCR_TAMPFREQ_2                ((uint32_t)0x00000400)        /*!<  */
+#define RTC_TAMPCR_TAMPTS                    ((uint32_t)0x00000080)        /*!<  */
+#define RTC_TAMPCR_TAMP2TRG                  ((uint32_t)0x00000010)        /*!<  */
+#define RTC_TAMPCR_TAMP2E                    ((uint32_t)0x00000008)        /*!<  */
+#define RTC_TAMPCR_TAMPIE                    ((uint32_t)0x00000004)        /*!<  */
+#define RTC_TAMPCR_TAMP1TRG                  ((uint32_t)0x00000002)        /*!<  */
+#define RTC_TAMPCR_TAMP1E                    ((uint32_t)0x00000001)        /*!<  */
+
+/********************  Bits definition for RTC_ALRMASSR register  *************/
+#define RTC_ALRMASSR_MASKSS                  ((uint32_t)0x0F000000)
+#define RTC_ALRMASSR_MASKSS_0                ((uint32_t)0x01000000)
+#define RTC_ALRMASSR_MASKSS_1                ((uint32_t)0x02000000)
+#define RTC_ALRMASSR_MASKSS_2                ((uint32_t)0x04000000)
+#define RTC_ALRMASSR_MASKSS_3                ((uint32_t)0x08000000)
+#define RTC_ALRMASSR_SS                      ((uint32_t)0x00007FFF)
+
+/********************  Bits definition for RTC_ALRMBSSR register  *************/
+#define RTC_ALRMBSSR_MASKSS                  ((uint32_t)0x0F000000)
+#define RTC_ALRMBSSR_MASKSS_0                ((uint32_t)0x01000000)
+#define RTC_ALRMBSSR_MASKSS_1                ((uint32_t)0x02000000)
+#define RTC_ALRMBSSR_MASKSS_2                ((uint32_t)0x04000000)
+#define RTC_ALRMBSSR_MASKSS_3                ((uint32_t)0x08000000)
+#define RTC_ALRMBSSR_SS                      ((uint32_t)0x00007FFF)
+
+/********************  Bits definition for RTC_OR register  ****************/
+#define RTC_OR_RTC_OUT_RMP                   ((uint32_t)0x00000002)        /*!<  */
+#define RTC_OR_ALARMOUTTYPE                  ((uint32_t)0x00000001)        /*!<  */
+
+/********************  Bits definition for RTC_BKP0R register  ****************/
+#define RTC_BKP0R                            ((uint32_t)0xFFFFFFFF)        /*!<  */
+
+/********************  Bits definition for RTC_BKP1R register  ****************/
+#define RTC_BKP1R                            ((uint32_t)0xFFFFFFFF)        /*!<  */
+
+/********************  Bits definition for RTC_BKP2R register  ****************/
+#define RTC_BKP2R                            ((uint32_t)0xFFFFFFFF)        /*!<  */
+
+/********************  Bits definition for RTC_BKP3R register  ****************/
+#define RTC_BKP3R                            ((uint32_t)0xFFFFFFFF)        /*!<  */
+
+/********************  Bits definition for RTC_BKP4R register  ****************/
+#define RTC_BKP4R                            ((uint32_t)0xFFFFFFFF)        /*!<  */
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Serial Peripheral Interface (SPI)                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for SPI_CR1 register  ********************/
+#define  SPI_CR1_CPHA                        ((uint32_t)0x00000001)            /*!< Clock Phase */
+#define  SPI_CR1_CPOL                        ((uint32_t)0x00000002)            /*!< Clock Polarity */
+#define  SPI_CR1_MSTR                        ((uint32_t)0x00000004)            /*!< Master Selection */
+#define  SPI_CR1_BR                          ((uint32_t)0x00000038)            /*!< BR[2:0] bits (Baud Rate Control) */
+#define  SPI_CR1_BR_0                        ((uint32_t)0x00000008)            /*!< Bit 0 */
+#define  SPI_CR1_BR_1                        ((uint32_t)0x00000010)            /*!< Bit 1 */
+#define  SPI_CR1_BR_2                        ((uint32_t)0x00000020)            /*!< Bit 2 */
+#define  SPI_CR1_SPE                         ((uint32_t)0x00000040)            /*!< SPI Enable */
+#define  SPI_CR1_LSBFIRST                    ((uint32_t)0x00000080)            /*!< Frame Format */
+#define  SPI_CR1_SSI                         ((uint32_t)0x00000100)            /*!< Internal slave select */
+#define  SPI_CR1_SSM                         ((uint32_t)0x00000200)            /*!< Software slave management */
+#define  SPI_CR1_RXONLY                      ((uint32_t)0x00000400)            /*!< Receive only */
+#define  SPI_CR1_DFF                         ((uint32_t)0x00000800)            /*!< Data Frame Format */
+#define  SPI_CR1_CRCNEXT                     ((uint32_t)0x00001000)            /*!< Transmit CRC next */
+#define  SPI_CR1_CRCEN                       ((uint32_t)0x00002000)            /*!< Hardware CRC calculation enable */
+#define  SPI_CR1_BIDIOE                      ((uint32_t)0x00004000)            /*!< Output enable in bidirectional mode */
+#define  SPI_CR1_BIDIMODE                    ((uint32_t)0x00008000)            /*!< Bidirectional data mode enable */
+
+/*******************  Bit definition for SPI_CR2 register  ********************/
+#define  SPI_CR2_RXDMAEN                     ((uint32_t)0x00000001)            /*!< Rx Buffer DMA Enable */
+#define  SPI_CR2_TXDMAEN                     ((uint32_t)0x00000002)            /*!< Tx Buffer DMA Enable */
+#define  SPI_CR2_SSOE                        ((uint32_t)0x00000004)            /*!< SS Output Enable */
+#define  SPI_CR2_FRF                         ((uint32_t)0x00000010)            /*!< Frame Format Enable */
+#define  SPI_CR2_ERRIE                       ((uint32_t)0x00000020)            /*!< Error Interrupt Enable */
+#define  SPI_CR2_RXNEIE                      ((uint32_t)0x00000040)            /*!< RX buffer Not Empty Interrupt Enable */
+#define  SPI_CR2_TXEIE                       ((uint32_t)0x00000080)            /*!< Tx buffer Empty Interrupt Enable */
+
+/********************  Bit definition for SPI_SR register  ********************/
+#define  SPI_SR_RXNE                         ((uint32_t)0x00000001)            /*!< Receive buffer Not Empty */
+#define  SPI_SR_TXE                          ((uint32_t)0x00000002)            /*!< Transmit buffer Empty */
+#define  SPI_SR_CHSIDE                       ((uint32_t)0x00000004)            /*!< Channel side */
+#define  SPI_SR_UDR                          ((uint32_t)0x00000008)            /*!< Underrun flag */
+#define  SPI_SR_CRCERR                       ((uint32_t)0x00000010)            /*!< CRC Error flag */
+#define  SPI_SR_MODF                         ((uint32_t)0x00000020)            /*!< Mode fault */
+#define  SPI_SR_OVR                          ((uint32_t)0x00000040)            /*!< Overrun flag */
+#define  SPI_SR_BSY                          ((uint32_t)0x00000080)            /*!< Busy flag */
+#define  SPI_SR_FRE                          ((uint32_t)0x00000100)            /*!< TI frame format error */  
+
+/********************  Bit definition for SPI_DR register  ********************/
+#define  SPI_DR_DR                           ((uint32_t)0x0000FFFF)            /*!< Data Register */
+
+/*******************  Bit definition for SPI_CRCPR register  ******************/
+#define  SPI_CRCPR_CRCPOLY                   ((uint32_t)0x0000FFFF)            /*!< CRC polynomial register */
+
+/******************  Bit definition for SPI_RXCRCR register  ******************/
+#define  SPI_RXCRCR_RXCRC                    ((uint32_t)0x0000FFFF)            /*!< Rx CRC Register */
+
+/******************  Bit definition for SPI_TXCRCR register  ******************/
+#define  SPI_TXCRCR_TXCRC                    ((uint32_t)0x0000FFFF)            /*!< Tx CRC Register */
+
+/******************  Bit definition for SPI_I2SCFGR register  *****************/
+#define  SPI_I2SCFGR_CHLEN                   ((uint32_t)0x00000001)            /*!<Channel length (number of bits per audio channel) */
+#define  SPI_I2SCFGR_DATLEN                  ((uint32_t)0x00000006)            /*!<DATLEN[1:0] bits (Data length to be transferred) */
+#define  SPI_I2SCFGR_DATLEN_0                ((uint32_t)0x00000002)            /*!<Bit 0 */
+#define  SPI_I2SCFGR_DATLEN_1                ((uint32_t)0x00000004)            /*!<Bit 1 */
+#define  SPI_I2SCFGR_CKPOL                   ((uint32_t)0x00000008)            /*!<steady state clock polarity */
+#define  SPI_I2SCFGR_I2SSTD                  ((uint32_t)0x00000030)            /*!<I2SSTD[1:0] bits (I2S standard selection) */
+#define  SPI_I2SCFGR_I2SSTD_0                ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define  SPI_I2SCFGR_I2SSTD_1                ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define  SPI_I2SCFGR_PCMSYNC                 ((uint32_t)0x00000080)            /*!<PCM frame synchronization */
+#define  SPI_I2SCFGR_I2SCFG                  ((uint32_t)0x00000300)            /*!<I2SCFG[1:0] bits (I2S configuration mode) */
+#define  SPI_I2SCFGR_I2SCFG_0                ((uint32_t)0x00000100)            /*!<Bit 0 */
+#define  SPI_I2SCFGR_I2SCFG_1                ((uint32_t)0x00000200)            /*!<Bit 1 */
+#define  SPI_I2SCFGR_I2SE                    ((uint32_t)0x00000400)            /*!<I2S Enable */
+#define  SPI_I2SCFGR_I2SMOD                  ((uint32_t)0x00000800)            /*!<I2S mode selection */
+
+/******************  Bit definition for SPI_I2SPR register  *******************/
+#define  SPI_I2SPR_I2SDIV                    ((uint32_t)0x000000FF)            /*!<I2S Linear prescaler */
+#define  SPI_I2SPR_ODD                       ((uint32_t)0x00000100)            /*!<Odd factor for the prescaler */
+#define  SPI_I2SPR_MCKOE                     ((uint32_t)0x00000200)            /*!<Master Clock Output Enable */
+
+/******************************************************************************/
+/*                                                                            */
+/*                       System Configuration (SYSCFG)                        */
+/*                                                                            */
+/******************************************************************************/
+/*****************  Bit definition for SYSCFG_CFGR1 register  ****************/
+#define SYSCFG_CFGR1_MEM_MODE               ((uint32_t)0x00000003) /*!< SYSCFG_Memory Remap Config */
+#define SYSCFG_CFGR1_MEM_MODE_0             ((uint32_t)0x00000001) /*!< SYSCFG_Memory Remap Config Bit 0 */
+#define SYSCFG_CFGR1_MEM_MODE_1             ((uint32_t)0x00000002) /*!< SYSCFG_Memory Remap Config Bit 1 */
+#define SYSCFG_CFGR1_BOOT_MODE              ((uint32_t)0x00000300) /*!< SYSCFG_Boot mode Config */
+#define SYSCFG_CFGR1_BOOT_MOD_0            ((uint32_t)0x00000100) /*!< SYSCFG_Boot mode Config Bit 0 */
+#define SYSCFG_CFGR1_BOOT_MODE_1            ((uint32_t)0x00000200) /*!< SYSCFG_Boot mode Config Bit 1 */
+
+/*****************  Bit definition for SYSCFG_CFGR2 register  ****************/
+#define SYSCFG_CFGR2_FWDISEN                ((uint32_t)0x00000001) /*!< Firewall disable bit */
+#define SYSCFG_CFGR2_CAPA                   ((uint32_t)0x0000000E) /*!< Connection of internal Vlcd rail to external capacitors */
+#define SYSCFG_CFGR2_CAPA_0                 ((uint32_t)0x00000002)
+#define SYSCFG_CFGR2_CAPA_1                 ((uint32_t)0x00000004)
+#define SYSCFG_CFGR2_CAPA_2                 ((uint32_t)0x00000008)
+#define SYSCFG_CFGR2_I2C_PB6_FMP            ((uint32_t)0x00000100) /*!< I2C PB6 Fast mode plus */
+#define SYSCFG_CFGR2_I2C_PB7_FMP            ((uint32_t)0x00000200) /*!< I2C PB7 Fast mode plus */
+#define SYSCFG_CFGR2_I2C_PB8_FMP            ((uint32_t)0x00000400) /*!< I2C PB8 Fast mode plus */
+#define SYSCFG_CFGR2_I2C_PB9_FMP            ((uint32_t)0x00000800) /*!< I2C PB9 Fast mode plus */
+#define SYSCFG_CFGR2_I2C1_FMP               ((uint32_t)0x00001000) /*!< I2C1 Fast mode plus */
+#define SYSCFG_CFGR2_I2C2_FMP               ((uint32_t)0x00002000) /*!< I2C2 Fast mode plus */
+
+/*****************  Bit definition for SYSCFG_EXTICR1 register  ***************/
+#define SYSCFG_EXTICR1_EXTI0            ((uint32_t)0x0000000F) /*!< EXTI 0 configuration */
+#define SYSCFG_EXTICR1_EXTI1            ((uint32_t)0x000000F0) /*!< EXTI 1 configuration */
+#define SYSCFG_EXTICR1_EXTI2            ((uint32_t)0x00000F00) /*!< EXTI 2 configuration */
+#define SYSCFG_EXTICR1_EXTI3            ((uint32_t)0x0000F000) /*!< EXTI 3 configuration */
+
+/** 
+  * @brief  EXTI0 configuration  
+  */
+#define SYSCFG_EXTICR1_EXTI0_PA         ((uint32_t)0x00000000) /*!< PA[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PB         ((uint32_t)0x00000001) /*!< PB[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PC         ((uint32_t)0x00000002) /*!< PC[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PH         ((uint32_t)0x00000005) /*!< PH[0] pin */
+
+/** 
+  * @brief  EXTI1 configuration  
+  */ 
+#define SYSCFG_EXTICR1_EXTI1_PA         ((uint32_t)0x00000000) /*!< PA[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PB         ((uint32_t)0x00000010) /*!< PB[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PC         ((uint32_t)0x00000020) /*!< PC[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PH         ((uint32_t)0x00000050) /*!< PH[1] pin */
+
+/** 
+  * @brief  EXTI2 configuration  
+  */
+#define SYSCFG_EXTICR1_EXTI2_PA         ((uint32_t)0x00000000) /*!< PA[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PB         ((uint32_t)0x00000100) /*!< PB[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PC         ((uint32_t)0x00000200) /*!< PC[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PD         ((uint32_t)0x00000300) /*!< PD[2] pin */
+
+/** 
+  * @brief  EXTI3 configuration  
+  */
+#define SYSCFG_EXTICR1_EXTI3_PA         ((uint32_t)0x00000000) /*!< PA[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PB         ((uint32_t)0x00001000) /*!< PB[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PC         ((uint32_t)0x00002000) /*!< PC[3] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR2 register  *****************/
+#define SYSCFG_EXTICR2_EXTI4            ((uint32_t)0x0000000F) /*!< EXTI 4 configuration */
+#define SYSCFG_EXTICR2_EXTI5            ((uint32_t)0x000000F0) /*!< EXTI 5 configuration */
+#define SYSCFG_EXTICR2_EXTI6            ((uint32_t)0x00000F00) /*!< EXTI 6 configuration */
+#define SYSCFG_EXTICR2_EXTI7            ((uint32_t)0x0000F000) /*!< EXTI 7 configuration */
+
+/** 
+  * @brief  EXTI4 configuration  
+  */
+#define SYSCFG_EXTICR2_EXTI4_PA         ((uint32_t)0x00000000) /*!< PA[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PB         ((uint32_t)0x00000001) /*!< PB[4] pin */
+#define SYSCFG_EXTICR2_EXTI4_PC         ((uint32_t)0x00000002) /*!< PC[4] pin */
+
+
+/** 
+  * @brief  EXTI5 configuration  
+  */
+#define SYSCFG_EXTICR2_EXTI5_PA         ((uint32_t)0x00000000) /*!< PA[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PB         ((uint32_t)0x00000010) /*!< PB[5] pin */
+#define SYSCFG_EXTICR2_EXTI5_PC         ((uint32_t)0x00000020) /*!< PC[5] pin */
+
+/** 
+  * @brief  EXTI6 configuration  
+  */
+#define SYSCFG_EXTICR2_EXTI6_PA         ((uint32_t)0x00000000) /*!< PA[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PB         ((uint32_t)0x00000100) /*!< PB[6] pin */
+#define SYSCFG_EXTICR2_EXTI6_PC         ((uint32_t)0x00000200) /*!< PC[6] pin */
+
+/** 
+  * @brief  EXTI7 configuration  
+  */
+#define SYSCFG_EXTICR2_EXTI7_PA         ((uint32_t)0x00000000) /*!< PA[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PB         ((uint32_t)0x00001000) /*!< PB[7] pin */
+#define SYSCFG_EXTICR2_EXTI7_PC         ((uint32_t)0x00002000) /*!< PC[7] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR3 register  *****************/
+#define SYSCFG_EXTICR3_EXTI8            ((uint32_t)0x0000000F) /*!< EXTI 8 configuration */
+#define SYSCFG_EXTICR3_EXTI9            ((uint32_t)0x000000F0) /*!< EXTI 9 configuration */
+#define SYSCFG_EXTICR3_EXTI10           ((uint32_t)0x00000F00) /*!< EXTI 10 configuration */
+#define SYSCFG_EXTICR3_EXTI11           ((uint32_t)0x0000F000) /*!< EXTI 11 configuration */
+
+/** 
+  * @brief  EXTI8 configuration  
+  */
+#define SYSCFG_EXTICR3_EXTI8_PA         ((uint32_t)0x00000000) /*!< PA[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PB         ((uint32_t)0x00000001) /*!< PB[8] pin */
+#define SYSCFG_EXTICR3_EXTI8_PC         ((uint32_t)0x00000002) /*!< PC[8] pin */
+
+/** 
+  * @brief  EXTI9 configuration  
+  */
+#define SYSCFG_EXTICR3_EXTI9_PA         ((uint32_t)0x00000000) /*!< PA[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PB         ((uint32_t)0x00000010) /*!< PB[9] pin */
+#define SYSCFG_EXTICR3_EXTI9_PC         ((uint32_t)0x00000020) /*!< PC[9] pin */
+
+/** 
+  * @brief  EXTI10 configuration  
+  */
+#define SYSCFG_EXTICR3_EXTI10_PA        ((uint32_t)0x00000000) /*!< PA[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PB        ((uint32_t)0x00000100) /*!< PB[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PC        ((uint32_t)0x00000200) /*!< PC[10] pin */
+
+/** 
+  * @brief  EXTI11 configuration  
+  */
+#define SYSCFG_EXTICR3_EXTI11_PA        ((uint32_t)0x00000000) /*!< PA[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PB        ((uint32_t)0x00001000) /*!< PB[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PC        ((uint32_t)0x00002000) /*!< PC[11] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR4 register  *****************/
+#define SYSCFG_EXTICR4_EXTI12           ((uint32_t)0x0000000F) /*!< EXTI 12 configuration */
+#define SYSCFG_EXTICR4_EXTI13           ((uint32_t)0x000000F0) /*!< EXTI 13 configuration */
+#define SYSCFG_EXTICR4_EXTI14           ((uint32_t)0x00000F00) /*!< EXTI 14 configuration */
+#define SYSCFG_EXTICR4_EXTI15           ((uint32_t)0x0000F000) /*!< EXTI 15 configuration */
+
+/** 
+  * @brief  EXTI12 configuration  
+  */
+#define SYSCFG_EXTICR4_EXTI12_PA        ((uint32_t)0x00000000) /*!< PA[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PB        ((uint32_t)0x00000001) /*!< PB[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PC        ((uint32_t)0x00000002) /*!< PC[12] pin */
+
+/** 
+  * @brief  EXTI13 configuration  
+  */
+#define SYSCFG_EXTICR4_EXTI13_PA        ((uint32_t)0x00000000) /*!< PA[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PB        ((uint32_t)0x00000010) /*!< PB[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PC        ((uint32_t)0x00000020) /*!< PC[13] pin */
+
+/** 
+  * @brief  EXTI14 configuration  
+  */
+#define SYSCFG_EXTICR4_EXTI14_PA        ((uint32_t)0x00000000) /*!< PA[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PB        ((uint32_t)0x00000100) /*!< PB[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PC        ((uint32_t)0x00000200) /*!< PC[14] pin */
+
+/** 
+  * @brief  EXTI15 configuration  
+  */
+#define SYSCFG_EXTICR4_EXTI15_PA        ((uint32_t)0x00000000) /*!< PA[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PB        ((uint32_t)0x00001000) /*!< PB[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PC        ((uint32_t)0x00002000) /*!< PC[15] pin */
+
+
+/*****************  Bit definition for SYSCFG_CFGR3 register  ****************/
+#define SYSCFG_CFGR3_EN_VREFINT               ((uint32_t)0x00000001) /*!< Vref Enable bit*/
+#define SYSCFG_CFGR3_VREF_OUT                 ((uint32_t)0x00000030) /*!< Verf_ADC connection bit */
+#define SYSCFG_CFGR3_VREF_OUT_0               ((uint32_t)0x00000010) /*!< Bit 0 */
+#define SYSCFG_CFGR3_VREF_OUT_1               ((uint32_t)0x00000020) /*!< Bit 1 */
+#define SYSCFG_CFGR3_ENBUF_VREFINT_ADC        ((uint32_t)0x00000100) /*!< VREFINT reference for ADC enable bit */
+#define SYSCFG_CFGR3_ENBUF_SENSOR_ADC         ((uint32_t)0x00000200) /*!< Sensor reference for ADC enable bit */
+#define SYSCFG_CFGR3_ENBUFLP_VREFINT_COMP     ((uint32_t)0x00001000) /*!< VREFINT reference for comparator 2 enable bit */
+#define SYSCFG_CFGR3_ENREF_HSI48              ((uint32_t)0x00002000) /*!< VREFINT reference or 48 MHz RC oscillator enable bit */
+#define SYSCFG_CFGR3_REF_HSI48_RDYF           ((uint32_t)0x04000000) /*!< VREFINT for 48 MHz RC oscillator ready flag */
+#define SYSCFG_CFGR3_SENSOR_ADC_RDYF          ((uint32_t)0x08000000) /*!< Sensor for ADC ready flag */
+#define SYSCFG_CFGR3_VREFINT_ADC_RDYF         ((uint32_t)0x10000000) /*!< VREFINT for ADC ready flag */
+#define SYSCFG_CFGR3_VREFINT_COMP_RDYF        ((uint32_t)0x20000000) /*!< VREFINT for comparator ready flag */
+#define SYSCFG_CFGR3_VREFINT_RDYF             ((uint32_t)0x40000000) /*!< VREFINT ready flag */
+#define SYSCFG_CFGR3_REF_LOCK                 ((uint32_t)0x80000000) /*!< CFGR3 lock bit */
+
+/* Bit names aliases maintained for legacy */
+
+#define SYSCFG_CFGR3_EN_BGAP                  SYSCFG_CFGR3_EN_VREFINT
+#define SYSCFG_CFGR3_ENBUF_BGAP_ADC           SYSCFG_CFGR3_ENBUF_VREFINT_ADC
+#define SYSCFG_CFGR3_ENBUFLP_BGAP_COMP        SYSCFG_CFGR3_ENBUFLP_VREFINT_COMP
+#define SYSCFG_CFGR3_ENREF_RC48MHz            SYSCFG_CFGR3_ENREF_HSI48
+#define SYSCFG_CFGR3_REF_RC48MHz_RDYF         SYSCFG_CFGR3_REF_HSI48_RDYF
+#define SYSCFG_VREFINT_ADC_RDYF               SYSCFG_CFGR3_VREFINT_ADC_RDYF
+
+/******************************************************************************/
+/*                                                                            */
+/*                               Timers (TIM)                                 */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TIM_CR1 register  ********************/
+#define  TIM_CR1_CEN                         ((uint32_t)0x00000001)            /*!<Counter enable */
+#define  TIM_CR1_UDIS                        ((uint32_t)0x00000002)            /*!<Update disable */
+#define  TIM_CR1_URS                         ((uint32_t)0x00000004)            /*!<Update request source */
+#define  TIM_CR1_OPM                         ((uint32_t)0x00000008)            /*!<One pulse mode */
+#define  TIM_CR1_DIR                         ((uint32_t)0x00000010)            /*!<Direction */
+
+#define  TIM_CR1_CMS                         ((uint32_t)0x00000060)            /*!<CMS[1:0] bits (Center-aligned mode selection) */
+#define  TIM_CR1_CMS_0                       ((uint32_t)0x00000020)            /*!<Bit 0 */
+#define  TIM_CR1_CMS_1                       ((uint32_t)0x00000040)            /*!<Bit 1 */
+
+#define  TIM_CR1_ARPE                        ((uint32_t)0x00000080)            /*!<Auto-reload preload enable */
+
+#define  TIM_CR1_CKD                         ((uint32_t)0x00000300)            /*!<CKD[1:0] bits (clock division) */
+#define  TIM_CR1_CKD_0                       ((uint32_t)0x00000100)            /*!<Bit 0 */
+#define  TIM_CR1_CKD_1                       ((uint32_t)0x00000200)            /*!<Bit 1 */
+
+/*******************  Bit definition for TIM_CR2 register  ********************/
+#define  TIM_CR2_CCPC                        ((uint32_t)0x00000001)            /*!<Capture/Compare Preloaded Control */
+#define  TIM_CR2_CCUS                        ((uint32_t)0x00000004)            /*!<Capture/Compare Control Update Selection */
+#define  TIM_CR2_CCDS                        ((uint32_t)0x00000008)            /*!<Capture/Compare DMA Selection */
+
+#define  TIM_CR2_MMS                         ((uint32_t)0x00000070)            /*!<MMS[2:0] bits (Master Mode Selection) */
+#define  TIM_CR2_MMS_0                       ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define  TIM_CR2_MMS_1                       ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define  TIM_CR2_MMS_2                       ((uint32_t)0x00000040)            /*!<Bit 2 */
+
+#define  TIM_CR2_TI1S                        ((uint32_t)0x00000080)            /*!<TI1 Selection */
+#define  TIM_CR2_OIS1                        ((uint32_t)0x00000100)            /*!<Output Idle state 1 (OC1 output) */
+#define  TIM_CR2_OIS1N                       ((uint32_t)0x00000200)            /*!<Output Idle state 1 (OC1N output) */
+#define  TIM_CR2_OIS2                        ((uint32_t)0x00000400)            /*!<Output Idle state 2 (OC2 output) */
+#define  TIM_CR2_OIS2N                       ((uint32_t)0x00000800)            /*!<Output Idle state 2 (OC2N output) */
+#define  TIM_CR2_OIS3                        ((uint32_t)0x00001000)            /*!<Output Idle state 3 (OC3 output) */
+#define  TIM_CR2_OIS3N                       ((uint32_t)0x00002000)            /*!<Output Idle state 3 (OC3N output) */
+#define  TIM_CR2_OIS4                        ((uint32_t)0x00004000)            /*!<Output Idle state 4 (OC4 output) */
+
+/*******************  Bit definition for TIM_SMCR register  *******************/
+#define  TIM_SMCR_SMS                        ((uint32_t)0x00000007)            /*!<SMS[2:0] bits (Slave mode selection) */
+#define  TIM_SMCR_SMS_0                      ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define  TIM_SMCR_SMS_1                      ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define  TIM_SMCR_SMS_2                      ((uint32_t)0x00000004)            /*!<Bit 2 */
+
+#define  TIM_SMCR_OCCS                       ((uint32_t)0x00000008)            /*!< OCREF clear selection */
+
+#define  TIM_SMCR_TS                         ((uint32_t)0x00000070)            /*!<TS[2:0] bits (Trigger selection) */
+#define  TIM_SMCR_TS_0                       ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define  TIM_SMCR_TS_1                       ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define  TIM_SMCR_TS_2                       ((uint32_t)0x00000040)            /*!<Bit 2 */
+
+#define  TIM_SMCR_MSM                        ((uint32_t)0x00000080)            /*!<Master/slave mode */
+
+#define  TIM_SMCR_ETF                        ((uint32_t)0x00000F00)            /*!<ETF[3:0] bits (External trigger filter) */
+#define  TIM_SMCR_ETF_0                      ((uint32_t)0x00000100)            /*!<Bit 0 */
+#define  TIM_SMCR_ETF_1                      ((uint32_t)0x00000200)            /*!<Bit 1 */
+#define  TIM_SMCR_ETF_2                      ((uint32_t)0x00000400)            /*!<Bit 2 */
+#define  TIM_SMCR_ETF_3                      ((uint32_t)0x00000800)            /*!<Bit 3 */
+
+#define  TIM_SMCR_ETPS                       ((uint32_t)0x00003000)            /*!<ETPS[1:0] bits (External trigger prescaler) */
+#define  TIM_SMCR_ETPS_0                     ((uint32_t)0x00001000)            /*!<Bit 0 */
+#define  TIM_SMCR_ETPS_1                     ((uint32_t)0x00002000)            /*!<Bit 1 */
+
+#define  TIM_SMCR_ECE                        ((uint32_t)0x00004000)            /*!<External clock enable */
+#define  TIM_SMCR_ETP                        ((uint32_t)0x00008000)            /*!<External trigger polarity */
+
+/*******************  Bit definition for TIM_DIER register  *******************/
+#define  TIM_DIER_UIE                        ((uint32_t)0x00000001)            /*!<Update interrupt enable */
+#define  TIM_DIER_CC1IE                      ((uint32_t)0x00000002)            /*!<Capture/Compare 1 interrupt enable */
+#define  TIM_DIER_CC2IE                      ((uint32_t)0x00000004)            /*!<Capture/Compare 2 interrupt enable */
+#define  TIM_DIER_CC3IE                      ((uint32_t)0x00000008)            /*!<Capture/Compare 3 interrupt enable */
+#define  TIM_DIER_CC4IE                      ((uint32_t)0x00000010)            /*!<Capture/Compare 4 interrupt enable */
+#define  TIM_DIER_COMIE                      ((uint32_t)0x00000020)            /*!<COM interrupt enable */
+#define  TIM_DIER_TIE                        ((uint32_t)0x00000040)            /*!<Trigger interrupt enable */
+#define  TIM_DIER_BIE                        ((uint32_t)0x00000080)            /*!<Break interrupt enable */
+#define  TIM_DIER_UDE                        ((uint32_t)0x00000100)            /*!<Update DMA request enable */
+#define  TIM_DIER_CC1DE                      ((uint32_t)0x00000200)            /*!<Capture/Compare 1 DMA request enable */
+#define  TIM_DIER_CC2DE                      ((uint32_t)0x00000400)            /*!<Capture/Compare 2 DMA request enable */
+#define  TIM_DIER_CC3DE                      ((uint32_t)0x00000800)            /*!<Capture/Compare 3 DMA request enable */
+#define  TIM_DIER_CC4DE                      ((uint32_t)0x00001000)            /*!<Capture/Compare 4 DMA request enable */
+#define  TIM_DIER_COMDE                      ((uint32_t)0x00002000)            /*!<COM DMA request enable */
+#define  TIM_DIER_TDE                        ((uint32_t)0x00004000)            /*!<Trigger DMA request enable */
+
+/********************  Bit definition for TIM_SR register  ********************/
+#define  TIM_SR_UIF                          ((uint32_t)0x00000001)            /*!<Update interrupt Flag */
+#define  TIM_SR_CC1IF                        ((uint32_t)0x00000002)            /*!<Capture/Compare 1 interrupt Flag */
+#define  TIM_SR_CC2IF                        ((uint32_t)0x00000004)            /*!<Capture/Compare 2 interrupt Flag */
+#define  TIM_SR_CC3IF                        ((uint32_t)0x00000008)            /*!<Capture/Compare 3 interrupt Flag */
+#define  TIM_SR_CC4IF                        ((uint32_t)0x00000010)            /*!<Capture/Compare 4 interrupt Flag */
+#define  TIM_SR_COMIF                        ((uint32_t)0x00000020)            /*!<COM interrupt Flag */
+#define  TIM_SR_TIF                          ((uint32_t)0x00000040)            /*!<Trigger interrupt Flag */
+#define  TIM_SR_BIF                          ((uint32_t)0x00000080)            /*!<Break interrupt Flag */
+#define  TIM_SR_CC1OF                        ((uint32_t)0x00000200)            /*!<Capture/Compare 1 Overcapture Flag */
+#define  TIM_SR_CC2OF                        ((uint32_t)0x00000400)            /*!<Capture/Compare 2 Overcapture Flag */
+#define  TIM_SR_CC3OF                        ((uint32_t)0x00000800)            /*!<Capture/Compare 3 Overcapture Flag */
+#define  TIM_SR_CC4OF                        ((uint32_t)0x00001000)            /*!<Capture/Compare 4 Overcapture Flag */
+
+/*******************  Bit definition for TIM_EGR register  ********************/
+#define  TIM_EGR_UG                          ((uint32_t)0x00000001)               /*!<Update Generation */
+#define  TIM_EGR_CC1G                        ((uint32_t)0x00000002)               /*!<Capture/Compare 1 Generation */
+#define  TIM_EGR_CC2G                        ((uint32_t)0x00000004)               /*!<Capture/Compare 2 Generation */
+#define  TIM_EGR_CC3G                        ((uint32_t)0x00000008)               /*!<Capture/Compare 3 Generation */
+#define  TIM_EGR_CC4G                        ((uint32_t)0x00000010)               /*!<Capture/Compare 4 Generation */
+#define  TIM_EGR_COMG                        ((uint32_t)0x00000020)               /*!<Capture/Compare Control Update Generation */
+#define  TIM_EGR_TG                          ((uint32_t)0x00000040)               /*!<Trigger Generation */
+#define  TIM_EGR_BG                          ((uint32_t)0x00000080)               /*!<Break Generation */
+
+/******************  Bit definition for TIM_CCMR1 register  *******************/
+#define  TIM_CCMR1_CC1S                      ((uint32_t)0x00000003)            /*!<CC1S[1:0] bits (Capture/Compare 1 Selection) */
+#define  TIM_CCMR1_CC1S_0                    ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define  TIM_CCMR1_CC1S_1                    ((uint32_t)0x00000002)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_OC1FE                     ((uint32_t)0x00000004)            /*!<Output Compare 1 Fast enable */
+#define  TIM_CCMR1_OC1PE                     ((uint32_t)0x00000008)            /*!<Output Compare 1 Preload enable */
+
+#define  TIM_CCMR1_OC1M                      ((uint32_t)0x00000070)            /*!<OC1M[2:0] bits (Output Compare 1 Mode) */
+#define  TIM_CCMR1_OC1M_0                    ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define  TIM_CCMR1_OC1M_1                    ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define  TIM_CCMR1_OC1M_2                    ((uint32_t)0x00000040)            /*!<Bit 2 */
+
+#define  TIM_CCMR1_OC1CE                     ((uint32_t)0x00000080)            /*!<Output Compare 1Clear Enable */
+
+#define  TIM_CCMR1_CC2S                      ((uint32_t)0x00000300)            /*!<CC2S[1:0] bits (Capture/Compare 2 Selection) */
+#define  TIM_CCMR1_CC2S_0                    ((uint32_t)0x00000100)            /*!<Bit 0 */
+#define  TIM_CCMR1_CC2S_1                    ((uint32_t)0x00000200)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_OC2FE                     ((uint32_t)0x00000400)            /*!<Output Compare 2 Fast enable */
+#define  TIM_CCMR1_OC2PE                     ((uint32_t)0x00000800)            /*!<Output Compare 2 Preload enable */
+
+#define  TIM_CCMR1_OC2M                      ((uint32_t)0x00007000)            /*!<OC2M[2:0] bits (Output Compare 2 Mode) */
+#define  TIM_CCMR1_OC2M_0                    ((uint32_t)0x00001000)            /*!<Bit 0 */
+#define  TIM_CCMR1_OC2M_1                    ((uint32_t)0x00002000)            /*!<Bit 1 */
+#define  TIM_CCMR1_OC2M_2                    ((uint32_t)0x00004000)            /*!<Bit 2 */
+
+#define  TIM_CCMR1_OC2CE                     ((uint32_t)0x00008000)            /*!<Output Compare 2 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+
+#define  TIM_CCMR1_IC1PSC                    ((uint32_t)0x0000000C)            /*!<IC1PSC[1:0] bits (Input Capture 1 Prescaler) */
+#define  TIM_CCMR1_IC1PSC_0                  ((uint32_t)0x00000004)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC1PSC_1                  ((uint32_t)0x00000008)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_IC1F                      ((uint32_t)0x000000F0)            /*!<IC1F[3:0] bits (Input Capture 1 Filter) */
+#define  TIM_CCMR1_IC1F_0                    ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC1F_1                    ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define  TIM_CCMR1_IC1F_2                    ((uint32_t)0x00000040)            /*!<Bit 2 */
+#define  TIM_CCMR1_IC1F_3                    ((uint32_t)0x00000080)            /*!<Bit 3 */
+
+#define  TIM_CCMR1_IC2PSC                    ((uint32_t)0x00000C00)            /*!<IC2PSC[1:0] bits (Input Capture 2 Prescaler) */
+#define  TIM_CCMR1_IC2PSC_0                  ((uint32_t)0x00000400)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC2PSC_1                  ((uint32_t)0x00000800)            /*!<Bit 1 */
+
+#define  TIM_CCMR1_IC2F                      ((uint32_t)0x0000F000)            /*!<IC2F[3:0] bits (Input Capture 2 Filter) */
+#define  TIM_CCMR1_IC2F_0                    ((uint32_t)0x00001000)            /*!<Bit 0 */
+#define  TIM_CCMR1_IC2F_1                    ((uint32_t)0x00002000)            /*!<Bit 1 */
+#define  TIM_CCMR1_IC2F_2                    ((uint32_t)0x00004000)            /*!<Bit 2 */
+#define  TIM_CCMR1_IC2F_3                    ((uint32_t)0x00008000)            /*!<Bit 3 */
+
+/******************  Bit definition for TIM_CCMR2 register  *******************/
+#define  TIM_CCMR2_CC3S                      ((uint32_t)0x00000003)            /*!<CC3S[1:0] bits (Capture/Compare 3 Selection) */
+#define  TIM_CCMR2_CC3S_0                    ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define  TIM_CCMR2_CC3S_1                    ((uint32_t)0x00000002)            /*!<Bit 1 */
+
+#define  TIM_CCMR2_OC3FE                     ((uint32_t)0x00000004)            /*!<Output Compare 3 Fast enable */
+#define  TIM_CCMR2_OC3PE                     ((uint32_t)0x00000008)            /*!<Output Compare 3 Preload enable */
+
+#define  TIM_CCMR2_OC3M                      ((uint32_t)0x00000070)            /*!<OC3M[2:0] bits (Output Compare 3 Mode) */
+#define  TIM_CCMR2_OC3M_0                    ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define  TIM_CCMR2_OC3M_1                    ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define  TIM_CCMR2_OC3M_2                    ((uint32_t)0x00000040)            /*!<Bit 2 */
+
+#define  TIM_CCMR2_OC3CE                     ((uint32_t)0x00000080)            /*!<Output Compare 3 Clear Enable */
+
+#define  TIM_CCMR2_CC4S                      ((uint32_t)0x00000300)            /*!<CC4S[1:0] bits (Capture/Compare 4 Selection) */
+#define  TIM_CCMR2_CC4S_0                    ((uint32_t)0x00000100)            /*!<Bit 0 */
+#define  TIM_CCMR2_CC4S_1                    ((uint32_t)0x00000200)            /*!<Bit 1 */
+
+#define  TIM_CCMR2_OC4FE                     ((uint32_t)0x00000400)            /*!<Output Compare 4 Fast enable */
+#define  TIM_CCMR2_OC4PE                     ((uint32_t)0x00000800)            /*!<Output Compare 4 Preload enable */
+
+#define  TIM_CCMR2_OC4M                      ((uint32_t)0x00007000)            /*!<OC4M[2:0] bits (Output Compare 4 Mode) */
+#define  TIM_CCMR2_OC4M_0                    ((uint32_t)0x00001000)            /*!<Bit 0 */
+#define  TIM_CCMR2_OC4M_1                    ((uint32_t)0x00002000)            /*!<Bit 1 */
+#define  TIM_CCMR2_OC4M_2                    ((uint32_t)0x00004000)            /*!<Bit 2 */
+
+#define  TIM_CCMR2_OC4CE                     ((uint32_t)0x00008000)            /*!<Output Compare 4 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+
+#define  TIM_CCMR2_IC3PSC                    ((uint32_t)0x0000000C)            /*!<IC3PSC[1:0] bits (Input Capture 3 Prescaler) */
+#define  TIM_CCMR2_IC3PSC_0                  ((uint32_t)0x00000004)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC3PSC_1                  ((uint32_t)0x00000008)            /*!<Bit 1 */
+
+#define  TIM_CCMR2_IC3F                      ((uint32_t)0x000000F0)            /*!<IC3F[3:0] bits (Input Capture 3 Filter) */
+#define  TIM_CCMR2_IC3F_0                    ((uint32_t)0x00000010)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC3F_1                    ((uint32_t)0x00000020)            /*!<Bit 1 */
+#define  TIM_CCMR2_IC3F_2                    ((uint32_t)0x00000040)            /*!<Bit 2 */
+#define  TIM_CCMR2_IC3F_3                    ((uint32_t)0x00000080)            /*!<Bit 3 */
+
+#define  TIM_CCMR2_IC4PSC                    ((uint32_t)0x00000C00)            /*!<IC4PSC[1:0] bits (Input Capture 4 Prescaler) */
+#define  TIM_CCMR2_IC4PSC_0                  ((uint32_t)0x00000400)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC4PSC_1                  ((uint32_t)0x00000800)            /*!<Bit 1 */
+
+#define  TIM_CCMR2_IC4F                      ((uint32_t)0x0000F000)            /*!<IC4F[3:0] bits (Input Capture 4 Filter) */
+#define  TIM_CCMR2_IC4F_0                    ((uint32_t)0x00001000)            /*!<Bit 0 */
+#define  TIM_CCMR2_IC4F_1                    ((uint32_t)0x00002000)            /*!<Bit 1 */
+#define  TIM_CCMR2_IC4F_2                    ((uint32_t)0x00004000)            /*!<Bit 2 */
+#define  TIM_CCMR2_IC4F_3                    ((uint32_t)0x00008000)            /*!<Bit 3 */
+
+/*******************  Bit definition for TIM_CCER register  *******************/
+#define  TIM_CCER_CC1E                       ((uint32_t)0x00000001)            /*!<Capture/Compare 1 output enable */
+#define  TIM_CCER_CC1P                       ((uint32_t)0x00000002)            /*!<Capture/Compare 1 output Polarity */
+#define  TIM_CCER_CC1NE                      ((uint32_t)0x00000004)            /*!<Capture/Compare 1 Complementary output enable */
+#define  TIM_CCER_CC1NP                      ((uint32_t)0x00000008)            /*!<Capture/Compare 1 Complementary output Polarity */
+#define  TIM_CCER_CC2E                       ((uint32_t)0x00000010)            /*!<Capture/Compare 2 output enable */
+#define  TIM_CCER_CC2P                       ((uint32_t)0x00000020)            /*!<Capture/Compare 2 output Polarity */
+#define  TIM_CCER_CC2NE                      ((uint32_t)0x00000040)            /*!<Capture/Compare 2 Complementary output enable */
+#define  TIM_CCER_CC2NP                      ((uint32_t)0x00000080)            /*!<Capture/Compare 2 Complementary output Polarity */
+#define  TIM_CCER_CC3E                       ((uint32_t)0x00000100)            /*!<Capture/Compare 3 output enable */
+#define  TIM_CCER_CC3P                       ((uint32_t)0x00000200)            /*!<Capture/Compare 3 output Polarity */
+#define  TIM_CCER_CC3NE                      ((uint32_t)0x00000400)            /*!<Capture/Compare 3 Complementary output enable */
+#define  TIM_CCER_CC3NP                      ((uint32_t)0x00000800)            /*!<Capture/Compare 3 Complementary output Polarity */
+#define  TIM_CCER_CC4E                       ((uint32_t)0x00001000)            /*!<Capture/Compare 4 output enable */
+#define  TIM_CCER_CC4P                       ((uint32_t)0x00002000)            /*!<Capture/Compare 4 output Polarity */
+#define  TIM_CCER_CC4NP                      ((uint32_t)0x00008000)            /*!<Capture/Compare 4 Complementary output Polarity */
+
+/*******************  Bit definition for TIM_CNT register  ********************/
+#define  TIM_CNT_CNT                         ((uint32_t)0x0000FFFF)            /*!<Counter Value */
+
+/*******************  Bit definition for TIM_PSC register  ********************/
+#define  TIM_PSC_PSC                         ((uint32_t)0x0000FFFF)            /*!<Prescaler Value */
+
+/*******************  Bit definition for TIM_ARR register  ********************/
+#define  TIM_ARR_ARR                         ((uint32_t)0x0000FFFF)            /*!<actual auto-reload Value */
+
+/*******************  Bit definition for TIM_RCR register  ********************/
+#define  TIM_RCR_REP                         ((uint32_t)0x000000FF)               /*!<Repetition Counter Value */
+
+/*******************  Bit definition for TIM_CCR1 register  *******************/
+#define  TIM_CCR1_CCR1                       ((uint32_t)0x0000FFFF)            /*!<Capture/Compare 1 Value */
+
+/*******************  Bit definition for TIM_CCR2 register  *******************/
+#define  TIM_CCR2_CCR2                       ((uint32_t)0x0000FFFF)            /*!<Capture/Compare 2 Value */
+
+/*******************  Bit definition for TIM_CCR3 register  *******************/
+#define  TIM_CCR3_CCR3                       ((uint32_t)0x0000FFFF)            /*!<Capture/Compare 3 Value */
+
+/*******************  Bit definition for TIM_CCR4 register  *******************/
+#define  TIM_CCR4_CCR4                       ((uint32_t)0x0000FFFF)            /*!<Capture/Compare 4 Value */
+
+/*******************  Bit definition for TIM_BDTR register  *******************/
+#define  TIM_BDTR_DTG                        ((uint32_t)0x000000FF)            /*!<DTG[0:7] bits (Dead-Time Generator set-up) */
+#define  TIM_BDTR_DTG_0                      ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define  TIM_BDTR_DTG_1                      ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define  TIM_BDTR_DTG_2                      ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define  TIM_BDTR_DTG_3                      ((uint32_t)0x00000008)            /*!<Bit 3 */
+#define  TIM_BDTR_DTG_4                      ((uint32_t)0x00000010)            /*!<Bit 4 */
+#define  TIM_BDTR_DTG_5                      ((uint32_t)0x00000020)            /*!<Bit 5 */
+#define  TIM_BDTR_DTG_6                      ((uint32_t)0x00000040)            /*!<Bit 6 */
+#define  TIM_BDTR_DTG_7                      ((uint32_t)0x00000080)            /*!<Bit 7 */
+
+#define  TIM_BDTR_LOCK                       ((uint32_t)0x00000300)            /*!<LOCK[1:0] bits (Lock Configuration) */
+#define  TIM_BDTR_LOCK_0                     ((uint32_t)0x00000100)            /*!<Bit 0 */
+#define  TIM_BDTR_LOCK_1                     ((uint32_t)0x00000200)            /*!<Bit 1 */
+
+#define  TIM_BDTR_OSSI                       ((uint32_t)0x00000400)            /*!<Off-State Selection for Idle mode */
+#define  TIM_BDTR_OSSR                       ((uint32_t)0x00000800)            /*!<Off-State Selection for Run mode */
+#define  TIM_BDTR_BKE                        ((uint32_t)0x00001000)            /*!<Break enable */
+#define  TIM_BDTR_BKP                        ((uint32_t)0x00002000)            /*!<Break Polarity */
+#define  TIM_BDTR_AOE                        ((uint32_t)0x00004000)            /*!<Automatic Output enable */
+#define  TIM_BDTR_MOE                        ((uint32_t)0x00008000)            /*!<Main Output enable */
+
+/*******************  Bit definition for TIM_DCR register  ********************/
+#define  TIM_DCR_DBA                         ((uint32_t)0x0000001F)            /*!<DBA[4:0] bits (DMA Base Address) */
+#define  TIM_DCR_DBA_0                       ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define  TIM_DCR_DBA_1                       ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define  TIM_DCR_DBA_2                       ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define  TIM_DCR_DBA_3                       ((uint32_t)0x00000008)            /*!<Bit 3 */
+#define  TIM_DCR_DBA_4                       ((uint32_t)0x00000010)            /*!<Bit 4 */
+
+#define  TIM_DCR_DBL                         ((uint32_t)0x00001F00)            /*!<DBL[4:0] bits (DMA Burst Length) */
+#define  TIM_DCR_DBL_0                       ((uint32_t)0x00000100)            /*!<Bit 0 */
+#define  TIM_DCR_DBL_1                       ((uint32_t)0x00000200)            /*!<Bit 1 */
+#define  TIM_DCR_DBL_2                       ((uint32_t)0x00000400)            /*!<Bit 2 */
+#define  TIM_DCR_DBL_3                       ((uint32_t)0x00000800)            /*!<Bit 3 */
+#define  TIM_DCR_DBL_4                       ((uint32_t)0x00001000)            /*!<Bit 4 */
+
+/*******************  Bit definition for TIM_DMAR register  *******************/
+#define  TIM_DMAR_DMAB                       ((uint32_t)0x0000FFFF)            /*!<DMA register for burst accesses */
+
+/*******************  Bit definition for TIM_OR register  *********************/
+/*******************  Bit definition for TIM_OR register  *********************/
+#define TIM2_OR_ETR_RMP                       ((uint32_t)0x00000007)            /*!<ETR_RMP[1:0] bits (TIM2 ETR remap) */
+#define TIM2_OR_ETR_RMP_0                     ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define TIM2_OR_ETR_RMP_1                     ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define TIM2_OR_ETR_RMP_2                     ((uint32_t)0x00000004)            /*!<Bit 2 */
+#define TIM2_OR_TI4_RMP                       ((uint32_t)0x0000018)            /*!<TI4_RMP[1:0] bits (TIM2 Input 4 remap) */
+#define TIM2_OR_TI4_RMP_0                     ((uint32_t)0x00000008)            /*!<Bit 0 */
+#define TIM2_OR_TI4_RMP_1                     ((uint32_t)0x00000010)            /*!<Bit 1 */
+
+#define TIM21_OR_ETR_RMP                      ((uint32_t)0x00000003)            /*!<ETR_RMP[1:0] bits (TIM21 ETR remap) */
+#define TIM21_OR_ETR_RMP_0                    ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define TIM21_OR_ETR_RMP_1                    ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define TIM21_OR_TI1_RMP                      ((uint32_t)0x0000001C)            /*!<TI1_RMP[2:0] bits (TIM21 Input 1 remap) */
+#define TIM21_OR_TI1_RMP_0                    ((uint32_t)0x00000004)            /*!<Bit 0 */
+#define TIM21_OR_TI1_RMP_1                    ((uint32_t)0x00000008)            /*!<Bit 1 */
+#define TIM21_OR_TI1_RMP_2                    ((uint32_t)0x00000010)            /*!<Bit 2 */
+#define TIM21_OR_TI2_RMP                      ((uint32_t)0x00000020)            /*!<TI2_RMP bit (TIM21 Input 2 remap) */
+
+#define TIM22_OR_ETR_RMP                      ((uint32_t)0x00000003)            /*!<ETR_RMP[1:0] bits (TIM22 ETR remap) */
+#define TIM22_OR_ETR_RMP_0                    ((uint32_t)0x00000001)            /*!<Bit 0 */
+#define TIM22_OR_ETR_RMP_1                    ((uint32_t)0x00000002)            /*!<Bit 1 */
+#define TIM22_OR_TI1_RMP                      ((uint32_t)0x0000000C)            /*!<TI1_RMP[2:0] bits (TIM22 Input 1 remap) */
+#define TIM22_OR_TI1_RMP_0                    ((uint32_t)0x00000004)            /*!<Bit 0 */
+#define TIM22_OR_TI1_RMP_1                    ((uint32_t)0x00000008)            /*!<Bit 1 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                          Touch Sensing Controller (TSC)                    */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TSC_CR register  *********************/
+#define  TSC_CR_TSCE                         ((uint32_t)0x00000001)            /*!<Touch sensing controller enable */
+#define  TSC_CR_START                        ((uint32_t)0x00000002)            /*!<Start acquisition */
+#define  TSC_CR_AM                           ((uint32_t)0x00000004)            /*!<Acquisition mode */
+#define  TSC_CR_SYNCPOL                      ((uint32_t)0x00000008)            /*!<Synchronization pin polarity */
+#define  TSC_CR_IODEF                        ((uint32_t)0x00000010)            /*!<IO default mode */
+
+#define  TSC_CR_MCV                          ((uint32_t)0x000000E0)            /*!<MCV[2:0] bits (Max Count Value) */
+#define  TSC_CR_MCV_0                        ((uint32_t)0x00000020)            /*!<Bit 0 */
+#define  TSC_CR_MCV_1                        ((uint32_t)0x00000040)            /*!<Bit 1 */
+#define  TSC_CR_MCV_2                        ((uint32_t)0x00000080)            /*!<Bit 2 */
+
+#define  TSC_CR_PGPSC                        ((uint32_t)0x00007000)            /*!<PGPSC[2:0] bits (Pulse Generator Prescaler) */
+#define  TSC_CR_PGPSC_0                      ((uint32_t)0x00001000)            /*!<Bit 0 */
+#define  TSC_CR_PGPSC_1                      ((uint32_t)0x00002000)            /*!<Bit 1 */
+#define  TSC_CR_PGPSC_2                      ((uint32_t)0x00004000)            /*!<Bit 2 */
+
+#define  TSC_CR_SSPSC                        ((uint32_t)0x00008000)            /*!<Spread Spectrum Prescaler */
+#define  TSC_CR_SSE                          ((uint32_t)0x00010000)            /*!<Spread Spectrum Enable */
+
+#define  TSC_CR_SSD                          ((uint32_t)0x00FE0000)            /*!<SSD[6:0] bits (Spread Spectrum Deviation) */
+#define  TSC_CR_SSD_0                        ((uint32_t)0x00020000)            /*!<Bit 0 */
+#define  TSC_CR_SSD_1                        ((uint32_t)0x00040000)            /*!<Bit 1 */
+#define  TSC_CR_SSD_2                        ((uint32_t)0x00080000)            /*!<Bit 2 */
+#define  TSC_CR_SSD_3                        ((uint32_t)0x00100000)            /*!<Bit 3 */
+#define  TSC_CR_SSD_4                        ((uint32_t)0x00200000)            /*!<Bit 4 */
+#define  TSC_CR_SSD_5                        ((uint32_t)0x00400000)            /*!<Bit 5 */
+#define  TSC_CR_SSD_6                        ((uint32_t)0x00800000)            /*!<Bit 6 */
+
+#define  TSC_CR_CTPL                         ((uint32_t)0x0F000000)            /*!<CTPL[3:0] bits (Charge Transfer pulse low) */
+#define  TSC_CR_CTPL_0                       ((uint32_t)0x01000000)            /*!<Bit 0 */
+#define  TSC_CR_CTPL_1                       ((uint32_t)0x02000000)            /*!<Bit 1 */
+#define  TSC_CR_CTPL_2                       ((uint32_t)0x04000000)            /*!<Bit 2 */
+#define  TSC_CR_CTPL_3                       ((uint32_t)0x08000000)            /*!<Bit 3 */
+
+#define  TSC_CR_CTPH                         ((uint32_t)0xF0000000)            /*!<CTPH[3:0] bits (Charge Transfer pulse high) */
+#define  TSC_CR_CTPH_0                       ((uint32_t)0x10000000)            /*!<Bit 0 */
+#define  TSC_CR_CTPH_1                       ((uint32_t)0x20000000)            /*!<Bit 1 */
+#define  TSC_CR_CTPH_2                       ((uint32_t)0x40000000)            /*!<Bit 2 */
+#define  TSC_CR_CTPH_3                       ((uint32_t)0x80000000)            /*!<Bit 3 */
+
+/*******************  Bit definition for TSC_IER register  ********************/
+#define  TSC_IER_EOAIE                       ((uint32_t)0x00000001)            /*!<End of acquisition interrupt enable */
+#define  TSC_IER_MCEIE                       ((uint32_t)0x00000002)            /*!<Max count error interrupt enable */
+
+/*******************  Bit definition for TSC_ICR register  ********************/
+#define  TSC_ICR_EOAIC                       ((uint32_t)0x00000001)            /*!<End of acquisition interrupt clear */
+#define  TSC_ICR_MCEIC                       ((uint32_t)0x00000002)            /*!<Max count error interrupt clear */
+
+/*******************  Bit definition for TSC_ISR register  ********************/
+#define  TSC_ISR_EOAF                        ((uint32_t)0x00000001)            /*!<End of acquisition flag */
+#define  TSC_ISR_MCEF                        ((uint32_t)0x00000002)            /*!<Max count error flag */
+
+/*******************  Bit definition for TSC_IOHCR register  ******************/
+#define  TSC_IOHCR_G1_IO1                    ((uint32_t)0x00000001)            /*!<GROUP1_IO1 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G1_IO2                    ((uint32_t)0x00000002)            /*!<GROUP1_IO2 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G1_IO3                    ((uint32_t)0x00000004)            /*!<GROUP1_IO3 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G1_IO4                    ((uint32_t)0x00000008)            /*!<GROUP1_IO4 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G2_IO1                    ((uint32_t)0x00000010)            /*!<GROUP2_IO1 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G2_IO2                    ((uint32_t)0x00000020)            /*!<GROUP2_IO2 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G2_IO3                    ((uint32_t)0x00000040)            /*!<GROUP2_IO3 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G2_IO4                    ((uint32_t)0x00000080)            /*!<GROUP2_IO4 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G3_IO1                    ((uint32_t)0x00000100)            /*!<GROUP3_IO1 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G3_IO2                    ((uint32_t)0x00000200)            /*!<GROUP3_IO2 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G3_IO3                    ((uint32_t)0x00000400)            /*!<GROUP3_IO3 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G3_IO4                    ((uint32_t)0x00000800)            /*!<GROUP3_IO4 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G4_IO1                    ((uint32_t)0x00001000)            /*!<GROUP4_IO1 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G4_IO2                    ((uint32_t)0x00002000)            /*!<GROUP4_IO2 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G4_IO3                    ((uint32_t)0x00004000)            /*!<GROUP4_IO3 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G4_IO4                    ((uint32_t)0x00008000)            /*!<GROUP4_IO4 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G5_IO1                    ((uint32_t)0x00010000)            /*!<GROUP5_IO1 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G5_IO2                    ((uint32_t)0x00020000)            /*!<GROUP5_IO2 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G5_IO3                    ((uint32_t)0x00040000)            /*!<GROUP5_IO3 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G5_IO4                    ((uint32_t)0x00080000)            /*!<GROUP5_IO4 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G6_IO1                    ((uint32_t)0x00100000)            /*!<GROUP6_IO1 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G6_IO2                    ((uint32_t)0x00200000)            /*!<GROUP6_IO2 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G6_IO3                    ((uint32_t)0x00400000)            /*!<GROUP6_IO3 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G6_IO4                    ((uint32_t)0x00800000)            /*!<GROUP6_IO4 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G7_IO1                    ((uint32_t)0x01000000)            /*!<GROUP7_IO1 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G7_IO2                    ((uint32_t)0x02000000)            /*!<GROUP7_IO2 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G7_IO3                    ((uint32_t)0x04000000)            /*!<GROUP7_IO3 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G7_IO4                    ((uint32_t)0x08000000)            /*!<GROUP7_IO4 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G8_IO1                    ((uint32_t)0x10000000)            /*!<GROUP8_IO1 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G8_IO2                    ((uint32_t)0x20000000)            /*!<GROUP8_IO2 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G8_IO3                    ((uint32_t)0x40000000)            /*!<GROUP8_IO3 schmitt trigger hysteresis mode */
+#define  TSC_IOHCR_G8_IO4                    ((uint32_t)0x80000000)            /*!<GROUP8_IO4 schmitt trigger hysteresis mode */
+
+/*******************  Bit definition for TSC_IOASCR register  *****************/
+#define  TSC_IOASCR_G1_IO1                   ((uint32_t)0x00000001)            /*!<GROUP1_IO1 analog switch enable */
+#define  TSC_IOASCR_G1_IO2                   ((uint32_t)0x00000002)            /*!<GROUP1_IO2 analog switch enable */
+#define  TSC_IOASCR_G1_IO3                   ((uint32_t)0x00000004)            /*!<GROUP1_IO3 analog switch enable */
+#define  TSC_IOASCR_G1_IO4                   ((uint32_t)0x00000008)            /*!<GROUP1_IO4 analog switch enable */
+#define  TSC_IOASCR_G2_IO1                   ((uint32_t)0x00000010)            /*!<GROUP2_IO1 analog switch enable */
+#define  TSC_IOASCR_G2_IO2                   ((uint32_t)0x00000020)            /*!<GROUP2_IO2 analog switch enable */
+#define  TSC_IOASCR_G2_IO3                   ((uint32_t)0x00000040)            /*!<GROUP2_IO3 analog switch enable */
+#define  TSC_IOASCR_G2_IO4                   ((uint32_t)0x00000080)            /*!<GROUP2_IO4 analog switch enable */
+#define  TSC_IOASCR_G3_IO1                   ((uint32_t)0x00000100)            /*!<GROUP3_IO1 analog switch enable */
+#define  TSC_IOASCR_G3_IO2                   ((uint32_t)0x00000200)            /*!<GROUP3_IO2 analog switch enable */
+#define  TSC_IOASCR_G3_IO3                   ((uint32_t)0x00000400)            /*!<GROUP3_IO3 analog switch enable */
+#define  TSC_IOASCR_G3_IO4                   ((uint32_t)0x00000800)            /*!<GROUP3_IO4 analog switch enable */
+#define  TSC_IOASCR_G4_IO1                   ((uint32_t)0x00001000)            /*!<GROUP4_IO1 analog switch enable */
+#define  TSC_IOASCR_G4_IO2                   ((uint32_t)0x00002000)            /*!<GROUP4_IO2 analog switch enable */
+#define  TSC_IOASCR_G4_IO3                   ((uint32_t)0x00004000)            /*!<GROUP4_IO3 analog switch enable */
+#define  TSC_IOASCR_G4_IO4                   ((uint32_t)0x00008000)            /*!<GROUP4_IO4 analog switch enable */
+#define  TSC_IOASCR_G5_IO1                   ((uint32_t)0x00010000)            /*!<GROUP5_IO1 analog switch enable */
+#define  TSC_IOASCR_G5_IO2                   ((uint32_t)0x00020000)            /*!<GROUP5_IO2 analog switch enable */
+#define  TSC_IOASCR_G5_IO3                   ((uint32_t)0x00040000)            /*!<GROUP5_IO3 analog switch enable */
+#define  TSC_IOASCR_G5_IO4                   ((uint32_t)0x00080000)            /*!<GROUP5_IO4 analog switch enable */
+#define  TSC_IOASCR_G6_IO1                   ((uint32_t)0x00100000)            /*!<GROUP6_IO1 analog switch enable */
+#define  TSC_IOASCR_G6_IO2                   ((uint32_t)0x00200000)            /*!<GROUP6_IO2 analog switch enable */
+#define  TSC_IOASCR_G6_IO3                   ((uint32_t)0x00400000)            /*!<GROUP6_IO3 analog switch enable */
+#define  TSC_IOASCR_G6_IO4                   ((uint32_t)0x00800000)            /*!<GROUP6_IO4 analog switch enable */
+#define  TSC_IOASCR_G7_IO1                   ((uint32_t)0x01000000)            /*!<GROUP7_IO1 analog switch enable */
+#define  TSC_IOASCR_G7_IO2                   ((uint32_t)0x02000000)            /*!<GROUP7_IO2 analog switch enable */
+#define  TSC_IOASCR_G7_IO3                   ((uint32_t)0x04000000)            /*!<GROUP7_IO3 analog switch enable */
+#define  TSC_IOASCR_G7_IO4                   ((uint32_t)0x08000000)            /*!<GROUP7_IO4 analog switch enable */
+#define  TSC_IOASCR_G8_IO1                   ((uint32_t)0x10000000)            /*!<GROUP8_IO1 analog switch enable */
+#define  TSC_IOASCR_G8_IO2                   ((uint32_t)0x20000000)            /*!<GROUP8_IO2 analog switch enable */
+#define  TSC_IOASCR_G8_IO3                   ((uint32_t)0x40000000)            /*!<GROUP8_IO3 analog switch enable */
+#define  TSC_IOASCR_G8_IO4                   ((uint32_t)0x80000000)            /*!<GROUP8_IO4 analog switch enable */
+
+/*******************  Bit definition for TSC_IOSCR register  ******************/
+#define  TSC_IOSCR_G1_IO1                    ((uint32_t)0x00000001)            /*!<GROUP1_IO1 sampling mode */
+#define  TSC_IOSCR_G1_IO2                    ((uint32_t)0x00000002)            /*!<GROUP1_IO2 sampling mode */
+#define  TSC_IOSCR_G1_IO3                    ((uint32_t)0x00000004)            /*!<GROUP1_IO3 sampling mode */
+#define  TSC_IOSCR_G1_IO4                    ((uint32_t)0x00000008)            /*!<GROUP1_IO4 sampling mode */
+#define  TSC_IOSCR_G2_IO1                    ((uint32_t)0x00000010)            /*!<GROUP2_IO1 sampling mode */
+#define  TSC_IOSCR_G2_IO2                    ((uint32_t)0x00000020)            /*!<GROUP2_IO2 sampling mode */
+#define  TSC_IOSCR_G2_IO3                    ((uint32_t)0x00000040)            /*!<GROUP2_IO3 sampling mode */
+#define  TSC_IOSCR_G2_IO4                    ((uint32_t)0x00000080)            /*!<GROUP2_IO4 sampling mode */
+#define  TSC_IOSCR_G3_IO1                    ((uint32_t)0x00000100)            /*!<GROUP3_IO1 sampling mode */
+#define  TSC_IOSCR_G3_IO2                    ((uint32_t)0x00000200)            /*!<GROUP3_IO2 sampling mode */
+#define  TSC_IOSCR_G3_IO3                    ((uint32_t)0x00000400)            /*!<GROUP3_IO3 sampling mode */
+#define  TSC_IOSCR_G3_IO4                    ((uint32_t)0x00000800)            /*!<GROUP3_IO4 sampling mode */
+#define  TSC_IOSCR_G4_IO1                    ((uint32_t)0x00001000)            /*!<GROUP4_IO1 sampling mode */
+#define  TSC_IOSCR_G4_IO2                    ((uint32_t)0x00002000)            /*!<GROUP4_IO2 sampling mode */
+#define  TSC_IOSCR_G4_IO3                    ((uint32_t)0x00004000)            /*!<GROUP4_IO3 sampling mode */
+#define  TSC_IOSCR_G4_IO4                    ((uint32_t)0x00008000)            /*!<GROUP4_IO4 sampling mode */
+#define  TSC_IOSCR_G5_IO1                    ((uint32_t)0x00010000)            /*!<GROUP5_IO1 sampling mode */
+#define  TSC_IOSCR_G5_IO2                    ((uint32_t)0x00020000)            /*!<GROUP5_IO2 sampling mode */
+#define  TSC_IOSCR_G5_IO3                    ((uint32_t)0x00040000)            /*!<GROUP5_IO3 sampling mode */
+#define  TSC_IOSCR_G5_IO4                    ((uint32_t)0x00080000)            /*!<GROUP5_IO4 sampling mode */
+#define  TSC_IOSCR_G6_IO1                    ((uint32_t)0x00100000)            /*!<GROUP6_IO1 sampling mode */
+#define  TSC_IOSCR_G6_IO2                    ((uint32_t)0x00200000)            /*!<GROUP6_IO2 sampling mode */
+#define  TSC_IOSCR_G6_IO3                    ((uint32_t)0x00400000)            /*!<GROUP6_IO3 sampling mode */
+#define  TSC_IOSCR_G6_IO4                    ((uint32_t)0x00800000)            /*!<GROUP6_IO4 sampling mode */
+#define  TSC_IOSCR_G7_IO1                    ((uint32_t)0x01000000)            /*!<GROUP7_IO1 sampling mode */
+#define  TSC_IOSCR_G7_IO2                    ((uint32_t)0x02000000)            /*!<GROUP7_IO2 sampling mode */
+#define  TSC_IOSCR_G7_IO3                    ((uint32_t)0x04000000)            /*!<GROUP7_IO3 sampling mode */
+#define  TSC_IOSCR_G7_IO4                    ((uint32_t)0x08000000)            /*!<GROUP7_IO4 sampling mode */
+#define  TSC_IOSCR_G8_IO1                    ((uint32_t)0x10000000)            /*!<GROUP8_IO1 sampling mode */
+#define  TSC_IOSCR_G8_IO2                    ((uint32_t)0x20000000)            /*!<GROUP8_IO2 sampling mode */
+#define  TSC_IOSCR_G8_IO3                    ((uint32_t)0x40000000)            /*!<GROUP8_IO3 sampling mode */
+#define  TSC_IOSCR_G8_IO4                    ((uint32_t)0x80000000)            /*!<GROUP8_IO4 sampling mode */
+
+/*******************  Bit definition for TSC_IOCCR register  ******************/
+#define  TSC_IOCCR_G1_IO1                    ((uint32_t)0x00000001)            /*!<GROUP1_IO1 channel mode */
+#define  TSC_IOCCR_G1_IO2                    ((uint32_t)0x00000002)            /*!<GROUP1_IO2 channel mode */
+#define  TSC_IOCCR_G1_IO3                    ((uint32_t)0x00000004)            /*!<GROUP1_IO3 channel mode */
+#define  TSC_IOCCR_G1_IO4                    ((uint32_t)0x00000008)            /*!<GROUP1_IO4 channel mode */
+#define  TSC_IOCCR_G2_IO1                    ((uint32_t)0x00000010)            /*!<GROUP2_IO1 channel mode */
+#define  TSC_IOCCR_G2_IO2                    ((uint32_t)0x00000020)            /*!<GROUP2_IO2 channel mode */
+#define  TSC_IOCCR_G2_IO3                    ((uint32_t)0x00000040)            /*!<GROUP2_IO3 channel mode */
+#define  TSC_IOCCR_G2_IO4                    ((uint32_t)0x00000080)            /*!<GROUP2_IO4 channel mode */
+#define  TSC_IOCCR_G3_IO1                    ((uint32_t)0x00000100)            /*!<GROUP3_IO1 channel mode */
+#define  TSC_IOCCR_G3_IO2                    ((uint32_t)0x00000200)            /*!<GROUP3_IO2 channel mode */
+#define  TSC_IOCCR_G3_IO3                    ((uint32_t)0x00000400)            /*!<GROUP3_IO3 channel mode */
+#define  TSC_IOCCR_G3_IO4                    ((uint32_t)0x00000800)            /*!<GROUP3_IO4 channel mode */
+#define  TSC_IOCCR_G4_IO1                    ((uint32_t)0x00001000)            /*!<GROUP4_IO1 channel mode */
+#define  TSC_IOCCR_G4_IO2                    ((uint32_t)0x00002000)            /*!<GROUP4_IO2 channel mode */
+#define  TSC_IOCCR_G4_IO3                    ((uint32_t)0x00004000)            /*!<GROUP4_IO3 channel mode */
+#define  TSC_IOCCR_G4_IO4                    ((uint32_t)0x00008000)            /*!<GROUP4_IO4 channel mode */
+#define  TSC_IOCCR_G5_IO1                    ((uint32_t)0x00010000)            /*!<GROUP5_IO1 channel mode */
+#define  TSC_IOCCR_G5_IO2                    ((uint32_t)0x00020000)            /*!<GROUP5_IO2 channel mode */
+#define  TSC_IOCCR_G5_IO3                    ((uint32_t)0x00040000)            /*!<GROUP5_IO3 channel mode */
+#define  TSC_IOCCR_G5_IO4                    ((uint32_t)0x00080000)            /*!<GROUP5_IO4 channel mode */
+#define  TSC_IOCCR_G6_IO1                    ((uint32_t)0x00100000)            /*!<GROUP6_IO1 channel mode */
+#define  TSC_IOCCR_G6_IO2                    ((uint32_t)0x00200000)            /*!<GROUP6_IO2 channel mode */
+#define  TSC_IOCCR_G6_IO3                    ((uint32_t)0x00400000)            /*!<GROUP6_IO3 channel mode */
+#define  TSC_IOCCR_G6_IO4                    ((uint32_t)0x00800000)            /*!<GROUP6_IO4 channel mode */
+#define  TSC_IOCCR_G7_IO1                    ((uint32_t)0x01000000)            /*!<GROUP7_IO1 channel mode */
+#define  TSC_IOCCR_G7_IO2                    ((uint32_t)0x02000000)            /*!<GROUP7_IO2 channel mode */
+#define  TSC_IOCCR_G7_IO3                    ((uint32_t)0x04000000)            /*!<GROUP7_IO3 channel mode */
+#define  TSC_IOCCR_G7_IO4                    ((uint32_t)0x08000000)            /*!<GROUP7_IO4 channel mode */
+#define  TSC_IOCCR_G8_IO1                    ((uint32_t)0x10000000)            /*!<GROUP8_IO1 channel mode */
+#define  TSC_IOCCR_G8_IO2                    ((uint32_t)0x20000000)            /*!<GROUP8_IO2 channel mode */
+#define  TSC_IOCCR_G8_IO3                    ((uint32_t)0x40000000)            /*!<GROUP8_IO3 channel mode */
+#define  TSC_IOCCR_G8_IO4                    ((uint32_t)0x80000000)            /*!<GROUP8_IO4 channel mode */
+
+/*******************  Bit definition for TSC_IOGCSR register  *****************/
+#define  TSC_IOGCSR_G1E                      ((uint32_t)0x00000001)            /*!<Analog IO GROUP1 enable */
+#define  TSC_IOGCSR_G2E                      ((uint32_t)0x00000002)            /*!<Analog IO GROUP2 enable */
+#define  TSC_IOGCSR_G3E                      ((uint32_t)0x00000004)            /*!<Analog IO GROUP3 enable */
+#define  TSC_IOGCSR_G4E                      ((uint32_t)0x00000008)            /*!<Analog IO GROUP4 enable */
+#define  TSC_IOGCSR_G5E                      ((uint32_t)0x00000010)            /*!<Analog IO GROUP5 enable */
+#define  TSC_IOGCSR_G6E                      ((uint32_t)0x00000020)            /*!<Analog IO GROUP6 enable */
+#define  TSC_IOGCSR_G7E                      ((uint32_t)0x00000040)            /*!<Analog IO GROUP7 enable */
+#define  TSC_IOGCSR_G8E                      ((uint32_t)0x00000080)            /*!<Analog IO GROUP8 enable */
+#define  TSC_IOGCSR_G1S                      ((uint32_t)0x00010000)            /*!<Analog IO GROUP1 status */
+#define  TSC_IOGCSR_G2S                      ((uint32_t)0x00020000)            /*!<Analog IO GROUP2 status */
+#define  TSC_IOGCSR_G3S                      ((uint32_t)0x00040000)            /*!<Analog IO GROUP3 status */
+#define  TSC_IOGCSR_G4S                      ((uint32_t)0x00080000)            /*!<Analog IO GROUP4 status */
+#define  TSC_IOGCSR_G5S                      ((uint32_t)0x00100000)            /*!<Analog IO GROUP5 status */
+#define  TSC_IOGCSR_G6S                      ((uint32_t)0x00200000)            /*!<Analog IO GROUP6 status */
+#define  TSC_IOGCSR_G7S                      ((uint32_t)0x00400000)            /*!<Analog IO GROUP7 status */
+#define  TSC_IOGCSR_G8S                      ((uint32_t)0x00800000)            /*!<Analog IO GROUP8 status */
+
+/*******************  Bit definition for TSC_IOGXCR register  *****************/
+#define  TSC_IOGXCR_CNT                      ((uint32_t)0x00003FFF)            /*!<CNT[13:0] bits (Counter value) */
+
+/******************************************************************************/
+/*                                                                            */
+/*      Universal Synchronous Asynchronous Receiver Transmitter (USART)       */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for USART_CR1 register  *******************/
+#define  USART_CR1_UE                        ((uint32_t)0x00000001)            /*!< USART Enable */
+#define  USART_CR1_UESM                      ((uint32_t)0x00000002)            /*!< USART Enable in STOP Mode */
+#define  USART_CR1_RE                        ((uint32_t)0x00000004)            /*!< Receiver Enable */
+#define  USART_CR1_TE                        ((uint32_t)0x00000008)            /*!< Transmitter Enable */
+#define  USART_CR1_IDLEIE                    ((uint32_t)0x00000010)            /*!< IDLE Interrupt Enable */
+#define  USART_CR1_RXNEIE                    ((uint32_t)0x00000020)            /*!< RXNE Interrupt Enable */
+#define  USART_CR1_TCIE                      ((uint32_t)0x00000040)            /*!< Transmission Complete Interrupt Enable */
+#define  USART_CR1_TXEIE                     ((uint32_t)0x00000080)            /*!< TXE Interrupt Enable */
+#define  USART_CR1_PEIE                      ((uint32_t)0x00000100)            /*!< PE Interrupt Enable */
+#define  USART_CR1_PS                        ((uint32_t)0x00000200)            /*!< Parity Selection */
+#define  USART_CR1_PCE                       ((uint32_t)0x00000400)            /*!< Parity Control Enable */
+#define  USART_CR1_WAKE                      ((uint32_t)0x00000800)            /*!< Receiver Wakeup method */
+#define  USART_CR1_M                         ((uint32_t)0x10001000)            /*!< Word length */
+#define  USART_CR1_M_0                       ((uint32_t)0x00001000)            /*!< Word length - Bit 0 */
+#define  USART_CR1_MME                       ((uint32_t)0x00002000)            /*!< Mute Mode Enable */
+#define  USART_CR1_CMIE                      ((uint32_t)0x00004000)            /*!< Character match interrupt enable */
+#define  USART_CR1_OVER8                     ((uint32_t)0x00008000)            /*!< Oversampling by 8-bit or 16-bit mode */
+#define  USART_CR1_DEDT                      ((uint32_t)0x001F0000)            /*!< DEDT[4:0] bits (Driver Enable Deassertion Time) */
+#define  USART_CR1_DEDT_0                    ((uint32_t)0x00010000)            /*!< Bit 0 */
+#define  USART_CR1_DEDT_1                    ((uint32_t)0x00020000)            /*!< Bit 1 */
+#define  USART_CR1_DEDT_2                    ((uint32_t)0x00040000)            /*!< Bit 2 */
+#define  USART_CR1_DEDT_3                    ((uint32_t)0x00080000)            /*!< Bit 3 */
+#define  USART_CR1_DEDT_4                    ((uint32_t)0x00100000)            /*!< Bit 4 */
+#define  USART_CR1_DEAT                      ((uint32_t)0x03E00000)            /*!< DEAT[4:0] bits (Driver Enable Assertion Time) */
+#define  USART_CR1_DEAT_0                    ((uint32_t)0x00200000)            /*!< Bit 0 */
+#define  USART_CR1_DEAT_1                    ((uint32_t)0x00400000)            /*!< Bit 1 */
+#define  USART_CR1_DEAT_2                    ((uint32_t)0x00800000)            /*!< Bit 2 */
+#define  USART_CR1_DEAT_3                    ((uint32_t)0x01000000)            /*!< Bit 3 */
+#define  USART_CR1_DEAT_4                    ((uint32_t)0x02000000)            /*!< Bit 4 */
+#define  USART_CR1_RTOIE                     ((uint32_t)0x04000000)            /*!< Receive Time Out interrupt enable */
+#define  USART_CR1_EOBIE                     ((uint32_t)0x08000000)            /*!< End of Block interrupt enable */
+#define  USART_CR1_M_1                       ((uint32_t)0x10000000)            /*!< Word length - Bit 1 */
+/******************  Bit definition for USART_CR2 register  *******************/
+#define  USART_CR2_ADDM7                     ((uint32_t)0x00000010)            /*!< 7-bit or 4-bit Address Detection */
+#define  USART_CR2_LBDL                      ((uint32_t)0x00000020)            /*!< LIN Break Detection Length */
+#define  USART_CR2_LBDIE                     ((uint32_t)0x00000040)            /*!< LIN Break Detection Interrupt Enable */
+#define  USART_CR2_LBCL                      ((uint32_t)0x00000100)            /*!< Last Bit Clock pulse */
+#define  USART_CR2_CPHA                      ((uint32_t)0x00000200)            /*!< Clock Phase */
+#define  USART_CR2_CPOL                      ((uint32_t)0x00000400)            /*!< Clock Polarity */
+#define  USART_CR2_CLKEN                     ((uint32_t)0x00000800)            /*!< Clock Enable */
+#define  USART_CR2_STOP                      ((uint32_t)0x00003000)            /*!< STOP[1:0] bits (STOP bits) */
+#define  USART_CR2_STOP_0                    ((uint32_t)0x00001000)            /*!< Bit 0 */
+#define  USART_CR2_STOP_1                    ((uint32_t)0x00002000)            /*!< Bit 1 */
+#define  USART_CR2_LINEN                     ((uint32_t)0x00004000)            /*!< LIN mode enable */
+#define  USART_CR2_SWAP                      ((uint32_t)0x00008000)            /*!< SWAP TX/RX pins */
+#define  USART_CR2_RXINV                     ((uint32_t)0x00010000)            /*!< RX pin active level inversion */
+#define  USART_CR2_TXINV                     ((uint32_t)0x00020000)            /*!< TX pin active level inversion */
+#define  USART_CR2_DATAINV                   ((uint32_t)0x00040000)            /*!< Binary data inversion */
+#define  USART_CR2_MSBFIRST                  ((uint32_t)0x00080000)            /*!< Most Significant Bit First */
+#define  USART_CR2_ABREN                     ((uint32_t)0x00100000)            /*!< Auto Baud-Rate Enable*/
+#define  USART_CR2_ABRMODE                   ((uint32_t)0x00600000)            /*!< ABRMOD[1:0] bits (Auto Baud-Rate Mode) */
+#define  USART_CR2_ABRMODE_0                 ((uint32_t)0x00200000)            /*!< Bit 0 */
+#define  USART_CR2_ABRMODE_1                 ((uint32_t)0x00400000)            /*!< Bit 1 */
+#define  USART_CR2_RTOEN                     ((uint32_t)0x00800000)            /*!< Receiver Time-Out enable */
+#define  USART_CR2_ADD                       ((uint32_t)0xFF000000)            /*!< Address of the USART node */
+
+/******************  Bit definition for USART_CR3 register  *******************/
+#define  USART_CR3_EIE                       ((uint32_t)0x00000001)            /*!< Error Interrupt Enable */
+#define  USART_CR3_IREN                      ((uint32_t)0x00000002)            /*!< IrDA mode Enable */
+#define  USART_CR3_IRLP                      ((uint32_t)0x00000004)            /*!< IrDA Low-Power */
+#define  USART_CR3_HDSEL                     ((uint32_t)0x00000008)            /*!< Half-Duplex Selection */
+#define  USART_CR3_NACK                      ((uint32_t)0x00000010)            /*!< SmartCard NACK enable */
+#define  USART_CR3_SCEN                      ((uint32_t)0x00000020)            /*!< SmartCard mode enable */
+#define  USART_CR3_DMAR                      ((uint32_t)0x00000040)            /*!< DMA Enable Receiver */
+#define  USART_CR3_DMAT                      ((uint32_t)0x00000080)            /*!< DMA Enable Transmitter */
+#define  USART_CR3_RTSE                      ((uint32_t)0x00000100)            /*!< RTS Enable */
+#define  USART_CR3_CTSE                      ((uint32_t)0x00000200)            /*!< CTS Enable */
+#define  USART_CR3_CTSIE                     ((uint32_t)0x00000400)            /*!< CTS Interrupt Enable */
+#define  USART_CR3_ONEBIT                    ((uint32_t)0x00000800)            /*!< One sample bit method enable */
+#define  USART_CR3_OVRDIS                    ((uint32_t)0x00001000)            /*!< Overrun Disable */
+#define  USART_CR3_DDRE                      ((uint32_t)0x00002000)            /*!< DMA Disable on Reception Error */
+#define  USART_CR3_DEM                       ((uint32_t)0x00004000)            /*!< Driver Enable Mode */
+#define  USART_CR3_DEP                       ((uint32_t)0x00008000)            /*!< Driver Enable Polarity Selection */
+#define  USART_CR3_SCARCNT                   ((uint32_t)0x000E0000)            /*!< SCARCNT[2:0] bits (SmartCard Auto-Retry Count) */
+#define  USART_CR3_SCARCNT_0                 ((uint32_t)0x00020000)            /*!< Bit 0 */
+#define  USART_CR3_SCARCNT_1                 ((uint32_t)0x00040000)            /*!< Bit 1 */
+#define  USART_CR3_SCARCNT_2                 ((uint32_t)0x00080000)            /*!< Bit 2 */
+#define  USART_CR3_WUS                       ((uint32_t)0x00300000)            /*!< WUS[1:0] bits (Wake UP Interrupt Flag Selection) */
+#define  USART_CR3_WUS_0                     ((uint32_t)0x00100000)            /*!< Bit 0 */
+#define  USART_CR3_WUS_1                     ((uint32_t)0x00200000)            /*!< Bit 1 */
+#define  USART_CR3_WUFIE                     ((uint32_t)0x00400000)            /*!< Wake Up Interrupt Enable */
+#define  USART_CR3_UCESM                     ((uint32_t)0x00800000)            /*!< Clock Enable in Stop mode */ 
+
+/******************  Bit definition for USART_BRR register  *******************/
+#define  USART_BRR_DIV_FRACTION              ((uint32_t)0x0000000F)                /*!< Fraction of USARTDIV */
+#define  USART_BRR_DIV_MANTISSA              ((uint32_t)0x0000FFF0)                /*!< Mantissa of USARTDIV */
+
+/******************  Bit definition for USART_GTPR register  ******************/
+#define  USART_GTPR_PSC                      ((uint32_t)0x000000FF)                /*!< PSC[7:0] bits (Prescaler value) */
+#define  USART_GTPR_GT                       ((uint32_t)0x0000FF00)                /*!< GT[7:0] bits (Guard time value) */
+
+
+/*******************  Bit definition for USART_RTOR register  *****************/
+#define  USART_RTOR_RTO                      ((uint32_t)0x00FFFFFF)            /*!< Receiver Time Out Value */
+#define  USART_RTOR_BLEN                     ((uint32_t)0xFF000000)            /*!< Block Length */
+
+/*******************  Bit definition for USART_RQR register  ******************/
+#define  USART_RQR_ABRRQ                    ((uint32_t)0x00000001)                /*!< Auto-Baud Rate Request */
+#define  USART_RQR_SBKRQ                    ((uint32_t)0x00000002)                /*!< Send Break Request */
+#define  USART_RQR_MMRQ                     ((uint32_t)0x00000004)                /*!< Mute Mode Request */
+#define  USART_RQR_RXFRQ                    ((uint32_t)0x00000008)                /*!< Receive Data flush Request */
+#define  USART_RQR_TXFRQ                    ((uint32_t)0x00000010)                /*!< Transmit data flush Request */
+
+/*******************  Bit definition for USART_ISR register  ******************/
+#define  USART_ISR_PE                        ((uint32_t)0x00000001)            /*!< Parity Error */
+#define  USART_ISR_FE                        ((uint32_t)0x00000002)            /*!< Framing Error */
+#define  USART_ISR_NE                        ((uint32_t)0x00000004)            /*!< Noise detected Flag */
+#define  USART_ISR_ORE                       ((uint32_t)0x00000008)            /*!< OverRun Error */
+#define  USART_ISR_IDLE                      ((uint32_t)0x00000010)            /*!< IDLE line detected */
+#define  USART_ISR_RXNE                      ((uint32_t)0x00000020)            /*!< Read Data Register Not Empty */
+#define  USART_ISR_TC                        ((uint32_t)0x00000040)            /*!< Transmission Complete */
+#define  USART_ISR_TXE                       ((uint32_t)0x00000080)            /*!< Transmit Data Register Empty */
+#define  USART_ISR_LBD                       ((uint32_t)0x00000100)            /*!< LIN Break Detection Flag */
+#define  USART_ISR_CTSIF                     ((uint32_t)0x00000200)            /*!< CTS interrupt flag */
+#define  USART_ISR_CTS                       ((uint32_t)0x00000400)            /*!< CTS flag */
+#define  USART_ISR_RTOF                      ((uint32_t)0x00000800)            /*!< Receiver Time Out */
+#define  USART_ISR_EOBF                      ((uint32_t)0x00001000)            /*!< End Of Block Flag */
+#define  USART_ISR_ABRE                      ((uint32_t)0x00004000)            /*!< Auto-Baud Rate Error */
+#define  USART_ISR_ABRF                      ((uint32_t)0x00008000)            /*!< Auto-Baud Rate Flag */
+#define  USART_ISR_BUSY                      ((uint32_t)0x00010000)            /*!< Busy Flag */
+#define  USART_ISR_CMF                       ((uint32_t)0x00020000)            /*!< Character Match Flag */
+#define  USART_ISR_SBKF                      ((uint32_t)0x00040000)            /*!< Send Break Flag */
+#define  USART_ISR_RWU                       ((uint32_t)0x00080000)            /*!< Receive Wake Up from mute mode Flag */
+#define  USART_ISR_WUF                       ((uint32_t)0x00100000)            /*!< Wake Up from stop mode Flag */
+#define  USART_ISR_TEACK                     ((uint32_t)0x00200000)            /*!< Transmit Enable Acknowledge Flag */
+#define  USART_ISR_REACK                     ((uint32_t)0x00400000)            /*!< Receive Enable Acknowledge Flag */
+
+/*******************  Bit definition for USART_ICR register  ******************/
+#define  USART_ICR_PECF                      ((uint32_t)0x00000001)            /*!< Parity Error Clear Flag */
+#define  USART_ICR_FECF                      ((uint32_t)0x00000002)            /*!< Framing Error Clear Flag */
+#define  USART_ICR_NCF                      ((uint32_t)0x00000004)             /*!< Noise detected Clear Flag */
+#define  USART_ICR_ORECF                     ((uint32_t)0x00000008)            /*!< OverRun Error Clear Flag */
+#define  USART_ICR_IDLECF                    ((uint32_t)0x00000010)            /*!< IDLE line detected Clear Flag */
+#define  USART_ICR_TCCF                      ((uint32_t)0x00000040)            /*!< Transmission Complete Clear Flag */
+#define  USART_ICR_LBDCF                     ((uint32_t)0x00000100)            /*!< LIN Break Detection Clear Flag */
+#define  USART_ICR_CTSCF                     ((uint32_t)0x00000200)            /*!< CTS Interrupt Clear Flag */
+#define  USART_ICR_RTOCF                     ((uint32_t)0x00000800)            /*!< Receiver Time Out Clear Flag */
+#define  USART_ICR_EOBCF                     ((uint32_t)0x00001000)            /*!< End Of Block Clear Flag */
+#define  USART_ICR_CMCF                      ((uint32_t)0x00020000)            /*!< Character Match Clear Flag */
+#define  USART_ICR_WUCF                      ((uint32_t)0x00100000)            /*!< Wake Up from stop mode Clear Flag */
+
+/*******************  Bit definition for USART_RDR register  ******************/
+#define  USART_RDR_RDR                       ((uint32_t)0x000001FF)                /*!< RDR[8:0] bits (Receive Data value) */
+
+/*******************  Bit definition for USART_TDR register  ******************/
+#define  USART_TDR_TDR                       ((uint32_t)0x000001FF)                /*!< TDR[8:0] bits (Transmit Data value) */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         USB Device General registers                       */
+/*                                                                            */
+/******************************************************************************/
+#define USB_BASE                           ((uint32_t)0x40005C00)           /*!< USB_IP Peripheral Registers base address */
+#define USB_PMAADDR                        ((uint32_t)0x40006000)           /*!< USB_IP Packet Memory Area base address */
+
+#define USB_CNTR                           (USB_BASE + 0x40)             /*!< Control register */
+#define USB_ISTR                           (USB_BASE + 0x44)             /*!< Interrupt status register */
+#define USB_FNR                            (USB_BASE + 0x48)             /*!< Frame number register */
+#define USB_DADDR                          (USB_BASE + 0x4C)             /*!< Device address register */
+#define USB_BTABLE                         (USB_BASE + 0x50)             /*!< Buffer Table address register */
+#define USB_LPMCSR                         (USB_BASE + 0x54)             /*!< LPM Control and Status register */
+#define USB_BCDR                           (USB_BASE + 0x58)             /*!< Battery Charging detector register*/
+
+/****************************  ISTR interrupt events  *************************/
+#define USB_ISTR_CTR                         ((uint16_t)0x8000)             /*!< Correct TRansfer (clear-only bit) */
+#define USB_ISTR_PMAOVR                      ((uint16_t)0x4000)             /*!< DMA OVeR/underrun (clear-only bit) */
+#define USB_ISTR_ERR                         ((uint16_t)0x2000)             /*!< ERRor (clear-only bit) */
+#define USB_ISTR_WKUP                        ((uint16_t)0x1000)             /*!< WaKe UP (clear-only bit) */
+#define USB_ISTR_SUSP                        ((uint16_t)0x0800)             /*!< SUSPend (clear-only bit) */
+#define USB_ISTR_RESET                       ((uint16_t)0x0400)             /*!< RESET (clear-only bit) */
+#define USB_ISTR_SOF                         ((uint16_t)0x0200)             /*!< Start Of Frame (clear-only bit) */
+#define USB_ISTR_ESOF                        ((uint16_t)0x0100)             /*!< Expected Start Of Frame (clear-only bit) */
+#define USB_ISTR_L1REQ                       ((uint16_t)0x0080)             /*!< LPM L1 state request  */
+#define USB_ISTR_DIR                         ((uint16_t)0x0010)             /*!< DIRection of transaction (read-only bit)  */
+#define USB_ISTR_EP_ID                       ((uint16_t)0x000F)             /*!< EndPoint IDentifier (read-only bit)  */
+
+#define USB_CLR_CTR                          (~USB_ISTR_CTR)             /*!< clear Correct TRansfer bit */
+#define USB_CLR_PMAOVR                       (~USB_ISTR_PMAOVR)          /*!< clear DMA OVeR/underrun bit*/
+#define USB_CLR_ERR                          (~USB_ISTR_ERR)             /*!< clear ERRor bit */
+#define USB_CLR_WKUP                         (~USB_ISTR_WKUP)            /*!< clear WaKe UP bit */
+#define USB_CLR_SUSP                         (~USB_ISTR_SUSP)            /*!< clear SUSPend bit */
+#define USB_CLR_RESET                        (~USB_ISTR_RESET)           /*!< clear RESET bit */
+#define USB_CLR_SOF                          (~USB_ISTR_SOF)             /*!< clear Start Of Frame bit */
+#define USB_CLR_ESOF                         (~USB_ISTR_ESOF)            /*!< clear Expected Start Of Frame bit */
+#define USB_CLR_L1REQ                        (~USB_ISTR_L1REQ)           /*!< clear LPM L1  bit */
+/*************************  CNTR control register bits definitions  ***********/
+#define USB_CNTR_CTRM                        ((uint16_t)0x8000)             /*!< Correct TRansfer Mask */
+#define USB_CNTR_PMAOVRM                     ((uint16_t)0x4000)             /*!< DMA OVeR/underrun Mask */
+#define USB_CNTR_ERRM                        ((uint16_t)0x2000)             /*!< ERRor Mask */
+#define USB_CNTR_WKUPM                       ((uint16_t)0x1000)             /*!< WaKe UP Mask */
+#define USB_CNTR_SUSPM                       ((uint16_t)0x0800)             /*!< SUSPend Mask */
+#define USB_CNTR_RESETM                      ((uint16_t)0x0400)             /*!< RESET Mask   */
+#define USB_CNTR_SOFM                        ((uint16_t)0x0200)             /*!< Start Of Frame Mask */
+#define USB_CNTR_ESOFM                       ((uint16_t)0x0100)             /*!< Expected Start Of Frame Mask */
+#define USB_CNTR_L1REQM                      ((uint16_t)0x0080)             /*!< LPM L1 state request interrupt mask */
+#define USB_CNTR_L1RESUME                    ((uint16_t)0x0020)             /*!< LPM L1 Resume request */
+#define USB_CNTR_RESUME                      ((uint16_t)0x0010)             /*!< RESUME request */
+#define USB_CNTR_FSUSP                       ((uint16_t)0x0008)             /*!< Force SUSPend */
+#define USB_CNTR_LPMODE                      ((uint16_t)0x0004)             /*!< Low-power MODE */
+#define USB_CNTR_PDWN                        ((uint16_t)0x0002)             /*!< Power DoWN */
+#define USB_CNTR_FRES                        ((uint16_t)0x0001)             /*!< Force USB RESet */
+/*************************  BCDR control register bits definitions  ***********/
+#define  USB_BCDR_DPPU                       ((uint16_t)0x8000)             /*!< DP Pull-up Enable */  
+#define  USB_BCDR_PS2DET                     ((uint16_t)0x0080)             /*!< PS2 port or proprietary charger detected */  
+#define  USB_BCDR_SDET                       ((uint16_t)0x0040)             /*!< Secondary detection (SD) status */  
+#define  USB_BCDR_PDET                       ((uint16_t)0x0020)             /*!< Primary detection (PD) status */ 
+#define  USB_BCDR_DCDET                      ((uint16_t)0x0010)             /*!< Data contact detection (DCD) status */ 
+#define  USB_BCDR_SDEN                       ((uint16_t)0x0008)             /*!< Secondary detection (SD) mode enable */ 
+#define  USB_BCDR_PDEN                       ((uint16_t)0x0004)             /*!< Primary detection (PD) mode enable */  
+#define  USB_BCDR_DCDEN                      ((uint16_t)0x0002)             /*!< Data contact detection (DCD) mode enable */
+#define  USB_BCDR_BCDEN                      ((uint16_t)0x0001)             /*!< Battery charging detector (BCD) enable */
+/***************************  LPM register bits definitions  ******************/
+#define  USB_LPMCSR_BESL                     ((uint16_t)0x00F0)             /*!< BESL value received with last ACKed LPM Token  */ 
+#define  USB_LPMCSR_REMWAKE                  ((uint16_t)0x0008)             /*!< bRemoteWake value received with last ACKed LPM Token */ 
+#define  USB_LPMCSR_LPMACK                   ((uint16_t)0x0002)             /*!< LPM Token acknowledge enable*/
+#define  USB_LPMCSR_LMPEN                    ((uint16_t)0x0001)             /*!< LPM support enable  */
+/********************  FNR Frame Number Register bit definitions   ************/
+#define USB_FNR_RXDP                         ((uint16_t)0x8000)             /*!< status of D+ data line */
+#define USB_FNR_RXDM                         ((uint16_t)0x4000)             /*!< status of D- data line */
+#define USB_FNR_LCK                          ((uint16_t)0x2000)             /*!< LoCKed */
+#define USB_FNR_LSOF                         ((uint16_t)0x1800)             /*!< Lost SOF */
+#define USB_FNR_FN                           ((uint16_t)0x07FF)             /*!< Frame Number */
+/********************  DADDR Device ADDRess bit definitions    ****************/
+#define USB_DADDR_EF                         ((uint8_t)0x80)                /*!< USB device address Enable Function */
+#define USB_DADDR_ADD                        ((uint8_t)0x7F)                /*!< USB device address */
+/******************************  Endpoint register    *************************/
+#define USB_EP0R                              USB_BASE                   /*!< endpoint 0 register address */
+#define USB_EP1R                             (USB_BASE + 0x04)           /*!< endpoint 1 register address */
+#define USB_EP2R                             (USB_BASE + 0x08)           /*!< endpoint 2 register address */
+#define USB_EP3R                             (USB_BASE + 0x0C)           /*!< endpoint 3 register address */
+#define USB_EP4R                             (USB_BASE + 0x10)           /*!< endpoint 4 register address */
+#define USB_EP5R                             (USB_BASE + 0x14)           /*!< endpoint 5 register address */
+#define USB_EP6R                             (USB_BASE + 0x18)           /*!< endpoint 6 register address */
+#define USB_EP7R                             (USB_BASE + 0x1C)           /*!< endpoint 7 register address */
+/* bit positions */ 
+#define USB_EP_CTR_RX                        ((uint16_t)0x8000)             /*!<  EndPoint Correct TRansfer RX */
+#define USB_EP_DTOG_RX                       ((uint16_t)0x4000)             /*!<  EndPoint Data TOGGLE RX */
+#define USB_EPRX_STAT                        ((uint16_t)0x3000)             /*!<  EndPoint RX STATus bit field */
+#define USB_EP_SETUP                         ((uint16_t)0x0800)             /*!<  EndPoint SETUP */
+#define USB_EP_T_FIELD                       ((uint16_t)0x0600)             /*!<  EndPoint TYPE */
+#define USB_EP_KIND                          ((uint16_t)0x0100)             /*!<  EndPoint KIND */
+#define USB_EP_CTR_TX                        ((uint16_t)0x0080)             /*!<  EndPoint Correct TRansfer TX */
+#define USB_EP_DTOG_TX                       ((uint16_t)0x0040)             /*!<  EndPoint Data TOGGLE TX */
+#define USB_EPTX_STAT                        ((uint16_t)0x0030)             /*!<  EndPoint TX STATus bit field */
+#define USB_EPADDR_FIELD                     ((uint16_t)0x000F)             /*!<  EndPoint ADDRess FIELD */
+
+/* EndPoint REGister MASK (no toggle fields) */
+#define USB_EPREG_MASK     (USB_EP_CTR_RX|USB_EP_SETUP|USB_EP_T_FIELD|USB_EP_KIND|USB_EP_CTR_TX|USB_EPADDR_FIELD)
+                                                                               /*!< EP_TYPE[1:0] EndPoint TYPE */
+#define USB_EP_TYPE_MASK                     ((uint16_t)0x0600)             /*!< EndPoint TYPE Mask */
+#define USB_EP_BULK                          ((uint16_t)0x0000)             /*!< EndPoint BULK */
+#define USB_EP_CONTROL                       ((uint16_t)0x0200)             /*!< EndPoint CONTROL */
+#define USB_EP_ISOCHRONOUS                   ((uint16_t)0x0400)             /*!< EndPoint ISOCHRONOUS */
+#define USB_EP_INTERRUPT                     ((uint16_t)0x0600)             /*!< EndPoint INTERRUPT */
+#define USB_EP_T_MASK      (~USB_EP_T_FIELD & USB_EPREG_MASK)
+                                                                 
+#define USB_EPKIND_MASK    (~USB_EP_KIND & USB_EPREG_MASK)            /*!< EP_KIND EndPoint KIND */
+                                                                               /*!< STAT_TX[1:0] STATus for TX transfer */
+#define USB_EP_TX_DIS                        ((uint16_t)0x0000)             /*!< EndPoint TX DISabled */
+#define USB_EP_TX_STALL                      ((uint16_t)0x0010)             /*!< EndPoint TX STALLed */
+#define USB_EP_TX_NAK                        ((uint16_t)0x0020)             /*!< EndPoint TX NAKed */
+#define USB_EP_TX_VALID                      ((uint16_t)0x0030)             /*!< EndPoint TX VALID */
+#define USB_EPTX_DTOG1                       ((uint16_t)0x0010)             /*!< EndPoint TX Data TOGgle bit1 */
+#define USB_EPTX_DTOG2                       ((uint16_t)0x0020)             /*!< EndPoint TX Data TOGgle bit2 */
+#define USB_EPTX_DTOGMASK  (USB_EPTX_STAT|USB_EPREG_MASK)
+                                                                               /*!< STAT_RX[1:0] STATus for RX transfer */
+#define USB_EP_RX_DIS                        ((uint16_t)0x0000)             /*!< EndPoint RX DISabled */
+#define USB_EP_RX_STALL                      ((uint16_t)0x1000)             /*!< EndPoint RX STALLed */
+#define USB_EP_RX_NAK                        ((uint16_t)0x2000)             /*!< EndPoint RX NAKed */
+#define USB_EP_RX_VALID                      ((uint16_t)0x3000)             /*!< EndPoint RX VALID */
+#define USB_EPRX_DTOG1                       ((uint16_t)0x1000)             /*!< EndPoint RX Data TOGgle bit1 */
+#define USB_EPRX_DTOG2                       ((uint16_t)0x2000)             /*!< EndPoint RX Data TOGgle bit1 */
+#define USB_EPRX_DTOGMASK  (USB_EPRX_STAT|USB_EPREG_MASK)
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Window WATCHDOG (WWDG)                             */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for WWDG_CR register  ********************/
+#define  WWDG_CR_T                           ((uint32_t)0x0000007F)               /*!< T[6:0] bits (7-Bit counter (MSB to LSB)) */
+#define  WWDG_CR_T0                          ((uint32_t)0x00000001)               /*!< Bit 0 */
+#define  WWDG_CR_T1                          ((uint32_t)0x00000002)               /*!< Bit 1 */
+#define  WWDG_CR_T2                          ((uint32_t)0x00000004)               /*!< Bit 2 */
+#define  WWDG_CR_T3                          ((uint32_t)0x00000008)               /*!< Bit 3 */
+#define  WWDG_CR_T4                          ((uint32_t)0x00000010)               /*!< Bit 4 */
+#define  WWDG_CR_T5                          ((uint32_t)0x00000020)               /*!< Bit 5 */
+#define  WWDG_CR_T6                          ((uint32_t)0x00000040)               /*!< Bit 6 */
+
+#define  WWDG_CR_WDGA                        ((uint32_t)0x00000080)               /*!< Activation bit */
+
+/*******************  Bit definition for WWDG_CFR register  *******************/
+#define  WWDG_CFR_W                          ((uint32_t)0x0000007F)            /*!< W[6:0] bits (7-bit window value) */
+#define  WWDG_CFR_W0                         ((uint32_t)0x00000001)            /*!< Bit 0 */
+#define  WWDG_CFR_W1                         ((uint32_t)0x00000002)            /*!< Bit 1 */
+#define  WWDG_CFR_W2                         ((uint32_t)0x00000004)            /*!< Bit 2 */
+#define  WWDG_CFR_W3                         ((uint32_t)0x00000008)            /*!< Bit 3 */
+#define  WWDG_CFR_W4                         ((uint32_t)0x00000010)            /*!< Bit 4 */
+#define  WWDG_CFR_W5                         ((uint32_t)0x00000020)            /*!< Bit 5 */
+#define  WWDG_CFR_W6                         ((uint32_t)0x00000040)            /*!< Bit 6 */
+
+#define  WWDG_CFR_WDGTB                      ((uint32_t)0x00000180)            /*!< WDGTB[1:0] bits (Timer Base) */
+#define  WWDG_CFR_WDGTB0                     ((uint32_t)0x00000080)            /*!< Bit 0 */
+#define  WWDG_CFR_WDGTB1                     ((uint32_t)0x00000100)            /*!< Bit 1 */
+
+#define  WWDG_CFR_EWI                        ((uint32_t)0x00000200)            /*!< Early Wakeup Interrupt */
+
+/*******************  Bit definition for WWDG_SR register  ********************/
+#define  WWDG_SR_EWIF                        ((uint32_t)0x00000001)               /*!< Early Wakeup Interrupt Flag */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_macros
+  * @{
+  */
+
+/******************************* ADC Instances ********************************/
+#define IS_ADC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == ADC1)
+
+/******************************** COMP Instances ******************************/
+#define IS_COMP_ALL_INSTANCE(INSTANCE) (((INSTANCE) == COMP1) || \
+                                       ((INSTANCE) == COMP2))
+
+/******************************* CRC Instances ********************************/
+#define IS_CRC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CRC)
+
+/******************************* DAC Instances ********************************/
+#define IS_DAC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == DAC)
+
+/******************************** DMA Instances *******************************/
+#define IS_DMA_STREAM_ALL_INSTANCE(INSTANCE) (((INSTANCE) == DMA1_Stream0) || \
+                                              ((INSTANCE) == DMA1_Stream1) || \
+                                              ((INSTANCE) == DMA1_Stream2) || \
+                                              ((INSTANCE) == DMA1_Stream3) || \
+                                              ((INSTANCE) == DMA1_Stream4) || \
+                                              ((INSTANCE) == DMA1_Stream5) || \
+                                              ((INSTANCE) == DMA1_Stream6) || \
+                                              ((INSTANCE) == DMA1_Stream7))
+
+/******************************* GPIO Instances *******************************/
+#define IS_GPIO_ALL_INSTANCE(INSTANCE) (((INSTANCE) == GPIOA) || \
+                                        ((INSTANCE) == GPIOB) || \
+                                        ((INSTANCE) == GPIOC) || \
+                                        ((INSTANCE) == GPIOD) || \
+                                        ((INSTANCE) == GPIOH))
+
+
+/******************************** I2C Instances *******************************/
+#define IS_I2C_ALL_INSTANCE(INSTANCE) (((INSTANCE) == I2C1) || \
+                                       ((INSTANCE) == I2C2))
+
+/******************************** I2S Instances *******************************/
+#define IS_I2S_INSTANCE(INSTANCE)  ((INSTANCE) == SPI2)
+
+/******************************* RNG Instances ********************************/
+#define IS_RNG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == RNG)
+
+/****************************** RTC Instances *********************************/
+#define IS_RTC_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == RTC)
+
+/******************************** SMBUS Instances *****************************/
+#define IS_SMBUS_INSTANCE(INSTANCE)  ((INSTANCE) == I2C1)
+
+/******************************** SPI Instances *******************************/
+#define IS_SPI_ALL_INSTANCE(INSTANCE) (((INSTANCE) == SPI1) || \
+                                       ((INSTANCE) == SPI2))
+/****************** LPTIM Instances : All supported instances *****************/
+#define IS_LPTIM_INSTANCE(INSTANCE)       ((INSTANCE) == LPTIM1)
+
+/****************** TIM Instances : All supported instances *******************/
+#define IS_TIM_INSTANCE(INSTANCE)       (((INSTANCE) == TIM2)   || \
+                                         ((INSTANCE) == TIM6)   || \
+                                         ((INSTANCE) == TIM21)  || \
+                                         ((INSTANCE) == TIM22))
+
+/************* TIM Instances : at least 1 capture/compare channel *************/
+#define IS_TIM_CC1_INSTANCE(INSTANCE)   (((INSTANCE) == TIM2)  || \
+                                         ((INSTANCE) == TIM21) || \
+                                         ((INSTANCE) == TIM22))
+
+/************ TIM Instances : at least 2 capture/compare channels *************/
+#define IS_TIM_CC2_INSTANCE(INSTANCE)  (((INSTANCE) == TIM2)  || \
+                                        ((INSTANCE) == TIM21) || \
+                                        ((INSTANCE) == TIM22))
+
+/************ TIM Instances : at least 3 capture/compare channels *************/
+#define IS_TIM_CC3_INSTANCE(INSTANCE)   ((INSTANCE) == TIM2)
+
+/************ TIM Instances : at least 4 capture/compare channels *************/
+#define IS_TIM_CC4_INSTANCE(INSTANCE)   ((INSTANCE) == TIM2)
+
+/******************** TIM Instances : Advanced-control timers *****************/
+
+/******************* TIM Instances : Timer input XOR function *****************/
+#define IS_TIM_XOR_INSTANCE(INSTANCE)      ((INSTANCE) == TIM2)
+
+
+/****************** TIM Instances : DMA requests generation (UDE) *************/
+#define IS_TIM_DMA_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2) || \
+                                            ((INSTANCE) == TIM6))
+/************ TIM Instances : DMA requests generation (CCxDE) *****************/
+#define IS_TIM_DMA_CC_INSTANCE(INSTANCE)   ((INSTANCE) == TIM2)
+
+/************ TIM Instances : DMA requests generation (COMDE) *****************/
+#define IS_TIM_CCDMA_INSTANCE(INSTANCE)    ((INSTANCE) == TIM2)
+
+/******************** TIM Instances : DMA burst feature ***********************/
+#define IS_TIM_DMABURST_INSTANCE(INSTANCE) ((INSTANCE) == TIM2)
+
+/****** TIM Instances : master mode available (TIMx_CR2.MMS available )********/
+#define IS_TIM_MASTER_INSTANCE(INSTANCE)   (((INSTANCE) == TIM2)   || \
+                                             ((INSTANCE) == TIM6)  || \
+                                             ((INSTANCE) == TIM21) || \
+                                             ((INSTANCE) == TIM22))
+
+/*********** TIM Instances : Slave mode available (TIMx_SMCR available )*******/
+#define IS_TIM_SLAVE_INSTANCE(INSTANCE)    (((INSTANCE) == TIM2)  || \
+                                            ((INSTANCE) == TIM21) || \
+                                            ((INSTANCE) == TIM22))
+
+/********************** TIM Instances : 32 bit Counter ************************/
+
+/***************** TIM Instances : external trigger input availabe ************/
+#define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM2)  || \
+                                            ((INSTANCE) == TIM21) || \
+                                            ((INSTANCE) == TIM22))
+
+/****************** TIM Instances : remapping capability **********************/
+#define IS_TIM_REMAP_INSTANCE(INSTANCE) (((INSTANCE) == TIM2)   || \
+                                         ((INSTANCE) == TIM21)  || \
+                                         ((INSTANCE) == TIM22))
+
+/******************* TIM Instances : output(s) available **********************/
+#define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
+    ((((INSTANCE) == TIM2) &&                  \
+     (((CHANNEL) == TIM_CHANNEL_1) ||          \
+      ((CHANNEL) == TIM_CHANNEL_2) ||          \
+      ((CHANNEL) == TIM_CHANNEL_3) ||          \
+      ((CHANNEL) == TIM_CHANNEL_4)))           \
+     ||                                        \
+     (((INSTANCE) == TIM21) &&                 \
+      (((CHANNEL) == TIM_CHANNEL_1) ||         \
+       ((CHANNEL) == TIM_CHANNEL_2)))          \
+     ||                                        \
+     (((INSTANCE) == TIM22) &&                 \
+      (((CHANNEL) == TIM_CHANNEL_1) ||         \
+       ((CHANNEL) == TIM_CHANNEL_2))))
+
+/******************** UART Instances : Asynchronous mode **********************/
+#define IS_UART_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                     ((INSTANCE) == USART2) || \
+                                     ((INSTANCE) == LPUART1))
+
+/******************** USART Instances : Synchronous mode **********************/
+#define IS_USART_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                    ((INSTANCE) == USART2))
+
+/****************** UART Instances : Hardware Flow control ********************/
+#define IS_UART_HWFLOW_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                           ((INSTANCE) == USART2) || \
+                                           ((INSTANCE) == LPUART1))
+
+
+/********************* UART Instances : Smard card mode ***********************/
+#define IS_SMARTCARD_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                         ((INSTANCE) == USART2))
+
+/*********************** UART Instances : IRDA mode ***************************/
+#define IS_IRDA_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                    ((INSTANCE) == USART2))     
+
+/****************************** IWDG Instances ********************************/
+#define IS_IWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == IWDG)
+
+/****************************** USB Instances ********************************/
+#define IS_USB_ALL_INSTANCE(INSTANCE) ((INSTANCE) == USB)
+
+/****************************** WWDG Instances ********************************/
+#define IS_WWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == WWDG)
+
+/**
+  * @}
+  */
+
+/******************************************************************************/
+/*  For a painless codes migration between the STM32L0xx device product       */
+/*  lines, the aliases defined below are put in place to overcome the         */
+/*  differences in the interrupt handlers and IRQn definitions.               */
+/*  No need to update developed interrupt code when moving across             */ 
+/*  product lines within the same STM32L0 Family                              */
+/******************************************************************************/ 
+
+/* Aliases for __IRQn */
+
+#define LPUART1_IRQn             RNG_LPUART1_IRQn
+#define AES_LPUART1_IRQn         RNG_LPUART1_IRQn
+#define AES_RNG_LPUART1_IRQn     RNG_LPUART1_IRQn
+
+#define TIM6_IRQn                TIM6_DAC_IRQn
+
+#define RCC_IRQn      RCC_CRS_IRQn
+
+/* Aliases for __IRQHandler */
+#define LPUART1_IRQHandler             RNG_LPUART1_IRQHandler
+#define AES_LPUART1_IRQHandler         RNG_LPUART1_IRQHandler
+#define AES_RNG_LPUART1_IRQHandler     RNG_LPUART1_IRQHandler
+
+#define TIM6_IRQHandler                TIM6_DAC_IRQHandler
+
+#define RCC_IRQHandler             RCC_CRS_IRQHandler
+  
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32L053xx_H */
+
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx.h
@@ -1,0 +1,206 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   CMSIS Cortex-M0+ Device Peripheral Access Layer Header File.
+  *          This file contains all the peripheral register's definitions, bits
+  *          definitions and memory mapping for STM32L0xx devices.
+  *
+  *          The file is the unique include file that the application programmer
+  *          is using in the C source code, usually in main.c. This file contains:
+  *           - Configuration section that allows to select:
+  *              - The device used in the target application
+  *              - To use or not the peripheral’s drivers in application code(i.e.
+  *                code will be based on direct access to peripheral’s registers
+  *                rather than drivers API), this option is controlled by
+  *                "#define USE_HAL_DRIVER"
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32l0xx
+  * @{
+  */
+
+#ifndef __STM32L0xx_H
+#define __STM32L0xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Library_configuration_section
+  * @{
+  */
+
+/* Uncomment the line below according to the target STM32 device used in your
+   application
+  */
+
+#if !defined (STM32L051xx) && !defined (STM32L052xx) && !defined (STM32L053xx) && !defined (STM32L062xx) && \
+    !defined (STM32L063xx) && !defined (STM32L061xx)
+  /* #define STM32L051xx */   /*!< STM32L051K8, STM32L051C6,STM32L051C8,STM32L051R6 and STM32L051R8 Devices */
+  /* #define STM32L052xx */   /*!< STM32L052K6, STM32L052K8,STM32L052C6,STM32L052C8,STM32L052R6 and STM32L052R8 Devices */
+  #define STM32L053xx         /*!< STM32L053C6, STM32L053C8, STM32L053R6, and STM32L053R8 Devices */
+  /* #define STM32L062xx */   /*!< STM32L062K8 */
+  /* #define STM32L063xx */   /*!< STM32L063C8, STM32L063R8 */
+  /* #define STM32L061xx */
+#endif
+
+/*  Tip: To avoid modifying this file each time you need to switch between these
+        devices, you can define the device in your toolchain compiler preprocessor.
+  */
+#if !defined  (USE_HAL_DRIVER)
+/**
+ * @brief Comment the line below if you will not use the peripherals drivers.
+   In this case, these drivers will not be included and the application code will
+   be based on direct access to peripherals registers
+   */
+  #define USE_HAL_DRIVER
+#endif /* USE_HAL_DRIVER */
+
+/**
+  * @brief CMSIS Device version number V1.1.0
+  */
+#define __STM32L0xx_CMSIS_DEVICE_VERSION_MAIN   (0x01) /*!< [31:24] main version */
+#define __STM32L0xx_CMSIS_DEVICE_VERSION_SUB1   (0x01) /*!< [23:16] sub1 version */
+#define __STM32L0xx_CMSIS_DEVICE_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
+#define __STM32L0xx_CMSIS_DEVICE_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
+#define __STM32L0xx_CMSIS_DEVICE_VERSION        ((__CMSIS_DEVICE_VERSION_MAIN     << 24)\
+                                      |(__CMSIS_DEVICE_HAL_VERSION_SUB1 << 16)\
+                                      |(__CMSIS_DEVICE_HAL_VERSION_SUB2 << 8 )\
+                                      |(__CMSIS_DEVICE_HAL_VERSION_RC))
+
+/**
+  * @}
+  */
+
+/** @addtogroup Device_Included
+  * @{
+  */
+
+#if defined(STM32L051xx)
+  #include "stm32l051xx.h"
+#elif defined(STM32L052xx)
+  #include "stm32l052xx.h"
+#elif defined(STM32L053xx)
+  #include "stm32l053xx.h"
+#elif defined(STM32L062xx)
+  #include "stm32l062xx.h"
+#elif defined(STM32L063xx)
+  #include "stm32l063xx.h"
+#elif defined(STM32L061xx)
+  #include "stm32l061xx.h"
+#else
+ #error "Please select first the target STM32L0xx device used in your application (in stm32l0xx.h file)"
+#endif
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_types
+  * @{
+  */
+typedef enum
+{
+  RESET = 0,
+  SET = !RESET
+} FlagStatus, ITStatus;
+
+typedef enum
+{
+  DISABLE = 0,
+  ENABLE = !DISABLE
+} FunctionalState;
+#define IS_FUNCTIONAL_STATE(STATE) (((STATE) == DISABLE) || ((STATE) == ENABLE))
+
+typedef enum
+{
+  ERROR = 0,
+  SUCCESS = !ERROR
+} ErrorStatus;
+
+/**
+  * @}
+  */
+
+
+/** @addtogroup Exported_macro
+  * @{
+  */
+#define SET_BIT(REG, BIT)     ((REG) |= (BIT))
+
+#define CLEAR_BIT(REG, BIT)   ((REG) &= ~(BIT))
+
+#define READ_BIT(REG, BIT)    ((REG) & (BIT))
+
+#define CLEAR_REG(REG)        ((REG) = (0x0))
+
+#define WRITE_REG(REG, VAL)   ((REG) = (VAL))
+
+#define READ_REG(REG)         ((REG))
+
+#define MODIFY_REG(REG, CLEARMASK, SETMASK)  WRITE_REG((REG), (((READ_REG(REG)) & (~(CLEARMASK))) | (SETMASK)))
+
+
+
+/**
+  * @}
+  */
+
+#if defined (USE_HAL_DRIVER)
+ #include "stm32l0xx_hal.h"
+#endif /* USE_HAL_DRIVER */
+
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32L0xx_H */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal.c
@@ -1,0 +1,702 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   HAL module driver.
+  *          This is the common part of the HAL initialization
+  *
+  @verbatim
+  ==============================================================================
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+    The common HAL driver contains a set of generic and common APIs that can be
+    used by the PPP peripheral drivers and the user to start using the HAL. 
+    [..]
+    The HAL contains two APIs' categories: 
+         (+) Common HAL APIs
+         (+) Services HAL APIs
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup HAL 
+  * @brief HAL module driver.
+  * @{
+  */
+
+#ifdef HAL_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/**
+ * @brief STM32L0xx HAL Driver version number V1.1.0
+   */
+#define __STM32L0xx_HAL_VERSION_MAIN   (0x01) /*!< [31:24] main version */
+#define __STM32L0xx_HAL_VERSION_SUB1   (0x01) /*!< [23:16] sub1 version */
+#define __STM32L0xx_HAL_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
+#define __STM32L0xx_HAL_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
+#define __STM32L0xx_HAL_VERSION         ((__STM32L0xx_HAL_VERSION_MAIN << 24)\
+                                        |(__STM32L0xx_HAL_VERSION_SUB1 << 16)\
+                                        |(__STM32L0xx_HAL_VERSION_SUB2 << 8 )\
+                                        |(__STM32L0xx_HAL_VERSION_RC))
+
+#define IDCODE_DEVID_MASK    ((uint32_t)0x00000FFF)
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+static __IO uint32_t uwTick;
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup HAL_Private_Functions
+  * @{
+  */
+
+/** @defgroup HAL_Group1 Initialization and de-initialization Functions 
+ *  @brief    Initialization and de-initialization functions
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+   [..]  This section provides functions allowing to:
+      (+) Initializes the Flash interface, the NVIC allocation and initial clock 
+          configuration. It initializes the source of time base also when timeout 
+          is needed and the backup domain when enabled.
+      (+) de-Initializes common part of the HAL.
+      (+) Configure The time base source to have 1ms time base with a dedicated 
+          Tick interrupt priority. 
+        (++) Systick timer is used by default as source of time base, but user 
+             can eventually implement his proper time base source (a general purpose 
+             timer for example or other time source), keeping in mind that Time base 
+             duration should be kept 1ms since PPP_TIMEOUT_VALUEs are defined and 
+             handled in milliseconds basis.
+        (++) Time base configuration function (HAL_InitTick ()) is called automatically 
+             at the beginning of the program after reset by HAL_Init() or at any time 
+             when clock is configured, by HAL_RCC_ClockConfig(). 
+        (++) Source of time base is configured  to generate interrupts at regular 
+             time intervals. Care must be taken if HAL_Delay() is called from a 
+             peripheral ISR process, the Tick interrupt line must have higher priority 
+            (numerically lower) than the peripheral interrupt. Otherwise the caller 
+            ISR process will be blocked. 
+       (++) functions affecting time base configurations are declared as __Weak  
+             to make  override possible  in case of other  implementations in user file.
+ 
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief This function configures the Flash prefetch, Flash preread and Buffer cache,
+  *        Configures time base source, NVIC and Low level hardware
+  * @note This function is called at the beginning of program after reset and before 
+  *       the clock configuration
+  * @note The time base configuration is based on MSI clock when exiting from Reset.
+  *       Once done, time base tick start incrementing.
+  *        In the default implementation,Systick is used as source of time base.
+  *        the tick variable is incremented each 1ms in its ISR.
+  * @param None
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_Init(void)
+{
+  /* Configure Buffer cache, Flash prefetch,  Flash preread */ 
+#if (BUFFER_CACHE_DISABLE != 0)
+  __HAL_FLASH_BUFFER_CACHE_DISABLE();
+#endif /* BUFFER_CACHE_DISABLE */
+
+#if (PREREAD_ENABLE != 0)
+  __HAL_FLASH_PREREAD_BUFFER_ENABLE();
+#endif /* PREREAD_ENABLE */
+
+#if (PREFETCH_ENABLE != 0)
+  __HAL_FLASH_PREFETCH_BUFFER_ENABLE();
+#endif /* PREFETCH_ENABLE */
+
+  /* Use systick as time base source and configure 1ms tick (default clock after Reset is MSI) */
+
+  HAL_InitTick(TICK_INT_PRIORITY);
+
+  /* Init the low level hardware */
+  HAL_MspInit();
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief This function de-Initializes common part of the HAL and stops the source
+  *        of time base.
+  * @note This function is optional.
+  * @param None
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DeInit(void)
+{
+  /* Reset of all peripherals */
+  __APB1_FORCE_RESET();
+  __APB1_RELEASE_RESET();
+
+  __APB2_FORCE_RESET();
+  __APB2_RELEASE_RESET();
+
+  __AHB_FORCE_RESET();
+  __AHB_RELEASE_RESET();
+
+  __IOP_FORCE_RESET();
+  __IOP_RELEASE_RESET();
+
+  /* De-Init the low level hardware */
+  HAL_MspDeInit();
+    
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the MSP.
+  * @param  None
+  * @retval None
+  */
+__weak void HAL_MspInit(void)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes the MSP.
+  * @param  None  
+  * @retval None
+  */
+__weak void HAL_MspDeInit(void)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief This function configures the source of the time base. 
+  *        The time source is configured  to have 1ms time base with a dedicated 
+  *        Tick interrupt priority.
+  * @note This function is called  automatically at the beginning of program after
+  *       reset by HAL_Init() or at any time when clock is reconfigured  by HAL_RCC_ClockConfig(). 
+  * @note In the default implementation, SysTick timer is the source of time base. 
+  *       It is used to generate interrupts at regular time intervals. 
+  *       Care must be taken if HAL_Delay() is called from a peripheral ISR process, 
+  *       The the SysTick interrupt must have higher priority (numerically lower) 
+  *       than the peripheral interrupt. Otherwise the caller ISR process will be blocked.
+  *       The function is declared as __Weak  to be overwritten  in case of other
+  *       implementation  in user file.
+  * @param TickPriority: Tick interrupt priority.
+  * @retval HAL status
+  */
+__weak HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
+{
+  /*Configure the SysTick to have interrupt in 1ms time basis*/
+  HAL_SYSTICK_Config(HAL_RCC_GetHCLKFreq()/1000);
+
+  /*Configure the SysTick IRQ priority */
+  HAL_NVIC_SetPriority(SysTick_IRQn, TickPriority ,0);
+
+   /* Return function status */
+  return HAL_OK;
+}
+
+/** @defgroup HAL_Group2 HAL Control functions 
+ *  @brief    HAL Control functions
+ *
+@verbatim
+ ===============================================================================
+                      ##### HAL Control functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Provide a tick value in millisecond
+      (+) Provide a blocking delay in millisecond
+      (+) Suspend the time base source interrupt
+      (+) Resume the time base source interrupt
+      (+) Get the HAL API driver version
+      (+) Get the device identifier
+      (+) Get the device revision identifier
+      (+) Configures low power mode behavior when the MCU is in Debug mode
+      
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief This function is called to increment  a global variable "uwTick"
+  *        used as application time base.
+  * @note In the default implementation, this variable is incremented each 1ms
+  *       in Systick ISR.
+ * @note This function is declared as __weak to be overwritten in case of other 
+  *      implementations in user file.
+  * @param None
+  * @retval None
+  */
+__weak void HAL_IncTick(void)
+{
+  uwTick++;
+}
+
+/**
+  * @brief Provides a tick value in millisecond.
+  * @note This function is declared as __weak to be overwritten in case of other 
+  *       implementations in user file.
+  * @param None
+  * @retval tick value
+  */
+__weak uint32_t HAL_GetTick(void)
+{
+  return uwTick;
+}
+
+/**
+  * @brief This function provides accurate delay (in milliseconds) based 
+  *        on variable incremented.
+  * @note In the default implementation , SysTick timer is the source of time base.
+  *       It is used to generate interrupts at regular time intervals where uwTick
+  *       is incremented.
+  * @note ThiS function is declared as __weak to be overwritten in case of other
+  *       implementations in user file.
+  * @param Delay: specifies the delay time length, in milliseconds.
+  * @retval None
+  */
+__weak void HAL_Delay(__IO uint32_t Delay)
+{
+  uint32_t tickstart = 0;
+  tickstart = HAL_GetTick();
+  while((HAL_GetTick() - tickstart) < Delay)
+  {
+  }
+}
+
+/**
+  * @brief Suspend Tick increment.
+  * @note In the default implementation , SysTick timer is the source of time base. It is
+  *       used to generate interrupts at regular time intervals. Once HAL_SuspendTick()
+  *       is called, the the SysTick interrupt will be disabled and so Tick increment 
+  *       is suspended.
+  * @note This function is declared as __weak to be overwritten in case of other
+  *       implementations in user file.
+  * @param None
+  * @retval None
+  */
+__weak void HAL_SuspendTick(void)
+{
+  /* Disable SysTick Interrupt */
+  SysTick->CTRL &= ~SysTick_CTRL_TICKINT_Msk;
+}
+
+/**
+  * @brief Resume Tick increment.
+  * @note In the default implementation , SysTick timer is the source of time base. It is
+  *       used to generate interrupts at regular time intervals. Once HAL_ResumeTick()
+  *       is called, the the SysTick interrupt will be enabled and so Tick increment 
+  *       is resumed.
+  * @note This function is declared as __weak to be overwritten in case of other
+  *       implementations in user file.
+  * @param None
+  * @retval None
+  */
+__weak void HAL_ResumeTick(void)
+{
+  /* Enable SysTick Interrupt */
+  SysTick->CTRL  |= SysTick_CTRL_TICKINT_Msk;
+}
+
+/**
+  * @brief Returns the HAL revision
+  * @param None
+  * @retval version: 0xXYZR (8bits for each decimal, R for RC)
+  */
+uint32_t HAL_GetHalVersion(void)
+{
+  return __STM32L0xx_HAL_VERSION;
+}
+
+/**
+  * @brief Returns the device revision identifier.
+  * @param None
+  * @retval Device revision identifier
+  */
+uint32_t HAL_GetREVID(void)
+{
+  return((DBGMCU->IDCODE) >> 16);
+}
+
+/**
+  * @brief  Returns the device identifier.
+  * @param  None
+  * @retval Device identifier
+  */
+uint32_t HAL_GetDEVID(void)
+{
+   return((DBGMCU->IDCODE) & IDCODE_DEVID_MASK);
+}
+
+/**
+  * @brief  Enable the Debug Module during SLEEP mode
+  * @param  None
+  * @retval None
+  */
+void HAL_EnableDBGSleepMode(void)
+{
+  SET_BIT(DBGMCU->CR, DBGMCU_CR_DBG_SLEEP);
+}
+
+/**
+  * @brief  Disable the Debug Module during SLEEP mode
+  * @param  None
+  * @retval None
+  */
+void HAL_DisableDBGSleepMode(void)
+{
+  CLEAR_BIT(DBGMCU->CR, DBGMCU_CR_DBG_SLEEP);
+}
+
+/**
+  * @brief  Enable the Debug Module during STOP mode
+  * @param  None
+  * @retval None
+  */
+void HAL_EnableDBGStopMode(void)
+{
+  SET_BIT(DBGMCU->CR, DBGMCU_CR_DBG_STOP);
+}
+
+/**
+  * @brief  Disable the Debug Module during STOP mode
+  * @param  None
+  * @retval None
+  */
+void HAL_DisableDBGStopMode(void)
+{
+  CLEAR_BIT(DBGMCU->CR, DBGMCU_CR_DBG_STOP);
+}
+
+/**
+  * @brief  Enable the Debug Module during STANDBY mode
+  * @param  None
+  * @retval None
+  */
+void HAL_EnableDBGStandbyMode(void)
+{
+  SET_BIT(DBGMCU->CR, DBGMCU_CR_DBG_STANDBY);
+}
+
+/**
+  * @brief  Disable the Debug Module during STANDBY mode
+  * @param  None
+  * @retval None
+  */
+void HAL_DisableDBGStandbyMode(void)
+{
+  CLEAR_BIT(DBGMCU->CR, DBGMCU_CR_DBG_STANDBY);
+}
+
+/**
+  * @brief  Configures low power mode behavior when the MCU is in Debug mode.
+  * @param Periph: specifies the low power mode.
+  *   This parameter can be any combination of the following values:
+  *     @arg DBGMCU_SLEEP: Keep debugger connection during SLEEP mode
+  *     @arg DBGMCU_STOP: Keep debugger connection during STOP mode
+  *     @arg DBGMCU_STANDBY: Keep debugger connection during STANDBY mode
+  * @param NewState: new state of the specified low power mode in Debug mode.
+  *   This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void HAL_DBG_LowPowerConfig(uint32_t Periph, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_DBGMCU_PERIPH(Periph));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  if (NewState != DISABLE)
+  {
+    DBGMCU->CR |= Periph;
+  }
+  else
+  {
+    DBGMCU->CR &= ~Periph;
+  }
+}
+
+/**
+  * @brief  Returns the boot mode as configured by user.
+  * @param  None.
+  * @retval The boot mode as configured by user. The returned value can be one 
+  *         of the following values:
+  *              - 0x00000000: Boot is configured in Main Flash memory
+  *              - 0x00000100: Boot is configured in System Flash memory
+  *              - 0x00000300: Boot is configured in Embedded SRAM memory
+  */
+uint32_t  HAL_GetBootMode(void)
+{
+  return (SYSCFG->CFGR1 & SYSCFG_CFGR1_BOOT_MODE);
+}
+
+/**
+  * @brief Configures the I2C fast mode plus driving capability.
+  * @param SYSCFG_I2CFastModePlus: selects the pin.
+  *   This parameter can be one of the following values:
+  *     @arg SYSCFG_I2CFastModePlus_PB6: Configure fast mode plus driving capability for PB6
+  *     @arg SYSCFG_I2CFastModePlus_PB7: Configure fast mode plus driving capability for PB7
+  *     @arg SYSCFG_I2CFastModePlus_PB8: Configure fast mode plus driving capability for PB8
+  *     @arg SYSCFG_I2CFastModePlus_PB9: Configure fast mode plus driving capability for PB9
+  *     @arg SYSCFG_I2CFastModePlus_I2C1: Configure fast mode plus driving capability for I2C1 pins
+  *     @arg SYSCFG_I2CFastModePlus_I2C2: Configure fast mode plus driving capability for I2C2 pins
+  * @param  NewState: This parameter can be:
+  *      ENABLE: Enable fast mode plus driving capability for selected I2C pin
+  *      DISABLE: Disable fast mode plus driving capability for selected I2C pin
+  * @note  For I2C1, fast mode plus driving capability can be enabled on all selected
+  *        I2C1 pins using SYSCFG_I2CFastModePlus_I2C1 parameter or independently
+  *        on each one of the following pins PB6, PB7, PB8 and PB9.
+  * @note  For remaining I2C1 pins (PA14, PA15...) fast mode plus driving capability
+  *        can be enabled only by using SYSCFG_I2CFastModePlus_I2C1 parameter.
+  * @note  For all I2C2 pins fast mode plus driving capability can be enabled
+  *        only by using SYSCFG_I2CFastModePlus_I2C2 parameter.
+  * @retval None
+  */
+void HAL_I2CFastModePlusConfig(uint32_t SYSCFG_I2CFastModePlus, FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_SYSCFG_I2C_FMP(SYSCFG_I2CFastModePlus));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    /* Enable fast mode plus driving capability for selected pin */
+    SYSCFG->CFGR2 |= (uint32_t)SYSCFG_I2CFastModePlus;
+  }
+  else
+  {
+    /* Disable fast mode plus driving capability for selected pin */
+    SYSCFG->CFGR2 &= (uint32_t)(~SYSCFG_I2CFastModePlus);
+  }
+}
+
+/**
+  * @brief Enables or disables the VREFINT.
+  * @param NewState: new state of the Vrefint.
+  *        This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+void HAL_VREFINT_Cmd(FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+
+  if (NewState != DISABLE)
+  {
+    /* Enable the VREFINT by setting EN_VREFINT bit in the CFGR3 register */
+    SYSCFG->CFGR3 |= SYSCFG_CFGR3_EN_VREFINT;
+  }
+  else
+  {
+    /* Disable the VREFINT by setting EN_VREFINT bit in the CFGR3 register */
+    SYSCFG->CFGR3 &= (uint32_t)~((uint32_t)SYSCFG_CFGR3_EN_VREFINT);
+  }
+}
+
+/**
+  * @brief Selects the output of internal reference voltage (VREFINT).
+  *        The VREFINT output can be routed to(PB0) or
+  *        (PB1) or both.
+  * @param SYSCFG_Vrefint_OUTPUT: new state of the Vrefint output.
+  *        This parameter can be one of the following values:
+  *     @arg SYSCFG_VREFINT_OUT_NONE
+  *     @arg SYSCFG_VREFINT_OUT_PB0
+  *     @arg SYSCFG_VREFINT_OUT_PB1
+  *     @arg SYSCFG_VREFINT_OUT_PB0_PB1
+  * @retval None
+  */
+void HAL_VREFINT_OutputSelect(uint32_t SYSCFG_Vrefint_OUTPUT)
+{
+  /* Check the parameters */
+  assert_param(IS_SYSCFG_VREFINT_OUT_SELECT(SYSCFG_Vrefint_OUTPUT));
+
+  /* Set the output Vrefint pin */
+  SYSCFG->CFGR3 &= ~(SYSCFG_CFGR3_VREF_OUT);
+  SYSCFG->CFGR3 |= (uint32_t)(SYSCFG_Vrefint_OUTPUT);
+}
+
+/**
+  * @brief Enables or disables the Buffer Vrefint for the ADC.
+  * @param NewState: new state of the Vrefint.
+  *        This parameter can be: ENABLE or DISABLE.
+  * @note This is functional only if the LOCK is not set  
+  * @retval None
+  */
+void HAL_ADC_EnableBuffer_Cmd(FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  
+  if (NewState != DISABLE)
+  {
+    /* Enable the Buffer for the ADC by setting EN_VREFINT bit and the ENBUF_VREFINT_ADC in the CFGR3 register */
+    SYSCFG->CFGR3 |= (SYSCFG_CFGR3_ENBUF_VREFINT_ADC | SYSCFG_CFGR3_EN_VREFINT);
+  }
+  else
+  {
+    /* Disable the Vrefint by resetting ENBUF_BGAP_ADC bit and the EN_VREFINT bit in the CFGR3 register */
+    SYSCFG->CFGR3 &= (uint32_t)~((uint32_t)(SYSCFG_CFGR3_ENBUF_VREFINT_ADC | SYSCFG_CFGR3_EN_VREFINT));
+  }
+}
+
+/**
+  * @brief Enables or disables the Buffer Sensor for the ADC.
+  * @param NewState: new state of the Vrefint.
+  *        This parameter can be: ENABLE or DISABLE.
+  * @note This is functional only if the LOCK is not set.
+  * @retval None
+  */
+void HAL_ADC_EnableBufferSensor_Cmd(FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  
+  if (NewState != DISABLE)
+  {
+    /* Enable the Buffer for the ADC by setting EN_VREFINT bit and the ENBUF_SENSOR_ADC in the CFGR3 register */
+    SYSCFG->CFGR3 |= (SYSCFG_CFGR3_ENBUF_SENSOR_ADC | SYSCFG_CFGR3_EN_VREFINT);
+  }
+  else
+  {
+    /* Disable the Vrefint by resetting EN_VREFINT bit and the ENBUF_SENSOR_ADC in the CFGR3 register */
+    SYSCFG->CFGR3 &= (uint32_t)~((uint32_t)(SYSCFG_CFGR3_ENBUF_SENSOR_ADC | SYSCFG_CFGR3_EN_VREFINT));
+  }
+}
+
+/**
+  * @brief  Enables or disables the Buffer Vrefint for the COMP.
+  * @param  NewState: new state of the Vrefint.
+  *          This parameter can be: ENABLE or DISABLE.
+  * @note   This is functional only if the LOCK is not set  
+  * @retval None
+  */
+void HAL_COMP_EnableBuffer_Cmd(FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  
+  if (NewState != DISABLE)
+  {
+    /* Enable the Buffer for the COMP by setting EN_VREFINT bit and the ENBUFLP_VREFINT_COMP in the CFGR3 register */
+    SYSCFG->CFGR3 |= (SYSCFG_CFGR3_ENBUFLP_VREFINT_COMP | SYSCFG_CFGR3_EN_VREFINT);
+  }
+  else
+  {
+    /* Disable the Vrefint by resetting ENBUFLP_BGAP_COMP bit and the EN_VREFINT bit in the CFGR3 register */
+    SYSCFG->CFGR3 &= (uint32_t)~((uint32_t)(SYSCFG_CFGR3_ENBUFLP_VREFINT_COMP | SYSCFG_CFGR3_EN_VREFINT));
+  }
+}
+
+/**
+  * @brief Enables or disables the Buffer Vrefint for the RC48.
+  * @param NewState: new state of the Vrefint.
+  *        This parameter can be: ENABLE or DISABLE.
+  * @note This is functional only if the LOCK is not set  
+  * @retval None
+  */
+void HAL_RC48_EnableBuffer_Cmd(FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  
+  if (NewState != DISABLE)
+  {
+    /* Enable the Buffer for the ADC by setting EN_VREFINT bit and the SYSCFG_CFGR3_ENREF_HSI48 in the CFGR3 register */
+    SYSCFG->CFGR3 |= (SYSCFG_CFGR3_ENREF_HSI48 | SYSCFG_CFGR3_EN_VREFINT);
+  }
+  else
+  {
+    /* Disable the Vrefint by resetting SYSCFG_CFGR3_ENREF_HSI48 bit and the EN_VREFINT bit in the CFGR3 register */
+    SYSCFG->CFGR3 &= (uint32_t)~((uint32_t)(SYSCFG_CFGR3_ENREF_HSI48 | SYSCFG_CFGR3_EN_VREFINT));
+  }
+}
+
+/**
+  * @brief  Enables or disables the Lock.
+  * @param  NewState: new state of the Lock.
+  *          This parameter can be: ENABLE or DISABLE. 
+  * @retval None
+  */
+void HAL_Lock_Cmd(FunctionalState NewState)
+{
+  /* Check the parameters */
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+  
+  if (NewState != DISABLE)
+  {
+    /* Enable the LOCK by setting REF_LOCK bit in the CFGR3 register */
+    SYSCFG->CFGR3 |= SYSCFG_CFGR3_REF_LOCK;
+  }
+  else
+  {
+    /* Disable the LOCK by setting REF_LOCK bit in the CFGR3 register */
+    SYSCFG->CFGR3 &= (uint32_t)~((uint32_t)SYSCFG_CFGR3_REF_LOCK);
+  }
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal.h
@@ -1,0 +1,240 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   This file contains all the functions prototypes for the HAL 
+  *          module driver.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_H
+#define __STM32L0xx_HAL_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_conf.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup HAL
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup HAL_Exported_Constants
+  * @{
+  */ 
+
+/** @defgroup HAL_DBGMCU_Low_Power_Config 
+  * @{
+  */
+#define DBGMCU_SLEEP                 DBGMCU_CR_DBG_SLEEP
+#define DBGMCU_STOP                  DBGMCU_CR_DBG_STOP
+#define DBGMCU_STANDBY               DBGMCU_CR_DBG_STANDBY
+#define IS_DBGMCU_PERIPH(PERIPH) ((((PERIPH) & 0xFFFFFFF8) == 0x00) && ((PERIPH) != 0x00))
+
+/**
+  * @}
+  */
+  
+
+/** @defgroup HAL_SYSCFG_I2C_FastModePlus_Config 
+  * @{
+  */ 
+#define SYSCFG_I2CFastModePlus_PB6       SYSCFG_CFGR2_I2C_PB6_FMP  /* Enable Fast Mode Plus on PB6 */
+#define SYSCFG_I2CFastModePlus_PB7       SYSCFG_CFGR2_I2C_PB7_FMP  /* Enable Fast Mode Plus on PB7 */
+#define SYSCFG_I2CFastModePlus_PB8       SYSCFG_CFGR2_I2C_PB8_FMP  /* Enable Fast Mode Plus on PB8 */
+#define SYSCFG_I2CFastModePlus_PB9       SYSCFG_CFGR2_I2C_PB9_FMP  /* Enable Fast Mode Plus on PB9 */
+#define SYSCFG_I2CFastModePlus_I2C1      SYSCFG_CFGR2_I2C1_FMP     /*!< Enable Fast Mode Plus on I2C1 pins */
+#define SYSCFG_I2CFastModePlus_I2C2      SYSCFG_CFGR2_I2C2_FMP     /*!< Enable Fast Mode Plus on I2C2 pins */
+
+#define IS_SYSCFG_I2C_FMP(PIN) (((PIN) == SYSCFG_I2CFastModePlus_PB6)  || \
+                                ((PIN) == SYSCFG_I2CFastModePlus_PB7)  || \
+                                ((PIN) == SYSCFG_I2CFastModePlus_PB8)  || \
+                                ((PIN) == SYSCFG_I2CFastModePlus_PB9)  || \
+                                ((PIN) == SYSCFG_I2CFastModePlus_I2C1) || \
+                                ((PIN) == SYSCFG_I2CFastModePlus_I2C2))
+
+/**
+  * @}
+  */  
+ 
+/** @defgroup HAL_SYSCFG_VREFINT_OUT_SELECT 
+  * @{
+  */ 
+#define SYSCFG_VREFINT_OUT_NONE          ((uint32_t)0x00000000) /* no pad connected */  
+#define SYSCFG_VREFINT_OUT_PB0           SYSCFG_CFGR3_VREF_OUT_0 /* Selects PBO as output for the Vrefint */
+#define SYSCFG_VREFINT_OUT_PB1           SYSCFG_CFGR3_VREF_OUT_1 /* Selects PB1 as output for the Vrefint */
+#define SYSCFG_VREFINT_OUT_PB0_PB1       SYSCFG_CFGR3_VREF_OUT   /* Selects PBO and PB1 as output for the Vrefint */
+
+#define IS_SYSCFG_VREFINT_OUT_SELECT(OUTPUT)   (((OUTPUT) == SYSCFG_VREFINT_OUT_PB0)  || \
+                                                ((OUTPUT) == SYSCFG_VREFINT_OUT_PB1)  || \
+                                                ((OUTPUT) == SYSCFG_VREFINT_OUT_PB0_PB1))
+
+/**
+  * @}
+  */ 
+
+/** @defgroup HAL_SYSCFG_flags_definition 
+  * @{
+  */
+
+#define SYSCFG_FLAG_RC48               SYSCFG_CFGR3_REF_HSI48_RDYF
+#define SYSCFG_FLAG_SENSOR_ADC         SYSCFG_CFGR3_SENSOR_ADC_RDYF
+#define SYSCFG_FLAG_VREF_ADC           SYSCFG_VREFINT_ADC_RDYF
+#define SYSCFG_FLAG_VREF_COMP          SYSCFG_CFGR3_VREFINT_COMP_RDYF
+#define SYSCFG_FLAG_VREF_READY         SYSCFG_CFGR3_VREFINT_RDYF
+
+#define IS_SYSCFG_FLAG(FLAG) (((FLAG) == SYSCFG_FLAG_RC48)        || \
+                              ((FLAG) == SYSCFG_FLAG_SENSOR_ADC)  || \
+                              ((FLAG) == SYSCFG_FLAG_VREF_ADC)    || \
+                              ((FLAG) == SYSCFG_FLAG_VREF_COMP)   || \
+                              ((FLAG) == SYSCFG_FLAG_VREF_READY))
+
+/**
+  * @}
+  */
+/* Exported macro ------------------------------------------------------------*/
+
+/** @brief  Freeze/Unfreeze Peripherals in Debug mode 
+  */
+#define __HAL_FREEZE_TIM2_DBGMCU()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_TIM2_STOP))
+#define __HAL_FREEZE_TIM6_DBGMCU()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_TIM6_STOP))
+#define __HAL_FREEZE_RTC_DBGMCU()            (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_RTC_STOP))
+#define __HAL_FREEZE_WWDG_DBGMCU()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_WWDG_STOP))
+#define __HAL_FREEZE_IWDG_DBGMCU()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_IWDG_STOP))
+#define __HAL_FREEZE_I2C1_TIMEOUT_DBGMCU()   (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_I2C1_STOP))
+#define __HAL_FREEZE_I2C2_TIMEOUT_DBGMCU()   (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_I2C2_STOP))
+#define __HAL_FREEZE_LPTIMER_DBGMCU()        (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_LPTIMER_STOP))
+#define __HAL_FREEZE_TIM22_DBGMCU()          (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM22_STOP))
+#define __HAL_FREEZE_TIM21_DBGMCU()          (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM21_STOP))
+
+#define __HAL_UNFREEZE_TIM2_DBGMCU()           (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM2_STOP))
+#define __HAL_UNFREEZE_TIM6_DBGMCU()           (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM6_STOP))
+#define __HAL_UNFREEZE_RTC_DBGMCU()            (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_RTC_STOP))
+#define __HAL_UNFREEZE_WWDG_DBGMCU()           (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_WWDG_STOP))
+#define __HAL_UNFREEZE_IWDG_DBGMCU()           (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_IWDG_STOP))
+#define __HAL_UNFREEZE_I2C1_TIMEOUT_DBGMCU()   (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_I2C1_STOP))
+#define __HAL_UNFREEZE_I2C2_TIMEOUT_DBGMCU()   (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_I2C2_STOP))
+#define __HAL_UNFREEZE_LPTIMER_DBGMCU()        (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_LPTIMER_STOP))
+#define __HAL_UNFREEZE_TIM22_DBGMCU()          (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM22_STOP))
+#define __HAL_UNFREEZE_TIM21_DBGMCU()          (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM21_STOP))
+
+/** @brief  Main Flash memory mapped at 0x00000000
+  */
+#define __HAL_REMAPMEMORY_FLASH             (SYSCFG->CFGR1 &= ~(SYSCFG_CFGR1_MEM_MODE))
+
+/** @brief  System Flash memory mapped at 0x00000000
+  */
+#define __HAL_REMAPMEMORY_SYSTEMFLASH       do {SYSCFG->CFGR1 &= ~(SYSCFG_CFGR1_MEM_MODE);\
+                                                SYSCFG->CFGR1 |= SYSCFG_CFGR1_MEM_MODE_0;\
+                                               }while(0);
+
+/** @brief  Embedded SRAM mapped at 0x00000000
+  */
+#define __HAL_REMAPMEMORY_SRAM       do {SYSCFG->CFGR1 &= ~(SYSCFG_CFGR1_MEM_MODE);\
+                                         SYSCFG->CFGR1 |= (SYSCFG_CFGR1_MEM_MODE_0 | SYSCFG_CFGR1_MEM_MODE_1);\
+                                         }while(0);
+
+/** @brief  Check whether the specified SYSCFG flag is set or not.
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *            SYSCFG_FLAG_PE: SRAM parity error flag.
+  *            @arg SYSCFG_FLAG_RC48
+  *            @arg SYSCFG_FLAG_SENSOR_ADC
+  *            @arg SYSCFG_FLAG_VREF_ADC
+  *            @arg SYSCFG_FLAG_VREF_COMP
+  *            @arg SYSCFG_FLAG_VREF_READY   
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_SYSCFG_GET_FLAG(__FLAG__) (((SYSCFG->CFGR3) & (__FLAG__)) == (__FLAG__))
+
+/**                  
+  * @}
+  */
+/* Exported functions --------------------------------------------------------*/
+
+/* Initialization and de-initialization functions  ******************************/
+HAL_StatusTypeDef HAL_Init(void);
+HAL_StatusTypeDef HAL_DeInit(void);
+void HAL_MspInit(void);
+void HAL_MspDeInit(void);
+HAL_StatusTypeDef HAL_InitTick (uint32_t TickPriority);
+
+/* Peripheral Control functions  ************************************************/
+void HAL_IncTick(void);
+void HAL_Delay(__IO uint32_t Delay);
+uint32_t HAL_GetTick(void);
+void HAL_SuspendTick(void);
+void HAL_ResumeTick(void);
+uint32_t HAL_GetHalVersion(void);
+uint32_t HAL_GetREVID(void);
+uint32_t HAL_GetDEVID(void);
+void HAL_EnableDBGSleepMode(void);
+void HAL_DisableDBGSleepMode(void);
+void HAL_EnableDBGStopMode(void);
+void HAL_DisableDBGStopMode(void);
+void HAL_EnableDBGStandbyMode(void);
+void HAL_DisableDBGStandbyMode(void);
+void HAL_DBG_LowPowerConfig(uint32_t Periph, FunctionalState NewState);
+uint32_t  HAL_GetBootMode(void);
+void HAL_I2CFastModePlusConfig(uint32_t SYSCFG_I2CFastModePlus, FunctionalState NewState);
+void HAL_VREFINT_Cmd(FunctionalState NewState);
+void HAL_VREFINT_OutputSelect(uint32_t SYSCFG_Vrefint_OUTPUT);
+void HAL_ADC_EnableBuffer_Cmd(FunctionalState NewState);
+void HAL_ADC_EnableBufferSensor_Cmd(FunctionalState NewState);
+void HAL_COMP_EnableBuffer_Cmd(FunctionalState NewState);
+void HAL_RC48_EnableBuffer_Cmd(FunctionalState NewState);
+void HAL_Lock_Cmd(FunctionalState NewState);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_adc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_adc.c
@@ -1,0 +1,1609 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_adc.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   This file provides firmware functions to manage the following 
+  *          functionalities of the Analog to Digital Convertor (ADC)
+  *          peripheral:
+  *           + Initialization and de-initialization functions
+  *             ++ Initialization and Configuration of ADC
+  *           + Operation functions
+  *             ++ Start, stop, get result of conversions of regular 
+  *             groups, using 3 possible modes : polling, interruption or DMA.
+  *             ++ Calibration feature
+  *           + Control functions
+  *             ++ Analog Watchdog configuration
+  *             ++ Regular Channels Configuration
+  *           + State functions
+  *             ++ ADC state machine management
+  *             ++ Interrupts and flags management
+  *         
+  @verbatim
+  ==============================================================================
+                    ##### ADC specific features #####
+  ==============================================================================
+  [..] 
+  (#) 12-bit, 10-bit, 8-bit or 6-bit configurable resolution.
+
+  (#) A built-in hardware oversampler allows to improve analog performances
+      while off-loading the related computational burden from the CPU.
+
+  (#) Interrupt generation at the end of conversion and in case of analog
+      watchdog or overrun events.
+  
+  (#) Single and continuous conversion modes.
+  
+  (#) Scan or discontinuous mode conversion of channel 0 to channel 18.
+
+  (#) Configurable scan direction (Upward from channel 0 to 18 or Backward from
+      channel 18 to channel 0)
+  
+  (#) Data alignment with in-built data coherency.
+  
+  (#) Channel-wise programmable sampling time.
+
+  (#) External trigger option with configurable polarity.
+
+  (#) DMA request generation during regular channel conversion.
+  
+  (#) ADC supply requirements: 2.4 V to 3.6 V at full speed and down to 1.8 V at 
+      slower speed.
+  
+  (#) ADC input range: VREF- =VIN =VREF+.
+
+  (#) ADC self-calibration.
+
+  (#) ADC is automatically powered off (AutoOff mode) except during the active
+      conversion phase. This dramatically reduces the power consumption of the
+      ADC.
+
+  (#) Wait mode to prevent ADC overrun in applications with low frequency.
+
+
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+
+    (#) Enable the ADC interface 
+        As prerequisite, into HAL_ADC_MspInit(), ADC clock must be configured  
+        at RCC top level.
+
+        Depending on both possible clock sources: PCLK clock or ADC asynchronous
+        clock. 
+          __ADC1_CLK_ENABLE();                                                            
+
+
+    (#) ADC pins configuration
+         (++) Enable the clock for the ADC GPIOs using the following function:
+             __GPIOx_CLK_ENABLE();   
+         (++) Configure these ADC pins in analog mode using HAL_GPIO_Init();  
+  
+     (#) Configure the ADC parameters (conversion resolution, oversampler, 
+         data alignment, continuous mode,...) using the HAL_ADC_Init() function.
+
+     (#) Activate the ADC peripheral using one of the start functions: 
+         HAL_ADC_Start(), HAL_ADC_Start_IT() or HAL_ADC_Start_DMA()
+  
+     *** Channels configuration ***
+     ===============================
+     [..]    
+       (+) To configure the ADC channels group, use HAL_ADC_ConfigChannel() function.   
+       (+) To read the ADC converted values, use the HAL_ADC_GetValue() function.
+            
+     *** DMA feature configuration ***
+     =================================
+     [..]
+       (+) To enable the DMA mode, use the HAL_ADC_Start_DMA() function.
+       (+) To enable the generation of DMA requests continuously at the end of 
+           the last DMA transfer, set .Init.DMAContinuousRequests to ENABLE and
+           call HAL_ADC_Init() function.
+
+  
+    @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup ADC 
+  * @brief ADC driver modules
+  * @{
+  */ 
+
+#ifdef HAL_ADC_MODULE_ENABLED
+    
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef* hadc);
+static void ADC_DMAConvCplt(DMA_HandleTypeDef *hdma);
+static void ADC_DMAHalfConvCplt(DMA_HandleTypeDef *hdma);
+static void ADC_DMAError(DMA_HandleTypeDef *hdma);
+static HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef* hadc, uint32_t ConversionGroup);
+static HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef* hadc);
+
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup ADC_Private_Functions
+  * @{
+  */ 
+
+/** @defgroup ADC_Group1 Initialization/de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the ADC. 
+      (+) De-initialize the ADC. 
+         
+@endverbatim
+  * @{
+  */
+
+
+/**
+  * @brief  Initializes the ADCx peripheral according to the specified parameters 
+  *         in the ADC_InitStruct.
+  * @note   This function is used to configure the global features of the ADC 
+  *         (ClockPrescaler, Resolution, Data Alignment and number of conversion), however,
+  *         the rest of the configuration parameters are specific to the regular
+  *         channels group (scan mode activation, continuous mode activation,
+  *         External trigger source and edge, DMA continuous request after the  
+  *         last transfer and End of conversion selection).
+  *         
+  *         As prerequisite, into HAL_ADC_MspInit(), ADC clock must be 
+  *         configured at RCC top level.
+  *         See commented example code below that can be copied 
+  *         and uncommented into HAL_ADC_MspInit().
+  *         
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
+{
+  uint32_t tickstart = 0x00;
+  
+  /* Check ADC handle */
+  if(hadc == NULL)
+  {
+     return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_CLOCKPRESCALER(hadc->Init.ClockPrescaler));
+  assert_param(IS_ADC_RESOLUTION(hadc->Init.Resolution));
+  assert_param(IS_ADC_SAMPLE_TIME(hadc->Init.SamplingTime));
+  assert_param(IS_ADC_SCAN_DIRECTION(hadc->Init.ScanDirection));  
+  assert_param(IS_ADC_DATA_ALIGN(hadc->Init.DataAlign)); 
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));	    
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.DiscontinuousConvMode));
+  assert_param(IS_ADC_EXTTRIG_EDGE(hadc->Init.ExternalTrigConvEdge));
+  assert_param(IS_ADC_EXTERNAL_TRIG_CONV(hadc->Init.ExternalTrigConv));   
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.DMAContinuousRequests));	    
+  assert_param(IS_ADC_EOC_SELECTION(hadc->Init.EOCSelection));
+  assert_param(IS_ADC_OVERRUN(hadc->Init.Overrun));	    
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.LowPowerAutoWait));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.LowPowerFrequencyMode));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.LowPowerAutoOff));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.OversamplingMode));
+
+  if(hadc->State == HAL_ADC_STATE_RESET)
+  {
+    /* Init the low level hardware */
+    HAL_ADC_MspInit(hadc);
+  }
+  
+  /* Initialize the ADC state */
+  hadc->State = HAL_ADC_STATE_BUSY;
+  
+  /* Configuration of ADC clock: clock source PCLK or asynchronous with 
+  selectable prescaler */
+  __HAL_ADC_CLOCK_PRESCALER(hadc);
+  
+  /* Set the Low Frequency mode */
+  ADC->CCR &= (uint32_t)~ADC_CCR_LFMEN;
+  ADC->CCR |=__HAL_ADC_CCR_LOWFREQUENCY(hadc->Init.LowPowerFrequencyMode);  
+   
+  /* Enable voltage regulator (if disabled at this step) */
+  if (HAL_IS_BIT_CLR(hadc->Instance->CR, ADC_CR_ADVREGEN))
+  {
+    /* Note: The software must wait for the startup time of the ADC voltage   */
+    /*       regulator before launching a calibration or enabling the ADC.    */
+    /*       This temporization must be implemented by software and is equal  */ 
+    /*       to 10 micro seconds in the worst case process/temperature/power supply.     */
+    
+    /* Disable the ADC (if not already disabled) */
+    if (__HAL_ADC_IS_ENABLED(hadc) != RESET )
+    {
+      /* Check if conditions to disable the ADC are fulfilled */
+      if (__HAL_ADC_DISABLING_CONDITIONS(hadc) != RESET)
+      {
+        __HAL_ADC_DISABLE(hadc);    
+      }
+      else  
+      {
+        hadc->State= HAL_ADC_STATE_ERROR;
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_ERROR;
+      }   
+      
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+
+      /* Wait for disabling completion */
+      while(HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADEN))
+      {
+        /* Check for the Timeout */
+        if(ADC_ENABLE_TIMEOUT != HAL_MAX_DELAY)
+        {          
+          if((HAL_GetTick() - tickstart ) > ADC_DISABLE_TIMEOUT)
+          {
+            hadc->State= HAL_ADC_STATE_TIMEOUT;
+            
+            /* Process unlocked */
+            __HAL_UNLOCK(hadc);
+            
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+      
+    }
+  
+    /* Set ADVREGEN bit */
+    hadc->Instance->CR |= ADC_CR_ADVREGEN;
+    /* Delay of 10 microseconds minimum (value from design, cf reference manual) */
+    /* Delay fixed to worst case: maximum CPU frequency                       */
+    HAL_Delay(10);
+  }
+  
+  /* Configuration of ADC:                                                    */
+  /*  - Resolution                                                            */
+  /*  - Data alignment                                                        */
+  /*  - Scan direction                                                         */
+  /*  - External trigger to start conversion                                  */
+  /*  - External trigger polarity                                             */
+  /*  - Continuous conversion mode                                            */
+  /*  - DMA continuous request                                                */
+  /*  - Overrun                                                               */
+  /*  - AutoDelay feature                                                     */
+  /*  - Discontinuous mode                                                    */
+  hadc->Instance->CFGR1 &= ~( ADC_CFGR1_RES   |
+                             ADC_CFGR1_ALIGN  |
+                             ADC_CFGR1_SCANDIR  |
+                             ADC_CFGR1_EXTSEL |
+                             ADC_CFGR1_EXTEN  |
+                             ADC_CFGR1_CONT   |
+                             ADC_CFGR1_DMACFG |
+                             ADC_CFGR1_OVRMOD |
+                             ADC_CFGR1_AUTDLY |
+                             ADC_CFGR1_AUTOFF |
+                             ADC_CFGR1_DISCEN);
+  
+  hadc->Instance->CFGR1 |= ( hadc->Init.Resolution                                       |
+                            hadc->Init.DataAlign                                         |
+                            hadc->Init.ScanDirection                                     |
+                            hadc->Init.ExternalTrigConvEdge                              |
+                            __HAL_ADC_CFGR1_CONTINUOUS(hadc->Init.ContinuousConvMode)    | 
+                            __HAL_ADC_CFGR1_DMAContReq(hadc->Init.DMAContinuousRequests) |
+                            hadc->Init.Overrun                                           |
+                            __HAL_ADC_CFGR1_AutoDelay(hadc->Init.LowPowerAutoWait)       |
+                            __HAL_ADC_CFGR1_AUTOFF(hadc->Init.LowPowerAutoOff));
+  
+  /* Configure the external trigger only if Conversion edge is not "NONE" */
+  if (hadc->Init.ExternalTrigConvEdge != ADC_EXTERNALTRIG_EDGE_NONE)
+  {
+    hadc->Instance->CFGR1 |= hadc->Init.ExternalTrigConv;
+  }
+  
+  /* Enable discontinuous mode only if continuous mode is disabled */
+  if ((hadc->Init.DiscontinuousConvMode == ENABLE) && (hadc->Init.ContinuousConvMode == DISABLE))
+  {  
+    /* Enable the selected ADC discontinuous mode */   
+    hadc->Instance->CFGR1 |= ( ADC_CFGR1_DISCEN);
+  }
+  
+  if (hadc->Init.OversamplingMode == ENABLE)
+  {
+    assert_param(IS_ADC_OVERSAMPLING_RATIO(hadc->Init.Oversample.Ratio));
+    assert_param(IS_ADC_RIGHT_BIT_SHIFT(hadc->Init.Oversample.RightBitShift));
+    assert_param(IS_ADC_TRIGGERED_OVERSAMPLING_MODE(hadc->Init.Oversample.TriggeredMode));
+
+    /* Configuration of Oversampler:                                          */
+    /*  - Oversampling Ratio                                                  */
+    /*  - Right bit shift                                                     */
+    /*  - Triggered mode                                                      */
+    
+    hadc->Instance->CFGR2 &= ~( ADC_CFGR2_OVSR |
+                                ADC_CFGR2_OVSS |
+                                ADC_CFGR2_TOVS );
+    
+    hadc->Instance->CFGR2 |= ( hadc->Init.Oversample.Ratio         |
+                               hadc->Init.Oversample.RightBitShift             |
+                               hadc->Init.Oversample.TriggeredMode );
+    
+    /* Enable OverSampling mode */
+     hadc->Instance->CFGR2 |= ADC_CFGR2_OVSE;
+  }
+  else
+  {
+    /* Disable OverSampling mode */
+     hadc->Instance->CFGR2 &= ~ADC_CFGR2_OVSE;
+  }    
+  
+  /* Clear the old sampling time */
+  hadc->Instance->SMPR &= (uint32_t)(~ADC_SMPR_SMPR);
+  
+  /* Set the new sample time */
+  hadc->Instance->SMPR |= hadc->Init.SamplingTime;
+  
+  
+  /* Set ADC error code to none */
+  hadc->ErrorCode = HAL_ADC_ERROR_NONE;
+  
+  /* Initialize the ADC state */
+  hadc->State = HAL_ADC_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deinitialize the ADC peripheral registers to its default reset values.
+  * @note   To not impact other ADCs, reset of common ADC registers have been
+  *         left commented below.
+  *         If needed, the example code can be copied and uncommented into
+  *         function HAL_ADC_MspDeInit().
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
+{
+  uint32_t tickstart = 0;
+  
+  /* Check ADC handle */
+  if(hadc == NULL)
+  {
+     return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_BUSY;
+  
+  /* Stop potential conversion ongoing */
+  if (HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADSTART) && HAL_IS_BIT_CLR(hadc->Instance->CR, ADC_CR_ADDIS))
+  {
+    /* Stop regular conversion */
+    hadc->Instance->CR |= ADC_CR_ADSTP;
+  }
+  
+  /* Disable ADC: Solution to recover from an unknown ADC state (for example, */
+  /* in case of forbidden action on register bits)                            */
+  /* Procedure to disable the ADC peripheral: wait for conversions            */
+  /* effectively stopped, then disable ADC                                    */
+  /* 1. Wait until ADSTART = 0 */
+  
+  /* Get timeout */
+  tickstart = HAL_GetTick();  
+  
+  while(HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADSTART))
+  {
+    /* Check for the Timeout */
+    if(ADC_STOP_CONVERSION_TIMEOUT != HAL_MAX_DELAY)
+    {
+      if((HAL_GetTick() - tickstart ) > ADC_STOP_CONVERSION_TIMEOUT)
+      {
+        hadc->State= HAL_ADC_STATE_TIMEOUT;
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  
+  /* 2. Disable the ADC peripheral */
+  __HAL_ADC_DISABLE(hadc);
+  
+    
+  /* Reset ADC registers****************/
+  /* Reset register IER */
+  __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_AWD | ADC_IT_OVR | ADC_IT_EOCAL | ADC_IT_EOS |  \
+                              ADC_IT_EOC | ADC_IT_RDY | ADC_IT_EOSMP ));
+      
+  /* Reset register ISR */
+  __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_AWD | ADC_FLAG_EOCAL | ADC_FLAG_OVR | ADC_FLAG_EOS |  \
+                              ADC_FLAG_EOC | ADC_FLAG_EOSMP | ADC_FLAG_RDY));
+  
+  /* Reset register CR */
+  /* Disable voltage regulator */
+  /* Note: Regulator disable useful for power saving */
+  /* Reset ADVREGEN bit */
+  hadc->Instance->CR &= ~ADC_CR_ADVREGEN;
+  
+  /* Bits ADC_CR_ADSTP, ADC_CR_ADSTART are in access mode "read-set": no direct reset applicable */
+  /* No action */
+  
+  /* Reset register CFGR1 */
+  hadc->Instance->CFGR1 &= ~(ADC_CFGR1_AWDCH  | ADC_CFGR1_AWDEN  | ADC_CFGR1_AWDSGL | \
+                             ADC_CFGR1_DISCEN | ADC_CFGR1_AUTOFF | ADC_CFGR1_AUTDLY | \
+                             ADC_CFGR1_CONT   | ADC_CFGR1_OVRMOD | ADC_CFGR1_EXTEN  | \
+                             ADC_CFGR1_EXTSEL | ADC_CFGR1_ALIGN  | ADC_CFGR1_RES    | \
+                             ADC_CFGR1_SCANDIR| ADC_CFGR1_DMACFG | ADC_CFGR1_DMAEN);
+
+  /* Reset register CFGR2 */
+  hadc->Instance->CFGR2 &= ~(ADC_CFGR2_TOVS  | ADC_CFGR2_OVSS  | ADC_CFGR2_OVSR | \
+                             ADC_CFGR2_OVSE  | ADC_CFGR2_CKMODE );
+  
+  /* Reset register SMPR */
+  hadc->Instance->SMPR &= ~(ADC_SMPR_SMPR);
+  
+  /* Reset register TR */
+  hadc->Instance->TR &= ~(ADC_TR_LT | ADC_TR_HT);
+  
+  /* Reset register CALFACT */
+  hadc->Instance->CALFACT &= ~(ADC_CALFACT_CALFACT);
+  
+  /* Reset register DR */
+  /* bits in access mode read only, no direct reset applicable*/
+
+  /* Reset register CALFACT */
+  hadc->Instance->CALFACT &= ~(ADC_CALFACT_CALFACT);
+
+    
+  /* DeInit the low level hardware */
+  HAL_ADC_MspDeInit(hadc);
+  
+  /* Set ADC error code to none */
+  hadc->ErrorCode = HAL_ADC_ERROR_NONE;
+  
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_RESET; 
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the ADC MSP.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.  
+  * @retval None
+  */
+__weak void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ADC_MspInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  DeInitializes the ADC MSP.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.  
+  * @retval None
+  */
+__weak void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ADC_MspDeInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Group2 I/O operation functions
+ *  @brief    I/O operation functions 
+ *
+@verbatim   
+ ===============================================================================
+             ##### IO operation functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Start conversion.
+      (+) Stop conversion.
+      (+) poll for conversion complete.
+      (+) poll for conversion event.
+      (+) Start conversion and enable interrupt.
+      (+) Stop conversion and disable interrupt.
+      (+) handle ADC interrupt request.
+      (+) Start conversion of regular channel and enable DMA transfer.
+      (+) Stop conversion of regular channel and disable DMA transfer.
+      (+) Get result of regular channel conversion.
+      (+) Handle ADC interrupt request.
+
+@endverbatim
+  * @{
+  */
+
+
+/**
+  * @brief  Enables ADC and starts conversion of the regular channels.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmpHALStatus = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_BUSY_REG;
+  
+  /* Set ADC error code to none */
+  hadc->ErrorCode = HAL_ADC_ERROR_NONE;
+
+  /* Enable ADC */
+  tmpHALStatus = ADC_Enable(hadc);
+  
+  /* Start conversion if ADC is effectively enabled */
+  if (tmpHALStatus != HAL_ERROR)
+  {
+    /* ADC start conversion command */
+    hadc->Instance->CR |= ADC_CR_ADSTART;
+  }
+      
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stop ADC conversion of regular channels, disable ADC peripheral.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmpHALStatus = HAL_OK;
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential conversion ongoing (regular conversion) */
+  tmpHALStatus = ADC_ConversionStop(hadc, REGULAR_GROUP);
+  
+  /* 2. Disable ADC peripheral if conversions are effectively stopped */
+  if (tmpHALStatus != HAL_ERROR)
+  {
+    /* Disable the ADC peripheral */
+    ADC_Disable(hadc);
+    
+    /* Check if ADC is effectively disabled */
+    if (hadc->State != HAL_ADC_STATE_ERROR)
+    {
+      /* Change ADC state */
+      hadc->State = HAL_ADC_STATE_READY;
+    }
+    else
+    {
+      return HAL_ERROR;
+    }
+  }
+  else
+  {   
+    return HAL_ERROR;
+  }  
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Poll for conversion complete.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @param  Timeout: Timeout value in millisecond.  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+  uint32_t tmp_Flag_EOC;
+ 
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* If interruption after each sequence */
+  if (hadc->Init.EOCSelection == EOC_SEQ_CONV)
+  {
+    tmp_Flag_EOC = ADC_FLAG_EOS;
+  }
+  /* If interruption after each conversion */
+  else /* EOC_SINGLE_CONV */
+  {
+    tmp_Flag_EOC = (ADC_FLAG_EOC | ADC_FLAG_EOS);
+  }
+    
+  /* Get timeout */ 
+  tickstart = HAL_GetTick();
+     
+  /* Wait until End of Conversion flag is raised */
+  while(HAL_IS_BIT_CLR(hadc->Instance->ISR, tmp_Flag_EOC))
+  {
+    /* Check for the Timeout */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)|| ((HAL_GetTick()  - tickstart ) > Timeout))
+      {
+        hadc->State= HAL_ADC_STATE_TIMEOUT;
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  
+  /* Clear end of conversion flag of regular group if low power feature       */
+  /* "LowPowerAutoWait " is disabled, to not interfere with this feature      */
+  /* until data register is read using function HAL_ADC_GetValue().           */
+  if (hadc->Init.LowPowerAutoWait == DISABLE)
+  {
+    /* Clear regular group conversion flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS));
+  }
+
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_EOC;
+  
+  /* Return ADC state */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Poll for conversion event.
+  * @param  hadc: ADC handle.
+  * @param  EventType: the ADC event type.
+  *          This parameter can be one of the following values:
+  *            @arg AWD_EVENT: ADC Analog watchdog event.
+  *            @arg OVR_EVENT: ADC Overrun event.
+  * @param  Timeout: Timeout value in millisecond.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventType, uint32_t Timeout)
+{
+  uint32_t tickstart = 0; 
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_EVENT_TYPE(EventType));
+  
+  /* Get timeout */
+  tickstart = HAL_GetTick();
+  
+  /* Check selected event flag */
+  while(!(__HAL_ADC_GET_FLAG(hadc,EventType)))
+  {
+    /* Check if timeout is disabled (set to infinite wait) */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        /* Update ADC state machine to timeout */
+        hadc->State = HAL_ADC_STATE_TIMEOUT;
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  
+  switch(EventType)
+  {
+    /* Check analog watchdog flag */
+  case AWD_EVENT:
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_AWD;
+    
+    /* Clear ADC analog watchdog flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD);
+    break;
+    
+    /* Case OVR_EVENT */
+  default:
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_ERROR;
+    
+    /* Clear ADC Overrun flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_OVR);
+    break;
+  }
+  
+  /* Return ADC state */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables the interrupt and starts ADC conversion of regular channels.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmpHALStatus = HAL_OK;
+    
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* State machine update: Change ADC state */
+  hadc->State = HAL_ADC_STATE_BUSY_REG;
+  
+  /* Set ADC error code to none */
+  hadc->ErrorCode = HAL_ADC_ERROR_NONE;
+  
+  /* Enable the ADC peripheral */
+  tmpHALStatus = ADC_Enable(hadc);
+  
+  /* Start conversion if ADC is effectively enabled */
+  if (tmpHALStatus != HAL_ERROR)
+  {
+    /* Enable ADC overrun interrupt */
+    __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);
+    
+    /* Enable ADC end of conversion interrupt */
+    switch(hadc->Init.EOCSelection)
+    {
+      case EOC_SEQ_CONV: 
+        __HAL_ADC_DISABLE_IT(hadc, ADC_IT_EOC);
+        __HAL_ADC_ENABLE_IT(hadc, ADC_IT_EOS);
+        break;
+      /* case EOC_SINGLE_CONV */
+      default:
+        __HAL_ADC_DISABLE_IT(hadc, ADC_IT_EOS);
+        __HAL_ADC_ENABLE_IT(hadc, ADC_IT_EOC);
+        break;
+    }
+    
+    /* ADC start conversion command */
+    hadc->Instance->CR |= ADC_CR_ADSTART;
+  }
+  
+  else
+  {
+    return HAL_ERROR;
+  }
+  
+    /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stop ADC conversion of regular channels, disable interruptions
+  *         EOC/EOS/OVR, disable ADC peripheral.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmpHALStatus = HAL_OK;
+    
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential conversion ongoing (regular conversion) */
+  tmpHALStatus = ADC_ConversionStop(hadc, REGULAR_GROUP);
+  
+  /* 2. Disable ADC peripheral if conversions are effectively stopped */
+  if (tmpHALStatus != HAL_ERROR)
+  {
+    /* Disable ADC interrupts */
+    __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_EOC | ADC_IT_EOS | ADC_IT_OVR));
+    
+    /* Disable the ADC peripheral */
+    ADC_Disable(hadc);
+    
+    /* Check if ADC is effectively disabled */
+    if (hadc->State != HAL_ADC_STATE_ERROR)
+    {
+      /* Change ADC state */
+      hadc->State = HAL_ADC_STATE_READY;
+    }
+    else
+    {
+      return HAL_ERROR;
+    }
+  }
+  else
+  {   
+    return HAL_ERROR;
+  }
+  
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles ADC interrupt request  
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+void HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_EOC_SELECTION(hadc->Init.EOCSelection));
+  
+  
+  /* Check End of Conversion flag for regular channels */
+  if( (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOC) && __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_EOC)) || \
+      (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS) && __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_EOS)) )
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_EOC;
+
+    
+    /* Disable interruption if no further conversion upcoming by continuous mode or external trigger */
+    if((hadc->Init.ContinuousConvMode == DISABLE) && \
+       (hadc->Init.ExternalTrigConvEdge == ADC_EXTERNALTRIG_EDGE_NONE)
+       )
+    {
+      /* Allowed to modify bits ADC_IT_EOC/ADC_IT_EOS only if bit ADSTART==0 (no conversion on going) */
+      if (HAL_IS_BIT_CLR(hadc->Instance->CR, ADC_CR_ADSTART))
+      {
+        /* Cases of interruption after each conversion or after each sequence */
+        /* If interruption after each sequence */
+        if (hadc->Init.EOCSelection == EOC_SEQ_CONV)
+        {
+          /* If End of Sequence is reached, disable interrupts */
+          if( __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS) )
+          {
+            /* DISABLE ADC end of sequence conversion interrupt  */
+            /* DISABLE ADC overrun interrupt */
+            __HAL_ADC_DISABLE_IT(hadc, ADC_IT_EOC | ADC_IT_EOS | ADC_IT_OVR);
+          }
+        }
+        /* If interruption after each conversion */
+        else
+        {
+          /* DISABLE ADC end of single conversion interrupt */
+          /* DISABLE ADC overrun interrupt */
+          __HAL_ADC_DISABLE_IT(hadc, ADC_IT_EOC | ADC_IT_OVR);
+        }
+      }
+      else
+      {
+        /* Change ADC state to error state */
+        hadc->State = HAL_ADC_STATE_ERROR;
+      }       
+    }    
+
+    /* Conversion complete callback */
+    /* Note: into callback, to determine if callback has been triggered from EOC or EOS, */
+    /*       it is possible to use: if( __HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS))         */
+    HAL_ADC_ConvCpltCallback(hadc);
+    
+    /* Clear regular channels conversion flag */
+    if (hadc->Init.LowPowerAutoWait != ENABLE)
+    {
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS) );
+    }
+  }
+  
+   
+  /* Check Analog watchdog flags */
+  if( (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_AWD) && __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_AWD)))
+  {
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_AWD;
+    
+    /* Level out of window callback */
+    HAL_ADC_LevelOutOfWindowCallback(hadc);
+    
+    /* Clear ADC Analog watchdog flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD);    
+  }  
+  
+  /* Check Overrun flag */
+  if(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_OVR) && __HAL_ADC_GET_IT_SOURCE(hadc, ADC_IT_OVR))
+  {
+    /* Change ADC state to overrun state */
+    hadc->State = HAL_ADC_STATE_ERROR;
+    
+    /* Set ADC error code to overrun */
+    hadc->ErrorCode |= HAL_ADC_ERROR_OVR;
+    
+    /* Clear the Overrun flag */
+    __HAL_ADC_CLEAR_FLAG(hadc,ADC_FLAG_OVR);
+    
+    /* Error callback */ 
+    HAL_ADC_ErrorCallback(hadc);
+  }
+}
+
+/**
+  * @brief  Enables ADC DMA request after last transfer (Single-ADC mode) and enables ADC peripheral  
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @param  pData: The destination Buffer address.
+  * @param  Length: The length of data to be transferred from ADC peripheral to memory.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length)
+{
+  HAL_StatusTypeDef tmpHALStatus = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Change ADC state */
+  hadc->State = HAL_ADC_STATE_BUSY_REG;
+  
+  /* Set ADC error code to none */
+  hadc->ErrorCode = HAL_ADC_ERROR_NONE;
+
+  /* Enable ADC */
+  tmpHALStatus = ADC_Enable(hadc);
+  
+  /* Start conversion if ADC is effectively enabled */
+  if (tmpHALStatus != HAL_ERROR)
+  {
+    /* Enable ADC DMA mode */
+    hadc->Instance->CFGR1 |= ADC_CFGR1_DMAEN;
+    
+    /* Set the DMA transfer complete callback */
+    hadc->DMA_Handle->XferCpltCallback = ADC_DMAConvCplt;
+
+    /* Set the DMA half transfer complete callback */
+    hadc->DMA_Handle->XferHalfCpltCallback = ADC_DMAHalfConvCplt;
+    
+    /* Set the DMA error callback */
+    hadc->DMA_Handle->XferErrorCallback = ADC_DMAError;
+    
+    /* Manage ADC and DMA start: ADC overrun interruption, DMA start,
+       ADC start (in case of SW start) */
+    
+    /* Enable ADC overrun interrupt */
+    __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);
+    
+    /* Enable the DMA Stream */
+    HAL_DMA_Start_IT(hadc->DMA_Handle, (uint32_t)&hadc->Instance->DR, (uint32_t)pData, Length);
+     
+    
+    /* ADC start conversion command */
+    hadc->Instance->CR |= ADC_CR_ADSTART;
+  }
+      
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disable ADC DMA (Single-ADC mode), disable ADC peripheral
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc)
+{
+  HAL_StatusTypeDef tmpHALStatus = HAL_OK;
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* 1. Stop potential conversion ongoing (regular conversion) */
+  tmpHALStatus = ADC_ConversionStop(hadc, REGULAR_GROUP);
+  
+  /* 2. Disable ADC peripheral if conversions are effectively stopped */
+  if (tmpHALStatus != HAL_ERROR)
+  {
+    /* Disable ADC DMA (ADC DMA configuration ADC_CFGR_DMACFG is kept) */
+    hadc->Instance->CFGR1 &= ~ADC_CFGR1_DMAEN;
+    
+    /* Disable the DMA Stream */
+    if (HAL_DMA_Abort(hadc->DMA_Handle) != HAL_OK)
+    {
+      /* Update ADC state machine to error */
+      hadc->State = HAL_ADC_STATE_ERROR;
+      
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+      
+      return HAL_ERROR;
+    }
+    
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+    
+    /* Disable the ADC peripheral */
+    ADC_Disable(hadc);
+    
+    /* Check if ADC is effectively disabled */
+    if (hadc->State != HAL_ADC_STATE_ERROR)
+    {
+      /* Change ADC state */
+      hadc->State = HAL_ADC_STATE_READY;
+    }
+    else
+    {
+      return HAL_ERROR;
+    }
+  }
+  else
+  {   
+    return HAL_ERROR;
+  }  
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Gets the converted value from data register of regular channel.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval Converted value
+  */
+uint32_t HAL_ADC_GetValue(ADC_HandleTypeDef* hadc)
+{       
+  /* Return the selected ADC converted value */ 
+  return hadc->Instance->DR;
+}
+
+/**
+  * @brief  Regular conversion complete callback in non blocking mode 
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+__weak void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ADC_ConvCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Regular conversion half DMA transfer callback in non blocking mode 
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+__weak void HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ADC_ConvHalfCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Analog watchdog callback in non blocking mode 
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+__weak void HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef* hadc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ADC_LevelOoutOfWindowCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Error ADC callback.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval None
+  */
+__weak void HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_ADC_ErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Group3 Peripheral Control functions
+ *  @brief   	Peripheral Control functions 
+ *
+@verbatim   
+ ===============================================================================
+             ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Configure channels.
+      (+) Configure the analog watch dog.
+      
+@endverbatim
+  * @{
+  */
+
+
+/**
+  * @brief  Configures the selected ADC regular channel: sampling time,
+  *         offset,.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @param  sConfig: ADC regular channel configuration structure.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConfTypeDef* sConfig)
+{
+    
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_CHANNEL(sConfig->Channel));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);    
+  
+  /* Enable selected channels */
+  hadc->Instance->CHSELR |= (uint32_t)(sConfig->Channel & ADC_CHANNEL_MASK);
+  
+  /* Management of internal measurement channels: Vlcd/VrefInt/TempSensor     */
+  /* internal measurement paths enable: If internal channel selected, enable  */
+  /* dedicated internal buffers and path.                                     */
+  
+  /* If Temperature sensor channel is selected, then enable the internal      */
+  /* buffers and path  */
+  if (((sConfig->Channel & ADC_CHANNEL_MASK) & ADC_CHANNEL_TEMPSENSOR ) == (ADC_CHANNEL_TEMPSENSOR & ADC_CHANNEL_MASK))
+  {
+    ADC->CCR |= ADC_CCR_TSEN;   
+  }
+  
+  /* If VRefInt channel is selected, then enable the internal buffers and path   */
+  if (((sConfig->Channel & ADC_CHANNEL_MASK) & ADC_CHANNEL_VREFINT) == (ADC_CHANNEL_VREFINT & ADC_CHANNEL_MASK))
+  {
+    ADC->CCR |= ADC_CCR_VREFEN;   
+  }
+  
+  /* If Vlcd channel is selected, then enable the internal buffers and path   */
+  if (((sConfig->Channel & ADC_CHANNEL_MASK) & ADC_CHANNEL_VLCD) == (ADC_CHANNEL_VLCD & ADC_CHANNEL_MASK))
+  {
+    ADC->CCR |= ADC_CCR_VLCDEN;   
+  }
+ 
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the analog watchdog.
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @param  AnalogWDGConfig : pointer to an ADC_AnalogWDGConfTypeDef structure 
+  *         that contains the configuration information of ADC analog watchdog.
+  * @retval HAL status	  
+  */
+HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDGConfTypeDef* AnalogWDGConfig)
+{
+  uint32_t tmpAWDHighThresholdShifted;
+  uint32_t tmpAWDLowThresholdShifted;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_ANALOG_WATCHDOG_MODE(AnalogWDGConfig->WatchdogMode));
+  assert_param(IS_ADC_CHANNEL(AnalogWDGConfig->Channel));
+  assert_param(IS_FUNCTIONAL_STATE(AnalogWDGConfig->ITMode));
+  
+  assert_param(IS_ADC_RANGE(__HAL_ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->HighThreshold));
+  assert_param(IS_ADC_RANGE(__HAL_ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->LowThreshold));
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Configure ADC Analog watchdog interrupt */
+  if(AnalogWDGConfig->ITMode == ENABLE)
+  {
+    /* Enable the ADC Analog watchdog interrupt */
+    __HAL_ADC_ENABLE_IT(hadc, ADC_IT_AWD);
+  }
+  else
+  {
+    /* Disable the ADC Analog watchdog interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_AWD);
+  }
+    
+  /* Configuration of analog watchdog:                                        */
+  /*  - Set the analog watchdog mode                                          */
+  /*  - Set the Analog watchdog channel (is not used if watchdog              */
+  /*    mode "all channels": ADC_CFGR1_AWD1SGL=0)                             */
+  hadc->Instance->CFGR1 &= ~( ADC_CFGR1_AWDSGL |
+                             ADC_CFGR1_AWDEN  |
+                             ADC_CFGR1_AWDCH   );
+  
+  hadc->Instance->CFGR1 |= ( AnalogWDGConfig->WatchdogMode |
+                            (AnalogWDGConfig->Channel & ADC_CHANNEL_AWD_MASK));
+  
+  
+  /* Shift the offset in function of the selected ADC resolution: Thresholds  */
+  /* have to be left-aligned on bit 11, the LSB (right bits) are set to 0     */
+  tmpAWDHighThresholdShifted = __HAL_ADC_AWD1Threshold_shift_resolution(hadc, AnalogWDGConfig->HighThreshold);
+  tmpAWDLowThresholdShifted  = __HAL_ADC_AWD1Threshold_shift_resolution(hadc, AnalogWDGConfig->LowThreshold);
+  
+  /* Clear High & Low high thresholds */
+  hadc->Instance->TR &= (uint32_t) ~ (ADC_TR_HT | ADC_TR_LT);
+  
+  /* Set the high threshold */
+  hadc->Instance->TR = __HAL_ADC_TRx_HighThreshold (tmpAWDHighThresholdShifted);
+  /* Set the low threshold */
+  hadc->Instance->TR |= tmpAWDLowThresholdShifted;  
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Group4 ADC Peripheral State functions
+ *  @brief   ADC Peripheral State functions 
+ *
+@verbatim   
+ ===============================================================================
+            ##### ADC Peripheral State functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides functions allowing to
+      (+) Check the ADC state.
+      (+) handle ADC interrupt request.
+         
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  return the ADC state
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval HAL state
+  */
+HAL_ADC_StateTypeDef HAL_ADC_GetState(ADC_HandleTypeDef* hadc)
+{
+  /* Return ADC state */
+  return hadc->State;
+}
+
+/**
+  * @brief  Return the ADC error code
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @retval ADC Error Code
+  */
+uint32_t HAL_ADC_GetError(ADC_HandleTypeDef *hadc)
+{
+  return hadc->ErrorCode;
+}
+
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  Enable the selected ADC.
+  * @note   Prerequisite condition to use this function: ADC must be disabled
+  *         and voltage regulator must be enabled (done into HAL_ADC_Init()).
+  * @param  hadc: ADC handle
+  * @retval HAL status.
+  */
+static HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef* hadc)
+{
+  uint32_t tickstart = 0;
+  
+  /* ADC enable and wait for ADC ready (in case of ADC is disabled or         */
+  /* enabling phase not yet completed: flag ADC ready not yet set).           */
+  /* Timeout implemented to not be stuck if ADC cannot be enabled (possible   */
+  /* causes: ADC clock not running, ...).                                     */
+  if (__HAL_ADC_IS_ENABLED(hadc) == RESET)
+  {
+    /* Check if conditions to enable the ADC are fulfilled */
+    if (__HAL_ADC_ENABLING_CONDITIONS(hadc) == RESET)
+    {
+      /* Update ADC state machine to error */
+      hadc->State = HAL_ADC_STATE_ERROR;
+      
+      /* Set ADC error code to ADC IP internal error */
+      hadc->ErrorCode |= HAL_ADC_ERROR_INTERNAL;
+      
+      return HAL_ERROR;
+    }
+    
+    /* Enable the ADC peripheral */
+    __HAL_ADC_ENABLE(hadc);
+    
+    /* Wait for ADC effectively enabled */
+    /* Get timeout */
+    tickstart = HAL_GetTick();  
+    
+    /* Skip polling for RDY ADRDY when AutoOFF is enabled  */
+    if (hadc->Init.LowPowerAutoOff != ENABLE)
+    {      
+      while(__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_RDY) == RESET)
+      {
+        /* Check for the Timeout */
+        if(ADC_ENABLE_TIMEOUT != HAL_MAX_DELAY)
+        {
+          if((HAL_GetTick() - tickstart ) > ADC_ENABLE_TIMEOUT)
+          {
+            /* Update ADC state machine to error */
+            hadc->State = HAL_ADC_STATE_ERROR;
+            
+            /* Set ADC error code to ADC IP internal error */
+            hadc->ErrorCode |= HAL_ADC_ERROR_INTERNAL;
+            
+            return HAL_ERROR;
+          }
+        }
+      }
+    }
+  }
+   
+  /* Return HAL status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disable the selected ADC.
+  * @note   Prerequisite condition to use this function: ADC conversions must be
+  *         stopped to disable the ADC.
+  * @param  hadc: ADC handle
+  * @retval HAL status.
+  */
+static HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef* hadc)
+{
+  uint32_t tickstart = 0;
+  
+  /* Verification if ADC is not already disabled:                             */
+  /* forbidden to disable ADC (set bit ADC_CR_ADDIS) if ADC is already        */
+  /* disabled.                                                                */
+  if (__HAL_ADC_IS_ENABLED(hadc) != RESET )
+  {
+    /* Check if conditions to disable the ADC are fulfilled */
+    if (__HAL_ADC_DISABLING_CONDITIONS(hadc) != RESET)
+    {
+      /* Disable the ADC peripheral */
+      __HAL_ADC_DISABLE(hadc);
+    }
+    else
+    {
+      /* Update ADC state machine to error */
+      hadc->State = HAL_ADC_STATE_ERROR;
+      
+      /* Set ADC error code to ADC internal error */
+      hadc->ErrorCode |= HAL_ADC_ERROR_INTERNAL;
+      
+      return HAL_ERROR;
+    }
+     
+    /* Wait for ADC effectively disabled */
+    /* Get timeout */
+    tickstart = HAL_GetTick();
+    
+    while(HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADEN))
+    {
+      /* Check for the Timeout */
+      if(ADC_ENABLE_TIMEOUT != HAL_MAX_DELAY)
+      {
+        if((HAL_GetTick() - tickstart ) > ADC_DISABLE_TIMEOUT)
+        {
+          /* Update ADC state machine to error */
+          hadc->State = HAL_ADC_STATE_ERROR;
+          
+          /* Set ADC error code to ADC internal error */
+          hadc->ErrorCode |= HAL_ADC_ERROR_INTERNAL;
+          
+          return HAL_ERROR;
+        }
+      }
+    }
+  }
+  
+  /* Return HAL status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stop ADC conversion.
+  * @note   Prerequisite condition to use this function: ADC conversions must be
+  *         stopped to disable the ADC.
+  * @param  hadc: ADC handle
+  * @param  ConversionGroup: Only ADC group regular.
+  *          This parameter can be one of the following values:
+  *            @arg REGULAR_GROUP: ADC regular conversion type.
+  * @retval HAL status.
+  */
+static HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef* hadc, uint32_t ConversionGroup)
+{
+  uint32_t tickstart = 0 ;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_CONVERSION_GROUP(ConversionGroup));
+    
+  /* Verification: if ADC is not already stopped, bypass this function */
+  if (HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADSTART))
+  {    
+    /* Stop potential conversion on regular group */
+    if (ConversionGroup == REGULAR_GROUP)
+    {
+      /* Software is allowed to set ADSTP only when ADSTART=1 and ADDIS=0 */
+      if (HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADSTART) && \
+          HAL_IS_BIT_CLR(hadc->Instance->CR, ADC_CR_ADDIS)                  )
+      {
+        /* Stop conversions on regular group */
+        hadc->Instance->CR |= ADC_CR_ADSTP;
+      }
+    }
+    
+    /* Wait for conversion effectively stopped */
+    /* Get timeout */
+    tickstart = HAL_GetTick();
+      
+    while((hadc->Instance->CR & ADC_CR_ADSTART) != RESET)
+    {
+      /* Check for the Timeout */
+      if(ADC_STOP_CONVERSION_TIMEOUT != HAL_MAX_DELAY)
+      {
+        if((HAL_GetTick() - tickstart ) > ADC_STOP_CONVERSION_TIMEOUT)
+        {
+          /* Update ADC state machine to error */
+          hadc->State = HAL_ADC_STATE_ERROR;
+          
+          /* Set ADC error code to ADC IP internal error */
+          hadc->ErrorCode |= HAL_ADC_ERROR_INTERNAL;
+          
+          return HAL_ERROR;
+        }
+      }
+    }    
+  }
+   
+  /* Return HAL status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  DMA transfer complete callback. 
+  * @param  hdma: pointer to DMA handle.
+  * @retval None
+  */
+static void ADC_DMAConvCplt(DMA_HandleTypeDef *hdma)   
+{
+    ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+    /* Change ADC state */
+    hadc->State = HAL_ADC_STATE_EOC;
+    
+    HAL_ADC_ConvCpltCallback(hadc); 
+}
+
+/**
+  * @brief  DMA half transfer complete callback. 
+  * @param  hdma: pointer to DMA handle.
+  * @retval None
+  */
+static void ADC_DMAHalfConvCplt(DMA_HandleTypeDef *hdma)   
+{
+    ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+    
+    /* Conversion complete callback */
+    HAL_ADC_ConvHalfCpltCallback(hadc); 
+}
+
+/**
+  * @brief  DMA error callback 
+  * @param  hdma: pointer to DMA handle.
+  * @retval None
+  */
+static void ADC_DMAError(DMA_HandleTypeDef *hdma)   
+{
+    ADC_HandleTypeDef* hadc = ( ADC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+    hadc->State= HAL_ADC_STATE_ERROR;
+    /* Set ADC error code to DMA error */
+    hadc->ErrorCode |= HAL_ADC_ERROR_DMA;
+    HAL_ADC_ErrorCallback(hadc); 
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_ADC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_adc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_adc.h
@@ -1,0 +1,939 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_adc.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   This file contains all the functions prototypes for the ADC firmware 
+  *          library.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_ADC_H
+#define __STM32L0xx_ADC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+   
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup ADC
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/   
+/** 
+  * @brief  HAL State structures definition  
+  */ 
+typedef enum
+{
+  HAL_ADC_STATE_RESET                   = 0x00,    /*!< ADC not yet initialized or disabled */
+  HAL_ADC_STATE_READY                   = 0x01,    /*!< ADC peripheral ready for use */
+  HAL_ADC_STATE_BUSY                    = 0x02,    /*!< An internal process is ongoing */ 
+  HAL_ADC_STATE_BUSY_REG                = 0x12,    /*!< Regular conversion is ongoing */
+  HAL_ADC_STATE_TIMEOUT                 = 0x03,    /*!< Timeout state */
+  HAL_ADC_STATE_ERROR                   = 0x04,    /*!< ADC state error */
+  HAL_ADC_STATE_EOC                     = 0x05,    /*!< Conversion is completed */
+  HAL_ADC_STATE_AWD                     = 0x06,    /*!< ADC state analog watchdog */
+}HAL_ADC_StateTypeDef;
+
+
+/** 
+  * @brief  ADC Oversampler structure definition  
+  */
+typedef struct
+{
+  uint32_t Ratio;                         /*!< Configures the oversampling ratio.
+                                               This parameter can be a value of @ref ADC_Oversampling_Ratio */
+  uint32_t RightBitShift;                 /*!< Configures the division coefficient for the Oversampler.
+                                               This parameter can be a value of @ref ADC_Right_Bit_Shift */
+  uint32_t TriggeredMode;                 /*!< Selects the regular triggered oversampling mode
+                                               This parameter can be a value of @ref ADC_Triggered_Oversampling_Mode */
+                                        
+}ADC_OversamplingTypeDef;
+
+/**
+  * @brief  ADC Init structure definition  
+  * @note   The setting of these parameters with function HAL_ADC_Init() is conditioned by the ADC state.
+  *         If ADC is not in the appropriate state to modify some parameters, these parameters setting is bypassed
+  *         without error reporting (as it can be the expected behaviour in case of intended action to update antother parameter (which fullfills the ADC state condition) on the fly).
+  */
+typedef struct
+{
+  uint32_t OversamplingMode;             /*!< Specifies whether the oversampling feature is enabled or disabled
+                                              This parameter can be set to ENABLE or DISABLE.
+                                              Note: This parameter can be modified only if there is no conversion is ongoing. */
+  ADC_OversamplingTypeDef  Oversample;   /*!< Specifies the Oversampling parameters
+                                              Note: This parameter can be modified only if there is no conversion is ongoing. */
+  uint32_t ClockPrescaler;               /*!< Selects the ADC clock frequency.
+                                              This parameter can be a value of @ref ADC_ClockPrescaler
+                                              Note: This parameter can be modified only if ADC is disabled. */
+  uint32_t Resolution;                   /*!< Configures the ADC resolution mode. 
+                                              This parameter can be a value of @ref ADC_Resolution
+                                              Note: This parameter can be modified only if ADC is disabled. */
+  uint32_t SamplingTime;                 /*!< The sample time value to be set for all channels.
+                                              This parameter can be a value of @ref ADC_sampling_times
+                                              Note: This parameter can be modified only if there is no conversion ongoing. */
+  uint32_t ScanDirection;                /*!< The scan sequence direction.
+                                              This parameter can be a value of @ref ADC_scan_direction
+                                              Note: This parameter can be modified only if there is no conversion is ongoing. */
+  uint32_t DataAlign;                    /*!< Specifies whether the ADC data  alignment is left or right.  
+                                              This parameter can be a value of @ref ADC_data_align
+                                              Note: This parameter can be modified only if there is no conversion is ongoing. */
+  uint32_t ContinuousConvMode;           /*!< Specifies whether the conversion is performed in Continuous or Single mode.
+                                              This parameter can be set to ENABLE or DISABLE.
+                                              Note: This parameter can be modified only if there is no conversion is ongoing. */
+  uint32_t DiscontinuousConvMode;        /*!< Specifies whether the conversion is performed
+                                              in Complete-sequence/Discontinuous-sequence.
+                                              Discontinuous mode can be enabled only if continuous mode is disabled.
+                                              This parameter can be set to ENABLE or DISABLE.
+                                              Note: This parameter can be modified only if there is no conversion is ongoing. */
+  uint32_t ExternalTrigConvEdge;         /*!< Select the external trigger edge and enable the trigger. 
+                                              This parameter can be a value of @ref ADC_External_trigger_Edge
+                                              Note: This parameter can be modified only if there is no conversion is ongoing. */
+  uint32_t ExternalTrigConv;             /*!< Select the external event used to trigger the start of conversion.
+                                              This parameter can be a value of @ref ADC_External_trigger_Source
+                                              Note: This parameter can be modified only if there is no conversion is ongoing. */
+  uint32_t DMAContinuousRequests;        /*!< Specifies whether the DMA requests are performed in one shot mode (DMA transfer stop when number of conversions is reached)
+                                              or in Continuous mode (DMA transfer unlimited, whatever number of conversions).
+                                              Note: In continuous mode, DMA must be configured in circular mode. Otherwise an overrun will be triggered when DMA buffer max pointer is reached.
+                                              This parameter can be set to ENABLE or DISABLE.
+                                              Note: This parameter can be modified only if there is no conversion is ongoing. */
+  uint32_t EOCSelection;                 /*!< Specifies what EOC (End Of Conversion) flag is used for conversion polling and interruption:  
+                                              end of single channel conversion or end of channels conversions sequence.
+                                              This parameter can be a value of @ref ADC_EOCSelection */ 
+  uint32_t Overrun;                      /*!< Select the behaviour in case of overrun: data preserved or overwritten 
+                                              This parameter has an effect on regular channels only, including in DMA mode.
+                                              This parameter can be a value of @ref ADC_Overrun
+                                              Note: This parameter can be modified only if there is no conversion is ongoing. */
+  uint32_t LowPowerAutoWait;             /*!< Specifies the usage of dynamic low power Auto Delay: new conversion start only
+                                              when the previous conversion (for regular channel) is completed.
+                                              This avoids risk of overrun for low frequency application. 
+                                              This parameter can be set to ENABLE or DISABLE.
+                                              Note: This parameter can be modified only if there is no conversion is ongoing. */
+  uint32_t LowPowerFrequencyMode;        /*!< When selecting an analog ADC clock frequency lower than 2.8MHz,
+                                              it is mandatory to first enable the Low Frequency Mode.
+                                              This parameter can be set to ENABLE or DISABLE.
+                                              Note: This parameter can be modified only if there is no conversion is ongoing. */
+  uint32_t LowPowerAutoOff;              /*!< When setting the AutoOff feature, the ADC is always powered off when not converting and automatically
+                                              wakes-up when a conversion is started (by software or hardware trigger).
+                                              This parameter can be set to ENABLE or DISABLE.
+                                              Note: This parameter can be modified only if there is no conversion is ongoing. */
+}ADC_InitTypeDef;
+
+/** 
+  * @brief  ADC handle Structure definition  
+  */ 
+typedef struct __ADC_HandleTypeDef
+{
+  ADC_TypeDef                   *Instance;              /*!< Register base address */
+
+  ADC_InitTypeDef               Init;                   /*!< ADC required parameters */
+
+  DMA_HandleTypeDef             *DMA_Handle;            /*!< Pointer DMA Handler */
+
+  HAL_LockTypeDef               Lock;                   /*!< ADC locking object */
+
+  __IO HAL_ADC_StateTypeDef     State;                  /*!< ADC communication state */
+
+  __IO uint32_t                 ErrorCode;              /*!< ADC Error code */
+}ADC_HandleTypeDef;
+
+/** 
+  * @brief  ADC Configuration regular Channel structure definition  
+  */ 
+typedef struct 
+{
+  uint32_t Channel;                /*!< the ADC channel to configure 
+                                        This parameter can be a value of @ref ADC_channels */ 
+}ADC_ChannelConfTypeDef;
+
+
+/** 
+  * @brief   ADC Configuration analog watchdog definition  
+  */ 
+typedef struct
+{
+  uint32_t WatchdogMode;      /*!< Configures the ADC analog watchdog mode: single/all channels.
+                                   This parameter can be a value of @ref ADC_analog_watchdog_mode */
+  uint32_t Channel;           /*!< Selects which ADC channel to monitor by analog watchdog.
+                                   This parameter has an effect only if watchdog mode is configured on single channel (parameter WatchdogMode)
+                                   This parameter can be a value of @ref ADC_channels */
+  uint32_t ITMode;            /*!< Specifies whether the analog watchdog is configured in interrupt or polling mode.
+                                   This parameter can be set to ENABLE or DISABLE */
+  uint32_t HighThreshold;     /*!< Configures the ADC analog watchdog High threshold value.
+                                   Depending of ADC resolution selected (12, 10, 8 or 6 bits),
+                                   this parameter must be a number between Min_Data = 0x000 and Max_Data = 0xFFF, 0x3FF, 0xFF or 0x3F respectively. */
+  uint32_t LowThreshold;      /*!< Configures the ADC analog watchdog High threshold value.
+                                   Depending of ADC resolution selected (12, 10, 8 or 6 bits),
+                                   this parameter must be a number between Min_Data = 0x000 and Max_Data = 0xFFF, 0x3FF, 0xFF or 0x3F respectively. */
+}ADC_AnalogWDGConfTypeDef;
+
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup ADC_Exported_Constants
+  * @{
+  */
+
+/** @defgroup ADC_Error_Code 
+  * @{
+  */ 
+#define HAL_ADC_ERROR_NONE        ((uint32_t)0x00)   /*!< No error           */
+#define HAL_ADC_ERROR_INTERNAL    ((uint32_t)0x01)   /*!< ADC IP internal error: if problem of clocking, 
+                                                          enable/disable, erroneous state */
+#define HAL_ADC_ERROR_OVR         ((uint32_t)0x01)   /*!< OVR error          */
+#define HAL_ADC_ERROR_DMA         ((uint32_t)0x02)   /*!< DMA transfer error */
+/**
+  * @}
+  */  
+
+/** @defgroup ADC_TimeOut_Values
+  * @{
+  */ 
+
+  /* Fixed timeout values for ADC calibration, enable settling time, disable  */
+  /* settling time.                                                           */
+  /* Values defined to be higher than worst cases: low clocks freq,           */
+  /* maximum prescalers.                                                      */
+  /* Unit: ms                                                                 */      
+#define ADC_ENABLE_TIMEOUT            10
+#define ADC_DISABLE_TIMEOUT           10
+#define ADC_STOP_CONVERSION_TIMEOUT   10
+
+  /* Delay of 10us fixed to worst case: maximum CPU frequency 180MHz to have  */
+  /* the minimum number of CPU cycles to fulfill this delay                   */
+  #define ADC_DELAY_10US_MIN_CPU_CYCLES         1800 
+/**
+  * @}
+  */
+
+/** @defgroup ADC_ClockPrescaler
+  * @{
+  */     
+#define ADC_CLOCK_ASYNC_DIV1              ((uint32_t)0x00000000)                                /*!< ADC Asynchronous clock mode divided by 1 */
+#define ADC_CLOCK_ASYNC_DIV2              (ADC_CCR_PRESC_0)                                     /*!< ADC Asynchronous clock mode divided by 2 */
+#define ADC_CLOCK_ASYNC_DIV4              (ADC_CCR_PRESC_1)                                     /*!< ADC Asynchronous clock mode divided by 2 */
+#define ADC_CLOCK_ASYNC_DIV6              (ADC_CCR_PRESC_1 | ADC_CCR_PRESC_0)                   /*!< ADC Asynchronous clock mode divided by 2 */
+#define ADC_CLOCK_ASYNC_DIV8              (ADC_CCR_PRESC_2)                                     /*!< ADC Asynchronous clock mode divided by 2 */
+#define ADC_CLOCK_ASYNC_DIV10             (ADC_CCR_PRESC_2 | ADC_CCR_PRESC_0)                   /*!< ADC Asynchronous clock mode divided by 2 */
+#define ADC_CLOCK_ASYNC_DIV12             (ADC_CCR_PRESC_2 | ADC_CCR_PRESC_1)                   /*!< ADC Asynchronous clock mode divided by 2 */
+#define ADC_CLOCK_ASYNC_DIV16             (ADC_CCR_PRESC_2 | ADC_CCR_PRESC_1 | ADC_CCR_PRESC_0) /*!< ADC Asynchronous clock mode divided by 2 */
+#define ADC_CLOCK_ASYNC_DIV32             (ADC_CCR_PRESC_3)                                     /*!< ADC Asynchronous clock mode divided by 2 */
+#define ADC_CLOCK_ASYNC_DIV64             (ADC_CCR_PRESC_3 | ADC_CCR_PRESC_0)                   /*!< ADC Asynchronous clock mode divided by 2 */
+#define ADC_CLOCK_ASYNC_DIV128            (ADC_CCR_PRESC_3 | ADC_CCR_PRESC_1)                   /*!< ADC Asynchronous clock mode divided by 2 */
+#define ADC_CLOCK_ASYNC_DIV256            (ADC_CCR_PRESC_3 | ADC_CCR_PRESC_1 | ADC_CCR_PRESC_0) /*!< ADC Asynchronous clock mode divided by 2 */
+
+#define ADC_CLOCKPRESCALER_PCLK_DIV1      ((uint32_t)ADC_CFGR2_CKMODE_0)  /*!< Synchronous clock mode divided by 1 */
+#define ADC_CLOCKPRESCALER_PCLK_DIV2      ((uint32_t)ADC_CFGR2_CKMODE_1)  /*!< Synchronous clock mode divided by 2 */
+#define ADC_CLOCKPRESCALER_PCLK_DIV4      ((uint32_t)ADC_CFGR2_CKMODE)    /*!< Synchronous clock mode divided by 4 */
+
+#define IS_ADC_CLOCKPRESCALER(ADC_CLOCK) (((ADC_CLOCK) == ADC_CLOCK_ASYNC_DIV1) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCKPRESCALER_PCLK_DIV1) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCKPRESCALER_PCLK_DIV2) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCKPRESCALER_PCLK_DIV4) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCK_ASYNC_DIV1  ) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCK_ASYNC_DIV2  ) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCK_ASYNC_DIV4  ) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCK_ASYNC_DIV6  ) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCK_ASYNC_DIV8  ) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCK_ASYNC_DIV10 ) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCK_ASYNC_DIV12 ) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCK_ASYNC_DIV16 ) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCK_ASYNC_DIV32 ) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCK_ASYNC_DIV64 ) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCK_ASYNC_DIV128 ) ||\
+                                          ((ADC_CLOCK) == ADC_CLOCK_ASYNC_DIV256))
+/**                                                       
+  * @}
+  */ 
+
+/** @defgroup ADC_Resolution
+  * @{
+  */ 
+#define ADC_RESOLUTION12b      ((uint32_t)0x00000000)          /*!<  ADC 12-bit resolution */
+#define ADC_RESOLUTION10b      ((uint32_t)ADC_CFGR1_RES_0)      /*!<  ADC 10-bit resolution */
+#define ADC_RESOLUTION8b       ((uint32_t)ADC_CFGR1_RES_1)      /*!<  ADC 8-bit resolution */
+#define ADC_RESOLUTION6b       ((uint32_t)ADC_CFGR1_RES)        /*!<  ADC 6-bit resolution */
+
+#define IS_ADC_RESOLUTION(RESOLUTION) (((RESOLUTION) == ADC_RESOLUTION12b) || \
+                                       ((RESOLUTION) == ADC_RESOLUTION10b) || \
+                                       ((RESOLUTION) == ADC_RESOLUTION8b) || \
+                                       ((RESOLUTION) == ADC_RESOLUTION6b))
+
+#define IS_ADC_RESOLUTION_8_6_BITS(RESOLUTION) (((RESOLUTION) == ADC_RESOLUTION8b) || \
+                                                ((RESOLUTION) == ADC_RESOLUTION6b))
+/**
+  * @}
+  */ 
+
+/** @defgroup ADC_data_align
+  * @{
+  */ 
+#define ADC_DATAALIGN_RIGHT      ((uint32_t)0x00000000)
+#define ADC_DATAALIGN_LEFT       ((uint32_t)ADC_CFGR1_ALIGN)
+
+#define IS_ADC_DATA_ALIGN(ALIGN) (((ALIGN) == ADC_DATAALIGN_RIGHT) || \
+                                  ((ALIGN) == ADC_DATAALIGN_LEFT))
+/**
+  * @}
+  */ 
+
+/** @defgroup ADC_External_trigger_Edge
+  * @{
+  */ 
+#define ADC_EXTERNALTRIG_EDGE_NONE           ((uint32_t)0x00000000)
+#define ADC_EXTERNALTRIG_EDGE_RISING         ((uint32_t)ADC_CFGR1_EXTEN_0)         
+#define ADC_EXTERNALTRIG_EDGE_FALLING        ((uint32_t)ADC_CFGR1_EXTEN_1)
+#define ADC_EXTERNALTRIG_EDGE_RISINGFALLING  ((uint32_t)ADC_CFGR1_EXTEN)
+
+#define IS_ADC_EXTTRIG_EDGE(EDGE) (((EDGE) == ADC_EXTERNALTRIG_EDGE_NONE) || \
+                                   ((EDGE) == ADC_EXTERNALTRIG_EDGE_RISING) || \
+                                   ((EDGE) == ADC_EXTERNALTRIG_EDGE_FALLING) || \
+                                   ((EDGE) == ADC_EXTERNALTRIG_EDGE_RISINGFALLING))
+/**
+  * @}
+  */ 
+
+/** @defgroup ADC_External_trigger_Source
+  * @{
+  */
+#define ADC_EXTERNALTRIG0_T6_TRGO               ((uint32_t)0x00000000)
+#define ADC_EXTERNALTRIG1_T21_CC2               ADC_CFGR1_EXTSEL_0
+#define ADC_EXTERNALTRIG2_T2_TRGO               ADC_CFGR1_EXTSEL_1
+#define ADC_EXTERNALTRIG3_T2_CC4                ((uint32_t)0x000000C0)
+#define ADC_EXTERNALTRIG4_T22_TRGO              ADC_CFGR1_EXTSEL_2
+#define ADC_EXTERNALTRIG7_EXT_IT11              ADC_CFGR1_EXTSEL
+
+#define IS_ADC_EXTERNAL_TRIG_CONV(CONV) (((CONV) == ADC_EXTERNALTRIG0_T6_TRGO  )  || \
+                                         ((CONV) == ADC_EXTERNALTRIG1_T21_CC2  )  || \
+                                         ((CONV) == ADC_EXTERNALTRIG2_T2_TRGO  )  || \
+                                         ((CONV) == ADC_EXTERNALTRIG3_T2_CC4   )  || \
+                                         ((CONV) == ADC_EXTERNALTRIG4_T22_TRGO )  || \
+                                         ((CONV) == ADC_EXTERNALTRIG7_EXT_IT11 )) 
+
+/**
+  * @}
+  */ 
+
+/** @defgroup ADC_EOCSelection
+  * @{
+  */ 
+#define EOC_SINGLE_CONV         ((uint32_t) ADC_ISR_EOC)
+#define EOC_SEQ_CONV            ((uint32_t) ADC_ISR_EOS)
+#define EOC_SINGLE_SEQ_CONV     ((uint32_t)(ADC_ISR_EOC | ADC_ISR_EOS))  /*!< reserved for future use */
+
+#define IS_ADC_EOC_SELECTION(EOC_SELECTION) (((EOC_SELECTION) == EOC_SINGLE_CONV)   || \
+                                             ((EOC_SELECTION) == EOC_SEQ_CONV)      || \
+                                             ((EOC_SELECTION) == EOC_SINGLE_SEQ_CONV))
+/**
+  * @}
+  */ 
+
+/** @defgroup ADC_Overrun
+  * @{
+  */ 
+#define OVR_DATA_PRESERVED              ((uint32_t)0x00000000)
+#define OVR_DATA_OVERWRITTEN            ((uint32_t)ADC_CFGR1_OVRMOD)
+
+#define IS_ADC_OVERRUN(OVR) (((OVR) == OVR_DATA_PRESERVED) || \
+                             ((OVR) == OVR_DATA_OVERWRITTEN))
+/**
+  * @}
+  */ 
+
+/** @defgroup ADC_channels
+  * @{
+  */
+#define ADC_CHANNEL_0           ((uint32_t)(ADC_CHSELR_CHSEL0))
+#define ADC_CHANNEL_1           ((uint32_t)(ADC_CHSELR_CHSEL1) | ADC_CFGR1_AWDCH_0)
+#define ADC_CHANNEL_2           ((uint32_t)(ADC_CHSELR_CHSEL2) | ADC_CFGR1_AWDCH_1)
+#define ADC_CHANNEL_3           ((uint32_t)(ADC_CHSELR_CHSEL3)| ADC_CFGR1_AWDCH_1 | ADC_CFGR1_AWDCH_0)
+#define ADC_CHANNEL_4           ((uint32_t)(ADC_CHSELR_CHSEL4)| ADC_CFGR1_AWDCH_2)
+#define ADC_CHANNEL_5           ((uint32_t)(ADC_CHSELR_CHSEL5)| ADC_CFGR1_AWDCH_2| ADC_CFGR1_AWDCH_0)
+#define ADC_CHANNEL_6           ((uint32_t)(ADC_CHSELR_CHSEL6)| ADC_CFGR1_AWDCH_2| ADC_CFGR1_AWDCH_1)
+#define ADC_CHANNEL_7           ((uint32_t)(ADC_CHSELR_CHSEL7)| ADC_CFGR1_AWDCH_2| ADC_CFGR1_AWDCH_1 | ADC_CFGR1_AWDCH_0)
+#define ADC_CHANNEL_8           ((uint32_t)(ADC_CHSELR_CHSEL8)| ADC_CFGR1_AWDCH_3)
+#define ADC_CHANNEL_9           ((uint32_t)(ADC_CHSELR_CHSEL9)| ADC_CFGR1_AWDCH_3| ADC_CFGR1_AWDCH_0)
+#define ADC_CHANNEL_10          ((uint32_t)(ADC_CHSELR_CHSEL10)| ADC_CFGR1_AWDCH_3| ADC_CFGR1_AWDCH_1)
+#define ADC_CHANNEL_11          ((uint32_t)(ADC_CHSELR_CHSEL11)| ADC_CFGR1_AWDCH_3| ADC_CFGR1_AWDCH_1| ADC_CFGR1_AWDCH_0)
+#define ADC_CHANNEL_12          ((uint32_t)(ADC_CHSELR_CHSEL12)| ADC_CFGR1_AWDCH_3| ADC_CFGR1_AWDCH_2)
+#define ADC_CHANNEL_13          ((uint32_t)(ADC_CHSELR_CHSEL13)| ADC_CFGR1_AWDCH_3| ADC_CFGR1_AWDCH_2| ADC_CFGR1_AWDCH_0)
+#define ADC_CHANNEL_14          ((uint32_t)(ADC_CHSELR_CHSEL14)| ADC_CFGR1_AWDCH_3| ADC_CFGR1_AWDCH_2| ADC_CFGR1_AWDCH_1)
+#define ADC_CHANNEL_15          ((uint32_t)(ADC_CHSELR_CHSEL15)| ADC_CFGR1_AWDCH_3| ADC_CFGR1_AWDCH_2| ADC_CFGR1_AWDCH_1| ADC_CFGR1_AWDCH_0)
+#define ADC_CHANNEL_16          ((uint32_t)(ADC_CHSELR_CHSEL16)| ADC_CFGR1_AWDCH_4)
+#define ADC_CHANNEL_17          ((uint32_t)(ADC_CHSELR_CHSEL17)| ADC_CFGR1_AWDCH_4| ADC_CFGR1_AWDCH_0)
+#define ADC_CHANNEL_18          ((uint32_t)(ADC_CHSELR_CHSEL18)| ADC_CFGR1_AWDCH_4| ADC_CFGR1_AWDCH_1)
+
+/* Internal channels */
+#define ADC_CHANNEL_VLCD         ADC_CHANNEL_16    
+#define ADC_CHANNEL_VREFINT      ADC_CHANNEL_17
+#define ADC_CHANNEL_TEMPSENSOR   ADC_CHANNEL_18    
+
+    
+#define IS_ADC_CHANNEL(CHANNEL) (((CHANNEL) == ADC_CHANNEL_0)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_1)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_2)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_3)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_4)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_5)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_6)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_7)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_8)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_9)           || \
+                                 ((CHANNEL) == ADC_CHANNEL_10)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_11)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_12)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_13)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_14)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_15)          || \
+                                 ((CHANNEL) == ADC_CHANNEL_TEMPSENSOR)  || \
+                                 ((CHANNEL) == ADC_CHANNEL_VREFINT)     || \
+                                 ((CHANNEL) == ADC_CHANNEL_VLCD))
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Channel_AWD_Masks
+  * @{
+  */
+#define ADC_CHANNEL_MASK        ((uint32_t)0x0007FFFF)
+#define ADC_CHANNEL_AWD_MASK    ((uint32_t)0x7C000000)
+/**
+  * @}
+  */
+
+
+/** @defgroup ADC_sampling_times
+  * @{
+  */
+    
+#define ADC_SAMPLETIME_1CYCLE_5       ((uint32_t)0x00000000)                          /*!<  ADC sampling time 1.5 cycle */
+#define ADC_SAMPLETIME_7CYCLES_5      ((uint32_t)ADC_SMPR_SMPR_0)                     /*!<  ADC sampling time 7.5 CYCLES */
+#define ADC_SAMPLETIME_13CYCLES_5     ((uint32_t)ADC_SMPR_SMPR_1)                     /*!<  ADC sampling time 13.5 CYCLES */
+#define ADC_SAMPLETIME_28CYCLES_5     ((uint32_t)(ADC_SMPR_SMPR_1 | ADC_SMPR_SMPR_0)) /*!<  ADC sampling time 28.5 CYCLES */
+#define ADC_SAMPLETIME_41CYCLES_5     ((uint32_t)ADC_SMPR_SMPR_2)                     /*!<  ADC sampling time 41.5 CYCLES */
+#define ADC_SAMPLETIME_55CYCLES_5     ((uint32_t)(ADC_SMPR_SMPR_2 | ADC_SMPR_SMPR_0)) /*!<  ADC sampling time 55.5 CYCLES */
+#define ADC_SAMPLETIME_71CYCLES_5     ((uint32_t)(ADC_SMPR_SMPR_2 | ADC_SMPR_SMPR_1)) /*!<  ADC sampling time 71.5 CYCLES */
+#define ADC_SAMPLETIME_239CYCLES_5    ((uint32_t)ADC_SMPR_SMPR)                       /*!<  ADC sampling time 239.5 CYCLES */
+
+#define IS_ADC_SAMPLE_TIME(TIME) (((TIME) == ADC_SAMPLETIME_1CYCLE_5   ) || \
+                                  ((TIME) == ADC_SAMPLETIME_7CYCLES_5  ) || \
+                                  ((TIME) == ADC_SAMPLETIME_13CYCLES_5 ) || \
+                                  ((TIME) == ADC_SAMPLETIME_28CYCLES_5 ) || \
+                                  ((TIME) == ADC_SAMPLETIME_41CYCLES_5 ) || \
+                                  ((TIME) == ADC_SAMPLETIME_55CYCLES_5 ) || \
+                                  ((TIME) == ADC_SAMPLETIME_71CYCLES_5 ) || \
+                                  ((TIME) == ADC_SAMPLETIME_239CYCLES_5))
+/**
+  * @}
+  */
+
+    /** @defgroup ADC_scan_direction
+  * @{
+  */ 
+#define ADC_SCAN_DIRECTION_UPWARD         ((uint32_t)0x00000000)
+#define ADC_SCAN_DIRECTION_BACKWARD        ADC_CFGR1_SCANDIR
+
+
+#define IS_ADC_SCAN_DIRECTION(DIRECTION) (((DIRECTION) == ADC_SCAN_DIRECTION_UPWARD) || \
+                                          ((DIRECTION) == ADC_SCAN_DIRECTION_BACKWARD))
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Oversampling_Ratio
+  * @{
+  */
+
+#define ADC_OVERSAMPLING_RATIO_2                    ((uint32_t)0x00000000)  /*!<  ADC Oversampling ratio 2x */
+#define ADC_OVERSAMPLING_RATIO_4                    ((uint32_t)0x00000004)  /*!<  ADC Oversampling ratio 4x */
+#define ADC_OVERSAMPLING_RATIO_8                    ((uint32_t)0x00000008)  /*!<  ADC Oversampling ratio 8x */
+#define ADC_OVERSAMPLING_RATIO_16                   ((uint32_t)0x0000000C)  /*!<  ADC Oversampling ratio 16x */
+#define ADC_OVERSAMPLING_RATIO_32                   ((uint32_t)0x00000010)  /*!<  ADC Oversampling ratio 32x */
+#define ADC_OVERSAMPLING_RATIO_64                   ((uint32_t)0x00000014)  /*!<  ADC Oversampling ratio 64x */
+#define ADC_OVERSAMPLING_RATIO_128                  ((uint32_t)0x00000018)  /*!<  ADC Oversampling ratio 128x */
+#define ADC_OVERSAMPLING_RATIO_256                  ((uint32_t)0x0000001C)  /*!<  ADC Oversampling ratio 256x */
+#define IS_ADC_OVERSAMPLING_RATIO(RATIO)          (((RATIO) == ADC_OVERSAMPLING_RATIO_2   ) || \
+                                                   ((RATIO) == ADC_OVERSAMPLING_RATIO_4   ) || \
+                                                   ((RATIO) == ADC_OVERSAMPLING_RATIO_8   ) || \
+                                                   ((RATIO) == ADC_OVERSAMPLING_RATIO_16  ) || \
+                                                   ((RATIO) == ADC_OVERSAMPLING_RATIO_32  ) || \
+                                                   ((RATIO) == ADC_OVERSAMPLING_RATIO_64  ) || \
+                                                   ((RATIO) == ADC_OVERSAMPLING_RATIO_128 ) || \
+                                                   ((RATIO) == ADC_OVERSAMPLING_RATIO_256 ))
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Right_Bit_Shift
+  * @{
+  */
+#define ADC_RIGHTBITSHIFT_NONE                       ((uint32_t)0x00000000)  /*!<  ADC No bit shift for oversampling */
+#define ADC_RIGHTBITSHIFT_1                          ((uint32_t)0x00000020)  /*!<  ADC 1 bit shift for oversampling */
+#define ADC_RIGHTBITSHIFT_2                          ((uint32_t)0x00000040)  /*!<  ADC 2 bits shift for oversampling */
+#define ADC_RIGHTBITSHIFT_3                          ((uint32_t)0x00000060)  /*!<  ADC 3 bits shift for oversampling */
+#define ADC_RIGHTBITSHIFT_4                          ((uint32_t)0x00000080)  /*!<  ADC 4 bits shift for oversampling */
+#define ADC_RIGHTBITSHIFT_5                          ((uint32_t)0x000000A0)  /*!<  ADC 5 bits shift for oversampling */
+#define ADC_RIGHTBITSHIFT_6                          ((uint32_t)0x000000C0)  /*!<  ADC 6 bits shift for oversampling */
+#define ADC_RIGHTBITSHIFT_7                          ((uint32_t)0x000000E0)  /*!<  ADC 7 bits shift for oversampling */
+#define ADC_RIGHTBITSHIFT_8                          ((uint32_t)0x00000100)  /*!<  ADC 8 bits shift for oversampling */
+#define IS_ADC_RIGHT_BIT_SHIFT(SHIFT)               (((SHIFT) == ADC_RIGHTBITSHIFT_NONE) || \
+                                                     ((SHIFT) == ADC_RIGHTBITSHIFT_1   ) || \
+                                                     ((SHIFT) == ADC_RIGHTBITSHIFT_2   ) || \
+                                                     ((SHIFT) == ADC_RIGHTBITSHIFT_3   ) || \
+                                                     ((SHIFT) == ADC_RIGHTBITSHIFT_4   ) || \
+                                                     ((SHIFT) == ADC_RIGHTBITSHIFT_5   ) || \
+                                                     ((SHIFT) == ADC_RIGHTBITSHIFT_6   ) || \
+                                                     ((SHIFT) == ADC_RIGHTBITSHIFT_7   ) || \
+                                                     ((SHIFT) == ADC_RIGHTBITSHIFT_8   ))
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Triggered_Oversampling_Mode
+  * @{
+  */
+#define ADC_TRIGGEREDMODE_SINGLE_TRIGGER            ((uint32_t)0x00000000)  /*!<  ADC No bit shift for oversampling */
+#define ADC_TRIGGEREDMODE_MULTI_TRIGGER             ((uint32_t)0x00000200)  /*!<  ADC No bit shift for oversampling */
+#define IS_ADC_TRIGGERED_OVERSAMPLING_MODE(MODE)     (((MODE) == ADC_TRIGGEREDMODE_SINGLE_TRIGGER) || \
+                                                      ((MODE) == ADC_TRIGGEREDMODE_MULTI_TRIGGER) )
+/**
+  * @}
+  */
+
+/** @defgroup ADC_analog_watchdog_mode
+  * @{
+  */ 
+#define ADC_ANALOGWATCHDOG_NONE                     ((uint32_t) 0x00000000)
+#define ADC_ANALOGWATCHDOG_SINGLE_REG               ((uint32_t)(ADC_CFGR1_AWDSGL | ADC_CFGR1_AWDEN))
+#define ADC_ANALOGWATCHDOG_ALL_REG                  ((uint32_t) ADC_CFGR1_AWDEN)
+                                                  
+                                                  
+#define IS_ADC_ANALOG_WATCHDOG_MODE(WATCHDOG)     (((WATCHDOG) == ADC_ANALOGWATCHDOG_NONE      )   || \
+                                                   ((WATCHDOG) == ADC_ANALOGWATCHDOG_SINGLE_REG)   || \
+                                                   ((WATCHDOG) == ADC_ANALOGWATCHDOG_ALL_REG   ))
+/**
+  * @}
+  */
+
+/** @defgroup ADC_conversion_type
+  * @{
+  */ 
+#define REGULAR_GROUP                         ((uint32_t)(ADC_FLAG_EOC | ADC_FLAG_EOS))                                              
+#define IS_ADC_CONVERSION_GROUP(CONVERSION)   ((CONVERSION) == REGULAR_GROUP)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Event_type
+  * @{
+  */ 
+#define AWD_EVENT              ((uint32_t)ADC_FLAG_AWD)
+#define OVR_EVENT              ((uint32_t)ADC_FLAG_OVR)
+    
+#define IS_ADC_EVENT_TYPE(EVENT) (((EVENT) == AWD_EVENT) || \
+                                  ((EVENT) == OVR_EVENT))
+/**
+  * @}
+  */
+  
+/** @defgroup ADC_interrupts_definition
+  * @{
+  */
+#define ADC_IT_RDY           ADC_IER_ADRDYIE     /*!< ADC Ready (ADRDY) interrupt source */
+#define ADC_IT_EOSMP         ADC_IER_EOSMPIE     /*!< ADC End of Sampling interrupt source */
+#define ADC_IT_EOC           ADC_IER_EOCIE       /*!< ADC End of Regular Conversion interrupt source */
+#define ADC_IT_EOS           ADC_IER_EOSEQIE     /*!< ADC End of Regular sequence of Conversions interrupt source */
+#define ADC_IT_OVR           ADC_IER_OVRIE       /*!< ADC overrun interrupt source */
+#define ADC_IT_AWD           ADC_IER_AWDIE       /*!< ADC Analog watchdog 1 interrupt source */
+#define ADC_IT_EOCAL         ADC_IER_EOCALIE     /*!< ADC End of Calibration interrupt source */
+
+/* Check of single flag */
+#define IS_ADC_IT(IT) (((IT) == ADC_IT_AWD)   || ((IT) == ADC_IT_RDY) || \
+                       ((IT) == ADC_IT_EOSMP) || ((IT) == ADC_IT_EOC) || \
+                       ((IT) == ADC_IT_EOS)   || ((IT) == ADC_IT_OVR))
+/**
+  * @}
+  */ 
+
+  
+
+/** @defgroup ADC_flags_definition
+  * @{
+  */
+#define ADC_FLAG_RDY           ADC_ISR_ADRDY    /*!< ADC Ready (ADRDY) flag */
+#define ADC_FLAG_EOSMP         ADC_ISR_EOSMP    /*!< ADC End of Sampling flag */
+#define ADC_FLAG_EOC           ADC_ISR_EOC      /*!< ADC End of Regular Conversion flag */
+#define ADC_FLAG_EOS           ADC_ISR_EOSEQ    /*!< ADC End of Regular sequence of Conversions flag */
+#define ADC_FLAG_OVR           ADC_ISR_OVR      /*!< ADC overrun flag */
+#define ADC_FLAG_AWD           ADC_ISR_AWD      /*!< ADC Analog watchdog flag */
+#define ADC_FLAG_EOCAL         ADC_ISR_EOCAL    /*!< ADC Enf Of Calibration flag */
+
+
+#define ADC_FLAG_ALL    (ADC_FLAG_RDY | ADC_FLAG_EOSMP | ADC_FLAG_EOC | ADC_FLAG_EOS |  \
+                         ADC_FLAG_OVR | ADC_FLAG_AWD   | ADC_FLAG_EOCAL)
+
+/* Check of single flag */
+#define IS_ADC_FLAG(FLAG) (((FLAG) == ADC_FLAG_RDY)  || ((FLAG) == ADC_FLAG_EOSMP) || \
+                           ((FLAG) == ADC_FLAG_EOC)  || ((FLAG) == ADC_FLAG_EOS)   || \
+                           ((FLAG) == ADC_FLAG_OVR)  || ((FLAG) == ADC_FLAG_AWD)   || \
+                           ((FLAG) == ADC_FLAG_EOCAL))
+/**
+  * @}
+  */
+
+
+/** @defgroup ADC_range_verification
+  * in function of ADC resolution selected (12, 10, 8 or 6 bits)
+  * @{
+  */ 
+#define IS_ADC_RANGE(RESOLUTION, ADC_VALUE)                                     \
+   ((((RESOLUTION) == ADC_RESOLUTION12b) && ((ADC_VALUE) <= ((uint32_t)0x0FFF))) || \
+    (((RESOLUTION) == ADC_RESOLUTION10b) && ((ADC_VALUE) <= ((uint32_t)0x03FF))) || \
+    (((RESOLUTION) == ADC_RESOLUTION8b)  && ((ADC_VALUE) <= ((uint32_t)0x00FF))) || \
+    (((RESOLUTION) == ADC_RESOLUTION6b)  && ((ADC_VALUE) <= ((uint32_t)0x003F))))
+/**
+  * @}
+  */ 
+
+/** @defgroup ADC_regular_nb_conv_verification
+  * @{
+  */ 
+#define IS_ADC_REGULAR_NB_CONV(LENGTH) (((LENGTH) >= ((uint32_t)1)) && ((LENGTH) <= ((uint32_t)16)))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/* Exported macro ------------------------------------------------------------*/
+     
+/** @defgroup ADC_Exported_Macro
+  * @{
+  */
+/** @brief Reset ADC handle state
+  * @param  __HANDLE__: ADC handle
+  * @retval None
+  */
+#define __HAL_ADC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_ADC_STATE_RESET)
+
+/**
+  * @brief Enable the ADC peripheral
+  * @param __HANDLE__: ADC handle
+  * @retval None
+  */
+#define __HAL_ADC_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR |= ADC_CR_ADEN)
+
+/**
+  * @brief Verification of hardware constraints before ADC can be enabled
+  * @param __HANDLE__: ADC handle
+  * @retval SET (ADC can be enabled) or RESET (ADC cannot be enabled)
+  */
+#define __HAL_ADC_ENABLING_CONDITIONS(__HANDLE__)           \
+       (( ( ((__HANDLE__)->Instance->CR) &                  \
+            (ADC_CR_ADCAL | ADC_CR_ADSTP | ADC_CR_ADSTART | \
+             ADC_CR_ADDIS | ADC_CR_ADEN )                   \
+           ) == RESET                                       \
+        ) ? SET : RESET)
+
+/**
+  * @brief Disable the ADC peripheral
+  * @param __HANDLE__: ADC handle
+  * @retval None
+  */
+#define __HAL_ADC_DISABLE(__HANDLE__)                                          \
+  do{                                                                          \
+         (__HANDLE__)->Instance->CR |= ADC_CR_ADDIS;                           \
+          __HAL_ADC_CLEAR_FLAG((__HANDLE__), (ADC_FLAG_EOSMP | ADC_FLAG_RDY)); \
+  } while(0)
+    
+/**
+  * @brief Verification of hardware constraints before ADC can be disabled
+  * @param __HANDLE__: ADC handle
+  * @retval SET (ADC can be disabled) or RESET (ADC cannot be disabled)
+  */
+#define __HAL_ADC_DISABLING_CONDITIONS(__HANDLE__)                             \
+       (( ( ((__HANDLE__)->Instance->CR) &                                     \
+            (ADC_CR_ADSTART | ADC_CR_ADEN)) == ADC_CR_ADEN   \
+        ) ? SET : RESET)
+         
+/**
+  * @brief Verification of ADC state: enabled or disabled
+  * @param __HANDLE__: ADC handle
+  * @retval SET (ADC enabled) or RESET (ADC disabled)
+  */
+#define __HAL_ADC_IS_ENABLED(__HANDLE__)                                                    \
+       (( ((((__HANDLE__)->Instance->CR) & (ADC_CR_ADEN | ADC_CR_ADDIS)) == ADC_CR_ADEN) && \
+          ((((__HANDLE__)->Instance->ISR) & ADC_FLAG_RDY) == ADC_FLAG_RDY)                  \
+        ) ? SET : RESET)
+         
+/**
+  * @brief Returns resolution bits in CFGR register: RES[1:0]. Return value among parameter to @ref ADC_Resolution.
+  * @param __HANDLE__: ADC handle
+  * @retval None
+  */
+#define __HAL_ADC_GET_RESOLUTION(__HANDLE__) (((__HANDLE__)->Instance->CFGR1) & ADC_CFGR1_RES)
+
+/**
+  * @brief Check if no conversion is ongoing on regular groups
+  * @param __HANDLE__: ADC handle
+  * @retval SET (conversion is on going) or RESET (no conversion is on going)
+  */
+#define __HAL_ADC_IS_CONVERSION_ONGOING(__HANDLE__) \
+       (( (((__HANDLE__)->Instance->CR) & (ADC_CR_ADSTART)) == RESET ) ? RESET : SET)
+ 
+/**
+  * @brief Enable ADC continuous conversion mode.
+  * @param _CONTINUOUS_MODE_: Continuous mode.
+  * @retval None
+  */
+#define __HAL_ADC_CFGR1_CONTINUOUS(_CONTINUOUS_MODE_) ((_CONTINUOUS_MODE_) << 13)
+
+/**
+  * @brief Configures the number of discontinuous conversions for the regular group channels.
+  * @param _NBR_DISCONTINUOUS_CONV_: Number of discontinuous conversions.
+  * @retval None
+  */
+#define __HAL_ADC_CFGR1_DISCONTINUOUS_NUM(_NBR_DISCONTINUOUS_CONV_) (((_NBR_DISCONTINUOUS_CONV_) - 1) << 17)
+
+/**
+  * @brief Enable the ADC DMA continuous request.
+  * @param _DMAContReq_MODE_: DMA continuous request mode.
+  * @retval None
+  */
+#define __HAL_ADC_CFGR1_DMAContReq(_DMAContReq_MODE_) ((_DMAContReq_MODE_) << 1)
+
+/**
+  * @brief Enable the ADC Auto Delay.
+  * @param _AutoDelay_: Auto delay bit enable or disable.
+  * @retval None
+  */
+#define __HAL_ADC_CFGR1_AutoDelay(_AutoDelay_) ((_AutoDelay_) << 14)
+
+/**
+  * @brief Enable the ADC LowPowerAutoOff.
+  * @param _AUTOFF_: AutoOff bit enable or disable.
+  * @retval None
+  */
+#define __HAL_ADC_CFGR1_AUTOFF(_AUTOFF_) ((_AUTOFF_) << 15)
+          
+/**
+  * @brief Configure the analog watchdog high threshold into registers TR1, TR2 or TR3.
+  * @param _Threshold_: Threshold value
+  * @retval None
+  */
+#define __HAL_ADC_TRx_HighThreshold(_Threshold_) ((_Threshold_) << 16)
+
+          /**
+  * @brief Enable the ADC Low Frequency mode.
+  * @param _LOW_FREQUENCY_MODE_: Low Frequency mode.
+  * @retval None
+  */
+#define __HAL_ADC_CCR_LOWFREQUENCY(_LOW_FREQUENCY_MODE_) ((_LOW_FREQUENCY_MODE_) << 25)
+    
+/**
+  * @brief Shift the offset in function of the selected ADC resolution. 
+  *        Offset has to be left-aligned on bit 11, the LSB (right bits) are set to 0
+  *        If resolution 12 bits, no shift.
+  *        If resolution 10 bits, shift of 2 ranks on the right.
+  *        If resolution 8 bits, shift of 4 ranks on the right.
+  *        If resolution 6 bits, shift of 6 ranks on the right.
+  *        therefore, shift = (12 - resolution) = 12 - (12- (((RES[1:0]) >> 3)*2))
+  * @param __HANDLE__: ADC handle.
+  * @param _Offset_: Value to be shifted
+  * @retval None
+  */
+#define __HAL_ADC_Offset_shift_resolution(__HANDLE__, _Offset_) \
+        ((_Offset_) << ((((__HANDLE__)->Instance->CFGR & ADC_CFGR1_RES) >> 3)*2))
+
+/**
+  * @brief Shift the AWD1 threshold in function of the selected ADC resolution.
+  *        Thresholds have to be left-aligned on bit 11, the LSB (right bits) are set to 0
+  *        If resolution 12 bits, no shift.
+  *        If resolution 10 bits, shift of 2 ranks on the right.
+  *        If resolution 8 bits, shift of 4 ranks on the right.
+  *        If resolution 6 bits, shift of 6 ranks on the right.
+  *        therefore, shift = (12 - resolution) = 12 - (12- (((RES[1:0]) >> 3)*2))
+  * @param __HANDLE__: ADC handle.
+  * @param _Threshold_: Value to be shifted
+  * @retval None
+  */
+#define __HAL_ADC_AWD1Threshold_shift_resolution(__HANDLE__, _Threshold_) \
+        ((_Threshold_) << ((((__HANDLE__)->Instance->CFGR1 & ADC_CFGR1_RES) >> 3)*2))
+       
+/**
+  * @brief Shift the value on the left, less significant are set to 0. 
+  * @param _Value_: Value to be shifted
+  * @param _Shift_: Number of shift to be done
+  * @retval None
+  */
+#define __HAL_ADC_Value_Shift_left(_Value_, _Shift_) ((_Value_) << (_Shift_))
+
+
+/**
+  * @brief Enable the ADC end of conversion interrupt.
+  * @param __HANDLE__: ADC handle.
+  * @param __INTERRUPT__: ADC Interrupt.
+  * @retval None
+  */
+#define __HAL_ADC_ENABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->IER) |= (__INTERRUPT__))
+
+/**
+  * @brief Disable the ADC end of conversion interrupt.
+  * @param __HANDLE__: ADC handle.
+  * @param __INTERRUPT__: ADC interrupt.
+  * @retval None
+  */
+#define __HAL_ADC_DISABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->IER) &= ~(__INTERRUPT__))
+
+/** @brief  Checks if the specified ADC interrupt source is enabled or disabled.
+  * @param __HANDLE__: specifies the ADC Handle.
+  * @param __INTERRUPT__: specifies the ADC interrupt source to check.
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_ADC_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->IER & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/**
+  * @brief Clear the ADC's pending flags
+  * @param __HANDLE__: ADC handle.
+  * @param __FLAG__: ADC flag.
+  * @retval None
+  */
+/* Note: bit cleared bit by writing 1 */
+#define __HAL_ADC_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->ISR) = (__FLAG__))
+
+/**
+  * @brief Get the selected ADC's flag status.
+  * @param __HANDLE__: ADC handle.
+  * @param __FLAG__: ADC flag.
+  * @retval None
+  */
+#define __HAL_ADC_GET_FLAG(__HANDLE__, __FLAG__) ((((__HANDLE__)->Instance->ISR) & (__FLAG__)) == (__FLAG__))
+
+    
+   
+/**
+  * @brief Configuration of ADC clock & prescaler: clock source PCLK or Asynchronous with selectable prescaler
+  * @param __HANDLE__: ADC handle
+  * @retval None
+  */
+
+#define __HAL_ADC_CLOCK_PRESCALER(__HANDLE__)                                       \
+  do{                                                                               \
+      if ((((__HANDLE__)->Init.ClockPrescaler) == ADC_CLOCKPRESCALER_PCLK_DIV1) ||  \
+          (((__HANDLE__)->Init.ClockPrescaler) == ADC_CLOCKPRESCALER_PCLK_DIV2) ||  \
+          (((__HANDLE__)->Init.ClockPrescaler) == ADC_CLOCKPRESCALER_PCLK_DIV2))    \
+      {                                                                             \
+        (__HANDLE__)->Instance->CFGR2 &= ~(ADC_CFGR2_CKMODE);                       \
+        (__HANDLE__)->Instance->CFGR2 |=  (__HANDLE__)->Init.ClockPrescaler;        \
+      }                                                                             \
+      else                                                                          \
+      {                                                                             \
+        /* CKMOD bits must be reset */                                              \
+        (__HANDLE__)->Instance->CFGR2 &= ~(ADC_CFGR2_CKMODE);                       \
+        ADC->CCR &= ~(ADC_CCR_PRESC);                                               \
+        ADC->CCR |=  (__HANDLE__)->Init.ClockPrescaler;                             \
+      }                                                                             \
+  } while(0)
+
+ /**
+  * @}
+  */
+         
+/* Include ADC HAL Extension module */
+#include "stm32l0xx_hal_adc_ex.h"
+    
+/* Exported functions --------------------------------------------------------*/  
+/* Initialization and de-initialization functions  **********************************/
+HAL_StatusTypeDef    HAL_ADC_Init(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef    HAL_ADC_DeInit(ADC_HandleTypeDef *hadc);
+void                 HAL_ADC_MspInit(ADC_HandleTypeDef* hadc);
+void                 HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc);
+
+/* IO operation functions  *****************************************************/
+/* Blocking mode: Polling */
+HAL_StatusTypeDef    HAL_ADC_Start(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef    HAL_ADC_Stop(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef    HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint32_t Timeout);                 
+HAL_StatusTypeDef    HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t EventType, uint32_t Timeout);
+                     
+/* Non-blocking mode: Interruption */
+HAL_StatusTypeDef    HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc);
+HAL_StatusTypeDef    HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc);
+                     
+/* Non-blocking mode: DMA */
+HAL_StatusTypeDef    HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pData, uint32_t Length);
+HAL_StatusTypeDef    HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc);
+                     
+/* ADC retrieve conversion value intended to be used with polling or interruption */
+uint32_t             HAL_ADC_GetValue(ADC_HandleTypeDef* hadc);
+                     
+/* ADC IRQHandler and Callbacks used in non-blocking modes (Interruption and DMA) */
+void                    HAL_ADC_IRQHandler(ADC_HandleTypeDef* hadc);
+void                 HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc);
+void                 HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc);
+void                 HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef* hadc);
+void                 HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc);
+
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef    HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConfTypeDef* sConfig);
+HAL_StatusTypeDef    HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDGConfTypeDef* AnalogWDGConfig);
+
+/* Peripheral State functions *************************************************/
+HAL_ADC_StateTypeDef HAL_ADC_GetState(ADC_HandleTypeDef* hadc);
+uint32_t             HAL_ADC_GetError(ADC_HandleTypeDef *hadc);
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__STM32L0xx_ADC_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_adc_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_adc_ex.c
@@ -1,0 +1,273 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_adc_ex.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   This file provides firmware functions to manage the following 
+  *          functionalities of the Analog to Digital Convertor (ADC)
+  *          peripheral:
+  *           + Start calibration.
+  *           + Read the calibration factor.
+  *           + Set a calibration factor.
+  *          
+  @verbatim
+  ==============================================================================
+                    ##### ADC specific features #####
+  ==============================================================================
+  [..] 
+  (#) Self calibration.
+
+
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+
+    (#) Call HAL_ADCEx_Calibration_Start() to start calibration
+    
+    (#) Read the calibration factor using HAL_ADCEx_Calibration_GetValue()
+  
+    (#) User can set a his calibration factor using HAL_ADCEx_Calibration_SetValue()
+  
+    @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup ADCEx 
+  * @brief ADC driver modules
+  * @{
+  */ 
+
+#ifdef HAL_ADC_MODULE_ENABLED
+    
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+
+/** @defgroup ADCEx_Group ADC Extended features functions
+ *  @brief    ADC Extended features functions 
+ *
+@verbatim   
+ ===============================================================================
+            ##### ADC Extended features functions #####
+ ===============================================================================  
+    [..]
+This subsection provides functions allowing to:
+      (+) Start calibration.
+      (+) Get calibration factor.
+      (+) Set calibration factor.
+
+@endverbatim
+  * @{
+  */
+
+
+/**
+  * @brief  Start an automatic calibration
+  * @param  hadc: pointer to a ADC_HandleTypeDef structure that contains
+  *         the configuration information for the specified ADC.
+  * @param  SingleDiff: Selection of single-ended or differential input
+  *          This parameter can be only of the following values:
+  *            @arg ADC_SINGLE_ENDED: Channel in mode input single ended
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef* hadc, uint32_t SingleDiff)
+{
+  uint32_t tickstart = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(SingleDiff));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+   
+  /* Disable the ADC (if not already disabled) */
+  if (__HAL_ADC_IS_ENABLED(hadc) != RESET )
+  {
+    /* Check if conditions to disable the ADC are fulfilled */
+    if (__HAL_ADC_DISABLING_CONDITIONS(hadc) != RESET)
+    {
+      __HAL_ADC_DISABLE(hadc);    
+    }
+    else  
+    {
+      hadc->State= HAL_ADC_STATE_ERROR;
+      
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+      
+      return HAL_ERROR;
+    }   
+    
+    /* Wait for ADC effectively disabled */
+    /* Get timeout */
+    tickstart = HAL_GetTick();  
+
+    /* Wait for disabling completion */
+    while(HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADEN))
+    {
+      /* Check for the Timeout */
+      if(ADC_DISABLE_TIMEOUT != HAL_MAX_DELAY)
+      {
+        if((HAL_GetTick() - tickstart ) > ADC_DISABLE_TIMEOUT)
+        {
+          hadc->State= HAL_ADC_STATE_TIMEOUT;
+          
+          /* Process unlocked */
+          __HAL_UNLOCK(hadc);
+          
+          return HAL_TIMEOUT;
+        }
+      }
+    }  
+  }
+
+  /* Start ADC calibration */
+  hadc->Instance->CR |= ADC_CR_ADCAL;
+
+  /* Get timeout */
+  tickstart = HAL_GetTick(); 
+
+  /* Wait for calibration completion */
+  while(HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_ADCAL))
+  {
+    /* Check for the Timeout */
+    if(ADC_CALIBRATION_TIMEOUT != HAL_MAX_DELAY)
+    {
+      if((HAL_GetTick() - tickstart ) > ADC_CALIBRATION_TIMEOUT)
+      {
+        hadc->State= HAL_ADC_STATE_TIMEOUT;
+        
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+        
+        return HAL_TIMEOUT;
+      }
+    }
+  }  
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return HAL_OK;
+  
+}
+
+/**
+  * @brief  Get the calibration factor.
+  * @param  hadc: ADC handle.
+  * @param  SingleDiff: This parameter can be only:
+  *           @arg ADC_SINGLE_ENDED: Channel in mode input single ended.
+  * @retval Calibration value.
+  */
+uint32_t HAL_ADCEx_Calibration_GetValue(ADC_HandleTypeDef* hadc, uint32_t SingleDiff)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(SingleDiff)); 
+  
+  /* Return the ADC calibration value */ 
+  return ((hadc->Instance->CALFACT) & 0x0000007F);
+}
+
+/**
+  * @brief  Set the calibration factor to overwrite automatic conversion result.
+  *         ADC must be enabled and no conversion is ongoing.
+  * @param  hadc: ADC handle
+  * @param  SingleDiff: This parameter can be only:
+  *           @arg ADC_SINGLE_ENDED: Channel in mode input single ended.
+  * @param  CalibrationFactor: Calibration factor (coded on 7 bits maximum)
+  * @retval HAL state
+  */
+HAL_StatusTypeDef HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef* hadc, uint32_t SingleDiff, uint32_t CalibrationFactor)
+{
+  HAL_StatusTypeDef tmpHALStatus = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(SingleDiff)); 
+  assert_param(IS_ADC_CALFACT(CalibrationFactor)); 
+  
+  /* Process locked */
+  __HAL_LOCK(hadc);
+  
+  /* Verification of hardware constraints before modifying the calibration    */
+  /* factors register: ADC must be enabled, no conversion on going.           */
+  if ( (__HAL_ADC_IS_ENABLED(hadc) != RESET)                            &&
+       (__HAL_ADC_IS_CONVERSION_ONGOING(hadc) == RESET)  )
+  {
+    /* Set the selected ADC calibration value */ 
+    hadc->Instance->CALFACT &= ~ADC_CALFACT_CALFACT;
+    hadc->Instance->CALFACT |= CalibrationFactor;
+  }
+  else
+  {
+    /* Update ADC state machine to error */
+    hadc->State = HAL_ADC_STATE_ERROR;
+    
+    /* Update ADC state machine to error */
+    tmpHALStatus = HAL_ERROR;
+  }
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+  
+  /* Return function status */
+  return tmpHALStatus;
+}
+
+/**
+  * @}
+  */
+
+
+#endif /* HAL_ADC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_adc_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_adc_ex.h
@@ -1,0 +1,121 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_adc_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief  This file contains all the functions prototypes for the ADC firmware 
+  *          library.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_ADC_EX_H
+#define __STM32L0xx_ADC_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+  
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup ADCEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup ADCEx_Exported_Constants
+  * @{
+  */
+
+ /** @defgroup ADCEx_TimeOut_Values
+  * @{
+  */ 
+#define ADC_CALIBRATION_TIMEOUT       10
+/**
+  * @}
+  */
+   
+  
+/** @defgroup ADCEx_Channel_Mode
+  * @{
+  */   
+#define ADC_SINGLE_ENDED                        (uint32_t)0x00000000   /* dummy value */
+#define IS_ADC_SINGLE_DIFFERENTIAL(SING_DIFF)   ((SING_DIFF) == ADC_SINGLE_ENDED)
+/**
+  * @}
+  */
+    
+/** @defgroup ADCEx_calibration_factor_length_verification
+  * @{
+  */ 
+/**
+  * @brief Calibration factor lenght verification (7 bits maximum)
+  * @param _Calibration_Factor_: Calibration factor value
+  * @retval None
+  */
+#define IS_ADC_CALFACT(_Calibration_Factor_) ((_Calibration_Factor_) <= ((uint32_t)0x7F))
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+   
+/* Exported functions --------------------------------------------------------*/  
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef   HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef* hadc, uint32_t SingleDiff);
+uint32_t            HAL_ADCEx_Calibration_GetValue(ADC_HandleTypeDef* hadc, uint32_t SingleDiff);
+HAL_StatusTypeDef   HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef* hadc, uint32_t SingleDiff, uint32_t CalibrationFactor);
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__STM32L0xx_ADC_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_comp.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_comp.c
@@ -1,0 +1,614 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_comp.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   COMP HAL module driver.
+  *    
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the COMP peripheral:
+  *           + Initialization/de-initialization functions
+  *           + I/O operation functions
+  *           + Peripheral Control functions 
+  *           + Peripheral State functions
+  *         
+  @verbatim
+================================================================================
+          ##### COMP Peripheral features #####
+================================================================================
+           
+  [..]       
+      The STM32L0xx device family integrates  2 analog comparators COMP1 and COMP2:
+      (#) The non inverting input and inverting input can be set to GPIO pins
+          as shown in table1. COMP Inputs below.
+  
+      (#) The COMP output is available using HAL_COMP_GetOutputLevel()
+          and can be set on GPIO pins. Refer to table 2. COMP Outputs below.
+  
+      (#) The COMP output can be redirected to embedded timers (TIM2, TIM21, TIM22...) and LPTIM
+          Refer to TIM and LPTIM drivers.
+  
+      (#) The comparators COMP1 and COMP2 can be combined in window mode and only COMP2 non inverting input can be used as non-inverting input.
+  
+      (#) The 2 comparators have interrupt capability with wake-up
+          from Sleep and Stop modes (through the EXTI controller):
+          (++) COMP1 is internally connected to EXTI Line 21
+          (++) COMP2 is internally connected to EXTI Line 22
+
+          From the corresponding IRQ handler, the right interrupt source can be retrieved with the 
+          macro __HAL_COMP_EXTI_GET_FLAG(). Possible values are:
+          (++) COMP_EXTI_LINE_COMP1_EVENT
+          (++) COMP_EXTI_LINE_COMP2_EVENT
+
+
+[..] Table 1. COMP Inputs for the STM32L0xx devices
+ +--------------------------------------------------+     
+ |                 |                | COMP1 | COMP2 | 
+ |-----------------|----------------|---------------|
+ |                 | 1/4 VREFINT    |  --   |  OK   |  
+ |                 | 1/2 VREFINT    |  --   |  OK   |
+ |                 | 3/4 VREFINT    |  --   |  OK   |
+ | Inverting Input | VREFINT        |  OK   |  OK   | 
+ |                 | DAC OUT (PA4)  |  OK   |  OK   |  
+ |                 | IO1            |  PA0  |  PA2  |  
+ |                 | IO2            |  PA5  |  PA5  |  
+ |                 | IO3            |  ---  |  PB3  |  
+ |-----------------|----------------|-------|-------|
+ |  Non Inverting  | IO1            |  PA1  |  PA3  |  
+ |    Input        | IO2            |  ---  |  PB4  |
+ |                 | IO3            |  ---  |  PB5  |  
+ |                 | IO4            |  ---  |  PB6  |  
+ |                 | IO5            |  ---  |  PB7  |  
+ +--------------------------------------------------+  
+  
+ [..] Table 2. COMP Outputs for the STM32L0xx devices
+ +---------------+     
+ | COMP1 | COMP2 | 
+ |-------|-------|
+ |  PA0  |  PA2  | 
+ |  PA6  |  PA7  |  
+ |  PA11 |  PA12 | 
+ +---------------+
+
+    
+            ##### How to use this driver #####
+================================================================================
+  [..]
+      This driver provides functions to configure and program the Comparators of all STM32L0xx devices.
+
+      To use the comparator, perform the following steps:
+  
+      (#)  Initialize the COMP low level resources by implementing the HAL_COMP_MspInit().
+      (++) Configure the comparator input in analog mode using HAL_GPIO_Init().
+      (++) Configure the comparator output in alternate function mode using HAL_GPIO_Init() to map the comparator 
+           output to the GPIO pin.
+      (++) If required enable the VREFINT reference using HAL_VREFINT_Cmd() and HAL_COMP_EnableBuffer_Cmd().
+      (++) If required enable the COMP interrupt by configuring and enabling EXTI line in Interrupt mode and 
+           selecting the desired sensitivity level using HAL_GPIO_Init() function. After that enable the comparator
+           interrupt vector using HAL_NVIC_EnableIRQ() function.
+  
+      (#) Configure the comparator using HAL_COMP_Init() function:
+      (++) Select the inverting input
+      (++) Select the non-inverting input
+      (++) Select the output polarity  
+      (++) Select the power mode
+      (++) Select the window mode
+  
+      (#) Enable the comparator using HAL_COMP_Start() function
+    
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup COMP 
+  * @brief COMP HAL module driver
+  * @{
+  */
+
+#ifdef HAL_COMP_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* CSR register reset value */ 
+#define COMP_CSR_RESET_VALUE             ((uint32_t)0x00000000)
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup COMP_Private_Functions
+  * @{
+  */
+
+/** @defgroup HAL_COMP_Group1 Initialization/de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+ ===============================================================================
+              ##### Initialization/de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions to initialize and de-initialize comparators 
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the COMP according to the specified
+  *         parameters in the COMP_InitTypeDef and create the associated handle.
+  * @note   If the selected comparator is locked, initialization can't be performed.
+  *         To unlock the configuration, perform a system reset.
+  * @note   When the LPTIM connection is enabled, the following pins LPTIM_IN1(PB5, PC0)
+            and LPTIM_IN2(PB7, PC2) should not be configured in AF. 
+  * @param  hcomp: COMP handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
+{
+ HAL_StatusTypeDef status = HAL_OK;
+  
+  /* Check the COMP handle allocation and lock status */
+  if((hcomp == NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != 0x00))
+  {
+    status = HAL_ERROR;
+  }
+  else
+  {
+    /* Check the parameter */
+    assert_param(IS_COMP_ALL_INSTANCE(hcomp->Instance));
+    assert_param(IS_COMP_INVERTINGINPUT(hcomp->Init.InvertingInput));
+    assert_param(IS_COMP_NONINVERTINGINPUT(hcomp->Init.NonInvertingInput));
+    assert_param(IS_COMP_LPTIMCONNECTION(hcomp->Init.LPTIMConnection));
+    assert_param(IS_COMP_OUTPUTPOL(hcomp->Init.OutputPol));
+    assert_param(IS_COMP_MODE(hcomp->Init.Mode));
+    
+    if(hcomp->Init.WindowMode != COMP_WINDOWMODE_DISABLED)
+    {
+      assert_param(IS_COMP_WINDOWMODE_INSTANCE(hcomp->Instance));
+      assert_param(IS_COMP_WINDOWMODE(hcomp->Init.WindowMode));
+    }
+    
+    if(hcomp->State == HAL_COMP_STATE_RESET)
+    {
+      /* Init SYSCFG and the low level hardware to access comparators */
+     __SYSCFG_CLK_ENABLE();
+      /* Init the low level hardware : SYSCFG to access comparators */
+      HAL_COMP_MspInit(hcomp);
+    }
+    
+    /* Change COMP peripheral state */
+    hcomp->State = HAL_COMP_STATE_BUSY;
+  
+    /* Set COMP parameters */
+      /*     Set COMPxINSEL bits according to hcomp->Init.InvertingInput value        */
+      /*     Set COMPxNONINSEL bits according to hcomp->Init.NonInvertingInput value  */
+      /*     Set COMPxPOL bit according to hcomp->Init.OutputPol value                */
+      /*     Set COMPxMODE bits according to hcomp->Init.Mode value                   */
+      /*     Set COMP1WM bit according to hcomp->Init.WindowMode value                */
+    MODIFY_REG(hcomp->Instance->CSR, COMP_CSR_UPDATE_PARAMETERS_MASK, \
+                                     hcomp->Init.InvertingInput    |  \
+                                     hcomp->Init.NonInvertingInput |  \
+                                     hcomp->Init.LPTIMConnection   |  \
+                                     hcomp->Init.OutputPol         |  \
+                                     hcomp->Init.Mode              |  \
+                                     hcomp->Init.WindowMode);
+
+
+    /* Initialize the COMP state*/
+    hcomp->State = HAL_COMP_STATE_READY;
+
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  DeInitializes the COMP peripheral 
+  * @note   Deinitialization can't be performed if the COMP configuration is locked.
+  *         To unlock the configuration, perform a system reset.
+  * @param  hcomp: COMP handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_COMP_DeInit(COMP_HandleTypeDef *hcomp)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check the COMP handle allocation and lock status */
+  if((hcomp == NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != 0x00))
+  {
+    status = HAL_ERROR;
+  }
+  else
+  {
+    /* Check the parameter */
+    assert_param(IS_COMP_ALL_INSTANCE(hcomp->Instance));
+
+    /* Set COMP_CSR register to reset value */
+    WRITE_REG(hcomp->Instance->CSR, COMP_CSR_RESET_VALUE);
+
+    /* DeInit the low level hardware: SYSCFG, GPIO, CLOCK and NVIC */
+    HAL_COMP_MspDeInit(hcomp);
+
+    hcomp->State = HAL_COMP_STATE_RESET;
+    
+    /* Release Lock */
+    __HAL_UNLOCK(hcomp);
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Initializes the COMP MSP.
+  * @param  hcomp: COMP handle
+  * @retval None
+  */
+__weak void HAL_COMP_MspInit(COMP_HandleTypeDef *hcomp)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_COMP_MspInit could be implenetd in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes COMP MSP.
+  * @param  hcomp: COMP handle
+  * @retval None
+  */
+__weak void HAL_COMP_MspDeInit(COMP_HandleTypeDef *hcomp)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_COMP_MspDeInit could be implenetd in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_COMP_Group2 I/O operation functions 
+ *  @brief   Data transfers functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to manage the COMP data 
+    transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Start the comparator 
+  * @param  hcomp: COMP handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_COMP_Start(COMP_HandleTypeDef *hcomp)
+{ 
+  HAL_StatusTypeDef status = HAL_OK;
+  
+  /* Check the COMP handle allocation and lock status */
+  if((hcomp == NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != 0x00))
+  {
+    status = HAL_ERROR;
+  }
+  else
+  {
+    /* Check the parameter */
+    assert_param(IS_COMP_ALL_INSTANCE(hcomp->Instance));
+
+    if(hcomp->State == HAL_COMP_STATE_READY)
+    {
+      /* Enable the selected comparator */
+      __HAL_COMP_ENABLE(hcomp);
+
+      hcomp->State = HAL_COMP_STATE_BUSY;      
+    }
+    else
+    {
+      status = HAL_ERROR;
+    }
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Stop the comparator 
+  * @param  hcomp: COMP handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_COMP_Stop(COMP_HandleTypeDef *hcomp)
+{ 
+  HAL_StatusTypeDef status = HAL_OK;
+  
+  /* Check the COMP handle allocation and lock status */
+  if((hcomp == NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != 0x00))
+  {
+    status = HAL_ERROR;
+  }
+  else
+  {
+    /* Check the parameter */
+    assert_param(IS_COMP_ALL_INSTANCE(hcomp->Instance));
+
+    if(hcomp->State == HAL_COMP_STATE_BUSY)
+    {
+      /* Disable the selected comparator */
+      __HAL_COMP_DISABLE(hcomp);
+
+      hcomp->State = HAL_COMP_STATE_READY;
+    }
+    else
+    {
+      status = HAL_ERROR;
+    }
+  }
+  
+  return status;
+}
+
+/**
+  * @brief  Enables the interrupt and starts the comparator
+  * @param  hcomp: COMP handle
+  * @param  mode: IT trigger mode: a value of @ref COMP_TriggerMode
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_COMP_Start_IT(COMP_HandleTypeDef *hcomp)
+{ 
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t extiline = 0;
+  
+  status = HAL_COMP_Start(hcomp);
+  if(status == HAL_OK)
+  {
+    /* Check the Exti Line output configuration */
+    extiline = __HAL_COMP_GET_EXTI_LINE(hcomp->Instance);
+
+    /* Configure the rising edge */
+    if((hcomp->Init.TriggerMode & COMP_TRIGGERMODE_IT_RISING) != 0x00)
+    {
+      __HAL_COMP_EXTI_RISING_IT_ENABLE(extiline);
+    }
+    else
+    {
+      __HAL_COMP_EXTI_RISING_IT_DISABLE(extiline);
+    }
+    
+    /* Configure the falling edge */
+    if((hcomp->Init.TriggerMode & COMP_TRIGGERMODE_IT_FALLING) != 0x00)
+    {
+      __HAL_COMP_EXTI_FALLING_IT_ENABLE(extiline);
+    }
+    else
+    {
+      __HAL_COMP_EXTI_FALLING_IT_DISABLE(extiline);
+    }
+    
+    /* Enable Exti interrupt mode */
+    __HAL_COMP_EXTI_ENABLE_IT(extiline);
+    
+    /* Clear COMP Exti pending bit */
+    __HAL_COMP_EXTI_CLEAR_FLAG(extiline);  
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Disable the interrupt and Stop the comparator 
+  * @param  hcomp: COMP handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_COMP_Stop_IT(COMP_HandleTypeDef *hcomp)
+{  
+  HAL_StatusTypeDef status = HAL_OK;
+  
+  /* Disable the Exti Line interrupt mode */
+  __HAL_COMP_EXTI_DISABLE_IT(__HAL_COMP_GET_EXTI_LINE(hcomp->Instance));
+  
+  status = HAL_COMP_Stop(hcomp);
+  
+  return status;
+}
+
+/**
+  * @brief  Comparator IRQ Handler 
+  * @param  hcomp: COMP handle
+  * @retval HAL status
+  */
+void HAL_COMP_IRQHandler(COMP_HandleTypeDef *hcomp)
+{
+  uint32_t extiline = __HAL_COMP_GET_EXTI_LINE(hcomp->Instance);
+  
+  /* Check COMP Exti flag */
+  if(__HAL_COMP_EXTI_GET_FLAG(extiline) != RESET)
+  {    
+    /* Clear COMP Exti pending bit */
+    __HAL_COMP_EXTI_CLEAR_FLAG(extiline);
+  }  
+  
+  /* COMP trigger user callback */
+  HAL_COMP_TriggerCallback(hcomp);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_COMP_Group3 Peripheral Control functions 
+ *  @brief   management functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to control the COMP data 
+    transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Lock the selected comparator configuration. 
+  * @param  hcomp: COMP handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_COMP_Lock(COMP_HandleTypeDef *hcomp)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check the COMP handle allocation and lock status */
+  if((hcomp == NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != 0x00))
+  {
+    status = HAL_ERROR;
+  }
+  else
+  {
+    /* Check the parameter */
+    assert_param(IS_COMP_ALL_INSTANCE(hcomp->Instance));
+
+    /* Set lock flag */
+    hcomp->State |= COMP_STATE_BIT_LOCK;
+
+    /* Set the lock bit corresponding to selected comparator */
+    __HAL_COMP_LOCK(hcomp);
+  }
+  
+  return status; 
+}
+
+/**
+  * @brief  Return the output level (high or low) of the selected comparator. 
+  *         The output level depends on the selected polarity.
+  *         If the polarity is not inverted:
+  *           - Comparator output is low when the non-inverting input is at a lower
+  *             voltage than the inverting input
+  *           - Comparator output is high when the non-inverting input is at a higher
+  *             voltage than the inverting input
+  *         If the polarity is inverted:
+  *           - Comparator output is high when the non-inverting input is at a lower
+  *             voltage than the inverting input
+  *           - Comparator output is low when the non-inverting input is at a higher
+  *             voltage than the inverting input
+  * @param  hcomp: COMP handle
+  * @retval Returns the selected comparator output level: COMP_OUTPUTLEVEL_LOW or COMP_OUTPUTLEVEL_HIGH.
+  *       
+  */
+uint32_t HAL_COMP_GetOutputLevel(COMP_HandleTypeDef *hcomp)
+{
+  /* Check the parameter */
+  assert_param(IS_COMP_ALL_INSTANCE(hcomp->Instance));
+  
+  return((uint32_t)(hcomp->Instance->CSR & COMP_OUTPUTLEVEL_HIGH));
+}
+
+/**
+  * @brief  Comparator callback.
+  * @param  hcomp: COMP handle
+  * @retval None
+  */
+__weak void HAL_COMP_TriggerCallback(COMP_HandleTypeDef *hcomp)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_COMP_TriggerCallback should be implemented in the user file
+   */
+}
+
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_COMP_Group4 Peripheral State functions 
+ *  @brief   Peripheral State functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================  
+    [..]
+    This subsection permit to get in run-time the status of the peripheral 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the COMP state
+  * @param  hcomp : COMP handle
+  * @retval HAL state
+  */
+HAL_COMP_StateTypeDef HAL_COMP_GetState(COMP_HandleTypeDef *hcomp)
+{
+  /* Check the COMP handle allocation */
+  if(hcomp == NULL)
+  {
+    return HAL_COMP_STATE_RESET;
+  }
+
+  /* Check the parameter */
+  assert_param(IS_COMP_ALL_INSTANCE(hcomp->Instance));
+
+  return hcomp->State;
+}
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_COMP_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_comp.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_comp.h
@@ -1,0 +1,425 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_comp.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of COMP HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_COMP_H
+#define __STM32L0xx_HAL_COMP_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup COMP
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+
+/** 
+  * @brief  COMP Init structure definition  
+  */
+  
+typedef struct
+{
+
+  uint32_t InvertingInput;     /*!< Selects the inverting input of the comparator.
+                                    This parameter can be a value of @ref COMP_InvertingInput */
+
+  uint32_t NonInvertingInput;  /*!< Selects the non inverting input of the comparator.
+                                    This parameter can be a value of @ref COMP_NonInvertingInput */
+
+  uint32_t LPTIMConnection;     /*!< Selects if the COMP connection to the LPTIM is established or not.
+                                    This parameter can be a value of @ref COMP_LPTIMConnection */
+
+  uint32_t OutputPol;          /*!< Selects the output polarity of the comparator.
+                                    This parameter can be a value of @ref COMP_OutputPolarity */
+
+  uint32_t Mode;               /*!< Selects the operating comsumption mode of the comparator
+                                    to adjust the speed/consumption.
+                                    This parameter can be a value of @ref COMP_Mode */
+
+  uint32_t WindowMode;         /*!< Selects the window mode of the comparator 2.
+                                    This parameter can be a value of @ref COMP_WindowMode */
+
+  uint32_t TriggerMode;        /*!< Selects the trigger mode of the comparator (interrupt mode).
+                                    This parameter can be a value of @ref COMP_TriggerMode */
+  
+}COMP_InitTypeDef;
+
+/** 
+  * @brief  HAL State structures definition  
+  */ 
+typedef enum
+{
+  HAL_COMP_STATE_RESET             = 0x00,    /*!< COMP not yet initialized or disabled             */
+  HAL_COMP_STATE_READY             = 0x01,    /*!< COMP initialized and ready for use               */
+  HAL_COMP_STATE_READY_LOCKED      = 0x11,    /*!< COMP initialized but the configuration is locked */
+  HAL_COMP_STATE_BUSY              = 0x02,    /*!< COMP is running                                  */
+  HAL_COMP_STATE_BUSY_LOCKED       = 0x12     /*!< COMP is running and the configuration is locked  */
+}HAL_COMP_StateTypeDef;
+
+/** 
+  * @brief  COMP Handle Structure definition  
+  */ 
+typedef struct
+{
+  COMP_TypeDef       *Instance;       /*!< Register base address    */
+  COMP_InitTypeDef   Init;            /*!< COMP required parameters */
+  HAL_LockTypeDef    Lock;            /*!< Locking object           */
+  __IO HAL_COMP_StateTypeDef  State;  /*!< COMP communication state */
+} COMP_HandleTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup COMP_Exported_Constants
+  * @{
+  */
+
+/** @defgroup COMP_OutputPolarity
+  * @{
+  */
+#define COMP_OUTPUTPOL_NONINVERTED             ((uint32_t)0x00000000)  /*!< COMP output on GPIO isn't inverted */
+#define COMP_OUTPUTPOL_INVERTED                COMP_CSR_COMPxPOLARITY       /*!< COMP output on GPIO is inverted */
+#define IS_COMP_OUTPUTPOL(POL)  (((POL) == COMP_OUTPUTPOL_NONINVERTED)  || \
+                                 ((POL) == COMP_OUTPUTPOL_INVERTED))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup COMP_InvertingInput
+  * @{
+  */
+
+/* Inverting Input specific to COMP1 */
+#define COMP_INVERTINGINPUT_VREFINT             ((uint32_t)0x00000000) /*!< VREFINT connected to comparator1 inverting input */
+#define COMP_INVERTINGINPUT_IO1                 ((uint32_t)0x00000010) /*!< I/O1 connected to comparator inverting input (PA0) for COMP1 and (PA2) for COMP2*/
+#define COMP_INVERTINGINPUT_DAC1                ((uint32_t)0x00000020) /*!< DAC1_OUT (PA4) connected to comparator inverting input */
+#define COMP_INVERTINGINPUT_IO2                 ((uint32_t)0x00000030) /*!< I/O2 (PA5) connected to comparator inverting input */
+
+/* Inverting Input specific to COMP2 */
+#define COMP_INVERTINGINPUT_1_4VREFINT          ((uint32_t)0x00000040) /*!< 1/4 VREFINT connected to comparator inverting input */
+#define COMP_INVERTINGINPUT_1_2VREFINT          ((uint32_t)0x00000050) /*!< 1/2 VREFINT connected to comparator inverting input */
+#define COMP_INVERTINGINPUT_3_4VREFINT          ((uint32_t)0x00000060) /*!< 3/4 VREFINT connected to comparator inverting input */
+#define COMP_INVERTINGINPUT_IO3                 ((uint32_t)0x00000070) /*!< I/O3 (PB3) for COMP2 connected to comparator inverting input */
+
+
+#define IS_COMP_INVERTINGINPUT(INPUT) (((INPUT) == COMP_INVERTINGINPUT_VREFINT)     || \
+                                        ((INPUT) == COMP_INVERTINGINPUT_IO1)         || \
+                                        ((INPUT) == COMP_INVERTINGINPUT_DAC1)        || \
+                                        ((INPUT) == COMP_INVERTINGINPUT_IO2)         || \
+                                        ((INPUT) == COMP_INVERTINGINPUT_1_4VREFINT)  || \
+                                        ((INPUT) == COMP_INVERTINGINPUT_1_2VREFINT)  || \
+                                        ((INPUT) == COMP_INVERTINGINPUT_3_4VREFINT)   || \
+                                        ((INPUT) == COMP_INVERTINGINPUT_IO3))
+
+/**
+  * @}
+  */ 
+
+
+/** @defgroup COMP_NonInvertingInput
+  * @{
+  */
+
+#define COMP_NONINVERTINGINPUT_IO1                 ((uint32_t)0x00000000) /*!< I/O1 (PA3) connected to comparator non inverting input */
+#define COMP_NONINVERTINGINPUT_IO2                 ((uint32_t)0x00000100) /*!< I/O2 (PB4) connected to comparator non inverting input */
+#define COMP_NONINVERTINGINPUT_IO3                 ((uint32_t)0x00000200) /*!< I/O3 (PB5) connected to comparator non inverting input */
+#define COMP_NONINVERTINGINPUT_IO4                 ((uint32_t)0x00000300) /*!< I/O1 (PB6) connected to comparator non inverting input */
+#define COMP_NONINVERTINGINPUT_IO5                 ((uint32_t)0x00000400) /*!< I/O3 (PB7) connected to comparator non inverting input */
+#define COMP_NONINVERTINGINPUT_IO6                 ((uint32_t)0x00000500) /*!< I/O3 (PB7) connected to comparator non inverting input */
+#define COMP_NONINVERTINGINPUT_IO7                 ((uint32_t)0x00000600) /*!< I/O3 (PB7) connected to comparator non inverting input */
+#define COMP_NONINVERTINGINPUT_IO8                 ((uint32_t)0x00000700) /*!< I/O3 (PB7) connected to comparator non inverting input */
+
+#define IS_COMP_NONINVERTINGINPUT(INPUT) (((INPUT) == COMP_NONINVERTINGINPUT_IO1) || \
+                                           ((INPUT) == COMP_NONINVERTINGINPUT_IO2) || \
+                                           ((INPUT) == COMP_NONINVERTINGINPUT_IO3) || \
+                                           ((INPUT) == COMP_NONINVERTINGINPUT_IO4) || \
+                                           ((INPUT) == COMP_NONINVERTINGINPUT_IO5) || \
+                                           ((INPUT) == COMP_NONINVERTINGINPUT_IO6) || \
+                                           ((INPUT) == COMP_NONINVERTINGINPUT_IO7) || \
+                                           ((INPUT) == COMP_NONINVERTINGINPUT_IO8))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup COMP_Mode
+  * @{
+  */
+/* Please refer to the electrical characteristics in the device datasheet for
+   the power consumption values */
+#define COMP_MODE_HIGHSPEED         COMP_CSR_COMP2SPEED     /*!< High Speed */
+#define COMP_MODE_LOWSPEED          ((uint32_t)0x00000000)  /*!< Low Speed */ 
+
+#define IS_COMP_MODE(SPEED)    (((SPEED) == COMP_MODE_HIGHSPEED) || \
+                                 ((SPEED) == COMP_MODE_LOWSPEED))
+/**
+  * @}
+  */
+
+/** @defgroup COMP_WindowMode
+  * @{
+  */
+#define COMP_WINDOWMODE_DISABLED               ((uint32_t)0x00000000)  /*!< Window mode disabled (Plus input of comparator 1 connected to PA1)*/
+#define COMP_WINDOWMODE_ENABLED                COMP_CSR_COMP1WM    /*!< Window mode enabled: Plus input of comparator 1 shorted with Plus input of comparator 2 */
+#define IS_COMP_WINDOWMODE(WINDOWMODE) (((WINDOWMODE) == COMP_WINDOWMODE_DISABLED) || \
+                                        ((WINDOWMODE) == COMP_WINDOWMODE_ENABLED))
+
+#define IS_COMP_WINDOWMODE_INSTANCE(INSTANCE) ((INSTANCE) == COMP1)
+/**
+  * @}
+  */
+
+/** @defgroup COMP_LPTIMConnection
+  * @{
+  */
+#define COMP_LPTIMCONNECTION_DISABLED               ((uint32_t)0x00000000)  /*!< COMPx signal is gated */
+#define COMP_LPTIMCONNECTION_ENABLED                COMP_CSR_COMP1LPTIM1IN1    /*!< COMPx signal is connected to LPTIM */
+#define IS_COMP_LPTIMCONNECTION(LPTIMCONNECTION)   (((LPTIMCONNECTION) == COMP_LPTIMCONNECTION_DISABLED) || \
+                                                    ((LPTIMCONNECTION) == COMP_LPTIMCONNECTION_ENABLED))
+
+/**
+  * @}
+  */
+
+/** @defgroup COMP_OutputLevel
+  * @{
+  */ 
+/* When output polarity is not inverted, comparator output is low when
+   the non-inverting input is at a lower voltage than the inverting input*/
+#define COMP_OUTPUTLEVEL_LOW                   ((uint32_t)0x00000000)
+/* When output polarity is not inverted, comparator output is high when
+   the non-inverting input is at a higher voltage than the inverting input */
+#define COMP_OUTPUTLEVEL_HIGH                  COMP_CSR_COMPxOUTVALUE
+/**
+  * @}
+  */ 
+
+/* CSR register Mask */ 
+#define COMP_CSR_UPDATE_PARAMETERS_MASK        ((uint32_t)0xC0008779)
+  
+#define COMP_LOCK_DISABLE                      ((uint32_t)0x00000000)
+#define COMP_LOCK_ENABLE                       COMP_CSR_COMPxLOCK
+
+#define COMP_STATE_BIT_LOCK                    ((uint32_t)0x10)
+
+/** @defgroup COMP_TriggerMode
+  * @{
+  */
+#define COMP_TRIGGERMODE_IT_RISING             ((uint32_t)0x00000001)   /*!< External Interrupt Mode with Rising edge trigger detection */
+#define COMP_TRIGGERMODE_IT_FALLING            ((uint32_t)0x00000002)   /*!< External Interrupt Mode with Falling edge trigger detection */
+#define COMP_TRIGGERMODE_IT_RISING_FALLING     ((uint32_t)0x00000003)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection */
+#define IS_COMP_TRIGGERMODE(MODE)  (((MODE) == COMP_TRIGGERMODE_IT_RISING)  || \
+                                    ((MODE) == COMP_TRIGGERMODE_IT_FALLING) || \
+                                    ((MODE) == COMP_TRIGGERMODE_IT_RISING_FALLING))
+/**
+  * @}
+  */ 
+
+/** @defgroup COMP_ExtiLineEvent
+  * @{
+  */
+
+#define COMP_EXTI_LINE_COMP2_EVENT             ((uint32_t)0x00400000)  /*!< External interrupt line 22 Connected to COMP2 */
+#define COMP_EXTI_LINE_COMP1_EVENT             ((uint32_t)0x00200000)  /*!< External interrupt line 21 Connected to COMP1 */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+  
+/* Exported macro ------------------------------------------------------------*/
+/** @brief Reset COMP handle state
+  * @param  __HANDLE__: COMP handle.
+  * @retval None
+  */
+#define __HAL_COMP_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_COMP_STATE_RESET)
+
+/**
+  * @brief Enables the specified comparator
+  * @param  __HANDLE__: COMP handle.
+  * @retval None.
+  */
+#define __HAL_COMP_ENABLE(__HANDLE__)          ((__HANDLE__)->Instance->CSR |= (COMP_CSR_COMPxEN))
+
+/**
+  * @brief Disables the specified comparator
+  * @param  __HANDLE__: COMP handle.
+  * @retval None.
+  */
+#define __HAL_COMP_DISABLE(__HANDLE__)         ((__HANDLE__)->Instance->CSR &= ~(COMP_CSR_COMPxEN))
+
+/**
+  * @brief Lock the specified comparator configuration
+  * @param  __HANDLE__: COMP handle.
+  * @retval None.
+  */
+#define __HAL_COMP_LOCK(__HANDLE__)            ((__HANDLE__)->Instance->CSR |= COMP_CSR_COMPxLOCK)
+
+/** @brief  Checks whether the specified COMP flag is set or not.
+  * @param  __HANDLE__: specifies the COMP Handle.
+  * @param  __FLAG__: specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg COMP_FLAG_LOCK:  lock flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_COMP_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->CSR & (__FLAG__)) == (__FLAG__))   
+
+
+/**
+  * @brief Enable the Exti Line rising edge trigger.
+  * @param  __EXTILINE__: specifies the COMP Exti sources to be enabled.
+  *          This parameter can be a value of @ref COMP_ExtiLineEvent 
+  * @retval None.
+  */                                         
+#define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__) (EXTI->RTSR |= (__EXTILINE__))
+
+/**
+  * @brief  Disable the Exti Line rising edge trigger.
+  * @param  __EXTILINE__: specifies the COMP Exti sources to be disabled.
+  *         This parameter can be a value of @ref COMP_ExtiLineEvent 
+  * @retval None.
+  */                                         
+#define __HAL_COMP_EXTI_RISING_IT_DISABLE(__EXTILINE__) (EXTI->RTSR &= ~(__EXTILINE__))
+
+/**
+  * @brief Enable the Exti Line falling edge trigger.
+  * @param  __EXTILINE__: specifies the COMP Exti sources to be enabled.
+  *          This parameter can be a value of @ref COMP_ExtiLineEvent 
+  * @retval None.
+  */                                         
+#define __HAL_COMP_EXTI_FALLING_IT_ENABLE(__EXTILINE__) (EXTI->FTSR |= (__EXTILINE__))
+
+/**
+  * @brief  Disable the Exti Line falling edge trigger.
+  * @param  __EXTILINE__: specifies the COMP Exti sources to be disabled.
+  *         This parameter can be a value of @ref COMP_ExtiLineEvent 
+  * @retval None.
+  */                                         
+#define __HAL_COMP_EXTI_FALLING_IT_DISABLE(__EXTILINE__) (EXTI->FTSR &= ~(__EXTILINE__))
+
+/**
+  * @brief  Get the specified EXTI line for a comparator instance
+  * @param  __INSTANCE__: specifies the COMP instance.
+  * @retval value of @ref COMP_ExtiLineEvent
+  */
+#define __HAL_COMP_GET_EXTI_LINE(__INSTANCE__) (((__INSTANCE__) == COMP1) ? COMP_EXTI_LINE_COMP1_EVENT : \
+                                                COMP_EXTI_LINE_COMP2_EVENT)
+
+/**
+  * @brief Enable the COMP Exti Line.
+  * @param  __EXTILINE__: specifies the COMP Exti sources to be enabled.
+  *          This parameter can be a value of @ref COMP_ExtiLineEvent 
+  * @retval None.
+  */                                         
+#define __HAL_COMP_EXTI_ENABLE_IT(__EXTILINE__)   (EXTI->IMR |= (__EXTILINE__))
+
+/**
+  * @brief Disable the COMP Exti Line.
+  * @param  __EXTILINE__: specifies the COMP Exti sources to be disabled.
+  *          This parameter can be a value of @ref COMP_ExtiLineEvent 
+  * @retval None.
+  */
+#define __HAL_COMP_EXTI_DISABLE_IT(__EXTILINE__)  (EXTI->IMR &= ~(__EXTILINE__))
+
+/**
+  * @brief  Checks whether the specified EXTI line flag is set or not.
+  * @param  __FLAG__: specifies the COMP Exti sources to be checked.
+  *          This parameter can be a value of @ref COMP_ExtiLineEvent 
+  * @retval The state of __FLAG__ (SET or RESET).
+  */
+#define __HAL_COMP_EXTI_GET_FLAG(__FLAG__)  (EXTI->PR & (__FLAG__))
+     
+/**
+  * @brief Clear the COMP Exti flags.
+  * @param  __FLAG__: specifies the COMP Exti sources to be cleared.
+  *          This parameter can be a value of @ref COMP_ExtiLineEvent 
+  * @retval None.
+  */
+#define __HAL_COMP_EXTI_CLEAR_FLAG(__FLAG__)   (EXTI->PR = (__FLAG__))
+
+
+/* Exported functions --------------------------------------------------------*/
+
+/* Initialization/de-initialization functions  **********************************/
+HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp);
+HAL_StatusTypeDef HAL_COMP_DeInit (COMP_HandleTypeDef *hcomp);
+void HAL_COMP_MspInit(COMP_HandleTypeDef *hcomp);
+void HAL_COMP_MspDeInit(COMP_HandleTypeDef *hcomp);
+
+/* I/O operation functions  *****************************************************/
+HAL_StatusTypeDef HAL_COMP_Start(COMP_HandleTypeDef *hcomp);
+HAL_StatusTypeDef HAL_COMP_Stop(COMP_HandleTypeDef *hcomp);
+HAL_StatusTypeDef HAL_COMP_Start_IT(COMP_HandleTypeDef *hcomp);
+HAL_StatusTypeDef HAL_COMP_Stop_IT(COMP_HandleTypeDef *hcomp);
+void HAL_COMP_IRQHandler(COMP_HandleTypeDef *hcomp);
+
+/* Peripheral Control functions  ************************************************/
+HAL_StatusTypeDef HAL_COMP_Lock(COMP_HandleTypeDef *hcomp);
+uint32_t HAL_COMP_GetOutputLevel(COMP_HandleTypeDef *hcomp);
+
+/* Callback in Interrupt mode */
+void HAL_COMP_TriggerCallback(COMP_HandleTypeDef *hcomp);
+
+/* Peripheral State functions  **************************************************/
+HAL_COMP_StateTypeDef HAL_COMP_GetState(COMP_HandleTypeDef *hcomp);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_COMP_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_conf.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_conf.h
@@ -1,0 +1,292 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_conf.h
+  * @author  MCD Application Team
+  * @version V1.0.0
+  * @date    22-April-2014
+  * @brief   HAL configuration file.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_CONF_H
+#define __STM32L0xx_HAL_CONF_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver 
+  */
+#define HAL_MODULE_ENABLED  
+#define HAL_ADC_MODULE_ENABLED   
+#define HAL_COMP_MODULE_ENABLED 
+#define HAL_CRC_MODULE_ENABLED  
+#define HAL_CRYP_MODULE_ENABLED  
+#define HAL_DAC_MODULE_ENABLED   
+#define HAL_DMA_MODULE_ENABLED
+#define HAL_FLASH_MODULE_ENABLED 
+#define HAL_GPIO_MODULE_ENABLED
+#define HAL_I2C_MODULE_ENABLED
+#define HAL_I2S_MODULE_ENABLED   
+#define HAL_IWDG_MODULE_ENABLED
+#define HAL_LCD_MODULE_ENABLED 
+#define HAL_LPTIM_MODULE_ENABLED
+#define HAL_PWR_MODULE_ENABLED  
+#define HAL_RCC_MODULE_ENABLED 
+#define HAL_RNG_MODULE_ENABLED   
+#define HAL_RTC_MODULE_ENABLED
+#define HAL_SPI_MODULE_ENABLED   
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_TSC_MODULE_ENABLED   
+#define HAL_UART_MODULE_ENABLED 
+#define HAL_USART_MODULE_ENABLED 
+#define HAL_IRDA_MODULE_ENABLED 
+#define HAL_SMARTCARD_MODULE_ENABLED 
+#define HAL_SMBUS_MODULE_ENABLED 
+#define HAL_WWDG_MODULE_ENABLED  
+#define HAL_CORTEX_MODULE_ENABLED
+#define HAL_PCD_MODULE_ENABLED 
+
+
+/* ########################## Oscillator Values adaptation ####################*/
+/**
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSE is used as system clock source, directly or through the PLL).  
+  */
+#if !defined  (HSE_VALUE) 
+  #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (HSE_STARTUP_TIMEOUT)
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)50)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief Internal Multiple Speed oscillator (MSI) default value.
+  *        This value is the default MSI range value after Reset.
+  */
+#if !defined  (MSI_VALUE)
+  #define MSI_VALUE    ((uint32_t)2000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* MSI_VALUE */
+   
+/**
+  * @brief Internal High Speed oscillator (HSI) value.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSI is used as system clock source, directly or through the PLL). 
+  */
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)16000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+   
+/**
+  * @brief External Low Speed oscillator (LSE) value.
+  *        This value is used by the UART, RTC HAL module to compute the system frequency
+  */
+#if !defined  (LSE_VALUE)
+  #define LSE_VALUE    ((uint32_t)32768) /*!< Value of the External oscillator in Hz*/
+#endif /* LSE_VALUE */
+
+   
+#if !defined  (LSE_STARTUP_TIMEOUT)
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)500)   /*!< Time out for LSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+   
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
+
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */     
+#define  VDD_VALUE                    ((uint32_t)3300) /*!< Value of VDD in mv */
+#define  TICK_INT_PRIORITY            ((uint32_t)3)    /*!< tick interrupt priority */            
+#define  USE_RTOS                     0     
+#define  PREFETCH_ENABLE              1              
+#define  PREREAD_ENABLE               1
+#define  BUFFER_CACHE_DISABLE         0
+
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the 
+  *        HAL drivers code
+  */
+/* #define USE_FULL_ASSERT    1 */
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file 
+  */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+  #include "stm32l0xx_hal_rcc.h"
+#endif /* HAL_RCC_MODULE_ENABLED */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+  #include "stm32l0xx_hal_gpio.h"
+#endif /* HAL_GPIO_MODULE_ENABLED */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+  #include "stm32l0xx_hal_dma.h"
+#endif /* HAL_DMA_MODULE_ENABLED */
+   
+#ifdef HAL_CORTEX_MODULE_ENABLED
+  #include "stm32l0xx_hal_cortex.h"
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+  #include "stm32l0xx_hal_adc.h"
+#endif /* HAL_ADC_MODULE_ENABLED */
+
+#ifdef HAL_COMP_MODULE_ENABLED
+  #include "stm32l0xx_hal_comp.h"
+#endif /* HAL_COMP_MODULE_ENABLED */
+   
+#ifdef HAL_CRC_MODULE_ENABLED
+  #include "stm32l0xx_hal_crc.h"
+#endif /* HAL_CRC_MODULE_ENABLED */
+
+#ifdef HAL_CRYP_MODULE_ENABLED
+  #include "stm32l0xx_hal_cryp.h"
+#endif /* HAL_CRYP_MODULE_ENABLED */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+  #include "stm32l0xx_hal_dac.h"
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+  #include "stm32l0xx_hal_flash.h"
+#endif /* HAL_FLASH_MODULE_ENABLED */
+ 
+#ifdef HAL_I2C_MODULE_ENABLED
+ #include "stm32l0xx_hal_i2c.h"
+#endif /* HAL_I2C_MODULE_ENABLED */
+
+#ifdef HAL_I2S_MODULE_ENABLED
+ #include "stm32l0xx_hal_i2s.h"
+#endif /* HAL_I2S_MODULE_ENABLED */
+
+#ifdef HAL_IWDG_MODULE_ENABLED
+ #include "stm32l0xx_hal_iwdg.h"
+#endif /* HAL_IWDG_MODULE_ENABLED */
+
+#ifdef HAL_LCD_MODULE_ENABLED
+ #include "stm32l0xx_hal_lcd.h"
+#endif /* HAL_LCD_MODULE_ENABLED */
+
+#ifdef HAL_LPTIM_MODULE_ENABLED
+#include "stm32l0xx_hal_lptim.h"
+#endif /* HAL_LPTIM_MODULE_ENABLED */
+   
+#ifdef HAL_PWR_MODULE_ENABLED
+ #include "stm32l0xx_hal_pwr.h"
+#endif /* HAL_PWR_MODULE_ENABLED */
+
+#ifdef HAL_RNG_MODULE_ENABLED
+ #include "stm32l0xx_hal_rng.h"
+#endif /* HAL_RNG_MODULE_ENABLED */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+ #include "stm32l0xx_hal_rtc.h"
+
+#endif /* HAL_RTC_MODULE_ENABLED */
+
+#ifdef HAL_SPI_MODULE_ENABLED
+ #include "stm32l0xx_hal_spi.h"
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+ #include "stm32l0xx_hal_tim.h"
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#ifdef HAL_TSC_MODULE_ENABLED
+ #include "stm32l0xx_hal_tsc.h"
+#endif /* HAL_TSC_MODULE_ENABLED */
+
+#ifdef HAL_UART_MODULE_ENABLED
+ #include "stm32l0xx_hal_uart.h"
+#endif /* HAL_UART_MODULE_ENABLED */
+
+#ifdef HAL_USART_MODULE_ENABLED
+ #include "stm32l0xx_hal_usart.h"
+#endif /* HAL_USART_MODULE_ENABLED */
+
+#ifdef HAL_IRDA_MODULE_ENABLED
+ #include "stm32l0xx_hal_irda.h"
+#endif /* HAL_IRDA_MODULE_ENABLED */
+
+#ifdef HAL_SMARTCARD_MODULE_ENABLED
+ #include "stm32l0xx_hal_smartcard.h"
+#endif /* HAL_SMARTCARD_MODULE_ENABLED */
+
+#ifdef HAL_SMBUS_MODULE_ENABLED
+ #include "stm32l0xx_hal_smbus.h"
+#endif /* HAL_SMBUS_MODULE_ENABLED */
+
+#ifdef HAL_WWDG_MODULE_ENABLED
+ #include "stm32l0xx_hal_wwdg.h"
+#endif /* HAL_WWDG_MODULE_ENABLED */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+ #include "stm32l0xx_hal_pcd.h"
+#endif /* HAL_PCD_MODULE_ENABLED */
+
+/* Exported macro ------------------------------------------------------------*/
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed. 
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+  #define assert_param(expr) ((expr) ? (void)0 : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  void assert_failed(uint8_t* file, uint32_t line);
+#else
+  #define assert_param(expr) ((void)0)
+#endif /* USE_FULL_ASSERT */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_CONF_H */
+ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_conf_template.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_conf_template.h
@@ -1,0 +1,292 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_conf.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   HAL configuration file.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_CONF_H
+#define __STM32L0xx_HAL_CONF_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* ########################## Module Selection ############################## */
+/**
+  * @brief This is the list of modules to be used in the HAL driver 
+  */
+#define HAL_MODULE_ENABLED  
+#define HAL_ADC_MODULE_ENABLED   
+#define HAL_COMP_MODULE_ENABLED 
+#define HAL_CRC_MODULE_ENABLED  
+#define HAL_CRYP_MODULE_ENABLED  
+#define HAL_DAC_MODULE_ENABLED   
+#define HAL_DMA_MODULE_ENABLED
+#define HAL_FLASH_MODULE_ENABLED 
+#define HAL_GPIO_MODULE_ENABLED
+#define HAL_I2C_MODULE_ENABLED
+#define HAL_I2S_MODULE_ENABLED   
+#define HAL_IWDG_MODULE_ENABLED
+#define HAL_LCD_MODULE_ENABLED 
+#define HAL_LPTIM_MODULE_ENABLED
+#define HAL_PWR_MODULE_ENABLED  
+#define HAL_RCC_MODULE_ENABLED 
+#define HAL_RNG_MODULE_ENABLED   
+#define HAL_RTC_MODULE_ENABLED
+#define HAL_SPI_MODULE_ENABLED   
+#define HAL_TIM_MODULE_ENABLED
+#define HAL_TSC_MODULE_ENABLED   
+#define HAL_UART_MODULE_ENABLED 
+#define HAL_USART_MODULE_ENABLED 
+#define HAL_IRDA_MODULE_ENABLED 
+#define HAL_SMARTCARD_MODULE_ENABLED 
+#define HAL_SMBUS_MODULE_ENABLED 
+#define HAL_WWDG_MODULE_ENABLED  
+#define HAL_CORTEX_MODULE_ENABLED
+#define HAL_PCD_MODULE_ENABLED 
+
+
+/* ########################## Oscillator Values adaptation ####################*/
+/**
+  * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSE is used as system clock source, directly or through the PLL).  
+  */
+#if !defined  (HSE_VALUE) 
+  #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (HSE_STARTUP_TIMEOUT)
+  #define HSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for HSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+/**
+  * @brief Internal Multiple Speed oscillator (MSI) default value.
+  *        This value is the default MSI range value after Reset.
+  */
+#if !defined  (MSI_VALUE)
+  #define MSI_VALUE    ((uint32_t)2000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* MSI_VALUE */
+   
+/**
+  * @brief Internal High Speed oscillator (HSI) value.
+  *        This value is used by the RCC HAL module to compute the system frequency
+  *        (when HSI is used as system clock source, directly or through the PLL). 
+  */
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)16000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+   
+/**
+  * @brief External Low Speed oscillator (LSE) value.
+  *        This value is used by the UART, RTC HAL module to compute the system frequency
+  */
+#if !defined  (LSE_VALUE)
+  #define LSE_VALUE    ((uint32_t)32768) /*!< Value of the External oscillator in Hz*/
+#endif /* LSE_VALUE */
+
+   
+#if !defined  (LSE_STARTUP_TIMEOUT)
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
+#endif /* HSE_STARTUP_TIMEOUT */
+
+   
+/* Tip: To avoid modifying this file each time you need to use different HSE,
+   ===  you can define the HSE value in your toolchain compiler preprocessor. */
+
+/* ########################### System Configuration ######################### */
+/**
+  * @brief This is the HAL system configuration section
+  */     
+#define  VDD_VALUE                    ((uint32_t)3300) /*!< Value of VDD in mv */
+#define  TICK_INT_PRIORITY            ((uint32_t)3)    /*!< tick interrupt priority */            
+#define  USE_RTOS                     0     
+#define  PREFETCH_ENABLE              1              
+#define  PREREAD_ENABLE               1
+#define  BUFFER_CACHE_DISABLE         0
+
+/* ########################## Assert Selection ############################## */
+/**
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the 
+  *        HAL drivers code
+  */
+/* #define USE_FULL_ASSERT    1 */
+
+/* Includes ------------------------------------------------------------------*/
+/**
+  * @brief Include module's header file 
+  */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+  #include "stm32l0xx_hal_rcc.h"
+#endif /* HAL_RCC_MODULE_ENABLED */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+  #include "stm32l0xx_hal_gpio.h"
+#endif /* HAL_GPIO_MODULE_ENABLED */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+  #include "stm32l0xx_hal_dma.h"
+#endif /* HAL_DMA_MODULE_ENABLED */
+   
+#ifdef HAL_CORTEX_MODULE_ENABLED
+  #include "stm32l0xx_hal_cortex.h"
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+  #include "stm32l0xx_hal_adc.h"
+#endif /* HAL_ADC_MODULE_ENABLED */
+
+#ifdef HAL_COMP_MODULE_ENABLED
+  #include "stm32l0xx_hal_comp.h"
+#endif /* HAL_COMP_MODULE_ENABLED */
+   
+#ifdef HAL_CRC_MODULE_ENABLED
+  #include "stm32l0xx_hal_crc.h"
+#endif /* HAL_CRC_MODULE_ENABLED */
+
+#ifdef HAL_CRYP_MODULE_ENABLED
+  #include "stm32l0xx_hal_cryp.h"
+#endif /* HAL_CRYP_MODULE_ENABLED */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+  #include "stm32l0xx_hal_dac.h"
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+  #include "stm32l0xx_hal_flash.h"
+#endif /* HAL_FLASH_MODULE_ENABLED */
+ 
+#ifdef HAL_I2C_MODULE_ENABLED
+ #include "stm32l0xx_hal_i2c.h"
+#endif /* HAL_I2C_MODULE_ENABLED */
+
+#ifdef HAL_I2S_MODULE_ENABLED
+ #include "stm32l0xx_hal_i2s.h"
+#endif /* HAL_I2S_MODULE_ENABLED */
+
+#ifdef HAL_IWDG_MODULE_ENABLED
+ #include "stm32l0xx_hal_iwdg.h"
+#endif /* HAL_IWDG_MODULE_ENABLED */
+
+#ifdef HAL_LCD_MODULE_ENABLED
+ #include "stm32l0xx_hal_lcd.h"
+#endif /* HAL_LCD_MODULE_ENABLED */
+
+#ifdef HAL_LPTIM_MODULE_ENABLED
+#include "stm32l0xx_hal_lptim.h"
+#endif /* HAL_LPTIM_MODULE_ENABLED */
+   
+#ifdef HAL_PWR_MODULE_ENABLED
+ #include "stm32l0xx_hal_pwr.h"
+#endif /* HAL_PWR_MODULE_ENABLED */
+
+#ifdef HAL_RNG_MODULE_ENABLED
+ #include "stm32l0xx_hal_rng.h"
+#endif /* HAL_RNG_MODULE_ENABLED */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+ #include "stm32l0xx_hal_rtc.h"
+
+#endif /* HAL_RTC_MODULE_ENABLED */
+
+#ifdef HAL_SPI_MODULE_ENABLED
+ #include "stm32l0xx_hal_spi.h"
+#endif /* HAL_SPI_MODULE_ENABLED */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+ #include "stm32l0xx_hal_tim.h"
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#ifdef HAL_TSC_MODULE_ENABLED
+ #include "stm32l0xx_hal_tsc.h"
+#endif /* HAL_TSC_MODULE_ENABLED */
+
+#ifdef HAL_UART_MODULE_ENABLED
+ #include "stm32l0xx_hal_uart.h"
+#endif /* HAL_UART_MODULE_ENABLED */
+
+#ifdef HAL_USART_MODULE_ENABLED
+ #include "stm32l0xx_hal_usart.h"
+#endif /* HAL_USART_MODULE_ENABLED */
+
+#ifdef HAL_IRDA_MODULE_ENABLED
+ #include "stm32l0xx_hal_irda.h"
+#endif /* HAL_IRDA_MODULE_ENABLED */
+
+#ifdef HAL_SMARTCARD_MODULE_ENABLED
+ #include "stm32l0xx_hal_smartcard.h"
+#endif /* HAL_SMARTCARD_MODULE_ENABLED */
+
+#ifdef HAL_SMBUS_MODULE_ENABLED
+ #include "stm32l0xx_hal_smbus.h"
+#endif /* HAL_SMBUS_MODULE_ENABLED */
+
+#ifdef HAL_WWDG_MODULE_ENABLED
+ #include "stm32l0xx_hal_wwdg.h"
+#endif /* HAL_WWDG_MODULE_ENABLED */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+ #include "stm32l0xx_hal_pcd.h"
+#endif /* HAL_PCD_MODULE_ENABLED */
+
+/* Exported macro ------------------------------------------------------------*/
+#ifdef  USE_FULL_ASSERT
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed. 
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+  #define assert_param(expr) ((expr) ? (void)0 : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  void assert_failed(uint8_t* file, uint32_t line);
+#else
+  #define assert_param(expr) ((void)0)
+#endif /* USE_FULL_ASSERT */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_CONF_H */
+ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_cortex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_cortex.c
@@ -1,0 +1,333 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_cortex.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   CORTEX HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the CORTEX:
+  *           + Initialization and de-initialization functions
+  *           + Peripheral Control functions 
+  *
+  @verbatim  
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+
+    [..]  
+    *** How to configure Interrupts using CORTEX HAL driver ***
+    ===========================================================
+    [..]     
+    This section provide functions allowing to configure the NVIC interrupts (IRQ).
+    The Cortex-M0+ exceptions are managed by CMSIS functions.
+      (#) Enable and Configure the priority of the selected IRQ Channels. 
+             The priority can be 0..3. 
+
+        -@- Lower priority values gives higher priority.
+        -@- Priority Order:
+            (#@) Lowest priority.
+            (#@) Lowest hardware priority (IRQn position).  
+    
+     (#)  Configure the priority of the selected IRQ Channels using HAL_NVIC_SetPriority() 
+
+     (#)  Enable the selected IRQ Channels using HAL_NVIC_EnableIRQ() 
+      
+    [..]  
+    *** How to configure Systick using CORTEX HAL driver ***
+    ========================================================
+    [..]
+    Setup SysTick Timer for time base 
+           
+   (+) The HAL_SYSTICK_Config()function calls the SysTick_Config() function which
+       is a CMSIS function that:
+        (++) Configures the SysTick Reload register with value passed as function parameter.
+        (++) Configures the SysTick IRQ priority to the lowest value (0x03).
+        (++) Resets the SysTick Counter register.
+        (++) Configures the SysTick Counter clock source to be Core Clock Source (HCLK).
+        (++) Enables the SysTick Interrupt.
+        (++) Starts the SysTick Counter.
+    
+   (+) You can change the SysTick Clock source to be HCLK_Div8 by calling the macro
+       __HAL_CORTEX_SYSTICKCLK_CONFIG(SYSTICK_CLKSOURCE_HCLK_DIV8) just after the
+       HAL_SYSTICK_Config() function call. The __HAL_CORTEX_SYSTICKCLK_CONFIG() macro is defined
+       inside the stm32l0xx_hal_cortex.h file.
+
+   (+) You can change the SysTick IRQ priority by calling the
+       HAL_NVIC_SetPriority(SysTick_IRQn,...) function just after the HAL_SYSTICK_Config() function 
+       call. The HAL_NVIC_SetPriority() call the NVIC_SetPriority() function which is a CMSIS function.
+
+   (+) To adjust the SysTick time base, use the following formula:
+                            
+       Reload Value = SysTick Counter Clock (Hz) x  Desired Time base (s)
+       (++) Reload Value is the parameter to be passed for HAL_SYSTICK_Config() function
+       (++) Reload Value should not exceed 0xFFFFFF
+   
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup CORTEX 
+  * @brief CORTEX HAL module driver
+  * @{
+  */
+
+#ifdef HAL_CORTEX_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup CORTEX_Private_Functions
+  * @{
+  */
+
+
+/** @defgroup CORTEX_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+  ==============================================================================
+              ##### Initialization and de-initialization functions #####
+  ==============================================================================
+    [..]
+      This section provides the CORTEX HAL driver functions allowing to configure Interrupts
+      Systick functionalities 
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Sets the priority of an interrupt.
+  * @param  IRQn: External interrupt number .
+  *         This parameter can be an enumerator of  IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to stm32l0xx.h file)
+  * @param  PreemptPriority: The pre-emption priority for the IRQn channel.
+  *         This parameter can be a value between 0 and 3.
+  *         A lower priority value indicates a higher priority 
+  * @param  SubPriority: The subpriority level for the IRQ channel.
+  *         with stm32l0xx devices, this parameter is a dummy value and it is ignored, because 
+  *         no subpriority supported in Cortex M0+ based products.   
+  * @retval None
+  */
+void HAL_NVIC_SetPriority(IRQn_Type IRQn, uint32_t PreemptPriority, uint32_t SubPriority)
+{ 
+    /* Check the parameters */
+  assert_param(IS_NVIC_PREEMPTION_PRIORITY(PreemptPriority));
+  NVIC_SetPriority(IRQn,PreemptPriority);
+}
+
+/**
+  * @brief  Enables a device specific interrupt in the NVIC interrupt controller.
+  * @note   To configure interrupts priority correctly, the NVIC_PriorityGroupConfig()
+  *         function should be called before. 
+  * @param  IRQn External interrupt number .
+  *         This parameter can be an enumerator of  IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to stm32l0xx.h file)  
+  * @retval None
+  */
+void HAL_NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  /* Enable interrupt */
+  NVIC_EnableIRQ(IRQn);
+}
+
+/**
+  * @brief  Disables a device specific interrupt in the NVIC interrupt controller.
+  * @param  IRQn External interrupt number .
+  *         This parameter can be an enumerator of IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to stm32l0xx.h file)  
+  * @retval None
+  */
+void HAL_NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  /* Disable interrupt */
+  NVIC_DisableIRQ(IRQn);
+}
+
+/**
+  * @brief  Initiates a system reset request to reset the MCU.
+  * @param None
+  * @retval None
+  */
+void HAL_NVIC_SystemReset(void)
+{
+  /* System Reset */
+  NVIC_SystemReset();
+}
+
+/**
+  * @brief  Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+  *         Counter is in free running mode to generate periodic interrupts.
+  * @param  TicksNumb: Specifies the ticks Number of ticks between two interrupts.
+  * @retval status:  - 0  Function succeeded.
+  *                  - 1  Function failed.
+  */
+uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb)
+{
+   return SysTick_Config(TicksNumb);
+}
+/**
+  * @}
+  */
+
+/** @defgroup CORTEX_Group2 Peripheral Control functions 
+ *  @brief   Cortex control functions 
+ *
+@verbatim   
+  ==============================================================================
+                      ##### Peripheral Control functions #####
+  ==============================================================================  
+    [..]
+      This subsection provides a set of functions allowing to control the CORTEX
+      (NVIC, SYSTICK) functionalities. 
+ 
+      
+@endverbatim
+  * @{
+  */
+
+
+
+/**
+  * @brief  Sets Pending bit of an external interrupt.
+  * @param  IRQn External interrupt number
+  *         This parameter can be an enumerator of @ref IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to stm32l0xx.h file)  
+  * @retval None
+  */
+void HAL_NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{ 
+  /* Set interrupt pending */
+  NVIC_SetPendingIRQ(IRQn);
+}
+
+/**
+  * @brief  Gets Pending Interrupt (reads the pending register in the NVIC 
+  *         and returns the pending bit for the specified interrupt).
+  * @param  IRQn External interrupt number .
+  *          This parameter can be an enumerator of  IRQn_Type enumeration
+  *          (For the complete STM32 Devices IRQ Channels list, please refer to stm32l0xx.h file)  
+  * @retval status: - 0  Interrupt status is not pending.
+  *                 - 1  Interrupt status is pending.
+  */
+uint32_t HAL_NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{ 
+  /* Return 1 if pending else 0 */
+  return NVIC_GetPendingIRQ(IRQn);
+}
+
+/**
+  * @brief  Clears the pending bit of an external interrupt.
+  * @param  IRQn External interrupt number .
+  *         This parameter can be an enumerator of  IRQn_Type enumeration
+  *         (For the complete STM32 Devices IRQ Channels list, please refer to stm32l0xx.h file)  
+  * @retval None
+  */
+void HAL_NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{ 
+  /* Clear pending interrupt */
+  NVIC_ClearPendingIRQ(IRQn);
+}
+
+
+/**
+  * @brief  Configures the SysTick clock source.
+  * @param  CLKSource: specifies the SysTick clock source.
+  *          This parameter can be one of the following values:
+  *             @arg SYSTICK_CLKSOURCE_HCLK_DIV8: AHB clock divided by 8 selected as SysTick clock source.
+  *             @arg SYSTICK_CLKSOURCE_HCLK: AHB clock selected as SysTick clock source.
+  * @retval None
+  */
+void HAL_SYSTICK_CLKSourceConfig(uint32_t CLKSource)
+{
+  /* Check the parameters */
+  assert_param(IS_SYSTICK_CLK_SOURCE(CLKSource));
+  if (CLKSource == SYSTICK_CLKSOURCE_HCLK)
+  {
+    SysTick->CTRL |= SYSTICK_CLKSOURCE_HCLK;
+  }
+  else
+  {
+    SysTick->CTRL &= ~SYSTICK_CLKSOURCE_HCLK;
+  }
+}
+
+/**
+  * @brief  This function handles SYSTICK interrupt request.
+  * @param  None
+  * @retval None
+  */
+void HAL_SYSTICK_IRQHandler(void)
+{
+  HAL_SYSTICK_Callback();
+}
+
+/**
+  * @brief  SYSTICK callback.
+  * @param  None
+  * @retval None
+  */
+__weak void HAL_SYSTICK_Callback(void)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SYSTICK_Callback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_CORTEX_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_cortex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_cortex.h
@@ -1,0 +1,132 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_cortex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of CORTEX HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_CORTEX_H
+#define __STM32L0xx_HAL_CORTEX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup CORTEX
+  * @{
+  */ 
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup CORTEX_Exported_Constants
+  * @{
+  */
+
+
+#define IS_NVIC_PREEMPTION_PRIORITY(PRIORITY)  ((PRIORITY) < 0x4)
+
+/** @defgroup CORTEX_SysTick_clock_source
+  * @{
+  */
+#define SYSTICK_CLKSOURCE_HCLK_DIV8    ((uint32_t)0x00000000)
+#define SYSTICK_CLKSOURCE_HCLK         ((uint32_t)0x00000004)
+#define IS_SYSTICK_CLK_SOURCE(SOURCE) (((SOURCE) == SYSTICK_CLKSOURCE_HCLK) || \
+                                       ((SOURCE) == SYSTICK_CLKSOURCE_HCLK_DIV8))
+/**
+  * @}
+  */
+
+/* Exported Macros -----------------------------------------------------------*/
+
+/** @brief Configures the SysTick clock source.
+  * @param __CLKSRC__: specifies the SysTick clock source.
+  *   This parameter can be one of the following values:
+  *     @arg SYSTICK_CLKSOURCE_HCLK_DIV8: AHB clock divided by 8 selected as SysTick clock source.
+  *     @arg SYSTICK_CLKSOURCE_HCLK: AHB clock selected as SysTick clock source.
+  * @retval None
+  */
+#define __HAL_CORTEX_SYSTICKCLK_CONFIG(__CLKSRC__)                             \
+                            do {                                               \
+                                 if ((__CLKSRC__) == SYSTICK_CLKSOURCE_HCLK)   \
+                                  {                                            \
+                                    SysTick->CTRL |= SYSTICK_CLKSOURCE_HCLK;   \
+                                  }                                            \
+                                 else                                          \
+                                    SysTick->CTRL &= ~SYSTICK_CLKSOURCE_HCLK;  \
+                                } while(0)
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+/* Initialization and de-initialization functions *******************************/
+void HAL_NVIC_SetPriority(IRQn_Type IRQn, uint32_t PreemptPriority, uint32_t SubPriority);
+void HAL_NVIC_EnableIRQ(IRQn_Type IRQn);
+void HAL_NVIC_DisableIRQ(IRQn_Type IRQn);
+void HAL_NVIC_SystemReset(void);
+uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb);
+
+/* Peripheral Control functions *************************************************/
+uint32_t HAL_NVIC_GetPendingIRQ(IRQn_Type IRQn);
+void HAL_NVIC_SetPendingIRQ(IRQn_Type IRQn);
+void HAL_NVIC_ClearPendingIRQ(IRQn_Type IRQn);
+void HAL_SYSTICK_CLKSourceConfig(uint32_t CLKSource);
+void HAL_SYSTICK_IRQHandler(void);
+void HAL_SYSTICK_Callback(void);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_CORTEX_H */
+ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_crc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_crc.c
@@ -1,0 +1,508 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_crc.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   CRC HAL module driver.
+  *    
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the CRC peripheral:
+  *           + Initialization and de-initialization functions
+  *           + Peripheral Control functions 
+  *           + Peripheral State functions
+  *         
+  @verbatim
+ ===============================================================================
+                     ##### CRC How to use this driver #####
+ ===============================================================================
+    [..]
+
+    (#) Enable CRC AHB clock using __CRC_CLK_ENABLE();
+
+    (#) Initialize CRC calculator
+         (++) specify generating polynomial (IP default or non-default one)
+         (++) specify initialization value (IP default or non-default one)
+         (++) specify input data format
+         (++) specify input or output data inversion mode if any
+
+    (#) Use HAL_CRC_Accumulate() function to compute the CRC value of the 
+        input data buffer starting with the previously computed CRC as 
+        initialization value
+
+    (#) Use HAL_CRC_Calculate() function to compute the CRC value of the 
+        input data buffer starting with the defined initialization value 
+        (default or non-default) to initiate CRC calculation
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup CRC 
+  * @brief CRC HAL module driver
+  * @{
+  */
+
+#ifdef HAL_CRC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static uint32_t CRC_Handle_8(CRC_HandleTypeDef *hcrc, uint8_t pBuffer[], uint32_t BufferLength);
+static uint32_t CRC_Handle_16(CRC_HandleTypeDef *hcrc, uint16_t pBuffer[], uint32_t BufferLength);
+
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup CRC_Private_Functions
+  * @{
+  */
+
+/** @defgroup CRC_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim    
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  
+      This section provides functions allowing to:
+
+      (#) Initialize the CRC according to the specified parameters 
+          in the CRC_InitTypeDef and create the associated handle
+
+      (#) DeInitialize the CRC peripheral
+
+      (#) Initialize the CRC MSP
+
+      (#) DeInitialize CRC MSP 
+ 
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the CRC according to the specified
+  *         parameters in the CRC_InitTypeDef and creates the associated handle.
+  * @param  hcrc: CRC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRC_Init(CRC_HandleTypeDef *hcrc)
+{
+  /* Check the CRC handle allocation */
+  if(hcrc == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  assert_param(IS_CRC_INSTANCE(hcrc->Instance));
+   
+  if(hcrc->State == HAL_CRC_STATE_RESET)
+  {
+    /* Init the low level hardware */
+    HAL_CRC_MspInit(hcrc);
+  }
+  
+  /* Change CRC peripheral state */
+  hcrc->State = HAL_CRC_STATE_BUSY;
+  
+  /* check whether or not non-default generating polynomial has been 
+   * picked up by user */
+  assert_param(IS_DEFAULT_POLYNOMIAL(hcrc->Init.DefaultPolynomialUse)); 
+  if (hcrc->Init.DefaultPolynomialUse == DEFAULT_POLYNOMIAL_ENABLE)
+  {
+    /* initialize IP with default generating polynomial */
+    WRITE_REG(hcrc->Instance->POL, DEFAULT_CRC32_POLY);  
+    MODIFY_REG(hcrc->Instance->CR, CRC_CR_POLYSIZE, CRC_POLYLENGTH_32B);
+  }
+  else
+  {
+    /* initialize CRC IP with generating polynomial defined by user */
+    if (HAL_CRCEx_Polynomial_Set(hcrc, hcrc->Init.GeneratingPolynomial, hcrc->Init.CRCLength) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+  }
+  
+  /* check whether or not non-default CRC initial value has been 
+   * picked up by user */
+  assert_param(IS_DEFAULT_INIT_VALUE(hcrc->Init.DefaultInitValueUse));
+  if (hcrc->Init.DefaultInitValueUse == DEFAULT_INIT_VALUE_ENABLE)
+  {
+    WRITE_REG(hcrc->Instance->INIT, DEFAULT_CRC_INITVALUE);  
+  }
+  else
+  {
+    WRITE_REG(hcrc->Instance->INIT, hcrc->Init.InitValue);
+  }
+  
+
+  /* set input data inversion mode */
+  assert_param(IS_CRC_INPUTDATA_INVERSION_MODE(hcrc->Init.InputDataInversionMode)); 
+  MODIFY_REG(hcrc->Instance->CR, CRC_CR_REV_IN, hcrc->Init.InputDataInversionMode); 
+  
+  /* set output data inversion mode */
+  assert_param(IS_CRC_OUTPUTDATA_INVERSION_MODE(hcrc->Init.OutputDataInversionMode)); 
+  MODIFY_REG(hcrc->Instance->CR, CRC_CR_REV_OUT, hcrc->Init.OutputDataInversionMode);  
+  
+  /* makes sure the input data format (bytes, halfwords or words stream)
+   * is properly specified by user */
+  assert_param(IS_CRC_INPUTDATA_FORMAT(hcrc->InputDataFormat));
+  
+  /* Change CRC peripheral state */
+  hcrc->State = HAL_CRC_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the CRC peripheral. 
+  * @param  hcrc: CRC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRC_DeInit(CRC_HandleTypeDef *hcrc)
+{ 
+  /* Check the CRC handle allocation */
+  if(hcrc == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  assert_param(IS_CRC_INSTANCE(hcrc->Instance));
+  
+  /* Check the CRC peripheral state */
+  if(hcrc->State == HAL_CRC_STATE_BUSY)
+  {
+    return HAL_BUSY;
+  }
+  
+  /* Change CRC peripheral state */
+  hcrc->State = HAL_CRC_STATE_BUSY;
+
+  /* DeInit the low level hardware */
+  HAL_CRC_MspDeInit(hcrc);
+
+  /* Change CRC peripheral state */
+  hcrc->State = HAL_CRC_STATE_RESET;
+ 
+  /* Process unlocked */
+  __HAL_UNLOCK(hcrc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the CRC MSP.
+  * @param  hcrc: CRC handle
+  * @retval None
+  */
+__weak void HAL_CRC_MspInit(CRC_HandleTypeDef *hcrc)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_CRC_MspInit can be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes the CRC MSP.
+  * @param  hcrc: CRC handle
+  * @retval None
+  */
+__weak void HAL_CRC_MspDeInit(CRC_HandleTypeDef *hcrc)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_CRC_MspDeInit can be implemented in the user file
+   */
+}
+  
+
+/**
+  * @}
+  */
+
+/** @defgroup CRC_Group2 Peripheral Control functions 
+ *  @brief    management functions. 
+ *
+@verbatim   
+ ===============================================================================
+             ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+
+      (#) Compute the 7, 8, 16 or 32-bit CRC value of an 8, 16 or 32-bit data buffer
+          using combination of the previous CRC value and the new one.
+          
+          or
+          
+      (#) Compute the 7, 8, 16 or 32-bit CRC value of an 8, 16 or 32-bit data buffer
+          independently of the previous CRC value.
+
+@endverbatim
+  * @{
+  */
+
+/**                  
+  * @brief  Compute the 7, 8, 16 or 32-bit CRC value of an 8, 16 or 32-bit data buffer
+  *         starting with the previously computed CRC as initialization value.
+  * @param  hcrc: CRC handle
+  * @param  pBuffer: pointer to the input data buffer, exact input data format is
+  *         provided by hcrc->InputDataFormat.  
+  * @param  BufferLength: input data buffer length
+  * @retval uint32_t CRC (returned value LSBs for CRC shorter than 32 bits)
+  */
+uint32_t HAL_CRC_Accumulate(CRC_HandleTypeDef *hcrc, uint32_t pBuffer[], uint32_t BufferLength)
+{
+  uint32_t index = 0; /* CRC input data buffer index */
+  uint32_t temp = 0;  /* CRC output (read from hcrc->Instance->DR register) */
+  
+  /* Process locked */
+  __HAL_LOCK(hcrc); 
+    
+  /* Change CRC peripheral state */  
+  hcrc->State = HAL_CRC_STATE_BUSY;
+  
+  switch (hcrc->InputDataFormat)
+  {
+    case CRC_INPUTDATA_FORMAT_WORDS:  
+      /* Enter Data to the CRC calculator */
+      for(index = 0; index < BufferLength; index++)
+      {
+        hcrc->Instance->DR = pBuffer[index];
+      }
+      temp = hcrc->Instance->DR;
+      break;
+      
+    case CRC_INPUTDATA_FORMAT_BYTES: 
+      temp = CRC_Handle_8(hcrc, (uint8_t*)pBuffer, BufferLength);
+      break;
+      
+    case CRC_INPUTDATA_FORMAT_HALFWORDS: 
+      temp = CRC_Handle_16(hcrc, (uint16_t*)pBuffer, BufferLength);
+      break;
+    default:
+      break;  
+  }
+  
+  /* Change CRC peripheral state */    
+  hcrc->State = HAL_CRC_STATE_READY; 
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hcrc);
+  
+  /* Return the CRC computed value */ 
+  return temp;
+}
+
+
+/**                  
+  * @brief  Compute the 7, 8, 16 or 32-bit CRC value of an 8, 16 or 32-bit data buffer
+  *         starting with hcrc->Instance->INIT as initialization value.
+  * @param  hcrc: CRC handle
+  * @param  pBuffer: pointer to the input data buffer, exact input data format is
+  *         provided by hcrc->InputDataFormat.  
+  * @param  BufferLength: input data buffer length
+  * @retval uint32_t CRC (returned value LSBs for CRC shorter than 32 bits)
+  */  
+uint32_t HAL_CRC_Calculate(CRC_HandleTypeDef *hcrc, uint32_t pBuffer[], uint32_t BufferLength)
+{
+  uint32_t index = 0; /* CRC input data buffer index */
+  uint32_t temp = 0;  /* CRC output (read from hcrc->Instance->DR register) */
+    
+  /* Process locked */
+  __HAL_LOCK(hcrc); 
+  
+  /* Change CRC peripheral state */  
+  hcrc->State = HAL_CRC_STATE_BUSY;
+  
+  /* Reset CRC Calculation Unit (hcrc->Instance->INIT is 
+  *  written in hcrc->Instance->DR) */
+  __HAL_CRC_DR_RESET(hcrc);
+  
+  switch (hcrc->InputDataFormat)
+  {
+    case CRC_INPUTDATA_FORMAT_WORDS:  
+      /* Enter 32-bit input data to the CRC calculator */
+      for(index = 0; index < BufferLength; index++)
+      {
+        hcrc->Instance->DR = pBuffer[index];
+      }
+      temp = hcrc->Instance->DR;
+      break;
+      
+    case CRC_INPUTDATA_FORMAT_BYTES: 
+      /* Specific 8-bit input data handling  */
+      temp = CRC_Handle_8(hcrc, (uint8_t*)pBuffer, BufferLength);
+      break;
+      
+    case CRC_INPUTDATA_FORMAT_HALFWORDS: 
+      /* Specific 16-bit input data handling  */
+      temp = CRC_Handle_16(hcrc, (uint16_t*)pBuffer, BufferLength);
+      break;
+    default:
+      break;
+  }
+
+  /* Change CRC peripheral state */    
+  hcrc->State = HAL_CRC_STATE_READY; 
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hcrc);
+  
+  /* Return the CRC computed value */ 
+  return temp;
+}
+
+
+
+/**
+  * @}
+  */
+
+/** @defgroup CRC_Group3 Peripheral State functions 
+ *  @brief    Peripheral State functions. 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================  
+    [..]
+    This subsection permits to get in run-time the status of the peripheral 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the CRC state.
+  * @param  hcrc: CRC handle
+  * @retval HAL state
+  */
+HAL_CRC_StateTypeDef HAL_CRC_GetState(CRC_HandleTypeDef *hcrc)
+{
+  return hcrc->State;
+}
+
+/**
+  * @}
+  */
+
+/**             
+  * @brief  Enter 8-bit input data to the CRC calculator.
+  *         Specific data handling to optimize processing time.  
+  * @param  hcrc: CRC handle
+  * @param  pBuffer: pointer to the input data buffer
+  * @param  BufferLength: input data buffer length
+  * @retval uint32_t CRC (returned value LSBs for CRC shorter than 32 bits)
+  */
+static uint32_t CRC_Handle_8(CRC_HandleTypeDef *hcrc, uint8_t pBuffer[], uint32_t BufferLength)
+{
+  uint32_t i; /* input data buffer index */
+  
+   /* Processing time optimization: 4 bytes are entered in a row with a single word write,
+    * last bytes must be carefully fed to the CRC calculator to ensure a correct type
+    * handling by the IP */
+   for(i = 0; i < (BufferLength/4); i++)
+   {
+     hcrc->Instance->DR = (uint32_t)(((uint32_t)(pBuffer[4*i])<<24) | ((uint32_t)(pBuffer[4*i+1])<<16) | ((uint32_t)(pBuffer[4*i+2])<<8) | (uint32_t)(pBuffer[4*i+3]));
+   }
+   /* last bytes specific handling */
+   if ((BufferLength%4) != 0)
+   {
+     if  (BufferLength%4 == 1)
+     {
+       *(__IO uint8_t*) (&hcrc->Instance->DR) = pBuffer[4*i];
+     }
+     if  (BufferLength%4 == 2)
+     {
+       *(__IO uint16_t*) (&hcrc->Instance->DR) = (uint16_t)(((uint32_t)(pBuffer[4*i])<<8) | (uint32_t)(pBuffer[4*i+1]));
+     }
+     if  (BufferLength%4 == 3)
+     {
+       *(__IO uint16_t*) (&hcrc->Instance->DR) = (uint16_t)(((uint32_t)(pBuffer[4*i])<<8) | (uint32_t)(pBuffer[4*i+1]));
+       *(__IO uint8_t*) (&hcrc->Instance->DR) = pBuffer[4*i+2];       
+     }
+   }
+  
+  /* Return the CRC computed value */ 
+  return hcrc->Instance->DR;
+}
+
+/**             
+  * @brief  Enter 16-bit input data to the CRC calculator.
+  *         Specific data handling to optimize processing time.  
+  * @param  hcrc: CRC handle
+  * @param  pBuffer: pointer to the input data buffer
+  * @param  BufferLength: input data buffer length
+  * @retval uint32_t CRC (returned value LSBs for CRC shorter than 32 bits)
+  */  
+static uint32_t CRC_Handle_16(CRC_HandleTypeDef *hcrc, uint16_t pBuffer[], uint32_t BufferLength)
+{
+  uint32_t i ;  /* input data buffer index */
+  
+  /* Processing time optimization: 2 HalfWords are entered in a row with a single word write,
+   * in case of odd length, last HalfWord must be carefully fed to the CRC calculator to ensure 
+   * a correct type handling by the IP */
+  for(i = 0; i < (BufferLength/2); i++)
+  {
+     hcrc->Instance->DR = (((uint32_t)(pBuffer[2*i])<<16) | (uint32_t)(pBuffer[2*i+1]));
+  }
+  if ((BufferLength%2) != 0)
+  {
+       *(__IO uint16_t*) (&hcrc->Instance->DR) = pBuffer[2*i]; 
+  }
+   
+  /* Return the CRC computed value */ 
+  return hcrc->Instance->DR;
+}
+/**
+  * @}
+  */
+
+#endif /* HAL_CRC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_crc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_crc.h
@@ -1,0 +1,346 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_crc.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of CRC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_CRC_H
+#define __STM32L0xx_HAL_CRC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup CRC
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+
+/** 
+  * @brief  CRC HAL State Structure definition  
+  */ 
+typedef enum
+{
+  HAL_CRC_STATE_RESET     = 0x00,   /*!< CRC Reset State                   */
+  HAL_CRC_STATE_READY     = 0x01,   /*!< CRC Initialized and ready for use */
+  HAL_CRC_STATE_BUSY      = 0x02,   /*!< CRC process is ongoing            */
+  HAL_CRC_STATE_TIMEOUT   = 0x03,   /*!< CRC Timeout State                 */
+  HAL_CRC_STATE_ERROR     = 0x04    /*!< CRC Error State                   */
+}HAL_CRC_StateTypeDef;
+
+/** 
+  * @brief CRC Init Structure definition  
+  */ 
+typedef struct
+{
+  uint8_t DefaultPolynomialUse;       /*!< This parameter is a value of @ref CRC_Default_Polynomial and indicates if default polynomial is used.  
+                                            If set to DEFAULT_POLYNOMIAL_ENABLE, resort to default 
+                                            X^32 + X^26 + X^23 + X^22 + X^16 + X^12 + X^11 + X^10 +X^8 + X^7 + X^5 + X^4 + X^2+ X +1. 
+                                            In that case, there is no need to set GeneratingPolynomial field.
+                                            If otherwise set to DEFAULT_POLYNOMIAL_DISABLE, GeneratingPolynomial and CRCLength fields must be set */
+
+  uint8_t DefaultInitValueUse;        /*!< This parameter is a value of @ref CRC_Default_InitValue_Use and indicates if default init value is used. 
+                                           If set to DEFAULT_INIT_VALUE_ENABLE, resort to default
+                                           0xFFFFFFFF value. In that case, there is no need to set InitValue field.   
+                                           If otherwise set to DEFAULT_INIT_VALUE_DISABLE,  InitValue field must be set */
+
+  uint32_t GeneratingPolynomial;      /*!< Set CRC generating polynomial. 7, 8, 16 or 32-bit long value for a polynomial degree
+                                           respectively equal to 7, 8, 16 or 32. This field is written in normal representation, 
+                                           e.g., for a polynomial of degree 7, X^7 + X^6 + X^5 + X^2 + 1 is written 0x65.
+                                           No need to specify it if DefaultPolynomialUse is set to DEFAULT_POLYNOMIAL_ENABLE   */                                                
+
+  uint32_t CRCLength;                 /*!< This parameter is a value of @ref CRC_Polynomial_Size_Definitions and indicates CRC length. 
+                                           Value can be either one of
+                                           CRC_POLYLENGTH_32B                  (32-bit CRC)
+                                           CRC_POLYLENGTH_16B                  (16-bit CRC)
+                                           CRC_POLYLENGTH_8B                   (8-bit CRC)
+                                           CRC_POLYLENGTH_7B                   (7-bit CRC) */
+                                              
+  uint32_t InitValue;                 /*!< Init value to initiate CRC computation. No need to specify it if DefaultInitValueUse 
+                                           is set to DEFAULT_INIT_VALUE_ENABLE   */                                                
+                                              
+  uint32_t InputDataInversionMode;    /*!< This parameter is a value of @ref CRC_Input_Data_Inversion and specifies input data inversion mode. 
+                                           Can be either one of the following values 
+                                           CRC_INPUTDATA_INVERSION_NONE      no input data inversion
+                                           CRC_INPUTDATA_INVERSION_BYTE      byte-wise inversion, 0x1A2B3C4D becomes 0x58D43CB2
+                                           CRC_INPUTDATA_INVERSION_HALFWORD  halfword-wise inversion, 0x1A2B3C4D becomes 0xD458B23C
+                                           CRC_INPUTDATA_INVERSION_WORD      word-wise inversion, 0x1A2B3C4D becomes 0xB23CD458 */  
+                                              
+  uint32_t OutputDataInversionMode;   /*!< This parameter is a value of @ref CRC_Output_Data_Inversion and specifies output data (i.e. CRC) inversion mode.
+                                            Can be either 
+                                            CRC_OUTPUTDATA_INVERSION_DISABLED   no CRC inversion, or 
+                                            CRC_OUTPUTDATA_INVERSION_ENABLED    CRC 0x11223344 is converted into 0x22CC4488 */                                           
+}CRC_InitTypeDef;
+
+
+/** 
+  * @brief  CRC Handle Structure definition  
+  */ 
+typedef struct
+{
+  CRC_TypeDef                 *Instance;   /*!< Register base address        */ 
+
+  CRC_InitTypeDef             Init;        /*!< CRC configuration parameters */
+
+  HAL_LockTypeDef             Lock;        /*!< CRC Locking object           */
+
+  __IO HAL_CRC_StateTypeDef   State;       /*!< CRC communication state      */
+
+  uint32_t InputDataFormat;                /*!< This parameter is a value of @ref CRC_Input_Buffer_Format and specifies input data format. 
+                                            Can be either 
+                                            CRC_INPUTDATA_FORMAT_BYTES       input data is a stream of bytes (8-bit data)
+                                            CRC_INPUTDATA_FORMAT_HALFWORDS   input data is a stream of half-words (16-bit data)
+                                            CRC_INPUTDATA_FORMAT_WORDS       input data is a stream of words (32-bits data)                                                                                        
+                                           Note that constant CRC_INPUT_FORMAT_UNDEFINED is defined but an initialization error
+                                           must occur if InputBufferFormat is not one of the three values listed above  */ 
+}CRC_HandleTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup CRC_Exported_Constants
+  * @{
+  */
+  
+/** @defgroup CRC_Default_Polynomial_Value
+  * @{
+  */
+#define DEFAULT_CRC32_POLY      0x04C11DB7
+
+/**
+  * @}
+  */
+
+/** @defgroup CRC_Default_Init_Value
+  * @{
+  */
+#define DEFAULT_CRC_INITVALUE   0xFFFFFFFF
+
+/**
+  * @}
+  */
+
+/** @defgroup CRC_Default_Polynomial
+  * @{
+  */
+#define DEFAULT_POLYNOMIAL_ENABLE       ((uint8_t)0x00)
+#define DEFAULT_POLYNOMIAL_DISABLE      ((uint8_t)0x01)
+#define IS_DEFAULT_POLYNOMIAL(DEFAULT) (((DEFAULT) == DEFAULT_POLYNOMIAL_ENABLE) || \
+                                        ((DEFAULT) == DEFAULT_POLYNOMIAL_DISABLE))
+/**
+  * @}
+  */
+ 
+/** @defgroup CRC_Default_InitValue_Use
+  * @{
+  */                                      
+#define DEFAULT_INIT_VALUE_ENABLE      ((uint8_t)0x00)
+#define DEFAULT_INIT_VALUE_DISABLE     ((uint8_t)0x01)
+#define IS_DEFAULT_INIT_VALUE(VALUE)  (((VALUE) == DEFAULT_INIT_VALUE_ENABLE) || \
+                                       ((VALUE) == DEFAULT_INIT_VALUE_DISABLE))
+
+/**
+  * @}
+  */
+
+/** @defgroup CRC_Polynomial_Sizes
+  * @{
+  */
+#define CRC_POLYLENGTH_32B                  ((uint32_t)0x00000000)
+#define CRC_POLYLENGTH_16B                  ((uint32_t)CRC_CR_POLYSIZE_0)
+#define CRC_POLYLENGTH_8B                   ((uint32_t)CRC_CR_POLYSIZE_1)
+#define CRC_POLYLENGTH_7B                   ((uint32_t)CRC_CR_POLYSIZE)
+#define IS_CRC_POL_LENGTH(LENGTH)     (((LENGTH) == CRC_POLYLENGTH_32B) || \
+                                       ((LENGTH) == CRC_POLYLENGTH_16B) || \
+                                       ((LENGTH) == CRC_POLYLENGTH_8B)  || \
+                                       ((LENGTH) == CRC_POLYLENGTH_7B))  
+/**
+  * @}
+  */
+
+/** @defgroup CRC_Polynomial_Size_Definitions
+  * @{
+  */
+#define HAL_CRC_LENGTH_32B     32
+#define HAL_CRC_LENGTH_16B     16
+#define HAL_CRC_LENGTH_8B       8
+#define HAL_CRC_LENGTH_7B       7
+
+/**
+  * @}
+  */  
+
+/** @defgroup CRC_Input_Data_Inversion
+  * @{
+  */
+#define CRC_INPUTDATA_INVERSION_NONE              ((uint32_t)0x00000000)
+#define CRC_INPUTDATA_INVERSION_BYTE              ((uint32_t)CRC_CR_REV_IN_0)
+#define CRC_INPUTDATA_INVERSION_HALFWORD          ((uint32_t)CRC_CR_REV_IN_1)
+#define CRC_INPUTDATA_INVERSION_WORD              ((uint32_t)CRC_CR_REV_IN)
+#define IS_CRC_INPUTDATA_INVERSION_MODE(MODE)     (((MODE) == CRC_INPUTDATA_INVERSION_NONE) || \
+                                                   ((MODE) == CRC_INPUTDATA_INVERSION_BYTE) || \
+                                                   ((MODE) == CRC_INPUTDATA_INVERSION_HALFWORD) || \
+                                                   ((MODE) == CRC_INPUTDATA_INVERSION_WORD))  
+/**
+  * @}
+  */  
+  
+/** @defgroup CRC_Output_Data_Inversion
+  * @{
+  */
+#define CRC_OUTPUTDATA_INVERSION_DISABLED         ((uint32_t)0x00000000)
+#define CRC_OUTPUTDATA_INVERSION_ENABLED          ((uint32_t)CRC_CR_REV_OUT)
+#define IS_CRC_OUTPUTDATA_INVERSION_MODE(MODE)    (((MODE) == CRC_OUTPUTDATA_INVERSION_DISABLED) || \
+                                                   ((MODE) == CRC_OUTPUTDATA_INVERSION_ENABLED))
+/**
+  * @}
+  */
+
+/** @defgroup CRC_Input_Buffer_Format
+  * @{
+  */
+/* WARNING: CRC_INPUT_FORMAT_UNDEFINED is created for reference purposes but
+ * an error is triggered in HAL_CRC_Init() if InputDataFormat field is set 
+ * to CRC_INPUT_FORMAT_UNDEFINED: the format MUST be defined by the user for 
+ * the CRC APIs to provide a correct result */   
+#define CRC_INPUTDATA_FORMAT_UNDEFINED             ((uint32_t)0x00000000)
+#define CRC_INPUTDATA_FORMAT_BYTES                 ((uint32_t)0x00000001)
+#define CRC_INPUTDATA_FORMAT_HALFWORDS             ((uint32_t)0x00000002)
+#define CRC_INPUTDATA_FORMAT_WORDS                 ((uint32_t)0x00000003)
+#define IS_CRC_INPUTDATA_FORMAT(FORMAT)           (((FORMAT) == CRC_INPUTDATA_FORMAT_BYTES) || \
+                                                   ((FORMAT) == CRC_INPUTDATA_FORMAT_HALFWORDS) || \
+                                                   ((FORMAT) == CRC_INPUTDATA_FORMAT_WORDS))
+/** 
+  * @}
+  */   
+
+/** 
+  * @}
+  */ 
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup CRC_Exported_Macro
+  * @{
+  */
+
+/** @brief Reset CRC handle state
+  * @param  __HANDLE__: CRC handle
+  * @retval None
+  */
+#define __HAL_CRC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_CRC_STATE_RESET)
+
+/**
+  * @brief  Check that instance is correctly set to CRC
+  * @param  __PERIPH__: CRC handle instance
+  * @retval None.
+  */
+#define IS_CRC_INSTANCE(__PERIPH__)     ((__PERIPH__) == CRC)
+
+/**
+  * @brief  Reset CRC Data Register.
+  * @param  __HANDLE__: CRC handle
+  * @retval None.
+  */
+#define __HAL_CRC_DR_RESET(__HANDLE__) ((__HANDLE__)->Instance->CR |= CRC_CR_RESET)
+
+/**
+  * @brief  Set CRC INIT non-default value
+  * @param  __HANDLE__    : CRC handle
+  * @param  __INIT__      : 32-bit initial value  
+  * @retval None.
+  */
+#define __HAL_CRC_INITIALCRCVALUE_CONFIG(__HANDLE__, __INIT__) ((__HANDLE__)->Instance->INIT = (__INIT__))    
+
+
+/**
+  * @brief  Set CRC output reversal
+  * @param  __HANDLE__    : CRC handle
+  * @retval None.
+  */
+#define  __HAL_CRC_OUTPUTREVERSAL_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR |= CRC_CR_REV_OUT)   
+
+
+/**
+  * @brief  Unset CRC output reversal
+  * @param  __HANDLE__    : CRC handle
+  * @retval None.
+  */
+#define __HAL_CRC_OUTPUTREVERSAL_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR &= ~(CRC_CR_REV_OUT))   
+
+
+/**
+  * @}
+  */
+
+
+/* Include CRC HAL Extension module */
+#include "stm32l0xx_hal_crc_ex.h"  
+
+/* Exported functions --------------------------------------------------------*/
+
+/* Initialization and de-initialization functions  ****************************/
+HAL_StatusTypeDef HAL_CRC_Init(CRC_HandleTypeDef *hcrc);
+HAL_StatusTypeDef HAL_CRC_DeInit (CRC_HandleTypeDef *hcrc);
+void HAL_CRC_MspInit(CRC_HandleTypeDef *hcrc);
+void HAL_CRC_MspDeInit(CRC_HandleTypeDef *hcrc);
+
+/* Peripheral Control functions ***********************************************/
+uint32_t HAL_CRC_Accumulate(CRC_HandleTypeDef *hcrc, uint32_t pBuffer[], uint32_t BufferLength);
+uint32_t HAL_CRC_Calculate(CRC_HandleTypeDef *hcrc, uint32_t pBuffer[], uint32_t BufferLength);
+
+/* Peripheral State and Error functions ***************************************/
+HAL_CRC_StateTypeDef HAL_CRC_GetState(CRC_HandleTypeDef *hcrc);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_CRC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_crc_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_crc_ex.c
@@ -1,0 +1,249 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_crc_ex.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Extended CRC HAL module driver.
+  *    
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the CRC peripheral:
+  *           + Initialization/de-initialization functions
+  *         
+  @verbatim
+  ==============================================================================
+                    ##### CRC specific features #####
+  ==============================================================================
+  [..] 
+  (#) Polynomial configuration.
+
+
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+
+    (#) Enable CRC AHB clock using __CRC_CLK_ENABLE();
+
+    (#) Initialize CRC calculator
+         (++) specify generating polynomial (IP default or non-default one)
+         (++) specify initialization value (IP default or non-default one)
+         (++) specify input data format
+         (++) specify input or output data inversion mode if any
+
+    (#) Use HAL_CRC_Accumulate() function to compute the CRC value of the 
+        input data buffer starting with the previously computed CRC as 
+        initialization value
+
+    (#) Use HAL_CRC_Calculate() function to compute the CRC value of the 
+        input data buffer starting with the defined initialization value 
+        (default or non-default) to initiate CRC calculation
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup CRCEx 
+  * @brief CRC driver modules
+  * @{
+  */ 
+
+#ifdef HAL_CRC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+
+/** @defgroup CRCEx_Group CRC Extended features functions
+ *  @brief    CRC Extended features functions 
+ *
+@verbatim   
+ ===============================================================================
+            ##### CRC Extended features functions #####
+ ===============================================================================  
+    [..]
+This subsection provides function allowing to:
+      (+) Set CRC polynomial if different from default one.
+ 
+@endverbatim
+  * @{
+  */
+
+
+/**
+  * @brief  Initializes the CRC polynomial if different from default one.
+  * @param  hcrc: CRC handle
+  * @param  Pol: CRC generating polynomial (7, 8, 16 or 32-bit long)
+  *         This parameter is written in normal representation, e.g.
+  *         for a polynomial of degree 7, X^7 + X^6 + X^5 + X^2 + 1 is written 0x65 
+  *         for a polynomial of degree 16, X^16 + X^12 + X^5 + 1 is written 0x1021     
+  * @param  PolyLength: CRC polynomial length 
+  *         This parameter can be one of the following values:
+  *          @arg CRC_POLYLENGTH_7B: 7-bit long CRC (generating polynomial of degree 7)
+  *          @arg CRC_POLYLENGTH_8B: 8-bit long CRC (generating polynomial of degree 8)
+  *          @arg CRC_POLYLENGTH_16B: 16-bit long CRC (generating polynomial of degree 16)
+  *          @arg CRC_POLYLENGTH_32B: 32-bit long CRC (generating polynomial of degree 32)                
+  * @retval HAL status
+  */                                   
+HAL_StatusTypeDef HAL_CRCEx_Polynomial_Set(CRC_HandleTypeDef *hcrc, uint32_t Pol, uint32_t PolyLength)
+{
+  uint32_t msb = 31; /* polynomial degree is 32 at most, so msb is initialized to max value */
+
+  /* Check the parameters */
+  assert_param(IS_CRC_POL_LENGTH(PolyLength));
+  
+  /* check polynomial definition vs polynomial size:
+   * polynomial length must be aligned with polynomial
+   * definition. HAL_ERROR is reported if Pol degree is 
+   * larger than that indicated by PolyLength.
+   * Look for MSB position: msb will contain the degree of
+   *  the second to the largest polynomial member. E.g., for
+   *  X^7 + X^6 + X^5 + X^2 + 1, msb = 6. */
+  while (((Pol & ((uint32_t)(0x1) << msb)) == 0) && (msb-- > 0))
+  {
+  }
+
+  switch (PolyLength)
+  {
+    case CRC_POLYLENGTH_7B:
+      if (msb >= HAL_CRC_LENGTH_7B) 
+      {
+        return  HAL_ERROR;
+      }
+      break;
+    case CRC_POLYLENGTH_8B:
+      if (msb >= HAL_CRC_LENGTH_8B) 
+      {
+        return  HAL_ERROR;
+      }
+      break;
+    case CRC_POLYLENGTH_16B:
+      if (msb >= HAL_CRC_LENGTH_16B) 
+      {
+        return  HAL_ERROR;
+      }
+      break;
+    case CRC_POLYLENGTH_32B:
+      /* no polynomial definition vs. polynomial length issue possible */
+      break;
+  default:
+      break;
+  }
+
+  /* set generating polynomial */
+  WRITE_REG(hcrc->Instance->POL, Pol);
+  
+  /* set generating polynomial size */
+  MODIFY_REG(hcrc->Instance->CR, CRC_CR_POLYSIZE, PolyLength);  
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the Reverse Input data mode.
+  * @param  hcrc: CRC handle
+  * @param  InputReverseMode: Input Data inversion mode
+  *         This parameter can be one of the following values:
+  *          @arg CRC_INPUTDATA_INVERSION_NONE: no change in bit order (default value)
+  *          @arg CRC_INPUTDATA_INVERSION_BYTE: Byte-wise bit reversal
+  *          @arg CRC_INPUTDATA_INVERSION_HALFWORD: HalfWord-wise bit reversal
+  *          @arg CRC_INPUTDATA_INVERSION_WORD: Word-wise bit reversal              
+  * @retval HAL status
+  */                                   
+HAL_StatusTypeDef HAL_CRC_Input_Data_Reverse(CRC_HandleTypeDef *hcrc, uint32_t InputReverseMode)
+{  
+  /* Check the parameters */
+  assert_param(IS_CRC_INPUTDATA_INVERSION_MODE(InputReverseMode));
+  
+  /* Change CRC peripheral state */
+  hcrc->State = HAL_CRC_STATE_BUSY;
+
+  /* set input data inversion mode */
+  MODIFY_REG(hcrc->Instance->CR, CRC_CR_REV_IN, InputReverseMode);    
+  /* Change CRC peripheral state */
+  hcrc->State = HAL_CRC_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the Reverse Output data mode.
+  * @param  hcrc: CRC handle
+  * @param  OutputReverseMode: Output Data inversion mode
+  *         This parameter can be one of the following values:
+  *          @arg CRC_OUTPUTDATA_INVERSION_DISABLED: no CRC inversion (default value)
+  *          @arg CRC_OUTPUTDATA_INVERSION_ENABLED: bit-level inversion (e.g for a 8-bit CRC: 0xB5 becomes 0xAD)            
+  * @retval HAL status
+  */                                   
+HAL_StatusTypeDef HAL_CRC_Output_Data_Reverse(CRC_HandleTypeDef *hcrc, uint32_t OutputReverseMode)
+{
+  /* Check the parameters */
+  assert_param(IS_CRC_OUTPUTDATA_INVERSION_MODE(OutputReverseMode));
+  
+  /* Change CRC peripheral state */
+  hcrc->State = HAL_CRC_STATE_BUSY;
+
+  /* set output data inversion mode */
+  MODIFY_REG(hcrc->Instance->CR, CRC_CR_REV_OUT, OutputReverseMode); 
+      
+  /* Change CRC peripheral state */
+  hcrc->State = HAL_CRC_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+
+#endif /* HAL_CRC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_crc_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_crc_ex.h
@@ -1,0 +1,104 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_crc_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of CRC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_CRC_EX_H
+#define __STM32L0xx_HAL_CRC_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup CRCEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+/* Exported constants --------------------------------------------------------*/
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup CRCEx_Extended_Exported_Macro
+  * @{
+  */
+
+
+/**
+  * @brief  Set CRC non-default polynomial
+  * @param  __HANDLE__    : CRC handle
+  * @param  __POLYNOMIAL__: 7, 8, 16 or 32-bit polynomial  
+  * @retval None.
+  */
+#define __HAL_CRC_POLYNOMIAL_CONFIG(__HANDLE__, __POLYNOMIAL__) ((__HANDLE__)->Instance->POL = (__POLYNOMIAL__))
+    
+    
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/* Initialization and de-initialization functions  ****************************/
+HAL_StatusTypeDef HAL_CRCEx_Polynomial_Set(CRC_HandleTypeDef *hcrc, uint32_t Pol, uint32_t PolyLength);
+HAL_StatusTypeDef HAL_CRC_Input_Data_Reverse(CRC_HandleTypeDef *hcrc, uint32_t InputReverseMode);
+HAL_StatusTypeDef HAL_CRC_Output_Data_Reverse(CRC_HandleTypeDef *hcrc, uint32_t OutputReverseMode);
+
+/* Peripheral Control functions ***********************************************/
+/* Peripheral State and Error functions ***************************************/
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_CRC_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_cryp.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_cryp.c
@@ -1,0 +1,2072 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_cryp.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   CRYP HAL module driver.
+  *    
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Cryptography (CRYP) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + Processing functions by algorithm using polling mode
+  *           + Processing functions by algorithm using interrupt mode
+  *           + Processing functions by algorithm using DMA mode
+  *           + Peripheral State functions
+  *         
+  @verbatim
+  ==============================================================================
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      The CRYP HAL driver can be used as follows:
+
+      (#)Initialize the CRYP low level resources by implementing the HAL_CRYP_MspInit():
+         (##) Enable the CRYP interface clock using __CRYP_CLK_ENABLE()
+         (##) In case of using interrupts (e.g. HAL_AES_ECB_Encrypt_IT())
+             (+) Configure the CRYP interrupt priority using HAL_NVIC_SetPriority()
+             (+) Enable the CRYP IRQ handler using HAL_NVIC_EnableIRQ()
+             (+) In CRYP IRQ handler, call HAL_CRYP_IRQHandler()
+         (##) In case of using DMA to control data transfer (e.g. HAL_AES_ECB_Encrypt_DMA())
+             (+) Enable the DMA1 interface clock using 
+                 (++) __DMA1_CLK_ENABLE()
+             (+) Configure and enable two DMA Channels one for managing data transfer from
+                 memory to peripheral (input channel) and another channel for managing data
+                 transfer from peripheral to memory (output channel)
+             (+) Associate the initilalized DMA handle to the CRYP DMA handle
+                 using  __HAL_LINKDMA()
+             (+) Configure the priority and enable the NVIC for the transfer complete
+                 interrupt on the two DMA Streams. The output stream should have higher
+                 priority than the input stream.
+                 (++) HAL_NVIC_SetPriority()
+                 (++) HAL_NVIC_EnableIRQ()
+    
+      (#)Initialize the CRYP HAL using HAL_CRYP_Init(). This function configures mainly:
+         (##) The data type: 1-bit, 8-bit, 16-bit and 32-bit
+         (##) The encryption/decryption key.
+         (##) The initialization vector (counter). It is not used ECB mode.
+    
+      (#)Three processing (encryption/decryption) functions are available:
+         (##) Polling mode: encryption and decryption APIs are blocking functions
+              i.e. they process the data and wait till the processing is finished
+              e.g. HAL_CRYP_AESCBC_Encrypt()
+         (##) Interrupt mode: encryption and decryption APIs are not blocking functions
+              i.e. they process the data under interrupt
+              e.g. HAL_CRYP_AESCBC_Encrypt_IT()
+         (##) DMA mode: encryption and decryption APIs are not blocking functions
+              i.e. the data transfer is ensured by DMA
+              e.g. HAL_CRYP_AESCBC_Encrypt_DMA()
+    
+      (#)When the processing function is called at first time after HAL_CRYP_Init()
+         the CRYP peripheral is initialized and processes the buffer in input.
+         At second call, the processing function performs an append of the already
+         processed buffer.
+         When a new data block is to be processed, call HAL_CRYP_Init() then the
+         processing function.
+         
+       (#)Call HAL_CRYP_DeInit() to deinitialize the CRYP peripheral.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup CRYP 
+  * @brief CRYP HAL module driver.
+  * @{
+  */
+
+#ifdef HAL_CRYP_MODULE_ENABLED
+#if !defined (STM32L051xx) && !defined (STM32L052xx) && !defined (STM32L053xx)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define  CRYP_ALGO_CHAIN_MASK         (AES_CR_MODE | AES_CR_CHMOD)
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void CRYP_SetInitVector(CRYP_HandleTypeDef *hcryp, uint8_t *InitVector);
+static void CRYP_SetKey(CRYP_HandleTypeDef *hcryp, uint8_t *Key);
+static HAL_StatusTypeDef CRYP_ProcessData(CRYP_HandleTypeDef *hcryp, uint8_t* Input, uint16_t Ilength, uint8_t* Output, uint32_t Timeout);
+static void CRYP_DMAInCplt(DMA_HandleTypeDef *hdma);
+static void CRYP_DMAOutCplt(DMA_HandleTypeDef *hdma);
+static void CRYP_DMAError(DMA_HandleTypeDef *hdma);
+static void CRYP_SetDMAConfig(CRYP_HandleTypeDef *hcryp, uint32_t inputaddr, uint16_t Size, uint32_t outputaddr);
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup CRYP_Private_Functions
+  * @{
+  */
+
+/** @defgroup CRYP_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions. 
+ *
+@verbatim    
+  ==============================================================================
+              ##### Initialization and de-initialization functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize the CRYP according to the specified parameters 
+          in the CRYP_InitTypeDef and creates the associated handle
+      (+) DeInitialize the CRYP peripheral
+      (+) Initialize the CRYP MSP
+      (+) DeInitialize CRYP MSP 
+ 
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the CRYP according to the specified
+  *         parameters in the CRYP_InitTypeDef and creates the associated handle.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_Init(CRYP_HandleTypeDef *hcryp)
+{  
+  /* Check the CRYP handle allocation */
+  if(hcryp == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_CRYP_DATATYPE(hcryp->Init.DataType));
+  
+  if(hcryp->State == HAL_CRYP_STATE_RESET)
+  {
+    /* Init the low level hardware */
+    HAL_CRYP_MspInit(hcryp);
+  }
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_BUSY;  
+  
+  /* Set the data type*/
+  AES->CR = hcryp->Init.DataType;
+  
+  /* Reset CrypInCount and CrypOutCount */
+  hcryp->CrypInCount = 0;
+  hcryp->CrypOutCount = 0;
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_READY;
+  
+  /* Set the default CRYP phase */
+  hcryp->Phase = HAL_CRYP_PHASE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the CRYP peripheral. 
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_DeInit(CRYP_HandleTypeDef *hcryp)
+{
+  /* Check the CRYP handle allocation */
+  if(hcryp == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_BUSY;
+  
+  /* Set the default CRYP phase */
+  hcryp->Phase = HAL_CRYP_PHASE_READY;
+  
+  /* Reset CrypInCount and CrypOutCount */
+  hcryp->CrypInCount = 0;
+  hcryp->CrypOutCount = 0;
+  
+  /* Disable the CRYP Peripheral Clock */
+  __HAL_CRYP_DISABLE();
+  
+  /* DeInit the low level hardware: CLOCK, NVIC.*/
+  HAL_CRYP_MspDeInit(hcryp);
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(hcryp);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the CRYP MSP.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @retval None
+  */
+__weak void HAL_CRYP_MspInit(CRYP_HandleTypeDef *hcryp)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_CRYP_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes CRYP MSP.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @retval None
+  */
+__weak void HAL_CRYP_MspDeInit(CRYP_HandleTypeDef *hcryp)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_CRYP_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup CRYP_Group2 AES processing functions 
+ *  @brief   processing functions. 
+ *
+@verbatim   
+  ==============================================================================
+                      ##### AES processing functions #####
+  ==============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Encrypt plaintext using AES algorithm in different chaining modes
+      (+) Decrypt cyphertext using AES algorithm in different chaining modes
+    [..]  Three processing functions are available:
+      (+) Polling mode
+      (+) Interrupt mode
+      (+) DMA mode
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES ECB encryption mode
+  *         then encrypt pPlainData. The cypher data are available in pCypherData
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16.
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @param  Timeout: Specify Timeout value 
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESECB_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData, uint32_t Timeout)
+{
+  /* Process Locked */
+  __HAL_LOCK(hcryp);
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_BUSY;
+  
+  /* Check if initialization phase has already been performed */
+  if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+  {
+    /* Set the key */
+    CRYP_SetKey(hcryp, hcryp->Init.pKey);
+    
+    /* Reset the CHMOD & MODE bits & */
+    AES->CR &= (uint32_t)(~CRYP_ALGO_CHAIN_MASK);
+    
+    /* Set the CRYP peripheral in AES ECB mode */
+    __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_ECB_ENCRYPT);
+    
+    /* Enable CRYP */
+    __HAL_CRYP_ENABLE();
+    
+    /* Set the phase */
+    hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+  }
+  
+  /* Write Plain Data and Get Cypher Data */
+  if(CRYP_ProcessData(hcryp,pPlainData, Size, pCypherData, Timeout) != HAL_OK)
+  {
+    return HAL_TIMEOUT;
+  }
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hcryp);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES CBC encryption mode
+  *         then encrypt pPlainData. The cypher data are available in pCypherData
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16.
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @param  Timeout: Specify Timeout value  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESCBC_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData, uint32_t Timeout)
+{
+  /* Process Locked */
+  __HAL_LOCK(hcryp);
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_BUSY;
+  
+  /* Check if initialization phase has already been performed */
+  if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+  {
+    /* Set the key */
+    CRYP_SetKey(hcryp, hcryp->Init.pKey);
+    
+    /* Reset the CHMOD & MODE bits & */
+    AES->CR &= (uint32_t)(~CRYP_ALGO_CHAIN_MASK);
+    
+    /* Set the CRYP peripheral in AES ECB mode */
+    __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_CBC_ENCRYPT);
+    
+    /* Set the Initialization Vector */
+    CRYP_SetInitVector(hcryp, hcryp->Init.pInitVect);
+    
+    /* Enable CRYP */
+    __HAL_CRYP_ENABLE();
+    
+    /* Set the phase */
+    hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+  }
+  
+    /* Write Plain Data and Get Cypher Data */
+    if(CRYP_ProcessData(hcryp,pPlainData, Size, pCypherData, Timeout) != HAL_OK)
+    {
+      return HAL_TIMEOUT;
+    }
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hcryp);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES CTR encryption mode
+  *         then encrypt pPlainData. The cypher data are available in pCypherData
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16.
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @param  Timeout: Specify Timeout value  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESCTR_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData, uint32_t Timeout)
+{  
+  /* Process Locked */
+  __HAL_LOCK(hcryp);
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_BUSY;
+  
+  /* Check if initialization phase has already been performed */
+  if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+  {
+    /* Set the key */
+    CRYP_SetKey(hcryp, hcryp->Init.pKey);
+    
+    /* Reset the CHMOD & MODE bits & */
+    AES->CR &= (uint32_t)(~CRYP_ALGO_CHAIN_MASK);
+    
+    /* Set the CRYP peripheral in AES ECB mode */
+    __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_CTR_ENCRYPT);
+    
+    /* Set the Initialization Vector */
+    CRYP_SetInitVector(hcryp, hcryp->Init.pInitVect);
+    
+    /* Enable CRYP */
+    __HAL_CRYP_ENABLE();
+    
+    /* Set the phase */
+    hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+  }
+  
+    /* Write Plain Data and Get Cypher Data */
+    if(CRYP_ProcessData(hcryp, pPlainData, Size, pCypherData, Timeout) != HAL_OK)
+    {
+      return HAL_TIMEOUT;
+    }
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hcryp);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES ECB decryption mode
+  *         then decrypted pCypherData. The cypher data are available in pPlainData
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16.
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @param  Timeout: Specify Timeout value  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData, uint32_t Timeout)
+{
+  /* Process Locked */
+  __HAL_LOCK(hcryp);
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_BUSY;
+  
+  /* Check if initialization phase has already been performed */
+  if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+  {
+    /* Set the key */
+    CRYP_SetKey(hcryp, hcryp->Init.pKey);
+    
+    /* Reset the CHMOD & MODE bits & */
+    AES->CR &= (uint32_t)(~CRYP_ALGO_CHAIN_MASK);
+    
+    /* Set the CRYP peripheral in AES ECB decryption mode (with key derivation) */
+    __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_ECB_KEYDERDECRYPT);
+    
+    /* Enable CRYP */
+    __HAL_CRYP_ENABLE();
+    
+    /* Set the phase */
+    hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+  }
+    
+  /* Write Plain Data and Get Cypher Data */
+  if(CRYP_ProcessData(hcryp, pCypherData, Size, pPlainData, Timeout) != HAL_OK)
+  {
+    return HAL_TIMEOUT;
+  }
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hcryp);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES ECB decryption mode
+  *         then decrypted pCypherData. The cypher data are available in pPlainData
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16.
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @param  Timeout: Specify Timeout value  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESCBC_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData, uint32_t Timeout)
+{
+  /* Process Locked */
+  __HAL_LOCK(hcryp);
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_BUSY;
+  
+  /* Check if initialization phase has already been performed */
+  if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+  {
+    /* Set the key */
+    CRYP_SetKey(hcryp, hcryp->Init.pKey);
+    
+    /* Reset the CHMOD & MODE bits & */
+    AES->CR &= (uint32_t)(~CRYP_ALGO_CHAIN_MASK);
+    
+    /* Set the CRYP peripheral in AES CBC decryption mode (with key derivation) */
+    __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_CBC_KEYDERDECRYPT);
+    
+    /* Set the Initialization Vector */
+    CRYP_SetInitVector(hcryp, hcryp->Init.pInitVect);
+    
+    /* Enable CRYP */
+    __HAL_CRYP_ENABLE();
+    
+    /* Set the phase */
+    hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+  }
+  
+  /* Write Plain Data and Get Cypher Data */
+  if(CRYP_ProcessData(hcryp, pCypherData, Size, pPlainData, Timeout) != HAL_OK)
+  {
+    return HAL_TIMEOUT;
+  }
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hcryp);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES CTR decryption mode
+  *         then decrypted pCypherData. The cypher data are available in pPlainData
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16.
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @param  Timeout: Specify Timeout value   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESCTR_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData, uint32_t Timeout)
+{  
+  /* Process Locked */
+  __HAL_LOCK(hcryp);
+  
+  /* Check if initialization phase has already been performed */
+  if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+  {
+    /* Change the CRYP state */
+    hcryp->State = HAL_CRYP_STATE_BUSY;
+    
+    /* Set the key */
+    CRYP_SetKey(hcryp, hcryp->Init.pKey);
+    
+    /* Reset the CHMOD & MODE bits & */
+    AES->CR &= (uint32_t)(~CRYP_ALGO_CHAIN_MASK);
+    
+    /* Set the CRYP peripheral in AES CTR decryption mode */
+    __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_CTR_DECRYPT);
+    
+    /* Set the Initialization Vector */
+    CRYP_SetInitVector(hcryp, hcryp->Init.pInitVect);
+   
+    /* Enable CRYP */
+    __HAL_CRYP_ENABLE();
+    
+    /* Set the phase */
+    hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+  }
+  
+  /* Write Plain Data and Get Cypher Data */
+  if(CRYP_ProcessData(hcryp, pCypherData, Size, pPlainData, Timeout) != HAL_OK)
+  {
+    return HAL_TIMEOUT;
+  }
+  
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hcryp);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES ECB encryption mode using Interrupt.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16 bytes
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESECB_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData)
+{
+  uint32_t inputaddr;
+  uint32_t outputaddr;
+  
+  if(hcryp->State == HAL_CRYP_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hcryp);
+    
+    /* Get the buffer addresses and sizes */
+    hcryp->CrypInCount = Size;
+    hcryp->pCrypInBuffPtr = pPlainData;
+    hcryp->pCrypOutBuffPtr = pCypherData;
+    hcryp->CrypOutCount = Size;
+    
+    /* Change the CRYP state */
+    hcryp->State = HAL_CRYP_STATE_BUSY;
+    
+    /* Check if initialization phase has already been performed */
+    if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+    {
+      /* Set the key */
+      CRYP_SetKey(hcryp, hcryp->Init.pKey);
+      
+      /* Reset the CHMOD & MODE bits & */
+      AES->CR &= (uint32_t)(~CRYP_ALGO_CHAIN_MASK);
+      
+      /* Set the CRYP peripheral in AES ECB mode */
+      __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_ECB_ENCRYPT);
+      
+      /* Set the phase */
+      hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+    }
+    
+    /* Enable Interrupts */
+    __HAL_CRYP_ENABLE_IT(AES_IT_CC);
+    
+    /* Enable CRYP */
+    __HAL_CRYP_ENABLE();
+    
+    /* Get the last input data adress */
+    inputaddr = (uint32_t)hcryp->pCrypInBuffPtr;
+    
+    /* Write the Input block in the Data Input register */
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR  = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR = *(uint32_t*)(inputaddr);
+    hcryp->pCrypInBuffPtr += 16;
+    hcryp->CrypInCount -= 16;
+    
+    /* Return function status */
+    return HAL_OK;
+  }
+  
+  else if(__HAL_CRYP_GET_FLAG(AES_FLAG_CCF))
+  {
+    /* Clear CCF Flag */
+    AES->CR |= AES_CR_CCFC;
+    
+    /* Get the last Output data adress */
+    outputaddr = (uint32_t)hcryp->pCrypOutBuffPtr;
+    
+    /* Read the Output block from the Data Output Register */
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    hcryp->pCrypOutBuffPtr += 16;
+    hcryp->CrypOutCount -= 16;
+    
+    /* Check if all input text is encrypted */
+    if(hcryp->CrypOutCount == 0)
+    {
+      /* Disable Computation Complete Interrupt */
+      __HAL_CRYP_DISABLE_IT(AES_IT_CC);
+      
+      /* Process Unlocked */
+      __HAL_UNLOCK(hcryp);
+      
+      /* Change the CRYP state */
+      hcryp->State = HAL_CRYP_STATE_READY;
+      
+      /* Call computation complete callback */
+      HAL_CRYPEx_ComputationCpltCallback(hcryp);
+    }
+    else /* Process the rest of input text */
+    {
+      /* Get the last Intput data adress */
+      inputaddr = (uint32_t)hcryp->pCrypInBuffPtr;
+      
+      /* Write the Input block in the Data Input register */
+      AES->DINR = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR  = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR = *(uint32_t*)(inputaddr);
+      hcryp->pCrypInBuffPtr += 16;
+      hcryp->CrypInCount -= 16;      
+    }
+  }
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES CBC encryption mode using Interrupt.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16 bytes
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESCBC_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData)
+{
+  uint32_t inputaddr;
+  uint32_t outputaddr;
+  
+  if(hcryp->State == HAL_CRYP_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hcryp);
+    
+    /* Get the buffer addresses and sizes */
+    hcryp->CrypInCount = Size;
+    hcryp->pCrypInBuffPtr = pPlainData;
+    hcryp->pCrypOutBuffPtr = pCypherData;
+    hcryp->CrypOutCount = Size;
+    
+    /* Change the CRYP state */
+    hcryp->State = HAL_CRYP_STATE_BUSY;
+    
+    /* Check if initialization phase has already been performed */
+    if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+    {
+      /* Set the key */
+      CRYP_SetKey(hcryp, hcryp->Init.pKey);
+      
+      /* Reset the CHMOD & MODE bits & */
+      AES->CR &= (uint32_t)(~CRYP_ALGO_CHAIN_MASK);
+      
+      /* Set the CRYP peripheral in AES CBC mode */
+      __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_CBC_ENCRYPT);
+      
+      /* Set the Initialization Vector */
+      CRYP_SetInitVector(hcryp, hcryp->Init.pInitVect);
+      
+      /* Set the phase */
+      hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+    }
+    
+    /* Enable Interrupts */
+    __HAL_CRYP_ENABLE_IT(AES_IT_CC);
+    
+    /* Enable CRYP */
+    __HAL_CRYP_ENABLE();
+    
+    /* Get the last input data adress */
+    inputaddr = (uint32_t)hcryp->pCrypInBuffPtr;
+    
+    /* Write the Input block in the Data Input register */
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR  = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR = *(uint32_t*)(inputaddr);
+    hcryp->pCrypInBuffPtr += 16;
+    hcryp->CrypInCount -= 16;
+    
+    /* Return function status */
+    return HAL_OK;
+  }
+  
+  else if(__HAL_CRYP_GET_FLAG(AES_FLAG_CCF))
+  {
+    /* Clear CCF Flag */
+    AES->CR |= AES_CR_CCFC;
+    
+    /* Get the last Output data adress */
+    outputaddr = (uint32_t)hcryp->pCrypOutBuffPtr;
+    
+    /* Read the Output block from the Data Output Register */
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    hcryp->pCrypOutBuffPtr += 16;
+    hcryp->CrypOutCount -= 16;
+    
+    /* Check if all input text is encrypted */
+    if(hcryp->CrypOutCount == 0)
+    {
+      /* Disable Computation Complete Interrupt */
+      __HAL_CRYP_DISABLE_IT(AES_IT_CC);
+      
+      /* Process Unlocked */
+      __HAL_UNLOCK(hcryp);
+      
+      /* Change the CRYP state */
+      hcryp->State = HAL_CRYP_STATE_READY;
+      
+      /* Call computation complete callback */
+      HAL_CRYPEx_ComputationCpltCallback(hcryp);
+    }
+    else /* Process the rest of input text */
+    {
+      /* Get the last Intput data adress */
+      inputaddr = (uint32_t)hcryp->pCrypInBuffPtr;
+      
+      /* Write the Input block in the Data Input register */
+      AES->DINR = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR  = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR = *(uint32_t*)(inputaddr);
+      hcryp->pCrypInBuffPtr += 16;
+      hcryp->CrypInCount -= 16;      
+    }
+  }
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES CTR encryption mode using Interrupt.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16 bytes
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESCTR_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData)
+{
+  uint32_t inputaddr;
+  uint32_t outputaddr;
+  
+  if(hcryp->State == HAL_CRYP_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hcryp);
+    
+    /* Get the buffer addresses and sizes */
+    hcryp->CrypInCount = Size;
+    hcryp->pCrypInBuffPtr = pPlainData;
+    hcryp->pCrypOutBuffPtr = pCypherData;
+    hcryp->CrypOutCount = Size;
+    
+    /* Change the CRYP state */
+    hcryp->State = HAL_CRYP_STATE_BUSY;
+    
+    /* Check if initialization phase has already been performed */
+    if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+    {
+      /* Set the key */
+      CRYP_SetKey(hcryp, hcryp->Init.pKey);
+      
+      /* Reset the CHMOD & MODE bits & */
+      AES->CR &= (uint32_t)(~CRYP_ALGO_CHAIN_MASK);
+      
+      /* Set the CRYP peripheral in AES CTR mode */
+      __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_CTR_ENCRYPT);
+      
+      /* Set the Initialization Vector */
+      CRYP_SetInitVector(hcryp, hcryp->Init.pInitVect);
+      
+      /* Set the phase */
+      hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+    }
+    
+    /* Enable Interrupts */
+    __HAL_CRYP_ENABLE_IT(AES_IT_CC);
+    
+    /* Enable CRYP */
+    __HAL_CRYP_ENABLE();
+    
+    /* Get the last input data adress */
+    inputaddr = (uint32_t)hcryp->pCrypInBuffPtr;
+    
+    /* Write the Input block in the Data Input register */
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR  = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR = *(uint32_t*)(inputaddr);
+    hcryp->pCrypInBuffPtr += 16;
+    hcryp->CrypInCount -= 16;
+    
+    /* Return function status */
+    return HAL_OK;
+  }
+  
+  else if(__HAL_CRYP_GET_FLAG(AES_FLAG_CCF))
+  {
+    /* Clear CCF Flag */
+    AES->CR |= AES_CR_CCFC;
+    
+    /* Get the last Output data adress */
+    outputaddr = (uint32_t)hcryp->pCrypOutBuffPtr;
+    
+    /* Read the Output block from the Data Output Register */
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    hcryp->pCrypOutBuffPtr += 16;
+    hcryp->CrypOutCount -= 16;
+    
+    /* Check if all input text is encrypted */
+    if(hcryp->CrypOutCount == 0)
+    {
+      /* Disable Computation Complete Interrupt */
+      __HAL_CRYP_DISABLE_IT(AES_IT_CC);
+      
+      /* Process Unlocked */
+      __HAL_UNLOCK(hcryp);
+      
+      /* Change the CRYP state */
+      hcryp->State = HAL_CRYP_STATE_READY;
+      
+      /* Call computation complete callback */
+      HAL_CRYPEx_ComputationCpltCallback(hcryp);
+    }
+    else /* Process the rest of input text */
+    {
+      /* Get the last Intput data adress */
+      inputaddr = (uint32_t)hcryp->pCrypInBuffPtr;
+      
+      /* Write the Input block in the Data Input register */
+      AES->DINR = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR  = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR = *(uint32_t*)(inputaddr);
+      hcryp->pCrypInBuffPtr += 16;
+      hcryp->CrypInCount -= 16;      
+    }
+  }
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES ECB decryption mode using Interrupt.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16.
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData)
+{
+  uint32_t inputaddr;
+  uint32_t outputaddr;
+  
+  if(hcryp->State == HAL_CRYP_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hcryp);
+    
+    /* Get the buffer addresses and sizes */
+    hcryp->CrypInCount = Size;
+    hcryp->pCrypInBuffPtr = pCypherData;
+    hcryp->pCrypOutBuffPtr = pPlainData;
+    hcryp->CrypOutCount = Size;
+    
+    /* Change the CRYP state */
+    hcryp->State = HAL_CRYP_STATE_BUSY;
+    
+  /* Check if initialization phase has already been performed */
+  if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+  {
+    /* Set the key */
+    CRYP_SetKey(hcryp, hcryp->Init.pKey);
+    
+    /* Reset the CHMOD & MODE bits & */
+    AES->CR &= (uint32_t)(~CRYP_ALGO_CHAIN_MASK);
+    
+    /* Set the CRYP peripheral in AES ECB decryption mode (with key derivation) */
+    __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_ECB_KEYDERDECRYPT);   
+    
+     /* Set the phase */
+     hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+  }
+     
+    /* Enable Interrupts */
+    __HAL_CRYP_ENABLE_IT(AES_IT_CC);
+    
+    /* Enable CRYP */
+    __HAL_CRYP_ENABLE();
+    
+    /* Get the last input data adress */
+    inputaddr = (uint32_t)hcryp->pCrypInBuffPtr;
+    
+    /* Write the Input block in the Data Input register */
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR  = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR = *(uint32_t*)(inputaddr);
+    hcryp->pCrypInBuffPtr += 16;
+    hcryp->CrypInCount -= 16;    
+    
+    /* Return function status */
+    return HAL_OK;
+  }
+
+  else if(__HAL_CRYP_GET_FLAG(AES_FLAG_CCF))
+  {
+    /* Clear CCF Flag */
+    AES->CR |= AES_CR_CCFC;
+    
+    /* Get the last Output data adress */
+    outputaddr = (uint32_t)hcryp->pCrypOutBuffPtr;
+    
+    /* Read the Output block from the Output register */
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    
+    hcryp->pCrypOutBuffPtr += 16;
+    hcryp->CrypOutCount -= 16;
+    
+    /* Check if all input text is decrypted */
+    if(hcryp->CrypOutCount == 0)
+    {
+      /* Disable Computation Complete Interrupt */
+      __HAL_CRYP_DISABLE_IT(AES_IT_CC);
+      
+      /* Process Unlocked */
+      __HAL_UNLOCK(hcryp);
+      
+      /* Change the CRYP state */
+      hcryp->State = HAL_CRYP_STATE_READY;
+      
+      /* Call computation complete callback */
+      HAL_CRYPEx_ComputationCpltCallback(hcryp);
+    }
+    else /* Process the rest of input text */
+    {
+      /* Get the last Intput data adress */
+      inputaddr = (uint32_t)hcryp->pCrypInBuffPtr;
+      
+      /* Write the Input block in the Data Input register */
+      AES->DINR = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR  = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR = *(uint32_t*)(inputaddr);
+      hcryp->pCrypInBuffPtr += 16;
+      hcryp->CrypInCount -= 16;      
+    }
+  }
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES CBC decryption mode using IT.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESCBC_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData)
+{
+  uint32_t inputaddr;
+  uint32_t outputaddr;
+  
+  if(hcryp->State == HAL_CRYP_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hcryp);
+    
+    /* Get the buffer addresses and sizes */
+    hcryp->CrypInCount = Size;
+    hcryp->pCrypInBuffPtr = pCypherData;
+    hcryp->pCrypOutBuffPtr = pPlainData;
+    hcryp->CrypOutCount = Size;
+    
+    /* Change the CRYP state */
+    hcryp->State = HAL_CRYP_STATE_BUSY;
+    
+  /* Check if initialization phase has already been performed */
+  if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+  {
+    /* Set the key */
+    CRYP_SetKey(hcryp, hcryp->Init.pKey);
+    
+    /* Reset the CHMOD & MODE bits & */
+    AES->CR &= (uint32_t)(~CRYP_ALGO_CHAIN_MASK);
+    
+    /* Set the CRYP peripheral in AES CBC decryption mode (with key derivation) */
+    __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_CBC_KEYDERDECRYPT);   
+    
+    /* Set the Initialization Vector */
+    CRYP_SetInitVector(hcryp, hcryp->Init.pInitVect);
+    
+     /* Set the phase */
+     hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+  }
+     
+    /* Enable Interrupts */
+    __HAL_CRYP_ENABLE_IT(AES_IT_CC);
+    
+    /* Enable CRYP */
+    __HAL_CRYP_ENABLE();
+    
+    /* Get the last input data adress */
+    inputaddr = (uint32_t)hcryp->pCrypInBuffPtr;
+    
+    /* Write the Input block in the Data Input register */
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR  = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR = *(uint32_t*)(inputaddr);
+    hcryp->pCrypInBuffPtr += 16;
+    hcryp->CrypInCount -= 16;    
+    
+    /* Return function status */
+    return HAL_OK;
+  }
+
+  else if(__HAL_CRYP_GET_FLAG(AES_FLAG_CCF))
+  {
+    /* Clear CCF Flag */
+    AES->CR |= AES_CR_CCFC;
+    
+    /* Get the last Output data adress */
+    outputaddr = (uint32_t)hcryp->pCrypOutBuffPtr;
+    
+    /* Read the Output block from the Output Register */
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    
+    hcryp->pCrypOutBuffPtr += 16;
+    hcryp->CrypOutCount -= 16;
+    
+    /* Check if all input text is decrypted */
+    if(hcryp->CrypOutCount == 0)
+    {
+      /* Disable Computation Complete Interrupt */
+      __HAL_CRYP_DISABLE_IT(AES_IT_CC);
+      
+      /* Process Unlocked */
+      __HAL_UNLOCK(hcryp);
+      
+      /* Change the CRYP state */
+      hcryp->State = HAL_CRYP_STATE_READY;
+      
+      /* Call computation complete callback */
+      HAL_CRYPEx_ComputationCpltCallback(hcryp);
+    }
+    else /* Process the rest of input text */
+    {
+      /* Get the last Intput data adress */
+      inputaddr = (uint32_t)hcryp->pCrypInBuffPtr;
+      
+      /* Write the Input block in the Data Input register */
+      AES->DINR = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR  = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR = *(uint32_t*)(inputaddr);
+      hcryp->pCrypInBuffPtr += 16;
+      hcryp->CrypInCount -= 16;      
+    }
+  }
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES CTR decryption mode using Interrupt.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESCTR_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData)
+{
+  uint32_t inputaddr;
+  uint32_t outputaddr;
+  
+  if(hcryp->State == HAL_CRYP_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hcryp);
+    
+    /* Get the buffer addresses and sizes */
+    hcryp->CrypInCount = Size;
+    hcryp->pCrypInBuffPtr = pCypherData;
+    hcryp->pCrypOutBuffPtr = pPlainData;
+    hcryp->CrypOutCount = Size;
+    
+    /* Change the CRYP state */
+    hcryp->State = HAL_CRYP_STATE_BUSY;
+    
+  /* Check if initialization phase has already been performed */
+  if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+  {
+    /* Set the key */
+    CRYP_SetKey(hcryp, hcryp->Init.pKey);
+    
+    /* Reset the CHMOD & MODE bits & */
+    AES->CR &= (uint32_t)(~CRYP_ALGO_CHAIN_MASK);
+    
+    /* Set the CRYP peripheral in AES CTR decryption mode */
+    __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_CTR_DECRYPT);   
+    
+    /* Set the Initialization Vector */
+    CRYP_SetInitVector(hcryp, hcryp->Init.pInitVect);
+    
+     /* Set the phase */
+     hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+  }
+     
+    /* Enable Interrupts */
+    __HAL_CRYP_ENABLE_IT(AES_IT_CC);
+    
+    /* Enable CRYP */
+    __HAL_CRYP_ENABLE();
+    
+    /* Get the last input data adress */
+    inputaddr = (uint32_t)hcryp->pCrypInBuffPtr;
+    
+    /* Write the Input block in the Data Input register */
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR  = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR = *(uint32_t*)(inputaddr);
+    hcryp->pCrypInBuffPtr += 16;
+    hcryp->CrypInCount -= 16;    
+    
+    /* Return function status */
+    return HAL_OK;
+  }
+
+  else if(__HAL_CRYP_GET_FLAG(AES_FLAG_CCF))
+  {
+    /* Clear CCF Flag */
+    AES->CR |= AES_CR_CCFC;
+    
+    /* Get the last Output data adress */
+    outputaddr = (uint32_t)hcryp->pCrypOutBuffPtr;
+    
+    /* Read the Output block from the Output Register */
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    
+    hcryp->pCrypOutBuffPtr += 16;
+    hcryp->CrypOutCount -= 16;
+    
+    /* Check if all input text is decrypted */
+    if(hcryp->CrypOutCount == 0)
+    {
+      /* Disable Computation Complete Interrupt */
+      __HAL_CRYP_DISABLE_IT(AES_IT_CC);
+      
+      /* Process Unlocked */
+      __HAL_UNLOCK(hcryp);
+      
+      /* Change the CRYP state */
+      hcryp->State = HAL_CRYP_STATE_READY;
+      
+      /* Call computation complete callback */
+      HAL_CRYPEx_ComputationCpltCallback(hcryp);
+    }
+    else /* Process the rest of input text */
+    {
+      /* Get the last Intput data adress */
+      inputaddr = (uint32_t)hcryp->pCrypInBuffPtr;
+      
+      /* Write the Input block in the Data Input register */
+      AES->DINR = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR  = *(uint32_t*)(inputaddr);
+      inputaddr+=4;
+      AES->DINR = *(uint32_t*)(inputaddr);
+      hcryp->pCrypInBuffPtr += 16;
+      hcryp->CrypInCount -= 16;      
+    }
+  }
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES ECB encryption mode using DMA.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16 bytes
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESECB_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData)
+{
+  uint32_t inputaddr;
+  uint32_t outputaddr;
+  
+  if((hcryp->State == HAL_CRYP_STATE_READY) || (hcryp->Phase == HAL_CRYP_PHASE_PROCESS))
+  {
+    /* Process Locked */
+    __HAL_LOCK(hcryp);
+    
+    inputaddr  = (uint32_t)pPlainData;
+    outputaddr = (uint32_t)pCypherData;
+    
+    /* Change the CRYP state */
+    hcryp->State = HAL_CRYP_STATE_BUSY;
+    
+    /* Check if initialization phase has already been performed */
+    if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+    {
+      /* Set the key */
+      CRYP_SetKey(hcryp, hcryp->Init.pKey);
+      
+      /* Set the CRYP peripheral in AES ECB mode */
+      __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_ECB_ENCRYPT);
+
+     /* Set the phase */
+     hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+    }
+    /* Set the input and output addresses and start DMA transfer */ 
+    CRYP_SetDMAConfig(hcryp, inputaddr, Size, outputaddr);
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hcryp);
+     
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;   
+  }
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES CBC encryption mode using DMA.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16.
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESCBC_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData)
+{
+  uint32_t inputaddr;
+  uint32_t outputaddr;
+  
+  if((hcryp->State == HAL_CRYP_STATE_READY) || (hcryp->Phase == HAL_CRYP_PHASE_PROCESS))
+  {
+    /* Process Locked */
+    __HAL_LOCK(hcryp);
+    
+    inputaddr  = (uint32_t)pPlainData;
+    outputaddr = (uint32_t)pCypherData;
+    
+    /* Change the CRYP state */
+    hcryp->State = HAL_CRYP_STATE_BUSY;
+  
+    /* Check if initialization phase has already been performed */
+    if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+    {
+      /* Set the key */
+      CRYP_SetKey(hcryp, hcryp->Init.pKey);
+      
+      /* Set the CRYP peripheral in AES ECB mode */
+      __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_CBC_ENCRYPT);
+      
+      /* Set the Initialization Vector */
+      CRYP_SetInitVector(hcryp, hcryp->Init.pInitVect);
+
+       /* Set the phase */
+       hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+     }
+     /* Set the input and output addresses and start DMA transfer */ 
+     CRYP_SetDMAConfig(hcryp, inputaddr, Size, outputaddr);
+     
+     /* Process Unlocked */
+     __HAL_UNLOCK(hcryp);
+     
+     /* Return function status */
+     return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;   
+  }
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES CTR encryption mode using DMA.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16.
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESCTR_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData)
+{
+  uint32_t inputaddr;
+  uint32_t outputaddr;
+  
+  if((hcryp->State == HAL_CRYP_STATE_READY) || (hcryp->Phase == HAL_CRYP_PHASE_PROCESS))
+  {
+    /* Process Locked */
+    __HAL_LOCK(hcryp);
+    
+    inputaddr  = (uint32_t)pPlainData;
+    outputaddr = (uint32_t)pCypherData;
+    
+  /* Change the CRYP state */
+  hcryp->State = HAL_CRYP_STATE_BUSY;
+  
+    /* Check if initialization phase has already been performed */
+    if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+    {
+      /* Set the key */
+      CRYP_SetKey(hcryp, hcryp->Init.pKey);
+      
+      /* Set the CRYP peripheral in AES ECB mode */
+      __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_CTR_ENCRYPT);
+      
+      /* Set the Initialization Vector */
+      CRYP_SetInitVector(hcryp, hcryp->Init.pInitVect);
+   
+       /* Set the phase */
+       hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+    }
+    
+    /* Set the input and output addresses and start DMA transfer */ 
+    CRYP_SetDMAConfig(hcryp, inputaddr, Size, outputaddr);
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hcryp);
+    
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;   
+  }
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES ECB decryption mode using DMA.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16 bytes
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData)
+{  
+  uint32_t inputaddr;
+  uint32_t outputaddr;
+  
+  if((hcryp->State == HAL_CRYP_STATE_READY) || (hcryp->Phase == HAL_CRYP_PHASE_PROCESS))
+  {
+    /* Process Locked */
+    __HAL_LOCK(hcryp);
+    
+    inputaddr  = (uint32_t)pCypherData;
+    outputaddr = (uint32_t)pPlainData;
+    
+    /* Change the CRYP state */
+    hcryp->State = HAL_CRYP_STATE_BUSY;
+    
+    /* Check if initialization phase has already been performed */
+    if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+    {
+    /* Set the key */
+    CRYP_SetKey(hcryp, hcryp->Init.pKey);
+    
+    /* Reset the CHMOD & MODE bits & */
+    AES->CR &= (uint32_t)(~CRYP_ALGO_CHAIN_MASK);
+    
+    /* Set the CRYP peripheral in AES ECB decryption mode (with key derivation) */
+    __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_ECB_KEYDERDECRYPT);
+ 
+     /* Set the phase */
+     hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+    }
+     
+    /* Set the input and output addresses and start DMA transfer */ 
+    CRYP_SetDMAConfig(hcryp, inputaddr, Size, outputaddr);
+    
+     /* Process Unlocked */
+     __HAL_UNLOCK(hcryp);
+    
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;   
+  }
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES CBC encryption mode using DMA.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16 bytes
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESCBC_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData)
+{
+  uint32_t inputaddr;
+  uint32_t outputaddr;
+  
+  if((hcryp->State == HAL_CRYP_STATE_READY) || (hcryp->Phase == HAL_CRYP_PHASE_PROCESS))
+  {
+    /* Process Locked */
+    __HAL_LOCK(hcryp);
+    
+    inputaddr  = (uint32_t)pCypherData;
+    outputaddr = (uint32_t)pPlainData;
+    
+    /* Change the CRYP state */
+    hcryp->State = HAL_CRYP_STATE_BUSY;
+    
+    /* Check if initialization phase has already been performed */
+    if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+    {
+      /* Set the key */
+      CRYP_SetKey(hcryp, hcryp->Init.pKey);
+
+      /* Reset the CHMOD & MODE bits & */
+      AES->CR &= (uint32_t)(~CRYP_ALGO_CHAIN_MASK);
+    
+      /* Set the CRYP peripheral in AES CBC decryption mode (with key derivation) */
+      __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_CBC_KEYDERDECRYPT);
+    
+      /* Set the Initialization Vector */
+      CRYP_SetInitVector(hcryp, hcryp->Init.pInitVect);
+  
+      /* Set the phase */
+      hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+    }
+    
+    /* Set the input and output addresses and start DMA transfer */ 
+    CRYP_SetDMAConfig(hcryp, inputaddr, Size, outputaddr);
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hcryp);
+    
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;   
+  }
+}
+
+/**
+  * @brief  Initializes the CRYP peripheral in AES CTR decryption mode using DMA.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  pCypherData: Pointer to the cyphertext buffer
+  * @param  Size: Length of the plaintext buffer, must be a multiple of 16
+  * @param  pPlainData: Pointer to the plaintext buffer
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CRYP_AESCTR_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData)
+{  
+  uint32_t inputaddr;
+  uint32_t outputaddr;
+  
+  if((hcryp->State == HAL_CRYP_STATE_READY) || (hcryp->Phase == HAL_CRYP_PHASE_PROCESS))
+  {
+    /* Process Locked */
+    __HAL_LOCK(hcryp);
+    
+    inputaddr  = (uint32_t)pCypherData;
+    outputaddr = (uint32_t)pPlainData;
+    
+    /* Change the CRYP state */
+    hcryp->State = HAL_CRYP_STATE_BUSY;
+    
+    /* Check if initialization phase has already been performed */
+    if(hcryp->Phase == HAL_CRYP_PHASE_READY)
+    {
+      /* Set the key */
+      CRYP_SetKey(hcryp, hcryp->Init.pKey);
+      
+      /* Set the CRYP peripheral in AES CTR mode */
+      __HAL_CRYP_SET_MODE(CRYP_CR_ALGOMODE_AES_CTR_DECRYPT);
+      
+      /* Set the Initialization Vector */
+      CRYP_SetInitVector(hcryp, hcryp->Init.pInitVect);
+    
+      /* Set the phase */
+      hcryp->Phase = HAL_CRYP_PHASE_PROCESS;
+    }
+    
+    /* Set the input and output addresses and start DMA transfer */ 
+    CRYP_SetDMAConfig(hcryp, inputaddr, Size, outputaddr);
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hcryp);
+    
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;   
+  }
+}
+
+/**
+  * @}
+  */
+
+
+/** @defgroup CRYP_Group3 DMA callback functions 
+ *  @brief   DMA callback functions. 
+ *
+@verbatim   
+  ==============================================================================
+                      ##### DMA callback functions  #####
+  ==============================================================================  
+    [..]  This section provides DMA callback functions:
+      (+) DMA Input data transfer complete
+      (+) DMA Output data transfer complete
+      (+) DMA error
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  CRYP error callbacks.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @retval None
+  */
+ __weak void HAL_CRYP_ErrorCallback(CRYP_HandleTypeDef *hcryp)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_CRYP_ErrorCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Input transfer completed callbacks.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @retval None
+  */
+__weak void HAL_CRYP_InCpltCallback(CRYP_HandleTypeDef *hcryp)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_CRYP_InCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Output transfer completed callbacks.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @retval None
+  */
+__weak void HAL_CRYP_OutCpltCallback(CRYP_HandleTypeDef *hcryp)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_CRYP_OutCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup CRYP_Group4 CRYP IRQ handler 
+ *  @brief   CRYP IRQ handler.
+ *
+@verbatim   
+  ==============================================================================
+                ##### CRYP IRQ handler management #####
+  ==============================================================================  
+[..]  This section provides CRYP IRQ handler function.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  This function handles CRYP interrupt request.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @retval None
+  */
+void HAL_CRYP_IRQHandler(CRYP_HandleTypeDef *hcryp)
+{
+  switch(AES->CR & CRYP_CR_ALGOMODE_DIRECTION)
+  {
+  case CRYP_CR_ALGOMODE_AES_ECB_ENCRYPT:
+    HAL_CRYP_AESECB_Encrypt_IT(hcryp, NULL, 0, NULL);
+    break;
+    
+  case CRYP_CR_ALGOMODE_AES_ECB_KEYDERDECRYPT:
+    HAL_CRYP_AESECB_Decrypt_IT(hcryp, NULL, 0, NULL);
+    break;
+    
+  case CRYP_CR_ALGOMODE_AES_CBC_ENCRYPT:
+    HAL_CRYP_AESCBC_Encrypt_IT(hcryp, NULL, 0, NULL);
+    break;
+    
+  case CRYP_CR_ALGOMODE_AES_CBC_KEYDERDECRYPT:
+    HAL_CRYP_AESCBC_Decrypt_IT(hcryp, NULL, 0, NULL);
+    break;
+    
+  case CRYP_CR_ALGOMODE_AES_CTR_ENCRYPT:
+    HAL_CRYP_AESCTR_Encrypt_IT(hcryp, NULL, 0, NULL);       
+    break;
+    
+  case CRYP_CR_ALGOMODE_AES_CTR_DECRYPT:
+    HAL_CRYP_AESCTR_Decrypt_IT(hcryp, NULL, 0, NULL);        
+    break;
+    
+  default:
+    break;
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup CRYP_Group5 Peripheral State functions 
+ *  @brief   Peripheral State functions. 
+ *
+@verbatim   
+  ==============================================================================
+                      ##### Peripheral State functions #####
+  ==============================================================================  
+    [..]
+    This subsection permits to get in run-time the status of the peripheral.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the CRYP state.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @retval HAL state
+  */
+HAL_CRYP_STATETypeDef HAL_CRYP_GetState(CRYP_HandleTypeDef *hcryp)
+{
+  return hcryp->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  DMA CRYP Input Data process complete callback.
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void CRYP_DMAInCplt(DMA_HandleTypeDef *hdma)  
+{
+  CRYP_HandleTypeDef* hcryp = (CRYP_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+  
+  /* Disable the DMA transfer for input request  */
+  AES->CR &= (uint32_t)(~AES_CR_DMAINEN);
+  
+  /* Call input data transfer complete callback */
+  HAL_CRYP_InCpltCallback(hcryp);
+}
+
+/**
+  * @brief  DMA CRYP Output Data process complete callback.
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void CRYP_DMAOutCplt(DMA_HandleTypeDef *hdma)
+{
+  CRYP_HandleTypeDef* hcryp = (CRYP_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+  
+  /* Disable the DMA transfer for output request by resetting the DOEN bit
+     in the DMACR register */
+  AES->CR &= (uint32_t)(~AES_CR_DMAOUTEN);
+  
+  /* Disable CRYP */
+  __HAL_CRYP_DISABLE();
+  
+  /* Change the CRYP state to ready */
+  hcryp->State = HAL_CRYP_STATE_READY;
+  
+  /* Call output data transfer complete callback */
+  HAL_CRYP_OutCpltCallback(hcryp);
+}
+
+/**
+  * @brief  DMA CRYP communication error callback. 
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void CRYP_DMAError(DMA_HandleTypeDef *hdma)
+{
+  CRYP_HandleTypeDef* hcryp = (CRYP_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+  hcryp->State= HAL_CRYP_STATE_READY;
+  HAL_CRYP_ErrorCallback(hcryp);
+}
+
+/**
+  * @brief  Writes the Key in Key registers. 
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  Key: Pointer to Key buffer
+  * @param  KeySize: Size of Key
+  * @retval None
+  */
+static void CRYP_SetKey(CRYP_HandleTypeDef *hcryp, uint8_t *Key)
+{
+  uint32_t keyaddr = (uint32_t)Key;
+  
+  AES->KEYR3 = __REV(*(uint32_t*)(keyaddr));
+  keyaddr+=4;
+  AES->KEYR2 = __REV(*(uint32_t*)(keyaddr));
+  keyaddr+=4;
+  AES->KEYR1 = __REV(*(uint32_t*)(keyaddr));
+  keyaddr+=4;
+  AES->KEYR0 = __REV(*(uint32_t*)(keyaddr));  
+}
+
+/**
+  * @brief  Writes the InitVector/InitCounter in IV registers. 
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  InitVector: Pointer to InitVector/InitCounter buffer
+  * @param  IVSize: Size of the InitVector/InitCounter
+  * @retval None
+  */
+static void CRYP_SetInitVector(CRYP_HandleTypeDef *hcryp, uint8_t *InitVector)
+{
+  uint32_t ivaddr = (uint32_t)InitVector;
+  
+  AES->IVR3 = __REV(*(uint32_t*)(ivaddr));
+  ivaddr+=4;
+  AES->IVR2 = __REV(*(uint32_t*)(ivaddr));
+  ivaddr+=4;
+  AES->IVR1 = __REV(*(uint32_t*)(ivaddr));
+  ivaddr+=4;
+  AES->IVR0 = __REV(*(uint32_t*)(ivaddr));
+}
+
+/**
+  * @brief  Process Data: Writes Input data in polling mode and read the output data
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  Input: Pointer to the Input buffer
+  * @param  Ilength: Length of the Input buffer, must be a multiple of 16.
+  * @param  Output: Pointer to the returned buffer
+  * @retval None
+  */
+static HAL_StatusTypeDef CRYP_ProcessData(CRYP_HandleTypeDef *hcryp, uint8_t* Input, uint16_t Ilength, uint8_t* Output, uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+  
+  uint32_t i = 0;
+  uint32_t inputaddr  = (uint32_t)Input;
+  uint32_t outputaddr = (uint32_t)Output;
+  
+  for(i=0; (i < Ilength); i+=16)
+  {
+    /* Write the Input block in the Data Input register */
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR  = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    AES->DINR = *(uint32_t*)(inputaddr);
+    inputaddr+=4;
+    
+    /* Get timeout */
+    tickstart = HAL_GetTick();
+
+    while(HAL_IS_BIT_CLR(AES->SR, AES_SR_CCF))
+    {    
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Change state */
+          hcryp->State = HAL_CRYP_STATE_TIMEOUT;
+          
+          /* Process Unlocked */          
+          __HAL_UNLOCK(hcryp);
+          
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+    /* Clear CCF Flag */
+    AES->CR |= AES_CR_CCFC;
+    
+    /* Read the Output block from the Data Output Register */
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+    *(uint32_t*)(outputaddr) = AES->DOUTR;
+    outputaddr+=4;
+  }
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the DMA configuration and start the DMA transfer
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @param  inputaddr: address of the Input buffer
+  * @param  Size: Size of the Input buffer, must be a multiple of 16.
+  * @param  outputaddr: address of the Output buffer
+  * @retval None
+  */
+static void CRYP_SetDMAConfig(CRYP_HandleTypeDef *hcryp, uint32_t inputaddr, uint16_t Size, uint32_t outputaddr)
+{
+  /* Set the CRYP DMA transfer complete callback */
+  hcryp->hdmain->XferCpltCallback = CRYP_DMAInCplt;
+  /* Set the DMA error callback */
+  hcryp->hdmain->XferErrorCallback = CRYP_DMAError;
+  
+  /* Set the CRYP DMA transfer complete callback */
+  hcryp->hdmaout->XferCpltCallback = CRYP_DMAOutCplt;
+  /* Set the DMA error callback */
+  hcryp->hdmaout->XferErrorCallback = CRYP_DMAError;
+  
+  /* Enable the DMA In DMA Stream */
+  HAL_DMA_Start_IT(hcryp->hdmain, inputaddr, (uint32_t)&AES->DINR, Size/4);
+  
+  /* Enable the DMA Out DMA Stream */
+  HAL_DMA_Start_IT(hcryp->hdmaout, (uint32_t)&AES->DOUTR, outputaddr, Size/4);
+  
+  /* Enable In and Out DMA requests */
+  AES->CR |= (AES_CR_DMAINEN | AES_CR_DMAOUTEN);
+  
+  /* Enable CRYP */
+  __HAL_CRYP_ENABLE();
+}
+
+/**
+  * @}
+  */
+#endif /* STM32L051xx && STM32L052xx && STM32L053xx*/
+#endif /* HAL_CRYP_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_cryp.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_cryp.h
@@ -1,0 +1,312 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_cryp.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of CRYP HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_CRYP_H
+#define __STM32L0xx_HAL_CRYP_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+   
+#if !defined (STM32L051xx) && !defined (STM32L052xx) && !defined (STM32L053xx)
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup CRYP
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+
+/** 
+  * @brief  CRYP Configuration Structure definition  
+  */
+typedef struct
+{  
+  uint32_t DataType;    /*!< 32-bit data, 16-bit data, 8-bit data or 1-bit string.
+                             This parameter can be a value of @ref CRYP_Data_Type */
+  
+  uint8_t* pKey;        /*!< The key used for encryption/decryption */
+  
+  uint8_t* pInitVect;   /*!< The initialization vector used also as initialization
+                             counter in CTR mode */
+  
+}CRYP_InitTypeDef;
+
+/** 
+  * @brief HAL CRYP State structures definition  
+  */ 
+typedef enum
+{
+  HAL_CRYP_STATE_RESET             = 0x00,  /*!< CRYP not yet initialized or disabled  */
+  HAL_CRYP_STATE_READY             = 0x01,  /*!< CRYP initialized and ready for use    */
+  HAL_CRYP_STATE_BUSY              = 0x02,  /*!< CRYP internal processing is ongoing   */
+  HAL_CRYP_STATE_TIMEOUT           = 0x03,  /*!< CRYP timeout state                    */
+  HAL_CRYP_STATE_ERROR             = 0x04   /*!< CRYP error state                      */ 
+    
+}HAL_CRYP_STATETypeDef;
+
+/** 
+  * @brief HAL CRYP phase structures definition  
+  */ 
+typedef enum
+{
+  HAL_CRYP_PHASE_READY             = 0x01,    /*!< CRYP peripheral is ready for initialization. */
+  HAL_CRYP_PHASE_PROCESS           = 0x02,    /*!< CRYP peripheral is in processing phase */
+}HAL_PhaseTypeDef;
+
+/** 
+  * @brief  CRYP handle Structure definition  
+  */ 
+typedef struct
+{   
+      CRYP_InitTypeDef         Init;             /*!< CRYP required parameters */
+  
+      uint8_t                  *pCrypInBuffPtr;  /*!< Pointer to CRYP processing (encryption, decryption,...) buffer */
+  
+      uint8_t                  *pCrypOutBuffPtr; /*!< Pointer to CRYP processing (encryption, decryption,...) buffer */
+  
+      __IO uint16_t            CrypInCount;      /*!< Counter of inputed data */
+                          
+      __IO uint16_t            CrypOutCount;     /*!< Counter of outputed data */
+  
+      HAL_StatusTypeDef        Status;           /*!< CRYP peripheral status */
+  
+      HAL_PhaseTypeDef         Phase;            /*!< CRYP peripheral phase */
+  
+      DMA_HandleTypeDef        *hdmain;          /*!< CRYP In DMA handle parameters */
+  
+      DMA_HandleTypeDef        *hdmaout;         /*!< CRYP Out DMA handle parameters */
+  
+      HAL_LockTypeDef          Lock;             /*!< CRYP locking object */
+  
+   __IO  HAL_CRYP_STATETypeDef State;            /*!< CRYP peripheral state */
+  
+}CRYP_HandleTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup CRYP_Exported_Constants
+  * @{
+  */
+
+/** @defgroup CRYP_Data_Type 
+  * @{
+  */
+#define CRYP_DATATYPE_32B         ((uint32_t)0x00000000)
+#define CRYP_DATATYPE_16B         AES_CR_DATATYPE_0
+#define CRYP_DATATYPE_8B          AES_CR_DATATYPE_1
+#define CRYP_DATATYPE_1B          AES_CR_DATATYPE
+
+#define IS_CRYP_DATATYPE(DATATYPE) (((DATATYPE) == CRYP_DATATYPE_32B) || \
+                                    ((DATATYPE) == CRYP_DATATYPE_16B) || \
+                                    ((DATATYPE) == CRYP_DATATYPE_8B)  || \
+                                    ((DATATYPE) == CRYP_DATATYPE_1B))  
+/**
+  * @}
+  */
+
+/** @defgroup CRYP_AlgoModeDirection
+  * @{
+  */ 
+#define CRYP_CR_ALGOMODE_DIRECTION              (uint32_t)(AES_CR_MODE|AES_CR_CHMOD)
+
+#define CRYP_CR_ALGOMODE_AES_ECB_ENCRYPT        ((uint32_t)0x00000000)
+#define CRYP_CR_ALGOMODE_AES_ECB_KEYDERDECRYPT  (AES_CR_MODE)
+#define CRYP_CR_ALGOMODE_AES_CBC_ENCRYPT        (AES_CR_CHMOD_0)
+#define CRYP_CR_ALGOMODE_AES_CBC_KEYDERDECRYPT  ((uint32_t)(AES_CR_CHMOD_0|AES_CR_MODE))
+#define CRYP_CR_ALGOMODE_AES_CTR_ENCRYPT        (AES_CR_CHMOD_1)
+#define CRYP_CR_ALGOMODE_AES_CTR_DECRYPT        ((uint32_t)(AES_CR_CHMOD_1 | AES_CR_MODE_1))
+/**
+  * @}
+  */
+  
+/** @defgroup AES_Interrupts
+  * @{
+  */ 
+#define AES_IT_CC                          AES_CR_CCIE  /*!< Computation Complete interrupt */
+#define AES_IT_ERR                         AES_CR_ERRIE /*!< Error interrupt                */
+
+#define IS_AES_IT(IT) ((((IT) & (uint32_t)0xFFFFF9FF) == 0x00000000) && ((IT) != 0x00000000))
+#define IS_AES_GET_IT(IT) (((IT) == AES_IT_CC) || ((IT) == AES_IT_ERR))
+
+/**
+  * @}
+  */
+
+
+/** @defgroup AES_Flags
+  * @{
+  */ 
+#define AES_FLAG_CCF                       AES_SR_CCF    /*!< Computation Complete Flag */
+#define AES_FLAG_RDERR                     AES_SR_RDERR  /*!< Read Error Flag           */
+#define AES_FLAG_WRERR                     AES_SR_WRERR  /*!< Write Error Flag          */
+
+#define IS_AES_FLAG(FLAG) (((FLAG) == AES_FLAG_CCF)    || \
+                           ((FLAG) == AES_FLAG_RDERR)  || \
+                           ((FLAG) == AES_FLAG_WRERR))
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+/** @brief Reset CRYP handle state
+  * @param  __HANDLE__: specifies the CRYP Handle.
+  * @retval None
+  */
+#define __HAL_CRYP_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_CRYP_STATE_RESET)
+
+/**
+  * @brief  Enable/Disable the CRYP peripheral.
+  * @param  None
+  * @retval None
+  */
+#define __HAL_CRYP_ENABLE()  (AES->CR |=  AES_CR_EN)
+#define __HAL_CRYP_DISABLE() (AES->CR &=  ~AES_CR_EN)
+
+/**
+  * @brief  Set the algorithm mode: AES-ECB, AES-CBC, AES-CTR, DES-ECB, DES-CBC,...
+  * @param  MODE: The algorithm mode.
+  * @retval None
+  */
+#define __HAL_CRYP_SET_MODE(MODE)  (AES->CR |= (uint32_t)(MODE))
+
+
+/** @brief  Check whether the specified CRYP flag is set or not.
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg AES_FLAG_CCF   : Computation Complete Flag
+  *            @arg AES_FLAG_RDERR : Read Error Flag
+  *            @arg AES_FLAG_WRERR : Write Error Flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_CRYP_GET_FLAG(__FLAG__) ((AES->SR & (__FLAG__)) == (__FLAG__))
+   
+/**
+  * @brief  Enable the CRYP interrupt.
+  * @param  __INTERRUPT__: CRYP Interrupt.
+  * @retval None
+  */
+#define __HAL_CRYP_ENABLE_IT(__INTERRUPT__) ((AES->CR) |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the CRYP interrupt.
+  * @param  __INTERRUPT__: CRYP interrupt.
+  * @retval None
+  */
+#define __HAL_CRYP_DISABLE_IT(__INTERRUPT__) ((AES->CR) &= ~(__INTERRUPT__))
+
+/* Include CRYP HAL Extension module */
+#include "stm32l0xx_hal_cryp_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+
+/* Initialization/de-initialization functions *********************************/
+HAL_StatusTypeDef HAL_CRYP_Init(CRYP_HandleTypeDef *hcryp);
+HAL_StatusTypeDef HAL_CRYP_DeInit(CRYP_HandleTypeDef *hcryp);
+
+/* AES encryption/decryption using polling  ***********************************/
+HAL_StatusTypeDef HAL_CRYP_AESECB_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData, uint32_t Timeout);
+HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData, uint32_t Timeout);
+HAL_StatusTypeDef HAL_CRYP_AESCBC_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData, uint32_t Timeout);
+HAL_StatusTypeDef HAL_CRYP_AESCBC_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData, uint32_t Timeout);
+HAL_StatusTypeDef HAL_CRYP_AESCTR_Encrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData, uint32_t Timeout);
+HAL_StatusTypeDef HAL_CRYP_AESCTR_Decrypt(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData, uint32_t Timeout);
+
+/* AES encryption/decryption using interrupt  *********************************/
+HAL_StatusTypeDef HAL_CRYP_AESECB_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData);
+HAL_StatusTypeDef HAL_CRYP_AESCBC_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData);
+HAL_StatusTypeDef HAL_CRYP_AESCTR_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData);
+HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData);
+HAL_StatusTypeDef HAL_CRYP_AESCTR_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData);
+HAL_StatusTypeDef HAL_CRYP_AESCBC_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData);
+
+/* AES encryption/decryption using DMA  ***************************************/
+HAL_StatusTypeDef HAL_CRYP_AESECB_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData);
+HAL_StatusTypeDef HAL_CRYP_AESECB_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData);
+HAL_StatusTypeDef HAL_CRYP_AESCBC_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData);
+HAL_StatusTypeDef HAL_CRYP_AESCBC_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData);
+HAL_StatusTypeDef HAL_CRYP_AESCTR_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pPlainData, uint16_t Size, uint8_t *pCypherData);
+HAL_StatusTypeDef HAL_CRYP_AESCTR_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint8_t *pCypherData, uint16_t Size, uint8_t *pPlainData);
+
+/* Processing functions  ********************************************************/
+void HAL_CRYP_IRQHandler(CRYP_HandleTypeDef *hcryp);
+
+/* Peripheral State functions  **************************************************/
+HAL_CRYP_STATETypeDef HAL_CRYP_GetState(CRYP_HandleTypeDef *hcryp);
+
+/* MSP functions  *************************************************************/
+void HAL_CRYP_MspInit(CRYP_HandleTypeDef *hcryp);
+void HAL_CRYP_MspDeInit(CRYP_HandleTypeDef *hcryp);
+
+/* CallBack functions  ********************************************************/
+void HAL_CRYP_ComputationCpltCallback(CRYP_HandleTypeDef *hcryp);
+void HAL_CRYP_InCpltCallback(CRYP_HandleTypeDef *hcryp);
+void HAL_CRYP_OutCpltCallback(CRYP_HandleTypeDef *hcryp);
+void HAL_CRYP_ErrorCallback(CRYP_HandleTypeDef *hcryp);
+
+/* Aliases for inter STM32 series compatibility */
+#define HAL_CRYP_ComputationCpltCallback         HAL_CRYPEx_ComputationCpltCallback
+
+#endif /* STM32L051xx && STM32L052xx && STM32L053xx*/
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_CRYP_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_cryp_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_cryp_ex.c
@@ -1,0 +1,168 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_cryp_ex.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   CRYPEx HAL module driver.
+  *    
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Cryptography (CRYP) extension peripheral:
+  *           + Computation completed callback.
+  *         
+  @verbatim
+  ==============================================================================
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      The CRYP HAL driver can be used as follows:
+
+      (#)Initialize the CRYP low level resources by implementing the HAL_CRYP_MspInit():
+         (##) Enable the CRYP interface clock using __CRYP_CLK_ENABLE()
+         (##) In case of using interrupts (e.g. HAL_AES_ECB_Encrypt_IT())
+             (+) Configure the CRYP interrupt priority using HAL_NVIC_SetPriority()
+             (+) Enable the CRYP IRQ handler using HAL_NVIC_EnableIRQ()
+             (+) In CRYP IRQ handler, call HAL_CRYP_IRQHandler()
+         (##) In case of using DMA to control data transfer (e.g. HAL_AES_ECB_Encrypt_DMA())
+             (+) Enable the DMA1 interface clock using 
+                 (++) __DMA1_CLK_ENABLE()
+             (+) Configure and enable two DMA Channels one for managing data transfer from
+                 memory to peripheral (input channel) and another channel for managing data
+                 transfer from peripheral to memory (output channel)
+             (+) Associate the initilalized DMA handle to the CRYP DMA handle
+                 using  __HAL_LINKDMA()
+             (+) Configure the priority and enable the NVIC for the transfer complete
+                 interrupt on the two DMA Streams. The output stream should have higher
+                 priority than the input stream.
+                 (++) HAL_NVIC_SetPriority()
+                 (++) HAL_NVIC_EnableIRQ()
+    
+      (#)Initialize the CRYP HAL using HAL_CRYP_Init(). This function configures mainly:
+         (##) The data type: 1-bit, 8-bit, 16-bit and 32-bit
+         (##) The encryption/decryption key.
+         (##) The initialization vector (counter). It is not used ECB mode.
+    
+      (#)Three processing (encryption/decryption) functions are available:
+         (##) Polling mode: encryption and decryption APIs are blocking functions
+              i.e. they process the data and wait till the processing is finished
+              e.g. HAL_CRYP_AESCBC_Encrypt()
+         (##) Interrupt mode: encryption and decryption APIs are not blocking functions
+              i.e. they process the data under interrupt
+              e.g. HAL_CRYP_AESCBC_Encrypt_IT()
+         (##) DMA mode: encryption and decryption APIs are not blocking functions
+              i.e. the data transfer is ensured by DMA
+              e.g. HAL_CRYP_AESCBC_Encrypt_DMA()
+    
+      (#)When the processing function is called at first time after HAL_CRYP_Init()
+         the CRYP peripheral is initialized and processes the buffer in input.
+         At second call, the processing function performs an append of the already
+         processed buffer.
+         When a new data block is to be processed, call HAL_CRYP_Init() then the
+         processing function.
+         
+       (#)Call HAL_CRYP_DeInit() to deinitialize the CRYP peripheral.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup CRYPEx 
+  * @brief CRYP HAL Extended module driver.
+  * @{
+  */
+
+#ifdef HAL_CRYP_MODULE_ENABLED
+#if !defined (STM32L051xx) && !defined (STM32L052xx) && !defined (STM32L053xx)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup CRYPEx_Private_Functions
+  * @{
+  */
+
+
+/** @defgroup CRYPEX_Group1 Extended features functions 
+ *  @brief    Extended features functions. 
+ *
+@verbatim   
+ ===============================================================================
+                 ##### Extended features functions #####
+ =============================================================================== 
+    [..]  This section provides callback functions:
+      (+) Computation completed.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Computation completed callbacks.
+  * @param  hcryp: pointer to a CRYP_HandleTypeDef structure that contains
+  *         the configuration information for CRYP module
+  * @retval None
+  */
+__weak void HAL_CRYPEx_ComputationCpltCallback(CRYP_HandleTypeDef *hcryp)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_CRYP_ComputationCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+#endif /* STM32L051xx && STM32L052xx && STM32L053xx*/
+#endif /* HAL_CRYP_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_cryp_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_cryp_ex.h
@@ -1,0 +1,82 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_cryp_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of CRYPEx HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_CRYP_EX_H
+#define __STM32L0xx_HAL_CRYP_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+   
+#if !defined (STM32L051xx) && !defined (STM32L052xx) && !defined (STM32L053xx)
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup CRYPEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+/* Exported constants --------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/* CallBack functions  ********************************************************/
+void HAL_CRYPEx_ComputationCpltCallback(CRYP_HandleTypeDef *hcryp);
+
+#endif /* STM32L051xx && STM32L052xx && STM32L053xx*/
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_CRYP_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_dac.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_dac.c
@@ -1,0 +1,770 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_dac.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   DAC HAL module driver.
+  *    
+  *         This file provides firmware functions to manage the following
+  *         functionalities of the Digital to Analog Converter (DAC) peripheral:
+  *           + DAC channels configuration: trigger, output buffer, data format
+  *           + DMA management  
+  *     
+  *
+  @verbatim
+  ==============================================================================
+                      ##### DAC Peripheral features #####
+  ==============================================================================
+    [..]        
+      *** DAC Channels ***
+      ====================
+    [..]  
+    The device integrates 1 12-bit Digital Analog Converters:
+      (#) DAC channel1 with DAC_OUT1 (PA4) as output
+  
+      *** DAC Triggers ***
+      ====================
+    [..]
+    Digital to Analog conversion can be non-triggered using DAC_Trigger_None
+    and DAC_OUT1/DAC_OUT2 is available once writing to DHRx register.
+    [..]
+    Digital to Analog conversion can be triggered by:
+      (#) External event: EXTI Line 9 (any GPIOx_Pin9) using DAC_Trigger_Ext_IT9.
+          The used pin (GPIOx_Pin9) must be configured in input mode.
+
+      (#) Timers TRGO: TIM2, TIM6 and TIM21
+          (DAC_Trigger_T2_TRGO, DAC_Trigger_T6_TRGO...)
+
+      (#) Software using DAC_Trigger_Software
+
+      *** DAC Buffer mode feature ***
+      ===============================
+      [..] 
+      Each DAC channel integrates an output buffer that can be used to
+      reduce the output impedance, and to drive external loads directly
+      without having to add an external operational amplifier.
+      To enable, the output buffer use
+      sConfig.DAC_OutputBuffer = DAC_OutputBuffer_Enable;
+      [..]
+      (@) Refer to the device datasheet for more details about output
+          impedance value with and without output buffer.
+
+       *** DAC wave generation feature ***
+       ===================================
+       [..]
+       Both DAC channels can be used to generate
+         (#) Noise wave using HAL_DAC_NoiseWaveGenerate()
+         (#) Triangle wave using HAL_DAC_TriangleWaveGenerate()
+
+       *** DAC data format ***
+       =======================
+       [..]
+       The DAC data format can be:
+         (#) 8-bit right alignment using DAC_ALIGN_8B_R
+         (#) 12-bit left alignment using DAC_ALIGN_12B_L
+         (#) 12-bit right alignment using DAC_ALIGN_12B_R
+
+       *** DAC data value to voltage correspondence ***
+       ================================================
+       [..]
+       The analog output voltage on each DAC channel pin is determined
+       by the following equation: 
+       DAC_OUTx = VREF+ * DOR / 4095
+       with  DOR is the Data Output Register
+          VEF+ is the input voltage reference (refer to the device datasheet)
+        e.g. To set DAC_OUT1 to 0.7V, use
+          Assuming that VREF+ = 3.3V, DAC_OUT1 = (3.3 * 868) / 4095 = 0.7V
+
+       *** DMA requests  ***
+       =====================
+       [..]
+       A DMA1 request can be generated when an external trigger (but not
+       a software trigger) occurs if DMA1 requests are enabled using
+       HAL_DAC_Start_DMA()
+       [..]
+       DMA1 requests are mapped as following:
+         (#) DAC channel1 : mapped on DMA1 Request9 channel2 which must be
+             already configured
+
+
+                      ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      (+) DAC APB clock must be enabled to get write access to DAC
+          registers using HAL_DAC_Init()
+      (+) Configure DAC_OUTx (DAC_OUT1: PA4) in analog mode.
+      (+) Configure the DAC channel using HAL_DAC_ConfigChannel() function.
+      (+) Enable the DAC channel using HAL_DAC_Start() or HAL_DAC_Start_DMA functions
+
+ @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup DAC 
+  * @brief DAC driver modules
+  * @{
+  */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+#if !defined (STM32L051xx) && !defined (STM32L061xx)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void DAC_DMAConvCpltCh1(DMA_HandleTypeDef *hdma);
+static void DAC_DMAErrorCh1(DMA_HandleTypeDef *hdma);
+static void DAC_DMAHalfConvCpltCh1(DMA_HandleTypeDef *hdma);
+
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup DAC_Private_Functions
+  * @{
+  */
+
+/** @defgroup DAC_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ *
+@verbatim
+  ==============================================================================
+              ##### Initialization and de-initialization functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the DAC.
+      (+) De-initialize the DAC.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the DAC peripheral according to the specified parameters
+  *         in the DAC_InitStruct.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Init(DAC_HandleTypeDef* hdac)
+{
+  /* Check DAC handle */
+  if(hdac == NULL)
+  {
+     return HAL_ERROR;
+  }
+  /* Check the parameters */
+  assert_param(IS_DAC_ALL_INSTANCE(hdac->Instance));
+
+  if(hdac->State == HAL_DAC_STATE_RESET)
+  {  
+    /* Init the low level hardware */
+    HAL_DAC_MspInit(hdac);
+  }
+
+  /* Initialize the DAC state*/
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Set DAC error code to none */
+  hdac->ErrorCode = HAL_DAC_ERROR_NONE;
+
+  /* Initialize the DAC state*/
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deinitializes the DAC peripheral registers to their default reset values.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_DeInit(DAC_HandleTypeDef* hdac)
+{
+  /* Check DAC handle */
+  if(hdac == NULL)
+  {
+     return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_DAC_ALL_INSTANCE(hdac->Instance));
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* DeInit the low level hardware */
+  HAL_DAC_MspDeInit(hdac);
+
+  /* Set DAC error code to none */
+  hdac->ErrorCode = HAL_DAC_ERROR_NONE;
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the DAC MSP.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_MspInit(DAC_HandleTypeDef* hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DAC_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes the DAC MSP.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.  
+  * @retval None
+  */
+__weak void HAL_DAC_MspDeInit(DAC_HandleTypeDef* hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DAC_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_Group2 I/O operation functions
+ *  @brief    I/O operation functions
+ *
+@verbatim
+  ==============================================================================
+             ##### IO operation functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Start conversion.
+      (+) Stop conversion.
+      (+) Start conversion and enable DMA transfer.
+      (+) Stop conversion and disable DMA transfer.
+      (+) Get result of conversion.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enables DAC and starts conversion of channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Start(DAC_HandleTypeDef* hdac, uint32_t channel)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(channel));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Enable the Peripharal */
+  __HAL_DAC_ENABLE(hdac, channel);
+
+  /* Check if software trigger enabled */
+  if(((hdac->Instance->CR & DAC_CR_TEN1) ==  DAC_CR_TEN1) && ((hdac->Instance->CR & DAC_CR_TSEL1) ==  DAC_CR_TSEL1))
+  {
+    /* Enable the selected DAC software conversion */
+    hdac->Instance->SWTRIGR |= (uint32_t)DAC_SWTRIGR_SWTRIG1;
+  }
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables DAC and stop conversion of channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Stop(DAC_HandleTypeDef* hdac, uint32_t channel)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(channel));
+  
+  /* Disable the Peripheral */
+  __HAL_DAC_DISABLE(hdac, channel);
+  
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables DAC and starts conversion of channel using DMA.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  * @param  pData: The destination peripheral Buffer address.
+  * @param  Length: The length of data to be transferred from memory to DAC peripheral
+  * @param  alignment: Specifies the data alignment for DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_ALIGN_8B_R: 8bit right data alignment selected
+  *            @arg DAC_ALIGN_12B_L: 12bit left data alignment selected
+  *            @arg DAC_ALIGN_12B_R: 12bit right data alignment selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Start_DMA(DAC_HandleTypeDef* hdac, uint32_t channel, uint32_t* pData, uint32_t Length, uint32_t alignment)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(channel));
+  assert_param(IS_DAC_ALIGN(alignment));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Set the DMA transfer complete callback for channel1 */
+  hdac->DMA_Handle1->XferCpltCallback = DAC_DMAConvCpltCh1;
+
+  /* Set the DMA half transfer complete callback for channel1 */
+  hdac->DMA_Handle1->XferHalfCpltCallback = DAC_DMAHalfConvCpltCh1;
+
+  /* Set the DMA error callback for channel1 */
+  hdac->DMA_Handle1->XferErrorCallback = DAC_DMAErrorCh1;
+
+  /* Enable the selected DAC channel1 DMA request */
+  hdac->Instance->CR |= DAC_CR_DMAEN1;
+
+  /* Case of use of channel 1 */
+  switch(alignment)
+  {
+    case DAC_ALIGN_12B_R:
+      /* Get DHR12R1 address */
+      tmpreg = (uint32_t)&hdac->Instance->DHR12R1;
+      break;
+    case DAC_ALIGN_12B_L:
+      /* Get DHR12L1 address */
+      tmpreg = (uint32_t)&hdac->Instance->DHR12L1;
+      break;
+    case DAC_ALIGN_8B_R:
+      /* Get DHR8R1 address */
+      tmpreg = (uint32_t)&hdac->Instance->DHR8R1;
+      break;
+    default:
+      break;
+  }
+
+  /* Enable the DMA Channel */
+  /* Enable the DAC DMA underrun interrupt */
+  __HAL_DAC_ENABLE_IT(hdac, DAC_IT_DMAUDR1);
+  
+  HAL_DMA_Start_IT(hdac->DMA_Handle1, (uint32_t)pData, tmpreg, Length);
+  
+  /* Enable the Peripharal */
+  __HAL_DAC_ENABLE(hdac, channel);
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hdac);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables DAC and stop conversion of channel using DMA.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_Stop_DMA(DAC_HandleTypeDef* hdac, uint32_t channel)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(channel));
+
+  /* Disable the selected DAC channel DMA request */
+    hdac->Instance->CR &= ~(DAC_CR_DMAEN1 << channel);
+
+  /* Disable the Peripharal */
+  __HAL_DAC_DISABLE(hdac, channel);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Returns the last data output value of the selected DAC channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  * @retval The selected DAC channel data output value.
+  */
+uint32_t HAL_DAC_GetValue(DAC_HandleTypeDef* hdac, uint32_t channel)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(channel));
+  
+  /* Returns the DAC channel data output register value */
+  return hdac->Instance->DOR1;
+}
+
+/**
+  * @}
+  */
+  
+/** @defgroup DAC_Group3 Peripheral Control functions
+ *  @brief    Peripheral Control functions 
+ *
+@verbatim
+  ==============================================================================
+             ##### Peripheral Control functions #####
+  ==============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Configure channels.
+      (+) Set the specified data holding register value for DAC channel.
+      (+) Set the specified data holding register value for Dual DAC channels.
+      
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configures the selected DAC channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  sConfig: DAC configuration structure.
+  * @param  channel: The selected DAC channel. 
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_ConfigChannel(DAC_HandleTypeDef* hdac, DAC_ChannelConfTypeDef* sConfig, uint32_t channel)
+{
+  uint32_t tmpreg1 = 0, tmpreg2 = 0;
+
+  /* Check the DAC parameters */
+  assert_param(IS_DAC_TRIGGER(sConfig->DAC_Trigger));
+  assert_param(IS_DAC_OUTPUT_BUFFER_STATE(sConfig->DAC_OutputBuffer));
+  assert_param(IS_DAC_TRIGGER(sConfig->DAC_Trigger));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Get the DAC CR value */
+  tmpreg1 = DAC->CR;
+  /* Clear BOFFx, TENx, TSELx, WAVEx and MAMPx bits */
+  tmpreg1 &= ~(((uint32_t)(DAC_CR_MAMP1 | DAC_CR_WAVE1 | DAC_CR_TSEL1 | DAC_CR_TEN1 | DAC_CR_BOFF1)) << channel);
+  /* Configure for the selected DAC channel: buffer output, trigger */
+  /* Set TSELx and TENx bits according to DAC_Trigger value */
+  /* Set BOFFx bit according to DAC_OutputBuffer value */   
+  tmpreg2 = (sConfig->DAC_Trigger | sConfig->DAC_OutputBuffer);
+  /* Calculate CR register value depending on DAC_Channel */
+  tmpreg1 |= tmpreg2 << channel;
+  /* Write to DAC CR */
+  DAC->CR = tmpreg1;
+  /* Disable wave generation */
+  DAC->CR &= ~(DAC_CR_WAVE1 << channel);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the specified data holding register value for DAC channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  alignment: Specifies the data alignment for DAC channel1.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_ALIGN_8B_R: 8bit right data alignment selected
+  *            @arg DAC_ALIGN_12B_L: 12bit left data alignment selected
+  *            @arg DAC_ALIGN_12B_R: 12bit right data alignment selected
+  * @param  data: Data to be loaded in the selected data holding register.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef* hdac, uint32_t channel, uint32_t alignment, uint32_t data)
+{
+  __IO uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(channel));
+  assert_param(IS_DAC_ALIGN(alignment));
+  assert_param(IS_DAC_DATA(data));
+
+  tmp = (uint32_t)DAC_BASE;
+
+  tmp += __HAL_DHR12R1_ALIGNEMENT(alignment);
+
+  /* Set the DAC channel1 selected data holding register */
+  *(__IO uint32_t *) tmp = data;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup DAC_Group4 DAC Peripheral State functions
+ *  @brief   DAC Peripheral State functions 
+ *
+@verbatim
+  ==============================================================================
+            ##### DAC Peripheral State functions #####
+  ==============================================================================
+    [..]
+    This subsection provides functions allowing to
+      (+) Check the DAC state.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  return the DAC state
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval HAL state
+  */
+HAL_DAC_StateTypeDef HAL_DAC_GetState(DAC_HandleTypeDef* hdac)
+{
+  /* Return DAC state */
+  return hdac->State;
+}
+
+/**
+  * @brief  Handles DAC interrupt request
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+void HAL_DAC_IRQHandler(DAC_HandleTypeDef* hdac)
+{
+  /* Check Overrun flag */
+  if(__HAL_DAC_GET_FLAG(hdac, DAC_FLAG_DMAUDR1))
+  {
+    /* Change DAC state to error state */
+    hdac->State = HAL_DAC_STATE_ERROR;
+
+    /* Set DAC error code to chanel1 DMA underrun error */
+    hdac->ErrorCode |= HAL_DAC_ERROR_DMAUNDERRUNCH1;
+
+    /* Clear the underrun flag */
+    __HAL_DAC_CLEAR_FLAG(hdac,DAC_FLAG_DMAUDR1);
+
+    /* Disable the selected DAC channel1 DMA request */
+    hdac->Instance->CR &= ~DAC_CR_DMAEN1;
+
+    /* Error callback */
+    HAL_DAC_DMAUnderrunCallbackCh1(hdac);
+  }
+}
+
+/**
+  * @brief  Return the DAC error code
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval DAC Error Code
+  */
+uint32_t HAL_DAC_GetError(DAC_HandleTypeDef *hdac)
+{
+  return hdac->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  Conversion complete callback in non blocking mode for Channel1 
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_ConvCpltCallbackCh1(DAC_HandleTypeDef* hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DAC_ConvCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Conversion half DMA transfer callback in non blocking mode for Channel1 
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_ConvHalfCpltCallbackCh1(DAC_HandleTypeDef* hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DAC_ConvHalfCpltCallbackCh1 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Error DAC callback for Channel1.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_ErrorCallbackCh1(DAC_HandleTypeDef *hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DAC_ErrorCallback could be implemented in the user file
+   */
+}
+
+
+/**
+  * @brief  DMA underrun DAC callback for channel1.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @retval None
+  */
+__weak void HAL_DAC_DMAUnderrunCallbackCh1(DAC_HandleTypeDef *hdac)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_DAC_DMAUnderrunCallbackCh1 could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DMA conversion complete callback. 
+  * @param  hdma: pointer to DMA handle.
+  * @retval None
+  */
+static void DAC_DMAConvCpltCh1(DMA_HandleTypeDef *hdma)   
+{
+  DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  HAL_DAC_ConvCpltCallbackCh1(hdac); 
+  
+  hdac->State= HAL_DAC_STATE_READY;
+}
+
+/**
+  * @brief  DMA half transfer complete callback.
+  * @param  hdma: pointer to DMA handle.
+  * @retval None
+  */
+static void DAC_DMAHalfConvCpltCh1(DMA_HandleTypeDef *hdma)
+{
+  DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* Conversion complete callback */
+  HAL_DAC_ConvHalfCpltCallbackCh1(hdac);
+}
+
+/**
+  * @brief  DMA error callback
+  * @param  hdma: pointer to DMA handle.
+  * @retval None
+  */
+static void DAC_DMAErrorCh1(DMA_HandleTypeDef *hdma)
+{
+  DAC_HandleTypeDef* hdac = ( DAC_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  /* Set DAC error code to DMA error */
+  hdac->ErrorCode |= HAL_DAC_ERROR_DMA;
+
+  HAL_DAC_ErrorCallbackCh1(hdac);
+
+  hdac->State= HAL_DAC_STATE_READY;
+}
+
+/**
+  * @}
+  */
+#endif /* STM32L051xx && STM32L061xx*/
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_dac.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_dac.h
@@ -1,0 +1,283 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_dac.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of DAC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_DAC_H
+#define __STM32L0xx_HAL_DAC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+   
+#if !defined (STM32L051xx) && !defined (STM32L061xx)
+   
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup DAC
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** 
+  * @brief  HAL State structures definition  
+  */ 
+typedef enum
+{
+  HAL_DAC_STATE_RESET             = 0x00,  /*!< DAC not yet initialized or disabled  */
+  HAL_DAC_STATE_READY             = 0x01,  /*!< DAC initialized and ready for use    */
+  HAL_DAC_STATE_BUSY              = 0x02,  /*!< DAC internal processing is ongoing   */
+  HAL_DAC_STATE_TIMEOUT           = 0x03,  /*!< DAC timeout state                    */
+  HAL_DAC_STATE_ERROR             = 0x04   /*!< DAC error state                      */
+ 
+}HAL_DAC_StateTypeDef;
+ 
+/** 
+  * @brief  DAC handle Structure definition  
+  */ 
+typedef struct
+{
+  DAC_TypeDef                 *Instance;     /*!< Register base address             */
+
+  __IO HAL_DAC_StateTypeDef   State;         /*!< DAC communication state           */
+
+  HAL_LockTypeDef             Lock;          /*!< DAC locking object                */
+
+  DMA_HandleTypeDef           *DMA_Handle1;  /*!< Pointer DMA handler for channel 1 */
+
+  __IO uint32_t               ErrorCode;      /*!< DAC Error code                   */
+
+}DAC_HandleTypeDef;
+
+/** 
+  * @brief   DAC Configuration regular Channel structure definition
+  */
+typedef struct
+{
+  uint32_t DAC_Trigger;       /*!< Specifies the external trigger for the selected DAC channel.
+                                   This parameter can be a value of @ref DAC_trigger_selection */
+
+  uint32_t DAC_OutputBuffer;  /*!< Specifies whether the DAC channel output buffer is enabled or disabled.
+                                   This parameter can be a value of @ref DAC_output_buffer */
+
+}DAC_ChannelConfTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup HAL DAC Error Code
+  * @{
+  */
+#define  HAL_DAC_ERROR_NONE              0x00    /*!< No error                          */
+#define  HAL_DAC_ERROR_DMAUNDERRUNCH1    0x01    /*!< DAC channel1 DMA underrun error   */
+#define  HAL_DAC_ERROR_DMA               0x04    /*!< DMA error                         */
+/**
+  * @}
+  */
+
+/** @defgroup DAC_trigger_selection
+  * @{
+  */
+#define DAC_TRIGGER_NONE                   ((uint32_t)0x00000000) /*!< Conversion is automatic once the DAC1_DHRxxxx register
+                                                                       has been loaded, and not by external trigger */
+#define DAC_TRIGGER_T6_TRGO                ((uint32_t)DAC_CR_TEN1) /*!< TIM6 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T21_TRGO               ((uint32_t)(DAC_CR_TSEL1_1 | DAC_CR_TSEL1_0 | DAC_CR_TEN1)) /*!< TIM21 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_T2_TRGO                ((uint32_t)(DAC_CR_TSEL1_2 | DAC_CR_TEN1)) /*!< TIM2 TRGO selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_EXT_IT9                ((uint32_t)(DAC_CR_TSEL1_2 | DAC_CR_TSEL1_1 | DAC_CR_TEN1)) /*!< EXTI Line9 event selected as external conversion trigger for DAC channel */
+#define DAC_TRIGGER_SOFTWARE               ((uint32_t)(DAC_CR_TSEL1 | DAC_CR_TEN1)) /*!< Conversion started by software trigger for DAC channel */
+
+#define IS_DAC_TRIGGER(TRIGGER) (((TRIGGER) == DAC_TRIGGER_NONE)     || \
+                                 ((TRIGGER) == DAC_TRIGGER_T6_TRGO)  || \
+                                 ((TRIGGER) == DAC_TRIGGER_T21_TRGO) || \
+                                 ((TRIGGER) == DAC_TRIGGER_T2_TRGO)  || \
+                                 ((TRIGGER) == DAC_TRIGGER_EXT_IT9)  || \
+                                 ((TRIGGER) == DAC_TRIGGER_SOFTWARE))
+/**
+  * @}
+  */
+
+/** @defgroup DAC_output_buffer
+  * @{
+  */
+#define DAC_OUTPUTBUFFER_ENABLE            ((uint32_t)0x00000000)
+#define DAC_OUTPUTBUFFER_DISABLE           ((uint32_t)DAC_CR_BOFF1)
+
+#define IS_DAC_OUTPUT_BUFFER_STATE(STATE) (((STATE) == DAC_OUTPUTBUFFER_ENABLE) || \
+                                           ((STATE) == DAC_OUTPUTBUFFER_DISABLE))
+/**
+  * @}
+  */
+
+/** @defgroup DAC_Channel_selection
+  * @{
+  */
+#define DAC_CHANNEL_1                      ((uint32_t)0x00000000)
+
+#define IS_DAC_CHANNEL(CHANNEL) ((CHANNEL) == DAC_CHANNEL_1)
+/**
+  * @}
+  */
+
+/** @defgroup DAC_data_alignement
+  * @{
+  */
+#define DAC_ALIGN_12B_R                    ((uint32_t)0x00000000)
+#define DAC_ALIGN_12B_L                    ((uint32_t)0x00000004)
+#define DAC_ALIGN_8B_R                     ((uint32_t)0x00000008)
+
+#define IS_DAC_ALIGN(ALIGN) (((ALIGN) == DAC_ALIGN_12B_R) || \
+                             ((ALIGN) == DAC_ALIGN_12B_L) || \
+                             ((ALIGN) == DAC_ALIGN_8B_R))
+/**
+  * @}
+  */
+
+
+/** @defgroup DAC_data
+  * @{
+  */
+#define IS_DAC_DATA(DATA) ((DATA) <= 0xFFF0)
+/**
+  * @}
+  */
+
+/** @defgroup DAC_flags_definition
+  * @{
+  */ 
+#define DAC_FLAG_DMAUDR1                   ((uint32_t)DAC_SR_DMAUDR1)
+
+#define IS_DAC_FLAG(FLAG) ((FLAG) == DAC_FLAG_DMAUDR1)
+/**
+  * @}
+  */
+
+/** @defgroup DAC_flags_definition
+  * @{
+  */ 
+#define DAC_IT_DMAUDR1                   ((uint32_t)DAC_CR_DMAUDRIE1)
+
+#define IS_DAC_IT(IT) ((IT) == DAC_IT_DMAUDR1)  
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+/** @brief Reset DAC handle state
+  * @param  __HANDLE__: specifies the DAC Handle.
+  * @retval None
+  */
+#define __HAL_DAC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_DAC_STATE_RESET)
+
+/* Enable the DAC peripheral */
+#define __HAL_DAC_ENABLE(__HANDLE__, __DAC_Channel__) \
+((__HANDLE__)->Instance->CR |=  (DAC_CR_EN1 << (__DAC_Channel__)))
+
+/* Disable the DAC peripheral */
+#define __HAL_DAC_DISABLE(__HANDLE__, __DAC_Channel__) \
+((__HANDLE__)->Instance->CR &=  ~(DAC_CR_EN1 << (__DAC_Channel__)))
+
+
+/* Set DHR12R1 alignment */
+#define __HAL_DHR12R1_ALIGNEMENT(__ALIGNEMENT__) (((uint32_t)0x00000008) + (__ALIGNEMENT__))
+
+/* Enable the DAC interrupt */
+#define __HAL_DAC_ENABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR) |= (__INTERRUPT__))
+
+/* Disable the DAC interrupt */
+#define __HAL_DAC_DISABLE_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR) &= ~(__INTERRUPT__))
+
+/* Get the selected DAC's flag status */
+#define __HAL_DAC_GET_FLAG(__HANDLE__, __FLAG__) ((((__HANDLE__)->Instance->SR) & (__FLAG__)) == (__FLAG__))
+
+/* Clear the DAC's flag */
+#define __HAL_DAC_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) = (__FLAG__))
+
+/* Include DAC HAL Extension module */
+#include "stm32l0xx_hal_dac_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/* Initialization and de-initialization functions *****************************/ 
+HAL_StatusTypeDef HAL_DAC_Init(DAC_HandleTypeDef* hdac);
+HAL_StatusTypeDef HAL_DAC_DeInit(DAC_HandleTypeDef* hdac);
+void HAL_DAC_MspInit(DAC_HandleTypeDef* hdac);
+void HAL_DAC_MspDeInit(DAC_HandleTypeDef* hdac);
+
+/* I/O operation functions ******************************************************/
+HAL_StatusTypeDef HAL_DAC_Start(DAC_HandleTypeDef* hdac, uint32_t channel);
+HAL_StatusTypeDef HAL_DAC_Stop(DAC_HandleTypeDef* hdac, uint32_t channel);
+HAL_StatusTypeDef HAL_DAC_Start_DMA(DAC_HandleTypeDef* hdac, uint32_t channel, uint32_t* pData, uint32_t Length, uint32_t alignment);
+HAL_StatusTypeDef HAL_DAC_Stop_DMA(DAC_HandleTypeDef* hdac, uint32_t channel);
+uint32_t HAL_DAC_GetValue(DAC_HandleTypeDef* hdac, uint32_t channel);
+
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef HAL_DAC_ConfigChannel(DAC_HandleTypeDef* hdac, DAC_ChannelConfTypeDef* sConfig, uint32_t channel);
+HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef* hdac, uint32_t channel, uint32_t alignment, uint32_t data);
+
+/* Peripheral State and Error functions ***************************************/
+HAL_DAC_StateTypeDef HAL_DAC_GetState(DAC_HandleTypeDef* hdac);
+void HAL_DAC_IRQHandler(DAC_HandleTypeDef* hdac);
+uint32_t HAL_DAC_GetError(DAC_HandleTypeDef *hdac);
+
+void HAL_DAC_ConvCpltCallbackCh1(DAC_HandleTypeDef* hdac);
+void HAL_DAC_ConvHalfCpltCallbackCh1(DAC_HandleTypeDef* hdac);
+void HAL_DAC_ErrorCallbackCh1(DAC_HandleTypeDef *hdac);
+void HAL_DAC_DMAUnderrunCallbackCh1(DAC_HandleTypeDef *hdac);
+
+#endif /* STM32L051xx && STM32L061xx*/
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /*__STM32L0xx_HAL_DAC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_dac_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_dac_ex.c
@@ -1,0 +1,202 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_dac_ex.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   DAC HAL module driver.
+  *    
+  *         This file provides firmware functions to manage the following
+  *         functionalities of the Digital to Analog Converter (DAC) peripheral:
+  *           + DAC wave generation
+  *     
+  @verbatim
+  
+ @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup DACEx 
+  * @brief DAC driver modules
+  * @{
+  */
+
+#ifdef HAL_DAC_MODULE_ENABLED
+#if !defined (STM32L051xx) && !defined (STM32L061xx)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup DACEx_Private_Functions
+  * @{
+  */
+
+  
+/** @defgroup DACEx_Group Peripheral Control functions
+ *  @brief   	Peripheral Control functions 
+ *
+@verbatim   
+  ==============================================================================
+             ##### Peripheral Control functions #####
+  ==============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Configure Triangle wave generation.
+      (+) Configure Noise wave generation.
+      
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enables or disables the selected DAC channel wave triangle generation.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  * @param  Amplitude: Select max triangle amplitude. 
+  *          This parameter can be one of the following values:
+  *            @arg DAC_TRIANGLEAMPLITUDE_1: Select max triangle amplitude of 1
+  *            @arg DAC_TRIANGLEAMPLITUDE_3: Select max triangle amplitude of 3
+  *            @arg DAC_TRIANGLEAMPLITUDE_7: Select max triangle amplitude of 7
+  *            @arg DAC_TRIANGLEAMPLITUDE_15: Select max triangle amplitude of 15
+  *            @arg DAC_TRIANGLEAMPLITUDE_31: Select max triangle amplitude of 31
+  *            @arg DAC_TRIANGLEAMPLITUDE_63: Select max triangle amplitude of 63
+  *            @arg DAC_TRIANGLEAMPLITUDE_127: Select max triangle amplitude of 127
+  *            @arg DAC_TRIANGLEAMPLITUDE_255: Select max triangle amplitude of 255
+  *            @arg DAC_TRIANGLEAMPLITUDE_511: Select max triangle amplitude of 511
+  *            @arg DAC_TRIANGLEAMPLITUDE_1023: Select max triangle amplitude of 1023
+  *            @arg DAC_TRIANGLEAMPLITUDE_2047: Select max triangle amplitude of 2047
+  *            @arg DAC_TRIANGLEAMPLITUDE_4095: Select max triangle amplitude of 4095
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DACEx_TriangleWaveGenerate(DAC_HandleTypeDef* hdac, uint32_t channel, uint32_t Amplitude)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(channel));
+  assert_param(IS_DAC_LFSR_UNMASK_TRIANGLE_AMPLITUDE(Amplitude));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Enable the selected wave generation for the selected DAC channel */
+  hdac->Instance->CR |= (DAC_WAVEGENERATION_TRIANGLE | Amplitude) << channel;
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables or disables the selected DAC channel wave noise generation.
+  * @param  channel: The selected DAC channel.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC Channel1 selected
+  * @param  Amplitude: Unmask DAC channel LFSR for noise wave generation.
+  *          This parameter can be one of the following values:
+  *            @arg DAC_LFSRUNMASK_BIT0: Unmask DAC channel LFSR bit0 for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS1_0: Unmask DAC channel LFSR bit[1:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS2_0: Unmask DAC channel LFSR bit[2:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS3_0: Unmask DAC channel LFSR bit[3:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS4_0: Unmask DAC channel LFSR bit[4:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS5_0: Unmask DAC channel LFSR bit[5:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS6_0: Unmask DAC channel LFSR bit[6:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS7_0: Unmask DAC channel LFSR bit[7:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS8_0: Unmask DAC channel LFSR bit[8:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS9_0: Unmask DAC channel LFSR bit[9:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS10_0: Unmask DAC channel LFSR bit[10:0] for noise wave generation
+  *            @arg DAC_LFSRUNMASK_BITS11_0: Unmask DAC channel LFSR bit[11:0] for noise wave generation
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DACEx_NoiseWaveGenerate(DAC_HandleTypeDef* hdac, uint32_t channel, uint32_t Amplitude)
+{
+  /* Check the parameters */
+  assert_param(IS_DAC_CHANNEL(channel));
+  assert_param(IS_DAC_LFSR_UNMASK_TRIANGLE_AMPLITUDE(Amplitude));
+
+  /* Process locked */
+  __HAL_LOCK(hdac);
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_BUSY;
+
+  /* Enable the selected wave generation for the selected DAC channel */
+  hdac->Instance->CR |= (DAC_WAVEGENERATION_NOISE | Amplitude) << channel;
+
+  /* Change DAC state */
+  hdac->State = HAL_DAC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hdac);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* STM32L051xx && STM32L061xx*/
+#endif /* HAL_DAC_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_dac_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_dac_ex.h
@@ -1,0 +1,160 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_dac_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of DAC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_DAC_EX_H
+#define __STM32L0xx_HAL_DAC_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !defined (STM32L051xx) && !defined (STM32L061xx)
+   
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup DACEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+   
+/** 
+  * @brief  HAL State structures definition  
+  */ 
+
+/* Exported constants --------------------------------------------------------*/
+  
+/** @defgroup DACEx_wave_generation
+  * @{
+  */
+#define DAC_WAVEGENERATION_NONE            ((uint32_t)0x00000000)
+#define DAC_WAVEGENERATION_NOISE           ((uint32_t)DAC_CR_WAVE1_0)
+#define DAC_WAVEGENERATION_TRIANGLE        ((uint32_t)DAC_CR_WAVE1_1)
+
+#define IS_DAC_GENERATE_WAVE(WAVE) (((WAVE) == DAC_WAVEGENERATION_NONE) || \
+                                    ((WAVE) == DAC_WAVEGENERATION_NOISE) || \
+                                    ((WAVE) == DAC_WAVEGENERATION_TRIANGLE))
+/**
+  * @}
+  */
+
+/** @defgroup DACEx_lfsrunmask_triangleamplitude
+  * @{
+  */
+#define DAC_LFSRUNMASK_BIT0                ((uint32_t)0x00000000) /*!< Unmask DAC channel LFSR bit0 for noise wave generation */
+#define DAC_LFSRUNMASK_BITS1_0             ((uint32_t)DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[1:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS2_0             ((uint32_t)DAC_CR_MAMP1_1) /*!< Unmask DAC channel LFSR bit[2:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS3_0             ((uint32_t)DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0)/*!< Unmask DAC channel LFSR bit[3:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS4_0             ((uint32_t)DAC_CR_MAMP1_2) /*!< Unmask DAC channel LFSR bit[4:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS5_0             ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[5:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS6_0             ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1) /*!< Unmask DAC channel LFSR bit[6:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS7_0             ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[7:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS8_0             ((uint32_t)DAC_CR_MAMP1_3) /*!< Unmask DAC channel LFSR bit[8:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS9_0             ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[9:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS10_0            ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_1) /*!< Unmask DAC channel LFSR bit[10:0] for noise wave generation */
+#define DAC_LFSRUNMASK_BITS11_0            ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[11:0] for noise wave generation */
+#define DAC_TRIANGLEAMPLITUDE_1            ((uint32_t)0x00000000) /*!< Select max triangle amplitude of 1 */
+#define DAC_TRIANGLEAMPLITUDE_3            ((uint32_t)DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 3 */
+#define DAC_TRIANGLEAMPLITUDE_7            ((uint32_t)DAC_CR_MAMP1_1) /*!< Select max triangle amplitude of 7 */
+#define DAC_TRIANGLEAMPLITUDE_15           ((uint32_t)DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 15 */
+#define DAC_TRIANGLEAMPLITUDE_31           ((uint32_t)DAC_CR_MAMP1_2) /*!< Select max triangle amplitude of 31 */
+#define DAC_TRIANGLEAMPLITUDE_63           ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 63 */
+#define DAC_TRIANGLEAMPLITUDE_127          ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1) /*!< Select max triangle amplitude of 127 */
+#define DAC_TRIANGLEAMPLITUDE_255          ((uint32_t)DAC_CR_MAMP1_2 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 255 */
+#define DAC_TRIANGLEAMPLITUDE_511          ((uint32_t)DAC_CR_MAMP1_3) /*!< Select max triangle amplitude of 511 */
+#define DAC_TRIANGLEAMPLITUDE_1023         ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 1023 */
+#define DAC_TRIANGLEAMPLITUDE_2047         ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_1) /*!< Select max triangle amplitude of 2047 */
+#define DAC_TRIANGLEAMPLITUDE_4095         ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 4095 */
+
+#define IS_DAC_LFSR_UNMASK_TRIANGLE_AMPLITUDE(VALUE) (((VALUE) == DAC_LFSRUNMASK_BIT0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS1_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS2_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS3_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS4_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS5_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS6_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS7_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS8_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS9_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS10_0) || \
+                                                      ((VALUE) == DAC_LFSRUNMASK_BITS11_0) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_1) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_3) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_7) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_15) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_31) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_63) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_127) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_255) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_511) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_1023) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_2047) || \
+                                                      ((VALUE) == DAC_TRIANGLEAMPLITUDE_4095))
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/  
+/* Exported functions --------------------------------------------------------*/  
+
+/* Peripheral Control methods *************************************************/
+HAL_StatusTypeDef HAL_DACEx_TriangleWaveGenerate(DAC_HandleTypeDef* hdac, uint32_t channel, uint32_t Amplitude);
+HAL_StatusTypeDef HAL_DACEx_NoiseWaveGenerate(DAC_HandleTypeDef* hdac, uint32_t channel, uint32_t Amplitude);
+
+#endif /* STM32L051xx && STM32L061xx*/
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /*__STM32L0xx_HAL_DAC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_def.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_def.h
@@ -1,0 +1,198 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_def.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   This file contains HAL common defines, enumeration, macros and 
+  *          structures definitions. 
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_DEF
+#define __STM32L0xx_HAL_DEF
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx.h"
+
+/* Exported types ------------------------------------------------------------*/
+
+/** 
+  * @brief  HAL Status structures definition  
+  */  
+typedef enum 
+{
+  HAL_OK       = 0x00,
+  HAL_ERROR    = 0x01,
+  HAL_BUSY     = 0x02,
+  HAL_TIMEOUT  = 0x03
+} HAL_StatusTypeDef;
+
+/** 
+  * @brief  HAL Lock structures definition  
+  */
+typedef enum 
+{
+  HAL_UNLOCKED = 0x00,
+  HAL_LOCKED   = 0x01  
+} HAL_LockTypeDef;
+
+/* Exported macro ------------------------------------------------------------*/
+#ifndef NULL
+  #define NULL      (void *) 0
+#endif
+
+#define HAL_MAX_DELAY      0xFFFFFFFF
+
+#define HAL_IS_BIT_SET(REG, BIT)         (((REG) & (BIT)) != RESET)
+#define HAL_IS_BIT_CLR(REG, BIT)         (((REG) & (BIT)) == RESET)
+
+#define __HAL_LINKDMA(__HANDLE__, __PPP_DMA_FIELD__, __DMA_HANDLE__)             \
+                        do{                                                    \
+                            (__HANDLE__)->__PPP_DMA_FIELD__ = &(__DMA_HANDLE__); \
+                            (__DMA_HANDLE__).Parent = (__HANDLE__);             \
+                          } while(0)
+
+/** @brief Reset the Handle's State field.
+  * @param __HANDLE__: specifies the Peripheral Handle.
+  * @note  This macro can be used for the following purpose: 
+  *          - When the Handle is declared as local variable; before passing it as parameter
+  *            to HAL_PPP_Init() for the first time, it is mandatory to use this macro 
+  *            to set to 0 the Handle's "State" field.
+  *            Otherwise, "State" field may have any random value and the first time the function 
+  *            HAL_PPP_Init() is called, the low level hardware initialization will be missed
+  *            (i.e. HAL_PPP_MspInit() will not be executed).
+  *          - When there is a need to reconfigure the low level hardware: instead of calling
+  *            HAL_PPP_DeInit() then HAL_PPP_Init(), user can make a call to this macro then HAL_PPP_Init().
+  *            In this later function, when the Handle's "State" field is set to 0, it will execute the function
+  *            HAL_PPP_MspInit() which will reconfigure the low level hardware.
+  * @retval None
+  */
+#define __HAL_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = 0)
+
+#if (USE_RTOS == 1)
+                            
+  /* Reserved for future use */
+  #error “USE_RTOS should be 0 in the current HAL release”
+                            
+#else
+  #define __HAL_LOCK(__HANDLE__)                                               \
+                                do{                                            \
+                                    if((__HANDLE__)->Lock == HAL_LOCKED)       \
+                                    {                                          \
+                                       return HAL_BUSY;                        \
+                                    }                                          \
+                                    else                                       \
+                                    {                                          \
+                                       (__HANDLE__)->Lock = HAL_LOCKED;        \
+                                    }                                          \
+                                  }while (0)
+
+  #define __HAL_UNLOCK(__HANDLE__)                                             \
+                                  do{                                          \
+                                      (__HANDLE__)->Lock = HAL_UNLOCKED;       \
+                                    }while (0)
+#endif /* USE_RTOS */
+
+#if  defined ( __GNUC__ )
+  #ifndef __weak
+    #define __weak   __attribute__((weak))
+  #endif /* __weak */
+  #ifndef __packed
+    #define __packed __attribute__((__packed__))
+  #endif /* __packed */
+#endif /* __GNUC__ */
+
+
+/* Macro to get variable aligned on 4-bytes, for __ICCARM__ the directive "#pragma data_alignment=4" must be used instead */
+#if defined   (__GNUC__)        /* GNU Compiler */
+  #ifndef __ALIGN_END
+    #define __ALIGN_END    __attribute__ ((aligned (4)))
+  #endif /* __ALIGN_END */
+  #ifndef __ALIGN_BEGIN  
+    #define __ALIGN_BEGIN
+  #endif /* __ALIGN_BEGIN */
+#else
+  #ifndef __ALIGN_END
+    #define __ALIGN_END
+  #endif /* __ALIGN_END */
+  #ifndef __ALIGN_BEGIN      
+    #if defined   (__CC_ARM)      /* ARM Compiler */
+      #define __ALIGN_BEGIN    __align(4)  
+    #elif defined (__ICCARM__)    /* IAR Compiler */
+      #define __ALIGN_BEGIN 
+    #endif /* __CC_ARM */
+  #endif /* __ALIGN_BEGIN */
+#endif /* __GNUC__ */
+
+/** 
+  * @brief  __RAM_FUNC definition
+  */ 
+#if defined ( __CC_ARM   )
+/* ARM Compiler
+   ------------
+   RAM functions are defined using the toolchain options. 
+   Functions that are executed in RAM should reside in a separate source module.
+   Using the 'Options for File' dialog you can simply change the 'Code / Const' 
+   area of a module to a memory space in physical RAM.
+   Available memory areas are declared in the 'Target' tab of the 'Options for Target'
+   dialog. 
+*/
+#define __RAM_FUNC HAL_StatusTypeDef 
+
+#elif defined ( __ICCARM__ )
+/* ICCARM Compiler
+   ---------------
+   RAM functions are defined using a specific toolchain keyword "__ramfunc". 
+*/
+#define __RAM_FUNC __ramfunc HAL_StatusTypeDef
+
+#elif defined   (  __GNUC__  )
+/* GNU Compiler
+   ------------
+  RAM functions are defined using a specific toolchain attribute 
+   "__attribute__((section(".RamFunc")))".
+*/
+#define __RAM_FUNC HAL_StatusTypeDef  __attribute__((section(".RamFunc")))
+
+#endif
+                                      
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ___STM32L0xx_HAL_DEF */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_dma.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_dma.c
@@ -1,0 +1,751 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_dma.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   DMA HAL module driver.
+  *    
+  *         This file provides firmware functions to manage the following 
+  *         functionalities of the Direct Memory Access (DMA) peripheral:
+  *           + Initialization/de-initialization functions
+  *           + I/O operation functions
+  *           + Peripheral State functions
+  *  
+  *           
+  @verbatim     
+  ==============================================================================      
+                        ##### How to use this driver #####
+  ============================================================================== 
+  [..]
+   (#) Enable and configure the peripheral to be connected to the DMA Channel
+       (except for internal SRAM / FLASH memories: no initialization is 
+       necessary). 
+          
+   (#) For a given Channel, program the required configuration through the following parameters:   
+       Channel request, Transfer Direction, Source and Destination data formats, 
+       Circular, Normal or peripheral flow control mode, Channel Priority level, 
+       Source and Destination Increment mode using HAL_DMA_Init() function.
+   
+     *** Polling mode IO operation ***
+     =================================   
+    [..] 
+          (+) Use HAL_DMA_Start() to start DMA transfer after the configuration of Source 
+              address and destination address and the Length of data to be transferred
+          (+) Use HAL_DMA_PollForTransfer() to poll for the end of current transfer, in this  
+              case a fixed Timeout can be configured by User depending from his application.
+               
+     *** Interrupt mode IO operation ***    
+     =================================== 
+    [..]     
+          (+) Configure the DMA interrupt priority using HAL_NVIC_SetPriority()
+          (+) Enable the DMA IRQ handler using HAL_NVIC_EnableIRQ() 
+          (+) Use HAL_DMA_Start_IT() to start DMA transfer after the configuration of  
+              Source address and destination address and the Length of data to be transferred. In this 
+              case the DMA interrupt is configured 
+          (+) Use HAL_DMA_IRQHandler() called under DMA_IRQHandler() Interrupt subroutine
+          (+) At the end of data transfer HAL_DMA_IRQHandler() function is executed and user can 
+              add his own function by customization of function pointer XferCpltCallback and 
+              XferErrorCallback (i.e a member of DMA handle structure). 
+                
+     (#) Use HAL_DMA_GetState() function to return the DMA state and HAL_DMA_GetError() in case of error 
+         detection.
+         
+     (#) Use HAL_DMA_Abort() function to abort the current transfer              
+                   
+     -@-   In Memory-to-Memory transfer mode, Circular mode is not allowed.          
+  
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup DMA 
+  * @brief DMA HAL module driver
+  * @{
+  */
+
+#ifdef HAL_DMA_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define HAL_TIMEOUT_DMA_ABORT    ((uint32_t)1000)  /* 1s  */
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void DMA_SetConfig(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
+
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup DMA_Private_Functions
+  * @{
+  */
+
+/** @defgroup DMA_Group1 Initialization/de-initialization functions 
+ *  @brief   Initialization/de-initialization functions 
+ *
+@verbatim   
+ ===============================================================================
+             ##### Initialization and de-initialization functions  #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the DMA
+      (+) De-Initialize the DMA 
+
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Initializes the DMA according to the specified
+  *         parameters in the DMA_InitTypeDef and create the associated handle.
+  * @param  hdma: Pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Channel.  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma)
+{ 
+  uint32_t tmp = 0;
+  
+  /* Check the DMA peripheral state */
+  if(hdma == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_DMA_ALL_PERIPH(hdma->Instance));
+  assert_param(IS_DMA_ALL_REQUEST(hdma->Init.Request));
+  assert_param(IS_DMA_DIRECTION(hdma->Init.Direction));
+  assert_param(IS_DMA_PERIPHERAL_INC_STATE(hdma->Init.PeriphInc));
+  assert_param(IS_DMA_MEMORY_INC_STATE(hdma->Init.MemInc));
+  assert_param(IS_DMA_PERIPHERAL_DATA_SIZE(hdma->Init.PeriphDataAlignment));
+  assert_param(IS_DMA_MEMORY_DATA_SIZE(hdma->Init.MemDataAlignment));
+  assert_param(IS_DMA_MODE(hdma->Init.Mode));
+  assert_param(IS_DMA_PRIORITY(hdma->Init.Priority));
+  
+  /* Change DMA peripheral state */
+  hdma->State = HAL_DMA_STATE_BUSY;
+
+  /* Get the CR register value */
+  tmp = hdma->Instance->CCR;
+  
+  /* Clear PL, MSIZE, PSIZE, MINC, PINC, CIRC, DIR bits */
+  tmp &= ((uint32_t)~(DMA_CCR_PL    | DMA_CCR_MSIZE  | DMA_CCR_PSIZE  | \
+                      DMA_CCR_MINC  | DMA_CCR_PINC   | DMA_CCR_CIRC   | \
+                      DMA_CCR_DIR));
+  
+  /* Prepare the DMA Channel configuration */
+  tmp |=  hdma->Init.Direction        |
+          hdma->Init.PeriphInc           | hdma->Init.MemInc           |
+          hdma->Init.PeriphDataAlignment | hdma->Init.MemDataAlignment |
+          hdma->Init.Mode                | hdma->Init.Priority;
+
+  /* Write to DMA Channel CR register */
+  hdma->Instance->CCR = tmp;  
+  
+  /* Write to DMA channel selection register */
+  if (hdma->Instance == DMA1_Channel1)
+  {
+    /*Reset request selection for DMA1 Channel1*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C1S;
+    
+    /* Configure request selection for DMA1 Channel1 */
+    DMA1_CSELR->CSELR |= hdma->Init.Request;
+  }
+  else if (hdma->Instance == DMA1_Channel2)
+  {
+    /*Reset request selection for DMA1 Channel2*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C2S;
+    
+    /* Configure request selection for DMA1 Channel2 */
+    DMA1_CSELR->CSELR |= (uint32_t)(hdma->Init.Request << 4);
+  }
+  else if (hdma->Instance == DMA1_Channel3)
+  {
+    /*Reset request selection for DMA1 Channel3*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C3S;
+    
+    /* Configure request selection for DMA1 Channel3 */
+    DMA1_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 8);
+  }
+  else if (hdma->Instance == DMA1_Channel4)
+  {
+    /*Reset request selection for DMA1 Channel4*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C4S;
+    
+    /* Configure request selection for DMA1 Channel4 */
+    DMA1_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 12);
+  }
+  else if (hdma->Instance == DMA1_Channel5)
+  {
+    /*Reset request selection for DMA1 Channel5*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C5S;
+    
+    /* Configure request selection for DMA1 Channel5 */
+    DMA1_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 16);
+  }
+  else if (hdma->Instance == DMA1_Channel6)
+  {
+    /*Reset request selection for DMA1 Channel6*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C6S;
+    
+    /* Configure request selection for DMA1 Channel6 */
+    DMA1_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 20);
+  }
+  else if (hdma->Instance == DMA1_Channel7)
+  {
+    /*Reset request selection for DMA1 Channel7*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C7S;
+    
+    /* Configure request selection for DMA1 Channel7 */
+    DMA1_CSELR->CSELR |= (uint32_t) (hdma->Init.Request << 24);
+  }
+   
+  /* Initialize the DMA state*/
+  hdma->State  = HAL_DMA_STATE_READY;
+  
+  return HAL_OK;
+}  
+  
+/**
+  * @brief  DeInitializes the DMA peripheral 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Channel.  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_DeInit(DMA_HandleTypeDef *hdma)
+{
+  /* Check the DMA peripheral state */
+  if(hdma == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the DMA peripheral state */
+  if(hdma->State == HAL_DMA_STATE_BUSY)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Disable the selected DMA Channelx */
+  __HAL_DMA_DISABLE(hdma);
+  
+  /* Reset DMA Channel control register */
+  hdma->Instance->CCR  = 0;
+  
+  /* Reset DMA Channel Number of Data to Transfer register */
+  hdma->Instance->CNDTR = 0;
+  
+  /* Reset DMA Channel peripheral address register */
+  hdma->Instance->CPAR  = 0;
+  
+  /* Reset DMA Channel memory address register */
+  hdma->Instance->CMAR = 0;
+
+  /* Clear all flags */
+  __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_GI_FLAG_INDEX(hdma));
+  __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma));
+  __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma));
+  __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
+  
+  /* Reset DMA channel selection register */
+  if (hdma->Instance == DMA1_Channel1)
+  {
+    /*Reset DMA request*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C1S;
+  }
+  else if (hdma->Instance == DMA1_Channel2)
+  {
+    /*Reset DMA request*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C2S;
+  }
+  else if (hdma->Instance == DMA1_Channel3)
+  {
+    /*Reset DMA request*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C3S;
+  }
+  else if (hdma->Instance == DMA1_Channel4)
+  {
+    /*Reset DMA request*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C4S;
+  }
+  else if (hdma->Instance == DMA1_Channel5)
+  {
+    /*Reset DMA request*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C5S;
+  }
+  else if (hdma->Instance == DMA1_Channel6)
+  {
+    /*Reset DMA request*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C6S;
+  }
+  else if (hdma->Instance == DMA1_Channel7)
+  {
+    /*Reset DMA request*/
+    DMA1_CSELR->CSELR &= ~DMA_CSELR_C7S;
+  }
+  
+  /* Initialise the error code */
+  hdma->ErrorCode = HAL_DMA_ERROR_NONE;
+
+  /* Initialize the DMA state */
+  hdma->State = HAL_DMA_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(hdma);
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Group2 I/O operation functions 
+ *  @brief   I/O operation functions  
+ *
+@verbatim   
+ ===============================================================================
+                      #####  IO operation functions  #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Configure the source, destination address and data length and Start DMA transfer
+      (+) Configure the source, destination address and data length and 
+          Start DMA transfer with interrupt
+      (+) Abort DMA transfer
+      (+) Poll for transfer complete
+      (+) Handle DMA interrupt request  
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Starts the DMA Transfer.
+  * @param  hdma      : pointer to a DMA_HandleTypeDef structure that contains
+  *                     the configuration information for the specified DMA Channel.  
+  * @param  SrcAddress: The source memory Buffer address
+  * @param  DstAddress: The destination memory Buffer address
+  * @param  DataLength: The length of data to be transferred from source to destination
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_Start(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength)
+{ 
+  /* Process locked */
+  __HAL_LOCK(hdma);  
+
+  /* Change DMA peripheral state */  
+  hdma->State = HAL_DMA_STATE_BUSY;  
+
+   /* Check the parameters */
+  assert_param(IS_DMA_BUFFER_SIZE(DataLength));
+  
+  /* Disable the peripheral */
+  __HAL_DMA_DISABLE(hdma);  
+  
+  /* Configure the source, destination address and the data length */
+  DMA_SetConfig(hdma, SrcAddress, DstAddress, DataLength);
+
+  /* Enable the Peripheral */
+  __HAL_DMA_ENABLE(hdma);  
+
+  return HAL_OK; 
+} 
+
+/**
+  * @brief  Start the DMA Transfer with interrupt enabled.
+  * @param  hdma:       pointer to a DMA_HandleTypeDef structure that contains
+  *                     the configuration information for the specified DMA Channel.  
+  * @param  SrcAddress: The source memory Buffer address
+  * @param  DstAddress: The destination memory Buffer address
+  * @param  DataLength: The length of data to be transferred from source to destination
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength)
+{
+  /* Process locked */
+  __HAL_LOCK(hdma);
+
+  /* Change DMA peripheral state */  
+  hdma->State = HAL_DMA_STATE_BUSY;  
+
+   /* Check the parameters */
+  assert_param(IS_DMA_BUFFER_SIZE(DataLength));
+  
+  /* Disable the peripheral */
+  __HAL_DMA_DISABLE(hdma);
+  
+  /* Configure the source, destination address and the data length */  
+  DMA_SetConfig(hdma, SrcAddress, DstAddress, DataLength);
+  
+  /* Enable the transfer complete interrupt */
+  __HAL_DMA_ENABLE_IT(hdma, DMA_IT_TC);
+
+  /* Enable the Half transfer complete interrupt */
+  __HAL_DMA_ENABLE_IT(hdma, DMA_IT_HT);  
+
+  /* Enable the transfer Error interrupt */
+  __HAL_DMA_ENABLE_IT(hdma, DMA_IT_TE);
+  
+   /* Enable the Peripheral */
+  __HAL_DMA_ENABLE(hdma);   
+  
+  return HAL_OK;    
+} 
+
+/**
+  * @brief  Aborts the DMA Transfer.
+  * @param  hdma  : pointer to a DMA_HandleTypeDef structure that contains
+  *                 the configuration information for the specified DMA Channel.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma)
+{
+  uint32_t tickstart = 0;
+  
+  /* Disable the channel */
+  __HAL_DMA_DISABLE(hdma);
+  
+  /* Get timeout */
+  tickstart = HAL_GetTick();
+  
+  /* Check if the DMA Channel is effectively disabled */
+  while((hdma->Instance->CCR & DMA_CCR_EN) != 0) 
+  {
+    /* Check for the Timeout */
+    if( (HAL_GetTick()  - tickstart ) > HAL_TIMEOUT_DMA_ABORT)
+    {
+      /* Update error code */
+      hdma->ErrorCode |= HAL_DMA_ERROR_TIMEOUT;
+      
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
+      
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_TIMEOUT;
+      
+      return HAL_TIMEOUT;
+    }
+  }
+  /* Process Unlocked */
+  __HAL_UNLOCK(hdma);
+  
+  /* Change the DMA state*/
+  hdma->State = HAL_DMA_STATE_READY; 
+  
+  return HAL_OK; 
+}
+
+/**
+  * @brief  Polling for transfer complete.
+  * @param  hdma:    pointer to a DMA_HandleTypeDef structure that contains
+  *                  the configuration information for the specified DMA Channel.
+  * @param  CompleteLevel: Specifies the DMA level complete.  
+  * @param  Timeout:       Timeout duration.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, uint32_t CompleteLevel, uint32_t Timeout)
+{
+  uint32_t temp;
+  uint32_t tickstart = 0;
+  
+  /* Get the level transfer complete flag */
+  if(CompleteLevel == HAL_DMA_FULL_TRANSFER)
+  {
+    /* Transfer Complete flag */
+    temp = __HAL_DMA_GET_TC_FLAG_INDEX(hdma);
+  }
+  else
+  {
+    /* Half Transfer Complete flag */
+    temp = __HAL_DMA_GET_HT_FLAG_INDEX(hdma);
+  }
+
+  /* Get timeout */
+  tickstart = HAL_GetTick();
+
+  while(__HAL_DMA_GET_FLAG(hdma, temp) == RESET)
+  {
+    if((__HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma)) != RESET))
+    {      
+      /* Clear the transfer error flags */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma));
+      
+      /* Update error code */
+      SET_BIT(hdma->ErrorCode, HAL_DMA_ERROR_TE);
+      
+      /* Change the DMA state */
+      hdma->State= HAL_DMA_STATE_ERROR;       
+      
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
+      
+      return HAL_ERROR;      
+    }      
+    /* Check for the Timeout */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        /* Update error code */
+        SET_BIT(hdma->ErrorCode, HAL_DMA_ERROR_TIMEOUT);
+        
+        /* Change the DMA state */
+        hdma->State= HAL_DMA_STATE_TIMEOUT;
+        
+        /* Process Unlocked */
+        __HAL_UNLOCK(hdma);
+      
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  if(CompleteLevel == HAL_DMA_FULL_TRANSFER)
+  {
+    /* Clear the transfer complete flag */
+    __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma));
+
+    /* The selected Channelx EN bit is cleared (DMA is disabled and 
+    all transfers are complete) */
+    hdma->State = HAL_DMA_STATE_READY;
+
+    /* Process unlocked */
+    __HAL_UNLOCK(hdma);  
+  }
+  else
+  { 
+    /* Clear the half transfer complete flag */
+    __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
+
+    /* The selected Channelx EN bit is cleared (DMA is disabled and 
+    all transfers are complete) */
+    hdma->State = HAL_DMA_STATE_READY_HALF;
+    
+    /* Process unlocked */
+    __HAL_UNLOCK(hdma); 
+  }
+  
+  return HAL_OK;
+}
+/**
+  * @brief  Handles DMA interrupt request.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Channel.  
+  * @retval None
+  */
+void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
+{        
+  /* Transfer Error Interrupt management ***************************************/
+  if(__HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma)) != RESET)
+  {
+    if(__HAL_DMA_GET_IT_SOURCE(hdma, DMA_IT_TE) != RESET)
+    {
+      /* Disable the transfer error interrupt */
+      __HAL_DMA_DISABLE_IT(hdma, DMA_IT_TE);
+    
+      /* Clear the transfer error flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TE_FLAG_INDEX(hdma));
+    
+      /* Update error code */
+      hdma->ErrorCode |= HAL_DMA_ERROR_TE;
+
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_ERROR;    
+    
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma); 
+    
+      if (hdma->XferErrorCallback != NULL)
+      {
+        /* Transfer error callback */
+        hdma->XferErrorCallback(hdma);
+      }
+    }
+  }
+
+  /* Half Transfer Complete Interrupt management ******************************/
+  if(__HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma)) != RESET)
+  {
+    if(__HAL_DMA_GET_IT_SOURCE(hdma, DMA_IT_HT) != RESET)
+    { 
+      /* Disable the half transfer interrupt if the DMA mode is not CIRCULAR */
+      if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+      {
+        /* Disable the half transfer interrupt */
+        __HAL_DMA_DISABLE_IT(hdma, DMA_IT_HT);
+      }
+      /* Clear the half transfer complete flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_HT_FLAG_INDEX(hdma));
+
+      /* Change DMA peripheral state */
+      hdma->State = HAL_DMA_STATE_READY_HALF;
+
+      if(hdma->XferHalfCpltCallback != NULL)
+      {
+        /* Half transfer callback */
+        hdma->XferHalfCpltCallback(hdma);
+      }
+    }
+  }
+  
+  /* Transfer Complete Interrupt management ***********************************/
+  if(__HAL_DMA_GET_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma)) != RESET)
+  {
+    if(__HAL_DMA_GET_IT_SOURCE(hdma, DMA_IT_TC) != RESET)
+    {
+      if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+      {
+        /* Disable the transfer complete interrupt */
+        __HAL_DMA_DISABLE_IT(hdma, DMA_IT_TC);
+      }
+      /* Clear the transfer complete flag */
+      __HAL_DMA_CLEAR_FLAG(hdma, __HAL_DMA_GET_TC_FLAG_INDEX(hdma));
+    
+      /* Update error code */
+      hdma->ErrorCode |= HAL_DMA_ERROR_NONE;
+
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_READY;    
+    
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
+    
+      if(hdma->XferCpltCallback != NULL)
+      {       
+        /* Transfer complete callback */
+        hdma->XferCpltCallback(hdma);
+      }
+    }
+  }
+}  
+
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Group3 Peripheral State functions
+ *  @brief    Peripheral State functions 
+ *
+@verbatim   
+ ===============================================================================
+                        ##### Peripheral State functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides functions allowing to
+      (+) Check the DMA state
+      (+) Get error code
+
+@endverbatim
+  * @{
+  */  
+
+/**
+  * @brief  Returns the DMA state.
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Channel.  
+  * @retval HAL state
+  */
+HAL_DMA_StateTypeDef HAL_DMA_GetState(DMA_HandleTypeDef *hdma)
+{
+  return hdma->State;
+}
+
+/**
+  * @brief  Return the DMA error code
+  * @param  hdma : pointer to a DMA_HandleTypeDef structure that contains
+  *              the configuration information for the specified DMA Channel.
+  * @retval DMA Error Code
+  */
+uint32_t HAL_DMA_GetError(DMA_HandleTypeDef *hdma)
+{
+  return hdma->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  Sets the DMA Transfer parameter.
+  * @param  hdma:       pointer to a DMA_HandleTypeDef structure that contains
+  *                     the configuration information for the specified DMA Channel.  
+  * @param  SrcAddress: The source memory Buffer address
+  * @param  DstAddress: The destination memory Buffer address
+  * @param  DataLength: The length of data to be transferred from source to destination
+  * @retval HAL status
+  */
+static void DMA_SetConfig(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength)
+{  
+  /* Configure DMA Channel data length */
+  hdma->Instance->CNDTR = DataLength;
+  
+  /* Peripheral to Memory */
+  if((hdma->Init.Direction) == DMA_MEMORY_TO_PERIPH)
+  {   
+    /* Configure DMA Channel destination address */
+    hdma->Instance->CPAR = DstAddress;
+    
+    /* Configure DMA Channel source address */
+    hdma->Instance->CMAR = SrcAddress;
+  }
+  /* Memory to Peripheral */
+  else
+  {
+    /* Configure DMA Channel source address */
+    hdma->Instance->CPAR = SrcAddress;
+    
+    /* Configure DMA Channel destination address */
+    hdma->Instance->CMAR = DstAddress;
+  }
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_DMA_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_dma.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_dma.h
@@ -1,0 +1,542 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_dma.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of DMA HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_DMA_H
+#define __STM32L0xx_HAL_DMA_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup DMA
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+
+/** 
+  * @brief  DMA Configuration Structure definition  
+  */
+typedef struct
+{
+  uint32_t Request;                   /*!< Specifies the request selected for the specified channel. 
+                                           This parameter can be a value of @ref DMA_request */
+    
+  uint32_t Direction;                 /*!< Specifies if the data will be transferred from memory to peripheral, 
+                                           from memory to memory or from peripheral to memory.
+                                           This parameter can be a value of @ref DMA_Data_transfer_direction */
+
+  uint32_t PeriphInc;                 /*!< Specifies whether the Peripheral address register should be incremented or not.
+                                           This parameter can be a value of @ref DMA_Peripheral_incremented_mode */  
+
+  uint32_t MemInc;                    /*!< Specifies whether the memory address register should be incremented or not.
+                                           This parameter can be a value of @ref DMA_Memory_incremented_mode */
+  
+  uint32_t PeriphDataAlignment;       /*!< Specifies the Peripheral data width.
+                                           This parameter can be a value of @ref DMA_Peripheral_data_size */   
+
+  uint32_t MemDataAlignment;          /*!< Specifies the Memory data width.
+                                           This parameter can be a value of @ref DMA_Memory_data_size */
+
+  uint32_t Mode;                      /*!< Specifies the operation mode of the DMAy Channelx.
+                                           This parameter can be a value of @ref DMA_mode
+                                           @note The circular buffer mode cannot be used if the memory-to-memory
+                                                 data transfer is configured on the selected Channel */ 
+
+  uint32_t Priority;                   /*!< Specifies the software priority for the DMAy Channelx.
+                                            This parameter can be a value of @ref DMA_Priority_level */
+} DMA_InitTypeDef;
+
+/** 
+  * @brief DMA Configuration enumeration values definition 
+  */  
+typedef enum 
+{
+  DMA_MODE            = 0,      /*!< Control related DMA mode Parameter in DMA_InitTypeDef        */
+  DMA_PRIORITY        = 1,      /*!< Control related priority level Parameter in DMA_InitTypeDef  */
+  
+} DMA_ControlTypeDef;
+
+/** 
+  * @brief  HAL DMA State structures definition  
+  */ 
+typedef enum
+{
+  HAL_DMA_STATE_RESET             = 0x00,  /*!< DMA not yet initialized or disabled */  
+  HAL_DMA_STATE_READY             = 0x01,  /*!< DMA process success and ready for use   */
+  HAL_DMA_STATE_BUSY              = 0x02,  /*!< DMA process is ongoing              */     
+  HAL_DMA_STATE_TIMEOUT           = 0x03,  /*!< DMA timeout state                   */  
+  HAL_DMA_STATE_ERROR             = 0x04,  /*!< DMA error state                     */
+  HAL_DMA_STATE_READY_HALF        = 0x05,  /*!< DMA Half process success            */
+}HAL_DMA_StateTypeDef;
+
+/** 
+  * @brief  HAL DMA Error Code structure definition  
+  */ 
+typedef enum
+{
+  HAL_DMA_FULL_TRANSFER      = 0x00,    /*!< Full transfer     */
+  HAL_DMA_HALF_TRANSFER      = 0x01,    /*!< Half Transfer     */
+
+}HAL_DMA_LevelCompleteTypeDef;
+
+
+/** 
+  * @brief  DMA handle Structure definition  
+  */ 
+typedef struct __DMA_HandleTypeDef
+{  
+  DMA_Channel_TypeDef    *Instance;                                                   /*!< Register base address                  */
+  
+  DMA_InitTypeDef       Init;                                                         /*!< DMA communication parameters           */ 
+  
+  HAL_LockTypeDef       Lock;                                                         /*!< DMA locking object                     */  
+  
+  __IO HAL_DMA_StateTypeDef  State;                                                   /*!< DMA transfer state                     */
+  
+  void                  *Parent;                                                      /*!< Parent object state                    */  
+  
+  void                  (* XferCpltCallback)( struct __DMA_HandleTypeDef * hdma);     /*!< DMA transfer complete callback         */
+  
+  void                  (* XferHalfCpltCallback)( struct __DMA_HandleTypeDef * hdma); /*!< DMA Half transfer complete callback    */
+
+  void                  (* XferErrorCallback)( struct __DMA_HandleTypeDef * hdma);    /*!< DMA transfer error callback            */
+  
+  __IO uint32_t          ErrorCode;                                                    /*!< DMA Error code                         */
+  
+} DMA_HandleTypeDef;    
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup DMA_Exported_Constants
+  * @{
+  */
+
+/** @defgroup DMA_Error_Code
+  * @{
+  */ 
+#define HAL_DMA_ERROR_NONE      ((uint32_t)0x00000000)    /*!< No error             */
+#define HAL_DMA_ERROR_TE        ((uint32_t)0x00000001)    /*!< Transfer error       */
+#define HAL_DMA_ERROR_TIMEOUT   ((uint32_t)0x00000020)    /*!< Timeout error        */
+/**
+  * @}
+  */
+
+#define IS_DMA_ALL_PERIPH(PERIPH) (((PERIPH) == DMA1_Channel1) || \
+                                   ((PERIPH) == DMA1_Channel2) || \
+                                   ((PERIPH) == DMA1_Channel3) || \
+                                   ((PERIPH) == DMA1_Channel4) || \
+                                   ((PERIPH) == DMA1_Channel5) || \
+                                   ((PERIPH) == DMA1_Channel6) || \
+                                   ((PERIPH) == DMA1_Channel7))
+
+#define IS_DMA_ALL_CONTROLLER(CONTROLLER) (((CONTROLLER) == DMA1))
+
+/**
+  * @}
+  */
+
+/** @defgroup DMA_request
+  * @{
+  */ 
+#define DMA_REQUEST_0                     ((uint32_t)0x00000000)
+#define DMA_REQUEST_1                     ((uint32_t)0x00000001)
+#define DMA_REQUEST_2                     ((uint32_t)0x00000002)
+#define DMA_REQUEST_3                     ((uint32_t)0x00000003)
+#define DMA_REQUEST_4                     ((uint32_t)0x00000004)
+#define DMA_REQUEST_5                     ((uint32_t)0x00000005)
+#define DMA_REQUEST_6                     ((uint32_t)0x00000006)
+#define DMA_REQUEST_7                     ((uint32_t)0x00000007)
+#define DMA_REQUEST_8                     ((uint32_t)0x00000008)
+#define DMA_REQUEST_9                     ((uint32_t)0x00000009)
+#define DMA_REQUEST_11                    ((uint32_t)0x0000000B)
+
+#define IS_DMA_ALL_REQUEST(REQUEST) (((REQUEST) == DMA_REQUEST_0) || \
+                                     ((REQUEST) == DMA_REQUEST_1) || \
+                                     ((REQUEST) == DMA_REQUEST_2) || \
+                                     ((REQUEST) == DMA_REQUEST_3) || \
+                                     ((REQUEST) == DMA_REQUEST_4) || \
+                                     ((REQUEST) == DMA_REQUEST_5) || \
+                                     ((REQUEST) == DMA_REQUEST_6) || \
+                                     ((REQUEST) == DMA_REQUEST_7) || \
+                                     ((REQUEST) == DMA_REQUEST_8) || \
+                                     ((REQUEST) == DMA_REQUEST_9) || \
+                                     ((REQUEST) == DMA_REQUEST_11))
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Data_transfer_direction
+  * @{
+  */ 
+#define DMA_PERIPH_TO_MEMORY         ((uint32_t)0x00000000)        /*!< Peripheral to memory direction */
+#define DMA_MEMORY_TO_PERIPH         ((uint32_t)DMA_CCR_DIR)       /*!< Memory to peripheral direction */
+#define DMA_MEMORY_TO_MEMORY         ((uint32_t)(DMA_CCR_MEM2MEM)) /*!< Memory to memory direction     */
+
+#define IS_DMA_DIRECTION(DIRECTION) (((DIRECTION) == DMA_PERIPH_TO_MEMORY ) || \
+                                     ((DIRECTION) == DMA_MEMORY_TO_PERIPH)  || \
+                                     ((DIRECTION) == DMA_MEMORY_TO_MEMORY)) 
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Data_buffer_size
+  * @{
+  */ 
+#define IS_DMA_BUFFER_SIZE(SIZE) (((SIZE) >= 0x1) && ((SIZE) < 0x10000))
+/**
+  * @}
+  */     
+    
+/** @defgroup DMA_Peripheral_incremented_mode
+  * @{
+  */ 
+#define DMA_PINC_ENABLE        ((uint32_t)DMA_CCR_PINC)  /*!< Peripheral increment mode Enable */
+#define DMA_PINC_DISABLE       ((uint32_t)0x00000000)    /*!< Peripheral increment mode Disable */
+
+#define IS_DMA_PERIPHERAL_INC_STATE(STATE) (((STATE) == DMA_PINC_ENABLE) || \
+                                            ((STATE) == DMA_PINC_DISABLE))
+/**
+  * @}
+  */ 
+
+/** @defgroup DMA_Memory_incremented_mode
+  * @{
+  */ 
+#define DMA_MINC_ENABLE         ((uint32_t)DMA_CCR_MINC)  /*!< Memory increment mode Enable  */
+#define DMA_MINC_DISABLE        ((uint32_t)0x00000000)    /*!< Memory increment mode Disable */
+
+#define IS_DMA_MEMORY_INC_STATE(STATE) (((STATE) == DMA_MINC_ENABLE)  || \
+                                        ((STATE) == DMA_MINC_DISABLE))
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Peripheral_data_size
+  * @{
+  */ 
+#define DMA_PDATAALIGN_BYTE          ((uint32_t)0x00000000)       /*!< Peripheral data alignment : Byte     */
+#define DMA_PDATAALIGN_HALFWORD      ((uint32_t)DMA_CCR_PSIZE_0)  /*!< Peripheral data alignment : HalfWord */
+#define DMA_PDATAALIGN_WORD          ((uint32_t)DMA_CCR_PSIZE_1)  /*!< Peripheral data alignment : Word     */
+
+#define IS_DMA_PERIPHERAL_DATA_SIZE(SIZE) (((SIZE) == DMA_PDATAALIGN_BYTE)     || \
+                                           ((SIZE) == DMA_PDATAALIGN_HALFWORD) || \
+                                           ((SIZE) == DMA_PDATAALIGN_WORD))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup DMA_Memory_data_size
+  * @{ 
+  */
+#define DMA_MDATAALIGN_BYTE          ((uint32_t)0x00000000)       /*!< Memory data alignment : Byte     */
+#define DMA_MDATAALIGN_HALFWORD      ((uint32_t)DMA_CCR_MSIZE_0)  /*!< Memory data alignment : HalfWord */
+#define DMA_MDATAALIGN_WORD          ((uint32_t)DMA_CCR_MSIZE_1)  /*!< Memory data alignment : Word     */
+
+#define IS_DMA_MEMORY_DATA_SIZE(SIZE) (((SIZE) == DMA_MDATAALIGN_BYTE)     || \
+                                       ((SIZE) == DMA_MDATAALIGN_HALFWORD) || \
+                                       ((SIZE) == DMA_MDATAALIGN_WORD ))
+/**
+  * @}
+  */
+
+/** @defgroup DMA_mode
+  * @{
+  */ 
+#define DMA_NORMAL         ((uint32_t)0x00000000)       /*!< Normal Mode                  */
+#define DMA_CIRCULAR       ((uint32_t)DMA_CCR_CIRC)    /*!< Circular Mode                */
+
+#define IS_DMA_MODE(MODE) (((MODE) == DMA_NORMAL )  || \
+                           ((MODE) == DMA_CIRCULAR)) 
+/**
+  * @}
+  */
+
+/** @defgroup DMA_Priority_level
+  * @{
+  */
+#define DMA_PRIORITY_LOW             ((uint32_t)0x00000000)    /*!< Priority level : Low       */
+#define DMA_PRIORITY_MEDIUM          ((uint32_t)DMA_CCR_PL_0)  /*!< Priority level : Medium    */
+#define DMA_PRIORITY_HIGH            ((uint32_t)DMA_CCR_PL_1)  /*!< Priority level : High      */
+#define DMA_PRIORITY_VERY_HIGH       ((uint32_t)DMA_CCR_PL)    /*!< Priority level : Very_High */
+
+#define IS_DMA_PRIORITY(PRIORITY) (((PRIORITY) == DMA_PRIORITY_LOW )   || \
+                                   ((PRIORITY) == DMA_PRIORITY_MEDIUM) || \
+                                   ((PRIORITY) == DMA_PRIORITY_HIGH)   || \
+                                   ((PRIORITY) == DMA_PRIORITY_VERY_HIGH)) 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup DMA_interrupt_enable_definitions
+  * @{
+  */
+
+#define DMA_IT_TC                         ((uint32_t)DMA_CCR_TCIE)
+#define DMA_IT_HT                         ((uint32_t)DMA_CCR_HTIE)
+#define DMA_IT_TE                         ((uint32_t)DMA_CCR_TEIE)
+
+/**
+  * @}
+  */
+
+/** @defgroup DMA_flag_definitions
+  * @{
+  */ 
+
+#define DMA_FLAG_GL1                      ((uint32_t)0x00000001)
+#define DMA_FLAG_TC1                      ((uint32_t)0x00000002)
+#define DMA_FLAG_HT1                      ((uint32_t)0x00000004)
+#define DMA_FLAG_TE1                      ((uint32_t)0x00000008)
+#define DMA_FLAG_GL2                      ((uint32_t)0x00000010)
+#define DMA_FLAG_TC2                      ((uint32_t)0x00000020)
+#define DMA_FLAG_HT2                      ((uint32_t)0x00000040)
+#define DMA_FLAG_TE2                      ((uint32_t)0x00000080)
+#define DMA_FLAG_GL3                      ((uint32_t)0x00000100)
+#define DMA_FLAG_TC3                      ((uint32_t)0x00000200)
+#define DMA_FLAG_HT3                      ((uint32_t)0x00000400)
+#define DMA_FLAG_TE3                      ((uint32_t)0x00000800)
+#define DMA_FLAG_GL4                      ((uint32_t)0x00001000)
+#define DMA_FLAG_TC4                      ((uint32_t)0x00002000)
+#define DMA_FLAG_HT4                      ((uint32_t)0x00004000)
+#define DMA_FLAG_TE4                      ((uint32_t)0x00008000)
+#define DMA_FLAG_GL5                      ((uint32_t)0x00010000)
+#define DMA_FLAG_TC5                      ((uint32_t)0x00020000)
+#define DMA_FLAG_HT5                      ((uint32_t)0x00040000)
+#define DMA_FLAG_TE5                      ((uint32_t)0x00080000)
+#define DMA_FLAG_GL6                      ((uint32_t)0x00100000)
+#define DMA_FLAG_TC6                      ((uint32_t)0x00200000)
+#define DMA_FLAG_HT6                      ((uint32_t)0x00400000)
+#define DMA_FLAG_TE6                      ((uint32_t)0x00800000)
+#define DMA_FLAG_GL7                      ((uint32_t)0x01000000)
+#define DMA_FLAG_TC7                      ((uint32_t)0x02000000)
+#define DMA_FLAG_HT7                      ((uint32_t)0x04000000)
+#define DMA_FLAG_TE7                      ((uint32_t)0x08000000)
+
+
+/**
+  * @}
+  */
+  
+/* Exported macro ------------------------------------------------------------*/
+
+/** @brief Reset DMA handle state
+  * @param  __HANDLE__: DMA handle
+  * @retval None
+  */
+#define __HAL_DMA_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_DMA_STATE_RESET)
+
+/**
+  * @brief  Enable the specified DMA Channel.
+  * @param  __HANDLE__: DMA handle
+  * @retval None.
+  */
+#define __HAL_DMA_ENABLE(__HANDLE__)        ((__HANDLE__)->Instance->CCR |=  DMA_CCR_EN)
+
+/**
+  * @brief  Disable the specified DMA Channel.
+  * @param  __HANDLE__: DMA handle
+  * @retval None.
+  */
+#define __HAL_DMA_DISABLE(__HANDLE__)       ((__HANDLE__)->Instance->CCR &=  ~DMA_CCR_EN)
+
+
+/* Interrupt & Flag management */
+
+/**
+  * @brief  Returns the current DMA Channel transfer complete flag.
+  * @param  __HANDLE__: DMA handle
+  * @retval The specified transfer complete flag index.
+  */
+
+#define __HAL_DMA_GET_TC_FLAG_INDEX(__HANDLE__) \
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TC1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TC2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TC3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TC4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TC5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TC6 :\
+   DMA_FLAG_TC7)
+
+/**
+  * @brief  Returns the current DMA Channel half transfer complete flag.
+  * @param  __HANDLE__: DMA handle
+  * @retval The specified half transfer complete flag index.
+  */      
+#define __HAL_DMA_GET_HT_FLAG_INDEX(__HANDLE__)\
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_HT1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_HT2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_HT3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_HT4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_HT5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_HT6 :\
+   DMA_FLAG_HT7)
+
+/**
+  * @brief  Returns the current DMA Channel transfer error flag.
+  * @param  __HANDLE__: DMA handle
+  * @retval The specified transfer error flag index.
+  */
+#define __HAL_DMA_GET_TE_FLAG_INDEX(__HANDLE__)\
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TE1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TE2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TE3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TE4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TE5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TE6 :\
+   DMA_FLAG_TE7)
+
+/**
+  * @brief  Returns the current DMA Channel Global interrupt flag.
+  * @param  __HANDLE__: DMA handle
+  * @retval The specified transfer error flag index.
+  */
+#define __HAL_DMA_GET_GI_FLAG_INDEX(__HANDLE__)\
+(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_ISR_GIF1 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_ISR_GIF2 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_ISR_GIF3 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_ISR_GIF4 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_ISR_GIF5 :\
+ ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_ISR_GIF6 :\
+   DMA_ISR_GIF7)
+/**
+  * @brief  Get the DMA Channel pending flags.
+  * @param  __HANDLE__: DMA handle
+  * @param  __FLAG__: Get the specified flag.
+  *          This parameter can be any combination of the following values:
+  *            @arg DMA_FLAG_TCIFx:  Transfer complete flag
+  *            @arg DMA_FLAG_HTIFx:  Half transfer complete flag
+  *            @arg DMA_FLAG_TEIFx:  Transfer error flag
+  *            @arg DMA_ISR_GIFx: Global interrupt flag
+  *         Where x can be 0_4, 1_5, 2_6 or 3_7 to select the DMA Channel flag.   
+  * @retval The state of FLAG (SET or RESET).
+  */
+#define __HAL_DMA_GET_FLAG(__HANDLE__, __FLAG__) (DMA1->ISR & (__FLAG__))
+
+/**
+  * @brief  Clears the DMA Channel pending flags.
+  * @param  __HANDLE__: DMA handle
+  * @param  __FLAG__: specifies the flag to clear.
+  *          This parameter can be any combination of the following values:
+  *            @arg DMA_FLAG_TCIFx:  Transfer complete flag
+  *            @arg DMA_FLAG_HTIFx:  Half transfer complete flag
+  *            @arg DMA_FLAG_TEIFx:  Transfer error flag
+  *            @arg DMA_ISR_GIFx: Global interrupt flag
+  *         Where x can be 0_4, 1_5, 2_6 or 3_7 to select the DMA Channel flag.   
+  * @retval None
+  */
+#define __HAL_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__) (DMA1->IFCR = (__FLAG__))
+
+/**
+  * @brief  Enables the specified DMA Channel interrupts.
+  * @param  __HANDLE__: DMA handle
+  * @param __INTERRUPT__: specifies the DMA interrupt sources to be enabled or disabled. 
+  *          This parameter can be any combination of the following values:
+  *            @arg DMA_IT_TC:  Transfer complete interrupt mask
+  *            @arg DMA_IT_HT:  Half transfer complete interrupt mask
+  *            @arg DMA_IT_TE:  Transfer error interrupt mask
+  * @retval None
+  */
+#define __HAL_DMA_ENABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->CCR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disables the specified DMA Channel interrupts.
+  * @param  __HANDLE__: DMA handle
+  * @param __INTERRUPT__: specifies the DMA interrupt sources to be enabled or disabled. 
+  *          This parameter can be any combination of the following values:
+  *            @arg DMA_IT_TC:  Transfer complete interrupt mask
+  *            @arg DMA_IT_HT:  Half transfer complete interrupt mask
+  *            @arg DMA_IT_TE:  Transfer error interrupt mask
+  * @retval None
+  */
+#define __HAL_DMA_DISABLE_IT(__HANDLE__, __INTERRUPT__)  ((__HANDLE__)->Instance->CCR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Checks whether the specified DMA Channel interrupt has occurred or not.
+  * @param  __HANDLE__: DMA handle
+  * @param  __INTERRUPT__: specifies the DMA interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg DMA_IT_TC:  Transfer complete interrupt mask
+  *            @arg DMA_IT_HT:  Half transfer complete interrupt mask
+  *            @arg DMA_IT_TE:  Transfer error interrupt mask
+  * @retval The state of DMA_IT (SET or RESET).
+  */
+#define __HAL_DMA_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)  (((__HANDLE__)->Instance->CCR & (__INTERRUPT__)))
+
+
+/* Exported functions --------------------------------------------------------*/
+  
+/* Initialization and de-initialization functions *****************************/
+HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma); 
+HAL_StatusTypeDef HAL_DMA_DeInit (DMA_HandleTypeDef *hdma);
+
+/* IO operation functions *****************************************************/
+HAL_StatusTypeDef HAL_DMA_Start (DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
+HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
+HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma);
+HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, uint32_t CompleteLevel, uint32_t Timeout);
+void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma);
+
+/* Peripheral State and Error functions ***************************************/
+HAL_DMA_StateTypeDef HAL_DMA_GetState(DMA_HandleTypeDef *hdma);
+uint32_t             HAL_DMA_GetError(DMA_HandleTypeDef *hdma);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_DMA_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_flash.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_flash.c
@@ -1,0 +1,706 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_flash.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   FLASH HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the internal FLASH memory:
+  *            + FLASH Interface configuration
+  *            + FLASH Memory Programming
+  *            + DATA EEPROM Programming
+  *            + Option Bytes Programming
+  *            + Interrupts and flags management
+  *
+  *  @verbatim
+
+  ==============================================================================
+                        ##### FLASH peripheral features #####
+  ==============================================================================
+           
+  [..] The Flash memory interface manages CPU accesses to the Flash memory. 
+       It implements the erase and program Flash memory operations 
+       and the read and write protection mechanisms.
+
+  [..] The FLASH main features are:
+      (+) Flash memory read operations
+      (+) Flash memory program/erase operations
+      (+) Read / write protections
+      (+) Option Bytes programming
+           
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]                             
+      This driver provides functions and macros to configure and program the FLASH 
+      memory of all STM32L0xx devices.
+    
+      (#) FLASH Memory IO Programming functions: 
+           (++) Lock and Unlock the FLASH interface using HAL_FLASH_Unlock() and 
+                HAL_FLASH_Lock() functions
+           (++) Program functions: byte, half word and word 
+           (++) There Two modes of programming :
+                (+++) Polling mode using HAL_FLASH_Program() function
+                (+++) Interrupt mode using HAL_FLASH_Program_IT() function
+    
+      (#) Interrupts and flags management functions : 
+           (++) Handle FLASH interrupts by calling HAL_FLASH_IRQHandler()
+           (++) Wait for last FLASH operation according to its status
+           (++) Get error flag status by calling HAL_GetErrorCode()          
+
+    [..] 
+      In addition to these functions, this driver includes a set of macros allowing
+      to handle the following operations:
+       (+) Set the latency
+       (+) Enable/Disable the prefetch buffer
+       (+) Enable/Disable the preread buffer
+       (+) Enable/Disable the Flash power-down
+       (+) Enable/Disable the FLASH interrupts
+       (+) Monitor the FLASH flags status
+
+ ===============================================================================
+                  ##### Programming operation functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to manage the FLASH 
+    program operations.
+
+   [..] The FLASH Memory Programming functions, includes the following functions:
+    (+) HAL_FLASH_Unlock(void);
+    (+) HAL_FLASH_Lock(void);
+    (+) HAL_FLASH_Program(uint32_t TypeProgram, uint32_t Address, uint32_t Data)
+    (+) HAL_FLASH_Program_IT(uint32_t TypeProgram, uint32_t Address, uint32_t Data)
+   
+    [..] Any operation of erase or program should follow these steps:
+    (#) Call the HAL_FLASH_Unlock() function to enable the flash control register and 
+        program memory access.
+    (#) Call the desired function to erase page or program data.
+    (#) Call the HAL_FLASH_Lock() to disable the flash program memory access 
+       (recommended to protect the FLASH memory against possible unwanted operation).
+
+  ==============================================================================
+                ##### Option Bytes Programming functions ##### 
+  ==============================================================================  
+
+    [..] The FLASH_Option Bytes Programming_functions, includes the following functions:
+    (+) HAL_FLASH_OB_Unlock(void);
+    (+) HAL_FLASH_OB_Lock(void);
+    (+) HAL_FLASH_OB_Launch(void);
+    (+) HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit);
+    (+) HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit);
+   
+    [..] Any operation of erase or program should follow these steps:
+    (#) Call the HAL_FLASH_OB_Unlock() function to enable the Flash option control 
+        register access.
+    (#) Call the following functions to program the desired option bytes.
+        (++) HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit);      
+    (#) Once all needed option bytes to be programmed are correctly written, call the
+        HAL_FLASH_OB_Launch(void) function to launch the Option Bytes programming process.
+    (#) Call the HAL_FLASH_OB_Lock() to disable the Flash option control register access (recommended
+        to protect the option Bytes against possible unwanted operations).
+
+    [..] Proprietary code Read Out Protection (PcROP):    
+    (#) The PcROP sector is selected by using the same option bytes as the Write
+        protection (nWRPi bits). As a result, these 2 options are exclusive each other.
+    (#) In order to activate the PcROP (change the function of the nWRPi option bits), 
+        the SPRMOD option bit must be activated.
+    (#) The active value of nWRPi bits is inverted when PCROP mode is active, this
+        means: if SPRMOD = 1 and nWRPi = 1 (default value), then the user page "i"
+        is read/write protected.
+    (#) To activate PCROP mode for Flash page(s), you need to follow the sequence below:
+        (++) For page(s) within the first 64KB of the Flash, use this function 
+             HAL_FLASHEx_AdvOBProgram with PCROPState = PCROPSTATE_ENABLE.
+
+
+  *  @endverbatim
+  *                      
+ ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup FLASH 
+  * @brief FLASH driver modules
+  * @{
+  */ 
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define HAL_FLASH_TIMEOUT_VALUE   ((uint32_t)0xFFFF0)
+    
+/* FLASH Mask */
+#define WRP01_MASK                 ((uint32_t)0x0000FFFF)
+#define PAGESIZE                   ((uint32_t)0x00000080)
+    
+/* Private macro -------------------------------------------------------------*/
+/*Variables used for Erase sectors under interruption*/
+FLASH_ProcessTypeDef pFlash;
+
+/* Private function prototypes -----------------------------------------------*/
+static void FLASH_Program_Word(uint32_t Address, uint32_t Data);
+HAL_StatusTypeDef FLASH_WaitForLastOperation(uint32_t Timeout);
+static void FLASH_SetErrorCode(void);
+
+
+/* Private functions ---------------------------------------------------------*/
+ 
+/** @defgroup FLASH_Private_Functions
+  * @{
+  */ 
+
+/** @defgroup FLASH_Group1 Programming operation functions 
+ *  @brief   Programming operation functions 
+ *
+@verbatim   
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Program word at a specified address
+  * @param  TypeProgram:  Indicate the way to program at a specified address.
+  *                           This parameter can be a value of @ref FLASH_Type_Program
+  * @param  Address:  specifies the address to be programmed.
+  * @param  Data: specifies the data to be programmed
+  * 
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Program(uint32_t TypeProgram, uint32_t Address, uint32_t Data)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_TYPEPROGRAM(TypeProgram));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE);
+  
+  if(status == HAL_OK)
+  {
+    if(TypeProgram == TYPEPROGRAM_WORD)
+    {
+      /*Program word (32-bit) at a specified address.*/
+      FLASH_Program_Word(Address, (uint32_t) Data);
+    }
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE);
+    
+    /* Reset PROG bit */
+    FLASH->PECR &= ~FLASH_PECR_PROG;
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(&pFlash);
+
+  return status;  
+}
+
+/**
+  * @brief   Program word at a specified address  with interrupt enabled.
+  * @param  TypeProgram:  Indicate the way to program at a specified address.
+  *                           This parameter can be a value of @ref FLASH_Type_Program
+  * @param  Address:  specifies the address to be programmed.
+  * @param  Data: specifies the data to be programmed
+  * 
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Program_IT(uint32_t TypeProgram, uint32_t Address, uint32_t Data)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_TYPEPROGRAM(TypeProgram));
+
+  /* Enable End of FLASH Operation interrupt */
+  __HAL_FLASH_ENABLE_IT(FLASH_IT_EOP);
+  
+  /* Enable Error source interrupt */
+  __HAL_FLASH_ENABLE_IT(FLASH_IT_ERR);
+  
+  /* Clear pending flags (if any) */  
+  __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP    | FLASH_FLAG_ENDHV | FLASH_FLAG_WRPERR |\
+                         FLASH_FLAG_PGAERR | FLASH_FLAG_SIZERR| FLASH_FLAG_OPTVERR |\
+                         FLASH_FLAG_RDERR  | FLASH_FLAG_NOTZEROERR);  
+
+  pFlash.ProcedureOnGoing = FLASH_PROC_PROGRAM;
+  pFlash.Address = Address;
+
+  if(TypeProgram == TYPEPROGRAM_WORD)
+  {
+    /*Program word (32-bit) at a specified address.*/
+    FLASH_Program_Word(Address, (uint32_t) Data);
+  }
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(&pFlash);
+  
+  return status;
+}
+
+/**
+  * @brief This function handles FLASH interrupt request.
+  * @param  None
+  * @retval None
+  */
+void HAL_FLASH_IRQHandler(void)
+{
+  uint32_t temp;
+  
+  /* If the program operation is completed, disable the PROG Bit */
+  FLASH->PECR &= (~FLASH_PECR_PROG);
+
+  /* If the erase operation is completed, disable the ERASE Bit */
+  FLASH->PECR &= (~FLASH_PECR_ERASE);
+
+  /* Check FLASH End of Operation flag  */
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_EOP))
+  {
+    if(pFlash.ProcedureOnGoing == FLASH_PROC_PAGEERASE)
+    {
+      /*Nb of sector to erased can be decreased*/
+      pFlash.NbPagesToErase--;
+
+      /* Check if there are still sectors to erase*/
+      if(pFlash.NbPagesToErase != 0)
+      {
+        temp = pFlash.Page;
+        /*Indicate user which sector has been erased*/
+        HAL_FLASH_EndOfOperationCallback(temp);
+
+        /* Clear pending flags (if any) */  
+        __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP    | FLASH_FLAG_ENDHV | FLASH_FLAG_WRPERR |\
+                              FLASH_FLAG_PGAERR | FLASH_FLAG_SIZERR| FLASH_FLAG_OPTVERR |\
+                              FLASH_FLAG_RDERR  | FLASH_FLAG_NOTZEROERR);  
+
+        /*Increment sector number*/
+        temp = pFlash.Page + PAGESIZE;
+        pFlash.Page = pFlash.Page + PAGESIZE;
+        FLASH_Erase_Page(temp);
+      }
+      else
+      {
+        /*No more sectors to Erase, user callback can be called.*/
+        /*Reset Sector and stop Erase sectors procedure*/
+        pFlash.Page = temp = 0xFFFFFFFF;
+        pFlash.ProcedureOnGoing = FLASH_PROC_NONE;
+        /* FLASH EOP interrupt user callback */
+        HAL_FLASH_EndOfOperationCallback(temp);
+        /* Clear FLASH End of Operation pending bit */
+        __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP);
+      }
+    }
+    else 
+    {
+      if(pFlash.ProcedureOnGoing  == FLASH_PROC_PROGRAM)
+      {
+        /*Program ended. Return the selected address*/
+        /* FLASH EOP interrupt user callback */
+        HAL_FLASH_EndOfOperationCallback(pFlash.Address);
+      }
+      pFlash.ProcedureOnGoing = FLASH_PROC_NONE;
+      /* Clear FLASH End of Operation pending bit */
+      __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP);
+    }
+
+  }
+  /* Check FLASH operation error flags */
+  if( (__HAL_FLASH_GET_FLAG(FLASH_FLAG_EOP) != RESET) || (__HAL_FLASH_GET_FLAG(FLASH_FLAG_ENDHV) != RESET) || \
+      (__HAL_FLASH_GET_FLAG(FLASH_FLAG_WRPERR) != RESET)|| (__HAL_FLASH_GET_FLAG(FLASH_FLAG_PGAERR) != RESET) || \
+      (__HAL_FLASH_GET_FLAG(FLASH_FLAG_SIZERR) != RESET)|| (__HAL_FLASH_GET_FLAG(FLASH_FLAG_OPTVERR) != RESET) || \
+      (__HAL_FLASH_GET_FLAG(FLASH_FLAG_RDERR) != RESET) || (__HAL_FLASH_GET_FLAG(FLASH_FLAG_NOTZEROERR) != RESET))
+  {
+    if(pFlash.ProcedureOnGoing == FLASH_PROC_PAGEERASE)
+    {
+      /*return the faulty sector*/
+      temp = pFlash.Page;
+      pFlash.Page = 0xFFFFFFFF;
+    }
+    else
+    {
+      /*retrun the faulty address*/
+      temp = pFlash.Address;
+    }
+    
+    /*Save the Error code*/
+    FLASH_SetErrorCode();
+
+    /* FLASH error interrupt user callback */
+    HAL_FLASH_OperationErrorCallback(temp);
+    /* Clear FLASH error pending bits */
+    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP    | FLASH_FLAG_ENDHV | FLASH_FLAG_WRPERR |\
+                           FLASH_FLAG_PGAERR | FLASH_FLAG_SIZERR| FLASH_FLAG_OPTVERR |\
+                           FLASH_FLAG_RDERR  | FLASH_FLAG_NOTZEROERR);
+
+    /*Stop the procedure ongoing*/
+    pFlash.ProcedureOnGoing = FLASH_PROC_NONE;
+  }
+  
+  if(pFlash.ProcedureOnGoing == FLASH_PROC_NONE)
+  {
+    /* Disable End of FLASH Operation interrupt */
+    __HAL_FLASH_DISABLE_IT(FLASH_IT_EOP);
+
+    /* Disable Error source interrupt */
+    __HAL_FLASH_DISABLE_IT(FLASH_IT_ERR);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(&pFlash);
+  }
+    
+} 
+
+/**
+  * @brief  FLASH end of operation interrupt callback
+  * @param  ReturnValue: The value saved in this parameter depends on the ongoing procedure
+  *                   Pages_Erase: Sector which has been erased 
+  *                    (if 0xFFFFFFFF, it means that all the selected sectors have been erased)
+  *                   Program: Address which was selected for data program
+  * @retval none
+  */
+__weak void HAL_FLASH_EndOfOperationCallback(uint32_t ReturnValue)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FLASH_EndOfOperationCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  FLASH operation error interrupt callback
+  * @param  ReturnValue: The value saved in this parameter depends on the ongoing procedure
+  *                   Pages_Erase: Sector number which returned an error
+  *                   Program: Address which was selected for data program
+  * @retval none
+  */
+__weak void HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_FLASH_OperationErrorCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Group2 Peripheral Control functions 
+ *  @brief   management functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to control the FLASH 
+    memory operations.
+
+@endverbatim
+  * @{
+  */  
+/**
+  * @brief  Unlock the FLASH control register access
+  * @param  None
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Unlock(void)  
+{
+  if((FLASH->PECR & FLASH_PECR_PRGLOCK) != RESET)
+  {
+    if((FLASH->PECR & FLASH_PECR_PELOCK) != RESET)
+     {  
+       /* Unlocking the Data memory and FLASH_PECR register access*/
+         FLASH->PEKEYR = FLASH_PEKEY1;
+         FLASH->PEKEYR = FLASH_PEKEY2;
+     }
+ 
+    /* Unlocking the program memory access */
+    FLASH->PRGKEYR = FLASH_PRGKEY1;
+    FLASH->PRGKEYR = FLASH_PRGKEY2;  
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+  
+  return HAL_OK; 
+}
+
+/**
+  * @brief  Locks the FLASH control register access
+  * @param  None
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_Lock(void)
+{
+  /* Set the PRGLOCK Bit to lock the program memory access */
+  FLASH->PECR |= FLASH_PECR_PRGLOCK;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Unlock the FLASH Option Control Registers access.
+  * @param  None
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_OB_Unlock(void)
+{
+  if((FLASH->PECR & FLASH_PECR_OPTLOCK) != RESET)
+  {
+      if((FLASH->PECR & FLASH_PECR_PELOCK) != RESET)
+     {  
+       /* Unlocking the Data memory and FLASH_PECR register access*/
+         FLASH->PEKEYR = FLASH_PEKEY1;
+         FLASH->PEKEYR = FLASH_PEKEY2;
+     }
+  
+    /* Unlocking the option bytes block access */
+    FLASH->OPTKEYR = FLASH_OPTKEY1;
+    FLASH->OPTKEYR = FLASH_OPTKEY2;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }  
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Lock the FLASH Option Control Registers access.
+  * @param  None
+  * @retval HAL_StatusTypeDef HAL Status 
+  */
+HAL_StatusTypeDef HAL_FLASH_OB_Lock(void)
+{
+  /* Set the OPTLOCK Bit to lock the option bytes block access */
+  FLASH->PECR |= FLASH_PECR_OPTLOCK;
+
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Launch the option byte loading.
+  * @param  None
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASH_OB_Launch(void)
+{
+  /* Set the OBL_Launch bit to lauch the option byte loading */
+  FLASH->PECR |= FLASH_PECR_OBL_LAUNCH;
+  
+  /* Wait for last operation to be completed */
+  return(FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));  
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Group3 Peripheral State and Errors functions 
+ *  @brief   Peripheral Errors functions 
+ *
+@verbatim   
+ ===============================================================================
+                ##### Peripheral Errors functions #####
+ ===============================================================================  
+    [..]
+    This subsection permit to get in run-time Errors of the FLASH peripheral.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Get the specific FLASH error flag.
+  * @param  None
+  * @retval FLASH_ErrorCode: The returned value can be:
+  *            @arg FLASH_ERROR_RD: FLASH Read Protection error flag (PCROP)
+  *            @arg FLASH_ERROR_ENDHV: FLASH Programming Sequence error flag 
+  *            @arg FLASH_ERROR_SIZE: FLASH Programming Parallelism error flag  
+  *            @arg FLASH_ERROR_PGA: FLASH Programming Alignment error flag
+  *            @arg FLASH_ERROR_WRP: FLASH Write protected error flag
+  *            @arg FLASH_ERROR_OPTV: FLASH Option valid error flag 
+  *            @arg FLASH_ERROR_NOTZERO: FLASH write operation is done in a not-erased region 
+  */
+FLASH_ErrorTypeDef HAL_FLASH_GetError(void)
+{ 
+   return pFlash.ErrorCode;
+}  
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  Wait for a FLASH operation to complete.
+  * @param  Timeout: maximum flash operationtimeout
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef FLASH_WaitForLastOperation(uint32_t Timeout)
+{
+  uint32_t tickstart = 0;
+
+  /* Wait for the FLASH operation to complete by polling on BUSY flag to be reset.
+     Even if the FLASH operation fails, the BUSY flag will be reset and an error
+     flag will be set */
+    
+  tickstart = HAL_GetTick();
+     
+  while(__HAL_FLASH_GET_FLAG(FLASH_FLAG_BSY)) 
+  { 
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        return HAL_TIMEOUT;
+      }
+    } 
+  }
+  
+
+   if( (__HAL_FLASH_GET_FLAG(FLASH_FLAG_WRPERR) != RESET) ||(__HAL_FLASH_GET_FLAG(FLASH_FLAG_PGAERR) != RESET) || \
+      (__HAL_FLASH_GET_FLAG(FLASH_FLAG_SIZERR) != RESET)||(__HAL_FLASH_GET_FLAG(FLASH_FLAG_OPTVERR) != RESET) || \
+      (__HAL_FLASH_GET_FLAG(FLASH_FLAG_RDERR) != RESET) ||(__HAL_FLASH_GET_FLAG(FLASH_FLAG_NOTZEROERR) != RESET))
+    {
+    /*Save the error code*/
+    FLASH_SetErrorCode();
+    return HAL_ERROR;
+   }
+
+  /* If there is an error flag set */
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Set the specific FLASH error flag.
+  * @param  None
+  * @retval None
+  */
+static void FLASH_SetErrorCode(void)
+{  
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_ENDHV))
+  {
+    pFlash.ErrorCode = FLASH_ERROR_ENDHV;
+  }
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_WRPERR))
+  { 
+    pFlash.ErrorCode = FLASH_ERROR_WRP;
+  }
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_PGAERR))
+  { 
+    pFlash.ErrorCode = FLASH_ERROR_PGA;
+  }
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_SIZERR))
+  { 
+    pFlash.ErrorCode = FLASH_ERROR_SIZE;
+  }
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_OPTVERR))
+  { 
+    pFlash.ErrorCode = FLASH_ERROR_OPTV;
+  }
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_RDERR))
+  { 
+    pFlash.ErrorCode = FLASH_ERROR_RD;
+  }
+  if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_NOTZEROERR))
+  { 
+   pFlash.ErrorCode = FLASH_ERROR_NOTZERO;
+  }
+} 
+
+/**
+  * @brief  Erases a specified page in program memory.
+  * @note   To correctly run this function, the HAL_FLASH_Unlock() function
+  *         must be called before.
+  *         Call the HAL_FLASH_Lock() to disable the flash memory access 
+  *         (recommended to protect the FLASH memory against possible unwanted operation)
+  * @param  Page_Address: The page address in program memory to be erased.
+  * @note   A Page is erased in the Program memory only if the address to load 
+  *         is the start address of a page (multiple of 256 bytes).
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+void FLASH_Erase_Page(uint32_t Page_Address)
+{
+  /* Set the ERASE bit */
+    FLASH->PECR |= FLASH_PECR_ERASE;
+
+    /* Set PROG bit */
+    FLASH->PECR |= FLASH_PECR_PROG;
+  
+    /* Write 00000000h to the first word of the program page to erase */
+    *(__IO uint32_t *)Page_Address = 0x00000000;
+}
+
+
+/**
+  * @brief  Program word (32-bit) at a specified address.
+  * @param  Address: specifies the address to be programmed.
+  * @param  Data: specifies the data to be programmed.
+  * @retval None
+  */
+static void FLASH_Program_Word(uint32_t Address, uint32_t Data)
+{
+  /* Check the parameters */
+  assert_param(IS_FLASH_PROGRAM_ADDRESS(Address));
+  
+  /* Set PROG bit */
+  FLASH->PECR |= FLASH_PECR_PROG;
+  
+  *(__IO uint32_t*)Address = Data;
+}
+
+#endif /* HAL_FLASH_MODULE_ENABLED */     
+/**
+  * @}
+  */
+   
+/**
+  * @}
+  */ 
+
+
+     
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_flash.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_flash.h
@@ -1,0 +1,503 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_flash.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   This file contains all the functions prototypes for the FLASH 
+  *          firmware library.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0XX_HAL_FLASH_H
+#define __STM32L0XX_HAL_FLASH_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup FLASH
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/**
+  * @brief  FLASH Error structure definition
+  */
+typedef enum
+{ 
+  FLASH_ERROR_RD      = 0x01,
+  FLASH_ERROR_ENDHV   = 0x02,
+  FLASH_ERROR_SIZE    = 0x04,
+  FLASH_ERROR_PGA     = 0x08,
+  FLASH_ERROR_WRP     = 0x10,
+  FLASH_ERROR_OPTV    = 0x20,
+  FLASH_ERROR_NOTZERO = 0x40
+}FLASH_ErrorTypeDef;
+
+/**
+  * @brief  FLASH Procedure structure definition
+  */
+typedef enum 
+{
+  FLASH_PROC_NONE = 0, 
+  FLASH_PROC_PAGEERASE,
+  FLASH_PROC_PROGRAM
+} FLASH_ProcedureTypeDef;
+
+/**
+  * @brief  FLASH Erase structure definition
+  */
+typedef struct
+{
+  uint32_t TypeErase;   /*!< TypeErase: Mass erase or sector Erase.
+                              This parameter can be a value of @ref FLASH_Type_Erase */
+
+  uint32_t Page;        /*!< Sector: Initial FLASH sector to erase when Mass erase is disabled
+                              This parameter must be an address value between 0x08000000 and 0x0800FFFF */
+  
+  uint32_t NbPages;    /*!< NbSectors: Number of sectors to be erased.
+                              This parameter must be a value between 1 and (max number of sectors - initial sector value) */
+  
+} FLASH_EraseInitTypeDef;
+
+/**
+  * @brief  FLASH Option Bytes PROGRAM structure definition
+  */
+typedef struct
+{
+  uint32_t OptionType;     /*!< OptionType: Option byte to be configured.
+                              This parameter can be a value of @ref FLASH_Option_Type */
+
+  uint32_t WRPState;      /*!< WRPState: Write protection activation or deactivation.
+                              This parameter can be a value of @ref FLASH_WRP_State */
+
+  uint32_t WRPSector;    /*!< WRPSector: specifies the sector(s) to be write protected.
+                              The value of this parameter depends on device used within the same series */
+
+  uint32_t RDPLevel;     /*!< RDPLevel: Set the read protection level..
+                              This parameter can be a value of @ref FLASH_Option_Bytes_Read_Protection */
+
+  uint32_t BORLevel;     /*!< BORLevel: Set the BOR Level.
+                              This parameter can be a value of @ref FLASH_Option_Bytes_BOR_Level */
+  uint8_t  USERConfig;     /*!< USERConfig: Program the FLASH User Option Byte: IWDG_SW / RST_STOP / RST_STDBY.
+                              This parameter can be a combination of @ref FLASH_Option_Bytes_IWatchdog, @ref FLASH_Option_Bytes_nRST_STOP and @ref FLASH_Option_Bytes_nRST_STDBY*/
+} FLASH_OBProgramInitTypeDef;
+
+/** 
+  * @brief  FLASH handle Structure definition  
+  */
+typedef struct
+{
+  __IO FLASH_ProcedureTypeDef ProcedureOnGoing;  /*Internal variable to indicate which procedure is ongoing or not in IT context*/
+  
+  __IO uint32_t               NbPagesToErase;    /*Internal variable to save the remaining sectors to erase in IT context*/
+  
+  __IO uint32_t               Page;              /*Internal variable to define the current sector which is erasing*/
+  
+  __IO uint32_t               Address;           /*Internal variable to save address selected for program*/
+  
+  HAL_LockTypeDef             Lock;              /* FLASH locking object */
+
+  __IO FLASH_ErrorTypeDef     ErrorCode;         /* FLASH error code */
+
+}FLASH_ProcessTypeDef;
+
+/*Variables used for Erase sectors under interruption*/
+extern FLASH_ProcessTypeDef pFlash;   
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup FLASH_Exported_Constants FLASH Exported Constants
+  * @{
+  */
+
+/** @defgroup FLASH_Type_Erase
+  * @{
+  */
+#define TYPEERASE_PAGEERASE       ((uint32_t)0x00)  /*!<Page erase only*/
+#define TYPEERASE_WORD            ((uint32_t)0x01)  /*!<Data erase word activation*/
+ 
+#define IS_TYPEERASE(VALUE)(((VALUE) == TYPEERASE_PAGEERASE) || \
+                              ((VALUE) == TYPEERASE_WORD)) 
+/**
+  * @}
+  */
+  
+/** @defgroup FLASH_Type_Program
+  * @{
+  */
+#define TYPEPROGRAM_BYTE            ((uint32_t)0x00)  /*!<Program byte (8-bit) at a specified address.*/
+#define TYPEPROGRAM_HALFWORD        ((uint32_t)0x01)  /*!<Program a half-word (16-bit) at a specified address.*/
+#define TYPEPROGRAM_WORD            ((uint32_t)0x02)  /*!<Program a word (32-bit) at a specified address.*/
+#define TYPEPROGRAM_FASTBYTE        ((uint32_t)0x04)  /*!<Fast Program byte (8-bit) at a specified address.*/
+#define TYPEPROGRAM_FASTHALFWORD    ((uint32_t)0x08)  /*!<Fast Program a half-word (16-bit) at a specified address.*/
+#define TYPEPROGRAM_FASTWORD        ((uint32_t)0x10)  /*!<Fast Program a word (32-bit) at a specified address.*/
+
+#define IS_TYPEPROGRAM(VALUE)(((VALUE) == TYPEPROGRAM_BYTE) || \
+                              ((VALUE) == TYPEPROGRAM_HALFWORD) || \
+                              ((VALUE) == TYPEPROGRAM_WORD) || \
+                              ((VALUE) == TYPEPROGRAM_FASTBYTE) || \
+                              ((VALUE) == TYPEPROGRAM_FASTHALFWORD) || \
+                              ((VALUE) == TYPEPROGRAM_FASTWORD))  
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_WRP_State
+  * @{
+  */
+#define WRPSTATE_DISABLE       ((uint32_t)0x00)  /*!<Disable the write protection of the desired bank 1 sectors*/
+#define WRPSTATE_ENABLE        ((uint32_t)0x01)  /*!<Enable the write protection of the desired bank 1 sectors*/
+
+#define IS_WRPSTATE(VALUE)(((VALUE) == WRPSTATE_DISABLE) || \
+                           ((VALUE) == WRPSTATE_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Option_Type
+  * @{
+  */
+#define OPTIONBYTE_WRP        ((uint32_t)0x01)  /*!<WRP option byte configuration*/
+#define OPTIONBYTE_RDP        ((uint32_t)0x02)  /*!<RDP option byte configuration*/
+#define OPTIONBYTE_USER       ((uint32_t)0x04)  /*!<USER option byte configuration*/
+#define OPTIONBYTE_BOR        ((uint32_t)0x08)  /*!<BOR option byte configuration*/
+
+#define IS_OPTIONBYTE(VALUE)(((VALUE) < (OPTIONBYTE_WRP|OPTIONBYTE_RDP|OPTIONBYTE_USER|OPTIONBYTE_BOR)))
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Interrupts
+  * @{
+  */
+#define FLASH_IT_EOP               FLASH_PECR_EOPIE  /*!< End of programming interrupt source */
+#define FLASH_IT_ERR               FLASH_PECR_ERRIE  /*!< Error interrupt source */
+#define IS_FLASH_IT(IT) ((((IT) & (uint32_t)0xFFFCFFFF) == 0x00000000) && (((IT) != 0x00000000)))
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_Address
+  * @{
+  */
+#define IS_FLASH_DATA_ADDRESS(ADDRESS) (((ADDRESS) >= DATA_EEPROM_BASE) && ((ADDRESS) <= DATA_EEPROM_END)) /* 2K */
+#define IS_FLASH_PROGRAM_ADDRESS(ADDRESS) (((ADDRESS) >= FLASH_BASE) && ((ADDRESS) <= FLASH_END)) /* 64K */ 
+#define IS_NBPAGES(PAGES) (((PAGES) >= 1) && ((PAGES) <= 512)) /* 512 pages from page0 to page 511 */  
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_Option_Bytes_Write_Protection
+  * @{
+  */
+#define OB_WRP_Pages0to31              ((uint32_t)0x00000001) /* Write protection of Sector0 */
+#define OB_WRP_Pages32to63             ((uint32_t)0x00000002) /* Write protection of Sector1 */
+#define OB_WRP_Pages64to95             ((uint32_t)0x00000004) /* Write protection of Sector2 */
+#define OB_WRP_Pages96to127            ((uint32_t)0x00000008) /* Write protection of Sector3 */
+#define OB_WRP_Pages128to159           ((uint32_t)0x00000010) /* Write protection of Sector4 */
+#define OB_WRP_Pages160to191           ((uint32_t)0x00000020) /* Write protection of Sector5 */
+#define OB_WRP_Pages192to223           ((uint32_t)0x00000040) /* Write protection of Sector6 */
+#define OB_WRP_Pages224to255           ((uint32_t)0x00000080) /* Write protection of Sector7 */
+#define OB_WRP_Pages256to287           ((uint32_t)0x00000100) /* Write protection of Sector8 */
+#define OB_WRP_Pages288to319           ((uint32_t)0x00000200) /* Write protection of Sector9 */
+#define OB_WRP_Pages320to351           ((uint32_t)0x00000400) /* Write protection of Sector10 */
+#define OB_WRP_Pages352to383           ((uint32_t)0x00000800) /* Write protection of Sector11 */
+#define OB_WRP_Pages384to415           ((uint32_t)0x00001000) /* Write protection of Sector12 */
+#define OB_WRP_Pages416to447           ((uint32_t)0x00002000) /* Write protection of Sector13 */
+#define OB_WRP_Pages448to479           ((uint32_t)0x00004000) /* Write protection of Sector14 */
+#define OB_WRP_Pages480to511           ((uint32_t)0x00008000) /* Write protection of Sector15 */
+
+#define OB_WRP_AllPages                ((uint32_t)0x0000FFFF) /*!< Write protection of all Sectors */
+
+#define IS_OB_WRP(PAGE) (((PAGE) != 0x0000000))
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Option_Bytes_Read_Protection
+  * @{
+  */ 
+
+/** 
+  * @brief FLASH_Option_Bytes_Read_Protection  
+  */ 
+#define OB_RDP_Level_0   ((uint8_t)0xAA)
+#define OB_RDP_Level_1   ((uint8_t)0xBB)
+/*#define OB_RDP_Level_2   ((uint8_t)0xCC)*/ /* Warning: When enabling read protection level 2 
+                                                it's no more possible to go back to level 1 or 0 */
+
+#define IS_OB_RDP(LEVEL) (((LEVEL) == OB_RDP_Level_0)||\
+                          ((LEVEL) == OB_RDP_Level_1))/*||\
+                          ((LEVEL) == OB_RDP_Level_2))*/
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_Option_Bytes_IWatchdog
+  * @{
+  */
+#define OB_IWDG_SW                     ((uint8_t)0x10)  /*!< Software WDG selected */
+#define OB_IWDG_HW                     ((uint8_t)0x00)  /*!< Hardware WDG selected */
+#define IS_OB_IWDG_SOURCE(SOURCE) (((SOURCE) == OB_IWDG_SW) || ((SOURCE) == OB_IWDG_HW))
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Option_Bytes_nRST_STOP
+  * @{
+  */
+#define OB_STOP_NoRST                  ((uint8_t)0x20) /*!< No reset generated when entering in STOP */
+#define OB_STOP_RST                    ((uint8_t)0x00) /*!< Reset generated when entering in STOP */
+#define IS_OB_STOP_SOURCE(SOURCE) (((SOURCE) == OB_STOP_NoRST) || ((SOURCE) == OB_STOP_RST))
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Option_Bytes_nRST_STDBY
+  * @{
+  */
+#define OB_STDBY_NoRST                 ((uint8_t)0x40) /*!< No reset generated when entering in STANDBY */
+#define OB_STDBY_RST                   ((uint8_t)0x00) /*!< Reset generated when entering in STANDBY */
+#define IS_OB_STDBY_SOURCE(SOURCE) (((SOURCE) == OB_STDBY_NoRST) || ((SOURCE) == OB_STDBY_RST))
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_Option_Bytes_BOR_Level
+  * @{
+  */
+
+#define OB_BOR_OFF       ((uint8_t)0x00) /*!< BOR is disabled at power down, the reset is asserted when the VDD 
+                                              power supply reaches the PDR(Power Down Reset) threshold (1.5V) */
+#define OB_BOR_LEVEL1    ((uint8_t)0x08) /*!< BOR Reset threshold levels for 1.7V - 1.8V VDD power supply    */
+#define OB_BOR_LEVEL2    ((uint8_t)0x09) /*!< BOR Reset threshold levels for 1.9V - 2.0V VDD power supply    */
+#define OB_BOR_LEVEL3    ((uint8_t)0x0A) /*!< BOR Reset threshold levels for 2.3V - 2.4V VDD power supply    */
+#define OB_BOR_LEVEL4    ((uint8_t)0x0B) /*!< BOR Reset threshold levels for 2.55V - 2.65V VDD power supply  */
+#define OB_BOR_LEVEL5    ((uint8_t)0x0C) /*!< BOR Reset threshold levels for 2.8V - 2.9V VDD power supply    */
+
+#define IS_OB_BOR_LEVEL(LEVEL)  (((LEVEL) == OB_BOR_OFF) || \
+                                 ((LEVEL) == OB_BOR_LEVEL1) || \
+                                 ((LEVEL) == OB_BOR_LEVEL2) || \
+                                 ((LEVEL) == OB_BOR_LEVEL3) || \
+                                 ((LEVEL) == OB_BOR_LEVEL4) || \
+                                 ((LEVEL) == OB_BOR_LEVEL5))
+
+/**
+  * @}
+  */
+  
+/** @defgroup FLASH_Flags
+  * @{
+  */ 
+
+#define FLASH_FLAG_BSY                 FLASH_SR_BSY             /*!< FLASH Busy flag */
+#define FLASH_FLAG_EOP                 FLASH_SR_EOP             /*!< FLASH End of Programming flag */
+#define FLASH_FLAG_ENDHV               FLASH_SR_ENHV            /*!< FLASH End of High Voltage flag */
+#define FLASH_FLAG_READY               FLASH_SR_READY           /*!< FLASH Ready flag after low power mode */
+#define FLASH_FLAG_WRPERR              FLASH_SR_WRPERR          /*!< FLASH Write protected error flag */
+#define FLASH_FLAG_PGAERR              FLASH_SR_PGAERR          /*!< FLASH Programming Alignment error flag */
+#define FLASH_FLAG_SIZERR              FLASH_SR_SIZERR          /*!< FLASH Size error flag  */
+#define FLASH_FLAG_OPTVERR             FLASH_SR_OPTVERR         /*!< FLASH Option Validity error flag  */
+#define FLASH_FLAG_RDERR               FLASH_SR_RDERR           /*!< FLASH Read protected error flag */
+#define FLASH_FLAG_NOTZEROERR          FLASH_SR_NOTZEROERR      /*!< FLASH Read protected error flag */
+    
+#define IS_FLASH_CLEAR_FLAG(FLAG) ((((FLAG) & (uint32_t)0xFFFED0FF) == 0x00000000) && ((FLAG) != 0x00000000))
+
+#define IS_FLASH_GET_FLAG(FLAG)  (((FLAG) == FLASH_FLAG_BSY) || ((FLAG) == FLASH_FLAG_EOP) || \
+                                  ((FLAG) == FLASH_FLAG_ENDHV) || ((FLAG) == FLASH_FLAG_READY ) || \
+                                  ((FLAG) ==  FLASH_FLAG_WRPERR) || ((FLAG) == FLASH_FLAG_PGAERR ) || \
+                                  ((FLAG) ==  FLASH_FLAG_SIZERR) || ((FLAG) == FLASH_FLAG_OPTVERR) || \
+                                  ((FLAG) ==  FLASH_FLAG_RDERR) || ((FLAG) ==  FLASH_FLAG_NOTZEROERR))
+/**
+  * @}
+  */ 
+
+/** @defgroup FLASH_Keys
+  * @{
+  */ 
+
+#define FLASH_PDKEY1               ((uint32_t)0x04152637) /*!< Flash power down key1 */
+#define FLASH_PDKEY2               ((uint32_t)0xFAFBFCFD) /*!< Flash power down key2: used with FLASH_PDKEY1 
+                                                              to unlock the RUN_PD bit in FLASH_ACR */
+
+#define FLASH_PEKEY1               ((uint32_t)0x89ABCDEF) /*!< Flash program erase key1 */
+#define FLASH_PEKEY2               ((uint32_t)0x02030405) /*!< Flash program erase key: used with FLASH_PEKEY2
+                                                               to unlock the write access to the FLASH_PECR register and
+                                                               data EEPROM */
+
+#define FLASH_PRGKEY1              ((uint32_t)0x8C9DAEBF) /*!< Flash program memory key1 */
+#define FLASH_PRGKEY2              ((uint32_t)0x13141516) /*!< Flash program memory key2: used with FLASH_PRGKEY2
+                                                               to unlock the program memory */
+
+#define FLASH_OPTKEY1              ((uint32_t)0xFBEAD9C8) /*!< Flash option key1 */
+#define FLASH_OPTKEY2              ((uint32_t)0x24252627) /*!< Flash option key2: used with FLASH_OPTKEY1 to
+                                                              unlock the write access to the option byte block */
+/**
+  * @}
+  */
+  
+/* CMSIS_Legacy */ 
+  
+#if defined ( __ICCARM__ )
+#define InterruptType_ACTLR_DISMCYCINT_Msk         IntType_ACTLR_DISMCYCINT_Msk
+#endif
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup FLASH_Interrupt FLASH Interrupt
+ *  @brief macros to handle FLASH interrupts
+ * @{
+ */
+
+/**
+  * @brief  Enables or disables the specified FLASH interrupts.
+  * @param  __INTERRUPT__: specifies the FLASH interrupt sources to be enabled or 
+  *         disabled.
+  *   This parameter can be any combination of the following values:
+  *     @arg FLASH_IT_EOP: FLASH end of programming Interrupt
+  *     @arg FLASH_IT_ERR: FLASH Error Interrupt
+  * @retval None 
+  */ 
+#define __HAL_FLASH_ENABLE_IT(__INTERRUPT__)  (FLASH->PECR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the specified FLASH interrupt.
+  * @param  __INTERRUPT__ : FLASH interrupt 
+  *         This parameter can be any combination of the following values:
+  *     @arg FLASH_IT_EOP: End of FLASH Operation Interrupt
+  *     @arg FLASH_IT_ERR: Error Interrupt    
+  * @retval none
+  */
+#define __HAL_FLASH_DISABLE_IT(__INTERRUPT__)  (FLASH->PECR &= ~(uint32_t)(__INTERRUPT__))
+
+/**
+  * @brief  Checks whether the specified FLASH flag is set or not.
+  * @param  __FLAG__: specifies the FLASH flag to check.
+  *   This parameter can be one of the following values:
+  *     @arg FLASH_FLAG_BSY: FLASH write/erase operations in progress flag 
+  *     @arg FLASH_FLAG_EOP: FLASH End of Operation flag
+  *     @arg FLASH_FLAG_READY: FLASH Ready flag after low power mode
+  *     @arg FLASH_FLAG_ENDHV: FLASH End of high voltage flag
+  *     @arg FLASH_FLAG_WRPERR: FLASH Write protected error flag 
+  *     @arg FLASH_FLAG_PGAERR: FLASH Programming Alignment error flag
+  *     @arg FLASH_FLAG_SIZERR: FLASH size error flag
+  *     @arg FLASH_FLAG_OPTVERR: FLASH Option validity error flag
+  *     @arg FLASH_FLAG_OPTVERRUSR: FLASH Option User validity error flag
+  *     @arg FLASH_FLAG_RDERR: FLASH Read protected error flag
+  *     @arg FLASH_FLAG_NOTZEROERR:  Not Zero area error flag  
+  * @retval The new state of FLASH_FLAG (SET or RESET).
+  */
+#define __HAL_FLASH_GET_FLAG(__FLAG__)   ((FLASH->SR & (__FLAG__)) == (__FLAG__))
+
+/**
+  * @brief  Clears the FLASH's pending flags.
+  * @param  __FLAG__: specifies the FLASH flags to clear.
+  *   This parameter can be any combination of the following values:
+  *     @arg FLASH_FLAG_EOP: FLASH End of Operation flag
+  *     @arg FLASH_FLAG_WRPERR: FLASH Write protected error flag 
+  *     @arg FLASH_FLAG_PGAERR: FLASH Programming Alignment error flag 
+  *     @arg FLASH_FLAG_SIZERR: FLASH size error flag    
+  *     @arg FLASH_FLAG_OPTVERR: FLASH Option validity error flag
+  *     @arg FLASH_FLAG_OPTVERRUSR: FLASH Option User validity error flag
+  *     @arg FLASH_FLAG_RDERR: FLASH Read protected error flag
+  *     @arg FLASH_FLAG_NOTZEROERR:  Not Zero area error flag  
+  * @retval None
+  */
+#define __HAL_FLASH_CLEAR_FLAG(__FLAG__)   (FLASH->SR = (__FLAG__)) 
+
+/**
+  * @}
+  */
+
+/* Include FLASH HAL Extension module */
+#include "stm32l0xx_hal_flash_ex.h"
+#include "stm32l0xx_hal_flash_ramfunc.h"
+
+/* Exported functions ------------------------------------------------------- */
+
+/** 
+  * @brief  FLASH memory functions that can be executed from FLASH.  
+  */
+/* Program operation functions  ***********************************************/
+HAL_StatusTypeDef HAL_FLASH_Program(uint32_t TypeProgram, uint32_t Address, uint32_t Data);
+HAL_StatusTypeDef HAL_FLASH_Program_IT(uint32_t TypeProgram, uint32_t Address, uint32_t Data);
+
+/* FLASH IRQ handler function */
+void HAL_FLASH_IRQHandler(void);
+
+/* Callbacks in non blocking modes */
+void HAL_FLASH_EndOfOperationCallback(uint32_t ReturnValue);
+void HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue); 
+
+/* Peripheral Control functions  **********************************************/
+HAL_StatusTypeDef HAL_FLASH_Unlock(void);
+HAL_StatusTypeDef HAL_FLASH_Lock(void);
+HAL_StatusTypeDef HAL_FLASH_OB_Unlock(void);
+HAL_StatusTypeDef HAL_FLASH_OB_Lock(void);
+
+/* Option bytes control */
+HAL_StatusTypeDef HAL_FLASH_OB_Launch(void);
+
+/* Peripheral State functions  ************************************************/
+FLASH_ErrorTypeDef HAL_FLASH_GetError(void);
+
+/* Non-User functions  ********************************************************/
+HAL_StatusTypeDef FLASH_WaitForLastOperation(uint32_t Timeout);
+void FLASH_Erase_Page(uint32_t Page_Address);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0XX_HAL_FLASH_H */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_flash_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_flash_ex.c
@@ -1,0 +1,1263 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_flash_ex.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   FLASH HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the internal FLASH memory:
+  *            + FLASH Interface configuration
+  *            + FLASH Memory Programming
+  *            + DATA EEPROM Programming
+  *            + Option Bytes Programming
+  *            + Interrupts and flags management
+  *
+  *  @verbatim
+  ==============================================================================
+               ##### Flash peripheral Extended features  #####
+  ==============================================================================
+           
+  [..] Comparing to other products, the FLASH interface for STM32L0xx
+       devices contains the following additional features        
+       (+) DATA_EEPROM memory management
+       (+) BOOT option bit configuration       
+       (+) PCROP protection for all sectors
+   
+                      ##### How to use this driver #####
+  ==============================================================================
+  [..] This driver provides functions to configure and program the FLASH memory 
+       of all STM32L0xx. It includes:       
+       (+) Full DATA_EEPROM erase and program management
+       (+) Boot activation
+       (+) PCROP protection configuration and control for all pages
+  
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+/** @addtogroup STM32L0XX_HAL_Driver
+  * @{
+  */
+
+/** @defgroup FLASHEx HAL FLASH Driver
+  * @brief FLASH HAL Extension module driver
+  * @{
+  */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define HAL_FLASH_TIMEOUT_VALUE   ((uint32_t)0x50000
+#define WRP01_MASK                ((uint32_t)0x0000FFFF)
+#define PAGESIZE                  ((uint32_t)0x00000080)
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static HAL_StatusTypeDef FLASH_OB_PCROPConfig(uint32_t OB_WRP, FunctionalState NewState);
+static HAL_StatusTypeDef FLASH_OB_PCROPSelectionConfig(uint16_t OB_PcROP);
+static HAL_StatusTypeDef FLASH_OB_BootConfig(uint16_t OB_BOOT);
+static HAL_StatusTypeDef FLASH_DATAEEPROM_FastProgramByte(uint32_t Address, uint8_t Data);
+static HAL_StatusTypeDef FLASH_DATAEEPROM_FastProgramHalfWord(uint32_t Address, uint16_t Data);
+static HAL_StatusTypeDef FLASH_DATAEEPROM_FastProgramWord(uint32_t Address, uint32_t Data);
+static HAL_StatusTypeDef FLASH_DATAEEPROM_ProgramByte(uint32_t Address, uint8_t Data);
+static HAL_StatusTypeDef FLASH_DATAEEPROM_ProgramHalfWord(uint32_t Address, uint16_t Data);
+static HAL_StatusTypeDef FLASH_DATAEEPROM_ProgramWord(uint32_t Address, uint32_t Data);
+static uint8_t FLASH_OB_GetUser(void);
+static uint32_t FLASH_OB_GetWRP(void);
+static FlagStatus FLASH_OB_GetRDP(void);
+static uint8_t FLASH_OB_GetBOR(void);
+static HAL_StatusTypeDef FLASH_OB_WRPConfig(uint32_t OB_WRP, FunctionalState NewState);
+static HAL_StatusTypeDef FLASH_OB_RDP_LevelConfig(uint8_t OB_RDP);
+static HAL_StatusTypeDef FLASH_OB_UserConfig(uint8_t OB_IWDG, uint8_t OB_STOP, uint8_t OB_STDBY);
+static HAL_StatusTypeDef FLASH_OB_BOR_LevelConfig(uint8_t OB_BOR);
+
+/* Aliases for legacy HAL versions compatibility */
+#define  DATA_EEPROM_FastProgramByte       FLASH_DATAEEPROM_FastProgramByte
+#define  DATA_EEPROM_FastProgramHalfWord   FLASH_DATAEEPROM_FastProgramHalfWord
+#define  DATA_EEPROM_FastProgramWord       FLASH_DATAEEPROM_FastProgramWord
+#define  DATA_EEPROM_ProgramByte           FLASH_DATAEEPROM_ProgramByte
+#define  DATA_EEPROM_ProgramHalfWord       FLASH_DATAEEPROM_ProgramHalfWord
+#define  DATA_EEPROM_ProgramWord           FLASH_DATAEEPROM_ProgramWord
+
+    
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup FLASHEx_Private_Functions Extended FLASH Private functions
+  * @{
+  */
+
+/** @defgroup FLASHEx_Group1 Peripheral extended features functions 
+ *  @brief   Data transfers functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Extended Features functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to manage the FLASH data 
+    transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Program option bytes
+  * @param  pAdvOBInit: pointer to an FLASH_AdvOBProgramInitTypeDef structure that
+  *         contains the configuration information for the programming.
+  * 
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASHEx_AdvOBProgram (FLASH_AdvOBProgramInitTypeDef *pAdvOBInit)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Check the parameters */
+  assert_param(IS_OBEX(pAdvOBInit->OptionType));
+
+  /*Program PCROP option byte*/
+  if ((pAdvOBInit->OptionType&OBEX_PCROP) == OBEX_PCROP)
+  {
+    /* Check the parameters */
+    assert_param(IS_PCROPSTATE(pAdvOBInit->PCROPState));
+    if (pAdvOBInit->PCROPState == PCROPSTATE_ENABLE)
+    {
+      /*Enable of Write protection on the selected Sector*/
+      status = FLASH_OB_PCROPConfig(pAdvOBInit->Pages, ENABLE);
+      status = FLASH_OB_PCROPSelectionConfig(OB_PCROP_SELECTED);
+    }
+    else
+    {
+      /*Disable of Write protection on the selected Sector*/ 
+      status = FLASH_OB_PCROPConfig(pAdvOBInit->Pages, DISABLE);
+      status = FLASH_OB_PCROPSelectionConfig(OB_PCROP_DESELECTED);
+    }
+  }   
+  /*Program BOOT config option byte*/
+  if ((pAdvOBInit->OptionType&OBEX_BOOTCONFIG) == OBEX_BOOTCONFIG)
+  {
+    status = FLASH_OB_BootConfig(pAdvOBInit->BootConfig);
+  }
+
+  return status;
+}
+
+/**
+  * @brief   Get the OBEX byte configuration
+  * @param  pAdvOBInit: pointer to an FLASH_AdvOBProgramInitTypeDef structure that
+  *         contains the configuration information for the programming.
+  * 
+  * @retval None
+  */
+void HAL_FLASHEx_AdvOBGetConfig(FLASH_AdvOBProgramInitTypeDef *pAdvOBInit)
+{
+  pAdvOBInit->OptionType = OBEX_PCROP| OBEX_BOOTCONFIG;
+  /*Get PCROP state */
+  pAdvOBInit->PCROPState = (FLASH->OBR & 0x00000100) >> 8;
+  /*Get PCROP protected Pages */
+  pAdvOBInit->Pages = FLASH->WRPR;
+  /*Get Boot config OB*/
+  pAdvOBInit->BootConfig = (FLASH->OBR & 0x80000000) >> 24;
+}
+
+/**
+  * @}
+  */
+  
+/** @defgroup FLASHEx_Group2 DATA EEPROM Programming functions
+ *  @brief   DATA EEPROM Programming functions
+ *
+@verbatim   
+ ===============================================================================
+                     ##### DATA EEPROM Programming functions ##### 
+ ===============================================================================  
+ 
+    [..] The FLASH_DATAEEPROM Programming_Functions, includes the following functions:
+        (+) HAL_FLASHEx_DATAEEPROM_Unlock(void);
+        (+) HAL_FLASHEx_DATAEEPROM_Lock(void);
+        (+) HAL_FLASHEx_DATAEEPROM_Erase(uint32_t Address)
+        (+) HAL_FLASHEx_DATAEEPROM_Program(uint32_t TypeProgram, uint32_t Address, uint32_t Data)
+   
+    [..] Any operation of erase or program should follow these steps:
+    (#) Call the HAL_FLASHEx_DATAEEPROM_Unlock() function to enable the data EEPROM access
+        and Flash program erase control register access.
+    (#) Call the desired function to erase or program data.
+    (#) Call the HAL_FLASHEx_DATAEEPROM_Lock() to disable the data EEPROM access
+        and Flash program erase control register access(recommended
+        to protect the DATA_EEPROM against possible unwanted operation).
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Unlocks the data memory and FLASH_PECR register access.
+  * @param  None
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASHEx_DATAEEPROM_Unlock(void)
+{
+  if((FLASH->PECR & FLASH_PECR_PELOCK) != RESET)
+  {  
+    /* Unlocking the Data memory and FLASH_PECR register access*/
+    FLASH->PEKEYR = FLASH_PEKEY1;
+    FLASH->PEKEYR = FLASH_PEKEY2;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Locks the Data memory and FLASH_PECR register access.
+  * @param  None
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASHEx_DATAEEPROM_Lock(void)
+{
+  /* Set the PELOCK Bit to lock the data memory and FLASH_PECR register access */
+  FLASH->PECR |= FLASH_PECR_PELOCK;
+  
+  return HAL_OK;
+}
+  
+/**
+  * @brief  Erase a word in data memory.
+  * @param  Address: specifies the address to be erased.
+  * @note   To correctly run this function, the HAL_FLASHEx_DATAEEPROM_Unlock() function
+  *         must be called before.
+  *         Call the HAL_FLASHEx_DATAEEPROM_Lock() to the data EEPROM access
+  *         and Flash program erase control register access(recommended to protect 
+  *         the DATA_EEPROM against possible unwanted operation).
+  * @retval FLASH Status: The returned value can be: 
+  *   FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT.
+  */
+HAL_StatusTypeDef HAL_FLASHEx_DATAEEPROM_Erase(uint32_t Address)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_FLASH_DATA_ADDRESS(Address));
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  
+  if(status == HAL_OK)
+  {
+    /* Write "00000000h" to valid address in the data memory" */
+    *(__IO uint32_t *) Address = 0x00000000;
+  }
+   
+  /* Return the erase status */
+  return status;
+}  
+
+/**
+  * @brief  Program word at a specified address
+  * @param  TypeProgram:  Indicate the way to program at a specified address.
+  *                           This parameter can be a value of @ref FLASH_Type_Program
+  * @param  Address:  specifies the address to be programmed.
+  * @param  Data: specifies the data to be programmed
+  * 
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+
+HAL_StatusTypeDef   HAL_FLASHEx_DATAEEPROM_Program(uint32_t TypeProgram, uint32_t Address, uint32_t Data)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_TYPEPROGRAM(TypeProgram));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  
+  if(status == HAL_OK)
+  {
+    if(TypeProgram == TYPEPROGRAM_FASTBYTE)
+    {
+      /*Program word (8-bit) at a specified address.*/
+      FLASH_DATAEEPROM_FastProgramByte(Address, (uint8_t) Data);
+      
+      /* Wait for last operation to be completed */
+      status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+    }
+    
+    if(TypeProgram == TYPEPROGRAM_FASTHALFWORD)
+    {
+      /*Program word (16-bit) at a specified address.*/
+      FLASH_DATAEEPROM_FastProgramHalfWord(Address, (uint16_t) Data);
+      
+      /* Wait for last operation to be completed */
+      status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+    }    
+    if(TypeProgram == TYPEPROGRAM_FASTWORD)
+    {
+      /*Program word (32-bit) at a specified address.*/
+      FLASH_DATAEEPROM_FastProgramWord(Address, (uint32_t) Data);
+      
+      /* Wait for last operation to be completed */
+      status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+    }
+    if(TypeProgram == TYPEPROGRAM_WORD)
+    {
+      /*Program word (32-bit) at a specified address.*/
+      FLASH_DATAEEPROM_ProgramWord(Address, (uint32_t) Data);
+      
+      /* Wait for last operation to be completed */
+      status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+    }
+       
+    if(TypeProgram == TYPEPROGRAM_HALFWORD)
+    {
+      /*Program word (16-bit) at a specified address.*/
+      FLASH_DATAEEPROM_ProgramHalfWord(Address, (uint16_t) Data);
+      
+      /* Wait for last operation to be completed */
+      status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+    }
+        
+    if(TypeProgram == TYPEPROGRAM_BYTE)
+    {
+      /*Program word (8-bit) at a specified address.*/
+      FLASH_DATAEEPROM_ProgramByte(Address, (uint8_t) Data);
+      
+      /* Wait for last operation to be completed */
+      status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+    }
+  } 
+  /* Process Unlocked */
+  __HAL_UNLOCK(&pFlash);
+
+  return status;
+}
+
+/**
+  * @brief  Erase the specified FLASH memory Pages 
+  * @param[in]  pEraseInit: pointer to an FLASH_EraseInitTypeDef structure that
+  *         contains the configuration information for the erasing.
+  * 
+  * @param[out]  PageError: pointer to variable  that
+  *         contains the configuration information on faulty sector in case of error 
+  *         (0xFFFFFFFF means that all the sectors have been correctly erased)
+  * 
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t *PageError)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  uint32_t index = 0;
+  
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_TYPEERASE(pEraseInit->TypeErase));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+
+  if (status == HAL_OK)
+  {
+    /*Initialization of PageError variable*/
+    *PageError = 0xFFFFFFFF;
+      
+    /* Check the parameters */
+      assert_param(IS_NBPAGES(pEraseInit->NbPages + pEraseInit->Page));
+
+      /* Erase by sector by sector to be done*/
+      for(index = pEraseInit->Page; index < ((pEraseInit->NbPages*PAGESIZE)+ pEraseInit->Page); index+=PAGESIZE)
+      {        
+        FLASH_Erase_Page(index);
+
+        /* Wait for last operation to be completed */
+        status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+        
+        /* If the erase operation is completed, disable the ERASE Bit */
+        FLASH->PECR &= (~FLASH_PECR_PROG);
+        FLASH->PECR &= (~FLASH_PECR_ERASE);
+
+        if (status != HAL_OK) 
+        {
+          /* In case of error, stop erase procedure and return the faulty sector*/
+          *PageError = index;
+          break;
+        }
+      }
+    }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(&pFlash);
+
+  return status;
+}
+
+/**
+  * @brief  Perform a page erase of the specified FLASH memory pages  with interrupt enabled
+  * @param  pEraseInit: pointer to an FLASH_EraseInitTypeDef structure that
+  *         contains the configuration information for the erasing.
+  * 
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_TYPEERASE(pEraseInit->TypeErase));
+
+  /* Enable End of FLASH Operation interrupt */
+  __HAL_FLASH_ENABLE_IT(FLASH_IT_EOP);
+  
+  /* Enable Error source interrupt */
+  __HAL_FLASH_ENABLE_IT(FLASH_IT_ERR);
+  
+  /* Clear pending flags (if any) */  
+  __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP    | FLASH_FLAG_ENDHV | FLASH_FLAG_WRPERR |\
+                         FLASH_FLAG_PGAERR | FLASH_FLAG_SIZERR| FLASH_FLAG_OPTVERR |\
+                         FLASH_FLAG_RDERR  | FLASH_FLAG_NOTZEROERR);  
+
+  if (pEraseInit->TypeErase == TYPEERASE_PAGEERASE)
+  {
+    /* Erase by sector to be done*/
+
+    /* Check the parameters */
+    assert_param(IS_NBPAGES(pEraseInit->NbPages + pEraseInit->Page));
+
+    pFlash.ProcedureOnGoing = FLASH_PROC_PAGEERASE;
+    pFlash.NbPagesToErase = pEraseInit->NbPages;
+    pFlash.Page = pEraseInit->Page;
+
+    /*Erase 1st page and wait for IT*/
+    FLASH_Erase_Page(pEraseInit->Page);
+  }
+
+  return status;
+}
+
+
+/**
+  * @brief  Program option bytes
+  * @param  pOBInit: pointer to an FLASH_OBInitStruct structure that
+  *         contains the configuration information for the programming.
+  * 
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+HAL_StatusTypeDef HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Process Locked */
+  __HAL_LOCK(&pFlash);
+
+  /* Check the parameters */
+  assert_param(IS_OPTIONBYTE(pOBInit->OptionType));
+
+  /*Write protection configuration*/
+  if((pOBInit->OptionType & OPTIONBYTE_WRP) == OPTIONBYTE_WRP)
+  {
+    assert_param(IS_WRPSTATE(pOBInit->WRPState));
+    if (pOBInit->WRPState == WRPSTATE_ENABLE)
+    {
+      /*Enable of Write protection on the selected Sector*/
+      status = FLASH_OB_WRPConfig(pOBInit->WRPSector, ENABLE);
+    }
+    else
+    {
+      /*Disable of Write protection on the selected Sector*/
+      status = FLASH_OB_WRPConfig(pOBInit->WRPSector, DISABLE);
+    }
+  }
+
+  /* Read protection configuration*/
+  if((pOBInit->OptionType & OPTIONBYTE_RDP) == OPTIONBYTE_RDP)
+  {
+    status = FLASH_OB_RDP_LevelConfig(pOBInit->RDPLevel);
+  }
+
+  /* USER  configuration*/
+  if((pOBInit->OptionType & OPTIONBYTE_USER) == OPTIONBYTE_USER)
+  {
+    status = FLASH_OB_UserConfig(pOBInit->USERConfig&OB_IWDG_SW, 
+                                     pOBInit->USERConfig&OB_STOP_NoRST,
+                                     pOBInit->USERConfig&OB_STDBY_NoRST);
+  }
+
+  /* BOR Level  configuration*/
+  if((pOBInit->OptionType & OPTIONBYTE_BOR) == OPTIONBYTE_BOR)
+  {
+    status = FLASH_OB_BOR_LevelConfig(pOBInit->BORLevel);
+  } 
+  /* Process Unlocked */
+  __HAL_UNLOCK(&pFlash);
+
+  return status;
+}
+
+/**
+  * @brief   Get the Option byte configuration
+  * @param  pOBInit: pointer to an FLASH_OBInitStruct structure that
+  *         contains the configuration information for the programming.
+  * 
+  * @retval None
+  */
+void HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit)
+{
+  pOBInit->OptionType = OPTIONBYTE_WRP | OPTIONBYTE_RDP | OPTIONBYTE_USER | OPTIONBYTE_BOR;
+
+  /*Get WRP*/
+  pOBInit->WRPSector = FLASH_OB_GetWRP();
+
+  /*Get RDP Level*/
+  pOBInit->RDPLevel = FLASH_OB_GetRDP();
+
+  /*Get USER*/
+  pOBInit->USERConfig = FLASH_OB_GetUser();
+
+  /*Get BOR Level*/
+  pOBInit->BORLevel = FLASH_OB_GetBOR();
+}
+
+/**
+  * @}
+  */
+  
+/**
+  * @brief  Returns the FLASH User Option Bytes values.
+  * @param  None
+  * @retval The FLASH User Option Bytes.
+  */
+static uint8_t FLASH_OB_GetUser(void)
+{
+  /* Return the User Option Byte */
+  return (uint8_t)(FLASH->OBR >> 20);
+}
+
+/**
+  * @brief  Returns the FLASH Write Protection Option Bytes value.
+  * @param  None
+  * @retval The FLASH Write Protection Option Bytes value.
+  */
+static uint32_t FLASH_OB_GetWRP(void)
+{
+  /* Return the FLASH write protection Register value */
+  return (uint32_t)(FLASH->WRPR);
+}
+
+/**
+  * @brief  Checks whether the FLASH Read out Protection Status is set or not.
+  * @param  None
+  * @retval FLASH ReadOut Protection Status(SET or RESET).
+  */
+static FlagStatus FLASH_OB_GetRDP(void)
+{
+  FlagStatus readstatus = RESET;
+  
+  if ((uint8_t)(FLASH->OBR) != (uint8_t)OB_RDP_Level_0)
+  {
+    readstatus = SET;
+  }
+  else
+  {
+    readstatus = RESET;
+  }
+  return readstatus;
+}
+
+/**
+  * @brief  Returns the FLASH BOR level.
+  * @param  None
+  * @retval The FLASH User Option Bytes.
+  */
+static uint8_t FLASH_OB_GetBOR(void)
+{
+  /* Return the BOR level */
+  return (uint8_t)((FLASH->OBR & (uint32_t)0x000F0000) >> 16);
+}
+
+/**
+  * @brief  Write protects the desired pages of the first 64KB of the Flash.
+  * @param  OB_WRP: specifies the address of the pages to be write protected.
+  *   This parameter can be:
+  *     @arg  value between OB_WRP_Pages0to31 and OB_WRP_Pages480to511
+  *     @arg  OB_WRP_AllPages
+  * @param  NewState: new state of the specified FLASH Pages Wtite protection.
+  *   This parameter can be: ENABLE or DISABLE.
+  * @retval HAL_StatusTypeDef
+  */
+static HAL_StatusTypeDef FLASH_OB_WRPConfig(uint32_t OB_WRP, FunctionalState NewState)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t WRP01_Data = 0;
+  uint32_t tmp1 = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_OB_WRP(OB_WRP));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+     
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+ 
+  if(status == HAL_OK)
+  {
+    if (NewState != DISABLE)
+    {
+      WRP01_Data = (uint16_t)(((OB_WRP & WRP01_MASK) | OB->WRP01));
+      tmp1 = (uint32_t)(~(WRP01_Data) << 16)|(WRP01_Data);
+      OB->WRP01 = tmp1;
+    }             
+    else
+    {
+      WRP01_Data = (uint16_t)(~OB_WRP & (WRP01_MASK & OB->WRP01));
+      tmp1 = (uint32_t)((~WRP01_Data) << 16)|(WRP01_Data);
+      OB->WRP01 = tmp1;
+    }
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation(HAL_FLASH_TIMEOUT_VALUE));
+  }
+
+  /* Return the write protection operation Status */
+  return status;      
+}
+/**
+  * @brief  Enables or disables the read out protection.
+  * @note   To correctly run this function, the FLASH_OB_Unlock() function
+  *         must be called before.
+  * @param  FLASH_ReadProtection_Level: specifies the read protection level. 
+  *   This parameter can be:
+  *     @arg OB_RDP_Level_0: No protection
+  *     @arg OB_RDP_Level_1: Read protection of the memory
+  *     @arg OB_RDP_Level_2: Chip protection
+  * 
+  *  !!!Warning!!! When enabling OB_RDP_Level_2 it's no more possible to go back to level 1 or 0
+  *   
+  * @retval FLASH Status: The returned value can be: 
+  *         FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT.
+  */
+static HAL_StatusTypeDef FLASH_OB_RDP_LevelConfig(uint8_t OB_RDP)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint16_t tmp1 = 0;
+  uint32_t tmp2 = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_OB_RDP(OB_RDP));
+  status = FLASH_WaitForLastOperation(HAL_FLASH_TIMEOUT_VALUE));
+  
+  /* calculate the option byte to write */
+  tmp1 =  ((uint16_t)(*(__IO uint16_t *)(OB_BASE)) & 0xFF00) | OB_RDP; 
+  tmp2 = (uint32_t)(((uint32_t)((uint32_t)(~tmp1) << 16)) | ((uint32_t)tmp1));
+  
+  if(status == HAL_OK)
+  {         
+   /* program read protection level */
+    OB->RDP = tmp2;
+  }
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+     
+  /* Return the Read protection operation Status */
+  return status;            
+}
+
+/**
+  * @brief  Programs the FLASH User Option Byte: IWDG_SW / RST_STOP / RST_STDBY.
+  * @param  OB_IWDG: Selects the WDG mode.
+  *   This parameter can be one of the following values:
+  *     @arg OB_IWDG_SW: Software WDG selected
+  *     @arg OB_IWDG_HW: Hardware WDG selected
+  * @param  OB_STOP: Reset event when entering STOP mode.
+  *   This parameter can be one of the following values:
+  *     @arg OB_STOP_NoRST: No reset generated when entering in STOP
+  *     @arg OB_STOP_RST: Reset generated when entering in STOP
+  * @param  OB_STDBY: Reset event when entering Standby mode.
+  *   This parameter can be one of the following values:
+  *     @arg OB_STDBY_NoRST: No reset generated when entering in STANDBY
+  *     @arg OB_STDBY_RST: Reset generated when entering in STANDBY
+  * @retval FLASH Status: The returned value can be: 
+  *         FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT.
+  */
+static HAL_StatusTypeDef FLASH_OB_UserConfig(uint8_t OB_IWDG, uint8_t OB_STOP, uint8_t OB_STDBY)
+{
+  HAL_StatusTypeDef status = HAL_OK; 
+  uint32_t tmp = 0, tmp1 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_OB_IWDG_SOURCE(OB_IWDG));
+  assert_param(IS_OB_STOP_SOURCE(OB_STOP));
+  assert_param(IS_OB_STDBY_SOURCE(OB_STDBY));
+
+  /* Get the User Option byte register */
+  tmp1 = (FLASH->OBR & 0x800F0000) >> 16;
+    
+  /* Calculate the user option byte to write */ 
+  tmp = (uint32_t)(((uint32_t)~((uint32_t)((uint32_t)(OB_IWDG) | (uint32_t)(OB_STOP) | (uint32_t)(OB_STDBY) | tmp1))) << 16);
+  tmp |= ((uint32_t)(OB_IWDG) | ((uint32_t)OB_STOP) | (uint32_t)(OB_STDBY) | tmp1);
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  
+  if(status == HAL_OK)
+  {  
+    /* Write the User Option Byte */              
+    OB->USER = tmp; 
+  }
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+       
+  /* Return the Option Byte program Status */
+  return status;
+}
+
+/**
+  * @brief  Programs the FLASH brownout reset threshold level Option Byte.
+  * @param  OB_BOR: Selects the brownout reset threshold level.
+  *   This parameter can be one of the following values:
+  *     @arg OB_BOR_OFF: BOR is disabled at power down, the reset is asserted when the VDD 
+  *                      power supply reaches the PDR(Power Down Reset) threshold (1.5V)
+  *     @arg OB_BOR_LEVEL1: BOR Reset threshold levels for 1.7V - 1.8V VDD power supply
+  *     @arg OB_BOR_LEVEL2: BOR Reset threshold levels for 1.9V - 2.0V VDD power supply
+  *     @arg OB_BOR_LEVEL3: BOR Reset threshold levels for 2.3V - 2.4V VDD power supply
+  *     @arg OB_BOR_LEVEL4: BOR Reset threshold levels for 2.55V - 2.65V VDD power supply
+  *     @arg OB_BOR_LEVEL5: BOR Reset threshold levels for 2.8V - 2.9V VDD power supply
+  * @retval FLASH Status: The returned value can be: 
+  * FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT.
+  */
+static HAL_StatusTypeDef FLASH_OB_BOR_LevelConfig(uint8_t OB_BOR)
+{
+  HAL_StatusTypeDef status = HAL_OK; 
+  uint32_t tmp = 0, tmp1 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_OB_BOR_LEVEL(OB_BOR));
+
+  /* Get the User Option byte register */
+  tmp1 = (FLASH->OBR & 0x000F0000) >> 16;
+     
+  /* Calculate the option byte to write */
+  tmp = (uint32_t)~(OB_BOR | tmp1)<<16;
+  tmp |= (OB_BOR | tmp1);
+    
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  
+  if(status == HAL_OK)
+  {  
+    /* Write the BOR Option Byte */            
+    OB->USER = tmp; 
+  }
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+        
+  /* Return the Option Byte program Status */
+  return status;
+}
+
+
+/**
+  * @brief  Enables or disables the read/write protection (PCROP) of the desired 
+  *         sectors, for the first 64KB of the Flash.
+  * @param  OB_WRP: specifies the address of the pages to be write protected.
+  *   This parameter can be:
+  *     @arg  value between OB_WRP_Pages0to31 and OB_WRP_Pages480to511
+  *     @arg  OB_WRP_AllPages
+  * @param  NewState: new state of the specified FLASH Pages Write protection.
+  *   This parameter can be: ENABLE or DISABLE.
+  * @retval FLASH Status: The returned value can be: 
+  *         FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT.
+  */
+static HAL_StatusTypeDef FLASH_OB_PCROPConfig(uint32_t OB_WRP, FunctionalState NewState)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t WRP01_Data = 0;
+  uint32_t tmp1 = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_OB_WRP(OB_WRP));
+  assert_param(IS_FUNCTIONAL_STATE(NewState));
+     
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+ 
+  if(status == HAL_OK)
+  {
+    if (NewState != DISABLE)
+    {
+      WRP01_Data = (uint16_t)(~OB_WRP & (WRP01_MASK & OB->WRP01));
+
+      tmp1 = (uint32_t)((~WRP01_Data) << 16)|(WRP01_Data);
+      OB->WRP01 = tmp1; 
+    }             
+    
+    else
+    {
+      WRP01_Data = (uint16_t)((OB_WRP & WRP01_MASK) | OB->WRP01);
+     
+      tmp1 = (uint32_t)(~(WRP01_Data) << 16)|(WRP01_Data);
+      OB->WRP01 = tmp1;
+    }
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  }
+
+  /* Return the write protection operation Status */
+  return status;       
+}
+
+/**
+  * @brief  Select the Protection Mode (SPRMOD).
+  * @note   Once SPRMOD bit is active, unprotection of a protected sector is not possible 
+  * @note   Read a protected sector will set RDERR Flag and write a protected sector will set WRPERR Flag
+  * @param  OB_PcROP: Select the Protection Mode of WPR bits. 
+  *   This parameter can be:
+  *     @arg OB_PCROP_SELECTED: nWRP control the  read&write protection (PcROP) of respective user sectors.
+  *     @arg OB_PCROP_DESELECTED: nWRP control the write protection of respective user sectors.
+  * @retval FLASH Status: The returned value can be: 
+  *         FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT.
+  */
+static HAL_StatusTypeDef FLASH_OB_PCROPSelectionConfig(uint16_t OB_PcROP)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint16_t tmp1 = 0;
+  uint32_t tmp2 = 0;
+  uint8_t optiontmp = 0;
+  uint16_t optiontmp2 = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_OB_PCROP_SELECT(OB_PcROP));
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  
+  /* Mask RDP Byte */
+  optiontmp =  (uint8_t)(*(__IO uint8_t *)(OB_BASE)); 
+  
+  /* Update Option Byte */
+  optiontmp2 = (uint16_t)(OB_PcROP | optiontmp); 
+  
+  
+  /* calculate the option byte to write */
+  tmp1 = (uint16_t)(~(optiontmp2 ));
+  tmp2 = (uint32_t)(((uint32_t)((uint32_t)(tmp1) << 16)) | ((uint32_t)optiontmp2));
+  
+  if(status == HAL_OK)
+  {         
+    /* program PCRop */
+    OB->RDP = tmp2;
+  }
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation(HAL_FLASH_TIMEOUT_VALUE));
+  
+  /* Return the Read protection operation Status */
+  return status;            
+}
+
+/**
+  * @brief  Select the Protection Mode (SPRMOD).
+  * @note   Once SPRMOD bit is active, unprotection of a protected sector is not possible 
+  * @note   Read a protected sector will set RDERR Flag and write a protected sector will set WRPERR Flag
+  * @param  None
+  * @retval FLASH Status: The returned value can be: 
+  *         FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT.
+  */
+HAL_StatusTypeDef HAL_FLASHEx_OB_SelectPCROP(void)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint16_t tmp1 = 0;
+  uint32_t tmp2 = 0;
+  uint8_t optiontmp = 0;
+  uint16_t optiontmp2 = 0;
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  
+  /* Mask RDP Byte */
+  optiontmp =  (uint8_t)(*(__IO uint8_t *)(OB_BASE)); 
+  
+  /* Update Option Byte */
+  optiontmp2 = (uint16_t)(FLASH_OBR_SPRMOD | optiontmp); 
+  
+  
+  /* calculate the option byte to write */
+  tmp1 = (uint16_t)(~(optiontmp2 ));
+  tmp2 = (uint32_t)(((uint32_t)((uint32_t)(tmp1) << 16)) | ((uint32_t)optiontmp2));
+  
+  if(status == HAL_OK)
+  {         
+    /* program PCRop */
+    OB->RDP = tmp2;
+  }
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation(HAL_FLASH_TIMEOUT_VALUE));
+  
+  /* Return the Read protection operation Status */
+  return status;            
+  
+}
+
+/**
+  * @brief  Deselect the Protection Mode (SPRMOD).
+  * @note   Once SPRMOD bit is active, unprotection of a protected sector is not possible 
+  * @note   Read a protected sector will set RDERR Flag and write a protected sector will set WRPERR Flag
+  * @param  None
+  * @retval FLASH Status: The returned value can be: 
+  *         FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT.
+  */
+HAL_StatusTypeDef HAL_FLASHEx_OB_DeSelectPCROP(void)
+{
+ HAL_StatusTypeDef status = HAL_OK;
+  uint16_t tmp1 = 0;
+  uint32_t tmp2 = 0;
+  uint8_t optiontmp = 0;
+  uint16_t optiontmp2 = 0;
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  
+  /* Mask RDP Byte */
+  optiontmp =  (uint8_t)(*(__IO uint8_t *)(OB_BASE)); 
+  
+  /* Update Option Byte */
+  optiontmp2 = (uint16_t)(optiontmp); 
+  
+  /* calculate the option byte to write */
+  tmp1 = (uint16_t)(~(optiontmp2 ));
+  tmp2 = (uint32_t)(((uint32_t)((uint32_t)(tmp1) << 16)) | ((uint32_t)optiontmp2));
+  
+  if(status == HAL_OK)
+  {         
+    /* program PCRop */
+    OB->RDP = tmp2;
+  }
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation(HAL_FLASH_TIMEOUT_VALUE));
+  
+  /* Return the Read protection operation Status */
+  return status;     
+}
+
+
+/**
+  * @brief  Sets or resets the BOOT1 option bit.
+  * @param  OB_BOOT1: Set or Reset the BOOT1 option bit.
+  *          This parameter can be one of the following values:
+  *             @arg OB_BOOT1_RESET: BOOT1 option bit reset
+  *             @arg OB_BOOT1_SET: BOOT1 option bit set
+  * @retval None
+  */
+static HAL_StatusTypeDef FLASH_OB_BootConfig(uint16_t OB_BOOT)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t tmp = 0, tmp1 = 0;
+
+  /* Check the parameters */
+  assert_param(IS_OB_BOOT1(OB_BOOT));
+
+  /* Get the User Option byte register */
+  tmp1 = (FLASH->OBR & 0x007F0000) >> 16;
+     
+  /* Calculate the option byte to write */
+  tmp = (uint32_t)~(OB_BOOT | tmp1)<<16;
+  tmp |= (OB_BOOT | tmp1);
+    
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  
+  if(status == HAL_OK)
+  {  
+    /* Write the BOOT Option Byte */            
+    OB->USER = tmp; 
+  }
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+       
+  /* Return the Option Byte program Status */
+  return status;
+}
+
+/**
+  * @brief  Write a Byte at a specified address in data memory.
+  * @note   To correctly run this function, the HAL_FLASHEx_DATAEEPROM_Unlock() function
+  *         must be called before.
+  *         Call the HAL_FLASHEx_DATAEEPROM_Lock() to the data EEPROM access
+  *         and Flash program erase control register access(recommended to protect 
+  *         the DATA_EEPROM against possible unwanted operation).
+  * @param  Address: specifies the address to be written.
+  * @param  Data: specifies the data to be written.
+  * @note   This function assumes that data word is already erased.
+  * @retval FLASH Status: The returned value can be:
+  *         FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT.
+  */
+static HAL_StatusTypeDef FLASH_DATAEEPROM_FastProgramByte(uint32_t Address, uint8_t Data)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Check the parameters */
+  assert_param(IS_FLASH_DATA_ADDRESS(Address)); 
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+    
+  if(status == HAL_OK)
+  {
+    /* Clear the FTDW bit */
+    FLASH->PECR &= (uint32_t)(~((uint32_t)FLASH_PECR_FTDW));
+
+    /* If the previous operation is completed, proceed to write the new Data */
+    *(__IO uint8_t *)Address = Data;
+            
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  }
+  /* Return the Write Status */
+  return status;
+}
+
+/**
+  * @brief  Writes a half word at a specified address in data memory.
+  * @note   To correctly run this function, the HAL_FLASHEx_DATAEEPROM_Unlock() function
+  *         must be called before.
+  *         Call the HAL_FLASHEx_DATAEEPROM_Lock() to he data EEPROM access
+  *         and Flash program erase control register access(recommended to protect 
+  *         the DATA_EEPROM against possible unwanted operation).
+  * @param  Address: specifies the address to be written.
+  * @param  Data: specifies the data to be written.
+  * @note   This function assumes that the is data word is already erased.
+  * @retval FLASH Status: The returned value can be: 
+  *         FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or  FLASH_TIMEOUT. 
+  */
+static HAL_StatusTypeDef FLASH_DATAEEPROM_FastProgramHalfWord(uint32_t Address, uint16_t Data)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Check the parameters */
+  assert_param(IS_FLASH_DATA_ADDRESS(Address));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+    
+  if(status == HAL_OK)
+  {
+    /* Clear the FTDW bit */
+    FLASH->PECR &= (uint32_t)(~((uint32_t)FLASH_PECR_FTDW));
+
+    /* If the previous operation is completed, proceed to write the new data */
+    *(__IO uint16_t *)Address = Data;
+  
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  }
+  /* Return the Write Status */
+  return status;
+}
+
+/**
+  * @brief  Programs a word at a specified address in data memory.
+  * @note   To correctly run this function, the HAL_FLASHEx_DATAEEPROM_Unlock() function
+  *         must be called before.
+  *         Call the HAL_FLASHEx_DATAEEPROM_Lock() to the data EEPROM access
+  *         and Flash program erase control register access(recommended to protect 
+  *         the DATA_EEPROM against possible unwanted operation).
+  * @param  Address: specifies the address to be written.
+  * @param  Data: specifies the data to be written.
+  * @note   This function assumes that the is data word is already erased.
+  * @retval FLASH Status: The returned value can be: 
+  *         FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT. 
+  */
+static HAL_StatusTypeDef FLASH_DATAEEPROM_FastProgramWord(uint32_t Address, uint32_t Data)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+
+  /* Check the parameters */
+  assert_param(IS_FLASH_DATA_ADDRESS(Address));
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  
+  if(status == HAL_OK)
+  {
+    /* Clear the FTDW bit */
+    FLASH->PECR &= (uint32_t)(~((uint32_t)FLASH_PECR_FTDW));
+  
+    /* If the previous operation is completed, proceed to program the new data */    
+    *(__IO uint32_t *)Address = Data;
+    
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));       
+  }
+  /* Return the Write Status */
+  return status;
+}
+
+/**
+  * @brief  Write a Byte at a specified address in data memory without erase.
+  * @note   To correctly run this function, the HAL_FLASHEx_DATAEEPROM_Unlock() function
+  *         must be called before.
+  *         Call the HAL_FLASHEx_DATAEEPROM_Lock() to he data EEPROM access
+  *         and Flash program erase control register access(recommended to protect 
+  *         the DATA_EEPROM against possible unwanted operation).
+  * @param  Address: specifies the address to be written.
+  * @param  Data: specifies the data to be written.
+  * @retval FLASH Status: The returned value can be: 
+  *   FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT. 
+  */
+static HAL_StatusTypeDef FLASH_DATAEEPROM_ProgramByte(uint32_t Address, uint8_t Data)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Check the parameters */
+  assert_param(IS_FLASH_DATA_ADDRESS(Address)); 
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  
+  if(status == HAL_OK)
+  {
+    /* Set the FTDW bit */
+    FLASH->PECR |= (uint32_t)FLASH_PECR_FTDW;
+    
+    *(__IO uint8_t *)Address = Data;
+    
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  }
+  /* Return the Write Status */
+  return status;
+}
+
+/**
+  * @brief  Writes a half word at a specified address in data memory without erase.
+  * @note   To correctly run this function, the HAL_FLASHEx_DATAEEPROM_Unlock function
+  *         must be called before.
+  *         Call the HAL_FLASHEx_DATAEEPROM_Lock() to he data EEPROM access
+  *         and Flash program erase control register access(recommended to protect 
+  *         the DATA_EEPROM against possible unwanted operation).
+  * @param  Address: specifies the address to be written.
+  * @param  Data: specifies the data to be written.
+  * @retval FLASH Status: The returned value can be:
+  *   FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or FLASH_TIMEOUT. 
+  */
+static HAL_StatusTypeDef FLASH_DATAEEPROM_ProgramHalfWord(uint32_t Address, uint16_t Data)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Check the parameters */
+  assert_param(IS_FLASH_DATA_ADDRESS(Address));
+
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  
+  if(status == HAL_OK)
+  {
+    /* Set the FTDW bit */
+    FLASH->PECR |= (uint32_t)FLASH_PECR_FTDW;
+    
+    *(__IO uint16_t *)Address = Data;
+   
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  }
+  /* Return the Write Status */
+  return status;
+}
+
+/**
+  * @brief  Programs a word at a specified address in data memory without erase.
+  * @note   To correctly run this function, the HAL_FLASHEx_DATAEEPROM_Unlock() function
+  *         must be called before.
+  *         Call the HAL_FLASHEx_DATAEEPROM_Lock() to he data EEPROM access
+  *         and Flash program erase control register access(recommended to protect 
+  *         the DATA_EEPROM against possible unwanted operation).
+  * @param  Address: specifies the address to be written.
+  * @param  Data: specifies the data to be written.
+  * @retval FLASH Status: The returned value can be:
+  *   FLASH_ERROR_PROGRAM, FLASH_ERROR_WRP, FLASH_COMPLETE or  FLASH_TIMEOUT. 
+  */
+static HAL_StatusTypeDef FLASH_DATAEEPROM_ProgramWord(uint32_t Address, uint32_t Data)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+  
+  /* Check the parameters */
+  assert_param(IS_FLASH_DATA_ADDRESS(Address));
+  
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  
+  if(status == HAL_OK)
+  {
+    /* Set the FTDW bit */
+    FLASH->PECR |= (uint32_t)FLASH_PECR_FTDW;
+    
+    *(__IO uint32_t *)Address = Data;
+
+    /* Wait for last operation to be completed */
+    status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE));
+  }
+  /* Return the Write Status */
+  return status;
+}
+
+
+/**
+  * @}
+  */   
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+     
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+
+

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_flash_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_flash_ex.h
@@ -1,0 +1,297 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_flash_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of FLASH HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_FLASH_EX_H
+#define __STM32L0xx_HAL_FLASH_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup FLASHEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+/**
+  * @brief  FLASH Advanced Option Bytes Program structure definition
+  */
+typedef struct
+{
+  uint32_t OptionType;     /*!< OptionType: Option byte to be configured for extension .
+                              This parameter can be a value of @ref FLASHEx_Option_Type */
+
+  uint32_t PCROPState;    /*!< PCROPState: PCROP activation or deactivation.
+                              This parameter can be a value of @ref FLASHEx_PCROP_State */
+
+  uint16_t Pages;       /*!< Sectors: specifies the sector(s) set for PCROP
+                            This parameter can be a value of @ref FLASHEx_Option_Bytes_PC_ReadWrite_Protection */
+ 
+  uint16_t BootConfig;         /*!< BootConfig: specifies Option bytes for boot config
+                                This parameter can be a value of @ref FLASHEx_Option_Bytes_BOOT1 */
+} FLASH_AdvOBProgramInitTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup FLASHEx_Exported_Constants
+  * @{
+  */  
+/** @defgroup FLASHEx_PCROP_State
+  * @{
+  */ 
+#define PCROPSTATE_DISABLE       ((uint32_t)0x00)  /*!<Disable PCROP */
+#define PCROPSTATE_ENABLE        ((uint32_t)0x01)  /*!<Enable PCROP  */
+  
+#define IS_PCROPSTATE(VALUE)(((VALUE) == PCROPSTATE_DISABLE) || \
+                             ((VALUE) == PCROPSTATE_ENABLE))  
+  
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_Option_Type
+  * @{
+  */ 
+#define OBEX_PCROP        ((uint32_t)0x01)  /*!<PCROP option byte configuration*/
+#define OBEX_BOOTCONFIG   ((uint32_t)0x02)  /*!<BOOTConfig option byte configuration*/
+
+#define IS_OBEX(VALUE)(((VALUE) == OBEX_PCROP) || \
+                       ((VALUE) == OBEX_BOOTCONFIG))  
+/**
+  * @}
+  */
+
+/** @defgroup FLASHEx_Latency
+  * @{
+  */ 
+#define FLASH_LATENCY_0                ((uint8_t)0x00)  /*!< FLASH Zero Latency cycle */
+#define FLASH_LATENCY_1                FLASH_ACR_LATENCY  /*!< FLASH One Latency cycle */
+
+#define IS_FLASH_LATENCY(LATENCY) (((LATENCY) == FLASH_LATENCY_0) || \
+                                   ((LATENCY) == FLASH_LATENCY_1))
+
+/**
+  * @}
+  */ 
+/** @defgroup FLASHEx_Option_Bytes_PC_ReadWrite_Protection
+  * @{
+  */
+#define OB_PCROP_Pages0to31              ((uint32_t)0x00000001) /* PC Read/Write  protection of Sector0 */
+#define OB_PCROP_Pages32to63             ((uint32_t)0x00000002) /* PC Read/Write  protection of Sector1 */
+#define OB_PCROP_Pages64to95             ((uint32_t)0x00000004) /* PC Read/Write  protection of Sector2 */
+#define OB_PCROP_Pages96to127            ((uint32_t)0x00000008) /* PC Read/Write  protection of Sector3 */
+#define OB_PCROP_Pages128to159           ((uint32_t)0x00000010) /* PC Read/Write  protection of Sector4 */
+#define OB_PCROP_Pages160to191           ((uint32_t)0x00000020) /* PC Read/Write  protection of Sector5 */
+#define OB_PCROP_Pages192to223           ((uint32_t)0x00000040) /* PC Read/Write  protection of Sector6 */
+#define OB_PCROP_Pages224to255           ((uint32_t)0x00000080) /* PC Read/Write  protection of Sector7 */
+#define OB_PCROP_Pages256to287           ((uint32_t)0x00000100) /* PC Read/Write  protection of Sector8 */
+#define OB_PCROP_Pages288to319           ((uint32_t)0x00000200) /* PC Read/Write  protection of Sector9 */
+#define OB_PCROP_Pages320to351           ((uint32_t)0x00000400) /* PC Read/Write  protection of Sector10 */
+#define OB_PCROP_Pages352to383           ((uint32_t)0x00000800) /* PC Read/Write  protection of Sector11 */
+#define OB_PCROP_Pages384to415           ((uint32_t)0x00001000) /* PC Read/Write  protection of Sector12 */
+#define OB_PCROP_Pages416to447           ((uint32_t)0x00002000) /* PC Read/Write  protection of Sector13 */
+#define OB_PCROP_Pages448to479           ((uint32_t)0x00004000) /* PC Read/Write  protection of Sector14 */
+#define OB_PCROP_Pages480to511           ((uint32_t)0x00008000) /* PC Read/Write  protection of Sector15 */
+#define OB_PCROP_AllPages                ((uint32_t)0x0000FFFF) /*!< PC Read/Write  protection of all Sectors */
+
+#define IS_OB_PCROP(PAGE) (((PAGE) != 0x0000000))
+
+/**
+  * @}
+  */
+  
+/** @defgroup FLASHEx_Option_Bytes_BOOT1
+  * @{
+  */
+
+#define OB_BOOT1_RESET                 ((uint16_t)0x0000) /*!< BOOT1 Reset */
+#define OB_BOOT1_SET                   ((uint16_t)0x8000) /*!< BOOT1 Set */
+#define IS_OB_BOOT1(BOOT1) (((BOOT1) == OB_BOOT1_RESET) || ((BOOT1) == OB_BOOT1_SET))
+
+/**
+  * @}
+  */
+
+/** @defgroup  FLASHEx_Selection_Protection_Mode
+  * @{
+  */
+#define OB_PCROP_DESELECTED     ((uint16_t)0x0000) /*!< Disabled PcROP, nWPRi bits used for Write Protection on sector i */
+#define OB_PCROP_SELECTED       ((uint16_t)0x0100) /*!< Enable PcROP, nWPRi bits used for PCRoP Protection on sector i   */
+#define IS_OB_PCROP_SELECT(PCROP) (((PCROP) == OB_PCROP_SELECTED) || ((PCROP) == OB_PCROP_DESELECTED))
+/**
+  * @}
+  */
+    
+/**
+  * @}
+  */
+    
+    
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup FLASHEx_Macros
+ *  @brief macros to control FLASH features 
+ *  @{
+ */
+ 
+/**
+  * @brief  Set the FLASH Latency.
+  * @param  __LATENCY__: FLASH Latency                   
+  *         The value of this parameter depend on device used within the same series
+  * @retval none
+  */ 
+#define __HAL_FLASH_SET_LATENCY(__LATENCY__) \
+                  MODIFY_REG(FLASH->ACR, FLASH_ACR_LATENCY, (uint32_t)(__LATENCY__))
+
+/**
+  * @brief  Enable the FLASH prefetch buffer.
+  * @retval none
+  */ 
+#define __HAL_FLASH_PREFETCH_BUFFER_ENABLE()  (FLASH->ACR |= FLASH_ACR_PRFTEN)
+
+/**
+  * @brief  Disable the FLASH prefetch buffer.
+  * @retval none
+  */ 
+#define __HAL_FLASH_PREFETCH_BUFFER_DISABLE()   (FLASH->ACR &= (~FLASH_ACR_PRFTEN))
+
+/**
+  * @brief  Enable the FLASH Buffer cache.
+  * @retval none
+  */ 
+#define __HAL_FLASH_BUFFER_CACHE_ENABLE()  (FLASH->ACR &= (~FLASH_ACR_DISAB_BUF))
+
+/**
+  * @brief  Disable the FLASH Buffer cache.
+  * @retval none
+  */ 
+#define __HAL_FLASH_BUFFER_CACHE_DISABLE()   (FLASH->ACR |= FLASH_ACR_DISAB_BUF)
+
+/**
+  * @brief  Enable the FLASH preread buffer
+  * @retval none
+  */ 
+#define __HAL_FLASH_PREREAD_BUFFER_ENABLE()  (FLASH->ACR |= FLASH_ACR_PRE_READ)
+
+/**
+  * @brief  Disable the FLASH preread buffer
+  * @retval none
+  */ 
+#define __HAL_FLASH_PREREAD_BUFFER_DISABLE()   (FLASH->ACR &= (~FLASH_ACR_PRE_READ))
+
+/**
+  * @brief  Enable the FLASH power down during Sleep mode
+  * @retval none
+  */ 
+#define __HAL_FLASH_SLEEP_POWERDOWN_ENABLE()   SET_BIT(FLASH->ACR, FLASH_ACR_SLEEP_PD)
+
+/**
+  * @brief  Disable the FLASH power down during Sleep mode
+  * @retval none
+  */ 
+#define __HAL_FLASH_SLEEP_POWERDOWN_DISABLE()   CLEAR_BIT(FLASH->ACR, FLASH_ACR_SLEEP_PD)
+
+/**
+  * @brief  Macro to enable or disable the Flash Run power down mode.
+  * @note   Writing this bit  to 0 this bit, automatically the keys are
+  *         loss and a new unlock sequence is necessary to re-write it to 1.
+  */
+
+#define __HAL_FLASH_POWER_DOWN_ENABLE() do { FLASH->PDKEYR = FLASH_PDKEY1;    \
+                                             FLASH->PDKEYR = FLASH_PDKEY2;    \
+                                             SET_BIT(FLASH->ACR, FLASH_ACR_RUN_PD);  \
+                                           } while (0)
+
+#define __HAL_FLASH_POWER_DOWN_DISABLE() do { FLASH->PDKEYR = FLASH_PDKEY1;    \
+                                              FLASH->PDKEYR = FLASH_PDKEY2;    \
+                                             CLEAR_BIT(FLASH->ACR, FLASH_ACR_RUN_PD);  \
+                                            } while (0)
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/* I/O operation functions  *****************************************************/
+/* Peripheral Control functions  ************************************************/
+HAL_StatusTypeDef HAL_FLASHEx_DATAEEPROM_Unlock(void);
+HAL_StatusTypeDef HAL_FLASHEx_DATAEEPROM_Lock(void);
+HAL_StatusTypeDef HAL_FLASHEx_DATAEEPROM_Erase(uint32_t Address);
+HAL_StatusTypeDef HAL_FLASHEx_DATAEEPROM_Program(uint32_t TypeProgram, uint32_t Address, uint32_t Data);
+
+/* Aliases for legacy HAL versions compatibility */
+#define  HAL_DATA_EEPROMEx_Unlock   HAL_FLASHEx_DATAEEPROM_Unlock
+#define  HAL_DATA_EEPROMEx_Lock     HAL_FLASHEx_DATAEEPROM_Lock
+#define  HAL_DATA_EEPROMEx_Erase    HAL_FLASHEx_DATAEEPROM_Erase
+#define  HAL_DATA_EEPROMEx_Program  HAL_FLASHEx_DATAEEPROM_Program
+
+HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t *PageError);
+HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit);
+
+HAL_StatusTypeDef HAL_FLASHEx_OB_SelectPCROP(void);
+HAL_StatusTypeDef HAL_FLASHEx_OB_DeSelectPCROP(void);
+
+HAL_StatusTypeDef HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit);
+void HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit);
+
+HAL_StatusTypeDef HAL_FLASHEx_AdvOBProgram (FLASH_AdvOBProgramInitTypeDef *pAdvOBInit);
+void  HAL_FLASHEx_AdvOBGetConfig(FLASH_AdvOBProgramInitTypeDef *pAdvOBInit);
+
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_FLASH_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_flash_ramfunc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_flash_ramfunc.c
@@ -1,0 +1,216 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_flash_ramfunc.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   FLASH RAMFUNC driver.
+  *          This file provides a Flash firmware functions which should be 
+  *          executed from internal SRAM
+  *            + FLASH HalfPage Programming
+  *            + FLASH Power Down in Run mode
+  *
+  *  @verbatim
+
+    *** ARM Compiler ***
+    --------------------
+    [..] RAM functions are defined using the toolchain options. 
+         Functions that are be executed in RAM should reside in a separate
+         source module. Using the 'Options for File' dialog you can simply change
+         the 'Code / Const' area of a module to a memory space in physical RAM.
+         Available memory areas are declared in the 'Target' tab of the 
+         Options for Target' dialog.
+
+    *** ICCARM Compiler ***
+    -----------------------
+    [..] RAM functions are defined using a specific toolchain keyword "__ramfunc".
+
+    *** GNU Compiler ***
+    --------------------
+    [..] RAM functions are defined using a specific toolchain attribute
+         "__attribute__((section(".RamFunc")))".
+  
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+/** @addtogroup STM32L0XX_HAL_Driver
+  * @{
+  */
+
+/** @defgroup FLASHRamfunc Driver
+  * @brief FLASH functions executed from RAM
+  * @{
+  */
+
+#ifdef HAL_FLASH_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static __RAM_FUNC  FLASH_Program_HalfPage(uint32_t Address, uint32_t *Data);
+
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup FLASHRamfunc_Private_Functions
+  * @{
+  */
+
+/** @defgroup FLASHRamfunc_Group1 Peripheral  features functions 
+ *  @brief   Data transfers functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### ramfunc functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions that should be executed from RAM 
+    transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Program a half page word at a specified address, 
+  * @note   This function should be executed from RAM        
+  * @param  Address:  specifies the address to be programmed, 
+  *         the address should be half page aligned.
+  * @param  *Data: specifies the buffer of data to be programmed,
+  *                the size of the buffer is 16 words.
+  * 
+  * @retval HAL_StatusTypeDef HAL Status
+  */
+__RAM_FUNC  HAL_FLASHEx_HalfPageProgram(uint32_t Address, uint32_t *Data)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t timeout = 0xFFFFFFFF;
+  /*Program word (32-bit) at a specified address.*/
+  FLASH_Program_HalfPage(Address, Data);
+  
+  /* Wait for a FLASH operation to complete or a TIMEOUT to occur */
+  while(((FLASH->SR & FLASH_FLAG_BSY) != 0x00) && (timeout != 0x00))
+  {
+    timeout--;
+  }
+  
+  if(timeout == 0x00 )
+    {
+      return HAL_TIMEOUT;
+    }
+  
+  /* Reset PROG bit */
+  FLASH->PECR &= ~FLASH_PECR_PROG;
+  FLASH->PECR &= ~FLASH_PECR_FPRG;
+  return status;
+}
+
+/**
+  * @brief   Enable the Power down in Run Mode
+  * @note    This function should be called and executed from SRAM memory
+  * @param  None
+  * @retval None
+  */
+__RAM_FUNC  HAL_FLASHEx_EnableRunPowerDown(void)
+{
+  /* Enable the Power Down in Run mode*/
+  __HAL_FLASH_POWER_DOWN_ENABLE();
+  
+  return HAL_OK;
+  
+}
+
+/**
+  * @brief   Disable the Power down in Run Mode
+  * @note    This function should be called and executed from SRAM memory
+  * @param  None
+  * @retval None
+  */
+__RAM_FUNC  HAL_FLASHEx_DisableRunPowerDown(void)
+{
+  /* Disable the Power Down in Run mode*/
+  __HAL_FLASH_POWER_DOWN_DISABLE();
+
+  return HAL_OK;  
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  Program a half page in program memory.
+  * @param  Address: The Half page address in program memory to be written.
+  * @param  Data:
+  * @retval None
+  */
+static __RAM_FUNC  FLASH_Program_HalfPage(uint32_t Address, uint32_t *Data)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t i =0;
+  
+  /* Set PROG bit */
+  FLASH->PECR |= FLASH_PECR_PROG;
+  
+  /* Set FPRG bit */
+  FLASH->PECR |= FLASH_PECR_FPRG;
+
+  *(__IO uint32_t*)Address = Data[0];
+  
+  for(i = 1; i <= 15; i++)
+  {  
+    *(__IO uint32_t*)(Address + 4) = Data[i];
+  } 
+  return status;
+}
+
+/**
+  * @}
+  */   
+#endif /* HAL_FLASH_MODULE_ENABLED */
+
+
+  
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+     
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+
+

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_flash_ramfunc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_flash_ramfunc.h
@@ -1,0 +1,89 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_flash_ramfunc.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of FLASH RAMFUNC driver.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_FLASH_RAMFUNC_H
+#define __STM32L0xx_FLASH_RAMFUNC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup FLASHRamfunc
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+
+
+/* Exported functions --------------------------------------------------------*/
+
+/* I/O operation functions  *****************************************************/
+/* Peripheral Control functions  ************************************************/
+
+__RAM_FUNC  HAL_FLASHEx_HalfPageProgram(uint32_t Address, uint32_t *Data);
+__RAM_FUNC  HAL_FLASHEx_EnableRunPowerDown(void);
+__RAM_FUNC  HAL_FLASHEx_DisableRunPowerDown(void);
+
+/* Aliases for legacy compatibility */
+#define FLASH_HalfPageProgram         HAL_FLASHEx_HalfPageProgram
+#define FLASH_EnableRunPowerDown      HAL_FLASHEx_EnableRunPowerDown
+#define FLASH_DisableRunPowerDown     HAL_FLASHEx_DisableRunPowerDown
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_FLASH_RAMFUNC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_gpio.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_gpio.c
@@ -1,0 +1,528 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_gpio.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   GPIO HAL module driver.  
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the General Purpose Input/Output (GPIO) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *         
+  @verbatim
+  ==============================================================================
+                    ##### GPIO Peripheral features #####
+  ==============================================================================
+  [..] 
+    (+) Each port bit of the general-purpose I/O (GPIO) ports can be individually 
+  configured by software in several modes:
+        (++) Input mode 
+        (++) Analog mode
+        (++) Output mode
+        (++) Alternate function mode
+        (++) External interrupt/event lines
+ 
+    (+) During and just after reset, the alternate functions and external interrupt  
+  lines are not active and the I/O ports are configured in input floating mode.
+  
+    (+) All GPIO pins have weak internal pull-up and pull-down resistors, which can be 
+  activated or not.
+
+    (+) In Output or Alternate mode, each IO can be configured on open-drain or push-pull
+  type and the IO speed can be selected depending on the VDD value.
+  
+    (+) The microcontroller IO pins are connected to onboard peripherals/modules through a 
+        multiplexer that allows only one peripheral alternate function (AF) connected 
+  to an IO pin at a time. In this way, there can be no conflict between peripherals 
+  sharing the same IO pin. 
+
+    (+) All ports have external interrupt/event capability. To use external interrupt 
+  lines, the port must be configured in input mode. All available GPIO pins are 
+  connected to the 16 external interrupt/event lines from EXTI0 to EXTI15.
+  
+    (+) The external interrupt/event controller consists of up to 23 edge detectors 
+  (16 lines are connected to GPIO) for generating event/interrupt requests (each 
+  input line can be independently configured to select the type (interrupt or event) 
+  and the corresponding trigger event (rising or falling or both). Each line can 
+  also be masked independently. 
+  
+                     ##### How to use this driver #####
+  ==============================================================================  
+  [..]             
+    (#) Enable the GPIO IOPORT clock using the following function: __GPIOx_CLK_ENABLE(). 
+  
+    (#) In case of external interrupt/event mode selection, enable the SYSCFG clock 
+       using the following function  __SYSCFG_CLK_ENABLE().  
+             
+    (#) Configure the GPIO pin(s) using HAL_GPIO_Init().
+        (++) Configure the IO mode using "Mode" member from GPIO_InitTypeDef structure
+        (++) Activate Pull-up, Pull-down resistor using "Pull" member from GPIO_InitTypeDef 
+             structure.
+        (++) In case of Output or alternate function mode selection: the speed is 
+             configured through "Speed" member from GPIO_InitTypeDef structure.
+        (++) In alternate mode is selection, the alternate function connected to the IO
+             is configured through "Alternate" member from GPIO_InitTypeDef structure.
+        (++) Analog mode is required when a pin is to be used as ADC channel 
+             or DAC output.
+        (++) In case of external interrupt/event selection the "Mode" member from 
+             GPIO_InitTypeDef structure select the type (interrupt or event) and 
+             the corresponding trigger event (rising or falling or both).
+   
+    (#) In case of external interrupt/event mode selection, configure NVIC IRQ priority 
+        mapped to the EXTI line using HAL_NVIC_SetPriority() and enable it using
+        HAL_NVIC_EnableIRQ().
+         
+    (#) To get the level of a pin configured in input mode use HAL_GPIO_ReadPin().
+            
+    (#) To set/reset the level of a pin configured in output mode use 
+        HAL_GPIO_WritePin()/HAL_GPIO_TogglePin().
+                 
+    (#) During and just after reset, the alternate functions are not 
+        active and the GPIO pins are configured in input floating mode (except JTAG
+        pins).
+  
+    (#) The LSE oscillator pins OSC32_IN and OSC32_OUT can be used as general purpose 
+        (PC14 and PC15, respectively) when the LSE oscillator is off. The LSE has 
+        priority over the GPIO function.
+  
+    (#) The HSE oscillator pins OSC_IN/OSC_OUT can be used as 
+        general purpose PH0 and PH1, respectively, when the HSE oscillator is off. 
+        The HSE has priority over the GPIO function.
+  
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup GPIO
+  * @brief GPIO HAL module driver
+  * @{
+  */
+
+#ifdef HAL_GPIO_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+#define GET_GPIO_SOURCE(__GPIOx__) \
+(((uint32_t)(__GPIOx__) == ((uint32_t)GPIOA_BASE))? 0 :\
+ ((uint32_t)(__GPIOx__) == ((uint32_t)(GPIOA_BASE + 0x0400)))? (uint32_t)1 :\
+ ((uint32_t)(__GPIOx__) == ((uint32_t)(GPIOA_BASE + 0x0800)))? (uint32_t)2 :\
+ ((uint32_t)(__GPIOx__) == ((uint32_t)(GPIOA_BASE + 0x0C00)))? (uint32_t)3 :\
+ ((uint32_t)(__GPIOx__) == ((uint32_t)(GPIOA_BASE + 0x1C00)))? (uint32_t)4 : (uint32_t)5)
+
+ 
+#define GPIO_MODE             ((uint32_t)0x00000003)
+#define EXTI_MODE             ((uint32_t)0x10000000)
+#define GPIO_MODE_IT          ((uint32_t)0x00010000)
+#define GPIO_MODE_EVT         ((uint32_t)0x00020000)
+#define RISING_EDGE           ((uint32_t)0x00100000) 
+#define FALLING_EDGE          ((uint32_t)0x00200000) 
+#define GPIO_OUTPUT_TYPE      ((uint32_t)0x00000010)
+
+#define GPIO_NUMBER           ((uint32_t)16)
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup GPIO_Private_Functions
+  * @{
+  */
+
+/** @defgroup GPIO_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+ 
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the GPIOx peripheral according to the specified parameters in the GPIO_Init.
+  * @param  GPIOx: where x can be (A..D and H) to select the GPIO peripheral for STM32L0XX family devices.
+  * @param  GPIO_Init: pointer to a GPIO_InitTypeDef structure that contains
+  *         the configuration information for the specified GPIO peripheral.
+  * @retval None
+  */
+void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
+{
+  uint32_t position;
+  uint32_t ioposition = 0x00;
+  uint32_t iocurrent = 0x00;
+  uint32_t temp = 0x00;
+  
+  /* Check the parameters */
+  assert_param(IS_GPIO_PIN(GPIO_Init->Pin));
+  assert_param(IS_GPIO_MODE(GPIO_Init->Mode));
+  assert_param(IS_GPIO_PULL(GPIO_Init->Pull)); 
+  
+  /* Configure the port pins */
+  for(position = 0; position < GPIO_NUMBER; position++)
+  {
+    /* Get the IO position */
+    ioposition = ((uint32_t)0x01) << position;
+    /* Get the current IO position */
+    iocurrent = (uint32_t)(GPIO_Init->Pin) & ioposition;
+    
+    if(iocurrent == ioposition)
+    {
+      /*--------------------- GPIO Mode Configuration ------------------------*/
+      /* In case of Alternate function mode selection */
+      if((GPIO_Init->Mode == GPIO_MODE_AF_PP) || (GPIO_Init->Mode == GPIO_MODE_AF_OD)) 
+      {
+        /* Check the Alternate function parameter */
+        assert_param(IS_GPIO_AF(GPIO_Init->Alternate));
+        /* Configure Alternate function mapped with the current IO */ 
+        temp = GPIOx->AFR[position >> 3];
+        temp &= ~((uint32_t)0xF << ((uint32_t)(position & (uint32_t)0x07) * 4)) ;
+        temp |= ((uint32_t)(GPIO_Init->Alternate) << (((uint32_t)position & (uint32_t)0x07) * 4)) ;
+        GPIOx->AFR[position >> 3] = temp;
+      } 
+
+      /* In case of Output or Alternate function mode selection */
+      if((GPIO_Init->Mode == GPIO_MODE_OUTPUT_PP) || (GPIO_Init->Mode == GPIO_MODE_AF_PP) ||
+         (GPIO_Init->Mode == GPIO_MODE_OUTPUT_OD) || (GPIO_Init->Mode == GPIO_MODE_AF_OD))
+      {
+        /* Check the Speed parameter */
+        assert_param(IS_GPIO_SPEED(GPIO_Init->Speed));
+        /* Configure the IO Speed */
+        temp = GPIOx->OSPEEDR;
+        temp &= ~(GPIO_OSPEEDER_OSPEED0 << (position * 2));
+        temp |= (GPIO_Init->Speed << (position * 2));
+        GPIOx->OSPEEDR = temp;
+
+        /* Configure the IO Output Type */
+        temp= GPIOx->OTYPER;
+        temp &= ~(GPIO_OTYPER_OT_0 << position) ;
+        temp |= (((GPIO_Init->Mode & GPIO_OUTPUT_TYPE) >> 4) << position);
+        GPIOx->OTYPER = temp;
+      }
+
+      /* Configure IO Direction mode (Input, Output, Alternate or Analog) */
+      temp = GPIOx->MODER;
+      temp &= ~(GPIO_MODER_MODE0 << (position * 2));
+      temp |= ((GPIO_Init->Mode & GPIO_MODE) << (position * 2));
+      GPIOx->MODER = temp;
+
+      /* Activate the Pull-up or Pull down resistor for the current IO */
+      temp = GPIOx->PUPDR;
+      temp &= ~(GPIO_PUPDR_PUPD0 << (position * 2));
+      temp |= ((GPIO_Init->Pull) << (position * 2)); 
+      GPIOx->PUPDR = temp;
+
+      /*--------------------- EXTI Mode Configuration ------------------------*/
+      /* Configure the External Interrupt or event for the current IO */
+      if((GPIO_Init->Mode & EXTI_MODE) == EXTI_MODE) 
+      {
+        /* Enable SYSCFG Clock */
+        __SYSCFG_CLK_ENABLE();
+
+        temp = SYSCFG->EXTICR[position >> 2];
+        temp &= ~((uint32_t)0x0F) << (4 * (position & 0x03));
+        temp |= ((uint32_t)(GET_GPIO_SOURCE(GPIOx)) << (4 * (position & 0x03)));
+        SYSCFG->EXTICR[position >> 2] = temp;
+
+        /* Clear EXTI line configuration */
+        temp = EXTI->IMR;
+        temp &= ~((uint32_t)iocurrent);
+        if((GPIO_Init->Mode & GPIO_MODE_IT) == GPIO_MODE_IT)
+        {
+          temp |= iocurrent;
+        }
+        EXTI->IMR = temp;
+
+        temp = EXTI->EMR;
+        temp &= ~((uint32_t)iocurrent);
+        if((GPIO_Init->Mode & GPIO_MODE_EVT) == GPIO_MODE_EVT)
+        {
+          temp |= iocurrent;
+        }
+        EXTI->EMR = temp;
+
+        /* Clear Rising Falling edge configuration */
+        temp = EXTI->RTSR;
+        temp &= ~((uint32_t)iocurrent);
+        if((GPIO_Init->Mode & RISING_EDGE) == RISING_EDGE)
+        {
+          temp |= iocurrent;
+        }
+        EXTI->RTSR = temp;
+
+        temp = EXTI->FTSR;
+        temp &= ~((uint32_t)iocurrent);
+        if((GPIO_Init->Mode & FALLING_EDGE) == FALLING_EDGE)
+        {
+          temp |= iocurrent;
+        }
+        EXTI->FTSR = temp;
+      }
+    }
+  }
+}
+
+/**
+  * @brief  De-initializes the GPIOx peripheral registers to their default reset values.
+  * @param  GPIOx: where x can be (A..D and H) to select the GPIO peripheral for STM32L0XX family devices. 
+  * @param  GPIO_Pin: specifies the port bit to be written.
+  *          This parameter can be one of GPIO_PIN_x where x can be (0..15) except for GPIOD(2) and GPIOH(1:0).
+  * @retval None
+  */
+void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
+{ 
+  uint32_t position;
+  uint32_t ioposition = 0x00;
+  uint32_t iocurrent = 0x00;
+  uint32_t tmp = 0x00;
+  
+  /* Configure the port pins */
+  for(position = 0; position < GPIO_NUMBER; position++)
+  {
+    /* Get the IO position */
+    ioposition = ((uint32_t)0x01) << position;
+    /* Get the current IO position */
+    iocurrent = (GPIO_Pin) & ioposition;
+    
+    if(iocurrent == ioposition)
+    {
+      /*------------------------- GPIO Mode Configuration --------------------*/
+      /* Configure IO Direction in Input Floting Mode */
+      GPIOx->MODER &= ~(GPIO_MODER_MODE0 << (position * 2));
+      
+      /* Configure the default Alternate Function in current IO */ 
+      GPIOx->AFR[position >> 3] &= ~((uint32_t)0xF << ((uint32_t)(position & (uint32_t)0x07) * 4)) ;
+      
+      /* Configure the default value for IO Speed */
+      GPIOx->OSPEEDR &= ~(GPIO_OSPEEDER_OSPEED0 << (position * 2));
+      
+      /* Configure the default value IO Output Type */
+      GPIOx->OTYPER  &= ~(GPIO_OTYPER_OT_0 << position) ;
+      
+      /* Deactivate the Pull-up oand Pull-down resistor for the current IO */
+      GPIOx->PUPDR &= ~(GPIO_PUPDR_PUPD0 << (position * 2));
+      
+      
+      /*------------------------- EXTI Mode Configuration --------------------*/
+      /* Configure the External Interrupt or event for the current IO */
+      tmp = ((uint32_t)0x0F) << (4 * (position & 0x03));
+      SYSCFG->EXTICR[position >> 2] &= ~tmp;
+      
+      /* Clear EXTI line configuration */
+      EXTI->IMR &= ~((uint32_t)iocurrent);
+      EXTI->EMR &= ~((uint32_t)iocurrent);
+      
+      /* Clear Rising Falling edge configuration */
+      EXTI->RTSR &= ~((uint32_t)iocurrent);
+      EXTI->FTSR &= ~((uint32_t)iocurrent);
+    }
+  }
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup GPIO_Group2 IO operation functions 
+ *  @brief   GPIO Read and Write
+ *
+@verbatim
+ ===============================================================================
+                       ##### IO operation functions #####
+ ===============================================================================
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Reads the specified input port pin.
+  * @param  GPIOx: where x can be (A..D and H) to select the GPIO peripheral for STM32L0xx family devices. 
+  * @param  GPIO_Pin: specifies the port bit to read.
+  *         This parameter can be GPIO_PIN_x where x can be (0..15) except for GPIOD(2) and GPIOH(1:0).
+  * @retval The input port pin value.
+  */
+GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  GPIO_PinState bitstatus;
+  
+  /* Check the parameters */
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+  
+  if((GPIOx->IDR & GPIO_Pin) != (uint32_t)GPIO_PIN_RESET)
+  {
+    bitstatus = GPIO_PIN_SET;
+  }
+  else
+  {
+    bitstatus = GPIO_PIN_RESET;
+  }
+  return bitstatus;
+}
+
+/**
+  * @brief  Sets or clears the selected data port bit.
+  * 
+  * @note   This function uses GPIOx_BSRR register to allow atomic read/modify 
+  *         accesses. In this way, there is no risk of an IRQ occurring between
+  *         the read and the modify access.
+  *               
+  * @param  GPIOx: where x can be (A..D and H) to select the GPIO peripheral for STM32L0xx family devices. 
+  * @param  GPIO_Pin: specifies the port bit to be written.
+  *          This parameter can be one of GPIO_PIN_x where x can be (0..15) except for GPIOD(2) and GPIOH(1:0).
+  * @param  PinState: specifies the value to be written to the selected bit.
+  *          This parameter can be one of the GPIO_PinState enum values:
+  *            GPIO_PIN_RESET: to clear the port pin
+  *            GPIO_PIN_SET: to set the port pin
+  * @retval None
+  */
+void HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState)
+{
+  /* Check the parameters */
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+  assert_param(IS_GPIO_PIN_ACTION(PinState));
+  
+  if(PinState != GPIO_PIN_RESET)
+  {
+    GPIOx->BSRR = GPIO_Pin;
+  }
+  else
+  {
+    GPIOx->BRR = GPIO_Pin ;
+  }
+}
+
+/**
+  * @brief  Toggles the specified GPIO pins.
+  * @param  GPIOx: Where x can be (A..D and H) to select the GPIO peripheral for STM32L0xx family devices.  
+  * @param  GPIO_Pin: Specifies the pins to be toggled.
+  * @retval None
+  */
+void HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  /* Check the parameters */
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+
+  GPIOx->ODR ^= GPIO_Pin;
+}
+
+/**
+* @brief  Locks GPIO Pins configuration registers.
+* @note   The locked registers are GPIOx_MODER, GPIOx_OTYPER, GPIOx_OSPEEDR,
+*         GPIOx_PUPDR, GPIOx_AFRL and GPIOx_AFRH.
+* @note   The configuration of the locked GPIO pins can no longer be modified
+*         until the next reset.
+* @param  GPIOx: where x can be (A..D and H) to select the GPIO peripheral for STM32F3 family
+* @param  GPIO_Pin: specifies the port bit to be locked.
+*         This parameter can be any combination of GPIO_Pin_x where x can be (0..15).
+* @retval None
+*/
+HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+{
+  __IO uint32_t tmp = GPIO_LCKR_LCKK;
+
+  /* Check the parameters */
+  assert_param(IS_GPIO_PIN(GPIO_Pin));
+
+  /* Apply lock key write sequence */
+  tmp |= GPIO_Pin;
+  /* Set LCKx bit(s): LCKK='1' + LCK[15-0] */
+  GPIOx->LCKR = tmp;
+  /* Reset LCKx bit(s): LCKK='0' + LCK[15-0] */
+  GPIOx->LCKR = GPIO_Pin;
+  /* Set LCKx bit(s): LCKK='1' + LCK[15-0] */
+  GPIOx->LCKR = tmp;
+  /* Read LCKK bit*/
+  tmp = GPIOx->LCKR;
+
+  if((GPIOx->LCKR & GPIO_LCKR_LCKK) != RESET)
+  {
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+/**
+  * @brief  This function handles EXTI interrupt request.
+  * @param  GPIO_Pin: Specifies the pins connected EXTI line
+  * @retval None
+  */
+void HAL_GPIO_EXTI_IRQHandler(uint16_t GPIO_Pin)
+{
+  /* EXTI line interrupt detected */
+  if(__HAL_GPIO_EXTI_GET_IT(GPIO_Pin) != RESET) 
+  { 
+    __HAL_GPIO_EXTI_CLEAR_IT(GPIO_Pin);
+    HAL_GPIO_EXTI_Callback(GPIO_Pin);
+  }
+}
+
+/**
+  * @brief  EXTI line detection callbacks.
+  * @param  GPIO_Pin: Specifies the pins connected EXTI line
+  * @retval None
+  */
+__weak void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_GPIO_EXTI_Callback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+#endif /* HAL_GPIO_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_gpio.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_gpio.h
@@ -1,0 +1,271 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_gpio.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of GPIO HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_GPIO_H
+#define __STM32L0xx_HAL_GPIO_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup GPIO
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+
+/** 
+  * @brief   GPIO Init structure definition  
+  */ 
+typedef struct
+{
+  uint32_t Pin;       /*!< Specifies the GPIO pins to be configured.
+                           This parameter can be any value of @ref GPIO_pins_define */
+
+  uint32_t Mode;      /*!< Specifies the operating mode for the selected pins.
+                           This parameter can be a value of @ref GPIO_mode_define */
+
+  uint32_t Pull;      /*!< Specifies the Pull-up or Pull-Down activation for the selected pins.
+                           This parameter can be a value of @ref GPIO_pull_define */
+
+  uint32_t Speed;     /*!< Specifies the speed for the selected pins.
+                           This parameter can be a value of @ref GPIO_speed_define */
+
+  uint32_t Alternate;  /*!< Peripheral to be connected to the selected pins 
+                            This parameter can be a value of @ref GPIOEx_Alternate_function_selection */
+}GPIO_InitTypeDef;
+
+/** 
+  * @brief  GPIO Bit SET and Bit RESET enumeration 
+  */
+typedef enum
+{
+  GPIO_PIN_RESET = 0,
+  GPIO_PIN_SET
+}GPIO_PinState;
+#define IS_GPIO_PIN_ACTION(ACTION) (((ACTION) == GPIO_PIN_RESET) || ((ACTION) == GPIO_PIN_SET))
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup GPIO_Exported_Constants
+  * @{
+  */
+
+/** @defgroup GPIO_pins_define
+  * @{
+  */
+#define GPIO_PIN_0                 ((uint16_t)0x0001)  /* Pin 0 selected    */
+#define GPIO_PIN_1                 ((uint16_t)0x0002)  /* Pin 1 selected    */
+#define GPIO_PIN_2                 ((uint16_t)0x0004)  /* Pin 2 selected    */
+#define GPIO_PIN_3                 ((uint16_t)0x0008)  /* Pin 3 selected    */
+#define GPIO_PIN_4                 ((uint16_t)0x0010)  /* Pin 4 selected    */
+#define GPIO_PIN_5                 ((uint16_t)0x0020)  /* Pin 5 selected    */
+#define GPIO_PIN_6                 ((uint16_t)0x0040)  /* Pin 6 selected    */
+#define GPIO_PIN_7                 ((uint16_t)0x0080)  /* Pin 7 selected    */
+#define GPIO_PIN_8                 ((uint16_t)0x0100)  /* Pin 8 selected    */
+#define GPIO_PIN_9                 ((uint16_t)0x0200)  /* Pin 9 selected    */
+#define GPIO_PIN_10                ((uint16_t)0x0400)  /* Pin 10 selected   */
+#define GPIO_PIN_11                ((uint16_t)0x0800)  /* Pin 11 selected   */
+#define GPIO_PIN_12                ((uint16_t)0x1000)  /* Pin 12 selected   */
+#define GPIO_PIN_13                ((uint16_t)0x2000)  /* Pin 13 selected   */
+#define GPIO_PIN_14                ((uint16_t)0x4000)  /* Pin 14 selected   */
+#define GPIO_PIN_15                ((uint16_t)0x8000)  /* Pin 15 selected   */
+#define GPIO_PIN_All               ((uint16_t)0xFFFF)  /* All pins selected */
+
+#define GPIO_PIN_MASK              ((uint32_t)0x0000FFFF) /* PIN mask for assert test */
+#define IS_GPIO_PIN(PIN)           (((PIN) & GPIO_PIN_MASK ) != (uint32_t)0x00)
+/**
+  * @}
+  */
+
+/** @defgroup GPIO_mode_define
+  * @brief GPIO Configuration Mode 
+  *        Elements values convention: 0xX0yz00YZ
+  *           - X  : GPIO mode or EXTI Mode
+  *           - y  : External IT or Event trigger detection 
+  *           - z  : IO configuration on External IT or Event
+  *           - Y  : Output type (Push Pull or Open Drain)
+  *           - Z  : IO Direction mode (Input, Output, Alternate or Analog)
+  * @{
+  */ 
+#define  GPIO_MODE_INPUT                        ((uint32_t)0x00000000)   /*!< Input Floating Mode                   */
+#define  GPIO_MODE_OUTPUT_PP                    ((uint32_t)0x00000001)   /*!< Output Push Pull Mode                 */
+#define  GPIO_MODE_OUTPUT_OD                    ((uint32_t)0x00000011)   /*!< Output Open Drain Mode                */
+#define  GPIO_MODE_AF_PP                        ((uint32_t)0x00000002)   /*!< Alternate Function Push Pull Mode     */
+#define  GPIO_MODE_AF_OD                        ((uint32_t)0x00000012)   /*!< Alternate Function Open Drain Mode    */
+
+#define  GPIO_MODE_ANALOG                       ((uint32_t)0x00000003)   /*!< Analog Mode  */
+    
+#define  GPIO_MODE_IT_RISING                    ((uint32_t)0x10110000)   /*!< External Interrupt Mode with Rising edge trigger detection          */
+#define  GPIO_MODE_IT_FALLING                   ((uint32_t)0x10210000)   /*!< External Interrupt Mode with Falling edge trigger detection         */
+#define  GPIO_MODE_IT_RISING_FALLING            ((uint32_t)0x10310000)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection  */
+ 
+#define  GPIO_MODE_EVT_RISING                   ((uint32_t)0x10120000)   /*!< External Event Mode with Rising edge trigger detection               */
+#define  GPIO_MODE_EVT_FALLING                  ((uint32_t)0x10220000)   /*!< External Event Mode with Falling edge trigger detection              */
+#define  GPIO_MODE_EVT_RISING_FALLING           ((uint32_t)0x10320000)   /*!< External Event Mode with Rising/Falling edge trigger detection       */
+  
+#define IS_GPIO_MODE(MODE) (((MODE) == GPIO_MODE_INPUT)              ||\
+                            ((MODE) == GPIO_MODE_OUTPUT_PP)          ||\
+                            ((MODE) == GPIO_MODE_OUTPUT_OD)          ||\
+                            ((MODE) == GPIO_MODE_AF_PP)              ||\
+                            ((MODE) == GPIO_MODE_AF_OD)              ||\
+                            ((MODE) == GPIO_MODE_IT_RISING)          ||\
+                            ((MODE) == GPIO_MODE_IT_FALLING)         ||\
+                            ((MODE) == GPIO_MODE_IT_RISING_FALLING)  ||\
+                            ((MODE) == GPIO_MODE_EVT_RISING)         ||\
+                            ((MODE) == GPIO_MODE_EVT_FALLING)        ||\
+                            ((MODE) == GPIO_MODE_EVT_RISING_FALLING) ||\
+                            ((MODE) == GPIO_MODE_ANALOG))
+
+/**
+  * @}
+  */
+/** @defgroup GPIO_speed_define
+  * @brief GPIO Output Maximum frequency
+  * @{
+  */  
+#define  GPIO_SPEED_LOW         ((uint32_t)0x00000000)  /*!< Low speed     */
+#define  GPIO_SPEED_MEDIUM      ((uint32_t)0x00000001)  /*!< Medium speed  */
+#define  GPIO_SPEED_FAST        ((uint32_t)0x00000002)  /*!< Fast speed    */
+#define  GPIO_SPEED_HIGH        ((uint32_t)0x00000003)  /*!< High speed    */
+
+#define IS_GPIO_SPEED(SPEED) (((SPEED) == GPIO_SPEED_LOW)  || ((SPEED) == GPIO_SPEED_MEDIUM) || \
+                              ((SPEED) == GPIO_SPEED_FAST) || ((SPEED) == GPIO_SPEED_HIGH))
+/**
+  * @}
+  */
+
+ /** @defgroup GPIO_pull_define
+   * @brief GPIO Pull-Up or Pull-Down Activation
+   * @{
+   */  
+#define  GPIO_NOPULL        ((uint32_t)0x00000000)   /*!< No Pull-up or Pull-down activation  */
+#define  GPIO_PULLUP        ((uint32_t)0x00000001)   /*!< Pull-up activation                  */
+#define  GPIO_PULLDOWN      ((uint32_t)0x00000002)   /*!< Pull-down activation                */
+
+#define IS_GPIO_PULL(PULL) (((PULL) == GPIO_NOPULL) || ((PULL) == GPIO_PULLUP) || \
+                            ((PULL) == GPIO_PULLDOWN))
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+/**
+  * @brief  Checks whether the specified EXTI line flag is set or not.
+  * @param  __EXTI_LINE__: specifies the EXTI line flag to check.
+  *         This parameter can be GPIO_PIN_x where x can be(0..15)
+  * @retval The new state of __EXTI_LINE__ (SET or RESET).
+  */
+#define __HAL_GPIO_EXTI_GET_FLAG(__EXTI_LINE__) (EXTI->PR & (__EXTI_LINE__))
+
+/**
+  * @brief  Clears the EXTI's line pending flags.
+  * @param  __EXTI_LINE__: specifies the EXTI lines flags to clear.
+  *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15)
+  * @retval None
+  */
+#define __HAL_GPIO_EXTI_CLEAR_FLAG(__EXTI_LINE__) (EXTI->PR = (__EXTI_LINE__))
+
+/**
+  * @brief  Checks whether the specified EXTI line is asserted or not.
+  * @param  __EXTI_LINE__: specifies the EXTI line to check.
+  *          This parameter can be GPIO_PIN_x where x can be(0..15)
+  * @retval The new state of __EXTI_LINE__ (SET or RESET).
+  */
+#define __HAL_GPIO_EXTI_GET_IT(__EXTI_LINE__) (EXTI->PR & (__EXTI_LINE__))
+
+/**
+  * @brief  Clears the EXTI's line pending bits.
+  * @param  __EXTI_LINE__: specifies the EXTI lines to clear.
+  *          This parameter can be any combination of GPIO_PIN_x where x can be (0..15)
+  * @retval None
+  */
+#define __HAL_GPIO_EXTI_CLEAR_IT(__EXTI_LINE__) (EXTI->PR = (__EXTI_LINE__))
+
+/**
+  * @brief  Generates a Software interrupt on selected EXTI line.
+  * @param  __EXTI_LINE__: specifies the EXTI line to check.
+  *          This parameter can be GPIO_PIN_x where x can be(0..15)
+  * @retval None
+  */
+#define __HAL_GPIO_EXTI_GENERATE_SWIT(__EXTI_LINE__) (EXTI->SWIER |= (__EXTI_LINE__))
+
+/* Include GPIO HAL Extension module */
+#include "stm32l0xx_hal_gpio_ex.h"
+
+/* Exported functions --------------------------------------------------------*/ 
+
+/* Initialization and de-initialization functions *******************************/
+void  HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init);
+void  HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin);
+
+/* IO operation functions *******************************************************/
+GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+void          HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState);
+void          HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+void          HAL_GPIO_EXTI_IRQHandler(uint16_t GPIO_Pin);
+void          HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_GPIO_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_gpio_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_gpio_ex.h
@@ -1,0 +1,428 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_gpio_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of GPIO HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_GPIO_EX_H
+#define __STM32L0xx_HAL_GPIO_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup GPIOEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup GPIOEx_Exported_Constants
+  * @{
+  */ 
+  
+/** @defgroup GPIOEx_Alternate_function_selection
+  * @{
+  */
+  
+/*------------------------- STM32L053xx/STM32L063xx---------------------------*/ 
+#if defined (STM32L053xx) || defined (STM32L063xx)
+/** 
+  * @brief   AF 0 selection  
+  */ 
+#define GPIO_AF0_SPI1          ((uint8_t)0x00)  /* SPI1 Alternate Function mapping     */
+#define GPIO_AF0_SPI2          ((uint8_t)0x00)  /* SPI2 Alternate Function mapping     */
+#define GPIO_AF0_USART1        ((uint8_t)0x00)  /* USART1 Alternate Function mapping   */
+#define GPIO_AF0_USART2        ((uint8_t)0x00)  /* USART2 Alternate Function mapping   */
+#define GPIO_AF0_LPUART1       ((uint8_t)0x00)  /* LPUART1 Alternate Function mapping  */
+#define GPIO_AF0_USB           ((uint8_t)0x00)  /* USB Alternate Function mapping      */
+#define GPIO_AF0_LPTIM         ((uint8_t)0x00)  /* LPTIM Alternate Function mapping    */
+#define GPIO_AF0_TSC           ((uint8_t)0x00)  /* TSC Alternate Function mapping      */
+#define GPIO_AF0_TIM2          ((uint8_t)0x00)  /* TIM2 Alternate Function mapping     */
+#define GPIO_AF0_TIM21         ((uint8_t)0x00)  /* TIM21 Alternate Function mapping    */
+#define GPIO_AF0_TIM22         ((uint8_t)0x00)  /* TIM22 Alternate Function mapping    */
+#define GPIO_AF0_EVENTOUT      ((uint8_t)0x00)  /* EVENTOUT Alternate Function mapping */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /* MCO Alternate Function mapping      */
+#define GPIO_AF0_SWDIO         ((uint8_t)0x00)  /* SWDIO Alternate Function mapping    */
+#define GPIO_AF0_SWCLK         ((uint8_t)0x00)  /* SWCLK Alternate Function mapping    */
+
+/** 
+  * @brief   AF 1 selection  
+  */ 
+#define GPIO_AF1_SPI1          ((uint8_t)0x01)  /* SPI1 Alternate Function mapping  */
+#define GPIO_AF1_SPI2          ((uint8_t)0x01)  /* SPI2 Alternate Function mapping  */
+#define GPIO_AF1_I2C1          ((uint8_t)0x01)  /* I2C1 Alternate Function mapping  */
+#define GPIO_AF1_LCD           ((uint8_t)0x01)  /* LCD Alternate Function mapping   */
+#define GPIO_AF1_TIM2          ((uint8_t)0x01)  /* TIM2 Alternate Function mapping  */
+#define GPIO_AF1_TIM21         ((uint8_t)0x01)  /* TIM21 Alternate Function mapping */
+/** 
+  * @brief   AF 2 selection  
+  */ 
+#define GPIO_AF2_SPI2          ((uint8_t)0x02)  /* SPI2 Alternate Function mapping       */
+#define GPIO_AF2_LPUART1       ((uint8_t)0x02)  /* LPUART1 Alternate Function mapping    */
+#define GPIO_AF2_USB           ((uint8_t)0x02)  /* USB Alternate Function mapping        */
+#define GPIO_AF2_LPTIM         ((uint8_t)0x02)  /* LPTIM Alternate Function mapping      */
+#define GPIO_AF2_TIM2          ((uint8_t)0x02)  /* TIM2 Alternate Function mapping       */
+#define GPIO_AF2_TIM22         ((uint8_t)0x02)  /* TIM22 Alternate Function mapping      */
+#define GPIO_AF2_EVENTOUT      ((uint8_t)0x02)  /* EVENTOUT Alternate Function mapping   */
+#define GPIO_AF2_RTC_50Hz      ((uint8_t)0x02)  /* RTC_OUT Alternate Function mapping    */
+
+/** 
+  * @brief   AF 3 selection  
+  */ 
+#define GPIO_AF3_I2C1          ((uint8_t)0x03)  /* I2C1 Alternate Function mapping     */
+#define GPIO_AF3_TSC           ((uint8_t)0x03)  /* TSC  Alternate Function mapping     */
+#define GPIO_AF3_EVENTOUT      ((uint8_t)0x03)  /* EVENTOUT Alternate Function mapping */
+
+/** 
+  * @brief   AF 4 selection  
+  */ 
+#define GPIO_AF4_I2C1            ((uint8_t)0x04)  /* I2C1 Alternate Function mapping     */
+#define GPIO_AF4_USART1          ((uint8_t)0x04)  /* USART1 Alternate Function mapping   */
+#define GPIO_AF4_USART2          ((uint8_t)0x04)  /* USART2 Alternate Function mapping   */
+#define GPIO_AF4_LPUART1         ((uint8_t)0x04)  /* LPUART1 Alternate Function mapping  */
+#define GPIO_AF4_TIM22           ((uint8_t)0x04)  /* TIM22 Alternate Function mapping    */
+#define GPIO_AF4_EVENTOUT        ((uint8_t)0x04)  /* EVENTOUT Alternate Function mapping */
+
+/** 
+  * @brief   AF 5 selection  
+  */ 
+#define GPIO_AF5_SPI2          ((uint8_t)0x05)  /* SPI2 Alternate Function mapping     */
+#define GPIO_AF5_I2C2          ((uint8_t)0x05)  /* I2C2 Alternate Function mapping     */
+#define GPIO_AF5_TIM2          ((uint8_t)0x05)  /* TIM2 Alternate Function mapping     */
+#define GPIO_AF5_TIM21         ((uint8_t)0x05)  /* TIM21 Alternate Function mapping    */
+#define GPIO_AF5_TIM22         ((uint8_t)0x05)  /* TIM22 Alternate Function mapping    */
+
+/** 
+  * @brief   AF 6 selection  
+  */ 
+#define GPIO_AF6_I2C2          ((uint8_t)0x06)  /* I2C2 Alternate Function mapping      */
+#define GPIO_AF6_TIM21         ((uint8_t)0x06)  /* TIM21 Alternate Function mapping     */
+#define GPIO_AF6_EVENTOUT      ((uint8_t)0x06)  /* EVENTOUT Alternate Function mapping  */
+
+/** 
+  * @brief   AF 7 selection  
+  */ 
+#define GPIO_AF7_COMP1        ((uint8_t)0x07)  /* COMP1 Alternate Function mapping     */
+#define GPIO_AF7_COMP2        ((uint8_t)0x07)  /* COMP2 Alternate Function mapping     */
+
+
+#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_SPI1)         ||     ((AF) == GPIO_AF2_SPI2)        || \
+                          ((AF) == GPIO_AF0_SPI2)         ||     ((AF) == GPIO_AF2_LPUART1)     || \
+                          ((AF) == GPIO_AF0_USART1)       ||     ((AF) == GPIO_AF2_USB)         || \
+                          ((AF) == GPIO_AF0_USART2)       ||     ((AF) == GPIO_AF2_LPTIM)       || \
+                          ((AF) == GPIO_AF0_LPUART1)      ||     ((AF) == GPIO_AF2_TIM2)        || \
+                          ((AF) == GPIO_AF0_USB)          ||     ((AF) == GPIO_AF2_TIM22)       || \
+                          ((AF) == GPIO_AF0_LPTIM)        ||     ((AF) == GPIO_AF2_EVENTOUT)    || \
+                          ((AF) == GPIO_AF0_TSC)          ||     ((AF) == GPIO_AF2_RTC_50Hz)    || \
+                          ((AF) == GPIO_AF0_TIM2)         ||     ((AF) == GPIO_AF3_I2C1)        || \
+                          ((AF) == GPIO_AF0_TIM21)        ||     ((AF) == GPIO_AF3_TSC)         || \
+                          ((AF) == GPIO_AF0_TIM22)        ||     ((AF) == GPIO_AF3_EVENTOUT)    || \
+                          ((AF) == GPIO_AF0_EVENTOUT)     ||     ((AF) == GPIO_AF4_I2C1)        || \
+                          ((AF) == GPIO_AF0_MCO)          ||     ((AF) == GPIO_AF4_USART1)      || \
+                          ((AF) == GPIO_AF0_SWDIO)        ||     ((AF) == GPIO_AF0_SWCLK)       || \
+                          ((AF) == GPIO_AF1_SPI1)         ||     ((AF) == GPIO_AF4_USART2)      || \
+                          ((AF) == GPIO_AF1_SPI2)         ||     ((AF) == GPIO_AF4_LPUART1)     || \
+                          ((AF) == GPIO_AF1_TIM2)         ||     ((AF) == GPIO_AF4_TIM22)       || \
+                          ((AF) == GPIO_AF1_I2C1)         ||     ((AF) == GPIO_AF4_EVENTOUT)    || \
+                          ((AF) == GPIO_AF1_LCD)          ||     ((AF) == GPIO_AF5_SPI2)        || \
+                          ((AF) == GPIO_AF5_I2C2)         ||     ((AF) == GPIO_AF5_TIM2)        || \
+                          ((AF) == GPIO_AF5_TIM21)        ||     ((AF) == GPIO_AF5_TIM22)       || \
+                          ((AF) == GPIO_AF6_I2C2)         ||     ((AF) == GPIO_AF6_TIM21)       || \
+                          ((AF) == GPIO_AF6_EVENTOUT)     ||     ((AF) == GPIO_AF7_COMP1)       || \
+                          ((AF) == GPIO_AF7_COMP2)        ||     ((AF) == GPIO_AF1_TIM21))
+
+#endif /* STM32L053xx || STM32L063xx */
+/*------------------------------------------------------------------------------------------*/
+
+/*------------------------- STM32L052xx/STM32L062xx---------------------------*/ 
+#if defined (STM32L052xx) || defined (STM32L062xx)
+/** 
+  * @brief   AF 0 selection  
+  */ 
+#define GPIO_AF0_SPI1          ((uint8_t)0x00)  /* SPI1 Alternate Function mapping               */
+#define GPIO_AF0_SPI2          ((uint8_t)0x00)  /* SPI2 Alternate Function mapping               */
+#define GPIO_AF0_USART1        ((uint8_t)0x00)  /* USART1 Alternate Function mapping             */
+#define GPIO_AF0_USART2        ((uint8_t)0x00)  /* USART2 Alternate Function mapping             */
+#define GPIO_AF0_LPUART1       ((uint8_t)0x00)  /* LPUART1 Alternate Function mapping            */
+#define GPIO_AF0_USB           ((uint8_t)0x00)  /* USB Alternate Function mapping                */
+#define GPIO_AF0_LPTIM         ((uint8_t)0x00)  /* LPTIM Alternate Function mapping              */
+#define GPIO_AF0_TSC           ((uint8_t)0x00)  /* TSC Alternate Function mapping                */
+#define GPIO_AF0_TIM2          ((uint8_t)0x00)  /* TIM2 Alternate Function mapping               */
+#define GPIO_AF0_TIM21         ((uint8_t)0x00)  /* TIM21 Alternate Function mapping              */
+#define GPIO_AF0_TIM22         ((uint8_t)0x00)  /* TIM22 Alternate Function mapping              */
+#define GPIO_AF0_EVENTOUT      ((uint8_t)0x00)  /* EVENTOUT Alternate Function mapping           */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /* MCO Alternate Function mapping                */
+#define GPIO_AF0_SWDIO         ((uint8_t)0x00)  /* SWDIO Alternate Function mapping              */
+#define GPIO_AF0_SWCLK         ((uint8_t)0x00)  /* SWCLK Alternate Function mapping              */
+
+
+/** 
+  * @brief   AF 1 selection  
+  */ 
+#define GPIO_AF1_SPI1          ((uint8_t)0x01)  /* SPI1 Alternate Function mapping */
+#define GPIO_AF1_SPI2          ((uint8_t)0x01)  /* SPI2 Alternate Function mapping */
+#define GPIO_AF1_I2C1          ((uint8_t)0x01)  /* I2C1 Alternate Function mapping */
+#define GPIO_AF1_TIM2          ((uint8_t)0x01)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF1_TIM21         ((uint8_t)0x01)  /* TIM21 Alternate Function mapping */
+/** 
+  * @brief   AF 2 selection  
+  */ 
+#define GPIO_AF2_SPI2          ((uint8_t)0x02)  /* SPI2 Alternate Function mapping               */
+#define GPIO_AF2_LPUART1       ((uint8_t)0x02)  /* LPUART1 Alternate Function mapping            */
+#define GPIO_AF2_USB           ((uint8_t)0x02)  /* USB Alternate Function mapping                */
+#define GPIO_AF2_LPTIM         ((uint8_t)0x02)  /* LPTIM Alternate Function mapping              */
+#define GPIO_AF2_TIM2          ((uint8_t)0x02)  /* TIM2 Alternate Function mapping               */
+#define GPIO_AF2_TIM22         ((uint8_t)0x02)  /* TIM22 Alternate Function mapping              */
+#define GPIO_AF2_EVENTOUT      ((uint8_t)0x02)  /* EVENTOUT Alternate Function mapping           */
+#define GPIO_AF2_RTC_50Hz      ((uint8_t)0x02)  /* RTC_OUT Alternate Function mapping            */
+
+/** 
+  * @brief   AF 3 selection  
+  */ 
+#define GPIO_AF3_I2C1          ((uint8_t)0x03)  /* I2C1 Alternate Function mapping     */
+#define GPIO_AF3_TSC           ((uint8_t)0x03)  /* TSC  Alternate Function mapping     */
+#define GPIO_AF3_EVENTOUT      ((uint8_t)0x03)  /* EVENTOUT Alternate Function mapping */
+
+/** 
+  * @brief   AF 4 selection  
+  */ 
+#define GPIO_AF4_I2C1            ((uint8_t)0x04)  /* I2C1 Alternate Function mapping     */
+#define GPIO_AF4_USART1          ((uint8_t)0x04)  /* USART1 Alternate Function mapping   */
+#define GPIO_AF4_USART2          ((uint8_t)0x04)  /* USART2 Alternate Function mapping   */
+#define GPIO_AF4_LPUART1         ((uint8_t)0x04)  /* LPUART1 Alternate Function mapping  */
+#define GPIO_AF4_TIM22           ((uint8_t)0x04)  /* TIM22 Alternate Function mapping    */
+#define GPIO_AF4_EVENTOUT        ((uint8_t)0x04)  /* EVENTOUT Alternate Function mapping */
+
+/** 
+  * @brief   AF 5 selection  
+  */ 
+#define GPIO_AF5_SPI2          ((uint8_t)0x05)  /* SPI2 Alternate Function mapping     */
+#define GPIO_AF5_I2C2          ((uint8_t)0x05)  /* I2C2 Alternate Function mapping     */
+#define GPIO_AF5_TIM2          ((uint8_t)0x05)  /* TIM2 Alternate Function mapping     */
+#define GPIO_AF5_TIM21         ((uint8_t)0x05)  /* TIM21 Alternate Function mapping    */
+#define GPIO_AF5_TIM22         ((uint8_t)0x05)  /* TIM22 Alternate Function mapping    */
+
+/** 
+  * @brief   AF 6 selection  
+  */ 
+#define GPIO_AF6_I2C2          ((uint8_t)0x06)  /* I2C2 Alternate Function mapping      */
+#define GPIO_AF6_TIM21         ((uint8_t)0x06)  /* TIM21 Alternate Function mapping     */
+#define GPIO_AF6_EVENTOUT      ((uint8_t)0x06)  /* EVENTOUT Alternate Function mapping  */
+
+/** 
+  * @brief   AF 7 selection  
+  */ 
+#define GPIO_AF7_COMP1        ((uint8_t)0x07)  /* COMP1 Alternate Function mapping     */
+#define GPIO_AF7_COMP2        ((uint8_t)0x07)  /* COMP2 Alternate Function mapping     */
+
+
+#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_SPI1)         ||     ((AF) == GPIO_AF2_SPI2)        || \
+                          ((AF) == GPIO_AF0_SPI2)         ||     ((AF) == GPIO_AF2_LPUART1)     || \
+                          ((AF) == GPIO_AF0_USART1)       ||     ((AF) == GPIO_AF2_USB)         || \
+                          ((AF) == GPIO_AF0_USART2)       ||     ((AF) == GPIO_AF2_LPTIM)       || \
+                          ((AF) == GPIO_AF0_LPUART1)      ||     ((AF) == GPIO_AF2_TIM2)        || \
+                          ((AF) == GPIO_AF0_USB)          ||     ((AF) == GPIO_AF2_TIM22)       || \
+                          ((AF) == GPIO_AF0_LPTIM)        ||     ((AF) == GPIO_AF2_EVENTOUT)    || \
+                          ((AF) == GPIO_AF0_TSC)          ||     ((AF) == GPIO_AF2_RTC_50Hz)    || \
+                          ((AF) == GPIO_AF0_TIM2)         ||     ((AF) == GPIO_AF3_I2C1)        || \
+                          ((AF) == GPIO_AF0_TIM21)        ||     ((AF) == GPIO_AF3_TSC)         || \
+                          ((AF) == GPIO_AF0_TIM22)        ||     ((AF) == GPIO_AF3_EVENTOUT)    || \
+                          ((AF) == GPIO_AF0_EVENTOUT)     ||     ((AF) == GPIO_AF4_I2C1)        || \
+                          ((AF) == GPIO_AF0_MCO)          ||     ((AF) == GPIO_AF4_USART1)      || \
+                          ((AF) == GPIO_AF0_SWDIO)        ||     ((AF) == GPIO_AF0_SWCLK)       || \
+                          ((AF) == GPIO_AF1_SPI1)         ||     ((AF) == GPIO_AF4_USART2)      || \
+                          ((AF) == GPIO_AF1_SPI2)         ||     ((AF) == GPIO_AF4_LPUART1)     || \
+                          ((AF) == GPIO_AF1_TIM2)         ||     ((AF) == GPIO_AF4_TIM22)       || \
+                          ((AF) == GPIO_AF1_I2C1)         ||     ((AF) == GPIO_AF4_EVENTOUT)    || \
+                          ((AF) == GPIO_AF6_EVENTOUT)     ||     ((AF) == GPIO_AF5_SPI2)        || \
+                          ((AF) == GPIO_AF5_I2C2)         ||     ((AF) == GPIO_AF5_TIM2)        || \
+                          ((AF) == GPIO_AF5_TIM21)        ||     ((AF) == GPIO_AF5_TIM22)       || \
+                          ((AF) == GPIO_AF6_I2C2)         ||     ((AF) == GPIO_AF6_TIM21)       || \
+                          ((AF) == GPIO_AF7_COMP2)        ||     ((AF) == GPIO_AF7_COMP1)       || \
+                          ((AF) == GPIO_AF1_TIM21))
+
+#endif /* STM32L052xx || STM32L062xx */
+/*------------------------------------------------------------------------------------------*/
+
+/*------------------------- STM32L051xx/STM32L061xx---------------------------*/ 
+#if defined (STM32L051xx)|| defined (STM32L061xx)
+/** 
+  * @brief   AF 0 selection  
+  */ 
+#define GPIO_AF0_SPI1          ((uint8_t)0x00)  /* SPI1 Alternate Function mapping               */
+#define GPIO_AF0_SPI2          ((uint8_t)0x00)  /* SPI2 Alternate Function mapping               */
+#define GPIO_AF0_USART1        ((uint8_t)0x00)  /* USART1 Alternate Function mapping             */
+#define GPIO_AF0_USART2        ((uint8_t)0x00)  /* USART2 Alternate Function mapping             */
+#define GPIO_AF0_LPUART1       ((uint8_t)0x00)  /* LPUART1 Alternate Function mapping            */
+#define GPIO_AF0_LPTIM         ((uint8_t)0x00)  /* LPTIM Alternate Function mapping              */
+#define GPIO_AF0_TSC           ((uint8_t)0x00)  /* TSC Alternate Function mapping                */
+#define GPIO_AF0_TIM2          ((uint8_t)0x00)  /* TIM2 Alternate Function mapping               */
+#define GPIO_AF0_TIM21         ((uint8_t)0x00)  /* TIM21 Alternate Function mapping              */
+#define GPIO_AF0_TIM22         ((uint8_t)0x00)  /* TIM22 Alternate Function mapping              */
+#define GPIO_AF0_EVENTOUT      ((uint8_t)0x00)  /* EVENTOUT Alternate Function mapping           */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /* MCO Alternate Function mapping                */
+#define GPIO_AF0_SWDIO         ((uint8_t)0x00)  /* SWDIO Alternate Function mapping              */
+#define GPIO_AF0_SWCLK         ((uint8_t)0x00)  /* SWCLK Alternate Function mapping              */
+
+
+/** 
+  * @brief   AF 1 selection  
+  */ 
+#define GPIO_AF1_SPI1          ((uint8_t)0x01)  /* SPI1 Alternate Function mapping */
+#define GPIO_AF1_SPI2          ((uint8_t)0x01)  /* SPI2 Alternate Function mapping */
+#define GPIO_AF1_I2C1          ((uint8_t)0x01)  /* I2C1 Alternate Function mapping */
+#define GPIO_AF1_TIM2          ((uint8_t)0x01)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF1_TIM21         ((uint8_t)0x01)  /* TIM21 Alternate Function mapping */
+/** 
+  * @brief   AF 2 selection  
+  */ 
+#define GPIO_AF2_SPI2          ((uint8_t)0x02)  /* SPI2 Alternate Function mapping               */
+#define GPIO_AF2_LPUART1       ((uint8_t)0x02)  /* LPUART1 Alternate Function mapping            */
+#define GPIO_AF2_LPTIM         ((uint8_t)0x02)  /* LPTIM Alternate Function mapping              */
+#define GPIO_AF2_TIM2          ((uint8_t)0x02)  /* TIM2 Alternate Function mapping               */
+#define GPIO_AF2_TIM22         ((uint8_t)0x02)  /* TIM22 Alternate Function mapping              */
+#define GPIO_AF2_EVENTOUT      ((uint8_t)0x02)  /* EVENTOUT Alternate Function mapping           */
+#define GPIO_AF2_RTC_50Hz      ((uint8_t)0x02)  /* RTC_OUT Alternate Function mapping            */
+
+/** 
+  * @brief   AF 3 selection  
+  */ 
+#define GPIO_AF3_I2C1          ((uint8_t)0x03)  /* I2C1 Alternate Function mapping     */
+#define GPIO_AF3_TSC           ((uint8_t)0x03)  /* TSC  Alternate Function mapping     */
+#define GPIO_AF3_EVENTOUT      ((uint8_t)0x03)  /* EVENTOUT Alternate Function mapping */
+
+
+/** 
+  * @brief   AF 4 selection  
+  */ 
+#define GPIO_AF4_I2C1            ((uint8_t)0x04)  /* I2C1 Alternate Function mapping     */
+#define GPIO_AF4_USART1          ((uint8_t)0x04)  /* USART1 Alternate Function mapping   */
+#define GPIO_AF4_USART2          ((uint8_t)0x04)  /* USART2 Alternate Function mapping   */
+#define GPIO_AF4_LPUART1         ((uint8_t)0x04)  /* LPUART1 Alternate Function mapping  */
+#define GPIO_AF4_TIM22           ((uint8_t)0x04)  /* TIM22 Alternate Function mapping    */
+#define GPIO_AF4_EVENTOUT        ((uint8_t)0x04)  /* EVENTOUT Alternate Function mapping */
+
+/** 
+  * @brief   AF 5 selection  
+  */ 
+#define GPIO_AF5_SPI2          ((uint8_t)0x05)  /* SPI2 Alternate Function mapping     */
+#define GPIO_AF5_I2C2          ((uint8_t)0x05)  /* I2C2 Alternate Function mapping     */
+#define GPIO_AF5_TIM2          ((uint8_t)0x05)  /* TIM2 Alternate Function mapping     */
+#define GPIO_AF5_TIM21         ((uint8_t)0x05)  /* TIM21 Alternate Function mapping    */
+#define GPIO_AF5_TIM22         ((uint8_t)0x05)  /* TIM22 Alternate Function mapping    */
+
+/** 
+  * @brief   AF 6 selection  
+  */ 
+#define GPIO_AF6_I2C2          ((uint8_t)0x06)  /* I2C2 Alternate Function mapping      */
+#define GPIO_AF6_TIM21         ((uint8_t)0x06)  /* TIM21 Alternate Function mapping     */
+#define GPIO_AF6_EVENTOUT      ((uint8_t)0x06)  /* EVENTOUT Alternate Function mapping  */
+
+/** 
+  * @brief   AF 7 selection  
+  */ 
+#define GPIO_AF7_COMP1        ((uint8_t)0x07)  /* COMP1 Alternate Function mapping     */
+#define GPIO_AF7_COMP2        ((uint8_t)0x07)  /* COMP2 Alternate Function mapping     */
+
+
+#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_SPI1)         ||     ((AF) == GPIO_AF2_SPI2)        || \
+                          ((AF) == GPIO_AF0_SPI2)         ||     ((AF) == GPIO_AF2_LPUART1)     || \
+                          ((AF) == GPIO_AF0_USART1)       ||     ((AF) == GPIO_AF2_TIM22)       || \
+                          ((AF) == GPIO_AF0_USART2)       ||     ((AF) == GPIO_AF2_LPTIM)       || \
+                          ((AF) == GPIO_AF0_LPUART1)      ||     ((AF) == GPIO_AF2_TIM2)        || \
+                          ((AF) == GPIO_AF0_LPTIM)        ||     ((AF) == GPIO_AF2_EVENTOUT)    || \
+                          ((AF) == GPIO_AF1_TIM21)        ||     ((AF) == GPIO_AF2_RTC_50Hz)    || \
+                          ((AF) == GPIO_AF0_TIM2)         ||     ((AF) == GPIO_AF3_I2C1)        || \
+                          ((AF) == GPIO_AF0_TIM21)        ||     ((AF) == GPIO_AF3_TSC)         || \
+                          ((AF) == GPIO_AF0_TIM22)        ||     ((AF) == GPIO_AF3_EVENTOUT)    || \
+                          ((AF) == GPIO_AF0_EVENTOUT)     ||     ((AF) == GPIO_AF4_I2C1)        || \
+                          ((AF) == GPIO_AF0_MCO)          ||     ((AF) == GPIO_AF4_USART1)      || \
+                          ((AF) == GPIO_AF0_SWDIO)        ||     ((AF) == GPIO_AF0_SWCLK)       || \
+                          ((AF) == GPIO_AF1_SPI1)         ||     ((AF) == GPIO_AF4_USART2)      || \
+                          ((AF) == GPIO_AF1_SPI2)         ||     ((AF) == GPIO_AF4_LPUART1)     || \
+                          ((AF) == GPIO_AF1_TIM2)         ||     ((AF) == GPIO_AF4_TIM22)       || \
+                          ((AF) == GPIO_AF1_I2C1)         ||     ((AF) == GPIO_AF4_EVENTOUT)    || \
+                          ((AF) == GPIO_AF6_EVENTOUT)     ||     ((AF) == GPIO_AF5_SPI2)        || \
+                          ((AF) == GPIO_AF5_I2C2)         ||     ((AF) == GPIO_AF5_TIM2)        || \
+                          ((AF) == GPIO_AF5_TIM21)        ||     ((AF) == GPIO_AF5_TIM22)       || \
+                          ((AF) == GPIO_AF6_I2C2)         ||     ((AF) == GPIO_AF6_TIM21)       || \
+                          ((AF) == GPIO_AF7_COMP2)        ||     ((AF) == GPIO_AF7_COMP1))       
+                         
+
+#endif /* STM32L051xx/STM32L061xx*/
+
+/* Aliases define maintained for legacy */
+#define GPIO_AF0_EVENOUT      GPIO_AF0_EVENTOUT
+#define GPIO_AF2_EVENOUT      GPIO_AF2_EVENTOUT
+#define GPIO_AF3_EVENOUT      GPIO_AF3_EVENTOUT
+#define GPIO_AF6_EVENOUT      GPIO_AF6_EVENTOUT
+/*------------------------------------------------------------------------------------------*/
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/ 
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_GPIO_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_i2c.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_i2c.c
@@ -1,0 +1,4081 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_i2c.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   I2C HAL module driver.
+  *    
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Inter Integrated Circuit (I2C) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral State functions
+  *         
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+    [..]
+    The I2C HAL driver can be used as follows:
+    
+    (#) Declare a I2C_HandleTypeDef handle structure, for example:
+        I2C_HandleTypeDef  hi2c; 
+
+    (#)Initialize the I2C low level resources by implement the HAL_I2C_MspInit ()API:
+        (##) Enable the I2Cx interface clock
+        (##) I2C pins configuration
+            (+++) Enable the clock for the I2C GPIOs
+            (+++) Configure I2C pins as alternate function open-drain
+        (##) NVIC configuration if you need to use interrupt process
+            (+++) Configure the I2Cx interrupt priority
+            (+++) Enable the NVIC I2C IRQ Channel
+        (##) DMA Configuration if you need to use DMA process
+            (+++) Declare a DMA_HandleTypeDef handle structure for the transmit or receive stream
+            (+++) Enable the DMAx interface clock using
+            (+++) Configure the DMA handle parameters
+            (+++) Configure the DMA Tx or Rx Stream
+            (+++) Associate the initilalized DMA handle to the hi2c DMA Tx or Rx handle
+            (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx or Rx Stream
+
+    (#) Configure the Communication Clock Timing, Own Address1, Master Adressing Mode, Dual Addressing mode,
+        Own Address2, Own Address2 Mask, General call and Nostretch mode in the hi2c Init structure.
+
+    (#) Initialize the I2C registers by calling the HAL_I2C_Init() API:
+        (+++) These API's configures also the low level Hardware GPIO, CLOCK, CORTEX...etc)
+            by calling the customed HAL_I2C_MspInit(&hi2c) API.
+
+    (#) To check if target device is ready for communication, use the function HAL_I2C_IsDeviceReady()
+
+    (#) For I2C IO and IO MEM operations, three mode of operations are available within this driver :
+
+    *** Polling mode IO operation ***
+    =================================
+    [..]
+      (+) Transmit in master mode an amount of data in blocking mode using HAL_I2C_Master_Transmit()
+      (+) Receive in master mode an amount of data in blocking mode using HAL_I2C_Master_Receive()
+      (+) Transmit in slave mode an amount of data in blocking mode using HAL_I2C_Slave_Transmit()
+      (+) Receive in slave mode an amount of data in blocking mode using HAL_I2C_Slave_Receive()
+
+    *** Polling mode IO MEM operation ***
+    =====================================
+    [..]
+      (+) Write an amount of data in blocking mode to a specific memory address using HAL_I2C_Mem_Write()
+      (+) Read an amount of data in blocking mode from a specific memory address using HAL_I2C_Mem_Read()
+
+
+    *** Interrupt mode IO operation ***
+    ===================================
+    [..]
+      (+) Transmit in master mode an amount of data in non blocking mode using HAL_I2C_Master_Transmit_IT()
+      (+) At transmission end of transfer HAL_I2C_MasterTxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MasterTxCpltCallback
+      (+) Receive in master mode an amount of data in non blocking mode using HAL_I2C_Master_Receive_IT()
+      (+) At reception end of transfer HAL_I2C_MasterRxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MasterRxCpltCallback
+      (+) Transmit in slave mode an amount of data in non blocking mode using HAL_I2C_Slave_Transmit_IT()
+      (+) At transmission end of transfer HAL_I2C_SlaveTxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_SlaveTxCpltCallback
+      (+) Receive in slave mode an amount of data in non blocking mode using HAL_I2C_Slave_Receive_IT()
+      (+) At reception end of transfer HAL_I2C_SlaveRxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_SlaveRxCpltCallback
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_I2C_ErrorCallback
+
+    *** Interrupt mode IO MEM operation ***
+    =======================================
+    [..]
+      (+) Write an amount of data in no-blocking mode with Interrupt to a specific memory address using
+          HAL_I2C_Mem_Write_IT()
+      (+) At MEM end of write transfer HAL_I2C_MemTxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MemTxCpltCallback
+      (+) Read an amount of data in no-blocking mode with Interrupt from a specific memory address using
+          HAL_I2C_Mem_Read_IT()
+      (+) At MEM end of read transfer HAL_I2C_MemRxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MemRxCpltCallback
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_I2C_ErrorCallback
+
+    *** DMA mode IO operation ***
+    ==============================
+    [..]
+      (+) Transmit in master mode an amount of data in non blocking mode (DMA) using
+          HAL_I2C_Master_Transmit_DMA()
+      (+) At transmission end of transfer HAL_I2C_MasterTxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MasterTxCpltCallback
+      (+) Receive in master mode an amount of data in non blocking mode (DMA) using
+          HAL_I2C_Master_Receive_DMA()
+      (+) At reception end of transfer HAL_I2C_MasterRxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MasterRxCpltCallback
+      (+) Transmit in slave mode an amount of data in non blocking mode (DMA) using
+          HAL_I2C_Slave_Transmit_DMA()
+      (+) At transmission end of transfer HAL_I2C_SlaveTxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_SlaveTxCpltCallback
+      (+) Receive in slave mode an amount of data in non blocking mode (DMA) using
+          HAL_I2C_Slave_Receive_DMA()
+      (+) At reception end of transfer HAL_I2C_SlaveRxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_SlaveRxCpltCallback
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_I2C_ErrorCallback
+
+    *** DMA mode IO MEM operation ***
+    =================================
+    [..]
+      (+) Write an amount of data in no-blocking mode with DMA to a specific memory address using
+          HAL_I2C_Mem_Write_DMA()
+      (+) At MEM end of write transfer HAL_I2C_MemTxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MemTxCpltCallback
+      (+) Read an amount of data in no-blocking mode with DMA from a specific memory address using
+          HAL_I2C_Mem_Read_DMA()
+      (+) At MEM end of read transfer HAL_I2C_MemRxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_I2C_MemRxCpltCallback
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_I2C_ErrorCallback
+
+
+     *** I2C HAL driver macros list ***
+     ==================================
+     [..]
+       Below the list of most used macros in I2C HAL driver.
+
+      (+) __HAL_I2C_ENABLE: Enable the I2C peripheral
+      (+) __HAL_I2C_DISABLE: Disable the I2C peripheral
+      (+) __HAL_I2C_GET_FLAG : Checks whether the specified I2C flag is set or not
+      (+) __HAL_I2C_CLEAR_FLAG : Clears the specified I2C pending flag
+      (+) __HAL_I2C_ENABLE_IT: Enables the specified I2C interrupt
+      (+) __HAL_I2C_DISABLE_IT: Disables the specified I2C interrupt
+
+     [..]
+       (@) You can refer to the I2C HAL driver header file for more useful macros
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup I2C 
+  * @brief I2C HAL module driver
+  * @{
+  */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define TIMING_CLEAR_MASK       ((uint32_t)0xF0FFFFFF)  /*<! I2C TIMING clear register Mask */
+#define I2C_TIMEOUT_ADDR    ((uint32_t)10000)  /* 10 s  */
+#define I2C_TIMEOUT_BUSY    ((uint32_t)25)     /* 25 ms */
+#define I2C_TIMEOUT_DIR     ((uint32_t)25)     /* 25 ms */
+#define I2C_TIMEOUT_RXNE    ((uint32_t)25)     /* 25 ms */
+#define I2C_TIMEOUT_STOPF   ((uint32_t)25)     /* 25 ms */
+#define I2C_TIMEOUT_TC      ((uint32_t)25)     /* 25 ms */
+#define I2C_TIMEOUT_TCR     ((uint32_t)25)     /* 25 ms */
+#define I2C_TIMEOUT_TXIS    ((uint32_t)25)     /* 25 ms */
+#define I2C_TIMEOUT_FLAG    ((uint32_t)25)     /* 25 ms */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void I2C_DMAMasterTransmitCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMAMasterReceiveCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMASlaveTransmitCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMASlaveReceiveCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMAMemTransmitCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMAMemReceiveCplt(DMA_HandleTypeDef *hdma);
+static void I2C_DMAError(DMA_HandleTypeDef *hdma);
+
+static HAL_StatusTypeDef I2C_RequestMemoryWrite(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout);
+static HAL_StatusTypeDef I2C_RequestMemoryRead(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout);
+static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
+static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout);
+static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout);
+static HAL_StatusTypeDef I2C_WaitOnSTOPFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout);
+static HAL_StatusTypeDef I2C_IsAcknowledgeFailed(I2C_HandleTypeDef *hi2c, uint32_t Timeout);
+
+static HAL_StatusTypeDef I2C_MasterTransmit_ISR(I2C_HandleTypeDef *hi2c);
+static HAL_StatusTypeDef I2C_MasterReceive_ISR(I2C_HandleTypeDef *hi2c);
+
+static HAL_StatusTypeDef I2C_SlaveTransmit_ISR(I2C_HandleTypeDef *hi2c);
+static HAL_StatusTypeDef I2C_SlaveReceive_ISR(I2C_HandleTypeDef *hi2c);
+
+static void I2C_TransferConfig(I2C_HandleTypeDef *hi2c,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request);
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup I2C_Private_Functions
+  * @{
+  */
+
+/** @defgroup HAL_I2C_Group1 Initialization/de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+ ===============================================================================
+              ##### Initialization/de-initialization functions #####
+ ===============================================================================
+    [..]  This subsection provides a set of functions allowing to initialize and 
+          de-initialiaze the I2Cx peripheral:
+
+      (+) User must Implement HAL_I2C_MspInit() function in which he configures 
+          all related peripherals resources (CLOCK, GPIO, DMA, IT and NVIC ).
+
+      (+) Call the function HAL_I2C_Init() to configure the selected device with 
+          the selected configuration:
+        (++) Clock Timing
+        (++) Own Address 1
+        (++) Addressing mode (Master, Slave)
+        (++) Dual Addressing mode
+        (++) Own Address 2
+        (++) Own Address 2 Mask
+        (++) General call mode
+        (++) Nostretch mode
+
+      (+) Call the function HAL_I2C_DeInit() to restore the default configuration 
+          of the selected I2Cx periperal.       
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the I2C according to the specified parameters 
+  *         in the I2C_InitTypeDef and create the associated handle.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Init(I2C_HandleTypeDef *hi2c)
+{ 
+  /* Check the I2C handle allocation */
+  if(hi2c == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+  assert_param(IS_I2C_OWN_ADDRESS1(hi2c->Init.OwnAddress1));
+  assert_param(IS_I2C_ADDRESSING_MODE(hi2c->Init.AddressingMode));
+  assert_param(IS_I2C_DUAL_ADDRESS(hi2c->Init.DualAddressMode));
+  assert_param(IS_I2C_OWN_ADDRESS2(hi2c->Init.OwnAddress2));
+  assert_param(IS_I2C_OWN_ADDRESS2_MASK(hi2c->Init.OwnAddress2Masks));
+  assert_param(IS_I2C_GENERAL_CALL(hi2c->Init.GeneralCallMode));
+  assert_param(IS_I2C_NO_STRETCH(hi2c->Init.NoStretchMode));
+
+  if(hi2c->State == HAL_I2C_STATE_RESET)
+  {
+    /* Init the low level hardware : GPIO, CLOCK, CORTEX...etc */
+    HAL_I2C_MspInit(hi2c);
+  }
+
+  hi2c->State = HAL_I2C_STATE_BUSY;
+  
+  /* Disable the selected I2C peripheral */
+  __HAL_I2C_DISABLE(hi2c);
+  
+  /*---------------------------- I2Cx TIMINGR Configuration ------------------*/
+  /* Configure I2Cx: Frequency range */
+  hi2c->Instance->TIMINGR = hi2c->Init.Timing & TIMING_CLEAR_MASK;
+  
+  /*---------------------------- I2Cx OAR1 Configuration ---------------------*/
+  /* Configure I2Cx: Own Address1 and ack own address1 mode */
+  hi2c->Instance->OAR1 &= ~I2C_OAR1_OA1EN;
+  if(hi2c->Init.OwnAddress1 != 0)
+  {
+    if(hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_7BIT)
+    {
+      hi2c->Instance->OAR1 = (I2C_OAR1_OA1EN | hi2c->Init.OwnAddress1);
+    }
+    else /* I2C_ADDRESSINGMODE_10BIT */
+    {
+      hi2c->Instance->OAR1 = (I2C_OAR1_OA1EN | I2C_OAR1_OA1MODE | hi2c->Init.OwnAddress1);
+    }
+  }
+  
+  /*---------------------------- I2Cx CR2 Configuration ----------------------*/
+  /* Configure I2Cx: Addressing Master mode */
+  if(hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_10BIT)
+  {
+    hi2c->Instance->CR2 = (I2C_CR2_ADD10);
+  }
+  /* Enable the AUTOEND by default, and enable NACK (should be disable only during Slave process */
+  hi2c->Instance->CR2 |= (I2C_CR2_AUTOEND | I2C_CR2_NACK);
+  
+  /*---------------------------- I2Cx OAR2 Configuration ---------------------*/
+  /* Configure I2Cx: Dual mode and Own Address2 */
+  hi2c->Instance->OAR2 = (hi2c->Init.DualAddressMode | hi2c->Init.OwnAddress2 | (hi2c->Init.OwnAddress2Masks << 8));
+
+  /*---------------------------- I2Cx CR1 Configuration ----------------------*/
+  /* Configure I2Cx: Generalcall and NoStretch mode */
+  hi2c->Instance->CR1 = (hi2c->Init.GeneralCallMode | hi2c->Init.NoStretchMode);
+  
+  /* Enable the selected I2C peripheral */
+  __HAL_I2C_ENABLE(hi2c);
+  
+  hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+  hi2c->State = HAL_I2C_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the I2C peripheral. 
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_DeInit(I2C_HandleTypeDef *hi2c)
+{
+  /* Check the I2C handle allocation */
+  if(hi2c == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+  
+  hi2c->State = HAL_I2C_STATE_BUSY;
+  
+  /* Disable the I2C Peripheral Clock */
+  __HAL_I2C_DISABLE(hi2c);
+  
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_I2C_MspDeInit(hi2c);
+  
+  hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+  hi2c->State = HAL_I2C_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief I2C MSP Init.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+ __weak void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_MspInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief I2C MSP DeInit
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+ __weak void HAL_I2C_MspDeInit(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_MspDeInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_I2C_Group2 I/O operation functions 
+ *  @brief   Data transfers functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to manage the I2C data 
+    transfers.
+
+    (#) There is two mode of transfer:
+       (++) Blocking mode : The communication is performed in the polling mode. 
+            The status of all data processing is returned by the same function 
+            after finishing transfer.  
+       (++) No-Blocking mode : The communication is performed using Interrupts 
+            or DMA. These functions return the status of the transfer startup.
+            The end of the data processing will be indicated through the 
+            dedicated I2C IRQ when using Interrupt mode or the DMA IRQ when 
+            using DMA mode.
+
+    (#) Blocking mode functions are :
+        (++) HAL_I2C_Master_Transmit()
+        (++) HAL_I2C_Master_Receive()
+        (++) HAL_I2C_Slave_Transmit()
+        (++) HAL_I2C_Slave_Receive()
+        (++) HAL_I2C_Mem_Write()
+        (++) HAL_I2C_Mem_Read()
+        (++) HAL_I2C_IsDeviceReady()
+        
+    (#) No-Blocking mode functions with Interrupt are :
+        (++) HAL_I2C_Master_Transmit_IT()
+        (++) HAL_I2C_Master_Receive_IT()
+        (++) HAL_I2C_Slave_Transmit_IT()
+        (++) HAL_I2C_Slave_Receive_IT()
+        (++) HAL_I2C_Mem_Write_IT()
+        (++) HAL_I2C_Mem_Read_IT()
+
+    (#) No-Blocking mode functions with DMA are :
+        (++) HAL_I2C_Master_Transmit_DMA()
+        (++) HAL_I2C_Master_Receive_DMA()
+        (++) HAL_I2C_Slave_Transmit_DMA()
+        (++) HAL_I2C_Slave_Receive_DMA()
+        (++) HAL_I2C_Mem_Write_DMA()
+        (++) HAL_I2C_Mem_Read_DMA()
+
+    (#) A set of Transfer Complete Callbacks are provided in No_Blocking mode:
+        (++) HAL_I2C_MemTxCpltCallback()
+        (++) HAL_I2C_MemRxCpltCallback()
+        (++) HAL_I2C_MasterTxCpltCallback()
+        (++) HAL_I2C_MasterRxCpltCallback()
+        (++) HAL_I2C_SlaveTxCpltCallback()
+        (++) HAL_I2C_SlaveRxCpltCallback()
+        (++) HAL_I2C_ErrorCallback()
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Transmits in master mode an amount of data in blocking mode.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t sizetmp = 0;
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {    
+    if((pData == NULL ) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+    
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_MASTER_BUSY_TX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    /* Size > 255, need to set RELOAD bit */
+    if(Size > 255)
+    {
+      I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
+      sizetmp = 255;
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_GENERATE_START_WRITE);
+      sizetmp = Size;
+    }
+      
+    do
+    {
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          return HAL_ERROR;
+        }
+        else
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = (*pData++);
+      sizetmp--;
+      Size--;
+
+      if((sizetmp == 0)&&(Size!=0))
+      {
+        /* Wait until TXE flag is set */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout) != HAL_OK)      
+        {
+          return HAL_TIMEOUT;
+        }
+        
+        if(Size > 255)
+        {
+          I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          sizetmp = 255;
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          sizetmp = Size;
+        }
+      }
+
+    }while(Size > 0);
+    
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is set */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+    
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+  	
+    /* Clear Configuration Register 2 */
+    __HAL_I2C_RESET_CR2(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY; 	  
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief  Receives in master mode an amount of data in blocking mode. 
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t sizetmp = 0;
+
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {    
+    if((pData == NULL ) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+    
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_MASTER_BUSY_RX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    /* Size > 255, need to set RELOAD bit */
+    if(Size > 255)
+    {
+      I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+      sizetmp = 255;
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+      sizetmp = Size;
+    }
+    
+    do
+    {
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, Timeout) != HAL_OK)      
+      {
+        return HAL_TIMEOUT;
+      }
+     
+      /* Write data to RXDR */
+      (*pData++) =hi2c->Instance->RXDR;
+      sizetmp--;
+      Size--;
+
+      if((sizetmp == 0)&&(Size!=0))
+      {
+        /* Wait until TCR flag is set */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout) != HAL_OK)      
+        {
+          return HAL_TIMEOUT;
+        }
+        
+        if(Size > 255)
+        {
+          I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          sizetmp = 255;
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          sizetmp = Size;
+        }
+      }
+
+    }while(Size > 0);
+    
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is set */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+    
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+  	
+    /* Clear Configuration Register 2 */
+    __HAL_I2C_RESET_CR2(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_READY; 	  
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief  Transmits in slave mode an amount of data in blocking mode. 
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {    
+    if((pData == NULL ) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_SLAVE_BUSY_RX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Wait until ADDR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, Timeout) != HAL_OK)      
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+    
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+
+    /* If 10bit addressing mode is selected */
+    if(hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_10BIT)
+    {
+      /* Wait until ADDR flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, Timeout) != HAL_OK)      
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+        return HAL_TIMEOUT;
+      }
+    
+      /* Clear ADDR flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+    }
+
+    /* Wait until DIR flag is set Transmitter mode */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_DIR, RESET, Timeout) != HAL_OK)      
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    do
+    {
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          return HAL_ERROR;
+        }
+        else
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+      
+      /* Read data from TXDR */
+      hi2c->Instance->TXDR = (*pData++);
+      Size--;
+    }while(Size > 0);
+    
+    /* Wait until STOP flag is set */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+	/* Normal use case for Transmitter mode */
+	/* A NACK is generated to confirm the end of transfer */
+	hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+    
+    /* Clear STOP flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_STOPF);
+    
+    /* Wait until BUSY flag is reset */ 
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, Timeout) != HAL_OK)      
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+    
+    /* Disable Address Acknowledge */
+    hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+    hi2c->State = HAL_I2C_STATE_READY;
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief  Receive in slave mode an amount of data in blocking mode 
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {  
+    if((pData == NULL ) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_SLAVE_BUSY_RX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Wait until ADDR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, Timeout) != HAL_OK)      
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+    
+    /* Wait until DIR flag is reset Receiver mode */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_DIR, SET, Timeout) != HAL_OK)      
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    while(Size > 0)
+    {
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnRXNEFlagUntilTimeout(hi2c, Timeout) != HAL_OK)      
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_TIMEOUT)
+        {
+          return HAL_TIMEOUT;
+        }
+        else
+        {
+          return HAL_ERROR;
+        }
+      }
+      
+      /* Read data from RXDR */
+      (*pData++) = hi2c->Instance->RXDR;
+      Size--;
+    }
+    
+    /* Wait until STOP flag is set */
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_STOPF);
+    
+    /* Wait until BUSY flag is reset */ 
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, Timeout) != HAL_OK)      
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    
+    /* Disable Address Acknowledge */
+    hi2c->Instance->CR2 |= I2C_CR2_NACK;
+    
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  } 
+}
+
+/**
+  * @brief  Transmit in master mode an amount of data in no-blocking mode with Interrupt
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+{   
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+    
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_MASTER_BUSY_TX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+    
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_WRITE);
+    }
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c); 
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process 
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+
+
+    /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    __HAL_I2C_ENABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_TXI );
+        
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  } 
+}
+
+/**
+  * @brief  Receive in master mode an amount of data in no-blocking mode with Interrupt
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+    
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_MASTER_BUSY_RX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+    
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+    }
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c); 
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process 
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+    
+    /* Enable ERR, TC, STOP, NACK, RXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    __HAL_I2C_ENABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_RXI );
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  } 
+}
+
+/**
+  * @brief  Transmit in slave mode an amount of data in no-blocking mode with Interrupt 
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_SLAVE_BUSY_TX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferSize = Size;
+    hi2c->XferCount = Size;
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c); 
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process 
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+    
+    /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    __HAL_I2C_ENABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_TXI );
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  } 
+}
+
+/**
+  * @brief  Receive in slave mode an amount of data in no-blocking mode with Interrupt 
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_SLAVE_BUSY_RX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    hi2c->pBuffPtr = pData;
+    hi2c->XferSize = Size;
+    hi2c->XferCount = Size;
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c); 
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process 
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+    
+    /* Enable ERR, TC, STOP, NACK, RXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    __HAL_I2C_ENABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief  Transmit in master mode an amount of data in no-blocking mode with DMA
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }     
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_MASTER_BUSY_TX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+    
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmatx->XferCpltCallback = I2C_DMAMasterTransmitCplt;
+    
+    /* Set the DMA error callback */
+    hi2c->hdmatx->XferErrorCallback = I2C_DMAError;
+    
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+    
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_WRITE);
+    }  
+
+    /* Wait until TXIS flag is set */
+    if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, I2C_TIMEOUT_TXIS) != HAL_OK)
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;   
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive in master mode an amount of data in no-blocking mode with DMA 
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }  
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_MASTER_BUSY_RX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+    
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmarx->XferCpltCallback = I2C_DMAMasterReceiveCplt;
+    
+    /* Set the DMA error callback */
+    hi2c->hdmarx->XferErrorCallback = I2C_DMAError;
+    
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData, hi2c->XferSize);
+    
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+    }
+
+    /* Wait until RXNE flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, I2C_TIMEOUT_RXNE) != HAL_OK)      
+    {
+      return HAL_TIMEOUT;
+    }
+
+    
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;   
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmit in slave mode an amount of data in no-blocking mode with DMA 
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }   
+    /* Process Locked */
+    __HAL_LOCK(hi2c); 
+    
+    hi2c->State = HAL_I2C_STATE_SLAVE_BUSY_TX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    hi2c->XferSize = Size;
+    
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmatx->XferCpltCallback = I2C_DMASlaveTransmitCplt;
+    
+    /* Set the DMA error callback */
+    hi2c->hdmatx->XferErrorCallback = I2C_DMAError;
+    
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+    
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Wait until ADDR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, I2C_TIMEOUT_ADDR) != HAL_OK)      
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+    
+    /* If 10bits addressing mode is selected */
+    if(hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_10BIT)
+    {
+      /* Wait until ADDR flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, I2C_TIMEOUT_ADDR) != HAL_OK)      
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+        return HAL_TIMEOUT;
+      }
+
+      /* Clear ADDR flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+    }
+    
+    /* Wait until DIR flag is set Transmitter mode */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_DIR, RESET, I2C_TIMEOUT_BUSY) != HAL_OK)      
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+      
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN; 
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive in slave mode an amount of data in no-blocking mode with DMA 
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size)
+{
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }   
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_SLAVE_BUSY_RX;
+    hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
+    
+    hi2c->pBuffPtr = pData;
+    hi2c->XferSize = Size;
+    hi2c->XferCount = Size;
+    
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmarx->XferCpltCallback = I2C_DMASlaveReceiveCplt;
+    
+    /* Set the DMA error callback */
+    hi2c->hdmarx->XferErrorCallback = I2C_DMAError;
+    
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData, Size);
+    
+    /* Enable Address Acknowledge */
+    hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Wait until ADDR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, I2C_TIMEOUT_ADDR) != HAL_OK)      
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_ADDR);
+    
+    /* Wait until DIR flag is set Receiver mode */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_DIR, SET, I2C_TIMEOUT_DIR) != HAL_OK)      
+    {
+      /* Disable Address Acknowledge */
+      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      return HAL_TIMEOUT;
+    }
+ 
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;  
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+/**
+  * @brief  Write an amount of data in blocking mode to a specific memory address
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t Sizetmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+  
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  { 
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_MEM_BUSY_TX;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+    
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryWrite(hi2c, DevAddress, MemAddress, MemAddSize, Timeout) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Set NBYTES to write and reload if size > 255 */
+    /* Size > 255, need to set RELOAD bit */
+    if(Size > 255)
+    {
+      I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      Sizetmp = 255;
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      Sizetmp = Size;
+    }
+    
+    do
+    {
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          return HAL_ERROR;
+        }
+        else
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+     
+      /* Write data to DR */
+      hi2c->Instance->TXDR = (*pData++);
+      Sizetmp--;
+      Size--;
+
+      if((Sizetmp == 0)&&(Size!=0))
+      {
+        /* Wait until TCR flag is set */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout) != HAL_OK)      
+        {
+          return HAL_TIMEOUT;
+        }
+
+        
+        if(Size > 255)
+        {
+          I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          Sizetmp = 255;
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          Sizetmp = Size;
+        }
+      }
+      
+    }while(Size > 0);
+    
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */ 
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+    
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+  	
+    /* Clear Configuration Register 2 */
+    __HAL_I2C_RESET_CR2(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY; 	  
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Read an amount of data in blocking mode from a specific memory address
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t Sizetmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+  
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {    
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_MEM_BUSY_RX;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+    
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryRead(hi2c, DevAddress, MemAddress, MemAddSize, Timeout) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    /* Size > 255, need to set RELOAD bit */
+    if(Size > 255)
+    {
+      I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+      Sizetmp = 255;
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+      Sizetmp = Size;
+    }
+    
+    do
+    {  
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, Timeout) != HAL_OK)      
+      {
+        return HAL_TIMEOUT;
+      }
+          
+      /* Read data from RXDR */
+      (*pData++) = hi2c->Instance->RXDR;
+
+      /* Decrement the Size counter */
+      Sizetmp--;
+      Size--;   
+
+      if((Sizetmp == 0)&&(Size!=0))
+      {
+        /* Wait until TCR flag is set */
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout) != HAL_OK)      
+        {
+          return HAL_TIMEOUT;
+        }
+        
+        if(Size > 255)
+        {
+          I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          Sizetmp = 255;
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c,DevAddress,Size, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          Sizetmp = Size;
+        }
+      }
+
+    }while(Size > 0);
+
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */ 
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+  	
+    /* Clear Configuration Register 2 */
+    __HAL_I2C_RESET_CR2(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_READY;
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+/**
+  * @brief  Write an amount of data in no-blocking mode with Interrupt to a specific memory address
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+  
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+    
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_MEM_BUSY_TX;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+    
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+    
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryWrite(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Set NBYTES to write and reload if size > 255 */
+    /* Size > 255, need to set RELOAD bit */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+    }  
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c); 
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process 
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+    
+    /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    __HAL_I2C_ENABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_TXI );
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Read an amount of data in no-blocking mode with Interrupt from a specific memory address
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+  
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+    
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_MEM_BUSY_RX;
+    
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+    
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryRead(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+      
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    /* Size > 255, need to set RELOAD bit */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c); 
+
+    /* Note : The I2C interrupts must be enabled after unlocking current process 
+              to avoid the risk of I2C interrupt handle execution before current
+              process unlock */
+    
+    /* Enable ERR, TC, STOP, NACK, RXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    __HAL_I2C_ENABLE_IT(hi2c, I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_RXI );
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }   
+}
+/**
+  * @brief  Write an amount of data in no-blocking mode with DMA to a specific memory address
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+  
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+    
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_MEM_BUSY_TX;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+    
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+    
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmatx->XferCpltCallback = I2C_DMAMemTransmitCplt;
+    
+    /* Set the DMA error callback */
+    hi2c->hdmatx->XferErrorCallback = I2C_DMAError;
+    
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+    
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryWrite(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+    
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > 255 */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+    }
+    
+    /* Wait until TXIS flag is set */
+    if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, I2C_TIMEOUT_TXIS) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;  
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Reads an amount of data in no-blocking mode with DMA from a specific memory address.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be read
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
+  
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_MEM_BUSY_RX;
+    
+    hi2c->pBuffPtr = pData;
+    hi2c->XferCount = Size;
+    if(Size > 255)
+    {
+      hi2c->XferSize = 255;
+    }
+    else
+    {
+      hi2c->XferSize = Size;
+    }
+
+    /* Set the I2C DMA transfer complete callback */
+    hi2c->hdmarx->XferCpltCallback = I2C_DMAMemReceiveCplt;
+    
+    /* Set the DMA error callback */
+    hi2c->hdmarx->XferErrorCallback = I2C_DMAError;
+    
+    /* Enable the DMA channel */
+    HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData, hi2c->XferSize);
+    
+    /* Send Slave Address and Memory Address */
+    if(I2C_RequestMemoryRead(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_ERROR;
+      }
+      else
+      {
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        return HAL_TIMEOUT;
+      }
+    }
+    
+    /* Set NBYTES to write and reload if size > 255 and generate RESTART */
+    if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+    }
+
+    /* Wait until RXNE flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, I2C_TIMEOUT_RXNE) != HAL_OK)      
+    {
+      return HAL_TIMEOUT;
+    }
+    
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;  
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Checks if target device is ready for communication. 
+  * @note   This function is used with Memory devices
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  Trials: Number of trials
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout)
+{  
+  uint32_t tickstart = 0;
+  
+  __IO uint32_t I2C_Trials = 0;
+ 
+  if(hi2c->State == HAL_I2C_STATE_READY)
+  {
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) == SET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_BUSY;
+    hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+    
+    do
+    {
+      /* Generate Start */
+      hi2c->Instance->CR2 = __HAL_I2C_GENERATE_START(hi2c->Init.AddressingMode,DevAddress);
+      
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is set or a NACK flag is set*/
+      tickstart = HAL_GetTick();
+      while((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET) && (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == RESET) && (hi2c->State != HAL_I2C_STATE_TIMEOUT))
+      {
+      	if(Timeout != HAL_MAX_DELAY)
+      	{
+          if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+          {
+            /* Device is ready */
+            hi2c->State = HAL_I2C_STATE_READY;
+            /* Process Unlocked */
+            __HAL_UNLOCK(hi2c);         
+            return HAL_TIMEOUT;
+          }
+        } 
+      }
+      
+      /* Check if the NACKF flag has not been set */
+      if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == RESET)
+      {
+        /* Wait until STOPF flag is reset */ 
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_STOPF, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+        
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+        /* Device is ready */
+        hi2c->State = HAL_I2C_STATE_READY;
+        
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+        
+        return HAL_OK;
+      }
+      else
+      {
+        /* Wait until STOPF flag is reset */ 
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_STOPF, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        /* Clear NACK Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+        /* Clear STOP Flag, auto generated with autoend*/
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+      }
+      
+      /* Check if the maximum allowed number of trials has been reached */
+      if (I2C_Trials++ == Trials)
+      {
+        /* Generate Stop */
+        hi2c->Instance->CR2 |= I2C_CR2_STOP;
+        
+        /* Wait until STOPF flag is reset */ 
+        if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_STOPF, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+        
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+      }      
+    }while(I2C_Trials < Trials);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+        
+    return HAL_TIMEOUT;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  This function handles I2C event interrupt request.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+void HAL_I2C_EV_IRQHandler(I2C_HandleTypeDef *hi2c)
+{
+  /* I2C in mode Transmitter ---------------------------------------------------*/
+  if (((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TCR) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TC) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ADDR) == SET)) && (__HAL_I2C_GET_IT_SOURCE(hi2c, (I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_TXI | I2C_IT_ADDRI)) == SET))
+  {     
+    /* Slave mode selected */
+    if (hi2c->State == HAL_I2C_STATE_SLAVE_BUSY_TX)
+    {
+      I2C_SlaveTransmit_ISR(hi2c);
+    }
+  }
+    
+  if (((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TCR) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TC) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)) && (__HAL_I2C_GET_IT_SOURCE(hi2c, (I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_TXI)) == SET))
+  {     
+    /* Master mode selected */
+    if ((hi2c->State == HAL_I2C_STATE_MASTER_BUSY_TX) || (hi2c->State == HAL_I2C_STATE_MEM_BUSY_TX))
+    {
+      I2C_MasterTransmit_ISR(hi2c);
+    }
+  }
+
+  /* I2C in mode Receiver ----------------------------------------------------*/
+  if (((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TCR) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TC) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ADDR) == SET)) && (__HAL_I2C_GET_IT_SOURCE(hi2c, (I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_RXI | I2C_IT_ADDRI)) == SET))
+  {
+    /* Slave mode selected */
+    if (hi2c->State == HAL_I2C_STATE_SLAVE_BUSY_RX)
+    {
+      I2C_SlaveReceive_ISR(hi2c);
+    }
+  } 
+  if (((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TCR) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TC) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET) || (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)) && (__HAL_I2C_GET_IT_SOURCE(hi2c, (I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_RXI)) == SET))
+  {
+    /* Master mode selected */
+    if ((hi2c->State == HAL_I2C_STATE_MASTER_BUSY_RX) || (hi2c->State == HAL_I2C_STATE_MEM_BUSY_RX))
+    {
+      I2C_MasterReceive_ISR(hi2c);
+    }
+  } 
+}
+
+/**
+  * @brief  This function handles I2C error interrupt request.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+void HAL_I2C_ER_IRQHandler(I2C_HandleTypeDef *hi2c)
+{
+  /* I2C Bus error interrupt occurred ------------------------------------*/
+  if((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BERR) == SET) && (__HAL_I2C_GET_IT_SOURCE(hi2c, I2C_IT_ERRI) == SET))
+  { 
+    hi2c->ErrorCode |= HAL_I2C_ERROR_BERR;
+   
+    /* Clear BERR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_BERR);
+  }
+  
+  /* I2C Over-Run/Under-Run interrupt occurred ----------------------------------------*/
+  if((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_OVR) == SET) && (__HAL_I2C_GET_IT_SOURCE(hi2c, I2C_IT_ERRI) == SET))
+  { 
+    hi2c->ErrorCode |= HAL_I2C_ERROR_OVR;
+
+    /* Clear OVR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_OVR);
+  }
+
+  /* I2C Arbitration Loss error interrupt occurred -------------------------------------*/
+  if((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ARLO) == SET) && (__HAL_I2C_GET_IT_SOURCE(hi2c, I2C_IT_ERRI) == SET))
+  { 
+    hi2c->ErrorCode |= HAL_I2C_ERROR_ARLO;
+
+    /* Clear ARLO flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_ARLO);
+  }
+
+  /* Call the Error Callback in case of Error detected */
+  if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+  {
+    hi2c->State = HAL_I2C_STATE_READY;
+    
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+}
+
+/**
+  * @brief  Master Tx Transfer completed callbacks.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+ __weak void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_TxCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Master Rx Transfer completed callbacks.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/** @brief  Slave Tx Transfer completed callbacks.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+ __weak void HAL_I2C_SlaveTxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_TxCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Slave Rx Transfer completed callbacks.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Memory Tx Transfer completed callbacks.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+ __weak void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_TxCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Memory Rx Transfer completed callbacks.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+__weak void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  I2C error callbacks.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval None
+  */
+ __weak void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2C_ErrorCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Group3 Peripheral State and Errors functions
+ *  @brief   Peripheral State and Errors functions
+ *
+@verbatim   
+ ===============================================================================
+            ##### Peripheral State and Errors functions #####
+ ===============================================================================  
+    [..]
+    This subsection permit to get in run-time the status of the peripheral 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the I2C state.
+  * @param  hi2c : I2C handle
+  * @retval HAL state
+  */
+HAL_I2C_StateTypeDef HAL_I2C_GetState(I2C_HandleTypeDef *hi2c)
+{
+  return hi2c->State;
+}
+
+/**
+* @brief  Return the I2C error code
+* @param  hi2c : pointer to a I2C_HandleTypeDef structure that contains
+  *              the configuration information for the specified I2C.
+* @retval I2C Error Code
+*/
+uint32_t HAL_I2C_GetError(I2C_HandleTypeDef *hi2c)
+{
+  return hi2c->ErrorCode;
+}
+
+/**
+  * @}
+  */  
+
+/**
+  * @brief  Handle Interrupt Flags Master Transmit Mode
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_MasterTransmit_ISR(I2C_HandleTypeDef *hi2c) 
+{
+  uint16_t DevAddress;
+  
+  /* Process Locked */
+  __HAL_LOCK(hi2c); 
+  
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == SET)
+  {
+    /* Write data to TXDR */
+    hi2c->Instance->TXDR = (*hi2c->pBuffPtr++);
+    hi2c->XferSize--;
+    hi2c->XferCount--;	
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TCR) == SET)
+  {
+    if((hi2c->XferSize == 0)&&(hi2c->XferCount!=0))
+    {
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+      
+      if(hi2c->XferCount > 255)
+      {    
+        I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferCount, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+        hi2c->XferSize = hi2c->XferCount;
+      }
+    }
+    else
+    {
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+      
+      /* Wrong size Status regarding TCR flag event */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_SIZE;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TC) == SET)
+  {
+    if(hi2c->XferCount == 0)
+    {
+      /* Generate Stop */
+      hi2c->Instance->CR2 |= I2C_CR2_STOP;
+    }
+    else
+    {
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+      
+      /* Wrong size Status regarding TCR flag event */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_SIZE;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+  {
+    /* Disable ERR, TC, STOP, NACK, TXI interrupt */
+    __HAL_I2C_DISABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_TXI );
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    __HAL_I2C_RESET_CR2(hi2c);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    if(hi2c->State == HAL_I2C_STATE_MEM_BUSY_TX)
+    {
+      HAL_I2C_MemTxCpltCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MasterTxCpltCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
+  {
+    /* Clear NACK Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+  
+  return HAL_OK;    
+}  
+
+/**
+  * @brief  Handle Interrupt Flags Master Receive Mode
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_MasterReceive_ISR(I2C_HandleTypeDef *hi2c) 
+{
+  uint16_t DevAddress;
+
+  /* Process Locked */
+  __HAL_LOCK(hi2c);
+  
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == SET)
+  {  
+    /* Read data from RXDR */
+    (*hi2c->pBuffPtr++) = hi2c->Instance->RXDR;
+    hi2c->XferSize--;
+    hi2c->XferCount--;
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TCR) == SET)
+  {
+    if((hi2c->XferSize == 0)&&(hi2c->XferCount!=0))
+    {                  
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+      
+      if(hi2c->XferCount > 255)
+      {
+        I2C_TransferConfig(hi2c,DevAddress,255, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+        hi2c->XferSize = 255;
+      }      
+      else
+      {    
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferCount, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+        hi2c->XferSize = hi2c->XferCount;
+      } 
+    } 
+    else
+    {
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+      
+      /* Wrong size Status regarding TCR flag event */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_SIZE;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TC) == SET)
+  {
+    if(hi2c->XferCount == 0)
+    {
+      /* Generate Stop */
+      hi2c->Instance->CR2 |= I2C_CR2_STOP;
+    }
+    else
+    {
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+      
+      /* Wrong size Status regarding TCR flag event */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_SIZE;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+  {
+    /* Disable ERR, TC, STOP, NACK, TXI interrupt */
+    __HAL_I2C_DISABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_RXI );
+      
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+      
+    /* Clear Configuration Register 2 */
+    __HAL_I2C_RESET_CR2(hi2c);
+    
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    if(hi2c->State == HAL_I2C_STATE_MEM_BUSY_RX)
+    {
+      HAL_I2C_MemRxCpltCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MasterRxCpltCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
+  {
+    /* Clear NACK Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+    
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c); 
+  
+  return HAL_OK; 
+
+}  
+
+/**
+  * @brief  Handle Interrupt Flags Slave Transmit Mode
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_SlaveTransmit_ISR(I2C_HandleTypeDef *hi2c) 
+{
+  /* Process locked */
+  __HAL_LOCK(hi2c);
+  
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) != RESET)
+  {
+    /* Check that I2C transfer finished */
+    /* if yes, normal usecase, a NACK is sent by the MASTER when Transfer is finished */
+    /* Mean XferCount == 0*/
+    /* So clear Flag NACKF only */
+    if(hi2c->XferCount == 0)
+    {
+      /* Clear NACK Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+    }
+    else
+    {
+      /* if no, error usecase, a Non-Acknowledge of last Data is generated by the MASTER*/
+      /* Clear NACK Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+      /* Set ErrorCode corresponding to a Non-Acknowledge */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+    
+      /* Call the Error callback to prevent upper layer */
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ADDR) == SET)
+  {
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_ADDR);
+  }
+  /* Check first if STOPF is set          */
+  /* to prevent a Write Data in TX buffer */
+  /* which is stuck in TXDR until next    */
+  /* communication with Master            */
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+  {
+    /* Disable ERRI, TCI, STOPI, NACKI, ADDRI, RXI, TXI interrupt */
+    __HAL_I2C_DISABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI );
+    
+    /* Disable Address Acknowledge */
+    hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    HAL_I2C_SlaveTxCpltCallback(hi2c);
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == SET)
+  {
+    /* Write data to TXDR only if XferCount not reach "0" */
+    /* A TXIS flag can be set, during STOP treatment      */
+    if(hi2c->XferCount > 0)
+    {
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = (*hi2c->pBuffPtr++);
+      hi2c->XferCount--;
+    }
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+  
+  return HAL_OK;
+}  
+
+/**
+  * @brief  Handle Interrupt Flags Slave Receive Mode
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_SlaveReceive_ISR(I2C_HandleTypeDef *hi2c) 
+{
+  /* Process Locked */
+  __HAL_LOCK(hi2c);
+  
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) != RESET)
+  {
+    /* Clear NACK Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+    
+    hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ADDR) == SET)
+  {
+    /* Clear ADDR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_ADDR);
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == SET)
+  {
+    /* Read data from RXDR */
+    (*hi2c->pBuffPtr++) = hi2c->Instance->RXDR;
+    hi2c->XferSize--;
+    hi2c->XferCount--;
+  }
+  else if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+  {
+    /* Disable ERRI, TCI, STOPI, NACKI, ADDRI, RXI, TXI interrupt */
+    __HAL_I2C_DISABLE_IT(hi2c,I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_RXI );
+    
+    /* Disable Address Acknowledge */
+    hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    hi2c->State = HAL_I2C_STATE_READY;
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    HAL_I2C_SlaveRxCpltCallback(hi2c);
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+  
+  return HAL_OK;     
+}  
+
+/**
+  * @brief  Master sends target device address followed by internal memory address for write request.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_RequestMemoryWrite(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout)   
+{
+  I2C_TransferConfig(hi2c,DevAddress,MemAddSize, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
+
+  /* Wait until TXIS flag is set */
+  if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+  {
+    if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* If Memory address size is 8Bit */
+  if(MemAddSize == I2C_MEMADD_SIZE_8BIT)
+  {
+    /* Send Memory Address */
+    hi2c->Instance->TXDR = __HAL_I2C_MEM_ADD_LSB(MemAddress);    
+  }      
+  /* If Memory address size is 16Bit */
+  else
+  {
+    /* Send MSB of Memory Address */
+    hi2c->Instance->TXDR = __HAL_I2C_MEM_ADD_MSB(MemAddress); 
+    
+    /* Wait until TXIS flag is set */
+    if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+    
+    /* Send LSB of Memory Address */
+    hi2c->Instance->TXDR = __HAL_I2C_MEM_ADD_LSB(MemAddress);  
+  }
+  
+  /* Wait until TCR flag is set */
+  if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, Timeout) != HAL_OK)      
+  {
+    return HAL_TIMEOUT;
+  }
+
+return HAL_OK;
+}
+
+/**
+  * @brief  Master sends target device address followed by internal memory address for read request.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  DevAddress: Target device address
+  * @param  MemAddress: Internal memory address
+  * @param  MemAddSize: Size of internal memory address
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_RequestMemoryRead(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout)
+{
+  I2C_TransferConfig(hi2c,DevAddress,MemAddSize, I2C_SOFTEND_MODE, I2C_GENERATE_START_WRITE);
+  
+  /* Wait until TXIS flag is set */
+  if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+  {
+    if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+    {
+      return HAL_ERROR;
+    }
+    else
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  
+  /* If Memory address size is 8Bit */
+  if(MemAddSize == I2C_MEMADD_SIZE_8BIT)
+  {
+    /* Send Memory Address */
+    hi2c->Instance->TXDR = __HAL_I2C_MEM_ADD_LSB(MemAddress);    
+  }      
+  /* If Mememory address size is 16Bit */
+  else
+  {
+    /* Send MSB of Memory Address */
+    hi2c->Instance->TXDR = __HAL_I2C_MEM_ADD_MSB(MemAddress); 
+    
+    /* Wait until TXIS flag is set */
+    if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, Timeout) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        return HAL_ERROR;
+      }
+      else
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+    
+    /* Send LSB of Memory Address */
+    hi2c->Instance->TXDR = __HAL_I2C_MEM_ADD_LSB(MemAddress);  
+  }
+  
+  /* Wait until TC flag is set */
+  if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TC, RESET, Timeout) != HAL_OK)      
+  {
+    return HAL_TIMEOUT;
+  }
+  
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  DMA I2C master transmit process complete callback.
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void I2C_DMAMasterTransmitCplt(DMA_HandleTypeDef *hdma) 
+{
+  uint16_t DevAddress;
+  I2C_HandleTypeDef* hi2c = (I2C_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+  
+  /* Check if last DMA request was done with RELOAD */
+  /* Set NBYTES to write and reload if size > 255 */
+  if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+  {
+    /* Wait until TCR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, I2C_TIMEOUT_TCR) != HAL_OK)      
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN; 
+    
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is reset */ 
+      if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+        }
+        else
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        }
+      }
+    
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+          
+      /* Clear Configuration Register 2 */
+      __HAL_I2C_RESET_CR2(hi2c);
+
+      hi2c->XferCount = 0;
+    
+      hi2c->State = HAL_I2C_STATE_READY;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      hi2c->pBuffPtr += hi2c->XferSize;
+      hi2c->XferCount -= hi2c->XferSize;
+      if(hi2c->XferCount > 255)
+      {
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+      }
+
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+              
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)hi2c->pBuffPtr, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+      
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if size > 255 */
+      if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      }  
+
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, I2C_TIMEOUT_TXIS) != HAL_OK)
+      {
+        /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+        /* Wait until STOPF flag is reset */ 
+        if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+        {
+          if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+          }
+          else
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          }
+        }
+      
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+            
+        /* Clear Configuration Register 2 */
+        __HAL_I2C_RESET_CR2(hi2c);
+
+        hi2c->XferCount = 0;
+      
+        hi2c->State = HAL_I2C_STATE_READY;
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+      else
+      {
+        /* Enable DMA Request */
+        hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+      }
+    }
+  }
+  else
+  {
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */ 
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+      }
+      else
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+    }
+  
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+  	
+    /* Clear Configuration Register 2 */
+    __HAL_I2C_RESET_CR2(hi2c);
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN; 
+  
+    hi2c->XferCount = 0;
+  
+    hi2c->State = HAL_I2C_STATE_READY;
+
+   /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MasterTxCpltCallback(hi2c);
+    }
+  }
+}
+
+/**
+  * @brief  DMA I2C slave transmit process complete callback. 
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void I2C_DMASlaveTransmitCplt(DMA_HandleTypeDef *hdma) 
+{
+  I2C_HandleTypeDef* hi2c = (I2C_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+  
+  /* Wait until STOP flag is set */
+  if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+  {
+    if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+    {
+      /* Normal Use case, a AF is generated by master */
+      /* to inform slave the end of transfer */
+      hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+    }
+    else
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+  }
+  
+  /* Clear STOP flag */
+  __HAL_I2C_CLEAR_FLAG(hi2c,I2C_FLAG_STOPF);
+  
+  /* Wait until BUSY flag is reset */ 
+  if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, I2C_TIMEOUT_BUSY) != HAL_OK)      
+  {
+    hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+  }
+  
+  /* Disable DMA Request */
+  hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN; 
+  
+  hi2c->XferCount = 0;
+  
+  hi2c->State = HAL_I2C_STATE_READY;
+
+  /* Check if Errors has been detected during transfer */
+  if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+  {
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+  else
+  {
+    HAL_I2C_SlaveTxCpltCallback(hi2c);
+  }
+}
+
+/**
+  * @brief DMA I2C master receive process complete callback 
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void I2C_DMAMasterReceiveCplt(DMA_HandleTypeDef *hdma) 
+{
+  I2C_HandleTypeDef* hi2c = (I2C_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+  uint16_t DevAddress;
+  
+  /* Check if last DMA request was done with RELOAD */
+  /* Set NBYTES to write and reload if size > 255 */
+  if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+  {
+    /* Wait until TCR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, I2C_TIMEOUT_TCR) != HAL_OK)      
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN; 
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is reset */ 
+      if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+        }
+        else
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        }
+      }
+    
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+          
+      /* Clear Configuration Register 2 */
+      __HAL_I2C_RESET_CR2(hi2c);
+    
+      hi2c->XferCount = 0;
+    
+      hi2c->State = HAL_I2C_STATE_READY;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      hi2c->pBuffPtr += hi2c->XferSize;
+      hi2c->XferCount -= hi2c->XferSize;
+      if(hi2c->XferCount > 255)
+      {
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+      }
+
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+              
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)hi2c->pBuffPtr, hi2c->XferSize);
+      
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if size > 255 */
+      if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      }  
+
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, I2C_TIMEOUT_RXNE) != HAL_OK)      
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+      
+      /* Check if Errors has been detected during transfer */
+      if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+      {
+        /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+        /* Wait until STOPF flag is reset */ 
+        if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+        {
+          if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+          }
+          else
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          }
+        }
+      
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+            
+        /* Clear Configuration Register 2 */
+        __HAL_I2C_RESET_CR2(hi2c);
+      
+        hi2c->XferCount = 0;
+      
+        hi2c->State = HAL_I2C_STATE_READY;
+      
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+      else
+      {
+        /* Enable DMA Request */
+        hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+      }
+    }
+  }
+  else
+  {
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */ 
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+      }
+      else
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+    }
+  
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+  	
+    /* Clear Configuration Register 2 */
+    __HAL_I2C_RESET_CR2(hi2c);
+  
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN; 
+  
+    hi2c->XferCount = 0;
+  
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MasterRxCpltCallback(hi2c);
+    }
+  }
+}
+
+/**
+  * @brief  DMA I2C slave receive process complete callback.
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void I2C_DMASlaveReceiveCplt(DMA_HandleTypeDef *hdma) 
+{  
+  I2C_HandleTypeDef* hi2c = (I2C_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+  
+  /* Wait until STOPF flag is reset */ 
+  if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+  {
+    if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+    }
+    else
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+  }
+  
+  /* Clear STOPF flag */
+  __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+  
+  /* Wait until BUSY flag is reset */ 
+  if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, I2C_TIMEOUT_BUSY) != HAL_OK)      
+  {
+    hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+  }
+  
+  /* Disable DMA Request */
+  hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN; 
+  
+  /* Disable Address Acknowledge */
+  hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+  hi2c->XferCount = 0;
+  
+  hi2c->State = HAL_I2C_STATE_READY;
+
+  /* Check if Errors has been detected during transfer */
+  if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+  {
+    HAL_I2C_ErrorCallback(hi2c);
+  }
+  else
+  {
+    HAL_I2C_SlaveRxCpltCallback(hi2c);
+  }
+}
+
+/**
+  * @brief DMA I2C Memory Write process complete callback 
+  * @param hdma : DMA handle
+  * @retval None
+  */
+static void I2C_DMAMemTransmitCplt(DMA_HandleTypeDef *hdma)   
+{
+  uint16_t DevAddress;
+  I2C_HandleTypeDef* hi2c = ( I2C_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  /* Check if last DMA request was done with RELOAD */
+  /* Set NBYTES to write and reload if size > 255 */
+  if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+  {
+    /* Wait until TCR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, I2C_TIMEOUT_TCR) != HAL_OK)      
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN; 
+    
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is reset */ 
+      if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+        }
+        else
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        }
+      }
+    
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+          
+      /* Clear Configuration Register 2 */
+      __HAL_I2C_RESET_CR2(hi2c);
+
+      hi2c->XferCount = 0;
+    
+      hi2c->State = HAL_I2C_STATE_READY;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      hi2c->pBuffPtr += hi2c->XferSize;
+      hi2c->XferCount -= hi2c->XferSize;
+      if(hi2c->XferCount > 255)
+      {
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+      }
+
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+              
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)hi2c->pBuffPtr, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+      
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if size > 255 */
+      if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      }  
+
+      /* Wait until TXIS flag is set */
+      if(I2C_WaitOnTXISFlagUntilTimeout(hi2c, I2C_TIMEOUT_TXIS) != HAL_OK)
+      {
+        /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+        /* Wait until STOPF flag is reset */ 
+        if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+        {
+          if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+          }
+          else
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          }
+        }
+      
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+            
+        /* Clear Configuration Register 2 */
+        __HAL_I2C_RESET_CR2(hi2c);
+
+        hi2c->XferCount = 0;
+      
+        hi2c->State = HAL_I2C_STATE_READY;
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+      else
+      {
+        /* Enable DMA Request */
+        hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+      }
+    }
+  }
+  else
+  {
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */ 
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+      }
+      else
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+    }
+  
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+  	
+    /* Clear Configuration Register 2 */
+    __HAL_I2C_RESET_CR2(hi2c);
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN; 
+  
+    hi2c->XferCount = 0;
+  
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MemTxCpltCallback(hi2c);
+    }
+  }
+}
+
+/**
+  * @brief  DMA I2C Memory Read process complete callback
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void I2C_DMAMemReceiveCplt(DMA_HandleTypeDef *hdma)   
+{  
+  I2C_HandleTypeDef* hi2c = ( I2C_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;  
+  uint16_t DevAddress;
+  
+  /* Check if last DMA request was done with RELOAD */
+  /* Set NBYTES to write and reload if size > 255 */
+  if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+  {
+    /* Wait until TCR flag is set */
+    if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_TCR, RESET, I2C_TIMEOUT_TCR) != HAL_OK)      
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+    }
+
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN; 
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is reset */ 
+      if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+      {
+        if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+        }
+        else
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        }
+      }
+    
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+          
+      /* Clear Configuration Register 2 */
+      __HAL_I2C_RESET_CR2(hi2c);
+    
+      hi2c->XferCount = 0;
+    
+      hi2c->State = HAL_I2C_STATE_READY;
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      hi2c->pBuffPtr += hi2c->XferSize;
+      hi2c->XferCount -= hi2c->XferSize;
+      if(hi2c->XferCount > 255)
+      {
+        hi2c->XferSize = 255;
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+      }
+
+      DevAddress = (hi2c->Instance->CR2 & I2C_CR2_SADD);
+              
+      /* Enable the DMA channel */
+      HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)hi2c->pBuffPtr, hi2c->XferSize);
+      
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if size > 255 */
+      if( (hi2c->XferSize == 255) && (hi2c->XferSize < hi2c->XferCount) )
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c,DevAddress,hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      }  
+
+      /* Wait until RXNE flag is set */
+      if(I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_RXNE, RESET, I2C_TIMEOUT_RXNE) != HAL_OK)      
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+      
+      /* Check if Errors has been detected during transfer */
+      if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+      {
+        /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+        /* Wait until STOPF flag is reset */ 
+        if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+        {
+          if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+          }
+          else
+          {
+            hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          }
+        }
+      
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+            
+        /* Clear Configuration Register 2 */
+        __HAL_I2C_RESET_CR2(hi2c);
+      
+        hi2c->XferCount = 0;
+      
+        hi2c->State = HAL_I2C_STATE_READY;
+        HAL_I2C_ErrorCallback(hi2c);
+      }
+      else
+      {
+        /* Enable DMA Request */
+        hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+      }
+    }
+  }
+  else
+  {
+    /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+    /* Wait until STOPF flag is reset */ 
+    if(I2C_WaitOnSTOPFlagUntilTimeout(hi2c, I2C_TIMEOUT_STOPF) != HAL_OK)
+    {
+      if(hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+      }
+      else
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      }
+    }
+  
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+  	
+    /* Clear Configuration Register 2 */
+    __HAL_I2C_RESET_CR2(hi2c);
+  
+    /* Disable DMA Request */
+    hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN; 
+  
+    hi2c->XferCount = 0;
+  
+    hi2c->State = HAL_I2C_STATE_READY;
+
+    /* Check if Errors has been detected during transfer */
+    if(hi2c->ErrorCode != HAL_I2C_ERROR_NONE)
+    {
+      HAL_I2C_ErrorCallback(hi2c);
+    }
+    else
+    {
+      HAL_I2C_MemRxCpltCallback(hi2c);
+    }
+  }
+}
+
+/**
+  * @brief  DMA I2C communication error callback. 
+  * @param hdma : DMA handle
+  * @retval None
+  */
+static void I2C_DMAError(DMA_HandleTypeDef *hdma)   
+{
+  I2C_HandleTypeDef* hi2c = ( I2C_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  /* Disable Acknowledge */
+  hi2c->Instance->CR2 |= I2C_CR2_NACK;
+  
+  hi2c->XferCount = 0;
+  
+  hi2c->State = HAL_I2C_STATE_READY;
+  
+  hi2c->ErrorCode |= HAL_I2C_ERROR_DMA;
+  
+  HAL_I2C_ErrorCallback(hi2c);
+}
+
+/**
+  * @brief  This function handles I2C Communication Timeout.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Flag: specifies the I2C flag to check.
+  * @param  Status: The new Flag status (SET or RESET).
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Flag, FlagStatus Status, uint32_t Timeout)  
+{  
+  uint32_t tickstart = HAL_GetTick();
+     
+  /* Wait until flag is set */
+  if(Status == RESET)
+  {    
+    while(__HAL_I2C_GET_FLAG(hi2c, Flag) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          hi2c->State= HAL_I2C_STATE_READY;
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    while(__HAL_I2C_GET_FLAG(hi2c, Flag) != RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          hi2c->State= HAL_I2C_STATE_READY;
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles I2C Communication Timeout for specific usage of TXIS flag.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout)  
+{  
+  uint32_t tickstart = HAL_GetTick();
+  
+  while(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == RESET)
+  {
+    /* Check if a NACK is detected */
+    if(I2C_IsAcknowledgeFailed(hi2c, Timeout) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+		
+    /* Check for the Timeout */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        hi2c->State= HAL_I2C_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  return HAL_OK;      
+}
+
+/**
+  * @brief  This function handles I2C Communication Timeout for specific usage of STOP flag.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_WaitOnSTOPFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout)
+{  
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+  
+  while(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET)
+  {
+    /* Check if a NACK is detected */
+    if(I2C_IsAcknowledgeFailed(hi2c, Timeout) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+		
+    /* Check for the Timeout */
+    if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      hi2c->State= HAL_I2C_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      return HAL_TIMEOUT;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles I2C Communication Timeout for specific usage of RXNE flag.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout)
+{  
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+  
+  while(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == RESET)
+  {
+    /* Check if a STOPF is detected */
+    if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+    {
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+      /* Clear Configuration Register 2 */
+      __HAL_I2C_RESET_CR2(hi2c);
+
+      hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+      hi2c->State= HAL_I2C_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      return HAL_ERROR;
+    }
+		
+    /* Check for the Timeout */
+    if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+    {
+      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+      hi2c->State= HAL_I2C_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hi2c);
+
+      return HAL_TIMEOUT;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles Acknowledge failed detection during an I2C Communication.
+  * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_IsAcknowledgeFailed(I2C_HandleTypeDef *hi2c, uint32_t Timeout)
+{
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+
+  if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
+  {
+    /* Generate stop if necessary only in case of I2C peripheral in MASTER mode */
+    if((hi2c->State == HAL_I2C_STATE_MASTER_BUSY_TX) || (hi2c->State == HAL_I2C_STATE_MEM_BUSY_TX)
+       || (hi2c->State == HAL_I2C_STATE_MEM_BUSY_RX))
+    {
+      /* No need to generate the STOP condition if AUTOEND mode is enabled */
+      /* Generate the STOP condition only in case of SOFTEND mode is enabled */
+      if((hi2c->Instance->CR2 & I2C_AUTOEND_MODE) != I2C_AUTOEND_MODE)
+      {
+        /* Generate Stop */
+        hi2c->Instance->CR2 |= I2C_CR2_STOP;
+      }
+    }
+		
+    /* Wait until STOP Flag is reset */
+    /* AutoEnd should be initiate after AF */
+    while(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          hi2c->State= HAL_I2C_STATE_READY;
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+
+    /* Clear NACKF Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+    /* Clear STOP Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+    /* Clear Configuration Register 2 */
+    __HAL_I2C_RESET_CR2(hi2c);
+
+    hi2c->ErrorCode = HAL_I2C_ERROR_AF;
+    hi2c->State= HAL_I2C_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2c);
+
+    return HAL_ERROR;
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles I2Cx communication when starting transfer or during transfer (TC or TCR flag are set).
+  * @param  hi2c: I2C handle.
+  * @param  DevAddress: specifies the slave address to be programmed.
+  * @param  Size: specifies the number of bytes to be programmed.
+  *   This parameter must be a value between 0 and 255.
+  * @param  Mode: new state of the I2C START condition generation.
+  *   This parameter can be one of the following values:
+  *     @arg I2C_RELOAD_MODE: Enable Reload mode .
+  *     @arg I2C_AUTOEND_MODE: Enable Automatic end mode.
+  *     @arg I2C_SOFTEND_MODE: Enable Software end mode.
+  * @param  Request: new state of the I2C START condition generation.
+  *   This parameter can be one of the following values:
+  *     @arg I2C_NO_STARTSTOP: Don't Generate stop and start condition.
+  *     @arg I2C_GENERATE_STOP: Generate stop condition (Size should be set to 0).
+  *     @arg I2C_GENERATE_START_READ: Generate Restart for read request.
+  *     @arg I2C_GENERATE_START_WRITE: Generate Restart for write request.
+  * @retval None
+  */
+static void I2C_TransferConfig(I2C_HandleTypeDef *hi2c,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request)
+{
+  uint32_t tmpreg = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+  assert_param(IS_TRANSFER_MODE(Mode));
+  assert_param(IS_TRANSFER_REQUEST(Request));
+    
+  /* Get the CR2 register value */
+  tmpreg = hi2c->Instance->CR2;
+  
+  /* clear tmpreg specific bits */
+  tmpreg &= (uint32_t)~((uint32_t)(I2C_CR2_SADD | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_AUTOEND | I2C_CR2_RD_WRN | I2C_CR2_START | I2C_CR2_STOP));
+  
+  /* update tmpreg */
+  tmpreg |= (uint32_t)(((uint32_t)DevAddress & I2C_CR2_SADD) | (((uint32_t)Size << 16 ) & I2C_CR2_NBYTES) | \
+            (uint32_t)Mode | (uint32_t)Request);
+  
+  /* update CR2 register */
+  hi2c->Instance->CR2 = tmpreg;  
+}  
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_I2C_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_i2c.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_i2c.h
@@ -1,0 +1,496 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_i2c.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of I2C HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_I2C_H
+#define __STM32L0xx_HAL_I2C_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"  
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup I2C
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+
+/** 
+  * @brief  I2C Configuration Structure definition  
+  */
+typedef struct
+{
+  uint32_t Timing;              /*!< Specifies the I2C_TIMINGR_register value.
+                                  This parameter calculated by referring to I2C initialization 
+                                         section in Reference manual */
+
+  uint32_t OwnAddress1;         /*!< Specifies the first device own address.
+                                  This parameter can be a 7-bit or 10-bit address. */
+
+  uint32_t AddressingMode;      /*!< Specifies if 7-bit or 10-bit addressing mode is selected.
+                                  This parameter can be a value of @ref I2C_addressing_mode */
+
+  uint32_t DualAddressMode;     /*!< Specifies if dual addressing mode is selected.
+                                  This parameter can be a value of @ref I2C_dual_addressing_mode */
+
+  uint32_t OwnAddress2;         /*!< Specifies the second device own address if dual addressing mode is selected
+                                  This parameter can be a 7-bit address. */
+
+  uint32_t OwnAddress2Masks;    /*!< Specifies the acknoledge mask address second device own address if dual addressing mode is selected
+                                  This parameter can be a value of @ref I2C_own_address2_masks */
+
+  uint32_t GeneralCallMode;     /*!< Specifies if general call mode is selected.
+                                  This parameter can be a value of @ref I2C_general_call_addressing_mode */
+
+  uint32_t NoStretchMode;       /*!< Specifies if nostretch mode is selected.
+                                  This parameter can be a value of @ref I2C_nostretch_mode */
+
+}I2C_InitTypeDef;
+
+/** 
+  * @brief  HAL State structures definition  
+  */ 
+typedef enum
+{
+  HAL_I2C_STATE_RESET           = 0x00,  /*!< I2C not yet initialized or disabled         */
+  HAL_I2C_STATE_READY           = 0x01,  /*!< I2C initialized and ready for use           */
+  HAL_I2C_STATE_BUSY            = 0x02,  /*!< I2C internal process is ongoing             */
+  HAL_I2C_STATE_MASTER_BUSY_TX  = 0x12,  /*!< Master Data Transmission process is ongoing */
+  HAL_I2C_STATE_MASTER_BUSY_RX  = 0x22,  /*!< Master Data Reception process is ongoing    */
+  HAL_I2C_STATE_SLAVE_BUSY_TX   = 0x32,  /*!< Slave Data Transmission process is ongoing  */
+  HAL_I2C_STATE_SLAVE_BUSY_RX   = 0x42,  /*!< Slave Data Reception process is ongoing     */
+  HAL_I2C_STATE_MEM_BUSY_TX     = 0x52,  /*!< Memory Data Transmission process is ongoing */
+  HAL_I2C_STATE_MEM_BUSY_RX     = 0x62,  /*!< Memory Data Reception process is ongoing    */
+  HAL_I2C_STATE_TIMEOUT         = 0x03,  /*!< Timeout state                               */
+  HAL_I2C_STATE_ERROR           = 0x04   /*!< Reception process is ongoing                */
+}HAL_I2C_StateTypeDef;
+
+/** 
+  * @brief  HAL I2C Error Code structure definition  
+  */ 
+typedef enum
+{
+  HAL_I2C_ERROR_NONE      = 0x00,    /*!< No error              */
+  HAL_I2C_ERROR_BERR      = 0x01,    /*!< BERR error            */
+  HAL_I2C_ERROR_ARLO      = 0x02,    /*!< ARLO error            */
+  HAL_I2C_ERROR_AF        = 0x04,    /*!< ACKF error            */
+  HAL_I2C_ERROR_OVR       = 0x08,    /*!< OVR error             */
+  HAL_I2C_ERROR_DMA       = 0x10,    /*!< DMA transfer error    */
+  HAL_I2C_ERROR_TIMEOUT   = 0x20,    /*!< Timeout error         */
+  HAL_I2C_ERROR_SIZE      = 0x40     /*!< Size Management error */
+}HAL_I2C_ErrorTypeDef;
+
+/** 
+  * @brief  I2C handle Structure definition  
+  */
+typedef struct
+{
+  I2C_TypeDef                *Instance;  /*!< I2C registers base address     */
+
+  I2C_InitTypeDef            Init;       /*!< I2C communication parameters   */
+
+  uint8_t                    *pBuffPtr;  /*!< Pointer to I2C transfer buffer */
+
+  uint16_t                   XferSize;   /*!< I2C transfer size              */
+
+  __IO uint16_t              XferCount;  /*!< I2C transfer counter           */
+
+  DMA_HandleTypeDef          *hdmatx;    /*!< I2C Tx DMA handle parameters   */
+
+  DMA_HandleTypeDef          *hdmarx;    /*!< I2C Rx DMA handle parameters   */
+
+  HAL_LockTypeDef            Lock;       /*!< I2C locking object             */
+
+  __IO HAL_I2C_StateTypeDef  State;      /*!< I2C communication state        */
+
+  __IO HAL_I2C_ErrorTypeDef  ErrorCode;  /* I2C Error code                   */
+
+}I2C_HandleTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup I2C_Exported_Constants
+  * @{
+  */
+
+/** @defgroup I2C_addressing_mode
+  * @{
+  */
+#define I2C_ADDRESSINGMODE_7BIT          ((uint32_t)0x00000001)
+#define I2C_ADDRESSINGMODE_10BIT         ((uint32_t)0x00000002)
+
+#define IS_I2C_ADDRESSING_MODE(MODE) (((MODE) == I2C_ADDRESSINGMODE_7BIT) || \
+                                      ((MODE) == I2C_ADDRESSINGMODE_10BIT))
+/**
+  * @}
+  */
+
+/** @defgroup I2C_dual_addressing_mode
+  * @{
+  */
+
+#define I2C_DUALADDRESS_DISABLED        ((uint32_t)0x00000000)
+#define I2C_DUALADDRESS_ENABLED         I2C_OAR2_OA2EN
+
+#define IS_I2C_DUAL_ADDRESS(ADDRESS) (((ADDRESS) == I2C_DUALADDRESS_DISABLED) || \
+                                      ((ADDRESS) == I2C_DUALADDRESS_ENABLED))
+/**
+  * @}
+  */
+
+/** @defgroup I2C_own_address2_masks
+  * @{
+  */
+
+#define I2C_OA2_NOMASK                  ((uint8_t)0x00)
+#define I2C_OA2_MASK01                  ((uint8_t)0x01)
+#define I2C_OA2_MASK02                  ((uint8_t)0x02)
+#define I2C_OA2_MASK03                  ((uint8_t)0x03)
+#define I2C_OA2_MASK04                  ((uint8_t)0x04)
+#define I2C_OA2_MASK05                  ((uint8_t)0x05)
+#define I2C_OA2_MASK06                  ((uint8_t)0x06)
+#define I2C_OA2_MASK07                  ((uint8_t)0x07)
+
+#define IS_I2C_OWN_ADDRESS2_MASK(MASK)  (((MASK) == I2C_OA2_NOMASK) || \
+                                         ((MASK) == I2C_OA2_MASK01) || \
+                                         ((MASK) == I2C_OA2_MASK02) || \
+                                         ((MASK) == I2C_OA2_MASK03) || \
+                                         ((MASK) == I2C_OA2_MASK04) || \
+                                         ((MASK) == I2C_OA2_MASK05) || \
+                                         ((MASK) == I2C_OA2_MASK06) || \
+                                         ((MASK) == I2C_OA2_MASK07))  
+/**
+  * @}
+  */
+
+/** @defgroup I2C_general_call_addressing_mode
+  * @{
+  */
+#define I2C_GENERALCALL_DISABLED        ((uint32_t)0x00000000)
+#define I2C_GENERALCALL_ENABLED         I2C_CR1_GCEN
+
+#define IS_I2C_GENERAL_CALL(CALL) (((CALL) == I2C_GENERALCALL_DISABLED) || \
+                                   ((CALL) == I2C_GENERALCALL_ENABLED))
+/**
+  * @}
+  */
+
+/** @defgroup I2C_nostretch_mode
+  * @{
+  */
+#define I2C_NOSTRETCH_DISABLED          ((uint32_t)0x00000000)
+#define I2C_NOSTRETCH_ENABLED           I2C_CR1_NOSTRETCH
+
+#define IS_I2C_NO_STRETCH(STRETCH) (((STRETCH) == I2C_NOSTRETCH_DISABLED) || \
+                                    ((STRETCH) == I2C_NOSTRETCH_ENABLED))
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Memory_Address_Size
+  * @{
+  */
+#define I2C_MEMADD_SIZE_8BIT            ((uint32_t)0x00000001)
+#define I2C_MEMADD_SIZE_16BIT           ((uint32_t)0x00000002)
+
+#define IS_I2C_MEMADD_SIZE(SIZE) (((SIZE) == I2C_MEMADD_SIZE_8BIT) || \
+                                  ((SIZE) == I2C_MEMADD_SIZE_16BIT))
+/**
+  * @}
+  */  
+  
+/** @defgroup I2C_ReloadEndMode_definition
+  * @{
+  */
+
+#define  I2C_RELOAD_MODE                I2C_CR2_RELOAD
+#define  I2C_AUTOEND_MODE               I2C_CR2_AUTOEND
+#define  I2C_SOFTEND_MODE               ((uint32_t)0x00000000)
+
+#define IS_TRANSFER_MODE(MODE)        (((MODE) == I2C_RELOAD_MODE)  || \
+                                       ((MODE) == I2C_AUTOEND_MODE) || \
+                                       ((MODE) == I2C_SOFTEND_MODE))
+/**
+  * @}
+  */
+
+/** @defgroup I2C_StartStopMode_definition
+  * @{
+  */
+
+#define  I2C_NO_STARTSTOP                 ((uint32_t)0x00000000)
+#define  I2C_GENERATE_STOP                I2C_CR2_STOP
+#define  I2C_GENERATE_START_READ          (uint32_t)(I2C_CR2_START | I2C_CR2_RD_WRN)
+#define  I2C_GENERATE_START_WRITE         I2C_CR2_START
+                              
+#define IS_TRANSFER_REQUEST(REQUEST)    (((REQUEST) == I2C_GENERATE_STOP)        || \
+                                         ((REQUEST) == I2C_GENERATE_START_READ)  || \
+                                         ((REQUEST) == I2C_GENERATE_START_WRITE) || \
+                                         ((REQUEST) == I2C_NO_STARTSTOP))
+                               
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Interrupt_configuration_definition
+  * @brief I2C Interrupt definition
+  *        Elements values convention: 0xXXXXXXXX
+  *           - XXXXXXXX  : Interrupt control mask
+  * @{
+  */
+#define I2C_IT_ERRI                       I2C_CR1_ERRIE
+#define I2C_IT_TCI                        I2C_CR1_TCIE
+#define I2C_IT_STOPI                      I2C_CR1_STOPIE
+#define I2C_IT_NACKI                      I2C_CR1_NACKIE
+#define I2C_IT_ADDRI                      I2C_CR1_ADDRIE
+#define I2C_IT_RXI                        I2C_CR1_RXIE
+#define I2C_IT_TXI                        I2C_CR1_TXIE
+
+/**
+  * @}
+  */
+
+
+/** @defgroup I2C_Flag_definition
+  * @{
+  */ 
+
+#define I2C_FLAG_TXE                      I2C_ISR_TXE
+#define I2C_FLAG_TXIS                     I2C_ISR_TXIS
+#define I2C_FLAG_RXNE                     I2C_ISR_RXNE
+#define I2C_FLAG_ADDR                     I2C_ISR_ADDR
+#define I2C_FLAG_AF                       I2C_ISR_NACKF
+#define I2C_FLAG_STOPF                    I2C_ISR_STOPF
+#define I2C_FLAG_TC                       I2C_ISR_TC
+#define I2C_FLAG_TCR                      I2C_ISR_TCR
+#define I2C_FLAG_BERR                     I2C_ISR_BERR
+#define I2C_FLAG_ARLO                     I2C_ISR_ARLO
+#define I2C_FLAG_OVR                      I2C_ISR_OVR
+#define I2C_FLAG_PECERR                   I2C_ISR_PECERR
+#define I2C_FLAG_TIMEOUT                  I2C_ISR_TIMEOUT
+#define I2C_FLAG_ALERT                    I2C_ISR_ALERT
+#define I2C_FLAG_BUSY                     I2C_ISR_BUSY
+#define I2C_FLAG_DIR                      I2C_ISR_DIR
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+  
+/* Exported macro ------------------------------------------------------------*/
+
+/** @brief Reset I2C handle state
+  * @param  __HANDLE__: specifies the I2C Handle.
+  *         This parameter can be I2C where x: 1 or 2 to select the I2C peripheral.
+  * @retval None
+  */
+#define __HAL_I2C_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_I2C_STATE_RESET)
+
+/** @brief  Enables or disables the specified I2C interrupts.
+  * @param  __HANDLE__: specifies the I2C Handle.
+  *         This parameter can be I2C where x: 1 or 2 to select the I2C peripheral.
+  * @param  __INTERRUPT__: specifies the interrupt source to enable or disable.
+  *        This parameter can be one of the following values:
+  *            @arg I2C_IT_ERRI: Errors interrupt enable
+  *            @arg I2C_IT_TCI: Transfer complete interrupt enable
+  *            @arg I2C_IT_STOPI: STOP detection interrupt enable
+  *            @arg I2C_IT_NACKI: NACK received interrupt enable
+  *            @arg I2C_IT_ADDRI: Address match interrupt enable
+  *            @arg I2C_IT_RXI: RX interrupt enable
+  *            @arg I2C_IT_TXI: TX interrupt enable
+  *   
+  * @retval None
+  */
+  
+#define __HAL_I2C_ENABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->CR1 |= (__INTERRUPT__))
+#define __HAL_I2C_DISABLE_IT(__HANDLE__, __INTERRUPT__)  ((__HANDLE__)->Instance->CR1 &= (~(__INTERRUPT__)))
+ 
+/** @brief  Checks if the specified I2C interrupt source is enabled or disabled.
+  * @param  __HANDLE__: specifies the I2C Handle.
+  *         This parameter can be I2C where x: 1 or 2 to select the I2C peripheral.
+  * @param  __INTERRUPT__: specifies the I2C interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg I2C_IT_ERRI: Errors interrupt enable
+  *            @arg I2C_IT_TCI: Transfer complete interrupt enable
+  *            @arg I2C_IT_STOPI: STOP detection interrupt enable
+  *            @arg I2C_IT_NACKI: NACK received interrupt enable
+  *            @arg I2C_IT_ADDRI: Address match interrupt enable
+  *            @arg I2C_IT_RXI: RX interrupt enable
+  *            @arg I2C_IT_TXI: TX interrupt enable
+  *   
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_I2C_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->CR1 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/** @brief  Checks whether the specified I2C flag is set or not.
+  * @param  __HANDLE__: specifies the I2C Handle.
+  *         This parameter can be I2C where x: 1 or 2 to select the I2C peripheral.
+  * @param  __FLAG__: specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg I2C_FLAG_TXE:      Transmit data register empty
+  *            @arg I2C_FLAG_TXIS:     Transmit interrupt status
+  *            @arg I2C_FLAG_RXNE:     Receive data register not empty
+  *            @arg I2C_FLAG_ADDR:     Address matched (slave mode)
+  *            @arg I2C_FLAG_AF:       Acknowledge failure received flag
+  *            @arg I2C_FLAG_STOPF:    STOP detection flag
+  *            @arg I2C_FLAG_TC:       Transfer complete (master mode)
+  *            @arg I2C_FLAG_TCR:      Transfer complete reload
+  *            @arg I2C_FLAG_BERR:     Bus error
+  *            @arg I2C_FLAG_ARLO:     Arbitration lost
+  *            @arg I2C_FLAG_OVR:      Overrun/Underrun
+  *            @arg I2C_FLAG_PECERR:   PEC error in reception
+  *            @arg I2C_FLAG_TIMEOUT:  Timeout or Tlow detection flag 
+  *            @arg I2C_FLAG_ALERT:    SMBus alert
+  *            @arg I2C_FLAG_BUSY:     Bus busy
+  *            @arg I2C_FLAG_DIR:      Transfer direction (slave mode)
+  *
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define I2C_FLAG_MASK  ((uint32_t)0x0001FFFF)
+#define __HAL_I2C_GET_FLAG(__HANDLE__, __FLAG__) (((((__HANDLE__)->Instance->ISR) & ((__FLAG__) & I2C_FLAG_MASK)) == ((__FLAG__) & I2C_FLAG_MASK)))
+
+/** @brief  Clears the I2C pending flags which are cleared by writing 1 in a specific bit.
+  * @param  __HANDLE__: specifies the I2C Handle.
+  *         This parameter can be I2C where x: 1 or 2 to select the I2C peripheral.
+  * @param  __FLAG__: specifies the flag to clear.
+  *          This parameter can be any combination of the following values:
+  *            @arg I2C_FLAG_ADDR:    Address matched (slave mode)
+  *            @arg I2C_FLAG_AF:      Acknowledge failure received flag
+  *            @arg I2C_FLAG_STOPF:   STOP detection flag
+  *            @arg I2C_FLAG_BERR:    Bus error
+  *            @arg I2C_FLAG_ARLO:    Arbitration lost
+  *            @arg I2C_FLAG_OVR:     Overrun/Underrun            
+  *            @arg I2C_FLAG_PECERR:  PEC error in reception
+  *            @arg I2C_FLAG_TIMEOUT: Timeout or Tlow detection flag 
+  *            @arg I2C_FLAG_ALERT:   SMBus alert
+  *   
+  * @retval None
+  */
+#define __HAL_I2C_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ICR = ((__FLAG__) & I2C_FLAG_MASK))
+ 
+
+#define __HAL_I2C_ENABLE(__HANDLE__)                            ((__HANDLE__)->Instance->CR1 |=  I2C_CR1_PE)
+#define __HAL_I2C_DISABLE(__HANDLE__)                           ((__HANDLE__)->Instance->CR1 &=  ~I2C_CR1_PE)
+
+#define __HAL_I2C_RESET_CR2(__HANDLE__)				((__HANDLE__)->Instance->CR2 &= (uint32_t)~((uint32_t)(I2C_CR2_SADD | I2C_CR2_HEAD10R | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_RD_WRN)))
+
+#define __HAL_I2C_MEM_ADD_MSB(__ADDRESS__)                       ((uint8_t)((uint16_t)(((uint16_t)((__ADDRESS__) & (uint16_t)(0xFF00))) >> 8)))
+#define __HAL_I2C_MEM_ADD_LSB(__ADDRESS__)                       ((uint8_t)((uint16_t)((__ADDRESS__) & (uint16_t)(0x00FF))))
+
+#define __HAL_I2C_GENERATE_START(__ADDMODE__,__ADDRESS__)       (((__ADDMODE__) == I2C_ADDRESSINGMODE_7BIT) ? (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | (I2C_CR2_START) | (I2C_CR2_AUTOEND)) & (~I2C_CR2_RD_WRN)) : \
+                                                                  (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | (I2C_CR2_ADD10) | (I2C_CR2_START)) & (~I2C_CR2_RD_WRN)))
+
+#define IS_I2C_OWN_ADDRESS1(ADDRESS1)   ((ADDRESS1) <= (uint32_t)0x000003FF)
+#define IS_I2C_OWN_ADDRESS2(ADDRESS2)   ((ADDRESS2) <= (uint16_t)0x00FF)
+
+/* Include I2C HAL Extension module */
+#include "stm32l0xx_hal_i2c_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/* Initialization/de-initialization functions**********************************/
+HAL_StatusTypeDef HAL_I2C_Init(I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef HAL_I2C_DeInit (I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MspDeInit(I2C_HandleTypeDef *hi2c);
+
+/* I/O operation functions  ***************************************************/
+ /******* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout);
+
+ /******* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+
+ /******* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+
+ /******* I2C IRQHandler and Callbacks used in non blocking modes (Interrupt and DMA) */
+void HAL_I2C_EV_IRQHandler(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_ER_IRQHandler(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_SlaveTxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_SlaveRxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c);
+void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c);
+
+/* Peripheral State functions  ************************************************/
+HAL_I2C_StateTypeDef HAL_I2C_GetState(I2C_HandleTypeDef *hi2c);
+uint32_t             HAL_I2C_GetError(I2C_HandleTypeDef *hi2c);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L0xx_HAL_I2C_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_i2c_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_i2c_ex.c
@@ -1,0 +1,288 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_i2c_ex.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Extended I2C HAL module driver.
+  *    
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Inter Integrated Circuit (I2C) peripheral:
+  *           + Extended Control methods
+  *         
+  @verbatim
+  ==============================================================================
+               ##### I2C peripheral extended features  #####
+  ==============================================================================
+           
+  [..] Comparing to other previous devices, the I2C interface for STM32L0XX
+       devices contains the following additional features
+       
+       (+) Possibility to disable or enable Analog Noise Filter
+       (+) Use of a configured Digital Noise Filter
+       (+) Disable or enable wakeup from Stop mode
+   
+                     ##### How to use this driver #####
+  ==============================================================================
+  [..] This driver provides functions to configure Noise Filter
+  
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup I2CEx 
+  * @brief I2C HAL module driver
+  * @{
+  */
+
+#ifdef HAL_I2C_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup I2CEX_Private_Functions
+  * @{
+  */
+
+
+/** @defgroup I2CEX_Group1 Peripheral Control methods 
+ *  @brief   management functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control methods #####
+ ===============================================================================  
+    [..] This section provides functions allowing to:
+      (+) Configure Noise Filters 
+
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Configures I2C Analog noise filter. 
+  * @param  hi2c : pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2Cx peripheral.
+  * @param  AnalogFilter : new state of the Analog filter.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2CEx_AnalogFilter_Config(I2C_HandleTypeDef *hi2c, uint32_t AnalogFilter)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+  assert_param(IS_I2C_ANALOG_FILTER(AnalogFilter));
+  
+  if((hi2c->State == HAL_I2C_STATE_BUSY) || (hi2c->State == HAL_I2C_STATE_MASTER_BUSY_TX) || (hi2c->State == HAL_I2C_STATE_MASTER_BUSY_RX)
+     || (hi2c->State == HAL_I2C_STATE_SLAVE_BUSY_TX) || (hi2c->State == HAL_I2C_STATE_SLAVE_BUSY_RX))
+  {
+    return HAL_BUSY;
+  }
+  
+  /* Process Locked */
+  __HAL_LOCK(hi2c);
+
+  hi2c->State = HAL_I2C_STATE_BUSY;
+  
+  /* Disable the selected I2C peripheral */
+  __HAL_I2C_DISABLE(hi2c);    
+  
+  /* Reset I2Cx ANOFF bit */
+  hi2c->Instance->CR1 &= ~(I2C_CR1_ANFOFF);    
+  
+  /* Set analog filter bit*/
+  hi2c->Instance->CR1 |= AnalogFilter;
+  
+  __HAL_I2C_ENABLE(hi2c); 
+  
+  hi2c->State = HAL_I2C_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK; 
+}
+
+/**
+  * @brief  Configures I2C Digital noise filter. 
+  * @param  hi2c : pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2Cx peripheral.
+  * @param  DigitalFilter : Coefficient of digital noise filter between 0x00 and 0x0F.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2CEx_DigitalFilter_Config(I2C_HandleTypeDef *hi2c, uint32_t DigitalFilter)
+{
+  uint32_t tmpreg = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+  assert_param(IS_I2C_DIGITAL_FILTER(DigitalFilter));
+  
+  if((hi2c->State == HAL_I2C_STATE_BUSY) || (hi2c->State == HAL_I2C_STATE_MASTER_BUSY_TX) || (hi2c->State == HAL_I2C_STATE_MASTER_BUSY_RX)
+     || (hi2c->State == HAL_I2C_STATE_SLAVE_BUSY_TX) || (hi2c->State == HAL_I2C_STATE_SLAVE_BUSY_RX))
+  {
+    return HAL_BUSY;
+  }
+  
+  /* Process Locked */
+  __HAL_LOCK(hi2c);
+
+  hi2c->State = HAL_I2C_STATE_BUSY;
+  
+  /* Disable the selected I2C peripheral */
+  __HAL_I2C_DISABLE(hi2c);  
+  
+  /* Get the old register value */
+  tmpreg = hi2c->Instance->CR1;
+  
+  /* Reset I2Cx DNF bits [11:8] */
+  tmpreg &= ~(I2C_CR1_DFN);
+  
+  /* Set I2Cx DNF coefficient */
+  tmpreg |= DigitalFilter << 8;
+  
+  /* Store the new register value */
+  hi2c->Instance->CR1 = tmpreg;
+  
+  __HAL_I2C_ENABLE(hi2c); 
+  
+  hi2c->State = HAL_I2C_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK; 
+}  
+
+/**
+  * @brief  Enables I2C wakeup from stop mode.
+  * @param  hi2c : pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2Cx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2CEx_EnableWakeUp (I2C_HandleTypeDef *hi2c)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+  
+  if((hi2c->State == HAL_I2C_STATE_BUSY) || (hi2c->State == HAL_I2C_STATE_MASTER_BUSY_TX) || (hi2c->State == HAL_I2C_STATE_MASTER_BUSY_RX)
+     || (hi2c->State == HAL_I2C_STATE_SLAVE_BUSY_TX) || (hi2c->State == HAL_I2C_STATE_SLAVE_BUSY_RX))
+  {
+    return HAL_BUSY;
+  }
+  
+  /* Process Locked */
+  __HAL_LOCK(hi2c);
+
+  hi2c->State = HAL_I2C_STATE_BUSY;
+  
+  /* Disable the selected I2C peripheral */
+  __HAL_I2C_DISABLE(hi2c);  
+  
+  /* Enable wakeup from stop mode */
+  hi2c->Instance->CR1 |= I2C_CR1_WUPEN;   
+  
+  __HAL_I2C_ENABLE(hi2c); 
+  
+  hi2c->State = HAL_I2C_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK; 
+}  
+
+
+/**
+  * @brief  Disables I2C wakeup from stop mode.
+  * @param  hi2c : pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2Cx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2CEx_DisableWakeUp (I2C_HandleTypeDef *hi2c)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
+  
+  if((hi2c->State == HAL_I2C_STATE_BUSY) || (hi2c->State == HAL_I2C_STATE_MASTER_BUSY_TX) || (hi2c->State == HAL_I2C_STATE_MASTER_BUSY_RX)
+     || (hi2c->State == HAL_I2C_STATE_SLAVE_BUSY_TX) || (hi2c->State == HAL_I2C_STATE_SLAVE_BUSY_RX))
+  {
+    return HAL_BUSY;
+  }
+  
+  /* Process Locked */
+  __HAL_LOCK(hi2c);
+
+  hi2c->State = HAL_I2C_STATE_BUSY;
+  
+  /* Disable the selected I2C peripheral */
+  __HAL_I2C_DISABLE(hi2c);  
+  
+  /* Enable wakeup from stop mode */
+  hi2c->Instance->CR1 &= ~(I2C_CR1_WUPEN);   
+  
+  __HAL_I2C_ENABLE(hi2c); 
+  
+  hi2c->State = HAL_I2C_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK; 
+}  
+
+/**
+  * @}
+  */  
+
+/**
+  * @}
+  */  
+
+#endif /* HAL_I2C_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_i2c_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_i2c_ex.h
@@ -1,0 +1,112 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_i2c_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of I2C HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_I2C_EX_H
+#define __STM32L0xx_HAL_I2C_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"  
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup I2CEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup I2CEx_Exported_Constants
+  * @{
+  */
+
+/** @defgroup I2CEx_Analog_Filter
+  * @{
+  */
+#define I2C_ANALOGFILTER_ENABLED        ((uint32_t)0x00000000)
+#define I2C_ANALOGFILTER_DISABLED       I2C_CR1_ANFOFF
+
+#define IS_I2C_ANALOG_FILTER(FILTER) (((FILTER) == I2C_ANALOGFILTER_ENABLED) || \
+                                      ((FILTER) == I2C_ANALOGFILTER_DISABLED))
+/**
+  * @}
+  */
+
+/** @defgroup I2CEx_Digital_Filter
+  * @{
+  */
+#define IS_I2C_DIGITAL_FILTER(FILTER)   ((FILTER) <= 0x0000000F)
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */ 
+  
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/* Peripheral Control methods  ************************************************/
+HAL_StatusTypeDef HAL_I2CEx_AnalogFilter_Config(I2C_HandleTypeDef *hi2c, uint32_t AnalogFilter);
+HAL_StatusTypeDef HAL_I2CEx_DigitalFilter_Config(I2C_HandleTypeDef *hi2c, uint32_t DigitalFilter);
+HAL_StatusTypeDef HAL_I2CEx_EnableWakeUp (I2C_HandleTypeDef *hi2c);
+HAL_StatusTypeDef HAL_I2CEx_DisableWakeUp (I2C_HandleTypeDef *hi2c);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_I2C_EX_H */
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_i2s.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_i2s.c
@@ -1,0 +1,1366 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_i2s.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   I2S HAL module driver.
+  *    
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Integrated Interchip Sound (I2S) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral State and Errors functions
+  @verbatim
+ ===============================================================================
+                  ##### How to use this driver #####
+ ===============================================================================
+ [..]
+    The I2S HAL driver can be used as follow:
+
+    (#) Declare a I2S_HandleTypeDef handle structure.
+    (#) Initialize the I2S low level resources by implement the HAL_I2S_MspInit() API:
+        (##) Enable the SPIx interface clock.
+        (##) I2S pins configuration:
+            (+++) Enable the clock for the I2S GPIOs.
+            (+++) Configure these I2S pins as alternate function pull-up.
+        (##) NVIC configuration if you need to use interrupt process (HAL_I2S_Transmit_IT()
+             and HAL_I2S_Receive_IT() APIs).
+            (+++) Configure the I2Sx interrupt priority.
+            (+++) Enable the NVIC I2S IRQ handle.
+        (##) DMA Configuration if you need to use DMA process (HAL_I2S_Transmit_DMA()
+             and HAL_I2S_Receive_DMA() APIs:
+            (+++) Declare a DMA handle structure for the Tx/Rx stream.
+            (+++) Enable the DMAx interface clock.
+            (+++) Configure the declared DMA handle structure with the required Tx/Rx parameters.
+            (+++) Configure the DMA Tx/Rx Stream.
+            (+++) Associate the initilalized DMA handle to the I2S DMA Tx/Rx handle.
+            (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the 
+                DMA Tx/Rx Stream.
+
+   (#) Program the Mode, Standard, Data Format, MCLK Output, Audio frequency and Polarity
+       using HAL_I2S_Init() function.
+
+   -@- The specific I2S interrupts (Transmission complete interrupt, 
+       RXNE interrupt and Error Interrupts) will be managed using the macros
+       __I2S_ENABLE_IT() and __I2S_DISABLE_IT() inside the transmit and receive process.
+   (#) Three mode of operations are available within this driver :     
+
+   *** Polling mode IO operation ***
+   =================================
+   [..]
+     (+) Send an amount of data in blocking mode using HAL_I2S_Transmit() 
+     (+) Receive an amount of data in blocking mode using HAL_I2S_Receive()
+
+   *** Interrupt mode IO operation ***
+   ===================================
+   [..]
+     (+) Send an amount of data in non blocking mode using HAL_I2S_Transmit_IT() 
+     (+) At transmission end of transfer HAL_I2S_TxCpltCallback is executed and user can
+         add his own code by customization of function pointer HAL_I2S_TxCpltCallback
+     (+) Receive an amount of data in non blocking mode using HAL_I2S_Receive_IT()
+     (+) At reception end of transfer HAL_I2S_RxCpltCallback is executed and user can
+         add his own code by customization of function pointer HAL_I2S_RxCpltCallback
+     (+) In case of transfer Error, HAL_I2S_ErrorCallback() function is executed and user can
+         add his own code by customization of function pointer HAL_I2S_ErrorCallback
+
+   *** DMA mode IO operation ***
+   ==============================
+   [..]
+     (+) Send an amount of data in non blocking mode (DMA) using HAL_I2S_Transmit_DMA() 
+     (+) At transmission end of half transfer HAL_I2S_TxHalfCpltCallback is executed and user can 
+         add his own code by customization of function pointer HAL_I2S_TxHalfCpltCallback 
+     (+) At transmission end of transfer HAL_I2S_TxCpltCallback is executed and user can 
+         add his own code by customization of function pointer HAL_I2S_TxCpltCallback
+     (+) Receive an amount of data in non blocking mode (DMA) using HAL_I2S_Receive_DMA() 
+     (+) At reception end of half transfer HAL_I2S_RxHalfCpltCallback is executed and user can 
+         add his own code by customization of function pointer HAL_I2S_RxHalfCpltCallback 
+     (+) At reception end of transfer HAL_I2S_RxCpltCallback is executed and user can 
+         add his own code by customization of function pointer HAL_I2S_RxCpltCallback
+     (+) In case of transfer Error, HAL_I2S_ErrorCallback() function is executed and user can 
+         add his own code by customization of function pointer HAL_I2S_ErrorCallback
+     (+) Pause the DMA Transfer using HAL_I2S_DMAPause()
+     (+) Resume the DMA Transfer using HAL_I2S_DMAResume()
+     (+) Stop the DMA Transfer using HAL_I2S_DMAStop()
+
+   *** I2S HAL driver macros list ***
+   ===================================
+   [..]
+     Below the list of most used macros in USART HAL driver.
+       
+      (+) __HAL_I2S_ENABLE: Enable the specified SPI peripheral (in I2S mode) 
+      (+) __HAL_I2S_DISABLE: Disable the specified SPI peripheral (in I2S mode)
+      (+) __HAL_I2S_ENABLE_IT : Enable the specified I2S interrupts
+      (+) __HAL_I2S_DISABLE_IT : Disable the specified I2S interrupts
+      (+) __HAL_I2S_GET_FLAG: Check whether the specified I2S flag is set or not
+
+    [..]
+      (@) You can refer to the I2S HAL driver header file for more useful macros
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup I2S 
+  * @brief I2S HAL module driver
+  * @{
+  */
+
+#ifdef HAL_I2S_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static HAL_StatusTypeDef I2S_Transmit_IT(I2S_HandleTypeDef *hi2s);
+static HAL_StatusTypeDef I2S_Receive_IT(I2S_HandleTypeDef *hi2s);
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup I2S_Private_Functions
+  * @{
+  */
+
+/** @defgroup  I2S_Group1 Initialization and de-initialization functions 
+  *  @brief    Initialization and Configuration functions 
+  *
+@verbatim    
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This subsection provides a set of functions allowing to initialize and 
+          de-initialiaze the I2Sx peripheral in simplex mode:
+
+      (+) User must Implement HAL_I2S_MspInit() function in which he configures 
+          all related peripherals resources (CLOCK, GPIO, DMA, IT and NVIC ).
+
+      (+) Call the function HAL_I2S_Init() to configure the selected device with 
+          the selected configuration:
+        (++) Mode
+        (++) Standard 
+        (++) Data Format
+        (++) MCLK Output
+        (++) Audio frequency
+        (++) Polarity
+
+      (+) Call the function HAL_I2S_DeInit() to restore the default configuration 
+          of the selected I2Sx periperal. 
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Initializes the I2S according to the specified parameters 
+  *         in the I2S_InitTypeDef and create the associated handle.
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s)
+{
+  uint32_t tmpreg = 0, i2sdiv = 2, i2sodd = 0, packetlength = 1;
+  uint32_t tmp = 0, i2sclk = 0;
+  
+  /* Check the I2S handle allocation */
+  if(hi2s == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the I2S parameters */
+  assert_param(IS_I2S_MODE(hi2s->Init.Mode));
+  assert_param(IS_I2S_STANDARD(hi2s->Init.Standard));
+  assert_param(IS_I2S_DATA_FORMAT(hi2s->Init.DataFormat));
+  assert_param(IS_I2S_MCLK_OUTPUT(hi2s->Init.MCLKOutput));
+  assert_param(IS_I2S_AUDIO_FREQ(hi2s->Init.AudioFreq));
+  assert_param(IS_I2S_CPOL(hi2s->Init.CPOL));  
+  
+  if(hi2s->State == HAL_I2S_STATE_RESET)
+  {
+    /* Init the low level hardware : GPIO, CLOCK, CORTEX...etc */
+    HAL_I2S_MspInit(hi2s);
+  }
+  
+  hi2s->State = HAL_I2S_STATE_BUSY;
+  
+  /*----------------------- SPIx I2SCFGR & I2SPR Configuration ---------------*/
+  /* Clear I2SMOD, I2SE, I2SCFG, PCMSYNC, I2SSTD, CKPOL, DATLEN and CHLEN bits */
+  hi2s->Instance->I2SCFGR &= (uint32_t)~((uint32_t)SPI_I2SCFGR_CHLEN | SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CKPOL | \
+                               SPI_I2SCFGR_I2SSTD | SPI_I2SCFGR_PCMSYNC | SPI_I2SCFGR_I2SCFG | \
+                               SPI_I2SCFGR_I2SE | SPI_I2SCFGR_I2SMOD); 
+  hi2s->Instance->I2SPR = 0x0002;
+
+  /* Get the I2SCFGR register value */
+  tmpreg = hi2s->Instance->I2SCFGR;
+
+  /* If the default frequency value has to be written, reinitialize i2sdiv and i2sodd */
+  /* If the requested audio frequency is not the default, compute the prescaler */
+  if(hi2s->Init.AudioFreq != I2S_AUDIOFREQ_DEFAULT)
+  {
+    /* Check the frame length (For the Prescaler computing) *******************/
+    if(hi2s->Init.DataFormat != I2S_DATAFORMAT_16B)
+    {
+      /* Packet length is 32 bits */
+      packetlength = 2;
+    }
+
+    /* Get I2S source Clock frequency  ****************************************/
+    /* I2S clock source is SystemClock for stm32l0xx devices */
+    
+    i2sclk = HAL_RCC_GetSysClockFreq();
+    
+    /* Compute the Real divider depending on the MCLK output state, with a floating point */
+    if(hi2s->Init.MCLKOutput == I2S_MCLKOUTPUT_ENABLE)
+    {
+      /* MCLK output is enabled */
+      tmp = (uint32_t)(((((i2sclk / 256) * 10) / hi2s->Init.AudioFreq)) + 5);
+    }
+    else
+    {
+      /* MCLK output is disabled */
+      tmp = (uint32_t)(((((i2sclk / (32 * packetlength)) *10 ) / hi2s->Init.AudioFreq)) + 5);
+    }
+
+    /* Remove the flatting point */
+    tmp = tmp / 10;  
+
+    /* Check the parity of the divider */
+    i2sodd = (uint32_t)(tmp & (uint32_t)1);
+
+    /* Compute the i2sdiv prescaler */
+    i2sdiv = (uint32_t)((tmp - i2sodd) / 2);
+
+    /* Get the Mask for the Odd bit (SPI_I2SPR[8]) register */
+    i2sodd = (uint32_t) (i2sodd << 8);
+  }
+
+  /* Test if the divider is 1 or 0 or greater than 0xFF */
+  if((i2sdiv < 2) || (i2sdiv > 0xFF))
+  {
+    /* Set the default values */
+    i2sdiv = 2;
+    i2sodd = 0;
+  }
+  
+  /* Write to SPIx I2SPR register the computed value */
+  hi2s->Instance->I2SPR = (uint32_t)((uint32_t)i2sdiv | (uint32_t)(i2sodd | (uint32_t)hi2s->Init.MCLKOutput));
+  
+  /* Configure the I2S with the I2S_InitStruct values */
+  tmpreg |= (uint32_t)(SPI_I2SCFGR_I2SMOD | hi2s->Init.Mode | hi2s->Init.Standard | hi2s->Init.DataFormat | hi2s->Init.CPOL);
+  
+  /* Write to SPIx I2SCFGR */  
+  hi2s->Instance->I2SCFGR = tmpreg;
+  
+  hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
+  hi2s->State= HAL_I2S_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief DeInitializes the I2S peripheral 
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_DeInit(I2S_HandleTypeDef *hi2s)
+{
+  /* Check the I2S handle allocation */
+  if(hi2s == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  hi2s->State = HAL_I2S_STATE_BUSY;
+  
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC... */
+  HAL_I2S_MspDeInit(hi2s);
+  
+  hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
+  hi2s->State = HAL_I2S_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hi2s);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief I2S MSP Init
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+ __weak void HAL_I2S_MspInit(I2S_HandleTypeDef *hi2s)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2S_MspInit could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @brief I2S MSP DeInit
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+ __weak void HAL_I2S_MspDeInit(I2S_HandleTypeDef *hi2s)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2S_MspDeInit could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup I2S_Group2 IO operation functions 
+  *  @brief Data transfers functions 
+  *
+@verbatim   
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to manage the I2S data 
+    transfers.
+
+    (#) There is two mode of transfer:
+       (++) Blocking mode : The communication is performed in the polling mode. 
+            The status of all data processing is returned by the same function 
+            after finishing transfer.  
+       (++) No-Blocking mode : The communication is performed using Interrupts 
+            or DMA. These functions return the status of the transfer startup.
+            The end of the data processing will be indicated through the 
+            dedicated I2S IRQ when using Interrupt mode or the DMA IRQ when 
+            using DMA mode.
+
+    (#) Blocking mode functions are :
+        (++) HAL_I2S_Transmit()
+        (++) HAL_I2S_Receive()
+        
+    (#) No-Blocking mode functions with Interrupt are :
+        (++) HAL_I2S_Transmit_IT()
+        (++) HAL_I2S_Receive_IT()
+
+    (#) No-Blocking mode functions with DMA are :
+        (++) HAL_I2S_Transmit_DMA()
+        (++) HAL_I2S_Receive_DMA()
+
+    (#) A set of Transfer Complete Callbacks are provided in No_Blocking mode:
+        (++) HAL_I2S_TxCpltCallback()
+        (++) HAL_I2S_RxCpltCallback()
+        (++) HAL_I2S_ErrorCallback()
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Transmit an amount of data in blocking mode
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @param pData: a 16-bit pointer to data buffer.
+  * @param Size: number of data sample to be sent:
+  * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
+  *       configuration phase, the Size parameter means the number of 16-bit data length 
+  *       in the transaction and when a 24-bit data frame or a 32-bit data frame is selected 
+  *       the Size parameter means the number of 16-bit data length. 
+  * @param  Timeout: Timeout duration
+  * @note The I2S is kept enabled at the end of transaction to avoid the clock de-synchronization 
+  *       between Master and Slave(example: audio streaming).
+  * @note This function can use an Audio Frequency up to 44KHz when I2S Clock Source is 32MHz
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_Transmit(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t tmp1 = 0, tmp2 = 0;  
+  if((pData == NULL ) || (Size == 0)) 
+  {
+    return  HAL_ERROR;
+  }
+  
+  if(hi2s->State == HAL_I2S_STATE_READY)
+  { 
+    tmp1 = hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN);
+    tmp2 = hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN);
+    if((tmp1 == I2S_DATAFORMAT_24B)|| \
+       (tmp2 == I2S_DATAFORMAT_32B))
+    {
+      hi2s->TxXferSize = Size*2;
+      hi2s->TxXferCount = Size*2;
+    }
+    else
+    {
+      hi2s->TxXferSize = Size;
+      hi2s->TxXferCount = Size;
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hi2s);
+    
+    hi2s->State = HAL_I2S_STATE_BUSY_TX;
+   
+    /* Check if the I2S is already enabled */ 
+    if((hi2s->Instance->I2SCFGR &SPI_I2SCFGR_I2SE) != SPI_I2SCFGR_I2SE)
+    {
+      /* Enable I2S peripheral */
+      __HAL_I2S_ENABLE(hi2s);
+    }
+    
+    while(hi2s->TxXferCount > 0)
+    {
+      hi2s->Instance->DR = (*pData++);
+      hi2s->TxXferCount--;   
+      /* Wait until TXE flag is set */
+      if (I2S_WaitFlagStateUntilTimeout(hi2s, I2S_FLAG_TXE, RESET, Timeout) != HAL_OK)
+      {
+        return HAL_TIMEOUT;
+      }
+    } 
+    /* Wait until Busy flag is reset */
+    if (I2S_WaitFlagStateUntilTimeout(hi2s, I2S_FLAG_BSY, SET, Timeout) != HAL_OK)
+    {
+      return HAL_TIMEOUT;
+    }
+
+    hi2s->State = HAL_I2S_STATE_READY; 
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2s);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in blocking mode 
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @param pData: a 16-bit pointer to data buffer.
+  * @param Size: number of data sample to be sent:
+  * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
+  *       configuration phase, the Size parameter means the number of 16-bit data length 
+  *       in the transaction and when a 24-bit data frame or a 32-bit data frame is selected 
+  *       the Size parameter means the number of 16-bit data length. 
+  * @param Timeout: Timeout duration
+  * @note The I2S is kept enabled at the end of transaction to avoid the clock de-synchronization 
+  *       between Master and Slave(example: audio streaming).
+  * @note In I2S Master Receiver mode, just after enabling the peripheral the clock will be generate
+  *       in continouse way and as the I2S is not disabled at the end of the I2S transaction.
+  * @note This function can use an Audio Frequency up to 44KHz when I2S Clock Source is 32MHz  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_Receive(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint32_t tmp1 = 0, tmp2 = 0;   
+  if((pData == NULL ) || (Size == 0)) 
+  {
+    return  HAL_ERROR;
+  }
+  
+  if(hi2s->State == HAL_I2S_STATE_READY)
+  { 
+    tmp1 = hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN);
+    tmp2 = hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN);
+    if((tmp1 == I2S_DATAFORMAT_24B)|| \
+       (tmp2 == I2S_DATAFORMAT_32B))
+    {
+      hi2s->RxXferSize = Size*2;
+      hi2s->RxXferCount = Size*2;
+    }
+    else
+    {
+      hi2s->RxXferSize = Size;
+      hi2s->RxXferCount = Size;
+    }
+    /* Process Locked */
+    __HAL_LOCK(hi2s);
+
+    hi2s->State = HAL_I2S_STATE_BUSY_RX;
+
+    /* Check if the I2S is already enabled */ 
+    if((hi2s->Instance->I2SCFGR & SPI_I2SCFGR_I2SE) != SPI_I2SCFGR_I2SE)
+    {
+      /* Enable I2S peripheral */
+      __HAL_I2S_ENABLE(hi2s);
+    }
+
+    /* Check if Master Receiver mode is selected */
+    if((hi2s->Instance->I2SCFGR & SPI_I2SCFGR_I2SCFG) == I2S_MODE_MASTER_RX)
+    {
+      /* Clear the Overrun Flag by a read operation on the SPI_DR register followed by a read
+      access to the SPI_SR register. */ 
+      __HAL_I2S_CLEAR_OVRFLAG(hi2s);
+    }
+
+    /* Receive data */
+    while(hi2s->RxXferCount > 0)
+    {
+      /* Wait until RXNE flag is set */
+      if (I2S_WaitFlagStateUntilTimeout(hi2s, I2S_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+      {
+        return HAL_TIMEOUT;
+      }
+
+      (*pData++) = hi2s->Instance->DR;
+      hi2s->RxXferCount--;
+    }
+
+    hi2s->State = HAL_I2S_STATE_READY; 
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2s);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Transmit an amount of data in non-blocking mode with Interrupt
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @param pData: a 16-bit pointer to data buffer.
+  * @param Size: number of data sample to be sent:
+  * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
+  *       configuration phase, the Size parameter means the number of 16-bit data length 
+  *       in the transaction and when a 24-bit data frame or a 32-bit data frame is selected 
+  *       the Size parameter means the number of 16-bit data length. 
+  * @note The I2S is kept enabled at the end of transaction to avoid the clock de-synchronization 
+  *       between Master and Slave(example: audio streaming).
+  * @note This function can use an Audio Frequency up to 32KHz when I2S Clock Source is 32MHz  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_Transmit_IT(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size)
+{
+  uint32_t tmp1 = 0, tmp2 = 0;     
+  if(hi2s->State == HAL_I2S_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;
+    }
+
+    hi2s->pTxBuffPtr = pData;
+    tmp1 = hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN);
+    tmp2 = hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN);
+    if((tmp1 == I2S_DATAFORMAT_24B)|| \
+      (tmp2 == I2S_DATAFORMAT_32B))
+    {
+      hi2s->TxXferSize = Size*2;
+      hi2s->TxXferCount = Size*2;
+    }
+    else
+    {
+      hi2s->TxXferSize = Size;
+      hi2s->TxXferCount = Size;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2s);
+
+    hi2s->State = HAL_I2S_STATE_BUSY_TX;
+    hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
+
+    /* Enable TXE and ERR interrupt */
+    __HAL_I2S_ENABLE_IT(hi2s, (I2S_IT_TXE | I2S_IT_ERR));
+
+    /* Check if the I2S is already enabled */ 
+    if((hi2s->Instance->I2SCFGR &SPI_I2SCFGR_I2SE) != SPI_I2SCFGR_I2SE)
+    {
+      /* Enable I2S peripheral */
+      __HAL_I2S_ENABLE(hi2s);
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2s);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in non-blocking mode with Interrupt
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @param pData: a 16-bit pointer to the Receive data buffer.
+  * @param Size: number of data sample to be sent:
+  * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
+  *       configuration phase, the Size parameter means the number of 16-bit data length 
+  *       in the transaction and when a 24-bit data frame or a 32-bit data frame is selected 
+  *       the Size parameter means the number of 16-bit data length. 
+  * @note The I2S is kept enabled at the end of transaction to avoid the clock de-synchronization 
+  *       between Master and Slave(example: audio streaming).
+  * @note It is recommended to use DMA for the I2S receiver to avoid de-synchronisation 
+  * between Master and Slave otherwise the I2S interrupt should be optimized. 
+  * @note This function can use an Audio Frequency up to 32KHz when I2S Clock Source is 32MHz  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_Receive_IT(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size)
+{
+  uint32_t tmp1 = 0, tmp2 = 0;     
+  if(hi2s->State == HAL_I2S_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;
+    }
+
+    hi2s->pRxBuffPtr = pData;
+    tmp1 = hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN);
+    tmp2 = hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN);
+    if((tmp1 == I2S_DATAFORMAT_24B)||\
+      (tmp2 == I2S_DATAFORMAT_32B))
+    {
+      hi2s->RxXferSize = Size*2;
+      hi2s->RxXferCount = Size*2;
+    }
+    else
+    {
+      hi2s->RxXferSize = Size;
+      hi2s->RxXferCount = Size;
+    }
+    /* Process Locked */
+    __HAL_LOCK(hi2s);
+    
+    hi2s->State = HAL_I2S_STATE_BUSY_RX;
+    hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
+    
+    /* Enable TXE and ERR interrupt */
+    __HAL_I2S_ENABLE_IT(hi2s, (I2S_IT_RXNE | I2S_IT_ERR));
+    
+    /* Check if the I2S is already enabled */ 
+    if((hi2s->Instance->I2SCFGR &SPI_I2SCFGR_I2SE) != SPI_I2SCFGR_I2SE)
+    {
+      /* Enable I2S peripheral */
+      __HAL_I2S_ENABLE(hi2s);
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2s);
+
+    return HAL_OK;
+  }
+
+  else
+  {
+    return HAL_BUSY; 
+  } 
+}
+
+/**
+  * @brief Transmit an amount of data in non-blocking mode with DMA
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @param pData: a 16-bit pointer to the Transmit data buffer.
+  * @param Size: number of data sample to be sent:
+  * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
+  *       configuration phase, the Size parameter means the number of 16-bit data length 
+  *       in the transaction and when a 24-bit data frame or a 32-bit data frame is selected 
+  *       the Size parameter means the number of 16-bit data length. 
+  * @note The I2S is kept enabled at the end of transaction to avoid the clock de-synchronization 
+  *       between Master and Slave(example: audio streaming).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_Transmit_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size)
+{
+  uint32_t *tmp;
+  uint32_t tmp1 = 0, tmp2 = 0;     
+  
+  if((pData == NULL) || (Size == 0)) 
+  {
+    return  HAL_ERROR;
+  }
+
+  if(hi2s->State == HAL_I2S_STATE_READY)
+  {  
+    hi2s->pTxBuffPtr = pData;
+    tmp1 = hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN);
+    tmp2 = hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN);
+    if((tmp1 == I2S_DATAFORMAT_24B)|| \
+      (tmp2 == I2S_DATAFORMAT_32B))
+    {
+      hi2s->TxXferSize = Size*2;
+      hi2s->TxXferCount = Size*2;
+    }
+    else
+    {
+      hi2s->TxXferSize = Size;
+      hi2s->TxXferCount = Size;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hi2s);
+
+    hi2s->State = HAL_I2S_STATE_BUSY_TX;
+    hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
+
+    /* Set the I2S Tx DMA Half transfert complete callback */
+    hi2s->hdmatx->XferHalfCpltCallback = I2S_DMATxHalfCplt;
+
+    /* Set the I2S Tx DMA transfert complete callback */
+    hi2s->hdmatx->XferCpltCallback = I2S_DMATxCplt;
+
+    /* Set the DMA error callback */
+    hi2s->hdmatx->XferErrorCallback = I2S_DMAError;
+
+    /* Enable the Tx DMA Stream */
+    tmp = (uint32_t*)&pData;
+    HAL_DMA_Start_IT(hi2s->hdmatx, *(uint32_t*)tmp, (uint32_t)&hi2s->Instance->DR, hi2s->TxXferSize);
+
+    /* Check if the I2S is already enabled */ 
+    if((hi2s->Instance->I2SCFGR &SPI_I2SCFGR_I2SE) != SPI_I2SCFGR_I2SE)
+    {
+      /* Enable I2S peripheral */
+      __HAL_I2S_ENABLE(hi2s);
+    }
+
+     /* Check if the I2S Tx request is already enabled */ 
+    if((hi2s->Instance->CR2 & SPI_CR2_TXDMAEN) != SPI_CR2_TXDMAEN)
+    {
+      /* Enable Tx DMA Request */  
+      hi2s->Instance->CR2 |= SPI_CR2_TXDMAEN;
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2s);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in non-blocking mode with DMA 
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @param pData: a 16-bit pointer to the Receive data buffer.
+  * @param Size: number of data sample to be sent:
+  * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
+  *       configuration phase, the Size parameter means the number of 16-bit data length 
+  *       in the transaction and when a 24-bit data frame or a 32-bit data frame is selected 
+  *       the Size parameter means the number of 16-bit data length. 
+  * @note The I2S is kept enabled at the end of transaction to avoid the clock de-synchronization 
+  *       between Master and Slave(example: audio streaming).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_I2S_Receive_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size)
+{
+  uint32_t *tmp;
+  uint32_t tmp1 = 0, tmp2 = 0;  
+  
+  if((pData == NULL) || (Size == 0))
+  {
+    return  HAL_ERROR;
+  }
+
+  if(hi2s->State == HAL_I2S_STATE_READY)
+  {
+    hi2s->pRxBuffPtr = pData;
+    tmp1 = hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN);
+    tmp2 = hi2s->Instance->I2SCFGR & (SPI_I2SCFGR_DATLEN | SPI_I2SCFGR_CHLEN);
+    if((tmp1 == I2S_DATAFORMAT_24B)|| \
+      (tmp2 == I2S_DATAFORMAT_32B))
+    {
+      hi2s->RxXferSize = Size*2;
+      hi2s->RxXferCount = Size*2;
+    }
+    else
+    {
+      hi2s->RxXferSize = Size;
+      hi2s->RxXferCount = Size;
+    }
+    /* Process Locked */
+    __HAL_LOCK(hi2s);
+
+    hi2s->State = HAL_I2S_STATE_BUSY_RX;
+    hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
+
+    /* Set the I2S Rx DMA Half transfert complete callback */
+    hi2s->hdmarx->XferHalfCpltCallback = I2S_DMARxHalfCplt;
+
+    /* Set the I2S Rx DMA transfert complete callback */
+    hi2s->hdmarx->XferCpltCallback = I2S_DMARxCplt;
+
+    /* Set the DMA error callback */
+    hi2s->hdmarx->XferErrorCallback = I2S_DMAError;
+
+    /* Check if Master Receiver mode is selected */
+    if((hi2s->Instance->I2SCFGR & SPI_I2SCFGR_I2SCFG) == I2S_MODE_MASTER_RX)
+    {
+      /* Clear the Overrun Flag by a read operation to the SPI_DR register followed by a read
+      access to the SPI_SR register. */ 
+      __HAL_I2S_CLEAR_OVRFLAG(hi2s);
+    }
+
+    /* Enable the Rx DMA Stream */
+    tmp = (uint32_t*)&pData;
+    HAL_DMA_Start_IT(hi2s->hdmarx, (uint32_t)&hi2s->Instance->DR, *(uint32_t*)tmp, hi2s->RxXferSize);
+
+    /* Check if the I2S is already enabled */ 
+    if((hi2s->Instance->I2SCFGR &SPI_I2SCFGR_I2SE) != SPI_I2SCFGR_I2SE)
+    {
+      /* Enable I2S peripheral */
+      __HAL_I2S_ENABLE(hi2s);
+    }
+
+     /* Check if the I2S Rx request is already enabled */ 
+    if((hi2s->Instance->CR2 &SPI_CR2_RXDMAEN) != SPI_CR2_RXDMAEN)
+    {
+      /* Enable Rx DMA Request */  
+      hi2s->Instance->CR2 |= SPI_CR2_RXDMAEN;
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hi2s);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Pauses the audio stream playing from the Media.
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_I2S_DMAPause(I2S_HandleTypeDef *hi2s)
+{
+  /* Process Locked */
+  __HAL_LOCK(hi2s);
+  
+  if(hi2s->State == HAL_I2S_STATE_BUSY_TX)
+  {
+    /* Disable the I2S DMA Tx request */
+    hi2s->Instance->CR2 &= (uint32_t)~((uint32_t)SPI_CR2_TXDMAEN);
+  }
+  else if(hi2s->State == HAL_I2S_STATE_BUSY_RX)
+  {
+    /* Disable the I2S DMA Rx request */
+    hi2s->Instance->CR2 &= (uint32_t)~((uint32_t)SPI_CR2_RXDMAEN);
+  }
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2s);
+  
+  return HAL_OK; 
+}
+
+/**
+  * @brief Resumes the audio stream playing from the Media.
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_I2S_DMAResume(I2S_HandleTypeDef *hi2s)
+{
+  /* Process Locked */
+  __HAL_LOCK(hi2s);
+  
+  if(hi2s->State == HAL_I2S_STATE_BUSY_TX)
+  {
+    /* Enable the I2S DMA Tx request */
+    hi2s->Instance->CR2 |= SPI_CR2_TXDMAEN;
+  }
+  else if(hi2s->State == HAL_I2S_STATE_BUSY_RX)
+  {
+    /* Enable the I2S DMA Rx request */
+    hi2s->Instance->CR2 |= SPI_CR2_RXDMAEN;
+  }
+
+  /* If the I2S peripheral is still not enabled, enable it */
+  if ((hi2s->Instance->I2SCFGR & SPI_I2SCFGR_I2SE) == 0)
+  {
+    /* Enable I2S peripheral */    
+    __HAL_I2S_ENABLE(hi2s);
+  }
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2s);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief Resumes the audio stream playing from the Media.
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_I2S_DMAStop(I2S_HandleTypeDef *hi2s)
+{
+  /* Process Locked */
+  __HAL_LOCK(hi2s);
+  
+  /* Disable the I2S Tx/Rx DMA requests */
+  hi2s->Instance->CR2 &= (uint32_t)~((uint32_t)SPI_CR2_TXDMAEN);
+  hi2s->Instance->CR2 &= (uint32_t)~((uint32_t)SPI_CR2_RXDMAEN);
+  
+  /* Abort the I2S DMA Stream tx */
+  if(hi2s->hdmatx != NULL)
+  {
+    HAL_DMA_Abort(hi2s->hdmatx);
+  }
+  /* Abort the I2S DMA Stream rx */
+  if(hi2s->hdmarx != NULL)
+  {
+    HAL_DMA_Abort(hi2s->hdmarx);
+  }
+
+  /* Disable I2S peripheral */
+  __HAL_I2S_DISABLE(hi2s);
+  
+  hi2s->State = HAL_I2S_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2s);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles I2S interrupt request.
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval HAL status
+  */
+void HAL_I2S_IRQHandler(I2S_HandleTypeDef *hi2s)
+{
+  uint32_t tmp1 = 0, tmp2 = 0;
+  if(hi2s->State == HAL_I2S_STATE_BUSY_RX)
+  {
+    tmp1 = __HAL_I2S_GET_FLAG(hi2s, I2S_FLAG_RXNE);
+    tmp2 = __HAL_I2S_GET_IT_SOURCE(hi2s, I2S_IT_RXNE);
+    /* I2S in mode Receiver --------------------------------------------------*/
+    if((tmp1 != RESET) && (tmp2 != RESET))
+    {
+      I2S_Receive_IT(hi2s);
+    }
+    tmp1 = __HAL_I2S_GET_FLAG(hi2s, I2S_FLAG_OVR);
+    tmp2 = __HAL_I2S_GET_IT_SOURCE(hi2s, I2S_IT_ERR);
+    /* I2S Overrun error interrupt occured -----------------------------------*/
+    if((tmp1 != RESET) && (tmp2 != RESET))
+    {
+      __HAL_I2S_CLEAR_OVRFLAG(hi2s);
+      hi2s->ErrorCode |= HAL_I2S_ERROR_OVR;
+    }
+  }
+
+  if(hi2s->State == HAL_I2S_STATE_BUSY_TX)
+  {
+    tmp1 = __HAL_I2S_GET_FLAG(hi2s, I2S_FLAG_TXE);
+    tmp2 = __HAL_I2S_GET_IT_SOURCE(hi2s, I2S_IT_TXE);
+    /* I2S in mode Tramitter -------------------------------------------------*/
+    if((tmp1 != RESET) && (tmp2 != RESET))
+    {
+      I2S_Transmit_IT(hi2s);
+    } 
+
+    tmp1 = __HAL_I2S_GET_FLAG(hi2s, I2S_FLAG_UDR);
+    tmp2 = __HAL_I2S_GET_IT_SOURCE(hi2s, I2S_IT_ERR);
+    /* I2S Underrun error interrupt occured ----------------------------------*/
+    if((tmp1 != RESET) && (tmp2 != RESET))
+    {
+      __HAL_I2S_CLEAR_UDRFLAG(hi2s);
+      hi2s->ErrorCode |= HAL_I2S_ERROR_UDR;
+    }
+  }
+
+  /* Call the Error call Back in case of Errors */
+  if(hi2s->ErrorCode != HAL_I2S_ERROR_NONE)
+  {
+    /* Set the I2S state ready to be able to start again the process */
+    hi2s->State= HAL_I2S_STATE_READY;
+    HAL_I2S_ErrorCallback(hi2s);
+  }
+}
+
+/**
+  * @brief Tx Transfer Half completed callbacks
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+ __weak void HAL_I2S_TxHalfCpltCallback(I2S_HandleTypeDef *hi2s)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2S_TxHalfCpltCallback could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @brief Tx Transfer completed callbacks
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+ __weak void HAL_I2S_TxCpltCallback(I2S_HandleTypeDef *hi2s)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2S_TxCpltCallback could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @brief Rx Transfer half completed callbacks
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+__weak void HAL_I2S_RxHalfCpltCallback(I2S_HandleTypeDef *hi2s)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2S_RxCpltCallback could be implenetd in the user file
+   */
+}
+
+/**
+  * @brief Rx Transfer completed callbacks
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+__weak void HAL_I2S_RxCpltCallback(I2S_HandleTypeDef *hi2s)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2S_RxCpltCallback could be implenetd in the user file
+   */
+}
+
+/**
+  * @brief I2S error callbacks
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval None
+  */
+ __weak void HAL_I2S_ErrorCallback(I2S_HandleTypeDef *hi2s)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_I2S_ErrorCallback could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup I2S_Group3 Peripheral State and Errors functions 
+  *  @brief   Peripheral State functions 
+  *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral State and Errors functions #####
+ ===============================================================================
+    [..]
+    This subsection permit to get in run-time the status of the peripheral 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the I2S state
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval HAL state
+  */
+HAL_I2S_StateTypeDef HAL_I2S_GetState(I2S_HandleTypeDef *hi2s)
+{
+  return hi2s->State;
+}
+
+/**
+  * @brief  Return the I2S error code
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval I2S Error Code
+  */
+HAL_I2S_ErrorTypeDef HAL_I2S_GetError(I2S_HandleTypeDef *hi2s)
+{
+  return hi2s->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief DMA I2S transmit process complete callback 
+  * @param hdma : DMA handle
+  * @retval None
+  */
+void I2S_DMATxCplt(DMA_HandleTypeDef *hdma)
+{
+  I2S_HandleTypeDef* hi2s = (I2S_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+  
+  if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+  {
+    hi2s->TxXferCount = 0;
+
+    /* Disable Tx DMA Request */
+    hi2s->Instance->CR2 &= (uint32_t)~((uint32_t)SPI_CR2_TXDMAEN);
+
+    hi2s->State = HAL_I2S_STATE_READY; 
+  }
+  HAL_I2S_TxCpltCallback(hi2s);
+}
+
+/**
+  * @brief DMA I2S transmit process half complete callback 
+  * @param hdma : DMA handle
+  * @retval None
+  */
+void I2S_DMATxHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  I2S_HandleTypeDef* hi2s = (I2S_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  HAL_I2S_TxHalfCpltCallback(hi2s);
+}
+
+/**
+  * @brief DMA I2S receive process complete callback 
+  * @param hdma : DMA handle
+  * @retval None
+  */
+void I2S_DMARxCplt(DMA_HandleTypeDef *hdma)
+{
+  I2S_HandleTypeDef* hi2s = (I2S_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+  {
+    /* Disable Rx DMA Request */
+    hi2s->Instance->CR2 &= (uint32_t)~((uint32_t)SPI_CR2_RXDMAEN);
+
+    hi2s->RxXferCount = 0;
+
+    hi2s->State = HAL_I2S_STATE_READY; 
+  }
+  HAL_I2S_RxCpltCallback(hi2s); 
+}
+
+/**
+  * @brief DMA I2S receive process half complete callback 
+  * @param hdma : DMA handle
+  * @retval None
+  */
+void I2S_DMARxHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  I2S_HandleTypeDef* hi2s = (I2S_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  HAL_I2S_RxHalfCpltCallback(hi2s); 
+}
+
+/**
+  * @brief DMA I2S communication error callback 
+  * @param hdma : DMA handle
+  * @retval None
+  */
+void I2S_DMAError(DMA_HandleTypeDef *hdma)
+{
+  I2S_HandleTypeDef* hi2s = (I2S_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  hi2s->TxXferCount = 0;
+  hi2s->RxXferCount = 0;
+
+  hi2s->State= HAL_I2S_STATE_READY;
+
+  hi2s->ErrorCode |= HAL_I2S_ERROR_DMA;
+  HAL_I2S_ErrorCallback(hi2s);
+}
+
+/**
+  * @brief Transmit an amount of data in non-blocking mode with Interrupt
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2S_Transmit_IT(I2S_HandleTypeDef *hi2s)
+{
+ if(hi2s->State == HAL_I2S_STATE_BUSY_TX)
+  {
+    /* Transmit data */
+    hi2s->Instance->DR = (*hi2s->pTxBuffPtr++);
+
+    hi2s->TxXferCount--;	
+    
+    if(hi2s->TxXferCount == 0)
+    {
+      /* Disable TXE and ERR interrupt */
+      __HAL_I2S_DISABLE_IT(hi2s, (uint32_t)(I2S_IT_TXE | I2S_IT_ERR));
+
+      hi2s->State = HAL_I2S_STATE_READY;
+
+      HAL_I2S_TxCpltCallback(hi2s);
+    }
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in non-blocking mode with Interrupt
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2S_Receive_IT(I2S_HandleTypeDef *hi2s)
+{
+  if(hi2s->State == HAL_I2S_STATE_BUSY_RX)
+  {
+    /* Receive data */
+    (*hi2s->pRxBuffPtr++) = hi2s->Instance->DR;
+
+    hi2s->RxXferCount--;
+
+    /* Check if Master Receiver mode is selected */
+    if((hi2s->Instance->I2SCFGR & SPI_I2SCFGR_I2SCFG) == I2S_MODE_MASTER_RX)
+    {
+      /* Clear the Overrun Flag by a read operation on the SPI_DR register followed by a read
+      access to the SPI_SR register. */ 
+      __HAL_I2S_CLEAR_OVRFLAG(hi2s);
+    }
+
+    if(hi2s->RxXferCount == 0)
+    {
+      /* Disable RXNE and ERR interrupt */
+      __HAL_I2S_DISABLE_IT(hi2s, (uint32_t)(I2S_IT_RXNE | I2S_IT_ERR));
+
+      hi2s->State = HAL_I2S_STATE_READY;
+
+      HAL_I2S_RxCpltCallback(hi2s);
+    }
+
+    return HAL_OK; 
+  }
+  else
+  {
+    return HAL_BUSY; 
+  } 
+}
+
+/**
+  * @brief This function handles I2S Communication Timeout.
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
+  * @param Flag: Flag checked
+  * @param State: Value of the flag expected
+  * @param Timeout: Duration of the timeout
+  * @retval HAL status
+  */
+HAL_StatusTypeDef I2S_WaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, uint32_t Flag, uint32_t Status, uint32_t Timeout)
+{
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+  
+  /* Wait until flag is set */
+  if(Status == RESET)
+  {
+    while(__HAL_I2S_GET_FLAG(hi2s, Flag) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Set the I2S State ready */
+          hi2s->State= HAL_I2S_STATE_READY;
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2s);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    while(__HAL_I2S_GET_FLAG(hi2s, Flag) != RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Set the I2S State ready */
+          hi2s->State= HAL_I2S_STATE_READY;
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2s);
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+  
+#endif /* HAL_I2S_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_i2s.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_i2s.h
@@ -1,0 +1,399 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_i2s.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of I2S HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_I2S_H
+#define __STM32L0xx_HAL_I2S_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"  
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup I2S
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+/** 
+  * @brief I2S Init structure definition  
+  */
+typedef struct
+{
+  uint32_t Mode;         /*!< Specifies the I2S operating mode.
+                              This parameter can be a value of @ref I2S_Mode */
+
+  uint32_t Standard;     /*!< Specifies the standard used for the I2S communication.
+                              This parameter can be a value of @ref I2S_Standard */
+
+  uint32_t DataFormat;   /*!< Specifies the data format for the I2S communication.
+                              This parameter can be a value of @ref I2S_Data_Format */
+
+  uint32_t MCLKOutput;   /*!< Specifies whether the I2S MCLK output is enabled or not.
+                              This parameter can be a value of @ref I2S_MCLK_Output */
+
+  uint32_t AudioFreq;    /*!< Specifies the frequency selected for the I2S communication.
+                              This parameter can be a value of @ref I2S_Audio_Frequency */
+
+  uint32_t CPOL;         /*!< Specifies the idle state of the I2S clock.
+                              This parameter can be a value of @ref I2S_Clock_Polarity */
+
+}I2S_InitTypeDef;
+
+/** 
+  * @brief  HAL State structures definition
+  */ 
+typedef enum
+{
+  HAL_I2S_STATE_RESET      = 0x00,  /*!< I2S not yet initialized or disabled  */
+  HAL_I2S_STATE_READY      = 0x01,  /*!< I2S initialized and ready for use    */
+  HAL_I2S_STATE_BUSY       = 0x02,  /*!< I2S internal process is ongoing      */
+  HAL_I2S_STATE_BUSY_TX    = 0x12,  /*!< Data Transmission process is ongoing */
+  HAL_I2S_STATE_BUSY_RX    = 0x22,  /*!< Data Reception process is ongoing    */
+  HAL_I2S_STATE_TIMEOUT    = 0x03,  /*!< I2S timeout state                    */
+  HAL_I2S_STATE_ERROR      = 0x04   /*!< I2S error state                      */
+
+}HAL_I2S_StateTypeDef;
+
+/** 
+  * @brief  HAL I2S Error Code structure definition  
+  */ 
+typedef enum
+{
+  HAL_I2S_ERROR_NONE      = 0x00,    /*!< No error                    */
+  HAL_I2S_ERROR_UDR       = 0x01,    /*!< I2S Underrun error          */
+  HAL_I2S_ERROR_OVR       = 0x02,    /*!< I2S Overrun error           */
+  HAL_I2S_ERROR_FRE       = 0x10,    /*!< I2S Frame format error      */
+  HAL_I2S_ERROR_DMA       = 0x20     /*!< DMA transfer error          */
+}HAL_I2S_ErrorTypeDef;
+
+/** 
+  * @brief I2S handle Structure definition  
+  */
+typedef struct
+{
+  SPI_TypeDef                *Instance;   /* I2S registers base address       */
+
+  I2S_InitTypeDef            Init;        /* I2S communication parameters     */
+
+  uint16_t                   *pTxBuffPtr; /* Pointer to I2S Tx transfer buffer*/
+
+  __IO uint16_t              TxXferSize;  /* I2S Tx transfer size             */
+
+  __IO uint16_t              TxXferCount; /* I2S Tx transfer Counter          */
+
+  uint16_t                   *pRxBuffPtr; /* Pointer to I2S Rx transfer buffer*/
+
+  __IO uint16_t              RxXferSize;  /* I2S Rx transfer size             */
+
+  __IO uint16_t              RxXferCount; /* I2S Rx transfer counter          */
+
+  DMA_HandleTypeDef          *hdmatx;     /* I2S Tx DMA handle parameters     */
+
+  DMA_HandleTypeDef          *hdmarx;     /* I2S Rx DMA handle parameters     */
+
+  __IO HAL_LockTypeDef       Lock;        /* I2S locking object               */
+
+  __IO HAL_I2S_StateTypeDef  State;       /* I2S communication state          */
+
+  __IO HAL_I2S_ErrorTypeDef  ErrorCode;   /* I2S Error code                   */
+
+}I2S_HandleTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup I2S_Exported_Constants
+  * @{
+  */ 
+
+/** @defgroup I2S_Mode
+  * @{
+  */
+#define I2S_MODE_SLAVE_TX                ((uint32_t)0x00000000)
+#define I2S_MODE_SLAVE_RX                ((uint32_t)0x00000100)
+#define I2S_MODE_MASTER_TX               ((uint32_t)0x00000200)
+#define I2S_MODE_MASTER_RX               ((uint32_t)0x00000300)
+
+#define IS_I2S_MODE(MODE) (((MODE) == I2S_MODE_SLAVE_TX)  || \
+                           ((MODE) == I2S_MODE_SLAVE_RX)  || \
+                           ((MODE) == I2S_MODE_MASTER_TX) || \
+                           ((MODE) == I2S_MODE_MASTER_RX))
+/**
+  * @}
+  */
+  
+/** @defgroup I2S_Standard
+  * @{
+  */
+#define I2S_STANDARD_PHILIPS             ((uint32_t)0x00000000)
+#define I2S_STANDARD_MSB                 ((uint32_t)0x00000010)
+#define I2S_STANDARD_LSB                 ((uint32_t)0x00000020)
+#define I2S_STANDARD_PCM_SHORT           ((uint32_t)0x00000030)
+#define I2S_STANDARD_PCM_LONG            ((uint32_t)0x000000B0)
+
+#define IS_I2S_STANDARD(STANDARD) (((STANDARD) == I2S_STANDARD_PHILIPS)   || \
+                                   ((STANDARD) == I2S_STANDARD_MSB)       || \
+                                   ((STANDARD) == I2S_STANDARD_LSB)       || \
+                                   ((STANDARD) == I2S_STANDARD_PCM_SHORT) || \
+                                   ((STANDARD) == I2S_STANDARD_PCM_LONG))
+/**
+  * @}
+  */
+  
+/** @defgroup I2S_Data_Format
+  * @{
+  */
+#define I2S_DATAFORMAT_16B               ((uint32_t)0x00000000)
+#define I2S_DATAFORMAT_16B_EXTENDED      ((uint32_t)0x00000001)
+#define I2S_DATAFORMAT_24B               ((uint32_t)0x00000003)
+#define I2S_DATAFORMAT_32B               ((uint32_t)0x00000005)
+
+#define IS_I2S_DATA_FORMAT(FORMAT) (((FORMAT) == I2S_DATAFORMAT_16B)          || \
+                                    ((FORMAT) == I2S_DATAFORMAT_16B_EXTENDED) || \
+                                    ((FORMAT) == I2S_DATAFORMAT_24B)          || \
+                                    ((FORMAT) == I2S_DATAFORMAT_32B))
+/**
+  * @}
+  */
+
+/** @defgroup I2S_MCLK_Output
+  * @{
+  */
+#define I2S_MCLKOUTPUT_ENABLE           ((uint32_t)SPI_I2SPR_MCKOE)
+#define I2S_MCLKOUTPUT_DISABLE          ((uint32_t)0x00000000)
+
+#define IS_I2S_MCLK_OUTPUT(OUTPUT) (((OUTPUT) == I2S_MCLKOUTPUT_ENABLE) || \
+                                    ((OUTPUT) == I2S_MCLKOUTPUT_DISABLE))
+/**
+  * @}
+  */
+
+/** @defgroup I2S_Audio_Frequency
+  * @{
+  */
+#define I2S_AUDIOFREQ_192K               ((uint32_t)192000)
+#define I2S_AUDIOFREQ_96K                ((uint32_t)96000)
+#define I2S_AUDIOFREQ_48K                ((uint32_t)48000)
+#define I2S_AUDIOFREQ_44K                ((uint32_t)44100)
+#define I2S_AUDIOFREQ_32K                ((uint32_t)32000)
+#define I2S_AUDIOFREQ_22K                ((uint32_t)22050)
+#define I2S_AUDIOFREQ_16K                ((uint32_t)16000)
+#define I2S_AUDIOFREQ_11K                ((uint32_t)11025)
+#define I2S_AUDIOFREQ_8K                 ((uint32_t)8000)
+#define I2S_AUDIOFREQ_DEFAULT            ((uint32_t)2)
+
+#define IS_I2S_AUDIO_FREQ(FREQ) ((((FREQ) >= I2S_AUDIOFREQ_8K) && \
+                                  ((FREQ) <= I2S_AUDIOFREQ_192K)) || \
+                                  ((FREQ) == I2S_AUDIOFREQ_DEFAULT))
+/**
+  * @}
+  */
+
+/** @defgroup I2S_Clock_Polarity
+  * @{
+  */
+#define I2S_CPOL_LOW                    ((uint32_t)0x00000000)
+#define I2S_CPOL_HIGH                   ((uint32_t)SPI_I2SCFGR_CKPOL)
+
+#define IS_I2S_CPOL(CPOL) (((CPOL) == I2S_CPOL_LOW) || \
+                           ((CPOL) == I2S_CPOL_HIGH))
+/**
+  * @}
+  */
+
+/** @defgroup I2S_Interrupt_configuration_definition
+  * @{
+  */
+#define I2S_IT_TXE                      SPI_CR2_TXEIE
+#define I2S_IT_RXNE                     SPI_CR2_RXNEIE
+#define I2S_IT_ERR                      SPI_CR2_ERRIE
+/**
+  * @}
+  */
+
+/** @defgroup I2S_Flag_definition
+  * @{
+  */
+#define I2S_FLAG_TXE                    SPI_SR_TXE
+#define I2S_FLAG_RXNE                   SPI_SR_RXNE
+
+#define I2S_FLAG_UDR                    SPI_SR_UDR
+#define I2S_FLAG_OVR                    SPI_SR_OVR
+#define I2S_FLAG_FRE                    SPI_SR_FRE
+
+#define I2S_FLAG_CHSIDE                 SPI_SR_CHSIDE
+#define I2S_FLAG_BSY                    SPI_SR_BSY
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+  
+/* Exported macro ------------------------------------------------------------*/
+
+/** @brief Reset I2S handle state
+  * @param  __HANDLE__: specifies the I2S Handle.
+  * @retval None
+  */
+#define __HAL_I2S_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_I2S_STATE_RESET)
+
+/** @brief  Enable or disable the specified SPI peripheral (in I2S mode).
+  * @param  __HANDLE__: specifies the I2S Handle. 
+  * @retval None
+  */
+#define __HAL_I2S_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->I2SCFGR |= SPI_I2SCFGR_I2SE)
+#define __HAL_I2S_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->I2SCFGR &= (uint32_t)~((uint32_t)SPI_I2SCFGR_I2SE))
+
+/** @brief  Enable or disable the specified I2S interrupts.
+  * @param  __HANDLE__: specifies the I2S Handle.
+  * @param  __INTERRUPT__: specifies the interrupt source to enable or disable.
+  *         This parameter can be one of the following values:
+  *            @arg I2S_IT_TXE: Tx buffer empty interrupt enable
+  *            @arg I2S_IT_RXNE: RX buffer not empty interrupt enable
+  *            @arg I2S_IT_ERR: Error interrupt enable
+  * @retval None
+  */  
+#define __HAL_I2S_ENABLE_IT(__HANDLE__, __INTERRUPT__) ((__HANDLE__)->Instance->CR2 |= (__INTERRUPT__))
+#define __HAL_I2S_DISABLE_IT(__HANDLE__, __INTERRUPT__) ((__HANDLE__)->Instance->CR2 &= ~(__INTERRUPT__))
+ 
+/** @brief  Checks if the specified I2S interrupt source is enabled or disabled.
+  * @param  __HANDLE__: specifies the I2S Handle.
+  *         This parameter can be I2S where x: 1, 2, or 3 to select the I2S peripheral.
+  * @param  __INTERRUPT__: specifies the I2S interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg I2S_IT_TXE: Tx buffer empty interrupt enable
+  *            @arg I2S_IT_RXNE: RX buffer not empty interrupt enable
+  *            @arg I2S_IT_ERR: Error interrupt enable
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_I2S_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->CR2 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/** @brief  Checks whether the specified I2S flag is set or not.
+  * @param  __HANDLE__: specifies the I2S Handle.
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg I2S_FLAG_RXNE: Receive buffer not empty flag
+  *            @arg I2S_FLAG_TXE: Transmit buffer empty flag
+  *            @arg I2S_FLAG_UDR: Underrun flag
+  *            @arg I2S_FLAG_OVR: Overrun flag
+  *            @arg I2S_FLAG_FRE: Frame error flag
+  *            @arg I2S_FLAG_CHSIDE: Channel Side flag
+  *            @arg I2S_FLAG_BSY: Busy flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_I2S_GET_FLAG(__HANDLE__, __FLAG__) ((((__HANDLE__)->Instance->SR) & (__FLAG__)) == (__FLAG__))
+
+/** @brief Clears the I2S OVR pending flag.
+  * @param  __HANDLE__: specifies the I2S Handle.
+  * @retval None
+  */
+#define __HAL_I2S_CLEAR_OVRFLAG(__HANDLE__) do{(__HANDLE__)->Instance->DR;\
+                                               (__HANDLE__)->Instance->SR;}while(0)
+/** @brief Clears the I2S UDR pending flag.
+  * @param  __HANDLE__: specifies the I2S Handle.
+  * @retval None
+  */
+#define __HAL_I2S_CLEAR_UDRFLAG(__HANDLE__)((__HANDLE__)->Instance->SR)
+
+/* Exported functions --------------------------------------------------------*/
+
+/* Initialization/de-initialization functions  **********************************/
+HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s);
+HAL_StatusTypeDef HAL_I2S_DeInit (I2S_HandleTypeDef *hi2s);
+void HAL_I2S_MspInit(I2S_HandleTypeDef *hi2s);
+void HAL_I2S_MspDeInit(I2S_HandleTypeDef *hi2s);
+
+/* I/O operation functions  *****************************************************/
+ /* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_I2S_Transmit(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2S_Receive(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size, uint32_t Timeout);
+
+ /* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_I2S_Transmit_IT(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2S_Receive_IT(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size);
+void HAL_I2S_IRQHandler(I2S_HandleTypeDef *hi2s);
+
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_I2S_Transmit_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2S_Receive_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size);
+
+HAL_StatusTypeDef HAL_I2S_DMAPause(I2S_HandleTypeDef *hi2s);
+HAL_StatusTypeDef HAL_I2S_DMAResume(I2S_HandleTypeDef *hi2s);
+HAL_StatusTypeDef HAL_I2S_DMAStop(I2S_HandleTypeDef *hi2s);
+
+/* Peripheral Control and State functions  **************************************/
+HAL_I2S_StateTypeDef HAL_I2S_GetState(I2S_HandleTypeDef *hi2s);
+HAL_I2S_ErrorTypeDef HAL_I2S_GetError(I2S_HandleTypeDef *hi2s);
+
+/* Callbacks used in non blocking modes (Interrupt and DMA) *******************/
+void HAL_I2S_TxHalfCpltCallback(I2S_HandleTypeDef *hi2s);
+void HAL_I2S_TxCpltCallback(I2S_HandleTypeDef *hi2s);
+void HAL_I2S_RxHalfCpltCallback(I2S_HandleTypeDef *hi2s);
+void HAL_I2S_RxCpltCallback(I2S_HandleTypeDef *hi2s);
+void HAL_I2S_ErrorCallback(I2S_HandleTypeDef *hi2s);
+
+void              I2S_DMATxCplt(DMA_HandleTypeDef *hdma);
+void              I2S_DMATxHalfCplt(DMA_HandleTypeDef *hdma); 
+void              I2S_DMARxCplt(DMA_HandleTypeDef *hdma);
+void              I2S_DMARxHalfCplt(DMA_HandleTypeDef *hdma);
+void              I2S_DMAError(DMA_HandleTypeDef *hdma);
+HAL_StatusTypeDef I2S_WaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, uint32_t Flag, uint32_t Status, uint32_t Timeout);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L0xx_HAL_I2S_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_irda.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_irda.c
@@ -1,0 +1,1456 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_irda.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   IRDA HAL module driver.
+  * 
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the IrDA (Infrared Data Association) Peripheral 
+  *          (IRDA)
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *
+  *           
+  @verbatim       
+ ===============================================================================
+                        ##### How to use this driver #####
+ ===============================================================================
+ [..]
+    The IRDA HAL driver can be used as follows:
+
+    
+    (#) Declare a IRDA_HandleTypeDef handle structure.
+    (#) Initialize the IRDA low level resources by implementing the HAL_IRDA_MspInit() API:
+        (##) Enable the USARTx interface clock.
+        (##) IRDA pins configuration:
+            (+) Enable the clock for the IRDA GPIOs.
+            (+) Configure these IRDA pins as alternate function pull-up.
+        (##) NVIC configuration if you need to use interrupt process (HAL_IRDA_Transmit_IT()
+             and HAL_IRDA_Receive_IT() APIs):
+            (+) Configure the USARTx interrupt priority.
+            (+) Enable the NVIC USART IRQ handle.
+        (##) DMA Configuration if you need to use DMA process (HAL_IRDA_Transmit_DMA()
+             and HAL_IRDA_Receive_DMA() APIs):
+            (+) Declare a DMA handle structure for the Tx/Rx channel.
+            (+) Enable the DMAx interface clock.
+            (+) Configure the declared DMA handle structure with the required Tx/Rx parameters.
+            (+) Configure the DMA Tx/Rx channel.
+            (+) Associate the initilalized DMA handle to the IRDA DMA Tx/Rx handle.
+            (+) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx/Rx channel.
+
+    (#) Program the Baud Rate, Word Length, Parity, IrDA Mode, Prescaler 
+        and Mode(Receiver/Transmitter) in the hirda Init structure.
+
+    (#) Initialize the IRDA registers by calling the HAL_IRDA_Init() API:
+        (++) This API configures also the low level Hardware GPIO, CLOCK, CORTEX...etc)
+            by calling the customed HAL_IRDA_MspInit() API.
+    -@@- The specific IRDA interrupts (Transmission complete interrupt, 
+        RXNE interrupt and Error Interrupts) will be managed using the macros
+        __HAL_IRDA_ENABLE_IT() and __HAL_IRDA_DISABLE_IT() inside the transmit and receive process.
+        
+    (#) Three operation modes are available within this driver :
+             
+    *** Polling mode IO operation ***
+    =================================
+    [..]    
+      (+) Send an amount of data in blocking mode using HAL_IRDA_Transmit() 
+      (+) Receive an amount of data in blocking mode using HAL_IRDA_Receive()
+       
+    *** Interrupt mode IO operation ***    
+    ===================================
+    [..]    
+      (+) Send an amount of data in non blocking mode using HAL_IRDA_Transmit_IT() 
+      (+) At transmission end of transfer HAL_IRDA_TxCpltCallback is executed and user can 
+           add his own code by customization of function pointer HAL_IRDA_TxCpltCallback
+      (+) Receive an amount of data in non blocking mode using HAL_IRDA_Receive_IT() 
+      (+) At reception end of transfer HAL_IRDA_RxCpltCallback is executed and user can 
+           add his own code by customization of function pointer HAL_IRDA_RxCpltCallback
+      (+) In case of transfer Error, HAL_IRDA_ErrorCallback() function is executed and user can 
+           add his own code by customization of function pointer HAL_IRDA_ErrorCallback
+
+    *** DMA mode IO operation ***    
+    =============================
+    [..]
+      (+) Send an amount of data in non blocking mode (DMA) using HAL_IRDA_Transmit_DMA() 
+      (+) At transmission end of transfer HAL_IRDA_TxCpltCallback is executed and user can 
+           add his own code by customization of function pointer HAL_IRDA_TxCpltCallback
+      (+) Receive an amount of data in non blocking mode (DMA) using HAL_IRDA_Receive_DMA() 
+      (+) At reception end of transfer HAL_IRDA_RxCpltCallback is executed and user can 
+           add his own code by customization of function pointer HAL_IRDA_RxCpltCallback
+      (+) In case of transfer Error, HAL_IRDA_ErrorCallback() function is executed and user can 
+           add his own code by customization of function pointer HAL_IRDA_ErrorCallback    
+
+    *** IRDA HAL driver macros list ***
+    ===================================
+    [..]
+      Below the list of most used macros in IRDA HAL driver.
+       
+     (+) __HAL_IRDA_ENABLE: Enable the IRDA peripheral 
+     (+) __HAL_IRDA_DISABLE: Disable the IRDA peripheral     
+     (+) __HAL_IRDA_GET_FLAG : Checks whether the specified IRDA flag is set or not
+     (+) __HAL_IRDA_CLEAR_FLAG : Clears the specified IRDA pending flag
+     (+) __HAL_IRDA_ENABLE_IT: Enables the specified IRDA interrupt
+     (+) __HAL_IRDA_DISABLE_IT: Disables the specified IRDA interrupt
+      
+     (@) You can refer to the IRDA HAL driver header file for more useful macros
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup IRDA 
+  * @brief IRDA HAL module driver
+  * @{
+  */
+#ifdef HAL_IRDA_MODULE_ENABLED
+    
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define TEACK_REACK_TIMEOUT            1000
+#define HAL_IRDA_TXDMA_TIMEOUTVALUE    22000
+#define IRDA_CR1_FIELDS  ((uint32_t)(USART_CR1_M | USART_CR1_PCE \
+                                   | USART_CR1_PS | USART_CR1_TE | USART_CR1_RE))
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void IRDA_DMATransmitCplt(DMA_HandleTypeDef *hdma);
+static void IRDA_DMATransmitHalfCplt(DMA_HandleTypeDef *hdma);
+static void IRDA_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
+static void IRDA_DMAReceiveHalfCplt(DMA_HandleTypeDef *hdma);
+static void IRDA_DMAError(DMA_HandleTypeDef *hdma); 
+static void IRDA_SetConfig (IRDA_HandleTypeDef *hirda);
+static HAL_StatusTypeDef IRDA_CheckIdleState(IRDA_HandleTypeDef *hirda);
+static HAL_StatusTypeDef IRDA_WaitOnFlagUntilTimeout(IRDA_HandleTypeDef *hirda, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
+static HAL_StatusTypeDef IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda);
+
+static HAL_StatusTypeDef IRDA_Receive_IT(IRDA_HandleTypeDef *hirda);
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup IRDA_Private_Functions
+  * @{
+  */
+
+/** @defgroup IRDA_Group1 Initialization/de-initialization functions 
+  *  @brief   Initialization and Configuration functions 
+  *
+@verbatim    
+===============================================================================
+            ##### Initialization and Configuration functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to initialize the USARTx 
+    in asynchronous IRDA mode.
+      (+) For the asynchronous mode only these parameters can be configured: 
+        (++) Baud Rate
+        (++) Word Length 
+        (++) Parity: If the parity is enabled, then the MSB bit of the data written
+             in the data register is transmitted but is changed by the parity bit.
+             Depending on the frame length defined by the M bit (8-bits or 9-bits)
+             or by the M1 and M0 bits (7-bit, 8-bit or 9-bit),
+             the possible IRDA frame formats are as listed in the following table:
+   +---------------------------------------------------------------+
+   | M1M0 bits |  PCE bit  |            IRDA frame                 |
+   |-----------|-----------|---------------------------------------|
+   |     00    |     0     |    | SB | 8-bit data | STB |          |
+   |-----------|-----------|---------------------------------------|
+   |     00    |     1     |    | SB | 7-bit data | PB | STB |     |
+   |-----------|-----------|---------------------------------------|
+   |     01    |     0     |    | SB | 9-bit data | STB |          |
+   |-----------|-----------|---------------------------------------|
+   |     01    |     1     |    | SB | 8-bit data | PB | STB |     |
+   |-----------------------|---------------------------------------|
+   |     10    |     0     |    | SB | 7-bit data | STB |          |
+   |-----------|-----------|---------------------------------------|
+   |     10    |     1     |    | SB | 6-bit data | PB | STB |     |
+   +---------------------------------------------------------------+
+          
+        (++) Power mode
+        (++) Prescaler setting       
+        (++) Receiver/transmitter modes
+
+    [..]
+    The HAL_IRDA_Init() API follows the USART asynchronous configuration procedures 
+    (details for the procedures are available in reference manual).
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Initializes the IRDA mode according to the specified
+  *         parameters in the IRDA_InitTypeDef and creates the associated handle .
+  * @param hirda: IRDA handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_IRDA_Init(IRDA_HandleTypeDef *hirda)
+{
+  /* Check the IRDA handle allocation */
+  if(hirda == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the USART/UART associated to the IRDA handle */
+  assert_param(IS_IRDA_INSTANCE(hirda->Instance));
+
+  if(hirda->State == HAL_IRDA_STATE_RESET)
+  {
+    /* Init the low level hardware : GPIO, CLOCK, CORTEX */
+    HAL_IRDA_MspInit(hirda);
+  }
+
+  hirda->State = HAL_IRDA_STATE_BUSY;
+
+  /* Disable the Peripheral to update the configuration registers */
+  __HAL_IRDA_DISABLE(hirda);
+
+  /* Set the IRDA Communication parameters */
+  IRDA_SetConfig(hirda);
+
+  /* In IRDA mode, the following bits must be kept cleared: 
+  - LINEN, STOP and CLKEN bits in the USART_CR2 register,
+  - SCEN and HDSEL bits in the USART_CR3 register.*/
+  hirda->Instance->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN | USART_CR2_STOP); 
+  hirda->Instance->CR3 &= ~(USART_CR3_SCEN | USART_CR3_HDSEL); 
+
+  /* set the UART/USART in IRDA mode */
+  hirda->Instance->CR3 |= USART_CR3_IREN; 
+
+  /* Enable the Peripheral */
+  __HAL_IRDA_ENABLE(hirda);
+
+  /* TEACK and/or REACK to check before moving hirda->State to Ready */
+  return (IRDA_CheckIdleState(hirda));
+}
+
+/**
+  * @brief DeInitializes the IRDA peripheral 
+  * @param hirda: IRDA handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_IRDA_DeInit(IRDA_HandleTypeDef *hirda)
+{
+  /* Check the IRDA handle allocation */
+  if(hirda == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the USART/UART associated to the IRDA handle */
+  assert_param(IS_IRDA_INSTANCE(hirda->Instance));
+
+  hirda->State = HAL_IRDA_STATE_BUSY;
+
+  /* DeInit the low level hardware */
+  HAL_IRDA_MspDeInit(hirda);
+  /* Disable the Peripheral */
+  __HAL_IRDA_DISABLE(hirda);
+
+  hirda->ErrorCode = HAL_IRDA_ERROR_NONE;
+  hirda->State = HAL_IRDA_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hirda);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief IRDA MSP Init
+  * @param hirda: IRDA handle
+  * @retval None
+  */
+ __weak void HAL_IRDA_MspInit(IRDA_HandleTypeDef *hirda)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_IRDA_MspInit could be implented in the user file
+   */ 
+}
+
+/**
+  * @brief IRDA MSP DeInit
+  * @param hirda: IRDA handle
+  * @retval None
+  */
+ __weak void HAL_IRDA_MspDeInit(IRDA_HandleTypeDef *hirda)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_IRDA_MspDeInit could be implented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup IRDA_Group2 IO operation functions 
+  *  @brief   IRDA Transmit-Receive functions  
+  *
+@verbatim    
+===============================================================================
+                      ##### IO operation functions #####
+===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to manage the IRDA asynchronous
+    data transfers.
+
+    (#) There are two modes of transfer:
+       (++) Blocking mode: the communication is performed in polling mode. 
+            The HAL status of all data processing is returned by the same function 
+            after finishing transfer.  
+       (++) No-Blocking mode: the communication is performed using Interrupts 
+           or DMA, these API's return the HAL status.
+           The end of the data processing will be indicated through the 
+           dedicated IRDA IRQ when using Interrupt mode or the DMA IRQ when 
+           using DMA mode.
+           The HAL_IRDA_TxCpltCallback(), HAL_IRDA_RxCpltCallback() user callbacks 
+           will be executed respectivelly at the end of the Transmit or Receive process
+           The HAL_IRDA_ErrorCallback() user callback will be executed when a communication error is detected
+
+    (#) Blocking mode API's are :
+        (++) HAL_IRDA_Transmit()
+        (++) HAL_IRDA_Receive() 
+        
+    (#) Non-Blocking mode API's with Interrupt are :
+        (++) HAL_IRDA_Transmit_IT()
+        (++) HAL_IRDA_Receive_IT()
+        (++) HAL_IRDA_IRQHandler()
+        (++) IRDA_Transmit_IT()
+        (++) IRDA_Receive_IT()
+
+    (#) Non-Blocking mode functions with DMA are :
+        (++) HAL_IRDA_Transmit_DMA()
+        (++) HAL_IRDA_Receive_DMA()
+
+    (#) A set of Transfer Complete Callbacks are provided in No_Blocking mode:
+        (++) HAL_IRDA_TxCpltCallback()
+        (++) HAL_IRDA_RxCpltCallback()
+        (++) HAL_IRDA_ErrorCallback()
+      
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Send an amount of data in blocking mode 
+  * @param hirda: IRDA handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be sent
+  * @param Timeout: Duration of the timeout
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_IRDA_Transmit(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+   uint16_t* tmp;
+   
+  if ((hirda->State == HAL_IRDA_STATE_READY) || (hirda->State == HAL_IRDA_STATE_BUSY_RX)) 
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hirda);
+    hirda->ErrorCode = HAL_IRDA_ERROR_NONE;
+
+    if(hirda->State == HAL_IRDA_STATE_BUSY_RX) 
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_TX;
+    }    
+    
+    hirda->TxXferSize = Size;
+    hirda->TxXferCount = Size;
+    while(hirda->TxXferCount > 0)
+    {
+      hirda->TxXferCount--;
+
+        if(IRDA_WaitOnFlagUntilTimeout(hirda, IRDA_FLAG_TXE, RESET, Timeout) != HAL_OK)
+        { 
+          return HAL_TIMEOUT;
+        }
+      if ((hirda->Init.WordLength == IRDA_WORDLENGTH_9B) && (hirda->Init.Parity == IRDA_PARITY_NONE))
+        {
+          tmp = (uint16_t*) pData;
+          hirda->Instance->TDR = (*tmp & (uint16_t)0x01FF);   
+          pData +=2;
+        }
+        else
+        { 
+          hirda->Instance->TDR = (*pData++ & (uint8_t)0xFF); 
+        }
+      } 
+
+    if(IRDA_WaitOnFlagUntilTimeout(hirda, IRDA_FLAG_TC, RESET, Timeout) != HAL_OK)
+    { 
+      return HAL_TIMEOUT;
+    } 
+
+    if(hirda->State == HAL_IRDA_STATE_BUSY_TX_RX) 
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_RX;
+    }
+    else
+    {
+      hirda->State = HAL_IRDA_STATE_READY;
+    }    
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hirda);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;   
+  }
+}
+
+/**
+  * @brief Receive an amount of data in blocking mode 
+  * @param hirda: IRDA handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @param Timeout: Duration of the timeout
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_IRDA_Receive(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{ 
+  uint16_t* tmp;
+  uint16_t uhMask;
+  
+  if ((hirda->State == HAL_IRDA_STATE_READY) || (hirda->State == HAL_IRDA_STATE_BUSY_TX))
+  { 
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;                                    
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hirda);
+    hirda->ErrorCode = HAL_IRDA_ERROR_NONE;
+
+    if(hirda->State == HAL_IRDA_STATE_BUSY_TX) 
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_RX;
+    }    
+    
+    hirda->RxXferSize = Size; 
+    hirda->RxXferCount = Size;
+
+    /* Computation of the mask to apply to the RDR register 
+       of the UART associated to the IRDA */
+    __HAL_IRDA_MASK_COMPUTATION(hirda);
+    uhMask = hirda->Mask;
+
+    /* Check data remaining to be received */
+    while(hirda->RxXferCount > 0)
+    {
+      hirda->RxXferCount--;
+
+      if(IRDA_WaitOnFlagUntilTimeout(hirda, IRDA_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+      { 
+        return HAL_TIMEOUT;
+      }         
+      if ((hirda->Init.WordLength == IRDA_WORDLENGTH_9B) && (hirda->Init.Parity == IRDA_PARITY_NONE))
+      {
+        tmp = (uint16_t*) pData ;
+        *tmp = (uint16_t)(hirda->Instance->RDR & uhMask);
+        pData +=2;
+      }
+      else
+      {
+        *pData++ = (uint8_t)(hirda->Instance->RDR & (uint8_t)uhMask); 
+      }       
+    } 
+
+    if(hirda->State == HAL_IRDA_STATE_BUSY_TX_RX) 
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_TX;
+    }
+    else
+    {
+      hirda->State = HAL_IRDA_STATE_READY;
+    }
+     
+    /* Process Unlocked */
+    __HAL_UNLOCK(hirda);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;   
+  }
+}
+
+/**
+  * @brief Send an amount of data in interrupt mode 
+  * @param hirda: IRDA handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size)
+{
+  if ((hirda->State == HAL_IRDA_STATE_READY) || (hirda->State == HAL_IRDA_STATE_BUSY_RX))
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hirda);
+    
+    hirda->pTxBuffPtr = pData;
+    hirda->TxXferSize = Size;
+    hirda->TxXferCount = Size;
+
+    hirda->ErrorCode = HAL_IRDA_ERROR_NONE;
+    if(hirda->State == HAL_IRDA_STATE_BUSY_RX) 
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_TX;
+    }
+        
+    /* Enable the IRDA Error Interrupt: (Frame error, noise error, overrun error) */
+    __HAL_IRDA_ENABLE_IT(hirda, IRDA_IT_ERR);
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hirda);    
+    
+    /* Enable the IRDA Transmit Complete Interrupt */
+    __HAL_IRDA_ENABLE_IT(hirda, IRDA_IT_TC);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;   
+  }
+}
+
+/**
+  * @brief Receive an amount of data in interrupt mode 
+  * @param hirda: IRDA handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_IRDA_Receive_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size)
+{  
+  if ((hirda->State == HAL_IRDA_STATE_READY) || (hirda->State == HAL_IRDA_STATE_BUSY_TX))
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    
+    /* Process Locked */
+  __HAL_LOCK(hirda);
+  
+    hirda->pRxBuffPtr = pData;
+    hirda->RxXferSize = Size;
+    hirda->RxXferCount = Size;
+  
+    /* Computation of the mask to apply to the RDR register 
+       of the UART associated to the IRDA */
+    __HAL_IRDA_MASK_COMPUTATION(hirda); 
+  
+    hirda->ErrorCode = HAL_IRDA_ERROR_NONE;  
+    if(hirda->State == HAL_IRDA_STATE_BUSY_TX) 
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_RX;
+    }
+    
+    /* Enable the IRDA Parity Error Interrupt */
+    __HAL_IRDA_ENABLE_IT(hirda, IRDA_IT_PE);
+    
+    /* Enable the IRDA Error Interrupt: (Frame error, noise error, overrun error) */
+    __HAL_IRDA_ENABLE_IT(hirda, IRDA_IT_ERR);
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hirda);
+    
+    /* Enable the IRDA Data Register not empty Interrupt */
+    __HAL_IRDA_ENABLE_IT(hirda, IRDA_IT_RXNE);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief Send an amount of data in DMA mode 
+  * @param hirda: IRDA handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_IRDA_Transmit_DMA(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size)
+{
+  uint32_t *tmp;
+  
+  if ((hirda->State == HAL_IRDA_STATE_READY) || (hirda->State == HAL_IRDA_STATE_BUSY_RX))
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hirda);
+    
+    hirda->pTxBuffPtr = pData;
+    hirda->TxXferSize = Size;
+    hirda->TxXferCount = Size; 
+    
+    hirda->ErrorCode = HAL_IRDA_ERROR_NONE;
+    
+    if(hirda->State == HAL_IRDA_STATE_BUSY_RX) 
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_TX;
+    }
+    
+    /* Set the IRDA DMA transfer complete callback */
+    hirda->hdmatx->XferCpltCallback = IRDA_DMATransmitCplt;
+    
+    /* Set the IRDA DMA half transfer complete callback */
+    hirda->hdmatx->XferHalfCpltCallback = IRDA_DMATransmitHalfCplt;
+
+    /* Set the DMA error callback */
+    hirda->hdmatx->XferErrorCallback = IRDA_DMAError;
+
+    /* Enable the IRDA transmit DMA channel */
+    tmp = (uint32_t*)&pData;
+    HAL_DMA_Start_IT(hirda->hdmatx, *(uint32_t*)tmp, (uint32_t)&hirda->Instance->TDR, Size);
+    
+    /* Enable the DMA transfer for transmit request by setting the DMAT bit
+       in the IRDA CR3 register */
+    hirda->Instance->CR3 |= USART_CR3_DMAT;
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hirda);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;   
+  }
+}
+
+/**
+  * @brief Receive an amount of data in DMA mode 
+  * @param hirda: IRDA handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @note   When the IRDA parity is enabled (PCE = 1), the received data contain 
+  *         the parity bit (MSB position)  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_IRDA_Receive_DMA(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size)
+{
+  uint32_t *tmp;
+  
+  if ((hirda->State == HAL_IRDA_STATE_READY) || (hirda->State == HAL_IRDA_STATE_BUSY_TX))
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hirda);
+    
+    hirda->pRxBuffPtr = pData;
+    hirda->RxXferSize = Size;
+
+    hirda->ErrorCode = HAL_IRDA_ERROR_NONE;
+    if(hirda->State == HAL_IRDA_STATE_BUSY_TX) 
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_RX;
+    }
+    
+    /* Set the IRDA DMA transfer complete callback */
+    hirda->hdmarx->XferCpltCallback = IRDA_DMAReceiveCplt;
+    
+    /* Set the IRDA DMA half transfer complete callback */
+    hirda->hdmarx->XferHalfCpltCallback = IRDA_DMAReceiveHalfCplt;
+    
+    /* Set the DMA error callback */
+    hirda->hdmarx->XferErrorCallback = IRDA_DMAError;
+
+    /* Enable the DMA channel */
+    tmp = (uint32_t*)&pData;
+    HAL_DMA_Start_IT(hirda->hdmarx, (uint32_t)&hirda->Instance->RDR, *(uint32_t*)tmp, Size);
+
+    /* Enable the DMA transfer for the receiver request by setting the DMAR bit 
+       in the IRDA CR3 register */
+     hirda->Instance->CR3 |= USART_CR3_DMAR;
+    
+     /* Process Unlocked */
+     __HAL_UNLOCK(hirda);
+     
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief Pauses the DMA Transfer.
+  * @param  hirda: pointer to a IRDA_HandleTypeDef structure that contains
+  *                the configuration information for the specified IRDA module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_IRDA_DMAPause(IRDA_HandleTypeDef *hirda)
+{
+  /* Process Locked */
+  __HAL_LOCK(hirda);
+  
+  if(hirda->State == HAL_IRDA_STATE_BUSY_TX)
+  {
+    /* Disable the UART DMA Tx request */
+    hirda->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAT);
+  }
+  else if(hirda->State == HAL_IRDA_STATE_BUSY_RX)
+  {
+    /* Disable the UART DMA Rx request */
+    hirda->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAR);
+  }
+  else if (hirda->State == HAL_IRDA_STATE_BUSY_TX_RX)
+  {
+    /* Disable the UART DMA Tx & Rx requests */
+    hirda->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAT);
+    hirda->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAR);
+  }
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hirda);
+  
+  return HAL_OK; 
+}
+
+/**
+  * @brief Resumes the DMA Transfer.
+  * @param  hirda: pointer to a IRDA_HandleTypeDef structure that contains
+  *                the configuration information for the specified UART module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_IRDA_DMAResume(IRDA_HandleTypeDef *hirda)
+{
+  /* Process Locked */
+  __HAL_LOCK(hirda);
+  
+  if(hirda->State == HAL_IRDA_STATE_BUSY_TX)
+  {
+    /* Enable the UART DMA Tx request */
+    hirda->Instance->CR3 |= USART_CR3_DMAT;
+  }
+  else if(hirda->State == HAL_IRDA_STATE_BUSY_RX)
+  {
+    /* Clear the Overrun flag before resumming the Rx transfer*/
+    __HAL_IRDA_CLEAR_IT(hirda, IRDA_CLEAR_OREF);
+
+    /* Enable the UART DMA Rx request */
+    hirda->Instance->CR3 |= USART_CR3_DMAR;
+  }
+  else if(hirda->State == HAL_IRDA_STATE_BUSY_TX_RX)
+  {
+    /* Clear the Overrun flag before resumming the Rx transfer*/
+    __HAL_IRDA_CLEAR_IT(hirda, IRDA_CLEAR_OREF);
+    
+    /* Enable the UART DMA Tx & Rx request */
+    hirda->Instance->CR3 |= USART_CR3_DMAT;
+    hirda->Instance->CR3 |= USART_CR3_DMAR;
+  }
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hirda);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief Stops the DMA Transfer.
+  * @param  hirda: pointer to a IRDA_HandleTypeDef structure that contains
+  *                the configuration information for the specified UART module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_IRDA_DMAStop(IRDA_HandleTypeDef *hirda)
+{
+  /* The Lock is not implemented on this API to allow the user application
+     to call the HAL UART API under callbacks HAL_UART_TxCpltCallback() / HAL_UART_RxCpltCallback():
+     when calling HAL_DMA_Abort() API the DMA TX/RX Transfer complete interrupt is generated
+     and the correspond call back is executed HAL_UART_TxCpltCallback() / HAL_UART_RxCpltCallback()
+     */
+
+  /* Disable the UART Tx/Rx DMA requests */
+  hirda->Instance->CR3 &= ~USART_CR3_DMAT;
+  hirda->Instance->CR3 &= ~USART_CR3_DMAR;
+  
+  /* Abort the UART DMA tx channel */
+  if(hirda->hdmatx != NULL)
+  {
+    HAL_DMA_Abort(hirda->hdmatx);
+  }
+  /* Abort the UART DMA rx channel */
+  if(hirda->hdmarx != NULL)
+  {
+    HAL_DMA_Abort(hirda->hdmarx);
+  }
+  
+  hirda->State = HAL_IRDA_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief This function handles IRDA interrupt request.
+  * @param hirda: IRDA handle
+  * @retval None
+  */
+void HAL_IRDA_IRQHandler(IRDA_HandleTypeDef *hirda)
+{
+  /* IRDA parity error interrupt occurred -------------------------------------*/
+  if((__HAL_IRDA_GET_IT(hirda, IRDA_IT_PE) != RESET) && (__HAL_IRDA_GET_IT_SOURCE(hirda, IRDA_IT_PE) != RESET))
+  { 
+    __HAL_IRDA_CLEAR_IT(hirda, IRDA_CLEAR_PEF);
+
+    hirda->ErrorCode |= HAL_IRDA_ERROR_PE;
+    /* Set the IRDA state ready to be able to start again the process */
+    hirda->State = HAL_IRDA_STATE_READY;
+  }
+  
+  /* IRDA frame error interrupt occured --------------------------------------*/
+  if((__HAL_IRDA_GET_IT(hirda, IRDA_IT_FE) != RESET) && (__HAL_IRDA_GET_IT_SOURCE(hirda, IRDA_IT_ERR) != RESET))
+  { 
+    __HAL_IRDA_CLEAR_IT(hirda, IRDA_CLEAR_FEF);
+
+    hirda->ErrorCode |= HAL_IRDA_ERROR_FE;
+    /* Set the IRDA state ready to be able to start again the process */
+    hirda->State = HAL_IRDA_STATE_READY;
+  }
+  
+  /* IRDA noise error interrupt occured --------------------------------------*/
+  if((__HAL_IRDA_GET_IT(hirda, IRDA_IT_NE) != RESET) && (__HAL_IRDA_GET_IT_SOURCE(hirda, IRDA_IT_ERR) != RESET))
+  { 
+    __HAL_IRDA_CLEAR_IT(hirda, IRDA_CLEAR_NEF);
+
+    hirda->ErrorCode |= HAL_IRDA_ERROR_NE; 
+    /* Set the IRDA state ready to be able to start again the process */
+    hirda->State = HAL_IRDA_STATE_READY;
+  }
+  
+  /* IRDA Over-Run interrupt occured -----------------------------------------*/
+  if((__HAL_IRDA_GET_IT(hirda, IRDA_IT_ORE) != RESET) && (__HAL_IRDA_GET_IT_SOURCE(hirda, IRDA_IT_ERR) != RESET))
+  { 
+    __HAL_IRDA_CLEAR_IT(hirda, IRDA_CLEAR_OREF);
+
+    hirda->ErrorCode |= HAL_IRDA_ERROR_ORE; 
+    /* Set the IRDA state ready to be able to start again the process */
+    hirda->State = HAL_IRDA_STATE_READY;
+  }
+  
+  /* Call IRDA Error Call back function if need be --------------------------*/
+  if(hirda->ErrorCode != HAL_IRDA_ERROR_NONE)
+  {
+    HAL_IRDA_ErrorCallback(hirda);
+  } 
+
+  /* IRDA in mode Receiver ---------------------------------------------------*/
+  if((__HAL_IRDA_GET_IT(hirda, IRDA_IT_RXNE) != RESET) && (__HAL_IRDA_GET_IT_SOURCE(hirda, IRDA_IT_RXNE) != RESET))
+  { 
+    IRDA_Receive_IT(hirda);
+    /* Clear RXNE interrupt flag */
+    __HAL_IRDA_SEND_REQ(hirda, IRDA_RXDATA_FLUSH_REQUEST);
+  }
+  
+  /* IRDA in mode Transmitter ------------------------------------------------*/
+ if((__HAL_IRDA_GET_IT(hirda, IRDA_IT_TXE) != RESET) &&(__HAL_IRDA_GET_IT_SOURCE(hirda, IRDA_IT_TXE) != RESET))
+  {
+    IRDA_Transmit_IT(hirda);
+  } 
+  
+}
+
+/**
+  * @brief Tx Half Transfer completed callback
+  * @param hirda: irda handle
+  * @retval None
+  */
+ __weak void HAL_IRDA_TxHalfCpltCallback(IRDA_HandleTypeDef *hirda)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_IRDA_TxHalfCpltCallback can be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief Tx Transfer completed callback
+  * @param hirda: irda handle
+  * @retval None
+  */
+ __weak void HAL_IRDA_TxCpltCallback(IRDA_HandleTypeDef *hirda)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_IRDA_TxCpltCallback can be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief Rx Half Transfer completed callback
+  * @param hirda: irda handle
+  * @retval None
+  */
+__weak void HAL_IRDA_RxHalfCpltCallback(IRDA_HandleTypeDef *hirda)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_IRDA_RxHalfCpltCallback can be implemented in the user file
+   */
+}
+
+/**
+  * @brief Rx Transfer completed callback
+  * @param hirda: irda handle
+  * @retval None
+  */
+__weak void HAL_IRDA_RxCpltCallback(IRDA_HandleTypeDef *hirda)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_IRDA_RxCpltCallback can be implemented in the user file
+   */
+}
+
+/**
+  * @brief IRDA error callback
+  * @param hirda: IRDA handle
+  * @retval None
+  */
+ __weak void HAL_IRDA_ErrorCallback(IRDA_HandleTypeDef *hirda)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_IRDA_ErrorCallback can be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup IRDA_Group3 Peripheral Control functions 
+  *  @brief   IRDA control functions 
+  *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to control the IRDA.
+     (+) HAL_IRDA_GetState() API can be helpful to check in run-time the state of the IRDA peripheral. 
+     (+) IRDA_SetConfig() API is used to configure the IRDA communications parameters.
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief return the IRDA state
+  * @param hirda: irda handle
+  * @retval HAL state
+  */
+HAL_IRDA_StateTypeDef HAL_IRDA_GetState(IRDA_HandleTypeDef *hirda)
+{
+  return hirda->State;
+}
+
+/**
+* @brief  Return the IRDA error code
+* @param  hirda : pointer to a IRDA_HandleTypeDef structure that contains
+  *              the configuration information for the specified IRDA.
+* @retval IRDA Error Code
+*/
+uint32_t HAL_IRDA_GetError(IRDA_HandleTypeDef *hirda)
+{
+  return hirda->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief Configure the IRDA peripheral 
+  * @param hirda: irda handle
+  * @retval None
+  */
+static void IRDA_SetConfig(IRDA_HandleTypeDef *hirda)
+{
+  uint32_t tmpreg      = 0x00000000;
+  uint32_t clocksource = 0x00000000;
+  
+  /* Check the communication parameters */ 
+  assert_param(IS_IRDA_BAUDRATE(hirda->Init.BaudRate));  
+  assert_param(IS_IRDA_WORD_LENGTH(hirda->Init.WordLength));
+  assert_param(IS_IRDA_PARITY(hirda->Init.Parity));
+  assert_param(IS_IRDA_TX_RX_MODE(hirda->Init.Mode));
+  assert_param(IS_IRDA_PRESCALER(hirda->Init.Prescaler)); 
+  assert_param(IS_IRDA_POWERMODE(hirda->Init.PowerMode)); 
+  /*-------------------------- USART CR1 Configuration -----------------------*/        
+  /* Configure the IRDA Word Length, Parity and transfer Mode: 
+  Set the M bits according to hirda->Init.WordLength value 
+  Set PCE and PS bits according to hirda->Init.Parity value
+  Set TE and RE bits according to hirda->Init.Mode value */
+  tmpreg = (uint32_t)hirda->Init.WordLength | hirda->Init.Parity | hirda->Init.Mode ;
+  
+  MODIFY_REG(hirda->Instance->CR1, IRDA_CR1_FIELDS, tmpreg);
+  
+  /*-------------------------- USART CR3 Configuration -----------------------*/
+  MODIFY_REG(hirda->Instance->CR3, USART_CR3_IRLP, hirda->Init.PowerMode);
+  
+  /*-------------------------- USART GTPR Configuration ----------------------*/  
+  MODIFY_REG(hirda->Instance->GTPR, (uint32_t)USART_GTPR_PSC, hirda->Init.Prescaler);
+  
+  /*-------------------------- USART BRR Configuration -----------------------*/ 
+  __HAL_IRDA_GETCLOCKSOURCE(hirda, clocksource);
+  switch (clocksource)
+  {
+  case IRDA_CLOCKSOURCE_PCLK1: 
+    hirda->Instance->BRR = (uint16_t)(HAL_RCC_GetPCLK1Freq() / hirda->Init.BaudRate);
+    break;
+  case IRDA_CLOCKSOURCE_PCLK2: 
+    hirda->Instance->BRR = (uint16_t)(HAL_RCC_GetPCLK2Freq() / hirda->Init.BaudRate);
+    break;
+  case IRDA_CLOCKSOURCE_HSI: 
+    hirda->Instance->BRR = (uint16_t)(HSI_VALUE / hirda->Init.BaudRate); 
+    break; 
+  case IRDA_CLOCKSOURCE_SYSCLK:  
+    hirda->Instance->BRR = (uint16_t)(HAL_RCC_GetSysClockFreq() / hirda->Init.BaudRate);
+    break;  
+  case IRDA_CLOCKSOURCE_LSE:                
+    hirda->Instance->BRR = (uint16_t)(LSE_VALUE / hirda->Init.BaudRate); 
+    break;
+  default:
+    break;
+  } 
+}
+
+/**
+  * @brief Check the IRDA Idle State
+  * @param hirda: IRDA handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef IRDA_CheckIdleState(IRDA_HandleTypeDef *hirda)
+{
+  /* Initialize the IRDA ErrorCode */
+  hirda->ErrorCode = HAL_IRDA_ERROR_NONE;
+  
+  /* Check if the Transmitter is enabled */
+  if((hirda->Instance->CR1 & USART_CR1_TE) == USART_CR1_TE)
+  {
+    /* Wait until TEACK flag is set */
+    if(IRDA_WaitOnFlagUntilTimeout(hirda, USART_ISR_TEACK, RESET, TEACK_REACK_TIMEOUT) != HAL_OK)
+    { 
+      hirda->State= HAL_IRDA_STATE_TIMEOUT;
+      return HAL_TIMEOUT;
+    }     
+  }
+  /* Check if the Receiver is enabled */
+  if((hirda->Instance->CR1 & USART_CR1_RE) == USART_CR1_RE)
+  {
+    if(IRDA_WaitOnFlagUntilTimeout(hirda, USART_ISR_REACK, RESET, TEACK_REACK_TIMEOUT) != HAL_OK)
+    { 
+      hirda->State= HAL_IRDA_STATE_TIMEOUT;
+      return HAL_TIMEOUT;
+    }       
+  }
+  /* Process Unlocked */
+  __HAL_UNLOCK(hirda);
+  
+  /* Initialize the IRDA state*/
+  hirda->State= HAL_IRDA_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handle IRDA Communication Timeout.
+  * @param  hirda: IRDA handle
+  * @param  Flag: specifies the IRDA flag to check.
+  * @param  Status: the flag status (SET or RESET). The function is locked in a while loop as long as the flag remains set to Status.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef IRDA_WaitOnFlagUntilTimeout(IRDA_HandleTypeDef *hirda, uint32_t Flag, FlagStatus Status, uint32_t Timeout)  
+{
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+  
+  /* Wait until flag is set */
+  if(Status == RESET)
+  {
+    while(__HAL_IRDA_GET_FLAG(hirda, Flag) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+          __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_TXE);
+          __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_RXNE);
+          __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_PE);
+          __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_ERR);
+
+          hirda->State= HAL_IRDA_STATE_TIMEOUT;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hirda);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    while(__HAL_IRDA_GET_FLAG(hirda, Flag) != RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+          __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_TXE);
+          __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_RXNE);
+          __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_PE);
+          __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_ERR);
+
+          hirda->State= HAL_IRDA_STATE_TIMEOUT;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hirda);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  return HAL_OK;      
+}
+
+/**
+  * @brief Receive an amount of data in non blocking mode. 
+  *         Function called under interruption only, once
+  *         interruptions have been enabled by HAL_IRDA_Transmit_IT()
+  * @param hirda: IRDA handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda)
+{
+  uint16_t* tmp;
+  
+  if((hirda->State == HAL_IRDA_STATE_BUSY_TX) || (hirda->State == HAL_IRDA_STATE_BUSY_TX_RX))
+  {
+    if(hirda->TxXferCount == 0)
+    {
+      /* Disable the IRDA Transmit Complete Interrupt */
+      __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_TXE);
+      
+      if(hirda->State == HAL_IRDA_STATE_BUSY_TX_RX) 
+      {
+        hirda->State = HAL_IRDA_STATE_BUSY_RX;
+      }
+      else
+      {
+        /* Disable the IRDA Error Interrupt: (Frame error, noise error, overrun error) */
+        __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_ERR);
+        
+        hirda->State = HAL_IRDA_STATE_READY;
+      }
+
+      HAL_IRDA_TxCpltCallback(hirda);
+      
+      return HAL_OK;
+    }
+    else
+    {
+      if ((hirda->Init.WordLength == IRDA_WORDLENGTH_9B) && (hirda->Init.Parity == IRDA_PARITY_NONE))
+      {
+        tmp = (uint16_t*) hirda->pTxBuffPtr;
+        hirda->Instance->TDR = (*tmp & (uint16_t)0x01FF);
+        hirda->pTxBuffPtr += 2;
+      }
+      else
+      {
+        hirda->Instance->TDR = (uint8_t)(*hirda->pTxBuffPtr++ & (uint8_t)0xFF); 
+      }
+      hirda->TxXferCount--;
+      return HAL_OK;
+    }
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in non blocking mode. 
+  *         Function called under interruption only, once
+  *         interruptions have been enabled by HAL_IRDA_Receive_IT()
+  * @param hirda: IRDA handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef IRDA_Receive_IT(IRDA_HandleTypeDef *hirda)
+{
+  uint16_t* tmp;
+  uint16_t uhMask = hirda->Mask;
+  
+  if ((hirda->State == HAL_IRDA_STATE_BUSY_RX) || (hirda->State == HAL_IRDA_STATE_BUSY_TX_RX))
+  {
+    if ((hirda->Init.WordLength == IRDA_WORDLENGTH_9B) && (hirda->Init.Parity == IRDA_PARITY_NONE))
+    {
+      tmp = (uint16_t*) hirda->pRxBuffPtr ;
+      *tmp = (uint16_t)(hirda->Instance->RDR & uhMask);
+      hirda->pRxBuffPtr  +=2;
+    }
+    else
+    {
+      *hirda->pRxBuffPtr++ = (uint8_t)(hirda->Instance->RDR & (uint8_t)uhMask); 
+    }
+    
+    if(--hirda->RxXferCount == 0)
+    {
+      while(HAL_IS_BIT_SET(hirda->Instance->ISR, IRDA_FLAG_RXNE))
+      {
+      }
+      __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_RXNE);
+      
+      if(hirda->State == HAL_IRDA_STATE_BUSY_TX_RX) 
+      {
+        hirda->State = HAL_IRDA_STATE_BUSY_TX;
+      }
+      else
+      {      
+        /* Disable the IRDA Parity Error Interrupt */
+        __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_PE);
+        
+        /* Disable the IRDA Error Interrupt: (Frame error, noise error, overrun error) */
+        __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_ERR);
+        
+        hirda->State = HAL_IRDA_STATE_READY;
+      }
+      
+      HAL_IRDA_RxCpltCallback(hirda);
+      
+      return HAL_OK;
+    }
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+  
+/**
+  * @brief DMA IRDA Tx transfer completed callback 
+  * @param hdma: DMA handle
+  * @retval None
+  */
+static void IRDA_DMATransmitCplt(DMA_HandleTypeDef *hdma)     
+{
+  IRDA_HandleTypeDef* hirda = ( IRDA_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  /* DMA Normal mode */
+  if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+  {
+    hirda->TxXferCount = 0;
+    
+    /* Disable the DMA transfer for transmit request by setting the DMAT bit
+    in the IRDA CR3 register */
+    hirda->Instance->CR3 &= (uint16_t)~((uint16_t)USART_CR3_DMAT);
+    
+    /* Wait for IRDA TC Flag */
+    if(IRDA_WaitOnFlagUntilTimeout(hirda, IRDA_FLAG_TC, RESET, HAL_IRDA_TXDMA_TIMEOUTVALUE) != HAL_OK)
+    {
+      /* Timeout Occured */ 
+      hirda->State = HAL_IRDA_STATE_TIMEOUT;
+      HAL_IRDA_ErrorCallback(hirda);
+    }
+    else
+    {
+      /* No Timeout */
+      
+      if(hirda->State == HAL_IRDA_STATE_BUSY_TX_RX)
+      {
+        hirda->State = HAL_IRDA_STATE_BUSY_RX;
+      }
+      else
+      {
+        hirda->State = HAL_IRDA_STATE_READY;
+      }
+      HAL_IRDA_TxCpltCallback(hirda);
+    }
+  }
+  /* DMA Circular mode */
+  else
+  {
+    HAL_IRDA_TxCpltCallback(hirda);
+  }
+}
+
+/**
+  * @brief DMA IRDA receive process half complete callback 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void IRDA_DMATransmitHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  IRDA_HandleTypeDef* hirda = ( IRDA_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  HAL_IRDA_TxHalfCpltCallback(hirda); 
+}
+
+/**
+  * @brief DMA IRDA Rx Transfer completed callback 
+  * @param hdma: DMA handle
+  * @retval None
+  */
+static void IRDA_DMAReceiveCplt(DMA_HandleTypeDef *hdma)  
+{
+  IRDA_HandleTypeDef* hirda = ( IRDA_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  /* DMA Normal mode */
+  if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+  {
+    hirda->RxXferCount = 0;
+    
+    /* Disable the DMA transfer for the receiver request by setting the DMAR bit 
+    in the IRDA CR3 register */
+    hirda->Instance->CR3 &= (uint16_t)~((uint16_t)USART_CR3_DMAR);
+    
+    if(hirda->State == HAL_IRDA_STATE_BUSY_TX_RX) 
+    {
+      hirda->State = HAL_IRDA_STATE_BUSY_TX;
+    }
+    else
+    {
+      hirda->State = HAL_IRDA_STATE_READY;
+    }
+  }
+  
+  HAL_IRDA_RxCpltCallback(hirda);
+}
+
+/**
+  * @brief DMA IRDA receive process half complete callback 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void IRDA_DMAReceiveHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  IRDA_HandleTypeDef* hirda = ( IRDA_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  HAL_IRDA_RxHalfCpltCallback(hirda); 
+}
+
+/**
+  * @brief DMA IRDA communication error callback 
+  * @param hdma: DMA handle
+  * @retval None
+  */
+static void IRDA_DMAError(DMA_HandleTypeDef *hdma)   
+{
+  IRDA_HandleTypeDef* hirda = ( IRDA_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  hirda->RxXferCount = 0;
+  hirda->TxXferCount = 0;
+  hirda->State= HAL_IRDA_STATE_READY;
+  hirda->ErrorCode |= HAL_IRDA_ERROR_DMA;
+  HAL_IRDA_ErrorCallback(hirda);
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_IRDA_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_irda.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_irda.h
@@ -1,0 +1,572 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_irda.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of IRDA HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_IRDA_H
+#define __STM32L0xx_HAL_IRDA_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup IRDA
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+
+/** 
+  * @brief IRDA Init Structure definition  
+  */ 
+typedef struct
+{
+  uint32_t BaudRate;                  /*!< This member configures the IRDA communication baud rate.
+                                           The baud rate register is computed using the following formula:
+                                              Baud Rate Register = ((PCLKx) / ((hirda->Init.BaudRate))) */
+
+  uint32_t WordLength;                /*!< Specifies the number of data bits transmitted or received in a frame.
+                                           This parameter can be a value of @ref IRDAEx_Word_Length */
+
+  uint32_t Parity;                    /*!< Specifies the parity mode.
+                                           This parameter can be a value of @ref IRDA_Parity
+                                           @note When parity is enabled, the computed parity is inserted
+                                                 at the MSB position of the transmitted data (9th bit when
+                                                 the word length is set to 9 data bits; 8th bit when the
+                                                 word length is set to 8 data bits). */
+ 
+  uint16_t Mode;                      /*!< Specifies wether the Receive or Transmit mode is enabled or disabled.
+                                           This parameter can be a value of @ref IRDA_Mode */
+  
+  uint8_t  Prescaler;                 /*!< Specifies the Prescaler value for dividing the UART/USART source clock
+                                           to achieve low-power frequency.
+                                           @note Prescaler value 0 is forbidden */
+  
+  uint16_t PowerMode;                 /*!< Specifies the IRDA power mode.
+                                           This parameter can be a value of @ref IRDA_Low_Power */
+}IRDA_InitTypeDef;
+
+/** 
+  * @brief HAL IRDA State structures definition  
+  */ 
+typedef enum
+{
+  HAL_IRDA_STATE_RESET             = 0x00,    /*!< Peripheral is not yet Initialized */
+  HAL_IRDA_STATE_READY             = 0x01,    /*!< Peripheral Initialized and ready for use */
+  HAL_IRDA_STATE_BUSY              = 0x02,    /*!< an internal process is ongoing */
+  HAL_IRDA_STATE_BUSY_TX           = 0x12,    /*!< Data Transmission process is ongoing */
+  HAL_IRDA_STATE_BUSY_RX           = 0x22,    /*!< Data Reception process is ongoing */
+  HAL_IRDA_STATE_BUSY_TX_RX        = 0x32,    /*!< Data Transmission and Reception process is ongoing */
+  HAL_IRDA_STATE_TIMEOUT           = 0x03,    /*!< Timeout state */
+  HAL_IRDA_STATE_ERROR             = 0x04     /*!< Error */
+}HAL_IRDA_StateTypeDef;
+
+/** 
+  * @brief  HAL IRDA Error Code structure definition  
+  */ 
+typedef enum
+{
+  HAL_IRDA_ERROR_NONE      = 0x00,    /*!< No error            */
+  HAL_IRDA_ERROR_PE        = 0x01,    /*!< Parity error        */
+  HAL_IRDA_ERROR_NE        = 0x02,    /*!< Noise error         */
+  HAL_IRDA_ERROR_FE        = 0x04,    /*!< frame error         */
+  HAL_IRDA_ERROR_ORE       = 0x08,    /*!< Overrun error       */
+  HAL_IRDA_ERROR_DMA       = 0x10     /*!< DMA transfer error  */
+}HAL_IRDA_ErrorTypeDef;
+
+/**
+  * @brief IRDA clock sources definition
+  */
+typedef enum
+{
+  IRDA_CLOCKSOURCE_PCLK1      = 0x00,    /*!< PCLK1 clock source  */
+  IRDA_CLOCKSOURCE_PCLK2      = 0x01,    /*!< PCLK2 clock source  */
+  IRDA_CLOCKSOURCE_HSI        = 0x02,    /*!< HSI clock source    */
+  IRDA_CLOCKSOURCE_SYSCLK     = 0x04,    /*!< SYSCLK clock source */
+  IRDA_CLOCKSOURCE_LSE        = 0x08     /*!< LSE clock source     */
+}IRDA_ClockSourceTypeDef;
+
+/** 
+  * @brief  IRDA handle Structure definition  
+  */
+typedef struct
+{
+  USART_TypeDef            *Instance;        /* IRDA registers base address        */
+
+  IRDA_InitTypeDef         Init;             /* IRDA communication parameters      */
+
+  uint8_t                  *pTxBuffPtr;      /* Pointer to IRDA Tx transfer Buffer */
+
+  uint16_t                 TxXferSize;       /* IRDA Tx Transfer size              */
+
+  uint16_t                 TxXferCount;      /* IRDA Tx Transfer Counter           */
+
+  uint8_t                  *pRxBuffPtr;      /* Pointer to IRDA Rx transfer Buffer */
+
+  uint16_t                 RxXferSize;       /* IRDA Rx Transfer size              */
+
+  uint16_t                 RxXferCount;      /* IRDA Rx Transfer Counter           */
+
+  uint16_t                 Mask;             /* IRDA RX RDR register mask         */
+
+  DMA_HandleTypeDef        *hdmatx;          /* IRDA Tx DMA Handle parameters      */
+
+  DMA_HandleTypeDef        *hdmarx;          /* IRDA Rx DMA Handle parameters      */
+
+  HAL_LockTypeDef          Lock;             /* Locking object                     */
+
+  __IO HAL_IRDA_StateTypeDef    State;       /* IRDA communication state           */
+
+  __IO HAL_IRDA_ErrorTypeDef    ErrorCode;   /* IRDA Error code                    */
+
+}IRDA_HandleTypeDef;
+
+/** 
+  * @brief  IRDA Configuration enumeration values definition  
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup IRDA_Exported_Constants  IRDA Exported Constants
+  * @{
+  */
+
+/** @defgroup IRDA_Parity
+  * @{
+  */ 
+#define IRDA_PARITY_NONE                    ((uint32_t)0x0000)
+#define IRDA_PARITY_EVEN                    ((uint32_t)USART_CR1_PCE)
+#define IRDA_PARITY_ODD                     ((uint32_t)(USART_CR1_PCE | USART_CR1_PS)) 
+#define IS_IRDA_PARITY(PARITY) (((PARITY) == IRDA_PARITY_NONE) || \
+                                ((PARITY) == IRDA_PARITY_EVEN) || \
+                                ((PARITY) == IRDA_PARITY_ODD))
+/**
+  * @}
+  */ 
+
+
+/** @defgroup IRDA_Transfer_Mode
+  * @{
+  */ 
+#define IRDA_MODE_RX                        ((uint32_t)USART_CR1_RE)
+#define IRDA_MODE_TX                        ((uint32_t)USART_CR1_TE)
+#define IRDA_MODE_TX_RX                     ((uint32_t)(USART_CR1_TE |USART_CR1_RE))
+#define IS_IRDA_TX_RX_MODE(MODE) ((((MODE) & (~((uint32_t)(IRDA_MODE_TX_RX)))) == (uint32_t)0x00) && ((MODE) != (uint32_t)0x00))
+/**
+  * @}
+  */
+
+/** @defgroup IRDA_Low_Power
+  * @{
+  */
+#define IRDA_POWERMODE_NORMAL                    ((uint32_t)0x0000)
+#define IRDA_POWERMODE_LOWPOWER                  ((uint32_t)USART_CR3_IRLP)
+#define IS_IRDA_POWERMODE(MODE) (((MODE) == IRDA_POWERMODE_LOWPOWER) || \
+                                 ((MODE) == IRDA_POWERMODE_NORMAL))
+/**
+  * @}
+  */
+    
+ /** @defgroup IRDA_State
+  * @{
+  */ 
+#define IRDA_STATE_DISABLE                  ((uint32_t)0x0000)
+#define IRDA_STATE_ENABLE                   ((uint32_t)USART_CR1_UE)
+#define IS_IRDA_STATE(STATE) (((STATE) == IRDA_STATE_DISABLE) || \
+                              ((STATE) == IRDA_STATE_ENABLE))
+/**
+  * @}
+  */
+
+ /** @defgroup IRDA_Mode
+  * @{
+  */ 
+#define IRDA_MODE_DISABLE                  ((uint32_t)0x0000)
+#define IRDA_MODE_ENABLE                   ((uint32_t)USART_CR3_IREN)
+#define IS_IRDA_MODE(STATE)  (((STATE) == IRDA_MODE_DISABLE) || \
+                              ((STATE) == IRDA_MODE_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup IRDA_One_Bit
+  * @{
+  */
+#define IRDA_ONE_BIT_SAMPLE_DISABLED          ((uint32_t)0x00000000)
+#define IRDA_ONE_BIT_SAMPLE_ENABLED           ((uint32_t)USART_CR3_ONEBIT)
+#define IS_IRDA_ONEBIT_SAMPLE(ONEBIT)         (((ONEBIT) == IRDA_ONE_BIT_SAMPLE_DISABLED) || \
+                                                  ((ONEBIT) == IRDA_ONE_BIT_SAMPLE_ENABLED))
+/**
+  * @}
+  */  
+  
+/** @defgroup IRDA_DMA_Tx
+  * @{
+  */
+#define IRDA_DMA_TX_DISABLE          ((uint32_t)0x00000000)
+#define IRDA_DMA_TX_ENABLE           ((uint32_t)USART_CR3_DMAT)
+#define IS_IRDA_DMA_TX(DMATX)         (((DMATX) == IRDA_DMA_TX_DISABLE) || \
+                                       ((DMATX) == IRDA_DMA_TX_ENABLE))
+/**
+  * @}
+  */  
+  
+/** @defgroup IRDA_DMA_Rx
+  * @{
+  */
+#define IRDA_DMA_RX_DISABLE           ((uint32_t)0x0000)
+#define IRDA_DMA_RX_ENABLE            ((uint32_t)USART_CR3_DMAR)
+#define IS_IRDA_DMA_RX(DMARX)         (((DMARX) == IRDA_DMA_RX_DISABLE) || \
+                                       ((DMARX) == IRDA_DMA_RX_ENABLE))
+/**
+  * @}
+  */
+  
+/** @defgroup IRDA_Flags
+  *        Elements values convention: 0xXXXX
+  *           - 0xXXXX  : Flag mask in the ISR register
+  * @{
+  */
+#define IRDA_FLAG_REACK                     ((uint32_t)0x00400000)
+#define IRDA_FLAG_TEACK                     ((uint32_t)0x00200000)  
+#define IRDA_FLAG_BUSY                      ((uint32_t)0x00010000)
+#define IRDA_FLAG_ABRF                      ((uint32_t)0x00008000)  
+#define IRDA_FLAG_ABRE                      ((uint32_t)0x00004000)
+#define IRDA_FLAG_TXE                       ((uint32_t)0x00000080)
+#define IRDA_FLAG_TC                        ((uint32_t)0x00000040)
+#define IRDA_FLAG_RXNE                      ((uint32_t)0x00000020)
+#define IRDA_FLAG_ORE                       ((uint32_t)0x00000008)
+#define IRDA_FLAG_NE                        ((uint32_t)0x00000004)
+#define IRDA_FLAG_FE                        ((uint32_t)0x00000002)
+#define IRDA_FLAG_PE                        ((uint32_t)0x00000001)
+/**
+  * @}
+  */ 
+
+/** @defgroup IRDA_Interrupt_definition
+  *        Elements values convention: 0000ZZZZ0XXYYYYYb
+  *           - YYYYY  : Interrupt source position in the XX register (5bits)
+  *           - XX  : Interrupt source register (2bits)
+  *                 - 01: CR1 register
+  *                 - 10: CR2 register
+  *                 - 11: CR3 register
+  *           - ZZZZ  : Flag position in the ISR register(4bits)
+  * @{   
+  */  
+#define IRDA_IT_PE                          ((uint16_t)0x0028)
+#define IRDA_IT_TXE                         ((uint16_t)0x0727)
+#define IRDA_IT_TC                          ((uint16_t)0x0626)
+#define IRDA_IT_RXNE                        ((uint16_t)0x0525)
+#define IRDA_IT_IDLE                        ((uint16_t)0x0424)
+
+
+                                
+/**       Elements values convention: 000000000XXYYYYYb
+  *           - YYYYY  : Interrupt source position in the XX register (5bits)
+  *           - XX  : Interrupt source register (2bits)
+  *                 - 01: CR1 register
+  *                 - 10: CR2 register
+  *                 - 11: CR3 register
+  */
+#define IRDA_IT_ERR                         ((uint16_t)0x0060)
+
+/**       Elements values convention: 0000ZZZZ00000000b
+  *           - ZZZZ  : Flag position in the ISR register(4bits)
+  */
+#define IRDA_IT_ORE                         ((uint16_t)0x0300)
+#define IRDA_IT_NE                          ((uint16_t)0x0200)
+#define IRDA_IT_FE                          ((uint16_t)0x0100)
+/**
+  * @}
+  */
+  
+/** @defgroup IRDA_IT_CLEAR_Flags
+  * @{
+  */
+#define IRDA_CLEAR_PEF                       USART_ICR_PECF            /*!< Parity Error Clear Flag */          
+#define IRDA_CLEAR_FEF                       USART_ICR_FECF            /*!< Framing Error Clear Flag */         
+#define IRDA_CLEAR_NEF                       USART_ICR_NCF             /*!< Noise detected Clear Flag */        
+#define IRDA_CLEAR_OREF                      USART_ICR_ORECF           /*!< OverRun Error Clear Flag */         
+#define IRDA_CLEAR_TCF                       USART_ICR_TCCF            /*!< Transmission Complete Clear Flag */ 
+/**
+  * @}
+  */ 
+
+
+
+/** @defgroup IRDA_Request_Parameters
+  * @{
+  */
+#define IRDA_AUTOBAUD_REQUEST            ((uint16_t)USART_RQR_ABRRQ)        /*!< Auto-Baud Rate Request */     
+#define IRDA_RXDATA_FLUSH_REQUEST        ((uint16_t)USART_RQR_RXFRQ)        /*!< Receive Data flush Request */ 
+#define IRDA_TXDATA_FLUSH_REQUEST        ((uint16_t)USART_RQR_TXFRQ)        /*!< Transmit data flush Request */
+#define IS_IRDA_REQUEST_PARAMETER(PARAM) (((PARAM) == IRDA_AUTOBAUD_REQUEST) || \
+                                          ((PARAM) == IRDA_SENDBREAK_REQUEST) || \
+                                          ((PARAM) == IRDA_MUTE_MODE_REQUEST) || \
+                                          ((PARAM) == IRDA_RXDATA_FLUSH_REQUEST) || \
+                                          ((PARAM) == IRDA_TXDATA_FLUSH_REQUEST))   
+/**
+  * @}
+  */
+  
+/** @defgroup IRDA_Interruption_Mask
+  * @{
+  */ 
+#define IRDA_IT_MASK  ((uint16_t)0x001F)  
+/**
+  * @}
+  */
+  
+/**
+ * @}
+ */
+
+  
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup IRDA_Exported_Macros
+  * @{
+  */
+
+/** @brief Reset IRDA handle state
+  * @param  __HANDLE__: specifies the IRDA Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @retval None
+  */
+#define __HAL_IRDA_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_IRDA_STATE_RESET)
+
+/** @brief  Check whether the specified IRDA flag is set or not.
+  * @param  __HANDLE__: specifies the IRDA Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  *         UART peripheral
+  * @param  __FLAG__: specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg IRDA_FLAG_REACK: Receive enable ackowledge flag
+  *            @arg IRDA_FLAG_TEACK: Transmit enable ackowledge flag
+  *            @arg IRDA_FLAG_BUSY:  Busy flag
+  *            @arg IRDA_FLAG_ABRF:  Auto Baud rate detection flag
+  *            @arg IRDA_FLAG_ABRE:  Auto Baud rate detection error flag
+  *            @arg IRDA_FLAG_TXE:   Transmit data register empty flag
+  *            @arg IRDA_FLAG_TC:    Transmission Complete flag
+  *            @arg IRDA_FLAG_RXNE:  Receive data register not empty flag
+  *            @arg IRDA_FLAG_IDLE:  Idle Line detection flag
+  *            @arg IRDA_FLAG_ORE:   OverRun Error flag
+  *            @arg IRDA_FLAG_NE:    Noise Error flag
+  *            @arg IRDA_FLAG_FE:    Framing Error flag
+  *            @arg IRDA_FLAG_PE:    Parity Error flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_IRDA_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->ISR & (__FLAG__)) == (__FLAG__))   
+
+/** @brief  Enable the specified IRDA interrupt.
+  * @param  __HANDLE__: specifies the IRDA Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  *         UART peripheral
+  * @param  __INTERRUPT__: specifies the IRDA interrupt source to enable.
+  *          This parameter can be one of the following values:
+  *            @arg IRDA_IT_TXE:  Transmit Data Register empty interrupt
+  *            @arg IRDA_IT_TC:   Transmission complete interrupt
+  *            @arg IRDA_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg IRDA_IT_IDLE: Idle line detection interrupt
+  *            @arg IRDA_IT_PE:   Parity Error interrupt
+  *            @arg IRDA_IT_ERR:  Error interrupt(Frame error, noise error, overrun error)
+  * @retval None
+  */
+#define __HAL_IRDA_ENABLE_IT(__HANDLE__, __INTERRUPT__) (((((uint8_t)(__INTERRUPT__)) >> 5) == 1)? ((__HANDLE__)->Instance->CR1 |= (1 << ((__INTERRUPT__) & IRDA_IT_MASK))): \
+                                                          ((((uint8_t)(__INTERRUPT__)) >> 5) == 2)? ((__HANDLE__)->Instance->CR2 |= (1 << ((__INTERRUPT__) & IRDA_IT_MASK))): \
+                                                          ((__HANDLE__)->Instance->CR3 |= (1 << ((__INTERRUPT__) & IRDA_IT_MASK))))
+
+/** @brief  Disable the specified IRDA interrupt.
+  * @param  __HANDLE__: specifies the IRDA Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @param  __INTERRUPT__: specifies the IRDA interrupt source to disable.
+  *          This parameter can be one of the following values:
+  *            @arg IRDA_IT_TXE:  Transmit Data Register empty interrupt
+  *            @arg IRDA_IT_TC:   Transmission complete interrupt
+  *            @arg IRDA_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg IRDA_IT_IDLE: Idle line detection interrupt
+  *            @arg IRDA_IT_PE:   Parity Error interrupt
+  *            @arg IRDA_IT_ERR:  Error interrupt(Frame error, noise error, overrun error)
+  * @retval None
+  */
+#define __HAL_IRDA_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (((((uint8_t)(__INTERRUPT__)) >> 5) == 1)? ((__HANDLE__)->Instance->CR1 &= ~ ((uint32_t)1 << ((__INTERRUPT__) & IRDA_IT_MASK))): \
+                                                           ((((uint8_t)(__INTERRUPT__)) >> 5) == 2)? ((__HANDLE__)->Instance->CR2 &= ~ ((uint32_t)1 << ((__INTERRUPT__) & IRDA_IT_MASK))): \
+                                                           ((__HANDLE__)->Instance->CR3 &= ~ ((uint32_t)1 << ((__INTERRUPT__) & IRDA_IT_MASK))))
+
+/** @brief  Check whether the specified IRDA interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the IRDA Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @param  __IT__: specifies the IRDA interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg IRDA_IT_TXE: Transmit Data Register empty interrupt
+  *            @arg IRDA_IT_TC:  Transmission complete interrupt
+  *            @arg IRDA_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg IRDA_IT_IDLE: Idle line detection interrupt
+  *            @arg IRDA_IT_ORE: OverRun Error interrupt
+  *            @arg IRDA_IT_NE: Noise Error interrupt
+  *            @arg IRDA_IT_FE: Framing Error interrupt
+  *            @arg IRDA_IT_PE: Parity Error interrupt  
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_IRDA_GET_IT(__HANDLE__, __IT__) ((__HANDLE__)->Instance->ISR & ((uint32_t)1 << ((__IT__)>> 0x08))) 
+
+/** @brief  Check whether the specified IRDA interrupt source is enabled.
+  * @param  __HANDLE__: specifies the IRDA Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @param  __IT__: specifies the IRDA interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg IRDA_IT_TXE: Transmit Data Register empty interrupt
+  *            @arg IRDA_IT_TC:  Transmission complete interrupt
+  *            @arg IRDA_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg IRDA_IT_IDLE: Idle line detection interrupt
+  *            @arg IRDA_IT_ORE: OverRun Error interrupt
+  *            @arg IRDA_IT_NE: Noise Error interrupt
+  *            @arg IRDA_IT_FE: Framing Error interrupt
+  *            @arg IRDA_IT_PE: Parity Error interrupt  
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_IRDA_GET_IT_SOURCE(__HANDLE__, __IT__) ((((((uint8_t)(__IT__)) >> 5) == 1)? (__HANDLE__)->Instance->CR1:(((((uint8_t)(__IT__)) >> 5) == 2)? \
+                                                          (__HANDLE__)->Instance->CR2 : (__HANDLE__)->Instance->CR3)) & ((uint32_t)1 << (((uint16_t)(__IT__)) & IRDA_IT_MASK)))
+
+/** @brief  Clear the specified IRDA ISR flag, in setting the proper ICR register flag.
+  * @param  __HANDLE__: specifies the IRDA Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @param  __IT_CLEAR__: specifies the interrupt clear register flag that needs to be set
+  *                       to clear the corresponding interrupt
+  *          This parameter can be one of the following values:
+  *            @arg IRDA_CLEAR_PEF: Parity Error Clear Flag
+  *            @arg IRDA_CLEAR_FEF: Framing Error Clear Flag
+  *            @arg IRDA_CLEAR_NEF: Noise detected Clear Flag
+  *            @arg IRDA_CLEAR_OREF: OverRun Error Clear Flag
+  *            @arg IRDA_CLEAR_TCF: Transmission Complete Clear Flag 
+  * @retval None
+  */
+#define __HAL_IRDA_CLEAR_IT(__HANDLE__, __IT_CLEAR__) ((__HANDLE__)->Instance->ICR |= (uint32_t)(__IT_CLEAR__))
+
+/** @brief  Set a specific IRDA request flag.
+  * @param  __HANDLE__: specifies the IRDA Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @param  __REQ__: specifies the request flag to set
+  *          This parameter can be one of the following values:
+  *            @arg IRDA_AUTOBAUD_REQUEST: Auto-Baud Rate Request     
+  *            @arg IRDA_RXDATA_FLUSH_REQUEST: Receive Data flush Request 
+  *            @arg IRDA_TXDATA_FLUSH_REQUEST: Transmit data flush Request 
+  *
+  * @retval None
+  */
+#define __HAL_IRDA_SEND_REQ(__HANDLE__, __REQ__) ((__HANDLE__)->Instance->RQR |= (uint16_t)(__REQ__)) 
+
+/** @brief  Enable UART/USART associated to IRDA Handle
+  * @param  __HANDLE__: specifies the IRDA Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @retval None
+  */
+#define __HAL_IRDA_ENABLE(__HANDLE__)                   ((__HANDLE__)->Instance->CR1 |=  USART_CR1_UE)
+
+/** @brief  Disable UART/USART associated to IRDA Handle
+  * @param  __HANDLE__: specifies the IRDA Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @retval None
+  */
+#define __HAL_IRDA_DISABLE(__HANDLE__)                  ((__HANDLE__)->Instance->CR1 &=  ~USART_CR1_UE)
+
+/** @brief  Ensure that IRDA Baud rate is less or equal to maximum value
+  * @param  __BAUDRATE__: specifies the IRDA Baudrate set by the user.
+  * @retval True or False
+  */   
+#define IS_IRDA_BAUDRATE(__BAUDRATE__) ((__BAUDRATE__) < 115201)
+
+/** @brief  Ensure that IRDA prescaler value is strictly larger than 0
+  * @param  __PRESCALER__: specifies the IRDA prescaler value set by the user.
+  * @retval True or False
+  */  
+#define IS_IRDA_PRESCALER(__PRESCALER__) ((__PRESCALER__) > 0)
+
+/**
+ * @}
+ */
+
+/* Include IRDA HAL Extension module */
+#include "stm32l0xx_hal_irda_ex.h"  
+
+/* Exported functions --------------------------------------------------------*/
+/* Initialization/de-initialization methods  **********************************/
+HAL_StatusTypeDef HAL_IRDA_Init(IRDA_HandleTypeDef *hirda);
+HAL_StatusTypeDef HAL_IRDA_DeInit(IRDA_HandleTypeDef *hirda);
+void HAL_IRDA_MspInit(IRDA_HandleTypeDef *hirda);
+void HAL_IRDA_MspDeInit(IRDA_HandleTypeDef *hirda);
+
+/* IO operation methods *******************************************************/
+HAL_StatusTypeDef HAL_IRDA_Transmit(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_IRDA_Receive(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_IRDA_Receive_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_IRDA_Transmit_DMA(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_IRDA_Receive_DMA(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_IRDA_DMAPause(IRDA_HandleTypeDef *hirda);
+HAL_StatusTypeDef HAL_IRDA_DMAResume(IRDA_HandleTypeDef *hirda);
+HAL_StatusTypeDef HAL_IRDA_DMAStop(IRDA_HandleTypeDef *hirda);
+void HAL_IRDA_IRQHandler(IRDA_HandleTypeDef *hirda);
+void HAL_IRDA_TxCpltCallback(IRDA_HandleTypeDef *hirda);
+void HAL_IRDA_RxCpltCallback(IRDA_HandleTypeDef *hirda);
+void HAL_IRDA_TxHalfCpltCallback(IRDA_HandleTypeDef *hirda);
+void HAL_IRDA_RxHalfCpltCallback(IRDA_HandleTypeDef *hirda);
+void HAL_IRDA_ErrorCallback(IRDA_HandleTypeDef *hirda);
+
+/* Peripheral State methods  **************************************************/
+HAL_IRDA_StateTypeDef HAL_IRDA_GetState(IRDA_HandleTypeDef *hirda);
+uint32_t HAL_IRDA_GetError(IRDA_HandleTypeDef *hirda);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_IRDA_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_irda_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_irda_ex.h
@@ -1,0 +1,221 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_irda_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of IRDA HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *                               
+  * <h2><center>&copy; COPYRIGHT(c) 2013 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_IRDA_EX_H
+#define __STM32L0xx_HAL_IRDA_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup IRDAEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup IRDAEx_Extended_Exported_Constants
+  * @{
+  */
+  
+/** @defgroup IRDAEx_Word_Length
+  * @{
+  */
+#define IRDA_WORDLENGTH_7B                  ((uint32_t)USART_CR1_M_1)
+#define IRDA_WORDLENGTH_8B                  ((uint32_t)0x00000000)
+#define IRDA_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M_0)
+#define IS_IRDA_WORD_LENGTH(LENGTH) (((LENGTH) == IRDA_WORDLENGTH_7B) || \
+                                     ((LENGTH) == IRDA_WORDLENGTH_8B) || \
+                                     ((LENGTH) == IRDA_WORDLENGTH_9B))
+/**
+  * @}
+  */
+  
+  
+/**
+  * @}
+  */  
+  
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup IRDAEx_Extended_Exported_Macros
+  * @{
+  */
+/** @brief  Reports the IRDA clock source.
+  * @param  __HANDLE__: specifies the UART Handle
+  * @param  __CLOCKSOURCE__ : output variable   
+  * @retval IRDA clocking source, written in __CLOCKSOURCE__.
+  */
+#define __HAL_IRDA_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__) \
+  do {                                                        \
+    if((__HANDLE__)->Instance == USART1)                      \
+    {                                                         \
+       switch(__HAL_RCC_GET_USART1_SOURCE())                  \
+       {                                                      \
+        case RCC_USART1CLKSOURCE_PCLK2:                       \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PCLK2;         \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART2)                 \
+    {                                                         \
+       switch(__HAL_RCC_GET_USART2_SOURCE())                  \
+       {                                                      \
+        case RCC_USART2CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if((__HANDLE__)->Instance == LPUART1)                \
+    {                                                         \
+       switch(__HAL_RCC_GET_LPUART1_SOURCE())                 \
+       {                                                      \
+        case RCC_LPUART1CLKSOURCE_PCLK1:                      \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_LPUART1CLKSOURCE_HSI:                        \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_LPUART1CLKSOURCE_SYSCLK:                     \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_LPUART1CLKSOURCE_LSE:                        \
+          (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+  } while(0)
+
+/** @brief  Reports the mask to apply to retrieve the received data
+  *         according to the word length and to the parity bits activation.
+  * @param  __HANDLE__: specifies the IRDA Handle
+  * @retval mask to apply to USART RDR register value.
+  */    
+#define __HAL_IRDA_MASK_COMPUTATION(__HANDLE__)                       \
+  do {                                                                \
+  if ((__HANDLE__)->Init.WordLength == IRDA_WORDLENGTH_9B)            \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == IRDA_PARITY_NONE)               \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x01FF ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x00FF ;                                 \
+     }                                                                \
+  }                                                                   \
+  else if ((__HANDLE__)->Init.WordLength == IRDA_WORDLENGTH_8B)       \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == IRDA_PARITY_NONE)               \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x00FF ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x007F ;                                 \
+     }                                                                \
+  }                                                                   \
+  else if ((__HANDLE__)->Init.WordLength == IRDA_WORDLENGTH_7B)       \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == IRDA_PARITY_NONE)               \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x007F ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x003F ;                                 \
+     }                                                                \
+  }                                                                   \
+} while(0)
+/**
+  * @}
+  */
+  
+/* Exported functions --------------------------------------------------------*/
+/* Initialization/de-initialization methods  **********************************/
+/* IO operation methods *******************************************************/
+/* Peripheral Control methods  ************************************************/
+/* Peripheral State methods  **************************************************/
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_IRDA_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_iwdg.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_iwdg.c
@@ -1,0 +1,410 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_iwdg.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   IWDG HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Independent Watchdog (IWDG) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral State functions
+  *         
+  @verbatim
+  ==============================================================================
+                    ##### IWDG Generic features #####
+  ==============================================================================
+    [..] 
+    (+) The IWDG can be started by either software or hardware (configurable
+         through option byte).
+
+    (+) The IWDG is clocked by its own dedicated Low-Speed clock (LSI) and
+         thus stays active even if the main clock fails.
+         Once the IWDG is started, the LSI is forced ON and cannot be disabled
+         (LSI cannot be disabled too), and the counter starts counting down from
+         the reset value of 0xFFF. When it reaches the end of count value (0x000)
+         a system reset is generated.
+
+    (+) The IWDG counter should be refreshed at regular intervals, otherwise the
+         watchdog generates an MCU reset when the counter reaches 0.
+
+    (+) The IWDG is implemented in the VDD voltage domain that is still functional
+         in STOP and STANDBY mode (IWDG reset can wake-up from STANDBY).
+         IWDGRST flag in RCC_CSR register can be used to inform when an IWDG
+         reset occurs.
+
+    [..] Min-max timeout value @32KHz (LSI): ~0.512ms / ~32.0s
+         The IWDG timeout may vary due to LSI frequency dispersion. STM32L0xx
+         devices provide the capability to measure the LSI frequency (LSI clock
+         connected internally to TIM5 CH4 input capture). The measured value
+         can be used to have an IWDG timeout with an acceptable accuracy.
+
+
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+    If Window option is disabled
+    
+      (+) Use IWDG using HAL_IWDG_Init() function to :
+         (++) Enable write access to IWDG_PR, IWDG_RLR.
+         (++) Configure the IWDG prescaler, counter reload value.
+              This reload value will be loaded in the IWDG counter each time the counter
+              is reloaded, then the IWDG will start counting down from this value.
+      (+) Use IWDG using HAL_IWDG_Start() function to :
+         (++) Reload IWDG counter with value defined in the IWDG_RLR register.
+         (++) Start the IWDG, when the IWDG is used in software mode (no need 
+              to enable the LSI, it will be enabled by hardware).
+      (+) Then the application program must refresh the IWDG counter at regular
+          intervals during normal operation to prevent an MCU reset, using
+          HAL_IWDG_Refresh() function.
+    [..] 
+    if Window option is enabled:
+      
+      (+) Use IWDG using HAL_IWDG_Start() function to enable IWDG downcounter
+      (+) Use IWDG using HAL_IWDG_Init() function to :
+         (++) Enable write access to IWDG_PR, IWDG_RLR and IWDG_WINR registers.
+         (++) Configure the IWDG prescaler, reload value and window value.
+      (+) Then the application program must refresh the IWDG counter at regular
+          intervals during normal operation to prevent an MCU reset, using
+          HAL_IWDG_Refresh() function.
+
+     *** IWDG HAL driver macros list ***
+     ====================================
+     [..]
+       Below the list of most used macros in IWDG HAL driver.
+       
+      (+) __HAL_IWDG_START: Enable the IWDG peripheral
+      (+) __HAL_IWDG_RELOAD_COUNTER: Reloads IWDG counter with value defined in the reload register    
+      (+) __HAL_IWDG_ENABLE_WRITE_ACCESS : Enable write access to IWDG_PR and IWDG_RLR registers
+      (+) __HAL_IWDG_DISABLE_WRITE_ACCESS : Disable write access to IWDG_PR and IWDG_RLR registers
+      (+) __HAL_IWDG_GET_FLAG: Get the selected IWDG's flag status    
+            
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup IWDG
+  * @brief IWDG HAL module driver.
+  * @{
+  */
+
+#ifdef HAL_IWDG_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup IWDG_Private_Functions
+  * @{
+  */
+
+/** @defgroup IWDG_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions.
+ *
+@verbatim
+ ===============================================================================
+          ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize the IWDG according to the specified parameters
+          in the IWDG_InitTypeDef and create the associated handle
+      (+) Manage Window option
+      (+) Initialize the IWDG MSP
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the IWDG according to the specified
+  *         parameters in the IWDG_InitTypeDef and creates the associated handle.
+  * @param  hiwdg: pointer to a IWDG_HandleTypeDef structure that contains
+  *                the configuration information for the specified IWDG module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the IWDG handle allocation */
+  if(hiwdg == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_IWDG_PRESCALER(hiwdg->Init.Prescaler));
+  assert_param(IS_IWDG_RELOAD(hiwdg->Init.Reload));
+  assert_param(IS_IWDG_WINDOW(hiwdg->Init.Window));
+
+  /* Check pending flag, if previous update not done, return error */
+  if((__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_PVU) != RESET)
+     &&(__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_RVU) != RESET)
+     &&(__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_WVU) != RESET))
+  {
+    return HAL_ERROR;
+  }
+
+  if(hiwdg->State == HAL_IWDG_STATE_RESET)
+  { 
+  /* Init the low level hardware */
+  HAL_IWDG_MspInit(hiwdg);
+  }
+
+  /* Change IWDG peripheral state */
+  hiwdg->State = HAL_IWDG_STATE_BUSY;
+
+  /* Enable write access to IWDG_PR, IWDG_RLR and IWDG_WINR registers */
+  /* by writing 0x5555 in KR */
+  __HAL_IWDG_ENABLE_WRITE_ACCESS(hiwdg);
+
+  /* Write to IWDG registers the IWDG_Prescaler & IWDG_Reload values to work with */
+  MODIFY_REG(hiwdg->Instance->PR, (uint32_t)IWDG_PR_PR, hiwdg->Init.Prescaler);
+  MODIFY_REG(hiwdg->Instance->RLR, (uint32_t)IWDG_RLR_RL, hiwdg->Init.Reload);
+
+  /* check if window option is enabled */
+  if (((hiwdg->Init.Window) != IWDG_WINDOW_DISABLE) || ((hiwdg->Instance->WINR) != IWDG_WINDOW_DISABLE))
+  {
+    tickstart = HAL_GetTick();
+
+     /* Wait for register to be updated */
+    while((uint32_t)(hiwdg->Instance->SR) != RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > 1000)
+      {
+        /* Set IWDG state */
+        hiwdg->State = HAL_IWDG_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Write to IWDG WINR the IWDG_Window value to compare with */
+    MODIFY_REG(hiwdg->Instance->WINR, (uint32_t)IWDG_WINR_WIN, hiwdg->Init.Window);
+
+  }
+  /* Change IWDG peripheral state */
+  hiwdg->State = HAL_IWDG_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the IWDG MSP.
+  * @param  hiwdg: pointer to a IWDG_HandleTypeDef structure that contains
+  *                the configuration information for the specified IWDG module.
+  * @retval None
+  */
+__weak void HAL_IWDG_MspInit(IWDG_HandleTypeDef *hiwdg)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_IWDG_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup IWDG_Group2 IO operation functions  
+ *  @brief   IO operation functions  
+ *
+@verbatim
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Start the IWDG.
+      (+) Refresh the IWDG.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Starts the IWDG.
+  * @param  hiwdg: pointer to a IWDG_HandleTypeDef structure that contains
+  *                the configuration information for the specified IWDG module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_IWDG_Start(IWDG_HandleTypeDef *hiwdg)
+{
+  uint32_t tickstart = 0;
+
+  /* Process locked */
+  __HAL_LOCK(hiwdg); 
+
+    /* Change IWDG peripheral state */
+  hiwdg->State = HAL_IWDG_STATE_BUSY;
+
+  /* Reload IWDG counter with value defined in the RLR register */
+  if ((hiwdg->Init.Window) == IWDG_WINDOW_DISABLE)
+  {
+  __HAL_IWDG_RELOAD_COUNTER(hiwdg);
+  }
+
+  /* Enable the IWDG peripheral */
+  __HAL_IWDG_START(hiwdg);
+
+  tickstart = HAL_GetTick();
+
+  /* Wait until PVU, RVU, WVU flag are RESET */
+  while( (__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_PVU) != RESET)
+        &&(__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_RVU) != RESET)
+          &&(__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_WVU) != RESET) )
+  {
+    
+    if((HAL_GetTick() - tickstart ) > 1000)
+    {
+      /* Set IWDG state */
+      hiwdg->State = HAL_IWDG_STATE_TIMEOUT;
+      
+      /* Process unlocked */
+      __HAL_UNLOCK(hiwdg);
+      
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Change IWDG peripheral state */
+  hiwdg->State = HAL_IWDG_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hiwdg);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Refreshes the IWDG.
+  * @param  hiwdg: pointer to a IWDG_HandleTypeDef structure that contains
+  *                the configuration information for the specified IWDG module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_IWDG_Refresh(IWDG_HandleTypeDef *hiwdg)
+{
+  uint32_t tickstart = 0;
+
+  /* Process Locked */
+  __HAL_LOCK(hiwdg);
+
+    /* Change IWDG peripheral state */
+  hiwdg->State = HAL_IWDG_STATE_BUSY;
+
+  tickstart = HAL_GetTick();
+
+  /* Wait until RVU flag is RESET */
+  while(__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_RVU) != RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > 1000)
+    {
+      /* Set IWDG state */
+      hiwdg->State = HAL_IWDG_STATE_TIMEOUT;
+
+       /* Process unlocked */
+      __HAL_UNLOCK(hiwdg);
+
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Reload IWDG counter with value defined in the reload register */
+  __HAL_IWDG_RELOAD_COUNTER(hiwdg);
+
+  /* Change IWDG peripheral state */
+  hiwdg->State = HAL_IWDG_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hiwdg);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup IWDG_Group3 Peripheral State functions 
+ *  @brief    Peripheral State functions.
+ *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================
+    [..]
+    This subsection permits to get in run-time the status of the peripheral
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the IWDG state.
+  * @param  hiwdg: pointer to a IWDG_HandleTypeDef structure that contains
+  *                the configuration information for the specified IWDG module.
+  * @retval HAL state
+  */
+HAL_IWDG_StateTypeDef HAL_IWDG_GetState(IWDG_HandleTypeDef *hiwdg)
+{
+  return hiwdg->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_IWDG_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_iwdg.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_iwdg.h
@@ -1,0 +1,296 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_iwdg.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of IWDG HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_IWDG_H
+#define __STM32L0xx_HAL_IWDG_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup IWDG
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** @defgroup IWDG_Exported_Types IWDG Exported Types
+  * @{
+  */
+
+/** 
+  * @brief  IWDG HAL State Structure definition
+  */
+typedef enum
+{
+  HAL_IWDG_STATE_RESET     = 0x00,  /*!< IWDG not yet initialized or disabled */
+  HAL_IWDG_STATE_READY     = 0x01,  /*!< IWDG initialized and ready for use   */
+  HAL_IWDG_STATE_BUSY      = 0x02,  /*!< IWDG internal process is ongoing     */
+  HAL_IWDG_STATE_TIMEOUT   = 0x03,  /*!< IWDG timeout state                   */
+  HAL_IWDG_STATE_ERROR     = 0x04   /*!< IWDG error state                     */
+
+}HAL_IWDG_StateTypeDef;
+
+/** 
+  * @brief  IWDG Init structure definition
+  */
+typedef struct
+{
+  uint32_t Prescaler;  /*!< Select the prescaler of the IWDG.
+                            This parameter can be a value of @ref IWDG_Prescaler */
+
+  uint32_t Reload;     /*!< Specifies the IWDG down-counter reload value.
+                            This parameter must be a number between Min_Data = 0 and Max_Data = 0x0FFF */
+
+  uint32_t Window;     /*!< Specifies the window value to be compared to the down-counter.
+                            This parameter must be a number between Min_Data = 0 and Max_Data = 0x0FFF */
+
+} IWDG_InitTypeDef;
+
+/** 
+  * @brief  IWDG Handle Structure definition  
+  */
+typedef struct
+{
+  IWDG_TypeDef                 *Instance;  /*!< Register base address    */
+
+  IWDG_InitTypeDef             Init;       /*!< IWDG required parameters */
+
+  HAL_LockTypeDef              Lock;      /*!< IWDG Locking object      */
+
+  __IO HAL_IWDG_StateTypeDef   State;      /*!< IWDG communication state */
+
+}IWDG_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup IWDG_Exported_Constants IWDG Exported Constants
+  * @{
+  */
+
+/** @defgroup IWDG_Registers_BitMask IWDG_Registers_BitMask
+  * @brief IWDG registers bit mask
+  * @{
+  */
+/* --- KR Register ---*/
+/* KR register bit mask */
+#define KR_KEY_RELOAD           ((uint32_t)0xAAAA)  /*!< IWDG Reload Counter Enable   */
+#define KR_KEY_ENABLE           ((uint32_t)0xCCCC)  /*!< IWDG Peripheral Enable       */
+#define KR_KEY_EWA              ((uint32_t)0x5555)  /*!< IWDG KR Write Access Enable  */
+#define KR_KEY_DWA              ((uint32_t)0x0000)  /*!< IWDG KR Write Access Disable */
+
+#define IS_IWDG_KR(__KR__) (((__KR__) == KR_KEY_RELOAD) || \
+                            ((__KR__) == KR_KEY_ENABLE))|| \
+                            ((__KR__) == KR_KEY_EWA))   || \
+                            ((__KR__) == KR_KEY_DWA))
+/**
+  * @}
+  */
+
+/** @defgroup IWDG_Flag_definition IWDG_Flag_definition
+  * @{
+  */
+#define IWDG_FLAG_PVU   ((uint32_t)IWDG_SR_PVU)  /*!< Watchdog counter prescaler value update flag */
+#define IWDG_FLAG_RVU   ((uint32_t)IWDG_SR_RVU)  /*!< Watchdog counter reload value update flag    */
+#define IWDG_FLAG_WVU   ((uint32_t)IWDG_SR_WVU)  /*!< Watchdog counter window value update Flag    */
+
+#define IS_IWDG_FLAG(FLAG) (((FLAG) == IWDG_FLAG_PVU) || \
+                            ((FLAG) == IWDG_FLAG_RVU) || \
+                            ((FLAG) == IWDG_FLAG_WVU))
+
+/**
+  * @}
+  */
+
+/** @defgroup IWDG_Prescaler IWDG_Prescaler
+  * @{
+  */
+#define IWDG_PRESCALER_4     ((uint8_t)0x00)  /*!< IWDG prescaler set to 4   */
+#define IWDG_PRESCALER_8     ((uint8_t)(IWDG_PR_PR_0))                  /*!< IWDG prescaler set to 8   */
+#define IWDG_PRESCALER_16    ((uint8_t)(IWDG_PR_PR_1))                  /*!< IWDG prescaler set to 16  */
+#define IWDG_PRESCALER_32    ((uint8_t)(IWDG_PR_PR_1 | IWDG_PR_PR_0))   /*!< IWDG prescaler set to 32  */
+#define IWDG_PRESCALER_64    ((uint8_t)(IWDG_PR_PR_2))                  /*!< IWDG prescaler set to 64  */
+#define IWDG_PRESCALER_128   ((uint8_t)(IWDG_PR_PR_2 | IWDG_PR_PR_0))   /*!< IWDG prescaler set to 128 */
+#define IWDG_PRESCALER_256   ((uint8_t)(IWDG_PR_PR_2 | IWDG_PR_PR_1))   /*!< IWDG prescaler set to 256 */
+
+#define IS_IWDG_PRESCALER(__PRESCALER__) (((__PRESCALER__) == IWDG_PRESCALER_4)  || \
+                                          ((__PRESCALER__) == IWDG_PRESCALER_8)  || \
+                                          ((__PRESCALER__) == IWDG_PRESCALER_16) || \
+                                          ((__PRESCALER__) == IWDG_PRESCALER_32) || \
+                                          ((__PRESCALER__) == IWDG_PRESCALER_64) || \
+                                          ((__PRESCALER__) == IWDG_PRESCALER_128)|| \
+                                          ((__PRESCALER__) == IWDG_PRESCALER_256))
+
+/**
+  * @}
+  */
+
+/** @defgroup IWDG_Reload_Value IWDG_Reload_Value
+  * @{
+  */
+#define IS_IWDG_RELOAD(__RELOAD__) ((__RELOAD__) <= 0xFFF)
+
+/**
+  * @}
+  */
+
+/** @defgroup IWDG_CounterWindow_Value
+  * @{
+  */
+#define IS_IWDG_WINDOW(VALUE) ((VALUE) <= 0xFFF)
+
+/**
+  * @}
+  */
+
+/** @defgroup IWDG_Window
+  * @{
+  */
+
+#define IWDG_WINDOW_DISABLE    0xFFF
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup IWDG_Exported_Macro
+  * @{
+  */
+
+/** @brief Reset IWDG handle state
+  * @param  __HANDLE__: IWDG handle
+  * @retval None
+  */
+#define __HAL_IWDG_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_IWDG_STATE_RESET)
+
+/**
+  * @brief  Enables the IWDG peripheral.
+  * @param  __HANDLE__: IWDG handle
+  * @retval None
+  */
+#define __HAL_IWDG_START(__HANDLE__) WRITE_REG((__HANDLE__)->Instance->KR, KR_KEY_ENABLE)
+
+/**
+  * @brief  Reloads IWDG counter with value defined in the reload register
+  *         (write access to IWDG_PR and IWDG_RLR registers disabled).
+  * @param  __HANDLE__: IWDG handle
+  * @retval None
+  */
+#define __HAL_IWDG_RELOAD_COUNTER(__HANDLE__) WRITE_REG((__HANDLE__)->Instance->KR, KR_KEY_RELOAD)
+
+/**
+  * @brief  Enables write access to IWDG_PR, IWDG_RLR and IWDG_WINR registers.
+  * @param  __HANDLE__: IWDG handle
+  * @retval None
+  */
+#define __HAL_IWDG_ENABLE_WRITE_ACCESS(__HANDLE__) WRITE_REG((__HANDLE__)->Instance->KR, KR_KEY_EWA)
+
+/**
+  * @brief  Disables write access to IWDG_PR, IWDG_RLR and IWDG_WINR registers.
+  * @param  __HANDLE__: IWDG handle
+  * @retval None
+  */
+#define __HAL_IWDG_DISABLE_WRITE_ACCESS(__HANDLE__) WRITE_REG((__HANDLE__)->Instance->KR, KR_KEY_DWA)
+
+/**
+  * @brief  Gets the selected IWDG's flag status.
+  * @param  __HANDLE__: IWDG handle
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg IWDG_FLAG_PVU:  Watchdog counter reload value update flag
+  *            @arg IWDG_FLAG_RVU:  Watchdog counter prescaler value flag
+  *            @arg IWDG_FLAG_WVU:  Watchdog counter window value flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE) .
+  */
+#define __HAL_IWDG_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR & (__FLAG__)) == (__FLAG__))
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup IWDG_Exported_Functions
+  * @{
+  */
+
+/* Initialization/de-initialization functions  ********************************/
+HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg);
+void HAL_IWDG_MspInit(IWDG_HandleTypeDef *hiwdg);
+
+/* I/O operation functions ****************************************************/
+HAL_StatusTypeDef HAL_IWDG_Start(IWDG_HandleTypeDef *hiwdg);
+HAL_StatusTypeDef HAL_IWDG_Refresh(IWDG_HandleTypeDef *hiwdg);
+
+/* Peripheral State functions  ************************************************/
+HAL_IWDG_StateTypeDef HAL_IWDG_GetState(IWDG_HandleTypeDef *hiwdg);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_IWDG_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_lcd.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_lcd.c
@@ -1,0 +1,577 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_lcd.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   LCD Controller HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the LCD Controller (LCD) peripheral:
+  *           + Initialization/de-initialization methods
+  *           + I/O operation methods
+  *           + Peripheral State methods
+  *           
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================   
+      [..] The LCD HAL driver can be used as follows:
+    
+      (#) Declare a LCD_HandleTypeDef handle structure.
+
+      (#) Initialize the LCD low level resources by implement the HAL_LCD_MspInit() API:
+          (##) Enable the LCDCLK (same as RTCCLK): to configure the RTCCLK/LCDCLK, proceed as follows:
+              (+) Enable the Power Controller (PWR) APB1 interface clock using the
+                 __PWR_CLK_ENABLE() macro.
+              (+) Enable access to RTC domain using the HAL_PWR_EnableBkUpAccess() function.
+              (+) Select the RTC clock source using the __HAL_RCC_RTC_CONFIG() function.    
+             
+      -@- The frequency generator allows you to achieve various LCD frame rates 
+            starting from an LCD input clock frequency (LCDCLK) which can vary 
+            from 32 kHz up to 1 MHz.
+          (##) LCD pins configuration:
+              (+) Enable the clock for the LCD GPIOs.
+              (+) Configure these LCD pins as alternate function no-pull.
+          (##) Enable the LCD interface clock.
+
+      (#) Program the Prescaler, Divider, Blink mode, Blink Frequency Duty, Bias,
+           Voltage Source, Dead Time, Pulse On Duration and Contrast in the hlcd Init structure.
+
+      (#) Initialize the LCD registers by calling the HAL_LCD_Init() API.
+
+      -@- The HAL_LCD_Init() API configures also the low level Hardware GPIO, CLOCK, ...etc)
+          by calling the custumed HAL_LCD_MspInit() API.
+      -@- After calling the HAL_LCD_Init() the LCD RAM memory is cleared
+
+      (#) Optionally you can update the LCD configuration using these macros:
+              (+) LCD High Drive using the __HAL_LCD_HIGHDRIVER_ENABLE() and __HAL_LCD_HIGHDRIVER_DISABLE() macros
+              (+) LCD Pulse ON Duration using the __HAL_LCD_PULSEONDURATION_CONFIG() macro
+              (+) LCD Dead Time using the __HAL_LCD_DEADTIME_CONFIG() macro  
+              (+) The LCD Blink mode and frequency using the __HAL_LCD_BLINK_CONFIG() macro
+              (+) The LCD Contrast using the __HAL_LCD_CONTRAST_CONFIG() macro  
+
+      (#) Write to the LCD RAM memory using the HAL_LCD_Write() API, this API can be called
+          more time to update the different LCD RAM registers before calling 
+          HAL_LCD_UpdateDisplayRequest() API.
+
+      (#) The HAL_LCD_Clear() API can be used to clear the LCD RAM memory.
+
+      (#) When LCD RAM memory is updated enable the update display request using
+          the HAL_LCD_UpdateDisplayRequest() API.
+
+      [..] LCD and low power modes:
+           (#) The LCD remain active during STOP mode.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup LCD 
+  * @brief LCD HAL module driver
+  * @{
+  */
+#ifdef HAL_LCD_MODULE_ENABLED
+#if !defined (STM32L051xx) && !defined (STM32L052xx) && !defined (STM32L062xx) && !defined (STM32L061xx)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define LCD_TIMEOUT_VALUE             1000
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup LCD_Private_Functions
+  * @{
+  */
+
+/** @defgroup LCD_Group1 Initialization/de-initialization methods 
+  *  @brief    Initialization and Configuration functions 
+  *
+@verbatim    
+===============================================================================
+            ##### Initialization and Configuration functions #####
+ ===============================================================================  
+    [..]
+
+@endverbatim
+  * @{
+  */
+ 
+/**
+  * @brief  DeInitializes the LCD peripheral. 
+  * @param  hlcd: LCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LCD_DeInit(LCD_HandleTypeDef *hlcd)
+{
+  /* Check the LCD handle allocation */
+  if(hlcd == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_LCD_ALL_INSTANCE(hlcd->Instance));
+
+  hlcd->State = HAL_LCD_STATE_BUSY;
+  
+  /* DeInit the low level hardware */
+  HAL_LCD_MspDeInit(hlcd);
+  
+  hlcd->ErrorCode = HAL_LCD_ERROR_NONE;
+  hlcd->State = HAL_LCD_STATE_RESET;
+    
+  /* Release Lock */
+  __HAL_UNLOCK(hlcd);
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Initializes the LCD peripheral according to the specified parameters 
+  *         in the LCD_InitStruct.
+  * @note   This function can be used only when the LCD is disabled.  
+  * @param  hlcd: LCD handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_LCD_Init(LCD_HandleTypeDef *hlcd)
+{
+  uint32_t tickstart = 0x00;
+  uint8_t counter = 0;
+    
+  /* Check the LCD handle allocation */
+  if(hlcd == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check function parameters */
+  assert_param(IS_LCD_ALL_INSTANCE(hlcd->Instance));
+  assert_param(IS_LCD_PRESCALER(hlcd->Init.Prescaler));
+  assert_param(IS_LCD_DIVIDER(hlcd->Init.Divider));
+  assert_param(IS_LCD_DUTY(hlcd->Init.Duty));
+  assert_param(IS_LCD_BIAS(hlcd->Init.Bias));  
+  assert_param(IS_LCD_VOLTAGE_SOURCE(hlcd->Init.VoltageSource));
+  assert_param(IS_LCD_PULSE_ON_DURATION(hlcd->Init.PulseOnDuration));
+  assert_param(IS_LCD_DEAD_TIME(hlcd->Init.DeadTime));
+  assert_param(IS_LCD_CONTRAST(hlcd->Init.Contrast)); 
+  assert_param(IS_LCD_BLINK_FREQUENCY(hlcd->Init.BlinkFrequency)); 
+  assert_param(IS_LCD_BLINK_MODE(hlcd->Init.BlinkMode)); 
+  
+  
+  if(hlcd->State == HAL_LCD_STATE_RESET)
+  {
+    /* Initialize the low level hardware (MSP) */
+    HAL_LCD_MspInit(hlcd);
+  }
+  
+  hlcd->State = HAL_LCD_STATE_BUSY;
+  
+  /* Disable the peripheral */
+  __HAL_LCD_DISABLE(hlcd);
+  
+  /* Clear the LCD_RAM registers and enable the display request by setting the UDR bit
+     in the LCD_SR register */
+  for(counter = LCD_RAM_REGISTER0; counter <= LCD_RAM_REGISTER15; counter++)
+  {
+    hlcd->Instance->RAM[counter] = 0;
+  }
+  /* Enable the display request */
+  hlcd->Instance->SR |= LCD_SR_UDR;
+  
+  /* Configure the LCD Prescaler, Divider, Blink mode and Blink Frequency: 
+  Set PS[3:0] bits according to hlcd->Init.Prescaler value 
+     Set DIV[3:0] bits according to hlcd->Init.Divider value
+     Set BLINK[1:0] bits according to hlcd->Init.BlinkMode value
+     Set BLINKF[2:0] bits according to hlcd->Init.BlinkFrequency value
+     Set DEAD[2:0] bits according to hlcd->Init.DeadTime value
+     Set PON[2:0] bits according to hlcd->Init.PulseOnDuration value 
+     Set CC[2:0] bits according to hlcd->Init.Contrast value */  
+  hlcd->Instance->FCR = (uint32_t)(hlcd->Init.Prescaler | hlcd->Init.Divider | \
+                                   hlcd->Init.BlinkMode | hlcd->Init.BlinkFrequency | \
+                                   hlcd->Init.DeadTime | hlcd->Init.PulseOnDuration | \
+                                   hlcd->Init.Contrast);
+  /* Wait until LCD Frame Control Register Synchronization flag (FCRSF) is set in the LCD_SR register 
+     This bit is set by hardware each time the LCD_FCR register is updated in the LCDCLK
+     domain. It is cleared by hardware when writing to the LCD_FCR register.*/
+  LCD_WaitForSynchro(hlcd);
+  
+  /* Configure the LCD Duty, Bias, Voltage Source, Dead Time, Pulse On Duration and Contrast: 
+     Set DUTY[2:0] bits according to hlcd->Init.Duty value 
+     Set BIAS[1:0] bits according to hlcd->Init.Bias value
+     Set VSEL bits according to hlcd->Init.VoltageSource value */
+  hlcd->Instance->CR = (uint32_t)(hlcd->Init.Duty | hlcd->Init.Bias | \
+                                  hlcd->Init.VoltageSource);
+  
+  /* Enable the peripheral */
+  __HAL_LCD_ENABLE(hlcd);
+  
+  /* Get timeout */
+  tickstart = HAL_GetTick();
+      
+  /* Wait Until the LCD is enabled */
+  while((hlcd->Instance->SR & LCD_FLAG_ENS) == (uint32_t)RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > LCD_TIMEOUT_VALUE)
+    { 
+      hlcd->ErrorCode = HAL_LCD_ERROR_ENS;     
+      return HAL_TIMEOUT;
+    } 
+  }
+  
+  /* Get timeout */
+  tickstart = HAL_GetTick();
+  
+  /*!< Wait Until the LCD Booster is ready */
+  while((hlcd->Instance->SR & LCD_FLAG_RDY) == (uint32_t)RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > LCD_TIMEOUT_VALUE)
+    {   
+      hlcd->ErrorCode = HAL_LCD_ERROR_RDY;  
+      return HAL_TIMEOUT;
+    } 
+  }
+ 
+  /* Initialize the LCD state */
+  hlcd->ErrorCode = HAL_LCD_ERROR_NONE;
+  hlcd->State= HAL_LCD_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  LCD MSP DeInit.
+  * @param  hlcd: LCD handle
+  * @retval None
+  */
+ __weak void HAL_LCD_MspDeInit(LCD_HandleTypeDef *hlcd)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_LCD_MspDeInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  LCD MSP Init.
+  * @param  hlcd: LCD handle
+  * @retval None
+  */
+ __weak void HAL_LCD_MspInit(LCD_HandleTypeDef *hlcd)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_LCD_MspInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup LCD_Group2 IO operation methods 
+  *  @brief LCD RAM functions 
+  *
+@verbatim   
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================  
+ [..] Using its double buffer memory the LCD controller ensures the coherency of the 
+ displayed information without having to use interrupts to control LCD_RAM 
+ modification.
+ The application software can access the first buffer level (LCD_RAM) through 
+ the APB interface. Once it has modified the LCD_RAM using the HAL_LCD_Write() API,
+ it sets the UDR flag in the LCD_SR register using the HAL_LCD_UpdateDisplayRequest() API.
+ This UDR flag (update display request) requests the updated information to be 
+ moved into the second buffer level (LCD_DISPLAY).
+ This operation is done synchronously with the frame (at the beginning of the 
+ next frame), until the update is completed, the LCD_RAM is write protected and 
+ the UDR flag stays high.
+ Once the update is completed another flag (UDD - Update Display Done) is set and
+ generates an interrupt if the UDDIE bit in the LCD_FCR register is set.
+ The time it takes to update LCD_DISPLAY is, in the worst case, one odd and one 
+ even frame.
+ The update will not occur (UDR = 1 and UDD = 0) until the display is 
+ enabled (LCDEN = 1).
+      
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Writes a word in the specific LCD RAM.
+  * @param  hlcd: LCD handle
+  * @param  RAMRegisterIndex: specifies the LCD RAM Register.
+  *   This parameter can be one of the following values:
+  *     @arg LCD_RAM_REGISTER0: LCD RAM Register 0
+  *     @arg LCD_RAM_REGISTER1: LCD RAM Register 1
+  *     @arg LCD_RAM_REGISTER2: LCD RAM Register 2
+  *     @arg LCD_RAM_REGISTER3: LCD RAM Register 3
+  *     @arg LCD_RAM_REGISTER4: LCD RAM Register 4
+  *     @arg LCD_RAM_REGISTER5: LCD RAM Register 5
+  *     @arg LCD_RAM_REGISTER6: LCD RAM Register 6 
+  *     @arg LCD_RAM_REGISTER7: LCD RAM Register 7  
+  *     @arg LCD_RAM_REGISTER8: LCD RAM Register 8
+  *     @arg LCD_RAM_REGISTER9: LCD RAM Register 9
+  *     @arg LCD_RAM_REGISTER10: LCD RAM Register 10
+  *     @arg LCD_RAM_REGISTER11: LCD RAM Register 11
+  *     @arg LCD_RAM_REGISTER12: LCD RAM Register 12 
+  *     @arg LCD_RAM_REGISTER13: LCD RAM Register 13 
+  *     @arg LCD_RAM_REGISTER14: LCD RAM Register 14 
+  *     @arg LCD_RAM_REGISTER15: LCD RAM Register 15
+  * @param  RAMRegisterMask: specifies the LCD RAM Register Data Mask.
+  * @param  Data: specifies LCD Data Value to be written.
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_LCD_Write(LCD_HandleTypeDef *hlcd, uint32_t RAMRegisterIndex, uint32_t RAMRegisterMask, uint32_t Data)
+{
+  uint32_t tickstart = 0x00; 
+  
+  if((hlcd->State == HAL_LCD_STATE_READY) || (hlcd->State == HAL_LCD_STATE_BUSY))
+  {
+    /* Check the parameters */
+    assert_param(IS_LCD_RAM_REGISTER(RAMRegisterIndex));
+    
+    if(hlcd->State == HAL_LCD_STATE_READY)
+    {
+      /* Process Locked */
+      __HAL_LOCK(hlcd);
+      hlcd->State = HAL_LCD_STATE_BUSY;
+      
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      /*!< Wait Until the LCD is ready */
+      while((hlcd->Instance->SR & LCD_FLAG_UDR) != (uint32_t)RESET)
+      {
+        if((HAL_GetTick() - tickstart) > LCD_TIMEOUT_VALUE)
+        { 
+          hlcd->ErrorCode = HAL_LCD_ERROR_UDR;      
+          return HAL_TIMEOUT;
+        } 
+      }
+    }
+    
+    /* Clear the data bytes position into LCD RAM register */
+    hlcd->Instance->RAM[RAMRegisterIndex] &= (uint32_t)RAMRegisterMask;
+    
+    /* Copy the new Data bytes to LCD RAM register */
+    hlcd->Instance->RAM[RAMRegisterIndex] |= (uint32_t)Data;
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief Clears the LCD RAM registers.
+  * @param hlcd: LCD handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_LCD_Clear(LCD_HandleTypeDef *hlcd)
+{
+  uint32_t tickstart = 0x00; 
+  uint32_t counter = 0;
+
+  if((hlcd->State == HAL_LCD_STATE_READY) || (hlcd->State == HAL_LCD_STATE_BUSY))
+  {
+    /* Process Locked */
+    __HAL_LOCK(hlcd);
+    
+    hlcd->State = HAL_LCD_STATE_BUSY;
+    
+    /* Get timeout */
+    tickstart = HAL_GetTick();
+    
+    /*!< Wait Until the LCD is ready */
+    while((hlcd->Instance->SR & LCD_FLAG_UDR) != (uint32_t)RESET)
+    {
+      if( (HAL_GetTick() - tickstart) > LCD_TIMEOUT_VALUE)
+      { 
+        hlcd->ErrorCode = HAL_LCD_ERROR_UDR;      
+        return HAL_TIMEOUT;
+      } 
+    }
+    /* Clear the LCD_RAM registers */
+    for(counter = LCD_RAM_REGISTER0; counter <= LCD_RAM_REGISTER15; counter++)
+    {
+      hlcd->Instance->RAM[counter] = 0;
+    }
+    
+    /* Update the LCD display */
+    HAL_LCD_UpdateDisplayRequest(hlcd);     
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Enables the Update Display Request.
+  * @param  hlcd: LCD handle
+  * @note   Each time software modifies the LCD_RAM it must set the UDR bit to 
+  *         transfer the updated data to the second level buffer. 
+  *         The UDR bit stays set until the end of the update and during this 
+  *         time the LCD_RAM is write protected. 
+  * @note   When the display is disabled, the update is performed for all 
+  *         LCD_DISPLAY locations.
+  *         When the display is enabled, the update is performed only for locations 
+  *         for which commons are active (depending on DUTY). For example if 
+  *         DUTY = 1/2, only the LCD_DISPLAY of COM0 and COM1 will be updated.    
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_LCD_UpdateDisplayRequest(LCD_HandleTypeDef *hlcd)
+{
+  uint32_t tickstart = 0x00;
+  
+  /* Clear the Update Display Done flag before starting the update display request */
+  __HAL_LCD_CLEAR_FLAG(hlcd, LCD_FLAG_UDD);
+  
+  /* Enable the display request */
+  hlcd->Instance->SR |= LCD_SR_UDR;
+  
+  /* Get timeout */
+  tickstart = HAL_GetTick();
+  
+  /*!< Wait Until the LCD display is done */
+  while((hlcd->Instance->SR & LCD_FLAG_UDD) == (uint32_t)RESET)
+  {
+    if( (HAL_GetTick() - tickstart) > LCD_TIMEOUT_VALUE)
+    { 
+      hlcd->ErrorCode = HAL_LCD_ERROR_UDD;      
+      return HAL_TIMEOUT;
+    } 
+  }
+
+  hlcd->State = HAL_LCD_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hlcd);
+  
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup LCD_Group3 Peripheral State methods 
+  *  @brief   LCD State functions 
+  *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================  
+    [..]
+     This subsection provides a set of functions allowing to control the LCD:
+      (+) HAL_LCD_GetState() API can be helpful to check in run-time the state of the LCD peripheral State. 
+      (+) HAL_LCD_GetError() API to return the LCD error code. 
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Returns the LCD state.
+  * @param hlcd: LCD handle
+  * @retval HAL state
+  */
+HAL_LCD_StateTypeDef HAL_LCD_GetState(LCD_HandleTypeDef *hlcd)
+{
+  return hlcd->State;
+}
+
+/**
+  * @brief Return the LCD error code
+  * @param hlcd: LCD handle
+  * @retval LCD Error Code
+  */
+uint32_t HAL_LCD_GetError(LCD_HandleTypeDef *hlcd)
+{
+  return hlcd->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  Waits until the LCD FCR register is synchronized in the LCDCLK domain.
+  *   This function must be called after any write operation to LCD_FCR register.
+  * @param  None
+  * @retval None
+  */
+HAL_StatusTypeDef LCD_WaitForSynchro(LCD_HandleTypeDef *hlcd)
+{
+  uint32_t tickstart = 0x00; 
+  
+  /* Get timeout */
+  tickstart = HAL_GetTick();
+
+  /* Loop until FCRSF flag is set */
+  while((hlcd->Instance->SR & LCD_FLAG_FCRSF) == (uint32_t)RESET)
+  {
+    if((HAL_GetTick() - tickstart) > LCD_TIMEOUT_VALUE)
+    {       
+      hlcd->ErrorCode = HAL_LCD_ERROR_FCRSF;
+      return HAL_TIMEOUT;
+    } 
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+#endif /* STM32L051xx && STM32L052xx && STM32L062xx && STM32L061xx*/
+#endif /* HAL_LCD_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_lcd.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_lcd.h
@@ -1,0 +1,707 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_lcd.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of LCD Controller HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_LCD_H
+#define __STM32L0xx_HAL_LCD_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !defined (STM32L051xx) && !defined (STM32L052xx) && !defined (STM32L062xx) && !defined (STM32L061xx) 
+   
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup LCD
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+
+/** 
+  * @brief LCD Init structure definition
+  */
+
+typedef struct
+{
+  uint32_t Prescaler;       /*!< Configures the LCD Prescaler. 
+                                 This parameter can be one value of @ref LCD_Prescaler */
+  uint32_t Divider;         /*!< Configures the LCD Divider.
+                                 This parameter can be one value of @ref LCD_Divider */
+  uint32_t Duty;            /*!< Configures the LCD Duty.
+                                 This parameter can be one value of @ref LCD_Duty */
+  uint32_t Bias;            /*!< Configures the LCD Bias.
+                                 This parameter can be one value of @ref LCD_Bias */ 
+  uint32_t VoltageSource;   /*!< Selects the LCD Voltage source.
+                                 This parameter can be one value of @ref LCD_Voltage_Source */  
+  uint32_t Contrast;        /*!< Configures the LCD Contrast.
+                                 This parameter can be one value of @ref LCD_Contrast */
+  uint32_t DeadTime;        /*!< Configures the LCD Dead Time.
+                                 This parameter can be one value of @ref LCD_DeadTime */
+  uint32_t PulseOnDuration; /*!< Configures the LCD Pulse On Duration.
+                                 This parameter can be one value of @ref LCD_PulseOnDuration */
+  uint32_t HighDrive;       /*!< Enable or disable the low resistance divider.
+                                 This parameter can be set to ENABLE or DISABLE. */ 
+  uint32_t BlinkMode;       /*!< Configures the LCD Blink Mode.
+                                 This parameter can be one value of @ref LCD_BlinkMode */
+  uint32_t BlinkFrequency;  /*!< Configures the LCD Blink frequency.
+                                 This parameter can be one value of @ref LCD_BlinkFrequency */
+}LCD_InitTypeDef;
+
+/** 
+  * @brief HAL LCD State structures definition
+  */ 
+typedef enum
+{
+  HAL_LCD_STATE_RESET             = 0x00,    /*!< Peripheral is not yet Initialized */
+  HAL_LCD_STATE_READY             = 0x01,    /*!< Peripheral Initialized and ready for use */
+  HAL_LCD_STATE_BUSY              = 0x02,    /*!< an internal process is ongoing */
+  HAL_LCD_STATE_TIMEOUT           = 0x03,    /*!< Timeout state */
+  HAL_LCD_STATE_ERROR             = 0x04     /*!< Error */
+}HAL_LCD_StateTypeDef;
+
+/** 
+  * @brief  HAL LCD Error Code structure definition
+  */ 
+typedef enum
+{
+  HAL_LCD_ERROR_NONE      = 0x00,    /*!< No error */
+  HAL_LCD_ERROR_FCRSF     = 0x01,    /*!< Synchro flag timeout error */
+  HAL_LCD_ERROR_UDR       = 0x02,    /*!< Update display request flag timeout error */
+  HAL_LCD_ERROR_UDD       = 0x04,    /*!< Update display done flag timeout error */
+  HAL_LCD_ERROR_ENS       = 0x08,    /*!< LCD enabled status flag timeout error */
+  HAL_LCD_ERROR_RDY       = 0x10     /*!< LCD Booster ready timeout error */
+}HAL_LCD_ErrorTypeDef;
+
+/** 
+  * @brief  UART handle Structure definition
+  */  
+typedef struct
+{
+  LCD_TypeDef            *Instance;          /* LCD registers base address */
+  
+  LCD_InitTypeDef         Init;              /* LCD communication parameters */
+
+  HAL_LockTypeDef         Lock;              /* Locking object */
+
+  __IO HAL_LCD_StateTypeDef    State;        /* LCD communication state */
+  
+  __IO HAL_LCD_ErrorTypeDef    ErrorCode;         /* LCD Error code */
+  
+}LCD_HandleTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup LCD_Exported_Constants
+  * @{
+  */
+
+#define IS_LCD_ALL_INSTANCE(INSTANCE) ((INSTANCE) == LCD)
+
+/** @defgroup LCD_Prescaler
+  * @{
+  */
+
+#define LCD_PRESCALER_1        ((uint32_t)0x00000000)  /*!< CLKPS = LCDCLK        */
+#define LCD_PRESCALER_2        ((uint32_t)0x00400000)  /*!< CLKPS = LCDCLK/2      */
+#define LCD_PRESCALER_4        ((uint32_t)0x00800000)  /*!< CLKPS = LCDCLK/4      */
+#define LCD_PRESCALER_8        ((uint32_t)0x00C00000)  /*!< CLKPS = LCDCLK/8      */
+#define LCD_PRESCALER_16       ((uint32_t)0x01000000)  /*!< CLKPS = LCDCLK/16     */
+#define LCD_PRESCALER_32       ((uint32_t)0x01400000)  /*!< CLKPS = LCDCLK/32     */
+#define LCD_PRESCALER_64       ((uint32_t)0x01800000)  /*!< CLKPS = LCDCLK/64     */
+#define LCD_PRESCALER_128      ((uint32_t)0x01C00000)  /*!< CLKPS = LCDCLK/128    */
+#define LCD_PRESCALER_256      ((uint32_t)0x02000000)  /*!< CLKPS = LCDCLK/256    */
+#define LCD_PRESCALER_512      ((uint32_t)0x02400000)  /*!< CLKPS = LCDCLK/512    */
+#define LCD_PRESCALER_1024     ((uint32_t)0x02800000)  /*!< CLKPS = LCDCLK/1024   */
+#define LCD_PRESCALER_2048     ((uint32_t)0x02C00000)  /*!< CLKPS = LCDCLK/2048   */
+#define LCD_PRESCALER_4096     ((uint32_t)0x03000000)  /*!< CLKPS = LCDCLK/4096   */
+#define LCD_PRESCALER_8192     ((uint32_t)0x03400000)  /*!< CLKPS = LCDCLK/8192   */
+#define LCD_PRESCALER_16384    ((uint32_t)0x03800000)  /*!< CLKPS = LCDCLK/16384  */
+#define LCD_PRESCALER_32768    ((uint32_t)0x03C00000)  /*!< CLKPS = LCDCLK/32768  */
+
+#define IS_LCD_PRESCALER(PRESCALER)    (((PRESCALER) == LCD_PRESCALER_1) || \
+                                        ((PRESCALER) == LCD_PRESCALER_2) || \
+                                        ((PRESCALER) == LCD_PRESCALER_4) || \
+                                        ((PRESCALER) == LCD_PRESCALER_8) || \
+                                        ((PRESCALER) == LCD_PRESCALER_16) || \
+                                        ((PRESCALER) == LCD_PRESCALER_32) || \
+                                        ((PRESCALER) == LCD_PRESCALER_64) || \
+                                        ((PRESCALER) == LCD_PRESCALER_128) || \
+                                        ((PRESCALER) == LCD_PRESCALER_256) || \
+                                        ((PRESCALER) == LCD_PRESCALER_512) || \
+                                        ((PRESCALER) == LCD_PRESCALER_1024) || \
+                                        ((PRESCALER) == LCD_PRESCALER_2048) || \
+                                        ((PRESCALER) == LCD_PRESCALER_4096) || \
+                                        ((PRESCALER) == LCD_PRESCALER_8192) || \
+                                        ((PRESCALER) == LCD_PRESCALER_16384) || \
+                                        ((PRESCALER) == LCD_PRESCALER_32768))
+
+/**
+  * @}
+  */
+  
+/** @defgroup LCD_Divider
+  * @{
+  */
+
+#define LCD_DIVIDER_16    ((uint32_t)0x00000000)  /*!< LCD frequency = CLKPS/16 */
+#define LCD_DIVIDER_17    ((uint32_t)0x00040000)  /*!< LCD frequency = CLKPS/17 */
+#define LCD_DIVIDER_18    ((uint32_t)0x00080000)  /*!< LCD frequency = CLKPS/18 */
+#define LCD_DIVIDER_19    ((uint32_t)0x000C0000)  /*!< LCD frequency = CLKPS/19 */
+#define LCD_DIVIDER_20    ((uint32_t)0x00100000)  /*!< LCD frequency = CLKPS/20 */
+#define LCD_DIVIDER_21    ((uint32_t)0x00140000)  /*!< LCD frequency = CLKPS/21 */
+#define LCD_DIVIDER_22    ((uint32_t)0x00180000)  /*!< LCD frequency = CLKPS/22 */
+#define LCD_DIVIDER_23    ((uint32_t)0x001C0000)  /*!< LCD frequency = CLKPS/23 */
+#define LCD_DIVIDER_24    ((uint32_t)0x00200000)  /*!< LCD frequency = CLKPS/24 */
+#define LCD_DIVIDER_25    ((uint32_t)0x00240000)  /*!< LCD frequency = CLKPS/25 */
+#define LCD_DIVIDER_26    ((uint32_t)0x00280000)  /*!< LCD frequency = CLKPS/26 */
+#define LCD_DIVIDER_27    ((uint32_t)0x002C0000)  /*!< LCD frequency = CLKPS/27 */
+#define LCD_DIVIDER_28    ((uint32_t)0x00300000)  /*!< LCD frequency = CLKPS/28 */
+#define LCD_DIVIDER_29    ((uint32_t)0x00340000)  /*!< LCD frequency = CLKPS/29 */
+#define LCD_DIVIDER_30    ((uint32_t)0x00380000)  /*!< LCD frequency = CLKPS/30 */
+#define LCD_DIVIDER_31    ((uint32_t)0x003C0000)  /*!< LCD frequency = CLKPS/31 */
+
+#define IS_LCD_DIVIDER(DIVIDER)    (((DIVIDER) == LCD_DIVIDER_16) || \
+                                    ((DIVIDER) == LCD_DIVIDER_17) || \
+                                    ((DIVIDER) == LCD_DIVIDER_18) || \
+                                    ((DIVIDER) == LCD_DIVIDER_19) || \
+                                    ((DIVIDER) == LCD_DIVIDER_20) || \
+                                    ((DIVIDER) == LCD_DIVIDER_21) || \
+                                    ((DIVIDER) == LCD_DIVIDER_22) || \
+                                    ((DIVIDER) == LCD_DIVIDER_23) || \
+                                    ((DIVIDER) == LCD_DIVIDER_24) || \
+                                    ((DIVIDER) == LCD_DIVIDER_25) || \
+                                    ((DIVIDER) == LCD_DIVIDER_26) || \
+                                    ((DIVIDER) == LCD_DIVIDER_27) || \
+                                    ((DIVIDER) == LCD_DIVIDER_28) || \
+                                    ((DIVIDER) == LCD_DIVIDER_29) || \
+                                    ((DIVIDER) == LCD_DIVIDER_30) || \
+                                    ((DIVIDER) == LCD_DIVIDER_31))
+
+/**
+  * @}
+  */
+
+
+/** @defgroup LCD_Duty
+  * @{
+  */
+  
+#define LCD_DUTY_STATIC                 ((uint32_t)0x00000000) /*!< Static duty */
+#define LCD_DUTY_1_2                    ((uint32_t)0x00000004) /*!< 1/2 duty    */
+#define LCD_DUTY_1_3                    ((uint32_t)0x00000008) /*!< 1/3 duty    */
+#define LCD_DUTY_1_4                    ((uint32_t)0x0000000C) /*!< 1/4 duty    */
+#define LCD_DUTY_1_8                    ((uint32_t)0x00000010) /*!< 1/4 duty    */
+
+#define IS_LCD_DUTY(DUTY) (((DUTY) == LCD_DUTY_STATIC) || \
+                           ((DUTY) == LCD_DUTY_1_2) || \
+                           ((DUTY) == LCD_DUTY_1_3) || \
+                           ((DUTY) == LCD_DUTY_1_4) || \
+                           ((DUTY) == LCD_DUTY_1_8))
+
+/**
+  * @}
+  */ 
+  
+
+/** @defgroup LCD_Bias
+  * @{
+  */
+  
+#define LCD_BIAS_1_4                    ((uint32_t)0x00000000)  /*!< 1/4 Bias */
+#define LCD_BIAS_1_2                    LCD_CR_BIAS_0           /*!< 1/2 Bias */
+#define LCD_BIAS_1_3                    LCD_CR_BIAS_1           /*!< 1/3 Bias */
+
+#define IS_LCD_BIAS(BIAS) (((BIAS) == LCD_BIAS_1_4) || \
+                           ((BIAS) == LCD_BIAS_1_2) || \
+                           ((BIAS) == LCD_BIAS_1_3))
+/**
+  * @}
+  */ 
+    
+/** @defgroup LCD_Voltage_Source
+  * @{
+  */
+  
+#define LCD_VOLTAGESOURCE_INTERNAL      ((uint32_t)0x00000000)  /*!< Internal voltage source for the LCD */
+#define LCD_VOLTAGESOURCE_EXTERNAL      LCD_CR_VSEL             /*!< External voltage source for the LCD */
+
+#define IS_LCD_VOLTAGE_SOURCE(SOURCE) (((SOURCE) == LCD_VOLTAGESOURCE_INTERNAL) || \
+                                       ((SOURCE) == LCD_VOLTAGESOURCE_EXTERNAL))
+
+/**
+  * @}
+  */  
+
+/** @defgroup LCD_Interrupts
+  * @{
+  */
+#define LCD_IT_SOF                      LCD_FCR_SOFIE
+#define LCD_IT_UDD                      LCD_FCR_UDDIE
+
+#define IS_LCD_IT(IT) ((((IT) & (uint32_t)0xFFFFFFF5) == 0x00) && ((IT) != 0x00))
+
+#define IS_LCD_GET_IT(IT) (((IT) == LCD_IT_SOF) || ((IT) == LCD_IT_UDD))
+ 
+/**
+  * @}
+  */
+
+/** @defgroup LCD_PulseOnDuration
+  * @{
+  */
+
+#define LCD_PULSEONDURATION_0           ((uint32_t)0x00000000) /*!< Pulse ON duration = 0 pulse   */
+#define LCD_PULSEONDURATION_1           ((uint32_t)0x00000010) /*!< Pulse ON duration = 1/CK_PS  */
+#define LCD_PULSEONDURATION_2           ((uint32_t)0x00000020) /*!< Pulse ON duration = 2/CK_PS  */
+#define LCD_PULSEONDURATION_3           ((uint32_t)0x00000030) /*!< Pulse ON duration = 3/CK_PS  */
+#define LCD_PULSEONDURATION_4           ((uint32_t)0x00000040) /*!< Pulse ON duration = 4/CK_PS  */
+#define LCD_PULSEONDURATION_5           ((uint32_t)0x00000050) /*!< Pulse ON duration = 5/CK_PS  */
+#define LCD_PULSEONDURATION_6           ((uint32_t)0x00000060) /*!< Pulse ON duration = 6/CK_PS  */
+#define LCD_PULSEONDURATION_7           ((uint32_t)0x00000070) /*!< Pulse ON duration = 7/CK_PS  */
+
+#define IS_LCD_PULSE_ON_DURATION(DURATION) (((DURATION) == LCD_PULSEONDURATION_0) || \
+                                            ((DURATION) == LCD_PULSEONDURATION_1) || \
+                                            ((DURATION) == LCD_PULSEONDURATION_2) || \
+                                            ((DURATION) == LCD_PULSEONDURATION_3) || \
+                                            ((DURATION) == LCD_PULSEONDURATION_4) || \
+                                            ((DURATION) == LCD_PULSEONDURATION_5) || \
+                                            ((DURATION) == LCD_PULSEONDURATION_6) || \
+                                            ((DURATION) == LCD_PULSEONDURATION_7))
+/**
+  * @}
+  */
+
+
+/** @defgroup LCD_DeadTime
+  * @{
+  */
+
+#define LCD_DEADTIME_0                  ((uint32_t)0x00000000) /*!< No dead Time  */
+#define LCD_DEADTIME_1                  ((uint32_t)0x00000080) /*!< One Phase between different couple of Frame   */
+#define LCD_DEADTIME_2                  ((uint32_t)0x00000100) /*!< Two Phase between different couple of Frame   */
+#define LCD_DEADTIME_3                  ((uint32_t)0x00000180) /*!< Three Phase between different couple of Frame */
+#define LCD_DEADTIME_4                  ((uint32_t)0x00000200) /*!< Four Phase between different couple of Frame  */
+#define LCD_DEADTIME_5                  ((uint32_t)0x00000280) /*!< Five Phase between different couple of Frame  */
+#define LCD_DEADTIME_6                  ((uint32_t)0x00000300) /*!< Six Phase between different couple of Frame   */
+#define LCD_DEADTIME_7                  ((uint32_t)0x00000380) /*!< Seven Phase between different couple of Frame */
+
+#define IS_LCD_DEAD_TIME(TIME) (((TIME) == LCD_DEADTIME_0) || \
+                                ((TIME) == LCD_DEADTIME_1) || \
+                                ((TIME) == LCD_DEADTIME_2) || \
+                                ((TIME) == LCD_DEADTIME_3) || \
+                                ((TIME) == LCD_DEADTIME_4) || \
+                                ((TIME) == LCD_DEADTIME_5) || \
+                                ((TIME) == LCD_DEADTIME_6) || \
+                                ((TIME) == LCD_DEADTIME_7))
+/**
+  * @}
+  */
+
+/** @defgroup LCD_BlinkMode
+  * @{
+  */
+
+#define LCD_BLINKMODE_OFF               ((uint32_t)0x00000000) /*!< Blink disabled            */
+#define LCD_BLINKMODE_SEG0_COM0         ((uint32_t)0x00010000) /*!< Blink enabled on SEG[0], COM[0] (1 pixel)   */
+#define LCD_BLINKMODE_SEG0_ALLCOM       ((uint32_t)0x00020000) /*!< Blink enabled on SEG[0], all COM (up to 
+                                                                    8 pixels according to the programmed duty)  */
+#define LCD_BLINKMODE_ALLSEG_ALLCOM     ((uint32_t)0x00030000) /*!< Blink enabled on all SEG and all COM (all pixels)  */
+
+#define IS_LCD_BLINK_MODE(MODE) (((MODE) == LCD_BLINKMODE_OFF) || \
+                                 ((MODE) == LCD_BLINKMODE_SEG0_COM0) || \
+                                 ((MODE) == LCD_BLINKMODE_SEG0_ALLCOM) || \
+                                 ((MODE) == LCD_BLINKMODE_ALLSEG_ALLCOM))
+/**
+  * @}
+  */    
+
+/** @defgroup LCD_BlinkFrequency
+  * @{
+  */
+
+#define LCD_BLINKFREQUENCY_DIV8         ((uint32_t)0x00000000) /*!< The Blink frequency = fLCD/8    */
+#define LCD_BLINKFREQUENCY_DIV16        ((uint32_t)0x00002000) /*!< The Blink frequency = fLCD/16   */
+#define LCD_BLINKFREQUENCY_DIV32        ((uint32_t)0x00004000) /*!< The Blink frequency = fLCD/32   */
+#define LCD_BLINKFREQUENCY_DIV64        ((uint32_t)0x00006000) /*!< The Blink frequency = fLCD/64   */
+#define LCD_BLINKFREQUENCY_DIV128       ((uint32_t)0x00008000) /*!< The Blink frequency = fLCD/128  */
+#define LCD_BLINKFREQUENCY_DIV256       ((uint32_t)0x0000A000) /*!< The Blink frequency = fLCD/256  */
+#define LCD_BLINKFREQUENCY_DIV512       ((uint32_t)0x0000C000) /*!< The Blink frequency = fLCD/512  */
+#define LCD_BLINKFREQUENCY_DIV1024      ((uint32_t)0x0000E000) /*!< The Blink frequency = fLCD/1024 */
+
+#define IS_LCD_BLINK_FREQUENCY(FREQUENCY) (((FREQUENCY) == LCD_BLINKFREQUENCY_DIV8) || \
+                                           ((FREQUENCY) == LCD_BLINKFREQUENCY_DIV16) || \
+                                           ((FREQUENCY) == LCD_BLINKFREQUENCY_DIV32) || \
+                                           ((FREQUENCY) == LCD_BLINKFREQUENCY_DIV64) || \
+                                           ((FREQUENCY) == LCD_BLINKFREQUENCY_DIV128) || \
+                                           ((FREQUENCY) == LCD_BLINKFREQUENCY_DIV256) || \
+                                           ((FREQUENCY) == LCD_BLINKFREQUENCY_DIV512) || \
+                                           ((FREQUENCY) == LCD_BLINKFREQUENCY_DIV1024))
+/**
+  * @}
+  */
+
+/** @defgroup LCD_Contrast
+  * @{
+  */
+
+#define LCD_CONTRASTLEVEL_0               ((uint32_t)0x00000000) /*!< Maximum Voltage = 2.60V    */
+#define LCD_CONTRASTLEVEL_1               ((uint32_t)0x00000400) /*!< Maximum Voltage = 2.73V    */
+#define LCD_CONTRASTLEVEL_2               ((uint32_t)0x00000800) /*!< Maximum Voltage = 2.86V    */
+#define LCD_CONTRASTLEVEL_3               ((uint32_t)0x00000C00) /*!< Maximum Voltage = 2.99V    */
+#define LCD_CONTRASTLEVEL_4               ((uint32_t)0x00001000) /*!< Maximum Voltage = 3.12V    */
+#define LCD_CONTRASTLEVEL_5               ((uint32_t)0x00001400) /*!< Maximum Voltage = 3.25V    */
+#define LCD_CONTRASTLEVEL_6               ((uint32_t)0x00001800) /*!< Maximum Voltage = 3.38V    */
+#define LCD_CONTRASTLEVEL_7               ((uint32_t)0x00001C00) /*!< Maximum Voltage = 3.51V    */
+
+#define IS_LCD_CONTRAST(CONTRAST) (((CONTRAST) == LCD_CONTRASTLEVEL_0) || \
+                                   ((CONTRAST) == LCD_CONTRASTLEVEL_1) || \
+                                   ((CONTRAST) == LCD_CONTRASTLEVEL_2) || \
+                                   ((CONTRAST) == LCD_CONTRASTLEVEL_3) || \
+                                   ((CONTRAST) == LCD_CONTRASTLEVEL_4) || \
+                                   ((CONTRAST) == LCD_CONTRASTLEVEL_5) || \
+                                   ((CONTRAST) == LCD_CONTRASTLEVEL_6) || \
+                                   ((CONTRAST) == LCD_CONTRASTLEVEL_7))
+/**
+  * @}
+  */
+      
+/** @defgroup LCD_Flag
+  * @{
+  */
+
+#define LCD_FLAG_ENS                    LCD_SR_ENS
+#define LCD_FLAG_SOF                    LCD_SR_SOF
+#define LCD_FLAG_UDR                    LCD_SR_UDR
+#define LCD_FLAG_UDD                    LCD_SR_UDD
+#define LCD_FLAG_RDY                    LCD_SR_RDY
+#define LCD_FLAG_FCRSF                  LCD_SR_FCRSR
+
+#define IS_LCD_GET_FLAG(FLAG) (((FLAG) == LCD_FLAG_ENS) || ((FLAG) == LCD_FLAG_SOF) || \
+                               ((FLAG) == LCD_FLAG_UDR) || ((FLAG) == LCD_FLAG_UDD) || \
+                               ((FLAG) == LCD_FLAG_RDY) || ((FLAG) == LCD_FLAG_FCRSF))
+
+#define IS_LCD_CLEAR_FLAG(FLAG) ((((FLAG) & (uint32_t)0xFFFFFFF5) == 0x00) && ((FLAG) != 0x00))
+/**
+  * @}
+  */   
+
+/** @defgroup LCD_RAMRegister
+  * @{
+  */
+
+#define LCD_RAM_REGISTER0               ((uint32_t)0x00000000) /*!< LCD RAM Register 0  */
+#define LCD_RAM_REGISTER1               ((uint32_t)0x00000001) /*!< LCD RAM Register 1  */
+#define LCD_RAM_REGISTER2               ((uint32_t)0x00000002) /*!< LCD RAM Register 2  */
+#define LCD_RAM_REGISTER3               ((uint32_t)0x00000003) /*!< LCD RAM Register 3  */
+#define LCD_RAM_REGISTER4               ((uint32_t)0x00000004) /*!< LCD RAM Register 4  */
+#define LCD_RAM_REGISTER5               ((uint32_t)0x00000005) /*!< LCD RAM Register 5  */
+#define LCD_RAM_REGISTER6               ((uint32_t)0x00000006) /*!< LCD RAM Register 6  */
+#define LCD_RAM_REGISTER7               ((uint32_t)0x00000007) /*!< LCD RAM Register 7  */
+#define LCD_RAM_REGISTER8               ((uint32_t)0x00000008) /*!< LCD RAM Register 8  */
+#define LCD_RAM_REGISTER9               ((uint32_t)0x00000009) /*!< LCD RAM Register 9  */
+#define LCD_RAM_REGISTER10              ((uint32_t)0x0000000A) /*!< LCD RAM Register 10 */
+#define LCD_RAM_REGISTER11              ((uint32_t)0x0000000B) /*!< LCD RAM Register 11 */
+#define LCD_RAM_REGISTER12              ((uint32_t)0x0000000C) /*!< LCD RAM Register 12 */
+#define LCD_RAM_REGISTER13              ((uint32_t)0x0000000D) /*!< LCD RAM Register 13 */
+#define LCD_RAM_REGISTER14              ((uint32_t)0x0000000E) /*!< LCD RAM Register 14 */
+#define LCD_RAM_REGISTER15              ((uint32_t)0x0000000F) /*!< LCD RAM Register 15 */
+
+#define IS_LCD_RAM_REGISTER(REGISTER) (((REGISTER) == LCD_RAM_REGISTER0) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER1) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER2) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER3) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER4) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER5) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER6) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER7) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER8) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER9) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER10) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER11) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER12) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER13) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER14) || \
+                                       ((REGISTER) == LCD_RAM_REGISTER15))
+
+/**
+  * @}
+  */  
+   
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup LCD_Exported_Macros
+  * @{
+  */
+
+/** @brief Reset LCD handle state
+  * @param  __HANDLE__: specifies the LCD Handle.
+  * @retval None
+  */
+#define __HAL_LCD_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_LCD_STATE_RESET)
+
+/** @brief  macros to enables or disables the LCD
+  * @param  __HANDLE__: specifies the LCD Handle.  
+  * @retval None
+  */     
+#define __HAL_LCD_ENABLE(__HANDLE__)   ((__HANDLE__)->Instance->CR |= LCD_CR_LCDEN)
+#define __HAL_LCD_DISABLE(__HANDLE__)  ((__HANDLE__)->Instance->CR &= ~LCD_CR_LCDEN)
+
+/** @brief  Macros to enable or disable the low resistance divider. Displays with high 
+  *         internal resistance may need a longer drive time to achieve 
+  *         satisfactory contrast. This function is useful in this case if some 
+  *         additional power consumption can be tolerated.
+  * @param  __HANDLE__: specifies the LCD Handle.
+  * @note   When this mode is enabled, the PulseOn Duration (PON) have to be 
+  *         programmed to 1/CK_PS (LCD_PULSEONDURATION_1).
+  * @retval None
+  */
+#define __HAL_LCD_HIGHDRIVER_ENABLE(__HANDLE__)                                \
+                              do{                                              \
+                                  ((__HANDLE__)->Instance->FCR |= LCD_FCR_HD); \
+                                  LCD_WaitForSynchro(__HANDLE__);              \
+                                 }while(0)
+
+#define __HAL_LCD_HIGHDRIVER_DISABLE(__HANDLE__)                               \
+                              do{                                              \
+                                  ((__HANDLE__)->Instance->FCR &= ~LCD_FCR_HD); \
+                                  LCD_WaitForSynchro(__HANDLE__);              \
+                                 }while(0)
+/**
+  * @brief  Macro to configure the LCD pulses on duration.
+  * @param  __HANDLE__: specifies the LCD Handle.
+  * @param  __DURATION__: specifies the LCD pulse on duration in terms of 
+  *         CK_PS (prescaled LCD clock period) pulses.
+  *   This parameter can be one of the following values:
+  *     @arg LCD_PULSEONDURATION_0: 0 pulse
+  *     @arg LCD_PULSEONDURATION_1: Pulse ON duration = 1/CK_PS
+  *     @arg LCD_PULSEONDURATION_2: Pulse ON duration = 2/CK_PS
+  *     @arg LCD_PULSEONDURATION_3: Pulse ON duration = 3/CK_PS
+  *     @arg LCD_PULSEONDURATION_4: Pulse ON duration = 4/CK_PS
+  *     @arg LCD_PULSEONDURATION_5: Pulse ON duration = 5/CK_PS
+  *     @arg LCD_PULSEONDURATION_6: Pulse ON duration = 6/CK_PS
+  *     @arg LCD_PULSEONDURATION_7: Pulse ON duration = 7/CK_PS
+  * @retval None
+  */
+#define __HAL_LCD_PULSEONDURATION_CONFIG(__HANDLE__, __DURATION__)                \
+        do{                                                                       \
+            MODIFY_REG((__HANDLE__)->Instance->FCR, LCD_FCR_PON, (__DURATION__)); \
+            LCD_WaitForSynchro(__HANDLE__);                                       \
+           }while(0)
+
+/**
+  * @brief  Macro to configure the LCD dead time.
+  * @param  __HANDLE__: specifies the LCD Handle.
+  * @param  __DEADTIME__: specifies the LCD dead time.
+  *   This parameter can be one of the following values:
+  *     @arg LCD_DEADTIME_0: No dead Time
+  *     @arg LCD_DEADTIME_1: One Phase between different couple of Frame
+  *     @arg LCD_DEADTIME_2: Two Phase between different couple of Frame
+  *     @arg LCD_DEADTIME_3: Three Phase between different couple of Frame
+  *     @arg LCD_DEADTIME_4: Four Phase between different couple of Frame
+  *     @arg LCD_DEADTIME_5: Five Phase between different couple of Frame
+  *     @arg LCD_DEADTIME_6: Six Phase between different couple of Frame 
+  *     @arg LCD_DEADTIME_7: Seven Phase between different couple of Frame
+  * @retval None
+  */
+#define __HAL_LCD_DEADTIME_CONFIG(__HANDLE__, __DEADTIME__)                        \
+        do{                                                                        \
+            MODIFY_REG((__HANDLE__)->Instance->FCR, LCD_FCR_DEAD, (__DEADTIME__)); \
+            LCD_WaitForSynchro(__HANDLE__);                                        \
+           }while(0)
+
+/**
+  * @brief  Macro to configure the LCD Contrast.
+  * @param  __HANDLE__: specifies the LCD Handle.
+  * @param  __CONTRAST__: specifies the LCD Contrast.
+  *   This parameter can be one of the following values:
+  *     @arg LCD_CONTRASTLEVEL_0: Maximum Voltage = 2.60V
+  *     @arg LCD_CONTRASTLEVEL_1: Maximum Voltage = 2.73V
+  *     @arg LCD_CONTRASTLEVEL_2: Maximum Voltage = 2.86V
+  *     @arg LCD_CONTRASTLEVEL_3: Maximum Voltage = 2.99V
+  *     @arg LCD_CONTRASTLEVEL_4: Maximum Voltage = 3.12V
+  *     @arg LCD_CONTRASTLEVEL_5: Maximum Voltage = 3.25V
+  *     @arg LCD_CONTRASTLEVEL_6: Maximum Voltage = 3.38V
+  *     @arg LCD_CONTRASTLEVEL_7: Maximum Voltage = 3.51V
+  * @retval None
+  */
+#define __HAL_LCD_CONTRAST_CONFIG(__HANDLE__, __CONTRAST__)                       \
+        do{                                                                       \
+            MODIFY_REG((__HANDLE__)->Instance->FCR, LCD_FCR_CC, (__CONTRAST__));  \
+            LCD_WaitForSynchro(__HANDLE__);                                       \
+           } while(0) 
+/**
+  * @brief  Macro to configure the LCD Blink mode and Blink frequency.
+  * @param  __HANDLE__: specifies the LCD Handle.
+  * @param  __BLINKMODE__: specifies the LCD blink mode.
+  *   This parameter can be one of the following values:
+  *     @arg LCD_BLINKMODE_OFF:           Blink disabled
+  *     @arg LCD_BLINKMODE_SEG0_COM0:     Blink enabled on SEG[0], COM[0] (1 pixel)
+  *     @arg LCD_BLINKMODE_SEG0_ALLCOM:   Blink enabled on SEG[0], all COM (up to 8 
+  *                                       pixels according to the programmed duty)
+  *     @arg LCD_BLINKMODE_ALLSEG_ALLCOM: Blink enabled on all SEG and all COM 
+  *                                       (all pixels)
+  * @param  __BLINKFREQUENCY__: specifies the LCD blink frequency.
+  *     @arg LCD_BLINKFREQUENCY_DIV8:    The Blink frequency = fLcd/8
+  *     @arg LCD_BLINKFREQUENCY_DIV16:   The Blink frequency = fLcd/16
+  *     @arg LCD_BLINKFREQUENCY_DIV32:   The Blink frequency = fLcd/32
+  *     @arg LCD_BLINKFREQUENCY_DIV64:   The Blink frequency = fLcd/64 
+  *     @arg LCD_BLINKFREQUENCY_DIV128:  The Blink frequency = fLcd/128
+  *     @arg LCD_BLINKFREQUENCY_DIV256:  The Blink frequency = fLcd/256
+  *     @arg LCD_BLINKFREQUENCY_DIV512:  The Blink frequency = fLcd/512
+  *     @arg LCD_BLINKFREQUENCY_DIV1024: The Blink frequency = fLcd/1024
+  * @retval None
+  */
+#define __HAL_LCD_BLINK_CONFIG(__HANDLE__, __BLINKMODE__, __BLINKFREQUENCY__)  \
+        do{                                                                    \
+            MODIFY_REG((__HANDLE__)->Instance->FCR, (LCD_FCR_BLINKF | LCD_FCR_BLINK), ((__BLINKMODE__) | (__BLINKFREQUENCY__))); \
+            LCD_WaitForSynchro(__HANDLE__);                                    \
+          }while(0)
+
+/** @brief  Enables or disables the specified LCD interrupt.
+  * @param  __HANDLE__: specifies the LCD Handle.
+  * @param  __INTERRUPT__: specifies the LCD interrupt source to be enabled or disabled.
+  *          This parameter can be one of the following values:
+  *     @arg LCD_IT_SOF: Start of Frame Interrupt
+  *     @arg LCD_IT_UDD: Update Display Done Interrupt
+  * @retval None
+  */
+#define __HAL_LCD_ENABLE_IT(__HANDLE__, __INTERRUPT__)                         \
+                         do{                                                   \
+                             ((__HANDLE__)->Instance->FCR |= (__INTERRUPT__)); \
+                             LCD_WaitForSynchro(__HANDLE__);                   \
+                            }while(0)         
+#define __HAL_LCD_DISABLE_IT(__HANDLE__, __INTERRUPT__)                        \
+                         do{                                                   \
+                             ((__HANDLE__)->Instance->FCR &= ~(__INTERRUPT__));\
+                             LCD_WaitForSynchro(__HANDLE__);                   \
+                            }while(0)    
+/** @brief  Checks whether the specified LCD interrupt is enabled or not.
+  * @param  __HANDLE__: specifies the LCD Handle.
+  * @param  __IT__: specifies the LCD interrupt source to check.
+  *        This parameter can be one of the following values:
+  *        @arg LCD_IT_SOF: Start of Frame Interrupt
+  *        @arg LCD_IT_UDD: Update Display Done Interrupt.
+  * @note If the device is in STOP mode (PCLK not provided) UDD will not 
+  *          generate an interrupt even if UDDIE = 1. 
+  *          If the display is not enabled the UDD interrupt will never occur.
+  * @retval The state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_LCD_GET_IT_SOURCE(__HANDLE__, __IT__) (((__HANDLE__)->Instance->FCR) & (__IT__))
+
+/** @brief  Checks whether the specified LCD flag is set or not.
+  * @param  __HANDLE__: specifies the LCD Handle.
+  * @param  __FLAG__: specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *        @arg LCD_FLAG_ENS: LCD Enabled flag. It indicates the LCD controller status.
+  * @note  The ENS bit is set immediately when the LCDEN bit in the LCD_CR 
+  *             goes from 0 to 1. On deactivation it reflects the real status of 
+  *             LCD so it becomes 0 at the end of the last displayed frame.  
+  *        @arg LCD_FLAG_SOF: Start of Frame flag. This flag is set by hardware at 
+  *             the beginning of a new frame, at the same time as the display data is 
+  *             updated.
+  *        @arg LCD_FLAG_UDR: Update Display Request flag.
+  *        @arg LCD_FLAG_UDD: Update Display Done flag. 
+  *        @arg LCD_FLAG_RDY: Step_up converter Ready flag. It indicates the status 
+  *             of the step-up converter.
+  *        @arg LCD_FLAG_FCRSF: LCD Frame Control Register Synchronization Flag. 
+  *             This flag is set by hardware each time the LCD_FCR register is updated 
+  *             in the LCDCLK domain. 
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_LCD_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR & (__FLAG__)) == (__FLAG__))   
+
+/** @brief  Clears the specified LCD pending flag.
+  * @param  __HANDLE__: specifies the LCD Handle.
+  * @param  __FLAG__: specifies the flag to check.
+  *        This parameter can be any combination of the following values:
+  *        @arg LCD_FLAG_SOF: Start of Frame Interrupt
+  *        @arg LCD_FLAG_UDD: Update Display Done Interrupt
+  * @retval None
+  */
+#define __HAL_LCD_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->CLR = (__FLAG__))
+
+/**
+  * @}
+  */
+  
+/* Exported functions ------------------------------------------------------- */
+/* Initialization/de-initialization methods  **********************************/
+HAL_StatusTypeDef HAL_LCD_DeInit(LCD_HandleTypeDef *hlcd);
+HAL_StatusTypeDef HAL_LCD_Init(LCD_HandleTypeDef *hlcd);
+void HAL_LCD_MspInit(LCD_HandleTypeDef *hlcd);
+void HAL_LCD_MspDeInit(LCD_HandleTypeDef *hlcd);
+ 
+/* IO operation methods *******************************************************/
+HAL_StatusTypeDef HAL_LCD_Write(LCD_HandleTypeDef *hlcd, uint32_t RAMRegisterIndex, uint32_t RAMRegisterMask, uint32_t Data);
+HAL_StatusTypeDef HAL_LCD_Clear(LCD_HandleTypeDef *hlcd);
+HAL_StatusTypeDef HAL_LCD_UpdateDisplayRequest(LCD_HandleTypeDef *hlcd);
+
+/* Peripheral State methods  **************************************************/
+HAL_LCD_StateTypeDef HAL_LCD_GetState(LCD_HandleTypeDef *hlcd);
+uint32_t HAL_LCD_GetError(LCD_HandleTypeDef *hlcd);
+
+/* Private functions ---------------------------------------------------------*/
+HAL_StatusTypeDef LCD_WaitForSynchro(LCD_HandleTypeDef *hlcd);
+
+#endif /* STM32L051xx && STM32L052xx && STM32L062xx && STM32L061xx*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_LCD_H */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/******************* (C) COPYRIGHT 2014 STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_lptim.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_lptim.c
@@ -1,0 +1,1602 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_lptim.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   LPTIM HAL module driver.
+  *    
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Low Power Timer (LPTIM) peripheral:
+  *           + Initialization and de-initialization functions.
+  *           + Start/Stop operation functions in polling mode.
+  *           + Start/Stop operation functions in interrupt mode.
+  *           + Reading operation functions.
+  *           + Peripheral State functions.
+  *         
+  @verbatim
+  ==============================================================================
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      The LPTIM HAL driver can be used as follows:
+
+      (#)Initialize the LPTIM low level resources by implementing the
+        HAL_LPTIM_MspInit():
+         (##) Enable the LPTIM interface clock using __LPTIM1_CLK_ENABLE().
+         (##) In case of using interrupts (e.g. HAL_LPTIM_PWM_Start_IT()):
+             (+) Configure the LPTIM interrupt priority using HAL_NVIC_SetPriority().
+             (+) Enable the LPTIM IRQ handler using HAL_NVIC_EnableIRQ().
+             (+) In LPTIM IRQ handler, call HAL_LPTIM_IRQHandler().
+    
+      (#)Initialize the LPTIM HAL using HAL_LPTIM_Init(). This function
+         configures mainly:
+         (##) The instance: Only LPTIM1 is present in STM32L053xx.
+         (##) Clock: the counter clock.
+                 - Source   : it can be either the ULPTIM input (IN1) or one of
+                              the internal clock; (APB, LSE, LSI or MSI).
+                 - Prescaler: select the clock divider.
+         (##)  UltraLowPowerClock : To be used only if the ULPTIM is selected
+               as counter clock source.
+                 - Polarity:   polarity of the active edge for the counter unit
+                               if the ULPTIM input is selected.
+                 - SampleTime: clock sampling time to configure the clock glitch
+                               filter.              
+         (##) Trigger: How the counter start.
+                 - Source: trigger can be software or one of the hardware triggers.
+                 - ActiveEdge : only for hardware trigger.
+                 - SampleTime : trigger sampling time to configure the trigger
+                                glitch filter.
+         (##) OutputPolarity : 2 opposite polarities are possibles.
+         (##) UpdateMode: specifies whether the update of the autoreload and
+              the compare values is done immediately or after the end of current
+              period.   
+    
+      (#)Six modes are available:
+      
+         (##) PWM Mode: To generate a PWM signal with specified period and pulse,
+         call HAL_LPTIM_PWM_Start() or HAL_LPTIM_PWM_Start_IT() for interruption
+         mode.
+         
+         (##) One Pulse Mode: To generate pulse with specified width in response
+         to a stimulus, call HAL_LPTIM_OnePulse_Start() or
+         HAL_LPTIM_OnePulse_Start_IT() for interruption mode.
+         
+         (##) Set once Mode: In this mode, the output changes the level (from
+         low level to high level if the output polarity is configured high, else
+         the opposite) when a compare match occurs. To start this mode, call 
+         HAL_LPTIM_SetOnce_Start() or HAL_LPTIM_SetOnce_Start_IT() for
+         interruption mode.
+         
+         (##) Encoder Mode: To use the encoder interface call
+         HAL_LPTIM_Encoder_Start() or HAL_LPTIM_Encoder_Start_IT() for 
+         interruption mode.
+         
+         (##) Time out Mode: an active edge on one selected trigger input rests
+         the counter. The first trigger event will start the timer, any
+         successive trigger event will reset the counter and the timer will
+         restart. To start this mode call HAL_LPTIM_TimeOut_Start_IT() or 
+         HAL_LPTIM_TimeOut_Start_IT() for interruption mode.
+         
+         (##) Counter Mode: counter can be used to count external events on
+         the LPTIM Input1 or it can be used to count internal clock cycles.
+         To start this mode, call HAL_LPTIM_Counter_Start() or 
+         HAL_LPTIM_Counter_Start_IT() for interruption mode.             
+
+    
+      (#) User can stop any process by calling the corresponding API:
+          HAL_LPTIM_Xxx_Stop() or HAL_LPTIM_Xxx_Stop_IT() if the process is
+          already started in interruption mode.
+         
+       (#)Call HAL_LPTIM_DeInit() to deinitialize the LPTIM peripheral.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup LPTIM 
+  * @brief LPTIM HAL module driver.
+  * @{
+  */
+
+#ifdef HAL_LPTIM_MODULE_ENABLED
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup LPTIM_Private_Functions
+  * @{
+  */
+
+/** @defgroup LPTIM_Group1 Initialization/de-initialization functions 
+ *  @brief    Initialization and Configuration functions. 
+ *
+@verbatim    
+  ==============================================================================
+              ##### Initialization and de-initialization functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize the LPTIM according to the specified parameters in the
+          LPTIM_InitTypeDef and creates the associated handle.
+      (+) DeInitialize the LPTIM peripheral.
+      (+) Initialize the LPTIM MSP.
+      (+) DeInitialize LPTIM MSP. 
+ 
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the LPTIM according to the specified parameters in the
+  *         LPTIM_InitTypeDef and creates the associated handle.
+  * @param  hlptim: LPTIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim)
+{
+  uint32_t tmpcfgr = 0;
+  
+  /* Check the LPTIM handle allocation */
+  if(hlptim == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  
+  assert_param(IS_LPTIM_CLOCK_SOURCE(hlptim->Init.Clock.Source));
+  assert_param(IS_LPTIM_CLOCK_PRESCALER(hlptim->Init.Clock.Prescaler));  
+  if((hlptim->Init.Clock.Source) ==  LPTIM_CLOCKSOURCE_ULPTIM)
+  {
+    assert_param(IS_LPTIM_CLOCK_POLARITY(hlptim->Init.UltraLowPowerClock.Polarity));
+    assert_param(IS_LPTIM_CLOCK_SAMPLE_TIME(hlptim->Init.UltraLowPowerClock.SampleTime));
+  }  
+  assert_param(IS_LPTIM_TRG_SOURCE(hlptim->Init.Trigger.Source));
+  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  {
+    assert_param(IS_LPTIM_TRIG_SAMPLE_TIME(hlptim->Init.Trigger.SampleTime));
+    assert_param(IS_LPTIM_EXT_TRG_POLARITY(hlptim->Init.Trigger.ActiveEdge));
+  }  
+  assert_param(IS_LPTIM_OUTPUT_POLARITY(hlptim->Init.OutputPolarity));  
+  assert_param(IS_LPTIM_UPDATE_MODE(hlptim->Init.UpdateMode));
+  assert_param(IS_LPTIM_COUNTER_SOURCE(hlptim->Init.CounterSource));
+  
+  if(hlptim->State == HAL_LPTIM_STATE_RESET)
+  {
+    /* Init the low level hardware */
+    HAL_LPTIM_MspInit(hlptim);
+  }
+  
+  /* Change the LPTIM state */
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
+  
+  /* Get the LPTIMx CFGR value */
+  tmpcfgr = hlptim->Instance->CFGR;
+  
+  if ((hlptim->Init.Clock.Source) ==  LPTIM_CLOCKSOURCE_ULPTIM)
+  {
+    tmpcfgr &= (uint32_t)(~(LPTIM_CFGR_CKPOL | LPTIM_CFGR_CKFLT));
+  }
+  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  {
+    tmpcfgr &= (uint32_t)(~ (LPTIM_CFGR_TRGFLT | LPTIM_CFGR_TRIGSEL));
+  }
+    
+  /* Clear CKSEL, PRESC, TRIGEN, TRGFLT, WAVPOL, PRELOAD & COUNTMODE bits */
+  tmpcfgr &= (uint32_t)(~(LPTIM_CFGR_CKSEL | LPTIM_CFGR_TRIGEN | LPTIM_CFGR_PRELOAD |
+                          LPTIM_CFGR_WAVPOL | LPTIM_CFGR_PRESC | LPTIM_CFGR_COUNTMODE ));
+  
+  /* Set initialization parameters */
+  tmpcfgr |= (hlptim->Init.Clock.Source    |
+              hlptim->Init.Clock.Prescaler |
+              hlptim->Init.OutputPolarity  |
+              hlptim->Init.UpdateMode      |
+              hlptim->Init.CounterSource);
+  
+  if ((hlptim->Init.Clock.Source) ==  LPTIM_CLOCKSOURCE_ULPTIM)
+  {
+    tmpcfgr |=  (hlptim->Init.UltraLowPowerClock.Polarity |
+                hlptim->Init.UltraLowPowerClock.SampleTime);
+  } 
+  
+  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  {
+    /* Enable External trigger and set the trigger source */
+    tmpcfgr |= (hlptim->Init.Trigger.Source     |
+                hlptim->Init.Trigger.ActiveEdge |
+                hlptim->Init.Trigger.SampleTime);
+  }
+  
+  /* Write to LPTIMx CFGR */
+  hlptim->Instance->CFGR = tmpcfgr;
+
+  /* Change the LPTIM state */
+  hlptim->State = HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the LPTIM peripheral. 
+  * @param  hlptim: LPTIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_DeInit(LPTIM_HandleTypeDef *hlptim)
+{
+  /* Check the LPTIM handle allocation */
+  if(hlptim == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Change the LPTIM state */
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
+  
+  /* Disable the LPTIM Peripheral Clock */
+  __HAL_LPTIM_DISABLE(hlptim);
+  
+  /* DeInit the low level hardware: CLOCK, NVIC.*/
+  HAL_LPTIM_MspDeInit(hlptim);
+  
+  /* Change the LPTIM state */
+  hlptim->State = HAL_LPTIM_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(hlptim);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the LPTIM MSP.
+  * @param  hlptim: LPTIM handle
+  * @retval None
+  */
+__weak void HAL_LPTIM_MspInit(LPTIM_HandleTypeDef *hlptim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_LPTIM_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes LPTIM MSP.
+  * @param  hlptim: LPTIM handle
+  * @retval None
+  */
+__weak void HAL_LPTIM_MspDeInit(LPTIM_HandleTypeDef *hlptim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_LPTIM_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup LPTIM_Group2 LPTIM Start-Stop operation functions 
+ *  @brief   Start-Stop operation functions. 
+ *
+@verbatim   
+  ==============================================================================
+                ##### LPTIM Start Stop operation functions #####
+  ==============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Start the PWM mode.
+      (+) Stop the PWM mode.
+      (+) Start the One pulse mode.
+      (+) Stop the One pulse mode.
+      (+) Start the Set once mode.
+      (+) Stop the Set once mode.
+      (+) Start the Encoder mode.
+      (+) Stop the Encoder mode.
+      (+) Start the Timeout mode.
+      (+) Stop the Timeout mode.      
+      (+) Start the Counter mode.
+      (+) Stop the Counter mode.
+      
+
+@endverbatim
+  * @{
+  */
+    
+/**
+  * @brief  Starts the LPTIM PWM generation.
+  * @param  hlptim : LPTIM handle
+  * @param  Period : Specifies the Autoreload value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @param  Pulse : Specifies the compare value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_PWM_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Pulse)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  assert_param(IS_LPTIM_PERIOD(Period));
+  assert_param(IS_LPTIM_PULSE(Pulse));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+ 
+  /* Reset WAVE bit to set PWM mode */
+  hlptim->Instance->CFGR &= ~LPTIM_CFGR_WAVE;
+  
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+  
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+  
+  /* Load the pulse value in the compare register */
+  __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
+  
+  /* Start timer in continuous mode */
+  __HAL_LPTIM_START_CONTINUOUS(hlptim);
+    
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the LPTIM PWM generation.
+  * @param  hlptim : LPTIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_PWM_Stop(LPTIM_HandleTypeDef *hlptim)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the LPTIM PWM generation in interrupt mode.
+  * @param  hlptim : LPTIM handle
+  * @param  Period : Specifies the Autoreload value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF
+  * @param  Pulse : Specifies the compare value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_PWM_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Pulse)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  assert_param(IS_LPTIM_PERIOD(Period));
+  assert_param(IS_LPTIM_PULSE(Pulse));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+ 
+  /* Reset WAVE bit to set PWM mode */
+  hlptim->Instance->CFGR &= ~LPTIM_CFGR_WAVE;
+  
+  /* Enable Autoreload write complete interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_ARROK);
+  
+  /* Enable Compare write complete interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_CMPOK);
+  
+  /* Enable Autoreload match interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_ARRM);
+  
+  /* Enable Compare match interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_CMPM);
+  
+  /* If external trigger source is used, then enable external trigger interrupt */
+  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  {
+    /* Enable external trigger interrupt */
+    __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_EXTTRIG);
+  }  
+  
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+  
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+  
+  /* Load the pulse value in the compare register */
+  __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
+  
+  /* Start timer in continuous mode */
+  __HAL_LPTIM_START_CONTINUOUS(hlptim);
+    
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the LPTIM PWM generation in interrupt mode.
+  * @param  hlptim : LPTIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_PWM_Stop_IT(LPTIM_HandleTypeDef *hlptim)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+  
+    /* Disable Autoreload write complete interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_ARROK);
+  
+  /* Disable Compare write complete interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_CMPOK);
+  
+  /* Disable Autoreload match interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_ARRM);
+  
+  /* Disable Compare match interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_CMPM);
+  
+  /* If external trigger source is used, then disable external trigger interrupt */
+  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  {
+    /* Disable external trigger interrupt */
+    __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_EXTTRIG);
+  }  
+
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the LPTIM One pulse generation.
+  * @param  hlptim : LPTIM handle
+  * @param  Period : Specifies the Autoreload value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @param  Pulse : Specifies the compare value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_OnePulse_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Pulse)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  assert_param(IS_LPTIM_PERIOD(Period));
+  assert_param(IS_LPTIM_PULSE(Pulse));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Reset WAVE bit to set one pulse mode */
+  hlptim->Instance->CFGR &= ~LPTIM_CFGR_WAVE;
+  
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+  
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+  
+  /* Load the pulse value in the compare register */
+  __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
+  
+  /* Start timer in continuous mode */
+  __HAL_LPTIM_START_SINGLE(hlptim);
+    
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the LPTIM One pulse generation.
+  * @param  hlptim : LPTIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_OnePulse_Stop(LPTIM_HandleTypeDef *hlptim)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the LPTIM One pulse generation in interrupt mode.
+  * @param  hlptim : LPTIM handle
+  * @param  Period : Specifies the Autoreload value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @param  Pulse : Specifies the compare value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_OnePulse_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Pulse)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  assert_param(IS_LPTIM_PERIOD(Period));
+  assert_param(IS_LPTIM_PULSE(Pulse));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Reset WAVE bit to set one pulse mode */
+  hlptim->Instance->CFGR &= ~LPTIM_CFGR_WAVE;
+  
+  /* Enable Autoreload write complete interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_ARROK);
+  
+  /* Enable Compare write complete interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_CMPOK);
+  
+  /* Enable Autoreload match interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_ARRM);
+  
+  /* Enable Compare match interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_CMPM);
+  
+  /* If external trigger source is used, then enable external trigger interrupt */
+  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  {
+    /* Enable external trigger interrupt */
+    __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_EXTTRIG);
+  }
+  
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+  
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+  
+  /* Load the pulse value in the compare register */
+  __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
+  
+  /* Start timer in continuous mode */
+  __HAL_LPTIM_START_SINGLE(hlptim);
+    
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the LPTIM One pulse generation in interrupt mode.
+  * @param  hlptim : LPTIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_OnePulse_Stop_IT(LPTIM_HandleTypeDef *hlptim)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+  
+  /* Disable Autoreload write complete interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_ARROK);
+  
+  /* Disable Compare write complete interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_CMPOK);
+  
+  /* Disable Autoreload match interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_ARRM);
+  
+  /* Disable Compare match interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_CMPM);
+  
+  /* If external trigger source is used, then disable external trigger interrupt */
+  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  {
+    /* Disable external trigger interrupt */
+    __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_EXTTRIG);
+  }
+  
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the LPTIM in Set once mode.
+  * @param  hlptim : LPTIM handle
+  * @param  Period : Specifies the Autoreload value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @param  Pulse : Specifies the compare value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_SetOnce_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Pulse)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  assert_param(IS_LPTIM_PERIOD(Period));
+  assert_param(IS_LPTIM_PULSE(Pulse));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Set WAVE bit to enable the set once mode */
+  hlptim->Instance->CFGR |= LPTIM_CFGR_WAVE;
+  
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+  
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+  
+  /* Load the pulse value in the compare register */
+  __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
+  
+  /* Start timer in continuous mode */
+  __HAL_LPTIM_START_SINGLE(hlptim);
+    
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the LPTIM Set once mode.
+  * @param  hlptim : LPTIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_SetOnce_Stop(LPTIM_HandleTypeDef *hlptim)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the LPTIM Set once mode in interrupt mode.
+  * @param  hlptim : LPTIM handle
+  * @param  Period : Specifies the Autoreload value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @param  Pulse : Specifies the compare value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_SetOnce_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Pulse)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  assert_param(IS_LPTIM_PERIOD(Period));
+  assert_param(IS_LPTIM_PULSE(Pulse));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Set WAVE bit to enable the set once mode */
+  hlptim->Instance->CFGR |= LPTIM_CFGR_WAVE;
+  
+  /* Enable Autoreload write complete interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_ARROK);
+  
+  /* Enable Compare write complete interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_CMPOK);
+  
+  /* Enable Autoreload match interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_ARRM);
+  
+  /* Enable Compare match interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_CMPM);
+  
+  /* If external trigger source is used, then enable external trigger interrupt */
+  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  {
+    /* Enable external trigger interrupt */
+    __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_EXTTRIG);
+  }  
+  
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+  
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+  
+  /* Load the pulse value in the compare register */
+  __HAL_LPTIM_COMPARE_SET(hlptim, Pulse);
+  
+  /* Start timer in continuous mode */
+  __HAL_LPTIM_START_SINGLE(hlptim);
+    
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the LPTIM Set once mode in interrupt mode.
+  * @param  hlptim : LPTIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_SetOnce_Stop_IT(LPTIM_HandleTypeDef *hlptim)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+
+  /* Disable Autoreload write complete interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_ARROK);
+  
+  /* Disable Compare write complete interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_CMPOK);
+  
+  /* Disable Autoreload match interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_ARRM);
+  
+  /* Disable Compare match interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_CMPM);
+  
+  /* If external trigger source is used, then disable external trigger interrupt */
+  if ((hlptim->Init.Trigger.Source) !=  LPTIM_TRIGSOURCE_SOFTWARE)
+  {
+    /* Disable external trigger interrupt */
+    __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_EXTTRIG);
+  } 
+  
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the Encoder interface.
+  * @param  hlptim : LPTIM handle
+  * @param  Period : Specifies the Autoreload value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_Encoder_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Period)
+{
+  uint32_t tmpcfgr = 0;
+   
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  assert_param(IS_LPTIM_PERIOD(Period));
+  assert_param(hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_APBCLOCK_LPOSC);
+  assert_param(hlptim->Init.Clock.Prescaler == LPTIM_PRESCALER_DIV1);
+  assert_param(IS_LPTIM_CLOCK_POLARITY(hlptim->Init.UltraLowPowerClock.Polarity));
+  
+  /* Configure edge sensitivity for encoder mode */
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Get the LPTIMx CFGR value */
+  tmpcfgr = hlptim->Instance->CFGR;
+  
+  /* Clear CKPOL bits */
+  tmpcfgr &= (uint32_t)(~LPTIM_CFGR_CKPOL);
+  
+  /* Set Input polarity */
+  tmpcfgr |=  hlptim->Init.UltraLowPowerClock.Polarity;
+  
+  /* Write to LPTIMx CFGR */
+  hlptim->Instance->CFGR = tmpcfgr;
+ 
+  /* Set ENC bit to enable the encoder interface */
+  hlptim->Instance->CFGR |= LPTIM_CFGR_ENC;
+  
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+  
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+  
+  /* Start timer in continuous mode */
+  __HAL_LPTIM_START_CONTINUOUS(hlptim);
+    
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the Encoder interface.
+  * @param  hlptim : LPTIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_Encoder_Stop(LPTIM_HandleTypeDef *hlptim)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+  
+  /* Reset ENC bit to disable the encoder interface */
+  hlptim->Instance->CFGR &= ~LPTIM_CFGR_ENC;
+  
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the Encoder interface in interrupt mode.
+  * @param  hlptim : LPTIM handle
+  * @param  Period : Specifies the Autoreload value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_Encoder_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t Period)
+{
+  uint32_t tmpcfgr = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  assert_param(IS_LPTIM_PERIOD(Period));
+  assert_param(hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_APBCLOCK_LPOSC);
+  assert_param(hlptim->Init.Clock.Prescaler == LPTIM_PRESCALER_DIV1);
+  assert_param(IS_LPTIM_CLOCK_POLARITY(hlptim->Init.UltraLowPowerClock.Polarity));
+  
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Configure edge sensitivity for encoder mode */
+  /* Get the LPTIMx CFGR value */
+  tmpcfgr = hlptim->Instance->CFGR;
+  
+  /* Clear CKPOL bits */
+  tmpcfgr &= (uint32_t)(~LPTIM_CFGR_CKPOL);
+  
+  /* Set Input polarity */
+  tmpcfgr |=  hlptim->Init.UltraLowPowerClock.Polarity;
+  
+  /* Write to LPTIMx CFGR */
+  hlptim->Instance->CFGR = tmpcfgr;
+ 
+  /* Set ENC bit to enable the encoder interface */
+  hlptim->Instance->CFGR |= LPTIM_CFGR_ENC;
+  
+  /* Enable "switch to down direction" interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_DOWN);
+  
+  /* Enable "switch to up direction" interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_UP);  
+
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+  
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+  
+  /* Start timer in continuous mode */
+  __HAL_LPTIM_START_CONTINUOUS(hlptim);
+    
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the Encoder interface in nterrupt mode.
+  * @param  hlptim : LPTIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_Encoder_Stop_IT(LPTIM_HandleTypeDef *hlptim)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+  
+  /* Reset ENC bit to disable the encoder interface */
+  hlptim->Instance->CFGR &= ~LPTIM_CFGR_ENC;
+  
+  /* Disable "switch to down direction" interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_DOWN);
+  
+  /* Disable "switch to up direction" interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_UP); 
+  
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the Timeout function. The first trigger event will start the
+  *         timer, any successive trigger event will reset the counter and
+  *         the timer restarts.
+  * @param  hlptim : LPTIM handle
+  * @param  Period : Specifies the Autoreload value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @param  Timeout : Specifies the TimeOut value to rest the counter.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_TimeOut_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Timeout)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  assert_param(IS_LPTIM_PERIOD(Period));
+  assert_param(IS_LPTIM_PULSE(Timeout));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Set TIMOUT bit to enable the timeout function */
+  hlptim->Instance->CFGR |= LPTIM_CFGR_TIMOUT;
+  
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+  
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+  
+  /* Load the Timeout value in the compare register */
+  __HAL_LPTIM_COMPARE_SET(hlptim, Timeout);
+  
+  /* Start timer in continuous mode */
+  __HAL_LPTIM_START_CONTINUOUS(hlptim);
+    
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the Timeout function.
+  * @param  hlptim : LPTIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_TimeOut_Stop(LPTIM_HandleTypeDef *hlptim)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+  
+  /* Reset TIMOUT bit to enable the timeout function */
+  hlptim->Instance->CFGR &= ~LPTIM_CFGR_TIMOUT;
+  
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the Timeout function in interrupt mode. The first trigger 
+  *         event will start the timer, any successive trigger event will reset
+  *         the counter and the timer restarts.
+  * @param  hlptim : LPTIM handle
+  * @param  Period : Specifies the Autoreload value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @param  Timeout : Specifies the TimeOut value to rest the counter.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_TimeOut_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Timeout)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  assert_param(IS_LPTIM_PERIOD(Period));
+  assert_param(IS_LPTIM_PULSE(Timeout));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Set TIMOUT bit to enable the timeout function */
+  hlptim->Instance->CFGR |= LPTIM_CFGR_TIMOUT;  
+  
+  /* Enable Compare match interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_CMPM);
+  
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+  
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+  
+  /* Load the Timeout value in the compare register */
+  __HAL_LPTIM_COMPARE_SET(hlptim, Timeout);
+  
+  /* Start timer in continuous mode */
+  __HAL_LPTIM_START_CONTINUOUS(hlptim);
+    
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the Timeout function in interrupt mode.
+  * @param  hlptim : LPTIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_TimeOut_Stop_IT(LPTIM_HandleTypeDef *hlptim)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+  
+  /* Reset TIMOUT bit to enable the timeout function */
+  hlptim->Instance->CFGR &= ~LPTIM_CFGR_TIMOUT;
+  
+  /* Disable Compare match interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_CMPM);
+  
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the Counter mode.
+  * @param  hlptim : LPTIM handle
+  * @param  Period : Specifies the Autoreload value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_Counter_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Period)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  assert_param(IS_LPTIM_PERIOD(Period));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* If clock source is not ULPTIM clock and counter source is external, then it must not be prescaled */
+  if((hlptim->Init.Clock.Source != LPTIM_CLOCKSOURCE_ULPTIM) && (hlptim->Init.CounterSource == LPTIM_COUNTERSOURCE_EXTERNAL))
+  {
+    /* Check if clock is prescaled */
+    assert_param(IS_LPTIM_CLOCK_PRESCALERDIV1(hlptim->Init.Clock.Prescaler));
+    /* Set clock prescaler to 0 */
+    hlptim->Instance->CFGR &= ~LPTIM_CFGR_PRESC;
+  }
+
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+  
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+  
+  /* Start timer in continuous mode */
+  __HAL_LPTIM_START_CONTINUOUS(hlptim);
+    
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the Counter mode.
+  * @param  hlptim : LPTIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_Counter_Stop(LPTIM_HandleTypeDef *hlptim)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+  
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the Counter mode in interrupt mode.
+  * @param  hlptim : LPTIM handle
+  * @param  Period : Specifies the Autoreload value.
+  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_Counter_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t Period)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  assert_param(IS_LPTIM_PERIOD(Period));
+               
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* If clock source is not ULPTIM clock and counter source is external, then it must not be prescaled */
+  if((hlptim->Init.Clock.Source != LPTIM_CLOCKSOURCE_ULPTIM) && (hlptim->Init.CounterSource == LPTIM_COUNTERSOURCE_EXTERNAL))
+  {
+    /* Check if clock is prescaled */
+    assert_param(IS_LPTIM_CLOCK_PRESCALERDIV1(hlptim->Init.Clock.Prescaler));
+    /* Set clock prescaler to 0 */
+    hlptim->Instance->CFGR &= ~LPTIM_CFGR_PRESC;
+  }
+  
+  /* Enable Autoreload write complete interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_ARROK);
+  
+  /* Enable Autoreload match interrupt */
+  __HAL_LPTIM_ENABLE_INTERRUPT(hlptim, LPTIM_IT_ARRM);
+  
+  /* Enable the Peripheral */
+  __HAL_LPTIM_ENABLE(hlptim);
+  
+  /* Load the period value in the autoreload register */
+  __HAL_LPTIM_AUTORELOAD_SET(hlptim, Period);
+  
+  /* Start timer in continuous mode */
+  __HAL_LPTIM_START_CONTINUOUS(hlptim);
+    
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the Counter mode in interrupt mode.
+  * @param  hlptim : LPTIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LPTIM_Counter_Stop_IT(LPTIM_HandleTypeDef *hlptim)
+{
+  /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  
+  /* Set the LPTIM state */
+  hlptim->State= HAL_LPTIM_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_LPTIM_DISABLE(hlptim);
+  
+  /* Disable Autoreload write complete interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_ARROK);
+  
+  /* Disable Autoreload match interrupt */
+  __HAL_LPTIM_DISABLE_INTERRUPT(hlptim, LPTIM_IT_ARRM);
+  
+  /* Change the TIM state*/
+  hlptim->State= HAL_LPTIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup LPTIM_Group3 LPTIM Read operation functions 
+ *  @brief  Read operation functions.
+ *
+@verbatim   
+  ==============================================================================
+                  ##### LPTIM Read operation functions #####
+  ==============================================================================  
+[..]  This section provides LPTIM Reading functions.
+      (+) Read the counter value.
+      (+) Read the period (Auto-reload) value.
+      (+) Read the pulse (Compare)value.
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  This function returns the current counter value.
+  * @param  hlptim: LPTIM handle
+  * @retval Counter value.
+  */
+uint32_t HAL_LPTIM_ReadCounter(LPTIM_HandleTypeDef *hlptim)
+{
+    /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  
+  return (hlptim->Instance->CNT);
+}
+
+/**
+  * @brief  This function return the current Autoreload (Period) value.
+  * @param  hlptim: LPTIM handle
+  * @retval Autoreload value.
+  */
+uint32_t HAL_LPTIM_ReadAutoReload(LPTIM_HandleTypeDef *hlptim)
+{
+    /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  
+  return (hlptim->Instance->ARR);
+}
+
+/**
+  * @brief  This function return the current Compare (Pulse) value.
+  * @param  hlptim: LPTIM handle
+  * @retval Compare value.
+  */
+uint32_t HAL_LPTIM_ReadCompare(LPTIM_HandleTypeDef *hlptim)
+{
+    /* Check the parameters */
+  assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
+  
+  return (hlptim->Instance->CMP);
+}
+
+/**
+  * @}
+  */
+
+
+
+/** @defgroup LPTIM_Group4 LPTIM IRQ handler 
+ *  @brief  LPTIM  IRQ handler.
+ *
+@verbatim   
+  ==============================================================================
+                      ##### LPTIM IRQ handler  #####
+  ==============================================================================  
+[..]  This section provides LPTIM IRQ handler function.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  This function handles LPTIM interrupt request.
+  * @param  hlptim: LPTIM handle
+  * @retval None
+  */
+void HAL_LPTIM_IRQHandler(LPTIM_HandleTypeDef *hlptim)
+{
+  /* Compare match interrupt */
+  if(__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_CMPM) != RESET)
+  {
+    if(__HAL_LPTIM_GET_ITSTATUS(hlptim, LPTIM_IT_CMPM) !=RESET)
+    {
+      /* Clear Compare match flag */
+      __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_CMPM);
+      
+      /* Compare match Callback */
+      HAL_LPTIM_CompareMatchCallback(hlptim);      
+    }
+  }
+  
+  /* Autoreload match interrupt */
+  if(__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_ARRM) != RESET)
+  {
+    if(__HAL_LPTIM_GET_ITSTATUS(hlptim, LPTIM_IT_ARRM) !=RESET)
+    {
+      /* Clear Autoreload match flag */
+      __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARRM);
+      
+      /* Autoreload match Callback */
+      HAL_LPTIM_AutoReloadMatchCallback(hlptim);      
+    }
+  }
+  
+  /* Trigger detected interrupt */
+  if(__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_EXTTRIG) != RESET)
+  {
+    if(__HAL_LPTIM_GET_ITSTATUS(hlptim, LPTIM_IT_EXTTRIG) !=RESET)
+    {
+      /* Clear Trigger detected flag */
+      __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_EXTTRIG);
+      
+      /* Trigger detected callback */
+      HAL_LPTIM_TriggerCallback(hlptim);      
+    }
+  }
+  
+  /* Compare write interrupt */
+  if(__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_CMPOK) != RESET)
+  {
+    if(__HAL_LPTIM_GET_ITSTATUS(hlptim, LPTIM_IT_CMPOK) !=RESET)
+    {
+      /* Clear Compare write flag */
+      __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_CMPOK);
+      
+      /* Compare write Callback */
+      HAL_LPTIM_CompareWriteCallback(hlptim);      
+    }
+  }
+  
+  /* Autoreload write interrupt */
+  if(__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_ARROK) != RESET)
+  {
+    if(__HAL_LPTIM_GET_ITSTATUS(hlptim, LPTIM_IT_ARROK) !=RESET)
+    {
+      /* Clear Autoreload write flag */
+      __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
+      
+      /* Autoreload write Callback */
+      HAL_LPTIM_AutoReloadWriteCallback(hlptim);      
+    }
+  }
+  
+  /* Direction counter changed from Down to Up interrupt */
+  if(__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_UP) != RESET)
+  {
+    if(__HAL_LPTIM_GET_ITSTATUS(hlptim, LPTIM_IT_UP) !=RESET)
+    {
+      /* Clear Direction counter changed from Down to Up flag */
+      __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_UP);
+      
+      /* Direction counter changed from Down to Up Callback */
+      HAL_LPTIM_DirectionUpCallback(hlptim);      
+    }
+  }
+  
+  /* Direction counter changed from Up to Down interrupt */
+  if(__HAL_LPTIM_GET_FLAG(hlptim, LPTIM_FLAG_DOWN) != RESET)
+  {
+    if(__HAL_LPTIM_GET_ITSTATUS(hlptim, LPTIM_IT_DOWN) !=RESET)
+    {
+      /* Clear Direction counter changed from Up to Down flag */
+      __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_DOWN);
+      
+      /* Direction counter changed from Up to Down Callback */
+      HAL_LPTIM_DirectionDownCallback(hlptim);      
+    }
+  }
+}
+
+/**
+  * @brief  Compare match callback in non blocking mode 
+  * @param  hlptim : LPTIM handle
+  * @retval None
+  */
+__weak void HAL_LPTIM_CompareMatchCallback(LPTIM_HandleTypeDef *hlptim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_LPTIM_CompareMatchCallback could be implemented in the user file
+   */  
+}
+
+/**
+  * @brief  Autoreload match callback in non blocking mode 
+  * @param  hlptim : LPTIM handle
+  * @retval None
+  */
+__weak void HAL_LPTIM_AutoReloadMatchCallback(LPTIM_HandleTypeDef *hlptim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_LPTIM_AutoReloadMatchCallback could be implemented in the user file
+   */  
+}
+
+/**
+  * @brief  Trigger detected callback in non blocking mode 
+  * @param  hlptim : LPTIM handle
+  * @retval None
+  */
+__weak void HAL_LPTIM_TriggerCallback(LPTIM_HandleTypeDef *hlptim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_LPTIM_TriggerCallback could be implemented in the user file
+   */  
+}
+
+/**
+  * @brief  Compare write callback in non blocking mode 
+  * @param  hlptim : LPTIM handle
+  * @retval None
+  */
+__weak void HAL_LPTIM_CompareWriteCallback(LPTIM_HandleTypeDef *hlptim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_LPTIM_CompareWriteCallback could be implemented in the user file
+   */  
+}
+
+/**
+  * @brief  Autoreload write callback in non blocking mode 
+  * @param  hlptim : LPTIM handle
+  * @retval None
+  */
+__weak void HAL_LPTIM_AutoReloadWriteCallback(LPTIM_HandleTypeDef *hlptim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_LPTIM_AutoReloadWriteCallback could be implemented in the user file
+   */  
+}
+
+/**
+  * @brief  Direction counter changed from Down to Up callback in non blocking mode 
+  * @param  hlptim : LPTIM handle
+  * @retval None
+  */
+__weak void HAL_LPTIM_DirectionUpCallback(LPTIM_HandleTypeDef *hlptim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_LPTIM_DirectionUpCallback could be implemented in the user file
+   */  
+}
+
+/**
+  * @brief  Direction counter changed from Up to Down callback in non blocking mode 
+  * @param  hlptim : LPTIM handle
+  * @retval None
+  */
+__weak void HAL_LPTIM_DirectionDownCallback(LPTIM_HandleTypeDef *hlptim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_LPTIM_DirectionDownCallback could be implemented in the user file
+   */  
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup LPTIM_Group5 Peripheral State functions 
+ *  @brief   Peripheral State functions. 
+ *
+@verbatim   
+  ==============================================================================
+                      ##### Peripheral State functions #####
+  ==============================================================================  
+    [..]
+    This subsection permits to get in run-time the status of the peripheral.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the LPTIM state.
+  * @param  hlptim: LPTIM handle
+  * @retval HAL state
+  */
+HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(LPTIM_HandleTypeDef *hlptim)
+{
+  return hlptim->State;
+}
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+#endif /* HAL_LPTIM_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_lptim.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_lptim.h
@@ -1,0 +1,624 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_lptim.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of LPTIM HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_LPTIM_H
+#define __STM32L0xx_HAL_LPTIM_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup LPTIM
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+
+/** 
+  * @brief  LPTIM Clock configuration definition  
+  */
+typedef struct
+{
+  uint32_t Source;         /*!< Selects the clock source.
+                           This parameter can be a value of @ref LPTIM_Clock_Source   */
+
+  uint32_t Prescaler;      /*!< Specifies the counter clock Prescaler.
+                           This parameter can be a value of @ref LPTIM_Clock_Prescaler */
+  
+}LPTIM_ClockConfigTypeDef;
+
+/** 
+  * @brief  LPTIM Clock configuration definition  
+  */
+typedef struct
+{
+  uint32_t Polarity;      /*!< Selects the polarity of the active edge for the counter unit
+                           if the ULPTIM input is selected.
+                           Note: This parameter is used only when Ultra low power clock source is used.
+                           Note: If the polarity is configured on 'both edges', an auxiliary clock
+                           (one of the Low power oscillator) must be active.
+                           This parameter can be a value of @ref LPTIM_Clock_Polarity */ 
+  
+  uint32_t SampleTime;     /*!< Selects the clock sampling time to configure the clock glitch filter.
+                           Note: This parameter is used only when Ultra low power clock source is used.
+                           This parameter can be a value of @ref LPTIM_Clock_Sample_Time */  
+  
+}LPTIM_ULPClockConfigTypeDef;
+
+/** 
+  * @brief  LPTIM Trigger configuration definition  
+  */
+typedef struct
+{
+  uint32_t Source;        /*!< Selects the Trigger source.
+                          This parameter can be a value of @ref LPTIM_Trigger_Source */
+  
+  uint32_t ActiveEdge;    /*!< Selects the Trigger active edge.
+                          Note: This parameter is used only when an external trigger is used.
+                          This parameter can be a value of @ref LPTIM_External_Trigger_Polarity */
+  
+  uint32_t SampleTime;    /*!< Selects the trigger sampling time to configure the clock glitch filter.
+                          Note: This parameter is used only when an external trigger is used.
+                          This parameter can be a value of @ref LPTIM_Trigger_Sample_Time  */  
+}LPTIM_TriggerConfigTypeDef;
+
+/** 
+  * @brief  LPTIM Initialization Structure definition  
+  */
+typedef struct
+{                                                    
+  LPTIM_ClockConfigTypeDef     Clock;               /*!< Specifies the clock parameters */
+                                                    
+  LPTIM_ULPClockConfigTypeDef  UltraLowPowerClock;  /*!< Specifies the Ultra Low Power clock parameters */
+                                                    
+  LPTIM_TriggerConfigTypeDef   Trigger;             /*!< Specifies the Trigger parameters */
+                                                    
+  uint32_t                     OutputPolarity;      /*!< Specifies the Output polarity.
+                                                    This parameter can be a value of @ref LPTIM_Output_Polarity */
+                                                    
+  uint32_t                     UpdateMode;          /*!< Specifies whether the update of the autorelaod and the compare
+                                                    values is done immediately or after the end of current period.
+                                                    This parameter can be a value of @ref LPTIM_Updating_Mode */
+
+  uint32_t                     CounterSource;       /*!< Specifies whether the counter is incremented each internal event
+                                                    or each external event.
+                                                    This parameter can be a value of @ref LPTIM_Counter_Source */  
+  
+}LPTIM_InitTypeDef;
+
+/** 
+  * @brief  HAL LPTIM State structure definition  
+  */ 
+typedef enum __HAL_LPTIM_StateTypeDef
+{
+  HAL_LPTIM_STATE_RESET            = 0x00,    /*!< Peripheral not yet initialized or disabled  */
+  HAL_LPTIM_STATE_READY            = 0x01,    /*!< Peripheral Initialized and ready for use    */
+  HAL_LPTIM_STATE_BUSY             = 0x02,    /*!< An internal process is ongoing              */    
+  HAL_LPTIM_STATE_TIMEOUT          = 0x03,    /*!< Timeout state                               */  
+  HAL_LPTIM_STATE_ERROR            = 0x04     /*!< Internal Process is ongoing                */                                                                             
+}HAL_LPTIM_StateTypeDef;
+
+/** 
+  * @brief  LPTIM handle Structure definition  
+  */ 
+typedef struct
+{
+      LPTIM_TypeDef              *Instance;         /*!< Register base address     */
+      
+      LPTIM_InitTypeDef           Init;             /*!< LPTIM required parameters */
+  
+      HAL_StatusTypeDef           Status;           /*!< LPTIM peripheral status   */  
+  
+      HAL_LockTypeDef             Lock;             /*!< LPTIM locking object      */
+  
+   __IO  HAL_LPTIM_StateTypeDef   State;            /*!< LPTIM peripheral state    */
+  
+}LPTIM_HandleTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup LPTIM_Exported_Constants
+  * @{
+  */
+
+/** @defgroup LPTIM_Autorelaod_Value
+  * @{
+  */
+#define IS_LPTIM_AUTORELOAD(AUTORELOAD)         ((AUTORELOAD) <= 0x0000FFFF)
+/**
+  * @}
+  */
+
+/** @defgroup LPTIM_Compare_Value
+  * @{
+  */
+#define IS_LPTIM_COMPARE(COMPARE)               ((COMPARE) <= 0x0000FFFF)
+/**
+  * @}
+  */
+
+/** @defgroup LPTIM_Clock_Source
+  * @{
+  */
+#define LPTIM_CLOCKSOURCE_APBCLOCK_LPOSC        ((uint32_t)0x00)
+#define LPTIM_CLOCKSOURCE_ULPTIM                LPTIM_CFGR_CKSEL
+                                                
+#define IS_LPTIM_CLOCK_SOURCE(SOURCE)           (((SOURCE) == LPTIM_CLOCKSOURCE_ULPTIM) || \
+                                                 ((SOURCE) == LPTIM_CLOCKSOURCE_APBCLOCK_LPOSC))
+/**                                             
+  * @}
+  */
+
+/** @defgroup LPTIM_Clock_Prescaler
+  * @{
+  */
+#define LPTIM_PRESCALER_DIV1                    ((uint32_t)0x000000)
+#define LPTIM_PRESCALER_DIV2                    LPTIM_CFGR_PRESC_0
+#define LPTIM_PRESCALER_DIV4                    LPTIM_CFGR_PRESC_1
+#define LPTIM_PRESCALER_DIV8                    ((uint32_t)(LPTIM_CFGR_PRESC_0 | LPTIM_CFGR_PRESC_1))
+#define LPTIM_PRESCALER_DIV16                   LPTIM_CFGR_PRESC_2
+#define LPTIM_PRESCALER_DIV32                   ((uint32_t)(LPTIM_CFGR_PRESC_0 | LPTIM_CFGR_PRESC_2))
+#define LPTIM_PRESCALER_DIV64                   ((uint32_t)(LPTIM_CFGR_PRESC_1 | LPTIM_CFGR_PRESC_2))
+#define LPTIM_PRESCALER_DIV128                  ((uint32_t)LPTIM_CFGR_PRESC)
+                                                
+#define IS_LPTIM_CLOCK_PRESCALER(PRESCALER)     (((PRESCALER) ==  LPTIM_PRESCALER_DIV1  ) || \
+                                                 ((PRESCALER) ==  LPTIM_PRESCALER_DIV2  ) || \
+                                                 ((PRESCALER) ==  LPTIM_PRESCALER_DIV4  ) || \
+                                                 ((PRESCALER) ==  LPTIM_PRESCALER_DIV8  ) || \
+                                                 ((PRESCALER) ==  LPTIM_PRESCALER_DIV16 ) || \
+                                                 ((PRESCALER) ==  LPTIM_PRESCALER_DIV32 ) || \
+                                                 ((PRESCALER) ==  LPTIM_PRESCALER_DIV64 ) || \
+                                                 ((PRESCALER) ==  LPTIM_PRESCALER_DIV128))
+#define IS_LPTIM_CLOCK_PRESCALERDIV1(PRESCALER) ((PRESCALER) ==  LPTIM_PRESCALER_DIV1)
+/**
+  * @}
+  */ 
+
+/** @defgroup LPTIM_Output_Polarity
+  * @{
+  */
+
+#define LPTIM_OUTPUTPOLARITY_HIGH               ((uint32_t)0x00000000)
+#define LPTIM_OUTPUTPOLARITY_LOW                (LPTIM_CFGR_WAVPOL)
+#define IS_LPTIM_OUTPUT_POLARITY(POLARITY)      (((POLARITY) == LPTIM_OUTPUTPOLARITY_LOW ) || \
+                                                 ((POLARITY) == LPTIM_OUTPUTPOLARITY_HIGH))
+/**
+  * @}
+  */
+
+/** @defgroup LPTIM_Clock_Sample_Time
+  * @{
+  */
+#define LPTIM_CLOCKSAMPLETIME_DIRECTTRANSISTION ((uint32_t)0x00000000)
+#define LPTIM_CLOCKSAMPLETIME_2TRANSISTIONS     LPTIM_CFGR_CKFLT_0
+#define LPTIM_CLOCKSAMPLETIME_4TRANSISTIONS     LPTIM_CFGR_CKFLT_1
+#define LPTIM_CLOCKSAMPLETIME_8TRANSISTIONS     LPTIM_CFGR_CKFLT
+#define IS_LPTIM_CLOCK_SAMPLE_TIME(SAMPLETIME)  (((SAMPLETIME) == LPTIM_CLOCKSAMPLETIME_DIRECTTRANSISTION) || \
+                                                 ((SAMPLETIME) == LPTIM_CLOCKSAMPLETIME_2TRANSISTIONS)     || \
+                                                 ((SAMPLETIME) == LPTIM_CLOCKSAMPLETIME_4TRANSISTIONS)     || \
+                                                 ((SAMPLETIME) == LPTIM_CLOCKSAMPLETIME_8TRANSISTIONS))
+/**
+  * @}
+  */
+
+/** @defgroup LPTIM_Clock_Polarity
+  * @{
+  */
+
+#define LPTIM_CLOCKPOLARITY_RISINGEDGE          ((uint32_t)0x00000000)
+#define LPTIM_CLOCKPOLARITY_FALLINGEDGE         LPTIM_CFGR_CKPOL_0
+#define LPTIM_CLOCKPOLARITY_BOTHEDGES           LPTIM_CFGR_CKPOL_1
+#define IS_LPTIM_CLOCK_POLARITY(POLARITY)       (((POLARITY) == LPTIM_CLOCKPOLARITY_RISINGEDGE)  || \
+                                                 ((POLARITY) == LPTIM_CLOCKPOLARITY_FALLINGEDGE) || \
+                                                 ((POLARITY) == LPTIM_CLOCKPOLARITY_BOTHEDGES))
+
+/**
+  * @}
+  */
+
+/** @defgroup LPTIM_Trigger_Source
+  * @{
+  */
+#define LPTIM_TRIGSOURCE_SOFTWARE               ((uint32_t)0x0000FFFF)
+#define LPTIM_TRIGSOURCE_0                      ((uint32_t)0x00000000)
+#define LPTIM_TRIGSOURCE_1                      ((uint32_t)LPTIM_CFGR_TRIGSEL_0)
+#define LPTIM_TRIGSOURCE_2                      LPTIM_CFGR_TRIGSEL_1
+#define LPTIM_TRIGSOURCE_3                      ((uint32_t)LPTIM_CFGR_TRIGSEL_0 | LPTIM_CFGR_TRIGSEL_1)
+#define LPTIM_TRIGSOURCE_4                      LPTIM_CFGR_TRIGSEL_2
+#define LPTIM_TRIGSOURCE_6                      ((uint32_t)LPTIM_CFGR_TRIGSEL_1 | LPTIM_CFGR_TRIGSEL_2)
+#define LPTIM_TRIGSOURCE_7                      LPTIM_CFGR_TRIGSEL
+#define IS_LPTIM_TRG_SOURCE(TRIG)               (((TRIG) == LPTIM_TRIGSOURCE_SOFTWARE) || \
+                                                 ((TRIG) == LPTIM_TRIGSOURCE_0) || \
+                                                 ((TRIG) == LPTIM_TRIGSOURCE_1) || \
+                                                 ((TRIG) == LPTIM_TRIGSOURCE_2) || \
+                                                 ((TRIG) == LPTIM_TRIGSOURCE_3) || \
+                                                 ((TRIG) == LPTIM_TRIGSOURCE_4) || \
+                                                 ((TRIG) == LPTIM_TRIGSOURCE_6) || \
+                                                 ((TRIG) == LPTIM_TRIGSOURCE_7))
+/**
+  * @}
+  */
+
+/** @defgroup LPTIM_External_Trigger_Polarity
+  * @{
+  */
+#define LPTIM_ACTIVEEDGE_RISING                LPTIM_CFGR_TRIGEN_0
+#define LPTIM_ACTIVEEDGE_FALLING               LPTIM_CFGR_TRIGEN_1
+#define LPTIM_ACTIVEEDGE_RISING_FALLING        LPTIM_CFGR_TRIGEN
+#define IS_LPTIM_EXT_TRG_POLARITY(POLAR)      (((POLAR) == LPTIM_ACTIVEEDGE_RISING         ) || \
+                                               ((POLAR) == LPTIM_ACTIVEEDGE_FALLING        ) || \
+                                               ((POLAR) == LPTIM_ACTIVEEDGE_RISING_FALLING ))
+
+/**
+  * @}
+  */
+
+/** @defgroup LPTIM_Trigger_Sample_Time
+  * @{
+  */
+#define LPTIM_TRIGSAMPLETIME_DIRECTTRANSISTION  ((uint32_t)0x00000000)
+#define LPTIM_TRIGSAMPLETIME_2TRANSISTIONS      LPTIM_CFGR_TRGFLT_0
+#define LPTIM_TRIGSAMPLETIME_4TRANSISTIONS      LPTIM_CFGR_TRGFLT_1
+#define LPTIM_TRIGSAMPLETIME_8TRANSISTIONS      LPTIM_CFGR_TRGFLT
+#define IS_LPTIM_TRIG_SAMPLE_TIME(SAMPLETIME)   (((SAMPLETIME) == LPTIM_TRIGSAMPLETIME_DIRECTTRANSISTION) || \
+                                                 ((SAMPLETIME) == LPTIM_TRIGSAMPLETIME_2TRANSISTIONS    ) || \
+                                                 ((SAMPLETIME) == LPTIM_TRIGSAMPLETIME_4TRANSISTIONS    ) || \
+                                                 ((SAMPLETIME) == LPTIM_TRIGSAMPLETIME_8TRANSISTIONS    ))
+/**
+  * @}
+  */
+
+/** @defgroup LPTIM_Updating_Mode
+  * @{
+  */
+
+#define LPTIM_UPDATE_IMMEDIATE                  ((uint32_t)0x00000000)
+#define LPTIM_UPDATE_ENDOFPERIOD                LPTIM_CFGR_PRELOAD
+#define IS_LPTIM_UPDATE_MODE(MODE)             (((MODE) == LPTIM_UPDATE_IMMEDIATE) || \
+                                                ((MODE) == LPTIM_UPDATE_ENDOFPERIOD))
+
+/**
+  * @}
+  */
+
+/** @defgroup LPTIM_Counter_Source
+  * @{
+  */
+
+#define LPTIM_COUNTERSOURCE_INTERNAL            ((uint32_t)0x00000000)
+#define LPTIM_COUNTERSOURCE_EXTERNAL            LPTIM_CFGR_COUNTMODE
+#define IS_LPTIM_COUNTER_SOURCE(SOURCE)        (((SOURCE) == LPTIM_COUNTERSOURCE_INTERNAL) || \
+                                                ((SOURCE) == LPTIM_COUNTERSOURCE_EXTERNAL))
+
+/**
+  * @}
+  */
+
+/** @defgroup LPTIM_Autorelaod_Value
+  * @{
+  */
+#define IS_LPTIM_PERIOD(PERIOD)               ((PERIOD) <= 0x0000FFFF)
+/**
+  * @}
+  */
+
+/** @defgroup LPTIM_Compare_Value
+  * @{
+  */
+#define IS_LPTIM_PULSE(PULSE)                 ((PULSE) <= 0x0000FFFF)
+/**
+  * @}
+  */
+ 
+/** @defgroup LPTIM_Flag_Definition
+  * @{
+  */
+
+#define LPTIM_FLAG_DOWN                          LPTIM_ISR_DOWN
+#define LPTIM_FLAG_UP                            LPTIM_ISR_UP
+#define LPTIM_FLAG_ARROK                         LPTIM_ISR_ARROK
+#define LPTIM_FLAG_CMPOK                         LPTIM_ISR_CMPOK
+#define LPTIM_FLAG_EXTTRIG                       LPTIM_ISR_EXTTRIG
+#define LPTIM_FLAG_ARRM                          LPTIM_ISR_ARRM
+#define LPTIM_FLAG_CMPM                          LPTIM_ISR_CMPM
+#define IS_LPTIM_FLAG_(FLAG)                     (((FLAG) == LPTIM_FLAG_DOWN) || \
+                                                  ((FLAG) == LPTIM_FLAG_UP) || \
+                                                  ((FLAG) == LPTIM_FLAG_ARROK) || \
+                                                  ((FLAG) == LPTIM_FLAG_CMPOK) || \
+                                                  ((FLAG) == LPTIM_FLAG_EXTTRIG) || \
+                                                  ((FLAG) == LPTIM_FLAG_ARRM) || \
+                                                  ((FLAG) == LPTIM_FLAG_CMPM))
+/**
+  * @}
+  */
+/** @defgroup LPTIM_Interrupts_Definition
+  * @{
+  */
+
+#define LPTIM_IT_DOWN                            LPTIM_IER_DOWNIE
+#define LPTIM_IT_UP                              LPTIM_IER_UPIE
+#define LPTIM_IT_ARROK                           LPTIM_IER_ARROKIE
+#define LPTIM_IT_CMPOK                           LPTIM_IER_CMPOKIE
+#define LPTIM_IT_EXTTRIG                         LPTIM_IER_EXTTRIGIE
+#define LPTIM_IT_ARRM                            LPTIM_IER_ARRMIE
+#define LPTIM_IT_CMPM                            LPTIM_IER_CMPMIE
+#define IS_LPTIM_IT(IT)                          (((IT) == LPTIM_IT_DOWN) || \
+                                                  ((IT) == LPTIM_IT_UP) || \
+                                                  ((IT) == LPTIM_IT_ARROK) || \
+                                                  ((IT) == LPTIM_IT_CMPOK) || \
+                                                  ((IT) == LPTIM_IT_EXTTRIG) || \
+                                                  ((IT) == LPTIM_IT_ARRM) || \
+                                                  ((IT) == LPTIM_IT_CMPM))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup LPTIM_Exported_Macros
+  * @{
+  */
+
+/** @brief Reset LPTIM handle state
+  * @param  __HANDLE__: LPTIM handle
+  * @retval None
+  */
+#define __HAL_LPTIM_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_LPTIM_STATE_RESET)
+
+/**
+  * @brief  Enable/Disable the LPTIM peripheral.
+  * @param  __HANDLE__: LPTIM handle
+  * @retval None
+  */
+#define __HAL_LPTIM_ENABLE(__HANDLE__)   ((__HANDLE__)->Instance->CR |=  (LPTIM_CR_ENABLE))
+#define __HAL_LPTIM_DISABLE(__HANDLE__)  ((__HANDLE__)->Instance->CR &=  ~(LPTIM_CR_ENABLE))
+
+/**
+  * @brief  Starts the LPTIM peripheral in Continuous or in single mode.
+  * @param  __HANDLE__: DMA handle
+  * @retval None
+  */
+#define __HAL_LPTIM_START_CONTINUOUS(__HANDLE__)  ((__HANDLE__)->Instance->CR |=  LPTIM_CR_CNTSTRT)
+#define __HAL_LPTIM_START_SINGLE(__HANDLE__)      ((__HANDLE__)->Instance->CR |=  LPTIM_CR_SNGSTRT)
+ 
+    
+/**
+  * @brief  Writes the passed parameter in the Autoreload register.
+  * @param  __HANDLE__: LPTIM handle
+  * @param  __VALUE__ : Autoreload value
+  * @retval None
+  */
+#define __HAL_LPTIM_AUTORELOAD_SET(__HANDLE__ , __VALUE__)  ((__HANDLE__)->Instance->ARR =  (__VALUE__))
+
+/**
+  * @brief  Writes the passed parameter in the Compare register.
+  * @param  __HANDLE__: LPTIM handle
+  * @param  __VALUE__ : Compare value
+  * @retval None
+  */
+#define __HAL_LPTIM_COMPARE_SET(__HANDLE__ , __VALUE__)     ((__HANDLE__)->Instance->CMP =  (__VALUE__))
+
+/**
+  * @brief  Checks whether the specified LPTIM flag is set or not.
+  * @param  __HANDLE__: LPTIM handle
+  * @param  __FLAG__  : LPTIM flag to check
+  *            This parameter can be a value of:
+  *            @arg LPTIM_FLAG_DOWN    : Counter direction change up Flag.
+  *            @arg LPTIM_FLAG_UP      : Counter direction change down to up Flag.
+  *            @arg LPTIM_FLAG_ARROK   : Autoreload register update OK Flag.
+  *            @arg LPTIM_FLAG_CMPOK   : Compare register update OK Flag.
+  *            @arg LPTIM_FLAG_EXTTRIG : External trigger edge event Flag.
+  *            @arg LPTIM_FLAG_ARRM    : Autoreload match Flag.
+  *            @arg LPTIM_FLAG_CMPM    : Compare match Flag.
+  * @retval The state of the specified flag (SET or RESET).
+  */
+#define __HAL_LPTIM_GET_FLAG(__HANDLE__, __FLAG__)          (((__HANDLE__)->Instance->ISR &(__FLAG__)) == (__FLAG__))
+
+/**
+  * @brief  Clears the specified LPTIM flag.
+  * @param  __HANDLE__: LPTIM handle.
+  * @param  __FLAG__  : LPTIM flag to clear.
+  *            This parameter can be a value of:
+  *            @arg LPTIM_FLAG_DOWN    : Counter direction change up Flag.
+  *            @arg LPTIM_FLAG_UP      : Counter direction change down to up Flag.
+  *            @arg LPTIM_FLAG_ARROK   : Autoreload register update OK Flag.
+  *            @arg LPTIM_FLAG_CMPOK   : Compare register update OK Flag.
+  *            @arg LPTIM_FLAG_EXTTRIG : External trigger edge event Flag.
+  *            @arg LPTIM_FLAG_ARRM    : Autoreload match Flag.
+  *            @arg LPTIM_FLAG_CMPM    : Compare match Flag.
+  * @retval None.
+  */
+#define __HAL_LPTIM_CLEAR_FLAG(__HANDLE__, __FLAG__)         ((__HANDLE__)->Instance->ICR  = (__FLAG__))
+
+/**
+  * @brief  Enable the specified LPTIM interrupt.
+  * @param  __HANDLE__    : LPTIM handle.
+  * @param  __INTERRUPT__ : LPTIM interrupt to set.
+  *            This parameter can be a value of:
+  *            @arg LPTIM_IT_DOWN    : Counter direction change up Interrupt.
+  *            @arg LPTIM_IT_UP      : Counter direction change down to up Interrupt.
+  *            @arg LPTIM_IT_ARROK   : Autoreload register update OK Interrupt.
+  *            @arg LPTIM_IT_CMPOK   : Compare register update OK Interrupt.
+  *            @arg LPTIM_IT_EXTTRIG : External trigger edge event Interrupt.
+  *            @arg LPTIM_IT_ARRM    : Autoreload match Interrupt.
+  *            @arg LPTIM_IT_CMPM    : Compare match Interrupt.
+  * @retval None.
+  */
+#define __HAL_LPTIM_ENABLE_INTERRUPT(__HANDLE__, __INTERRUPT__)         ((__HANDLE__)->Instance->IER  |= (__INTERRUPT__))
+
+ /**
+  * @brief  Disable the specified LPTIM interrupt.
+  * @param  __HANDLE__    : LPTIM handle.
+  * @param  __INTERRUPT__ : LPTIM interrupt to set.
+  *            This parameter can be a value of:
+  *            @arg LPTIM_IT_DOWN    : Counter direction change up Interrupt.
+  *            @arg LPTIM_IT_UP      : Counter direction change down to up Interrupt.
+  *            @arg LPTIM_IT_ARROK   : Autoreload register update OK Interrupt.
+  *            @arg LPTIM_IT_CMPOK   : Compare register update OK Interrupt.
+  *            @arg LPTIM_IT_EXTTRIG : External trigger edge event Interrupt.
+  *            @arg LPTIM_IT_ARRM    : Autoreload match Interrupt.
+  *            @arg LPTIM_IT_CMPM    : Compare match Interrupt.
+  * @retval None.
+  */
+#define __HAL_LPTIM_DISABLE_INTERRUPT(__HANDLE__, __INTERRUPT__)         ((__HANDLE__)->Instance->IER  &= (~(__INTERRUPT__)))
+
+    /**
+  * @brief  Checks whether the specified LPTIM interrupt is set or not.
+  * @param  __HANDLE__    : LPTIM handle.
+  * @param  __INTERRUPT__ : LPTIM interrupt to check.
+  *            This parameter can be a value of:
+  *            @arg LPTIM_IT_DOWN    : Counter direction change up Interrupt.
+  *            @arg LPTIM_IT_UP      : Counter direction change down to up Interrupt.
+  *            @arg LPTIM_IT_ARROK   : Autoreload register update OK Interrupt.
+  *            @arg LPTIM_IT_CMPOK   : Compare register update OK Interrupt.
+  *            @arg LPTIM_IT_EXTTRIG : External trigger edge event Interrupt.
+  *            @arg LPTIM_IT_ARRM    : Autoreload match Interrupt.
+  *            @arg LPTIM_IT_CMPM    : Compare match Interrupt.
+  * @retval Interrupt status.
+  */
+    
+#define __HAL_LPTIM_GET_ITSTATUS(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->IER & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/**
+  * @}
+  */
+   
+/* Exported functions --------------------------------------------------------*/
+/* Initialization/de-initialization functions  ********************************/
+HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim);
+HAL_StatusTypeDef HAL_LPTIM_DeInit(LPTIM_HandleTypeDef *hlptim);
+
+/* MSP functions  *************************************************************/
+void HAL_LPTIM_MspInit(LPTIM_HandleTypeDef *hlptim);
+void HAL_LPTIM_MspDeInit(LPTIM_HandleTypeDef *hlptim);
+
+/* Start/Stop operation functions  *********************************************/
+/* ################################# PWM Mode ################################*/
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_LPTIM_PWM_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Pulse);
+HAL_StatusTypeDef HAL_LPTIM_PWM_Stop(LPTIM_HandleTypeDef *hlptim);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_LPTIM_PWM_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Pulse);
+HAL_StatusTypeDef HAL_LPTIM_PWM_Stop_IT(LPTIM_HandleTypeDef *hlptim);
+
+/* ############################# One Pulse Mode ##############################*/
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_LPTIM_OnePulse_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Pulse);
+HAL_StatusTypeDef HAL_LPTIM_OnePulse_Stop(LPTIM_HandleTypeDef *hlptim);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_LPTIM_OnePulse_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Pulse);
+HAL_StatusTypeDef HAL_LPTIM_OnePulse_Stop_IT(LPTIM_HandleTypeDef *hlptim);
+
+/* ############################## Set once Mode ##############################*/
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_LPTIM_SetOnce_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Pulse);
+HAL_StatusTypeDef HAL_LPTIM_SetOnce_Stop(LPTIM_HandleTypeDef *hlptim);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_LPTIM_SetOnce_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Pulse);
+HAL_StatusTypeDef HAL_LPTIM_SetOnce_Stop_IT(LPTIM_HandleTypeDef *hlptim);
+
+/* ############################### Encoder Mode ##############################*/
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_LPTIM_Encoder_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Period);
+HAL_StatusTypeDef HAL_LPTIM_Encoder_Stop(LPTIM_HandleTypeDef *hlptim);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_LPTIM_Encoder_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t Period);
+HAL_StatusTypeDef HAL_LPTIM_Encoder_Stop_IT(LPTIM_HandleTypeDef *hlptim);
+
+/* ############################# Time out  Mode ##############################*/
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_LPTIM_TimeOut_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Timeout);
+HAL_StatusTypeDef HAL_LPTIM_TimeOut_Stop(LPTIM_HandleTypeDef *hlptim);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_LPTIM_TimeOut_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t Period, uint32_t Timeout);
+HAL_StatusTypeDef HAL_LPTIM_TimeOut_Stop_IT(LPTIM_HandleTypeDef *hlptim);
+
+/* ############################## Counter Mode ###############################*/
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_LPTIM_Counter_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Period);
+HAL_StatusTypeDef HAL_LPTIM_Counter_Stop(LPTIM_HandleTypeDef *hlptim);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_LPTIM_Counter_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t Period);
+HAL_StatusTypeDef HAL_LPTIM_Counter_Stop_IT(LPTIM_HandleTypeDef *hlptim);
+
+/* Reading operation functions ************************************************/
+uint32_t HAL_LPTIM_ReadCounter(LPTIM_HandleTypeDef *hlptim);
+uint32_t HAL_LPTIM_ReadAutoReload(LPTIM_HandleTypeDef *hlptim);
+uint32_t HAL_LPTIM_ReadCompare(LPTIM_HandleTypeDef *hlptim);
+
+/* LPTIM IRQ functions  *******************************************************/
+void HAL_LPTIM_IRQHandler(LPTIM_HandleTypeDef *hlptim);
+
+/* CallBack functions  ********************************************************/
+void HAL_LPTIM_CompareMatchCallback(LPTIM_HandleTypeDef *hlptim);
+void HAL_LPTIM_AutoReloadMatchCallback(LPTIM_HandleTypeDef *hlptim);
+void HAL_LPTIM_TriggerCallback(LPTIM_HandleTypeDef *hlptim);
+void HAL_LPTIM_CompareWriteCallback(LPTIM_HandleTypeDef *hlptim);
+void HAL_LPTIM_AutoReloadWriteCallback(LPTIM_HandleTypeDef *hlptim);
+void HAL_LPTIM_DirectionUpCallback(LPTIM_HandleTypeDef *hlptim);
+void HAL_LPTIM_DirectionDownCallback(LPTIM_HandleTypeDef *hlptim);
+
+/* Peripheral State functions  ************************************************/
+HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(LPTIM_HandleTypeDef *hlptim);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_LPTIM_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_msp_template.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_msp_template.c
@@ -1,0 +1,133 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_bsp_template.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   HAL BSP module.
+  *          This file template is located in the HAL folder and should be copied 
+  *          to the user folder.
+  *         
+  @verbatim
+ ===============================================================================
+                     ##### How to use this driver #####
+ ===============================================================================
+    [..]
+    This file is generated automatically by MicroXplorer and eventually modified 
+    by the user
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup HAL_MSP
+  * @brief HAL MSP module.
+  * @{
+  */
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup HAL_MSP_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Initializes the Global BSP.
+  * @param  None
+  * @retval None
+  */
+void HAL_MspInit(void)
+{
+  /* NOTE : This function is generated automatically by STM32CubeMX and eventually  
+            modified by the user
+   */ 
+}
+
+/**
+  * @brief  DeInitializes the Global MSP.
+  * @param  None  
+  * @retval None
+  */
+void HAL_MspDeInit(void)
+{
+  /* NOTE : This function is generated automatically by STM32CubeMX and eventually  
+            modified by the user
+   */
+}
+
+/**
+  * @brief  Initializes the PPP MSP.
+  * @param  None
+  * @retval None
+  */
+void HAL_PPP_MspInit(void)
+{
+  /* NOTE : This function is generated automatically by STM32CubeMX and eventually  
+            modified by the user
+   */ 
+}
+
+/**
+  * @brief  DeInitializes the PPP MSP.
+  * @param  None  
+  * @retval None
+  */
+void HAL_PPP_MspDeInit(void)
+{
+  /* NOTE : This function is generated automatically by STM32CubeMX and eventually  
+            modified by the user
+   */
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pcd.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pcd.c
@@ -1,0 +1,1309 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_pcd.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   PCD HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the USB Peripheral Controller:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions 
+  *           + Peripheral State functions
+  *         
+  @verbatim
+  ==============================================================================
+                    ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      The PCD HAL driver can be used as follows:
+
+     (#) Declare a PCD_HandleTypeDef handle structure, for example:
+         PCD_HandleTypeDef  hpcd;
+        
+     (#) Fill parameters of Init structure in HCD handle
+  
+     (#) Call HAL_PCD_Init() API to initialize the HCD peripheral (Core, Device core, ...) 
+
+     (#) Initialize the PCD low level resources through the HAL_PCD_MspInit() API:
+         (##) Enable the PCD/USB Low Level interface clock using 
+              (+++) __USB_CLK_ENABLE;
+           
+         (##) Initialize the related GPIO clocks
+         (##) Configure PCD pin-out
+         (##) Configure PCD NVIC interrupt
+    
+     (#)Associate the Upper USB device stack to the HAL PCD Driver:
+         (##) hpcd.pData = pdev;
+
+     (#)Enable HCD transmission and reception:
+         (##) HAL_PCD_Start();
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PCD 
+  * @brief PCD HAL module driver
+  * @{
+  */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define BTABLE_ADDRESS                  (0x000)  
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd);
+void PCD_WritePMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes);
+void PCD_ReadPMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes);
+/* Private functions ---------------------------------------------------------*/
+
+
+/** @defgroup PCD_Private_Functions
+  * @{
+  */
+
+/** @defgroup PCD_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+ ===============================================================================
+            ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+ 
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the PCD according to the specified
+  *         parameters in the PCD_InitTypeDef and create the associated handle.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
+{ 
+  uint32_t i = 0;
+
+  uint32_t wInterrupt_Mask = 0;
+  
+  /* Check the PCD handle allocation */
+  if(hpcd == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_PCD_ALL_INSTANCE(hpcd->Instance));
+
+  hpcd->State = PCD_BUSY;
+  
+  /* Init the low level hardware : GPIO, CLOCK, NVIC... */
+  HAL_PCD_MspInit(hpcd);
+
+ /* Init endpoints structures */
+ for (i = 0; i < hpcd->Init.dev_endpoints ; i++)
+ {
+   /* Init ep structure */
+   hpcd->IN_ep[i].is_in = 1;
+   hpcd->IN_ep[i].num = i;
+   /* Control until ep is actvated */
+   hpcd->IN_ep[i].type = PCD_EP_TYPE_CTRL;
+   hpcd->IN_ep[i].maxpacket =  0;
+   hpcd->IN_ep[i].xfer_buff = 0;
+   hpcd->IN_ep[i].xfer_len = 0;
+ }
+ 
+ for (i = 0; i < hpcd->Init.dev_endpoints ; i++)
+ {
+   hpcd->OUT_ep[i].is_in = 0;
+   hpcd->OUT_ep[i].num = i;
+   /* Control until ep is activated */
+   hpcd->OUT_ep[i].type = PCD_EP_TYPE_CTRL;
+   hpcd->OUT_ep[i].maxpacket = 0;
+   hpcd->OUT_ep[i].xfer_buff = 0;
+   hpcd->OUT_ep[i].xfer_len = 0;
+ }
+  
+ /* Init Device */
+ /*CNTR_FRES = 1*/
+ hpcd->Instance->CNTR = USB_CNTR_FRES;
+ 
+ /*CNTR_FRES = 0*/
+ hpcd->Instance->CNTR = 0;
+ 
+ /*Clear pending interrupts*/
+ hpcd->Instance->ISTR = 0;
+ 
+  /*Set Btable Adress*/
+ hpcd->Instance->BTABLE = BTABLE_ADDRESS;
+  
+  /*set wInterrupt_Mask global variable*/
+  wInterrupt_Mask = USB_CNTR_CTRM  | USB_CNTR_WKUPM | USB_CNTR_SUSPM | USB_CNTR_ERRM \
+    | USB_CNTR_ESOFM | USB_CNTR_RESETM;
+  
+  /*Set interrupt mask*/
+  hpcd->Instance->CNTR = wInterrupt_Mask;
+  
+  hpcd->USB_Address = 0;
+  hpcd->State= PCD_READY;
+
+ return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the PCD peripheral 
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DeInit(PCD_HandleTypeDef *hpcd)
+{
+  /* Check the PCD handle allocation */
+  if(hpcd == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  hpcd->State = PCD_BUSY;
+  
+  /* Stop Device */
+  HAL_PCD_Stop(hpcd);
+    
+  /* DeInit the low level hardware */
+  HAL_PCD_MspDeInit(hpcd);
+  
+  hpcd->State = PCD_READY; 
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the PCD MSP.
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_MspInit could be implenetd in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes PCD MSP.
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+__weak void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_MspDeInit could be implenetd in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup PCD_Group2 IO operation functions 
+ *  @brief   Data transfers functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to manage the PCD data 
+    transfers.
+
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Start The USB OTG Device.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_Start(PCD_HandleTypeDef *hpcd)
+{ 
+  /* Enabling DP Pull-Down bit to Connect internal pull-up on USB DP line */
+  hpcd->Instance->BCDR |= USB_BCDR_DPPU;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stop The USB OTG Device.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_Stop(PCD_HandleTypeDef *hpcd)
+{ 
+  __HAL_LOCK(hpcd); 
+  
+    /* disable all interrupts and force USB reset */
+  hpcd->Instance->CNTR = USB_CNTR_FRES;
+  
+  /* clear interrupt status register */
+  hpcd->Instance->ISTR = 0;
+  
+  /* switch-off device */
+  hpcd->Instance->CNTR = (USB_CNTR_FRES | USB_CNTR_PDWN);
+  
+  __HAL_UNLOCK(hpcd); 
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles PCD interrupt request.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
+{
+  uint32_t wInterrupt_Mask = 0;
+  
+  if (__HAL_PCD_GET_FLAG (hpcd, USB_ISTR_CTR))
+  {
+    /* servicing of the endpoint correct transfer interrupt */
+    /* clear of the CTR flag into the sub */
+    PCD_EP_ISR_Handler(hpcd);
+  }
+
+  if (__HAL_PCD_GET_FLAG (hpcd, USB_ISTR_RESET))
+  {
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_RESET);
+    HAL_PCD_ResetCallback(hpcd);
+    HAL_PCD_SetAddress(hpcd, 0);
+  }
+
+  if (__HAL_PCD_GET_FLAG (hpcd, USB_ISTR_PMAOVR))
+  {
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_PMAOVR);    
+  }
+
+  if (__HAL_PCD_GET_FLAG (hpcd, USB_ISTR_ERR))
+  {
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_ERR); 
+  }
+
+  if (__HAL_PCD_GET_FLAG (hpcd, USB_ISTR_WKUP))
+  {
+    
+    hpcd->Instance->CNTR &= ~(USB_CNTR_LPMODE);
+    
+    /*set wInterrupt_Mask global variable*/
+    wInterrupt_Mask = USB_CNTR_CTRM  | USB_CNTR_WKUPM | USB_CNTR_SUSPM | USB_CNTR_ERRM \
+      | USB_CNTR_ESOFM | USB_CNTR_RESETM;
+    
+    /*Set interrupt mask*/
+    hpcd->Instance->CNTR = wInterrupt_Mask;
+    
+    HAL_PCD_ResumeCallback(hpcd);
+    
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_WKUP);     
+  }
+
+  if (__HAL_PCD_GET_FLAG (hpcd, USB_ISTR_SUSP))
+  {    
+    /* clear of the ISTR bit must be done after setting of CNTR_FSUSP */
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_SUSP);  
+    
+    /* Force low-power mode in the macrocell */
+    hpcd->Instance->CNTR |= USB_CNTR_FSUSP;
+    hpcd->Instance->CNTR |= USB_CNTR_LPMODE;
+    
+    if (__HAL_PCD_GET_FLAG (hpcd, USB_ISTR_WKUP) == 0)
+    {
+      HAL_PCD_SuspendCallback(hpcd);
+    }
+  }
+
+  if (__HAL_PCD_GET_FLAG (hpcd, USB_ISTR_SOF))
+  {
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_SOF); 
+    HAL_PCD_SOFCallback(hpcd);
+  }
+
+  if (__HAL_PCD_GET_FLAG (hpcd, USB_ISTR_ESOF))
+  {
+    /* clear ESOF flag in ISTR */
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_ESOF); 
+  }
+}
+
+/**
+  * @brief  Data out stage callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_DataOutStageCallback could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @brief  Data IN stage callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_DataOutStageCallback could be implenetd in the user file
+   */ 
+}
+/**
+  * @brief  Setup stage callback
+  * @param  hpcd: ppp handle
+  * @retval None
+  */
+ __weak void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_DataOutStageCallback could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @brief  USB Start Of Frame callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_DataOutStageCallback could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @brief  USB Reset callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_DataOutStageCallback could be implenetd in the user file
+   */ 
+}
+
+
+/**
+  * @brief  Suspend event callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_DataOutStageCallback could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @brief  Resume event callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_ResumeCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_DataOutStageCallback could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @brief  Incomplete ISO OUT callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_ISOOUTIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_DataOutStageCallback could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @brief  Incomplete ISO IN  callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_ISOINIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_DataOutStageCallback could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @brief  Connection event callbacks
+  * @param  hpcd: PCD handle
+  * @retval None
+  */
+ __weak void HAL_PCD_ConnectCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_DataOutStageCallback could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @brief  Disconnection event callbacks
+  * @param  hpcd: ppp handle
+  * @retval None
+  */
+ __weak void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCD_DataOutStageCallback could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+  
+/** @defgroup PCD_Group3 Peripheral Control functions 
+ *  @brief   management functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to control the PCD data 
+    transfers.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Send an amount of data in blocking mode 
+  * @param  hpcd: PCD handle
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DevConnect(PCD_HandleTypeDef *hpcd)
+{
+  __HAL_LOCK(hpcd); 
+  
+  /* Enabling DP Pull-Down bit to Connect internal pull-up on USB DP line */
+  hpcd->Instance->BCDR |= USB_BCDR_DPPU;
+  
+  __HAL_UNLOCK(hpcd); 
+  return HAL_OK;
+}
+
+/**
+  * @brief  Send an amount of data in blocking mode 
+  * @param  hpcd: PCD handle
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_DevDisconnect(PCD_HandleTypeDef *hpcd)
+{
+  __HAL_LOCK(hpcd); 
+  
+  /* Disable DP Pull-Down bit*/
+   hpcd->Instance->BCDR &= ~(USB_BCDR_DPPU);
+  
+  __HAL_UNLOCK(hpcd); 
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the USB Device address 
+  * @param  hpcd: PCD handle
+  * @param  address: new device address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_SetAddress(PCD_HandleTypeDef *hpcd, uint8_t address)
+{
+   __HAL_LOCK(hpcd); 
+
+   if(address == 0) 
+   {
+     /* set device address and enable function */
+     hpcd->Instance->DADDR = USB_DADDR_EF;
+   }
+   else /* USB Address will be applied later */
+   {
+     hpcd->USB_Address = address;
+   }
+
+  __HAL_UNLOCK(hpcd);   
+  return HAL_OK;
+}
+/**
+  * @brief  Open and configure an endpoint
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @param  ep_mps: endpoint max packert size
+  * @param  ep_type: endpoint type   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint16_t ep_mps, uint8_t ep_type)
+{
+  HAL_StatusTypeDef  ret = HAL_OK;
+  PCD_EPTypeDef *ep;
+  
+  if ((ep_addr & 0x80) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr & 0x7F];
+  }
+  ep->num   = ep_addr & 0x7F;
+  
+  ep->is_in = (0x80 & ep_addr) != 0;
+  ep->maxpacket = ep_mps;
+  ep->type = ep_type;
+  
+  __HAL_LOCK(hpcd); 
+
+/* initialize Endpoint */
+  switch (ep->type)
+  {
+  case PCD_EP_TYPE_CTRL:
+    PCD_SET_EPTYPE(hpcd->Instance, ep->num, USB_EP_CONTROL);
+    break;
+  case PCD_EP_TYPE_BULK:
+    PCD_SET_EPTYPE(hpcd->Instance, ep->num, USB_EP_BULK);
+    break;
+  case PCD_EP_TYPE_INTR:
+    PCD_SET_EPTYPE(hpcd->Instance, ep->num, USB_EP_INTERRUPT);
+    break;
+  case PCD_EP_TYPE_ISOC:
+    PCD_SET_EPTYPE(hpcd->Instance, ep->num, USB_EP_ISOCHRONOUS);
+    break;
+  } 
+  
+  PCD_SET_EP_ADDRESS(hpcd->Instance, ep->num, ep->num);
+  
+  if (ep->doublebuffer == 0) 
+  {
+    if (ep->is_in)
+    {
+      /*Set the endpoint Transmit buffer address */
+      PCD_SET_EP_TX_ADDRESS(hpcd->Instance, ep->num, ep->pmaadress);
+      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num);
+      /* Configure NAK status for the Endpoint*/
+      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_NAK); 
+    }
+    else
+    {
+      /*Set the endpoint Receive buffer address */
+      PCD_SET_EP_RX_ADDRESS(hpcd->Instance, ep->num, ep->pmaadress);
+      /*Set the endpoint Receive buffer counter*/
+      PCD_SET_EP_RX_CNT(hpcd->Instance, ep->num, ep->maxpacket);
+      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num);
+      /* Configure VALID status for the Endpoint*/
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_VALID);
+    }
+  }
+  /*Double Buffer*/
+  else
+  {
+    /*Set the endpoint as double buffered*/
+    PCD_SET_EP_DBUF(hpcd->Instance, ep->num);
+    /*Set buffer address for double buffered mode*/
+    PCD_SET_EP_DBUF_ADDR(hpcd->Instance, ep->num,ep->pmaaddr0, ep->pmaaddr1);
+    
+    if (ep->is_in==0)
+    {
+      /* Clear the data toggle bits for the endpoint IN/OUT*/
+      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num);
+      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num);
+      
+      /* Reset value of the data toggle bits for the endpoint out*/
+      PCD_TX_DTOG(hpcd->Instance, ep->num);
+      
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_VALID);
+      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS);
+    }
+    else
+    {
+      /* Clear the data toggle bits for the endpoint IN/OUT*/
+      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num);
+      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num);
+      PCD_RX_DTOG(hpcd->Instance, ep->num);
+      /* Configure DISABLE status for the Endpoint*/
+      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS);
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_DIS);
+    }
+  } 
+  
+  __HAL_UNLOCK(hpcd);   
+  return ret;
+}
+
+
+/**
+  * @brief  Deactivate an endpoint
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{  
+  PCD_EPTypeDef *ep;
+  
+  if ((ep_addr & 0x80) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr & 0x7F];
+  }
+  ep->num   = ep_addr & 0x7F;
+  
+  ep->is_in = (0x80 & ep_addr) != 0;
+  
+  __HAL_LOCK(hpcd); 
+
+  if (ep->doublebuffer == 0) 
+  {
+    if (ep->is_in)
+    {
+      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num);
+      /* Configure DISABLE status for the Endpoint*/
+      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS); 
+    }
+    else
+    {
+      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num);
+      /* Configure DISABLE status for the Endpoint*/
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_DIS);
+    }
+  }
+  /*Double Buffer*/
+  else
+  { 
+    if (ep->is_in==0)
+    {
+      /* Clear the data toggle bits for the endpoint IN/OUT*/
+      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num);
+      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num);
+      
+      /* Reset value of the data toggle bits for the endpoint out*/
+      PCD_TX_DTOG(hpcd->Instance, ep->num);
+      
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_DIS);
+      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS);
+    }
+    else
+    {
+      /* Clear the data toggle bits for the endpoint IN/OUT*/
+      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num);
+      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num);
+      PCD_RX_DTOG(hpcd->Instance, ep->num);
+      /* Configure DISABLE status for the Endpoint*/
+      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS);
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_DIS);
+    }
+  } 
+  
+  __HAL_UNLOCK(hpcd);   
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Receive an amount of data  
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @param  pBuf: pointer to the reception buffer   
+  * @param  len: amount of data to be received
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len)
+{
+  
+ PCD_EPTypeDef *ep;
+  
+  ep = &hpcd->OUT_ep[ep_addr & 0x7F];
+  
+  /*setup and start the Xfer */
+  ep->xfer_buff = pBuf;  
+  ep->xfer_len = len;
+  ep->xfer_count = 0;
+  ep->is_in = 0;
+  ep->num = ep_addr & 0x7F;
+   
+  __HAL_LOCK(hpcd); 
+   
+  /* Multi packet transfer*/
+  if (ep->xfer_len > ep->maxpacket)
+  {
+    len=ep->maxpacket;
+    ep->xfer_len-=len; 
+  }
+  else
+  {
+    len=ep->xfer_len;
+    ep->xfer_len =0;
+  }
+  
+  /* configure and validate Rx endpoint */
+  if (ep->doublebuffer == 0) 
+  {
+    /*Set RX buffer count*/
+    PCD_SET_EP_RX_CNT(hpcd->Instance, ep->num, len);
+  }
+  else
+  {
+    /*Set the Double buffer counter*/
+    PCD_SET_EP_DBUF1_CNT(hpcd->Instance, ep->num, ep->is_in, len);
+  } 
+  
+  PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_VALID);
+  
+  __HAL_UNLOCK(hpcd); 
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get Received Data Size
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval Data Size
+  */
+uint16_t HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  return hpcd->OUT_ep[ep_addr & 0x7F].xfer_count;
+}
+/**
+  * @brief  Send an amount of data  
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @param  pBuf: pointer to the transmission buffer   
+  * @param  len: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len)
+{
+  PCD_EPTypeDef *ep;
+  uint16_t pmabuffer = 0;
+    
+  ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  
+  /*setup and start the Xfer */
+  ep->xfer_buff = pBuf;  
+  ep->xfer_len = len;
+  ep->xfer_count = 0;
+  ep->is_in = 1;
+  ep->num = ep_addr & 0x7F;
+  
+  __HAL_LOCK(hpcd); 
+  
+  /*Multi packet transfer*/
+  if (ep->xfer_len > ep->maxpacket)
+  {
+    len=ep->maxpacket;
+    ep->xfer_len-=len; 
+  }
+  else
+  {  
+    len=ep->xfer_len;
+    ep->xfer_len =0;
+  }
+  
+  /* configure and validate Tx endpoint */
+  if (ep->doublebuffer == 0) 
+  {
+    PCD_WritePMA(hpcd->Instance, ep->xfer_buff, ep->pmaadress, len);
+    PCD_SET_EP_TX_CNT(hpcd->Instance, ep->num, len);
+  }
+  else
+  {
+    /*Set the Double buffer counter*/
+    PCD_SET_EP_DBUF1_CNT(hpcd->Instance, ep->num, ep->is_in, len);
+    
+    /*Write the data to the USB endpoint*/
+    if (PCD_GET_ENDPOINT(hpcd->Instance, ep->num)& USB_EP_DTOG_TX)
+    {
+      pmabuffer = ep->pmaaddr1;
+    }
+    else
+    {
+      pmabuffer = ep->pmaaddr0;
+    }
+    PCD_WritePMA(hpcd->Instance, ep->xfer_buff, pmabuffer, len);
+    PCD_FreeUserBuffer(hpcd->Instance, ep->num, ep->is_in);
+  }
+
+  PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_VALID);
+  
+  __HAL_UNLOCK(hpcd);
+     
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set a STALL condition over an endpoint
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  PCD_EPTypeDef *ep;
+   
+  __HAL_LOCK(hpcd); 
+   
+  if ((0x80 & ep_addr) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr];
+  }
+  
+  ep->is_stall = 1;
+  ep->num   = ep_addr & 0x7F;
+  ep->is_in = ((ep_addr & 0x80) == 0x80);
+  
+  if (ep->num == 0)
+  {
+    /* This macro sets STALL status for RX & TX*/ 
+    PCD_SET_EP_TXRX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_STALL, USB_EP_TX_STALL); 
+  }
+  else
+  {
+    if (ep->is_in)
+    {
+      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num , USB_EP_TX_STALL); 
+    }
+    else
+    {
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num , USB_EP_RX_STALL);
+    }
+  }
+  __HAL_UNLOCK(hpcd); 
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Clear a STALL condition over in an endpoint
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  PCD_EPTypeDef *ep;
+  
+  if ((0x80 & ep_addr) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr];
+  }
+  
+  ep->is_stall = 0;
+  ep->num   = ep_addr & 0x7F;
+  ep->is_in = ((ep_addr & 0x80) == 0x80);
+  
+  __HAL_LOCK(hpcd); 
+  
+  if (ep->is_in)
+  {
+    PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num);
+    PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_VALID);
+  }
+  else
+  {
+    PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num);
+    PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_VALID);
+  }
+  __HAL_UNLOCK(hpcd); 
+    
+  return HAL_OK;
+}
+
+/**
+  * @brief  Flush an endpoint
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{ 
+  return HAL_OK;
+}
+
+/**
+  * @brief  HAL_PCD_ActiveRemoteWakeup : active remote wakeup signalling
+  * @param  hpcd: PCD handle
+  * @retval status
+  */
+HAL_StatusTypeDef HAL_PCD_ActiveRemoteWakeup(PCD_HandleTypeDef *hpcd)
+{
+  hpcd->Instance->CNTR |= USB_CNTR_RESUME;
+  return HAL_OK;  
+}
+
+/**
+  * @brief  HAL_PCD_DeActiveRemoteWakeup : de-active remote wakeup signalling
+  * @param  hpcd: PCD handle
+  * @retval status
+  */
+HAL_StatusTypeDef HAL_PCD_DeActiveRemoteWakeup(PCD_HandleTypeDef *hpcd)
+{
+  hpcd->Instance->CNTR &= ~(USB_CNTR_RESUME);
+  return HAL_OK;  
+}
+
+/**
+  * @}
+  */
+  
+/** @defgroup PCD_Group4 Peripheral State functions 
+ *  @brief   Peripheral State functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================  
+    [..]
+    This subsection permit to get in run-time the status of the peripheral 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the PCD state
+  * @param  hpcd : PCD handle
+  * @retval HAL state
+  */
+PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd)
+{
+  return hpcd->State;
+}
+/**
+  * @}
+  */
+
+/**
+  * @brief  This function handles PCD Endpoint interrupt request.
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
+{
+  PCD_EPTypeDef *ep;
+  uint16_t count=0;
+  uint8_t EPindex;
+  __IO uint16_t wIstr;  
+  __IO uint16_t wEPVal = 0;
+  
+  /* stay in loop while pending interrupts */
+  while (((wIstr = hpcd->Instance->ISTR) & USB_ISTR_CTR) != 0)
+  {
+    /* extract highest priority endpoint number */
+    EPindex = (uint8_t)(wIstr & USB_ISTR_EP_ID);
+    
+    if (EPindex == 0)
+    {
+      /* Decode and service control endpoint interrupt */
+      
+      /* DIR bit = origin of the interrupt */   
+      if ((wIstr & USB_ISTR_DIR) == 0)
+      {
+        /* DIR = 0 */
+        
+        /* DIR = 0      => IN  int */
+        /* DIR = 0 implies that (EP_CTR_TX = 1) always  */
+        PCD_CLEAR_TX_EP_CTR(hpcd->Instance, PCD_ENDP0);
+        ep = &hpcd->IN_ep[0];
+        
+        ep->xfer_count = PCD_GET_EP_TX_CNT(hpcd->Instance, ep->num);
+        ep->xfer_buff += ep->xfer_count;
+ 
+        /* TX COMPLETE */
+        HAL_PCD_DataInStageCallback(hpcd, 0);
+        
+        
+        if((hpcd->USB_Address > 0)&& ( ep->xfer_len == 0))
+        {
+          hpcd->Instance->DADDR = (hpcd->USB_Address | USB_DADDR_EF);
+          hpcd->USB_Address = 0;
+        }
+        
+      }
+      else
+      {
+        /* DIR = 1 */
+        
+        /* DIR = 1 & CTR_RX       => SETUP or OUT int */
+        /* DIR = 1 & (CTR_TX | CTR_RX) => 2 int pending */
+        ep = &hpcd->OUT_ep[0];
+        wEPVal = PCD_GET_ENDPOINT(hpcd->Instance, PCD_ENDP0);
+        
+        if ((wEPVal & USB_EP_SETUP) != 0)
+        {
+          /* Get SETUP Packet*/
+          ep->xfer_count = PCD_GET_EP_RX_CNT(hpcd->Instance, ep->num);
+          PCD_ReadPMA(hpcd->Instance, (uint8_t*)hpcd->Setup ,ep->pmaadress , ep->xfer_count);       
+          /* SETUP bit kept frozen while CTR_RX = 1*/ 
+          PCD_CLEAR_RX_EP_CTR(hpcd->Instance, PCD_ENDP0); 
+          
+          /* Process SETUP Packet*/
+          HAL_PCD_SetupStageCallback(hpcd);
+        }
+        
+        else if ((wEPVal & USB_EP_CTR_RX) != 0)
+        {
+          PCD_CLEAR_RX_EP_CTR(hpcd->Instance, PCD_ENDP0);
+          /* Get Control Data OUT Packet*/
+          ep->xfer_count = PCD_GET_EP_RX_CNT(hpcd->Instance, ep->num);
+          
+          if (ep->xfer_count != 0)
+          {
+            PCD_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaadress, ep->xfer_count);
+            ep->xfer_buff+=ep->xfer_count;
+          }
+          
+          /* Process Control Data OUT Packet*/
+           HAL_PCD_DataOutStageCallback(hpcd, 0);
+          
+          PCD_SET_EP_RX_CNT(hpcd->Instance, PCD_ENDP0, ep->maxpacket);
+          PCD_SET_EP_RX_STATUS(hpcd->Instance, PCD_ENDP0, USB_EP_RX_VALID);
+        }
+      }
+    }
+    else
+    {
+      
+      /* Decode and service non control endpoints interrupt  */
+      
+      /* process related endpoint register */
+      wEPVal = PCD_GET_ENDPOINT(hpcd->Instance, EPindex);
+      if ((wEPVal & USB_EP_CTR_RX) != 0)
+      {  
+        /* clear int flag */
+        PCD_CLEAR_RX_EP_CTR(hpcd->Instance, EPindex);
+        ep = &hpcd->OUT_ep[EPindex];
+        
+        /* OUT double Buffering*/
+        if (ep->doublebuffer == 0)
+        {
+          count = PCD_GET_EP_RX_CNT(hpcd->Instance, ep->num);
+          if (count != 0)
+          {
+            PCD_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaadress, count);
+          }
+        }
+        else
+        {
+          if (PCD_GET_ENDPOINT(hpcd->Instance, ep->num) & USB_EP_DTOG_RX)
+          {
+            /*read from endpoint BUF0Addr buffer*/
+            count = PCD_GET_EP_DBUF0_CNT(hpcd->Instance, ep->num);
+            if (count != 0)
+            {
+              PCD_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr0, count);
+            }
+          }
+          else
+          {
+            /*read from endpoint BUF1Addr buffer*/
+            count = PCD_GET_EP_DBUF1_CNT(hpcd->Instance, ep->num);
+            if (count != 0)
+            {
+              PCD_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr1, count);
+            }
+          }
+          PCD_FreeUserBuffer(hpcd->Instance, ep->num, PCD_EP_DBUF_OUT);  
+        }
+        /*multi-packet on the NON control OUT endpoint*/
+        ep->xfer_count+=count;
+        ep->xfer_buff+=count;
+       
+        if ((ep->xfer_len == 0) || (count < ep->maxpacket))
+        {
+          /* RX COMPLETE */
+          HAL_PCD_DataOutStageCallback(hpcd, ep->num);
+        }
+        else
+        {
+          HAL_PCD_EP_Receive(hpcd, ep->num, ep->xfer_buff, ep->xfer_len);
+        }
+        
+      } /* if((wEPVal & EP_CTR_RX) */
+      
+      if ((wEPVal & USB_EP_CTR_TX) != 0)
+      {
+        ep = &hpcd->IN_ep[EPindex];
+        
+        /* clear int flag */
+        PCD_CLEAR_TX_EP_CTR(hpcd->Instance, EPindex);
+        
+        /* IN double Buffering*/
+        if (ep->doublebuffer == 0)
+        {
+          ep->xfer_count = PCD_GET_EP_TX_CNT(hpcd->Instance, ep->num);
+          if (ep->xfer_count != 0)
+          {
+            PCD_WritePMA(hpcd->Instance, ep->xfer_buff, ep->pmaadress, ep->xfer_count);
+          }
+        }
+        else
+        {
+          if (PCD_GET_ENDPOINT(hpcd->Instance, ep->num) & USB_EP_DTOG_TX)
+          {
+            /*read from endpoint BUF0Addr buffer*/
+            ep->xfer_count = PCD_GET_EP_DBUF0_CNT(hpcd->Instance, ep->num);
+            if (ep->xfer_count != 0)
+            {
+              PCD_WritePMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr0, ep->xfer_count);
+            }
+          }
+          else
+          {
+            /*read from endpoint BUF1Addr buffer*/
+            ep->xfer_count = PCD_GET_EP_DBUF1_CNT(hpcd->Instance, ep->num);
+            if (ep->xfer_count != 0)
+            {
+              PCD_WritePMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr1, ep->xfer_count);
+            }
+          }
+          PCD_FreeUserBuffer(hpcd->Instance, ep->num, PCD_EP_DBUF_IN);  
+        }
+        /*multi-packet on the NON control IN endpoint*/
+        ep->xfer_count = PCD_GET_EP_TX_CNT(hpcd->Instance, ep->num);
+        ep->xfer_buff+=ep->xfer_count;
+       
+        /* Zero Length Packet? */
+        if (ep->xfer_len == 0)
+        {
+          /* TX COMPLETE */
+          HAL_PCD_DataInStageCallback(hpcd, ep->num);
+        }
+        else
+        {
+          HAL_PCD_EP_Transmit(hpcd, ep->num, ep->xfer_buff, ep->xfer_len);
+        }
+      } 
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief Copy a buffer from user memory area to packet memory area (PMA)
+  * @param   pbUsrBuf: pointer to user memory area.
+  * @param   wPMABufAddr: address into PMA.
+  * @param   wNBytes: no. of bytes to be copied.
+  * @retval None
+  */
+void PCD_WritePMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes)
+{
+  uint32_t n = (wNBytes + 1) >> 1; 
+  uint32_t i;
+  uint16_t temp1, temp2;
+  uint16_t *pdwVal;
+  pdwVal = (uint16_t *)(wPMABufAddr + (uint32_t)USBx + 0x400);
+  
+  for (i = n; i != 0; i--)
+  {
+    temp1 = (uint16_t) * pbUsrBuf;
+    pbUsrBuf++;
+    temp2 = temp1 | (uint16_t) * pbUsrBuf << 8;
+    *pdwVal++ = temp2;
+    pbUsrBuf++;
+  }
+}
+
+/**
+  * @brief Copy a buffer from user memory area to packet memory area (PMA)
+  * @param   pbUsrBuf    = pointer to user memory area.
+  * @param   wPMABufAddr: address into PMA.
+  * @param   wNBytes: no. of bytes to be copied.
+  * @retval None
+  */
+void PCD_ReadPMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes)
+{
+  uint32_t n = (wNBytes + 1) >> 1;
+  uint32_t i;
+  uint16_t *pdwVal;
+  pdwVal = (uint16_t *)(wPMABufAddr + (uint32_t)USBx + 0x400);
+  for (i = n; i != 0; i--)
+  {
+    *(uint16_t*)pbUsrBuf++ = *pdwVal++;
+    pbUsrBuf++;
+  }
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_PCD_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pcd.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pcd.h
@@ -1,0 +1,690 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_pcd.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of PCD HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_PCD_H
+#define __STM32L0xx_HAL_PCD_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"  
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PCD
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+
+   /** 
+  * @brief  PCD State structures definition  
+  */  
+typedef enum 
+{
+  PCD_READY    = 0x00,
+  PCD_ERROR    = 0x01,
+  PCD_BUSY     = 0x02,
+  PCD_TIMEOUT  = 0x03
+} PCD_StateTypeDef;
+
+typedef enum
+{
+  /* double buffered endpoint direction */
+  PCD_EP_DBUF_OUT,
+  PCD_EP_DBUF_IN,
+  PCD_EP_DBUF_ERR,
+}PCD_EP_DBUF_DIR;
+
+/* endpoint buffer number */
+typedef enum 
+{
+  PCD_EP_NOBUF,
+  PCD_EP_BUF0,
+  PCD_EP_BUF1
+}PCD_EP_BUF_NUM;  
+
+#define PCD_ENDP0                             ((uint8_t)0)
+#define PCD_ENDP1                             ((uint8_t)1)
+#define PCD_ENDP2                             ((uint8_t)2)
+#define PCD_ENDP3                             ((uint8_t)3)
+#define PCD_ENDP4                             ((uint8_t)4)
+#define PCD_ENDP5                             ((uint8_t)5)
+#define PCD_ENDP6                             ((uint8_t)6)
+#define PCD_ENDP7                             ((uint8_t)7)
+
+/*  Endpoint Kind */
+#define PCD_SNG_BUF                                      0
+#define PCD_DBL_BUF                                      1
+
+#define IS_PCD_ALL_INSTANCE            IS_USB_ALL_INSTANCE
+/** 
+  * @brief  PCD Initialization Structure definition  
+  */
+typedef struct
+{
+  uint32_t dev_endpoints;        /*!< Device Endpoints number.
+                                      This parameter depends on the used USB core.   
+                                      This parameter must be a number between Min_Data = 1 and Max_Data = 15 */ 
+
+  uint32_t speed;                /*!< USB Core speed.
+                                      This parameter can be any value of @ref PCD_Speed                */ 
+                             
+  uint32_t ep0_mps;              /*!< Set the Endpoint 0 Max Packet size. 
+                                      This parameter can be any value of @ref PCD_USB_EP0_MPS                   */ 
+                       
+  uint32_t phy_itface;           /*!< Select the used PHY interface.
+                                      This parameter can be any value of @ref PCD_USB_Core_PHY                  */ 
+                                
+  uint32_t Sof_enable;           /*!< Enable or disable the output of the SOF signal.
+                                      This parameter can be set to ENABLE or DISABLE                        */  
+  
+  uint32_t low_power_enable;       /*!< Enable or disable Low Power mode
+                                        This parameter can be set to ENABLE or DISABLE                      */ 
+  
+  uint32_t lpm_enable;             /*!< Enable or disable Link Power Management.
+                                        This parameter can be set to ENABLE or DISABLE */ 
+
+  uint32_t battery_charging_enable; /*!< Enable or disable Battery charging.
+                                         This parameter can be set to ENABLE or DISABLE */ 
+                                
+}PCD_InitTypeDef;
+
+typedef struct
+{
+  uint8_t   num;            /*!< Endpoint number
+                                This parameter must be a number between Min_Data = 1 and Max_Data = 15    */ 
+                                
+  uint8_t   is_in;          /*!< Endpoint direction
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1     */ 
+  
+  uint8_t   is_stall;       /*!< Endpoint stall condition
+                                This parameter must be a number between Min_Data = 0 and Max_Data = 1     */ 
+  
+  uint8_t   type;           /*!< Endpoint type
+                                 This parameter can be any value of @ref PCD_USB_EP_Type                     */ 
+                                
+  uint16_t  pmaadress;      /*!< PMA Address
+                                 This parameter can be any value between Min_addr = 0 and Max_addr = 1K   */ 
+  
+  
+  uint16_t  pmaaddr0;       /*!< PMA Address0
+                                 This parameter can be any value between Min_addr = 0 and Max_addr = 1K   */   
+  
+  
+  uint16_t  pmaaddr1;        /*!< PMA Address1
+                                 This parameter can be any value between Min_addr = 0 and Max_addr = 1K   */   
+  
+  
+  uint8_t   doublebuffer;    /*!< Double buffer enable
+                                 This parameter can be 0 or 1                                             */    
+                                
+  uint32_t  maxpacket;      /*!< Endpoint Max packet size
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 64KB */
+
+  uint8_t   *xfer_buff;     /*!< Pointer to transfer buffer                                               */
+                                
+  
+  uint32_t  xfer_len;       /*!< Current transfer length                                                  */
+  
+  uint32_t  xfer_count;     /*!< Partial transfer length in case of multi packet transfer                 */
+
+}PCD_EPTypeDef;
+
+typedef   USB_TypeDef PCD_TypeDef; 
+
+/** 
+  * @brief  PCD Handle Structure definition  
+  */ 
+typedef struct
+{
+  PCD_TypeDef             *Instance;   /*!< Register base address              */ 
+  PCD_InitTypeDef         Init;       /*!< PCD required parameters            */
+  __IO uint8_t            USB_Address; /*!< USB Address            */  
+  PCD_EPTypeDef           IN_ep[5];  /*!< IN endpoint parameters             */
+  PCD_EPTypeDef           OUT_ep[5]; /*!< OUT endpoint parameters            */ 
+  HAL_LockTypeDef         Lock;       /*!< PCD peripheral status              */
+  __IO PCD_StateTypeDef   State;      /*!< PCD communication state            */
+  uint32_t                Setup[12];  /*!< Setup packet buffer                */
+  void                    *pData;      /*!< Pointer to upper stack Handler     */    
+  
+} PCD_HandleTypeDef;
+ 
+#include "stm32l0xx_hal_pcd_ex.h"    
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup PCD_Exported_Constants
+  * @{
+  */
+
+/** @defgroup PCD_Speed
+  * @{
+  */
+#define PCD_SPEED_HIGH               0 /* Not Supported */
+#define PCD_SPEED_FULL               2
+/**
+  * @}
+  */
+  
+  /** @defgroup PCD_USB_Core_PHY
+  * @{
+  */
+#define PCD_PHY_EMBEDDED             2
+/**
+  * @}
+  */
+
+  /** @defgroup PCD_USB_EP0_MPS
+  * @{
+  */
+#define DEP0CTL_MPS_64                         0
+#define DEP0CTL_MPS_32                         1
+#define DEP0CTL_MPS_16                         2
+#define DEP0CTL_MPS_8                          3
+
+#define PCD_EP0MPS_64                          DEP0CTL_MPS_64
+#define PCD_EP0MPS_32                          DEP0CTL_MPS_32
+#define PCD_EP0MPS_16                          DEP0CTL_MPS_16
+#define PCD_EP0MPS_08                          DEP0CTL_MPS_8 
+/**
+  * @}
+  */ 
+  
+/** @defgroup PCD_USB_EP_Type
+  * @{
+  */
+#define PCD_EP_TYPE_CTRL                                 0
+#define PCD_EP_TYPE_ISOC                                 1
+#define PCD_EP_TYPE_BULK                                 2
+#define PCD_EP_TYPE_INTR                                 3
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+  
+/* Exported macros -----------------------------------------------------------*/
+
+/** @defgroup PCD_Interrupt_Clock
+ *  @brief macros to handle interrupts and specific clock configurations
+ * @{
+ */
+#define __HAL_PCD_GET_FLAG(__HANDLE__, __INTERRUPT__)      ((((__HANDLE__)->Instance->ISTR) & (__INTERRUPT__)) == (__INTERRUPT__))
+#define __HAL_PCD_CLEAR_FLAG(__HANDLE__, __INTERRUPT__)    (((__HANDLE__)->Instance->ISTR) = ~(__INTERRUPT__))
+
+#define  USB_EXTI_LINE_WAKEUP              ((uint32_t)0x00040000)  /*!< External interrupt line 18 Connected to the USB FS EXTI Line */
+
+#define __HAL_USB_EXTI_ENABLE_IT()    EXTI->IMR |= USB_EXTI_LINE_WAKEUP
+#define __HAL_USB_EXTI_DISABLE_IT()   EXTI->IMR &= ~(USB_EXTI_LINE_WAKEUP)
+#define __HAL_USB_EXTI_GENERATE_SWIT() (EXTI->SWIER |= USB_EXTI_LINE_WAKEUP)
+
+/* Internal macros -----------------------------------------------------------*/
+
+/* SetENDPOINT */
+#define PCD_SET_ENDPOINT(USBx, bEpNum,wRegValue)  (*(&USBx->EP0R + bEpNum * 2)= (uint16_t)wRegValue)
+
+/* GetENDPOINT */
+#define PCD_GET_ENDPOINT(USBx, bEpNum)        (*(&USBx->EP0R + bEpNum * 2))
+
+
+
+/**
+  * @brief  sets the type in the endpoint register(bits EP_TYPE[1:0])
+  * @param  bEpNum: Endpoint Number.
+  * @param  wType: Endpoint Type.
+  * @retval None
+  */
+#define PCD_SET_EPTYPE(USBx, bEpNum,wType) (PCD_SET_ENDPOINT(USBx, bEpNum,\
+                                  ((PCD_GET_ENDPOINT(USBx, bEpNum) & USB_EP_T_MASK) | wType )))
+
+/**
+  * @brief  gets the type in the endpoint register(bits EP_TYPE[1:0])
+  * @param  bEpNum: Endpoint Number.
+  * @retval Endpoint Type
+  */
+#define PCD_GET_EPTYPE(USBx, bEpNum) (PCD_GET_ENDPOINT(USBx, bEpNum) & USB_EP_T_FIELD)
+
+
+/**
+  * @brief free buffer used from the application realizing it to the line
+          toggles bit SW_BUF in the double buffered endpoint register
+  * @param   bEpNum, bDir
+  * @retval None
+  */
+#define PCD_FreeUserBuffer(USBx, bEpNum, bDir)\
+{\
+  if (bDir == PCD_EP_DBUF_OUT)\
+  { /* OUT double buffered endpoint */\
+    PCD_TX_DTOG(USBx, bEpNum);\
+  }\
+  else if (bDir == PCD_EP_DBUF_IN)\
+  { /* IN double buffered endpoint */\
+    PCD_RX_DTOG(USBx, bEpNum);\
+  }\
+}
+
+/**
+  * @brief gets direction of the double buffered endpoint
+  * @param   bEpNum: Endpoint Number.
+  * @retval EP_DBUF_OUT, EP_DBUF_IN,
+  *         EP_DBUF_ERR if the endpoint counter not yet programmed.
+  */
+#define PCD_GET_DB_DIR(USBx, bEpNum)\
+{\
+  if ((uint16_t)(*PCD_EP_RX_CNT(USBx, bEpNum) & 0xFC00) != 0)\
+    return(PCD_EP_DBUF_OUT);\
+  else if (((uint16_t)(*PCD_EP_TX_CNT(USBx, bEpNum)) & 0x03FF) != 0)\
+    return(PCD_EP_DBUF_IN);\
+  else\
+    return(PCD_EP_DBUF_ERR);\
+}
+
+/**
+  * @brief  sets the status for tx transfer (bits STAT_TX[1:0]).
+  * @param  bEpNum: Endpoint Number.
+  * @param  wState: new state
+  * @retval None
+  */
+#define PCD_SET_EP_TX_STATUS(USBx, bEpNum, wState) {\
+   register uint16_t _wRegVal;       \
+   \
+    _wRegVal = PCD_GET_ENDPOINT(USBx, bEpNum) & USB_EPTX_DTOGMASK;\
+   /* toggle first bit ? */     \
+   if((USB_EPTX_DTOG1 & wState)!= 0)      \
+     _wRegVal ^= USB_EPTX_DTOG1;        \
+   /* toggle second bit ?  */         \
+   if((USB_EPTX_DTOG2 & wState)!= 0)      \
+     _wRegVal ^= USB_EPTX_DTOG2;        \
+   PCD_SET_ENDPOINT(USBx, bEpNum, (_wRegVal | USB_EP_CTR_RX|USB_EP_CTR_TX));    \
+  } /* PCD_SET_EP_TX_STATUS */
+
+/**
+  * @brief  sets the status for rx transfer (bits STAT_TX[1:0])
+  * @param  bEpNum: Endpoint Number.
+  * @param  wState: new state
+  * @retval None
+  */
+#define PCD_SET_EP_RX_STATUS(USBx, bEpNum,wState) {\
+    register uint16_t _wRegVal;   \
+    \
+    _wRegVal = PCD_GET_ENDPOINT(USBx, bEpNum) & USB_EPRX_DTOGMASK;\
+    /* toggle first bit ? */  \
+    if((USB_EPRX_DTOG1 & wState)!= 0) \
+      _wRegVal ^= USB_EPRX_DTOG1;  \
+    /* toggle second bit ? */  \
+    if((USB_EPRX_DTOG2 & wState)!= 0) \
+      _wRegVal ^= USB_EPRX_DTOG2;  \
+    PCD_SET_ENDPOINT(USBx, bEpNum, (_wRegVal | USB_EP_CTR_RX|USB_EP_CTR_TX)); \
+  } /* PCD_SET_EP_RX_STATUS */
+
+/**
+  * @brief  sets the status for rx & tx (bits STAT_TX[1:0] & STAT_RX[1:0])
+  * @param  bEpNum: Endpoint Number.
+  * @param  wStaterx: new state.
+  * @param  wStatetx: new state.
+  * @retval None
+  */
+#define PCD_SET_EP_TXRX_STATUS(USBx,bEpNum,wStaterx,wStatetx) {\
+    register uint32_t _wRegVal;   \
+    \
+    _wRegVal = PCD_GET_ENDPOINT(USBx, bEpNum) & (USB_EPRX_DTOGMASK |USB_EPTX_STAT) ;\
+    /* toggle first bit ? */  \
+    if((USB_EPRX_DTOG1 & wStaterx)!= 0) \
+      _wRegVal ^= USB_EPRX_DTOG1;  \
+    /* toggle second bit ? */  \
+    if((USB_EPRX_DTOG2 & wStaterx)!= 0) \
+      _wRegVal ^= USB_EPRX_DTOG2;  \
+    /* toggle first bit ? */     \
+    if((USB_EPTX_DTOG1 & wStatetx)!= 0)      \
+      _wRegVal ^= USB_EPTX_DTOG1;        \
+    /* toggle second bit ?  */         \
+    if((USB_EPTX_DTOG2 & wStatetx)!= 0)      \
+      _wRegVal ^= USB_EPTX_DTOG2;        \
+    PCD_SET_ENDPOINT(USBx, bEpNum, _wRegVal | USB_EP_CTR_RX|USB_EP_CTR_TX);    \
+  } /* PCD_SET_EP_TXRX_STATUS */
+
+/**
+  * @brief  gets the status for tx/rx transfer (bits STAT_TX[1:0]
+  *         /STAT_RX[1:0])
+  * @param  bEpNum: Endpoint Number.
+  * @retval status
+  */
+#define PCD_GET_EP_TX_STATUS(USBx, bEpNum) ((uint16_t)PCD_GET_ENDPOINT(USBx, bEpNum) & USB_EPTX_STAT)
+
+#define PCD_GET_EP_RX_STATUS(USBx, bEpNum) ((uint16_t)PCD_GET_ENDPOINT(USBx, bEpNum) & USB_EPRX_STAT)
+
+/**
+  * @brief  sets directly the VALID tx/rx-status into the endpoint register
+  * @param  bEpNum: Endpoint Number.
+  * @retval None
+  */
+#define PCD_SET_EP_TX_VALID(USBx, bEpNum)     (PCD_SET_EP_TX_STATUS(USBx, bEpNum, USB_EP_TX_VALID))
+
+#define PCD_SET_EP_RX_VALID(USBx, bEpNum)     (PCD_SET_EP_RX_STATUS(USBx, bEpNum, USB_EP_RX_VALID))
+
+/**
+  * @brief  checks stall condition in an endpoint.
+  * @param  bEpNum: Endpoint Number.
+  * @retval TRUE = endpoint in stall condition.
+  */
+#define PCD_GET_EP_TX_STALL_STATUS(USBx, bEpNum) (PCD_GET_EP_TX_STATUS(USBx, bEpNum) \
+                                   == USB_EP_TX_STALL)
+#define PCD_GET_EP_RX_STALL_STATUS(USBx, bEpNum) (PCD_GET_EP_RX_STATUS(USBx, bEpNum) \
+                                   == USB_EP_RX_STALL)
+
+/**
+  * @brief  set & clear EP_KIND bit.
+  * @param  bEpNum: Endpoint Number.
+  * @retval None
+  */
+#define PCD_SET_EP_KIND(USBx, bEpNum)    (PCD_SET_ENDPOINT(USBx, bEpNum, \
+                                (USB_EP_CTR_RX|USB_EP_CTR_TX|((PCD_GET_ENDPOINT(USBx, bEpNum) | USB_EP_KIND) & USB_EPREG_MASK))))
+#define PCD_CLEAR_EP_KIND(USBx, bEpNum)  (PCD_SET_ENDPOINT(USBx, bEpNum, \
+                                (USB_EP_CTR_RX|USB_EP_CTR_TX|(PCD_GET_ENDPOINT(USBx, bEpNum) & USB_EPKIND_MASK))))
+
+/**
+  * @brief  Sets/clears directly STATUS_OUT bit in the endpoint register.
+  * @param  bEpNum: Endpoint Number.
+  * @retval None
+  */
+#define PCD_SET_OUT_STATUS(USBx, bEpNum)    PCD_SET_EP_KIND(USBx, bEpNum)
+#define PCD_CLEAR_OUT_STATUS(USBx, bEpNum)  PCD_CLEAR_EP_KIND(USBx, bEpNum)
+
+/**
+  * @brief  Sets/clears directly EP_KIND bit in the endpoint register.
+  * @param  bEpNum: Endpoint Number.
+  * @retval None
+  */
+#define PCD_SET_EP_DBUF(USBx, bEpNum)   PCD_SET_EP_KIND(USBx, bEpNum)
+#define PCD_CLEAR_EP_DBUF(USBx, bEpNum) PCD_CLEAR_EP_KIND(USBx, bEpNum)
+
+/**
+  * @brief  Clears bit CTR_RX / CTR_TX in the endpoint register.
+  * @param  bEpNum: Endpoint Number.
+  * @retval None
+  */
+#define PCD_CLEAR_RX_EP_CTR(USBx, bEpNum)   (PCD_SET_ENDPOINT(USBx, bEpNum,\
+                                   PCD_GET_ENDPOINT(USBx, bEpNum) & 0x7FFF & USB_EPREG_MASK))
+#define PCD_CLEAR_TX_EP_CTR(USBx, bEpNum)   (PCD_SET_ENDPOINT(USBx, bEpNum,\
+                                   PCD_GET_ENDPOINT(USBx, bEpNum) & 0xFF7F & USB_EPREG_MASK))
+
+/**
+  * @brief  Toggles DTOG_RX / DTOG_TX bit in the endpoint register.
+  * @param  bEpNum: Endpoint Number.
+  * @retval None
+  */
+#define PCD_RX_DTOG(USBx, bEpNum)    (PCD_SET_ENDPOINT(USBx, bEpNum, \
+                                   USB_EP_CTR_RX|USB_EP_CTR_TX|USB_EP_DTOG_RX | (PCD_GET_ENDPOINT(USBx, bEpNum) & USB_EPREG_MASK)))
+#define PCD_TX_DTOG(USBx, bEpNum)    (PCD_SET_ENDPOINT(USBx, bEpNum, \
+                                   USB_EP_CTR_RX|USB_EP_CTR_TX|USB_EP_DTOG_TX | (PCD_GET_ENDPOINT(USBx, bEpNum) & USB_EPREG_MASK)))
+
+/**
+  * @brief  Clears DTOG_RX / DTOG_TX bit in the endpoint register.
+  * @param  bEpNum: Endpoint Number.
+  * @retval None
+  */
+#define PCD_CLEAR_RX_DTOG(USBx, bEpNum)  if((PCD_GET_ENDPOINT(USBx, bEpNum) & USB_EP_DTOG_RX) != 0)\
+    PCD_RX_DTOG(USBx, bEpNum)
+#define PCD_CLEAR_TX_DTOG(USBx, bEpNum)  if((PCD_GET_ENDPOINT(USBx, bEpNum) & USB_EP_DTOG_TX) != 0)\
+    PCD_TX_DTOG(USBx, bEpNum)
+      
+/**
+  * @brief  Sets address in an endpoint register.
+  * @param  bEpNum: Endpoint Number.
+  * @param  bAddr: Address.
+  * @retval None
+  */
+#define PCD_SET_EP_ADDRESS(USBx, bEpNum,bAddr) PCD_SET_ENDPOINT(USBx, bEpNum,\
+    USB_EP_CTR_RX|USB_EP_CTR_TX|(PCD_GET_ENDPOINT(USBx, bEpNum) & USB_EPREG_MASK) | bAddr)
+
+/**
+  * @brief  Gets address in an endpoint register.
+  * @param  bEpNum: Endpoint Number.
+  * @retval None
+  */
+#define PCD_GET_EP_ADDRESS(USBx, bEpNum) ((uint8_t)(PCD_GET_ENDPOINT(USBx, bEpNum) & USB_EPADDR_FIELD))
+#define PCD_EP_TX_ADDRESS(USBx, bEpNum) ((uint16_t *)((USBx->BTABLE+bEpNum*8)+     ((uint32_t)USBx + 0x400)))
+#define PCD_EP_TX_CNT(USBx, bEpNum) ((uint16_t *)((USBx->BTABLE+bEpNum*8+2)+  ((uint32_t)USBx + 0x400)))
+#define PCD_EP_RX_ADDRESS(USBx, bEpNum) ((uint16_t *)((USBx->BTABLE+bEpNum*8+4)+  ((uint32_t)USBx + 0x400)))
+#define PCD_EP_RX_CNT(USBx, bEpNum) ((uint16_t *)((USBx->BTABLE+bEpNum*8+6)+  ((uint32_t)USBx + 0x400)))
+
+/**
+  * @brief  sets address of the tx/rx buffer.
+  * @param  bEpNum: Endpoint Number.
+  * @param  wAddr: address to be set (must be word aligned).
+  * @retval None
+  */
+#define PCD_SET_EP_TX_ADDRESS(USBx, bEpNum,wAddr) (*PCD_EP_TX_ADDRESS(USBx, bEpNum) = ((wAddr >> 1) << 1))
+#define PCD_SET_EP_RX_ADDRESS(USBx, bEpNum,wAddr) (*PCD_EP_RX_ADDRESS(USBx, bEpNum) = ((wAddr >> 1) << 1))
+
+/**
+  * @brief  Gets address of the tx/rx buffer.
+  * @param  bEpNum: Endpoint Number.
+  * @retval address of the buffer.
+  */
+#define PCD_GET_EP_TX_ADDRESS(USBx, bEpNum) ((uint16_t)*PCD_EP_TX_ADDRESS(USBx, bEpNum))
+#define PCD_GET_EP_RX_ADDRESS(USBx, bEpNum) ((uint16_t)*PCD_EP_RX_ADDRESS(USBx, bEpNum))
+
+/**
+  * @brief  Sets counter of rx buffer with no. of blocks.
+  * @param  bEpNum: Endpoint Number.
+  * @param  wCount: Counter.
+  * @retval None
+  */
+#define PCD_CALC_BLK32(dwReg,wCount,wNBlocks) {\
+    wNBlocks = wCount >> 5;\
+    if((wCount & 0x1f) == 0)\
+      wNBlocks--;\
+    *pdwReg = (uint16_t)((wNBlocks << 10) | 0x8000);\
+  }/* PCD_CALC_BLK32 */
+
+#define PCD_CALC_BLK2(dwReg,wCount,wNBlocks) {\
+    wNBlocks = wCount >> 1;\
+    if((wCount & 0x1) != 0)\
+      wNBlocks++;\
+    *pdwReg = (uint16_t)(wNBlocks << 10);\
+  }/* PCD_CALC_BLK2 */
+
+#define PCD_SET_EP_CNT_RX_REG(dwReg,wCount)  {\
+    uint16_t wNBlocks;\
+    if(wCount > 62){PCD_CALC_BLK32(dwReg,wCount,wNBlocks);}\
+    else {PCD_CALC_BLK2(dwReg,wCount,wNBlocks);}\
+  }/* PCD_SET_EP_CNT_RX_REG */
+
+#define PCD_SET_EP_RX_DBUF0_CNT(USBx, bEpNum,wCount) {\
+    uint16_t *pdwReg = PCD_EP_TX_CNT(USBx, bEpNum); \
+    PCD_SET_EP_CNT_RX_REG(pdwReg, wCount);\
+  }
+/**
+  * @brief  sets counter for the tx/rx buffer.
+  * @param  bEpNum: Endpoint Number.
+  * @param  wCount: Counter value.
+  * @retval None
+  */
+#define PCD_SET_EP_TX_CNT(USBx, bEpNum,wCount) (*PCD_EP_TX_CNT(USBx, bEpNum) = wCount)
+#define PCD_SET_EP_RX_CNT(USBx, bEpNum,wCount) {\
+    uint16_t *pdwReg = PCD_EP_RX_CNT(USBx, bEpNum); \
+    PCD_SET_EP_CNT_RX_REG(pdwReg, wCount);\
+  }
+
+/**
+  * @brief  gets counter of the tx buffer.
+  * @param  bEpNum: Endpoint Number.
+  * @retval Counter value
+  */
+#define PCD_GET_EP_TX_CNT(USBx, bEpNum)((uint16_t)(*PCD_EP_TX_CNT(USBx, bEpNum)) & 0x3ff)
+#define PCD_GET_EP_RX_CNT(USBx, bEpNum)((uint16_t)(*PCD_EP_RX_CNT(USBx, bEpNum)) & 0x3ff)
+
+/**
+  * @brief  Sets buffer 0/1 address in a double buffer endpoint.
+  * @param  bEpNum: Endpoint Number.
+  * @param  wBuf0Addr: buffer 0 address.
+  * @retval Counter value
+  */
+#define PCD_SET_EP_DBUF0_ADDR(USBx, bEpNum,wBuf0Addr) {PCD_SET_EP_TX_ADDRESS(USBx, bEpNum, wBuf0Addr);}
+#define PCD_SET_EP_DBUF1_ADDR(USBx, bEpNum,wBuf1Addr) {PCD_SET_EP_RX_ADDRESS(USBx, bEpNum, wBuf1Addr);}
+
+/**
+  * @brief  Sets addresses in a double buffer endpoint.
+  * @param  bEpNum: Endpoint Number.
+  * @param  wBuf0Addr: buffer 0 address.
+  * @param  wBuf1Addr = buffer 1 address.
+  * @retval None
+  */
+#define PCD_SET_EP_DBUF_ADDR(USBx, bEpNum,wBuf0Addr,wBuf1Addr) { \
+    PCD_SET_EP_DBUF0_ADDR(USBx, bEpNum, wBuf0Addr);\
+    PCD_SET_EP_DBUF1_ADDR(USBx, bEpNum, wBuf1Addr);\
+  } /* PCD_SET_EP_DBUF_ADDR */
+
+/**
+  * @brief  Gets buffer 0/1 address of a double buffer endpoint.
+  * @param  bEpNum: Endpoint Number.
+  * @retval None
+  */
+#define PCD_GET_EP_DBUF0_ADDR(USBx, bEpNum) (PCD_GET_EP_TX_ADDRESS(USBx, bEpNum))
+#define PCD_GET_EP_DBUF1_ADDR(USBx, bEpNum) (PCD_GET_EP_RX_ADDRESS(USBx, bEpNum))
+
+/**
+  * @brief  Gets buffer 0/1 address of a double buffer endpoint.
+  * @param  bEpNum: Endpoint Number.
+  *        bDir: endpoint dir  EP_DBUF_OUT = OUT 
+  *         EP_DBUF_IN  = IN 
+  * @param  wCount: Counter value 
+  * @retval None
+  */
+#define PCD_SET_EP_DBUF0_CNT(USBx, bEpNum, bDir, wCount)  { \
+    if(bDir == PCD_EP_DBUF_OUT)\
+      /* OUT endpoint */ \
+    {PCD_SET_EP_RX_DBUF0_CNT(USBx, bEpNum,wCount);} \
+    else if(bDir == PCD_EP_DBUF_IN)\
+      /* IN endpoint */ \
+      *PCD_EP_TX_CNT(USBx, bEpNum) = (uint32_t)wCount;  \
+  } /* SetEPDblBuf0Count*/
+
+#define PCD_SET_EP_DBUF1_CNT(USBx, bEpNum, bDir, wCount)  { \
+    if(bDir == PCD_EP_DBUF_OUT)\
+      /* OUT endpoint */ \
+    {PCD_SET_EP_RX_CNT(USBx, bEpNum,wCount);}\
+    else if(bDir == PCD_EP_DBUF_IN)\
+      /* IN endpoint */\
+      *PCD_EP_RX_CNT(USBx, bEpNum) = (uint32_t)wCount; \
+  } /* SetEPDblBuf1Count */
+
+#define PCD_SET_EP_DBUF_CNT(USBx, bEpNum, bDir, wCount) {\
+    PCD_SET_EP_DBUF0_CNT(USBx, bEpNum, bDir, wCount); \
+    PCD_SET_EP_DBUF1_CNT(USBx, bEpNum, bDir, wCount); \
+  } /* PCD_SET_EP_DBUF_CNT  */
+
+/**
+  * @brief  Gets buffer 0/1 rx/tx counter for double buffering.
+  * @param  bEpNum: Endpoint Number.
+  * @retval None
+  */
+#define PCD_GET_EP_DBUF0_CNT(USBx, bEpNum) (PCD_GET_EP_TX_CNT(USBx, bEpNum))
+#define PCD_GET_EP_DBUF1_CNT(USBx, bEpNum) (PCD_GET_EP_RX_CNT(USBx, bEpNum))
+
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/* Initialization/de-initialization functions  **********************************/
+HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_DeInit (PCD_HandleTypeDef *hpcd);
+void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd);
+
+/* I/O operation functions  *****************************************************/
+ /* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_PCD_Start(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_Stop(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd);
+
+void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_ResumeCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_ISOOUTIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_ISOINIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
+void HAL_PCD_ConnectCallback(PCD_HandleTypeDef *hpcd);
+void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd);
+
+
+
+/* Peripheral Control functions  ************************************************/
+HAL_StatusTypeDef HAL_PCD_DevConnect(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_DevDisconnect(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_SetAddress(PCD_HandleTypeDef *hpcd, uint8_t address);
+HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint16_t ep_mps, uint8_t ep_type);
+HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len);
+HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len);
+uint16_t          HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_ActiveRemoteWakeup(PCD_HandleTypeDef *hpcd);
+HAL_StatusTypeDef HAL_PCD_DeActiveRemoteWakeup(PCD_HandleTypeDef *hpcd);
+/* Peripheral State functions  **************************************************/
+PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L0xx_HAL_PCD_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pcd_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pcd_ex.c
@@ -1,0 +1,151 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_pcd_ex.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Extended PCD HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the USB Peripheral Controller:
+  *           + Configururation of the PMA for EP
+  *         
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PCDEx 
+  * @brief PCDEx HAL module driver
+  * @{
+  */
+
+#ifdef HAL_PCD_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+
+/** @defgroup PCDEx_Private_Functions
+  * @{
+  */
+
+/** @defgroup PCDEx_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+ ===============================================================================
+                 ##### Peripheral extended features functions #####
+ ===============================================================================
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Configure PMA for EP
+  * @param  pdev : Device instance
+  * @param  ep_addr: endpoint address
+  * @param  ep_Kind: endpoint Kind
+  *                  USB_SNG_BUF: Single Buffer used
+  *                  USB_DBL_BUF: Double Buffer used
+  * @param  pmaadress: EP address in The PMA: In case of single buffer endpoint
+  *                   this parameter is 16-bit value providing the address
+  *                   in PMA allocated to endpoint.
+  *                   In case of double buffer endpoint this parameter
+  *                   is a 32-bit value providing the endpoint buffer 0 address
+  *                   in the LSB part of 32-bit value and endpoint buffer 1 address
+  *                   in the MSB part of 32-bit value.
+  * @retval : status
+  */
+
+HAL_StatusTypeDef  HAL_PCDEx_PMAConfig(PCD_HandleTypeDef *hpcd, 
+                        uint16_t ep_addr,
+                        uint16_t ep_kind,
+                        uint32_t pmaadress)
+
+{
+  PCD_EPTypeDef *ep;
+  
+  /* initialize ep structure*/
+  if ((0x80 & ep_addr) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr];
+  }
+  
+  /* Here we check if the endpoint is single or double Buffer*/
+  if (ep_kind == PCD_SNG_BUF)
+  {
+    /*Single Buffer*/
+    ep->doublebuffer = 0;
+    /*Configure te PMA*/
+    ep->pmaadress = (uint16_t)pmaadress;
+  }
+  else /*USB_DBL_BUF*/
+  {
+    /*Double Buffer Endpoint*/
+    ep->doublebuffer = 1;
+    /*Configure the PMA*/
+    ep->pmaaddr0 =  pmaadress & 0xFFFF;
+    ep->pmaaddr1 =  (pmaadress & 0xFFFF0000) >> 16;
+  }
+  
+  return HAL_OK; 
+}
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+#endif /* HAL_PCD_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pcd_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pcd_ex.h
@@ -1,0 +1,82 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_pcd.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of PCD HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_PCD_EX_H
+#define __STM32L0xx_HAL_PCD_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"  
+   
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PCDEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/* Exported macros -----------------------------------------------------------*/
+/* Internal macros -----------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+HAL_StatusTypeDef HAL_PCDEx_PMAConfig(PCD_HandleTypeDef *hpcd, 
+                                     uint16_t ep_addr,
+                                     uint16_t ep_kind,
+                                     uint32_t pmaadress);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L0xx_HAL_PCD_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pwr.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pwr.c
@@ -1,0 +1,643 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_pwr.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   PWR HAL module driver.
+  *
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Power Controller (PWR) peripheral:
+  *           + Initialization/de-initialization functions
+  *           + Peripheral Control functions 
+  *
+  @verbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PWR
+  * @brief PWR HAL module driver
+  * @{
+  */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup PWR_Private_Functions
+  * @{
+  */
+
+/** @defgroup PWR_Group1 Initialization and De-initialization functions 
+  *  @brief Initialization and Configuration functions
+  *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]
+      After reset, the backup domain (RTC registers, RTC backup data
+      registers) is protected against possible unwanted
+      write accesses.
+      To enable access to the RTC Domain and RTC registers, proceed as follows:
+        (+) Enable the Power Controller (PWR) APB1 interface clock using the
+            __PWR_CLK_ENABLE() macro.
+        (+) Enable access to RTC domain using the HAL_PWR_EnableBkUpAccess() function.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Deinitializes the HAL PWR peripheral registers to their default reset values.
+  * @param None
+  * @retval None
+  */
+void HAL_PWR_DeInit(void)
+{
+  __PWR_FORCE_RESET();
+  __PWR_RELEASE_RESET();
+}
+
+/**
+  * @brief Enables access to the backup domain (RTC registers, RTC
+  *         backup data registers ).
+  * @note   If the HSE divided by 2, 4, 8 or 16 is used as the RTC clock, the
+  *         Backup Domain Access should be kept enabled.
+  * @param None
+  * @retval None
+  */
+void HAL_PWR_EnableBkUpAccess(void)
+{
+  /* Enable access to RTC and backup registers */
+  PWR->CR |= PWR_CR_DBP;
+}
+
+/**
+  * @brief Disables access to the backup domain (RTC registers, RTC
+  *         backup data registers).
+  * @note   If the HSE divided by 2, 4, 8 or 16 is used as the RTC clock, the
+  *         Backup Domain Access should be kept enabled.
+  * @param None
+  * @retval None
+  */
+void HAL_PWR_DisableBkUpAccess(void)
+{
+  /* Disable access to RTC and backup registers */
+  PWR->CR &= (uint32_t)~((uint32_t)PWR_CR_DBP);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup PWR_Group2 Peripheral Control functions 
+  *  @brief Low Power modes configuration functions
+  *
+@verbatim
+
+ ===============================================================================
+                 ##### Peripheral Control functions #####
+ ===============================================================================
+     
+    *** PVD configuration ***
+    =========================
+    [..]
+      (+) The PVD is used to monitor the VDD power supply by comparing it to a
+          threshold selected by the PVD Level (PLS[2:0] bits in the PWR_CR).
+      (+) The PVD can use an external input analog voltage (PVD_IN) which is compared 
+      internally to VREFINT. The PVD_IN (PB7) has to be configured in Analog mode 
+      when PWR_PVDLevel_7 is selected (PLS[2:0] = 111).
+
+      (+) A PVDO flag is available to indicate if VDD/VDDA is higher or lower
+          than the PVD threshold. This event is internally connected to the EXTI
+          line16 and can generate an interrupt if enabled. This is done through
+          __HAL_PVD_EXTI_ENABLE_IT() macro.
+      (+) The PVD is stopped in Standby mode.
+
+    *** WakeUp pin configuration ***
+    ================================
+    [..]
+      (+) WakeUp pin is used to wake up the system from Standby mode. This pin is
+          forced in input pull-down configuration and is active on rising edges.
+      (+) There are two WakeUp pins:
+          WakeUp Pin 1 on PA.00.
+          WakeUp Pin 2 on PC.13.
+
+    [..]
+    *** Main and Backup Regulators configuration ***
+    ================================================
+
+      (+) The main internal regulator can be configured to have a tradeoff between
+          performance and power consumption when the device does not operate at
+          the maximum frequency. This is done through __HAL_PWR_VOLTAGESCALING_CONFIG()
+          macro which configure VOS bit in PWR_CR register:
+        (++) When this bit is set (Regulator voltage output Scale 1 mode selected)
+             the System frequency can go up to 32 MHz.
+        (++) When this bit is reset (Regulator voltage output Scale 2 mode selected)
+             the System frequency can go up to 16 MHz.
+        (++) When this bit is reset (Regulator voltage output Scale 3 mode selected)
+             the System frequency can go up to 4.2 MHz.
+              
+        Refer to the datasheets for more details.
+
+    *** Low Power modes configuration ***
+    =====================================
+     [..]
+      The device features 5 low-power modes:
+      (+) Low power run mode: regulator in low power mode, limited clock frequency, 
+        limited number of peripherals running.
+      (+) Sleep mode: Cortex-M0+ core stopped, peripherals kept running.
+      (+) Low power sleep mode: Cortex-M0+ core stopped, limited clock frequency, 
+         limited number of peripherals running, regulator in low power mode.
+      (+) Stop mode: All clocks are stopped, regulator running, regulator in low power mode.
+      (+) Standby mode: VCORE domain powered off
+  
+   *** Low power run mode ***
+   =========================
+    [..]
+       To further reduce the consumption when the system is in Run mode, the regulator can be
+        configured in low power mode. In this mode, the system frequency should not exceed
+        MSI frequency range1.
+        In Low power run mode, all I/O pins keep the same state as in Run mode.
+  
+      (+) Entry:
+        (++) VCORE in range2
+        (++) Decrease the system frequency tonot exceed the frequency of MSI frequency range1.
+        (++) The regulator is forced in low power mode using the HAL_PWREx_EnableLowPowerRunMode()
+             function.
+      (+) Exit:
+        (++) The regulator is forced in Main regulator mode using the HAL_PWREx_DisableLowPowerRunMode()
+              function.
+        (++) Increase the system frequency if needed.
+  
+   *** Sleep mode ***
+   ==================
+    [..]
+      (+) Entry:
+          The Sleep mode is entered by using the HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFx)
+              functions with
+          (++) PWR_SLEEPENTRY_WFI: enter SLEEP mode with WFI instruction
+          (++) PWR_SLEEPENTRY_WFE: enter SLEEP mode with WFE instruction
+     
+      (+) Exit:
+        (++) Any peripheral interrupt acknowledged by the nested vectored interrupt
+              controller (NVIC) can wake up the device from Sleep mode.
+
+   *** Low power sleep mode ***
+   ============================
+    [..]
+      (+) Entry:
+          The Low power sleep mode is entered by using the HAL_PWR_EnterSLEEPMode(PWR_LOWPOWERREGULATOR_ON, PWR_SLEEPENTRY_WFx)
+              functions with
+          (++) PWR_SLEEPENTRY_WFI: enter SLEEP mode with WFI instruction
+          (++) PWR_SLEEPENTRY_WFE: enter SLEEP mode with WFE instruction
+       (+) The Flash memory can be switched off by using the control bits (SLEEP_PD in the FLASH_ACR register. 
+             This reduces power consumption but increases the wake-up time.
+         
+      (+) Exit:
+        (++) If the WFI instruction was used to enter Low power sleep mode, any peripheral interrupt
+              acknowledged by the nested vectored interrupt controller (NVIC) can wake up the device
+              from Low power sleep mode. If the WFE instruction was used to enter Low power sleep mode,
+              the MCU exits Sleep mode as soon as an event occurs. 
+                
+   *** Stop mode ***
+   =================
+    [..]
+      The Stop mode is based on the Cortex-M0+ deepsleep mode combined with peripheral
+      clock gating. The voltage regulator can be configured either in normal or low-power mode.
+      In Stop mode, all clocks in the VCORE domain are stopped, the PLL, the MSI, the HSI and
+      the HSE RC oscillators are disabled. Internal SRAM and register contents are preserved.
+      To get the lowest consumption in Stop mode, the internal Flash memory also enters low
+      power mode. When the Flash memory is in power-down mode, an additional startup delay is
+      incurred when waking up from Stop mode.
+      To minimize the consumption In Stop mode, VREFINT, the BOR, PVD, and temperature
+      sensor can be switched off before entering Stop mode. They can be switched on again by
+      software after exiting Stop mode using the ULP bit in the PWR_CR register.
+      In Stop mode, all I/O pins keep the same state as in Run mode.
+
+      (+) Entry:
+           The Stop mode is entered using the HAL_PWR_EnterSTOPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI )
+             function with:
+          (++) Main regulator ON.
+          (++) Low Power regulator ON.
+          (++) PWR_SLEEPENTRY_WFI: enter SLEEP mode with WFI instruction
+          (++) PWR_SLEEPENTRY_WFE: enter SLEEP mode with WFE instruction
+      (+) Exit:
+        (++) By issuing an interrupt or a wakeup event, the MSI or HSI16 RC
+             oscillator is selected as system clock depending the bit STOPWUCK in the RCC_CFGR
+             register
+
+   *** Standby mode ***
+   ====================
+     [..]
+      The Standby mode allows to achieve the lowest power consumption. It is based on the
+      Cortex-M0+ deepsleep mode, with the voltage regulator disabled. The VCORE domain is
+      consequently powered off. The PLL, the MSI, the HSI oscillator and the HSE oscillator are
+      also switched off. SRAM and register contents are lost except for the RTC registers, RTC
+      backup registers and Standby circuitry.
+      
+      To minimize the consumption In Standby mode, VREFINT, the BOR, PVD, and temperature
+       sensor can be switched off before entering the Standby mode. They can be switched 
+       on again by software after exiting the Standby mode.
+       function.
+      
+      (+) Entry:
+        (++) The Standby mode is entered using the HAL_PWR_EnterSTANDBYMode() function.
+      (+) Exit:
+        (++) WKUP pin rising edge, RTC alarm (Alarm A and Alarm B), RTC wakeup,
+             tamper event, time-stamp event, external reset in NRST pin, IWDG reset.
+
+   *** Auto-wakeup (AWU) from low-power mode ***
+   =============================================
+    [..]
+      The MCU can be woken up from low-power mode by an RTC Alarm event, an RTC 
+      Wakeup event, a tamper event, a time-stamp event, or a comparator event, 
+      without depending on an external interrupt (Auto-wakeup mode).
+
+    (+) RTC auto-wakeup (AWU) from the Stop mode
+        (++) To wake up from the Stop mode with an RTC alarm event, it is necessary to:
+             (+++) Configure the EXTI Line 17 to be sensitive to rising edges (Interrupt 
+                   or Event modes) using the EXTI_Init() function.
+             (+++) Enable the RTC Alarm Interrupt using the RTC_ITConfig() function
+             (+++) Configure the RTC to generate the RTC alarm using the RTC_SetAlarm() 
+                   and RTC_AlarmCmd() functions.
+        (++) To wake up from the Stop mode with an RTC Tamper or time stamp event, it 
+             is necessary to:
+             (+++) Configure the EXTI Line 19 to be sensitive to rising edges (Interrupt 
+                   or Event modes) using the EXTI_Init() function.
+             (+++) Enable the RTC Tamper or time stamp Interrupt using the RTC_ITConfig() 
+                   function.
+             (+++) Configure the RTC to detect the tamper or time stamp event using the
+                   RTC_TimeStampConfig(), RTC_TamperTriggerConfig() and RTC_TamperCmd()
+                   functions.
+        (++) To wake up from the Stop mode with an RTC WakeUp event, it is necessary to:
+             (+++) Configure the EXTI Line 20 to be sensitive to rising edges (Interrupt 
+                   or Event modes) using the EXTI_Init() function.
+             (+++) Enable the RTC WakeUp Interrupt using the RTC_ITConfig() function.
+             (+++) Configure the RTC to generate the RTC WakeUp event using the RTC_WakeUpClockConfig(), 
+                   RTC_SetWakeUpCounter() and RTC_WakeUpCmd() functions.
+
+    (+) RTC auto-wakeup (AWU) from the Standby mode
+        (++) To wake up from the Standby mode with an RTC alarm event, it is necessary to:
+             (+++) Enable the RTC Alarm Interrupt using the RTC_ITConfig() function.
+             (+++) Configure the RTC to generate the RTC alarm using the RTC_SetAlarm() 
+                   and RTC_AlarmCmd() functions.
+        (++) To wake up from the Standby mode with an RTC Tamper or time stamp event, it 
+             is necessary to:
+             (+++) Enable the RTC Tamper or time stamp Interrupt using the RTC_ITConfig() 
+                   function.
+             (+++) Configure the RTC to detect the tamper or time stamp event using the
+                   RTC_TimeStampConfig(), RTC_TamperTriggerConfig() and RTC_TamperCmd()
+                   functions.
+        (++) To wake up from the Standby mode with an RTC WakeUp event, it is necessary to:
+             (+++) Enable the RTC WakeUp Interrupt using the RTC_ITConfig() function
+             (+++) Configure the RTC to generate the RTC WakeUp event using the RTC_WakeUpClockConfig(), 
+                   RTC_SetWakeUpCounter() and RTC_WakeUpCmd() functions.
+
+    (+) Comparator auto-wakeup (AWU) from the Stop mode
+        (++) To wake up from the Stop mode with an comparator 1 or comparator 2 wakeup
+             event, it is necessary to:
+             (+++) Configure the EXTI Line 21 for comparator 1 or EXTI Line 22 for comparator 2 
+                   to be sensitive to to the selected edges (falling, rising or falling 
+                   and rising) (Interrupt or Event modes) using the EXTI_Init() function.
+             (+++) Configure the comparator to generate the event.      
+        
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Configures the voltage threshold detected by the Power Voltage Detector(PVD).
+  * @param sConfigPVD: pointer to an PWR_PVDTypeDef structure that contains the configuration
+  *        information for the PVD.
+  * @note Refer to the electrical characteristics of your device datasheet for
+  *         more details about the voltage threshold corresponding to each
+  *         detection level.
+  * @retval None
+  */
+void HAL_PWR_PVDConfig(PWR_PVDTypeDef *sConfigPVD)
+{
+ uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_PWR_PVD_LEVEL(sConfigPVD->PVDLevel));
+
+  tmpreg = PWR->CR;
+
+  /* Clear PLS[7:5] bits */
+  tmpreg &= ~ (uint32_t)PWR_CR_PLS;
+
+  /* Set PLS[7:5] bits according to PVDLevel value */
+  tmpreg |= sConfigPVD->PVDLevel;
+
+  /* Store the new value */
+  PWR->CR = tmpreg;
+
+  /* Configure the EXTI 16 interrupt */
+  if((sConfigPVD->Mode == PWR_MODE_IT_RISING_FALLING) ||\
+     (sConfigPVD->Mode == PWR_MODE_IT_FALLING) ||\
+     (sConfigPVD->Mode == PWR_MODE_IT_RISING)) 
+  {
+    __HAL_PVD_EXTI_ENABLE_IT(PWR_EXTI_LINE_PVD);
+  }
+  
+  /* Clear the edge trigger  for the EXTI Line 16 (PVD) */
+  EXTI->RTSR &= ~EXTI_RTSR_TR16;
+  EXTI->FTSR &= ~EXTI_FTSR_TR16;
+
+  /* Configure the rising edge */
+  if((sConfigPVD->Mode == PWR_MODE_IT_RISING_FALLING) ||\
+     (sConfigPVD->Mode == PWR_MODE_IT_RISING))
+  {
+    EXTI->RTSR |= PWR_EXTI_LINE_PVD;
+  }
+  /* Configure the falling edge */
+  if((sConfigPVD->Mode == PWR_MODE_IT_RISING_FALLING) ||\
+     (sConfigPVD->Mode == PWR_MODE_IT_FALLING))
+  {
+    EXTI->FTSR |= PWR_EXTI_LINE_PVD;
+  }
+}
+
+/**
+  * @brief Enables the Power Voltage Detector(PVD).
+  * @param None
+  * @retval None
+  */
+void HAL_PWR_EnablePVD(void)
+{
+  /* Enable the power voltage detector */
+  PWR->CR |= PWR_CR_PVDE;
+}
+
+/**
+  * @brief Disables the Power Voltage Detector(PVD).
+  * @param None
+  * @retval None
+  */
+void HAL_PWR_DisablePVD(void)
+{
+  /* Disable the power voltage detector */
+  PWR->CR &= (uint32_t)~((uint32_t)PWR_CR_PVDE);
+}
+
+/**
+  * @brief Enables the WakeUp PINx functionality.
+  * @param WakeUpPinx: Specifies the Power Wake-Up pin to enable.
+  *         This parameter can be one of the following values:
+  *           @arg PWR_WAKEUP_PIN1
+  *           @arg PWR_WAKEUP_PIN2
+  * @retval None
+  */
+void HAL_PWR_EnableWakeUpPin(uint32_t WakeUpPinx)
+{
+  /* Check the parameter */
+  assert_param(IS_PWR_WAKEUP_PIN(WakeUpPinx));
+  /* Enable the EWUPx pin */
+  PWR->CSR |= WakeUpPinx;
+}
+
+/**
+  * @brief Disables the WakeUp PINx functionality.
+  * @param WakeUpPinx: Specifies the Power Wake-Up pin to disable.
+  *         This parameter can be one of the following values:
+  *           @arg PWR_WAKEUP_PIN1
+  *           @arg PWR_WAKEUP_PIN2  
+  * @retval None
+  */
+void HAL_PWR_DisableWakeUpPin(uint32_t WakeUpPinx)
+{
+  /* Check the parameter */
+  assert_param(IS_PWR_WAKEUP_PIN(WakeUpPinx));
+  /* Disable the EWUPx pin */
+  PWR->CSR &= ~WakeUpPinx;
+}
+
+/**
+  * @brief Enters Sleep mode.
+  * @note In Sleep mode, all I/O pins keep the same state as in Run mode.
+  * @param Regulator: Specifies the regulator state in SLEEP mode.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_MAINREGULATOR_ON: SLEEP mode with regulator ON
+  *            @arg PWR_LOWPOWERREGULATOR_ON: SLEEP mode with low power regulator ON
+  * @param SLEEPEntry: Specifies if SLEEP mode is entered with WFI or WFE instruction.
+  *           When WFI entry is used, tick interrupt have to be disabled if not desired as 
+  *           the interrupt wake up source.
+  *           This parameter can be one of the following values:
+  *            @arg PWR_SLEEPENTRY_WFI: enter SLEEP mode with WFI instruction
+  *            @arg PWR_SLEEPENTRY_WFE: enter SLEEP mode with WFE instruction
+  * @retval None
+  */
+void HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry)
+{
+   uint32_t tmpreg = 0;
+  /* Check the parameters */
+  assert_param(IS_PWR_REGULATOR(Regulator));
+  assert_param(IS_PWR_SLEEP_ENTRY(SLEEPEntry));
+
+   /* Select the regulator state in Sleep mode ---------------------------------*/
+  tmpreg = PWR->CR;
+  /* Clear PDDS and LPDS bits */
+  tmpreg &= (uint32_t)~(PWR_CR_PDDS | PWR_CR_LPSDSR);
+
+ /* Set LPSDSR bit according to PWR_Regulator value */
+  tmpreg |= Regulator;
+
+  /* Store the new value */
+  PWR->CR = tmpreg;
+  
+  /* Clear SLEEPDEEP bit of Cortex System Control Register */
+  SCB->SCR &= (uint32_t)~((uint32_t)SCB_SCR_SLEEPDEEP_Msk);
+
+  /* Select SLEEP mode entry -------------------------------------------------*/
+  if(SLEEPEntry == PWR_SLEEPENTRY_WFI)
+  {
+    /* Request Wait For Interrupt */
+    __WFI();
+  }
+  else
+  {
+    /* Request Wait For Event */
+    __SEV();
+    __WFE();
+    __WFE();
+  }
+}
+
+/**
+  * @brief Enters Stop mode. 
+  * @note In Stop mode, all I/O pins keep the same state as in Run mode.
+  * @note When exiting Stop mode by issuing an interrupt or a wakeup event,
+  *        MSI or HSI16 RCoscillator is selected as system clock depending 
+  *        the bit STOPWUCK in the RCC_CFGR register.
+  * @note When the voltage regulator operates in low power mode, an additional
+  *         startup delay is incurred when waking up from Stop mode. 
+  *         By keeping the internal regulator ON during Stop mode, the consumption
+  *         is higher although the startup time is reduced.    
+  * @param Regulator: Specifies the regulator state in Stop mode.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_MAINREGULATOR_ON: Stop mode with regulator ON
+  *            @arg PWR_LOWPOWERREGULATOR_ON: Stop mode with low power regulator ON
+  * @param STOPEntry: Specifies if Stop mode in entered with WFI or WFE instruction.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_STOPENTRY_WFI: Enter Stop mode with WFI instruction
+  *            @arg PWR_STOPENTRY_WFE: Enter Stop mode with WFE instruction   
+  * @retval None
+  */
+void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_PWR_REGULATOR(Regulator));
+  assert_param(IS_PWR_STOP_ENTRY(STOPEntry));
+
+  /* Select the regulator state in Stop mode ---------------------------------*/
+  tmpreg = PWR->CR;
+  /* Clear PDDS and LPDS bits */
+  tmpreg &= (uint32_t)~(PWR_CR_PDDS | PWR_CR_LPSDSR);
+
+ /* Set LPSDSR bit according to PWR_Regulator value */
+  tmpreg |= Regulator;
+
+  /* Store the new value */
+  PWR->CR = tmpreg;
+
+  /* Set SLEEPDEEP bit of Cortex System Control Register */
+  SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+
+  /* Select Stop mode entry --------------------------------------------------*/
+  if(STOPEntry == PWR_STOPENTRY_WFI)
+  {
+    /* Request Wait For Interrupt */
+    __WFI();
+  }
+  else
+  {
+    /* Request Wait For Event */
+    __SEV();
+    __WFE();
+    __WFE();
+  }
+ 
+  /* Reset SLEEPDEEP bit of Cortex System Control Register */
+  SCB->SCR &= (uint32_t)~((uint32_t)SCB_SCR_SLEEPDEEP_Msk);
+}
+
+/**
+  * @brief Enters Standby mode.
+  * @note In Standby mode, all I/O pins are high impedance except for:
+  *          - Reset pad (still available) 
+  *          - RTC_AF1 pin (PC13) if configured for tamper, time-stamp, RTC
+  *            Alarm out, or RTC clock calibration out.
+  *          - RTC_AF2 pin (PC13) if configured for tamper.
+  *          - WKUP pin 1 (PA0) if enabled.
+  *          - WKUP pin 2 (PC13) if enabled.
+  * @param None
+  * @retval None
+  */
+void HAL_PWR_EnterSTANDBYMode(void)
+{
+  /* Select Standby mode */
+  PWR->CR |= PWR_CR_PDDS;
+
+  /* Set SLEEPDEEP bit of Cortex System Control Register */
+  SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+
+  /* This option is used to ensure that store operations are completed */
+#if defined ( __CC_ARM)
+  __force_stores();
+#endif
+  /* Request Wait For Interrupt */
+  __WFI();
+}
+
+/**
+  * @brief This function handles the PWR PVD interrupt request.
+  * @note This API should be called under the PVD_IRQHandler().
+  * @param None
+  * @retval None
+  */
+void HAL_PWR_PVD_IRQHandler(void)
+{
+  /* Check PWR exti flag */
+  if(__HAL_PVD_EXTI_GET_FLAG(PWR_EXTI_LINE_PVD) != RESET)
+  {
+    /* PWR PVD interrupt user callback */
+    HAL_PWR_PVDCallback();
+
+    /* Clear PWR Exti pending bit */
+    __HAL_PVD_EXTI_CLEAR_FLAG(PWR_EXTI_LINE_PVD);
+  }
+}
+
+/**
+  * @brief  PWR PVD interrupt callback
+  * @param  None 
+  * @retval None
+  */
+__weak void HAL_PWR_PVDCallback(void)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PWR_PVDCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_PWR_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pwr.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pwr.h
@@ -1,0 +1,334 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_pwr.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of PWR HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_PWR_H
+#define __STM32L0xx_HAL_PWR_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PWR
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/**
+  * @brief  PWR PVD configuration structure definition
+  */
+typedef struct
+{
+  uint32_t PVDLevel;   /*!< PVDLevel: Specifies the PVD detection level.
+                            This parameter can be a value of @ref PWR_PVD_detection_level */
+
+  uint32_t Mode;      /*!< Mode: Specifies the operating mode for the selected pins.
+                           This parameter can be a value of @ref PWR_PVD_Mode */
+}PWR_PVDTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup PWR_Exported_Constants
+  * @{
+  */
+
+/** @defgroup PWR_WakeUp_Pins
+  * @{
+  */
+
+#define PWR_WAKEUP_PIN1                 PWR_CSR_EWUP1
+#define PWR_WAKEUP_PIN2                 PWR_CSR_EWUP2
+#define IS_PWR_WAKEUP_PIN(PIN) (((PIN) == PWR_WAKEUP_PIN1) || \
+                                ((PIN) == PWR_WAKEUP_PIN2))
+/**
+  * @}
+  */
+
+/** @defgroup PWR_PVD_detection_level
+  * @{
+  */
+#define PWR_PVDLEVEL_0                  PWR_CR_PLS_LEV0
+#define PWR_PVDLEVEL_1                  PWR_CR_PLS_LEV1
+#define PWR_PVDLEVEL_2                  PWR_CR_PLS_LEV2
+#define PWR_PVDLEVEL_3                  PWR_CR_PLS_LEV3
+#define PWR_PVDLEVEL_4                  PWR_CR_PLS_LEV4
+#define PWR_PVDLEVEL_5                  PWR_CR_PLS_LEV5
+#define PWR_PVDLEVEL_6                  PWR_CR_PLS_LEV6
+#define PWR_PVDLEVEL_7                  PWR_CR_PLS_LEV7  /* External input analog voltage 
+                                                            (Compare internally to VREFINT) */
+#define IS_PWR_PVD_LEVEL(LEVEL) (((LEVEL) == PWR_PVDLEVEL_0) || ((LEVEL) == PWR_PVDLEVEL_1)|| \
+                                 ((LEVEL) == PWR_PVDLEVEL_2) || ((LEVEL) == PWR_PVDLEVEL_3)|| \
+                                 ((LEVEL) == PWR_PVDLEVEL_4) || ((LEVEL) == PWR_PVDLEVEL_5)|| \
+                                 ((LEVEL) == PWR_PVDLEVEL_6) || ((LEVEL) == PWR_PVDLEVEL_7))
+/**
+  * @}
+  */
+
+/** @defgroup PWR_PVD_Mode
+  * @{
+  */
+#define  PWR_MODE_EVT                  ((uint32_t)0x00000000)   /*!< No Interrupt */
+#define  PWR_MODE_IT_RISING            ((uint32_t)0x00000001)   /*!< External Interrupt Mode with Rising edge trigger detection */
+#define  PWR_MODE_IT_FALLING           ((uint32_t)0x00000002)   /*!< External Interrupt Mode with Falling edge trigger detection */
+#define  PWR_MODE_IT_RISING_FALLING    ((uint32_t)0x00000003)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection */
+#define IS_PWR_PVD_MODE(MODE) (((MODE) == PWR_MODE_EVT) || ((MODE) == PWR_MODE_IT_RISING)|| \
+                               ((MODE) == PWR_MODE_IT_FALLING) || ((MODE) == PWR_MODE_IT_RISING_FALLING))
+/**
+  * @}
+  */
+
+/** @defgroup PWR_Regulator_state_in_SLEEP_STOP_mode
+  * @{
+  */
+#define PWR_MAINREGULATOR_ON                        ((uint32_t)0x00000000)
+#define PWR_LOWPOWERREGULATOR_ON                    PWR_CR_LPSDSR
+
+#define IS_PWR_REGULATOR(REGULATOR) (((REGULATOR) == PWR_MAINREGULATOR_ON) || \
+                                     ((REGULATOR) == PWR_LOWPOWERREGULATOR_ON))
+/**
+  * @}
+  */
+
+/** @defgroup PWR_SLEEP_mode_entry
+  * @{
+  */
+#define PWR_SLEEPENTRY_WFI              ((uint8_t)0x01)
+#define PWR_SLEEPENTRY_WFE              ((uint8_t)0x02)
+#define IS_PWR_SLEEP_ENTRY(ENTRY) (((ENTRY) == PWR_SLEEPENTRY_WFI) || ((ENTRY) == PWR_SLEEPENTRY_WFE))
+/**
+  * @}
+  */
+
+/** @defgroup PWR_STOP_mode_entry
+  * @{
+  */
+#define PWR_STOPENTRY_WFI               ((uint8_t)0x01)
+#define PWR_STOPENTRY_WFE               ((uint8_t)0x02)
+#define IS_PWR_STOP_ENTRY(ENTRY) (((ENTRY) == PWR_STOPENTRY_WFI) || ((ENTRY) == PWR_STOPENTRY_WFE) )
+/**
+  * @}
+  */
+
+/** @defgroup PWR_Regulator_Voltage_Scale
+  * @{
+  */
+
+#define PWR_REGULATOR_VOLTAGE_SCALE1       PWR_CR_VOS_0
+#define PWR_REGULATOR_VOLTAGE_SCALE2       PWR_CR_VOS_1
+#define PWR_REGULATOR_VOLTAGE_SCALE3       PWR_CR_VOS
+
+#define IS_PWR_VOLTAGE_SCALING_RANGE(RANGE) (((RANGE) == PWR_REGULATOR_VOLTAGE_SCALE1) || \
+                                             ((RANGE) == PWR_REGULATOR_VOLTAGE_SCALE2) || \
+                                             ((RANGE) == PWR_REGULATOR_VOLTAGE_SCALE3))
+/**
+  * @}
+  */
+
+/** @defgroup PWR_Flag
+  * @{
+  */
+#define PWR_FLAG_WU                     PWR_CSR_WUF
+#define PWR_FLAG_SB                     PWR_CSR_SBF
+#define PWR_FLAG_PVDO                   PWR_CSR_PVDO
+#define PWR_FLAG_VREFINTRDY             PWR_CSR_VREFINTRDYF
+#define PWR_FLAG_VOS                    PWR_CSR_VOSF
+#define PWR_FLAG_REGLP                  PWR_CSR_REGLPF
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup PWR_Exported_Macro
+  * @{
+  */
+
+/** @brief  macros configure the main internal regulator output voltage.
+  * @param  __REGULATOR__: specifies the regulator output voltage to achieve
+  *         a tradeoff between performance and power consumption when the device does
+  *         not operate at the maximum frequency (refer to the datasheets for more details).
+  *          This parameter can be one of the following values:
+  *            @arg PWR_REGULATOR_VOLTAGE_SCALE1: Regulator voltage output Scale 1 mode,
+  *                                                System frequency up to 32 MHz.
+  *            @arg PWR_REGULATOR_VOLTAGE_SCALE2: Regulator voltage output Scale 2 mode,
+  *                                                System frequency up to 16 MHz.
+  *            @arg PWR_REGULATOR_VOLTAGE_SCALE3: Regulator voltage output Scale 3 mode,
+  *                                                System frequency up to 4.2 MHz
+  * @retval None
+  */
+#define __HAL_PWR_VOLTAGESCALING_CONFIG(__REGULATOR__) (MODIFY_REG(PWR->CR, PWR_CR_VOS, (__REGULATOR__)))
+
+/** @brief  Check PWR flag is set or not.
+  * @param  __FLAG__: specifies the flag to check.
+  *           This parameter can be one of the following values:
+  *            @arg PWR_FLAG_WU: Wake Up flag. This flag indicates that a wakeup event
+  *                  was received from the WKUP pin or from the RTC alarm (Alarm B),
+  *                  RTC Tamper event, RTC TimeStamp event or RTC Wakeup.
+  *                  An additional wakeup event is detected if the WKUP pin is enabled
+  *                  (by setting the EWUP bit) when the WKUP pin level is already high.
+  *            @arg PWR_FLAG_SB: StandBy flag. This flag indicates that the system was
+  *                  resumed from StandBy mode.
+  *            @arg PWR_FLAG_PVDO: PVD Output. This flag is valid only if PVD is enabled 
+  *                  by the HAL_PWR_EnablePVD() function. The PVD is stopped by Standby mode
+  *                  For this reason, this bit is equal to 0 after Standby or reset
+  *                  until the PVDE bit is set.
+  *            @arg PWR_FLAG_VREFINTRDY: Internal voltage reference (VREFINT) ready flag.
+  *                 This bit indicates the state of the internal voltage reference, VREFINT.
+  *            @arg PWR_FLAG_VOS: Voltage Scaling select flag. A delay is required for
+  *                 the internal regulator to be ready after the voltage range is changed.
+  *                 The VOSF bit indicates that the regulator has reached the voltage level
+  *                 defined with bits VOS of PWR_CR register.
+  *            @arg PWR_FLAG_REGLP: Regulator LP flag. When the MCU exits from Low power run
+  *                 mode, this bit stays at 1 until the regulator is ready in main mode.
+  *                 A polling on this bit is recommended to wait for the regulator main mode.
+  *                 This bit is reset by hardware when the regulator is ready.
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_PWR_GET_FLAG(__FLAG__) ((PWR->CSR & (__FLAG__)) == (__FLAG__))
+
+/** @brief  Clear the PWR's pending flags.
+  * @param  __FLAG__: specifies the flag to clear.
+  *          This parameter can be one of the following values:
+  *            @arg PWR_FLAG_WU: Wake Up flag
+  *            @arg PWR_FLAG_SB: StandBy flag
+  */
+#define __HAL_PWR_CLEAR_FLAG(__FLAG__) (PWR->CR |=  (__FLAG__) << 2)
+
+#define PWR_EXTI_LINE_PVD  ((uint32_t)0x00010000)  /*!< External interrupt line 16 Connected to the PVD EXTI Line */
+/**
+  * @brief Enable the PVD Exti Line.
+  * @param  __EXTILINE__: specifies the PVD Exti sources to be enabled.
+  * This parameter can be:
+  *   @arg PWR_EXTI_LINE_PVD
+  * @retval None.
+  */
+#define __HAL_PVD_EXTI_ENABLE_IT(__EXTILINE__)   (EXTI->IMR |= (__EXTILINE__))
+
+/**
+  * @brief Disable the PVD EXTI Line.
+  * @param  __EXTILINE__: specifies the PVD EXTI sources to be disabled.
+  * This parameter can be:
+  *  @arg PWR_EXTI_LINE_PVD
+  * @retval None.
+  */
+#define __HAL_PVD_EXTI_DISABLE_IT(__EXTILINE__)  (EXTI->IMR &= ~(__EXTILINE__))
+
+/**
+  * @brief  Generates a Software interrupt on selected EXTI line.
+  * @param  __EXTILINE__: specifies the PVD EXTI sources to be disabled.
+  * This parameter can be:
+  *  @arg PWR_EXTI_LINE_PVD
+  * @retval None
+  */
+#define __HAL_PVD_EXTI_GENERATE_SWIT(__EXTI_LINE__) (EXTI->SWIER |= (__EXTI_LINE__))
+
+/**
+  * @brief checks whether the specified PVD Exti interrupt flag is set or not.
+  * @param  __EXTILINE__: specifies the PVD Exti sources to be cleared.
+  * This parameter can be:
+  *   @arg PWR_EXTI_LINE_PVD
+  * @retval EXTI PVD Line Status.
+  */
+#define __HAL_PVD_EXTI_GET_FLAG(__EXTILINE__)  (EXTI->PR & (__EXTILINE__))
+
+/**
+  * @brief Clear the PVD Exti flag.
+  * @param  __EXTILINE__: specifies the PVD Exti sources to be cleared.
+  * This parameter can be:
+  *   @arg PWR_EXTI_LINE_PVD  
+  * @retval None.
+  */
+#define __HAL_PVD_EXTI_CLEAR_FLAG(__EXTILINE__)  (EXTI->PR = (__EXTILINE__))
+
+/**
+  * @}
+  */
+
+/* Include PWR HAL Extension module */
+#include "stm32l0xx_hal_pwr_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+
+/* Initialization and de-initialization functions *******************************/
+void HAL_PWR_DeInit(void);
+void HAL_PWR_EnableBkUpAccess(void);
+void HAL_PWR_DisableBkUpAccess(void);
+
+/* Peripheral Control functions  ************************************************/
+void HAL_PWR_PVDConfig(PWR_PVDTypeDef *sConfigPVD);
+void HAL_PWR_EnablePVD(void);
+void HAL_PWR_DisablePVD(void);
+
+/* WakeUp pins configuration functions ****************************************/
+void HAL_PWR_EnableWakeUpPin(uint32_t WakeUpPinx);
+void HAL_PWR_DisableWakeUpPin(uint32_t WakeUpPinx);
+
+/* Low Power modes configuration functions ************************************/
+void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry);
+void HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry);
+void HAL_PWR_EnterSTANDBYMode(void);
+
+void HAL_PWR_PVD_IRQHandler(void);
+void HAL_PWR_PVDCallback(void);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L0xx_HAL_PWR_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pwr_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pwr_ex.c
@@ -1,0 +1,174 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_pwr_ex.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Extended PWR HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Power Controller (PWR) peripheral:
+  *           + Extended Initialization and de-initialization functions
+  *           + Extended Peripheral Control functions
+  *         
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PWREx 
+  * @brief PWR HAL module driver
+  * @{
+  */
+
+#ifdef HAL_PWR_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup PWREx_Private_Functions
+  * @{
+  */
+
+/** @defgroup PWREx_Group1 Peripheral Extended features functions
+  *  @brief Low Power modes configuration functions 
+  *
+@verbatim
+
+ ===============================================================================
+                 ##### Peripheral extended features functions #####
+ ===============================================================================
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enables the Fast WakeUp from Ultra Low Power mode.
+  * @note This bit works in conjunction with ULP bit. 
+  *        Means, when ULP = 1 and FWU = 1 :VREFINT startup time is ignored when 
+  *        exiting from low power mode.
+  * @param  None
+  * @retval None
+  */
+void HAL_PWREx_EnableFastWakeUp(void)
+{
+  /* Enable the fast wake up */
+  PWR->CR |= PWR_CR_FWU;
+}
+
+/**
+  * @brief  Disables the Fast WakeUp from Ultra Low Power mode.
+  * @param  None
+  * @retval None
+  */
+void HAL_PWREx_DisableFastWakeUp(void)
+{
+  /* Disable the fast wake up */
+  PWR->CR &= (uint32_t)~((uint32_t)PWR_CR_FWU);
+}
+
+/**
+  * @brief  Enables the Ultra Low Power mode
+  * @param  None
+  * @retval None
+  */
+void HAL_PWREx_EnableUltraLowPower(void)
+{
+  /* Enable the Ultra Low Power mode */
+  PWR->CR |= PWR_CR_ULP;
+}
+
+/**
+  * @brief  Disables the Ultra Low Power mode
+  * @param  None
+  * @retval None
+  */
+void HAL_PWREx_DisableUltraLowPower(void)
+{
+  /* Disable the Ultra Low Power mode */
+  PWR->CR &= (uint32_t)~((uint32_t)PWR_CR_ULP);
+}
+
+/**
+  * @brief  Enters the Low Power Run mode.
+  * @note   Low power run mode can only be entered when VCORE is in range 2.
+  *         In addition, the dynamic voltage scaling must not be used when Low
+  *         power run mode is selected. Only Stop and Sleep modes with regulator
+  *         configured in Low power mode is allowed when Low power run mode is 
+  *         selected.
+  * @note   In Low power run mode, all I/O pins keep the same state as in Run mode.
+  * @param  None
+  * @retval None
+  */
+void HAL_PWREx_EnableLowPowerRunMode(void)
+{
+  /* Enters the Low Power Run mode */
+  PWR->CR |= PWR_CR_LPSDSR;
+  PWR->CR |= PWR_CR_LPRUN;
+}
+
+/**
+  * @brief  Exits the Low Power Run mode.
+  * @param  None
+  * @retval None
+  */
+void HAL_PWREx_DisableLowPowerRunMode(void)
+{
+  /* Exits the Low Power Run mode */
+  PWR->CR &= (uint32_t)~((uint32_t)PWR_CR_LPRUN);
+  PWR->CR &= (uint32_t)~((uint32_t)PWR_CR_LPSDSR);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_PWR_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pwr_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_pwr_ex.h
@@ -1,0 +1,102 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_pwr_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of PWR HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_PWR_EX_H
+#define __STM32L0xx_HAL_PWR_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PWREx
+  * @{
+  */
+
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup PWREx_Exported macro
+ * @{
+ */
+
+/** @brief  Macros to enable or disable the Deep-sleep mode with Flash memory kept off.
+  * @note   When entering low power mode (stop or standby only), if DS_EE_KOFF and RUN_PD of
+  *         FLASH_ACR register are both set , the Flash memory will not be woken up 
+  *         when exiting from deep-sleep mode.
+  */
+#define __HAL_PWR_FLASHWAKEUP_ENABLE() CLEAR_BIT(PWR->CR, PWR_CR_DSEEKOFF)
+#define __HAL_PWR_FLASHWAKEUP_DISABLE() SET_BIT(PWR->CR, PWR_CR_DSEEKOFF)
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/* Peripheral Control methods  ************************************************/
+void HAL_PWREx_EnableFastWakeUp(void);
+void HAL_PWREx_DisableFastWakeUp(void);
+void HAL_PWREx_EnableUltraLowPower(void);
+void HAL_PWREx_DisableUltraLowPower(void);
+void HAL_PWREx_EnableLowPowerRunMode(void);
+void HAL_PWREx_DisableLowPowerRunMode(void);
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L0xx_HAL_PWR_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rcc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rcc.c
@@ -1,0 +1,1341 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_rcc.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   RCC HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Reset and Clock Control (RCC) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + Peripheral Control functions
+  *       
+  @verbatim                
+  ==============================================================================
+                      ##### RCC specific features #####
+  ==============================================================================
+    [..] After reset the device is running from MSI (2 MHz) with Flash 0 WS, 
+         all peripherals are off except internal SRAM, Flash and SW-DP.
+         (+) There is no prescaler on High speed (AHB) and Low speed (APB) busses;
+             all peripherals mapped on these busses are running at MSI speed.
+         (+) The clock for all peripherals is switched off, except the SRAM and 
+             FLASH.
+         (+) All GPIOs are in input floating state, except the SW-DP pins which
+             are assigned to be used for debug purpose.
+    [..] Once the device started from reset, the user application has to:
+         (+) Configure the clock source to be used to drive the System clock
+             (if the application needs higher frequency/performance)
+         (+) Configure the System clock frequency and Flash settings
+         (+) Configure the AHB and APB busses prescalers
+         (+) Enable the clock for the peripheral(s) to be used
+         (+) Configure the clock source(s) for peripherals whose clocks are not
+             derived from the System clock (ADC, RTC/LCD, RNG and IWDG)
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RCC 
+  * @brief RCC HAL module driver
+  * @{
+  */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define HSE_TIMEOUT_VALUE          HSE_STARTUP_TIMEOUT
+#define HSI_TIMEOUT_VALUE          ((uint32_t)100)  /* 100 ms */
+#define LSI_TIMEOUT_VALUE          ((uint32_t)100)  /* 100 ms */
+#define PLL_TIMEOUT_VALUE          ((uint32_t)100)  /* 100 ms */
+#define HSI48_TIMEOUT_VALUE        ((uint32_t)100)  /* 100 ms */
+#define MSI_TIMEOUT_VALUE          ((uint32_t)100)  /* 100 ms */    
+#define CLOCKSWITCH_TIMEOUT_VALUE  ((uint32_t)5000) /* 5 s    */
+
+/* Private macro -------------------------------------------------------------*/
+#define __MCO1_CLK_ENABLE()   __GPIOA_CLK_ENABLE()
+#define MCO1_GPIO_PORT        GPIOA
+#define MCO1_PIN              GPIO_PIN_8
+#define MCO2_PIN              GPIO_PIN_9
+
+/* Private variables ---------------------------------------------------------*/
+static __IO const uint8_t PLLMulTable[9] = {3, 4, 6, 8, 12, 16, 24, 32, 48};
+static __IO const uint8_t APBAHBPrescTable[16] = {0, 0, 0, 0, 1, 2, 3, 4, 1, 2, 3, 4, 6, 7, 8, 9};
+const uint32_t MSIRangeTable[7] = {64000, 128000, 256000, 512000, 1000000, 2000000, 4000000};
+
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup RCC_Private_Functions
+  * @{
+  */
+
+/** @defgroup RCC_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+ ===============================================================================
+           ##### Initialization and de-initialization functions #####
+ ===============================================================================
+   [..] 
+      This section provide functions allowing to configure the internal/external 
+         clocks, PLL, CSS and MCO.
+   [..] Internal/external clock and PLL configuration
+         (#) HSI (high-speed internal), 16 MHz factory-trimmed RC used directly 
+             or through the PLL as System clock source.
+         (#) MSI (multi-speed internal), multispeed low power RC 
+             (65.536 KHz to 4.194 MHz) MHz used as System clock source.
+         (#) LSI (low-speed internal), 37 KHz low consumption RC used as IWDG 
+             and/or RTC clock source.
+         (#) HSE (high-speed external), 1 to 24 MHz crystal oscillator used 
+             directly or through the PLL as System clock source. Can be used 
+             also as RTC clock source.
+         (#) LSE (low-speed external), 32 KHz oscillator used as RTC clock source.
+         (#) PLL (clocked by HSI or HSE), for System clock and USB (48 MHz).
+         (#) CSS (Clock security system), once enable and if a HSE clock failure 
+             occurs (HSE used directly or through PLL as System clock source), 
+             the System clock is automatically switched to MSI and an interrupt 
+             is generated if enabled. 
+             The interrupt is linked to the Cortex-M3 NMI (Non-Maskable Interrupt) 
+             exception vector.
+         (#) MCO (microcontroller clock output), used to output SYSCLK, HSI, MSI, 
+             HSE, PLL, LSI or LSE clock (through a configurable prescaler) on 
+             PA8 pin.
+ [..] System, AHB and APB busses clocks configuration  
+         (#) Several clock sources can be used to drive the System clock (SYSCLK): MSI, HSI,
+             HSE and PLL.
+             The AHB clock (HCLK) is derived from System clock through configurable 
+             prescaler and used to clock the CPU, memory and peripherals mapped 
+             on IOPORT, AHB bus (DMA,Flash...). APB1 (PCLK1) and APB2 (PCLK2) clocks are derived 
+             from AHB clock through configurable prescalers and used to clock 
+             the peripherals mapped on these busses. You can use 
+             "HAL_RCC_GetSysClockFreq()" function to retrieve the frequencies of these clocks.  
+
+         -@- All the peripheral clocks are derived from the System clock (SYSCLK) except:
+           (+@) I2S: the I2S clock can be derived from an external clock mapped on the I2S_CKIN pin. 
+              
+           (+@) RTC: the RTC clock can be derived either from the LSI, LSE or HSE clock
+                divided by 2 to 16. You have to use __HAL_RCC_RTC_CONFIG() and __HAL_RCC_RTC_ENABLE()
+                macros to configure this clock. 
+           (+@) USB FS,and RNG  require a frequency equal to 48 MHz to work correctly
+                This clock is derived from the main PLL or HSI48 RC oscillator.
+           (+@) IWDG clock which is always the LSI clock.
+       
+         (#) For the STM32L0xx devices, the maximum
+             frequency of the SYSCLK ,HCLK, APB1 and APB2 is 32 MHz. 
+             Depending on the device voltage range, the maximum frequency should
+             be adapted accordingly:
+ ----------------------------------------------------------------
+ |  Wait states  |                HCLK clock frequency (MHz)      |
+ |               |------------------------------------------------|
+ |   (Latency)   |            voltage range       | voltage range |
+ |               |            1.65 V - 3.6 V      | 2.0 V - 3.6 V |
+ |               |----------------|---------------|---------------|
+ |               |  VCORE = 1.2 V | VCORE = 1.5 V | VCORE = 1.8 V |
+ |-------------- |----------------|---------------|---------------|
+ |0WS(1CPU cycle)|0 < HCLK <= 2   |0 < HCLK <= 8  |0 < HCLK <= 16 |
+ |---------------|----------------|---------------|---------------|
+ |1WS(2CPU cycle)|2 < HCLK <= 4   |8 < HCLK <= 16 |16 < HCLK <= 32|
+  ----------------------------------------------------------------
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Resets the RCC clock configuration to the default reset state.
+  * @note   The default reset state of the clock configuration is given below:
+  *           - MSI ON and used as system clock source (MSI range is not modified
+  *           - by this function, it keep the value configured by user application)
+  *           - HSI, HSE and PLL OFF
+  *           - AHB, APB1 and APB2 prescaler set to 1.
+  *           - CSS and MCO OFF
+  *           - All interrupts disabled
+  * @note   This function doesn't modify the configuration of the
+  * @note      -Peripheral clocks
+  * @note      -HSI48, LSI, LSE and RTC clocks                  
+  * @param  None
+  * @retval None
+  */
+void HAL_RCC_DeInit(void)
+{
+  /* Set MSION bit */
+  SET_BIT(RCC->CR, RCC_CR_MSION); 
+  
+  /* Reset HSION, HSEON, CSSON, PLLON */
+  CLEAR_BIT(RCC->CR, RCC_CR_HSEON | RCC_CR_HSION| RCC_CR_HSIKERON| RCC_CR_CSSHSEON | RCC_CR_PLLON); 
+  
+  /* Reset CFGR register */
+  CLEAR_REG(RCC->CFGR);
+  
+  /* Reset HSEBYP bit */
+  CLEAR_BIT(RCC->CR, RCC_CR_HSEBYP);
+  
+  /* Disable all interrupts */
+  CLEAR_REG(RCC->CIER); 
+}
+
+/**
+  * @brief  Initializes the RCC Oscillators according to the specified parameters in the
+  *         RCC_OscInitTypeDef.
+  * @param  RCC_OscInitStruct: pointer to an RCC_OscInitTypeDef structure that
+  *         contains the configuration information for the RCC Oscillators.
+  * @note   The PLL is not disabled when used as system clock.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
+{
+
+   uint32_t tickstart = 0;   
+ 
+  /* Check the parameters */
+  assert_param(IS_RCC_OSCILLATORTYPE(RCC_OscInitStruct->OscillatorType));
+  /*------------------------------- HSE Configuration ------------------------*/ 
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_HSE) == RCC_OSCILLATORTYPE_HSE)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_HSE(RCC_OscInitStruct->HSEState));
+    /* When the HSE is used as system clock or clock source for PLL in these cases HSE will not disabled */
+    if((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_HSE) || ((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_PLL) && ((RCC->CFGR & RCC_CFGR_PLLSRC) == RCC_CFGR_PLLSRC_HSE)))
+    {
+      if((__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != RESET) && (RCC_OscInitStruct->HSEState != RCC_HSE_ON))
+      {
+        return HAL_ERROR;
+      }
+    }
+    else
+    {
+      /* Reset HSEON and HSEBYP bits before configuring the HSE --------------*/
+      __HAL_RCC_HSE_CONFIG(RCC_HSE_OFF);
+      
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+    
+      /* Wait till HSE is disabled */  
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != RESET)
+      {
+        if((HAL_GetTick() - tickstart ) > HSE_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }      
+      }
+      
+      /* Set the new HSE configuration ---------------------------------------*/
+      __HAL_RCC_HSE_CONFIG(RCC_OscInitStruct->HSEState);
+      
+      /* Check the HSE State */
+      if((RCC_OscInitStruct->HSEState) == RCC_HSE_ON)
+      {
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+      
+        /* Wait till HSE is ready */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) == RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > HSE_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }      
+        }      
+      }
+      else
+      {
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+      
+        /* Wait till HSE is  bypassed or disabled */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != RESET)
+        {
+           if((HAL_GetTick() - tickstart ) > HSE_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }      
+        }
+      }
+    }
+  }
+  /*----------------------------- HSI Configuration --------------------------*/ 
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_HSI) == RCC_OSCILLATORTYPE_HSI)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_HSI(RCC_OscInitStruct->HSIState));
+    assert_param(IS_RCC_CALIBRATION_VALUE(RCC_OscInitStruct->HSICalibrationValue));
+    
+    /* When the HSI is used as system clock it will not disabled */
+    if((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_HSI) || ((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_PLL) && ((RCC->CFGR & RCC_CFGR_PLLSRC) == RCC_CFGR_PLLSRC_HSI)))
+    {
+      /* When HSI is used as system clock it will not disabled */
+      if((__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) != RESET) && (RCC_OscInitStruct->HSIState != RCC_HSI_ON))
+      {
+        return HAL_ERROR;
+      }
+      /* Otherwise, just the calibration is allowed */
+      else
+      {
+        /* Adjusts the Internal High Speed oscillator (HSI) calibration value.*/
+        __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->HSICalibrationValue);
+      }
+    }
+    else
+    {
+      /* Check the HSI State */
+      if((RCC_OscInitStruct->HSIState)!= RCC_HSI_OFF)
+      {
+        /* Enable the Internal High Speed oscillator (HSI or HSIdiv4 */
+        __HAL_RCC_HSI_CONFIG(RCC_OscInitStruct->HSIState);
+        
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+      
+        /* Wait till HSI is ready */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) == RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > HSI_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }      
+        } 
+                
+        /* Adjusts the Internal High Speed oscillator (HSI) calibration value.*/
+        __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->HSICalibrationValue);
+      }
+      else
+      {
+        /* Disable the Internal High Speed oscillator (HSI). */
+        __HAL_RCC_HSI_CONFIG(RCC_OscInitStruct->HSIState);
+       
+        /* Get Start Tick*/
+        tickstart = HAL_GetTick();
+      
+        /* Wait till HSI is ready */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) != RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > HSI_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }      
+        } 
+      }
+    }
+  }
+   /*----------------------------- MSI Configuration --------------------------*/ 
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_MSI) == RCC_OSCILLATORTYPE_MSI)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_MSI(RCC_OscInitStruct->MSIState));
+    assert_param(IS_RCC_MSICALIBRATION_VALUE(RCC_OscInitStruct->MSICalibrationValue));
+    
+        
+    /* When the MSI is used as system clock it will not disabled */
+    if((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_CFGR_SWS_MSI) )
+    {
+      if((__HAL_RCC_GET_FLAG(RCC_FLAG_MSIRDY) != RESET) && (RCC_OscInitStruct->MSIState != RCC_MSI_ON))
+      {
+        return HAL_ERROR;
+      }
+      
+       /* Otherwise, just the calibration and MSI range change are allowed */
+      else
+      {
+       /* Selects the Multiple Speed oscillator (MSI) clock range .*/
+        __HAL_RCC_MSI_RANGE_CONFIG (RCC_OscInitStruct->MSIClockRange);   
+        /* Adjusts the Multiple Speed oscillator (MSI) calibration value.*/
+        __HAL_RCC_MSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->MSICalibrationValue);
+      }
+    }
+    else
+    {
+      /* Check the MSI State */
+      if((RCC_OscInitStruct->MSIState)!= RCC_MSI_OFF)
+      {
+        /* Enable the Internal High Speed oscillator (MSI). */
+        __HAL_RCC_MSI_ENABLE();
+        
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+      
+        /* Wait till MSI is ready */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_MSIRDY) == RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > MSI_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }      
+        } 
+         /* Selects the Multiple Speed oscillator (MSI) clock range .*/
+        __HAL_RCC_MSI_RANGE_CONFIG (RCC_OscInitStruct->MSIClockRange);   
+         /* Adjusts the Multiple Speed oscillator (MSI) calibration value.*/
+        __HAL_RCC_MSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->MSICalibrationValue);
+        
+      }
+      else
+      {
+        /* Disable the Internal High Speed oscillator (MSI). */
+        __HAL_RCC_MSI_DISABLE();
+        
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+      
+        /* Wait till MSI is ready */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_MSIRDY) != RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > MSI_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }      
+        } 
+      }
+    }
+  }
+  /*------------------------------ LSI Configuration -------------------------*/ 
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_LSI) == RCC_OSCILLATORTYPE_LSI)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_LSI(RCC_OscInitStruct->LSIState));
+    
+    /* Check the LSI State */
+    if((RCC_OscInitStruct->LSIState)!= RCC_LSI_OFF)
+    {
+      /* Enable the Internal Low Speed oscillator (LSI). */
+      __HAL_RCC_LSI_ENABLE();
+      
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      /* Wait till LSI is ready */  
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY) == RESET)
+      {
+        if((HAL_GetTick() - tickstart ) > LSI_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }      
+      } 
+    }
+    else
+    {
+      /* Disable the Internal Low Speed oscillator (LSI). */
+      __HAL_RCC_LSI_DISABLE();
+      
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      /* Wait till LSI is ready */  
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY) != RESET)
+      {
+        if((HAL_GetTick() - tickstart ) > LSI_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }      
+      } 
+    }
+  }
+  
+  
+   /*------------------------------ HSI48 Configuration -------------------------*/ 
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_HSI48) == RCC_OSCILLATORTYPE_HSI48)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_HSI48(RCC_OscInitStruct->HSI48State));
+    
+    /* Check the HSI48 State */
+    if((RCC_OscInitStruct->HSI48State)!= RCC_HSI48_OFF)
+    {
+      /* Enable the Internal Low Speed oscillator (HSI48). */
+      __HAL_RCC_HSI48_ENABLE();
+      
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      /* Wait till HSI48 is ready */  
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSI48RDY) == RESET)
+      {
+        if((HAL_GetTick() - tickstart ) > HSI48_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }      
+      } 
+    }
+    else
+    {
+      /* Disable the Internal Low Speed oscillator (HSI48). */
+      __HAL_RCC_HSI48_DISABLE();
+      
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      /* Wait till HSI48 is ready */  
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSI48RDY) != RESET)
+      {
+        if((HAL_GetTick() - tickstart ) > HSI48_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }      
+      } 
+    }
+  }
+  /*------------------------------ LSE Configuration -------------------------*/ 
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_LSE) == RCC_OSCILLATORTYPE_LSE)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_LSE(RCC_OscInitStruct->LSEState));
+
+    /* Enable Power Clock*/
+    __PWR_CLK_ENABLE();
+
+    /* Enable write access to Backup domain */
+    PWR->CR |= PWR_CR_DBP;
+
+    /* Wait for Backup domain Write protection disable */
+    tickstart = HAL_GetTick();
+ 
+    while((PWR->CR & PWR_CR_DBP) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > DBP_TIMEOUT_VALUE)
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Reset LSEON and LSEBYP bits before configuring the LSE ----------------*/
+    __HAL_RCC_LSE_CONFIG(RCC_LSE_OFF);
+    
+    /* Get timeout */
+    tickstart = HAL_GetTick();
+      
+    /* Wait till LSE is ready */  
+    while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) != RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > LSE_TIMEOUT_VALUE)
+      {
+        return HAL_TIMEOUT;
+      }      
+    } 
+    
+    /* Set the new LSE configuration -----------------------------------------*/
+    __HAL_RCC_LSE_CONFIG(RCC_OscInitStruct->LSEState);
+    /* Check the LSE State */
+    if((RCC_OscInitStruct->LSEState) == RCC_LSE_ON)
+    {     
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      /* Wait till LSE is ready */  
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) == RESET)
+      {
+        if((HAL_GetTick() - tickstart ) > LSE_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }      
+      }
+    }
+    else
+    {
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      /* Wait till LSE is ready */  
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) != RESET)
+      {
+        if((HAL_GetTick() - tickstart ) > LSE_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }      
+      }
+    }
+  }
+  /*-------------------------------- PLL Configuration -----------------------*/
+  /* Check the parameters */
+  assert_param(IS_RCC_PLL(RCC_OscInitStruct->PLL.PLLState));
+  if ((RCC_OscInitStruct->PLL.PLLState) != RCC_PLL_NONE)
+  {
+    /* Check if the PLL is used as system clock or not */
+    if(__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_PLL)
+    { 
+      if((RCC_OscInitStruct->PLL.PLLState) == RCC_PLL_ON)
+      {
+        /* Check the parameters */
+        assert_param(IS_RCC_PLLSOURCE(RCC_OscInitStruct->PLL.PLLSource));
+        assert_param(IS_RCC_PLL_MUL(RCC_OscInitStruct->PLL.PLLMUL));
+        assert_param(IS_RCC_PLL_DIV(RCC_OscInitStruct->PLL.PLLDIV));
+        
+        
+        /* Disable the main PLL. */
+        __HAL_RCC_PLL_DISABLE();
+        
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+      
+        /* Wait till PLL is ready */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) != RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > PLL_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }      
+        }        
+
+        /* Configure the main PLL clock source, multiplication and division factors. */
+        __HAL_RCC_PLL_CONFIG(RCC_OscInitStruct->PLL.PLLSource,
+                             RCC_OscInitStruct->PLL.PLLMUL,
+                             RCC_OscInitStruct->PLL.PLLDIV);
+        /* Enable the main PLL. */
+        __HAL_RCC_PLL_ENABLE();
+
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+      
+        /* Wait till PLL is ready */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) == RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > PLL_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }      
+        }
+      }
+      else
+      {
+        /* Disable the main PLL. */
+        __HAL_RCC_PLL_DISABLE();       
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+      
+        /* Wait till PLL is ready */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) != RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > PLL_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }      
+        }
+      }
+    }
+    else
+    {
+      return HAL_ERROR;
+    }
+  }
+  return HAL_OK;
+}
+ 
+/**
+  * @brief  Initializes the CPU, AHB and APB busses clocks according to the specified 
+  *         parameters in the RCC_ClkInitStruct.
+  * @param  RCC_ClkInitStruct: pointer to an RCC_OscInitTypeDef structure that
+  *         contains the configuration information for the RCC peripheral.
+  * @param  FLatency: FLASH Latency, this parameter depends on System Clock Frequency
+  * 
+  * @note   The SystemCoreClock CMSIS variable is used to store System Clock Frequency 
+  *         and updated by HAL_RCC_GetHCLKFreq() function called within this function
+  *                 
+  * @note   The MSI is used (enabled by hardware) as system clock source after
+  *         startup from Reset, wake-up from STOP and STANDBY mode, or in case
+  *         of failure of the HSE used directly or indirectly as system clock
+  *         (if the Clock Security System CSS is enabled).
+  *           
+  * @note   A switch from one clock source to another occurs only if the target
+  *         clock source is ready (clock stable after startup delay or PLL locked). 
+  *         If a clock source which is not yet ready is selected, the switch will
+  *         occur when the clock source will be ready. 
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, uint32_t FLatency)
+{
+
+  uint32_t tickstart = 0;
+ 
+  /* Check the parameters */
+  assert_param(IS_RCC_CLOCKTYPE(RCC_ClkInitStruct->ClockType));
+  assert_param(IS_FLASH_LATENCY(FLatency));
+ 
+  /* To correctly read data from FLASH memory, the number of wait states (LATENCY) 
+    must be correctly programmed according to the frequency of the CPU clock 
+    (HCLK) and the supply voltage of the device. */
+  
+  /* Increasing the CPU frequency */
+  if(FLatency > (FLASH->ACR & FLASH_ACR_LATENCY))
+  {    
+    /* Program the new number of wait states to the LATENCY bits in the FLASH_ACR register */
+    __HAL_FLASH_SET_LATENCY(FLatency);
+    
+    /* Check that the new number of wait states is taken into account to access the Flash
+    memory by reading the FLASH_ACR register */
+    if((FLASH->ACR & FLASH_ACR_LATENCY) != FLatency)
+    {
+      return HAL_ERROR;
+    }
+
+    /*-------------------------- HCLK Configuration --------------------------*/
+    if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_HCLK) == RCC_CLOCKTYPE_HCLK)
+    {
+      assert_param(IS_RCC_HCLK(RCC_ClkInitStruct->AHBCLKDivider));
+      MODIFY_REG(RCC->CFGR, RCC_CFGR_HPRE, RCC_ClkInitStruct->AHBCLKDivider);
+    }
+
+    /*------------------------- SYSCLK Configuration ---------------------------*/ 
+    if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_SYSCLK) == RCC_CLOCKTYPE_SYSCLK)
+    {    
+      assert_param(IS_RCC_SYSCLKSOURCE(RCC_ClkInitStruct->SYSCLKSource));
+      
+      /* HSE is selected as System Clock Source */
+      if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_HSE)
+      {
+        /* Check the HSE ready flag */  
+        if(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) == RESET)
+        {
+          return HAL_ERROR;
+        }
+      }
+      
+          /* MSI is selected as System Clock Source */
+      else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_MSI)
+      {
+        /* Check the MSI ready flag */  
+        if(__HAL_RCC_GET_FLAG(RCC_FLAG_MSIRDY) == RESET)
+        {
+          return HAL_ERROR;
+        }
+      }
+      /* PLL is selected as System Clock Source */
+      else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_PLLCLK)
+      {
+        /* Check the PLL ready flag */  
+        if(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) == RESET)
+        {
+          return HAL_ERROR;
+        }
+      }
+      /* HSI is selected as System Clock Source */
+      else
+      {
+        /* Check the HSI ready flag */  
+        if(__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) == RESET)
+        {
+          return HAL_ERROR;
+        }
+      }
+      MODIFY_REG(RCC->CFGR, RCC_CFGR_SW, RCC_ClkInitStruct->SYSCLKSource);
+ 
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_HSE)
+      {
+        while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_HSE)
+        {
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          } 
+        }
+      }
+      else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_PLLCLK)
+      {
+        while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_PLL)
+        {
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          } 
+        }
+      }
+      else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_MSI)
+      {
+        while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_MSI)
+        {
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          } 
+        }
+      }
+      else
+      {
+        while(__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_HSI)
+        {
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+    }    
+  }
+  /* Decreasing the CPU frequency */
+  else
+  {
+    /*-------------------------- HCLK Configuration --------------------------*/
+    if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_HCLK) == RCC_CLOCKTYPE_HCLK)
+    {
+      assert_param(IS_RCC_HCLK(RCC_ClkInitStruct->AHBCLKDivider));
+      MODIFY_REG(RCC->CFGR, RCC_CFGR_HPRE, RCC_ClkInitStruct->AHBCLKDivider);
+    }
+
+    /*------------------------- SYSCLK Configuration -------------------------*/
+    if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_SYSCLK) == RCC_CLOCKTYPE_SYSCLK)
+    {    
+      assert_param(IS_RCC_SYSCLKSOURCE(RCC_ClkInitStruct->SYSCLKSource));
+      
+      /* HSE is selected as System Clock Source */
+      if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_HSE)
+      {
+        /* Check the HSE ready flag */  
+        if(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) == RESET)
+        {
+          return HAL_ERROR;
+        }
+      }
+
+      /* MSI is selected as System Clock Source */
+      else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_MSI)
+      {
+        /* Check the MSI ready flag */  
+        if(__HAL_RCC_GET_FLAG(RCC_FLAG_MSIRDY) == RESET)
+        {
+          return HAL_ERROR;
+        }
+      }
+      /* PLL is selected as System Clock Source */
+      else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_PLLCLK)
+      {
+        /* Check the PLL ready flag */  
+        if(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) == RESET)
+        {
+          return HAL_ERROR;
+        }
+      }
+      /* HSI is selected as System Clock Source */
+      else
+      {
+        /* Check the HSI ready flag */  
+        if(__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) == RESET)
+        {
+          return HAL_ERROR;
+        }
+      }
+      MODIFY_REG(RCC->CFGR, RCC_CFGR_SW, RCC_ClkInitStruct->SYSCLKSource);
+      
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_HSE)
+      {
+        while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_HSE)
+        {
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          } 
+        }
+      }
+      else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_PLLCLK)
+      {
+        while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_PLL)
+        {
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          } 
+        }
+      }
+      else if(RCC_ClkInitStruct->SYSCLKSource == RCC_SYSCLKSOURCE_MSI)
+      {
+        while (__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_MSI)
+        {
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          } 
+        }
+      }
+      else
+      {
+        while(__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_CFGR_SWS_HSI)
+        {
+          if((HAL_GetTick() - tickstart ) > CLOCKSWITCH_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }  
+        }
+      }
+    }
+    
+    /* Program the new number of wait states to the LATENCY bits in the FLASH_ACR register */
+    __HAL_FLASH_SET_LATENCY(FLatency);
+    
+    /* Check that the new number of wait states is taken into account to access the Flash
+    memory by reading the FLASH_ACR register */
+    if((FLASH->ACR & FLASH_ACR_LATENCY) != FLatency)
+    {
+      return HAL_ERROR;
+    }
+ }
+
+  /*-------------------------- PCLK1 Configuration ---------------------------*/ 
+  if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_PCLK1) == RCC_CLOCKTYPE_PCLK1)
+  {
+    assert_param(IS_RCC_PCLK(RCC_ClkInitStruct->APB1CLKDivider));
+    MODIFY_REG(RCC->CFGR, RCC_CFGR_PPRE1, RCC_ClkInitStruct->APB1CLKDivider);
+  }
+  
+  /*-------------------------- PCLK2 Configuration ---------------------------*/ 
+  if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_PCLK2) == RCC_CLOCKTYPE_PCLK2)
+  {
+    assert_param(IS_RCC_PCLK(RCC_ClkInitStruct->APB2CLKDivider));
+    MODIFY_REG(RCC->CFGR, RCC_CFGR_PPRE2, ((RCC_ClkInitStruct->APB2CLKDivider) << 3));
+  }
+
+  /* Configure the source of time base considering new system clocks settings*/
+  HAL_InitTick (TICK_INT_PRIORITY);
+  
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Group2 Peripheral Control functions 
+ *  @brief   RCC clocks control functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to control the RCC Clocks 
+    frequencies.
+      
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Selects the clock source to output on MCO pin.
+  * @note   MCO pin should be configured in alternate function mode.
+  * @param  RCC_MCOx: specifies the output direction for the clock source.
+  *           For STM32L0xx family this parameter can have only one value:
+  *            @arg RCC_MCO1: Clock source to output on MCO pin(PA8).
+  *            @arg RCC_MCO2: Clock source to output on MCO pin(PA9).
+  * @param  RCC_MCOSource: specifies the clock source to output.
+  *          This parameter can be one of the following values:
+  *     @arg RCC_MCO1SOURCE_NOCLOCK: No clock selected
+  *     @arg RCC_MCO1SOURCE_SYSCLK: System clock selected
+  *     @arg RCC_MCO1SOURCE_HSI: HSI oscillator clock selected
+  *     @arg RCC_MCO1SOURCE_MSI: MSI oscillator clock selected  
+  *     @arg RCC_MCO1SOURCE_HSE: HSE oscillator clock selected
+  *     @arg RCC_MCO1SOURCE_PLLCLK: PLL clock selected
+  *     @arg RCC_MCO1SOURCE_LSI: LSI clock selected
+  *     @arg RCC_MCO1SOURCE_LSE: LSE clock selected    
+  *     @arg RCC_MCO1SOURCE_HSI48: HSI48 clock selected
+  * @param  RCC_MCODIV: specifies the MCO DIV.
+  *     This parameter can be one of the following values: 
+  *     @arg RCC_MCODIV_1: no division applied to MCO clock 
+  *     @arg RCC_MCODIV_2: division by 2 applied to MCO clock
+  *     @arg RCC_MCODIV_4: division by 4 applied to MCO clock
+  *     @arg RCC_MCODIV_8: division by 8 applied to MCO clock
+  *     @arg RCC_MCODIV_16: division by 16 applied to MCO clock        
+  * @retval None
+  */
+void HAL_RCC_MCOConfig( uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_MCODiv)
+{
+  GPIO_InitTypeDef GPIO_InitStruct;
+  /* Check the parameters */
+  assert_param(IS_RCC_MCO(RCC_MCOx));
+  assert_param(IS_RCC_MCODIV(RCC_MCODiv));
+  assert_param(IS_RCC_MCO1SOURCE(RCC_MCOSource));
+    
+    /* MCO Clock Enable */
+    __MCO1_CLK_ENABLE();
+    
+    /* Configure the MCO1 pin in alternate function mode */    
+  if(RCC_MCOx == RCC_MCO1)
+  {    
+    GPIO_InitStruct.Pin = MCO1_PIN;
+  }
+    else
+  {    
+    GPIO_InitStruct.Pin = MCO2_PIN;
+  }    
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Alternate = GPIO_AF0_MCO;
+    HAL_GPIO_Init(MCO1_GPIO_PORT, &GPIO_InitStruct);
+    
+    /* Mask MCO1 and MCO1PRE[2:0] bits then Select MCO1 clock source and prescaler */
+    MODIFY_REG(RCC->CFGR, (RCC_CFGR_MCOSEL | RCC_CFGR_MCO_PRE), ((RCC_MCOSource << 24 | RCC_MCODiv )));
+}
+
+/**
+  * @brief  Enables the Clock Security System.
+  * @note   If a failure is detected on the HSE oscillator clock, this oscillator
+  *         is automatically disabled and an interrupt is generated to inform the
+  *         software about the failure (Clock Security System Interrupt, CSSI),
+  *         allowing the MCU to perform rescue operations. The CSSI is linked to 
+  *         the Cortex-M0+ NMI (Non-Maskable Interrupt) exception vector.  
+  * @param  None
+  * @retval None
+  */
+void HAL_RCC_EnableCSS(void)
+{
+   SET_BIT(RCC->CR, RCC_CR_CSSHSEON) ;
+}
+
+
+/**
+  * @brief  Returns the SYSCLK frequency
+  *        
+  * @note   The system frequency computed by this function is not the real 
+  *         frequency in the chip. It is calculated based on the predefined 
+  *         constant and the selected clock source:
+  * @note     If SYSCLK source is MSI, function returns values based on MSI
+  *             Value as defined by the MSI range.
+  * @note     If SYSCLK source is HSI, function returns values based on HSI_VALUE(*)
+  * @note     If SYSCLK source is HSE, function returns values based on HSE_VALUE(**)
+  * @note     If SYSCLK source is PLL, function returns values based on HSE_VALUE(**) 
+  *           or HSI_VALUE(*) multiplied/divided by the PLL factors.         
+  * @note     (*) HSI_VALUE is a constant defined in stm32l0xx_hal_conf.h file (default value
+  *               16 MHz) but the real value may vary depending on the variations
+  *               in voltage and temperature.
+  * @note     (**) HSE_VALUE is a constant defined in stm32l0xx_hal_conf.h file (default value
+  *                8 MHz), user has to ensure that HSE_VALUE is same as the real
+  *                frequency of the crystal used. Otherwise, this function may
+  *                have wrong result.
+  *                  
+  * @note   The result of this function could be not correct when using fractional
+  *         value for HSE crystal.
+  *           
+  * @note   This function can be used by the user application to compute the 
+  *         baudrate for the communication peripherals or configure other parameters.
+  *           
+  * @note   Each time SYSCLK changes, this function must be called to update the
+  *         right SYSCLK value. Otherwise, any configuration based on this function will be incorrect.
+  *         
+  *               
+  * @param  None
+  * @retval SYSCLK frequency
+  */
+uint32_t HAL_RCC_GetSysClockFreq(void)
+{
+  uint32_t pllmul = 0, plldiv = 0, pllsource = 0,  msirange = 0;
+  uint32_t sysclockfreq = 0;
+    
+  /* Get SYSCLK source -------------------------------------------------------*/
+ 
+  /*MSI frequency range in HZ*/
+  msirange = (RCC->ICSCR & RCC_ICSCR_MSIRANGE) >> 13;
+  msirange = MSIRangeTable[msirange];
+  
+  switch (RCC->CFGR & RCC_CFGR_SWS)
+  {
+    case RCC_CFGR_SWS_MSI: /* MSI used as system clock */ 
+    {  
+      sysclockfreq = msirange;
+      break;
+    }
+    case RCC_CFGR_SWS_HSI:  /* HSI used as system clock */
+    {
+      if ((RCC->CR & RCC_CR_HSIDIVF) != 0)
+      {
+        sysclockfreq =  (HSI_VALUE >> 2);
+      }
+      else 
+      {
+        sysclockfreq =  HSI_VALUE;
+      }
+      break;
+    }
+    case RCC_CFGR_SWS_HSE:  /* HSE used as system clock */
+    {
+      sysclockfreq = HSE_VALUE;
+      break;
+    }
+    case RCC_CFGR_SWS_PLL:  /* PLL used as system clock */
+    {
+      /* Get PLL clock source and multiplication factor ----------------------*/
+      pllmul = RCC->CFGR & RCC_CFGR_PLLMUL;
+      plldiv = RCC->CFGR & RCC_CFGR_PLLDIV;
+      pllmul = PLLMulTable[(pllmul >> 18)];
+      plldiv = (plldiv >> 22) + 1;
+      
+      pllsource = RCC->CFGR & RCC_CFGR_PLLSRC;
+
+      if (pllsource == RCC_CFGR_PLLSRC_HSI)
+      {
+        /* HSI oscillator clock selected as PLL clock source */
+        sysclockfreq =(((HSI_VALUE) * pllmul) / plldiv);
+      }
+      else
+      {
+        /* HSE selected as PLL clock source */
+       sysclockfreq = (((HSE_VALUE) * pllmul) / plldiv);
+      }
+      break;
+    }
+    default: /* MSI used as system clock */
+    {
+      sysclockfreq =  msirange;
+      break;
+    }
+  }
+  return sysclockfreq;
+}
+
+/**
+  * @brief  Returns the HCLK frequency     
+  * @note   Each time HCLK changes, this function must be called to update the
+  *         right HCLK value. Otherwise, any configuration based on this function will be incorrect.
+  *
+  * @note   The SystemCoreClock CMSIS variable is used to store System Clock Frequency 
+  *         and updated within this function                   
+  * @param  None
+  * @retval HCLK frequency
+  */
+uint32_t HAL_RCC_GetHCLKFreq(void)
+{
+  SystemCoreClock =  HAL_RCC_GetSysClockFreq() >> APBAHBPrescTable[((RCC->CFGR & RCC_CFGR_HPRE) >> 4)];
+  
+  return (SystemCoreClock);
+
+}
+
+/**
+  * @brief  Returns the PCLK1 frequency     
+  * @note   Each time PCLK1 changes, this function must be called to update the
+  *         right PCLK1 value. Otherwise, any configuration based on this function will be incorrect.
+  * @param  None
+  * @retval PCLK1 frequency
+  */
+uint32_t HAL_RCC_GetPCLK1Freq(void)
+{
+  
+ return ( HAL_RCC_GetHCLKFreq() >> APBAHBPrescTable[((RCC->CFGR & RCC_CFGR_PPRE1) >> 8)]);
+  
+}    
+
+/**
+  * @brief  Returns the PCLK2 frequency     
+  * @note   Each time PCLK2 changes, this function must be called to update the
+  *         right PCLK2 value. Otherwise, any configuration based on this function will be incorrect.
+  * @param  None
+  * @retval PCLK2 frequency
+  */
+uint32_t HAL_RCC_GetPCLK2Freq(void)
+{
+  
+  return ( HAL_RCC_GetHCLKFreq() >> APBAHBPrescTable[((RCC->CFGR & RCC_CFGR_PPRE2) >> 11)]);
+  
+} 
+
+/**
+  * @brief  Configures the RCC_OscInitStruct according to the internal 
+  * RCC configuration registers.
+  * @param  RCC_OscInitStruct: pointer to an RCC_OscInitTypeDef structure that 
+  * will be configured.
+  * @retval None
+  */
+void HAL_RCC_GetOscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
+{
+  /* Set all possible values for the Oscillator type parameter ---------------*/
+  RCC_OscInitStruct->OscillatorType = RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_MSI | RCC_OSCILLATORTYPE_HSI | \
+                                      RCC_OSCILLATORTYPE_HSI48 | RCC_OSCILLATORTYPE_LSE | RCC_OSCILLATORTYPE_LSI;
+  
+  /* Get the HSE configuration -----------------------------------------------*/
+  if((RCC->CR &RCC_CR_HSEBYP) == RCC_CR_HSEBYP)
+  {
+    RCC_OscInitStruct->HSEState = RCC_HSE_BYPASS;
+  }
+  else if((RCC->CR &RCC_CR_HSEON) == RCC_CR_HSEON)
+  {
+    RCC_OscInitStruct->HSEState = RCC_HSE_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->HSEState = RCC_HSE_OFF;
+  }
+  
+  /* Get the MSI configuration -----------------------------------------------*/
+  if((RCC->CR &RCC_CR_MSION) == RCC_CR_MSION)
+  {
+    RCC_OscInitStruct->MSIState = RCC_MSI_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->MSIState = RCC_MSI_OFF;
+  }
+  
+  RCC_OscInitStruct->MSICalibrationValue = (uint32_t)((RCC->CR &RCC_ICSCR_MSITRIM) >> 24); 
+  RCC_OscInitStruct->MSIClockRange = (uint32_t)((RCC->ICSCR &RCC_ICSCR_MSIRANGE) >> 13); 
+  
+  /* Get the HSI48 configuration -----------------------------------------------*/
+  if((RCC->CRRCR &RCC_CRRCR_HSI48ON) == RCC_CRRCR_HSI48ON)
+  {
+    RCC_OscInitStruct->HSI48State = RCC_HSI48_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->HSI48State = RCC_HSI48_OFF;
+  }
+  
+  /* Get the HSI configuration -----------------------------------------------*/
+  if((RCC->CR &RCC_CR_HSION) == RCC_CR_HSION)
+  {
+    RCC_OscInitStruct->HSIState = RCC_HSI_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->HSIState = RCC_HSI_OFF;
+  }
+  
+  RCC_OscInitStruct->HSICalibrationValue = (uint32_t)((RCC->ICSCR &RCC_ICSCR_HSITRIM) >> 8);
+  
+  /* Get the LSE configuration -----------------------------------------------*/
+  if((RCC->CSR &RCC_CSR_LSEBYP) == RCC_CSR_LSEBYP)
+  {
+    RCC_OscInitStruct->LSEState = RCC_LSE_BYPASS;
+  }
+  else if((RCC->CSR &RCC_CSR_LSEON) == RCC_CSR_LSEON)
+  {
+    RCC_OscInitStruct->LSEState = RCC_LSE_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->LSEState = RCC_LSE_OFF;
+  }
+  
+  /* Get the LSI configuration -----------------------------------------------*/
+  if((RCC->CSR &RCC_CSR_LSION) == RCC_CSR_LSION)
+  {
+    RCC_OscInitStruct->LSIState = RCC_LSI_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->LSIState = RCC_LSI_OFF;
+  }
+  
+  /* Get the PLL configuration -----------------------------------------------*/
+  if((RCC->CR &RCC_CR_PLLON) == RCC_CR_PLLON)
+  {
+    RCC_OscInitStruct->PLL.PLLState = RCC_PLL_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->PLL.PLLState = RCC_PLL_OFF;
+  }
+  RCC_OscInitStruct->PLL.PLLSource = (uint32_t)(RCC->CFGR & RCC_CFGR_PLLSRC);
+  RCC_OscInitStruct->PLL.PLLMUL = (uint32_t)(RCC->CFGR & RCC_CFGR_PLLMUL) >> 18;
+  RCC_OscInitStruct->PLL.PLLDIV = (uint32_t)(RCC->CFGR & RCC_CFGR_PLLDIV) >> 22;
+
+}
+
+/**
+  * @brief  Configures the RCC_ClkInitStruct according to the internal 
+  * RCC configuration registers.
+  * @param  RCC_OscInitStruct: pointer to an RCC_ClkInitTypeDef structure that 
+  * will be configured.
+  * @param  pFLatency: Pointer on the Flash Latency.
+  * @retval None
+  */
+void HAL_RCC_GetClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, uint32_t *pFLatency)
+{
+  /* Set all possible values for the Clock type parameter --------------------*/
+  RCC_ClkInitStruct->ClockType = RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
+   
+  /* Get the SYSCLK configuration --------------------------------------------*/ 
+  RCC_ClkInitStruct->SYSCLKSource = (uint32_t)(RCC->CFGR & RCC_CFGR_SW);
+  
+  /* Get the HCLK configuration ----------------------------------------------*/ 
+  RCC_ClkInitStruct->AHBCLKDivider = (uint32_t)(RCC->CFGR & RCC_CFGR_HPRE); 
+  
+  /* Get the APB1 configuration ----------------------------------------------*/ 
+  RCC_ClkInitStruct->APB1CLKDivider = (uint32_t)(RCC->CFGR & RCC_CFGR_PPRE1);   
+  
+  /* Get the APB2 configuration ----------------------------------------------*/ 
+  RCC_ClkInitStruct->APB2CLKDivider = (uint32_t)((RCC->CFGR & RCC_CFGR_PPRE2) >> 3);
+  
+  /* Get the Flash Wait State (Latency) configuration ------------------------*/   
+  *pFLatency = (uint32_t)(FLASH->ACR & FLASH_ACR_LATENCY); 
+}
+
+/**
+  * @brief This function handles the RCC CSS interrupt request.
+  * @note This API should be called under the NMI_Handler().
+  * @param None
+  * @retval None
+  */
+void HAL_RCC_NMI_IRQHandler(void)
+{
+  /* Check RCC CSSF flag  */
+  if(__HAL_RCC_GET_IT(RCC_IT_CSS))
+  {
+    /* RCC Clock Security System interrupt user callback */
+    HAL_RCC_CCSCallback();
+
+    /* Clear RCC CSS pending bit */
+    __HAL_RCC_CLEAR_IT(RCC_IT_CSS);
+  }
+}
+
+/**
+  * @brief  RCC Clock Security System interrupt callback
+  * @param  none 
+  * @retval none
+  */
+__weak void HAL_RCC_CCSCallback(void)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RCC_CCSCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RCC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rcc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rcc.h
@@ -1,0 +1,1147 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_rcc.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of RCC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_RCC_H
+#define __STM32L0xx_HAL_RCC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RCC
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/**
+  * @brief  RCC PLL configuration structure definition
+  */
+typedef struct
+{
+  uint32_t PLLState;   /*!< The new state of the PLL.
+                            This parameter can be a value of @ref RCC_PLL_Config */
+
+  uint32_t PLLSource;  /*!< RCC_PLLSource: PLL entry clock source.
+                            This parameter must be a value of @ref RCC_PLL_Clock_Source */
+
+  uint32_t PLLMUL;       /*!< PLLMUL: Multiplication factor for PLL VCO output clock
+                              This parameter must of @ref RCC_PLLMultiplication_Factor */
+
+  uint32_t PLLDIV;       /*!< PLLDIV: Division factor for main system clock (SYSCLK)
+                            This parameter must be a value of @ref RCC_PLLDivider_Factor */
+
+}RCC_PLLInitTypeDef;
+
+/**
+  * @brief  RCC Internal/External Oscillator (HSE, HSI, LSE and LSI) configuration structure definition  
+  */
+typedef struct
+{
+  uint32_t OscillatorType;       /*!< The oscillators to be configured.
+                                      This parameter can be a value of @ref RCC_Oscillator_Type */
+
+  uint32_t HSEState;             /*!< The new state of the HSE.
+                                      This parameter can be a value of @ref RCC_HSE_Config */
+
+  uint32_t LSEState;             /*!< The new state of the LSE.
+                                      This parameter can be a value of @ref RCC_LSE_Config */
+
+  uint32_t HSIState;             /*!< The new state of the HSI.
+                                      This parameter can be a value of @ref RCC_HSI_Config */
+
+  uint32_t HSICalibrationValue;  /*!< The calibration trimming value.
+                                      This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x1F */
+
+  uint32_t LSIState;             /*!< The new state of the LSI.
+                                      This parameter can be a value of @ref RCC_LSI_Config */
+
+  uint32_t HSI48State;             /*!< The new state of the HSI48.
+                                      This parameter can be a value of @ref RCC_HSI48_Config */
+
+  uint32_t MSIState;             /*!< The new state of the MSI.
+                                      This parameter can be a value of @ref RCC_MSI_Config */
+
+  uint32_t MSICalibrationValue;  /*!< The calibration trimming value.
+                                      This parameter must be a number between Min_Data = 0x00 and Max_Data = 0xFF */
+
+  uint32_t MSIClockRange;         /*!< The MSI  frequency  range.
+                                      This parameter can be a value of @ref RCC_MSI_Clock_Range  */
+
+  RCC_PLLInitTypeDef PLL;        /*!< PLL structure parameters */
+
+}RCC_OscInitTypeDef;
+
+/**
+  * @brief  RCC System, AHB and APB busses clock configuration structure definition  
+  */
+typedef struct
+{
+  uint32_t ClockType;             /*!< The clock to be configured.
+                                       This parameter can be a value of @ref RCC_System_Clock_Type */
+
+  uint32_t SYSCLKSource;          /*!< The clock source (SYSCLKS) used as system clock.
+                                       This parameter can be a value of @ref RCC_System_Clock_Source */
+
+  uint32_t AHBCLKDivider;         /*!< The AHB clock (HCLK) divider. This clock is derived from the system clock (SYSCLK).
+                                       This parameter can be a value of @ref RCC_AHB_Clock_Source */
+
+  uint32_t APB1CLKDivider;        /*!< The APB1 clock (PCLK1) divider. This clock is derived from the AHB clock (HCLK).
+                                       This parameter can be a value of @ref RCC_APB1_APB2_Clock_Source */
+
+  uint32_t APB2CLKDivider;        /*!< The APB2 clock (PCLK2) divider. This clock is derived from the AHB clock (HCLK).
+                                       This parameter can be a value of @ref RCC_APB1_APB2_Clock_Source */
+
+}RCC_ClkInitTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup RCC_Exported_Constants
+  * @{
+  */
+
+/** @defgroup RCC_BitAddress_AliasRegion
+  * @brief RCC registers bit address in the alias region
+  * @{
+  */
+#define RCC_OFFSET                (RCC_BASE - PERIPH_BASE)
+/* --- CR Register ---*/
+/* Alias word address of HSION bit */
+#define RCC_CR_OFFSET             (RCC_OFFSET + 0x00)
+/* --- CFGR Register ---*/
+/* Alias word address of I2SSRC bit */
+#define RCC_CFGR_OFFSET           (RCC_OFFSET + 0x08)
+/* --- CSR Register ---*/
+#define RCC_CSR_OFFSET            (RCC_OFFSET + 0x74)
+
+/* CR register byte 3 (Bits[23:16]) base address */
+#define CR_BYTE2_ADDRESS          ((uint32_t)0x40023802)
+
+/* CIER register byte 0 (Bits[0:8]) base address */
+#define CIER_BYTE0_ADDRESS         ((uint32_t)(RCC_BASE + 0x10 + 0x00))
+
+#define LSE_TIMEOUT_VALUE          LSE_STARTUP_TIMEOUT
+#define DBP_TIMEOUT_VALUE          ((uint32_t)100)  /* 100 ms */
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Oscillator_Type
+  * @{
+  */
+#define RCC_OSCILLATORTYPE_NONE            ((uint32_t)0x00000000)
+#define RCC_OSCILLATORTYPE_HSE             ((uint32_t)0x00000001)
+#define RCC_OSCILLATORTYPE_HSI             ((uint32_t)0x00000002)
+#define RCC_OSCILLATORTYPE_LSE             ((uint32_t)0x00000004)
+#define RCC_OSCILLATORTYPE_LSI             ((uint32_t)0x00000008)
+#define RCC_OSCILLATORTYPE_MSI             ((uint32_t)0x00000010)
+#define RCC_OSCILLATORTYPE_HSI48           ((uint32_t)0x00000020)
+
+#define IS_RCC_OSCILLATORTYPE(OSCILLATOR) ((OSCILLATOR) <= 0x3F)
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_HSE_Config
+  * @{
+  */
+#define RCC_HSE_OFF                     ((uint32_t)0x00000000)
+#define RCC_HSE_ON                      RCC_CR_HSEON
+#define RCC_HSE_BYPASS                  ((uint32_t)(RCC_CR_HSEBYP | RCC_CR_HSEON))
+
+#define IS_RCC_HSE(HSE) (((HSE) == RCC_HSE_OFF) || ((HSE) == RCC_HSE_ON) || \
+                         ((HSE) == RCC_HSE_BYPASS))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_LSE_Config
+  * @{
+  */
+#define RCC_LSE_OFF                      ((uint32_t)0x00000000)
+#define RCC_LSE_ON                       RCC_CSR_LSEON
+#define RCC_LSE_BYPASS                   ((uint32_t)(RCC_CSR_LSEBYP | RCC_CSR_LSEON))
+
+#define IS_RCC_LSE(LSE) (((LSE) == RCC_LSE_OFF) || ((LSE) == RCC_LSE_ON) || \
+                         ((LSE) == RCC_LSE_BYPASS))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_HSI_Config
+  * @{
+  */
+#define RCC_HSI_OFF                      ((uint8_t)0x00)
+#define RCC_HSI_ON                       ((uint8_t)0x01)
+#define RCC_HSI_DIV4                     ((uint8_t)0x09)
+#define IS_RCC_HSI(HSI) (((HSI) == RCC_HSI_OFF) || ((HSI) == RCC_HSI_ON) || \
+                         ((HSI) == RCC_HSI_DIV4))
+
+/**
+  * @}
+  */ 
+
+/** @defgroup RCC_MSI_Clock_Range
+  * @{
+  */
+
+#define RCC_MSIRANGE_0                   RCC_ICSCR_MSIRANGE_0 /*!< MSI = 65.536 KHz  */
+#define RCC_MSIRANGE_1                   RCC_ICSCR_MSIRANGE_1 /*!< MSI = 131.072 KHz */
+#define RCC_MSIRANGE_2                   RCC_ICSCR_MSIRANGE_2 /*!< MSI = 262.144 KHz */
+#define RCC_MSIRANGE_3                   RCC_ICSCR_MSIRANGE_3 /*!< MSI = 524.288 KHz */
+#define RCC_MSIRANGE_4                   RCC_ICSCR_MSIRANGE_4 /*!< MSI = 1.048 MHz   */
+#define RCC_MSIRANGE_5                   RCC_ICSCR_MSIRANGE_5 /*!< MSI = 2.097 MHz   */
+#define RCC_MSIRANGE_6                   RCC_ICSCR_MSIRANGE_6 /*!< MSI = 4.194 MHz   */
+
+#define IS_RCC_MSI_CLOCK_RANGE(RANGE) (((RANGE) == RCC_MSIRANGE_0) || \
+                                       ((RANGE) == RCC_MSIRANGE_1) || \
+                                       ((RANGE) == RCC_MSIRANGE_2) || \
+                                       ((RANGE) == RCC_MSIRANGE_3) || \
+                                       ((RANGE) == RCC_MSIRANGE_4) || \
+                                       ((RANGE) == RCC_MSIRANGE_5) || \
+                                       ((RANGE) == RCC_MSIRANGE_6))
+
+/**
+  * @}
+  */ 
+
+/** @defgroup RCC_LSI_Config
+  * @{
+  */
+#define RCC_LSI_OFF                      ((uint8_t)0x00)
+#define RCC_LSI_ON                       ((uint8_t)0x01)
+
+#define IS_RCC_LSI(LSI) (((LSI) == RCC_LSI_OFF) || ((LSI) == RCC_LSI_ON))
+/**
+  * @}
+  */
+
+    
+/** @defgroup RCC_MSI_Config
+  * @{
+  */
+#define RCC_MSI_OFF                      ((uint8_t)0x00)
+#define RCC_MSI_ON                       ((uint8_t)0x01)
+
+#define IS_RCC_MSI(MSI) (((MSI) == RCC_MSI_OFF) || ((MSI) == RCC_MSI_ON))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_HSI48_Config
+  * @{
+  */
+#define RCC_HSI48_OFF                      ((uint8_t)0x00)
+#define RCC_HSI48_ON                       ((uint8_t)0x01)
+
+#define IS_RCC_HSI48(HSI48) (((HSI48) == RCC_HSI48_OFF) || ((HSI48) == RCC_HSI48_ON))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLL_Config
+  * @{
+  */
+#define RCC_PLL_NONE                      ((uint8_t)0x00)
+#define RCC_PLL_OFF                       ((uint8_t)0x01)
+#define RCC_PLL_ON                        ((uint8_t)0x02)
+
+#define IS_RCC_PLL(PLL) (((PLL) == RCC_PLL_NONE) ||((PLL) == RCC_PLL_OFF) || ((PLL) == RCC_PLL_ON))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLL_Clock_Source
+  * @{
+  */
+#define RCC_PLLSOURCE_HSI                RCC_CFGR_PLLSRC_HSI
+#define RCC_PLLSOURCE_HSE                RCC_CFGR_PLLSRC_HSE
+
+#define IS_RCC_PLLSOURCE(SOURCE) (((SOURCE) == RCC_PLLSOURCE_HSI) || \
+                                  ((SOURCE) == RCC_PLLSOURCE_HSE))
+
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLLMultiplication_Factor
+  * @{
+  */
+
+#define RCC_PLLMUL_3                     RCC_CFGR_PLLMUL3
+#define RCC_PLLMUL_4                     RCC_CFGR_PLLMUL4
+#define RCC_PLLMUL_6                     RCC_CFGR_PLLMUL6
+#define RCC_PLLMUL_8                     RCC_CFGR_PLLMUL8
+#define RCC_PLLMUL_12                    RCC_CFGR_PLLMUL12
+#define RCC_PLLMUL_16                    RCC_CFGR_PLLMUL16
+#define RCC_PLLMUL_24                    RCC_CFGR_PLLMUL24
+#define RCC_PLLMUL_32                    RCC_CFGR_PLLMUL32
+#define RCC_PLLMUL_48                    RCC_CFGR_PLLMUL48
+#define IS_RCC_PLL_MUL(MUL) (((MUL) == RCC_PLLMUL_3) || ((MUL) == RCC_PLLMUL_4) || \
+                             ((MUL) == RCC_PLLMUL_6) || ((MUL) == RCC_PLLMUL_8) || \
+                             ((MUL) == RCC_PLLMUL_12) || ((MUL) == RCC_PLLMUL_16) || \
+                             ((MUL) == RCC_PLLMUL_24) || ((MUL) == RCC_PLLMUL_32) || \
+                             ((MUL) == RCC_PLLMUL_48))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLLDivider_Factor
+  * @{
+  */
+
+#define RCC_PLLDIV_2                     RCC_CFGR_PLLDIV2
+#define RCC_PLLDIV_3                     RCC_CFGR_PLLDIV3
+#define RCC_PLLDIV_4                     RCC_CFGR_PLLDIV4
+#define IS_RCC_PLL_DIV(DIV) (((DIV) == RCC_PLLDIV_2) || ((DIV) == RCC_PLLDIV_3) || \
+                             ((DIV) == RCC_PLLDIV_4))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_System_Clock_Type
+  * @{
+  */
+#define RCC_CLOCKTYPE_SYSCLK             ((uint32_t)0x00000001)
+#define RCC_CLOCKTYPE_HCLK               ((uint32_t)0x00000002)
+#define RCC_CLOCKTYPE_PCLK1              ((uint32_t)0x00000004)
+#define RCC_CLOCKTYPE_PCLK2              ((uint32_t)0x00000008)
+
+#define IS_RCC_CLOCKTYPE(CLK) ((1 <= (CLK)) && ((CLK) <= 15))
+/**
+  * @}
+  */
+  
+/** @defgroup RCC_System_Clock_Source
+  * @{
+  */
+#define RCC_SYSCLKSOURCE_MSI             RCC_CFGR_SW_MSI
+#define RCC_SYSCLKSOURCE_HSI             RCC_CFGR_SW_HSI
+#define RCC_SYSCLKSOURCE_HSE             RCC_CFGR_SW_HSE
+#define RCC_SYSCLKSOURCE_PLLCLK          RCC_CFGR_SW_PLL
+
+#define IS_RCC_SYSCLKSOURCE(SOURCE) (((SOURCE) == RCC_SYSCLKSOURCE_HSI) || \
+                                     ((SOURCE) == RCC_SYSCLKSOURCE_HSE) || \
+                                     ((SOURCE) == RCC_SYSCLKSOURCE_MSI) || \
+                                     ((SOURCE) == RCC_SYSCLKSOURCE_PLLCLK))
+/**
+  * @}
+  */ 
+
+/** @defgroup RCC_AHB_Clock_Source
+  * @{
+  */
+#define RCC_SYSCLK_DIV1                  RCC_CFGR_HPRE_DIV1
+#define RCC_SYSCLK_DIV2                  RCC_CFGR_HPRE_DIV2
+#define RCC_SYSCLK_DIV4                  RCC_CFGR_HPRE_DIV4
+#define RCC_SYSCLK_DIV8                  RCC_CFGR_HPRE_DIV8
+#define RCC_SYSCLK_DIV16                 RCC_CFGR_HPRE_DIV16
+#define RCC_SYSCLK_DIV64                 RCC_CFGR_HPRE_DIV64
+#define RCC_SYSCLK_DIV128                RCC_CFGR_HPRE_DIV128
+#define RCC_SYSCLK_DIV256                RCC_CFGR_HPRE_DIV256
+#define RCC_SYSCLK_DIV512                RCC_CFGR_HPRE_DIV512
+
+#define IS_RCC_HCLK(HCLK) (((HCLK) == RCC_SYSCLK_DIV1)   || ((HCLK) == RCC_SYSCLK_DIV2)   || \
+                           ((HCLK) == RCC_SYSCLK_DIV4)   || ((HCLK) == RCC_SYSCLK_DIV8)   || \
+                           ((HCLK) == RCC_SYSCLK_DIV16)  || ((HCLK) == RCC_SYSCLK_DIV64)  || \
+                           ((HCLK) == RCC_SYSCLK_DIV128) || ((HCLK) == RCC_SYSCLK_DIV256) || \
+                           ((HCLK) == RCC_SYSCLK_DIV512))
+/**
+  * @}
+  */ 
+  
+/** @defgroup RCC_APB1_APB2_Clock_Source
+  * @{
+  */
+#define RCC_HCLK_DIV1                    RCC_CFGR_PPRE1_DIV1
+#define RCC_HCLK_DIV2                    RCC_CFGR_PPRE1_DIV2
+#define RCC_HCLK_DIV4                    RCC_CFGR_PPRE1_DIV4
+#define RCC_HCLK_DIV8                    RCC_CFGR_PPRE1_DIV8
+#define RCC_HCLK_DIV16                   RCC_CFGR_PPRE1_DIV16
+
+#define IS_RCC_PCLK(PCLK) (((PCLK) == RCC_HCLK_DIV1) || ((PCLK) == RCC_HCLK_DIV2) || \
+                           ((PCLK) == RCC_HCLK_DIV4) || ((PCLK) == RCC_HCLK_DIV8) || \
+                           ((PCLK) == RCC_HCLK_DIV16))
+/**
+  * @}
+  */ 
+
+/** @defgroup RCC_RTC_Clock_Source
+  * @{
+  */
+#define RCC_RTCCLKSOURCE_LSE             RCC_CSR_RTCSEL_LSE
+#define RCC_RTCCLKSOURCE_LSI             RCC_CSR_RTCSEL_LSI
+#define RCC_RTCCLKSOURCE_HSE_DIV2        RCC_CSR_RTCSEL_HSE
+#define RCC_RTCCLKSOURCE_HSE_DIV4        ((uint32_t)RCC_CSR_RTCSEL_HSE | RCC_CR_RTCPRE_0)
+#define RCC_RTCCLKSOURCE_HSE_DIV8        ((uint32_t)RCC_CSR_RTCSEL_HSE | RCC_CR_RTCPRE_1)
+#define RCC_RTCCLKSOURCE_HSE_DIV16       ((uint32_t)RCC_CSR_RTCSEL_HSE | RCC_CR_RTCPRE)
+#define IS_RCC_RTCCLK_SOURCE(SOURCE) (((SOURCE) == RCC_RTCCLKSOURCE_LSE) || \
+                                      ((SOURCE) == RCC_RTCCLKSOURCE_LSI) || \
+                                      ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV2) || \
+                                      ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV4) || \
+                                      ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV8) || \
+                                      ((SOURCE) == RCC_RTCCLKSOURCE_HSE_DIV16))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_MCO_Clock_Source
+  * @{
+  */
+#define RCC_MCO1SOURCE_NOCLOCK            ((uint8_t)0x00)
+#define RCC_MCO1SOURCE_SYSCLK             ((uint8_t)0x01)
+#define RCC_MCO1SOURCE_HSI                ((uint8_t)0x02)
+#define RCC_MCO1SOURCE_MSI                ((uint8_t)0x03)
+#define RCC_MCO1SOURCE_HSE                ((uint8_t)0x04)
+#define RCC_MCO1SOURCE_PLLCLK             ((uint8_t)0x05)
+#define RCC_MCO1SOURCE_LSI                ((uint8_t)0x06)
+#define RCC_MCO1SOURCE_LSE                ((uint8_t)0x07)
+#define RCC_MCO1SOURCE_HSI48              ((uint8_t)0x08)
+
+#define IS_RCC_MCO1SOURCE(SOURCE) (((SOURCE) == RCC_MCO1SOURCE_NOCLOCK) || ((SOURCE) == RCC_MCO1SOURCE_SYSCLK) || \
+                                   ((SOURCE) == RCC_MCO1SOURCE_HSI)  || ((SOURCE) == RCC_MCO1SOURCE_MSI) || \
+                                   ((SOURCE) == RCC_MCO1SOURCE_HSE)  || ((SOURCE) == RCC_MCO1SOURCE_PLLCLK) || \
+                                   ((SOURCE) == RCC_MCO1SOURCE_LSI) || ((SOURCE) == RCC_MCO1SOURCE_LSE) || \
+                                   ((SOURCE) == RCC_MCO1SOURCE_HSI48))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_MCOPrescaler
+  * @{
+  */
+
+#define RCC_MCODIV_1            RCC_CFGR_MCO_PRE_1
+#define RCC_MCODIV_2            RCC_CFGR_MCO_PRE_2
+#define RCC_MCODIV_4            RCC_CFGR_MCO_PRE_4
+#define RCC_MCODIV_8            RCC_CFGR_MCO_PRE_8
+#define RCC_MCODIV_16           RCC_CFGR_MCO_PRE_16
+
+#define IS_RCC_MCODIV(DIV) (((DIV) == RCC_MCODIV_1)  || \
+                            ((DIV) == RCC_MCODIV_2)  || \
+                            ((DIV) == RCC_MCODIV_4)  || \
+                            ((DIV) == RCC_MCODIV_8)  || \
+                            ((DIV) == RCC_MCODIV_16))
+/**
+  * @}
+  */  
+
+/** @defgroup RCC_MCO_Index
+  * @{
+  */
+#define RCC_MCO1                         ((uint32_t)0x00000000)
+#define RCC_MCO2                         ((uint32_t)0x00000001)
+
+#define IS_RCC_MCO(MCOx) (((MCOx) == RCC_MCO1) || ((MCOx) == RCC_MCO2))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Interrupt
+  * @{
+  */
+#define RCC_IT_LSIRDY                    RCC_CIFR_LSIRDYF
+#define RCC_IT_LSERDY                    RCC_CIFR_LSERDYF
+#define RCC_IT_HSIRDY                    RCC_CIFR_HSIRDYF
+#define RCC_IT_HSERDY                    RCC_CIFR_HSERDYF
+#define RCC_IT_PLLRDY                    RCC_CIFR_PLLRDYF
+#define RCC_IT_MSIRDY                    RCC_CIFR_MSIRDYF
+#define RCC_IT_HSI48RDY                  RCC_CIFR_HSI48RDYF
+#define RCC_IT_LSECSS                    RCC_CIFR_LSECSSF
+#define RCC_IT_CSS                       RCC_CIFR_CSSF
+
+#define IS_RCC_IT(IT) (((IT) == RCC_IT_LSIRDY) || ((IT) == RCC_IT_LSERDY) || \
+                           ((IT) == RCC_IT_HSIRDY) || ((IT) == RCC_IT_HSERDY) || \
+                           ((IT) == RCC_IT_PLLRDY) || ((IT) == RCC_IT_MSIRDY) || \
+                           ((IT) == RCC_IT_HSI48RDY)  || ((IT) == RCC_IT_LSECSS))
+
+#define IS_RCC_GET_IT(IT) (((IT) == RCC_IT_LSIRDY) || ((IT) == RCC_IT_LSERDY) || \
+                           ((IT) == RCC_IT_HSIRDY) || ((IT) == RCC_IT_HSERDY) || \
+                           ((IT) == RCC_IT_PLLRDY) || ((IT) == RCC_IT_MSIRDY) || \
+                           ((IT) == RCC_IT_CSS)  || ((IT) == RCC_IT_HSI48RDY) || \
+                           ((IT) == RCC_IT_LSECSS))
+
+#define IS_RCC_CLEAR_IT(IT) (((IT) == RCC_IT_LSIRDY) || ((IT) == RCC_IT_LSERDY) || \
+                           ((IT) == RCC_IT_HSIRDY) || ((IT) == RCC_IT_HSERDY) || \
+                           ((IT) == RCC_IT_PLLRDY) || ((IT) == RCC_IT_MSIRDY) || \
+                           ((IT) == RCC_IT_CSS)  || ((IT) == RCC_IT_HSI48RDY) || \
+                           ((IT) == RCC_IT_LSECSS))
+
+/**
+  * @}
+  */
+  
+/** @defgroup RCC_Flag
+  *        Elements values convention: 0XXYYYYYb
+  *           - YYYYY  : Flag position in the register
+  *           - 0XX  : Register index
+  *                 - 01: CR register
+  *                 - 10: CSR register
+  *                 - 11: CRRCR register
+  * @{
+  */
+/* Flags in the CR register */
+#define RCC_FLAG_HSIRDY                  ((uint8_t)0x22)
+#define RCC_FLAG_HSIDIV                  ((uint8_t)0x24)
+#define RCC_FLAG_MSIRDY                  ((uint8_t)0x29)
+#define RCC_FLAG_HSERDY                  ((uint8_t)0x31)
+#define RCC_FLAG_PLLRDY                  ((uint8_t)0x39)
+
+/* Flags in the CSR register */
+#define RCC_FLAG_LSERDY                  ((uint8_t)0x49)
+#define RCC_FLAG_LSECSS                  ((uint8_t)0x4E)
+#define RCC_FLAG_LSIRDY                  ((uint8_t)0x41)
+#define RCC_FLAG_FIREWALLRST             ((uint8_t)0x58)
+#define RCC_FLAG_OBLRST                  ((uint8_t)0x59)
+#define RCC_FLAG_PINRST                  ((uint8_t)0x5A)
+#define RCC_FLAG_PORRST                  ((uint8_t)0x5B)
+#define RCC_FLAG_SFTRST                  ((uint8_t)0x5C)
+#define RCC_FLAG_IWDGRST                 ((uint8_t)0x5D)
+#define RCC_FLAG_WWDGRST                 ((uint8_t)0x5E)
+#define RCC_FLAG_LPWRRST                 ((uint8_t)0x5F)
+
+/* Flags in the CRRCR register */
+#define RCC_FLAG_HSI48RDY                ((uint8_t)0x61)
+
+
+
+#define IS_RCC_CALIBRATION_VALUE(VALUE) ((VALUE) <= 0x1F)
+#define IS_RCC_MSICALIBRATION_VALUE(VALUE) ((VALUE) <= 0xFF)
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */   
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup RCC_Exported macro
+ * @{
+ */
+
+/** @brief  Enable or disable the AHB peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it.
+  */
+#define __DMA1_CLK_ENABLE()          (RCC->AHBENR |= (RCC_AHBENR_DMA1EN))
+#define __MIF_CLK_ENABLE()           (RCC->AHBENR |= (RCC_AHBENR_MIFEN))
+#define __CRC_CLK_ENABLE()           (RCC->AHBENR |= (RCC_AHBENR_CRCEN))
+
+
+#define __DMA1_CLK_DISABLE()          (RCC->AHBENR  &= ~ (RCC_AHBENR_DMA1EN))
+#define __MIF_CLK_DISABLE()           (RCC->AHBENR  &= ~ (RCC_AHBENR_MIFEN))
+#define __CRC_CLK_DISABLE()           (RCC->AHBENR  &= ~ (RCC_AHBENR_CRCEN))
+
+
+/** @brief  Enable or disable the IOPORT peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it.
+  */
+#define __GPIOA_CLK_ENABLE()         (RCC->IOPENR |= (RCC_IOPENR_GPIOAEN))
+#define __GPIOB_CLK_ENABLE()         (RCC->IOPENR |= (RCC_IOPENR_GPIOBEN))
+#define __GPIOC_CLK_ENABLE()         (RCC->IOPENR |= (RCC_IOPENR_GPIOCEN))
+#define __GPIOD_CLK_ENABLE()         (RCC->IOPENR |= (RCC_IOPENR_GPIODEN))
+#define __GPIOH_CLK_ENABLE()         (RCC->IOPENR |= (RCC_IOPENR_GPIOHEN))
+
+#define __GPIOA_CLK_DISABLE()        (RCC->IOPENR &= ~(RCC_IOPENR_GPIOAEN))
+#define __GPIOB_CLK_DISABLE()        (RCC->IOPENR &= ~(RCC_IOPENR_GPIOBEN))
+#define __GPIOC_CLK_DISABLE()        (RCC->IOPENR &= ~(RCC_IOPENR_GPIOCEN))
+#define __GPIOD_CLK_DISABLE()        (RCC->IOPENR &= ~(RCC_IOPENR_GPIODEN))
+#define __GPIOH_CLK_DISABLE()        (RCC->IOPENR &= ~(RCC_IOPENR_GPIOHEN))
+
+
+/** @brief  Enable or disable the Low Speed APB (APB1) peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  */
+#define __WWDG_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_WWDGEN))
+#define __PWR_CLK_ENABLE()     (RCC->APB1ENR |= (RCC_APB1ENR_PWREN))
+
+#define __WWDG_CLK_DISABLE()    (RCC->APB1ENR &= ~ (RCC_APB1ENR_WWDGEN))
+#define __PWR_CLK_DISABLE()     (RCC->APB1ENR &= ~ (RCC_APB1ENR_PWREN))
+
+/** @brief  Enable or disable the High Speed APB (APB2) peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it.
+  */
+#define __SYSCFG_CLK_ENABLE()   (RCC->APB2ENR |= (RCC_APB2ENR_SYSCFGEN))
+#define __DBGMCU_CLK_ENABLE()   (RCC->APB2ENR |= (RCC_APB2ENR_DBGMCUEN))
+
+#define __SYSCFG_CLK_DISABLE()   (RCC->APB2ENR &= ~  (RCC_APB2ENR_SYSCFGEN))
+#define __DBGMCU_CLK_DISABLE()   (RCC->APB2ENR &= ~  (RCC_APB2ENR_DBGMCUEN))
+
+/** @brief  Force or release AHB peripheral reset.
+  */
+#define __AHB_FORCE_RESET()     (RCC->AHBRSTR = 0xFFFFFFFF)
+#define __DMA1_FORCE_RESET()    (RCC->AHBRSTR |= (RCC_AHBRSTR_DMA1RST))
+#define __MIF_FORCE_RESET()     (RCC->AHBRSTR |= (RCC_AHBRSTR_MIFRST))
+#define __CRC_FORCE_RESET()     (RCC->AHBRSTR |= (RCC_AHBRSTR_CRCRST))
+
+#define __AHB_RELEASE_RESET()     (RCC->AHBRSTR = 0x00)
+#define __CRC_RELEASE_RESET()     (RCC->AHBRSTR &= ~ (RCC_AHBRSTR_CRCRST))
+#define __DMA1_RELEASE_RESET()    (RCC->AHBRSTR &= ~ (RCC_AHBRSTR_DMA1RST))
+#define __MIF_RELEASE_RESET()     (RCC->AHBRSTR &= ~ (RCC_AHBRSTR_MIFRST))
+
+
+/** @brief  Force or release IOPORT peripheral reset.
+  */
+#define __IOP_FORCE_RESET()     (RCC->IOPRSTR = 0xFFFFFFFF) 
+#define __GPIOA_FORCE_RESET()   (RCC->IOPRSTR |= (RCC_IOPRSTR_GPIOARST))
+#define __GPIOB_FORCE_RESET()   (RCC->IOPRSTR |= (RCC_IOPRSTR_GPIOBRST))
+#define __GPIOC_FORCE_RESET()   (RCC->IOPRSTR |= (RCC_IOPRSTR_GPIOCRST))
+#define __GPIOD_FORCE_RESET()   (RCC->IOPRSTR |= (RCC_IOPRSTR_GPIODRST))
+#define __GPIOH_FORCE_RESET()   (RCC->IOPRSTR |= (RCC_IOPRSTR_GPIOHRST))
+
+#define __IOP_RELEASE_RESET()   (RCC->IOPRSTR = 0x00) 
+#define __GPIOA_RELEASE_RESET() (RCC->IOPRSTR &= ~(RCC_IOPRSTR_GPIOARST))
+#define __GPIOB_RELEASE_RESET() (RCC->IOPRSTR &= ~(RCC_IOPRSTR_GPIOBRST))
+#define __GPIOC_RELEASE_RESET() (RCC->IOPRSTR &= ~(RCC_IOPRSTR_GPIOCRST))
+#define __GPIOD_RELEASE_RESET() (RCC->IOPRSTR &= ~(RCC_IOPRSTR_GPIODRST))
+#define __GPIOH_RELEASE_RESET() (RCC->IOPRSTR &= ~(RCC_IOPRSTR_GPIOHRST))
+
+/** @brief  Force or release APB1 peripheral reset.
+  */
+#define __APB1_FORCE_RESET()     (RCC->APB1RSTR = 0xFFFFFFFF)  
+#define __WWDG_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_WWDGRST))
+#define __PWR_FORCE_RESET()      (RCC->APB1RSTR |= (RCC_APB1RSTR_PWRRST))
+
+#define __APB1_RELEASE_RESET()     (RCC->APB1RSTR = 0x00)
+#define __WWDG_RELEASE_RESET()     (RCC->APB1RSTR &= ~ (RCC_APB1RSTR_WWDGRST))
+#define __PWR_RELEASE_RESET()      (RCC->APB1RSTR &= ~ (RCC_APB1RSTR_PWRRST))
+
+/** @brief  Force or release APB2 peripheral reset.
+  */
+#define __APB2_FORCE_RESET()       (RCC->APB2RSTR = 0xFFFFFFFF)  
+#define __DBGMCU_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_DBGMCURST))
+#define __SYSCFG_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_SYSCFGRST))
+
+#define __APB2_RELEASE_RESET()       (RCC->APB2RSTR = 0x00)
+#define __DBGMCU_RELEASE_RESET()     (RCC->APB2RSTR &= ~ (RCC_APB2RSTR_DBGMCURST))
+#define __SYSCFG_RELEASE_RESET()     (RCC->APB2RSTR &= ~ (RCC_APB2RSTR_SYSCFGRST))
+
+/** @brief  Enable or disable the AHB peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __CRC_CLK_SLEEP_ENABLE()           (RCC->AHBSMENR |= (RCC_AHBSMENR_CRCSMEN))
+#define __MIF_CLK_SLEEP_ENABLE()           (RCC->AHBSMENR |= (RCC_AHBSMENR_MIFSMEN))
+#define __SRAM_CLK_SLEEP_ENABLE()          (RCC->AHBSMENR |= (RCC_AHBSMENR_SRAMSMEN))
+#define __DMA1_CLK_SLEEP_ENABLE()          (RCC->AHBSMENR |= (RCC_AHBSMENR_DMA1SMEN))
+
+#define __CRC_CLK_SLEEP_DISABLE()           (RCC->AHBSMENR  &= ~ (RCC_AHBSMENR_CRCSMEN))
+#define __MIF_CLK_SLEEP_DISABLE()           (RCC->AHBSMENR  &= ~ (RCC_AHBSMENR_MIFSMEN))
+#define __SRAM_CLK_SLEEP_DISABLE()          (RCC->AHBSMENR  &= ~ (RCC_AHBSMENR_SRAMSMEN))
+#define __DMA1_CLK_SLEEP_DISABLE()          (RCC->AHBSMENR  &= ~ (RCC_AHBSMENR_DMA1SMEN))
+
+/** @brief  Enable or disable the IOPORT peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+
+#define __GPIOA_CLK_SLEEP_ENABLE()         (RCC->IOPSMENR |= (RCC_IOPSMENR_GPIOASMEN))
+#define __GPIOB_CLK_SLEEP_ENABLE()         (RCC->IOPSMENR |= (RCC_IOPSMENR_GPIOBSMEN))
+#define __GPIOC_CLK_SLEEP_ENABLE()         (RCC->IOPSMENR |= (RCC_IOPSMENR_GPIOCSMEN))
+#define __GPIOD_CLK_SLEEP_ENABLE()         (RCC->IOPSMENR |= (RCC_IOPSMENR_GPIODSMEN))
+#define __GPIOH_CLK_SLEEP_ENABLE()         (RCC->IOPSMENR |= (RCC_IOPSMENR_GPIOHSMEN))
+
+#define __GPIOA_CLK_SLEEP_DISABLE()        (RCC->IOPSMENR &= ~(RCC_IOPSMENR_GPIOASMEN))
+#define __GPIOB_CLK_SLEEP_DISABLE()        (RCC->IOPSMENR &= ~(RCC_IOPSMENR_GPIOBSMEN))
+#define __GPIOC_CLK_SLEEP_DISABLE()        (RCC->IOPSMENR &= ~(RCC_IOPSMENR_GPIOCSMEN))
+#define __GPIOD_CLK_SLEEP_DISABLE()        (RCC->IOPSMENR &= ~(RCC_IOPSMENR_GPIODSMEN))
+#define __GPIOH_CLK_SLEEP_DISABLE()        (RCC->IOPSMENR &= ~(RCC_IOPSMENR_GPIOHSMEN))
+
+/** @brief  Enable or disable the APB1 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __WWDG_CLK_SLEEP_ENABLE()    (RCC->APB1SMENR |= (RCC_APB1SMENR_WWDGSMEN))
+#define __PWR_CLK_SLEEP_ENABLE()     (RCC->APB1SMENR |= (RCC_APB1SMENR_PWRSMEN))
+
+#define __WWDG_CLK_SLEEP_DISABLE()    (RCC->APB1SMENR &= ~ (RCC_APB1SMENR_WWDGSMEN))
+#define __PWR_CLK_SLEEP_DISABLE()     (RCC->APB1SMENR &= ~ (RCC_APB1SMENR_PWRSMEN))
+
+/** @brief  Enable or disable the APB2 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#define __SYSCFG_CLK_SLEEP_ENABLE()   (RCC->APB2SMENR |= (RCC_APB2SMENR_SYSCFGSMEN))
+#define __DBGMCU_CLK_SLEEP_ENABLE()   (RCC->APB2SMENR |= (RCC_APB2SMENR_DBGMCUSMEN))
+
+#define __SYSCFG_CLK_SLEEP_DISABLE()   (RCC->APB2SMENR &= ~  (RCC_APB2SMENR_SYSCFGSMEN))
+#define __DBGMCU_CLK_SLEEP_DISABLE()   (RCC->APB2SMENR &= ~  (RCC_APB2SMENR_DBGMCUSMEN))
+
+/** @brief  Macro to enable or disable the Internal High Speed oscillator (HSI).
+  * @note     After enabling the HSI, the application software should wait on 
+  *           HSIRDY flag to be set indicating that HSI clock is stable and can
+  *           be used to clock the PLL and/or system clock.
+  * @note     HSI can not be stopped if it is used directly or through the PLL
+  *           as system clock. In this case, you have to select another source 
+  *           of the system clock then stop the HSI.
+  * @note     The HSI is stopped by hardware when entering STOP and STANDBY modes. 
+  * @param    __STATE__: specifies the new state of the HSI.
+  *           This parameter can be one of the following values:
+  *            @arg RCC_HSI_OFF: turn OFF the HSI oscillator
+  *            @arg RCC_HSI_ON: turn ON the HSI oscillator
+  *            @arg RCC_HSI_DIV4: turn ON the HSI oscillator and divide it by 4
+  * @note   When the HSI is stopped, HSIRDY flag goes low after 6 HSI oscillator
+  *         clock cycles. 
+  */
+#define __HAL_RCC_HSI_CONFIG(__STATE__) \
+                  MODIFY_REG(RCC->CR, RCC_CR_HSION|RCC_CR_HSIDIVEN, (uint32_t)(__STATE__))
+
+/** @brief  Macros to enable or disable the Internal High Speed oscillator (HSI).
+  * @note   The HSI is stopped by hardware when entering STOP and STANDBY modes.
+  *         It is used (enabled by hardware) as system clock source after startup
+  *         from Reset, wakeup from STOP and STANDBY mode, or in case of failure
+  *         of the HSE used directly or indirectly as system clock (if the Clock
+  *         Security System CSS is enabled).
+  * @note   HSI can not be stopped if it is used as system clock source. In this case,
+  *         you have to select another source of the system clock then stop the HSI.  
+  * @note   After enabling the HSI, the application software should wait on HSIRDY
+  *         flag to be set indicating that HSI clock is stable and can be used as
+  *         system clock source.
+  * @note   When the HSI is stopped, HSIRDY flag goes low after 6 HSI oscillator
+  *         clock cycles.  
+  */
+#define __HAL_RCC_HSI_ENABLE()  SET_BIT(RCC->CR, RCC_CR_HSION)
+#define __HAL_RCC_HSI_DISABLE() CLEAR_BIT(RCC->CR, RCC_CR_HSION)
+
+/**
+  * @brief  Macros to enable or disable the Internal Multi Speed oscillator (MSI).
+  * @note     The MSI is stopped by hardware when entering STOP and STANDBY modes.
+  *           It is used (enabled by hardware) as system clock source after
+  *           startup from Reset, wakeup from STOP and STANDBY mode, or in case
+  *           of failure of the HSE used directly or indirectly as system clock
+  *           (if the Clock Security System CSS is enabled).
+  * @note     MSI can not be stopped if it is used as system clock source.
+  *           In this case, you have to select another source of the system
+  *           clock then stop the MSI.
+  * @note     After enabling the MSI, the application software should wait on
+  *           MSIRDY flag to be set indicating that MSI clock is stable and can
+  *           be used as system clock source.
+  * @note   When the MSI is stopped, MSIRDY flag goes low after 6 MSI oscillator
+  *         clock cycles.
+  */
+#define __HAL_RCC_MSI_ENABLE()  SET_BIT(RCC->CR, RCC_CR_MSION)
+#define __HAL_RCC_MSI_DISABLE() CLEAR_BIT(RCC->CR, RCC_CR_MSION)
+
+/**
+  * @brief  Macro to enable or disable the Internal High Speed oscillator for USB (HSI48).
+  * @note   After enabling the HSI48, the application software should wait on 
+  *         HSI48RDY flag to be set indicating that HSI48 clock is stable and can
+  *         be used to clock the USB.
+  * @note   The HSI48 is stopped by hardware when entering STOP and STANDBY modes.
+  */
+#define __HAL_RCC_HSI48_ENABLE()  do { SET_BIT(RCC->CRRCR, RCC_CRRCR_HSI48ON);   \
+                                                    RCC->APB2ENR |=  RCC_APB2ENR_SYSCFGEN; \
+                                                    SYSCFG->CFGR3 |= (SYSCFG_CFGR3_ENREF_HSI48 | SYSCFG_CFGR3_EN_VREFINT);  \
+                                                   } while (0)
+#define __HAL_RCC_HSI48_DISABLE()  do { CLEAR_BIT(RCC->CRRCR, RCC_CRRCR_HSI48ON);   \
+                                                    SYSCFG->CFGR3 &= (uint32_t)~((uint32_t)(SYSCFG_CFGR3_ENREF_HSI48 | SYSCFG_CFGR3_EN_VREFINT));  \
+                                                   } while (0)
+
+/** @brief  Macro to adjust the Internal High Speed oscillator (HSI) calibration value.
+  * @note   The calibration is used to compensate for the variations in voltage
+  *         and temperature that influence the frequency of the internal HSI RC.
+  * @param  __HSICalibrationValue__: specifies the calibration trimming value.
+  *         This parameter must be a number between 0 and 0x1F.
+  */
+#define __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(__HSICalibrationValue__) (MODIFY_REG(RCC->ICSCR,\
+        RCC_ICSCR_HSITRIM, (uint32_t)(__HSICalibrationValue__) << 8))
+
+/** @brief  Macro Adjusts the Internal Multi Speed oscillator (MSI) calibration value.
+  * @note   The calibration is used to compensate for the variations in voltage
+  *         and temperature that influence the frequency of the internal MSI RC.
+  *         Refer to the Application Note AN3300 for more details on how to  
+  *         calibrate the MSI.
+  * @param  __MSICalibrationValue__: specifies the calibration trimming value.
+  *         This parameter must be a number between 0 and 0xFF.
+  */
+#define __HAL_RCC_MSI_CALIBRATIONVALUE_ADJUST(__MSICalibrationValue__) (MODIFY_REG(RCC->ICSCR,\
+        RCC_ICSCR_MSITRIM, (uint32_t)(__MSICalibrationValue__) << 24))
+
+/**
+  * @brief  Macro to configures the Internal Multi Speed oscillator (MSI) clock range.
+  * @note     After restart from Reset or wakeup from STANDBY, the MSI clock is 
+  *           around 2.097 MHz. The MSI clock does not change after wake-up from
+  *           STOP mode.
+  * @note    The MSI clock range can be modified on the fly.
+  * @param  RCC_MSIRange: specifies the MSI Clock range.
+  *   This parameter must be one of the following values:
+  *     @arg RCC_MSIRANGE_0: MSI clock is around 65.536 KHz
+  *     @arg RCC_MSIRANGE_1: MSI clock is around 131.072 KHz
+  *     @arg RCC_MSIRANGE_2: MSI clock is around 262.144 KHz
+  *     @arg RCC_MSIRANGE_3: MSI clock is around 524.288 KHz
+  *     @arg RCC_MSIRANGE_4: MSI clock is around 1.048 MHz
+  *     @arg RCC_MSIRANGE_5: MSI clock is around 2.097 MHz (default after Reset or wake-up from STANDBY)
+  *     @arg RCC_MSIRANGE_6: MSI clock is around 4.194 MHz
+  */
+#define __HAL_RCC_MSI_RANGE_CONFIG(__RCC_MSIRange__) (MODIFY_REG(RCC->ICSCR,\
+        RCC_ICSCR_MSIRANGE, (uint32_t)(__RCC_MSIRange__) ))
+
+/** @brief  Macros to enable or disable the Internal Low Speed oscillator (LSI).
+  * @note   After enabling the LSI, the application software should wait on 
+  *         LSIRDY flag to be set indicating that LSI clock is stable and can
+  *         be used to clock the IWDG and/or the RTC.
+  * @note   LSI can not be disabled if the IWDG is running.
+  * @note   When the LSI is stopped, LSIRDY flag goes low after 6 LSI oscillator
+  *         clock cycles. 
+  */
+#define __HAL_RCC_LSI_ENABLE() SET_BIT(RCC->CSR, RCC_CSR_LSION)
+#define __HAL_RCC_LSI_DISABLE() CLEAR_BIT(RCC->CSR, RCC_CSR_LSION)
+
+/**
+  * @brief  Macro to configure the External High Speed oscillator (HSE).
+  * @note   After enabling the HSE (RCC_HSE_ON or RCC_HSE_Bypass), the application
+  *         software should wait on HSERDY flag to be set indicating that HSE clock
+  *         is stable and can be used to clock the PLL and/or system clock.
+  * @note   HSE state can not be changed if it is used directly or through the
+  *         PLL as system clock. In this case, you have to select another source
+  *         of the system clock then change the HSE state (ex. disable it).
+  * @note   The HSE is stopped by hardware when entering STOP and STANDBY modes.  
+  * @note   This function reset the CSSON bit, so if the clock security system(CSS)
+  *         was previously enabled you have to enable it again after calling this
+  *         function.    
+  * @param  __STATE__: specifies the new state of the HSE.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_HSE_OFF: turn OFF the HSE oscillator, HSERDY flag goes low after
+  *                              6 HSE oscillator clock cycles.
+  *            @arg RCC_HSE_ON: turn ON the HSE oscillator.
+  *            @arg RCC_HSE_BYPASS: HSE oscillator bypassed with external clock.
+  */
+#define __HAL_RCC_HSE_CONFIG(__STATE__) \
+                  MODIFY_REG(RCC->CR, RCC_CR_HSEON|RCC_CR_HSEBYP, (uint32_t)(__STATE__))
+
+/**
+  * @brief  Macro to configure the External Low Speed oscillator (LSE).
+  * @note   As the LSE is in the Backup domain and write access is denied to
+  *         this domain after reset, you have to enable write access using 
+  *         HAL_PWR_EnableBkUpAccess() function before to configure the LSE
+  *         (to be done once after reset).  
+  * @note   After enabling the LSE (RCC_LSE_ON or RCC_LSE_BYPASS), the application
+  *         software should wait on LSERDY flag to be set indicating that LSE clock
+  *         is stable and can be used to clock the RTC.
+  * @param  __STATE__: specifies the new state of the LSE.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_LSE_OFF: turn OFF the LSE oscillator, LSERDY flag goes low after
+  *                              6 LSE oscillator clock cycles.
+  *            @arg RCC_LSE_ON: turn ON the LSE oscillator.
+  *            @arg RCC_LSE_BYPASS: LSE oscillator bypassed with external clock.
+  */
+#define __HAL_RCC_LSE_CONFIG(__STATE__) \
+                  MODIFY_REG(RCC->CSR, RCC_CSR_LSEON|RCC_CSR_LSEBYP, (uint32_t)(__STATE__))
+
+/** @brief  Macros to enable or disable the the RTC clock.
+  * @note   These macros must be used only after the RTC clock source was selected.
+  */
+#define __HAL_RCC_RTC_ENABLE() SET_BIT(RCC->CSR, RCC_CSR_RTCEN)
+#define __HAL_RCC_RTC_DISABLE() CLEAR_BIT(RCC->CSR, RCC_CSR_RTCEN)
+
+/**
+  * @brief  Configures  or  Get the RTC and LCD clock (RTCCLK / LCDCLK).
+  * @note     As the RTC clock configuration bits are in the RTC domain and write
+  *           access is denied to this domain after reset, you have to enable write
+  *           access using PWR_RTCAccessCmd(ENABLE) function before to configure
+  *           the RTC clock source (to be done once after reset).    
+  * @note     Once the RTC clock is configured it can't be changed unless the RTC
+  *           is reset using RCC_RTCResetCmd function, or by a Power On Reset (POR)
+  * @note     The RTC clock (RTCCLK) is used also to clock the LCD (LCDCLK).
+  *
+  * @param  RCC_RTCCLKSource: specifies the RTC clock source.
+  *   This parameter can be one of the following values:
+  *     @arg RCC_RTCCLKSOURCE_LSE: LSE selected as RTC clock
+  *     @arg RCC_RTCCLKSOURCE_LSI: LSI selected as RTC clock
+  *     @arg RCC_RTCCLKSOURCE_HSE_DIV2: HSE divided by 2 selected as RTC clock
+  *     @arg RCC_RTCCLKSOURCE_HSE_DIV4: HSE divided by 4 selected as RTC clock
+  *     @arg RCC_RTCCLKSOURCE_HSE_DIV8: HSE divided by 8 selected as RTC clock
+  *     @arg RCC_RTCCLKSOURCE_HSE_DIV16: HSE divided by 16 selected as RTC clock
+  *
+  * @note     If the LSE or LSI is used as RTC clock source, the RTC continues to
+  *           work in STOP and STANDBY modes, and can be used as wakeup source.
+  *           However, when the HSE clock is used as RTC clock source, the RTC
+  *           cannot be used in STOP and STANDBY modes.          
+  * @note     The maximum input clock frequency for RTC is 1MHz (when using HSE as
+  *           RTC clock source).
+  */
+#define __HAL_RCC_RTC_CLKPRESCALER(__RTCCLKSource__) (((__RTCCLKSource__) & RCC_CSR_RTCSEL) == RCC_CSR_RTCSEL) ?    \
+                                                 MODIFY_REG(RCC->CR, RCC_CR_RTCPRE, ((__RTCCLKSource__) & 0xFFFCFFFF)) : CLEAR_BIT(RCC->CR, RCC_CR_RTCPRE)
+
+#define __HAL_RCC_RTC_CONFIG(__RTCCLKSource__) do { __HAL_RCC_RTC_CLKPRESCALER(__RTCCLKSource__);    \
+                                                   MODIFY_REG( RCC->CSR, RCC_CSR_RTCSEL, (uint32_t)(__RTCCLKSource__));  \
+                                                   } while (0)
+
+#define  __HAL_RCC_GET_RTC_SOURCE() ((uint32_t)(READ_BIT(RCC->CSR, RCC_CSR_RTCSEL)))
+
+/** @brief  Macros to force or release the Backup domain reset.
+  * @note   This function resets the RTC peripheral (including the backup registers)
+  *         and the RTC clock source selection in RCC_CSR register.
+  * @note   The BKPSRAM is not affected by this reset.   
+  */
+#define __HAL_RCC_BACKUPRESET_FORCE()  SET_BIT(RCC->CSR, RCC_CSR_RTCRST) 
+#define __HAL_RCC_BACKUPRESET_RELEASE() CLEAR_BIT(RCC->CSR, RCC_CSR_RTCRST) 
+
+/** @brief  Macros to enable or disable the main PLL.
+  * @note   After enabling the main PLL, the application software should wait on 
+  *         PLLRDY flag to be set indicating that PLL clock is stable and can
+  *         be used as system clock source.
+  * @note   The main PLL can not be disabled if it is used as system clock source
+  * @note   The main PLL is disabled by hardware when entering STOP and STANDBY modes.
+  */
+#define __HAL_RCC_PLL_ENABLE() SET_BIT(RCC->CR, RCC_CR_PLLON)
+#define __HAL_RCC_PLL_DISABLE() CLEAR_BIT(RCC->CR, RCC_CR_PLLON)
+
+/** @brief  Macro to configure the main PLL clock source, multiplication and division factors.
+  * @note   This function must be used only when the main PLL is disabled.
+  * @param  __RCC_PLLSource__: specifies the PLL entry clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_PLLSOURCE_HSI: HSI oscillator clock selected as PLL clock entry
+  *            @arg RCC_PLLSOURCE_HSE: HSE oscillator clock selected as PLL clock entry
+  * @param  __PLLMUL__: specifies the multiplication factor to generate the PLL VCO clock
+  *         This parameter must be one of the following values:
+  *            @arg RCC_CFGR_PLLMUL3: PLLVCO = PLL clock entry x 3
+  *            @arg RCC_CFGR_PLLMUL4: PLLVCO = PLL clock entry x 4
+  *            @arg RCC_CFGR_PLLMUL6: PLLVCO = PLL clock entry x 6
+  *            @arg RCC_CFGR_PLLMUL8: PLLVCO = PLL clock entry x 8
+  *            @arg RCC_CFGR_PLLMUL12: PLLVCO = PLL clock entry x 12
+  *            @arg RCC_CFGR_PLLMUL16: PLLVCO = PLL clock entry x 16
+  *            @arg RCC_CFGR_PLLMUL24: PLLVCO = PLL clock entry x 24  
+  *            @arg RCC_CFGR_PLLMUL32: PLLVCO = PLL clock entry x 32
+  *            @arg RCC_CFGR_PLLMUL48: PLLVCO = PLL clock entry x 48
+  * @note   The PLL VCO clock frequency must not exceed 96 MHz when the product is in
+  *         Range 1, 48 MHz when the product is in Range 2 and 24 MHz when the product is
+  *         in Range 3.
+  * @param  __PLLDIV__: specifies the PLL output clock division from PLL VCO clock
+  *         This parameter must be one of the following values:
+  *            @arg RCC_PLLDIV_2: PLL clock output = PLLVCO / 2
+  *            @arg RCC_PLLDIV_3: PLL clock output = PLLVCO / 3
+  *            @arg RCC_PLLDIV_4: PLL clock output = PLLVCO / 4
+  */
+
+#define __HAL_RCC_PLL_CONFIG(__RCC_PLLSource__ , __PLLMUL__ ,__PLLDIV__ ) \
+            MODIFY_REG(RCC->CFGR, RCC_CFGR_PLLMUL | RCC_CFGR_PLLDIV | RCC_CFGR_PLLSRC, (uint32_t)((__PLLMUL__)| (__PLLDIV__)| (__RCC_PLLSource__)))
+
+/** @brief  Macro to get the clock source used as system clock.
+  * @retval The clock source used as system clock. The returned value can be one
+  *         of the following:
+  *              - RCC_CFGR_SWS_HSI: HSI used as system clock.
+  *              - RCC_CFGR_SWS_HSE: HSE used as system clock.
+  *              - RCC_CFGR_SWS_PLL: PLL used as system clock.
+  */
+#define __HAL_RCC_GET_SYSCLK_SOURCE() ((uint32_t)(RCC->CFGR & RCC_CFGR_SWS))
+
+/** @brief  Macro to get the oscillator used as PLL clock source.
+  * @retval The oscillator used as PLL clock source. The returned value can be one
+  *         of the following:
+  *              - RCC_PLLSOURCE_HSI: HSI oscillator is used as PLL clock source.
+  *              - RCC_PLLSOURCE_HSE: HSE oscillator is used as PLL clock source.
+  */
+#define __HAL_RCC_GET_PLL_OSCSOURCE() ((uint32_t)(RCC->CFGR & RCC_CFGR_PLLSRC))
+
+/** @defgroup RCC_Flags_Interrupts_Management
+  * @brief macros to manage the specified RCC Flags and interrupts.
+  * @{
+  */
+
+/** @brief  Enable RCC interrupt (Perform Byte access to RCC_CIER[0:7] bits to enable
+  *         the selected interrupts).
+  * @note   The CSS interrupt doesn't have an enable bit; once the CSS is enabled
+  *         and if the HSE clock fails, the CSS interrupt occurs and an NMI is
+  *         automatically generated. The NMI will be executed indefinitely, and 
+  *         since NMI has higher priority than any other IRQ (and main program)
+  *         the application will be stacked in the NMI ISR unless the CSS interrupt
+  *         pending bit is cleared.            
+  * @param  __INTERRUPT__: specifies the RCC interrupt sources to be enabled.
+  *         This parameter can be any combination of the following values:
+  *     @arg RCC_IT_LSIRDY: LSI ready interrupt
+  *     @arg RCC_IT_LSERDY: LSE ready interrupt
+  *     @arg RCC_IT_HSIRDY: HSI ready interrupt
+  *     @arg RCC_IT_HSERDY: HSE ready interrupt
+  *     @arg RCC_IT_PLLRDY: PLL ready interrupt
+  *     @arg RCC_IT_MSIRDY: MSI ready interrupt
+  *     @arg RCC_IT_LSECSS: LSE CSS interrupt  
+  */
+#define __HAL_RCC_ENABLE_IT(__INTERRUPT__) (*(__IO uint8_t *) CIER_BYTE0_ADDRESS |= (__INTERRUPT__))
+
+/** @brief Disable RCC interrupt (Perform Byte access to RCC_CIER[0:7] bits to disable 
+  *        the selected interrupts).
+  * @note   The CSS interrupt doesn't have an enable bit; once the CSS is enabled
+  *         and if the HSE clock fails, the CSS interrupt occurs and an NMI is
+  *         automatically generated. The NMI will be executed indefinitely, and 
+  *         since NMI has higher priority than any other IRQ (and main program)
+  *         the application will be stacked in the NMI ISR unless the CSS interrupt
+  *         pending bit is cleared.
+  * @param  __INTERRUPT__: specifies the RCC interrupt sources to be disabled.
+  *         This parameter can be any combination of the following values:
+  *     @arg RCC_IT_LSIRDY: LSI ready interrupt
+  *     @arg RCC_IT_LSERDY: LSE ready interrupt
+  *     @arg RCC_IT_HSIRDY: HSI ready interrupt
+  *     @arg RCC_IT_HSERDY: HSE ready interrupt
+  *     @arg RCC_IT_PLLRDY: PLL ready interrupt
+  *     @arg RCC_IT_MSIRDY: MSI ready interrupt
+  *     @arg RCC_IT_LSECSS: LSE CSS interrupt  
+  */
+#define __HAL_RCC_DISABLE_IT(__INTERRUPT__) (*(__IO uint8_t *) CIER_BYTE0_ADDRESS &= ~(__INTERRUPT__))
+
+/** @brief  Clear the RCC's interrupt pending bits (Perform Byte access to RCC_CIR[23:16]
+  *         bits to clear the selected interrupt pending bits.
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear.
+  *         This parameter can be any combination of the following values:
+  *     @arg RCC_IT_LSIRDY: LSI ready interrupt
+  *     @arg RCC_IT_LSERDY: LSE ready interrupt
+  *     @arg RCC_IT_HSIRDY: HSI ready interrupt
+  *     @arg RCC_IT_HSERDY: HSE ready interrupt
+  *     @arg RCC_IT_PLLRDY: PLL ready interrupt
+  *     @arg RCC_IT_MSIRDY: MSI ready interrupt 
+  *     @arg RCC_IT_LSECSS: LSE CSS interrupt
+  *     @arg RCC_IT_CSS: Clock Security System interrupt
+  */
+ #define __HAL_RCC_CLEAR_IT(__INTERRUPT__) (RCC->CICR = (__INTERRUPT__))
+
+/** @brief  Check the RCC's interrupt has occurred or not.
+  * @param  __INTERRUPT__: specifies the RCC interrupt source to check.
+  *         This parameter can be one of the following values:
+  *     @arg RCC_IT_LSIRDY: LSI ready interrupt
+  *     @arg RCC_IT_LSERDY: LSE ready interrupt  
+  *     @arg RCC_IT_HSIRDY: HSI ready interrupt
+  *     @arg RCC_IT_HSERDY: HSE ready interrupt
+  *     @arg RCC_IT_PLLRDY: PLL ready interrupt
+  *     @arg RCC_IT_MSIRDY: MSI ready interrupt
+  *     @arg RCC_IT_LSECSS: LSE CSS interrupt 
+  *     @arg RCC_IT_CSS: Clock Security System interrupt
+  * @retval The new state of __INTERRUPT__ (TRUE or FALSE).
+  */
+#define __HAL_RCC_GET_IT(__INTERRUPT__) ((RCC->CIFR & (__INTERRUPT__)) == (__INTERRUPT__))
+
+/** @brief Set RMVF bit to clear the reset flags.
+  *         The reset flags are: RCC_FLAG_OBLRST, RCC_FLAG_PINRST, RCC_FLAG_PORRST, 
+  *         RCC_FLAG_SFTRST, RCC_FLAG_IWDGRST, RCC_FLAG_WWDGRST, RCC_FLAG_LPWRRST.
+  */
+#define __HAL_RCC_CLEAR_RESET_FLAGS() (RCC->CSR |= RCC_CSR_RMVF)
+
+/** @brief  Check RCC flag is set or not.
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *     @arg RCC_FLAG_HSIRDY: HSI oscillator clock ready
+  *     @arg RCC_FLAG_MSIRDY: MSI oscillator clock ready  
+  *     @arg RCC_FLAG_HSERDY: HSE oscillator clock ready
+  *     @arg RCC_FLAG_PLLRDY: PLL clock ready
+  *     @arg RCC_FLAG_LSECSS: LSE oscillator clock CSS detected  
+  *     @arg RCC_FLAG_LSERDY: LSE oscillator clock ready
+  *     @arg RCC_FLAG_LSIRDY: LSI oscillator clock ready
+  *     @arg RCC_FLAG_OBLRST: Option Byte Loader (OBL) reset 
+  *     @arg RCC_FLAG_PINRST: Pin reset
+  *     @arg RCC_FLAG_PORRST: POR/PDR reset
+  *     @arg RCC_FLAG_SFTRST: Software reset
+  *     @arg RCC_FLAG_IWDGRST: Independent Watchdog reset
+  *     @arg RCC_FLAG_WWDGRST: Window Watchdog reset
+  *     @arg RCC_FLAG_LPWRRST: Low Power reset
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define RCC_FLAG_MASK  ((uint8_t)0x1F)
+#define __HAL_RCC_GET_FLAG(__FLAG__) (((((((__FLAG__) >> 5) == 1)? RCC->CR :((((__FLAG__) >> 5) == 2) ? RCC->CSR :((((__FLAG__) >> 5) == 3)? \
+              RCC->CRRCR :RCC->CIFR))) & ((uint32_t)1 << ((__FLAG__) & RCC_FLAG_MASK))) != 0 ) ? 1 : 0 )  
+
+/**
+  * @}
+  */
+
+#define __RCC_PLLSRC() ((RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC) >> POSITION_VAL(RCC_PLLCFGR_PLLSRC))
+/**
+  * @}
+  */
+
+/* Include RCC HAL Extension module */
+#include "stm32L0xx_hal_rcc_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/* Initialization and de-initialization methods  ******************************/
+void HAL_RCC_DeInit(void);
+HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef *RCC_OscInitStruct);
+HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef *RCC_ClkInitStruct, uint32_t FLatency);
+
+/* Peripheral Control methods  ************************************************/
+void     HAL_RCC_MCOConfig(uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_MCODiv);
+void     HAL_RCC_EnableCSS(void);
+uint32_t HAL_RCC_GetSysClockFreq(void);
+uint32_t HAL_RCC_GetHCLKFreq(void);
+uint32_t HAL_RCC_GetPCLK1Freq(void);
+uint32_t HAL_RCC_GetPCLK2Freq(void);
+void     HAL_RCC_GetOscConfig(RCC_OscInitTypeDef *RCC_OscInitStruct);
+void     HAL_RCC_GetClockConfig(RCC_ClkInitTypeDef *RCC_ClkInitStruct, uint32_t *pFLatency);
+
+/* CSS NMI IRQ handler */
+void HAL_RCC_NMI_IRQHandler(void);
+
+/* User Callbacks in non blocking mode (IT mode) */ 
+void HAL_RCC_CCSCallback(void);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_RCC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rcc_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rcc_ex.c
@@ -1,0 +1,535 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_rcc_ex.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Extended RCC HAL module driver.
+  *    
+  *          This file provides firmware functions to manage the following 
+  *          functionalities RCC extension peripheral:
+  *           + Extended Peripheral Control functions
+  *  
+  @verbatim                
+  ==============================================================================
+                      ##### RCC specific features #####
+  ==============================================================================
+    For CRS, RCC Extension HAL driver can be used as follows:
+
+      (#) In System clock configuration, HSI48 need to be enabled
+
+      (#] Enable CRS clock in IP MSP init which will use CRS functions
+
+      (#) Call CRS functions like this
+          (##) Prepare synchronization configuration necessary for HSI48 calibration
+              (+++) Default values can be set for frequency Error Measurement (reload and error limit)
+                        and also HSI48 oscillator smooth trimming.
+              (+++) Macro __HAL_RCC_CRS_CALCULATE_RELOADVALUE can be also used to calculate 
+                        directly reload value with target and synchronization frequencies values
+          (##) Call function HAL_RCCEx_CRSConfig which
+              (+++) Reset CRS registers to their default values.
+              (+++) Configure CRS registers with synchronization configuration 
+              (+++) Enable automatic calibration and frequency error counter feature
+
+          (##) A polling function is provided to wait for complete Synchronization
+              (+++) Call function 'HAL_RCCEx_CRSWaitSynchronization()'
+              (+++) According to CRS status, user can decide to adjust again the calibration or continue
+                        application if synchronization is OK
+              
+      (#) User can retrieve information related to synchronization in calling function
+            HAL_RCCEx_CRSGetSynchronizationInfo()
+
+      (#) Regarding synchronization status and synchronization information, user can try a new calibration
+           in changing synchronization configuration and call again HAL_RCCEx_CRSConfig.
+           Note: When the SYNC event is detected during the downcounting phase (before reaching the zero value), 
+           it means that the actual frequency is lower than the target (and so, that the TRIM value should be 
+           incremented), while when it is detected during the upcounting phase it means that the actual frequency 
+           is higher (and that the TRIM value should be decremented).
+
+      (#) To use IT mode, user needs to handle it in calling different macros available to do it
+            (__HAL_RCC_CRS_XXX_IT). Interruptions will go through RCC Handler (RCC_IRQn/RCC_CRS_IRQHandler)
+              (+++) Call function HAL_RCCEx_CRSConfig()
+              (+++) Enable RCC_IRQn (thnaks to NVIC functions)
+              (+++) Enable CRS IT (__HAL_RCC_CRS_ENABLE_IT)
+              [+++) Implement CRS status management in RCC_CRS_IRQHandler
+
+      (#) To force a SYNC EVENT, user can use function 'HAL_RCCEx_CRSSoftwareSynchronizationGenerate()'. Function can be 
+            called before calling HAL_RCCEx_CRSConfig (for instance in Systick handler)
+       
+   @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RCCEx 
+  * @brief RCC Extension HAL module driver
+  * @{
+  */
+
+#ifdef HAL_RCC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Bit position in register */
+#define CRS_CFGR_FELIM_BITNUMBER    16
+#define CRS_CR_TRIM_BITNUMBER       8
+#define CRS_ISR_FECAP_BITNUMBER     16
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup RCCEx_Private_Functions
+  * @{
+  */
+
+/** @defgroup RCCEx_Group1 Extended Peripheral Control functions 
+ *  @brief  Extended Peripheral Control functions  
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Extended Peripheral Control functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to control the RCC Clocks 
+    frequencies.
+      
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the RCC extended peripherals clocks according to the specified parameters in the
+  *         RCC_PeriphCLKInitTypeDef.
+  * @param  PeriphClkInit: pointer to an RCC_PeriphCLKInitTypeDef structure that
+  *         contains the configuration information for the Extended Peripherals clocks(USART1,USART2, LPUART1, 
+  *         I2C1, RTC, USB/RNG  and LPTIM1 clocks).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
+{
+  uint32_t tickstart = 0;   
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RCC_PERIPHCLK(PeriphClkInit->PeriphClockSelection));
+
+  /*------------------------------- USART1 Configuration ------------------------*/ 
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USART1) == RCC_PERIPHCLK_USART1)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_USART1CLKSOURCE(PeriphClkInit->Usart1ClockSelection));
+    
+    /* Configure the USART1 clock source */
+    __HAL_RCC_USART1_CONFIG(PeriphClkInit->Usart1ClockSelection);
+  }
+  
+  /*----------------------------- USART2 Configuration --------------------------*/ 
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USART2) == RCC_PERIPHCLK_USART2)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_USART2CLKSOURCE(PeriphClkInit->Usart2ClockSelection));
+    
+    /* Configure the USART2 clock source */
+    __HAL_RCC_USART2_CONFIG(PeriphClkInit->Usart2ClockSelection);
+  }
+  
+  /*------------------------------ LPUART1 Configuration ------------------------*/ 
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_LPUART1) == RCC_PERIPHCLK_LPUART1)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_LPUART1CLKSOURCE(PeriphClkInit->Lpuart1ClockSelection));
+    
+    /* Configure the LPUAR1 clock source */
+    __HAL_RCC_LPUART1_CONFIG(PeriphClkInit->Lpuart1ClockSelection);
+  }
+
+  /*------------------------------ I2C1 Configuration ------------------------*/ 
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2C1) == RCC_PERIPHCLK_I2C1)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_I2C1CLKSOURCE(PeriphClkInit->I2c1ClockSelection));
+    
+    /* Configure the I2C1 clock source */
+    __HAL_RCC_I2C1_CONFIG(PeriphClkInit->I2c1ClockSelection);
+  }
+    
+  
+  /*---------------------------- RTC configuration -------------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_RTC) == (RCC_PERIPHCLK_RTC))
+  {
+        /* Enable Power Clock*/
+    __PWR_CLK_ENABLE();
+    
+    /* Enable write access to Backup domain */
+    PWR->CR |= PWR_CR_DBP;
+    
+    /* Wait for Backup domain Write protection disable */
+    tickstart = HAL_GetTick();
+    
+    while((PWR->CR & PWR_CR_DBP) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > DBP_TIMEOUT_VALUE)
+      {
+        return HAL_TIMEOUT;
+      }      
+    }
+    
+    /* Reset the Backup domain only if the RTC Clock source selection is modified */ 
+    if((RCC->CSR & RCC_CSR_RTCSEL) != (PeriphClkInit->RTCClockSelection & RCC_CSR_RTCSEL))
+    {
+      /* Store the content of CSR register before the reset of Backup Domain */
+      tmpreg = (RCC->CSR & ~(RCC_CSR_RTCSEL));
+      /* RTC Clock selection can be changed only if the Backup Domain is reset */
+      __HAL_RCC_BACKUPRESET_FORCE();
+      __HAL_RCC_BACKUPRESET_RELEASE();
+      /* Restore the Content of CSR register */
+      RCC->CSR = tmpreg;
+    }
+    
+    /* If LSE is selected as RTC clock source, wait for LSE reactivation */
+    if(PeriphClkInit->RTCClockSelection == RCC_RTCCLKSOURCE_LSE)
+    {
+      /* Get timeout */   
+      tickstart = HAL_GetTick();
+      
+      /* Wait till LSE is ready */  
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) == RESET)
+      {
+        if((HAL_GetTick() - tickstart ) > LSE_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }      
+      }  
+    }
+    __HAL_RCC_RTC_CONFIG(PeriphClkInit->RTCClockSelection);
+  }
+#if !defined(STM32L051xx) && !defined(STM32L061xx)  
+ /*---------------------------- USB and RNG configuration --------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USB) == (RCC_PERIPHCLK_USB))
+  {
+    assert_param(IS_RCC_USBCLKSOURCE(PeriphClkInit->UsbClockSelection));
+    __HAL_RCC_USB_CONFIG(PeriphClkInit->UsbClockSelection);
+  }
+#endif /* !(STM32L051xx) && !(STM32L061xx) */
+  
+  /*---------------------------- LPTIM1 configuration ------------------------*/
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_LPTIM1) == (RCC_PERIPHCLK_LPTIM1))
+  {
+    assert_param(IS_RCC_LPTIMCLK(PeriphClkInit->LptimClockSelection));
+    __HAL_RCC_LPTIM1_CONFIG(PeriphClkInit->LptimClockSelection);
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get the RCC_ClkInitStruct according to the internal
+  * RCC configuration registers.
+  * @param  PeriphClkInit: pointer to an RCC_PeriphCLKInitTypeDef structure that
+  *         returns the configuration information for the Extended Peripherals clocks(USART1,USART2, LPUART1, 
+  *         I2C1, RTC, USB/RNG  and LPTIM1 clocks).
+  * @retval None
+  */
+void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
+{
+   /* Set all possible values for the extended clock type parameter -----------*/
+  /* Common part first */
+  #if !defined(STM32L051xx) && !defined(STM32L061xx)  
+  PeriphClkInit->PeriphClockSelection = RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_USART2 | RCC_PERIPHCLK_LPUART1 | \
+                                        RCC_PERIPHCLK_I2C1   | RCC_PERIPHCLK_I2C2   | RCC_PERIPHCLK_RTC     | \
+                                        RCC_PERIPHCLK_USB    | RCC_PERIPHCLK_LPTIM1;
+  
+ #else 
+  PeriphClkInit->PeriphClockSelection = RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_USART2 | RCC_PERIPHCLK_LPUART1 | \
+                                        RCC_PERIPHCLK_I2C1   | RCC_PERIPHCLK_I2C2   | RCC_PERIPHCLK_RTC     | \
+                                        RCC_PERIPHCLK_LPTIM1;
+  #endif /* !(STM32L051xx) && !(STM32L061xx) */
+  
+  /* Get the USART1 configuration --------------------------------------------*/
+  PeriphClkInit->Usart1ClockSelection  = __HAL_RCC_GET_USART1_SOURCE();
+  /* Get the USART2 clock source ---------------------------------------------*/
+  PeriphClkInit->Usart2ClockSelection  = __HAL_RCC_GET_USART2_SOURCE();
+   /* Get the LPUART1 clock source ---------------------------------------------*/
+  PeriphClkInit->Lpuart1ClockSelection = __HAL_RCC_GET_LPUART1_SOURCE();
+  /* Get the I2C1 clock source -----------------------------------------------*/
+  PeriphClkInit->I2c1ClockSelection    = __HAL_RCC_GET_I2C1_SOURCE();
+  /* Get the LPTIM1 clock source -----------------------------------------------*/
+  PeriphClkInit->LptimClockSelection   = __HAL_RCC_GET_LPTIM1_SOURCE();
+  /* Get the RTC clock source -----------------------------------------------*/
+  PeriphClkInit->RTCClockSelection     = __HAL_RCC_GET_RTC_SOURCE();
+
+#if !defined(STM32L051xx) && !defined(STM32L061xx)  
+  /* Get the USB/RNG clock source -----------------------------------------------*/
+  PeriphClkInit->UsbClockSelection  = __HAL_RCC_GET_USB_SOURCE();
+#endif /* !(STM32L051xx) && !(STM32L061xx) */
+}
+
+/**
+  * @brief  Enables the LSE Clock Security System.
+  * @param  None
+  * @retval None
+  */
+void HAL_RCCEx_EnableLSECSS(void)
+{
+   SET_BIT(RCC->CSR, RCC_CSR_LSECSSON) ;
+}
+
+/**
+  * @brief  Disables the LSE Clock Security System.
+  * @param  None
+  * @retval None
+  */
+void HAL_RCCEx_DisableLSECSS(void)
+{
+   CLEAR_BIT(RCC->CSR, RCC_CSR_LSECSSON) ;
+}
+
+#if !defined(STM32L051xx) && !defined(STM32L061xx)
+    
+/**
+  * @brief  Start automatic synchronization using polling mode
+  * @param  pInit Pointer on RCC_CRSInitTypeDef structure
+  * @retval None
+  */
+void HAL_RCCEx_CRSConfig(RCC_CRSInitTypeDef *pInit)
+{
+  /* Check the parameters */
+  assert_param(IS_RCC_CRS_SYNC_DIV(pInit->Prescaler));
+  assert_param(IS_RCC_CRS_SYNC_SOURCE(pInit->Source));
+  assert_param(IS_RCC_CRS_SYNC_POLARITY(pInit->Polarity));
+  assert_param(IS_RCC_CRS_RELOADVALUE(pInit->ReloadValue));
+  assert_param(IS_RCC_CRS_ERRORLIMIT(pInit->ErrorLimitValue));
+  assert_param(IS_RCC_CRS_HSI48CALIBRATION(pInit->HSI48CalibrationValue));
+
+
+  /* CONFIGURATION */
+
+  /* Before configuration, reset CRS registers to their default values*/
+  __CRS_FORCE_RESET();
+  __CRS_RELEASE_RESET();
+
+  /* Configure Synchronization input */
+  /* Clear SYNCDIV[2:0], SYNCSRC[1:0] & SYNCSPOL bits */
+  CRS->CFGR &= ~(CRS_CFGR_SYNCDIV | CRS_CFGR_SYNCSRC | CRS_CFGR_SYNCPOL);
+
+  /* Set the CRS_CFGR_SYNCDIV[2:0] bits according to Prescaler value */
+  CRS->CFGR |= pInit->Prescaler;
+
+  /* Set the SYNCSRC[1:0] bits according to Source value */
+  CRS->CFGR |= pInit->Source;
+
+  /* Set the SYNCSPOL bits according to Polarity value */
+  CRS->CFGR |= pInit->Polarity;
+
+  /* Configure Frequency Error Measurement */
+  /* Clear RELOAD[15:0] & FELIM[7:0] bits*/
+  CRS->CFGR &= ~(CRS_CFGR_RELOAD | CRS_CFGR_FELIM);
+
+  /* Set the RELOAD[15:0] bits according to ReloadValue value */
+  CRS->CFGR |= pInit->ReloadValue;
+
+  /* Set the FELIM[7:0] bits according to ErrorLimitValue value */
+  CRS->CFGR |= (pInit->ErrorLimitValue << CRS_CFGR_FELIM_BITNUMBER);
+
+  /* Adjust HSI48 oscillator smooth trimming */
+  /* Clear TRIM[5:0] bits */
+  CRS->CR &= ~CRS_CR_TRIM;
+
+  /* Set the TRIM[5:0] bits according to RCC_CRS_HSI48CalibrationValue value */
+  CRS->CR |= (pInit->HSI48CalibrationValue << CRS_CR_TRIM_BITNUMBER);
+
+
+  /* START AUTOMATIC SYNCHRONIZATION*/
+  
+  /* Enable Automatic trimming */
+  __HAL_RCC_CRS_ENABLE_AUTOMATIC_CALIB();
+
+  /* Enable Frequency error counter */
+  __HAL_RCC_CRS_ENABLE_FREQ_ERROR_COUNTER();
+
+}
+
+/**
+  * @brief  Generate the software synchronization event
+  * @param  None
+  * @retval None
+  */
+void HAL_RCCEx_CRSSoftwareSynchronizationGenerate(void)
+{
+  CRS->CR |= CRS_CR_SWSYNC;
+}
+
+
+/**
+  * @brief  Function to return synchronization info 
+  * @param  pSynchroInfo Pointer on RCC_CRSSynchroInfoTypeDef structure
+  * @retval None
+  */
+void HAL_RCCEx_CRSGetSynchronizationInfo(RCC_CRSSynchroInfoTypeDef *pSynchroInfo)
+{
+  /* Check the parameter */
+  assert_param(pSynchroInfo != NULL);
+  
+  /* Get the reload value */
+  pSynchroInfo->ReloadValue = (uint32_t)(CRS->CFGR & CRS_CFGR_RELOAD);
+  
+  /* Get HSI48 oscillator smooth trimming */
+  pSynchroInfo->HSI48CalibrationValue = (uint32_t)((CRS->CR & CRS_CR_TRIM) >> CRS_CR_TRIM_BITNUMBER);
+
+  /* Get Frequency error capture */
+  pSynchroInfo->FreqErrorCapture = (uint32_t)((CRS->ISR & CRS_ISR_FECAP) >> CRS_ISR_FECAP_BITNUMBER);
+
+  /* Get Frequency error direction */
+  pSynchroInfo->FreqErrorDirection = (uint32_t)(CRS->ISR & CRS_ISR_FEDIR);
+  
+  
+}
+
+/**
+* @brief This function handles CRS Synchronization Timeout.
+* @param Timeout: Duration of the timeout
+* @note  Timeout is based on the maximum time to receive a SYNC event based on synchronization
+*        frequency.
+* @note    If Timeout set to HAL_MAX_DELAY, HAL_TIMEOUT will be never returned.
+* @retval Combination of Synchronization status
+*          This parameter can be a combination of the following values:
+*            @arg RCC_CRS_TIMEOUT
+*            @arg RCC_CRS_SYNCOK
+*            @arg RCC_CRS_SYNCWARM
+*            @arg RCC_CRS_SYNCERR
+*            @arg RCC_CRS_SYNCMISS
+*            @arg RCC_CRS_TRIMOV
+*/
+RCC_CRSStatusTypeDef HAL_RCCEx_CRSWaitSynchronization(uint32_t Timeout)
+{
+  RCC_CRSStatusTypeDef crsstatus = RCC_CRS_NONE;
+  uint32_t tickstart = 0;
+  
+  /* Get timeout */
+  tickstart = HAL_GetTick();
+  
+  /* Check that if one of CRS flags have been set */
+  while(RCC_CRS_NONE == crsstatus)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        crsstatus = RCC_CRS_TIMEOUT;
+      }
+    }
+    /* Check CRS SYNCOK flag  */
+    if(__HAL_RCC_CRS_GET_FLAG(RCC_CRS_FLAG_SYNCOK))
+    {
+      /* CRS SYNC event OK */
+      crsstatus |= RCC_CRS_SYNCOK;
+    
+      /* Clear CRS SYNC event OK bit */
+      __HAL_RCC_CRS_CLEAR_FLAG(RCC_CRS_FLAG_SYNCOK);
+    }
+    
+    /* Check CRS SYNCWARN flag  */
+    if(__HAL_RCC_CRS_GET_FLAG(RCC_CRS_FLAG_SYNCWARN))
+    {
+      /* CRS SYNC warning */
+      crsstatus |= RCC_CRS_SYNCWARM;
+    
+      /* Clear CRS SYNCWARN bit */
+      __HAL_RCC_CRS_CLEAR_FLAG(RCC_CRS_FLAG_SYNCWARN);
+    }
+    
+    /* Check CRS TRIM overflow flag  */
+    if(__HAL_RCC_CRS_GET_FLAG(RCC_CRS_FLAG_TRIMOVF))
+    {
+      /* CRS SYNC Error */
+      crsstatus |= RCC_CRS_TRIMOV;
+    
+      /* Clear CRS Error bit */
+      __HAL_RCC_CRS_CLEAR_FLAG(RCC_CRS_FLAG_TRIMOVF);
+    }
+    
+    /* Check CRS Error flag  */
+    if(__HAL_RCC_CRS_GET_FLAG(RCC_CRS_FLAG_SYNCERR))
+    {
+      /* CRS SYNC Error */
+      crsstatus |= RCC_CRS_SYNCERR;
+    
+      /* Clear CRS Error bit */
+      __HAL_RCC_CRS_CLEAR_FLAG(RCC_CRS_FLAG_SYNCERR);
+    }
+    
+    /* Check CRS SYNC Missed flag  */
+    if(__HAL_RCC_CRS_GET_FLAG(RCC_CRS_FLAG_SYNCMISS))
+    {
+      /* CRS SYNC Missed */
+      crsstatus |= RCC_CRS_SYNCMISS;
+    
+      /* Clear CRS SYNC Missed bit */
+      __HAL_RCC_CRS_CLEAR_FLAG(RCC_CRS_FLAG_SYNCMISS);
+    }
+    
+    /* Check CRS Expected SYNC flag  */
+    if(__HAL_RCC_CRS_GET_FLAG(RCC_CRS_FLAG_ESYNC))
+    {
+      /* frequency error counter reached a zero value */
+      __HAL_RCC_CRS_CLEAR_FLAG(RCC_CRS_FLAG_ESYNC);
+    }
+  }
+  
+  return crsstatus;
+}
+          
+#endif /* !(STM32L051xx) && !(STM32L061xx) */  
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RCC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rcc_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rcc_ex.h
@@ -1,0 +1,1121 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_rcc_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of RCC HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_RCC_EX_H
+#define __STM32L0xx_HAL_RCC_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RCCEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+/** 
+  * @brief  RCC extended clocks structure definition  
+  */
+#if !defined(STM32L051xx) && !defined(STM32L061xx) 
+typedef struct
+{
+  uint32_t PeriphClockSelection;   /*!< The Extended Clock to be configured.
+                                        This parameter can be a value of @ref RCCEx_Periph_Clock_Selection */
+  uint32_t Usart1ClockSelection;   /*!< USART1 clock source      
+                                        This parameter can be a value of @ref RCCEx_USART1_Clock_Source */
+                                   
+  uint32_t Usart2ClockSelection;   /*!< USART2 clock source      
+                                        This parameter can be a value of @ref RCCEx_USART2_Clock_Source */
+                                   
+  uint32_t Lpuart1ClockSelection;  /*!< LPUART1 clock source      
+                                        This parameter can be a value of @ref RCCEx_LPUART_Clock_Source */
+                                   
+  uint32_t I2c1ClockSelection;     /*!< I2C1 clock source      
+                                        This parameter can be a value of @ref RCCEx_I2C1_Clock_Source */
+                                   
+  uint32_t RTCClockSelection;      /*!< Specifies RTC Clock Prescalers Selection
+                                        This parameter can be a value of @ref RCCEx_RTC_Clock_Source */
+                                                                         
+  uint32_t UsbClockSelection;      /*!< Specifies USB and RNG Clock  Selection
+                                        This parameter can be a value of @ref RCCEx_USB_Clock_Source */
+
+  uint32_t LptimClockSelection;    /*!< LPTIM1 clock source
+                                        This parameter can be a value of @ref RCCEx_LPTIM1_Clock_Source */
+  
+}RCC_PeriphCLKInitTypeDef;
+#endif /* !(STM32L051xx) && !(STM32L061xx) */
+
+#if defined(STM32L051xx) || defined(STM32L061xx) 
+typedef struct
+{
+  uint32_t PeriphClockSelection;   /*!< The Extended Clock to be configured.
+                                        This parameter can be a value of @ref RCCEx_Periph_Clock_Selection */
+  uint32_t Usart1ClockSelection;   /*!< USART1 clock source      
+                                        This parameter can be a value of @ref RCCEx_USART1_Clock_Source */
+                                   
+  uint32_t Usart2ClockSelection;   /*!< USART2 clock source      
+                                        This parameter can be a value of @ref RCCEx_USART2_Clock_Source */
+                                   
+  uint32_t Lpuart1ClockSelection;  /*!< LPUART1 clock source      
+                                        This parameter can be a value of @ref RCCEx_LPUART1_Clock_Source */
+                                   
+  uint32_t I2c1ClockSelection;     /*!< I2C1 clock source      
+                                        This parameter can be a value of @ref RCCEx_I2C1_Clock_Source */
+                                   
+  uint32_t RTCClockSelection;      /*!< Specifies RTC Clock Prescalers Selection
+                                        This parameter can be a value of @ref RCCEx_RTC_Clock_Source */
+                                                                         
+  uint32_t LptimClockSelection;    /*!< LPTIM1 clock source
+                                        This parameter can be a value of @ref RCCEx_LPTIM1_Clock_Source */
+  
+}RCC_PeriphCLKInitTypeDef;
+#endif /* STM32L051xx || STM32L061xx */
+
+#if !defined(STM32L051xx) && !defined(STM32L061xx) 
+/** 
+  * @brief  RCC CRS Status structures definition  
+  */  
+typedef enum 
+{
+  RCC_CRS_NONE      = 0x00,
+  RCC_CRS_TIMEOUT   = 0x01,
+  RCC_CRS_SYNCOK    = 0x02,
+  RCC_CRS_SYNCWARM  = 0x04,
+  RCC_CRS_SYNCERR   = 0x08,
+  RCC_CRS_SYNCMISS  = 0x10,
+  RCC_CRS_TRIMOV    = 0x20
+} RCC_CRSStatusTypeDef;
+
+/** 
+  * @brief RCC_CRS Init structure definition  
+  */
+typedef struct
+{
+  uint32_t Prescaler;             /*!< Specifies the division factor of the SYNC signal.
+                                     This parameter can be a value of @ref RCCEx_CRS_SynchroDivider */
+
+  uint32_t Source;                /*!< Specifies the SYNC signal source.
+                                     This parameter can be a value of @ref RCCEx_CRS_SynchroSource */
+
+  uint32_t Polarity;              /*!< Specifies the input polarity for the SYNC signal source.
+                                     This parameter can be a value of @ref RCCEx_CRS_SynchroPolarity */
+
+  uint32_t ReloadValue;           /*!< Specifies the value to be loaded in the frequency error counter with each SYNC event.
+                                      It can be calculated in using macro __HAL_RCC_CRS_CALCULATE_RELOADVALUE(_FTARGET_, _FSYNC_)
+                                     This parameter must be a number between 0 and 0xFFFF or a value of @ref RCCEx_CRS_ReloadValueDefault .*/
+
+  uint32_t ErrorLimitValue;       /*!< Specifies the value to be used to evaluate the captured frequency error value.
+                                     This parameter must be a number between 0 and 0xFF or a value of @ref RCCEx_CRS_ErrorLimitDefault */
+
+  uint32_t HSI48CalibrationValue; /*!< Specifies a user-programmable trimming value to the HSI48 oscillator.
+                                     This parameter must be a number between 0 and 0x3F or a value of @ref RCCEx_CRS_HSI48CalibrationDefault */
+   
+}RCC_CRSInitTypeDef;
+
+/** 
+  * @brief RCC_CRS Synchronization structure definition  
+  */
+typedef struct
+{
+  uint32_t ReloadValue;           /*!< Specifies the value loaded in the Counter reload value.
+                                     This parameter must be a number between 0 and 0xFFFF*/
+
+  uint32_t HSI48CalibrationValue; /*!< Specifies value loaded in HSI48 oscillator smooth trimming.
+                                     This parameter must be a number between 0 and 0x3F */
+   
+  uint32_t FreqErrorCapture;      /*!< Specifies the value loaded in the .FECAP, the frequency error counter 
+                                       value latched in the time of the last SYNC event.
+                                    This parameter must be a number between 0 and 0xFFFF */
+                                    
+  uint32_t FreqErrorDirection;    /*!< Specifies the value loaded in the .FEDIR, the counting direction of the 
+                                                                    frequency error counter latched in the time of the last SYNC event. 
+                                                                    It shows whether the actual frequency is below or above the target.
+                                    This parameter must be a value of @ref RCCEx_CRS_FreqErrorDirection*/
+
+}RCC_CRSSynchroInfoTypeDef;
+#endif /* !(STM32L051xx ) && !(STM32L061xx ) */
+ 
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup RCCEx_Exported_Constants
+  * @{
+  */
+
+/** @defgroup RCCEx_Periph_Clock_Selection
+  * @{
+  */
+#if !defined(STM32L051xx) && !defined(STM32L061xx) 
+#define RCC_PERIPHCLK_USART1           ((uint32_t)0x00000001)
+#define RCC_PERIPHCLK_USART2           ((uint32_t)0x00000002)
+#define RCC_PERIPHCLK_LPUART1          ((uint32_t)0x00000004)
+#define RCC_PERIPHCLK_I2C1             ((uint32_t)0x00000008)
+#define RCC_PERIPHCLK_I2C2             ((uint32_t)0x00000010)
+#define RCC_PERIPHCLK_RTC              ((uint32_t)0x00000020)
+#define RCC_PERIPHCLK_USB              ((uint32_t)0x00000040)
+#define RCC_PERIPHCLK_LPTIM1           ((uint32_t)0x00000080)
+
+
+#define IS_RCC_PERIPHCLK(CLK) ((CLK) <= (RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_USART2 | RCC_PERIPHCLK_LPUART1 | \
+                                         RCC_PERIPHCLK_I2C1   | RCC_PERIPHCLK_I2C2 | RCC_PERIPHCLK_RTC       |  \
+                                         RCC_PERIPHCLK_USB | RCC_PERIPHCLK_LPTIM1))
+#endif /* !(STM32L051xx) && !(STM32L061xx) */
+
+#if defined(STM32L051xx) || defined(STM32L061xx) 
+#define RCC_PERIPHCLK_USART1           ((uint32_t)0x00000001)
+#define RCC_PERIPHCLK_USART2           ((uint32_t)0x00000002)
+#define RCC_PERIPHCLK_LPUART1          ((uint32_t)0x00000004)
+#define RCC_PERIPHCLK_I2C1             ((uint32_t)0x00000008)
+#define RCC_PERIPHCLK_I2C2             ((uint32_t)0x00000010)
+#define RCC_PERIPHCLK_RTC              ((uint32_t)0x00000020)
+#define RCC_PERIPHCLK_LPTIM1           ((uint32_t)0x00000080)
+
+
+#define IS_RCC_PERIPHCLK(CLK) ((CLK) <= (RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_USART2 | RCC_PERIPHCLK_LPUART1 | \
+                                         RCC_PERIPHCLK_I2C1   | RCC_PERIPHCLK_I2C2 | RCC_PERIPHCLK_RTC       |  \
+                                         RCC_PERIPHCLK_LPTIM1))
+#endif /* !(STM32L051xx) && !(STM32L061xx) */
+/**
+  * @}
+  */
+  
+/** @defgroup RCCEx_USART1_Clock_Source
+  * @{
+  */
+#define RCC_USART1CLKSOURCE_PCLK2        ((uint32_t)0x00000000) 
+#define RCC_USART1CLKSOURCE_SYSCLK       RCC_CCIPR_USART1SEL_0
+#define RCC_USART1CLKSOURCE_HSI          RCC_CCIPR_USART1SEL_1
+#define RCC_USART1CLKSOURCE_LSE          (RCC_CCIPR_USART1SEL_0 | RCC_CCIPR_USART1SEL_1)
+#define IS_RCC_USART1CLKSOURCE(SOURCE)  (((SOURCE) == RCC_USART1CLKSOURCE_PCLK2)  || \
+                                         ((SOURCE) == RCC_USART1CLKSOURCE_SYSCLK) || \
+                                         ((SOURCE) == RCC_USART1CLKSOURCE_LSE)    || \
+                                         ((SOURCE) == RCC_USART1CLKSOURCE_HSI))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_USART2_Clock_Source
+  * @{
+  */
+#define RCC_USART2CLKSOURCE_PCLK1        ((uint32_t)0x00000000) 
+#define RCC_USART2CLKSOURCE_SYSCLK       RCC_CCIPR_USART2SEL_0
+#define RCC_USART2CLKSOURCE_HSI          RCC_CCIPR_USART2SEL_1
+#define RCC_USART2CLKSOURCE_LSE          (RCC_CCIPR_USART2SEL_0 | RCC_CCIPR_USART2SEL_1)
+#define IS_RCC_USART2CLKSOURCE(SOURCE)  (((SOURCE) == RCC_USART2CLKSOURCE_PCLK1)  || \
+                                         ((SOURCE) == RCC_USART2CLKSOURCE_SYSCLK) || \
+                                         ((SOURCE) == RCC_USART2CLKSOURCE_LSE)    || \
+                                         ((SOURCE) == RCC_USART2CLKSOURCE_HSI))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_LPUART_Clock_Source
+  * @{
+  */
+#define RCC_LPUART1CLKSOURCE_PCLK1        ((uint32_t)0x00000000) 
+#define RCC_LPUART1CLKSOURCE_SYSCLK       RCC_CCIPR_LPUART1SEL_0
+#define RCC_LPUART1CLKSOURCE_HSI          RCC_CCIPR_LPUART1SEL_1
+#define RCC_LPUART1CLKSOURCE_LSE          (RCC_CCIPR_LPUART1SEL_0 | RCC_CCIPR_LPUART1SEL_1)
+#define IS_RCC_LPUART1CLKSOURCE(SOURCE)  (((SOURCE) == RCC_LPUART1CLKSOURCE_PCLK1)  || \
+                                         ((SOURCE) == RCC_LPUART1CLKSOURCE_SYSCLK) || \
+                                         ((SOURCE) == RCC_LPUART1CLKSOURCE_LSE)    || \
+                                         ((SOURCE) == RCC_LPUART1CLKSOURCE_HSI))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_I2C1_Clock_Source
+  * @{
+  */
+#define RCC_I2C1CLKSOURCE_PCLK1          ((uint32_t)0x00000000) 
+#define RCC_I2C1CLKSOURCE_SYSCLK         RCC_CCIPR_I2C1SEL_0
+#define RCC_I2C1CLKSOURCE_HSI            RCC_CCIPR_I2C1SEL_1
+#define IS_RCC_I2C1CLKSOURCE(SOURCE)  (((SOURCE) == RCC_I2C1CLKSOURCE_PCLK1) || \
+                                       ((SOURCE) == RCC_I2C1CLKSOURCE_SYSCLK)|| \
+                                       ((SOURCE) == RCC_I2C1CLKSOURCE_HSI))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_TIM_PRescaler_Selection
+  * @{
+  */
+#define RCC_TIMPRES_DESACTIVATED        ((uint8_t)0x00)
+#define RCC_TIMPRES_ACTIVATED           ((uint8_t)0x01)
+/**
+  * @}
+  */
+
+#if !defined(STM32L051xx) && !defined(STM32L061xx)
+/** @defgroup RCCEx_USB_Clock_Source
+  * @{
+  */
+#define RCC_USBCLKSOURCE_HSI48           RCC_CCIPR_HSI48SEL
+#define RCC_USBCLKSOURCE_PLLCLK          ((uint32_t)0x00000000)
+
+#define IS_RCC_USBCLKSOURCE(SOURCE)  (((SOURCE) == RCC_USBCLKSOURCE_HSI48) || \
+                                      ((SOURCE) == RCC_USBCLKSOURCE_PLLCLK))
+/**
+  * @}
+  */
+  
+/** @defgroup RCCEx_RNG_Clock_Source
+  * @{
+  */
+#define RCC_RNGCLKSOURCE_HSI48           RCC_CCIPR_HSI48SEL
+#define RCC_RNGCLKSOURCE_PLLCLK          ((uint32_t)0x00000000)
+
+#define IS_RCC_RNGCLKSOURCE(SOURCE)  (((SOURCE) == RCC_RNGCLKSOURCE_HSI48) || \
+                                      ((SOURCE) == RCC_RNGCLKSOURCE_PLLCLK))
+/**
+  * @}
+  */  
+
+/** @defgroup RCCEx_HSI48M_Clock_Source 
+  * @{
+  */
+
+#define RCC_HSI48M_PLL                 ((uint32_t)0x00000000)
+#define RCC_HSI48M_RC48                 RCC_CCIPR_HSI48SEL
+
+#define IS_RCC_HSI48MCLKSOURCE(HSI48MCLK) (((HSI48MCLK) == RCC_HSI48M_PLL) || ((HSI48MCLK) == RCC_HSI48M_RC48))
+
+/**
+  * @}
+  */
+#endif /* !(STM32L051xx ) && !(STM32L061xx ) */ 
+
+/** @defgroup RCCEx_LPTIM1_Clock_Source
+  * @{
+  */
+#define RCC_LPTIM1CLKSOURCE_PCLK        ((uint32_t)0x00000000)
+#define RCC_LPTIM1CLKSOURCE_LSI         RCC_CCIPR_LPTIM1SEL_0
+#define RCC_LPTIM1CLKSOURCE_HSI         RCC_CCIPR_LPTIM1SEL_1
+#define RCC_LPTIM1CLKSOURCE_LSE         RCC_CCIPR_LPTIM1SEL
+
+#define IS_RCC_LPTIMCLK(LPTIMCLK)     (((LPTIMCLK) == RCC_LPTIM1CLKSOURCE_PCLK) || \
+                                       ((LPTIMCLK) == RCC_LPTIM1CLKSOURCE_LSI)  || \
+                                       ((LPTIMCLK) == RCC_LPTIM1CLKSOURCE_HSI)  || \
+                                       ((LPTIMCLK) == RCC_LPTIM1CLKSOURCE_LSE))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_StopWakeUp_Clock
+  * @{
+  */
+
+#define RCC_StopWakeUpClock_MSI                ((uint32_t)0x00)
+#define RCC_StopWakeUpClock_HSI                RCC_CFGR_STOPWUCK
+
+#define IS_RCC_STOPWAKEUP_CLOCK(SOURCE) (((SOURCE) == RCC_StopWakeUpClock_MSI) || \
+                                         ((SOURCE) == RCC_StopWakeUpClock_HSI))
+/**
+  * @}
+  */ 
+
+/** @defgroup RCCEx_LSEDrive_Configuration
+  * @{
+  */
+
+#define RCC_LSEDRIVE_LOW                 ((uint32_t)0x00000000)
+#define RCC_LSEDRIVE_MEDIUMLOW           RCC_CSR_LSEDRV_0
+#define RCC_LSEDRIVE_MEDIUMHIGH          RCC_CSR_LSEDRV_1
+#define RCC_LSEDRIVE_HIGH                RCC_CSR_LSEDRV
+#define IS_RCC_LSE_DRIVE(DRIVE) (((DRIVE) == RCC_LSEDRIVE_LOW) || ((DRIVE) == RCC_LSEDRIVE_MEDIUMLOW) || \
+                                 ((DRIVE) == RCC_LSEDRIVE_MEDIUMHIGH) || ((DRIVE) == RCC_LSEDRIVE_HIGH))
+/**
+  * @}
+  */  
+
+#if !defined(STM32L051xx) && !defined(STM32L061xx)
+/** @defgroup RCCEx_CRS_SynchroSource
+  * @{
+  */
+#define RCC_CRS_SYNC_SOURCE_GPIO       ((uint32_t)0x00)        /*!< Synchro Signal source GPIO */
+#define RCC_CRS_SYNC_SOURCE_LSE        CRS_CFGR_SYNCSRC_0      /*!< Synchro Signal source LSE */
+#define RCC_CRS_SYNC_SOURCE_USB        CRS_CFGR_SYNCSRC_1      /*!< Synchro Signal source USB SOF (default)*/
+  
+#define IS_RCC_CRS_SYNC_SOURCE(_SOURCE_) (((_SOURCE_) == RCC_CRS_SYNC_SOURCE_GPIO) || \
+                                      ((_SOURCE_) == RCC_CRS_SYNC_SOURCE_LSE) ||\
+                                      ((_SOURCE_) == RCC_CRS_SYNC_SOURCE_USB))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CRS_SynchroDivider
+  * @{
+  */
+#define RCC_CRS_SYNC_DIV1        ((uint32_t)0x00)                          /*!< Synchro Signal not divided (default) */
+#define RCC_CRS_SYNC_DIV2        CRS_CFGR_SYNCDIV_0                        /*!< Synchro Signal divided by 2 */
+#define RCC_CRS_SYNC_DIV4        CRS_CFGR_SYNCDIV_1                        /*!< Synchro Signal divided by 4 */
+#define RCC_CRS_SYNC_DIV8        (CRS_CFGR_SYNCDIV_1 | CRS_CFGR_SYNCDIV_0) /*!< Synchro Signal divided by 8 */
+#define RCC_CRS_SYNC_DIV16       CRS_CFGR_SYNCDIV_2                        /*!< Synchro Signal divided by 16 */
+#define RCC_CRS_SYNC_DIV32       (CRS_CFGR_SYNCDIV_2 | CRS_CFGR_SYNCDIV_0) /*!< Synchro Signal divided by 32 */
+#define RCC_CRS_SYNC_DIV64       (CRS_CFGR_SYNCDIV_2 | CRS_CFGR_SYNCDIV_1) /*!< Synchro Signal divided by 64 */
+#define RCC_CRS_SYNC_DIV128      CRS_CFGR_SYNCDIV                          /*!< Synchro Signal divided by 128 */
+  
+#define IS_RCC_CRS_SYNC_DIV(_DIV_) (((_DIV_) == RCC_CRS_SYNC_DIV1) || ((_DIV_) == RCC_CRS_SYNC_DIV2)   ||\
+                                ((_DIV_) == RCC_CRS_SYNC_DIV4) || ((_DIV_) == RCC_CRS_SYNC_DIV8)   || \
+                                ((_DIV_) == RCC_CRS_SYNC_DIV16) || ((_DIV_) == RCC_CRS_SYNC_DIV32) || \
+                                ((_DIV_) == RCC_CRS_SYNC_DIV64) || ((_DIV_) == RCC_CRS_SYNC_DIV128))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CRS_SynchroPolarity
+  * @{
+  */
+#define RCC_CRS_SYNC_POLARITY_RISING        ((uint32_t)0x00)      /*!< Synchro Active on rising edge (default) */
+#define RCC_CRS_SYNC_POLARITY_FALLING       CRS_CFGR_SYNCPOL      /*!< Synchro Active on falling edge */
+  
+#define IS_RCC_CRS_SYNC_POLARITY(_POLARITY_) (((_POLARITY_) == RCC_CRS_SYNC_POLARITY_RISING) || \
+                                      ((_POLARITY_) == RCC_CRS_SYNC_POLARITY_FALLING))
+/**
+  * @}
+  */
+  
+/** @defgroup RCCEx_CRS_ReloadValueDefault
+  * @{
+  */
+#define RCC_CRS_RELOADVALUE_DEFAULT         ((uint32_t)0xBB7F)      /*!< The reset value of the RELOAD field corresponds 
+                                                              to a target frequency of 48 MHz and a synchronization signal frequency of 1 kHz (SOF signal from USB). */
+    
+#define IS_RCC_CRS_RELOADVALUE(_VALUE_) (((_VALUE_) <= 0xFFFF))
+/**
+  * @}
+  */
+  
+/** @defgroup RCCEx_CRS_ErrorLimitDefault
+  * @{
+  */
+#define RCC_CRS_ERRORLIMIT_DEFAULT          ((uint32_t)0x22)      /*!< Default Frequency error limit */
+    
+#define IS_RCC_CRS_ERRORLIMIT(_VALUE_) (((_VALUE_) <= 0xFF))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CRS_HSI48CalibrationDefault
+  * @{
+  */
+#define RCC_CRS_HSI48CALIBRATION_DEFAULT    ((uint32_t)0x20)      /*!< The default value is 32, which corresponds to the middle of the trimming interval. 
+                                                                The trimming step is around 67 kHz between two consecutive TRIM steps. A higher TRIM value
+                                                                corresponds to a higher output frequency */
+    
+#define IS_RCC_CRS_HSI48CALIBRATION(_VALUE_) (((_VALUE_) <= 0x3F))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CRS_FreqErrorDirection
+  * @{
+  */
+#define RCC_CRS_FREQERRORDIR_UP             ((uint32_t)0x00)          /*!< Upcounting direction, the actual frequency is above the target */
+#define RCC_CRS_FREQERRORDIR_DOWN           ((uint32_t)CRS_ISR_FEDIR) /*!< Downcounting direction, the actual frequency is below the target */
+    
+#define IS_RCC_CRS_FREQERRORDIR(_DIR_) (((_DIR_) == RCC_CRS_FREQERRORDIR_UP) || \
+                                      ((_DIR_) == RCC_CRS_FREQERRORDIR_DOWN))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_CRS_Interrupt_Sources
+  * @{
+  */
+#define RCC_CRS_IT_SYNCOK             CRS_ISR_SYNCOKF    /*!< SYNC event OK */
+#define RCC_CRS_IT_SYNCWARN           CRS_ISR_SYNCWARNF  /*!< SYNC warning */
+#define RCC_CRS_IT_ERR                CRS_ISR_ERRF       /*!< error */
+#define RCC_CRS_IT_ESYNC              CRS_ISR_ESYNCF     /*!< Expected SYNC */
+#define RCC_CRS_IT_TRIMOVF            CRS_ISR_TRIMOVF    /*!< Trimming overflow or underflow */
+#define RCC_CRS_IT_SYNCERR            CRS_ISR_SYNCERR    /*!< SYNC error */
+#define RCC_CRS_IT_SYNCMISS           CRS_ISR_SYNCMISS    /*!< SYNC missed*/
+
+/**
+  * @}
+  */
+  
+/** @defgroup RCCEx_CRS_Flags
+  * @{
+  */
+#define RCC_CRS_FLAG_SYNCOK             CRS_ISR_SYNCOKF     /* SYNC event OK flag     */
+#define RCC_CRS_FLAG_SYNCWARN           CRS_ISR_SYNCWARNF   /* SYNC warning flag      */
+#define RCC_CRS_FLAG_ERR                CRS_ISR_ERRF        /* Error flag        */
+#define RCC_CRS_FLAG_ESYNC              CRS_ISR_ESYNCF      /* Expected SYNC flag     */
+#define RCC_CRS_FLAG_TRIMOVF            CRS_ISR_TRIMOVF     /*!< Trimming overflow or underflow */
+#define RCC_CRS_FLAG_SYNCERR            CRS_ISR_SYNCERR     /*!< SYNC error */
+#define RCC_CRS_FLAG_SYNCMISS           CRS_ISR_SYNCMISS    /*!< SYNC missed*/
+
+/**
+  * @}
+  */
+
+#endif /* !(STM32L051xx ) && !(STM32L061xx ) */  
+/**
+  * @}
+  */ 
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup RCCEx_Exported_Macros
+  * @{
+  */
+
+/** @brief  Enable or disable the AHB peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before
+  *         using it.
+  */
+
+#if defined(STM32L062xx) || defined(STM32L063xx)
+#define __CRYP_CLK_ENABLE()          (RCC->AHBENR |= (RCC_AHBENR_CRYPEN))
+#define __CRYP_CLK_DISABLE()         (RCC->AHBENR  &= ~ (RCC_AHBENR_CRYPEN))
+#endif /* STM32L062xx || STM32L063xx  */
+
+#if !defined(STM32L051xx) && !defined(STM32L061xx) 
+#define __TSC_CLK_ENABLE()             (RCC->AHBENR |= (RCC_AHBENR_TSCEN))
+#define __TSC_CLK_DISABLE()            (RCC->AHBENR  &= ~ (RCC_AHBENR_TSCEN))
+
+#define __RNG_CLK_ENABLE()            (RCC->AHBENR |= (RCC_AHBENR_RNGEN))
+#define __RNG_CLK_DISABLE()           (RCC->AHBENR  &= ~ (RCC_AHBENR_RNGEN))
+#endif /* !(STM32L051xx ) && !(STM32L061xx ) */
+
+/** @brief  Enable or disable the APB1 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it.   
+  */
+
+#if !defined(STM32L051xx) && !defined(STM32L061xx) 
+#define __USB_CLK_ENABLE()         (RCC->APB1ENR |= (RCC_APB1ENR_USBEN))
+#define __USB_CLK_DISABLE()        (RCC->APB1ENR &= ~ (RCC_APB1ENR_USBEN))
+#endif /* !(STM32L051xx ) && !(STM32L061xx ) */
+
+#if !defined(STM32L051xx) && !defined(STM32L061xx)
+#define __CRS_CLK_ENABLE()     (RCC->APB1ENR |= (RCC_APB1ENR_CRSEN))
+#define __CRS_CLK_DISABLE()    (RCC->APB1ENR &= ~(RCC_APB1ENR_CRSEN))
+#endif /* !(STM32L051xx ) && !(STM32L061xx ) */
+       
+
+#if defined(STM32L053xx) || defined(STM32L063xx)
+#define __LCD_CLK_ENABLE()            (RCC->APB1ENR |= (RCC_APB1ENR_LCDEN))
+#define __LCD_CLK_DISABLE()           (RCC->APB1ENR &= ~ (RCC_APB1ENR_LCDEN))
+#endif /* STM32L053xx || STM32L063xx  */
+
+#if defined(STM32L053xx) || defined(STM32L063xx) || \
+    defined(STM32L052xx) || defined(STM32L062xx) || \
+    defined(STM32L051xx) || defined(STM32L061xx)
+#define __TIM2_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_TIM2EN))
+#define __TIM6_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_TIM6EN))
+#define __SPI2_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_SPI2EN))
+#define __USART2_CLK_ENABLE()  (RCC->APB1ENR |= (RCC_APB1ENR_USART2EN))
+#define __LPUART1_CLK_ENABLE()  (RCC->APB1ENR |= (RCC_APB1ENR_LPUART1EN))
+#define __I2C1_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_I2C1EN))
+#define __I2C2_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_I2C2EN))
+#define __DAC_CLK_ENABLE()     (RCC->APB1ENR |= (RCC_APB1ENR_DACEN))
+#define __LPTIM1_CLK_ENABLE()   (RCC->APB1ENR |= (RCC_APB1ENR_LPTIM1EN))
+
+#define __TIM2_CLK_DISABLE()    (RCC->APB1ENR &= ~ (RCC_APB1ENR_TIM2EN))
+#define __TIM6_CLK_DISABLE()    (RCC->APB1ENR &= ~ (RCC_APB1ENR_TIM6EN))
+#define __SPI2_CLK_DISABLE()    (RCC->APB1ENR &= ~ (RCC_APB1ENR_SPI2EN))
+#define __USART2_CLK_DISABLE()  (RCC->APB1ENR &= ~ (RCC_APB1ENR_USART2EN))
+#define __LPUART1_CLK_DISABLE()  (RCC->APB1ENR &= ~ (RCC_APB1ENR_LPUART1EN))
+#define __I2C1_CLK_DISABLE()    (RCC->APB1ENR &= ~ (RCC_APB1ENR_I2C1EN))
+#define __I2C2_CLK_DISABLE()    (RCC->APB1ENR &= ~ (RCC_APB1ENR_I2C2EN))
+#define __DAC_CLK_DISABLE()     (RCC->APB1ENR &= ~ (RCC_APB1ENR_DACEN))
+#define __LPTIM1_CLK_DISABLE()   (RCC->APB1ENR &= ~ (RCC_APB1ENR_LPTIM1EN))
+#endif /* STM32L051xx  || STM32L061xx  || */
+       /* STM32L052xx  || STM32L062xx  || */
+       /* STM32L053xx  || STM32L063xx  || */
+       
+/** @brief  Enable or disable the APB2 peripheral clock.
+  * @note   After reset, the peripheral clock (used for registers read/write access)
+  *         is disabled and the application software has to enable this clock before 
+  *         using it.   
+  */
+
+#if defined(STM32L053xx) || defined(STM32L063xx) || \
+    defined(STM32L052xx) || defined(STM32L062xx) || \
+    defined(STM32L051xx) || defined(STM32L061xx)
+#define __TIM21_CLK_ENABLE()    (RCC->APB2ENR |= (RCC_APB2ENR_TIM21EN))
+#define __TIM22_CLK_ENABLE()    (RCC->APB2ENR |= (RCC_APB2ENR_TIM22EN))
+#define __FIREWALL_CLK_ENABLE() (RCC->APB2ENR |= (RCC_APB2ENR_MIFIEN))
+#define __ADC1_CLK_ENABLE()     (RCC->APB2ENR |= (RCC_APB2ENR_ADC1EN))
+#define __SPI1_CLK_ENABLE()     (RCC->APB2ENR |= (RCC_APB2ENR_SPI1EN))
+#define __USART1_CLK_ENABLE()   (RCC->APB2ENR |= (RCC_APB2ENR_USART1EN))
+
+#define __TIM21_CLK_DISABLE()    (RCC->APB2ENR &= ~  (RCC_APB2ENR_TIM21EN))
+#define __TIM22_CLK_DISABLE()    (RCC->APB2ENR &= ~  (RCC_APB2ENR_TIM22EN))
+#define __FIREWALL_CLK_DISABLE() (RCC->APB2ENR &= ~  (RCC_APB2ENR_MIFIEN))
+#define __ADC1_CLK_DISABLE()     (RCC->APB2ENR &= ~  (RCC_APB2ENR_ADC1EN))
+#define __SPI1_CLK_DISABLE()     (RCC->APB2ENR &= ~  (RCC_APB2ENR_SPI1EN))
+#define __USART1_CLK_DISABLE()   (RCC->APB2ENR &= ~  (RCC_APB2ENR_USART1EN))
+#endif /* STM32L051xx  || STM32L061xx  || */
+       /* STM32L052xx  || STM32L062xx  || */
+       /* STM32L053xx  || STM32L063xx  || */
+
+/** @brief  Force or release AHB peripheral reset.
+  */  
+#if defined(STM32L062xx) || defined(STM32L063xx)
+#define __CRYP_FORCE_RESET()    (RCC->AHBRSTR |= (RCC_AHBRSTR_CRYPRST))
+#define __CRYP_RELEASE_RESET()   (RCC->AHBRSTR &= ~ (RCC_AHBRSTR_CRYPRST))
+#endif /* STM32L062xx || STM32L063xx  */
+
+#if !defined(STM32L051xx) && !defined(STM32L061xx)
+#define __TSC_FORCE_RESET()        (RCC->AHBRSTR |= (RCC_AHBRSTR_TSCRST))
+#define __TSC_RELEASE_RESET()      (RCC->AHBRSTR &= ~ (RCC_AHBRSTR_TSCRST))
+#define __RNG_FORCE_RESET()        (RCC->AHBRSTR |= (RCC_AHBRSTR_RNGRST))
+#define __RNG_RELEASE_RESET()      (RCC->AHBRSTR &= ~ (RCC_AHBRSTR_RNGRST))
+#endif /* !(STM32L051xx ) && !(STM32L061xx ) */
+
+/** @brief  Force or release APB1 peripheral reset.
+  */  
+#if defined(STM32L053xx) || defined(STM32L063xx) || \
+    defined(STM32L052xx) || defined(STM32L062xx) || \
+    defined(STM32L051xx) || defined(STM32L061xx)
+#define __TIM2_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM2RST))
+#define __TIM6_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM6RST))
+#define __LPTIM1_FORCE_RESET()   (RCC->APB1RSTR |= (RCC_APB1RSTR_LPTIM1RST))
+#define __I2C1_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_I2C1RST))
+#define __I2C2_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_I2C2RST))
+#define __USART2_FORCE_RESET()   (RCC->APB1RSTR |= (RCC_APB1RSTR_USART2RST))
+#define __LPUART1_FORCE_RESET()  (RCC->APB1RSTR |= (RCC_APB1RSTR_LPUART1RST))
+#define __SPI2_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_SPI2RST))
+#define __DAC_FORCE_RESET()      (RCC->APB1RSTR |= (RCC_APB1RSTR_DACRST))
+
+#define __TIM2_RELEASE_RESET()     (RCC->APB1RSTR &= ~ (RCC_APB1RSTR_TIM2RST))
+#define __TIM6_RELEASE_RESET()     (RCC->APB1RSTR &= ~ (RCC_APB1RSTR_TIM6RST))
+#define __LPTIM1_RELEASE_RESET()   (RCC->APB1RSTR &= ~ (RCC_APB1RSTR_LPTIM1RST))
+#define __I2C1_RELEASE_RESET()     (RCC->APB1RSTR &= ~ (RCC_APB1RSTR_I2C1RST))
+#define __I2C2_RELEASE_RESET()     (RCC->APB1RSTR &= ~ (RCC_APB1RSTR_I2C2RST))
+#define __USART2_RELEASE_RESET()   (RCC->APB1RSTR &= ~ (RCC_APB1RSTR_USART2RST))
+#define __LPUART1_RELEASE_RESET()  (RCC->APB1RSTR &= ~ (RCC_APB1RSTR_LPUART1RST))
+#define __SPI2_RELEASE_RESET()     (RCC->APB1RSTR &= ~ (RCC_APB1RSTR_SPI2RST))
+#define __DAC_RELEASE_RESET()      (RCC->APB1RSTR &= ~ (RCC_APB1RSTR_DACRST))
+#endif /* STM32L051xx  || STM32L061xx  || */
+       /* STM32L052xx  || STM32L062xx  || */
+       /* STM32L053xx  || STM32L063xx  || */
+       
+#if !defined(STM32L051xx) && !defined(STM32L061xx)
+#define __USB_FORCE_RESET()        (RCC->APB1RSTR |= (RCC_APB1RSTR_USBRST))
+#define __USB_RELEASE_RESET()      (RCC->APB1RSTR &= ~ (RCC_APB1RSTR_USBRST))
+#endif /* !(STM32L051xx ) && !(STM32L061xx ) */
+
+#if !defined(STM32L051xx) && !defined(STM32L061xx)
+#define __CRS_FORCE_RESET()      (RCC->APB1RSTR |= (RCC_APB1RSTR_CRSRST))
+#define __CRS_RELEASE_RESET()    (RCC->APB1RSTR &= ~(RCC_APB1RSTR_CRSRST))
+#endif /* !(STM32L051xx ) && !(STM32L061xx ) */
+
+#if defined(STM32L053xx) || defined(STM32L063xx)
+#define __LCD_FORCE_RESET()           (RCC->APB1RSTR |= (RCC_APB1RSTR_LCDRST))
+#define __LCD_RELEASE_RESET()         (RCC->APB1RSTR &= ~ (RCC_APB1RSTR_LCDRST))
+#endif /* STM32L053xx || STM32L063xx  */
+
+/** @brief  Force or release APB2 peripheral reset.
+  */ 
+#if defined(STM32L053xx) || defined(STM32L063xx) || \
+    defined(STM32L052xx) || defined(STM32L062xx) || \
+    defined(STM32L051xx) || defined(STM32L061xx)
+#define __USART1_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_USART1RST))
+#define __ADC1_FORCE_RESET()       (RCC->APB2RSTR |= (RCC_APB2RSTR_ADC1RST))
+#define __SPI1_FORCE_RESET()       (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI1RST))
+#define __TIM21_FORCE_RESET()      (RCC->APB2RSTR |= (RCC_APB2RSTR_TIM21RST))
+#define __TIM22_FORCE_RESET()      (RCC->APB2RSTR |= (RCC_APB2RSTR_TIM22RST))
+
+#define __USART1_RELEASE_RESET()     (RCC->APB2RSTR &= ~ (RCC_APB2RSTR_USART1RST))
+#define __ADC1_RELEASE_RESET()       (RCC->APB2RSTR &= ~ (RCC_APB2RSTR_ADC1RST))
+#define __SPI1_RELEASE_RESET()       (RCC->APB2RSTR &= ~ (RCC_APB2RSTR_SPI1RST))
+#define __TIM21_RELEASE_RESET()      (RCC->APB2RSTR &= ~ (RCC_APB2RSTR_TIM21RST))
+#define __TIM22_RELEASE_RESET()      (RCC->APB2RSTR &= ~ (RCC_APB2RSTR_TIM22RST))
+#endif /* STM32L051xx  || STM32L061xx  || */
+       /* STM32L052xx  || STM32L062xx  || */
+       /* STM32L053xx  || STM32L063xx  || */
+
+/** @brief  Enable or disable the AHB peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+
+#if !defined(STM32L051xx) && !defined(STM32L061xx)
+#define __TSC_CLK_SLEEP_ENABLE()           (RCC->AHBSMENR |= (RCC_AHBSMENR_TSCSMEN))
+#define __RNG_CLK_SLEEP_ENABLE()           (RCC->AHBSMENR |= (RCC_AHBSMENR_RNGSMEN))
+#define __TSC_CLK_SLEEP_DISABLE()          (RCC->AHBSMENR  &= ~ (RCC_AHBSMENR_TSCSMEN))
+#define __RNG_CLK_SLEEP_DISABLE()          (RCC->AHBSMENR  &= ~ (RCC_AHBSMENR_RNGSMEN))
+#endif /* !(STM32L051xx ) && !(STM32L061xx ) */
+       
+#if defined(STM32L062xx) || defined(STM32L063xx)
+#define __CRYP_CLK_SLEEP_ENABLE()          (RCC->AHBLPENR |= (RCC_AHBSMENR_CRYPSMEN))
+#define __CRYP_CLK_SLEEP_DISABLE()         (RCC->AHBLPENR  &= ~ (RCC_AHBSMENR_CRYPSMEN))
+#endif /* STM32L062xx || STM32L063xx  */
+
+
+/** @brief  Enable or disable the APB1 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+
+#if defined(STM32L053xx) || defined(STM32L063xx) || \
+    defined(STM32L052xx) || defined(STM32L062xx) || \
+    defined(STM32L051xx) || defined(STM32L061xx)
+#define __TIM2_CLK_SLEEP_ENABLE()    (RCC->APB1SMENR |= (RCC_APB1SMENR_TIM2SMEN))
+#define __TIM6_CLK_SLEEP_ENABLE()    (RCC->APB1SMENR |= (RCC_APB1SMENR_TIM6SMEN))
+#define __SPI2_CLK_SLEEP_ENABLE()    (RCC->APB1SMENR |= (RCC_APB1SMENR_SPI2SMEN))
+#define __USART2_CLK_SLEEP_ENABLE()  (RCC->APB1SMENR |= (RCC_APB1SMENR_USART2SMEN))
+#define __LPUART1_CLK_SLEEP_ENABLE()  (RCC->APB1SMENR |= (RCC_APB1SMENR_LPUART1SMEN))
+#define __I2C1_CLK_SLEEP_ENABLE()    (RCC->APB1SMENR |= (RCC_APB1SMENR_I2C1SMEN))
+#define __I2C2_CLK_SLEEP_ENABLE()    (RCC->APB1SMENR |= (RCC_APB1SMENR_I2C2SMEN))
+#define __DAC_CLK_SLEEP_ENABLE()     (RCC->APB1SMENR |= (RCC_APB1SMENR_DACSMEN))
+#define __LPTIM1_CLK_SLEEP_ENABLE()   (RCC->APB1SMENR |= (RCC_APB1SMENR_LPTIM1SMEN))
+
+#define __TIM2_CLK_SLEEP_DISABLE()    (RCC->APB1SMENR &= ~ (RCC_APB1SMENR_TIM2SMEN))
+#define __TIM6_CLK_SLEEP_DISABLE()    (RCC->APB1SMENR &= ~ (RCC_APB1SMENR_TIM6SMEN))
+#define __SPI2_CLK_SLEEP_DISABLE()    (RCC->APB1SMENR &= ~ (RCC_APB1SMENR_SPI2SMEN))
+#define __USART2_CLK_SLEEP_DISABLE()  (RCC->APB1SMENR &= ~ (RCC_APB1SMENR_USART2SMEN))
+#define __LPUART1_CLK_SLEEP_DISABLE()  (RCC->APB1SMENR &= ~ (RCC_APB1SMENR_LPUART1SMEN))
+#define __I2C1_CLK_SLEEP_DISABLE()    (RCC->APB1SMENR &= ~ (RCC_APB1SMENR_I2C1SMEN))
+#define __I2C2_CLK_SLEEP_DISABLE()    (RCC->APB1SMENR &= ~ (RCC_APB1SMENR_I2C2SMEN))
+#define __DAC_CLK_SLEEP_DISABLE()     (RCC->APB1SMENR &= ~ (RCC_APB1SMENR_DACSMEN))
+#define __LPTIM1_CLK_SLEEP_DISABLE()   (RCC->APB1SMENR &= ~ (RCC_APB1SMENR_LPTIM1SMEN))
+#endif /* STM32L051xx  || STM32L061xx  || */
+       /* STM32L052xx  || STM32L062xx  || */
+       /* STM32L053xx  || STM32L063xx  || */
+       
+#if !defined(STM32L051xx) && !defined(STM32L061xx)
+#define __USB_CLK_SLEEP_ENABLE()   (RCC->APB1SMENR |= (RCC_APB1SMENR_USBSMEN))
+#define __USB_CLK_SLEEP_DISABLE()  (RCC->APB1SMENR &= ~ (RCC_APB1SMENR_USBSMEN))
+
+#define __CRS_CLK_SLEEP_ENABLE()   (RCC->APB1SMENR |= (RCC_APB1SMENR_CRSSMEN))
+#define __CRS_CLK_SLEEP_DISABLE()  (RCC->APB1SMENR &= ~ (RCC_APB1SMENR_CRSSMEN))
+#endif /* !(STM32L051xx ) && !(STM32L061xx ) */
+
+#if defined(STM32L053xx) || defined(STM32L063xx)
+#define __LCD_CLK_SLEEP_ENABLE()      (RCC->APB1SMENR |= (RCC_APB1SMENR_LCDSMEN))
+#define __LCD_CLK_SLEEP_DISABLE()     (RCC->APB1SMENR &= ~ (RCC_APB1SMENR_LCDSMEN))
+#endif /* STM32L053xx || STM32L063xx  */
+
+/** @brief  Enable or disable the APB2 peripheral clock during Low Power (Sleep) mode.
+  * @note   Peripheral clock gating in SLEEP mode can be used to further reduce
+  *         power consumption.
+  * @note   After wakeup from SLEEP mode, the peripheral clock is enabled again.
+  * @note   By default, all peripheral clocks are enabled during SLEEP mode.
+  */
+#if defined(STM32L053xx) || defined(STM32L063xx) || \
+    defined(STM32L052xx) || defined(STM32L062xx) || \
+    defined(STM32L051xx) || defined(STM32L061xx)
+#define __TIM21_CLK_SLEEP_ENABLE()    (RCC->APB2SMENR |= (RCC_APB2SMENR_TIM21SMEN))
+#define __TIM22_CLK_SLEEP_ENABLE()    (RCC->APB2SMENR |= (RCC_APB2SMENR_TIM22SMEN))
+#define __ADC1_CLK_SLEEP_ENABLE()     (RCC->APB2SMENR |= (RCC_APB2SMENR_ADC1SMEN))
+#define __SPI1_CLK_SLEEP_ENABLE()     (RCC->APB2SMENR |= (RCC_APB2SMENR_SPI1SMEN))
+#define __USART1_CLK_SLEEP_ENABLE()   (RCC->APB2SMENR |= (RCC_APB2SMENR_USART1SMEN))
+
+#define __TIM21_CLK_SLEEP_DISABLE()    (RCC->APB2SMENR &= ~  (RCC_APB2SMENR_TIM21SMEN))
+#define __TIM22_CLK_SLEEP_DISABLE()    (RCC->APB2SMENR &= ~  (RCC_APB2SMENR_TIM22SMEN))
+#define __ADC1_CLK_SLEEP_DISABLE()     (RCC->APB2SMENR &= ~  (RCC_APB2SMENR_ADC1SMEN))
+#define __SPI1_CLK_SLEEP_DISABLE()     (RCC->APB2SMENR &= ~  (RCC_APB2SMENR_SPI1SMEN))
+#define __USART1_CLK_SLEEP_DISABLE()   (RCC->APB2SMENR &= ~  (RCC_APB2SMENR_USART1SMEN))
+#endif /* STM32L051xx  || STM32L061xx  || */
+       /* STM32L052xx  || STM32L062xx  || */
+       /* STM32L053xx  || STM32L063xx  || */
+
+/** @brief macro to configure the I2C1 clock (I2C1CLK).
+  *
+  * @param  __I2C1CLKSource__: specifies the I2C1 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_I2C1CLKSOURCE_PCLK1: PCLK1 selected as I2C1 clock  
+  *            @arg RCC_I2C1CLKSOURCE_HSI: HSI selected as I2C1 clock
+  *            @arg RCC_I2C1CLKSOURCE_SYSCLK: System Clock selected as I2C1 clock 
+  */
+#define __HAL_RCC_I2C1_CONFIG(__I2C1CLKSource__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_I2C1SEL, (uint32_t)(__I2C1CLKSource__))
+
+/** @brief  macro to get the I2C1 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_I2C1CLKSOURCE_PCLK1: PCLK1 selected as I2C1 clock  
+  *            @arg RCC_I2C1CLKSOURCE_HSI: HSI selected as I2C1 clock
+  *            @arg RCC_I2C1CLKSOURCE_SYSCLK: System Clock selected as I2C1 clock
+  */
+#define __HAL_RCC_GET_I2C1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_I2C1SEL)))
+
+/** @brief macro to configure the USART1 clock (USART1CLK).
+  *
+  * @param  __USART1CLKSource__: specifies the USART1 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_USART1CLKSOURCE_PCLK2: PCLK2 selected as USART1 clock
+  *            @arg RCC_USART1CLKSOURCE_HSI: HSI selected as USART1 clock
+  *            @arg RCC_USART1CLKSOURCE_SYSCLK: System Clock selected as USART1 clock
+  *            @arg RCC_USART1CLKSOURCE_LSE: LSE selected as USART1 clock
+  */
+#define __HAL_RCC_USART1_CONFIG(__USART1CLKSource__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_USART1SEL, (uint32_t)(__USART1CLKSource__))
+
+/** @brief  macro to get the USART1 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_USART1CLKSOURCE_PCLK2: PCLK2 selected as USART1 clock
+  *            @arg RCC_USART1CLKSOURCE_HSI: HSI selected as USART1 clock
+  *            @arg RCC_USART1CLKSOURCE_SYSCLK: System Clock selected as USART1 clock
+  *            @arg RCC_USART1CLKSOURCE_LSE: LSE selected as USART1 clock
+  */
+#define __HAL_RCC_GET_USART1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_USART1SEL)))
+
+/** @brief macro to configure the USART2 clock (USART2CLK).
+  *
+  * @param  __USART2CLKSource__: specifies the USART2 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_USART2CLKSOURCE_PCLK1: PCLK1 selected as USART2 clock
+  *            @arg RCC_USART2CLKSOURCE_HSI: HSI selected as USART2 clock
+  *            @arg RCC_USART2CLKSOURCE_SYSCLK: System Clock selected as USART2 clock
+  *            @arg RCC_USART2CLKSOURCE_LSE: LSE selected as USART2 clock
+  */
+#define __HAL_RCC_USART2_CONFIG(__USART2CLKSource__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_USART2SEL, (uint32_t)(__USART2CLKSource__))
+
+/** @brief  macro to get the USART2 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_USART2CLKSOURCE_PCLK1: PCLK1 selected as USART2 clock
+  *            @arg RCC_USART2CLKSOURCE_HSI: HSI selected as USART2 clock
+  *            @arg RCC_USART2CLKSOURCE_SYSCLK: System Clock selected as USART2 clock
+  *            @arg RCC_USART2CLKSOURCE_LSE: LSE selected as USART2 clock
+  */
+#define __HAL_RCC_GET_USART2_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_USART2SEL)))
+
+/** @brief macro to configure the LPUART1 clock (LPUART1CLK).
+  *
+  * @param  __LPUART1CLKSource__: specifies the LPUART1 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_LPUART1CLKSOURCE_PCLK1: PCLK1 selected as LPUART1 clock
+  *            @arg RCC_LPUART1CLKSOURCE_HSI: HSI selected as LPUART1 clock
+  *            @arg RCC_LPUART1CLKSOURCE_SYSCLK: System Clock selected as LPUART1 clock
+  *            @arg RCC_LPUART1CLKSOURCE_LSE: LSE selected as LPUART1 clock
+  */
+#define __HAL_RCC_LPUART1_CONFIG(__LPUART1CLKSource__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_LPUART1SEL, (uint32_t)(__LPUART1CLKSource__))
+
+/** @brief  macro to get the LPUART1 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_LPUART1CLKSOURCE_PCLK1: PCLK1 selected as LPUART1 clock
+  *            @arg RCC_LPUART1CLKSOURCE_HSI: HSI selected as LPUART1 clock
+  *            @arg RCC_LPUART1CLKSOURCE_SYSCLK: System Clock selected as LPUART1 clock
+  *            @arg RCC_LPUART1CLKSOURCE_LSE: LSE selected as LPUART1 clock
+  */
+#define __HAL_RCC_GET_LPUART1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_LPUART1SEL)))
+
+/** @brief macro to configure the LPTIM1 clock (LPTIM1CLK).
+  *
+  * @param  __LPTIM1CLKSource__: specifies the LPTIM1 clock source.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_LPTIM1CLKSOURCE_PCLK: PCLK selected as LPTIM1 clock
+  *            @arg RCC_LPTIM1CLKSOURCE_LSI : HSI  selected as LPTIM1 clock
+  *            @arg RCC_LPTIM1CLKSOURCE_HSI : LSI  selected as LPTIM1 clock
+  *            @arg RCC_LPTIM1CLKSOURCE_LSE : LSE  selected as LPTIM1 clock
+  */
+#define __HAL_RCC_LPTIM1_CONFIG(__LPTIM1CLKSource__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_LPTIM1SEL, (uint32_t)(__LPTIM1CLKSource__))
+
+/** @brief  macro to get the LPTIM1 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_LPTIM1CLKSOURCE_PCLK: PCLK selected as LPUART1 clock
+  *            @arg RCC_LPTIM1CLKSOURCE_LSI : HSI selected as LPUART1 clock
+  *            @arg RCC_LPTIM1CLKSOURCE_HSI : System Clock selected as LPUART1 clock
+  *            @arg RCC_LPTIM1CLKSOURCE_LSE : LSE selected as LPUART1 clock
+  */
+#define __HAL_RCC_GET_LPTIM1_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_LPTIM1SEL)))
+
+#if !defined(STM32L051xx) && !defined(STM32L061xx)
+/** @brief  Macro to configure the USB clock (USBCLK).
+  * @param  __USBCLKSource__: specifies the USB clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_USBCLKSOURCE_HSI48:  HSI48 selected as USB clock
+  *            @arg RCC_USBCLKSOURCE_PLLCLK: PLL Clock selected as USB clock
+  */
+#define __HAL_RCC_USB_CONFIG(__USBCLKSource__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_HSI48SEL, (uint32_t)(__USBCLKSource__))
+
+/** @brief  Macro to get the USB clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_USBCLKSOURCE_HSI48:  HSI48 selected as USB clock
+  *            @arg RCC_USBCLKSOURCE_PLLCLK: PLL Clock selected as USB clock
+  */
+#define __HAL_RCC_GET_USB_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_HSI48SEL)))
+
+/** @brief  Macro to configure the RNG clock (RNGCLK).
+  * @param  __RNGCLKSource__: specifies the USB clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_RNGCLKSOURCE_HSI48:  HSI48 selected as RNG clock
+  *            @arg RCC_RNGCLKSOURCE_PLLCLK: PLL Clock selected as RNG clock
+  */
+#define __HAL_RCC_RNG_CONFIG(__RNGCLKSource__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_HSI48SEL, (uint32_t)(__RNGCLKSource__))
+
+/** @brief  Macro to get the RNG clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_RNGCLKSOURCE_HSI48:  HSI48 selected as RNG clock
+  *            @arg RCC_RNGCLKSOURCE_PLLCLK: PLL Clock selected as RNG clock
+  */
+#define __HAL_RCC_GET_RNG_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_HSI48SEL)))
+
+/** @brief macro to select the HSI48M clock source 
+  * @note   This macro can be replaced by either __HAL_RCC_RNG_CONFIG or
+  *         __HAL_RCC_USB_CONFIG to configure respectively RNG or UBS clock sources.
+  *
+  * @param  __HSI48MCLKSource__: specifies the HSI48M clock source dedicated for 
+  *          USB an RNG peripherals.                 
+  *          This parameter can be one of the following values:
+  *            @arg RCC_HSI48M_PLL: A dedicated 48MHZ PLL output.
+  *            @arg RCC_HSI48M_RC48: 48MHZ issued from internal HSI48 oscillator. 
+  */
+#define __HAL_RCC_HSI48M_CONFIG(__HSI48MCLKSource__) \
+                  MODIFY_REG(RCC->CCIPR, RCC_CCIPR_HSI48SEL, (uint32_t)(__HSI48MCLKSource__))                    
+
+/** @brief  macro to get the HSI48M clock source.
+  * @note   This macro can be replaced by either __HAL_RCC_GET_RNG_SOURCE or
+  *         __HAL_RCC_GET_USB_SOURCE to get respectively RNG or UBS clock sources.
+  * @retval The clock source can be one of the following values:
+  *           @arg RCC_HSI48M_PLL: A dedicated 48MHZ PLL output.
+  *            @arg RCC_HSI48M_RC48: 48MHZ issued from internal HSI48 oscillator. 
+  */
+#define __HAL_RCC_GET_HSI48M_SOURCE() ((uint32_t)(READ_BIT(RCC->CCIPR, RCC_CCIPR_HSI48SEL)))       
+#endif /* !(STM32L051xx ) && !(STM32L061xx ) */
+
+/**
+  * @brief    Macros to enable or disable the force of the Internal High Speed oscillator (HSI)
+  *           in STOP mode to be quickly available as kernel clock for USART and I2C.
+  * @note     The Enable of this function has not effect on the HSION bit.
+  *   This parameter can be: ENABLE or DISABLE.
+  * @retval None
+  */
+#define __HAL_RCC_HSISTOP_ENABLE()  SET_BIT(RCC->CR, RCC_CR_HSIKERON)
+#define __HAL_RCC_HSISTOP_DISABLE() CLEAR_BIT(RCC->CR, RCC_CR_HSIKERON)                   
+
+/**
+  * @brief  Macro to configures the External Low Speed oscillator (LSE) drive capability.
+  * @param  RCC_LSEDrive: specifies the new state of the LSE drive capability.
+  *          This parameter can be one of the following values:
+  *            @arg RCC_LSEDRIVE_LOW: LSE oscillator low drive capability.
+  *            @arg RCC_LSEDRIVE_MEDIUMLOW: LSE oscillator medium low drive capability.
+  *            @arg RCC_LSEDRIVE_MEDIUMHIGH: LSE oscillator medium high drive capability.
+  *            @arg RCC_LSEDRIVE_HIGH: LSE oscillator high drive capability.
+  * @retval None
+  */ 
+#define __HAL_RCC_LSEDRIVE_CONFIG(__RCC_LSEDrive__) (MODIFY_REG(RCC->CSR,\
+        RCC_CSR_LSEDRV, (uint32_t)(__RCC_LSEDrive__) ))
+
+/**
+  * @brief  Macro to configures the wake up from stop clock.
+  * @param  RCC_STOPWUCLK: specifies the clock source used after wake up from stop 
+  *   This parameter can be one of the following values:
+  *     @arg RCC_StopWakeUpClock_MSI:    MSI selected as system clock source
+  *     @arg RCC_StopWakeUpClock_HSI:    HSI selected as system clock source
+  * @retval None
+  */
+#define __HAL_RCC_WAKEUPSTOP_CLK_CONFIG(__RCC_STOPWUCLK__) (MODIFY_REG(RCC->CFGR,\
+        RCC_CFGR_STOPWUCK, (uint32_t)(__RCC_STOPWUCLK__) ))
+ 
+#if !defined(STM32L051xx) && !defined(STM32L061xx)
+/**
+  * @brief  Enables the specified CRS interrupts.
+  * @param  __INTERRUPT__: specifies the CRS interrupt sources to be enabled.
+  *          This parameter can be any combination of the following values:
+  *              @arg RCC_CRS_IT_SYNCOK
+  *              @arg RCC_CRS_IT_SYNCWARN
+  *              @arg RCC_CRS_IT_ERR
+  *              @arg RCC_CRS_IT_ESYNC
+  * @retval None
+  */
+#define __HAL_RCC_CRS_ENABLE_IT(__INTERRUPT__)   (CRS->CR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disables the specified CRS interrupts.
+  * @param  __INTERRUPT__: specifies the CRS interrupt sources to be disabled.
+  *          This parameter can be any combination of the following values:
+  *              @arg RCC_CRS_IT_SYNCOK
+  *              @arg RCC_CRS_IT_SYNCWARN
+  *              @arg RCC_CRS_IT_ERR
+  *              @arg RCC_CRS_IT_ESYNC
+  * @retval None
+  */
+#define __HAL_RCC_CRS_DISABLE_IT(__INTERRUPT__)  (CRS->CR &= ~(__INTERRUPT__))
+
+/** @brief  Check the CRS's interrupt has occurred or not.
+  * @param  __INTERRUPT__: specifies the CRS interrupt source to check.
+  *         This parameter can be one of the following values:
+  *              @arg RCC_CRS_IT_SYNCOK
+  *              @arg RCC_CRS_IT_SYNCWARN
+  *              @arg RCC_CRS_IT_ERR
+  *              @arg RCC_CRS_IT_ESYNC
+  * @retval The new state of __INTERRUPT__ (SET or RESET).
+  */
+#define __HAL_RCC_CRS_GET_IT_SOURCE(__INTERRUPT__)     ((CRS->CR & (__INTERRUPT__))? SET : RESET)
+
+/** @brief  Clear the CRS's interrupt pending bits
+  *         bits to clear the selected interrupt pending bits.
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear.
+  *         This parameter can be any combination of the following values:
+  *              @arg RCC_CRS_IT_SYNCOK
+  *              @arg RCC_CRS_IT_SYNCWARN
+  *              @arg RCC_CRS_IT_ERR
+  *              @arg RCC_CRS_IT_ESYNC
+  *              @arg RCC_CRS_IT_TRIMOVF
+  *              @arg RCC_CRS_IT_SYNCERR
+  *              @arg RCC_CRS_IT_SYNCMISS
+  */
+/* CRS IT Error Mask */
+#define  RCC_CRS_IT_ERROR_MASK                 ((uint32_t)(RCC_CRS_IT_TRIMOVF | RCC_CRS_IT_SYNCERR | RCC_CRS_IT_SYNCMISS))
+
+#define __HAL_RCC_CRS_CLEAR_IT(__INTERRUPT__)   ((((__INTERRUPT__) &  RCC_CRS_IT_ERROR_MASK)!= 0) ? (CRS->ICR |= CRS_ICR_ERRC) : \
+                                            (CRS->ICR = (__INTERRUPT__)))
+
+/**
+  * @brief  Checks whether the specified CRS flag is set or not.
+  * @param  _FLAG_: specifies the flag to check.
+  *          This parameter can be one of the following values:
+  *              @arg RCC_CRS_FLAG_SYNCOK
+  *              @arg RCC_CRS_FLAG_SYNCWARN
+  *              @arg RCC_CRS_FLAG_ERR
+  *              @arg RCC_CRS_FLAG_ESYNC
+  *              @arg RCC_CRS_FLAG_TRIMOVF
+  *              @arg RCC_CRS_FLAG_SYNCERR
+  *              @arg RCC_CRS_FLAG_SYNCMISS
+  * @retval The new state of _FLAG_ (TRUE or FALSE).
+  */
+#define __HAL_RCC_CRS_GET_FLAG(_FLAG_)  ((CRS->ISR & (_FLAG_)) == (_FLAG_))
+
+/**
+  * @brief  Clears the CRS specified FLAG.
+  * @param _FLAG_: specifies the flag to clear.
+  *          This parameter can be one of the following values:
+  *              @arg RCC_CRS_FLAG_SYNCOK
+  *              @arg RCC_CRS_FLAG_SYNCWARN
+  *              @arg RCC_CRS_FLAG_ERR
+  *              @arg RCC_CRS_FLAG_ESYNC
+  *              @arg RCC_CRS_FLAG_TRIMOVF
+  *              @arg RCC_CRS_FLAG_SYNCERR
+  *              @arg RCC_CRS_FLAG_SYNCMISS
+  * @retval None
+  */
+
+/* CRS Flag Error Mask */
+#define RCC_CRS_FLAG_ERROR_MASK                 ((uint32_t)(RCC_CRS_FLAG_TRIMOVF | RCC_CRS_FLAG_SYNCERR | RCC_CRS_FLAG_SYNCMISS))
+
+#define __HAL_RCC_CRS_CLEAR_FLAG(__FLAG__)   ((((__FLAG__) & RCC_CRS_FLAG_ERROR_MASK)!= 0) ? (CRS->ICR |= CRS_ICR_ERRC) : \
+                                            (CRS->ICR = (__FLAG__)))
+
+
+/**
+  * @brief  Enables the oscillator clock for frequency error counter.
+  * @note   when the CEN bit is set the CRS_CFGR register becomes write-protected.
+  * @param  None
+  * @retval None
+  */
+#define __HAL_RCC_CRS_ENABLE_FREQ_ERROR_COUNTER() (CRS->CR |= CRS_CR_CEN)
+
+/**
+  * @brief  Disables the oscillator clock for frequency error counter.
+  * @param  None
+  * @retval None
+  */
+#define __HAL_RCC_CRS_DISABLE_FREQ_ERROR_COUNTER()  (CRS->CR &= ~CRS_CR_CEN)
+
+/**
+  * @brief  Enables the automatic hardware adjustment of TRIM bits.
+  * @note   When the AUTOTRIMEN bit is set the CRS_CFGR register becomes write-protected.
+  * @param  None
+  * @retval None
+  */
+#define __HAL_RCC_CRS_ENABLE_AUTOMATIC_CALIB()  (CRS->CR |= CRS_CR_AUTOTRIMEN)
+
+/**
+  * @brief  Enables or disables the automatic hardware adjustment of TRIM bits.
+  * @param  None
+  * @retval None
+  */
+#define __HAL_RCC_CRS_DISABLE_AUTOMATIC_CALIB()  (CRS->CR &= ~CRS_CR_AUTOTRIMEN)
+
+/**
+  * @brief  Macro to calculate reload value to be set in CRS register according to target and sync frequencies
+  * @note   The RELOAD value should be selected according to the ratio between the target frequency and the frequency 
+  *             of the synchronization source after prescaling. It is then decreased by one in order to 
+  *             reach the expected synchronization on the zero value. The formula is the following:
+  *             RELOAD = (fTARGET / fSYNC) -1
+  * @param  _FTARGET_ Target frequency (value in Hz)
+  * @param  _FSYNC_ Synchronization signal frequency (value in Hz)
+  * @retval None
+  */
+#define __HAL_RCC_CRS_CALCULATE_RELOADVALUE(_FTARGET_, _FSYNC_)  (((_FTARGET_) / (_FSYNC_)) - 1)
+
+#endif /* !(STM32L051xx) && !(STM32L061xx) */
+
+/**
+  * @}
+  */
+
+        
+/* Exported functions --------------------------------------------------------*/
+HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit);
+void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit);
+void HAL_RCCEx_EnableLSECSS(void);
+void HAL_RCCEx_DisableLSECSS(void);
+#if !defined(STM32L051xx) && !defined(STM32L061xx)
+void                  HAL_RCCEx_CRSConfig(RCC_CRSInitTypeDef *pInit);
+void                  HAL_RCCEx_CRSSoftwareSynchronizationGenerate(void);
+void                  HAL_RCCEx_CRSGetSynchronizationInfo(RCC_CRSSynchroInfoTypeDef *pSynchroInfo);
+RCC_CRSStatusTypeDef  HAL_RCCEx_CRSWaitSynchronization(uint32_t Timeout);
+#endif /* !(STM32L051xx) && !(STM32L061xx) */
+       
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_RCC_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rng.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rng.c
@@ -1,0 +1,429 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_rng.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   RNG HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Random Number Generator (RNG) peripheral:
+  *           + Initialization/de-initialization functions
+  *           + Peripheral Control functions 
+  *           + Peripheral State functions
+  *         
+  @verbatim
+  ==============================================================================
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      The RNG HAL driver can be used as follows:
+
+         (#) Enable the RNG controller clock using __RNG_CLK_ENABLE() macro.
+         (#) Activate the RNG peripheral using __HAL_RNG_ENABLE() macro.
+         (#) Wait until the 32 bit Random Number Generator contains a valid 
+             random data using (polling/interrupt) mode.   
+         (#) Get the 32 bit random number using HAL_RNG_GetRandomNumber() function.
+  
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RNG 
+  * @brief RNG HAL module driver.
+  * @{
+  */
+
+#ifdef HAL_RNG_MODULE_ENABLED
+#if !defined (STM32L051xx) && !defined (STM32L061xx)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define RNG_TIMEOUT_VALUE     1000
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup RNG_Private_Functions
+  * @{
+  */
+
+/** @defgroup RNG_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions. 
+ *
+@verbatim    
+ ===============================================================================
+          ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize the RNG according to the specified parameters 
+          in the RNG_InitTypeDef and create the associated handle
+      (+) DeInitialize the RNG peripheral
+      (+) Initialize the RNG MSP
+      (+) DeInitialize RNG MSP 
+ 
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the RNG according to the specified
+  *         parameters in the RNG_InitTypeDef and creates the associated handle.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RNG_Init(RNG_HandleTypeDef *hrng)
+{ 
+  /* Check the RNG handle allocation */
+  if(hrng == NULL)
+  {
+    return HAL_ERROR;
+  }
+   
+  if(hrng->State == HAL_RNG_STATE_RESET)
+  {
+    /* Init the low level hardware */
+    HAL_RNG_MspInit(hrng);
+  }
+
+  /* Change RNG peripheral state */
+  hrng->State = HAL_RNG_STATE_BUSY;
+  
+  /* Enable the RNG Peripheral */
+  __HAL_RNG_ENABLE(hrng);
+  
+  /* Initialize the RNG state */
+  hrng->State = HAL_RNG_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the RNG peripheral. 
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RNG_DeInit(RNG_HandleTypeDef *hrng)
+{ 
+  /* Check the RNG peripheral state */
+  if(hrng->State == HAL_RNG_STATE_BUSY)
+  {
+    return HAL_BUSY;
+  }
+  
+  /* Update the RNG state */  
+  hrng->State = HAL_RNG_STATE_BUSY;
+  
+  /* Disable the RNG Peripheral */
+  __HAL_RNG_DISABLE(hrng);
+  
+  /* Set the RNG registers to their reset values */
+  hrng->Instance->CR &= 0xFFFFFFF3;
+  hrng->Instance->SR &= 0xFFFFFF98;
+  hrng->Instance->DR &= 0x0;
+  
+  /* DeInit the low level hardware */
+  HAL_RNG_MspDeInit(hrng);
+  
+  /* Update the RNG state */    
+  hrng->State = HAL_RNG_STATE_RESET; 
+  
+  /* Release Lock */
+  __HAL_UNLOCK(hrng);
+
+  /* Return the function status */  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the RNG MSP.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval None
+  */
+__weak void HAL_RNG_MspInit(RNG_HandleTypeDef *hrng)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RNG_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes the RNG MSP.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval None
+  */
+__weak void HAL_RNG_MspDeInit(RNG_HandleTypeDef *hrng)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RNG_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RNG_Group2 Peripheral Control functions 
+ *  @brief    management functions. 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Get the 32 bit Random number
+      (+) Get the 32 bit Random number with interrupt enabled
+      (+) Handle RNG interrupt request 
+
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns a 32-bit random number.
+  * @note   Each time the random number data is read the RNG_FLAG_DRDY flag 
+  *         is automatically cleared.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval 32-bit random number
+  */
+uint32_t HAL_RNG_GetRandomNumber(RNG_HandleTypeDef *hrng)
+{
+  uint32_t random32bit = 0;
+  uint32_t tickstart = 0;    
+  
+  /* Process Locked */
+  __HAL_LOCK(hrng); 
+  
+  /* Get timeout */
+  tickstart = HAL_GetTick();
+  
+  /* Check if data register contains valid random data */
+  while(__HAL_RNG_GET_FLAG(hrng, RNG_FLAG_DRDY) == RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > RNG_TIMEOUT_VALUE)
+    {    
+      return HAL_TIMEOUT;
+    } 
+  }
+  
+  /* Get a 32bit Random number */ 
+  random32bit = hrng->Instance->DR;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrng);
+  
+  /* Return the 32 bit random number */   
+  return random32bit;
+}
+
+/**
+  * @brief  Returns a 32-bit random number with interrupt enabled.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval 32-bit random number
+  */
+uint32_t HAL_RNG_GetRandomNumber_IT(RNG_HandleTypeDef *hrng)
+{
+  uint32_t random32bit = 0;
+  
+  /* Process Locked */
+  __HAL_LOCK(hrng);
+  
+  /* Change RNG peripheral state */  
+  hrng->State = HAL_RNG_STATE_BUSY;  
+  
+  /* Get a 32bit Random number */ 
+  random32bit = hrng->Instance->DR;
+  
+  /* Enable the RNG Interrupts: Data Ready, Clock error, Seed error */ 
+  __HAL_RNG_ENABLE_IT(hrng); 
+  
+  /* Return the 32 bit random number */   
+  return random32bit;
+}
+
+/**
+  * @brief  Handles RNG interrupt request.
+  * @note   In the case of a clock error, the RNG is no more able to generate 
+  *         random numbers because the PLL48CLK clock is not correct. User has 
+  *         to check that the clock controller is correctly configured to provide
+  *         the RNG clock and clear the CEIS bit using __HAL_RNG_CLEAR_FLAG(). 
+  *         The clock error has no impact on the previously generated 
+  *         random numbers, and the RNG_DR register contents can be used.
+  * @note   In the case of a seed error, the generation of random numbers is 
+  *         interrupted as long as the SECS bit is '1'. If a number is 
+  *         available in the RNG_DR register, it must not be used because it may 
+  *         not have enough entropy. In this case, it is recommended to clear the 
+  *         SEIS bit using __HAL_RNG_CLEAR_FLAG(), then disable and enable 
+  *         the RNG peripheral to reinitialize and restart the RNG.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval None
+
+  */
+void HAL_RNG_IRQHandler(RNG_HandleTypeDef *hrng)
+{
+  /* RNG clock error interrupt occurred */
+  if(__HAL_RNG_GET_FLAG(hrng, RNG_IT_CEI) != RESET)
+  { 
+    HAL_RNG_ErrorCallback(hrng);
+    
+    /* Clear the clock error flag */
+    __HAL_RNG_CLEAR_FLAG(hrng, RNG_IT_CEI);
+    
+    /* Change RNG peripheral state */
+    hrng->State = HAL_RNG_STATE_ERROR;
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrng);
+  }
+  
+  /* RNG seed error interrupt occurred */
+  if(__HAL_RNG_GET_FLAG(hrng, RNG_IT_SEI) != RESET)
+  { 
+    HAL_RNG_ErrorCallback(hrng);
+    
+    /* Clear the seed error flag */
+    __HAL_RNG_CLEAR_FLAG(hrng, RNG_IT_SEI);
+    
+    /* Change RNG peripheral state */
+    hrng->State = HAL_RNG_STATE_ERROR;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrng);    
+  }
+  
+  /* Check RNG data ready flag */    
+  if(__HAL_RNG_GET_FLAG(hrng, RNG_FLAG_DRDY) != RESET)
+  {
+    /* Data Ready callback */ 
+    HAL_RNG_ReadyCallback(hrng);
+    
+    /* Change RNG peripheral state */
+    hrng->State = HAL_RNG_STATE_READY; 
+      
+    /* Clear the RNG Data Ready flag */
+    __HAL_RNG_CLEAR_FLAG(hrng, RNG_FLAG_DRDY);
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrng);
+  }
+} 
+
+/**
+  * @brief  Data Ready callback in non-blocking mode. 
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval None
+  */
+
+__weak void HAL_RNG_ReadyCallback(RNG_HandleTypeDef* hrng)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RNG_ReadyCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  RNG error callbacks.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval None
+  */
+__weak void HAL_RNG_ErrorCallback(RNG_HandleTypeDef *hrng)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RNG_ErrorCallback could be implemented in the user file
+   */ 
+}
+ 
+/**
+  * @}
+  */
+
+/** @defgroup RNG_Group3 Peripheral State functions 
+ *  @brief    Peripheral State functions. 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================  
+    [..]
+    This subsection permits to get in run-time the status of the peripheral 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the RNG state.
+  * @param  hrng: pointer to a RNG_HandleTypeDef structure that contains
+  *                the configuration information for RNG.
+  * @retval HAL state
+  */
+HAL_RNG_StateTypeDef HAL_RNG_GetState(RNG_HandleTypeDef *hrng)
+{
+  return hrng->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+#endif /* STM32L051xx && STM32L061xx*/
+#endif /* HAL_RNG_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+                  

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rng.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rng.h
@@ -1,0 +1,224 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_rng.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of RNG HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_RNG_H
+#define __STM32L0xx_HAL_RNG_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !defined (STM32L051xx) && !defined (STM32L061xx)
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RNG
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+
+/** 
+  * @brief  RNG HAL State Structure definition  
+  */ 
+typedef enum
+{
+  HAL_RNG_STATE_RESET     = 0x00,  /*!< RNG not yet initialized or disabled */
+  HAL_RNG_STATE_READY     = 0x01,  /*!< RNG initialized and ready for use   */
+  HAL_RNG_STATE_BUSY      = 0x02,  /*!< RNG internal process is ongoing     */ 
+  HAL_RNG_STATE_TIMEOUT   = 0x03,  /*!< RNG timeout state                   */
+  HAL_RNG_STATE_ERROR     = 0x04   /*!< RNG error state                     */
+    
+}HAL_RNG_StateTypeDef;
+
+/** 
+  * @brief  RNG Handle Structure definition  
+  */ 
+typedef struct
+{
+  RNG_TypeDef                 *Instance;  /*!< Register base address   */ 
+  
+  HAL_LockTypeDef             Lock;       /*!< RNG locking object      */
+  
+  __IO HAL_RNG_StateTypeDef   State;      /*!< RNG communication state */
+  
+}RNG_HandleTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup RNG_Exported_Constants
+  * @{
+  */
+
+/** @defgroup RNG_Interrupt_definition
+  * @{
+  */ 
+#define RNG_IT_CEI   ((uint32_t)0x20)  /*!< Clock error interrupt */
+#define RNG_IT_SEI   ((uint32_t)0x40)  /*!< Seed error interrupt  */
+
+#define IS_RNG_IT(IT) (((IT) == RNG_IT_CEI) || \
+                       ((IT) == RNG_IT_SEI))
+/**
+  * @}
+  */
+
+
+/** @defgroup RNG_Flag_definition
+  * @{
+  */ 
+#define RNG_FLAG_DRDY   ((uint32_t)0x0001)  /*!< Data ready                 */
+#define RNG_FLAG_CECS   ((uint32_t)0x0002)  /*!< Clock error current status */
+#define RNG_FLAG_SECS   ((uint32_t)0x0004)  /*!< Seed error current status  */
+
+#define IS_RNG_FLAG(FLAG) (((FLAG) == RNG_FLAG_DRDY) || \
+                           ((FLAG) == RNG_FLAG_CECS) || \
+                           ((FLAG) == RNG_FLAG_SECS))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
+  
+/* Exported macro ------------------------------------------------------------*/
+
+/** @brief Reset RNG handle state
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_RNG_STATE_RESET)
+
+/**
+  * @brief  Enables the RNG peripheral.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR |=  RNG_CR_RNGEN)
+
+/**
+  * @brief  Disables the RNG peripheral.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR &= ~RNG_CR_RNGEN)
+
+/**
+  * @brief  Gets the selected RNG's flag status.
+  * @param  __HANDLE__: RNG Handle
+  * @param  __FLAG__: RNG flag
+  * @retval The new state of RNG_FLAG (SET or RESET).
+  */
+#define __HAL_RNG_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR & (__FLAG__)) == (__FLAG__))
+
+/**
+  * @brief  Clears the RNG's pending flags.
+  * @param  __HANDLE__: RNG Handle
+  * @param  __FLAG__: RNG flag
+  * @retval None
+  */
+#define __HAL_RNG_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) = ~(__FLAG__))
+    
+/**
+  * @brief  Enables the RNG interrupts.
+  * @param  __HANDLE__: RNG Handle
+  * @retval None
+  */
+#define __HAL_RNG_ENABLE_IT(__HANDLE__) ((__HANDLE__)->Instance->CR |=  RNG_CR_IE)
+    
+/**
+  * @brief  Disables the RNG interrupts.
+  * @param  __HANDLE__: RNG Handle
+  *         This parameter can be one of the following values:
+  *            @arg RNG_FLAG_DRDY:  Data ready interrupt
+  *            @arg RNG_FLAG_CECS:  Clock error interrupt
+  *            @arg RNG_FLAG_SECS:  Seed error interrupt
+  * @retval None
+  */
+#define __HAL_RNG_DISABLE_IT(__HANDLE__) ((__HANDLE__)->Instance->CR &= ~RNG_CR_IE)
+
+/**
+  * @brief  Checks whether the specified RNG interrupt has occurred or not.
+  * @param  __HANDLE__: RNG Handle
+  * @param  __INTERRUPT__: specifies the RNG interrupt source to check.
+  *         This parameter can be one of the following values:
+  *            @arg RNG_FLAG_DRDY: Data ready interrupt
+  *            @arg RNG_FLAG_CECS: Clock error interrupt
+  *            @arg RNG_FLAG_SECS: Seed error interrupt
+  * @retval The new state of RNG_FLAG (SET or RESET).
+  */
+#define __HAL_RNG_GET_IT(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->SR & (__INTERRUPT__)) == (__INTERRUPT__))   
+
+/* Exported functions --------------------------------------------------------*/
+
+/* Initialization/de-initialization functions  **********************************/
+HAL_StatusTypeDef HAL_RNG_Init(RNG_HandleTypeDef *hrng);
+HAL_StatusTypeDef HAL_RNG_DeInit (RNG_HandleTypeDef *hrng);
+void HAL_RNG_MspInit(RNG_HandleTypeDef *hrng);
+void HAL_RNG_MspDeInit(RNG_HandleTypeDef *hrng);
+
+/* Peripheral Control functions  ************************************************/
+uint32_t HAL_RNG_GetRandomNumber(RNG_HandleTypeDef *hrng);
+uint32_t HAL_RNG_GetRandomNumber_IT(RNG_HandleTypeDef *hrng);
+void HAL_RNG_IRQHandler(RNG_HandleTypeDef *hrng);
+void HAL_RNG_ReadyCallback(RNG_HandleTypeDef* hrng);
+void HAL_RNG_ErrorCallback(RNG_HandleTypeDef *hrng);
+
+/* Peripheral State functions  **************************************************/
+HAL_RNG_StateTypeDef HAL_RNG_GetState(RNG_HandleTypeDef *hrng);
+
+#endif /* STM32L051xx && STM32L061xx*/
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_RNG_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rtc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rtc.c
@@ -1,0 +1,1567 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_rtc.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   RTC HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Real Time Clock (RTC) peripheral:
+  *           + Initialization/de-initialization functions
+  *           + I/O operation functions
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
+  *         
+  @verbatim
+  ==============================================================================
+              ##### Backup Domain Operating Condition #####
+  ==============================================================================
+  [..] As long as the supply voltage remains in the operating range, 
+       the RTC never stops, regardless of the device status (Run mode, 
+       low power modes or under reset).
+
+                   ##### Backup Domain Reset #####
+  ==================================================================
+  [..] The backup domain reset sets all RTC registers and the RCC_CSR register 
+       to their reset values.
+  [..] A backup domain reset is generated when one of the following events occurs:
+    (+) Software reset, triggered by setting the RTCRST bit in the 
+        RCC Control Status register (RCC_CSR).
+    (+) Power reset (BOR/POR/PDR).
+
+                   ##### Backup Domain Access #####
+  ==================================================================
+  [..] After reset, the backup domain (RTC registers and RTC backup data registers) 
+       is protected against possible unwanted write accesses. 
+  [..] To enable access to the RTC Domain and RTC registers, proceed as follows:
+    (+) Enable the Power Controller (PWR) APB1 interface clock using the
+        __PWR_CLK_ENABLE() function.
+    (+) Enable access to RTC domain using the HAL_PWR_EnableBkUpAccess() function.
+    (+) Select the RTC clock source using the __HAL_RCC_RTC_CONFIG() function.
+    (+) Enable RTC Clock using the __HAL_RCC_RTC_ENABLE() function.
+
+
+                  ##### How to use this driver #####
+  ==================================================================
+  [..]
+    (+) Enable the RTC domain access (see description in the section above).
+    (+) Configure the RTC Prescaler (Asynchronous and Synchronous) and RTC hour
+        format using the HAL_RTC_Init() function.
+
+  *** Time and Date configuration ***
+  ===================================
+  [..] 
+    (+) To configure the RTC Calendar (Time and Date) use the HAL_RTC_SetTime()
+        and HAL_RTC_SetDate() functions.
+    (+) To read the RTC Calendar, use the HAL_RTC_GetTime() and HAL_RTC_GetDate() functions.
+
+  *** Alarm configuration ***
+  ===========================
+  [..]
+    (+) To configure the RTC Alarm use the HAL_RTC_SetAlarm() function.
+        You can also configure the RTC Alarm with interrupt mode using the HAL_RTC_SetAlarm_IT() function.
+    (+) To read the RTC Alarm, use the HAL_RTC_GetAlarm() function.
+
+  *** RTC Wakeup configuration ***
+  ================================
+  [..] 
+    (+) To configure the RTC Wakeup Clock source and Counter use the HAL_RTC_SetWakeUpTimer()
+        function. You can also configure the RTC Wakeup timer with interrupt mode
+        using the HAL_RTC_SetWakeUpTimer_IT() function.
+    (+) To read the RTC WakeUp Counter register, use the HAL_RTC_GetWakeUpTimer()
+        function.
+        
+  *** Outputs configuration ***
+  =============================
+  [..]  The RTC has 2 different outputs:
+    (+) RTC_ALARM: this output is used to manage the RTC Alarm A, Alarm B
+        and WaKeUp signals.
+        To output the selected RTC signal, use the HAL_RTC_Init() function.             
+    (+) RTC_CALIB: this output is 512Hz signal or 1Hz.
+        To enable the RTC_CALIB, use the HAL_RTCEx_SetCalibrationOutPut() function.
+    (+) Two pins can be used as RTC_ALARM or RTC_CALIB (PC13, PB14) managed on 
+        the RTC_OR register.
+    (+) When the RTC_CALIB or RTC_ALARM output is selected, the RTC_OUT pin is
+        automatically configured in output alternate function. 
+        
+  *** Smooth digital Calibration configuration ***
+  ================================================
+  [..]
+    (+) Configure the RTC Original Digital Calibration Value and the corresponding
+        calibration cycle period (32s,16s and 8s) using the HAL_RTCEx_SetSmoothCalib() 
+        function.
+
+  *** TimeStamp configuration ***
+  ===============================
+  [..]
+    (+) Enables the RTC TimeStamp using the HAL_RTC_SetTimeStamp() function.
+        You can also configure the RTC TimeStamp with interrupt mode using the
+        HAL_RTC_SetTimeStamp_IT() function.
+    (+) To read the RTC TimeStamp Time and Date register, use the HAL_RTC_GetTimeStamp()
+        function.
+
+  *** Tamper configuration ***
+  ============================
+  [..]
+    (+) Enable the RTC Tamper and Configure the Tamper filter count, trigger Edge 
+        or Level according to the Tamper filter (if equal to 0 Edge else Level) 
+        value, sampling frequency, NoErase, MaskFlag,  precharge or discharge and
+        Pull-UP using the HAL_RTC_SetTamper() function. You can configure RTC Tamper
+        with interrupt mode using HAL_RTC_SetTamper_IT() function.
+    (+) The default configuration of the Tamper erases the backup registers. To avoid
+        erase, enable the NoErase field on the RTC_TAMPCR register.
+
+  *** Backup Data Registers configuration ***
+  ===========================================
+  [..]
+    (+) To write to the RTC Backup Data registers, use the HAL_RTC_BKUPWrite()
+        function.
+    (+) To read the RTC Backup Data registers, use the HAL_RTC_BKUPRead()
+        function.
+    (+) The backup registers are reset when a tamper detection event occurs        
+
+
+                  ##### RTC and low power modes #####
+  ==================================================================
+  [..] The MCU can be woken up from a low power mode by an RTC alternate
+       function.
+  [..] The RTC alternate functions are the RTC alarms (Alarm A and Alarm B),
+       RTC wakeup, RTC tamper event detection and RTC time stamp event detection.
+       These RTC alternate functions can wake up the system from the Stop and 
+       Standby low power modes.
+  [..] The system can also wake up from low power modes without depending
+       on an external interrupt (Auto-wakeup mode), by using the RTC alarm
+       or the RTC wakeup events.
+  [..] The RTC provides a programmable time base for waking up from the
+       Stop or Standby mode at regular intervals.
+       Wakeup from STOP and Standby modes is possible only when the RTC clock source
+       is LSE or LSI.
+
+   @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RTC 
+  * @brief RTC HAL module driver
+  * @{
+  */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Masks Definition */
+#define RTC_TR_RESERVED_MASK    ((uint32_t)0x007F7F7F)
+#define RTC_DR_RESERVED_MASK    ((uint32_t)0x00FFFF3F)
+#define RTC_INIT_MASK           ((uint32_t)0xFFFFFFFF)
+#define RTC_RSF_MASK            ((uint32_t)0xFFFFFF5F)
+#define RTC_FLAGS_MASK          ((uint32_t)(RTC_FLAG_TSOVF | RTC_FLAG_TSF | RTC_FLAG_WUTF | \
+                                            RTC_FLAG_ALRBF | RTC_FLAG_INITF | RTC_FLAG_RSF | \
+                                            RTC_FLAG_INITS | RTC_FLAG_WUTWF | RTC_FLAG_ALRBWF | \
+                                            RTC_FLAG_TAMP1F | RTC_FLAG_TAMP2F | \
+                                            RTC_FLAG_RECALPF | RTC_FLAG_SHPF))
+
+#define RTC_TIMEOUT_VALUE  1000
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup RTC_Private_Functions
+  * @{
+  */
+
+/** @defgroup RTC_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+   [..] This section provides functions allowing to initialize and configure the 
+         RTC Prescaler (Synchronous and Asynchronous), RTC Hour format, disable 
+         RTC registers Write protection, enter and exit the RTC initialization mode,
+         RTC registers synchronization check and reference clock detection enable.
+         (#) The RTC Prescaler is programmed to generate the RTC 1Hz time base.
+             It is split into 2 programmable prescalers to minimize power consumption.
+             (++) A 7-bit asynchronous prescaler and a 13-bit synchronous prescaler.
+             (++) When both prescalers are used, it is recommended to configure the 
+                 asynchronous prescaler to a high value to minimize power consumption.
+         (#) All RTC registers are Write protected. Writing to the RTC registers
+             is enabled by writing a key into the Write Protection register, RTC_WPR.
+         (#) To configure the RTC Calendar, user application should enter 
+             initialization mode. In this mode, the calendar counter is stopped
+             and its value can be updated. When the initialization sequence is 
+             complete, the calendar restarts counting after 4 RTCCLK cycles.
+         (#) To read the calendar through the shadow registers after Calendar 
+             initialization, calendar update or after wakeup from low power modes
+             the software must first clear the RSF flag. The software must then
+             wait until it is set again before reading the calendar, which means
+             that the calendar registers have been correctly copied into the
+             RTC_TR and RTC_DR shadow registers.The HAL_RTC_WaitForSynchro() function 
+             implements the above software sequence (RSF clear and RSF check).
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the RTC peripheral
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc)
+{
+  /* Check the RTC peripheral state */
+  if(hrtc == NULL)
+  {
+     return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_RTC_HOUR_FORMAT(hrtc->Init.HourFormat));
+  assert_param(IS_RTC_ASYNCH_PREDIV(hrtc->Init.AsynchPrediv));
+  assert_param(IS_RTC_SYNCH_PREDIV(hrtc->Init.SynchPrediv));
+  assert_param(IS_RTC_OUTPUT(hrtc->Init.OutPut));
+  assert_param(IS_RTC_OUTPUT_REMAP(hrtc->Init.OutPutRemap));
+  assert_param(IS_RTC_OUTPUT_POL(hrtc->Init.OutPutPolarity));
+  assert_param(IS_RTC_OUTPUT_TYPE(hrtc->Init.OutPutType));
+  
+  if(hrtc->State == HAL_RTC_STATE_RESET)
+  {
+    /* Initialize RTC MSP */
+    HAL_RTC_MspInit(hrtc);
+  }
+
+  /* Set RTC state */
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state */
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    /* Clear RTC_CR FMT, OSEL and POL Bits */
+    hrtc->Instance->CR &= ((uint32_t)~(RTC_CR_FMT | RTC_CR_OSEL | RTC_CR_POL));
+    /* Set RTC_CR register */
+    hrtc->Instance->CR |= (uint32_t)(hrtc->Init.HourFormat | hrtc->Init.OutPut | hrtc->Init.OutPutPolarity);
+
+    /* Configure the RTC PRER */
+    hrtc->Instance->PRER = (uint32_t)(hrtc->Init.SynchPrediv);
+    hrtc->Instance->PRER |= (uint32_t)(hrtc->Init.AsynchPrediv << 16);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
+
+    hrtc->Instance->OR &= (uint32_t)~(RTC_OR_ALARMOUTTYPE | RTC_OR_RTC_OUT_RMP);
+    hrtc->Instance->OR |= (uint32_t)(hrtc->Init.OutPutType | hrtc->Init.OutPutRemap);
+
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state */
+    hrtc->State = HAL_RTC_STATE_READY;
+
+    return HAL_OK;
+  }
+}
+
+/**
+  * @brief  DeInitializes the RTC peripheral
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @note   This function doesn't reset the RTC Backup Data registers.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc)
+{
+  uint32_t tickstart;
+
+  /* Set RTC state */
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state */
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    /* Reset TR, DR and CR registers */
+    hrtc->Instance->TR = (uint32_t)0x00000000;
+    hrtc->Instance->DR = (uint32_t)0x00002101;
+    /* Reset All CR bits except CR[2:0] */
+    hrtc->Instance->CR &= (uint32_t)0x00000007;
+
+    tickstart = HAL_GetTick();
+
+    /* Wait till WUTWF flag is set and if Time out is reached exit */
+    while(((hrtc->Instance->ISR) & RTC_ISR_WUTWF) == (uint32_t)RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        /* Set RTC state */
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Reset all RTC CR register bits */
+    hrtc->Instance->CR &= (uint32_t)0x00000000;
+    hrtc->Instance->WUTR = (uint32_t)0x0000FFFF;
+    hrtc->Instance->PRER = (uint32_t)0x007F00FF; 
+    hrtc->Instance->ALRMAR = (uint32_t)0x00000000;
+    hrtc->Instance->ALRMBR = (uint32_t)0x00000000;
+    hrtc->Instance->SHIFTR = (uint32_t)0x00000000;
+    hrtc->Instance->CALR = (uint32_t)0x00000000;
+    hrtc->Instance->ALRMASSR = (uint32_t)0x00000000;
+    hrtc->Instance->ALRMBSSR = (uint32_t)0x00000000;
+
+    /* Reset ISR register and exit initialization mode */
+    hrtc->Instance->ISR = (uint32_t)0x00000000;
+
+    /* Reset Tamper configuration register */
+    hrtc->Instance->TAMPCR = 0x00000000;
+
+    /* Reset Option register */
+    hrtc->Instance->OR = 0x00000000;
+
+    /* If  RTC_CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
+    if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == RESET)
+    {
+      if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);  
+
+        hrtc->State = HAL_RTC_STATE_ERROR;
+
+        return HAL_ERROR;
+      }
+    }
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* De-Initialize RTC MSP */
+  HAL_RTC_MspDeInit(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the RTC MSP.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.  
+  * @retval None
+  */
+__weak void HAL_RTC_MspInit(RTC_HandleTypeDef* hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_MspInit could be implenetd in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes the RTC MSP.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC. 
+  * @retval None
+  */
+__weak void HAL_RTC_MspDeInit(RTC_HandleTypeDef* hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_MspDeInit could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Group2 RTC Time and Date functions
+ *  @brief   RTC Time and Date functions
+ *
+@verbatim
+ ===============================================================================
+                 ##### RTC Time and Date functions #####
+ ===============================================================================
+ 
+ [..] This section provide functions allowing to control RTC features
+      (Time, Date, Alarm, Timestamp, Tamper, RefClock ...).
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Sets RTC current time.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTime: Pointer to Time structure
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg FORMAT_BIN: Binary data format 
+  *            @arg FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format)
+{
+  uint32_t tmpreg = 0;
+
+ /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_RTC_DAYLIGHT_SAVING(sTime->DayLightSaving));
+  assert_param(IS_RTC_STORE_OPERATION(sTime->StoreOperation));
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if(Format == FORMAT_BIN)
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      assert_param(IS_RTC_HOUR12(sTime->Hours));
+      assert_param(IS_RTC_HOURFORMAT12(sTime->TimeFormat));
+    }
+    else
+    {
+      sTime->TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(sTime->Hours));
+    }
+    assert_param(IS_RTC_MINUTES(sTime->Minutes));
+    assert_param(IS_RTC_SECONDS(sTime->Seconds));
+
+    tmpreg = (uint32_t)(((uint32_t)RTC_ByteToBcd2(sTime->Hours) << 16) | \
+                        ((uint32_t)RTC_ByteToBcd2(sTime->Minutes) << 8) | \
+                        ((uint32_t)RTC_ByteToBcd2(sTime->Seconds)) | \
+                        (((uint32_t)sTime->TimeFormat) << 16));
+  }
+  else
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      tmpreg = RTC_Bcd2ToByte(sTime->Hours);
+      assert_param(IS_RTC_HOUR12(tmpreg));
+      assert_param(IS_RTC_HOURFORMAT12(sTime->TimeFormat));
+    }
+    else
+    {
+      sTime->TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(RTC_Bcd2ToByte(sTime->Hours)));
+    }
+    assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sTime->Minutes)));
+    assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sTime->Seconds)));
+    tmpreg = (((uint32_t)(sTime->Hours) << 16) | \
+              ((uint32_t)(sTime->Minutes) << 8) | \
+              ((uint32_t)sTime->Seconds) | \
+              ((uint32_t)(sTime->TimeFormat) << 16));
+  }
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state */
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    /* Process Unlocked */ 
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    /* Set the RTC_TR register */
+    hrtc->Instance->TR = (uint32_t)(tmpreg & RTC_TR_RESERVED_MASK);
+
+    /* Clear the bits to be configured */
+    hrtc->Instance->CR &= (uint32_t)~RTC_CR_BCK;
+
+    /* Configure the RTC_CR register */
+    hrtc->Instance->CR |= (uint32_t)(sTime->DayLightSaving | sTime->StoreOperation);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
+
+    /* If  CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
+    if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == RESET)
+    {
+      if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_ERROR;
+
+        /* Process Unlocked */ 
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_ERROR;
+      }
+    }
+
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+    
+   hrtc->State = HAL_RTC_STATE_READY;
+
+   __HAL_UNLOCK(hrtc); 
+
+   return HAL_OK;
+  }
+}
+
+/**
+  * @brief  Gets RTC current time.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTime: Pointer to Time structure
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg FORMAT_BIN: Binary data format 
+  *            @arg FORMAT_BCD: BCD data format
+  * @note   Call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the values
+  *         in the higher-order calendar shadow registers.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+  /* Get subseconds values from the correspondent registers*/
+  sTime->SubSeconds = (uint32_t)(hrtc->Instance->SSR);
+
+  /* Get the TR register */
+  tmpreg = (uint32_t)(hrtc->Instance->TR & RTC_TR_RESERVED_MASK);
+
+  /* Fill the structure fields with the read parameters */
+  sTime->Hours = (uint8_t)((tmpreg & (RTC_TR_HT | RTC_TR_HU)) >> 16);
+  sTime->Minutes = (uint8_t)((tmpreg & (RTC_TR_MNT | RTC_TR_MNU)) >>8);
+  sTime->Seconds = (uint8_t)(tmpreg & (RTC_TR_ST | RTC_TR_SU));
+  sTime->TimeFormat = (uint8_t)((tmpreg & (RTC_TR_PM)) >> 16);
+
+  /* Check the input parameters format */
+  if(Format == FORMAT_BIN)
+  {
+    /* Convert the time structure parameters to Binary format */
+    sTime->Hours = (uint8_t)RTC_Bcd2ToByte(sTime->Hours);
+    sTime->Minutes = (uint8_t)RTC_Bcd2ToByte(sTime->Minutes);
+    sTime->Seconds = (uint8_t)RTC_Bcd2ToByte(sTime->Seconds);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets RTC current date.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sDate: Pointer to date structure
+  * @param  Format: specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg FORMAT_BIN: Binary data format 
+  *            @arg FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format)
+{
+  uint32_t datetmpreg = 0;
+
+ /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+ /* Process Locked */
+ __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if((Format == FORMAT_BIN) && ((sDate->Month & 0x10) == 0x10))
+  {
+    sDate->Month = (sDate->Month & (uint32_t)~(0x10)) + 0x0A;
+  }
+
+  assert_param(IS_RTC_WEEKDAY(sDate->WeekDay));
+
+  if(Format == FORMAT_BIN)
+  {
+    assert_param(IS_RTC_YEAR(sDate->Year));
+    assert_param(IS_RTC_MONTH(sDate->Month));
+    assert_param(IS_RTC_DATE(sDate->Date));
+
+   datetmpreg = (((uint32_t)RTC_ByteToBcd2(sDate->Year) << 16) | \
+                 ((uint32_t)RTC_ByteToBcd2(sDate->Month) << 8) | \
+                 ((uint32_t)RTC_ByteToBcd2(sDate->Date)) | \
+                 ((uint32_t)sDate->WeekDay << 13));
+  }
+  else
+  {
+    assert_param(IS_RTC_YEAR(RTC_Bcd2ToByte(sDate->Year)));
+    datetmpreg = RTC_Bcd2ToByte(sDate->Month);
+    assert_param(IS_RTC_MONTH(datetmpreg));
+    datetmpreg = RTC_Bcd2ToByte(sDate->Date);
+    assert_param(IS_RTC_DATE(datetmpreg));
+
+    datetmpreg = ((((uint32_t)sDate->Year) << 16) | \
+                  (((uint32_t)sDate->Month) << 8) | \
+                  ((uint32_t)sDate->Date) | \
+                  (((uint32_t)sDate->WeekDay) << 13));
+  }
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state*/
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    /* Process Unlocked */ 
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    /* Set the RTC_DR register */
+    hrtc->Instance->DR = (uint32_t)(datetmpreg & RTC_DR_RESERVED_MASK);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
+
+    /* If  CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
+    if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == RESET)
+    {
+      if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);  
+
+        hrtc->State = HAL_RTC_STATE_ERROR;
+
+        /* Process Unlocked */ 
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_ERROR;
+      }
+    }
+
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    hrtc->State = HAL_RTC_STATE_READY ;
+
+    /* Process Unlocked */ 
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_OK;
+  }
+}
+
+/**
+  * @brief  Gets RTC current date.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sDate: Pointer to Date structure
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg FORMAT_BIN:  Binary data format 
+  *            @arg FORMAT_BCD:  BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format)
+{
+  uint32_t datetmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+  /* Get the DR register */
+  datetmpreg = (uint32_t)(hrtc->Instance->DR & RTC_DR_RESERVED_MASK);
+
+  /* Fill the structure fields with the read parameters */
+  sDate->Year = (uint8_t)((datetmpreg & (RTC_DR_YT | RTC_DR_YU)) >> 16);
+  sDate->Month = (uint8_t)((datetmpreg & (RTC_DR_MT | RTC_DR_MU)) >> 8);
+  sDate->Date = (uint8_t)(datetmpreg & (RTC_DR_DT | RTC_DR_DU));
+  sDate->WeekDay = (uint8_t)((datetmpreg & (RTC_DR_WDU)) >> 13); 
+
+  /* Check the input parameters format */
+  if(Format == FORMAT_BIN)
+  {
+    /* Convert the date structure parameters to Binary format */
+    sDate->Year = (uint8_t)RTC_Bcd2ToByte(sDate->Year);
+    sDate->Month = (uint8_t)RTC_Bcd2ToByte(sDate->Month);
+    sDate->Date = (uint8_t)RTC_Bcd2ToByte(sDate->Date);
+  }
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Group3 RTC Alarm functions
+ *  @brief   RTC Alarm functions
+ *
+@verbatim   
+ ===============================================================================
+                 ##### RTC Alarm functions #####
+ ===============================================================================  
+ 
+ [..] This section provides functions allowing to configure Alarm feature
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Sets the specified RTC Alarm.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sAlarm: Pointer to Alarm structure
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             @arg FORMAT_BIN: Binary data format 
+  *             @arg FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format)
+{
+  uint32_t tickstart;
+  uint32_t tmpreg = 0, subsecondtmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_ALARM(sAlarm->Alarm));
+  assert_param(IS_ALARM_MASK(sAlarm->AlarmMask));
+  assert_param(IS_RTC_ALARM_DATE_WEEKDAY_SEL(sAlarm->AlarmDateWeekDaySel));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_VALUE(sAlarm->AlarmTime.SubSeconds));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_MASK(sAlarm->AlarmSubSecondMask));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if(Format == FORMAT_BIN)
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      assert_param(IS_RTC_HOUR12(sAlarm->AlarmTime.Hours));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    }
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(sAlarm->AlarmTime.Hours));
+    }
+    assert_param(IS_RTC_MINUTES(sAlarm->AlarmTime.Minutes));
+    assert_param(IS_RTC_SECONDS(sAlarm->AlarmTime.Seconds));
+
+    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(sAlarm->AlarmDateWeekDay));
+    }
+    else
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(sAlarm->AlarmDateWeekDay));
+    }
+
+    tmpreg = (((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Hours) << 16) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Minutes) << 8) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Seconds)) | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmDateWeekDay) << 24) | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
+              ((uint32_t)sAlarm->AlarmMask));
+  }
+  else
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours);
+      assert_param(IS_RTC_HOUR12(tmpreg));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    }
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours)));
+    }
+
+    assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes)));
+    assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds)));
+
+    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(tmpreg));
+    }
+    else
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(tmpreg));
+    }
+
+    tmpreg = (((uint32_t)(sAlarm->AlarmTime.Hours) << 16) | \
+              ((uint32_t)(sAlarm->AlarmTime.Minutes) << 8) | \
+              ((uint32_t) sAlarm->AlarmTime.Seconds) | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16) | \
+              ((uint32_t)(sAlarm->AlarmDateWeekDay) << 24) | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
+              ((uint32_t)sAlarm->AlarmMask));   
+  }
+
+  /* Configure the Alarm A or Alarm B Sub Second registers */
+  subsecondtmpreg = (uint32_t)((uint32_t)(sAlarm->AlarmTime.SubSeconds) | (uint32_t)(sAlarm->AlarmSubSecondMask));
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the Alarm register */
+  if(sAlarm->Alarm == RTC_ALARM_A)
+  {
+    /* Disable the Alarm A interrupt */
+    __HAL_RTC_ALARMA_DISABLE(hrtc);
+
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRA);
+
+    tickstart = HAL_GetTick();
+    /* Wait till RTC ALRAWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+        
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */ 
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hrtc->Instance->ALRMAR = (uint32_t)tmpreg;
+    /* Configure the Alarm A Sub Second register */
+    hrtc->Instance->ALRMASSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMA_ENABLE(hrtc);
+  }
+  else
+  {
+    /* Disable the Alarm B interrupt */
+    __HAL_RTC_ALARMB_DISABLE(hrtc);
+
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRB);
+
+    tickstart = HAL_GetTick();
+    /* Wait till RTC ALRBWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hrtc->Instance->ALRMBR = (uint32_t)tmpreg;
+    /* Configure the Alarm B Sub Second register */
+    hrtc->Instance->ALRMBSSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMB_ENABLE(hrtc);
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets the specified RTC Alarm with Interrupt
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sAlarm: Pointer to Alarm structure
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             @arg FORMAT_BIN: Binary data format 
+  *             @arg FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format)
+{
+  uint32_t tickstart;
+  uint32_t tmpreg = 0, subsecondtmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_ALARM(sAlarm->Alarm));
+  assert_param(IS_ALARM_MASK(sAlarm->AlarmMask));
+  assert_param(IS_RTC_ALARM_DATE_WEEKDAY_SEL(sAlarm->AlarmDateWeekDaySel));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_VALUE(sAlarm->AlarmTime.SubSeconds));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_MASK(sAlarm->AlarmSubSecondMask));
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if(Format == FORMAT_BIN)
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      assert_param(IS_RTC_HOUR12(sAlarm->AlarmTime.Hours));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    }
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(sAlarm->AlarmTime.Hours));
+    }
+    assert_param(IS_RTC_MINUTES(sAlarm->AlarmTime.Minutes));
+    assert_param(IS_RTC_SECONDS(sAlarm->AlarmTime.Seconds));
+
+    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(sAlarm->AlarmDateWeekDay));
+    }
+    else
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(sAlarm->AlarmDateWeekDay));
+    }
+    tmpreg = (((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Hours) << 16) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Minutes) << 8) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Seconds)) | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmDateWeekDay) << 24) | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
+              ((uint32_t)sAlarm->AlarmMask));
+  }
+  else
+  {
+    if((hrtc->Instance->CR & RTC_CR_FMT) != (uint32_t)RESET)
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours);
+      assert_param(IS_RTC_HOUR12(tmpreg));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    } 
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00;
+      assert_param(IS_RTC_HOUR24(RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours)));
+    }
+
+    assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes)));
+    assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds)));
+    
+    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(tmpreg));
+    }
+    else
+    {
+      tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(tmpreg));
+    }
+    tmpreg = (((uint32_t)(sAlarm->AlarmTime.Hours) << 16) | \
+              ((uint32_t)(sAlarm->AlarmTime.Minutes) << 8) | \
+              ((uint32_t) sAlarm->AlarmTime.Seconds) | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16) | \
+              ((uint32_t)(sAlarm->AlarmDateWeekDay) << 24) | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
+              ((uint32_t)sAlarm->AlarmMask));     
+  }
+  /* Configure the Alarm A or Alarm B Sub Second registers */
+  subsecondtmpreg = (uint32_t)((uint32_t)(sAlarm->AlarmTime.SubSeconds) | (uint32_t)(sAlarm->AlarmSubSecondMask));
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the Alarm register */
+  if(sAlarm->Alarm == RTC_ALARM_A)
+  {
+    /* Disable the Alarm A interrupt */
+    __HAL_RTC_ALARMA_DISABLE(hrtc);
+    
+    /* Clear flag alarm A */
+    __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
+
+    tickstart = HAL_GetTick();
+    /* Wait till RTC ALRAWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT; 
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hrtc->Instance->ALRMAR = (uint32_t)tmpreg;
+    /* Configure the Alarm A Sub Second register */
+    hrtc->Instance->ALRMASSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMA_ENABLE(hrtc);
+    /* Configure the Alarm interrupt */
+    __HAL_RTC_ALARM_ENABLE_IT(hrtc,RTC_IT_ALRA);
+  }
+  else
+  {
+    /* Disable the Alarm B interrupt */
+    __HAL_RTC_ALARMB_DISABLE(hrtc);
+    
+    /* Clear flag alarm B */
+    __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
+
+    tickstart = HAL_GetTick();
+    /* Wait till RTC ALRBWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hrtc->Instance->ALRMBR = (uint32_t)tmpreg;
+    /* Configure the Alarm B Sub Second register */
+    hrtc->Instance->ALRMBSSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMB_ENABLE(hrtc);
+    /* Configure the Alarm interrupt */
+    __HAL_RTC_ALARM_ENABLE_IT(hrtc, RTC_IT_ALRB);
+  }
+
+  /* RTC Alarm Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_EXTI_ENABLE_IT(RTC_EXTI_LINE_ALARM_EVENT);
+
+  EXTI->RTSR |= RTC_EXTI_LINE_ALARM_EVENT;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY; 
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactive the specified RTC Alarm
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Alarm: Specifies the Alarm.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_ALARM_A:  AlarmA
+  *            @arg RTC_ALARM_B:  AlarmB
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alarm)
+{
+  uint32_t tickstart;
+
+  /* Check the parameters */
+  assert_param(IS_ALARM(Alarm));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  if(Alarm == RTC_ALARM_A)
+  {
+    /* AlarmA */
+    __HAL_RTC_ALARMA_DISABLE(hrtc);
+
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRA);
+
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC ALRxWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == RESET)
+    {
+      if( (HAL_GetTick()  - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  else
+  {
+    /* AlarmB */
+    __HAL_RTC_ALARMB_DISABLE(hrtc);
+
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc,RTC_IT_ALRB);
+
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC ALRxWF flag is set and if Time out is reached exit */
+    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK; 
+}
+
+/**
+  * @brief  Gets the RTC Alarm value and masks.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sAlarm: Pointer to Date structure
+  * @param  Alarm: Specifies the Alarm.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_ALARM_A: AlarmA
+  *             @arg RTC_ALARM_B: AlarmB  
+  * @param  Format: Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             @arg FORMAT_BIN: Binary data format 
+  *             @arg FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_GetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Alarm, uint32_t Format)
+{
+  uint32_t tmpreg = 0, subsecondtmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_ALARM(Alarm));
+
+  if(Alarm == RTC_ALARM_A)
+  {
+    /* AlarmA */
+    sAlarm->Alarm = RTC_ALARM_A;
+
+    tmpreg = (uint32_t)(hrtc->Instance->ALRMAR);
+    subsecondtmpreg = (uint32_t)((hrtc->Instance->ALRMASSR ) & RTC_ALRMASSR_SS);
+  }
+  else
+  {
+    sAlarm->Alarm = RTC_ALARM_B;
+
+    tmpreg = (uint32_t)(hrtc->Instance->ALRMBR);
+    subsecondtmpreg = (uint32_t)((hrtc->Instance->ALRMBSSR) & RTC_ALRMBSSR_SS);
+  }
+
+  /* Fill the structure with the read parameters */
+  sAlarm->AlarmTime.Hours = (uint32_t)((tmpreg & (RTC_ALRMBR_HT | RTC_ALRMBR_HU)) >> 16);
+  sAlarm->AlarmTime.Minutes = (uint32_t)((tmpreg & (RTC_ALRMBR_MNT | RTC_ALRMBR_MNU)) >> 8);
+  sAlarm->AlarmTime.Seconds = (uint32_t)(tmpreg & (RTC_ALRMBR_ST | RTC_ALRMBR_SU));
+  sAlarm->AlarmTime.TimeFormat = (uint32_t)((tmpreg & RTC_ALRMBR_PM) >> 16);
+  sAlarm->AlarmTime.SubSeconds = (uint32_t) subsecondtmpreg;
+  sAlarm->AlarmDateWeekDay = (uint32_t)((tmpreg & (RTC_ALRMBR_DT | RTC_ALRMBR_DU)) >> 24);
+  sAlarm->AlarmDateWeekDaySel = (uint32_t)(tmpreg & RTC_ALRMBR_WDSEL);
+  sAlarm->AlarmMask = (uint32_t)(tmpreg & RTC_ALARMMASK_ALL);
+
+  if(Format == FORMAT_BIN)
+  {
+    sAlarm->AlarmTime.Hours = RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours);
+    sAlarm->AlarmTime.Minutes = RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes);
+    sAlarm->AlarmTime.Seconds = RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds);
+    sAlarm->AlarmDateWeekDay = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles Alarm interrupt request.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTC_AlarmIRQHandler(RTC_HandleTypeDef* hrtc)
+{
+  if(__HAL_RTC_ALARM_GET_IT(hrtc, RTC_IT_ALRA))
+  {
+    /* Get the status of the Interrupt */
+    if((uint32_t)(hrtc->Instance->CR & RTC_IT_ALRA) != (uint32_t)RESET)
+    {
+      /* AlarmA callback */
+      HAL_RTC_AlarmAEventCallback(hrtc);
+
+      /* Clear the Alarm interrupt pending bit */
+      __HAL_RTC_ALARM_CLEAR_FLAG(hrtc,RTC_FLAG_ALRAF);
+    }
+  }
+
+  if(__HAL_RTC_ALARM_GET_IT(hrtc, RTC_IT_ALRB))
+  {
+    /* Get the status of the Interrupt */
+    if((uint32_t)(hrtc->Instance->CR & RTC_IT_ALRB) != (uint32_t)RESET)
+    {
+      /* AlarmB callback */
+      HAL_RTCEx_AlarmBEventCallback(hrtc);
+
+      /* Clear the Alarm interrupt pending bit */
+      __HAL_RTC_ALARM_CLEAR_FLAG(hrtc,RTC_FLAG_ALRBF);
+    }
+  }
+
+  /* Clear the EXTI's line Flag for RTC Alarm */
+  __HAL_RTC_EXTI_CLEAR_FLAG(RTC_EXTI_LINE_ALARM_EVENT);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+}
+
+/**
+  * @brief  Alarm A callback.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_AlarmAEventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  This function handles AlarmA Polling request.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+
+  uint32_t tickstart;
+
+  /* Get Timeout value */
+  tickstart = HAL_GetTick();
+  
+  while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAF) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Alarm interrupt pending bit */
+  __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Group4 Peripheral Control functions 
+ *  @brief   Peripheral Control functions 
+ *
+@verbatim
+ ===============================================================================
+                     ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]
+    This subsection provides functions allowing to
+      (+) get the RTC state
+      (+) poll for alarm, timestamp, tamper or wakeup timer events
+      (+) handle alarm, timestamp, tamper or wakeup timer interrupt request.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Waits until the RTC Time and Date registers (RTC_TR and RTC_DR) are
+  *         synchronized with RTC APB clock.
+  * @note   The RTC Resynchronization mode is write protected, use the 
+  *         __HAL_RTC_WRITEPROTECTION_DISABLE() before calling this function.
+  * @note   To read the calendar through the shadow registers after Calendar 
+  *         initialization, calendar update or after wakeup from low power modes
+  *         the software must first clear the RSF flag.
+  *         The software must then wait until it is set again before reading
+  *         the calendar, which means that the calendar registers have been
+  *         correctly copied into the RTC_TR and RTC_DR shadow registers.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc)
+{
+  uint32_t tickstart;
+
+  /* Clear RSF flag */
+  hrtc->Instance->ISR &= (uint32_t)RTC_RSF_MASK;
+
+  tickstart = HAL_GetTick();
+
+  /* Wait the registers to be synchronised */
+  while((hrtc->Instance->ISR & RTC_ISR_RSF) == (uint32_t)RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+
+  return HAL_OK;
+}
+
+/** @defgroup RTC_Group5 Peripheral State functions 
+ *  @brief   Peripheral State functions 
+ *
+@verbatim   
+ ===============================================================================
+                     ##### Peripheral State functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides functions allowing to
+      (+) Get RTC state
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Returns the RTC state.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL state
+  */
+HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef* hrtc)
+{
+  return hrtc->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  Enters the RTC Initialization mode.
+  * @note   The RTC Initialization mode is write protected, use the
+  *         __HAL_RTC_WRITEPROTECTION_DISABLE() before calling this function.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef RTC_EnterInitMode(RTC_HandleTypeDef* hrtc)
+{
+  uint32_t tickstart;
+
+  /* Check if the Initialization mode is set */
+  if((hrtc->Instance->ISR & RTC_ISR_INITF) == (uint32_t)RESET)
+  {
+    /* Set the Initialization mode */
+    hrtc->Instance->ISR = (uint32_t)RTC_INIT_MASK;
+
+    tickstart = HAL_GetTick();
+    /* Wait till RTC is in INIT state and if Time out is reached exit */
+    while((hrtc->Instance->ISR & RTC_ISR_INITF) == (uint32_t)RESET)
+    {
+      if((HAL_GetTick()  - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Converts a 2 digit decimal to BCD format.
+  * @param  Value: Byte to be converted
+  * @retval Converted byte
+  */
+uint8_t RTC_ByteToBcd2(uint8_t Value)
+{
+  uint32_t bcdhigh = 0;
+
+  while(Value >= 10)
+  {
+    bcdhigh++;
+    Value -= 10;
+  }
+
+  return  ((uint8_t)(bcdhigh << 4) | Value);
+}
+
+/**
+  * @brief  Converts from 2 digit BCD to Binary.
+  * @param  Value: BCD value to be converted
+  * @retval Converted word
+  */
+uint8_t RTC_Bcd2ToByte(uint8_t Value)
+{
+  uint32_t tmp = 0;
+  tmp = ((uint8_t)(Value & (uint8_t)0xF0) >> (uint8_t)0x4) * 10;
+  return (tmp + (Value & (uint8_t)0x0F));
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RTC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rtc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rtc.h
@@ -1,0 +1,765 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_rtc.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of RTC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_RTC_H
+#define __STM32L0xx_HAL_RTC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RTC
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** 
+  * @brief  HAL State structures definition  
+  */
+typedef enum
+{
+  HAL_RTC_STATE_RESET             = 0x00,  /*!< RTC not yet initialized or disabled */
+  HAL_RTC_STATE_READY             = 0x01,  /*!< RTC initialized and ready for use   */
+  HAL_RTC_STATE_BUSY              = 0x02,  /*!< RTC process is ongoing              */
+  HAL_RTC_STATE_TIMEOUT           = 0x03,  /*!< RTC timeout state                   */
+  HAL_RTC_STATE_ERROR             = 0x04   /*!< RTC error state                     */
+
+}HAL_RTCStateTypeDef;
+
+/** 
+  * @brief  RTC Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t HourFormat;      /*!< Specifies the RTC Hour Format.
+                                 This parameter can be a value of @ref RTC_Hour_Formats */
+
+  uint32_t AsynchPrediv;    /*!< Specifies the RTC Asynchronous Predivider value.
+                                 This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x7F */
+                               
+  uint32_t SynchPrediv;     /*!< Specifies the RTC Synchronous Predivider value.
+                                 This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x7FFF */
+
+  uint32_t OutPut;          /*!< Specifies which signal will be routed to the RTC output.
+                                 This parameter can be a value of @ref RTC_Output_selection_Definitions */
+
+  uint32_t OutPutRemap;    /*!< Specifies the remap for RTC output.
+                                 This parameter can be a value of @ref  RTC_Output_ALARM_OUT_Remap */
+
+  uint32_t OutPutPolarity;  /*!< Specifies the polarity of the output signal.  
+                                 This parameter can be a value of @ref RTC_Output_Polarity_Definitions */
+
+  uint32_t OutPutType;      /*!< Specifies the RTC Output Pin mode.
+                                 This parameter can be a value of @ref RTC_Output_Type_ALARM_OUT */
+}RTC_InitTypeDef;
+
+/** 
+  * @brief  RTC Time structure definition  
+  */
+typedef struct
+{
+  uint8_t Hours;            /*!< Specifies the RTC Time Hour.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 12 if the RTC_HourFormat_12 is selected.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 23 if the RTC_HourFormat_24 is selected */
+
+  uint8_t Minutes;          /*!< Specifies the RTC Time Minutes.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 59 */
+
+  uint8_t Seconds;          /*!< Specifies the RTC Time Seconds.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 59 */
+
+  uint32_t SubSeconds;      /*!< Specifies the RTC Time SubSeconds.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 59 */
+
+  uint8_t TimeFormat;       /*!< Specifies the RTC AM/PM Time.
+                                 This parameter can be a value of @ref RTC_AM_PM_Definitions */
+
+  uint32_t DayLightSaving;  /*!< Specifies DayLight Save Operation.
+                                 This parameter can be a value of @ref RTC_DayLightSaving_Definitions */
+
+  uint32_t StoreOperation;  /*!< Specifies RTC_StoreOperation value to be written in the BCK bit 
+                                 in CR register to store the operation.
+                                 This parameter can be a value of @ref RTC_StoreOperation_Definitions */
+}RTC_TimeTypeDef;
+
+/** 
+  * @brief  RTC Date structure definition
+  */
+typedef struct
+{
+  uint8_t WeekDay;  /*!< Specifies the RTC Date WeekDay.
+                         This parameter can be a value of @ref RTC_WeekDay_Definitions */
+
+  uint8_t Month;    /*!< Specifies the RTC Date Month (in BCD format).
+                         This parameter can be a value of @ref RTC_Month_Date_Definitions */
+
+  uint8_t Date;     /*!< Specifies the RTC Date.
+                         This parameter must be a number between Min_Data = 1 and Max_Data = 31 */
+
+  uint8_t Year;     /*!< Specifies the RTC Date Year.
+                         This parameter must be a number between Min_Data = 0 and Max_Data = 99 */
+
+}RTC_DateTypeDef;
+
+/** 
+  * @brief  RTC Alarm structure definition
+  */
+typedef struct
+{
+  RTC_TimeTypeDef AlarmTime;     /*!< Specifies the RTC Alarm Time members */
+
+  uint32_t AlarmMask;            /*!< Specifies the RTC Alarm Masks.
+                                      This parameter can be a value of @ref RTC_AlarmMask_Definitions */
+  
+  uint32_t AlarmSubSecondMask;   /*!< Specifies the RTC Alarm SubSeconds Masks.
+                                      This parameter can be a value of @ref RTC_Alarm_Sub_Seconds_Masks_Definitions */
+
+  uint32_t AlarmDateWeekDaySel;  /*!< Specifies the RTC Alarm is on Date or WeekDay.
+                                     This parameter can be a value of @ref RTC_AlarmDateWeekDay_Definitions */
+
+  uint8_t AlarmDateWeekDay;      /*!< Specifies the RTC Alarm Date/WeekDay.
+                                      If the Alarm Date is selected, this parameter must be set to a value in the 1-31 range.
+                                      If the Alarm WeekDay is selected, this parameter can be a value of @ref RTC_WeekDay_Definitions */
+
+  uint32_t Alarm;                /*!< Specifies the alarm .
+                                      This parameter can be a value of @ref RTC_Alarms_Definitions */
+}RTC_AlarmTypeDef;
+
+/** 
+  * @brief  Time Handle Structure definition
+  */
+typedef struct
+{
+  RTC_TypeDef               *Instance;  /*!< Register base address    */
+
+  RTC_InitTypeDef           Init;       /*!< RTC required parameters  */
+
+  HAL_LockTypeDef           Lock;       /*!< RTC locking object       */
+
+  __IO HAL_RTCStateTypeDef  State;      /*!< Time communication state */
+
+}RTC_HandleTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup RTC_Exported_Constants
+  * @{
+  */
+
+/** @defgroup RTC_Hour_Formats
+  * @{
+  */
+#define RTC_HOURFORMAT_24              ((uint32_t)0x00000000)
+#define RTC_HOURFORMAT_12              ((uint32_t)0x00000040)
+
+#define IS_RTC_HOUR_FORMAT(FORMAT)     (((FORMAT) == RTC_HOURFORMAT_12) || \
+                                        ((FORMAT) == RTC_HOURFORMAT_24))
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Output_selection_Definitions
+  * @{
+  */
+#define RTC_OUTPUT_DISABLE             ((uint32_t)0x00000000)
+#define RTC_OUTPUT_ALARMA              ((uint32_t)RTC_CR_OSEL_0)
+#define RTC_OUTPUT_ALARMB              ((uint32_t)RTC_CR_OSEL_1)
+#define RTC_OUTPUT_WAKEUP              ((uint32_t)RTC_CR_OSEL)
+
+#define IS_RTC_OUTPUT(OUTPUT) (((OUTPUT) == RTC_OUTPUT_DISABLE) || \
+                               ((OUTPUT) == RTC_OUTPUT_ALARMA)  || \
+                               ((OUTPUT) == RTC_OUTPUT_ALARMB)  || \
+                               ((OUTPUT) == RTC_OUTPUT_WAKEUP))
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Output_Polarity_Definitions
+  * @{
+  */
+#define RTC_OUTPUT_POLARITY_HIGH       ((uint32_t)0x00000000)
+#define RTC_OUTPUT_POLARITY_LOW        ((uint32_t)0x00100000)
+
+#define IS_RTC_OUTPUT_POL(POL) (((POL) == RTC_OUTPUT_POLARITY_HIGH) || \
+                                ((POL) == RTC_OUTPUT_POLARITY_LOW))
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Output_Type_ALARM_OUT
+  * @{
+  */
+#define RTC_OUTPUT_TYPE_OPENDRAIN      ((uint32_t)0x00000000)
+#define RTC_OUTPUT_TYPE_PUSHPULL       ((uint32_t)RTC_OR_ALARMOUTTYPE)
+
+#define IS_RTC_OUTPUT_TYPE(TYPE) (((TYPE) == RTC_OUTPUT_TYPE_OPENDRAIN) || \
+                                  ((TYPE) == RTC_OUTPUT_TYPE_PUSHPULL))
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Output_ALARM_OUT_Remap
+  * @{
+  */
+#define RTC_OUTPUT_REMAP_PC13               ((uint32_t)0x00000000)
+#define RTC_OUTPUT_REMAP_PB14               ((uint32_t)RTC_OR_RTC_OUT_RMP)
+#define IS_RTC_OUTPUT_REMAP(REMAP)     (((REMAP) == RTC_OUTPUT_REMAP_PC13) || \
+                                        ((REMAP) == RTC_OUTPUT_REMAP_PB14))
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Asynchronous_Predivider
+  * @{
+  */
+#define IS_RTC_ASYNCH_PREDIV(PREDIV)   ((PREDIV) <= (uint32_t)0x7F)
+/**
+  * @}
+  */
+
+
+/** @defgroup RTC_Synchronous_Predivider
+  * @{
+  */
+#define IS_RTC_SYNCH_PREDIV(PREDIV)    ((PREDIV) <= (uint32_t)0x7FFF)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Time_Definitions
+  * @{
+  */
+#define IS_RTC_HOUR12(HOUR)            (((HOUR) > (uint32_t)0) && ((HOUR) <= (uint32_t)12))
+#define IS_RTC_HOUR24(HOUR)            ((HOUR) <= (uint32_t)23)
+#define IS_RTC_MINUTES(MINUTES)        ((MINUTES) <= (uint32_t)59)
+#define IS_RTC_SECONDS(SECONDS)        ((SECONDS) <= (uint32_t)59)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_AM_PM_Definitions
+  * @{
+  */
+#define RTC_HOURFORMAT12_AM            ((uint8_t)0x00)
+#define RTC_HOURFORMAT12_PM            ((uint8_t)0x40)
+
+#define IS_RTC_HOURFORMAT12(PM)  (((PM) == RTC_HOURFORMAT12_AM) || ((PM) == RTC_HOURFORMAT12_PM))
+/**
+  * @}
+  */
+
+/** @defgroup RTC_DayLightSaving_Definitions
+  * @{
+  */
+#define RTC_DAYLIGHTSAVING_SUB1H       ((uint32_t)0x00020000)
+#define RTC_DAYLIGHTSAVING_ADD1H       ((uint32_t)0x00010000)
+#define RTC_DAYLIGHTSAVING_NONE        ((uint32_t)0x00000000)
+
+#define IS_RTC_DAYLIGHT_SAVING(SAVE) (((SAVE) == RTC_DAYLIGHTSAVING_SUB1H) || \
+                                      ((SAVE) == RTC_DAYLIGHTSAVING_ADD1H) || \
+                                      ((SAVE) == RTC_DAYLIGHTSAVING_NONE))
+/**
+  * @}
+  */
+
+/** @defgroup RTC_StoreOperation_Definitions
+  * @{
+  */
+#define RTC_STOREOPERATION_RESET        ((uint32_t)0x00000000)
+#define RTC_STOREOPERATION_SET          ((uint32_t)0x00040000)
+
+#define IS_RTC_STORE_OPERATION(OPERATION) (((OPERATION) == RTC_STOREOPERATION_RESET) || \
+                                           ((OPERATION) == RTC_STOREOPERATION_SET))
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Input_parameter_format_definitions
+  * @{
+  */
+#define FORMAT_BIN                      ((uint32_t)0x000000000)
+#define FORMAT_BCD                      ((uint32_t)0x000000001)
+
+#define IS_RTC_FORMAT(FORMAT) (((FORMAT) == FORMAT_BIN) || ((FORMAT) == FORMAT_BCD))
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Year_Date_Definitions
+  * @{
+  */
+#define IS_RTC_YEAR(YEAR)              ((YEAR) <= (uint32_t)99)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Month_Date_Definitions
+  * @{
+  */
+
+/* Coded in BCD format */
+#define RTC_MONTH_JANUARY              ((uint8_t)0x01)
+#define RTC_MONTH_FEBRUARY             ((uint8_t)0x02)
+#define RTC_MONTH_MARCH                ((uint8_t)0x03)
+#define RTC_MONTH_APRIL                ((uint8_t)0x04)
+#define RTC_MONTH_MAY                  ((uint8_t)0x05)
+#define RTC_MONTH_JUNE                 ((uint8_t)0x06)
+#define RTC_MONTH_JULY                 ((uint8_t)0x07)
+#define RTC_MONTH_AUGUST               ((uint8_t)0x08)
+#define RTC_MONTH_SEPTEMBER            ((uint8_t)0x09)
+#define RTC_MONTH_OCTOBER              ((uint8_t)0x10)
+#define RTC_MONTH_NOVEMBER             ((uint8_t)0x11)
+#define RTC_MONTH_DECEMBER             ((uint8_t)0x12)
+
+#define IS_RTC_MONTH(MONTH)            (((MONTH) >= (uint32_t)1) && ((MONTH) <= (uint32_t)12))
+#define IS_RTC_DATE(DATE)              (((DATE) >= (uint32_t)1) && ((DATE) <= (uint32_t)31))
+/**
+  * @}
+  */
+
+/** @defgroup RTC_WeekDay_Definitions
+  * @{
+  */
+#define RTC_WEEKDAY_MONDAY             ((uint8_t)0x01)
+#define RTC_WEEKDAY_TUESDAY            ((uint8_t)0x02)
+#define RTC_WEEKDAY_WEDNESDAY          ((uint8_t)0x03)
+#define RTC_WEEKDAY_THURSDAY           ((uint8_t)0x04)
+#define RTC_WEEKDAY_FRIDAY             ((uint8_t)0x05)
+#define RTC_WEEKDAY_SATURDAY           ((uint8_t)0x06)
+#define RTC_WEEKDAY_SUNDAY             ((uint8_t)0x07)
+
+#define IS_RTC_WEEKDAY(WEEKDAY) (((WEEKDAY) == RTC_WEEKDAY_MONDAY)    || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_TUESDAY)   || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_WEDNESDAY) || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_THURSDAY)  || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_FRIDAY)    || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_SATURDAY)  || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_SUNDAY))
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Alarm_Definitions
+  * @{
+  */
+#define IS_RTC_ALARM_DATE_WEEKDAY_DATE(DATE) (((DATE) >(uint32_t) 0) && ((DATE) <= (uint32_t)31))
+#define IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(WEEKDAY) (((WEEKDAY) == RTC_WEEKDAY_MONDAY)    || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_TUESDAY)   || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_WEDNESDAY) || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_THURSDAY)  || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_FRIDAY)    || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_SATURDAY)  || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_SUNDAY))
+/**
+  * @}
+  */
+
+
+/** @defgroup RTC_AlarmDateWeekDay_Definitions
+  * @{
+  */
+#define RTC_ALARMDATEWEEKDAYSEL_DATE      ((uint32_t)0x00000000)
+#define RTC_ALARMDATEWEEKDAYSEL_WEEKDAY   ((uint32_t)0x40000000)
+
+#define IS_RTC_ALARM_DATE_WEEKDAY_SEL(SEL) (((SEL) == RTC_ALARMDATEWEEKDAYSEL_DATE) || \
+                                            ((SEL) == RTC_ALARMDATEWEEKDAYSEL_WEEKDAY))
+/**
+  * @}
+  */
+
+
+/** @defgroup RTC_AlarmMask_Definitions
+  * @{
+  */
+#define RTC_ALARMMASK_NONE                ((uint32_t)0x00000000)
+#define RTC_ALARMMASK_DATEWEEKDAY         RTC_ALRMAR_MSK4
+#define RTC_ALARMMASK_HOURS               RTC_ALRMAR_MSK3
+#define RTC_ALARMMASK_MINUTES             RTC_ALRMAR_MSK2
+#define RTC_ALARMMASK_SECONDS             RTC_ALRMAR_MSK1
+#define RTC_ALARMMASK_ALL                 ((uint32_t)0x80808080)
+
+#define IS_ALARM_MASK(MASK)  (((MASK) & 0x7F7F7F7F) == (uint32_t)RESET)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Alarms_Definitions
+  * @{
+  */
+#define RTC_ALARM_A                       RTC_CR_ALRAE
+#define RTC_ALARM_B                       RTC_CR_ALRBE
+
+#define IS_ALARM(ALARM)      (((ALARM) == RTC_ALARM_A) || ((ALARM) == RTC_ALARM_B))
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Alarm_Sub_Seconds_Value
+  * @{
+  */
+#define IS_RTC_ALARM_SUB_SECOND_VALUE(VALUE) ((VALUE) <= (uint32_t)0x00007FFF)
+/**
+  * @}
+  */
+
+  /** @defgroup RTC_Alarm_Sub_Seconds_Masks_Definitions
+  * @{
+  */
+#define RTC_ALARMSUBSECONDMASK_ALL         ((uint32_t)0x00000000)  /*!< All Alarm SS fields are masked.
+                                                                        There is no comparison on sub seconds
+                                                                        for Alarm */
+#define RTC_ALARMSUBSECONDMASK_SS14_1      ((uint32_t)0x01000000)  /*!< SS[14:1] are don't care in Alarm
+                                                                        comparison. Only SS[0] is compared.    */
+#define RTC_ALARMSUBSECONDMASK_SS14_2      ((uint32_t)0x02000000)  /*!< SS[14:2] are don't care in Alarm
+                                                                        comparison. Only SS[1:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_3      ((uint32_t)0x03000000)  /*!< SS[14:3] are don't care in Alarm
+                                                                        comparison. Only SS[2:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_4      ((uint32_t)0x04000000)  /*!< SS[14:4] are don't care in Alarm
+                                                                        comparison. Only SS[3:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_5      ((uint32_t)0x05000000)  /*!< SS[14:5] are don't care in Alarm
+                                                                        comparison. Only SS[4:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_6      ((uint32_t)0x06000000)  /*!< SS[14:6] are don't care in Alarm
+                                                                        comparison. Only SS[5:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_7      ((uint32_t)0x07000000)  /*!< SS[14:7] are don't care in Alarm
+                                                                        comparison. Only SS[6:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_8      ((uint32_t)0x08000000)  /*!< SS[14:8] are don't care in Alarm
+                                                                        comparison. Only SS[7:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_9      ((uint32_t)0x09000000)  /*!< SS[14:9] are don't care in Alarm
+                                                                        comparison. Only SS[8:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_10     ((uint32_t)0x0A000000)  /*!< SS[14:10] are don't care in Alarm
+                                                                        comparison. Only SS[9:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_11     ((uint32_t)0x0B000000)  /*!< SS[14:11] are don't care in Alarm
+                                                                        comparison. Only SS[10:0] are compared */
+#define RTC_ALARMSUBSECONDMASK_SS14_12     ((uint32_t)0x0C000000)  /*!< SS[14:12] are don't care in Alarm
+                                                                        comparison.Only SS[11:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_SS14_13     ((uint32_t)0x0D000000)  /*!< SS[14:13] are don't care in Alarm
+                                                                        comparison. Only SS[12:0] are compared */
+#define RTC_ALARMSUBSECONDMASK_SS14        ((uint32_t)0x0E000000)  /*!< SS[14] is don't care in Alarm
+                                                                        comparison.Only SS[13:0] are compared  */
+#define RTC_ALARMSUBSECONDMASK_None        ((uint32_t)0x0F000000)  /*!< SS[14:0] are compared and must match
+                                                                        to activate alarm. */
+
+#define IS_RTC_ALARM_SUB_SECOND_MASK(MASK)   (((MASK) == RTC_ALARMSUBSECONDMASK_ALL) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_1) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_2) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_3) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_4) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_5) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_6) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_7) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_8) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_9) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_10) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_11) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_12) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_13) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_None))
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Interrupts_Definitions
+  * @{
+  */
+#define RTC_IT_TS                         ((uint32_t)RTC_CR_TSIE)
+#define RTC_IT_WUT                        ((uint32_t)RTC_CR_WUTIE)
+#define RTC_IT_ALRA                       ((uint32_t)RTC_CR_ALRAIE)
+#define RTC_IT_ALRB                       ((uint32_t)RTC_CR_ALRBIE)
+#define RTC_IT_TAMP                       ((uint32_t)RTC_TAMPCR_TAMPIE) /* Used only to Enable the Tamper Interrupt */
+#define RTC_IT_TAMP1                      ((uint32_t)RTC_TAMPCR_TAMP1IE)
+#define RTC_IT_TAMP2                      ((uint32_t)RTC_TAMPCR_TAMP2IE)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Flags_Definitions
+  * @{
+  */
+#define RTC_FLAG_RECALPF                  ((uint32_t)RTC_ISR_RECALPF)
+#define RTC_FLAG_TAMP2F                   ((uint32_t)RTC_ISR_TAMP2F)
+#define RTC_FLAG_TAMP1F                   ((uint32_t)RTC_ISR_TAMP1F)
+#define RTC_FLAG_TSOVF                    ((uint32_t)RTC_ISR_TSOVF)
+#define RTC_FLAG_TSF                      ((uint32_t)RTC_ISR_TSF)
+#define RTC_FLAG_WUTF                     ((uint32_t)RTC_ISR_WUTF)
+#define RTC_FLAG_ALRBF                    ((uint32_t)RTC_ISR_ALRBF)
+#define RTC_FLAG_ALRAF                    ((uint32_t)RTC_ISR_ALRAF)
+#define RTC_FLAG_INITF                    ((uint32_t)RTC_ISR_INITF)
+#define RTC_FLAG_RSF                      ((uint32_t)RTC_ISR_RSF)
+#define RTC_FLAG_INITS                    ((uint32_t)RTC_ISR_INITS)
+#define RTC_FLAG_SHPF                     ((uint32_t)RTC_ISR_SHPF)
+#define RTC_FLAG_WUTWF                    ((uint32_t)RTC_ISR_WUTWF)
+#define RTC_FLAG_ALRBWF                   ((uint32_t)RTC_ISR_ALRBWF)
+#define RTC_FLAG_ALRAWF                   ((uint32_t)RTC_ISR_ALRAWF)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+/** @brief Reset RTC handle state
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_RTC_STATE_RESET)
+
+/**
+  * @brief  Disable the write protection for RTC registers.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WRITEPROTECTION_DISABLE(__HANDLE__)             \
+                        do{                                       \
+                            (__HANDLE__)->Instance->WPR = 0xCA;   \
+                            (__HANDLE__)->Instance->WPR = 0x53;   \
+                          } while(0)
+
+/**
+  * @brief  Enable the write protection for RTC registers.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WRITEPROTECTION_ENABLE(__HANDLE__)              \
+                        do{                                       \
+                            (__HANDLE__)->Instance->WPR = 0xFF;   \
+                          } while(0)
+
+/**
+  * @brief  Enable the RTC ALARMA peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMA_ENABLE(__HANDLE__)                           ((__HANDLE__)->Instance->CR |= (RTC_CR_ALRAE))
+
+/**
+  * @brief  Disable the RTC ALARMA peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMA_DISABLE(__HANDLE__)                          ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ALRAE))
+
+/**
+  * @brief  Enable the RTC ALARMB peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMB_ENABLE(__HANDLE__)                           ((__HANDLE__)->Instance->CR |= (RTC_CR_ALRBE))
+
+/**
+  * @brief  Disable the RTC ALARMB peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMB_DISABLE(__HANDLE__)                          ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ALRBE))
+
+/**
+  * @brief  Enable the RTC Alarm interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Alarm interrupt sources to be enabled or disabled.
+  *          This parameter can be any combination of the following values:
+  *             @arg RTC_IT_ALRA: Alarm A interrupt
+  *             @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_ENABLE_IT(__HANDLE__, __INTERRUPT__)          ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the RTC Alarm interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC Alarm interrupt sources to be enabled or disabled.
+  *         This parameter can be any combination of the following values:
+  *            @arg RTC_IT_ALRA: Alarm A interrupt
+  *            @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_DISABLE_IT(__HANDLE__, __INTERRUPT__)         ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified RTC Alarm interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Alarm interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_ALRA: Alarm A interrupt
+  *            @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_GET_IT(__HANDLE__, __FLAG__)                  ((((((__HANDLE__)->Instance->ISR)& ((__FLAG__)>> 4)) & 0x0000FFFF) != RESET)? SET : RESET)
+
+/**
+  * @brief  Get the selected RTC Alarm's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Alarm Flag sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_ALRAF
+  *            @arg RTC_FLAG_ALRBF
+  *            @arg RTC_FLAG_ALRAWF
+  *            @arg RTC_FLAG_ALRBWF
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_GET_FLAG(__HANDLE__, __FLAG__)                (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET)? SET : RESET)
+
+/**
+  * @brief  Clear the RTC Alarm's pending flags.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Alarm Flag sources to be enabled or disabled.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_ALRAF
+  *             @arg RTC_FLAG_ALRBF
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_CLEAR_FLAG(__HANDLE__, __FLAG__)                  ((__HANDLE__)->Instance->ISR) = (~(((__FLAG__) | RTC_ISR_INIT)& 0x0000FFFF)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+
+#define RTC_EXTI_LINE_ALARM_EVENT             ((uint32_t)0x00020000)  /*!< External interrupt line 17 Connected to the RTC Alarm event */
+#define RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT  ((uint32_t)0x00080000)  /*!< External interrupt line 19 Connected to the RTC Tamper and Time Stamp events */
+#define RTC_EXTI_LINE_WAKEUPTIMER_EVENT       ((uint32_t)0x00100000)  /*!< External interrupt line 20 Connected to the RTC Wakeup event */
+
+/**
+  * @brief  Enable the RTC Exti line.
+  * @param  __EXTILINE__: specifies the RTC Exti sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_EXTI_LINE_ALARM_EVENT
+  *            @arg RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT
+  *            @arg RTC_EXTI_LINE_WAKEUPTIMER_EVENT
+  * @retval None
+  */
+#define __HAL_RTC_EXTI_ENABLE_IT(__EXTILINE__)   (EXTI->IMR |= (__EXTILINE__))
+
+/* alias define maintained for legacy */
+#define __HAL_RTC_ENABLE_IT   __HAL_RTC_EXTI_ENABLE_IT
+
+/**
+  * @brief  Disable the RTC Exti line.
+  * @param  __EXTILINE__: specifies the RTC Exti sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_EXTI_LINE_ALARM_EVENT
+  *            @arg RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT
+  *            @arg RTC_EXTI_LINE_WAKEUPTIMER_EVENT
+  * @retval None
+  */
+#define __HAL_RTC_EXTI_DISABLE_IT(__EXTILINE__)  (EXTI->IMR &= ~(__EXTILINE__))
+
+/* alias define maintained for legacy */
+#define __HAL_RTC_DISABLE_IT   __HAL_RTC_EXTI_DISABLE_IT
+
+/**
+  * @brief  Generates a Software interrupt on selected EXTI line.
+  * @param  __EXTILINE__: specifies the RTC Exti sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_EXTI_LINE_ALARM_EVENT
+  *            @arg RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT
+  *            @arg RTC_EXTI_LINE_WAKEUPTIMER_EVENT
+  * @retval None
+  */
+#define __HAL_RTC_EXTI_GENERATE_SWIT(__EXTI_LINE__) (EXTI->SWIER |= (__EXTI_LINE__))
+
+/**
+  * @brief  Clear the RTC Exti flags.
+  * @param  __FLAG__: specifies the RTC Exti sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_EXTI_LINE_ALARM_EVENT
+  *            @arg RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT
+  *            @arg RTC_EXTI_LINE_WAKEUPTIMER_EVENT
+  * @retval None
+  */
+#define __HAL_RTC_EXTI_CLEAR_FLAG(__FLAG__)  (EXTI->PR = (__FLAG__))
+
+/* alias define maintained for legacy */
+#define __HAL_RTC_CLEAR_FLAG   __HAL_RTC_EXTI_CLEAR_FLAG
+
+/* Include RTC HAL Extension module */
+#include "stm32l0xx_hal_rtc_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+
+/* Initialization and de-initialization functions  ****************************/
+HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc);
+void HAL_RTC_MspInit(RTC_HandleTypeDef *hrtc);
+void HAL_RTC_MspDeInit(RTC_HandleTypeDef *hrtc);
+
+/* RTC Time and Date functions ************************************************/
+HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format);
+
+HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alarm);
+HAL_StatusTypeDef HAL_RTC_GetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Alarm, uint32_t Format);
+
+/* Peripheral State functions ***************************************************/
+HAL_StatusTypeDef   HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc);
+HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
+void                HAL_RTC_AlarmIRQHandler(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef   HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+void         HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc);
+
+/* Peripheral State functions *************************************************/
+HAL_StatusTypeDef  RTC_EnterInitMode(RTC_HandleTypeDef* hrtc);
+uint8_t            RTC_ByteToBcd2(uint8_t Value);
+uint8_t            RTC_Bcd2ToByte(uint8_t Value);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_RTC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rtc_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rtc_ex.c
@@ -1,0 +1,1638 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_rtc_ex.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Extended RTC HAL module driver.
+  *
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Real Time Clock (RTC) Extension peripheral:
+  *           + RTC Time Stamp functions
+  *           + RTC Tamper functions 
+  *           + RTC Wake-up functions
+  *           + Extension Control functions
+  *           + Extension RTC features functions    
+  *
+  @verbatim
+  ==============================================================================
+              ##### Backup Domain Operating Condition #####
+  ==============================================================================
+  [..] As long as the supply voltage remains in the operating range, 
+       the RTC never stops, regardless of the device status (Run mode, 
+       low power modes or under reset).
+
+                   ##### Backup Domain Reset #####
+  ==================================================================
+  [..] The backup domain reset sets all RTC registers and the RCC_CSR register 
+       to their reset values.
+  [..] A backup domain reset is generated when one of the following events occurs:
+    (+) Software reset, triggered by setting the RTCRST bit in the 
+        RCC Control Status register (RCC_CSR).
+    (+) Power reset (BOR/POR/PDR).
+
+                   ##### Backup Domain Access #####
+  ==================================================================
+  [..] After reset, the backup domain (RTC registers and RTC backup data registers) 
+       is protected against possible unwanted write accesses. 
+  [..] To enable access to the RTC Domain and RTC registers, proceed as follows:
+    (+) Enable the Power Controller (PWR) APB1 interface clock using the
+        __PWR_CLK_ENABLE() function.
+    (+) Enable access to RTC domain using the HAL_PWR_EnableBkUpAccess() function.
+    (+) Select the RTC clock source using the __HAL_RCC_RTC_CONFIG() function.
+    (+) Enable RTC Clock using the __HAL_RCC_RTC_ENABLE() function.
+
+
+                  ##### How to use this driver #####
+  ==============================================================================
+  [..]
+    (+) Enable the RTC domain access.
+    (+) Configure the RTC Prescaler (Asynchronous and Synchronous) and RTC hour
+        format using the HAL_RTC_Init() function.
+
+  *** Time and Date configuration ***
+  ===================================
+  [..] 
+    (+) To configure the RTC Calendar (Time and Date) use the HAL_RTC_SetTime()
+        and HAL_RTC_SetDate() functions.
+    (+) To read the RTC Calendar, use the HAL_RTC_GetTime() and HAL_RTC_GetDate() functions.
+
+  *** Alarm configuration ***
+  ===========================
+  [..]
+    (+) To configure the RTC Alarm use the HAL_RTC_SetAlarm() function.
+        You can also configure the RTC Alarm with interrupt mode using the HAL_RTC_SetAlarm_IT() function.
+    (+) To read the RTC Alarm, use the HAL_RTC_GetAlarm() function.
+
+  *** RTC Wakeup configuration ***
+  ================================
+  [..] 
+    (+) To configure the RTC Wakeup Clock source and Counter use the HAL_RTC_SetWakeUpTimer()
+        function. You can also configure the RTC Wakeup timer in interrupt mode 
+        using the HAL_RTC_SetWakeUpTimer_IT() function.
+    (+) To read the RTC WakeUp Counter register, use the HAL_RTC_GetWakeUpTimer()
+        function.
+        
+  *** Outputs configuration ***
+  =============================
+  [..] The RTC has 2 different outputs:
+    (+) RTC_ALARM: this output is used to manage the RTC Alarm A, Alarm B
+        and WaKeUp signals.
+        To output the selected RTC signal, use the HAL_RTC_Init() function.             
+    (+) RTC_CALIB: this output is 512Hz signal or 1Hz.
+        To enable the RTC_CALIB, use the HAL_RTCEx_SetCalibrationOutPut() function.
+    (+) Two pins can be used as RTC_ALARM or RTC_CALIB (PC13, PB14) managed on 
+        the RTC_OR register.
+    (+) When the RTC_CALIB or RTC_ALARM output is selected, the RTC_OUT pin is
+        automatically configured in output alternate function. 
+        
+  *** Smooth digital Calibration configuration ***
+  ================================================
+  [..]
+    (+) Configure the RTC Original Digital Calibration Value and the corresponding
+        calibration cycle period (32s,16s and 8s) using the HAL_RTCEx_SetSmoothCalib() 
+        function.
+
+  *** TimeStamp configuration ***
+  ===============================
+  [..]
+    (+) Enables the RTC TimeStamp using the HAL_RTC_SetTimeStamp() function.
+        You can also configure the RTC TimeStamp with interrupt mode using the
+        HAL_RTC_SetTimeStamp_IT() function.
+    (+) To read the RTC TimeStamp Time and Date register, use the HAL_RTC_GetTimeStamp()
+        function.
+
+  *** Tamper configuration ***
+  ============================
+  [..]
+    (+) Enable the RTC Tamper and Configure the Tamper filter count, trigger Edge 
+        or Level according to the Tamper filter (if equal to 0 Edge else Level) 
+        value, sampling frequency, NoErase, MaskFlag,  precharge or discharge and
+        Pull-UP using the HAL_RTC_SetTamper() function. You can configure RTC Tamper
+        with interrupt mode using HAL_RTC_SetTamper_IT() function.
+    (+) The default configuration of the Tamper erases the backup registers. To avoid
+        erase, enable the NoErase field on the RTC_TAMPCR register.
+
+  *** Backup Data Registers configuration ***
+  ===========================================
+  [..]
+    (+) To write to the RTC Backup Data registers, use the HAL_RTC_BKUPWrite()
+        function.
+    (+) To read the RTC Backup Data registers, use the HAL_RTC_BKUPRead()
+        function.
+    (+) The backup registers are reset when a tamper detection event occurs        
+
+
+                  ##### RTC and low power modes #####
+  ==================================================================
+  [..] The MCU can be woken up from a low power mode by an RTC alternate
+       function.
+  [..] The RTC alternate functions are the RTC alarms (Alarm A and Alarm B),
+       RTC wakeup, RTC tamper event detection and RTC time stamp event detection.
+       These RTC alternate functions can wake up the system from the Stop and 
+       Standby low power modes.
+  [..] The system can also wake up from low power modes without depending
+       on an external interrupt (Auto-wakeup mode), by using the RTC alarm
+       or the RTC wakeup events.
+  [..] The RTC provides a programmable time base for waking up from the
+       Stop or Standby mode at regular intervals.
+       Wakeup from STOP and Standby modes is possible only when the RTC clock source
+       is LSE or LSI.
+
+   @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RTCEx 
+  * @brief RTC HAL module driver
+  * @{
+  */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Masks Definition */
+#define RTC_TR_RESERVED_MASK    ((uint32_t)0x007F7F7F)
+#define RTC_DR_RESERVED_MASK    ((uint32_t)0x00FFFF3F) 
+#define RTC_INIT_MASK           ((uint32_t)0xFFFFFFFF)  
+#define RTC_RSF_MASK            ((uint32_t)0xFFFFFF5F)
+#define RTC_FLAGS_MASK          ((uint32_t)(RTC_FLAG_TSOVF | RTC_FLAG_TSF | RTC_FLAG_WUTF | \
+                                            RTC_FLAG_ALRBF | RTC_FLAG_INITF | RTC_FLAG_RSF | \
+                                            RTC_FLAG_INITS | RTC_FLAG_WUTWF | RTC_FLAG_ALRBWF | \
+                                            RTC_FLAG_TAMP1F | RTC_FLAG_TAMP2F | \
+                                            RTC_FLAG_RECALPF | RTC_FLAG_SHPF))
+
+#define RTC_TIMEOUT_VALUE  1000
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup RTCEx_Private_Functions
+  * @{
+  */
+
+/** @defgroup RTCEx_Group1 RTC TimeStamp and Tamper functions
+ *  @brief   RTC TimeStamp and Tamper functions
+  *
+@verbatim
+ ===============================================================================
+                 ##### RTC TimeStamp and Tamper functions #####
+ ===============================================================================
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Sets TimeStamp.
+  * @note   This API must be called before enabling the TimeStamp feature.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  TimeStampEdge: Specifies the pin edge on which the TimeStamp is
+  *         activated.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPEDGE_RISING: the Time stamp event occurs on the  
+  *                                        rising edge of the related pin.
+  *             @arg RTC_TIMESTAMPEDGE_FALLING: the Time stamp event occurs on the 
+  *                                         falling edge of the related pin.
+  * @param  RTC_TimeStampPin: specifies the RTC TimeStamp Pin.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPPIN_PC13: PC13 is selected as RTC TimeStamp Pin.
+  *               The RTC TimeStamp Pin is per default PC13, but for reasons of
+  *               compatibility, this parameter is used.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIMESTAMP_EDGE(TimeStampEdge));
+  assert_param(IS_RTC_TIMESTAMP_PIN(RTC_TimeStampPin));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Get the RTC_CR register and clear the bits to be configured */
+  tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
+
+  tmpreg|= TimeStampEdge;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the Time Stamp TSEDGE and Enable bits */
+  hrtc->Instance->CR = (uint32_t)tmpreg;
+
+  __HAL_RTC_TIMESTAMP_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY; 
+
+  /* Process Unlocked */ 
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets TimeStamp with Interrupt.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @note   This API must be called before enabling the TimeStamp feature.
+  * @param  TimeStampEdge: Specifies the pin edge on which the TimeStamp is
+  *         activated.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPEDGE_RISING: the Time stamp event occurs on the  
+  *                                        rising edge of the related pin.
+  *             @arg RTC_TIMESTAMPEDGE_FALLING: the Time stamp event occurs on the 
+  *                                         falling edge of the related pin.
+  * @param  RTC_TimeStampPin: Specifies the RTC TimeStamp Pin.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPPIN_PC13: PC13 is selected as RTC TimeStamp Pin.
+  *               The RTC TimeStamp Pin is per default PC13, but for reasons of 
+  *               compatibility, this parameter is used.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIMESTAMP_EDGE(TimeStampEdge));
+  assert_param(IS_RTC_TIMESTAMP_PIN(RTC_TimeStampPin));
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Get the RTC_CR register and clear the bits to be configured */
+  tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
+
+  tmpreg |= TimeStampEdge;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the Time Stamp TSEDGE and Enable bits */
+  hrtc->Instance->CR = (uint32_t)tmpreg;
+
+  __HAL_RTC_TIMESTAMP_ENABLE(hrtc);
+
+  /* Enable IT timestamp */
+  __HAL_RTC_TIMESTAMP_ENABLE_IT(hrtc,RTC_IT_TS);
+
+  /* RTC timestamp Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_EXTI_ENABLE_IT(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT);
+
+  EXTI->RTSR |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates TimeStamp.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTimeStamp(RTC_HandleTypeDef *hrtc)
+{
+  uint32_t tmpreg = 0;
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* In case of interrupt mode is used, the interrupt source must disabled */
+  __HAL_RTC_TIMESTAMP_DISABLE_IT(hrtc, RTC_IT_TS);
+
+  /* Get the RTC_CR register and clear the bits to be configured */
+  tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
+
+  /* Configure the Time Stamp TSEDGE and Enable bits */
+  hrtc->Instance->CR = (uint32_t)tmpreg;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Gets the RTC TimeStamp value.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTimeStamp: Pointer to Time structure
+  * @param  sTimeStampDate: Pointer to Date structure
+  * @param  Format: specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             FORMAT_BIN: Binary data format 
+  *             FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_GetTimeStamp(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef* sTimeStamp, RTC_DateTypeDef* sTimeStampDate, uint32_t Format)
+{
+  uint32_t tmptime = 0, tmpdate = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+  /* Get the TimeStamp time and date registers values */
+  tmptime = (uint32_t)(hrtc->Instance->TSTR & RTC_TR_RESERVED_MASK);
+  tmpdate = (uint32_t)(hrtc->Instance->TSDR & RTC_DR_RESERVED_MASK);
+
+  /* Fill the Time structure fields with the read parameters */
+  sTimeStamp->Hours = (uint8_t)((tmptime & (RTC_TR_HT | RTC_TR_HU)) >> 16);
+  sTimeStamp->Minutes = (uint8_t)((tmptime & (RTC_TR_MNT | RTC_TR_MNU)) >> 8);
+  sTimeStamp->Seconds = (uint8_t)(tmptime & (RTC_TR_ST | RTC_TR_SU));
+  sTimeStamp->TimeFormat = (uint8_t)((tmptime & (RTC_TR_PM)) >> 16);
+  sTimeStamp->SubSeconds = (uint32_t) hrtc->Instance->TSSSR;
+
+  /* Fill the Date structure fields with the read parameters */
+  sTimeStampDate->Year = 0;
+  sTimeStampDate->Month = (uint8_t)((tmpdate & (RTC_DR_MT | RTC_DR_MU)) >> 8);
+  sTimeStampDate->Date = (uint8_t)(tmpdate & (RTC_DR_DT | RTC_DR_DU));
+  sTimeStampDate->WeekDay = (uint8_t)((tmpdate & (RTC_DR_WDU)) >> 13);
+
+  /* Check the input parameters format */
+  if(Format == FORMAT_BIN)
+  {
+    /* Convert the TimeStamp structure parameters to Binary format */
+    sTimeStamp->Hours = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Hours);
+    sTimeStamp->Minutes = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Minutes);
+    sTimeStamp->Seconds = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Seconds);
+
+    /* Convert the DateTimeStamp structure parameters to Binary format */
+    sTimeStampDate->Month = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->Month);
+    sTimeStampDate->Date = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->Date);
+    sTimeStampDate->WeekDay = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->WeekDay);
+  }
+
+  /* Clear the TIMESTAMP Flag */
+  __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets Tamper
+  * @note   By calling this API we disable the tamper interrupt for all tampers.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTamper: Pointer to Tamper Structure.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TAMPER(sTamper->Tamper));
+  assert_param(IS_TAMPER_TRIGGER(sTamper->Trigger));
+  assert_param(IS_TAMPER_ERASE_MODE(sTamper->NoErase));
+  assert_param(IS_TAMPER_MASKFLAG_STATE(sTamper->MaskFlag));
+  assert_param(IS_TAMPER_FILTER(sTamper->Filter));
+  assert_param(IS_TAMPER_SAMPLING_FREQ(sTamper->SamplingFrequency));
+  assert_param(IS_TAMPER_PRECHARGE_DURATION(sTamper->PrechargeDuration));
+  assert_param(IS_TAMPER_PULLUP_STATE(sTamper->TamperPullUp));
+  assert_param(IS_TAMPER_TIMESTAMPONTAMPER_DETECTION(sTamper->TimeStampOnTamperDetection));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Configure the tamper trigger */
+  if(sTamper->Trigger != RTC_TAMPERTRIGGER_RISINGEDGE)
+  { 
+    sTamper->Trigger = (uint32_t)(sTamper->Tamper << 1); 
+  }
+
+  if(sTamper->NoErase == RTC_TAMPERERASEBACKUP_ENABLED)
+  {  
+    /* Configure the RTC_TAMPCR register */
+    sTamper->NoErase = RTC_TAMPERERASEBACKUP_ENABLED;
+  }
+  else
+  { 
+    sTamper->NoErase = (uint32_t)(sTamper->Tamper << 17);
+  }
+
+  if(sTamper->MaskFlag == RTC_MASKTAMPERFLAG_DISABLED)
+  {  
+    /* Configure the RTC_TAMPCR register */
+    sTamper->MaskFlag = RTC_MASKTAMPERFLAG_DISABLED;
+  }
+  else
+  {
+    sTamper->MaskFlag = (uint32_t)(sTamper->Tamper << 18);
+  }
+
+  tmpreg = ((uint32_t)sTamper->Tamper | (uint32_t)sTamper->Trigger  | (uint32_t)sTamper->NoErase |\
+            (uint32_t)sTamper->MaskFlag | (uint32_t)sTamper->Filter | (uint32_t)sTamper->SamplingFrequency |\
+            (uint32_t)sTamper->PrechargeDuration | (uint32_t)sTamper->TamperPullUp | sTamper->TimeStampOnTamperDetection);
+
+  hrtc->Instance->TAMPCR &= (uint32_t)~((uint32_t)sTamper->Tamper | (uint32_t)(sTamper->Tamper << 1) | (uint32_t)RTC_TAMPCR_TAMPTS |\
+                                       (uint32_t)RTC_TAMPCR_TAMPFREQ | (uint32_t)RTC_TAMPCR_TAMPFLT | (uint32_t)RTC_TAMPCR_TAMPPRCH |\
+                                       (uint32_t)RTC_TAMPCR_TAMPPUDIS | (uint32_t)RTC_TAMPCR_TAMPIE | (uint32_t)RTC_TAMPCR_TAMP1IE |\
+                                       (uint32_t)RTC_TAMPCR_TAMP2IE);
+
+  hrtc->Instance->TAMPCR |= tmpreg;
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets Tamper with interrupt.
+  * @note   By calling this API we force the tamper interrupt for all tampers.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTamper: Pointer to RTC Tamper.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper)
+{
+  uint32_t tmpreg = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TAMPER(sTamper->Tamper));
+  assert_param(IS_TAMPER_INTERRUPT(sTamper->Interrupt));
+  assert_param(IS_TAMPER_TRIGGER(sTamper->Trigger));
+  assert_param(IS_TAMPER_ERASE_MODE(sTamper->NoErase));
+  assert_param(IS_TAMPER_MASKFLAG_STATE(sTamper->MaskFlag));
+  assert_param(IS_TAMPER_FILTER(sTamper->Filter));
+  assert_param(IS_TAMPER_SAMPLING_FREQ(sTamper->SamplingFrequency));
+  assert_param(IS_TAMPER_PRECHARGE_DURATION(sTamper->PrechargeDuration));
+  assert_param(IS_TAMPER_PULLUP_STATE(sTamper->TamperPullUp));
+  assert_param(IS_TAMPER_TIMESTAMPONTAMPER_DETECTION(sTamper->TimeStampOnTamperDetection));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Configure the tamper trigger */
+  if(sTamper->Trigger != RTC_TAMPERTRIGGER_RISINGEDGE)
+  {
+    sTamper->Trigger = (uint32_t)(sTamper->Tamper << 1);
+  }
+
+  if(sTamper->NoErase == RTC_TAMPERERASEBACKUP_ENABLED)
+  {
+    /* Configure the RTC_TAMPCR register */
+    sTamper->NoErase = RTC_TAMPERERASEBACKUP_ENABLED;
+  }
+  else
+  {
+    sTamper->NoErase = (uint32_t)(sTamper->Tamper << 17);
+  }
+  
+  if(sTamper->MaskFlag == RTC_MASKTAMPERFLAG_DISABLED)
+  {
+    /* Configure the RTC_TAMPCR register */
+    sTamper->MaskFlag = RTC_MASKTAMPERFLAG_DISABLED;
+  }
+  else
+  {
+    sTamper->MaskFlag = (uint32_t)(sTamper->Tamper << 18);
+  }
+
+  tmpreg = ((uint32_t)sTamper->Tamper | (uint32_t)sTamper->Interrupt | (uint32_t)sTamper->Trigger  | (uint32_t)sTamper->NoErase |\
+            (uint32_t)sTamper->MaskFlag | (uint32_t)sTamper->Filter | (uint32_t)sTamper->SamplingFrequency |\
+            (uint32_t)sTamper->PrechargeDuration | (uint32_t)sTamper->TamperPullUp | sTamper->TimeStampOnTamperDetection);
+  
+  hrtc->Instance->TAMPCR &= (uint32_t)~((uint32_t)sTamper->Tamper | (uint32_t)(sTamper->Tamper << 1) | (uint32_t)RTC_TAMPCR_TAMPTS |\
+                                       (uint32_t)RTC_TAMPCR_TAMPFREQ | (uint32_t)RTC_TAMPCR_TAMPFLT | (uint32_t)RTC_TAMPCR_TAMPPRCH |\
+                                       (uint32_t)RTC_TAMPCR_TAMPPUDIS | (uint32_t)RTC_TAMPCR_TAMPIE | (uint32_t)RTC_TAMPCR_TAMP1IE |\
+                                       (uint32_t)RTC_TAMPCR_TAMP2IE);
+
+  hrtc->Instance->TAMPCR |= tmpreg;
+
+  /* RTC Tamper Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_EXTI_ENABLE_IT(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT);
+
+  EXTI->RTSR |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT;
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates Tamper.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Tamper: Selected tamper pin.
+  *          This parameter can be RTC_Tamper_1 and/or RTC_TAMPER_2.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTamper(RTC_HandleTypeDef *hrtc, uint32_t Tamper)
+{
+  assert_param(IS_TAMPER(Tamper));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the selected Tamper pin */
+  hrtc->Instance->TAMPCR &= (uint32_t)~Tamper;
+
+  if (Tamper == RTC_TAMPER_1)
+  {
+    /* Disable the Tamper1 interrupt */
+    hrtc->Instance->TAMPCR &= (uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP1);
+  }
+  else
+  {
+    /* Disable the Tamper2 interrupt */
+    hrtc->Instance->TAMPCR &= (uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP2);
+  }
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets wake up timer.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  WakeUpCounter: Wake up counter
+  * @param  WakeUpClock: Wake up clock
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock)
+{
+  uint32_t tickstart;
+
+  /* Check the parameters */
+  assert_param(IS_WAKEUP_CLOCK(WakeUpClock));
+  assert_param(IS_WAKEUP_COUNTER(WakeUpCounter));
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
+
+  tickstart = HAL_GetTick();
+
+  /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
+  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+      hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+      /* Process Unlocked */ 
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Clear the Wakeup Timer clock source bits in CR register */
+  hrtc->Instance->CR &= (uint32_t)~RTC_CR_WUCKSEL;
+
+  /* Configure the clock source */
+  hrtc->Instance->CR |= (uint32_t)WakeUpClock;
+
+  /* Configure the Wakeup Timer counter */
+  hrtc->Instance->WUTR = (uint32_t)WakeUpCounter;
+
+   /* Enable the Wakeup Timer */
+  __HAL_RTC_WAKEUPTIMER_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets wake up timer with interrupt
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  WakeUpCounter: Wake up counter
+  * @param  WakeUpClock: Wake up clock  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock)
+{
+  uint32_t tickstart;
+
+  /* Check the parameters */
+  assert_param(IS_WAKEUP_CLOCK(WakeUpClock));
+  assert_param(IS_WAKEUP_COUNTER(WakeUpCounter));
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
+
+  tickstart = HAL_GetTick();
+
+  /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
+  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+      hrtc->State = HAL_RTC_STATE_TIMEOUT; 
+
+      /* Process Unlocked */ 
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Configure the Wakeup Timer counter */
+  hrtc->Instance->WUTR = (uint32_t)WakeUpCounter;
+
+  /* Clear the Wakeup Timer clock source bits in CR register */
+  hrtc->Instance->CR &= (uint32_t)~RTC_CR_WUCKSEL;
+
+  /* Configure the clock source */
+  hrtc->Instance->CR |= (uint32_t)WakeUpClock;
+
+  /* RTC WakeUpTimer Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_EXTI_ENABLE_IT(RTC_EXTI_LINE_WAKEUPTIMER_EVENT);
+
+  EXTI->RTSR |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT;
+
+  /* Configure the Interrupt in the RTC_CR register */
+  __HAL_RTC_WAKEUPTIMER_ENABLE_IT(hrtc,RTC_IT_WUT);
+  
+  /* Enable the Wakeup Timer */
+  __HAL_RTC_WAKEUPTIMER_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY; 
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates wake up timer counter.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC. 
+  * @retval HAL status
+  */
+uint32_t HAL_RTCEx_DeactivateWakeUpTimer(RTC_HandleTypeDef *hrtc)
+{
+  uint32_t tickstart;
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Disable the Wakeup Timer */
+  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
+
+  /* In case of interrupt mode is used, the interrupt source must disabled */
+  __HAL_RTC_WAKEUPTIMER_DISABLE_IT(hrtc,RTC_IT_WUT);
+
+  tickstart = HAL_GetTick();
+  /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
+  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+      hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Gets wake up timer counter.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC. 
+  * @retval Counter value
+  */
+uint32_t HAL_RTCEx_GetWakeUpTimer(RTC_HandleTypeDef *hrtc)
+{
+  /* Get the counter value */
+  return ((uint32_t)(hrtc->Instance->WUTR & RTC_WUTR_WUT));
+}
+
+/**
+  * @brief  Writes a data in a specified RTC Backup data register.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC. 
+  * @param  BackupRegister: RTC Backup data Register number.
+  *          This parameter can be: RTC_BKP_DRx where x can be from 0 to 19 to 
+  *                                 specify the register.
+  * @param  Data: Data to be written in the specified RTC Backup data register.
+  * @retval None
+  */
+void HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister, uint32_t Data)
+{
+  uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_BKP(BackupRegister));
+
+  tmp = (uint32_t)&(hrtc->Instance->BKP0R);
+  tmp += (BackupRegister * 4);
+
+  /* Write the specified register */
+  *(__IO uint32_t *)tmp = (uint32_t)Data;
+}
+
+/**
+  * @brief  Reads data from the specified RTC Backup data Register.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC. 
+  * @param  BackupRegister: RTC Backup data Register number.
+  *          This parameter can be: RTC_BKP_DRx where x can be from 0 to 19 to 
+  *                                 specify the register.
+  * @retval Read value
+  */
+uint32_t HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister)
+{
+  uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_BKP(BackupRegister));
+
+  tmp = (uint32_t)&(hrtc->Instance->BKP0R);
+  tmp += (BackupRegister * 4);
+  
+  /* Read the specified register */
+  return (*(__IO uint32_t *)tmp);
+}
+
+/**
+  * @brief  Sets the Smooth calibration parameters.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.  
+  * @param  SmoothCalibPeriod: Select the Smooth Calibration Period.
+  *          This parameter can be can be one of the following values :
+  *             @arg RTC_SMOOTHCALIB_PERIOD_32SEC: The smooth calibration periode is 32s.
+  *             @arg RTC_SMOOTHCALIB_PERIOD_16SEC: The smooth calibration periode is 16s.
+  *             @arg RTC_SMOOTHCALIB_PERIOD_8SEC: The smooth calibartion periode is 8s.
+  * @param  SmoothCalibPlusPulses: Select to Set or reset the CALP bit.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_SMOOTHCALIB_PLUSPULSES_SET: Add one RTCCLK puls every 2*11 pulses.
+  *             @arg RTC_SMOOTHCALIB_PLUSPULSES_RESET: No RTCCLK pulses are added.
+  * @param  SmouthCalibMinusPulsesValue: Select the value of CALM[8:0] bits.
+  *          This parameter can be one any value from 0 to 0x000001FF.
+  * @note   To deactivate the smooth calibration, the field SmoothCalibPlusPulses 
+  *         must be equal to SMOOTHCALIB_PLUSPULSES_RESET and the field
+  *         SmouthCalibMinusPulsesValue mut be equal to 0.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef* hrtc, uint32_t SmoothCalibPeriod, uint32_t SmoothCalibPlusPulses, uint32_t SmouthCalibMinusPulsesValue)
+{
+  uint32_t tickstart;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_SMOOTH_CALIB_PERIOD(SmoothCalibPeriod));
+  assert_param(IS_RTC_SMOOTH_CALIB_PLUS(SmoothCalibPlusPulses));
+  assert_param(IS_RTC_SMOOTH_CALIB_MINUS(SmouthCalibMinusPulsesValue));
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* check if a calibration is pending*/
+  if((hrtc->Instance->ISR & RTC_ISR_RECALPF) != RESET)
+  {
+    tickstart = HAL_GetTick();
+
+    /* check if a calibration is pending*/
+    while((hrtc->Instance->ISR & RTC_ISR_RECALPF) != RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        /* Change RTC state */
+        hrtc->State = HAL_RTC_STATE_TIMEOUT; 
+        
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Configure the Smooth calibration settings */
+  hrtc->Instance->CALR = (uint32_t)((uint32_t)SmoothCalibPeriod | (uint32_t)SmoothCalibPlusPulses | (uint32_t)SmouthCalibMinusPulsesValue);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY; 
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the Synchronization Shift Control Settings.
+  * @note   When REFCKON is set, firmware must not write to Shift control register. 
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.    
+  * @param  ShiftAdd1S: Select to add or not 1 second to the time calendar.
+  *          This parameter can be one of the following values :
+  *             @arg RTC_SHIFTADD1S_SET: Add one second to the clock calendar. 
+  *             @arg RTC_SHIFTADD1S_RESET: No effect.
+  * @param  ShiftSubFS: Select the number of Second Fractions to substitute.
+  *          This parameter can be one any value from 0 to 0x7FFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef* hrtc, uint32_t ShiftAdd1S, uint32_t ShiftSubFS)
+{
+  uint32_t tickstart;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_SHIFT_ADD1S(ShiftAdd1S));
+  assert_param(IS_RTC_SHIFT_SUBFS(ShiftSubFS));
+
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+    tickstart = HAL_GetTick();
+
+    /* Wait until the shift is completed*/
+    while((hrtc->Instance->ISR & RTC_ISR_SHPF) != RESET)
+    {
+      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */ 
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Check if the reference clock detection is disabled */
+    if((hrtc->Instance->CR & RTC_CR_REFCKON) == RESET)
+    {
+      /* Configure the Shift settings */
+      hrtc->Instance->SHIFTR = (uint32_t)(uint32_t)(ShiftSubFS) | (uint32_t)(ShiftAdd1S);
+
+      /* If  RTC_CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
+      if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == RESET)
+      {
+        if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+        {
+          /* Enable the write protection for RTC registers */
+          __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+          hrtc->State = HAL_RTC_STATE_ERROR;
+
+          /* Process Unlocked */ 
+          __HAL_UNLOCK(hrtc);
+
+          return HAL_ERROR;
+        }
+      }
+    }
+    else
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+      
+      /* Change RTC state */
+      hrtc->State = HAL_RTC_STATE_ERROR;
+      
+      /* Process Unlocked */ 
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_ERROR;
+    }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.    
+  * @param  CalibOutput : Select the Calibration output Selection .
+  *          This parameter can be one of the following values:
+  *             @arg RTC_CALIBOUTPUT_512HZ: A signal has a regular waveform at 512Hz.
+  *             @arg RTC_CALIBOUTPUT_1HZ: A signal has a regular waveform at 1Hz.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetCalibrationOutPut(RTC_HandleTypeDef* hrtc, uint32_t CalibOutput)
+{
+  /* Check the parameters */
+  assert_param(IS_RTC_CALIB_OUTPUT(CalibOutput));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Clear flags before config */
+  hrtc->Instance->CR &= (uint32_t)~RTC_CR_COSEL;
+
+  /* Configure the RTC_CR register */
+  hrtc->Instance->CR |= (uint32_t)CalibOutput;
+
+  __HAL_RTC_CALIBRATION_OUTPUT_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.    
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateCalibrationOutPut(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */ 
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  __HAL_RTC_CALIBRATION_OUTPUT_DISABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables the RTC reference clock detection.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.    
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetRefClock(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state*/
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    __HAL_RTC_CLOCKREF_DETECTION_ENABLE(hrtc);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+   /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disable the RTC reference clock detection.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateRefClock(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+  
+  /* Set Initialization mode */
+  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Set RTC state*/
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_ERROR;
+  }
+  else
+  {
+    __HAL_RTC_CLOCKREF_DETECTION_DISABLE(hrtc);
+
+    /* Exit Initialization mode */
+    hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables the Bypass Shadow feature.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.  
+  * @note   When the Bypass Shadow is enabled the calendar value are taken
+  *         directly from the Calendar counter.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_EnableBypassShadow(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set the BYPSHAD bit */
+  hrtc->Instance->CR |= (uint8_t)RTC_CR_BYPSHAD;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables the Bypass Shadow feature.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.  
+  * @note   When the Bypass Shadow is enabled the calendar value are taken
+  *         directly from the Calendar counter.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef* hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Reset the BYPSHAD bit */
+  hrtc->Instance->CR &= (uint8_t)~RTC_CR_BYPSHAD;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles TimeStamp interrupt request.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTCEx_TamperTimeStampIRQHandler(RTC_HandleTypeDef *hrtc)
+{  
+  if(__HAL_RTC_TIMESTAMP_GET_IT(hrtc, RTC_IT_TS))
+  {
+    /* Get the status of the Interrupt */
+    if((uint32_t)(hrtc->Instance->CR & RTC_IT_TS) != (uint32_t)RESET)
+    {
+      /* TIMESTAMP callback */ 
+      HAL_RTCEx_TimeStampEventCallback(hrtc);
+
+      /* Clear the TIMESTAMP interrupt pending bit */
+      __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc,RTC_FLAG_TSF);
+    }
+  }
+
+  /* Get the status of the Interrupt */
+  if(__HAL_RTC_TAMPER_GET_IT(hrtc,RTC_IT_TAMP1))
+  {
+    /* Get the TAMPER Interrupt enable bit and pending bit */
+    if(((hrtc->Instance->TAMPCR & (RTC_TAMPCR_TAMPIE))) != (uint32_t)RESET)
+    {
+      /* Tamper callback */
+      HAL_RTCEx_Tamper1EventCallback(hrtc);
+
+      /* Clear the Tamper interrupt pending bit */
+      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc,RTC_FLAG_TAMP1F);
+    }
+  }
+
+  /* Get the status of the Interrupt */
+  if(__HAL_RTC_TAMPER_GET_IT(hrtc, RTC_IT_TAMP2))
+  {
+    /* Get the TAMPER Interrupt enable bit and pending bit */
+    if(((hrtc->Instance->TAMPCR & RTC_TAMPCR_TAMPIE)) != (uint32_t)RESET)
+    {
+      /* Tamper callback */
+      HAL_RTCEx_Tamper2EventCallback(hrtc);
+
+      /* Clear the Tamper interrupt pending bit */
+      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP2F);
+    }
+  }
+  /* Clear the EXTI's Flag for RTC TimeStamp and Tamper */
+  __HAL_RTC_EXTI_CLEAR_FLAG(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+}
+
+/**
+  * @brief  This function handles Wake Up Timer interrupt request.
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+void HAL_RTCEx_WakeUpTimerIRQHandler(RTC_HandleTypeDef *hrtc)
+{  
+  if(__HAL_RTC_WAKEUPTIMER_GET_IT(hrtc, RTC_IT_WUT))
+  {
+    /* Get the status of the Interrupt */
+    if((uint32_t)(hrtc->Instance->CR & RTC_IT_WUT) != (uint32_t)RESET)
+    {
+      /* WAKEUPTIMER callback */ 
+      HAL_RTCEx_WakeUpTimerEventCallback(hrtc);
+      
+      /* Clear the WAKEUPTIMER interrupt pending bit */
+      __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
+    }
+  }
+
+  /* Clear the EXTI's line Flag for RTC WakeUpTimer */
+  __HAL_RTC_EXTI_CLEAR_FLAG(RTC_EXTI_LINE_WAKEUPTIMER_EVENT);
+  
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+}
+
+/**
+  * @brief  Alarm B callback.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTCEx_AlarmBEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_AlarmBEventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  TimeStamp callback. 
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+__weak void HAL_RTCEx_TimeStampEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_TimeStampEventCallback could be implemented in the user file
+  */
+}
+
+/**
+  * @brief  Tamper 1 callback.
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+__weak void HAL_RTCEx_Tamper1EventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_Tamper1EventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Tamper 2 callback. 
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+__weak void HAL_RTCEx_Tamper2EventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_Tamper2EventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Wake Up Timer callback.
+  * @param  hrtc: RTC handle
+  * @retval None
+  */
+__weak void HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_RTC_WakeUpTimerEventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  This function handles AlarmB Polling request.
+  * @param  hrtc: pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{ 
+  uint32_t tickstart; 
+
+  /* Get Timeout value */
+  tickstart = HAL_GetTick();   
+  
+  while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBF) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Alarm Flag */
+  __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles TimeStamp polling request.
+  * @param  hrtc: RTC handle
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTimeStampEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{ 
+  uint32_t tickstart; 
+
+  /* Get Timeout value */
+  tickstart = HAL_GetTick();   
+
+  while(__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSF) == RESET)
+  {
+    if(__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSOVF) != RESET)
+    {
+      /* Clear the TIMESTAMP OverRun Flag */
+      __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSOVF);
+
+      /* Change TIMESTAMP state */
+      hrtc->State = HAL_RTC_STATE_ERROR; 
+
+      return HAL_ERROR; 
+    }
+
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles Tamper1 Polling.
+  * @param  hrtc: RTC handle
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper1Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart;
+
+  /* Get Timeout value */
+  tickstart = HAL_GetTick();
+
+  /* Get the status of the Interrupt */
+  while(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP1F)== RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Tamper Flag */
+  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc,RTC_FLAG_TAMP1F);
+  
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+  
+  return HAL_OK; 
+}
+
+/**
+  * @brief  This function handles Tamper2 Polling.
+  * @param  hrtc: RTC handle
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper2Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart; 
+
+  /* Get Timeout value */
+  tickstart = HAL_GetTick();
+
+  /* Get the status of the Interrupt */
+  while(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP2F) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Tamper Flag */
+  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc,RTC_FLAG_TAMP2F);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  This function handles Wake Up Timer Polling.
+  * @param  hrtc: RTC handle
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart;
+
+  /* Get Timeout value */
+  tickstart = HAL_GetTick();
+
+  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTF) == RESET)
+  {
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+      
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the WAKEUPTIMER Flag */
+  __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
+  
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RTC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rtc_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_rtc_ex.h
@@ -1,0 +1,681 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_rtc_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of PWR HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_RTC_EX_H
+#define __STM32L0xx_HAL_RTC_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RTCEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+   
+/**
+  * @brief  RTC Tamper structure definition
+  */
+typedef struct
+{
+  uint32_t Tamper;                      /*!< Specifies the Tamper Pin.
+                                             This parameter can be a value of @ref  RTCEx_Tamper_Pins_Definitions */
+
+  uint32_t Interrupt;                   /*!< Specifies the Tamper Interrupt.
+                                             This parameter can be a value of @ref  RTCEx_Tamper_Interrupt_Definitions */
+
+  uint32_t Trigger;                     /*!< Specifies the Tamper Trigger.
+                                             This parameter can be a value of @ref  RTCEx_Tamper_Trigger_Definitions */
+
+  uint32_t NoErase;                     /*!< Specifies the Tamper no erase mode.
+                                             This parameter can be a value of @ref  RTCEx_Tamper_EraseBackUp_Definitions */
+
+  uint32_t MaskFlag;                     /*!< Specifies the Tamper Flag masking.
+                                             This parameter can be a value of @ref RTCEx_Tamper_MaskFlag_Definitions   */
+
+  uint32_t Filter;                      /*!< Specifies the RTC Filter Tamper.
+                                             This parameter can be a value of @ref RTCEx_Tamper_Filter_Definitions */
+
+  uint32_t SamplingFrequency;           /*!< Specifies the sampling frequency.
+                                             This parameter can be a value of @ref RTCEx_Tamper_Sampling_Frequencies_Definitions */
+
+  uint32_t PrechargeDuration;           /*!< Specifies the Precharge Duration .
+                                             This parameter can be a value of @ref RTCEx_Tamper_Pin_Precharge_Duration_Definitions */
+
+  uint32_t TamperPullUp;                /*!< Specifies the Tamper PullUp .
+                                             This parameter can be a value of @ref RTCEx_Tamper_PullUP_Definitions */
+
+  uint32_t TimeStampOnTamperDetection;  /*!< Specifies the TimeStampOnTamperDetection.
+                                             This parameter can be a value of @ref RTCEx_Tamper_TimeStampOnTamperDetection_Definitions */
+}RTC_TamperTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup RTCEx_Exported_Constants
+  * @{
+  */
+
+/** @defgroup RTCEx_Backup_Registers_Definitions
+  * @{
+  */
+#define RTC_BKP_DR0                       ((uint32_t)0x00000000)
+#define RTC_BKP_DR1                       ((uint32_t)0x00000001)
+#define RTC_BKP_DR2                       ((uint32_t)0x00000002)
+#define RTC_BKP_DR3                       ((uint32_t)0x00000003)
+#define RTC_BKP_DR4                       ((uint32_t)0x00000004)
+
+#define IS_RTC_BKP(BKP)                   (((BKP) == RTC_BKP_DR0) || \
+                                           ((BKP) == RTC_BKP_DR1) || \
+                                           ((BKP) == RTC_BKP_DR2) || \
+                                           ((BKP) == RTC_BKP_DR3) || \
+                                           ((BKP) == RTC_BKP_DR4))
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Time_Stamp_Edges_definitions
+  * @{
+  */ 
+#define RTC_TIMESTAMPEDGE_RISING          ((uint32_t)0x00000000)
+#define RTC_TIMESTAMPEDGE_FALLING         ((uint32_t)0x00000008)
+
+#define IS_TIMESTAMP_EDGE(EDGE) (((EDGE) == RTC_TIMESTAMPEDGE_RISING) || \
+                                 ((EDGE) == RTC_TIMESTAMPEDGE_FALLING))
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Pins_Definitions
+  * @{
+  */
+#define RTC_TAMPER_1                    RTC_TAMPCR_TAMP1E
+#define RTC_TAMPER_2                    RTC_TAMPCR_TAMP2E
+
+#define IS_TAMPER(TAMPER) ((((TAMPER) & (uint32_t)0xFFFFFFF6) == 0x00) && ((TAMPER) != (uint32_t)RESET))
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Interrupt_Definitions
+  * @{
+  */
+#define RTC_TAMPER1_INTERRUPT                RTC_TAMPCR_TAMP1IE
+#define RTC_TAMPER2_INTERRUPT                RTC_TAMPCR_TAMP2IE
+#define RTC_TAMPER1_2_INTERRUPT              RTC_TAMPCR_TAMPIE
+
+#define IS_TAMPER_INTERRUPT(INTERRUPT) (((INTERRUPT) == RTC_TAMPER1_INTERRUPT) || \
+                                        ((INTERRUPT) == RTC_TAMPER2_INTERRUPT) || \
+                                        ((INTERRUPT) == RTC_TAMPER1_2_INTERRUPT))
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_TimeStamp_Pin_Selection
+  * @{
+  */
+#define RTC_TIMESTAMPPIN_PC13              ((uint32_t)0x00000000)
+
+#define IS_RTC_TIMESTAMP_PIN(PIN)  ((PIN) == RTC_TIMESTAMPPIN_PC13)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Trigger_Definitions
+  * @{
+  */
+#define RTC_TAMPERTRIGGER_RISINGEDGE       ((uint32_t)0x00000000)
+#define RTC_TAMPERTRIGGER_FALLINGEDGE      ((uint32_t)0x00000002)
+#define RTC_TAMPERTRIGGER_LOWLEVEL         RTC_TAMPERTRIGGER_RISINGEDGE
+#define RTC_TAMPERTRIGGER_HIGHLEVEL        RTC_TAMPERTRIGGER_FALLINGEDGE
+
+#define IS_TAMPER_TRIGGER(TRIGGER) (((TRIGGER) == RTC_TAMPERTRIGGER_RISINGEDGE) || \
+                                        ((TRIGGER) == RTC_TAMPERTRIGGER_FALLINGEDGE) || \
+                                        ((TRIGGER) == RTC_TAMPERTRIGGER_LOWLEVEL) || \
+                                        ((TRIGGER) == RTC_TAMPERTRIGGER_HIGHLEVEL)) 
+
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_EraseBackUp_Definitions
+* @{
+*/
+#define RTC_TAMPERERASEBACKUP_ENABLED               ((uint32_t)0x00000000)
+#define RTC_TAMPERERASEBACKUP_DISABLED              ((uint32_t)0x00020000)
+
+#define IS_TAMPER_ERASE_MODE(MODE)                 (((MODE) == RTC_TAMPERERASEBACKUP_ENABLED) || \
+                                                    ((MODE) == RTC_TAMPERERASEBACKUP_DISABLED))
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_MaskFlag_Definitions
+* @{
+*/
+#define RTC_MASKTAMPERFLAG_DISABLED                ((uint32_t)0x00000000)
+#define RTC_MASKTAMPERFLAG_ENABLED                 ((uint32_t)0x00040000)
+
+#define IS_TAMPER_MASKFLAG_STATE(STATE)                  (((STATE) == RTC_MASKTAMPERFLAG_ENABLED) || \
+                                                    ((STATE) == RTC_MASKTAMPERFLAG_DISABLED))
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Filter_Definitions
+  * @{
+  */
+#define RTC_TAMPERFILTER_DISABLE   ((uint32_t)0x00000000)  /*!< Tamper filter is disabled */
+
+#define RTC_TAMPERFILTER_2SAMPLE   ((uint32_t)0x00000800)  /*!< Tamper is activated after 2
+                                                                consecutive samples at the active level */
+#define RTC_TAMPERFILTER_4SAMPLE   ((uint32_t)0x00001000)  /*!< Tamper is activated after 4
+                                                                consecutive samples at the active level */
+#define RTC_TAMPERFILTER_8SAMPLE   ((uint32_t)0x00001800)  /*!< Tamper is activated after 8
+                                                                consecutive samples at the active leve. */
+
+#define IS_TAMPER_FILTER(FILTER)  (((FILTER) == RTC_TAMPERFILTER_DISABLE) || \
+                                   ((FILTER) == RTC_TAMPERFILTER_2SAMPLE) || \
+                                   ((FILTER) == RTC_TAMPERFILTER_4SAMPLE) || \
+                                   ((FILTER) == RTC_TAMPERFILTER_8SAMPLE))
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Sampling_Frequencies_Definitions
+  * @{
+  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV32768  ((uint32_t)0x00000000)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 32768 */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV16384  ((uint32_t)0x00000100)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 16384 */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV8192   ((uint32_t)0x00000200)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 8192  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV4096   ((uint32_t)0x00000300)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 4096  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV2048   ((uint32_t)0x00000400)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 2048  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV1024   ((uint32_t)0x00000500)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 1024  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV512    ((uint32_t)0x00000600)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 512   */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV256    ((uint32_t)0x00000700)  /*!< Each of the tamper inputs are sampled
+                                                                             with a frequency =  RTCCLK / 256   */
+
+#define IS_TAMPER_SAMPLING_FREQ(FREQ) (((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV32768)|| \
+                                       ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV16384)|| \
+                                       ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV8192) || \
+                                       ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV4096) || \
+                                       ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV2048) || \
+                                       ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV1024) || \
+                                       ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV512)  || \
+                                       ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV256))
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Pin_Precharge_Duration_Definitions
+  * @{
+  */
+#define RTC_TAMPERPRECHARGEDURATION_1RTCCLK ((uint32_t)0x00000000)  /*!< Tamper pins are pre-charged before
+                                                                         sampling during 1 RTCCLK cycle  */
+#define RTC_TAMPERPRECHARGEDURATION_2RTCCLK ((uint32_t)0x00002000)  /*!< Tamper pins are pre-charged before
+                                                                         sampling during 2 RTCCLK cycles */
+#define RTC_TAMPERPRECHARGEDURATION_4RTCCLK ((uint32_t)0x00004000)  /*!< Tamper pins are pre-charged before
+                                                                         sampling during 4 RTCCLK cycles */
+#define RTC_TAMPERPRECHARGEDURATION_8RTCCLK ((uint32_t)0x00006000)  /*!< Tamper pins are pre-charged before
+                                                                         sampling during 8 RTCCLK cycles */
+
+#define IS_TAMPER_PRECHARGE_DURATION(DURATION) (((DURATION) == RTC_TAMPERPRECHARGEDURATION_1RTCCLK) || \
+                                                ((DURATION) == RTC_TAMPERPRECHARGEDURATION_2RTCCLK) || \
+                                                ((DURATION) == RTC_TAMPERPRECHARGEDURATION_4RTCCLK) || \
+                                                ((DURATION) == RTC_TAMPERPRECHARGEDURATION_8RTCCLK))
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_TimeStampOnTamperDetection_Definitions
+  * @{
+  */
+#define RTC_TIMESTAMPONTAMPERDETECTION_ENABLE  ((uint32_t)RTC_TAMPCR_TAMPTS)  /*!< TimeStamp on Tamper Detection event saved        */
+#define RTC_TIMESTAMPONTAMPERDETECTION_DISABLE ((uint32_t)0x00000000)         /*!< TimeStamp on Tamper Detection event is not saved */
+
+#define IS_TAMPER_TIMESTAMPONTAMPER_DETECTION(DETECTION) (((DETECTION) == RTC_TIMESTAMPONTAMPERDETECTION_ENABLE) || \
+                                                          ((DETECTION) == RTC_TIMESTAMPONTAMPERDETECTION_DISABLE))
+/**
+  * @}
+  */
+
+/** @defgroup  RTCEx_Tamper_PullUP_Definitions
+  * @{
+  */
+#define RTC_TAMPER_PULLUP_ENABLE  ((uint32_t)0x00000000)             /*!< TimeStamp on Tamper Detection event saved        */
+#define RTC_TAMPER_PULLUP_DISABLE ((uint32_t)RTC_TAMPCR_TAMPPUDIS)   /*!< TimeStamp on Tamper Detection event is not saved */
+
+#define IS_TAMPER_PULLUP_STATE(STATE) (((STATE) == RTC_TAMPER_PULLUP_ENABLE) || \
+                                       ((STATE) == RTC_TAMPER_PULLUP_DISABLE))
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Wakeup_Timer_Definitions
+  * @{
+  */
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV16        ((uint32_t)0x00000000)
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV8         ((uint32_t)0x00000001)
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV4         ((uint32_t)0x00000002)
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV2         ((uint32_t)0x00000003)
+#define RTC_WAKEUPCLOCK_CK_SPRE_16BITS      ((uint32_t)0x00000004)
+#define RTC_WAKEUPCLOCK_CK_SPRE_17BITS      ((uint32_t)0x00000006)
+
+#define IS_WAKEUP_CLOCK(CLOCK) (((CLOCK) == RTC_WAKEUPCLOCK_RTCCLK_DIV16)       || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_RTCCLK_DIV8)    || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_RTCCLK_DIV4)    || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_RTCCLK_DIV2)    || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_CK_SPRE_16BITS) || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_CK_SPRE_17BITS))
+
+#define IS_WAKEUP_COUNTER(COUNTER)  ((COUNTER) <= 0xFFFF)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Digital_Calibration_Definitions
+  * @{
+  */
+#define RTC_CALIBSIGN_POSITIVE            ((uint32_t)0x00000000)
+#define RTC_CALIBSIGN_NEGATIVE            ((uint32_t)0x00000080)
+
+#define IS_RTC_CALIB_SIGN(SIGN) (((SIGN) == RTC_CALIBSIGN_POSITIVE) || \
+                                 ((SIGN) == RTC_CALIBSIGN_NEGATIVE))
+
+#define IS_RTC_CALIB_VALUE(VALUE) ((VALUE) < 0x20)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Smooth_calib_period_Definitions
+  * @{
+  */
+#define RTC_SMOOTHCALIB_PERIOD_32SEC   ((uint32_t)0x00000000)  /*!< If RTCCLK = 32768 Hz, Smooth calibation
+                                                                    period is 32s,  else 2exp20 RTCCLK seconds */
+#define RTC_SMOOTHCALIB_PERIOD_16SEC   ((uint32_t)0x00002000)  /*!< If RTCCLK = 32768 Hz, Smooth calibation 
+                                                                    period is 16s, else 2exp19 RTCCLK seconds */
+#define RTC_SMOOTHCALIB_PERIOD_8SEC    ((uint32_t)0x00004000)  /*!< If RTCCLK = 32768 Hz, Smooth calibation 
+                                                                    period is 8s, else 2exp18 RTCCLK seconds */
+
+#define IS_RTC_SMOOTH_CALIB_PERIOD(PERIOD) (((PERIOD) == RTC_SMOOTHCALIB_PERIOD_32SEC) || \
+                                            ((PERIOD) == RTC_SMOOTHCALIB_PERIOD_16SEC) || \
+                                            ((PERIOD) == RTC_SMOOTHCALIB_PERIOD_8SEC))
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Smooth_calib_Plus_pulses_Definitions
+  * @{
+  */
+#define RTC_SMOOTHCALIB_PLUSPULSES_SET    ((uint32_t)0x00008000)  /*!< The number of RTCCLK pulses added
+                                                                       during a X -second window = Y - CALM[8:0]
+                                                                       with Y = 512, 256, 128 when X = 32, 16, 8 */
+#define RTC_SMOOTHCALIB_PLUSPULSES_RESET  ((uint32_t)0x00000000)  /*!< The number of RTCCLK pulses subbstited
+                                                                       during a 32-second window = CALM[8:0] */
+
+#define IS_RTC_SMOOTH_CALIB_PLUS(PLUS) (((PLUS) == RTC_SMOOTHCALIB_PLUSPULSES_SET) || \
+                                        ((PLUS) == RTC_SMOOTHCALIB_PLUSPULSES_RESET))
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Smooth_calib_Minus_pulses_Definitions
+  * @{
+  */
+#define  IS_RTC_SMOOTH_CALIB_MINUS(VALUE) ((VALUE) <= 0x000001FF)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Add_1_Second_Parameter_Definitions
+  * @{
+  */
+#define RTC_SHIFTADD1S_RESET      ((uint32_t)0x00000000)
+#define RTC_SHIFTADD1S_SET        ((uint32_t)0x80000000)
+
+#define IS_RTC_SHIFT_ADD1S(SEL) (((SEL) == RTC_SHIFTADD1S_RESET) || \
+                                 ((SEL) == RTC_SHIFTADD1S_SET))
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Substract_Fraction_Of_Second_Value
+  * @{
+  */
+#define IS_RTC_SHIFT_SUBFS(FS) ((FS) <= 0x00007FFF)
+/**
+  * @}
+  */
+
+ /** @defgroup RTCEx_Calib_Output_selection_Definitions
+  * @{
+  */
+#define RTC_CALIBOUTPUT_512HZ            ((uint32_t)0x00000000)
+#define RTC_CALIBOUTPUT_1HZ              ((uint32_t)0x00080000)
+
+#define IS_RTC_CALIB_OUTPUT(OUTPUT)  (((OUTPUT) == RTC_CALIBOUTPUT_512HZ) || \
+                                      ((OUTPUT) == RTC_CALIBOUTPUT_1HZ))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup RTCEx_Exported macro
+ * @{
+ */
+
+/**
+  * @brief  Enable the RTC WakeUp Timer peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_ENABLE(__HANDLE__)                      ((__HANDLE__)->Instance->CR |= (RTC_CR_WUTE))
+
+/**
+  * @brief  Disable the RTC WakeUp Timer peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_DISABLE(__HANDLE__)                     ((__HANDLE__)->Instance->CR &= ~(RTC_CR_WUTE))
+
+/**
+  * @brief  Enable the RTC TimeStamp peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_ENABLE(__HANDLE__)                        ((__HANDLE__)->Instance->CR |= (RTC_CR_TSE))
+
+/**
+  * @brief  Disable the RTC TimeStamp peripheral.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_DISABLE(__HANDLE__)                       ((__HANDLE__)->Instance->CR &= ~(RTC_CR_TSE))
+
+/**
+  * @brief  Enable the RTC calibration output.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CALIBRATION_OUTPUT_ENABLE(__HANDLE__)                 ((__HANDLE__)->Instance->CR |= (RTC_CR_COE))
+
+/**
+  * @brief  Disable the calibration output.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CALIBRATION_OUTPUT_DISABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR &= ~(RTC_CR_COE))
+
+/**
+  * @brief  Enable the clock reference detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CLOCKREF_DETECTION_ENABLE(__HANDLE__)                 ((__HANDLE__)->Instance->CR |= (RTC_CR_REFCKON))
+
+/**
+  * @brief  Disable the clock reference detection.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CLOCKREF_DETECTION_DISABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR &= ~(RTC_CR_REFCKON))
+
+/**
+  * @brief  Enable the RTC TimeStamp interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC TimeStamp interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_ENABLE_IT(__HANDLE__, __INTERRUPT__)      ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the RTC TimeStamp interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC TimeStamp interrupt sources to be enabled or disabled. 
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_DISABLE_IT(__HANDLE__, __INTERRUPT__)     ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Enable the RTC WakeUpTimer interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC WakeUpTimer interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT: WakeUpTimer A interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_ENABLE_IT(__HANDLE__, __INTERRUPT__)    ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the RTC WakeUpTimer interrupt.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __INTERRUPT__: specifies the RTC WakeUpTimer interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT: WakeUpTimer A interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_DISABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified RTC Tamper interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Tamper interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg  RTC_IT_TAMP1
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_GET_IT(__HANDLE__, __FLAG__)                 (((((__HANDLE__)->Instance->ISR) & ((__FLAG__)>> 4)) != RESET)? SET : RESET)
+
+/**
+  * @brief  Check whether the specified RTC WakeUpTimer interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC WakeUpTimer interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT:  WakeUpTimer A interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_GET_IT(__HANDLE__, __FLAG__)            (((((__HANDLE__)->Instance->ISR) & ((__FLAG__)>> 4)) != RESET)? SET : RESET)
+
+/**
+  * @brief  Check whether the specified RTC TimeStamp interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC TimeStamp interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_GET_IT(__HANDLE__, __FLAG__)              (((((__HANDLE__)->Instance->ISR) & ((__FLAG__)>> 4)) != RESET)? SET : RESET)
+
+/**
+  * @brief  Get the selected RTC TimeStamp's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC TimeStamp Flag sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_TSF
+  *            @arg RTC_FLAG_TSOVF
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)            (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET)? SET : RESET)
+
+/**
+  * @brief  Get the selected RTC WakeUpTimer's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC WakeUpTimer Flag sources to be enabled or disabled.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_WUTF
+  *             @arg RTC_FLAG_WUTWF
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_GET_FLAG(__HANDLE__, __FLAG__)          (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET)? SET : RESET)
+
+/**
+  * @brief  Get the selected RTC Tamper's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Tamper Flag sources to be enabled or disabled.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_TAMP1F
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_GET_FLAG(__HANDLE__, __FLAG__)               (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET)? SET : RESET)
+
+/**
+  * @brief  Get the selected RTC shift operation's flag status.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC shift operation Flag is pending or not.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_SHPF
+  * @retval None
+  */
+#define __HAL_RTC_SHIFT_GET_FLAG(__HANDLE__, __FLAG__)                (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != RESET)? SET : RESET)
+
+/**
+  * @brief  Clear the RTC Time Stamp's pending flags.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Alarm Flag sources to be enabled or disabled.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_TSF
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)              ((__HANDLE__)->Instance->ISR) = (~(((__FLAG__) | RTC_ISR_INIT)& 0x0000FFFF)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @brief  Clear the RTC Tamper's pending flags.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Tamper Flag sources to be enabled or disabled.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_TAMP1F
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_CLEAR_FLAG(__HANDLE__, __FLAG__)                 ((__HANDLE__)->Instance->ISR) = (~(((__FLAG__) | RTC_ISR_INIT)& 0x0000FFFF)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @brief  Clear the RTC Wake Up timer's pending flags.
+  * @param  __HANDLE__: specifies the RTC handle.
+  * @param  __FLAG__: specifies the RTC Tamper Flag sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_WUTF
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(__HANDLE__, __FLAG__)            ((__HANDLE__)->Instance->ISR) = (~(((__FLAG__) | RTC_ISR_INIT)& 0x0000FFFF)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT)) 
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/* RTC TimeStamp and Tamper functions *****************************************/
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin);
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTimeStamp(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_GetTimeStamp(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTimeStamp, RTC_DateTypeDef *sTimeStampDate, uint32_t Format);
+
+HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper);
+HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTamper(RTC_HandleTypeDef *hrtc, uint32_t Tamper);
+
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock);
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock);
+uint32_t HAL_RTCEx_DeactivateWakeUpTimer(RTC_HandleTypeDef *hrtc);
+uint32_t HAL_RTCEx_GetWakeUpTimer(RTC_HandleTypeDef *hrtc);
+
+void HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister, uint32_t Data);
+uint32_t HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister);
+
+HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef *hrtc, uint32_t SmoothCalibPeriod, uint32_t SmoothCalibPlusPulses, uint32_t SmouthCalibMinusPulsesValue);
+HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef *hrtc, uint32_t ShiftAdd1S, uint32_t ShiftSubFS);
+HAL_StatusTypeDef HAL_RTCEx_SetCalibrationOutPut(RTC_HandleTypeDef *hrtc, uint32_t CalibOutput);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateCalibrationOutPut(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_SetRefClock(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateRefClock(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_EnableBypassShadow(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef *hrtc);
+
+/* Peripheral State functions ***************************************************/
+void HAL_RTCEx_TamperTimeStampIRQHandler(RTC_HandleTypeDef *hrtc);
+void HAL_RTCEx_WakeUpTimerIRQHandler(RTC_HandleTypeDef *hrtc);
+
+void HAL_RTCEx_AlarmBEventCallback(RTC_HandleTypeDef *hrtc); 
+void HAL_RTCEx_TimeStampEventCallback(RTC_HandleTypeDef *hrtc);
+void HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef *hrtc);
+void HAL_RTCEx_Tamper1EventCallback(RTC_HandleTypeDef *hrtc);
+void HAL_RTCEx_Tamper2EventCallback(RTC_HandleTypeDef *hrtc);
+
+HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+HAL_StatusTypeDef HAL_RTCEx_PollForTimeStampEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper1Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper2Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_PWR_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_smartcard.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_smartcard.c
@@ -1,0 +1,1307 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_smartcard.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   SMARTCARD HAL module driver.
+  *
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the SmartCard.
+  *           + Initialization and de-initialization methods
+  *           + IO operation methods
+  *           + Peripheral Control methods
+  *
+  *           
+  @verbatim       
+ ===============================================================================
+                        ##### How to use this driver #####
+ ===============================================================================
+    [..]
+    The SMARTCARD HAL driver can be used as follow:
+    
+    (#) Declare a SMARTCARD_HandleTypeDef handle structure.
+    (#) Associate a USART to the SMARTCARD handle hsc.
+    (#) Initialize the SMARTCARD low level resources by implementing the HAL_SMARTCARD_MspInit ()API:
+        (##) Enable the USARTx interface clock.
+        (##) USART pins configuration:
+            (+) Enable the clock for the USART GPIOs.
+            (+) Configure these USART pins as alternate function pull-up.
+        (##) NVIC configuration if you need to use interrupt process (HAL_SMARTCARD_Transmit_IT()
+             and HAL_SMARTCARD_Receive_IT() APIs):
+            (+) Configure the USARTx interrupt priority.
+            (+) Enable the NVIC USART IRQ handle.
+            (@) The specific USART interrupts (Transmission complete interrupt, 
+                RXNE interrupt and Error Interrupts) will be managed using the macros
+                __HAL_SMARTCARD_ENABLE_IT() and __HAL_SMARTCARD_DISABLE_IT() inside the transmit and receive process.
+        (##) DMA Configuration if you need to use DMA process (HAL_SMARTCARD_Transmit_DMA()
+             and HAL_SMARTCARD_Receive_DMA() APIs):
+            (+) Declare a DMA handle structure for the Tx/Rx stream.
+            (+) Enable the DMAx interface clock.
+            (+) Configure the declared DMA handle structure with the required Tx/Rx parameters.                
+            (+) Configure the DMA Tx/Rx Stream.
+            (+) Associate the initialized DMA handle to the SMARTCARD DMA Tx/Rx handle.
+            (+) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx/Rx Stream.
+
+    (#) Program the Baud Rate, Parity, Mode(Receiver/Transmitter), clock enabling/disabling and accordingly,
+        the clock parameters (parity, phase, last bit), prescaler value, guard time and NACK on transmission
+        error enabling or disabling in the hsc Init structure.
+        
+    (#) If required, program SMARTCARD advanced features (TX/RX pins swap, TimeOut, auto-retry counter,...)
+        in the hsc AdvancedInit structure.
+
+    (#) Initialize the SMARTCARD associated USART registers by calling
+        the HAL_SMARTCARD_Init() API.                                 
+        
+    (@) HAL_SMARTCARD_Init() API also configure also the low level Hardware GPIO, CLOCK, CORTEX...etc) by 
+        calling the customized HAL_SMARTCARD_MspInit() API.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup SMARTCARD 
+  * @brief HAL SMARTCARD module driver
+  * @{
+  */
+#ifdef HAL_SMARTCARD_MODULE_ENABLED
+    
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define TEACK_REACK_TIMEOUT               1000
+#define HAL_SMARTCARD_TXDMA_TIMEOUTVALUE  22000
+#define USART_CR1_FIELDS      ((uint32_t)(USART_CR1_M | USART_CR1_PCE | USART_CR1_PS | \
+                                          USART_CR1_TE | USART_CR1_RE | USART_CR1_OVER8))
+#define USART_CR2_CLK_FIELDS  ((uint32_t)(USART_CR2_CLKEN|USART_CR2_CPOL|USART_CR2_CPHA|USART_CR2_LBCL))   
+#define USART_CR2_FIELDS      ((uint32_t)(USART_CR2_RTOEN|USART_CR2_CLK_FIELDS|USART_CR2_STOP))
+#define USART_CR3_FIELDS      ((uint32_t)(USART_CR3_ONEBIT|USART_CR3_NACK|USART_CR3_SCARCNT))  
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void SMARTCARD_DMATransmitCplt(DMA_HandleTypeDef *hdma);
+static void SMARTCARD_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SMARTCARD_DMAError(DMA_HandleTypeDef *hdma); 
+static void SMARTCARD_SetConfig(SMARTCARD_HandleTypeDef *hsc);
+static HAL_StatusTypeDef SMARTCARD_WaitOnFlagUntilTimeout(SMARTCARD_HandleTypeDef *hsc, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
+static HAL_StatusTypeDef SMARTCARD_CheckIdleState(SMARTCARD_HandleTypeDef *hsc);
+static HAL_StatusTypeDef SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsc);
+static HAL_StatusTypeDef SMARTCARD_Receive_IT(SMARTCARD_HandleTypeDef *hsc);
+static void SMARTCARD_AdvFeatureConfig(SMARTCARD_HandleTypeDef *hsc);
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup SMARTCARD_Private_Functions
+  * @{
+  */
+
+/** @defgroup SMARTCARD_Group1 Initialization/de-initialization functions 
+  *  @brief    Initialization and Configuration functions 
+  *
+@verbatim    
+===============================================================================
+            ##### Initialization and Configuration functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to initialize the USARTx 
+    associated to the SmartCard.
+      (+) These parameters can be configured: 
+        (++) Baud Rate
+        (++) Parity: parity should be enabled,
+             Frame Length is fixed to 8 bits plus parity:
+             the USART frame format is given in the following table:
+   +---------------------------------------------------------------+
+   | M1M0 bits |  PCE bit  |            USART frame                |
+   |-----------------------|---------------------------------------|
+   |     01    |    1      |    | SB | 8 bit data | PB | STB |     |
+   +---------------------------------------------------------------+
+        (++) Receiver/transmitter modes
+        (++) Synchronous mode (and if enabled, phase, polarity and last bit parameters)
+        (++) Prescaler value
+        (++) Guard bit time 
+        (++) NACK enabling or disabling on transmission error               
+
+      (+) The following advanced features can be configured as well:
+        (++) TX and/or RX pin level inversion
+        (++) data logical level inversion
+        (++) RX and TX pins swap
+        (++) RX overrun detection disabling
+        (++) DMA disabling on RX error
+        (++) MSB first on communication line
+        (++) Time out enabling (and if activated, timeout value)
+        (++) Block length
+        (++) Auto-retry counter       
+        
+    [..]                                                  
+    The HAL_SMARTCARD_Init() API follow respectively the USART (a)synchronous configuration procedures 
+    (details for the procedures are available in reference manual).
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Initializes the SMARTCARD mode according to the specified
+  *         parameters in the SMARTCARD_InitTypeDef and creates the associated handle .
+  * @param hsc: SMARTCARD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMARTCARD_Init(SMARTCARD_HandleTypeDef *hsc)
+{
+  /* Check the SMARTCARD handle allocation */
+  if(hsc == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the USART associated to the SmartCard */
+  assert_param(IS_SMARTCARD_INSTANCE(hsc->Instance));
+  
+  if(hsc->State == HAL_SMARTCARD_STATE_RESET)
+  {  
+    /* Init the low level hardware : GPIO, CLOCK, CORTEX */
+    HAL_SMARTCARD_MspInit(hsc);
+  }
+  
+  hsc->State = HAL_SMARTCARD_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_SMARTCARD_DISABLE(hsc);
+  
+  /* Set the SMARTCARD Communication parameters */
+  SMARTCARD_SetConfig(hsc);
+  
+  if(hsc->AdvancedInit.AdvFeatureInit != SMARTCARD_ADVFEATURE_NO_INIT)
+  {
+    SMARTCARD_AdvFeatureConfig(hsc);
+  }
+  
+  /* In SmartCard mode, the following bits must be kept cleared: 
+  - LINEN in the USART_CR2 register,
+  - HDSEL and IREN  bits in the USART_CR3 register.*/
+  hsc->Instance->CR2 &= ~(USART_CR2_LINEN); 
+  hsc->Instance->CR3 &= ~(USART_CR3_HDSEL | USART_CR3_IREN); 
+  
+  /* set the USART in SMARTCARD mode */ 
+  hsc->Instance->CR3 |= USART_CR3_SCEN; 
+  
+  /* Enable the Peripheral */
+  __HAL_SMARTCARD_ENABLE(hsc);
+  
+  /* TEACK and/or REACK to check before moving hsc->State to Ready */
+  return (SMARTCARD_CheckIdleState(hsc));
+}
+
+/**
+  * @brief DeInitializes the SMARTCARD peripheral 
+  * @param hsc: SMARTCARD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMARTCARD_DeInit(SMARTCARD_HandleTypeDef *hsc)
+{
+  /* Check the SMARTCARD handle allocation */
+  if(hsc == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_SMARTCARD_INSTANCE(hsc->Instance));
+  
+  hsc->State = HAL_SMARTCARD_STATE_BUSY;
+  
+  /* DeInit the low level hardware */
+  HAL_SMARTCARD_MspDeInit(hsc);
+  
+  hsc->ErrorCode = HAL_SMARTCARD_ERROR_NONE;
+  hsc->State = HAL_SMARTCARD_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(hsc);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief SMARTCARD MSP Init
+  * @param hsc: SMARTCARD handle
+  * @retval None
+  */
+ __weak void HAL_SMARTCARD_MspInit(SMARTCARD_HandleTypeDef *hsc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SMARTCARD_MspInit could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @brief SMARTCARD MSP DeInit
+  * @param hsc: SMARTCARD handle
+  * @retval None
+  */
+ __weak void HAL_SMARTCARD_MspDeInit(SMARTCARD_HandleTypeDef *hsc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SMARTCARD_MspDeInit could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup SMARTCARD_Group2 IO operation functions 
+  *  @brief SMARTCARD Transmit/Receive functions 
+  *
+@verbatim   
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================  
+    This subsection provides a set of functions allowing to manage the SMARTCARD data transfers.
+
+    (#) There are two mode of transfer:
+       (+) Blocking mode: The communication is performed in polling mode. 
+            The HAL status of all data processing is returned by the same function 
+            after finishing transfer.  
+       (+) No-Blocking mode: The communication is performed using Interrupts 
+           or DMA, These API's return the HAL status.
+           The end of the data processing will be indicated through the 
+           dedicated SMARTCARD IRQ when using Interrupt mode or the DMA IRQ when 
+           using DMA mode.
+           The HAL_SMARTCARD_TxCpltCallback(), HAL_SMARTCARD_RxCpltCallback() user callbacks 
+           will be executed respectivelly at the end of the transmit or Receive process
+           The HAL_SMARTCARD_ErrorCallback()user callback will be executed when a communication error is detected
+
+    (#) Blocking mode API's are :
+        (+) HAL_SMARTCARD_Transmit()
+        (+) HAL_SMARTCARD_Receive() 
+        
+    (#) Non-Blocking mode API's with Interrupt are :
+        (+) HAL_SMARTCARD_Transmit_IT()
+        (+) HAL_SMARTCARD_Receive_IT()
+        (+) HAL_SMARTCARD_IRQHandler()
+        (+) SMARTCARD_Transmit_IT()
+        (+) SMARTCARD_Receive_IT()    
+
+    (#) No-Blocking mode functions with DMA are :
+        (+) HAL_SMARTCARD_Transmit_DMA()
+        (+) HAL_SMARTCARD_Receive_DMA()
+
+    (#) A set of Transfer Complete Callbacks are provided in No_Blocking mode:
+        (+) HAL_SMARTCARD_TxCpltCallback()
+        (+) HAL_SMARTCARD_RxCpltCallback()
+        (+) HAL_SMARTCARD_ErrorCallback()
+      
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Send an amount of data in blocking mode 
+  * @param hsc: SMARTCARD handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be sent
+  * @param Timeout : Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  if((hsc->State == HAL_SMARTCARD_STATE_READY) || (hsc->State == HAL_SMARTCARD_STATE_BUSY_RX))
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hsc);
+    hsc->ErrorCode = HAL_SMARTCARD_ERROR_NONE;    
+    /* Check if a non-blocking receive process is ongoing or not */
+    if(hsc->State == HAL_SMARTCARD_STATE_BUSY_RX) 
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_TX;
+    }
+    
+    hsc->TxXferSize = Size;
+    hsc->TxXferCount = Size;
+    while(hsc->TxXferCount > 0)
+    {
+      hsc->TxXferCount--;      
+      if(SMARTCARD_WaitOnFlagUntilTimeout(hsc, SMARTCARD_FLAG_TXE, RESET, Timeout) != HAL_OK)  
+      { 
+        return HAL_TIMEOUT;
+      }
+      hsc->Instance->TDR = (*pData++ & (uint8_t)0xFF);     
+    }
+    if(SMARTCARD_WaitOnFlagUntilTimeout(hsc, SMARTCARD_FLAG_TC, RESET, Timeout) != HAL_OK)  
+    { 
+      return HAL_TIMEOUT;
+    }
+    /* Check if a non-blocking receive Process is ongoing or not */
+    if(hsc->State == HAL_SMARTCARD_STATE_BUSY_TX_RX) 
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_RX;
+    }
+    else
+    {
+      hsc->State = HAL_SMARTCARD_STATE_READY;
+    }
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsc);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;   
+  }
+}
+
+/**
+  * @brief Receive an amount of data in blocking mode 
+  * @param hsc: SMARTCARD handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @param Timeout : Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMARTCARD_Receive(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{ 
+  if((hsc->State == HAL_SMARTCARD_STATE_READY) || (hsc->State == HAL_SMARTCARD_STATE_BUSY_TX))
+  { 
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hsc);
+    
+    hsc->ErrorCode = HAL_SMARTCARD_ERROR_NONE;
+    /* Check if a non-blocking transmit process is ongoing or not */
+    if(hsc->State == HAL_SMARTCARD_STATE_BUSY_TX) 
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_RX;
+    }    
+    
+    hsc->RxXferSize = Size; 
+    hsc->RxXferCount = Size;
+    /* Check the remain data to be received */
+    while(hsc->RxXferCount > 0)
+    {
+      hsc->RxXferCount--;    
+      if(SMARTCARD_WaitOnFlagUntilTimeout(hsc, SMARTCARD_FLAG_RXNE, RESET, Timeout) != HAL_OK)  
+      { 
+        return HAL_TIMEOUT;
+      }          
+      *pData++ = (uint8_t)(hsc->Instance->RDR & (uint8_t)0x00FF);              
+    }
+    
+    /* Check if a non-blocking transmit Process is ongoing or not */
+    if(hsc->State == HAL_SMARTCARD_STATE_BUSY_TX_RX) 
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_TX;
+    }
+    else
+    {
+      hsc->State = HAL_SMARTCARD_STATE_READY;
+    }    
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsc);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;   
+  }
+}
+
+/**
+  * @brief Send an amount of data in interrupt mode 
+  * @param hsc: SMARTCARD handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size)
+{
+  if((hsc->State == HAL_SMARTCARD_STATE_READY) || (hsc->State == HAL_SMARTCARD_STATE_BUSY_RX))
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hsc);
+    
+    hsc->pTxBuffPtr = pData;
+    hsc->TxXferSize = Size;
+    hsc->TxXferCount = Size;
+    
+    hsc->ErrorCode = HAL_SMARTCARD_ERROR_NONE;
+    /* Check if a receive process is ongoing or not */
+    if(hsc->State == HAL_SMARTCARD_STATE_BUSY_RX) 
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_TX;
+    }
+
+    /* Enable the SMARTCARD Error Interrupt: (Frame error, noise error, overrun error) */
+    __HAL_SMARTCARD_ENABLE_IT(hsc, SMARTCARD_IT_ERR);
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsc);    
+    
+    /* Enable the SMARTCARD Transmit Complete Interrupt */
+    __HAL_SMARTCARD_ENABLE_IT(hsc, SMARTCARD_IT_TC);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in interrupt mode 
+  * @param hsc: SMARTCARD handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMARTCARD_Receive_IT(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size)
+{
+  if((hsc->State == HAL_SMARTCARD_STATE_READY) || (hsc->State == HAL_SMARTCARD_STATE_BUSY_TX))
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    
+    /* Process Locked */
+  __HAL_LOCK(hsc);
+  
+    hsc->pRxBuffPtr = pData;
+    hsc->RxXferSize = Size;
+    hsc->RxXferCount = Size;
+    
+    hsc->ErrorCode = HAL_SMARTCARD_ERROR_NONE; 
+    /* Check if a transmit process is ongoing or not */
+    if(hsc->State == HAL_SMARTCARD_STATE_BUSY_TX) 
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_RX;
+    }    
+    
+    /* Enable the SMARTCARD Parity Error Interrupt */
+    __HAL_SMARTCARD_ENABLE_IT(hsc, SMARTCARD_IT_PE);
+    
+    /* Enable the SMARTCARD Error Interrupt: (Frame error, noise error, overrun error) */
+    __HAL_SMARTCARD_ENABLE_IT(hsc, SMARTCARD_IT_ERR);
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsc);
+    
+    /* Enable the SMARTCARD Data Register not empty Interrupt */
+    __HAL_SMARTCARD_ENABLE_IT(hsc, SMARTCARD_IT_RXNE);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief Send an amount of data in DMA mode 
+  * @param hsc: SMARTCARD handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMARTCARD_Transmit_DMA(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size)
+{
+  uint32_t *tmp;
+  
+  if((hsc->State == HAL_SMARTCARD_STATE_READY) || (hsc->State == HAL_SMARTCARD_STATE_BUSY_RX))
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hsc);
+    
+    hsc->pTxBuffPtr = pData;
+    hsc->TxXferSize = Size;
+    hsc->TxXferCount = Size; 
+  
+    hsc->ErrorCode = HAL_SMARTCARD_ERROR_NONE;  
+    /* Check if a receive process is ongoing or not */
+    if(hsc->State == HAL_SMARTCARD_STATE_BUSY_RX) 
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_TX;
+    }
+    
+    /* Set the SMARTCARD DMA transfert complete callback */
+    hsc->hdmatx->XferCpltCallback = SMARTCARD_DMATransmitCplt;
+    
+    /* Set the SMARTCARD error callback */
+    hsc->hdmatx->XferErrorCallback = SMARTCARD_DMAError;
+
+    /* Enable the SMARTCARD transmit DMA Stream */
+    tmp = (uint32_t*)&pData;
+    HAL_DMA_Start_IT(hsc->hdmatx, *(uint32_t*)tmp, (uint32_t)&hsc->Instance->TDR, Size);
+    
+    /* Enable the DMA transfer for transmit request by setting the DMAT bit
+       in the SMARTCARD associated USART CR3 register */
+    hsc->Instance->CR3 |= USART_CR3_DMAT;
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsc);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;   
+  }
+}
+
+/**
+  * @brief Receive an amount of data in DMA mode 
+  * @param hsc: SMARTCARD handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @note   The SMARTCARD-associated USART parity is enabled (PCE = 1), 
+  *         the received data contain the parity bit (MSB position)   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMARTCARD_Receive_DMA(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size)
+{
+  uint32_t *tmp;
+  
+  if((hsc->State == HAL_SMARTCARD_STATE_READY) || (hsc->State == HAL_SMARTCARD_STATE_BUSY_TX))
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(hsc);
+    
+    hsc->pRxBuffPtr = pData;
+    hsc->RxXferSize = Size;
+    
+    hsc->ErrorCode = HAL_SMARTCARD_ERROR_NONE;
+    /* Check if a transmit rocess is ongoing or not */
+    if(hsc->State == HAL_SMARTCARD_STATE_BUSY_TX) 
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_RX;
+    }    
+    
+    /* Set the SMARTCARD DMA transfert complete callback */
+    hsc->hdmarx->XferCpltCallback = SMARTCARD_DMAReceiveCplt;
+    
+    /* Set the SMARTCARD DMA error callback */
+    hsc->hdmarx->XferErrorCallback = SMARTCARD_DMAError;
+    
+    /* Enable the DMA Stream */
+    tmp = (uint32_t*)&pData;
+    HAL_DMA_Start_IT(hsc->hdmarx, (uint32_t)&hsc->Instance->RDR, *(uint32_t*)tmp, Size);
+    
+    /* Enable the DMA transfer for the receiver request by setting the DMAR bit 
+    in the SMARTCARD associated USART CR3 register */
+    hsc->Instance->CR3 |= USART_CR3_DMAR;
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsc);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+    
+/**
+  * @brief SMARTCARD interrupt requests handling.
+  * @param hsc: SMARTCARD handle
+  * @retval None
+  */
+void HAL_SMARTCARD_IRQHandler(SMARTCARD_HandleTypeDef *hsc)
+{
+  /* SMARTCARD parity error interrupt occurred -------------------------------*/
+  if((__HAL_SMARTCARD_GET_IT(hsc, SMARTCARD_IT_PE) != RESET) && (__HAL_SMARTCARD_GET_IT_SOURCE(hsc, SMARTCARD_IT_PE) != RESET))
+  { 
+    __HAL_SMARTCARD_CLEAR_IT(hsc, SMARTCARD_CLEAR_PEF);
+    hsc->ErrorCode |= HAL_SMARTCARD_ERROR_PE;
+    /* Set the SMARTCARD state ready to be able to start again the process */
+    hsc->State = HAL_SMARTCARD_STATE_READY;
+  }
+  
+  /* SMARTCARD frame error interrupt occured ---------------------------------*/
+  if((__HAL_SMARTCARD_GET_IT(hsc, SMARTCARD_IT_FE) != RESET) && (__HAL_SMARTCARD_GET_IT_SOURCE(hsc, SMARTCARD_IT_ERR) != RESET))
+  { 
+    __HAL_SMARTCARD_CLEAR_IT(hsc, SMARTCARD_CLEAR_FEF);
+    hsc->ErrorCode |= HAL_SMARTCARD_ERROR_FE;
+    /* Set the SMARTCARD state ready to be able to start again the process */
+    hsc->State = HAL_SMARTCARD_STATE_READY;
+  }
+  
+  /* SMARTCARD noise error interrupt occured ---------------------------------*/
+  if((__HAL_SMARTCARD_GET_IT(hsc, SMARTCARD_IT_NE) != RESET) && (__HAL_SMARTCARD_GET_IT_SOURCE(hsc, SMARTCARD_IT_ERR) != RESET))
+  { 
+    __HAL_SMARTCARD_CLEAR_IT(hsc, SMARTCARD_CLEAR_NEF);
+    hsc->ErrorCode |= HAL_SMARTCARD_ERROR_NE; 
+    /* Set the SMARTCARD state ready to be able to start again the process */
+    hsc->State = HAL_SMARTCARD_STATE_READY;
+  }
+  
+  /* SMARTCARD Over-Run interrupt occured ------------------------------------*/
+  if((__HAL_SMARTCARD_GET_IT(hsc, SMARTCARD_IT_ORE) != RESET) && (__HAL_SMARTCARD_GET_IT_SOURCE(hsc, SMARTCARD_IT_ERR) != RESET))
+  { 
+    __HAL_SMARTCARD_CLEAR_IT(hsc, SMARTCARD_CLEAR_OREF);
+    hsc->ErrorCode |= HAL_SMARTCARD_ERROR_ORE; 
+    /* Set the SMARTCARD state ready to be able to start again the process */
+    hsc->State = HAL_SMARTCARD_STATE_READY;
+  }
+  
+  /* SMARTCARD receiver timeout interrupt occured ----------------------------*/
+  if((__HAL_SMARTCARD_GET_IT(hsc, SMARTCARD_IT_RTO) != RESET) && (__HAL_SMARTCARD_GET_IT_SOURCE(hsc, SMARTCARD_IT_RTO) != RESET))
+  { 
+    __HAL_SMARTCARD_CLEAR_IT(hsc, SMARTCARD_CLEAR_RTOF);
+    hsc->ErrorCode |= HAL_SMARTCARD_ERROR_RTO; 
+    /* Set the SMARTCARD state ready to be able to start again the process */
+    hsc->State = HAL_SMARTCARD_STATE_READY;
+  }
+  
+  /* Call SMARTCARD Error Call back function if need be ----------------------*/
+  if(hsc->ErrorCode != HAL_SMARTCARD_ERROR_NONE)
+  {
+    HAL_SMARTCARD_ErrorCallback(hsc);
+  } 
+  
+  /* SMARTCARD in mode Receiver ----------------------------------------------*/
+  if((__HAL_SMARTCARD_GET_IT(hsc, SMARTCARD_IT_RXNE) != RESET) && (__HAL_SMARTCARD_GET_IT_SOURCE(hsc, SMARTCARD_IT_RXNE) != RESET))
+  { 
+    SMARTCARD_Receive_IT(hsc);
+    /* Clear RXNE interrupt flag */
+    __HAL_SMARTCARD_SEND_REQ(hsc, SMARTCARD_RXDATA_FLUSH_REQUEST);
+  }
+  
+  /* SMARTCARD in mode Receiver, end of block interruption -------------------*/
+  if((__HAL_SMARTCARD_GET_IT(hsc, SMARTCARD_IT_EOB) != RESET) && (__HAL_SMARTCARD_GET_IT_SOURCE(hsc, SMARTCARD_IT_EOB) != RESET))
+  { 
+    hsc->State = HAL_SMARTCARD_STATE_READY;
+    HAL_SMARTCARD_RxCpltCallback(hsc);
+    /* Clear EOBF interrupt after HAL_SMARTCARD_RxCpltCallback() call for the End of Block information
+    * to be available during HAL_SMARTCARD_RxCpltCallback() processing */
+    __HAL_SMARTCARD_CLEAR_IT(hsc, SMARTCARD_CLEAR_EOBF);
+  }  
+  
+  /* SMARTCARD in mode Transmitter -------------------------------------------*/
+  if((__HAL_SMARTCARD_GET_IT(hsc, SMARTCARD_IT_TC) != RESET) && (__HAL_SMARTCARD_GET_IT_SOURCE(hsc, SMARTCARD_IT_TC) != RESET))
+  {
+    SMARTCARD_Transmit_IT(hsc);
+  } 
+} 
+
+/**
+  * @brief Tx Transfer completed callbacks
+  * @param hsc: SMARTCARD handle
+  * @retval None
+  */
+ __weak void HAL_SMARTCARD_TxCpltCallback(SMARTCARD_HandleTypeDef *hsc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SMARTCARD_TxCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief Rx Transfer completed callbacks
+  * @param hsc: SMARTCARD handle
+  * @retval None
+  */
+__weak void HAL_SMARTCARD_RxCpltCallback(SMARTCARD_HandleTypeDef *hsc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SMARTCARD_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief SMARTCARD error callbacks
+  * @param hsc: SMARTCARD handle
+  * @retval None
+  */
+ __weak void HAL_SMARTCARD_ErrorCallback(SMARTCARD_HandleTypeDef *hsc)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SMARTCARD_ErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */  
+
+/** @defgroup SMARTCARD_Group3 Peripheral State functions 
+  *  @brief   SMARTCARD State functions 
+  *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to initialize the SMARTCARD.
+     (+) HAL_SMARTCARD_GetState() API is helpful to check in run-time the state of the SMARTCARD peripheral 
+     (+) SMARTCARD_SetConfig() API configures the SMARTCARD peripheral  
+     (+) SMARTCARD_CheckIdleState() API ensures that TEACK and/or REACK are set after initialization 
+
+@endverbatim
+  * @{
+  */
+
+
+/**
+  * @brief return the SMARTCARD state
+  * @param hsc: SMARTCARD handle
+  * @retval HAL state
+  */
+HAL_SMARTCARD_StateTypeDef HAL_SMARTCARD_GetState(SMARTCARD_HandleTypeDef *hsc)
+{
+  return hsc->State;
+}
+
+/**
+* @brief  Return the SMARTCARD error code
+* @param  hsc : pointer to a SMARTCARD_HandleTypeDef structure that contains
+  *              the configuration information for the specified SMARTCARD.
+* @retval SMARTCARD Error Code
+*/
+uint32_t HAL_SMARTCARD_GetError(SMARTCARD_HandleTypeDef *hsc)
+{
+  return hsc->ErrorCode;
+}
+
+/**
+  * @}
+  */
+  
+/**
+  * @brief Send an amount of data in non blocking mode 
+  * @param hsc: SMARTCARD handle.
+  *         Function called under interruption only, once
+  *         interruptions have been enabled by HAL_SMARTCARD_Transmit_IT()      
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsc)
+{
+  if((hsc->State == HAL_SMARTCARD_STATE_BUSY_TX) || (hsc->State == HAL_SMARTCARD_STATE_BUSY_TX_RX)) 
+  {
+    if(hsc->TxXferCount == 0)
+    {
+      /* Disable the SMARTCARD Transmit Complete Interrupt */
+      __HAL_SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_TC);
+      
+      /* Check if a receive Process is ongoing or not */
+      if(hsc->State == HAL_SMARTCARD_STATE_BUSY_TX_RX) 
+      {
+        hsc->State = HAL_SMARTCARD_STATE_BUSY_RX;
+      }
+      else
+      { 
+        /* Disable the SMARTCARD Error Interrupt: (Frame error, noise error, overrun error) */
+        __HAL_SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_ERR);
+      
+        hsc->State = HAL_SMARTCARD_STATE_READY;
+      }
+      
+      HAL_SMARTCARD_TxCpltCallback(hsc);
+      
+      return HAL_OK;
+    }
+    else
+    {    
+      hsc->Instance->TDR = (*hsc->pTxBuffPtr++ & (uint8_t)0xFF);     
+      hsc->TxXferCount--;
+  
+      return HAL_OK;
+    }
+  }
+  else
+  {
+    return HAL_BUSY;   
+  }
+}
+
+/**
+  * @brief Receive an amount of data in non blocking mode 
+  * @param hsc: SMARTCARD handle.
+  *         Function called under interruption only, once
+  *         interruptions have been enabled by HAL_SMARTCARD_Receive_IT()      
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SMARTCARD_Receive_IT(SMARTCARD_HandleTypeDef *hsc)
+{
+  if((hsc->State == HAL_SMARTCARD_STATE_BUSY_RX) || (hsc->State == HAL_SMARTCARD_STATE_BUSY_TX_RX))
+  {
+    *hsc->pRxBuffPtr++ = (uint8_t)(hsc->Instance->RDR & (uint8_t)0xFF);  
+    
+    if(--hsc->RxXferCount == 0)
+    {
+      while(HAL_IS_BIT_SET(hsc->Instance->ISR, SMARTCARD_FLAG_RXNE))
+      {
+      }
+      __HAL_SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_RXNE);
+      
+      /* Check if a transmit Process is ongoing or not */
+      if(hsc->State == HAL_SMARTCARD_STATE_BUSY_TX_RX) 
+      {
+        hsc->State = HAL_SMARTCARD_STATE_BUSY_TX;
+      }
+      else
+      {
+        /* Disable the SMARTCARD Parity Error Interrupt */
+        __HAL_SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_PE);
+         
+        /* Disable the SMARTCARD Error Interrupt: (Frame error, noise error, overrun error) */
+        __HAL_SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_ERR);
+        
+        hsc->State = HAL_SMARTCARD_STATE_READY;
+      }
+      
+      HAL_SMARTCARD_RxCpltCallback(hsc);
+      
+      return HAL_OK;
+    }
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief Configure the SMARTCARD associated USART peripheral 
+  * @param hsc: SMARTCARD handle
+  * @retval None
+  */
+static void SMARTCARD_SetConfig(SMARTCARD_HandleTypeDef *hsc)
+{
+  uint32_t tmpreg = 0x00000000;
+  uint32_t clocksource = 0x00000000;
+  
+  /* Check the parameters */ 
+  assert_param(IS_SMARTCARD_INSTANCE(hsc->Instance));
+  assert_param(IS_SMARTCARD_BAUDRATE(hsc->Init.BaudRate)); 
+  assert_param(IS_SMARTCARD_WORD_LENGTH(hsc->Init.WordLength));  
+  assert_param(IS_SMARTCARD_STOPBITS(hsc->Init.StopBits));   
+  assert_param(IS_SMARTCARD_PARITY(hsc->Init.Parity));
+  assert_param(IS_SMARTCARD_MODE(hsc->Init.Mode));
+  assert_param(IS_SMARTCARD_POLARITY(hsc->Init.CLKPolarity));
+  assert_param(IS_SMARTCARD_PHASE(hsc->Init.CLKPhase));
+  assert_param(IS_SMARTCARD_LASTBIT(hsc->Init.CLKLastBit));    
+  assert_param(IS_SMARTCARD_ONEBIT_SAMPLING(hsc->Init.OneBitSampling));
+  assert_param(IS_SMARTCARD_NACK(hsc->Init.NACKState));
+  assert_param(IS_SMARTCARD_TIMEOUT(hsc->Init.TimeOutEnable));
+  assert_param(IS_SMARTCARD_AUTORETRY_COUNT(hsc->Init.AutoRetryCount)); 
+
+  /*-------------------------- USART CR1 Configuration -----------------------*/
+  /* In SmartCard mode, M and PCE are forced to 1 (8 bits + parity).
+   * Oversampling is forced to 16 (OVER8 = 0).
+   * Configure the Parity and Mode: 
+   *  set PS bit according to hsc->Init.Parity value
+   *  set TE and RE bits according to hsc->Init.Mode value */
+  tmpreg = (uint32_t) hsc->Init.Parity | hsc->Init.Mode;
+  /* in case of TX-only mode, if NACK is enabled, the USART must be able to monitor 
+     the bidirectional line to detect a NACK signal in case of parity error. 
+     Therefore, the receiver block must be enabled as well (RE bit must be set). */
+  if((hsc->Init.Mode == SMARTCARD_MODE_TX) && (hsc->Init.NACKState == SMARTCARD_NACK_ENABLED))
+  {
+    tmpreg |= USART_CR1_RE;   
+  }
+  tmpreg |= (uint32_t) hsc->Init.WordLength;
+  MODIFY_REG(hsc->Instance->CR1, USART_CR1_FIELDS, tmpreg);
+
+  /*-------------------------- USART CR2 Configuration -----------------------*/
+  /* Stop bits are forced to 1.5 (STOP = 11) */
+  tmpreg = hsc->Init.StopBits;
+  /* Synchronous mode is activated by default */
+  tmpreg |= (uint32_t) USART_CR2_CLKEN | hsc->Init.CLKPolarity; 
+  tmpreg |= (uint32_t) hsc->Init.CLKPhase | hsc->Init.CLKLastBit;
+  tmpreg |= (uint32_t) hsc->Init.TimeOutEnable;
+  MODIFY_REG(hsc->Instance->CR2, USART_CR2_FIELDS, tmpreg); 
+    
+  /*-------------------------- USART CR3 Configuration -----------------------*/
+  /* Configure 
+   * - one-bit sampling method versus three samples' majority rule 
+   *   according to hsc->Init.OneBitSampling 
+   * - NACK transmission in case of parity error according 
+   *   to hsc->Init.NACKEnable   
+   * - autoretry counter according to hsc->Init.AutoRetryCount     */
+  tmpreg =  (uint32_t) hsc->Init.OneBitSampling | hsc->Init.NACKState;
+  tmpreg |= (uint32_t) (hsc->Init.AutoRetryCount << SMARTCARD_CR3_SCARCNT_LSB_POS);
+  MODIFY_REG(hsc->Instance-> CR3,USART_CR3_FIELDS, tmpreg);
+  
+  /*-------------------------- USART GTPR Configuration ----------------------*/
+  tmpreg = (uint32_t) (hsc->Init.Prescaler | (hsc->Init.GuardTime << SMARTCARD_GTPR_GT_LSB_POS));
+  MODIFY_REG(hsc->Instance->GTPR, (uint32_t)(USART_GTPR_GT|USART_GTPR_PSC), tmpreg); 
+  
+  /*-------------------------- USART RTOR Configuration ----------------------*/ 
+  tmpreg =   (uint32_t) (hsc->Init.BlockLength << SMARTCARD_RTOR_BLEN_LSB_POS);
+  if(hsc->Init.TimeOutEnable == SMARTCARD_TIMEOUT_ENABLED)
+  {
+    assert_param(IS_SMARTCARD_TIMEOUT_VALUE(hsc->Init.TimeOutValue));
+    tmpreg |=  (uint32_t) hsc->Init.TimeOutValue;
+  }
+  MODIFY_REG(hsc->Instance->RTOR, (USART_RTOR_RTO|USART_RTOR_BLEN), tmpreg);
+  
+  /*-------------------------- USART BRR Configuration -----------------------*/
+  __HAL_SMARTCARD_GETCLOCKSOURCE(hsc, clocksource);
+  switch (clocksource)
+  {
+  case SMARTCARD_CLOCKSOURCE_PCLK1: 
+    hsc->Instance->BRR = (uint16_t)(HAL_RCC_GetPCLK1Freq() / hsc->Init.BaudRate);
+    break;
+  case SMARTCARD_CLOCKSOURCE_PCLK2: 
+    hsc->Instance->BRR = (uint16_t)(HAL_RCC_GetPCLK2Freq() / hsc->Init.BaudRate);
+    break;
+  case SMARTCARD_CLOCKSOURCE_HSI: 
+    hsc->Instance->BRR = (uint16_t)(HSI_VALUE / hsc->Init.BaudRate); 
+    break; 
+  case SMARTCARD_CLOCKSOURCE_SYSCLK:  
+    hsc->Instance->BRR = (uint16_t)(HAL_RCC_GetSysClockFreq() / hsc->Init.BaudRate);
+    break;  
+  case SMARTCARD_CLOCKSOURCE_LSE:                
+    hsc->Instance->BRR = (uint16_t)(LSE_VALUE / hsc->Init.BaudRate); 
+    break;
+  default:
+    break;
+  } 
+}
+
+/**
+  * @brief Check the SMARTCARD Idle State
+  * @param hsc: SMARTCARD handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SMARTCARD_CheckIdleState(SMARTCARD_HandleTypeDef *hsc)
+{
+  
+  /* Initialize the SMARTCARD ErrorCode */
+  hsc->ErrorCode = HAL_SMARTCARD_ERROR_NONE;
+
+  /* Check if the Transmitter is enabled */
+  if((hsc->Instance->CR1 & USART_CR1_TE) == USART_CR1_TE)
+  {
+    /* Wait until TEACK flag is set */
+    if(SMARTCARD_WaitOnFlagUntilTimeout(hsc, USART_ISR_TEACK, RESET, TEACK_REACK_TIMEOUT) != HAL_OK)  
+    { 
+      return HAL_TIMEOUT;
+    } 
+  }
+  /* Check if the Receiver is enabled */
+  if((hsc->Instance->CR1 & USART_CR1_RE) == USART_CR1_RE)
+  {
+    /* Wait until REACK flag is set */
+    if(SMARTCARD_WaitOnFlagUntilTimeout(hsc, USART_ISR_REACK, RESET, TEACK_REACK_TIMEOUT) != HAL_OK)  
+    { 
+      return HAL_TIMEOUT;
+    }
+  }
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hsc);
+        
+  /* Initialize the SMARTCARD state*/
+  hsc->State= HAL_SMARTCARD_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief Configure the SMARTCARD associated USART peripheral advanced feautures 
+  * @param hsc: SMARTCARD handle  
+  * @retval None
+  */
+static void SMARTCARD_AdvFeatureConfig(SMARTCARD_HandleTypeDef *hsc)
+{  
+  /* Check whether the set of advanced features to configure is properly set */ 
+  assert_param(IS_SMARTCARD_ADVFEATURE_INIT(hsc->AdvancedInit.AdvFeatureInit));
+  
+  /* if required, configure TX pin active level inversion */
+  if(HAL_IS_BIT_SET(hsc->AdvancedInit.AdvFeatureInit, SMARTCARD_ADVFEATURE_TXINVERT_INIT))
+  {
+    assert_param(IS_SMARTCARD_ADVFEATURE_TXINV(hsc->AdvancedInit.TxPinLevelInvert));
+    MODIFY_REG(hsc->Instance->CR2, USART_CR2_TXINV, hsc->AdvancedInit.TxPinLevelInvert);
+  }
+  
+  /* if required, configure RX pin active level inversion */
+  if(HAL_IS_BIT_SET(hsc->AdvancedInit.AdvFeatureInit, SMARTCARD_ADVFEATURE_RXINVERT_INIT))
+  {
+    assert_param(IS_SMARTCARD_ADVFEATURE_RXINV(hsc->AdvancedInit.RxPinLevelInvert));
+    MODIFY_REG(hsc->Instance->CR2, USART_CR2_RXINV, hsc->AdvancedInit.RxPinLevelInvert);
+  }
+  
+  /* if required, configure data inversion */
+  if(HAL_IS_BIT_SET(hsc->AdvancedInit.AdvFeatureInit, SMARTCARD_ADVFEATURE_DATAINVERT_INIT))
+  {
+    assert_param(IS_SMARTCARD_ADVFEATURE_DATAINV(hsc->AdvancedInit.DataInvert));
+    MODIFY_REG(hsc->Instance->CR2, USART_CR2_DATAINV, hsc->AdvancedInit.DataInvert);
+  }
+  
+  /* if required, configure RX/TX pins swap */
+  if(HAL_IS_BIT_SET(hsc->AdvancedInit.AdvFeatureInit, SMARTCARD_ADVFEATURE_SWAP_INIT))
+  {
+    assert_param(IS_SMARTCARD_ADVFEATURE_SWAP(hsc->AdvancedInit.Swap));
+    MODIFY_REG(hsc->Instance->CR2, USART_CR2_SWAP, hsc->AdvancedInit.Swap);
+  }
+  
+  /* if required, configure RX overrun detection disabling */
+  if(HAL_IS_BIT_SET(hsc->AdvancedInit.AdvFeatureInit, SMARTCARD_ADVFEATURE_RXOVERRUNDISABLE_INIT))
+  {
+    assert_param(IS_SMARTCARD_OVERRUN(hsc->AdvancedInit.OverrunDisable));  
+    MODIFY_REG(hsc->Instance->CR3, USART_CR3_OVRDIS, hsc->AdvancedInit.OverrunDisable);
+  }
+  
+  /* if required, configure DMA disabling on reception error */
+  if(HAL_IS_BIT_SET(hsc->AdvancedInit.AdvFeatureInit, SMARTCARD_ADVFEATURE_DMADISABLEONERROR_INIT))
+  {
+    assert_param(IS_SMARTCARD_ADVFEATURE_DMAONRXERROR(hsc->AdvancedInit.DMADisableonRxError));   
+    MODIFY_REG(hsc->Instance->CR3, USART_CR3_DDRE, hsc->AdvancedInit.DMADisableonRxError);
+  }
+  
+  /* if required, configure MSB first on communication line */  
+  if(HAL_IS_BIT_SET(hsc->AdvancedInit.AdvFeatureInit, SMARTCARD_ADVFEATURE_MSBFIRST_INIT))
+  {
+    assert_param(IS_SMARTCARD_ADVFEATURE_MSBFIRST(hsc->AdvancedInit.MSBFirst));   
+    MODIFY_REG(hsc->Instance->CR2, USART_CR2_MSBFIRST, hsc->AdvancedInit.MSBFirst);
+  }
+}
+  
+/**
+  * @brief  This function handles SMARTCARD Communication Timeout.
+  * @param  hsc: SMARTCARD handle
+  * @param  Flag: specifies the SMARTCARD flag to check.
+  * @param  Status: The new Flag status (SET or RESET).
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SMARTCARD_WaitOnFlagUntilTimeout(SMARTCARD_HandleTypeDef *hsc, uint32_t Flag, FlagStatus Status, uint32_t Timeout)  
+{
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+
+  /* Wait until flag is set */
+  if(Status == RESET)
+  {    
+    while(__HAL_SMARTCARD_GET_FLAG(hsc, Flag) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+          __HAL_SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_TXE);
+          __HAL_SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_RXNE);
+          __HAL_SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_PE);
+          __HAL_SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_ERR);
+
+          hsc->State= HAL_SMARTCARD_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hsc);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    while(__HAL_SMARTCARD_GET_FLAG(hsc, Flag) != RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+          __HAL_SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_TXE);
+          __HAL_SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_RXNE);
+          __HAL_SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_PE);
+          __HAL_SMARTCARD_DISABLE_IT(hsc, SMARTCARD_IT_ERR);
+
+          hsc->State= HAL_SMARTCARD_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hsc);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief DMA SMARTCARD transmit process complete callback 
+  * @param hdma: DMA handle
+  * @retval None
+  */
+static void SMARTCARD_DMATransmitCplt(DMA_HandleTypeDef *hdma)     
+{
+  SMARTCARD_HandleTypeDef* hsc = ( SMARTCARD_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  hsc->TxXferCount = 0;
+  
+  /* Disable the DMA transfer for transmit request by setting the DMAT bit
+  in the SMARTCARD associated USART CR3 register */
+  hsc->Instance->CR3 &= (uint16_t)~((uint16_t)USART_CR3_DMAT);
+  
+  /* Wait for SMARTCARD TC Flag */
+  if(SMARTCARD_WaitOnFlagUntilTimeout(hsc, SMARTCARD_FLAG_TC, RESET, HAL_SMARTCARD_TXDMA_TIMEOUTVALUE) != HAL_OK)
+  {
+    /* Timeout Occured */ 
+    hsc->State = HAL_SMARTCARD_STATE_TIMEOUT;
+    HAL_SMARTCARD_ErrorCallback(hsc);
+  }
+  else
+  {
+    /* No Timeout */
+    /* Check if a receive Process is ongoing or not */
+    if(hsc->State == HAL_SMARTCARD_STATE_BUSY_TX_RX) 
+    {
+      hsc->State = HAL_SMARTCARD_STATE_BUSY_RX;
+    }
+    else
+    {
+      hsc->State = HAL_SMARTCARD_STATE_READY;
+    }
+    HAL_SMARTCARD_TxCpltCallback(hsc);
+  }
+}
+
+/**
+  * @brief DMA SMARTCARD receive process complete callback 
+  * @param hdma: DMA handle
+  * @retval None
+  */
+static void SMARTCARD_DMAReceiveCplt(DMA_HandleTypeDef *hdma)  
+{
+  SMARTCARD_HandleTypeDef* hsc = ( SMARTCARD_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  hsc->RxXferCount = 0;
+  
+  /* Disable the DMA transfer for the receiver request by setting the DMAR bit 
+     in the SMARTCARD associated USART CR3 register */
+  hsc->Instance->CR3 &= (uint16_t)~((uint16_t)USART_CR3_DMAR);
+  
+  /* Check if a transmit Process is ongoing or not */
+  if(hsc->State == HAL_SMARTCARD_STATE_BUSY_TX_RX) 
+  {
+    hsc->State = HAL_SMARTCARD_STATE_BUSY_TX;
+  }
+  else
+  {
+    hsc->State = HAL_SMARTCARD_STATE_READY;
+  }
+  
+  HAL_SMARTCARD_RxCpltCallback(hsc);
+}
+
+/**
+  * @brief DMA SMARTCARD communication error callback 
+  * @param hdma: DMA handle
+  * @retval None
+  */
+static void SMARTCARD_DMAError(DMA_HandleTypeDef *hdma)
+{
+  SMARTCARD_HandleTypeDef* hsc = ( SMARTCARD_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  hsc->RxXferCount = 0;
+  hsc->TxXferCount = 0;
+  hsc->State= HAL_SMARTCARD_STATE_READY;
+  hsc->ErrorCode |= HAL_SMARTCARD_ERROR_DMA;
+  HAL_SMARTCARD_ErrorCallback(hsc);
+}
+/**
+  * @}
+  */
+
+#endif /* HAL_SMARTCARD_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_smartcard.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_smartcard.h
@@ -1,0 +1,799 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_smartcard.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of SMARTCARD HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_SMARTCARD_H
+#define __STM32L0xx_HAL_SMARTCARD_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup SMARTCARD
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** 
+  * @brief SMARTCARD Init Structure definition
+  */
+typedef struct
+{
+  uint32_t BaudRate;                  /*!< Configures the SmartCard communication baud rate.
+                                           The baud rate register is computed using the following formula:
+                                              Baud Rate Register = ((PCLKx) / ((hsc->Init.BaudRate))) */
+                                           
+  uint32_t WordLength;                /*!< Specifies the number of data bits transmitted or received in a frame.
+                                           This parameter @ref SMARTCARD_Word_Length can only be set to 9 (8 data + 1 parity bits). */
+
+  uint32_t StopBits;                  /*!< Specifies the number of stop bits @ref SMARTCARD_Stop_Bits. 
+                                           Only 1.5 stop bits are authorized in SmartCard mode. */
+
+  uint32_t Parity;                    /*!< Specifies the parity mode.
+                                           This parameter can be a value of @ref SMARTCARD_Parity
+                                           @note The parity is enabled by default (PCE is forced to 1).
+                                                 Since the WordLength is forced to 8 bits + parity, M is
+                                                 forced to 1 and the parity bit is the 9th bit. */
+ 
+  uint32_t Mode;                      /*!< Specifies whether the Receive or Transmit mode is enabled or disabled.
+                                           This parameter can be a value of @ref SMARTCARD_Mode */
+
+  uint32_t CLKPolarity;               /*!< Specifies the steady state of the serial clock.
+                                           This parameter can be a value of @ref SMARTCARD_Clock_Polarity */
+
+  uint32_t CLKPhase;                  /*!< Specifies the clock transition on which the bit capture is made.
+                                           This parameter can be a value of @ref SMARTCARD_Clock_Phase */
+
+  uint32_t CLKLastBit;                /*!< Specifies whether the clock pulse corresponding to the last transmitted
+                                           data bit (MSB) has to be output on the SCLK pin in synchronous mode.
+                                           This parameter can be a value of @ref SMARTCARD_Last_Bit */
+                                             
+  uint32_t OneBitSampling;            /*!< Specifies wether a single sample or three samples' majority vote is selected.
+                                           Selecting the single sample method increases the receiver tolerance to clock
+                                           deviations. This parameter can be a value of @ref SMARTCARD_OneBit_Sampling */
+
+  uint32_t  Prescaler;                 /*!< Specifies the SmartCard Prescaler */
+  
+  uint32_t  GuardTime;                 /*!< Specifies the SmartCard Guard Time */
+  
+  uint32_t NACKState;                  /*!< Specifies whether the SmartCard NACK transmission is enabled
+                                            in case of parity error.
+                                            This parameter can be a value of @ref SMARTCARD_NACK_Enable */ 
+                                           
+  uint32_t TimeOutEnable;              /*!< Specifies whether the receiver timeout is enabled. 
+                                            This parameter can be a value of @ref SMARTCARD_Timeout_Enable*/
+  
+  uint32_t TimeOutValue;               /*!< Specifies the receiver time out value in number of baud blocks: 
+                                            it is used to implement the Character Wait Time (CWT) and 
+                                            Block Wait Time (BWT). It is coded over 24 bits. */ 
+                                           
+  uint32_t BlockLength;                /*!< Specifies the SmartCard Block Length in T=1 Reception mode.
+                                            This parameter can be any value from 0x0 to 0xFF */ 
+                                           
+  uint32_t AutoRetryCount;              /*!< Specifies the SmartCard auto-retry count (number of retries in
+                                             receive and transmit mode). When set to 0, retransmission is 
+                                             disabled. Otherwise, its maximum value is 7 (before signalling
+                                             an error) */  
+
+}SMARTCARD_InitTypeDef;
+
+/** 
+  * @brief  SMARTCARD advanced features initalization structure definition  
+  */
+typedef struct
+{
+  uint32_t AdvFeatureInit;            /*!< Specifies which advanced SMARTCARD features is initialized. Several
+                                           advanced features may be initialized at the same time. This parameter 
+                                           can be a value of @ref SMARTCARD_Advanced_Features_Initialization_Type */
+
+  uint32_t TxPinLevelInvert;          /*!< Specifies whether the TX pin active level is inverted.
+                                           This parameter can be a value of @ref SMARTCARD_Tx_Inv  */
+
+  uint32_t RxPinLevelInvert;          /*!< Specifies whether the RX pin active level is inverted.
+                                           This parameter can be a value of @ref SMARTCARD_Rx_Inv  */
+
+  uint32_t DataInvert;                /*!< Specifies whether data are inverted (positive/direct logic
+                                           vs negative/inverted logic).
+                                           This parameter can be a value of @ref SMARTCARD_Data_Inv */
+
+  uint32_t Swap;                      /*!< Specifies whether TX and RX pins are swapped.   
+                                           This parameter can be a value of @ref SMARTCARD_Rx_Tx_Swap */
+
+  uint32_t OverrunDisable;            /*!< Specifies whether the reception overrun detection is disabled.   
+                                           This parameter can be a value of @ref SMARTCARD_Overrun_Disable */
+
+  uint32_t DMADisableonRxError;       /*!< Specifies whether the DMA is disabled in case of reception error.     
+                                           This parameter can be a value of @ref SMARTCARD_DMA_Disable_on_Rx_Error */
+
+  uint32_t MSBFirst;                  /*!< Specifies whether MSB is sent first on UART line.      
+                                           This parameter can be a value of @ref SMARTCARD_MSB_First */
+}SMARTCARD_AdvFeatureInitTypeDef;
+
+/** 
+  * @brief HAL State structures definition  
+  */ 
+typedef enum
+{
+  HAL_SMARTCARD_STATE_RESET             = 0x00,    /*!< Peripheral is not yet Initialized */
+  HAL_SMARTCARD_STATE_READY             = 0x01,    /*!< Peripheral Initialized and ready for use */
+  HAL_SMARTCARD_STATE_BUSY              = 0x02,    /*!< an internal process is ongoing */
+  HAL_SMARTCARD_STATE_BUSY_TX           = 0x12,    /*!< Data Transmission process is ongoing */
+  HAL_SMARTCARD_STATE_BUSY_RX           = 0x22,    /*!< Data Reception process is ongoing */
+  HAL_SMARTCARD_STATE_BUSY_TX_RX        = 0x32,    /*!< Data Transmission and Reception process is ongoing */ 
+  HAL_SMARTCARD_STATE_TIMEOUT           = 0x03,    /*!< Timeout state */
+  HAL_SMARTCARD_STATE_ERROR             = 0x04     /*!< Error */
+}HAL_SMARTCARD_StateTypeDef;
+
+/** 
+  * @brief  HAL SMARTCARD Error Code structure definition
+  */
+typedef enum
+{
+  HAL_SMARTCARD_ERROR_NONE      = 0x00,    /*!< No error                */
+  HAL_SMARTCARD_ERROR_PE        = 0x01,    /*!< Parity error            */
+  HAL_SMARTCARD_ERROR_NE        = 0x02,    /*!< Noise error             */
+  HAL_SMARTCARD_ERROR_FE        = 0x04,    /*!< frame error             */
+  HAL_SMARTCARD_ERROR_ORE       = 0x08,    /*!< Overrun error           */
+  HAL_SMARTCARD_ERROR_DMA       = 0x10,    /*!< DMA transfer error      */
+  HAL_SMARTCARD_ERROR_RTO       = 0x20     /*!< Receiver TimeOut error  */
+}HAL_SMARTCARD_ErrorTypeDef;
+
+/**
+  * @brief  SMARTCARD clock sources definition
+  */
+typedef enum
+{
+  SMARTCARD_CLOCKSOURCE_PCLK1      = 0x00,    /*!< PCLK1 clock source  */
+  SMARTCARD_CLOCKSOURCE_PCLK2      = 0x01,    /*!< PCLK2 clock source  */
+  SMARTCARD_CLOCKSOURCE_HSI        = 0x02,    /*!< HSI clock source    */
+  SMARTCARD_CLOCKSOURCE_SYSCLK     = 0x04,    /*!< SYSCLK clock source */
+  SMARTCARD_CLOCKSOURCE_LSE        = 0x08     /*!< LSE clock source    */
+}SMARTCARD_ClockSourceTypeDef;
+
+/** 
+  * @brief  SMARTCARD handle Structure definition
+  */
+typedef struct
+{
+  USART_TypeDef                   *Instance;        /* USART registers base address                          */
+
+  SMARTCARD_InitTypeDef           Init;             /* SmartCard communication parameters                    */
+
+  SMARTCARD_AdvFeatureInitTypeDef AdvancedInit;     /* SmartCard advanced features initialization parameters */
+
+  uint8_t                         *pTxBuffPtr;      /* Pointer to SmartCard Tx transfer Buffer               */
+
+  uint16_t                        TxXferSize;       /* SmartCard Tx Transfer size                            */
+
+  uint16_t                        TxXferCount;      /* SmartCard Tx Transfer Counter                         */
+
+  uint8_t                         *pRxBuffPtr;      /* Pointer to SmartCard Rx transfer Buffer               */
+
+  uint16_t                        RxXferSize;       /* SmartCard Rx Transfer size                            */
+
+  uint16_t                        RxXferCount;      /* SmartCard Rx Transfer Counter                         */
+
+  DMA_HandleTypeDef               *hdmatx;          /* SmartCard Tx DMA Handle parameters                    */
+
+  DMA_HandleTypeDef               *hdmarx;          /* SmartCard Rx DMA Handle parameters                    */
+
+  HAL_LockTypeDef                 Lock;             /* Locking object                                        */
+
+  __IO HAL_SMARTCARD_StateTypeDef      State;      /* SmartCard communication state                          */
+
+  __IO HAL_SMARTCARD_ErrorTypeDef      ErrorCode;  /* SmartCard Error code                                   */
+
+}SMARTCARD_HandleTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup SMARTCARD_Exported_Constants
+  * @{
+  */
+
+/** @defgroup SMARTCARD_Word_Length
+  * @{
+  */
+#define SMARTCARD_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M_0)
+#define IS_SMARTCARD_WORD_LENGTH(LENGTH) ((LENGTH) == SMARTCARD_WORDLENGTH_9B) 
+/**
+  * @}
+  */
+  
+/** @defgroup SMARTCARD_Stop_Bits
+  * @{
+  */
+#define SMARTCARD_STOPBITS_1_5                   ((uint32_t)(USART_CR2_STOP))
+#define IS_SMARTCARD_STOPBITS(STOPBITS) ((STOPBITS) == SMARTCARD_STOPBITS_1_5)
+/**
+  * @}
+  */   
+
+/** @defgroup SMARTCARD_Parity
+  * @{
+  */ 
+#define SMARTCARD_PARITY_EVEN                    ((uint32_t)USART_CR1_PCE)
+#define SMARTCARD_PARITY_ODD                     ((uint32_t)(USART_CR1_PCE | USART_CR1_PS)) 
+#define IS_SMARTCARD_PARITY(PARITY) (((PARITY) == SMARTCARD_PARITY_EVEN) || \
+                                     ((PARITY) == SMARTCARD_PARITY_ODD))
+/**
+  * @}
+  */ 
+
+/** @defgroup SMARTCARD_Mode
+  * @{
+  */ 
+#define SMARTCARD_MODE_RX                        ((uint32_t)USART_CR1_RE)
+#define SMARTCARD_MODE_TX                        ((uint32_t)USART_CR1_TE)
+#define SMARTCARD_MODE_TX_RX                     ((uint32_t)(USART_CR1_TE |USART_CR1_RE))
+#define IS_SMARTCARD_MODE(MODE) ((((MODE) & (uint32_t)0xFFF3) == 0x00) && ((MODE) != (uint32_t)0x00))
+/**
+  * @}
+  */
+
+/** @defgroup SMARTCARD_Clock_Polarity
+  * @{
+  */
+#define SMARTCARD_POLARITY_LOW                   ((uint32_t)0x0000)
+#define SMARTCARD_POLARITY_HIGH                  ((uint32_t)USART_CR2_CPOL)
+#define IS_SMARTCARD_POLARITY(CPOL) (((CPOL) == SMARTCARD_POLARITY_LOW) || ((CPOL) == SMARTCARD_POLARITY_HIGH))
+/**
+  * @}
+  */ 
+
+/** @defgroup SMARTCARD_Clock_Phase
+  * @{
+  */
+#define SMARTCARD_PHASE_1EDGE                    ((uint32_t)0x0000)
+#define SMARTCARD_PHASE_2EDGE                    ((uint32_t)USART_CR2_CPHA)
+#define IS_SMARTCARD_PHASE(CPHA) (((CPHA) == SMARTCARD_PHASE_1EDGE) || ((CPHA) == SMARTCARD_PHASE_2EDGE))
+/**
+  * @}
+  */
+
+/** @defgroup SMARTCARD_Last_Bit
+  * @{
+  */
+#define SMARTCARD_LASTBIT_DISABLE                ((uint32_t)0x0000)
+#define SMARTCARD_LASTBIT_ENABLE                 ((uint32_t)USART_CR2_LBCL)
+#define IS_SMARTCARD_LASTBIT(LASTBIT) (((LASTBIT) == SMARTCARD_LASTBIT_DISABLE) || \
+                                       ((LASTBIT) == SMARTCARD_LASTBIT_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup SMARTCARD_OneBit_Sampling
+  * @{
+  */
+#define SMARTCARD_ONEBIT_SAMPLING_DISABLED   ((uint32_t)0x0000)
+#define SMARTCARD_ONEBIT_SAMPLING_ENABLED    ((uint32_t)USART_CR3_ONEBIT)
+#define IS_SMARTCARD_ONEBIT_SAMPLING(ONEBIT) (((ONEBIT) == SMARTCARD_ONEBIT_SAMPLING_DISABLED) || \
+                                              ((ONEBIT) == SMARTCARD_ONEBIT_SAMPLING_ENABLED))
+/**
+  * @}
+  */  
+
+
+/** @defgroup SMARTCARD_NACK_Enable
+  * @{
+  */
+#define SMARTCARD_NACK_ENABLED           ((uint32_t)USART_CR3_NACK)
+#define SMARTCARD_NACK_DISABLED          ((uint32_t)0x0000)
+#define IS_SMARTCARD_NACK(NACK) (((NACK) == SMARTCARD_NACK_ENABLED) || \
+                                       ((NACK) == SMARTCARD_NACK_DISABLED))
+/**
+  * @}
+  */
+
+/** @defgroup SMARTCARD_Timeout_Enable
+  * @{
+  */
+#define SMARTCARD_TIMEOUT_DISABLED      ((uint32_t)0x00000000)
+#define SMARTCARD_TIMEOUT_ENABLED       ((uint32_t)USART_CR2_RTOEN)
+#define IS_SMARTCARD_TIMEOUT(TIMEOUT) (((TIMEOUT) == SMARTCARD_TIMEOUT_DISABLED) || \
+                                       ((TIMEOUT) == SMARTCARD_TIMEOUT_ENABLED))
+/**
+  * @}
+  */
+  
+/** @defgroup SmartCard_DMA_Requests
+  * @{
+  */
+
+#define SMARTCARD_DMAREQ_TX                    ((uint32_t)USART_CR3_DMAT)
+#define SMARTCARD_DMAREQ_RX                    ((uint32_t)USART_CR3_DMAR)
+
+/**
+  * @}
+  */
+
+/** @defgroup SMARTCARD_Advanced_Features_Initialization_Type
+  * @{
+  */
+#define SMARTCARD_ADVFEATURE_NO_INIT                 ((uint32_t)0x00000000)
+#define SMARTCARD_ADVFEATURE_TXINVERT_INIT           ((uint32_t)0x00000001)
+#define SMARTCARD_ADVFEATURE_RXINVERT_INIT           ((uint32_t)0x00000002)
+#define SMARTCARD_ADVFEATURE_DATAINVERT_INIT         ((uint32_t)0x00000004)
+#define SMARTCARD_ADVFEATURE_SWAP_INIT               ((uint32_t)0x00000008)
+#define SMARTCARD_ADVFEATURE_RXOVERRUNDISABLE_INIT   ((uint32_t)0x00000010)
+#define SMARTCARD_ADVFEATURE_DMADISABLEONERROR_INIT  ((uint32_t)0x00000020)
+#define SMARTCARD_ADVFEATURE_MSBFIRST_INIT           ((uint32_t)0x00000080)
+#define IS_SMARTCARD_ADVFEATURE_INIT(INIT)           ((INIT) <= (SMARTCARD_ADVFEATURE_NO_INIT | \
+                                                            SMARTCARD_ADVFEATURE_TXINVERT_INIT | \
+                                                            SMARTCARD_ADVFEATURE_RXINVERT_INIT | \
+                                                            SMARTCARD_ADVFEATURE_DATAINVERT_INIT | \
+                                                            SMARTCARD_ADVFEATURE_SWAP_INIT | \
+                                                            SMARTCARD_ADVFEATURE_RXOVERRUNDISABLE_INIT | \
+                                                            SMARTCARD_ADVFEATURE_DMADISABLEONERROR_INIT   | \
+                                                            SMARTCARD_ADVFEATURE_MSBFIRST_INIT))  
+/**
+  * @}
+  */
+
+/** @defgroup SMARTCARD_Tx_Inv
+  * @{
+  */
+#define SMARTCARD_ADVFEATURE_TXINV_DISABLE   ((uint32_t)0x00000000)
+#define SMARTCARD_ADVFEATURE_TXINV_ENABLE    ((uint32_t)USART_CR2_TXINV)
+#define IS_SMARTCARD_ADVFEATURE_TXINV(TXINV) (((TXINV) == SMARTCARD_ADVFEATURE_TXINV_DISABLE) || \
+                                         ((TXINV) == SMARTCARD_ADVFEATURE_TXINV_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup SMARTCARD_Rx_Inv
+  * @{
+  */
+#define SMARTCARD_ADVFEATURE_RXINV_DISABLE   ((uint32_t)0x00000000)
+#define SMARTCARD_ADVFEATURE_RXINV_ENABLE    ((uint32_t)USART_CR2_RXINV)
+#define IS_SMARTCARD_ADVFEATURE_RXINV(RXINV) (((RXINV) == SMARTCARD_ADVFEATURE_RXINV_DISABLE) || \
+                                         ((RXINV) == SMARTCARD_ADVFEATURE_RXINV_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup SMARTCARD_Data_Inv
+  * @{
+  */
+#define SMARTCARD_ADVFEATURE_DATAINV_DISABLE     ((uint32_t)0x00000000)
+#define SMARTCARD_ADVFEATURE_DATAINV_ENABLE      ((uint32_t)USART_CR2_DATAINV)
+#define IS_SMARTCARD_ADVFEATURE_DATAINV(DATAINV) (((DATAINV) == SMARTCARD_ADVFEATURE_DATAINV_DISABLE) || \
+                                             ((DATAINV) == SMARTCARD_ADVFEATURE_DATAINV_ENABLE))
+/**
+  * @}
+  */ 
+  
+/** @defgroup SMARTCARD_Rx_Tx_Swap
+  * @{
+  */
+#define SMARTCARD_ADVFEATURE_SWAP_DISABLE   ((uint32_t)0x00000000)
+#define SMARTCARD_ADVFEATURE_SWAP_ENABLE    ((uint32_t)USART_CR2_SWAP)
+#define IS_SMARTCARD_ADVFEATURE_SWAP(SWAP) (((SWAP) == SMARTCARD_ADVFEATURE_SWAP_DISABLE) || \
+                                       ((SWAP) == SMARTCARD_ADVFEATURE_SWAP_ENABLE))
+/**
+  * @}
+  */ 
+
+/** @defgroup SMARTCARD_Overrun_Disable
+  * @{
+  */
+#define SMARTCARD_ADVFEATURE_OVERRUN_ENABLE   ((uint32_t)0x00000000)
+#define SMARTCARD_ADVFEATURE_OVERRUN_DISABLE  ((uint32_t)USART_CR3_OVRDIS)
+#define IS_SMARTCARD_OVERRUN(OVERRUN)         (((OVERRUN) == SMARTCARD_ADVFEATURE_OVERRUN_ENABLE) || \
+                                          ((OVERRUN) == SMARTCARD_ADVFEATURE_OVERRUN_DISABLE))
+/**
+  * @}
+  */  
+
+/** @defgroup SMARTCARD_DMA_Disable_on_Rx_Error
+  * @{
+  */
+#define SMARTCARD_ADVFEATURE_DMA_ENABLEONRXERROR       ((uint32_t)0x00000000)
+#define SMARTCARD_ADVFEATURE_DMA_DISABLEONRXERROR      ((uint32_t)USART_CR3_DDRE)
+#define IS_SMARTCARD_ADVFEATURE_DMAONRXERROR(DMA)      (((DMA) == SMARTCARD_ADVFEATURE_DMA_ENABLEONRXERROR) || \
+                                                   ((DMA) == SMARTCARD_ADVFEATURE_DMA_DISABLEONRXERROR))
+/**
+  * @}
+  */  
+
+/** @defgroup SMARTCARD_MSB_First
+  * @{
+  */
+#define SMARTCARD_ADVFEATURE_MSBFIRST_DISABLE      ((uint32_t)0x00000000)
+#define SMARTCARD_ADVFEATURE_MSBFIRST_ENABLE       ((uint32_t)USART_CR2_MSBFIRST)
+#define IS_SMARTCARD_ADVFEATURE_MSBFIRST(MSBFIRST) (((MSBFIRST) == SMARTCARD_ADVFEATURE_MSBFIRST_DISABLE) || \
+                                               ((MSBFIRST) == SMARTCARD_ADVFEATURE_MSBFIRST_ENABLE))
+/**
+  * @}
+  */  
+
+/** @defgroup SmartCard_Flags
+  *        Elements values convention: 0xXXXX
+  *           - 0xXXXX  : Flag mask in the ISR register
+  * @{
+  */
+#define SMARTCARD_FLAG_REACK                     ((uint32_t)0x00400000)
+#define SMARTCARD_FLAG_TEACK                     ((uint32_t)0x00200000)
+#define SMARTCARD_FLAG_BUSY                      ((uint32_t)0x00010000)
+#define SMARTCARD_FLAG_EOBF                      ((uint32_t)0x00001000)
+#define SMARTCARD_FLAG_RTOF                      ((uint32_t)0x00000800)
+#define SMARTCARD_FLAG_TXE                       ((uint32_t)0x00000080)
+#define SMARTCARD_FLAG_TC                        ((uint32_t)0x00000040)
+#define SMARTCARD_FLAG_RXNE                      ((uint32_t)0x00000020)
+#define SMARTCARD_FLAG_ORE                       ((uint32_t)0x00000008)
+#define SMARTCARD_FLAG_NE                        ((uint32_t)0x00000004)
+#define SMARTCARD_FLAG_FE                        ((uint32_t)0x00000002)
+#define SMARTCARD_FLAG_PE                        ((uint32_t)0x00000001)
+/**
+  * @}
+  */
+
+/** @defgroup SMARTCARD_Interrupt_definition
+  *        Elements values convention: 0000ZZZZ0XXYYYYYb
+  *           - YYYYY  : Interrupt source position in the XX register (5bits)
+  *           - XX  : Interrupt source register (2bits)
+  *                 - 01: CR1 register
+  *                 - 10: CR2 register
+  *                 - 11: CR3 register
+  *           - ZZZZ  : Flag position in the ISR register(4bits)
+  * @{
+  */
+  
+#define SMARTCARD_IT_PE                          ((uint16_t)0x0028)
+#define SMARTCARD_IT_TXE                         ((uint16_t)0x0727)
+#define SMARTCARD_IT_TC                          ((uint16_t)0x0626)
+#define SMARTCARD_IT_RXNE                        ((uint16_t)0x0525)
+
+#define SMARTCARD_IT_ERR                         ((uint16_t)0x0060)
+#define SMARTCARD_IT_ORE                         ((uint16_t)0x0300)
+#define SMARTCARD_IT_NE                          ((uint16_t)0x0200)
+#define SMARTCARD_IT_FE                          ((uint16_t)0x0100)
+
+#define SMARTCARD_IT_EOB                         ((uint16_t)0x0C3B)
+#define SMARTCARD_IT_RTO                         ((uint16_t)0x0B3A)
+/**
+  * @}
+  */ 
+
+
+/** @defgroup SMARTCARD_IT_CLEAR_Flags
+  * @{
+  */
+#define SMARTCARD_CLEAR_PEF                       USART_ICR_PECF            /*!< Parity Error Clear Flag */          
+#define SMARTCARD_CLEAR_FEF                       USART_ICR_FECF            /*!< Framing Error Clear Flag */         
+#define SMARTCARD_CLEAR_NEF                       USART_ICR_NCF             /*!< Noise detected Clear Flag */        
+#define SMARTCARD_CLEAR_OREF                      USART_ICR_ORECF           /*!< OverRun Error Clear Flag */         
+#define SMARTCARD_CLEAR_TCF                       USART_ICR_TCCF            /*!< Transmission Complete Clear Flag */ 
+#define SMARTCARD_CLEAR_RTOF                      USART_ICR_RTOCF           /*!< Receiver Time Out Clear Flag */     
+#define SMARTCARD_CLEAR_EOBF                      USART_ICR_EOBCF           /*!< End Of Block Clear Flag */          
+/**
+  * @}
+  */
+
+/** @defgroup SMARTCARD_Request_Parameters
+  * @{
+  */        
+#define SMARTCARD_RXDATA_FLUSH_REQUEST        ((uint32_t)USART_RQR_RXFRQ)        /*!< Receive Data flush Request */ 
+#define SMARTCARD_TXDATA_FLUSH_REQUEST        ((uint32_t)USART_RQR_TXFRQ)        /*!< Transmit data flush Request */
+#define IS_SMARTCARD_REQUEST_PARAMETER(PARAM) (((PARAM) == SMARTCARD_RXDATA_FLUSH_REQUEST) || \
+                                               ((PARAM) == SMARTCARD_TXDATA_FLUSH_REQUEST))   
+/**
+  * @}
+  */
+  
+  
+/** @defgroup SMARTCARD_CR3_SCAR_CNT_LSB_POS
+  * @{
+  */
+#define SMARTCARD_CR3_SCARCNT_LSB_POS            ((uint32_t) 17)
+/**
+  * @}
+  */
+  
+/** @defgroup SMARTCARD_GTPR_GT_LSBPOS
+  * @{
+  */
+#define SMARTCARD_GTPR_GT_LSB_POS            ((uint32_t) 8)
+/**
+  * @}
+  */ 
+  
+/** @defgroup SMARTCARD_RTOR_BLEN_LSBPOS
+  * @{
+  */
+#define SMARTCARD_RTOR_BLEN_LSB_POS          ((uint32_t) 24)
+/**
+  * @}
+  */    
+ 
+/** @defgroup SMARTCARD_Interruption_Mask
+  * @{
+  */ 
+#define SMARTCARD_IT_MASK  ((uint16_t)0x001F)  
+/**
+  * @}
+  */
+    
+/**
+  * @}
+  */    
+    
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup SMARTCARD_Exported_Macros
+  * @{
+  */
+
+/** @brief Reset SMARTCARD handle state
+  * @param  __HANDLE__: specifies the SMARTCARD Handle.
+  *         The Handle Instance which can be USART1 or USART2
+  * @retval None
+  */
+#define __HAL_SMARTCARD_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_SMARTCARD_STATE_RESET)
+
+/** @brief  Flushs the Smartcard DR register 
+  * @param  __HANDLE__: specifies the SMARTCARD Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @retval None
+  */
+#define __HAL_SMARTCARD_FLUSH_DRREGISTER(__HANDLE__) (__HAL_SMARTCARD_SEND_REQ((__HANDLE__), SMARTCARD_RXDATA_FLUSH_REQUEST))
+
+/** @brief  Checks whether the specified Smartcard flag is set or not.
+  * @param  __HANDLE__: specifies the SMARTCARD Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @param  __FLAG__: specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg SMARTCARD_FLAG_REACK: Receive enable ackowledge flag
+  *            @arg SMARTCARD_FLAG_TEACK: Transmit enable ackowledge flag
+  *            @arg SMARTCARD_FLAG_BUSY:  Busy flag
+  *            @arg SMARTCARD_FLAG_EOBF:  End of block flag   
+  *            @arg SMARTCARD_FLAG_RTOF:  Receiver timeout flag
+  *            @arg SMARTCARD_FLAG_TXE:   Transmit data register empty flag
+  *            @arg SMARTCARD_FLAG_TC:    Transmission Complete flag
+  *            @arg SMARTCARD_FLAG_RXNE:  Receive data register not empty flag
+  *            @arg SMARTCARD_FLAG_ORE:   OverRun Error flag
+  *            @arg SMARTCARD_FLAG_NE:    Noise Error flag
+  *            @arg SMARTCARD_FLAG_FE:    Framing Error flag
+  *            @arg SMARTCARD_FLAG_PE:    Parity Error flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_SMARTCARD_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->ISR & (__FLAG__)) == (__FLAG__))
+
+/** @brief  Enables the specified SmartCard interrupt.
+  * @param  __HANDLE__: specifies the SMARTCARD Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @param  __INTERRUPT__: specifies the SMARTCARD interrupt to enable.
+  *          This parameter can be one of the following values:
+  *            @arg SMARTCARD_IT_EOBF: End Of Block interrupt
+  *            @arg SMARTCARD_IT_RTOF: Receive TimeOut interrupt
+  *            @arg SMARTCARD_IT_TXE:  Transmit Data Register empty interrupt
+  *            @arg SMARTCARD_IT_TC:   Transmission complete interrupt
+  *            @arg SMARTCARD_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg SMARTCARD_IT_PE:   Parity Error interrupt
+  *            @arg SMARTCARD_IT_ERR:  Error interrupt(Frame error, noise error, overrun error)
+  * @retval None
+  */
+#define __HAL_SMARTCARD_ENABLE_IT(__HANDLE__, __INTERRUPT__)   (((((uint8_t)(__INTERRUPT__)) >> 5) == 1)? ((__HANDLE__)->Instance->CR1 |= (1 << ((__INTERRUPT__) & SMARTCARD_IT_MASK))): \
+                                                        ((((uint8_t)(__INTERRUPT__)) >> 5) == 2)? ((__HANDLE__)->Instance->CR2 |= (1 << ((__INTERRUPT__) & SMARTCARD_IT_MASK))): \
+                                                        ((__HANDLE__)->Instance->CR3 |= (1 << ((__INTERRUPT__) & SMARTCARD_IT_MASK))))
+/** @brief  Disables the specified SmartCard interrupt.
+  * @param  __HANDLE__: specifies the SMARTCARD Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @param  __INTERRUPT__: specifies the SMARTCARD interrupt to enable.
+  *          This parameter can be one of the following values:
+  *            @arg SMARTCARD_IT_EOBF: End Of Block interrupt
+  *            @arg SMARTCARD_IT_RTOF: Receive TimeOut interrupt
+  *            @arg SMARTCARD_IT_TXE:  Transmit Data Register empty interrupt
+  *            @arg SMARTCARD_IT_TC:   Transmission complete interrupt
+  *            @arg SMARTCARD_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg SMARTCARD_IT_PE:   Parity Error interrupt
+  *            @arg SMARTCARD_IT_ERR:  Error interrupt(Frame error, noise error, overrun error)
+  * @retval None
+  */
+#define __HAL_SMARTCARD_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (((((uint8_t)(__INTERRUPT__)) >> 5) == 1)? ((__HANDLE__)->Instance->CR1 &= ~ ((uint32_t)1 << ((__INTERRUPT__) & SMARTCARD_IT_MASK))): \
+                                                        ((((uint8_t)(__INTERRUPT__)) >> 5) == 2)? ((__HANDLE__)->Instance->CR2 &= ~ ((uint32_t)1 << ((__INTERRUPT__) & SMARTCARD_IT_MASK))): \
+                                                        ((__HANDLE__)->Instance->CR3 &= ~ ((uint32_t)1 << ((__INTERRUPT__) & SMARTCARD_IT_MASK))))
+
+/** @brief  Checks whether the specified SmartCard interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the SMARTCARD Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @param  __IT__: specifies the SMARTCARD interrupt to check.
+  *          This parameter can be one of the following values:
+  *            @arg SMARTCARD_IT_EOBF: End Of Block interrupt
+  *            @arg SMARTCARD_IT_RTOF: Receive TimeOut interrupt  
+  *            @arg SMARTCARD_IT_TXE:  Transmit Data Register empty interrupt
+  *            @arg SMARTCARD_IT_TC:   Transmission complete interrupt
+  *            @arg SMARTCARD_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg SMARTCARD_IT_ORE:  OverRun Error interrupt
+  *            @arg SMARTCARD_IT_NE:   Noise Error interrupt
+  *            @arg SMARTCARD_IT_FE:   Framing Error interrupt
+  *            @arg SMARTCARD_IT_PE:   Parity Error interrupt
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_SMARTCARD_GET_IT(__HANDLE__, __IT__) ((__HANDLE__)->Instance->ISR & ((uint32_t)1 << ((__IT__)>> 0x08))) 
+
+/** @brief  Checks whether the specified SmartCard interrupt interrupt source is enabled.
+  * @param  __HANDLE__: specifies the SMARTCARD Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @param  __IT__: specifies the SMARTCARD interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg SMARTCARD_IT_EOBF: End Of Block interrupt
+  *            @arg SMARTCARD_IT_RTOF: Receive TimeOut interrupt  
+  *            @arg SMARTCARD_IT_TXE:  Transmit Data Register empty interrupt
+  *            @arg SMARTCARD_IT_TC:   Transmission complete interrupt
+  *            @arg SMARTCARD_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg SMARTCARD_IT_ORE:  OverRun Error interrupt
+  *            @arg SMARTCARD_IT_NE:   Noise Error interrupt
+  *            @arg SMARTCARD_IT_FE:   Framing Error interrupt
+  *            @arg SMARTCARD_IT_PE:   Parity Error interrupt
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_SMARTCARD_GET_IT_SOURCE(__HANDLE__, __IT__) ((((((uint8_t)(__IT__)) >> 5) == 1)? (__HANDLE__)->Instance->CR1:(((((uint8_t)(__IT__)) >> 5) == 2)? \
+                                                               (__HANDLE__)->Instance->CR2 : (__HANDLE__)->Instance->CR3)) & ((uint32_t)1 << \
+                                                               (((uint16_t)(__IT__)) & SMARTCARD_IT_MASK)))
+
+
+/** @brief  Clears the specified SMARTCARD ISR flag, in setting the proper ICR register flag.
+  * @param  __HANDLE__: specifies the SMARTCARD Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @param  __IT_CLEAR__: specifies the interrupt clear register flag that needs to be set
+  *                       to clear the corresponding interrupt
+  *          This parameter can be one of the following values:
+  *            @arg USART_CLEAR_PEF: Parity Error Clear Flag
+  *            @arg USART_CLEAR_FEF: Framing Error Clear Flag
+  *            @arg USART_CLEAR_NEF: Noise detected Clear Flag
+  *            @arg USART_CLEAR_OREF: OverRun Error Clear Flag
+  *            @arg USART_CLEAR_TCF: Transmission Complete Clear Flag
+  *            @arg USART_CLEAR_RTOF: Receiver Time Out Clear Flag
+  *            @arg USART_CLEAR_EOBF: End Of Block Clear Flag 
+  * @retval None
+  */
+#define __HAL_SMARTCARD_CLEAR_IT(__HANDLE__, __IT_CLEAR__) ((__HANDLE__)->Instance->ICR = (uint32_t)(__IT_CLEAR__)) 
+
+/** @brief  Set a specific SMARTCARD request flag.
+  * @param  __HANDLE__: specifies the SMARTCARD Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @param  __REQ__: specifies the request flag to set
+  *          This parameter can be one of the following values:  
+  *            @arg SMARTCARD_RXDATA_FLUSH_REQUEST: Receive Data flush Request 
+  *            @arg SMARTCARD_TXDATA_FLUSH_REQUEST: Transmit data flush Request 
+  *
+  * @retval None
+  */ 
+#define __HAL_SMARTCARD_SEND_REQ(__HANDLE__, __REQ__) ((__HANDLE__)->Instance->RQR |= (uint32_t)(__REQ__)) 
+
+/** @brief  Enable the USART associated to the SMARTCARD Handle
+  * @param  __HANDLE__: specifies the SMARTCARD Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @retval None
+  */ 
+#define __HAL_SMARTCARD_ENABLE(__HANDLE__)               ( (__HANDLE__)->Instance->CR1 |=  USART_CR1_UE)
+
+/** @brief  Disable the USART associated to the SMARTCARD Handle
+  * @param  __HANDLE__: specifies the SMARTCARD Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @retval None
+  */
+#define __HAL_SMARTCARD_DISABLE(__HANDLE__)              ( (__HANDLE__)->Instance->CR1 &=  ~USART_CR1_UE)
+
+/** @brief  Macros to enable or disable the SmartCard DMA request.
+  * @param  __HANDLE__: specifies the SMARTCARD Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @param  __REQUEST__: specifies the SmartCard DMA request.
+  *          This parameter can be one of the following values:
+  *            @arg SMARTCARD_DMAREQ_TX: SmartCard DMA transmit request
+  *            @arg SMARTCARD_DMAREQ_RX: SmartCard DMA receive request
+  */
+#define __HAL_SMARTCARD_DMA_REQUEST_ENABLE(__HANDLE__, __REQUEST__)    ((__HANDLE__)->Instance->CR3 |=  (__REQUEST__))
+#define __HAL_SMARTCARD_DMA_REQUEST_DISABLE(__HANDLE__, __REQUEST__)   ((__HANDLE__)->Instance->CR3 &=  ~(__REQUEST__))
+
+/** @brief  Check the Baud rate range. The maximum Baud Rate is derived from the 
+  *         maximum clock on F3 (i.e. 72 MHz) divided by the oversampling used 
+  *         on the SMARTCARD (i.e. 16) 
+  * @param  __BAUDRATE__: Baud rate set by the configuration function.
+  * @retval Test result (TRUE or FALSE) 
+  */ 
+#define IS_SMARTCARD_BAUDRATE(__BAUDRATE__) ((__BAUDRATE__) < 4500001)
+
+/** @brief  Check the block length range. The maximum SMARTCARD block length is 0xFF.
+  * @param  __LENGTH__: block length.
+  * @retval Test result (TRUE or FALSE) 
+  */
+#define IS_SMARTCARD_BLOCKLENGTH(__LENGTH__) ((__LENGTH__) <= 0xFF)
+
+/** @brief  Check the receiver timeout value. The maximum SMARTCARD receiver timeout 
+  *         value is 0xFFFFFF.
+  * @param  __TIMEOUTVALUE__: receiver timeout value.
+  * @retval Test result (TRUE or FALSE) 
+  */
+#define IS_SMARTCARD_TIMEOUT_VALUE(__TIMEOUTVALUE__)    ((__TIMEOUTVALUE__) <= 0xFFFFFF)
+
+/** @brief  Check the SMARTCARD autoretry counter value. The maximum number of 
+  *         retransmissions is 0x7.
+  * @param  __COUNT__: number of retransmissions
+  * @retval Test result (TRUE or FALSE) 
+  */
+#define IS_SMARTCARD_AUTORETRY_COUNT(__COUNT__)         ((__COUNT__) <= 0x7)
+
+/**
+  * @}
+  */ 
+
+/* Include SMARTCARD HAL Extension module */
+#include "stm32l0xx_hal_smartcard_ex.h"
+/* Exported functions --------------------------------------------------------*/
+/* Initialization/de-initialization functions  **********************************/
+HAL_StatusTypeDef HAL_SMARTCARD_Init(SMARTCARD_HandleTypeDef *hsc);
+HAL_StatusTypeDef HAL_SMARTCARD_DeInit(SMARTCARD_HandleTypeDef *hsc);
+void HAL_SMARTCARD_MspInit(SMARTCARD_HandleTypeDef *hsc);
+void HAL_SMARTCARD_MspDeInit(SMARTCARD_HandleTypeDef *hsc);
+
+/* IO operation functions *******************************************************/
+HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SMARTCARD_Receive(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SMARTCARD_Receive_IT(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SMARTCARD_Transmit_DMA(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SMARTCARD_Receive_DMA(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size);
+void HAL_SMARTCARD_IRQHandler(SMARTCARD_HandleTypeDef *hsc);
+void HAL_SMARTCARD_TxCpltCallback(SMARTCARD_HandleTypeDef *hsc);
+void HAL_SMARTCARD_RxCpltCallback(SMARTCARD_HandleTypeDef *hsc);
+void HAL_SMARTCARD_ErrorCallback(SMARTCARD_HandleTypeDef *hsc);
+
+/* Peripheral State functions  **************************************************/
+HAL_SMARTCARD_StateTypeDef HAL_SMARTCARD_GetState(SMARTCARD_HandleTypeDef *hsc);
+uint32_t HAL_SMARTCARD_GetError(SMARTCARD_HandleTypeDef *hsc);
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_SMARTCARD_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_smartcard_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_smartcard_ex.c
@@ -1,0 +1,184 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_smartcard_ex.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   SMARTCARD HAL module driver.
+  *
+  *          This file provides extended firmware functions to manage the following 
+  *          functionalities of the SmartCard.
+  *           + Initialization and de-initialization functions
+  *           + Peripheral Control functions
+  @verbatim
+ ===============================================================================
+                        ##### How to use this driver #####
+ ===============================================================================
+    [..]
+    The Extended SMARTCARD HAL driver can be used as follow:
+
+    (#) After having configured the SMARTCARD basic features with HAL_SMARTCARD_Init(), 
+        then if required, program SMARTCARD advanced features (TX/RX pins swap, TimeOut, 
+        auto-retry counter,...) in the hsc AdvancedInit structure.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup SMARTCARDEx
+  * @brief SMARTCARD Extended HAL module driver
+  * @{
+  */
+#ifdef HAL_SMARTCARD_MODULE_ENABLED
+    
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup SMARTCARDEx_Private_Functions
+  * @{
+  */
+
+/** @defgroup SMARTCARDEx_Group1 Extended Peripheral Control functions
+  * @brief    Extended control functions
+  *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to initialize the SMARTCARD.
+     (+) HAL_SMARTCARDEx_BlockLength_Config() API allows to configure the Block Length on the fly 
+     (+) HAL_SMARTCARDEx_TimeOut_Config() API allows to configure the receiver timeout value on the fly  
+     (+) HAL_SMARTCARDEx_EnableReceiverTimeOut() API enables the receiver timeout feature
+     (+) HAL_SMARTCARDEx_DisableReceiverTimeOut() API disables the receiver timeout feature
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Update on the fly the SMARTCARD block length in RTOR register
+  * @param hsc: SMARTCARD handle
+  * @param BlockLength: SMARTCARD block length (8-bit long at most)  
+  * @retval None
+  */
+void HAL_SMARTCARDEx_BlockLength_Config(SMARTCARD_HandleTypeDef *hsc, uint8_t BlockLength)
+{
+  MODIFY_REG(hsc->Instance->RTOR, USART_RTOR_BLEN, ((uint32_t)BlockLength << SMARTCARD_RTOR_BLEN_LSB_POS));
+}
+
+/**
+  * @brief Update on the fly the receiver timeout value in RTOR register
+  * @param hsc: SMARTCARD handle
+  * @param TimeOutValue: receiver timeout value in number of baud blocks. The timeout
+  *                     value must be less or equal to 0x0FFFFFFFF. 
+  * @retval None
+  */
+void HAL_SMARTCARDEx_TimeOut_Config(SMARTCARD_HandleTypeDef *hsc, uint32_t TimeOutValue)
+{
+  assert_param(IS_SMARTCARD_TIMEOUT_VALUE(hsc->Init.TimeOutValue));
+  MODIFY_REG(hsc->Instance->RTOR, USART_RTOR_RTO, TimeOutValue); 
+}
+
+/**
+  * @brief Enable the SMARTCARD receiver timeout feature
+  * @param hsc: SMARTCARD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMARTCARDEx_EnableReceiverTimeOut(SMARTCARD_HandleTypeDef *hsc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hsc);
+
+  hsc->State = HAL_SMARTCARD_STATE_BUSY;
+
+  /* Set the USART RTOEN bit */
+  hsc->Instance->CR2 |= USART_CR2_RTOEN;
+
+  hsc->State = HAL_SMARTCARD_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hsc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Disable the SMARTCARD receiver timeout feature
+  * @param hsc: SMARTCARD handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMARTCARDEx_DisableReceiverTimeOut(SMARTCARD_HandleTypeDef *hsc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hsc);
+
+  hsc->State = HAL_SMARTCARD_STATE_BUSY;
+
+  /* Clear the USART RTOEN bit */
+  hsc->Instance->CR2 &= ~(USART_CR2_RTOEN);
+
+  hsc->State = HAL_SMARTCARD_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hsc);
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_SMARTCARD_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_smartcard_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_smartcard_ex.h
@@ -1,0 +1,135 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_smartcard_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of SMARTCARD HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_SMARTCARD_EX_H
+#define __STM32L0xx_HAL_SMARTCARD_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup SMARTCARDEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/* Exported macro ------------------------------------------------------------*/
+   
+/** @brief  Reports the SMARTCARD clock source.
+  * @param  __HANDLE__: specifies the USART Handle
+  * @param  __CLOCKSOURCE__ : output variable   
+  * @retval the USART clocking source, written in __CLOCKSOURCE__.
+  */
+#define __HAL_SMARTCARD_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__) \
+  do {                                                             \
+    if((__HANDLE__)->Instance == USART1)                           \
+    {                                                              \
+       switch(__HAL_RCC_GET_USART1_SOURCE())                       \
+       {                                                           \
+        case RCC_USART1CLKSOURCE_PCLK2:                            \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PCLK2;         \
+          break;                                                   \
+        case RCC_USART1CLKSOURCE_HSI:                              \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_HSI;           \
+          break;                                                   \
+        case RCC_USART1CLKSOURCE_SYSCLK:                           \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_SYSCLK;        \
+          break;                                                   \
+        case RCC_USART1CLKSOURCE_LSE:                              \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_LSE;           \
+          break;                                                   \
+        default:                                                   \
+          break;                                                   \
+       }                                                           \
+    }                                                              \
+    else if((__HANDLE__)->Instance == USART2)                      \
+    {                                                              \
+       switch(__HAL_RCC_GET_USART2_SOURCE())                       \
+       {                                                           \
+        case RCC_USART2CLKSOURCE_PCLK1:                            \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_PCLK1;         \
+          break;                                                   \
+        case RCC_USART2CLKSOURCE_HSI:                              \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_HSI;           \
+          break;                                                   \
+        case RCC_USART2CLKSOURCE_SYSCLK:                           \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_SYSCLK;        \
+          break;                                                   \
+        case RCC_USART2CLKSOURCE_LSE:                              \
+          (__CLOCKSOURCE__) = SMARTCARD_CLOCKSOURCE_LSE;           \
+          break;                                                   \
+        default:                                                   \
+          break;                                                   \
+       }                                                           \
+    }                                                              \
+  } while(0)
+
+/* Exported functions --------------------------------------------------------*/
+/* Initialization and de-initialization functions  ****************************/
+/* IO operation functions *****************************************************/
+/* Peripheral Control functions ***********************************************/
+void HAL_SMARTCARDEx_BlockLength_Config(SMARTCARD_HandleTypeDef *hsc, uint8_t BlockLength);
+void HAL_SMARTCARDEx_TimeOut_Config(SMARTCARD_HandleTypeDef *hsc, uint32_t TimeOutValue);
+HAL_StatusTypeDef HAL_SMARTCARDEx_EnableReceiverTimeOut(SMARTCARD_HandleTypeDef *hsc);
+HAL_StatusTypeDef HAL_SMARTCARDEx_DisableReceiverTimeOut(SMARTCARD_HandleTypeDef *hsc);
+
+/* Peripheral State and Error functions ***************************************/
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_SMARTCARD_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_smbus.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_smbus.c
@@ -1,0 +1,1850 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_smbus.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   SMBUS HAL module driver.
+  *    
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the System Management Bus (SMBus) peripheral,
+  *          based on I2C principales of operation :
+  *           + Initialization/de-initialization functions
+  *           + I/O operation functions
+  *           + Peripheral Control functions 
+  *           + Peripheral State functions
+  *         
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+    [..]
+    The SMBUS HAL driver can be used as follows:
+    
+    (#) Declare a SMBUS_HandleTypeDef handle structure, for example:
+        SMBUS_HandleTypeDef  hsmbus; 
+
+    (#)Initialize the SMBUS low level resources by implement the HAL_SMBUS_MspInit ()API:
+        (##) Enable the SMBUSx interface clock
+        (##) SMBUS pins configuration
+            (+) Enable the clock for the SMBUS GPIOs
+            (+) Configure SMBUS pins as alternate function open-drain
+        (##) NVIC configuration if you need to use interrupt process
+            (+) Configure the SMBUSx interrupt priority 
+            (+) Enable the NVIC SMBUS IRQ Channel
+
+    (#) Configure the Communication Clock Timing, Bus Timeout, Own Address1, Master Adressing Mode,
+        Dual Addressing mode, Own Address2, Own Address2 Mask, General call, Nostretch mode,
+        Peripheral mode and Packet Error Check mode in the hsmbus Init structure.
+
+    (#) Initialize the SMBUS registers by calling the HAL_SMBUS_Init() API:
+        (+) These API's configures also the low level Hardware GPIO, CLOCK, CORTEX...etc)
+            by calling the customed HAL_SMBUS_MspInit(&hsmbus) API.
+
+    (#) To check if target device is ready for communication, use the function HAL_SMBUS_IsDeviceReady()
+
+    (#) For SMBUS IO operations, only one mode of operations is available within this driver :
+            
+    *** Interrupt mode IO operation ***
+    ===================================
+    [..]
+      (+) Transmit in master/host SMBUS mode an amount of data in non blocking mode using HAL_SMBUS_Master_Transmit_IT()
+      (++) At transmission end of transfer HAL_SMBUS_MasterTxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_SMBUS_MasterTxCpltCallback
+      (+) Receive in master/host SMBUS mode an amount of data in non blocking mode using HAL_SMBUS_Master_Receive_IT()
+      (++) At reception end of transfer HAL_SMBUS_MasterRxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_SMBUS_MasterRxCpltCallback
+      (+) Abort a master/host SMBUS process commnunication with Interrupt using HAL_SMBUS_Master_Abort_IT()
+      (++) The associated previous transfer callback is called at the end of abort process
+      (++) mean HAL_SMBUS_MasterTxCpltCallback in case of previous state was master transmit
+      (++) mean HAL_SMBUS_MasterRxCpltCallback in case of previous state was master receive
+      (+) Enable the Address listen mode in slave/device SMBUS mode using HAL_SMBUS_Slave_Listen_IT()
+      (++) When address slave/device SMBUS match, HAL_SMBUS_SlaveAddrCallback is executed and user can
+           add his own code to check the Address Match Code and the transmission direction request by master/host (Write/Read).
+      (++) At Listen mode end HAL_SMBUS_SlaveListenCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_SMBUS_SlaveListenCpltCallback
+      (+) Transmit in slave/device SMBUS mode an amount of data in non blocking mode using HAL_SMBUS_Slave_Transmit_IT()
+      (++) At transmission end of transfer HAL_SMBUS_SlaveTxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_SMBUS_SlaveTxCpltCallback
+      (+) Receive in slave/device SMBUS mode an amount of data in non blocking mode using HAL_SMBUS_Slave_Receive_IT()
+      (++) At reception end of transfer HAL_SMBUS_SlaveRxCpltCallback is executed and user can
+           add his own code by customization of function pointer HAL_SMBUS_SlaveRxCpltCallback
+      (+) Enable/Disable the SMBUS alert mode using HAL_SMBUS_EnableAlert_IT() HAL_SMBUS_DisableAlert_IT()
+      (++) When SMBUS Alert is generated HAL_SMBUS_ErrorCallback() is executed and user can
+           add his own code by customization of function pointer HAL_SMBUS_ErrorCallback
+           to check the Alert Error Code using function HAL_SMBUS_GetError()
+      (+) Get HAL state machine or error values using HAL_SMBUS_GetState() or HAL_SMBUS_GetError()
+      (+) In case of transfer Error, HAL_SMBUS_ErrorCallback() function is executed and user can
+           add his own code by customization of function pointer HAL_SMBUS_ErrorCallback
+           to check the Error Code using function HAL_SMBUS_GetError()
+
+     *** SMBUS HAL driver macros list ***
+     ==================================
+     [..]
+       Below the list of most used macros in SMBUS HAL driver.
+
+      (+) __HAL_SMBUS_ENABLE: Enable the SMBUS peripheral
+      (+) __HAL_SMBUS_DISABLE: Disable the SMBUS peripheral
+      (+) __HAL_SMBUS_GET_FLAG : Checks whether the specified SMBUS flag is set or not
+      (+) __HAL_SMBUS_CLEAR_FLAG : Clears the specified SMBUS pending flag
+      (+) __HAL_SMBUS_ENABLE_IT: Enables the specified SMBUS interrupt
+      (+) __HAL_SMBUS_DISABLE_IT: Disables the specified SMBUS interrupt
+
+     [..]
+       (@) You can refer to the SMBUS HAL driver header file for more useful macros
+
+            
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup SMBUS
+  * @brief SMBUS HAL module driver
+  * @{
+  */
+
+#ifdef HAL_SMBUS_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define TIMING_CLEAR_MASK   ((uint32_t)0xF0FFFFFF)      /*<! SMBUS TIMING clear register Mask */
+#define HAL_TIMEOUT_ADDR    ((uint32_t)10000)           /* 10 s  */
+#define HAL_TIMEOUT_BUSY    ((uint32_t)25)              /* 25 ms */
+#define HAL_TIMEOUT_DIR     ((uint32_t)25)              /* 25 ms */
+#define HAL_TIMEOUT_RXNE    ((uint32_t)25)              /* 25 ms */
+#define HAL_TIMEOUT_STOPF   ((uint32_t)25)              /* 25 ms */
+#define HAL_TIMEOUT_TC      ((uint32_t)25)              /* 25 ms */
+#define HAL_TIMEOUT_TCR     ((uint32_t)25)              /* 25 ms */
+#define HAL_TIMEOUT_TXIS    ((uint32_t)25)              /* 25 ms */
+#define MAX_NBYTE_SIZE      255
+
+/* Private macro -------------------------------------------------------------*/
+#define __SMBUS_GET_ISR_REG(__HANDLE__) ((__HANDLE__)->Instance->ISR)
+#define __SMBUS_CHECK_FLAG(__ISR__, __FLAG__) ((((__ISR__) & ((__FLAG__) & SMBUS_FLAG_MASK)) == ((__FLAG__) & SMBUS_FLAG_MASK)))
+
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout(SMBUS_HandleTypeDef *hsmbus, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
+
+static HAL_StatusTypeDef SMBUS_Enable_IRQ(SMBUS_HandleTypeDef *hsmbus, uint16_t InterruptRequest);
+static HAL_StatusTypeDef SMBUS_Disable_IRQ(SMBUS_HandleTypeDef *hsmbus, uint16_t InterruptRequest);
+static HAL_StatusTypeDef SMBUS_Master_ISR(SMBUS_HandleTypeDef *hsmbus);
+static HAL_StatusTypeDef SMBUS_Slave_ISR(SMBUS_HandleTypeDef *hsmbus);
+
+static void SMBUS_TransferConfig(SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request);
+
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup SMBUS_Private_Functions
+  * @{
+  */
+
+/** @defgroup SMBUS_Group1 Initialization and de-initialization functions
+  *  @brief    Initialization and Configuration functions 
+  *
+@verbatim    
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This subsection provides a set of functions allowing to initialize and 
+          de-initialiaze the SMBUSx peripheral:
+
+      (+) User must Implement HAL_SMBUS_MspInit() function in which he configures 
+          all related peripherals resources (CLOCK, GPIO, IT and NVIC ).
+
+      (+) Call the function HAL_SMBUS_Init() to configure the selected device with 
+          the selected configuration:
+        (++) Clock Timing
+        (++) Bus Timeout
+        (++) Analog Filer mode
+        (++) Own Address 1
+        (++) Addressing mode (Master, Slave)
+        (++) Dual Addressing mode
+        (++) Own Address 2
+        (++) Own Address 2 Mask
+        (++) General call mode
+        (++) Nostretch mode
+        (++) Packet Error Check mode
+        (++) Peripheral mode
+
+      (+) Call the function HAL_SMBUS_DeInit() to restore the default configuration 
+          of the selected SMBUSx periperal.       
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the SMBUS according to the specified parameters 
+  *         in the SMBUS_InitTypeDef and create the associated handle.
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMBUS_Init(SMBUS_HandleTypeDef *hsmbus)
+{ 
+  /* Check the SMBUS handle allocation */
+  if(hsmbus == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_SMBUS_INSTANCE(hsmbus->Instance));
+  assert_param(IS_SMBUS_ANALOG_FILTER(hsmbus->Init.AnalogFilter));
+  assert_param(IS_SMBUS_OWN_ADDRESS1(hsmbus->Init.OwnAddress1));
+  assert_param(IS_SMBUS_ADDRESSING_MODE(hsmbus->Init.AddressingMode));
+  assert_param(IS_SMBUS_DUAL_ADDRESS(hsmbus->Init.DualAddressMode));
+  assert_param(IS_SMBUS_OWN_ADDRESS2(hsmbus->Init.OwnAddress2));
+  assert_param(IS_SMBUS_OWN_ADDRESS2_MASK(hsmbus->Init.OwnAddress2Masks));
+  assert_param(IS_SMBUS_GENERAL_CALL(hsmbus->Init.GeneralCallMode));
+  assert_param(IS_SMBUS_NO_STRETCH(hsmbus->Init.NoStretchMode));
+  assert_param(IS_SMBUS_PEC(hsmbus->Init.PacketErrorCheckMode));
+  assert_param(IS_SMBUS_PERIPHERAL_MODE(hsmbus->Init.PeripheralMode));
+
+  if(hsmbus->State == HAL_SMBUS_STATE_RESET)
+  {
+    /* Init the low level hardware : GPIO, CLOCK, NVIC */
+    HAL_SMBUS_MspInit(hsmbus);
+  }
+  
+  hsmbus->State = HAL_SMBUS_STATE_BUSY;
+  
+  /* Disable the selected SMBUS peripheral */
+  __HAL_SMBUS_DISABLE(hsmbus);
+  
+  /*---------------------------- SMBUSx TIMINGR Configuration ----------------*/
+  /* Configure SMBUSx: Frequency range */
+  hsmbus->Instance->TIMINGR = hsmbus->Init.Timing & TIMING_CLEAR_MASK;
+  
+  /*---------------------------- SMBUSx TIMEOUTR Configuration ---------------*/
+  /* Configure SMBUSx: Bus Timeout  */
+  hsmbus->Instance->TIMEOUTR = hsmbus->Init.SMBusTimeout;
+
+  /*---------------------------- SMBUSx OAR1 Configuration -------------------*/
+  /* Configure SMBUSx: Own Address1 and ack own address1 mode */
+  hsmbus->Instance->OAR1 &= ~I2C_OAR1_OA1EN;
+  if(hsmbus->Init.OwnAddress1 != 0)
+  {
+    if(hsmbus->Init.AddressingMode == SMBUS_ADDRESSINGMODE_7BIT)
+    {
+      hsmbus->Instance->OAR1 = (I2C_OAR1_OA1EN | hsmbus->Init.OwnAddress1);
+    }
+    else /* SMBUS_ADDRESSINGMODE_10BIT */
+    {
+      hsmbus->Instance->OAR1 = (I2C_OAR1_OA1EN | I2C_OAR1_OA1MODE | hsmbus->Init.OwnAddress1);
+    }
+  }
+
+  /*---------------------------- SMBUSx CR2 Configuration --------------------*/
+  /* Configure SMBUSx: Addressing Master mode */
+  if(hsmbus->Init.AddressingMode == SMBUS_ADDRESSINGMODE_10BIT)
+  {
+    hsmbus->Instance->CR2 = (I2C_CR2_ADD10);
+  }
+  /* Enable the AUTOEND by default, and enable NACK (should be disable only during Slave process) */
+  /* AUTOEND and NACK bit will be manage during Transfer process */
+  hsmbus->Instance->CR2 |= (I2C_CR2_AUTOEND | I2C_CR2_NACK);
+  
+  /*---------------------------- SMBUSx OAR2 Configuration -----------------------*/  
+  /* Configure SMBUSx: Dual mode and Own Address2 */
+  hsmbus->Instance->OAR2 = (hsmbus->Init.DualAddressMode | hsmbus->Init.OwnAddress2 | (hsmbus->Init.OwnAddress2Masks << 8));
+
+  /*---------------------------- SMBUSx CR1 Configuration ------------------------*/
+  /* Configure SMBUSx: Generalcall and NoStretch mode */
+  hsmbus->Instance->CR1 = (hsmbus->Init.GeneralCallMode | hsmbus->Init.NoStretchMode | hsmbus->Init.PacketErrorCheckMode | hsmbus->Init.PeripheralMode | hsmbus->Init.AnalogFilter);
+  
+  /* Enable Slave Byte Control only in case of Packet Error Check is enabled and SMBUS Peripheral is set in Slave mode */
+  if( (hsmbus->Init.PacketErrorCheckMode == SMBUS_PEC_ENABLED)
+     && ( (hsmbus->Init.PeripheralMode == SMBUS_PERIPHERAL_MODE_SMBUS_SLAVE) || (hsmbus->Init.PeripheralMode == SMBUS_PERIPHERAL_MODE_SMBUS_SLAVE_ARP) ) )
+  {
+    hsmbus->Instance->CR1 |= I2C_CR1_SBC;
+  }
+
+  /* Enable the selected SMBUS peripheral */
+  __HAL_SMBUS_ENABLE(hsmbus);
+  
+  hsmbus->ErrorCode = HAL_SMBUS_ERROR_NONE;
+  hsmbus->PreviousState = HAL_SMBUS_STATE_READY;
+  hsmbus->State = HAL_SMBUS_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the SMBUS peripheral. 
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMBUS_DeInit(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* Check the SMBUS handle allocation */
+  if(hsmbus == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_SMBUS_INSTANCE(hsmbus->Instance));
+  
+  hsmbus->State = HAL_SMBUS_STATE_BUSY;
+  
+  /* Disable the SMBUS Peripheral Clock */
+  __HAL_SMBUS_DISABLE(hsmbus);
+  
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_SMBUS_MspDeInit(hsmbus);
+  
+  hsmbus->ErrorCode = HAL_SMBUS_ERROR_NONE;
+  hsmbus->PreviousState =  HAL_SMBUS_STATE_RESET;
+  hsmbus->State = HAL_SMBUS_STATE_RESET;
+  
+   /* Release Lock */
+  __HAL_UNLOCK(hsmbus);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief SMBUS MSP Init.
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval None
+  */
+ __weak void HAL_SMBUS_MspInit(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SMBUS_MspInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief SMBUS MSP DeInit
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval None
+  */
+ __weak void HAL_SMBUS_MspDeInit(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SMBUS_MspDeInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup SMBUS_Group2 IO operation functions
+ *  @brief   Data transfers functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to manage the SMBUS data 
+    transfers.
+
+    (#) Blocking mode function to check if device is ready for usage is :
+        (++) HAL_SMBUS_IsDeviceReady()
+
+    (#) There is only one mode of transfer:
+       (++) No-Blocking mode : The communication is performed using Interrupts.
+            These functions return the status of the transfer startup.
+            The end of the data processing will be indicated through the 
+            dedicated SMBUS IRQ when using Interrupt mode.
+
+    (#) No-Blocking mode functions with Interrupt are :
+        (++) HAL_SMBUS_Master_Transmit_IT()
+        (++) HAL_SMBUS_Master_Receive_IT()
+        (++) HAL_SMBUS_Slave_Transmit_IT()
+        (++) HAL_SMBUS_Slave_Receive_IT()
+        (++) HAL_SMBUS_Slave_Listen_IT()
+        (++) HAL_SMBUS_EnableAlert_IT()
+        (++) HAL_SMBUS_DisableAlert_IT()
+
+    (#) A set of Transfer Complete Callbacks are provided in No_Blocking mode:
+        (++) HAL_SMBUS_MasterTxCpltCallback()
+        (++) HAL_SMBUS_MasterRxCpltCallback()
+        (++) HAL_SMBUS_SlaveTxCpltCallback()
+        (++) HAL_SMBUS_SlaveRxCpltCallback()
+        (++) HAL_SMBUS_SlaveAddrCallback()
+        (++) HAL_SMBUS_SlaveListenCpltCallback()
+        (++) HAL_SMBUS_ErrorCallback()
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Transmit in master/host SMBUS mode an amount of data in no-blocking mode with Interrupt
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @param  DevAddress: Target device address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  XferOptions: Options of Transfer, value of @ref SMBUS_XferOptions_definition
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMBUS_Master_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+{   
+  /* Check the parameters */
+  assert_param(IS_SMBUS_TRANSFER_OPTIONS_REQUEST(XferOptions));
+
+  if(hsmbus->State == HAL_SMBUS_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hsmbus);
+    
+    hsmbus->State = HAL_SMBUS_STATE_MASTER_BUSY_TX;
+    hsmbus->ErrorCode = HAL_SMBUS_ERROR_NONE;
+    /* Prepare transfer parameters */
+    hsmbus->pBuffPtr = pData;
+    hsmbus->XferCount = Size;
+    hsmbus->XferOptions = XferOptions;
+
+    /* In case of Quick command, remove autoend mode */
+    /* Manage the stop generation by software */
+    if(hsmbus->pBuffPtr == NULL)
+    {
+      hsmbus->XferOptions &= ~SMBUS_AUTOEND_MODE;
+    }
+
+    if(Size > MAX_NBYTE_SIZE)
+    {
+      hsmbus->XferSize = MAX_NBYTE_SIZE;
+    }
+    else
+    {
+      hsmbus->XferSize = Size;
+    }
+    
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > MAX_NBYTE_SIZE and generate RESTART */
+    if( (hsmbus->XferSize == MAX_NBYTE_SIZE) && (hsmbus->XferSize < hsmbus->XferCount) )
+    {
+      SMBUS_TransferConfig(hsmbus,DevAddress,hsmbus->XferSize, SMBUS_RELOAD_MODE, SMBUS_GENERATE_START_WRITE);
+    }
+    else
+    {
+      /* If transfer direction not change, do not generate Restart Condition */
+      /* Mean Previous state is same as current state */
+      if(hsmbus->PreviousState == HAL_SMBUS_STATE_MASTER_BUSY_TX)
+      {
+        SMBUS_TransferConfig(hsmbus,DevAddress,hsmbus->XferSize, hsmbus->XferOptions, SMBUS_NO_STARTSTOP);
+      }
+      /* Else transfer direction change, so generate Restart with new transfer direction */
+      else
+      {
+        SMBUS_TransferConfig(hsmbus,DevAddress,hsmbus->XferSize, hsmbus->XferOptions, SMBUS_GENERATE_START_WRITE);
+      }
+
+      /* If PEC mode is enable, size to transmit manage by SW part should be Size-1 byte, corresponding to PEC byte */
+      /* PEC byte is automatically sent by HW block, no need to manage it in Transmit process */
+      if(__HAL_SMBUS_GET_PEC_MODE(hsmbus) != RESET)
+      {
+        hsmbus->XferSize--;
+        hsmbus->XferCount--;
+      }
+    }
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsmbus); 
+
+    /* Note : The SMBUS interrupts must be enabled after unlocking current process 
+              to avoid the risk of SMBUS interrupt handle execution before current
+              process unlock */
+    SMBUS_Enable_IRQ(hsmbus, SMBUS_IT_TX);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  } 
+}
+
+/**
+  * @brief  Receive in master/host SMBUS mode an amount of data in no-blocking mode with Interrupt
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @param  DevAddress: Target device address
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  XferOptions: Options of Transfer, value of @ref SMBUS_XferOptions_definition
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMBUS_Master_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+{
+  /* Check the parameters */
+  assert_param(IS_SMBUS_TRANSFER_OPTIONS_REQUEST(XferOptions));
+
+  if(hsmbus->State == HAL_SMBUS_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hsmbus);
+
+    hsmbus->State = HAL_SMBUS_STATE_MASTER_BUSY_RX;
+    hsmbus->ErrorCode = HAL_SMBUS_ERROR_NONE;
+
+    /* Prepare transfer parameters */
+    hsmbus->pBuffPtr = pData;
+    hsmbus->XferCount = Size;
+    hsmbus->XferOptions = XferOptions;
+
+    /* In case of Quick command, remove autoend mode */
+    /* Manage the stop generation by software */
+    if(hsmbus->pBuffPtr == NULL)
+    {
+      hsmbus->XferOptions &= ~SMBUS_AUTOEND_MODE;
+    }
+
+    if(Size > MAX_NBYTE_SIZE)
+    {
+      hsmbus->XferSize = MAX_NBYTE_SIZE;
+    }
+    else
+    {
+      hsmbus->XferSize = Size;
+    }
+
+    /* Send Slave Address */
+    /* Set NBYTES to write and reload if size > MAX_NBYTE_SIZE and generate RESTART */
+    if( (hsmbus->XferSize == MAX_NBYTE_SIZE) && (hsmbus->XferSize < hsmbus->XferCount) )
+    {
+      SMBUS_TransferConfig(hsmbus,DevAddress,hsmbus->XferSize, SMBUS_RELOAD_MODE, SMBUS_GENERATE_START_READ);
+    }
+    else
+    {
+      /* If transfer direction not change, do not generate Restart Condition */
+      /* Mean Previous state is same as current state */
+      if(hsmbus->PreviousState == HAL_SMBUS_STATE_MASTER_BUSY_RX)
+      {
+        SMBUS_TransferConfig(hsmbus,DevAddress,hsmbus->XferSize, hsmbus->XferOptions, SMBUS_NO_STARTSTOP);
+      }
+      /* Else transfer direction change, so generate Restart with new transfer direction */
+      else
+      {
+        SMBUS_TransferConfig(hsmbus,DevAddress,hsmbus->XferSize, hsmbus->XferOptions, SMBUS_GENERATE_START_READ);
+      }
+    }
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsmbus); 
+
+    /* Note : The SMBUS interrupts must be enabled after unlocking current process 
+              to avoid the risk of SMBUS interrupt handle execution before current
+              process unlock */
+    SMBUS_Enable_IRQ(hsmbus, SMBUS_IT_RX);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  } 
+}
+
+/**
+  * @brief  Abort a master/host SMBUS process commnunication with Interrupt
+  * @note : This abort can be called only if state is ready
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @param  DevAddress: Target device address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMBUS_Master_Abort_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress)
+{
+  if(hsmbus->State == HAL_SMBUS_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hsmbus);
+    
+    /* Keep the same state as previous */
+    /* to perform as well the call of the corresponding end of transfer callback */
+    if(hsmbus->PreviousState == HAL_SMBUS_STATE_MASTER_BUSY_TX)
+    {
+      hsmbus->State = HAL_SMBUS_STATE_MASTER_BUSY_TX;
+    }
+    else if(hsmbus->PreviousState == HAL_SMBUS_STATE_MASTER_BUSY_RX)
+    {
+      hsmbus->State = HAL_SMBUS_STATE_MASTER_BUSY_RX;
+    }
+    else
+    {
+      /* Wrong usage of abort function */
+      /* This function should be used only in case of abort monitored by master device */
+      return HAL_ERROR;
+    }
+    hsmbus->ErrorCode = HAL_SMBUS_ERROR_NONE;
+    
+    /* Set NBYTES to 1 to generate a dummy read on SMBUS peripheral */
+    /* Set AUTOEND mode, this will generate a NACK then STOP condition to abort the current transfer */
+    SMBUS_TransferConfig(hsmbus, DevAddress, 1, SMBUS_AUTOEND_MODE, SMBUS_NO_STARTSTOP);
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsmbus); 
+
+    /* Note : The SMBUS interrupts must be enabled after unlocking current process 
+              to avoid the risk of SMBUS interrupt handle execution before current
+              process unlock */
+    if(hsmbus->State == HAL_SMBUS_STATE_MASTER_BUSY_TX)
+    {
+      SMBUS_Enable_IRQ(hsmbus, SMBUS_IT_TX);
+    }
+    else if(hsmbus->State == HAL_SMBUS_STATE_MASTER_BUSY_RX)
+    {
+      SMBUS_Enable_IRQ(hsmbus, SMBUS_IT_RX);
+    }
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  } 
+}
+
+/**
+  * @brief  Transmit in slave/device SMBUS mode an amount of data in no-blocking mode with Interrupt 
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  XferOptions: Options of Transfer, value of @ref SMBUS_XferOptions_definition
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMBUS_Slave_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+{
+  /* Check the parameters */
+  assert_param(IS_SMBUS_TRANSFER_OPTIONS_REQUEST(XferOptions));
+
+  if(hsmbus->State == HAL_SMBUS_STATE_LISTEN)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Disable Interrupts, to prevent preemption during treatment in case of multicall */
+    SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_ADDR | SMBUS_IT_TX);
+
+    /* Process Locked */
+    __HAL_LOCK(hsmbus);
+    
+    hsmbus->State |= HAL_SMBUS_STATE_SLAVE_BUSY_TX;
+    hsmbus->ErrorCode = HAL_SMBUS_ERROR_NONE;
+    
+    /* Enable Address Acknowledge */
+    hsmbus->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Prepare transfer parameters */
+    hsmbus->pBuffPtr = pData;
+    hsmbus->XferSize = Size;
+    hsmbus->XferCount = Size;
+    hsmbus->XferOptions = XferOptions;
+
+    /* Set NBYTE to transmit */
+    SMBUS_TransferConfig(hsmbus,0,hsmbus->XferSize, hsmbus->XferOptions, SMBUS_NO_STARTSTOP);
+
+    /* If PEC mode is enable, size to transmit should be Size-1 byte, corresponding to PEC byte */
+    /* PEC byte is automatically sent by HW block, no need to manage it in Transmit process */
+    if(__HAL_SMBUS_GET_PEC_MODE(hsmbus) != RESET)
+    {
+      hsmbus->XferSize--;
+      hsmbus->XferCount--;
+    }
+    
+    /* Clear ADDR flag after prepare the transfer parameters */
+    /* This action will generate an acknowledge to the HOST */
+    __HAL_SMBUS_CLEAR_FLAG(hsmbus,SMBUS_FLAG_ADDR);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsmbus); 
+
+    /* Note : The SMBUS interrupts must be enabled after unlocking current process 
+              to avoid the risk of SMBUS interrupt handle execution before current
+              process unlock */
+    /* REnable ADDR interrupt */
+    SMBUS_Enable_IRQ(hsmbus, SMBUS_IT_TX | SMBUS_IT_ADDR);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR; 
+  } 
+}
+
+/**
+  * @brief  Receive in slave/device SMBUS mode an amount of data in no-blocking mode with Interrupt 
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @param  pData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param  XferOptions: Options of Transfer, value of @ref SMBUS_XferOptions_definition
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMBUS_Slave_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+{
+  /* Check the parameters */
+  assert_param(IS_SMBUS_TRANSFER_OPTIONS_REQUEST(XferOptions));
+
+  if(hsmbus->State == HAL_SMBUS_STATE_LISTEN)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;
+    }
+    
+    /* Disable Interrupts, to prevent preemption during treatment in case of multicall */
+    SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_ADDR | SMBUS_IT_RX);
+
+    /* Process Locked */
+    __HAL_LOCK(hsmbus);
+    
+    hsmbus->State |= HAL_SMBUS_STATE_SLAVE_BUSY_RX;
+    hsmbus->ErrorCode = HAL_SMBUS_ERROR_NONE;
+    
+    /* Enable Address Acknowledge */
+    hsmbus->Instance->CR2 &= ~I2C_CR2_NACK;
+
+    /* Prepare transfer parameters */
+    hsmbus->pBuffPtr = pData;
+    hsmbus->XferSize = Size;
+    hsmbus->XferCount = Size;
+    hsmbus->XferOptions = XferOptions;
+    
+    /* Set NBYTE to receive */
+    /* If XferSize equal "1", or XferSize equal "2" with PEC requested (mean 1 data byte + 1 PEC byte */
+    /* no need to set RELOAD bit mode, a ACK will be automatically generated in that case */
+    /* else need to set RELOAD bit mode to generate an automatic ACK at each byte Received */
+    /* This RELOAD bit will be reset for last BYTE to be receive in SMBUS_Slave_ISR */
+    if((hsmbus->XferSize == 1) || ((hsmbus->XferSize == 2) && (__HAL_SMBUS_GET_PEC_MODE(hsmbus) != RESET)))
+    {
+      SMBUS_TransferConfig(hsmbus,0,hsmbus->XferSize, hsmbus->XferOptions, SMBUS_NO_STARTSTOP);
+    }
+    else
+    {
+      SMBUS_TransferConfig(hsmbus,0,/*hsmbus->XferSize*/1, hsmbus->XferOptions | SMBUS_RELOAD_MODE, SMBUS_NO_STARTSTOP);
+    }
+
+    /* Clear ADDR flag after prepare the transfer parameters */
+    /* This action will generate an acknowledge to the HOST */
+    __HAL_SMBUS_CLEAR_FLAG(hsmbus,SMBUS_FLAG_ADDR);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsmbus); 
+
+    /* Note : The SMBUS interrupts must be enabled after unlocking current process 
+              to avoid the risk of SMBUS interrupt handle execution before current
+              process unlock */
+    /* REnable ADDR interrupt */
+    SMBUS_Enable_IRQ(hsmbus, SMBUS_IT_RX | SMBUS_IT_ADDR);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR; 
+  }
+}
+/**
+  * @brief  This function enable the Address listen mode in Slave mode
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMBUS_EnableListen_IT(SMBUS_HandleTypeDef *hsmbus)
+{
+  hsmbus->State = HAL_SMBUS_STATE_LISTEN;
+  
+  /* Enable the Address Match interrupt */
+  SMBUS_Enable_IRQ(hsmbus, SMBUS_IT_ADDR);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function disable the Address listen mode
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMBUS_DisableListen_IT(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* Disable Address listen mode only if a transfer is not ongoing */
+  if(hsmbus->State == HAL_SMBUS_STATE_LISTEN)
+  {
+    hsmbus->State = HAL_SMBUS_STATE_READY;
+  
+    /* Disable the Address Match interrupt */
+    SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_ADDR);
+  
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Enable SMBUS alert.
+  * @param  hsmbus : pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUSx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMBUS_EnableAlert_IT(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* Enable SMBus alert */
+  hsmbus->Instance->CR1 |= I2C_CR1_ALERTEN;   
+
+  /* Clear ALERT flag */
+  __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_ALERT);
+
+  /* Enable Alert Interrupt */
+  SMBUS_Enable_IRQ(hsmbus, SMBUS_IT_ALERT);
+
+  return HAL_OK; 
+}
+/**
+  * @brief  Disable SMBUS alert.
+  * @param  hsmbus : pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUSx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMBUS_DisableAlert_IT(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* Enable SMBus alert */
+  hsmbus->Instance->CR1 &= ~I2C_CR1_ALERTEN;   
+  
+  /* Disable Alert Interrupt */
+  SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_ALERT);
+
+  return HAL_OK; 
+}
+/**
+  * @brief  Checks if target device is ready for communication. 
+  * @note   This function is used with Memory devices
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @param  DevAddress: Target device address
+  * @param  Trials: Number of trials
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMBUS_IsDeviceReady(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout)
+{
+  uint32_t tickstart = 0x00;
+  __IO uint32_t SMBUS_Trials = 0x00;
+
+  if(hsmbus->State == HAL_SMBUS_STATE_READY)
+  {
+    if(__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_BUSY) != RESET)
+    {
+      return HAL_BUSY;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hsmbus);
+    
+    hsmbus->State = HAL_SMBUS_STATE_BUSY;
+    hsmbus->ErrorCode = HAL_SMBUS_ERROR_NONE;
+    
+    do
+    {
+      /* Generate Start */
+      hsmbus->Instance->CR2 = __HAL_SMBUS_GENERATE_START(hsmbus->Init.AddressingMode,DevAddress);
+      
+      /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
+      /* Wait until STOPF flag is set or a NACK flag is set*/
+      tickstart = HAL_GetTick();
+      while((__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_STOPF) == RESET) && (__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_AF) == RESET) && (hsmbus->State != HAL_SMBUS_STATE_TIMEOUT))
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          hsmbus->State = HAL_SMBUS_STATE_TIMEOUT;
+        } 
+      }
+      
+      /* Check if the NACKF flag has not been set */
+      if (__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_AF) == RESET)
+      {
+        /* Wait until STOPF flag is reset */ 
+        if(SMBUS_WaitOnFlagUntilTimeout(hsmbus, SMBUS_FLAG_STOPF, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+        
+        /* Clear STOP Flag */
+        __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_STOPF);
+
+        /* Device is ready */
+        hsmbus->State = HAL_SMBUS_STATE_READY;
+        
+        /* Process Unlocked */
+        __HAL_UNLOCK(hsmbus);
+        
+        return HAL_OK;
+      }
+      else
+      {
+        /* Wait until STOPF flag is reset */ 
+        if(SMBUS_WaitOnFlagUntilTimeout(hsmbus, SMBUS_FLAG_STOPF, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        /* Clear NACK Flag */
+        __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_AF);
+
+        /* Clear STOP Flag, auto generated with autoend*/
+        __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_STOPF);
+      }
+      
+      /* Check if the maximum allowed numbe of trials has bee reached */
+      if (SMBUS_Trials++ == Trials)
+      {
+        /* Generate Stop */
+        hsmbus->Instance->CR2 |= I2C_CR2_STOP;
+        
+        /* Wait until STOPF flag is reset */ 
+        if(SMBUS_WaitOnFlagUntilTimeout(hsmbus, SMBUS_FLAG_STOPF, RESET, Timeout) != HAL_OK)      
+        {
+          return HAL_TIMEOUT;
+        }
+        
+        /* Clear STOP Flag */
+        __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_STOPF);
+      }      
+    }while(SMBUS_Trials++ < Trials);
+
+    hsmbus->State = HAL_SMBUS_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsmbus);
+
+    return HAL_TIMEOUT;
+  }      
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  This function handles SMBUS event interrupt request.
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval None
+  */
+void HAL_SMBUS_EV_IRQHandler(SMBUS_HandleTypeDef *hsmbus)
+{
+  uint32_t tmpisrvalue = 0;
+  
+  /* Use a local variable to store the current ISR flags */
+  /* This action will avoid a wrong treatment due to ISR flags change during interrupt handler */
+  tmpisrvalue = __SMBUS_GET_ISR_REG(hsmbus);
+    
+  /* SMBUS in mode Transmitter ---------------------------------------------------*/
+  if (((__SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TXIS) != RESET) || (__SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TCR) != RESET) || (__SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TC) != RESET) || (__SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_STOPF) != RESET) || (__SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_AF) != RESET)) && (__HAL_SMBUS_GET_IT_SOURCE(hsmbus, (SMBUS_IT_TCI| SMBUS_IT_STOPI| SMBUS_IT_NACKI | SMBUS_IT_TXI)) != RESET))
+  {     
+    /* Slave mode selected */
+    if ((hsmbus->State & HAL_SMBUS_STATE_SLAVE_BUSY_TX) == HAL_SMBUS_STATE_SLAVE_BUSY_TX)
+    {
+      SMBUS_Slave_ISR(hsmbus);
+    }
+    /* Master mode selected */
+    else if((hsmbus->State & HAL_SMBUS_STATE_MASTER_BUSY_TX) == HAL_SMBUS_STATE_MASTER_BUSY_TX)
+    {
+      SMBUS_Master_ISR(hsmbus);
+    }
+  }
+    
+  /* SMBUS in mode Receiver ----------------------------------------------------*/
+  if (((__SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_RXNE) != RESET) || (__SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TCR) != RESET) || (__SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TC) != RESET) || (__SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_STOPF) != RESET) || (__SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_AF) != RESET)) && (__HAL_SMBUS_GET_IT_SOURCE(hsmbus, (SMBUS_IT_TCI| SMBUS_IT_STOPI| SMBUS_IT_NACKI | SMBUS_IT_RXI)) != RESET))
+  {
+    /* Slave mode selected */
+    if ((hsmbus->State & HAL_SMBUS_STATE_SLAVE_BUSY_RX) == HAL_SMBUS_STATE_SLAVE_BUSY_RX)
+    {
+      SMBUS_Slave_ISR(hsmbus);
+    }
+    /* Master mode selected */
+    else if((hsmbus->State & HAL_SMBUS_STATE_MASTER_BUSY_RX) == HAL_SMBUS_STATE_MASTER_BUSY_RX)
+    {
+      SMBUS_Master_ISR(hsmbus);
+    }
+  } 
+      
+   /* SMBUS in mode Listener Only --------------------------------------------------*/
+   /* Slave mode selected */
+  if (((__SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_ADDR) != RESET) || (__SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_STOPF) != RESET) || (__SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_AF) != RESET))
+     && ((__HAL_SMBUS_GET_IT_SOURCE(hsmbus, SMBUS_IT_ADDRI) != RESET) || (__HAL_SMBUS_GET_IT_SOURCE(hsmbus, SMBUS_IT_STOPI) != RESET) || (__HAL_SMBUS_GET_IT_SOURCE(hsmbus, SMBUS_IT_NACKI) != RESET)))
+  {
+    if (hsmbus->State == HAL_SMBUS_STATE_LISTEN)
+    {
+      SMBUS_Slave_ISR(hsmbus);
+    }
+  }
+}
+
+/**
+  * @brief  This function handles SMBUS error interrupt request.
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval None
+  */
+void HAL_SMBUS_ER_IRQHandler(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* SMBUS Bus error interrupt occurred ------------------------------------*/
+  if((__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_BERR) != RESET) && (__HAL_SMBUS_GET_IT_SOURCE(hsmbus, SMBUS_IT_ERRI) != RESET))
+  { 
+    hsmbus->ErrorCode |= HAL_SMBUS_ERROR_BERR;
+   
+    /* Clear BERR flag */
+    __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_BERR);
+  }
+  
+  /* SMBUS Over-Run/Under-Run interrupt occurred ----------------------------------------*/
+  if((__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_OVR) != RESET) && (__HAL_SMBUS_GET_IT_SOURCE(hsmbus, SMBUS_IT_ERRI) != RESET))
+  { 
+    hsmbus->ErrorCode |= HAL_SMBUS_ERROR_OVR;
+
+    /* Clear OVR flag */
+    __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_OVR);
+  }
+
+  /* SMBUS Arbitration Loss error interrupt occurred ------------------------------------*/
+  if((__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_ARLO) != RESET) && (__HAL_SMBUS_GET_IT_SOURCE(hsmbus, SMBUS_IT_ERRI) != RESET))
+  { 
+    hsmbus->ErrorCode |= HAL_SMBUS_ERROR_ARLO;
+
+    /* Clear ARLO flag */
+    __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_ARLO);
+  }
+
+  /* SMBUS Timeout error interrupt occurred ---------------------------------------------*/
+  if((__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_TIMEOUT) != RESET) && (__HAL_SMBUS_GET_IT_SOURCE(hsmbus, SMBUS_IT_ERRI) != RESET))
+  { 
+    hsmbus->ErrorCode |= HAL_SMBUS_ERROR_BUSTIMEOUT;
+
+    /* Clear TIMEOUT flag */
+    __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_TIMEOUT);
+  }
+
+  /* SMBUS Alert error interrupt occurred -----------------------------------------------*/
+  if((__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_ALERT) != RESET) && (__HAL_SMBUS_GET_IT_SOURCE(hsmbus, SMBUS_IT_ERRI) != RESET))
+  { 
+    hsmbus->ErrorCode |= HAL_SMBUS_ERROR_ALERT;
+
+    /* Clear ALERT flag */
+    __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_ALERT);
+  }
+
+  /* SMBUS Packet Error Check error interrupt occurred ----------------------------------*/
+  if((__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_PECERR) != RESET) && (__HAL_SMBUS_GET_IT_SOURCE(hsmbus, SMBUS_IT_ERRI) != RESET))
+  { 
+    hsmbus->ErrorCode |= HAL_SMBUS_ERROR_PECERR;
+
+    /* Clear PEC error flag */
+    __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_PECERR);
+  }
+  
+  /* Call the Error Callback in case of Error detected */
+  if((hsmbus->ErrorCode != HAL_SMBUS_ERROR_NONE)&&(hsmbus->ErrorCode != HAL_SMBUS_ERROR_ACKF))
+  {
+    /* Do not Reset the the HAL state in case of ALERT error */
+    if((hsmbus->ErrorCode & HAL_SMBUS_ERROR_ALERT) != HAL_SMBUS_ERROR_ALERT)
+    {
+      /* Reset only HAL_SMBUS_STATE_SLAVE_BUSY_XX and HAL_SMBUS_STATE_MASTER_BUSY_XX */
+      /* keep HAL_SMBUS_STATE_SLAVE_LISTEN if set */
+      hsmbus->State &= (uint32_t)~((uint32_t)HAL_SMBUS_STATE_MASTER_BUSY_RX | HAL_SMBUS_STATE_MASTER_BUSY_TX | HAL_SMBUS_STATE_SLAVE_BUSY_RX | HAL_SMBUS_STATE_SLAVE_BUSY_TX);
+    }
+    
+    /* Call the Error callback to prevent upper layer */
+    HAL_SMBUS_ErrorCallback(hsmbus);
+  }
+}
+
+/**
+  * @brief  Master Tx Transfer completed callbacks.
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval None
+  */
+ __weak void HAL_SMBUS_MasterTxCpltCallback(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SMBUS_TxCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Master Rx Transfer completed callbacks.
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval None
+  */
+__weak void HAL_SMBUS_MasterRxCpltCallback(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SMBUS_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/** @brief  Slave Tx Transfer completed callbacks.
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval None
+  */
+ __weak void HAL_SMBUS_SlaveTxCpltCallback(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SMBUS_TxCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Slave Rx Transfer completed callbacks.
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval None
+  */
+__weak void HAL_SMBUS_SlaveRxCpltCallback(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SMBUS_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Slave Address Match callbacks.
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @param  TransferDirection: Master request Transfer Direction (Write/Read)
+  * @param  AddrMatchCode: Address Match Code
+  * @retval None
+  */
+__weak void HAL_SMBUS_AddrCallback(SMBUS_HandleTypeDef *hsmbus, uint8_t TransferDirection, uint16_t AddrMatchCode)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SMBUS_SlaveAddrCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Slave Listen Complete callbacks.
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval None
+  */
+__weak void HAL_SMBUS_ListenCpltCallback(SMBUS_HandleTypeDef *hsmbus)
+{
+    /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SMBUS_SlaveListenCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  SMBUS error callbacks.
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval None
+  */
+ __weak void HAL_SMBUS_ErrorCallback(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SMBUS_ErrorCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup SMBUS_Group3 Peripheral State and Errors functions 
+ *  @brief   Peripheral State and Errors functions 
+ *
+@verbatim   
+ ===============================================================================
+            ##### Peripheral State and Errors functions #####
+ ===============================================================================  
+    [..]
+    This subsection permit to get in run-time the status of the peripheral 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the SMBUS state.
+  * @param  hsmbus : SMBUS handle
+  * @retval HAL state
+  */
+HAL_SMBUS_StateTypeDef HAL_SMBUS_GetState(SMBUS_HandleTypeDef *hsmbus)
+{
+  return hsmbus->State;
+}
+
+/**
+* @brief  Return the SMBUS error code
+* @param  hsmbus : pointer to a SMBUS_HandleTypeDef structure that contains
+  *              the configuration information for the specified SMBUS.
+* @retval SMBUS Error Code
+*/
+uint32_t HAL_SMBUS_GetError(SMBUS_HandleTypeDef *hsmbus)
+{
+  return hsmbus->ErrorCode;
+}
+
+/**
+  * @}
+  */  
+
+/**
+  * @brief  Interrupt Sub-Routine which handle the Interrupt Flags Master Mode
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SMBUS_Master_ISR(SMBUS_HandleTypeDef *hsmbus) 
+{
+  uint16_t DevAddress;
+
+  /* Process Locked */
+  __HAL_LOCK(hsmbus);
+  
+  if(__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_AF) != RESET)
+  {
+    /* Clear NACK Flag */
+    __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_AF);
+    
+    /* Set corresponding Error Code */
+    /* No need to generate STOP, it is automatically done */
+    hsmbus->ErrorCode |= HAL_SMBUS_ERROR_ACKF;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsmbus);
+    
+    /* Call the Error callback to prevent upper layer */
+    HAL_SMBUS_ErrorCallback(hsmbus);
+  }
+  else if(__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_STOPF) != RESET)
+  {
+      
+    /* Call the corresponding callback to inform upper layer of End of Transfer */
+    if(hsmbus->State == HAL_SMBUS_STATE_MASTER_BUSY_TX)
+    {
+      /* Disable Interrupt */
+      SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_TX);
+
+      /* Clear STOP Flag */
+      __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_STOPF);
+      
+      /* Clear Configuration Register 2 */
+      __HAL_SMBUS_RESET_CR2(hsmbus);
+    
+
+      /* Flush remaining data in Fifo register in case of error occurs before TXEmpty */
+      /* Disable the selected SMBUS peripheral */
+      __HAL_SMBUS_DISABLE(hsmbus);
+
+      hsmbus->PreviousState = HAL_SMBUS_STATE_READY;
+      hsmbus->State = HAL_SMBUS_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hsmbus);
+  
+      /* REenable the selected SMBUS peripheral */
+      __HAL_SMBUS_ENABLE(hsmbus);
+
+      HAL_SMBUS_MasterTxCpltCallback(hsmbus);
+    }
+    else if(hsmbus->State == HAL_SMBUS_STATE_MASTER_BUSY_RX)
+    {
+      /* Disable Interrupt */
+      SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_RX);
+
+      /* Clear STOP Flag */
+      __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_STOPF);
+      
+      /* Clear Configuration Register 2 */
+      __HAL_SMBUS_RESET_CR2(hsmbus);
+    
+      hsmbus->PreviousState = HAL_SMBUS_STATE_READY;
+      hsmbus->State = HAL_SMBUS_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hsmbus);
+  
+      HAL_SMBUS_MasterRxCpltCallback(hsmbus);
+    }
+  }
+  else if(__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_RXNE) != RESET)
+  {  
+    /* Read data from RXDR */
+    (*hsmbus->pBuffPtr++) = hsmbus->Instance->RXDR;
+    hsmbus->XferSize--;
+    hsmbus->XferCount--;
+  }
+  else if(__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_TXIS) != RESET)
+  {
+    /* Write data to TXDR */
+    hsmbus->Instance->TXDR = (*hsmbus->pBuffPtr++);
+    hsmbus->XferSize--;
+    hsmbus->XferCount--;	
+  }
+  else if(__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_TCR) != RESET)
+  {
+    if((hsmbus->XferSize == 0)&&(hsmbus->XferCount!=0))
+    {
+      DevAddress = (hsmbus->Instance->CR2 & I2C_CR2_SADD);
+      
+      if(hsmbus->XferCount > MAX_NBYTE_SIZE)
+      {    
+        SMBUS_TransferConfig(hsmbus,DevAddress,MAX_NBYTE_SIZE, SMBUS_RELOAD_MODE, SMBUS_NO_STARTSTOP);
+        hsmbus->XferSize = MAX_NBYTE_SIZE;
+      }
+      else
+      {
+        SMBUS_TransferConfig(hsmbus,DevAddress,hsmbus->XferSize, SMBUS_AUTOEND_MODE, SMBUS_GENERATE_START_WRITE);
+        /* If PEC mode is enable, size to transmit should be Size-1 byte, corresponding to PEC byte */
+        /* PEC byte is automatically sent by HW block, no need to manage it in Transmit process */
+        if(__HAL_SMBUS_GET_PEC_MODE(hsmbus) != RESET)
+        {
+          hsmbus->XferSize--;
+          hsmbus->XferCount--;
+        }
+        hsmbus->XferSize = hsmbus->XferCount;
+      }
+    }
+    else if((hsmbus->XferSize == 0)&&(hsmbus->XferCount==0))
+    {
+      /* Call TxCpltCallback if no stop mode is set */
+      if(__HAL_SMBUS_GET_STOP_MODE(hsmbus) != SMBUS_AUTOEND_MODE)
+      {
+        /* Call the corresponding callback to inform upper layer of End of Transfer */
+        if(hsmbus->State == HAL_SMBUS_STATE_MASTER_BUSY_TX)
+        {
+          /* Disable Interrupt */
+          SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_TX);
+          hsmbus->PreviousState = hsmbus->State;
+          hsmbus->State = HAL_SMBUS_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hsmbus);
+      
+          HAL_SMBUS_MasterTxCpltCallback(hsmbus);
+        }
+        else if(hsmbus->State == HAL_SMBUS_STATE_MASTER_BUSY_RX)
+        {
+          SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_RX);
+          hsmbus->PreviousState = hsmbus->State;
+          hsmbus->State = HAL_SMBUS_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hsmbus);
+      
+          HAL_SMBUS_MasterRxCpltCallback(hsmbus);
+        }
+      }
+    }
+  }
+  else if(__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_TC) != RESET)
+  {
+    if(hsmbus->XferCount == 0)
+    {
+      /* Specific use case for Quick command */
+      if(hsmbus->pBuffPtr == NULL)
+      {
+        /* Generate a Stop command */
+        hsmbus->Instance->CR2 |= I2C_CR2_STOP;
+      }
+      /* Call TxCpltCallback if no stop mode is set */
+      else if(__HAL_SMBUS_GET_STOP_MODE(hsmbus) != SMBUS_AUTOEND_MODE)
+      {
+        /* No Generate Stop, to permit restart mode */
+        /* The stop will be done at the end of transfer, when SMBUS_AUTOEND_MODE enable */
+        
+        /* Call the corresponding callback to inform upper layer of End of Transfer */
+        if(hsmbus->State == HAL_SMBUS_STATE_MASTER_BUSY_TX)
+        {
+          /* Disable Interrupt */
+          SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_TX);
+          hsmbus->PreviousState = hsmbus->State;
+          hsmbus->State = HAL_SMBUS_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hsmbus);
+      
+          HAL_SMBUS_MasterTxCpltCallback(hsmbus);
+        }
+        else if(hsmbus->State == HAL_SMBUS_STATE_MASTER_BUSY_RX)
+        {
+          SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_RX);
+          hsmbus->PreviousState = hsmbus->State;
+          hsmbus->State = HAL_SMBUS_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hsmbus);
+      
+          HAL_SMBUS_MasterRxCpltCallback(hsmbus);
+        }
+      }
+    }
+  }
+    
+  /* Process Unlocked */
+  __HAL_UNLOCK(hsmbus); 
+  
+  return HAL_OK; 
+}
+
+/**
+  * @brief  Interrupt Sub-Routine which handle the Interrupt Flags Slave Mode
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SMBUS_Slave_ISR(SMBUS_HandleTypeDef *hsmbus) 
+{
+  uint8_t TransferDirection = 0;
+  uint16_t SlaveAddrCode = 0;
+
+  /* Process Locked */
+  __HAL_LOCK(hsmbus);
+  
+  if(__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_AF) != RESET)
+  {
+    /* Check that SMBUS transfer finished */
+    /* if yes, normal usecase, a NACK is sent by the HOST when Transfer is finished */
+    /* Mean XferCount == 0*/
+    /* So clear Flag NACKF only */
+    if(hsmbus->XferCount == 0)
+    {
+      /* Clear NACK Flag */
+      __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_AF);
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hsmbus);
+    }
+    else
+    {
+      /* if no, error usecase, a Non-Acknowledge of last Data is generated by the HOST*/
+      /* Clear NACK Flag */
+      __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_AF);
+
+      /* Set HAL State to "Idle" State, mean to LISTEN state */
+      /* So reset Slave Busy state */
+      hsmbus->PreviousState = hsmbus->State;
+      hsmbus->State &= (uint32_t)~((uint32_t)HAL_SMBUS_STATE_SLAVE_BUSY_TX);
+      hsmbus->State &= (uint32_t)~((uint32_t)HAL_SMBUS_STATE_SLAVE_BUSY_RX);
+
+      /* Disable RX/TX Interrupts, keep only ADDR Interrupt */
+      SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_RX | SMBUS_IT_TX);
+
+      /* Set ErrorCode corresponding to a Non-Acknowledge */
+      hsmbus->ErrorCode |= HAL_SMBUS_ERROR_ACKF;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hsmbus);
+
+      /* Call the Error callback to prevent upper layer */
+      HAL_SMBUS_ErrorCallback(hsmbus);
+    }
+  }
+  else if(__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_ADDR) != RESET)
+  {
+    TransferDirection = __HAL_SMBUS_GET_DIR(hsmbus);
+    SlaveAddrCode = __HAL_SMBUS_GET_ADDR_MATCH(hsmbus);
+      
+    /* Disable ADDR interrupt to prevent multiple ADDRInterrupt*/
+    /* Other ADDRInterrupt will be treat in next Listen usecase */
+    __HAL_SMBUS_DISABLE_IT(hsmbus, SMBUS_IT_ADDRI);
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsmbus);
+
+    /* Call Slave Addr callback */
+    HAL_SMBUS_AddrCallback(hsmbus, TransferDirection, SlaveAddrCode);
+  }
+  else if((__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_RXNE) != RESET) || (__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_TCR) != RESET))
+  {
+    /* Read data from RXDR */
+    (*hsmbus->pBuffPtr++) = hsmbus->Instance->RXDR;
+    hsmbus->XferSize--;
+    hsmbus->XferCount--;
+
+    if(hsmbus->XferCount == 1)
+    {
+      /* Receive last Byte, can be PEC byte in case of PEC BYTE enabled */
+      /* or only the last Byte of Transfer */
+      /* So reset the RELOAD bit mode */
+      hsmbus->XferOptions &= ~SMBUS_RELOAD_MODE;
+      SMBUS_TransferConfig(hsmbus,0 ,1 , hsmbus->XferOptions, SMBUS_NO_STARTSTOP);
+    }
+    else if(hsmbus->XferCount == 0)
+    {
+      /* Last Byte is received, disable Interrupt */
+      SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_RX);
+
+      /* Remove HAL_SMBUS_STATE_SLAVE_BUSY_RX, keep only HAL_SMBUS_STATE_SLAVE_LISTEN */
+      hsmbus->PreviousState = hsmbus->State;
+      hsmbus->State &= (uint32_t)~((uint32_t)HAL_SMBUS_STATE_SLAVE_BUSY_RX);
+      
+      /* Process Unlocked */
+      __HAL_UNLOCK(hsmbus);
+
+      /* Call the Rx complete callback to inform upper layer of the end of receive process */
+      HAL_SMBUS_SlaveRxCpltCallback(hsmbus);
+    }
+    else
+    {
+      /* Set Reload for next Bytes */
+      SMBUS_TransferConfig(hsmbus,0, 1, SMBUS_RELOAD_MODE, SMBUS_NO_STARTSTOP);
+
+      /* Ack last Byte Read */
+      hsmbus->Instance->CR2 &= ~I2C_CR2_NACK;
+    }
+  }
+  else if(__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_TXIS) != RESET)
+  {
+    /* Write data to TXDR only if XferCount not reach "0" */
+    /* A TXIS flag can be set, during STOP treatment      */
+
+    /* Check if all Datas have already been sent */
+    /* If it is the case, this last write in TXDR is not sent, correspond to a dummy TXIS event */
+    if(hsmbus->XferCount > 0)
+    {
+      /* Write data to TXDR */
+      hsmbus->Instance->TXDR = (*hsmbus->pBuffPtr++);
+      hsmbus->XferCount--;
+      hsmbus->XferSize--;
+    }
+
+    if(hsmbus->XferSize == 0)
+    {
+      /* Last Byte is Transmitted */
+      /* Remove HAL_SMBUS_STATE_SLAVE_BUSY_TX, keep only HAL_SMBUS_STATE_SLAVE_LISTEN */
+      SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_TX);
+      hsmbus->PreviousState = hsmbus->State;
+      hsmbus->State &= (uint32_t)~((uint32_t)HAL_SMBUS_STATE_SLAVE_BUSY_TX);
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hsmbus);
+
+      /* Call the Tx complete callback to inform upper layer of the end of transmit process */
+      HAL_SMBUS_SlaveTxCpltCallback(hsmbus);
+    }
+  }
+
+  /* Check if STOPF is set */
+  if(__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_STOPF) != RESET)
+  {
+    if((hsmbus->State & HAL_SMBUS_STATE_LISTEN) == HAL_SMBUS_STATE_LISTEN)
+    {
+      /* Disable RX and TX Interrupts */
+      SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_RX | SMBUS_IT_TX);
+
+      /* Disable ADDR Interrupt */
+      SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_ADDR);
+
+      /* Disable Address Acknowledge */
+      hsmbus->Instance->CR2 |= I2C_CR2_NACK;
+
+      /* Clear Configuration Register 2 */
+      __HAL_SMBUS_RESET_CR2(hsmbus);
+
+      /* Clear STOP Flag */
+      __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_STOPF);
+
+     /* Clear ADDR flag */
+     __HAL_SMBUS_CLEAR_FLAG(hsmbus,SMBUS_FLAG_ADDR);
+
+      hsmbus->XferOptions = 0;
+      hsmbus->PreviousState = hsmbus->State;
+      hsmbus->State = HAL_SMBUS_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hsmbus);
+
+      /* Call the Slave Complete callback, to prevent upper layer of the end of slave usecase */
+      HAL_SMBUS_ListenCpltCallback(hsmbus);
+    }
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hsmbus);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Manage the enabling of Interrupts
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @param  InterruptRequest : Value of @ref SMBUS_Interrupt_configuration_definition.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SMBUS_Enable_IRQ(SMBUS_HandleTypeDef *hsmbus, uint16_t InterruptRequest) 
+{
+  uint32_t tmpisr = 0;
+
+  if((InterruptRequest & SMBUS_IT_ALERT) == SMBUS_IT_ALERT)
+  {
+    /* Enable ERR interrupt */
+    tmpisr |= SMBUS_IT_ERRI;
+  }
+  
+  if((InterruptRequest & SMBUS_IT_ADDR) == SMBUS_IT_ADDR)
+  {
+    /* Enable ADDR, STOP interrupt */
+    tmpisr |= SMBUS_IT_ADDRI | SMBUS_IT_STOPI | SMBUS_IT_NACKI | SMBUS_IT_ERRI;
+  }
+  
+  if((InterruptRequest & SMBUS_IT_TX) == SMBUS_IT_TX)
+  {
+    /* Enable ERR, TC, STOP, NACK, RXI interrupt */
+    tmpisr |= SMBUS_IT_ERRI | SMBUS_IT_TCI | SMBUS_IT_STOPI | SMBUS_IT_NACKI | SMBUS_IT_TXI;
+  }
+  
+  if((InterruptRequest & SMBUS_IT_RX) == SMBUS_IT_RX)
+  {
+    /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+    tmpisr |= SMBUS_IT_ERRI | SMBUS_IT_TCI | SMBUS_IT_STOPI | SMBUS_IT_NACKI | SMBUS_IT_RXI;
+  }
+  
+  /* Enable interrupts only at the end */
+  /* to avoid the risk of SMBUS interrupt handle execution before */
+  /* all interrupts requested done */
+  __HAL_SMBUS_ENABLE_IT(hsmbus, tmpisr);
+
+  return HAL_OK;     
+}
+/**
+  * @brief  Manage the disabling of Interrupts
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @param  InterruptRequest : Value of @ref SMBUS_Interrupt_configuration_definition.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SMBUS_Disable_IRQ(SMBUS_HandleTypeDef *hsmbus, uint16_t InterruptRequest) 
+{
+  uint32_t tmpisr = 0;
+
+  if( ((InterruptRequest & SMBUS_IT_ALERT) == SMBUS_IT_ALERT) && (hsmbus->State == HAL_SMBUS_STATE_READY) )
+  {
+    /* Disable ERR interrupt */
+    tmpisr |= SMBUS_IT_ERRI;
+  }
+  
+  if((InterruptRequest & SMBUS_IT_TX) == SMBUS_IT_TX)
+  {
+    /* Disable TC, STOP, NACK, TXI interrupt */
+    tmpisr |= SMBUS_IT_TCI | SMBUS_IT_TXI;
+    
+    if((__HAL_SMBUS_GET_ALERT_ENABLED(hsmbus) == RESET)
+       && ((hsmbus->State & HAL_SMBUS_STATE_LISTEN) != HAL_SMBUS_STATE_LISTEN))
+    {
+      /* Disable ERR interrupt */
+      tmpisr |= SMBUS_IT_ERRI;
+    }
+    
+    if((hsmbus->State & HAL_SMBUS_STATE_LISTEN) != HAL_SMBUS_STATE_LISTEN)
+    {
+      /* Disable STOPI, NACKI */
+      tmpisr |= SMBUS_IT_STOPI | SMBUS_IT_NACKI;
+    }
+  }
+  
+  if((InterruptRequest & SMBUS_IT_RX) == SMBUS_IT_RX)
+  {
+    /* Disable TC, STOP, NACK, RXI interrupt */
+    tmpisr |= SMBUS_IT_TCI | SMBUS_IT_RXI;
+    
+    if((__HAL_SMBUS_GET_ALERT_ENABLED(hsmbus) == RESET)
+       && ((hsmbus->State & HAL_SMBUS_STATE_LISTEN) != HAL_SMBUS_STATE_LISTEN))
+    {
+      /* Disable ERR interrupt */
+      tmpisr |= SMBUS_IT_ERRI;
+    }
+
+    if((hsmbus->State & HAL_SMBUS_STATE_LISTEN) != HAL_SMBUS_STATE_LISTEN)
+    {
+      /* Disable STOPI, NACKI */
+      tmpisr |= SMBUS_IT_STOPI | SMBUS_IT_NACKI;
+    }
+  }
+  
+  if((InterruptRequest & SMBUS_IT_ADDR) == SMBUS_IT_ADDR)
+  {
+    /* Enable ADDR, STOP interrupt */
+    tmpisr |= SMBUS_IT_ADDRI | SMBUS_IT_STOPI | SMBUS_IT_NACKI;
+
+    if(__HAL_SMBUS_GET_ALERT_ENABLED(hsmbus) == RESET) 
+    {
+      /* Disable ERR interrupt */
+      tmpisr |= SMBUS_IT_ERRI;
+    }
+  }
+
+  /* Disable interrupts only at the end */
+  /* to avoid a breaking situation like at "t" time */
+  /* all disable interrupts request are not done */
+  __HAL_SMBUS_DISABLE_IT(hsmbus, tmpisr);
+  
+  return HAL_OK;
+}
+/**
+  * @brief  This function handles SMBUS Communication Timeout.
+  * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUS.
+  * @param  Flag: specifies the SMBUS flag to check.
+  * @param  Status: The new Flag status (SET or RESET).
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout(SMBUS_HandleTypeDef *hsmbus, uint32_t Flag, FlagStatus Status, uint32_t Timeout)  
+{  
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+  
+  /* Wait until flag is set */
+  if(Status == RESET)
+  {    
+    while(__HAL_SMBUS_GET_FLAG(hsmbus, Flag) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          hsmbus->PreviousState = hsmbus->State;
+          hsmbus->State= HAL_SMBUS_STATE_READY;
+        
+          /* Process Unlocked */
+          __HAL_UNLOCK(hsmbus);
+        
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    while(__HAL_SMBUS_GET_FLAG(hsmbus, Flag) != RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          hsmbus->PreviousState = hsmbus->State;
+          hsmbus->State= HAL_SMBUS_STATE_READY;
+        
+          /* Process Unlocked */
+          __HAL_UNLOCK(hsmbus);
+        
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles SMBUSx communication when starting transfer or during transfer (TC or TCR flag are set).
+  * @param  hsmbus: SMBUS handle.
+  * @param  DevAddress: specifies the slave address to be programmed.
+  * @param  Size: specifies the number of bytes to be programmed.
+  *   This parameter must be a value between 0 and 255.
+  * @param  Mode: new state of the SMBUS START condition generation.
+  *   This parameter can be one or a combination  of the following values:
+  *     @arg SMBUS_NO_MODE: No specific mode enabled.
+  *     @arg SMBUS_RELOAD_MODE: Enable Reload mode.
+  *     @arg SMBUS_AUTOEND_MODE: Enable Automatic end mode.
+  *     @arg SMBUS_SOFTEND_MODE: Enable Software end mode and Reload mode.
+  * @param  Request: new state of the SMBUS START condition generation.
+  *   This parameter can be one of the following values:
+  *     @arg SMBUS_NO_STARTSTOP: Don't Generate stop and start condition.
+  *     @arg SMBUS_GENERATE_STOP: Generate stop condition (Size should be set to 0).
+  *     @arg SMBUS_GENERATE_START_READ: Generate Restart for read request.
+  *     @arg SMBUS_GENERATE_START_WRITE: Generate Restart for write request.
+  * @retval None
+  */
+static void SMBUS_TransferConfig(SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request)
+{
+  uint32_t tmpreg = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_SMBUS_INSTANCE(hsmbus->Instance));
+  assert_param(IS_SMBUS_TRANSFER_MODE(Mode));
+  assert_param(IS_SMBUS_TRANSFER_REQUEST(Request));
+    
+  /* Get the CR2 register value */
+  tmpreg = hsmbus->Instance->CR2;
+  
+  /* clear tmpreg specific bits */
+  tmpreg &= (uint32_t)~((uint32_t)(I2C_CR2_SADD | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_AUTOEND | I2C_CR2_RD_WRN | I2C_CR2_START | I2C_CR2_STOP | I2C_CR2_PECBYTE));
+  
+  /* update tmpreg */
+  tmpreg |= (uint32_t)(((uint32_t)DevAddress & I2C_CR2_SADD) | (((uint32_t)Size << 16 ) & I2C_CR2_NBYTES) | \
+              (uint32_t)Mode | (uint32_t)Request);
+    
+  /* update CR2 register */
+  hsmbus->Instance->CR2 = tmpreg;  
+}  
+
+/**
+  * @}
+  */
+
+#endif /* HAL_SMBUS_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_smbus.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_smbus.h
@@ -1,0 +1,565 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_smbus.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of SMBUS HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_SMBUS_H
+#define __STM32L0xx_HAL_SMBUS_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"  
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup SMBUS
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+
+/** 
+  * @brief  SMBUS Configuration Structure definition  
+  */
+typedef struct
+{
+  uint32_t Timing;                 /*!< Specifies the SMBUS_TIMINGR_register value.
+                                        This parameter calculated by referring to SMBUS initialization 
+                                        section in Reference manual */
+
+  uint32_t AnalogFilter;           /*!< Specifies if Analog Filter is enable or not.
+                                     This parameter can be a a value of @ref SMBUS_Analog_Filter */
+
+  uint32_t OwnAddress1;            /*!< Specifies the first device own address.
+                                     This parameter can be a 7-bit or 10-bit address. */
+
+  uint32_t AddressingMode;         /*!< Specifies if 7-bit or 10-bit addressing mode for master is selected.
+                                     This parameter can be a value of @ref SMBUS_addressing_mode */
+
+  uint32_t DualAddressMode;        /*!< Specifies if dual addressing mode is selected.
+                                     This parameter can be a value of @ref SMBUS_dual_addressing_mode */
+
+  uint32_t OwnAddress2;            /*!< Specifies the second device own address if dual addressing mode is selected
+                                     This parameter can be a 7-bit address. */
+
+  uint32_t OwnAddress2Masks;       /*!< Specifies the acknoledge mask address second device own address if dual addressing mode is selected
+                                     This parameter can be a value of @ref SMBUS_own_address2_masks */
+
+  uint32_t GeneralCallMode;        /*!< Specifies if general call mode is selected.
+                                     This parameter can be a value of @ref SMBUS_general_call_addressing_mode */
+
+  uint32_t NoStretchMode;          /*!< Specifies if nostretch mode is selected.
+                                     This parameter can be a value of @ref SMBUS_nostretch_mode */
+
+  uint32_t PacketErrorCheckMode;   /*!< Specifies if Packet Error Check mode is selected.
+                                     This parameter can be a value of @ref SMBUS_packet_error_check_mode */
+
+  uint32_t PeripheralMode;         /*!< Specifies which mode of Periphal is selected.
+                                     This parameter can be a value of @ref SMBUS_peripheral_mode */
+
+  uint32_t SMBusTimeout;           /*!< Specifies the content of the 32 Bits SMBUS_TIMEOUT_register value.
+                                     (Enable bits and different timeout values)
+                                     This parameter calculated by referring to SMBUS initialization 
+                                         section in Reference manual */
+} SMBUS_InitTypeDef;
+
+/** 
+  * @brief  HAL State structures definition
+  */ 
+typedef enum
+{
+  HAL_SMBUS_STATE_RESET           = 0x00,  /*!< SMBUS not yet initialized or disabled         */
+  HAL_SMBUS_STATE_READY           = 0x01,  /*!< SMBUS initialized and ready for use           */
+  HAL_SMBUS_STATE_BUSY            = 0x02,  /*!< SMBUS internal process is ongoing             */
+  HAL_SMBUS_STATE_MASTER_BUSY_TX  = 0x12,  /*!< Master Data Transmission process is ongoing   */
+  HAL_SMBUS_STATE_MASTER_BUSY_RX  = 0x22,  /*!< Master Data Reception process is ongoing      */
+  HAL_SMBUS_STATE_SLAVE_BUSY_TX   = 0x32,  /*!< Slave Data Transmission process is ongoing    */
+  HAL_SMBUS_STATE_SLAVE_BUSY_RX   = 0x42,  /*!< Slave Data Reception process is ongoing       */
+  HAL_SMBUS_STATE_TIMEOUT         = 0x03,  /*!< Timeout state                                 */
+  HAL_SMBUS_STATE_ERROR           = 0x04,  /*!< Reception process is ongoing                  */
+  HAL_SMBUS_STATE_LISTEN          = 0x08,   /*!< Address Listen Mode is ongoing                */
+/* Aliases for inter STM32 series compatibility */
+  HAL_SMBUS_STATE_SLAVE_LISTEN    = HAL_SMBUS_STATE_LISTEN
+}HAL_SMBUS_StateTypeDef;
+
+/** 
+  * @brief  HAL SMBUS Error Code structure definition  
+  */ 
+typedef enum
+{
+  HAL_SMBUS_ERROR_NONE        = 0x00,    /*!< No error             */
+  HAL_SMBUS_ERROR_BERR        = 0x01,    /*!< BERR error           */
+  HAL_SMBUS_ERROR_ARLO        = 0x02,    /*!< ARLO error           */
+  HAL_SMBUS_ERROR_ACKF        = 0x04,    /*!< ACKF error           */
+  HAL_SMBUS_ERROR_OVR         = 0x08,    /*!< OVR error            */
+  HAL_SMBUS_ERROR_HALTIMEOUT  = 0x10,    /*!< Timeout error        */
+  HAL_SMBUS_ERROR_BUSTIMEOUT  = 0x20,    /*!< Bus Timeout error    */
+  HAL_SMBUS_ERROR_ALERT       = 0x40,    /*!< Alert error          */
+  HAL_SMBUS_ERROR_PECERR      = 0x80     /*!< PEC error            */
+
+}HAL_SMBUS_ErrorTypeDef;
+
+/** 
+  * @brief  SMBUS handle Structure definition  
+  */
+typedef struct
+{
+  I2C_TypeDef                  *Instance;       /*!< SMBUS registers base address       */
+
+  SMBUS_InitTypeDef            Init;            /*!< SMBUS communication parameters     */
+
+  uint8_t                      *pBuffPtr;       /*!< Pointer to SMBUS transfer buffer   */
+
+  uint16_t                     XferSize;        /*!< SMBUS transfer size                */
+
+  __IO uint16_t                XferCount;       /*!< SMBUS transfer counter             */
+
+  __IO uint32_t                XferOptions;     /*!< SMBUS transfer options             */
+
+  __IO HAL_SMBUS_StateTypeDef  PreviousState;   /*!< SMBUS communication Previous tate  */
+
+  HAL_LockTypeDef              Lock;            /*!< SMBUS locking object               */
+
+  __IO HAL_SMBUS_StateTypeDef  State;           /*!< SMBUS communication state          */
+
+  __IO HAL_SMBUS_ErrorTypeDef  ErrorCode;       /*!< SMBUS Error code                   */
+
+}SMBUS_HandleTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup SMBUS_Exported_Constants
+  * @{
+  */
+
+/** @defgroup SMBUS_Analog_Filter
+  * @{
+  */
+#define SMBUS_ANALOGFILTER_ENABLED              ((uint32_t)0x00000000)
+#define SMBUS_ANALOGFILTER_DISABLED             I2C_CR1_ANFOFF
+
+#define IS_SMBUS_ANALOG_FILTER(FILTER)          (((FILTER) == SMBUS_ANALOGFILTER_ENABLED) || \
+                                                 ((FILTER) == SMBUS_ANALOGFILTER_DISABLED))
+/**
+  * @}
+  */
+
+/** @defgroup SMBUS_addressing_mode
+  * @{
+  */
+#define SMBUS_ADDRESSINGMODE_7BIT               ((uint32_t)0x00000001) 
+#define SMBUS_ADDRESSINGMODE_10BIT              ((uint32_t)0x00000002)
+
+#define IS_SMBUS_ADDRESSING_MODE(MODE)          (((MODE) == SMBUS_ADDRESSINGMODE_7BIT)  || \
+                                                 ((MODE) == SMBUS_ADDRESSINGMODE_10BIT))
+/**
+  * @}
+  */
+
+/** @defgroup SMBUS_dual_addressing_mode
+  * @{
+  */
+
+#define SMBUS_DUALADDRESS_DISABLED              ((uint32_t)0x00000000)
+#define SMBUS_DUALADDRESS_ENABLED               I2C_OAR2_OA2EN
+
+#define IS_SMBUS_DUAL_ADDRESS(ADDRESS)          (((ADDRESS) == SMBUS_DUALADDRESS_DISABLED) || \
+                                                 ((ADDRESS) == SMBUS_DUALADDRESS_ENABLED))
+/**
+  * @}
+  */
+
+/** @defgroup SMBUS_own_address2_masks
+  * @{
+  */
+
+#define SMBUS_OA2_NOMASK                        ((uint8_t)0x00)
+#define SMBUS_OA2_MASK01                        ((uint8_t)0x01)
+#define SMBUS_OA2_MASK02                        ((uint8_t)0x02)
+#define SMBUS_OA2_MASK03                        ((uint8_t)0x03)
+#define SMBUS_OA2_MASK04                        ((uint8_t)0x04)
+#define SMBUS_OA2_MASK05                        ((uint8_t)0x05)
+#define SMBUS_OA2_MASK06                        ((uint8_t)0x06)
+#define SMBUS_OA2_MASK07                        ((uint8_t)0x07)
+
+#define IS_SMBUS_OWN_ADDRESS2_MASK(MASK)        (((MASK) == SMBUS_OA2_NOMASK)   || \
+                                                 ((MASK) == SMBUS_OA2_MASK01)    || \
+                                                 ((MASK) == SMBUS_OA2_MASK02)    || \
+                                                 ((MASK) == SMBUS_OA2_MASK03)    || \
+                                                 ((MASK) == SMBUS_OA2_MASK04)    || \
+                                                 ((MASK) == SMBUS_OA2_MASK05)    || \
+                                                 ((MASK) == SMBUS_OA2_MASK06)    || \
+                                                 ((MASK) == SMBUS_OA2_MASK07))  
+/**
+  * @}
+  */
+
+
+/** @defgroup SMBUS_general_call_addressing_mode
+  * @{
+  */
+#define SMBUS_GENERALCALL_DISABLED              ((uint32_t)0x00000000)
+#define SMBUS_GENERALCALL_ENABLED               I2C_CR1_GCEN
+
+#define IS_SMBUS_GENERAL_CALL(CALL)             (((CALL) == SMBUS_GENERALCALL_DISABLED) || \
+                                                 ((CALL) == SMBUS_GENERALCALL_ENABLED))
+/**
+  * @}
+  */
+
+/** @defgroup SMBUS_nostretch_mode
+  * @{
+  */
+#define SMBUS_NOSTRETCH_DISABLED                ((uint32_t)0x00000000)
+#define SMBUS_NOSTRETCH_ENABLED                 I2C_CR1_NOSTRETCH
+
+#define IS_SMBUS_NO_STRETCH(STRETCH)            (((STRETCH) == SMBUS_NOSTRETCH_DISABLED) || \
+                                                 ((STRETCH) == SMBUS_NOSTRETCH_ENABLED))
+/**
+  * @}
+  */
+
+/** @defgroup SMBUS_packet_error_check_mode
+  * @{
+  */
+#define SMBUS_PEC_DISABLED                      ((uint32_t)0x00000000)
+#define SMBUS_PEC_ENABLED                       I2C_CR1_PECEN
+
+#define IS_SMBUS_PEC(PEC)                       (((PEC) == SMBUS_PEC_DISABLED) || \
+                                                 ((PEC) == SMBUS_PEC_ENABLED))
+/**
+  * @}
+  */
+
+/** @defgroup SMBUS_peripheral_mode
+  * @{
+  */
+#define SMBUS_PERIPHERAL_MODE_SMBUS_HOST        (uint32_t)(I2C_CR1_SMBHEN)
+#define SMBUS_PERIPHERAL_MODE_SMBUS_SLAVE       (uint32_t)(0x00000000)
+#define SMBUS_PERIPHERAL_MODE_SMBUS_SLAVE_ARP   (uint32_t)(I2C_CR1_SMBDEN)
+
+#define IS_SMBUS_PERIPHERAL_MODE(MODE)          (((MODE) == SMBUS_PERIPHERAL_MODE_SMBUS_HOST)   || \
+                                                 ((MODE) == SMBUS_PERIPHERAL_MODE_SMBUS_SLAVE)  || \
+                                                 ((MODE) == SMBUS_PERIPHERAL_MODE_SMBUS_SLAVE_ARP))
+/**
+  * @}
+  */
+
+/** @defgroup SMBUS_ReloadEndMode_definition
+  * @{
+  */
+
+#define  SMBUS_SOFTEND_MODE                     ((uint32_t)0x00000000)
+#define  SMBUS_RELOAD_MODE                      I2C_CR2_RELOAD
+#define  SMBUS_AUTOEND_MODE                     I2C_CR2_AUTOEND
+#define  SMBUS_SENDPEC_MODE                     I2C_CR2_PECBYTE
+
+#define IS_SMBUS_TRANSFER_MODE(MODE)            (((MODE) == SMBUS_RELOAD_MODE)                          || \
+                                                 ((MODE) == SMBUS_AUTOEND_MODE)                         || \
+                                                 ((MODE) == SMBUS_SOFTEND_MODE)                         || \
+                                                 ((MODE) == (SMBUS_AUTOEND_MODE | SMBUS_SENDPEC_MODE))  || \
+                                                 ((MODE) == (SMBUS_AUTOEND_MODE | SMBUS_RELOAD_MODE))   || \
+                                                 ((MODE) == (SMBUS_AUTOEND_MODE | SMBUS_SENDPEC_MODE | SMBUS_RELOAD_MODE )))
+
+/**
+  * @}
+  */
+
+/** @defgroup SMBUS_StartStopMode_definition
+  * @{
+  */
+
+#define  SMBUS_NO_STARTSTOP                     ((uint32_t)0x00000000)
+#define  SMBUS_GENERATE_STOP                    I2C_CR2_STOP
+#define  SMBUS_GENERATE_START_READ              (uint32_t)(I2C_CR2_START | I2C_CR2_RD_WRN)
+#define  SMBUS_GENERATE_START_WRITE             I2C_CR2_START
+                              
+#define IS_SMBUS_TRANSFER_REQUEST(REQUEST)      (((REQUEST) == SMBUS_GENERATE_STOP)             || \
+                                                 ((REQUEST) == SMBUS_GENERATE_START_READ)       || \
+                                                 ((REQUEST) == SMBUS_GENERATE_START_WRITE)      || \
+                                                 ((REQUEST) == SMBUS_NO_STARTSTOP))
+/**
+  * @}
+  */
+
+/** @defgroup SMBUS_XferOptions_definition
+  * @{
+  */
+
+#define  SMBUS_FIRST_FRAME                      ((uint32_t)(SMBUS_SOFTEND_MODE))
+#define  SMBUS_NEXT_FRAME                       ((uint32_t)(SMBUS_RELOAD_MODE | SMBUS_SOFTEND_MODE))
+#define  SMBUS_FIRST_AND_LAST_FRAME_NO_PEC      SMBUS_AUTOEND_MODE 
+#define  SMBUS_LAST_FRAME_NO_PEC                SMBUS_AUTOEND_MODE
+#define  SMBUS_FIRST_AND_LAST_FRAME_WITH_PEC    ((uint32_t)(SMBUS_AUTOEND_MODE | SMBUS_SENDPEC_MODE))
+#define  SMBUS_LAST_FRAME_WITH_PEC              ((uint32_t)(SMBUS_AUTOEND_MODE | SMBUS_SENDPEC_MODE))
+
+#define IS_SMBUS_TRANSFER_OPTIONS_REQUEST(REQUEST)    (((REQUEST) == SMBUS_FIRST_FRAME)                       || \
+                                                       ((REQUEST) == SMBUS_NEXT_FRAME)                        || \
+                                                       ((REQUEST) == SMBUS_FIRST_AND_LAST_FRAME_NO_PEC)       || \
+                                                       ((REQUEST) == SMBUS_LAST_FRAME_NO_PEC)                 || \
+                                                       ((REQUEST) == SMBUS_FIRST_AND_LAST_FRAME_WITH_PEC)     || \
+                                                       ((REQUEST) == SMBUS_LAST_FRAME_WITH_PEC))
+
+/**
+  * @}
+  */
+
+/** @defgroup SMBUS_Interrupt_configuration_definition
+  * @brief SMBUS Interrupt definition
+  *        Elements values convention: 0xXXXXXXXX
+  *           - XXXXXXXX  : Interrupt control mask
+  * @{
+  */
+#define SMBUS_IT_ERRI                     I2C_CR1_ERRIE
+#define SMBUS_IT_TCI                      I2C_CR1_TCIE
+#define SMBUS_IT_STOPI                    I2C_CR1_STOPIE
+#define SMBUS_IT_NACKI                    I2C_CR1_NACKIE
+#define SMBUS_IT_ADDRI                    I2C_CR1_ADDRIE
+#define SMBUS_IT_RXI                      I2C_CR1_RXIE
+#define SMBUS_IT_TXI                      I2C_CR1_TXIE
+#define SMBUS_IT_TX                       (SMBUS_IT_ERRI | SMBUS_IT_TCI | SMBUS_IT_STOPI | SMBUS_IT_NACKI | SMBUS_IT_TXI)
+#define SMBUS_IT_RX                       (SMBUS_IT_ERRI | SMBUS_IT_TCI | SMBUS_IT_NACKI | SMBUS_IT_RXI)
+#define SMBUS_IT_ALERT                    (SMBUS_IT_ERRI)
+#define SMBUS_IT_ADDR                     (SMBUS_IT_ADDRI | SMBUS_IT_STOPI | SMBUS_IT_NACKI)
+/**
+  * @}
+  */
+
+/** @defgroup SMBUS_Flag_definition
+  * @brief Flag definition
+  *        Elements values convention: 0xXXXXYYYY
+  *           - XXXXXXXX  : Flag mask
+  * @{
+  */ 
+
+#define  SMBUS_FLAG_TXE                   I2C_ISR_TXE
+#define  SMBUS_FLAG_TXIS                  I2C_ISR_TXIS
+#define  SMBUS_FLAG_RXNE                  I2C_ISR_RXNE
+#define  SMBUS_FLAG_ADDR                  I2C_ISR_ADDR
+#define  SMBUS_FLAG_AF                    I2C_ISR_NACKF
+#define  SMBUS_FLAG_STOPF                 I2C_ISR_STOPF
+#define  SMBUS_FLAG_TC                    I2C_ISR_TC
+#define  SMBUS_FLAG_TCR                   I2C_ISR_TCR
+#define  SMBUS_FLAG_BERR                  I2C_ISR_BERR
+#define  SMBUS_FLAG_ARLO                  I2C_ISR_ARLO
+#define  SMBUS_FLAG_OVR                   I2C_ISR_OVR
+#define  SMBUS_FLAG_PECERR                I2C_ISR_PECERR
+#define  SMBUS_FLAG_TIMEOUT               I2C_ISR_TIMEOUT
+#define  SMBUS_FLAG_ALERT                 I2C_ISR_ALERT
+#define  SMBUS_FLAG_BUSY                  I2C_ISR_BUSY
+#define  SMBUS_FLAG_DIR                   I2C_ISR_DIR
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+/** @brief Reset SMBUS handle state
+  * @param  __HANDLE__: specifies the SMBUS Handle.
+  *         This parameter can be SMBUSx where x: 1 or 2 to select the SMBUS peripheral.
+  * @retval None
+  */
+#define __HAL_SMBUS_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_SMBUS_STATE_RESET)
+
+/** @brief  Enable or disable the specified SMBUS interrupts.
+  * @param  __HANDLE__: specifies the SMBUS Handle.
+  *         This parameter can be SMBUSx where x: 1 or 2 to select the SMBUS peripheral.
+  * @param  __INTERRUPT__: specifies the interrupt source to enable or disable.
+  *        This parameter can be one of the following values:
+  *            @arg SMBUS_IT_ERRI: Errors interrupt enable
+  *            @arg SMBUS_IT_TCI: Transfer complete interrupt enable
+  *            @arg SMBUS_IT_STOPI: STOP detection interrupt enable
+  *            @arg SMBUS_IT_NACKI: NACK received interrupt enable
+  *            @arg SMBUS_IT_ADDRI: Address match interrupt enable
+  *            @arg SMBUS_IT_RXI: RX interrupt enable
+  *            @arg SMBUS_IT_TXI: TX interrupt enable
+  *   
+  * @retval None
+  */
+  
+#define __HAL_SMBUS_ENABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->CR1 |= (__INTERRUPT__))
+#define __HAL_SMBUS_DISABLE_IT(__HANDLE__, __INTERRUPT__)  ((__HANDLE__)->Instance->CR1 &= (~(__INTERRUPT__)))
+ 
+/** @brief  Checks if the specified SMBUS interrupt source is enabled or disabled.
+  * @param  __HANDLE__: specifies the SMBUS Handle.
+  *         This parameter can be SMBUSx where x: 1 or 2 to select the SMBUS peripheral.
+  * @param  __INTERRUPT__: specifies the SMBUS interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg SMBUS_IT_ERRI: Errors interrupt enable
+  *            @arg SMBUS_IT_TCI: Transfer complete interrupt enable
+  *            @arg SMBUS_IT_STOPI: STOP detection interrupt enable
+  *            @arg SMBUS_IT_NACKI: NACK received interrupt enable
+  *            @arg SMBUS_IT_ADDRI: Address match interrupt enable
+  *            @arg SMBUS_IT_RXI: RX interrupt enable
+  *            @arg SMBUS_IT_TXI: TX interrupt enable
+  *   
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_SMBUS_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->CR1 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/** @brief  Checks whether the specified SMBUS flag is set or not.
+  * @param  __HANDLE__: specifies the SMBUS Handle.
+  *         This parameter can be SMBUSx where x: 1 or 2 to select the SMBUS peripheral.
+  * @param  __FLAG__: specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg SMBUS_FLAG_TXE:     Transmit data register empty
+  *            @arg SMBUS_FLAG_TXIS:    Transmit interrupt status
+  *            @arg SMBUS_FLAG_RXNE:    Receive data register not empty
+  *            @arg SMBUS_FLAG_ADDR:    Address matched (slave mode)
+  *            @arg SMBUS_FLAG_AF       NACK received flag
+  *            @arg SMBUS_FLAG_STOPF:   STOP detection flag
+  *            @arg SMBUS_FLAG_TC:      Transfer complete (master mode)
+  *            @arg SMBUS_FLAG_TCR:     Transfer complete reload
+  *            @arg SMBUS_FLAG_BERR:    Bus error
+  *            @arg SMBUS_FLAG_ARLO:    Arbitration lost
+  *            @arg SMBUS_FLAG_OVR:     Overrun/Underrun
+  *            @arg SMBUS_FLAG_PECERR:  PEC error in reception
+  *            @arg SMBUS_FLAG_TIMEOUT: Timeout or Tlow detection flag 
+  *            @arg SMBUS_FLAG_ALERT:   SMBus alert
+  *            @arg SMBUS_FLAG_BUSY:    Bus busy
+  *            @arg SMBUS_FLAG_DIR:     Transfer direction (slave mode)
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define SMBUS_FLAG_MASK  ((uint32_t)0x0001FFFF)
+#define __HAL_SMBUS_GET_FLAG(__HANDLE__, __FLAG__) (((((__HANDLE__)->Instance->ISR) & ((__FLAG__) & SMBUS_FLAG_MASK)) == ((__FLAG__) & SMBUS_FLAG_MASK)))
+    
+/** @brief  Clears the SMBUS pending flags which are cleared by writing 1 in a specific bit.
+  * @param  __HANDLE__: specifies the SMBUS Handle.
+  *         This parameter can be SMBUSx where x: 1 or 2 to select the SMBUS peripheral.
+  * @param  __FLAG__: specifies the flag to clear.
+  *          This parameter can be any combination of the following values:
+  *            @arg SMBUS_FLAG_ADDR:    Address matched (slave mode)
+  *            @arg SMBUS_FLAG_AF:      NACK received flag
+  *            @arg SMBUS_FLAG_STOPF:   STOP detection flag
+  *            @arg SMBUS_FLAG_BERR:    Bus error
+  *            @arg SMBUS_FLAG_ARLO:    Arbitration lost
+  *            @arg SMBUS_FLAG_OVR:     Overrun/Underrun
+  *            @arg SMBUS_FLAG_PECERR:  PEC error in reception
+  *            @arg SMBUS_FLAG_TIMEOUT: Timeout or Tlow detection flag 
+  *            @arg SMBUS_FLAG_ALERT:		SMBus alert
+  * @retval None
+  */
+#define __HAL_SMBUS_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ICR = ((__FLAG__) & SMBUS_FLAG_MASK))
+ 
+
+#define __HAL_SMBUS_ENABLE(__HANDLE__)                          ((__HANDLE__)->Instance->CR1 |=  I2C_CR1_PE)
+#define __HAL_SMBUS_DISABLE(__HANDLE__)                         ((__HANDLE__)->Instance->CR1 &=  ~I2C_CR1_PE)
+
+#define __HAL_SMBUS_RESET_CR1(__HANDLE__)                       ((__HANDLE__)->Instance->CR1 &= (uint32_t)~((uint32_t)(I2C_CR1_SMBHEN | I2C_CR1_SMBDEN | I2C_CR1_PECEN)))
+#define __HAL_SMBUS_RESET_CR2(__HANDLE__)                       ((__HANDLE__)->Instance->CR2 &= (uint32_t)~((uint32_t)(I2C_CR2_SADD | I2C_CR2_HEAD10R | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_RD_WRN)))
+
+#define __HAL_SMBUS_GENERATE_START(__ADDMODE__,__ADDRESS__)     (((__ADDMODE__) == SMBUS_ADDRESSINGMODE_7BIT) ? (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | (I2C_CR2_START) | (I2C_CR2_AUTOEND)) & (~I2C_CR2_RD_WRN)) : \
+                                                                  (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | (I2C_CR2_ADD10) | (I2C_CR2_START)) & (~I2C_CR2_RD_WRN)))
+
+#define __HAL_SMBUS_GET_ADDR_MATCH(__HANDLE__)                  (((__HANDLE__)->Instance->ISR & I2C_ISR_ADDCODE) >> 17)
+#define __HAL_SMBUS_GET_DIR(__HANDLE__)                         (((__HANDLE__)->Instance->ISR & I2C_ISR_DIR) >> 16)
+#define __HAL_SMBUS_GET_STOP_MODE(__HANDLE__)                   ((__HANDLE__)->Instance->CR2 & I2C_CR2_AUTOEND)
+#define __HAL_SMBUS_GET_PEC_MODE(__HANDLE__)                    ((__HANDLE__)->Instance->CR2 & I2C_CR2_PECBYTE)
+#define __HAL_SMBUS_GET_ALERT_ENABLED(__HANDLE__)                ((__HANDLE__)->Instance->CR1 & I2C_CR1_ALERTEN)
+#define __HAL_SMBUS_GENERATE_NACK(__HANDLE__)                   ((__HANDLE__)->Instance->CR2 |= I2C_CR2_NACK)
+
+#define IS_SMBUS_OWN_ADDRESS1(ADDRESS1)                         ((ADDRESS1) <= (uint32_t)0x000003FF)
+#define IS_SMBUS_OWN_ADDRESS2(ADDRESS2)                         ((ADDRESS2) <= (uint16_t)0x00FF)
+
+/* Exported functions --------------------------------------------------------*/
+/* Initialization and de-initialization functions  ****************************/
+HAL_StatusTypeDef HAL_SMBUS_Init(SMBUS_HandleTypeDef *hsmbus);
+HAL_StatusTypeDef HAL_SMBUS_DeInit (SMBUS_HandleTypeDef *hsmbus);
+void HAL_SMBUS_MspInit(SMBUS_HandleTypeDef *hsmbus);
+void HAL_SMBUS_MspDeInit(SMBUS_HandleTypeDef *hsmbus);
+
+/* IO operation functions  ****************************************************/
+HAL_StatusTypeDef HAL_SMBUS_EnableAlert_IT(SMBUS_HandleTypeDef *hsmbus);
+HAL_StatusTypeDef HAL_SMBUS_DisableAlert_IT(SMBUS_HandleTypeDef *hsmbus);
+HAL_StatusTypeDef HAL_SMBUS_EnableListen_IT(SMBUS_HandleTypeDef *hsmbus);
+HAL_StatusTypeDef HAL_SMBUS_DisableListen_IT(SMBUS_HandleTypeDef *hsmbus);
+/* Aliases for inter STM32 series compatibility */
+#define HAL_SMBUS_Slave_Listen_IT   HAL_SMBUS_EnableListen_IT
+
+/******* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_SMBUS_IsDeviceReady(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout);
+
+/******* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_SMBUS_Master_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_SMBUS_Master_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_SMBUS_Master_Abort_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress);
+HAL_StatusTypeDef HAL_SMBUS_Slave_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_SMBUS_Slave_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
+
+/******* SMBUS IRQHandler and Callbacks used in non blocking modes (Interrupt) */
+void HAL_SMBUS_EV_IRQHandler(SMBUS_HandleTypeDef *hsmbus);
+void HAL_SMBUS_ER_IRQHandler(SMBUS_HandleTypeDef *hsmbus);
+void HAL_SMBUS_MasterTxCpltCallback(SMBUS_HandleTypeDef *hsmbus);
+void HAL_SMBUS_MasterRxCpltCallback(SMBUS_HandleTypeDef *hsmbus);
+void HAL_SMBUS_SlaveTxCpltCallback(SMBUS_HandleTypeDef *hsmbus);
+void HAL_SMBUS_SlaveRxCpltCallback(SMBUS_HandleTypeDef *hsmbus);
+void HAL_SMBUS_AddrCallback(SMBUS_HandleTypeDef *hsmbus, uint8_t TransferDirection, uint16_t AddrMatchCode);
+void HAL_SMBUS_ListenCpltCallback(SMBUS_HandleTypeDef *hsmbus);
+/* Aliases for inter STM32 series compatibility */
+#define HAL_SMBUS_SlaveAddrCallback         HAL_SMBUS_AddrCallback
+#define HAL_SMBUS_SlaveListenCpltCallback   HAL_SMBUS_ListenCpltCallback
+
+void HAL_SMBUS_ErrorCallback(SMBUS_HandleTypeDef *hsmbus);
+
+/* Peripheral State and Errors functions  *************************************/
+HAL_SMBUS_StateTypeDef HAL_SMBUS_GetState(SMBUS_HandleTypeDef *hsmbus);
+uint32_t               HAL_SMBUS_GetError(SMBUS_HandleTypeDef *hsmbus);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* __STM32L0xx_HAL_SMBUS_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_spi.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_spi.c
@@ -1,0 +1,2312 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_spi.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   SPI HAL module driver.
+  *
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Serial Peripheral Interface (SPI) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions 
+  *           + Peripheral State functions
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+    [..]
+      The SPI HAL driver can be used as follows:
+
+      (#) Declare a SPI_HandleTypeDef handle structure, for example:
+          SPI_HandleTypeDef  hspi; 
+
+      (#)Initialize the SPI low level resources by implement the HAL_SPI_MspInit ()API:
+          (##) Enable the SPIx interface clock 
+          (##) SPI pins configuration
+              (+++) Enable the clock for the SPI GPIOs 
+              (+++) Configure these SPI pins as alternate function push-pull
+          (##) NVIC configuration if you need to use interrupt process
+              (+++) Configure the SPIx interrupt priority
+              (+++) Enable the NVIC SPI IRQ handle
+          (##) DMA Configuration if you need to use DMA process
+              (+++) Declare a DMA_HandleTypeDef handle structure for the transmit or receive stream
+              (+++) Enable the DMAx interface clock using 
+              (+++) Configure the DMA handle parameters 
+              (+++) Configure the DMA Tx or Rx Stream
+              (+++) Associate the initilalized hdma_tx handle to the hspi DMA Tx or Rx handle
+              (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx or Rx Stream
+
+      (#) Program the Mode, Direction , Data size, Baudrate Prescaler, NSS 
+          management, Clock polarity and phase, FirstBit and CRC configuration in the hspi Init structure.
+
+      (#) Initialize the SPI registers by calling the HAL_SPI_Init() API:
+          (++) This API configures also the low level Hardware GPIO, CLOCK, CORTEX...etc)
+              by calling the customed HAL_SPI_MspInit(&hspi) API.
+    [..]
+       Circular mode restriction:
+      (#) The DMA circular mode cannot be used when the SPI is configured in these modes:
+          (##) Master 2Lines RxOnly
+          (##) Master 1Line Rx
+      (#) The CRC feature is not managed when the DMA circular mode is enabled
+      (#) When the SPI DMA Pause/Stop features are used, we must use the following APIs 
+          the HAL_SPI_DMAPause()/ HAL_SPI_DMAStop() only under the SPI callbacks
+
+    [..]
+    Using the HAL it is not possible to reach all supported SPI frequency with the differents SPI Modes,
+    the following table resume the max SPI frequency reached with data size 8bits/16bits:
+   +-----------------------------------------------------------------------------------------+
+   |         |                | 2Lines Fullduplex  |     2Lines RxOnly  |        1Line       |
+   | Process | Tranfert mode  |--------------------|--------------------|--------------------|
+   |         |                |  Master  |  Slave  |  Master  |  Slave  |  Master  |  Slave  |
+   |=========================================================================================|
+   |    T    |     Polling    |  Fcpu/2  |  Fcpu/2 |    NA    |    NA   |    NA    |   NA    |
+   |    X    |----------------|----------|---------|----------|---------|----------|---------|
+   |    /    |     Interrupt  |  Fcpu/4  | Fcpu/16 |    NA    |    NA   |    NA    |   NA    |
+   |    R    |----------------|----------|---------|----------|---------|----------|---------|
+   |    X    |       DMA      |  Fcpu/2  |  Fcpu/2 |    NA    |    NA   |    NA    |   NA    |
+   |=========|================|==========|=========|==========|=========|==========|=========|
+   |         |     Polling    |  Fcpu/2  |  Fcpu/4 |  Fcpu/16 |  Fcpu/8 |  Fcpu/8  |  Fcpu/8 |
+   |         |----------------|----------|---------|----------|---------|----------|---------|
+   |    R    |     Interrupt  |  Fcpu/8  | Fcpu/16 |  Fcpu/8  |  Fcpu/8 |  Fcpu/8  |  Fcpu/4 |
+   |    X    |----------------|----------|---------|----------|---------|----------|---------|
+   |         |       DMA      |  Fcpu/4  |  Fcpu/2 |  Fcpu/4  | Fcpu/16 |  Fcpu/2  | Fcpu/16 |
+   |=========|================|==========|=========|==========|=========|==========|=========|
+   |         |     Polling    |  Fcpu/2  |  Fcpu/2 |    NA    |    NA   |  Fcpu/8  |  Fcpu/8 |
+   |         |----------------|----------|---------|----------|---------|----------|---------|
+   |    T    |     Interrupt  |  Fcpu/2  |  Fcpu/4 |    NA    |    NA   |  Fcpu/16 |  Fcpu/8 |
+   |    X    |----------------|----------|---------|----------|---------|----------|---------|
+   |         |       DMA      |  Fcpu/2  |  Fcpu/2 |    NA    |    NA   |  Fcpu/8  | Fcpu/16 |
+   +-----------------------------------------------------------------------------------------+
+  @note The max SPI frequency depend on SPI data size (4bits, 5bits,..., 8bits,...15bits, 16bits),
+        SPI mode(2 Lines fullduplex, 2 lines RxOnly, 1 line TX/RX) and Process mode (Polling, IT, DMA).
+  @note
+   (#) TX/RX processes are HAL_SPI_TransmitReceive(), HAL_SPI_TransmitReceive_IT() and HAL_SPI_TransmitReceive_DMA()
+   (#) RX processes are HAL_SPI_Receive(), HAL_SPI_Receive_IT() and HAL_SPI_Receive_DMA()
+   (#) TX processes are HAL_SPI_Transmit(), HAL_SPI_Transmit_IT() and HAL_SPI_Transmit_DMA()
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup SPI 
+  * @brief SPI HAL module driver
+  * @{
+  */
+
+#ifdef HAL_SPI_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define SPI_TIMEOUT_VALUE  100
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void SPI_TxCloseIRQHandler(SPI_HandleTypeDef *hspi);
+static void SPI_TxISR(SPI_HandleTypeDef *hspi);
+static void SPI_RxCloseIRQHandler(SPI_HandleTypeDef *hspi);
+static void SPI_2LinesRxISR(SPI_HandleTypeDef *hspi);
+static void SPI_RxISR(SPI_HandleTypeDef *hspi);
+static void SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAHalfTransmitCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAHalfReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAHalfTransmitReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAError(DMA_HandleTypeDef *hdma);
+static HAL_StatusTypeDef SPI_WaitOnFlagUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
+
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup SPI_Private_Functions
+  * @{
+  */
+
+/** @defgroup SPI_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This subsection provides a set of functions allowing to initialize and 
+          de-initialiaze the SPIx peripheral:
+
+      (+) User must Implement HAL_SPI_MspInit() function in which he configures 
+          all related peripherals resources (CLOCK, GPIO, DMA, IT and NVIC ).
+
+      (+) Call the function HAL_SPI_Init() to configure the selected device with 
+          the selected configuration:
+        (++) Mode
+        (++) Direction 
+        (++) Data Size
+        (++) Clock Polarity and Phase
+        (++) NSS Management
+        (++) BaudRate Prescaler
+        (++) FirstBit
+        (++) TIMode
+        (++) CRC Calculation
+        (++) CRC Polynomial if CRC enabled
+
+      (+) Call the function HAL_SPI_DeInit() to restore the default configuration 
+          of the selected SPIx periperal.       
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the SPI according to the specified parameters 
+  *         in the SPI_InitTypeDef and create the associated handle.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi)
+{
+  /* Check the SPI handle allocation */
+  if(hspi == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_SPI_MODE(hspi->Init.Mode));
+  assert_param(IS_SPI_DIRECTION_MODE(hspi->Init.Direction));
+  assert_param(IS_SPI_DATASIZE(hspi->Init.DataSize));
+  assert_param(IS_SPI_CPOL(hspi->Init.CLKPolarity));
+  assert_param(IS_SPI_CPHA(hspi->Init.CLKPhase));
+  assert_param(IS_SPI_NSS(hspi->Init.NSS));
+  assert_param(IS_SPI_BAUDRATE_PRESCALER(hspi->Init.BaudRatePrescaler));
+  assert_param(IS_SPI_FIRST_BIT(hspi->Init.FirstBit));
+  assert_param(IS_SPI_TIMODE(hspi->Init.TIMode));
+  assert_param(IS_SPI_CRC_CALCULATION(hspi->Init.CRCCalculation));
+  assert_param(IS_SPI_CRC_POLYNOMIAL(hspi->Init.CRCPolynomial));
+
+  if(hspi->State == HAL_SPI_STATE_RESET)
+  {
+    /* Init the low level hardware : GPIO, CLOCK, NVIC... */
+    HAL_SPI_MspInit(hspi);
+  }
+  
+  hspi->State = HAL_SPI_STATE_BUSY;
+
+  /* Disble the selected SPI peripheral */
+  __HAL_SPI_DISABLE(hspi);
+
+  /*----------------------- SPIx CR1 & CR2 Configuration ---------------------*/
+  /* Configure : SPI Mode, Communication Mode, Data size, Clock polarity and phase, NSS management,
+  Communication speed, First bit and CRC calculation state */
+  hspi->Instance->CR1 = (hspi->Init.Mode | hspi->Init.Direction | hspi->Init.DataSize |
+                         hspi->Init.CLKPolarity | hspi->Init.CLKPhase | (hspi->Init.NSS & SPI_CR1_SSM) |
+                         hspi->Init.BaudRatePrescaler | hspi->Init.FirstBit  | hspi->Init.CRCCalculation);
+
+  /* Configure : NSS management */
+  hspi->Instance->CR2 = (((hspi->Init.NSS >> 16) & SPI_CR2_SSOE) | hspi->Init.TIMode);
+
+  /*---------------------------- SPIx CRCPOLY Configuration ------------------*/
+  /* Configure : CRC Polynomial */
+  hspi->Instance->CRCPR = hspi->Init.CRCPolynomial;
+
+  /* Activate the SPI mode (Make sure that I2SMOD bit in I2SCFGR register is reset) */
+  hspi->Instance->I2SCFGR &= (uint32_t)~((uint32_t)SPI_I2SCFGR_I2SMOD);
+
+  hspi->ErrorCode = HAL_SPI_ERROR_NONE;
+  hspi->State = HAL_SPI_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the SPI peripheral 
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_DeInit(SPI_HandleTypeDef *hspi)
+{
+  /* Check the SPI handle allocation */
+  if(hspi == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  hspi->State = HAL_SPI_STATE_BUSY;
+
+  /* Disable the SPI Peripheral Clock */
+  __HAL_SPI_DISABLE(hspi);
+
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC... */
+  HAL_SPI_MspDeInit(hspi);
+
+  hspi->ErrorCode = HAL_SPI_ERROR_NONE;
+  hspi->State = HAL_SPI_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hspi);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief SPI MSP Init
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval None
+  */
+ __weak void HAL_SPI_MspInit(SPI_HandleTypeDef *hspi)
+ {
+   /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SPI_MspInit could be implenetd in the user file
+   */
+}
+
+/**
+  * @brief SPI MSP DeInit
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval None
+  */
+ __weak void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SPI_MspDeInit could be implenetd in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Group2 IO operation functions
+ *  @brief   Data transfers functions
+ *
+@verbatim
+  ==============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    This subsection provides a set of functions allowing to manage the SPI
+    data transfers.
+
+    [..] The SPI supports master and slave mode :
+
+    (#) There are two mode of transfer:
+       (++) Blocking mode: The communication is performed in polling mode.
+            The HAL status of all data processing is returned by the same function
+            after finishing transfer.
+       (++) No-Blocking mode: The communication is performed using Interrupts
+           or DMA, These API's return the HAL status.
+           The end of the data processing will be indicated through the 
+           dedicated SPI IRQ when using Interrupt mode or the DMA IRQ when 
+           using DMA mode.
+           The HAL_SPI_TxCpltCallback(), HAL_SPI_RxCpltCallback() and HAL_SPI_TxRxCpltCallback() user callbacks 
+           will be executed respectivelly at the end of the transmit or Receive process
+           The HAL_SPI_ErrorCallback()user callback will be executed when a communication error is detected
+
+    (#) Blocking mode API's are :
+        (++) HAL_SPI_Transmit()in 1Line (simplex) and 2Lines (full duplex) mode
+        (++) HAL_SPI_Receive() in 1Line (simplex) and 2Lines (full duplex) mode
+        (++) HAL_SPI_TransmitReceive() in full duplex mode
+
+    (#) Non-Blocking mode API's with Interrupt are :
+        (++) HAL_SPI_Transmit_IT()in 1Line (simplex) and 2Lines (full duplex) mode
+        (++) HAL_SPI_Receive_IT() in 1Line (simplex) and 2Lines (full duplex) mode
+        (++) HAL_SPI_TransmitReceive_IT()in full duplex mode
+        (++) HAL_SPI_IRQHandler()
+
+    (#) No-Blocking mode functions with DMA are :
+        (++) HAL_SPI_Transmit_DMA()in 1Line (simplex) and 2Lines (full duplex) mode
+        (++) HAL_SPI_Receive_DMA() in 1Line (simplex) and 2Lines (full duplex) mode
+        (++) HAL_SPI_TransmitReceie_DMA() in full duplex mode
+
+    (#) A set of Transfer Complete Callbacks are provided in No_Blocking mode:
+        (++) HAL_SPI_TxCpltCallback()
+        (++) HAL_SPI_RxCpltCallback()
+        (++) HAL_SPI_ErrorCallback()
+        (++) HAL_SPI_TxRxCpltCallback()
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Transmit an amount of data in blocking mode
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+
+  if(hspi->State == HAL_SPI_STATE_READY)
+  {
+    if((pData == NULL ) || (Size == 0)) 
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Check the parameters */
+    assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
+
+    /* Process Locked */
+    __HAL_LOCK(hspi);
+
+    /* Configure communication */
+    hspi->State = HAL_SPI_STATE_BUSY_TX;
+    hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+
+    hspi->pTxBuffPtr = pData;
+    hspi->TxXferSize = Size;
+    hspi->TxXferCount = Size;
+
+    /*Init field not used in handle to zero */
+    hspi->TxISR = 0;
+    hspi->RxISR = 0;
+    hspi->RxXferSize   = 0;
+    hspi->RxXferCount  = 0;
+
+    /* Reset CRC Calculation */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+    {
+      __HAL_SPI_RESET_CRC(hspi);
+    }
+
+    if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+    {
+      /* Configure communication direction : 1Line */
+      __HAL_SPI_1LINE_TX(hspi);
+    }
+
+    /* Check if the SPI is already enabled */ 
+    if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+    {
+      /* Enable SPI peripheral */
+      __HAL_SPI_ENABLE(hspi);
+    }
+
+    /* Transmit data in 8 Bit mode */
+    if(hspi->Init.DataSize == SPI_DATASIZE_8BIT)
+    {
+
+      if((hspi->Init.Mode == SPI_MODE_SLAVE)|| (hspi->TxXferCount == 0x01))
+      {
+        hspi->Instance->DR = (*hspi->pTxBuffPtr++);
+        hspi->TxXferCount--;
+      }
+
+      while(hspi->TxXferCount > 0)
+      {
+        /* Wait until TXE flag is set to send data */
+        if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_TXE, RESET, Timeout) != HAL_OK)
+        { 
+          return HAL_TIMEOUT;
+        }
+        hspi->Instance->DR = (*hspi->pTxBuffPtr++);
+        hspi->TxXferCount--;
+      }
+      /* Enable CRC Transmission */
+      if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED) 
+      {
+        hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+      }
+    }
+    /* Transmit data in 16 Bit mode */
+    else
+    {
+      if((hspi->Init.Mode == SPI_MODE_SLAVE) || (hspi->TxXferCount == 0x01))
+      {
+        hspi->Instance->DR = *((uint16_t*)hspi->pTxBuffPtr);
+        hspi->pTxBuffPtr+=2;
+        hspi->TxXferCount--;
+      }
+
+      while(hspi->TxXferCount > 0)
+      {
+        /* Wait until TXE flag is set to send data */
+        if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_TXE, RESET, Timeout) != HAL_OK)
+        { 
+          return HAL_TIMEOUT;
+        }
+        hspi->Instance->DR = *((uint16_t*)hspi->pTxBuffPtr);
+        hspi->pTxBuffPtr+=2;
+        hspi->TxXferCount--;
+      }
+      /* Enable CRC Transmission */
+      if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED) 
+      {
+        hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+      }
+    }
+
+    /* Wait until TXE flag is set to send data */
+    if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_TXE, RESET, Timeout) != HAL_OK)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+      return HAL_TIMEOUT;
+    }
+
+    /* Wait until Busy flag is reset before disabling SPI */
+    if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_BSY, SET, Timeout) != HAL_OK)
+    { 
+      hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+      return HAL_TIMEOUT;
+    }
+ 
+    /* Clear OVERUN flag in 2 Lines communication mode because received is not read */
+    if(hspi->Init.Direction == SPI_DIRECTION_2LINES)
+    {
+      __HAL_SPI_CLEAR_OVRFLAG(hspi);
+    }
+
+    hspi->State = HAL_SPI_STATE_READY; 
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive an amount of data in blocking mode 
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  __IO uint16_t tmpreg;
+  uint32_t tmp = 0;
+
+  if(hspi->State == HAL_SPI_STATE_READY)
+  {
+    if((pData == NULL ) || (Size == 0)) 
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hspi);
+
+    /* Configure communication */
+    hspi->State       = HAL_SPI_STATE_BUSY_RX;
+    hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+
+    hspi->pRxBuffPtr  = pData;
+    hspi->RxXferSize  = Size;
+    hspi->RxXferCount = Size;
+
+    /*Init field not used in handle to zero */
+    hspi->RxISR = 0;
+    hspi->TxISR = 0;
+    hspi->TxXferSize   = 0;
+    hspi->TxXferCount  = 0;
+
+    /* Configure communication direction : 1Line */
+    if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+    {
+      __HAL_SPI_1LINE_RX(hspi);
+    }
+
+    /* Reset CRC Calculation */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+    {
+      __HAL_SPI_RESET_CRC(hspi);
+    }
+    
+    if((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES))
+    {
+      /* Process Unlocked */
+      __HAL_UNLOCK(hspi);
+
+      /* Call transmit-receive function to send Dummy data on Tx line and generate clock on CLK line */
+      return HAL_SPI_TransmitReceive(hspi, pData, pData, Size, Timeout);
+    }
+
+    /* Check if the SPI is already enabled */ 
+    if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+    {
+      /* Enable SPI peripheral */
+      __HAL_SPI_ENABLE(hspi);
+    }
+
+    /* Receive data in 8 Bit mode */
+    if(hspi->Init.DataSize == SPI_DATASIZE_8BIT)
+    {
+      while(hspi->RxXferCount > 1)
+      {
+        /* Wait until RXNE flag is set */
+        if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+        { 
+          return HAL_TIMEOUT;
+        }
+
+        (*hspi->pRxBuffPtr++) = hspi->Instance->DR;
+        hspi->RxXferCount--;
+      }
+      /* Enable CRC Transmission */
+      if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED) 
+      {
+        hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+      }
+    }
+    /* Receive data in 16 Bit mode */
+    else
+    {
+      while(hspi->RxXferCount > 1)
+      {
+        /* Wait until RXNE flag is set to read data */
+        if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+        { 
+          return HAL_TIMEOUT;
+        }
+
+        *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+        hspi->pRxBuffPtr+=2;
+        hspi->RxXferCount--;
+      }
+      /* Enable CRC Transmission */
+      if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED) 
+      {
+        hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+      }
+    }
+
+    /* Wait until RXNE flag is set */
+    if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+    { 
+      return HAL_TIMEOUT;
+    }
+
+    /* Receive last data in 8 Bit mode */
+    if(hspi->Init.DataSize == SPI_DATASIZE_8BIT)
+    {
+      (*hspi->pRxBuffPtr++) = hspi->Instance->DR;
+    }
+    /* Receive last data in 16 Bit mode */
+    else
+    {
+      *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+      hspi->pRxBuffPtr+=2;
+    }
+    hspi->RxXferCount--;
+
+    /* Wait until RXNE flag is set: CRC Received */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+    {
+      if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+      {
+        hspi->ErrorCode |= HAL_SPI_ERROR_CRC;
+        return HAL_TIMEOUT;
+      }
+
+      /* Read CRC to Flush RXNE flag */
+      tmpreg = hspi->Instance->DR;
+    }
+    
+    if((hspi->Init.Mode == SPI_MODE_MASTER)&&((hspi->Init.Direction == SPI_DIRECTION_1LINE)||(hspi->Init.Direction == SPI_DIRECTION_2LINES_RXONLY)))
+    {
+      /* Disable SPI peripheral */
+      __HAL_SPI_DISABLE(hspi);
+    }
+
+    hspi->State = HAL_SPI_STATE_READY;
+
+    tmp = __HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR);
+    /* Check if CRC error occurred */
+    if((hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED) && (tmp != RESET))
+    {  
+      hspi->ErrorCode |= HAL_SPI_ERROR_CRC;
+
+      /* Reset CRC Calculation */
+      __HAL_SPI_RESET_CRC(hspi);
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hspi);
+
+      return HAL_ERROR; 
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmit and Receive an amount of data in blocking mode 
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @param  pTxData: pointer to transmission data buffer
+  * @param  pRxData: pointer to reception data buffer to be
+  * @param  Size: amount of data to be sent
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size, uint32_t Timeout)
+{
+  __IO uint16_t tmpreg;
+  uint32_t tmpstate = 0, tmp = 0;
+  
+  tmpstate = hspi->State; 
+  if((tmpstate == HAL_SPI_STATE_READY) || (tmpstate == HAL_SPI_STATE_BUSY_RX))
+  {
+    if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Check the parameters */
+    assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
+
+    /* Process Locked */
+    __HAL_LOCK(hspi);
+ 
+    /* Don't overwrite in case of HAL_SPI_STATE_BUSY_RX */
+    if(hspi->State == HAL_SPI_STATE_READY)
+    {
+      hspi->State = HAL_SPI_STATE_BUSY_TX_RX;
+    }
+
+     /* Configure communication */   
+    hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+
+    hspi->pRxBuffPtr  = pRxData;
+    hspi->RxXferSize  = Size;
+    hspi->RxXferCount = Size;  
+    
+    hspi->pTxBuffPtr  = pTxData;
+    hspi->TxXferSize  = Size; 
+    hspi->TxXferCount = Size;
+
+    /*Init field not used in handle to zero */
+    hspi->RxISR = 0;
+    hspi->TxISR = 0;
+
+    /* Reset CRC Calculation */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+    {
+      __HAL_SPI_RESET_CRC(hspi);
+    }
+
+    /* Check if the SPI is already enabled */ 
+    if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+    {
+      /* Enable SPI peripheral */
+      __HAL_SPI_ENABLE(hspi);
+    }
+
+    /* Transmit and Receive data in 16 Bit mode */
+    if(hspi->Init.DataSize == SPI_DATASIZE_16BIT)
+    {
+      if((hspi->Init.Mode == SPI_MODE_SLAVE) || ((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->TxXferCount == 0x01)))
+      {
+        hspi->Instance->DR = *((uint16_t*)hspi->pTxBuffPtr);
+        hspi->pTxBuffPtr+=2;
+        hspi->TxXferCount--;
+      }
+      if(hspi->TxXferCount == 0)
+      {
+        /* Enable CRC Transmission */
+        if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+        {
+          hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+        }
+
+        /* Wait until RXNE flag is set */
+        if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+        { 
+          return HAL_TIMEOUT;
+        }
+
+        *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+        hspi->pRxBuffPtr+=2;
+        hspi->RxXferCount--;
+      }
+      else
+      {
+        while(hspi->TxXferCount > 0)
+        {
+          /* Wait until TXE flag is set to send data */
+          if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_TXE, RESET, Timeout) != HAL_OK)
+          { 
+            return HAL_TIMEOUT;
+          }
+
+          hspi->Instance->DR = *((uint16_t*)hspi->pTxBuffPtr);
+          hspi->pTxBuffPtr+=2;
+          hspi->TxXferCount--;
+
+          /* Enable CRC Transmission */
+          if((hspi->TxXferCount == 0) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED))
+          {
+            hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+          }
+
+          /* Wait until RXNE flag is set */
+          if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+          { 
+            return HAL_TIMEOUT;
+          }
+          
+          *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+          hspi->pRxBuffPtr+=2;
+          hspi->RxXferCount--;
+        }
+        /* Receive the last byte */
+        if(hspi->Init.Mode == SPI_MODE_SLAVE)
+        {
+          /* Wait until RXNE flag is set */
+          if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+          {
+            return HAL_TIMEOUT;
+          }
+          
+          *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+          hspi->pRxBuffPtr+=2;
+          hspi->RxXferCount--;
+        }
+      }
+    }
+    /* Transmit and Receive data in 8 Bit mode */
+    else
+    {
+      if((hspi->Init.Mode == SPI_MODE_SLAVE) || ((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->TxXferCount == 0x01)))
+      {
+        hspi->Instance->DR = (*hspi->pTxBuffPtr++);
+        hspi->TxXferCount--;
+      }
+      if(hspi->TxXferCount == 0)
+      {
+        /* Enable CRC Transmission */
+        if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+        {
+          hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+        }
+
+        /* Wait until RXNE flag is set */
+        if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+
+        (*hspi->pRxBuffPtr) = hspi->Instance->DR;
+        hspi->RxXferCount--;
+      }
+      else
+      {
+        while(hspi->TxXferCount > 0)
+        {
+          /* Wait until TXE flag is set to send data */
+          if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_TXE, RESET, Timeout) != HAL_OK)
+          {
+            return HAL_TIMEOUT;
+          }
+
+          hspi->Instance->DR = (*hspi->pTxBuffPtr++);
+          hspi->TxXferCount--;
+
+          /* Enable CRC Transmission */
+          if((hspi->TxXferCount == 0) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED))
+          {
+            hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+          }
+
+            /* Wait until RXNE flag is set */
+            if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+            {
+              return HAL_TIMEOUT;
+            }
+            
+            (*hspi->pRxBuffPtr++) = hspi->Instance->DR;
+            hspi->RxXferCount--;
+        }
+        if(hspi->Init.Mode == SPI_MODE_SLAVE)
+        {
+          /* Wait until RXNE flag is set */
+          if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+          {
+            return HAL_TIMEOUT;
+          }
+          
+          (*hspi->pRxBuffPtr++) = hspi->Instance->DR;
+          hspi->RxXferCount--;
+        }
+      }
+    }
+
+    /* Read CRC from DR to close CRC calculation process */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+    {
+      /* Wait until RXNE flag is set */
+      if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+      {
+        hspi->ErrorCode |= HAL_SPI_ERROR_CRC;
+        return HAL_TIMEOUT;
+      }
+      /* Read CRC */
+      tmpreg = hspi->Instance->DR;
+    }
+
+    /* Wait until Busy flag is reset before disabling SPI */
+    if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_BSY, SET, Timeout) != HAL_OK)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+      return HAL_TIMEOUT;
+    }
+    
+    hspi->State = HAL_SPI_STATE_READY;
+
+    tmp = __HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR);
+    /* Check if CRC error occurred */
+    if((hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED) && (tmp != RESET))
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_CRC;
+
+      /* Reset CRC Calculation */
+      if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+      {
+        __HAL_SPI_RESET_CRC(hspi);
+      }
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hspi);
+      
+      return HAL_ERROR; 
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmit an amount of data in no-blocking mode with Interrupt
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+{
+  if(hspi->State == HAL_SPI_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Check the parameters */
+    assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
+
+    /* Process Locked */
+    __HAL_LOCK(hspi);
+
+    /* Configure communication */
+    hspi->State        = HAL_SPI_STATE_BUSY_TX;
+    hspi->ErrorCode    = HAL_SPI_ERROR_NONE;
+
+    hspi->TxISR = &SPI_TxISR;
+    hspi->pTxBuffPtr   = pData;
+    hspi->TxXferSize   = Size;
+    hspi->TxXferCount  = Size;
+
+    /*Init field not used in handle to zero */
+    hspi->RxISR = 0;
+    hspi->RxXferSize   = 0;
+    hspi->RxXferCount  = 0;
+
+    /* Configure communication direction : 1Line */
+    if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+    {
+      __HAL_SPI_1LINE_TX(hspi);
+    }
+
+    /* Reset CRC Calculation */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+    {
+      __HAL_SPI_RESET_CRC(hspi);
+    }
+
+    if (hspi->Init.Direction == SPI_DIRECTION_2LINES)
+    {
+      __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_TXE));
+    }else
+    {
+      /* Enable TXE and ERR interrupt */
+      __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_ERR));
+    }
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+
+    /* Check if the SPI is already enabled */ 
+    if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+    {
+      /* Enable SPI peripheral */
+      __HAL_SPI_ENABLE(hspi);
+    }
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive an amount of data in no-blocking mode with Interrupt
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+{
+  if(hspi->State == HAL_SPI_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hspi);
+
+    /* Configure communication */
+    hspi->State        = HAL_SPI_STATE_BUSY_RX;
+    hspi->ErrorCode    = HAL_SPI_ERROR_NONE;
+
+    hspi->RxISR = &SPI_RxISR;
+    hspi->pRxBuffPtr   = pData;
+    hspi->RxXferSize   = Size;
+    hspi->RxXferCount  = Size ; 
+
+   /*Init field not used in handle to zero */
+    hspi->TxISR = 0;
+    hspi->TxXferSize   = 0;
+    hspi->TxXferCount  = 0;
+
+    /* Configure communication direction : 1Line */
+    if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+    {
+       __HAL_SPI_1LINE_RX(hspi);
+    }
+    else if((hspi->Init.Direction == SPI_DIRECTION_2LINES) && (hspi->Init.Mode == SPI_MODE_MASTER))
+    {
+       /* Process Unlocked */
+       __HAL_UNLOCK(hspi);
+
+       /* Call transmit-receive function to send Dummy data on Tx line and generate clock on CLK line */
+       return HAL_SPI_TransmitReceive_IT(hspi, pData, pData, Size);
+    }
+
+    /* Reset CRC Calculation */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+    {
+      __HAL_SPI_RESET_CRC(hspi);
+    }
+
+    /* Enable TXE and ERR interrupt */
+    __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_RXNE | SPI_IT_ERR));
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+
+    /* Note : The SPI must be enabled after unlocking current process 
+              to avoid the risk of SPI interrupt handle execution before current
+              process unlock */
+
+        /* Check if the SPI is already enabled */ 
+    if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+    {
+      /* Enable SPI peripheral */
+      __HAL_SPI_ENABLE(hspi);
+    }
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief  Transmit and Receive an amount of data in no-blocking mode with Interrupt 
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @param  pTxData: pointer to transmission data buffer
+  * @param  pRxData: pointer to reception data buffer to be
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size)
+{
+ uint32_t tmpstate = 0;
+
+ tmpstate = hspi->State;
+  if((tmpstate == HAL_SPI_STATE_READY) || \
+     ((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES) && (tmpstate == HAL_SPI_STATE_BUSY_RX)))
+  {
+    if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0)) 
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Check the parameters */
+    assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
+
+    /* Process locked */
+    __HAL_LOCK(hspi);
+
+    /* Don't overwrite in case of HAL_SPI_STATE_BUSY_RX */
+    if(hspi->State != HAL_SPI_STATE_BUSY_RX)
+    {
+      hspi->State = HAL_SPI_STATE_BUSY_TX_RX;
+    }
+
+    /* Configure communication */
+    hspi->ErrorCode    = HAL_SPI_ERROR_NONE;
+
+    hspi->TxISR = &SPI_TxISR;
+    hspi->pTxBuffPtr   = pTxData;
+    hspi->TxXferSize   = Size;
+    hspi->TxXferCount  = Size;
+
+    hspi->RxISR = &SPI_2LinesRxISR;
+    hspi->pRxBuffPtr   = pRxData;
+    hspi->RxXferSize   = Size;
+    hspi->RxXferCount  = Size;
+
+    /* Reset CRC Calculation */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+    {
+      __HAL_SPI_RESET_CRC(hspi);
+    }
+
+    /* Enable TXE, RXNE and ERR interrupt */
+    __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+
+    /* Check if the SPI is already enabled */ 
+    if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+    {
+      /* Enable SPI peripheral */
+      __HAL_SPI_ENABLE(hspi);
+    }
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief  Transmit an amount of data in no-blocking mode with DMA
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+{
+  if(hspi->State == HAL_SPI_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Check the parameters */
+    assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
+
+    /* Process Locked */
+    __HAL_LOCK(hspi);
+
+    /* Configure communication */
+    hspi->State       = HAL_SPI_STATE_BUSY_TX;
+    hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+
+    hspi->pTxBuffPtr  = pData;
+    hspi->TxXferSize  = Size;
+    hspi->TxXferCount = Size;
+
+    /*Init field not used in handle to zero */
+    hspi->TxISR = 0;
+    hspi->RxISR = 0;
+    hspi->RxXferSize   = 0;
+    hspi->RxXferCount  = 0;
+
+    /* Configure communication direction : 1Line */
+    if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+    {
+      __HAL_SPI_1LINE_TX(hspi);
+    }
+
+    /* Reset CRC Calculation */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+    {
+      __HAL_SPI_RESET_CRC(hspi);
+    }
+    
+    /* Set the SPI TxDMA Half transfer complete callback */
+    hspi->hdmatx->XferHalfCpltCallback = SPI_DMAHalfTransmitCplt;
+    
+    /* Set the SPI TxDMA transfer complete callback */
+    hspi->hdmatx->XferCpltCallback = SPI_DMATransmitCplt;
+
+    /* Set the DMA error callback */
+    hspi->hdmatx->XferErrorCallback = SPI_DMAError;
+
+    /* Enable the Tx DMA Stream */
+    HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->DR, hspi->TxXferCount);
+
+    /* Enable Tx DMA Request */
+    hspi->Instance->CR2 |= SPI_CR2_TXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+
+    /* Check if the SPI is already enabled */ 
+    if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+    {
+      /* Enable SPI peripheral */
+      __HAL_SPI_ENABLE(hspi);
+    }
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Receive an amount of data in no-blocking mode with DMA 
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @param  pData: pointer to data buffer
+  * @note  When the CRC feature is enabled the pData Length must be Size + 1. 
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+{
+  if(hspi->State == HAL_SPI_STATE_READY)
+  {
+    if((pData == NULL) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(hspi);
+
+    /* Configure communication */
+    hspi->State       = HAL_SPI_STATE_BUSY_RX;
+    hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+
+    hspi->pRxBuffPtr  = pData;
+    hspi->RxXferSize  = Size;
+    hspi->RxXferCount = Size;
+
+    /*Init field not used in handle to zero */
+    hspi->RxISR = 0;
+    hspi->TxISR = 0;
+    hspi->TxXferSize   = 0;
+    hspi->TxXferCount  = 0;
+
+    /* Configure communication direction : 1Line */
+    if(hspi->Init.Direction == SPI_DIRECTION_1LINE)
+    {
+       __HAL_SPI_1LINE_RX(hspi);
+    }
+    else if((hspi->Init.Direction == SPI_DIRECTION_2LINES)&&(hspi->Init.Mode == SPI_MODE_MASTER))
+    {
+       /* Process Unlocked */
+       __HAL_UNLOCK(hspi);
+
+       /* Call transmit-receive function to send Dummy data on Tx line and generate clock on CLK line */
+       return HAL_SPI_TransmitReceive_DMA(hspi, pData, pData, Size);
+    }
+
+    /* Reset CRC Calculation */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+    {
+      __HAL_SPI_RESET_CRC(hspi);
+    }
+    
+    /* Set the SPI RxDMA Half transfer complete callback */
+    hspi->hdmarx->XferHalfCpltCallback = SPI_DMAHalfReceiveCplt;
+    
+    /* Set the SPI Rx DMA transfer complete callback */
+    hspi->hdmarx->XferCpltCallback = SPI_DMAReceiveCplt;
+
+    /* Set the DMA error callback */
+    hspi->hdmarx->XferErrorCallback = SPI_DMAError;
+
+    /* Enable the Rx DMA Stream */
+    HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->DR, (uint32_t)hspi->pRxBuffPtr, hspi->RxXferCount);
+
+    /* Enable Rx DMA Request */  
+    hspi->Instance->CR2 |= SPI_CR2_RXDMAEN;  
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+
+    /* Check if the SPI is already enabled */ 
+    if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+    {
+      /* Enable SPI peripheral */
+      __HAL_SPI_ENABLE(hspi);
+    }
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Transmit and Receive an amount of data in no-blocking mode with DMA 
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @param  pTxData: pointer to transmission data buffer
+  * @param  pRxData: pointer to reception data buffer
+  * @note  When the CRC feature is enabled the pRxData Length must be Size + 1 
+  * @param  Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size)
+{
+  uint32_t tmpstate = 0;
+  tmpstate = hspi->State;
+  if((tmpstate == HAL_SPI_STATE_READY) || ((hspi->Init.Mode == SPI_MODE_MASTER) && \
+     (hspi->Init.Direction == SPI_DIRECTION_2LINES) && (tmpstate == HAL_SPI_STATE_BUSY_RX)))
+  {
+    if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Check the parameters */
+    assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
+    
+    /* Process locked */
+    __HAL_LOCK(hspi);
+
+    /* Don't overwrite in case of HAL_SPI_STATE_BUSY_RX */
+    if(hspi->State != HAL_SPI_STATE_BUSY_RX)
+    {
+      hspi->State = HAL_SPI_STATE_BUSY_TX_RX;
+    }
+
+    /* Configure communication */
+    hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
+
+    hspi->pTxBuffPtr  = (uint8_t*)pTxData;
+    hspi->TxXferSize  = Size;
+    hspi->TxXferCount = Size;
+
+    hspi->pRxBuffPtr  = (uint8_t*)pRxData;
+    hspi->RxXferSize  = Size;
+    hspi->RxXferCount = Size;
+
+    /*Init field not used in handle to zero */
+    hspi->RxISR = 0;
+    hspi->TxISR = 0;
+
+    /* Reset CRC Calculation */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+    {
+      __HAL_SPI_RESET_CRC(hspi);
+    }
+
+    /* Check if we are in Rx only or in Rx/Tx Mode and configure the DMA transfer complete callback */
+    if(hspi->State == HAL_SPI_STATE_BUSY_RX)
+    {
+      /* Set the SPI Rx DMA Half transfer complete callback */
+      hspi->hdmarx->XferHalfCpltCallback = SPI_DMAHalfReceiveCplt;
+      
+      hspi->hdmarx->XferCpltCallback = SPI_DMAReceiveCplt;
+    }
+    else
+    {
+      /* Set the SPI Tx/Rx DMA Half transfer complete callback */
+      hspi->hdmarx->XferHalfCpltCallback = SPI_DMAHalfTransmitReceiveCplt;
+      
+      hspi->hdmarx->XferCpltCallback = SPI_DMATransmitReceiveCplt;
+    }
+
+    /* Set the DMA error callback */
+    hspi->hdmarx->XferErrorCallback = SPI_DMAError;
+
+    /* Enable the Rx DMA Stream */
+    HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->DR, (uint32_t)hspi->pRxBuffPtr, hspi->RxXferCount);
+
+    /* Enable Rx DMA Request */  
+    hspi->Instance->CR2 |= SPI_CR2_RXDMAEN;
+
+    /* Set the SPI Tx DMA transfer complete callback as NULL because the communication closing
+    is performed in DMA reception complete callback  */
+    hspi->hdmatx->XferCpltCallback = NULL;
+
+    /* Set the DMA error callback */
+    hspi->hdmatx->XferErrorCallback = SPI_DMAError;
+
+    /* Enable the Tx DMA Stream */
+    HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->DR, hspi->TxXferCount);
+
+    /* Check if the SPI is already enabled */ 
+    if((hspi->Instance->CR1 &SPI_CR1_SPE) != SPI_CR1_SPE)
+    {
+      /* Enable SPI peripheral */
+      __HAL_SPI_ENABLE(hspi);
+    }
+
+    /* Enable Tx DMA Request */  
+    hspi->Instance->CR2 |= SPI_CR2_TXDMAEN;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Pauses the DMA Transfer.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for the specified SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_DMAPause(SPI_HandleTypeDef *hspi)
+{
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+  
+  /* Disable the SPI DMA Tx & Rx requests */
+  hspi->Instance->CR2 &= (uint32_t)(~SPI_CR2_TXDMAEN);
+  hspi->Instance->CR2 &= (uint32_t)(~SPI_CR2_RXDMAEN);
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+  
+  return HAL_OK; 
+}
+
+/**
+  * @brief Resumes the DMA Transfer.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for the specified SPI module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_DMAResume(SPI_HandleTypeDef *hspi)
+{
+  /* Process Locked */
+  __HAL_LOCK(hspi);
+  
+  /* Enable the SPI DMA Tx & Rx requests */
+  hspi->Instance->CR2 |= SPI_CR2_TXDMAEN;
+  hspi->Instance->CR2 |= SPI_CR2_RXDMAEN;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief Stops the DMA Transfer.
+  * @param  huart: pointer to a UART_HandleTypeDef structure that contains
+  *                the configuration information for the specified UART module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SPI_DMAStop(SPI_HandleTypeDef *hspi)
+{
+  /* The Lock is not implemented on this API to allow the user application
+     to call the HAL SPI API under callbacks HAL_SPI_TxCpltCallback() or HAL_SPI_RxCpltCallback() or HAL_SPI_TxRxCpltCallback():
+     when calling HAL_DMA_Abort() API the DMA TX/RX Transfer complete interrupt is generated
+     and the correspond call back is executed HAL_SPI_TxCpltCallback() or HAL_SPI_RxCpltCallback() or HAL_SPI_TxRxCpltCallback()
+     */
+  
+  /* Abort the SPI DMA tx Stream */
+  if(hspi->hdmatx != NULL)
+  {
+    HAL_DMA_Abort(hspi->hdmatx);
+  }
+  /* Abort the SPI DMA rx Stream */
+  if(hspi->hdmarx != NULL)
+  {
+    HAL_DMA_Abort(hspi->hdmarx);
+  }
+  
+  /* Disable the SPI DMA Tx & Rx requests */
+  hspi->Instance->CR2 &= (uint32_t)(~SPI_CR2_TXDMAEN);
+  hspi->Instance->CR2 &= (uint32_t)(~SPI_CR2_RXDMAEN);
+  
+  hspi->State = HAL_SPI_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles SPI interrupt request.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval HAL status
+  */
+void HAL_SPI_IRQHandler(SPI_HandleTypeDef *hspi)
+{
+  uint32_t tmp1 = 0, tmp2 = 0, tmp3 = 0;
+
+  tmp1 = __HAL_SPI_GET_FLAG(hspi, SPI_FLAG_RXNE);
+  tmp2 = __HAL_SPI_GET_IT_SOURCE(hspi, SPI_IT_RXNE);
+  tmp3 = __HAL_SPI_GET_FLAG(hspi, SPI_FLAG_OVR);
+  /* SPI in mode Receiver and Overrun not occurred ---------------------------*/
+  if((tmp1 != RESET) && (tmp2 != RESET) && (tmp3 == RESET))
+  {
+    hspi->RxISR(hspi);
+    return;
+  } 
+
+  tmp1 = __HAL_SPI_GET_FLAG(hspi, SPI_FLAG_TXE);
+  tmp2 = __HAL_SPI_GET_IT_SOURCE(hspi, SPI_IT_TXE);
+  /* SPI in mode Tramitter ---------------------------------------------------*/
+  if((tmp1 != RESET) && (tmp2 != RESET))
+  {
+    hspi->TxISR(hspi);
+    return;
+  }
+
+  if(__HAL_SPI_GET_IT_SOURCE(hspi, SPI_IT_ERR) != RESET)
+  {
+    /* SPI CRC error interrupt occured ---------------------------------------*/
+    if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_CRC;
+      __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+    }
+    /* SPI Mode Fault error interrupt occured --------------------------------*/
+    if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_MODF) != RESET)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_MODF;
+      __HAL_SPI_CLEAR_MODFFLAG(hspi);
+    }
+    
+    /* SPI Overrun error interrupt occured -----------------------------------*/
+    if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_OVR) != RESET)
+    {
+      if(hspi->State != HAL_SPI_STATE_BUSY_TX)
+      {
+        hspi->ErrorCode |= HAL_SPI_ERROR_OVR;
+        __HAL_SPI_CLEAR_OVRFLAG(hspi);      
+      }
+    }
+
+    /* SPI Frame error interrupt occured -------------------------------------*/
+    if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_FRE) != RESET)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_FRE;
+      __HAL_SPI_CLEAR_FREFLAG(hspi);
+    }
+
+    /* Call the Error call Back in case of Errors */
+    if(hspi->ErrorCode!=HAL_SPI_ERROR_NONE)
+    {
+      hspi->State = HAL_SPI_STATE_READY;
+      HAL_SPI_ErrorCallback(hspi);
+    }
+  }
+}
+
+/**
+  * @brief Tx Transfer completed callbacks
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SPI_TxCpltCallback could be implenetd in the user file
+   */
+}
+
+/**
+  * @brief Rx Transfer completed callbacks
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SPI_RxCpltCallback() could be implenetd in the user file
+   */
+}
+
+/**
+  * @brief Tx and Rx Transfer completed callbacks
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SPI_TxRxCpltCallback() could be implenetd in the user file
+   */
+}
+
+/**
+  * @brief Tx Half Transfer completed callbacks
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_TxHalfCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SPI_TxHalfCpltCallback could be implenetd in the user file
+   */
+}
+
+/**
+  * @brief Rx Half Transfer completed callbacks
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_RxHalfCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SPI_RxHalfCpltCallback() could be implenetd in the user file
+   */
+}
+
+/**
+  * @brief Tx and Rx Transfer completed callbacks
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval None
+  */
+__weak void HAL_SPI_TxRxHalfCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SPI_TxRxHalfCpltCallback() could be implenetd in the user file
+   */
+}
+
+/**
+  * @brief SPI error callbacks
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval None
+  */
+ __weak void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : - This function Should not be modified, when the callback is needed,
+            the HAL_SPI_ErrorCallback() could be implenetd in the user file.
+            - The ErrorCode parameter in the hspi handle is updated by the SPI processes
+            and user can use HAL_SPI_GetError() API to check the latest error occured.
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Group3 Peripheral State and Errors functions 
+  *  @brief   SPI control functions 
+  *
+@verbatim
+ ===============================================================================
+                      ##### Peripheral State and Errors functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to control the SPI.
+     (+) HAL_SPI_GetState() API can be helpful to check in run-time the state of the SPI peripheral
+     (+) HAL_SPI_GetError() check in run-time Errors occurring during communication
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the SPI state
+  * @param  hspi : SPI handle
+  * @retval SPI state
+  */
+HAL_SPI_StateTypeDef HAL_SPI_GetState(SPI_HandleTypeDef *hspi)
+{
+  return hspi->State;
+}
+
+/**
+  * @brief  Return the SPI error code
+  * @param  hspi : SPI handle
+  * @retval SPI Error Code
+  */
+HAL_SPI_ErrorTypeDef HAL_SPI_GetError(SPI_HandleTypeDef *hspi)
+{
+  return hspi->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+  /**
+  * @brief  Interrupt Handler to close Tx transfer 
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval void
+  */
+static void SPI_TxCloseIRQHandler(SPI_HandleTypeDef *hspi)
+{
+  /* Wait until TXE flag is set to send data */
+  if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_TXE, RESET, SPI_TIMEOUT_VALUE) != HAL_OK)
+  {
+    hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+  }
+
+  /* Disable TXE interrupt */
+  __HAL_SPI_DISABLE_IT(hspi, (uint32_t)SPI_IT_TXE);
+
+  /* Disable ERR interrupt if Receive process is finished */
+  if(__HAL_SPI_GET_IT_SOURCE(hspi, SPI_IT_RXNE) == RESET)
+  {
+    __HAL_SPI_DISABLE_IT(hspi, (uint32_t)SPI_IT_ERR);
+
+    /* Wait until Busy flag is reset before disabling SPI */
+    if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_BSY, SET, SPI_TIMEOUT_VALUE) != HAL_OK)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    }
+
+    /* Clear OVERUN flag in 2 Lines communication mode because received is not read */
+    if(hspi->Init.Direction == SPI_DIRECTION_2LINES)
+    {
+      __HAL_SPI_CLEAR_OVRFLAG(hspi);
+    }
+    
+    /* Check if Errors has been detected during transfer */
+    if(hspi->ErrorCode ==  HAL_SPI_ERROR_NONE)
+    {
+      /* Check if we are in Tx or in Rx/Tx Mode */
+      if(hspi->State == HAL_SPI_STATE_BUSY_TX_RX)
+      {
+        /* Set state to READY before run the Callback Complete */
+        hspi->State = HAL_SPI_STATE_READY;
+        HAL_SPI_TxRxCpltCallback(hspi);
+      }
+      else
+      {
+        /* Set state to READY before run the Callback Complete */
+        hspi->State = HAL_SPI_STATE_READY;
+        HAL_SPI_TxCpltCallback(hspi);
+      }
+    }
+    else
+    {
+      /* Set state to READY before run the Callback Complete */
+      hspi->State = HAL_SPI_STATE_READY;
+      /* Call Error call back in case of Error */
+      HAL_SPI_ErrorCallback(hspi);
+    }
+  }
+}
+
+/**
+  * @brief  Interrupt Handler to transmit amount of data in no-blocking mode 
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval void
+  */
+static void SPI_TxISR(SPI_HandleTypeDef *hspi)
+{
+  /* Transmit data in 8 Bit mode */
+  if(hspi->Init.DataSize == SPI_DATASIZE_8BIT)
+  {
+    hspi->Instance->DR = (*hspi->pTxBuffPtr++);
+  }
+  /* Transmit data in 16 Bit mode */
+  else
+  {
+    hspi->Instance->DR = *((uint16_t*)hspi->pTxBuffPtr);
+    hspi->pTxBuffPtr+=2;
+  }
+  hspi->TxXferCount--;
+
+  if(hspi->TxXferCount == 0)
+  {
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+    {
+      /* calculate and transfer CRC on Tx line */
+      hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;
+    }
+    SPI_TxCloseIRQHandler(hspi);
+  }
+}
+
+/**
+  * @brief  Interrupt Handler to close Rx transfer 
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval void
+  */
+static void SPI_RxCloseIRQHandler(SPI_HandleTypeDef *hspi)
+{
+  __IO uint16_t tmpreg;
+
+  if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+  {
+    /* Wait until RXNE flag is set to send data */
+    if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, RESET, SPI_TIMEOUT_VALUE) != HAL_OK)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    }
+
+    /* Read CRC to reset RXNE flag */
+    tmpreg = hspi->Instance->DR;
+
+    /* Wait until RXNE flag is set to send data */
+    if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, SET, SPI_TIMEOUT_VALUE) != HAL_OK)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    }
+
+    /* Check if CRC error occurred */
+    if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_CRC;
+
+      /* Reset CRC Calculation */
+      __HAL_SPI_RESET_CRC(hspi);
+    }
+  }
+
+  /* Disable RXNE and ERR interrupt */
+  __HAL_SPI_DISABLE_IT(hspi, (uint32_t)(SPI_IT_RXNE));
+
+  /* if Transmit process is finished */
+  if(__HAL_SPI_GET_IT_SOURCE(hspi, SPI_IT_TXE) == RESET)
+  {
+    /* Disable ERR interrupt */
+    __HAL_SPI_DISABLE_IT(hspi, (uint32_t)(SPI_IT_ERR));
+
+    if((hspi->Init.Mode == SPI_MODE_MASTER)&&((hspi->Init.Direction == SPI_DIRECTION_1LINE)||(hspi->Init.Direction == SPI_DIRECTION_2LINES_RXONLY)))
+    {
+      /* Disable SPI peripheral */
+      __HAL_SPI_DISABLE(hspi);
+    }
+    
+    /* Check if Errors has been detected during transfer */
+    if(hspi->ErrorCode ==  HAL_SPI_ERROR_NONE)
+    {
+      /* Check if we are in Rx or in Rx/Tx Mode */
+      if(hspi->State == HAL_SPI_STATE_BUSY_TX_RX)
+      {
+        /* Set state to READY before run the Callback Complete */
+        hspi->State = HAL_SPI_STATE_READY;
+        HAL_SPI_TxRxCpltCallback(hspi);
+      }
+      else
+      {
+        /* Set state to READY before run the Callback Complete */
+        hspi->State = HAL_SPI_STATE_READY;
+        HAL_SPI_RxCpltCallback(hspi);
+      }
+    }
+    else
+    {
+      /* Set state to READY before run the Callback Complete */
+      hspi->State = HAL_SPI_STATE_READY;
+      /* Call Error call back in case of Error */
+      HAL_SPI_ErrorCallback(hspi);
+    }
+  }
+}
+
+/**
+  * @brief  Interrupt Handler to receive amount of data in 2Lines mode 
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval void
+  */
+static void SPI_2LinesRxISR(SPI_HandleTypeDef *hspi)
+{
+  /* Receive data in 8 Bit mode */
+  if(hspi->Init.DataSize == SPI_DATASIZE_8BIT)
+  {
+    (*hspi->pRxBuffPtr++) = hspi->Instance->DR;
+  }
+  /* Receive data in 16 Bit mode */
+  else
+  {
+    *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+    hspi->pRxBuffPtr+=2;
+  }
+  hspi->RxXferCount--;
+
+  if(hspi->RxXferCount==0)
+  {
+    SPI_RxCloseIRQHandler(hspi);
+  }
+}
+
+/**
+  * @brief  Interrupt Handler to receive amount of data in no-blocking mode 
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval void
+  */
+static void SPI_RxISR(SPI_HandleTypeDef *hspi)
+{
+  /* Receive data in 8 Bit mode */
+  if(hspi->Init.DataSize == SPI_DATASIZE_8BIT)
+  {
+    (*hspi->pRxBuffPtr++) = hspi->Instance->DR;
+  }
+  /* Receive data in 16 Bit mode */
+  else
+  {
+    *((uint16_t*)hspi->pRxBuffPtr) = hspi->Instance->DR;
+    hspi->pRxBuffPtr+=2;
+  }
+    hspi->RxXferCount--;
+
+  /* Enable CRC Transmission */
+  if((hspi->RxXferCount == 1) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED))
+  {
+    /* Set CRC Next to calculate CRC on Rx side */
+    hspi->Instance->CR1 |= SPI_CR1_CRCNEXT;  
+  }
+
+  if(hspi->RxXferCount == 0)
+  {
+    SPI_RxCloseIRQHandler(hspi);
+  }
+}
+
+/**
+  * @brief DMA SPI transmit process complete callback 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+
+  /* DMA Normal Mode */
+  if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+  {
+    /* Wait until TXE flag is set to send data */
+    if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_TXE, RESET, SPI_TIMEOUT_VALUE) != HAL_OK)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    }
+    
+    /* Disable Tx DMA Request */
+    hspi->Instance->CR2 &= (uint32_t)~((uint32_t)SPI_CR2_TXDMAEN);
+
+    /* Wait until Busy flag is reset before disabling SPI */
+    if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_BSY, SET, SPI_TIMEOUT_VALUE) != HAL_OK)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    }
+
+    hspi->TxXferCount = 0;
+
+    hspi->State = HAL_SPI_STATE_READY;
+  }
+
+  /* Clear OVERUN flag in 2 Lines communication mode because received is not read */
+  if(hspi->Init.Direction == SPI_DIRECTION_2LINES)
+  {
+   __HAL_SPI_CLEAR_OVRFLAG(hspi);
+  }
+
+  /* Check if Errors has been detected during transfer */
+  if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+  {
+    HAL_SPI_ErrorCallback(hspi);
+  }
+  else
+  {
+    HAL_SPI_TxCpltCallback(hspi);
+  }
+}
+
+/**
+  * @brief DMA SPI receive process complete callback 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  __IO uint16_t tmpreg;
+
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  /* DMA Normal mode */
+  if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+  {
+    if((hspi->Init.Mode == SPI_MODE_MASTER)&&((hspi->Init.Direction == SPI_DIRECTION_1LINE)||(hspi->Init.Direction == SPI_DIRECTION_2LINES_RXONLY)))
+    {
+      /* Disable SPI peripheral */
+      __HAL_SPI_DISABLE(hspi);
+    }
+
+    /* Disable Rx DMA Request */
+    hspi->Instance->CR2 &= (uint32_t)~((uint32_t)SPI_CR2_RXDMAEN);
+    /* Disable Tx DMA Request (done by default to handle the case Master RX direction 2 lines) */
+    hspi->Instance->CR2 &= (uint32_t)~((uint32_t)SPI_CR2_TXDMAEN);
+
+    hspi->RxXferCount = 0;
+    hspi->State = HAL_SPI_STATE_READY;
+
+    /* Reset CRC Calculation */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+    {
+      /* Wait until RXNE flag is set to send data */
+      if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, RESET, SPI_TIMEOUT_VALUE) != HAL_OK)
+      {
+        hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+      }
+
+      /* Read CRC */
+      tmpreg = hspi->Instance->DR;
+
+      /* Wait until RXNE flag is set */
+      if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, SET, SPI_TIMEOUT_VALUE) != HAL_OK)
+      {
+        hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+      }
+
+      /* Check if CRC error occurred */
+      if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+      {
+        hspi->ErrorCode |= HAL_SPI_ERROR_CRC;
+        __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+      }
+    }
+
+    /* Check if Errors has been detected during transfer */
+    if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+    {
+      HAL_SPI_ErrorCallback(hspi);
+    }
+    else
+    {
+      HAL_SPI_RxCpltCallback(hspi);
+    }
+  }
+  else
+  {
+    HAL_SPI_RxCpltCallback(hspi);
+  }  
+}
+
+/**
+  * @brief DMA SPI transmit receive process complete callback 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma)   
+{
+  __IO uint16_t tmpreg;
+
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+  {
+    /* Reset CRC Calculation */
+    if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+    {
+      /* Check if CRC is done on going (RXNE flag set) */
+      if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, SET, SPI_TIMEOUT_VALUE) == HAL_OK)
+      {
+        /* Wait until RXNE flag is set to send data */
+        if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_RXNE, RESET, SPI_TIMEOUT_VALUE) != HAL_OK)
+        {
+          hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+        }
+      }
+      /* Read CRC */
+      tmpreg = hspi->Instance->DR;
+
+      /* Check if CRC error occurred */
+      if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
+      {
+        hspi->ErrorCode |= HAL_SPI_ERROR_CRC;
+        __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
+      }
+    }
+    /* Wait until TXE flag is set to send data */
+    if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_TXE, RESET, SPI_TIMEOUT_VALUE) != HAL_OK)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    }
+  
+    /* Disable Tx DMA Request */
+    hspi->Instance->CR2 &= (uint32_t)~((uint32_t)SPI_CR2_TXDMAEN);
+
+    /* Wait until Busy flag is reset before disabling SPI */
+    if(SPI_WaitOnFlagUntilTimeout(hspi, SPI_FLAG_BSY, SET, SPI_TIMEOUT_VALUE) != HAL_OK)
+    {
+      hspi->ErrorCode |= HAL_SPI_ERROR_FLAG;
+    }
+
+    /* Disable Rx DMA Request */
+    hspi->Instance->CR2 &= (uint32_t)~((uint32_t)SPI_CR2_RXDMAEN);
+
+    hspi->TxXferCount = 0;
+    hspi->RxXferCount = 0;
+
+    hspi->State = HAL_SPI_STATE_READY;
+
+    /* Check if Errors has been detected during transfer */
+    if(hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+    {
+      HAL_SPI_ErrorCallback(hspi);
+    }
+    else
+    {
+      HAL_SPI_TxRxCpltCallback(hspi);
+    }
+  }
+  else
+  {
+    HAL_SPI_TxRxCpltCallback(hspi);
+  }
+}
+
+/**
+  * @brief DMA SPI half transmit process complete callback 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAHalfTransmitCplt(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  HAL_SPI_TxHalfCpltCallback(hspi);
+}
+
+/**
+  * @brief DMA SPI half receive process complete callback 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAHalfReceiveCplt(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  HAL_SPI_RxHalfCpltCallback(hspi);
+}
+
+/**
+  * @brief DMA SPI Half transmit receive process complete callback 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAHalfTransmitReceiveCplt(DMA_HandleTypeDef *hdma)   
+{
+  SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  HAL_SPI_TxRxHalfCpltCallback(hspi);
+}
+
+
+/**
+  * @brief DMA SPI communication error callback 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+static void SPI_DMAError(DMA_HandleTypeDef *hdma)
+{
+  SPI_HandleTypeDef* hspi = (SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  hspi->TxXferCount = 0;
+  hspi->RxXferCount = 0;
+  hspi->State= HAL_SPI_STATE_READY;
+  hspi->ErrorCode |= HAL_SPI_ERROR_DMA;
+  HAL_SPI_ErrorCallback(hspi);
+}
+
+/**
+  * @brief This function handles SPI Communication Timeout.
+  * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
+  *                the configuration information for SPI module.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef SPI_WaitOnFlagUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Flag, FlagStatus Status, uint32_t Timeout)  
+{
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+
+  /* Wait until flag is set */
+  if(Status == RESET)
+  {
+    while(__HAL_SPI_GET_FLAG(hspi, Flag) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Disable the SPI and reset the CRC: the CRC value should be cleared
+             on both master and slave sides in order to resynchronize the master
+             and slave for their respective CRC calculation */
+
+          /* Disable TXE, RXNE and ERR interrupts for the interrupt process */
+          __HAL_SPI_DISABLE_IT(hspi, (uint32_t)(SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
+
+          /* Disable SPI peripheral */
+          __HAL_SPI_DISABLE(hspi);
+
+          /* Reset CRC Calculation */
+          if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+          {
+            __HAL_SPI_RESET_CRC(hspi);
+          }
+
+          hspi->State= HAL_SPI_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hspi);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    while(__HAL_SPI_GET_FLAG(hspi, Flag) != RESET)
+    {
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Disable the SPI and reset the CRC: the CRC value should be cleared
+             on both master and slave sides in order to resynchronize the master
+             and slave for their respective CRC calculation */
+
+          /* Disable TXE, RXNE and ERR interrupts for the interrupt process */
+          __HAL_SPI_DISABLE_IT(hspi, (uint32_t)(SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
+
+          /* Disable SPI peripheral */
+          __HAL_SPI_DISABLE(hspi);
+
+          /* Reset CRC Calculation */
+          if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
+          {
+            __HAL_SPI_RESET_CRC(hspi);
+          }
+
+          hspi->State= HAL_SPI_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hspi);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+
+/**
+  * @}
+  */
+
+#endif /* HAL_SPI_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_spi.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_spi.h
@@ -1,0 +1,488 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_spi.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of SPI HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_SPI_H
+#define __STM32L0xx_HAL_SPI_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"  
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup SPI
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** 
+  * @brief  SPI Configuration Structure definition  
+  */
+typedef struct
+{
+  uint32_t Mode;               /*!< Specifies the SPI operating mode.
+                                    This parameter can be a value of @ref SPI_mode */
+
+  uint32_t Direction;          /*!< Specifies the SPI Directional mode state.
+                                    This parameter can be a value of @ref SPI_Direction_mode */
+
+  uint32_t DataSize;           /*!< Specifies the SPI data size.
+                                    This parameter can be a value of @ref SPI_data_size */
+
+  uint32_t CLKPolarity;        /*!< Specifies the serial clock steady state.
+                                    This parameter can be a value of @ref SPI_Clock_Polarity */
+
+  uint32_t CLKPhase;           /*!< Specifies the clock active edge for the bit capture.
+                                    This parameter can be a value of @ref SPI_Clock_Phase */
+
+  uint32_t NSS;                /*!< Specifies whether the NSS signal is managed by
+                                    hardware (NSS pin) or by software using the SSI bit.
+                                    This parameter can be a value of @ref SPI_Slave_Select_management */
+
+  uint32_t BaudRatePrescaler;  /*!< Specifies the Baud Rate prescaler value which will be
+                                    used to configure the transmit and receive SCK clock.
+                                    This parameter can be a value of @ref SPI_BaudRate_Prescaler
+                                    @note The communication clock is derived from the master
+                                    clock. The slave clock does not need to be set */
+
+  uint32_t FirstBit;           /*!< Specifies whether data transfers start from MSB or LSB bit.
+                                    This parameter can be a value of @ref SPI_MSB_LSB_transmission */
+
+  uint32_t TIMode;             /*!< Specifies if the TI mode is enabled or not.
+                                    This parameter can be a value of @ref SPI_TI_mode */
+
+  uint32_t CRCCalculation;     /*!< Specifies if the CRC calculation is enabled or not.
+                                    This parameter can be a value of @ref SPI_CRC_Calculation */
+
+  uint32_t CRCPolynomial;      /*!< Specifies the polynomial used for the CRC calculation.
+                                    This parameter must be a number between Min_Data = 0 and Max_Data = 65535 */
+
+}SPI_InitTypeDef;
+
+/**
+  * @brief  HAL SPI State structure definition
+  */
+typedef enum
+{
+  HAL_SPI_STATE_RESET      = 0x00,  /*!< SPI not yet initialized or disabled                */
+  HAL_SPI_STATE_READY      = 0x01,  /*!< SPI initialized and ready for use                  */
+  HAL_SPI_STATE_BUSY       = 0x02,  /*!< SPI process is ongoing                             */
+  HAL_SPI_STATE_BUSY_TX    = 0x12,  /*!< Data Transmission process is ongoing               */
+  HAL_SPI_STATE_BUSY_RX    = 0x22,  /*!< Data Reception process is ongoing                  */
+  HAL_SPI_STATE_BUSY_TX_RX = 0x32,  /*!< Data Transmission and Reception process is ongoing */
+  HAL_SPI_STATE_ERROR      = 0x03   /*!< SPI error state                                    */
+    
+}HAL_SPI_StateTypeDef;
+
+/** 
+  * @brief  HAL SPI Error Code structure definition  
+  */ 
+typedef enum
+{
+  HAL_SPI_ERROR_NONE      = 0x00,    /*!< No error             */
+  HAL_SPI_ERROR_MODF      = 0x01,    /*!< MODF error           */
+  HAL_SPI_ERROR_CRC       = 0x02,    /*!< CRC error            */
+  HAL_SPI_ERROR_OVR       = 0x04,    /*!< OVR error            */
+  HAL_SPI_ERROR_FRE       = 0x08,    /*!< FRE error            */
+  HAL_SPI_ERROR_DMA       = 0x10,    /*!< DMA transfer error   */
+  HAL_SPI_ERROR_FLAG      = 0x20     /*!< Flag: RXNE,TXE, BSY  */
+
+}HAL_SPI_ErrorTypeDef;
+
+/** 
+  * @brief  SPI handle Structure definition
+  */
+typedef struct __SPI_HandleTypeDef
+{
+  SPI_TypeDef                *Instance;    /* SPI registers base address */
+
+  SPI_InitTypeDef            Init;         /* SPI communication parameters */
+
+  uint8_t                    *pTxBuffPtr;  /* Pointer to SPI Tx transfer Buffer */
+
+  uint16_t                   TxXferSize;   /* SPI Tx transfer size */
+  
+  uint16_t                   TxXferCount;  /* SPI Tx Transfer Counter */
+
+  uint8_t                    *pRxBuffPtr;  /* Pointer to SPI Rx transfer Buffer */
+
+  uint16_t                   RxXferSize;   /* SPI Rx transfer size */
+
+  uint16_t                   RxXferCount;  /* SPI Rx Transfer Counter */
+
+  DMA_HandleTypeDef          *hdmatx;      /* SPI Tx DMA handle parameters */
+
+  DMA_HandleTypeDef          *hdmarx;      /* SPI Rx DMA handle parameters */
+
+  void                       (*RxISR)(struct __SPI_HandleTypeDef * hspi); /* function pointer on Rx ISR */
+
+  void                       (*TxISR)(struct __SPI_HandleTypeDef * hspi); /* function pointer on Tx ISR */
+
+  HAL_LockTypeDef            Lock;         /* SPI locking object */
+
+  __IO HAL_SPI_StateTypeDef  State;        /* SPI communication state */
+
+  __IO HAL_SPI_ErrorTypeDef  ErrorCode;         /* SPI Error code */
+
+}SPI_HandleTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup SPI_Exported_Constants
+  * @{
+  */
+
+/** @defgroup SPI_mode
+  * @{
+  */
+#define SPI_MODE_SLAVE                  ((uint32_t)0x00000000)
+#define SPI_MODE_MASTER                 (SPI_CR1_MSTR | SPI_CR1_SSI)
+
+#define IS_SPI_MODE(MODE) (((MODE) == SPI_MODE_SLAVE) || \
+                           ((MODE) == SPI_MODE_MASTER))
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Direction_mode
+  * @{
+  */
+#define SPI_DIRECTION_2LINES             ((uint32_t)0x00000000)
+#define SPI_DIRECTION_2LINES_RXONLY      SPI_CR1_RXONLY
+#define SPI_DIRECTION_1LINE              SPI_CR1_BIDIMODE
+
+#define IS_SPI_DIRECTION_MODE(MODE) (((MODE) == SPI_DIRECTION_2LINES)        || \
+                                     ((MODE) == SPI_DIRECTION_2LINES_RXONLY) || \
+                                     ((MODE) == SPI_DIRECTION_1LINE))
+
+#define IS_SPI_DIRECTION_2LINES_OR_1LINE(MODE) (((MODE) == SPI_DIRECTION_2LINES)  || \
+                                                ((MODE) == SPI_DIRECTION_1LINE))
+
+#define IS_SPI_DIRECTION_2LINES(MODE) ((MODE) == SPI_DIRECTION_2LINES)
+
+/**
+  * @}
+  */
+
+/** @defgroup SPI_data_size
+  * @{
+  */
+#define SPI_DATASIZE_8BIT               ((uint32_t)0x00000000)
+#define SPI_DATASIZE_16BIT              SPI_CR1_DFF
+
+#define IS_SPI_DATASIZE(DATASIZE) (((DATASIZE) == SPI_DATASIZE_16BIT) || \
+                                   ((DATASIZE) == SPI_DATASIZE_8BIT))
+/**
+  * @}
+  */ 
+
+/** @defgroup SPI_Clock_Polarity
+  * @{
+  */
+#define SPI_POLARITY_LOW                ((uint32_t)0x00000000)
+#define SPI_POLARITY_HIGH               SPI_CR1_CPOL
+
+#define IS_SPI_CPOL(CPOL) (((CPOL) == SPI_POLARITY_LOW) || \
+                           ((CPOL) == SPI_POLARITY_HIGH))
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Clock_Phase
+  * @{
+  */
+#define SPI_PHASE_1EDGE                 ((uint32_t)0x00000000)
+#define SPI_PHASE_2EDGE                 SPI_CR1_CPHA
+
+#define IS_SPI_CPHA(CPHA) (((CPHA) == SPI_PHASE_1EDGE) || \
+                           ((CPHA) == SPI_PHASE_2EDGE))
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Slave_Select_management
+  * @{
+  */
+#define SPI_NSS_SOFT                    SPI_CR1_SSM
+#define SPI_NSS_HARD_INPUT              ((uint32_t)0x00000000)
+#define SPI_NSS_HARD_OUTPUT             ((uint32_t)0x00040000)
+
+#define IS_SPI_NSS(NSS) (((NSS) == SPI_NSS_SOFT)       || \
+                         ((NSS) == SPI_NSS_HARD_INPUT) || \
+                         ((NSS) == SPI_NSS_HARD_OUTPUT))
+/**
+  * @}
+  */ 
+
+/** @defgroup SPI_BaudRate_Prescaler
+  * @{
+  */
+#define SPI_BAUDRATEPRESCALER_2         ((uint32_t)0x00000000)
+#define SPI_BAUDRATEPRESCALER_4         ((uint32_t)0x00000008)
+#define SPI_BAUDRATEPRESCALER_8         ((uint32_t)0x00000010)
+#define SPI_BAUDRATEPRESCALER_16        ((uint32_t)0x00000018)
+#define SPI_BAUDRATEPRESCALER_32        ((uint32_t)0x00000020)
+#define SPI_BAUDRATEPRESCALER_64        ((uint32_t)0x00000028)
+#define SPI_BAUDRATEPRESCALER_128       ((uint32_t)0x00000030)
+#define SPI_BAUDRATEPRESCALER_256       ((uint32_t)0x00000038)
+
+#define IS_SPI_BAUDRATE_PRESCALER(PRESCALER) (((PRESCALER) == SPI_BAUDRATEPRESCALER_2)   || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_4)   || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_8)   || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_16)  || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_32)  || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_64)  || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_128) || \
+                                              ((PRESCALER) == SPI_BAUDRATEPRESCALER_256))
+/**
+  * @}
+  */ 
+
+/** @defgroup SPI_MSB_LSB_transmission
+  * @{
+  */
+#define SPI_FIRSTBIT_MSB                ((uint32_t)0x00000000)
+#define SPI_FIRSTBIT_LSB                SPI_CR1_LSBFIRST
+
+#define IS_SPI_FIRST_BIT(BIT) (((BIT) == SPI_FIRSTBIT_MSB) || \
+                               ((BIT) == SPI_FIRSTBIT_LSB))
+/**
+  * @}
+  */
+
+/** @defgroup SPI_TI_mode
+  * @{
+  */
+#define SPI_TIMODE_DISABLED             ((uint32_t)0x00000000)
+#define SPI_TIMODE_ENABLED              SPI_CR2_FRF
+
+#define IS_SPI_TIMODE(MODE) (((MODE) == SPI_TIMODE_DISABLED) || \
+                             ((MODE) == SPI_TIMODE_ENABLED))
+/**
+  * @}
+  */
+
+/** @defgroup SPI_CRC_Calculation
+  * @{
+  */
+#define SPI_CRCCALCULATION_DISABLED     ((uint32_t)0x00000000)
+#define SPI_CRCCALCULATION_ENABLED      SPI_CR1_CRCEN
+
+#define IS_SPI_CRC_CALCULATION(CALCULATION) (((CALCULATION) == SPI_CRCCALCULATION_DISABLED) || \
+                                             ((CALCULATION) == SPI_CRCCALCULATION_ENABLED))
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Interrupt_configuration_definition
+  * @{
+  */
+#define SPI_IT_TXE                      SPI_CR2_TXEIE
+#define SPI_IT_RXNE                     SPI_CR2_RXNEIE
+#define SPI_IT_ERR                      SPI_CR2_ERRIE
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Flag_definition
+  * @{
+  */
+#define SPI_FLAG_RXNE                   SPI_SR_RXNE
+#define SPI_FLAG_TXE                    SPI_SR_TXE
+#define SPI_FLAG_CRCERR                 SPI_SR_CRCERR
+#define SPI_FLAG_MODF                   SPI_SR_MODF
+#define SPI_FLAG_OVR                    SPI_SR_OVR
+#define SPI_FLAG_BSY                    SPI_SR_BSY
+#define SPI_FLAG_FRE                    SPI_SR_FRE
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+/** @brief Reset SPI handle state
+  * @param  __HANDLE__: specifies the SPI handle.
+  *         This parameter can be SPIx where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define __HAL_SPI_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_SPI_STATE_RESET)
+
+/** @brief  Enable or disable the specified SPI interrupts.
+  * @param  __HANDLE__: specifies the SPI handle.
+  *         This parameter can be SPIx where x: 1, 2, or 3 to select the SPI peripheral.
+  * @param  __INTERRUPT__: specifies the interrupt source to enable or disable.
+  *         This parameter can be one of the following values:
+  *            @arg SPI_IT_TXE: Tx buffer empty interrupt enable
+  *            @arg SPI_IT_RXNE: RX buffer not empty interrupt enable
+  *            @arg SPI_IT_ERR: Error interrupt enable
+  * @retval None
+  */
+#define __HAL_SPI_ENABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->CR2 |= (__INTERRUPT__))
+#define __HAL_SPI_DISABLE_IT(__HANDLE__, __INTERRUPT__)  ((__HANDLE__)->Instance->CR2 &= (~(__INTERRUPT__)))
+
+/** @brief  Check if the specified SPI interrupt source is enabled or disabled.
+  * @param  __HANDLE__: specifies the SPI handle.
+  *         This parameter can be SPIx where x: 1, 2, or 3 to select the SPI peripheral.
+  * @param  __INTERRUPT__: specifies the SPI interrupt source to check.
+  *          This parameter can be one of the following values:
+  *             @arg SPI_IT_TXE: Tx buffer empty interrupt enable
+  *             @arg SPI_IT_RXNE: RX buffer not empty interrupt enable
+  *             @arg SPI_IT_ERR: Error interrupt enable
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_SPI_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->CR2 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/** @brief  Check whether the specified SPI flag is set or not.
+  * @param  __HANDLE__: specifies the SPI handle.
+  *         This parameter can be SPIx where x: 1, 2, or 3 to select the SPI peripheral.
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg SPI_FLAG_RXNE: Receive buffer not empty flag
+  *            @arg SPI_FLAG_TXE: Transmit buffer empty flag
+  *            @arg SPI_FLAG_CRCERR: CRC error flag
+  *            @arg SPI_FLAG_MODF: Mode fault flag
+  *            @arg SPI_FLAG_OVR: Overrun flag
+  *            @arg SPI_FLAG_BSY: Busy flag
+  *            @arg SPI_FLAG_FRE: Frame format error flag  
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_SPI_GET_FLAG(__HANDLE__, __FLAG__) ((((__HANDLE__)->Instance->SR) & (__FLAG__)) == (__FLAG__))
+
+/** @brief  Clear the SPI CRCERR pending flag.
+  * @param  __HANDLE__: specifies the SPI handle.
+  *         This parameter can be SPIx where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define __HAL_SPI_CLEAR_CRCERRFLAG(__HANDLE__) ((__HANDLE__)->Instance->SR &= (uint32_t)~((uint32_t)SPI_FLAG_CRCERR))
+
+/** @brief  Clear the SPI MODF pending flag.
+  * @param  __HANDLE__: specifies the SPI handle.
+  *         This parameter can be SPIx where x: 1, 2, or 3 to select the SPI peripheral. 
+  * @retval None
+  */
+#define __HAL_SPI_CLEAR_MODFFLAG(__HANDLE__) do{(__HANDLE__)->Instance->SR;\
+                                                (__HANDLE__)->Instance->CR1 &= (uint32_t)~((uint32_t)SPI_CR1_SPE);}while(0) 
+
+/** @brief  Clear the SPI OVR pending flag.
+  * @param  __HANDLE__: specifies the SPI handle.
+  *         This parameter can be SPIx where x: 1, 2, or 3 to select the SPI peripheral. 
+  * @retval None
+  */
+#define __HAL_SPI_CLEAR_OVRFLAG(__HANDLE__) do{(__HANDLE__)->Instance->DR;\
+                                               (__HANDLE__)->Instance->SR;}while(0) 
+
+/** @brief  Clear the SPI FRE pending flag.
+  * @param  __HANDLE__: specifies the SPI handle.
+  *         This parameter can be SPIx where x: 1, 2, or 3 to select the SPI peripheral.
+  * @retval None
+  */
+#define __HAL_SPI_CLEAR_FREFLAG(__HANDLE__) ((__HANDLE__)->Instance->SR)
+
+#define __HAL_SPI_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR1 |=  SPI_CR1_SPE)
+#define __HAL_SPI_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR1 &=  (uint32_t)~((uint32_t)SPI_CR1_SPE))
+
+#define IS_SPI_CRC_POLYNOMIAL(POLYNOMIAL) (((POLYNOMIAL) >= 0x1) && ((POLYNOMIAL) <= 0xFFFF))
+
+#define __HAL_SPI_1LINE_TX(__HANDLE__) ((__HANDLE__)->Instance->CR1 |= SPI_CR1_BIDIOE)
+
+#define __HAL_SPI_1LINE_RX(__HANDLE__) ((__HANDLE__)->Instance->CR1 &= (uint32_t)~((uint32_t)SPI_CR1_BIDIOE)) 
+
+#define __HAL_SPI_RESET_CRC(__HANDLE__) do{(__HANDLE__)->Instance->CR1 &= (uint32_t)~((uint32_t)SPI_CR1_CRCEN);\
+                                           (__HANDLE__)->Instance->CR1 |= SPI_CR1_CRCEN;}while(0)
+
+/* Exported functions --------------------------------------------------------*/
+
+/* Initialization/de-initialization functions  **********************************/
+HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi);
+HAL_StatusTypeDef HAL_SPI_DeInit (SPI_HandleTypeDef *hspi);
+void HAL_SPI_MspInit(SPI_HandleTypeDef *hspi);
+void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi);
+
+/* I/O operation functions  *****************************************************/
+HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_DMAPause(SPI_HandleTypeDef *hspi);
+HAL_StatusTypeDef HAL_SPI_DMAResume(SPI_HandleTypeDef *hspi);
+HAL_StatusTypeDef HAL_SPI_DMAStop(SPI_HandleTypeDef *hspi);
+
+void HAL_SPI_IRQHandler(SPI_HandleTypeDef *hspi);
+void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_TxHalfCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_RxHalfCpltCallback(SPI_HandleTypeDef *hspi);
+void HAL_SPI_TxRxHalfCpltCallback(SPI_HandleTypeDef *hspi);
+
+/* Peripheral State and Control functions  **************************************/
+HAL_SPI_StateTypeDef HAL_SPI_GetState(SPI_HandleTypeDef *hspi);
+HAL_SPI_ErrorTypeDef HAL_SPI_GetError(SPI_HandleTypeDef *hspi);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_SPI_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_tim.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_tim.c
@@ -1,0 +1,4779 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_tim.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   TIM HAL module driver.
+  * @brief   This file provides firmware functions to manage the following 
+  *          functionalities of the Timer (TIM) peripheral:
+  *           + Time Base Initialization
+  *           + Time Base Start
+  *           + Time Base Start Interruption
+  *           + Time Base Start DMA
+  *           + Time Output Compare/PWM Initialization
+  *           + Time Output Compare/PWM Channel Configuration
+  *           + Time Output Compare/PWM  Start
+  *           + Time Output Compare/PWM  Start Interruption
+  *           + Time Output Compare/PWM Start DMA
+  *           + Time Input Capture Initialization
+  *           + Time Input Capture Channel Configuration
+  *           + Time Input Capture Start
+  *           + Time Input Capture Start Interruption 
+  *           + Time Input Capture Start DMA
+  *           + Time One Pulse Initialization
+  *           + Time One Pulse Channel Configuration
+  *           + Time One Pulse Start 
+  *           + Time Encoder Interface Initialization
+  *           + Time Encoder Interface Start
+  *           + Time Encoder Interface Start Interruption
+  *           + Time Encoder Interface Start DMA
+  *           + Time OCRef clear configuration
+  *           + Time External Clock configuration
+  *           + Time Complementary signal bread and dead time configuration
+  *           + Time Master and Slave synchronization configuration
+  @verbatim
+  ==============================================================================
+                      ##### TIMER Generic features #####
+  ==============================================================================
+    [..] The Timer features include: 
+         (#) 16-bit up, down, up/down auto-reload counter.
+         (#) 16-bit programmable prescaler allowing dividing (also on the fly) the counter clock
+             frequency either by any factor between 1 and 65536.
+         (#) Up to 4 independent channels for:
+           (++) Input Capture
+           (++) Output Compare
+           (++) PWM generation (Edge and Center-aligned Mode)
+           (++) One-pulse mode output
+         (#) Synchronization circuit to control the timer with external signals and to interconnect
+            several timers together.
+         (#) Supports incremental (quadrature) encoder and hall-sensor circuitry for positioning
+           purposes                
+   
+            ##### How to use this driver #####
+================================================================================
+    [..]
+     (#) Enable the TIM interface clock using 
+         __TIMx_CLK_ENABLE(); 
+       
+     (#) TIM pins configuration
+          (++) Enable the clock for the TIM GPIOs using the following function:
+              __GPIOx_CLK_ENABLE();   
+          (++) Configure these TIM pins in Alternate function mode using HAL_GPIO_Init();  
+
+     (#) The external Clock can be configured, if needed (the default clock is the internal clock from the APBx), 
+         using the following function:
+         HAL_TIM_ConfigClockSource, the clock configuration should be done before any start function.
+  
+     (#) Configure the TIM in the desired functioning mode using one of the 
+         initialization function of this driver:
+         (++) HAL_TIM_Base_Init: to use the Timer to generate a simple time base
+         (++) HAL_TIM_OC_Init and HAL_TIM_OC_ConfigChannel: to use the Timer to generate an 
+              Output Compare signal.
+         (++) HAL_TIM_PWM_Init and HAL_TIM_PWM_ConfigChannel: to use the Timer to generate a 
+              PWM signal.
+         (++) HAL_TIM_IC_Init and HAL_TIM_IC_ConfigChannel: to use the Timer to measure an 
+              external signal.
+         (++) HAL_TIM_OnePulse_Init and HAL_TIM_OnePulse_ConfigChannel: to use the Timer in One Pulse Mode.
+         (++) HAL_TIM_Encoder_Init: to use the Timer Encoder Interface.
+
+     (#) Activate the TIM peripheral using one of the start functions: 
+         HAL_TIM_Base_Start(), HAL_TIM_Base_Start_DMA(), HAL_TIM_Base_Start_IT(),
+         HAL_TIM_OC_Start(), HAL_TIM_OC_Start_DMA(), HAL_TIM_OC_Start_IT(),
+         HAL_TIM_IC_Start(), HAL_TIM_IC_Start_DMA(), HAL_TIM_IC_Start_IT(),
+         HAL_TIM_PWM_Start(), HAL_TIM_PWM_Start_DMA(), HAL_TIM_PWM_Start_IT(),
+         HAL_TIM_OnePulse_Start(), HAL_TIM_OnePulse_Start_IT(),
+         HAL_TIM_Encoder_Start(), HAL_TIM_Encoder_Start_DMA() or HAL_TIM_Encoder_Start_IT()
+
+     (#) The DMA Burst is managed with the two following functions:
+         HAL_TIM_DMABurst_WriteStart
+         HAL_TIM_DMABurst_ReadStart
+  
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup TIM 
+  * @brief TIM HAL module driver
+  * @{
+  */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure);
+static void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+static void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+static void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+static void TIM_OC4_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+static void TIM_TI1_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection, uint32_t TIM_ICFilter);
+static void TIM_TI1_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICFilter);
+static void TIM_TI2_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection, uint32_t TIM_ICFilter);
+static void TIM_TI2_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICFilter);
+static void TIM_TI3_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection, uint32_t TIM_ICFilter);
+static void TIM_TI4_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection, uint32_t TIM_ICFilter);
+static void TIM_ETR_SetConfig(TIM_TypeDef* TIMx, uint32_t TIM_ExtTRGPrescaler, uint32_t TIM_ExtTRGPolarity, uint32_t ExtTRGFilter);
+static void TIM_ITRx_SetConfig(TIM_TypeDef* TIMx, uint16_t TIM_ITRx);
+static void TIM_CCxChannelCmd(TIM_TypeDef* TIMx, uint32_t Channel, uint32_t ChannelState);
+static void TIM_DMAPeriodElapsedCplt(DMA_HandleTypeDef *hdma);
+static void TIM_DMATriggerCplt(DMA_HandleTypeDef *hdma);
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup TIM_Private_Functions
+  * @{
+  */
+
+/** @defgroup TIM_Group1 Initialization/de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the TIM. 
+      (+) De-initialize the TIM.
+ 
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM Time base Unit according to the specified
+  *         parameters in the TIM_HandleTypeDef and create the associated handle.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Init(TIM_HandleTypeDef *htim)
+{ 
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance)); 
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+  
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {  
+    /* Init the low level hardware : GPIO, CLOCK, NVIC */
+    HAL_TIM_Base_MspInit(htim);
+  }
+    
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+  
+  /* Set the Time Base configuration */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init); 
+  
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Output Compare according to the specified
+  *         parameters in the TIM_HandleTypeDef and create the associated handle.
+  * @param  htim: TIM Output Compare handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Init(TIM_HandleTypeDef* htim)
+{
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+ 
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {  
+    /* Init the low level hardware : GPIO, CLOCK, NVIC */
+    HAL_TIM_OC_MspInit(htim);
+  }
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+
+  /* Init the base time for the Output Compare */  
+  TIM_Base_SetConfig(htim->Instance, &htim->Init); 
+  
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM PWM Time Base according to the specified
+  *         parameters in the TIM_HandleTypeDef and create the associated handle.
+  * @param  htim: TIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Init(TIM_HandleTypeDef *htim)
+{
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {  
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIM_PWM_MspInit(htim);
+  }
+  
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+  
+  /* Init the base time for the PWM */  
+  TIM_Base_SetConfig(htim->Instance, &htim->Init); 
+   
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Input Capture Time base according to the specified
+  *         parameters in the TIM_HandleTypeDef and create the associated handle.
+  * @param  htim: TIM Input Capture handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Init(TIM_HandleTypeDef *htim)
+{
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision)); 
+  
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {  
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIM_IC_MspInit(htim);
+  }
+  
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+  
+  /* Init the base time for the input capture */  
+  TIM_Base_SetConfig(htim->Instance, &htim->Init); 
+   
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM One Pulse Time Base according to the specified
+  *         parameters in the TIM_HandleTypeDef and create the associated handle.
+  * @param  htim: TIM OnePulse handle
+  * @param  OnePulseMode: Select the One pulse mode.
+  *         This parameter can be one of the following values:
+  *            @arg TIM_OPMODE_SINGLE: Only one pulse will be generated.
+  *            @arg TIM_OPMODE_REPETITIVE: Repetitive pulses wil be generated.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Init(TIM_HandleTypeDef *htim, uint32_t OnePulseMode)
+{
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
+  assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+  assert_param(IS_TIM_OPM_MODE(OnePulseMode));
+  
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {  
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIM_OnePulse_MspInit(htim);
+  }
+  
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+  
+  /* Configure the Time base in the One Pulse Mode */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);
+  
+  /* Reset the OPM Bit */
+  htim->Instance->CR1 &= ~TIM_CR1_OPM;
+
+  /* Configure the OPM Mode */
+  htim->Instance->CR1 |= OnePulseMode;
+   
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Encoder Interface and create the associated handle.
+  * @param  htim: TIM Encoder Interface handle
+  * @param  sConfig: TIM Encoder Interface configuration structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_InitTypeDef* sConfig)
+{
+  uint32_t tmpsmcr = 0;
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+  
+  /* Check the TIM handle allocation */
+  if(htim == NULL)
+  {
+    return HAL_ERROR;
+  }
+   
+  /* Check the parameters */
+  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_ENCODER_MODE(sConfig->EncoderMode));
+  assert_param(IS_TIM_IC_SELECTION(sConfig->IC1Selection));
+  assert_param(IS_TIM_IC_SELECTION(sConfig->IC2Selection));
+  assert_param(IS_TIM_IC_POLARITY(sConfig->IC1Polarity));
+  assert_param(IS_TIM_IC_POLARITY(sConfig->IC2Polarity));
+  assert_param(IS_TIM_IC_PRESCALER(sConfig->IC1Prescaler));
+  assert_param(IS_TIM_IC_PRESCALER(sConfig->IC2Prescaler));
+  assert_param(IS_TIM_IC_FILTER(sConfig->IC1Filter));
+  assert_param(IS_TIM_IC_FILTER(sConfig->IC2Filter));
+
+  if(htim->State == HAL_TIM_STATE_RESET)
+  {  
+    /* Init the low level hardware : GPIO, CLOCK, NVIC and DMA */
+    HAL_TIM_Encoder_MspInit(htim);
+  }
+  
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+  
+  /* Reset the SMS bits */
+  htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+  
+  /* Configure the Time base in the Encoder Mode */
+  TIM_Base_SetConfig(htim->Instance, &htim->Init);  
+  
+  /* Get the TIMx SMCR register value */
+  tmpsmcr = htim->Instance->SMCR;
+
+  /* Get the TIMx CCMR1 register value */
+  tmpccmr1 = htim->Instance->CCMR1;
+
+  /* Get the TIMx CCER register value */
+  tmpccer = htim->Instance->CCER;
+
+  /* Set the encoder Mode */
+  tmpsmcr |= sConfig->EncoderMode;
+
+  /* Select the Capture Compare 1 and the Capture Compare 2 as input */
+  tmpccmr1 &= ~(TIM_CCMR1_CC1S | TIM_CCMR1_CC2S);
+  tmpccmr1 |= (sConfig->IC1Selection | (sConfig->IC2Selection << 8));
+  
+  /* Set the the Capture Compare 1 and the Capture Compare 2 prescalers and filters */
+  tmpccmr1 &= ~(TIM_CCMR1_IC1PSC | TIM_CCMR1_IC2PSC);
+  tmpccmr1 &= ~(TIM_CCMR1_IC1F | TIM_CCMR1_IC2F);
+  tmpccmr1 |= sConfig->IC1Prescaler | (sConfig->IC2Prescaler << 8);
+  tmpccmr1 |= (sConfig->IC1Filter << 4) | (sConfig->IC2Filter << 12);
+
+  /* Set the TI1 and the TI2 Polarities */
+  tmpccer &= ~(TIM_CCER_CC1P | TIM_CCER_CC2P);
+  tmpccer &= ~(TIM_CCER_CC1NP | TIM_CCER_CC2NP);
+  tmpccer |= sConfig->IC1Polarity | (sConfig->IC2Polarity << 4);
+  
+  /* Write to TIMx SMCR */
+  htim->Instance->SMCR = tmpsmcr;
+
+  /* Write to TIMx CCMR1 */
+  htim->Instance->CCMR1 = tmpccmr1;
+
+  /* Write to TIMx CCER */
+  htim->Instance->CCER = tmpccer;
+  
+  /* Initialize the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the TIM Base peripheral 
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_DeInit(TIM_HandleTypeDef *htim)
+{  
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+   
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+    
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_TIM_Base_MspDeInit(htim);
+  
+  /* Change TIM state */  
+  htim->State = HAL_TIM_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+                            
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the TIM peripheral 
+  * @param  htim: TIM Output Compare handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  
+   htim->State = HAL_TIM_STATE_BUSY;
+   
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+  
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC and DMA */
+  HAL_TIM_OC_MspDeInit(htim);
+    
+  /* Change TIM state */  
+  htim->State = HAL_TIM_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(htim); 
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the TIM peripheral 
+  * @param  htim: TIM handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  
+  htim->State = HAL_TIM_STATE_BUSY;
+  
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+    
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC and DMA */
+  HAL_TIM_PWM_MspDeInit(htim);
+    
+  /* Change TIM state */  
+  htim->State = HAL_TIM_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(htim); 
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the TIM peripheral 
+  * @param  htim: TIM Input Capture handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+
+  htim->State = HAL_TIM_STATE_BUSY;
+  
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+    
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC and DMA */
+  HAL_TIM_IC_MspDeInit(htim);
+    
+  /* Change TIM state */  
+  htim->State = HAL_TIM_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(htim);
+   
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the TIM One Pulse  
+  * @param  htim: TIM One Pulse handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  
+  htim->State = HAL_TIM_STATE_BUSY;
+  
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+  
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_TIM_OnePulse_MspDeInit(htim);
+    
+  /* Change TIM state */  
+  htim->State = HAL_TIM_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(htim); 
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the TIM Encoder interface  
+  * @param  htim: TIM Encoder handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_DeInit(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  
+  htim->State = HAL_TIM_STATE_BUSY;
+  
+  /* Disable the TIM Peripheral Clock */
+  __HAL_TIM_DISABLE(htim);
+  
+  /* DeInit the low level hardware: GPIO, CLOCK, NVIC */
+  HAL_TIM_Encoder_MspDeInit(htim);
+    
+  /* Change TIM state */  
+  htim->State = HAL_TIM_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(htim); 
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Base MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_Base_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Initializes the TIM Output Compare MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_OC_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_OC_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Initializes the TIM PWM MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_PWM_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_PWM_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Initializes the TIM INput Capture MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_IC_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_IC_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Initializes the TIM One Pulse MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_OnePulse_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_OnePulse_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Initializes the TIM Encoder Interface MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_Encoder_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes TIM Base MSP.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_Base_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes TIM Output Compare MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_OC_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_OC_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes TIM PWM MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_PWM_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_PWM_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes TIM Input Capture MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_IC_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_IC_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes TIM One Pulse MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_OnePulse_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_OnePulse_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes TIM Encoder Interface MSP.
+  * @param  htim: TIM handle
+  * @retval None
+  */
+__weak void HAL_TIM_Encoder_MspDeInit(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_Encoder_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Group2 I/O operation functions
+ *  @brief    I/O operation functions 
+ *
+@verbatim
+ ===============================================================================
+                        ##### IO operation functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Start the Time Base.
+      (+) Stop the Time Base.
+      (+) Start the Time Base and enable interrupt.
+      (+) Stop the Time Base and disable interrupt.
+      (+) Start the Time Base and enable DMA transfer.
+      (+) Stop the Time Base and disable DMA transfer.
+      (+) Start the Output Compare/PWM.
+      (+) Stop the Output Compare/PWM.
+      (+) Start the Output Compare/PWM and enable interrupts.
+      (+) Stop the Output Compare/PWM and disable interrupts.
+      (+) Start the Output Compare/PWM and enable DMA transfers.
+      (+) Stop the Output Compare/PWM and disable DMA transfers.
+      (+) Start the Input Capture measurement.
+      (+) Stop the Input Capture.
+      (+) Start the Input Capture and enable interrupts.
+      (+) Stop the Input Capture and disable interrupts.
+      (+) Start the Input Capture and enable DMA transfers.
+      (+) Stop the Input Capture and disable DMA transfers.
+      (+) Start the One Pulse generation.
+      (+) Stop the One Pulse.
+      (+) Start the One Pulse and enable interrupts.
+      (+) Stop the One Pulse and disable interrupts.
+      (+) Start the Encoder Interface.
+      (+) Stop the Encoder Interface.
+      (+) Start the Encoder Interface and enable interrupts.
+      (+) Stop the Encoder Interface and disable interrupts.
+      (+) Start the Encoder Interface and enable DMA transfers.
+      (+) Stop the Encoder Interface and disable DMA transfers.
+      (+) Start the Hall Sensor Interface.
+      (+) Stop the Hall Sensor Interface.
+      (+) Start the Hall Sensor Interface and enable interrupts.
+      (+) Stop the Hall Sensor Interface and disable interrupts.
+      (+) Start the Hall Sensor Interface and enable DMA transfers.
+      (+) Stop the Hall Sensor Interface and disable DMA transfers.
+      (+) Handle TIM interrupt request. 
+               
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Starts the TIM Base generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Start(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+  
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+  
+  /* Change the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Base generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Stop(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  
+  /* Set the TIM state */
+  htim->State= HAL_TIM_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+  
+  /* Change the TIM state*/
+  htim->State= HAL_TIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Base generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Start_IT(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  
+  /* Enable the TIM Update interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_UPDATE);
+      
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+      
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Base generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Stop_IT(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  /* Disable the TIM Update interrupt */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_UPDATE);
+      
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+    
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Base generation in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  pData: The source Buffer address.
+  * @param  Length: The length of data to be transferred from memory to peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_INSTANCE(htim->Instance)); 
+  
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((pData == 0 ) && (Length > 0)) 
+    {
+      return HAL_ERROR;                                    
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }  
+  /* Set the DMA Period elapsed callback */
+  htim->hdma[TIM_DMA_ID_UPDATE]->XferCpltCallback = TIM_DMAPeriodElapsedCplt;
+     
+  /* Set the DMA error callback */
+  htim->hdma[TIM_DMA_ID_UPDATE]->XferErrorCallback = HAL_TIM_DMAError ;
+  
+  /* Enable the DMA Stream */
+  HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)pData, (uint32_t)&htim->Instance->ARR, Length);
+  
+  /* Enable the TIM Update DMA request */
+  __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_UPDATE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);  
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Base generation in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Base_Stop_DMA(TIM_HandleTypeDef *htim)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_INSTANCE(htim->Instance));
+  
+  /* Disable the TIM Update DMA request */
+  __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_UPDATE);
+      
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+    
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+      
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation.
+  * @param  htim : pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.   
+  * @param  Channel: TIM Channel to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  
+  /* Enable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+  
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim); 
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  
+  /* Disable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+  
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);  
+  
+  /* Return function status */
+  return HAL_OK;
+}  
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {       
+      /* Enable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      /* Enable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+    
+    case TIM_CHANNEL_3:
+    {
+      /* Enable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+    
+    case TIM_CHANNEL_4:
+    {
+      /* Enable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+    
+    default:
+    break;
+  } 
+
+  /* Enable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {       
+      /* Disable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+    
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+    
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+    
+    default:
+    break; 
+  } 
+  
+  /* Disable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+  
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);  
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Output Compare signal generation in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  pData: The source Buffer address.
+  * @param  Length: The length of data to be transferred from memory to TIM peripheral
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if(((uint32_t)pData == 0 ) && (Length > 0)) 
+    {
+      return HAL_ERROR;                                    
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }    
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {      
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length);
+      
+      /* Enable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length);
+      
+      /* Enable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+    
+    case TIM_CHANNEL_3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3,Length);
+      
+      /* Enable the TIM Capture/Compare 3 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+    
+    case TIM_CHANNEL_4:
+    {
+     /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4, Length);
+      
+      /* Enable the TIM Capture/Compare 4 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+    
+    default:
+    break;
+  }
+
+  /* Enable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);  
+  
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim); 
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Output Compare signal generation in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {       
+      /* Disable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+    
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+    
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+    
+    default:
+    break;
+  } 
+  
+  /* Disable the Output compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+  
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+  
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the PWM signal generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+
+  /* Enable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+    
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+  
+  /* Return function status */
+  return HAL_OK;
+} 
+
+/**
+  * @brief  Stops the PWM signal generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{ 
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+    
+  /* Disable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+  
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+  
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+} 
+
+/**
+  * @brief  Starts the PWM signal generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channel to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {       
+      /* Enable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      /* Enable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+    
+    case TIM_CHANNEL_3:
+    {
+      /* Enable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+    
+    case TIM_CHANNEL_4:
+    {
+      /* Enable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+    
+    default:
+    break;
+  } 
+  
+  /* Enable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+  
+  /* Return function status */
+  return HAL_OK;
+} 
+
+/**
+  * @brief  Stops the PWM signal generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT (TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {       
+      /* Disable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+    
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+    
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+    
+    default:
+    break; 
+  }
+  
+  /* Disable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+  
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+  
+  /* Return function status */
+  return HAL_OK;
+} 
+
+/**
+  * @brief  Starts the TIM PWM signal generation in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  pData: The source Buffer address.
+  * @param  Length: The length of data to be transferred from memory to TIM peripheral
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if(((uint32_t)pData == 0 ) && (Length > 0)) 
+    {
+      return HAL_ERROR;                                    
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }    
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {      
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length);
+      
+      /* Enable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length);
+      
+      /* Enable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+    
+    case TIM_CHANNEL_3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3,Length);
+      
+      /* Enable the TIM Output Capture/Compare 3 request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+    
+    case TIM_CHANNEL_4:
+    {
+     /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4, Length);
+      
+      /* Enable the TIM Capture/Compare 4 DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+    
+    default:
+    break;
+  }
+
+  /* Enable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+  
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim); 
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM PWM signal generation in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {       
+      /* Disable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+    
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+    
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+    
+    default:
+    break;
+  } 
+  
+  /* Disable the Capture compare channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+  
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+  
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Input Capture measurement.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Start (TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  
+  /* Enable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+    
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);  
+
+  /* Return function status */
+  return HAL_OK;  
+} 
+
+/**
+  * @brief  Stops the TIM Input Capture measurement.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{ 
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  
+  /* Disable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+  
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim); 
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Input Capture measurement in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Start_IT (TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {       
+      /* Enable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      /* Enable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+    
+    case TIM_CHANNEL_3:
+    {
+      /* Enable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+    
+    case TIM_CHANNEL_4:
+    {
+      /* Enable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+    
+    default:
+    break;
+  }  
+  /* Enable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+    
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);  
+
+  /* Return function status */
+  return HAL_OK;  
+} 
+
+/**
+  * @brief  Stops the TIM Input Capture measurement in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel : TIM Channels to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {       
+      /* Disable the TIM Capture/Compare 1 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+    }
+    break;
+    
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC3);
+    }
+    break;
+    
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4 interrupt */
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC4);
+    }
+    break;
+    
+    default:
+    break; 
+  } 
+  
+  /* Disable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE); 
+  
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim); 
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Input Capture measurement on in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel : TIM Channels to be enabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  pData: The destination Buffer address.
+  * @param  Length: The length of data to be transferred from TIM peripheral to memory.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+  
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((pData == 0 ) && (Length > 0)) 
+    {
+      return HAL_ERROR;                                    
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }  
+   
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData, Length); 
+      
+      /* Enable the TIM Capture/Compare 1 DMA request */      
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData, Length);
+      
+      /* Enable the TIM Capture/Compare 2  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+    
+    case TIM_CHANNEL_3:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)&htim->Instance->CCR3, (uint32_t)pData, Length);
+      
+      /* Enable the TIM Capture/Compare 3  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+    
+    case TIM_CHANNEL_4:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)&htim->Instance->CCR4, (uint32_t)pData, Length);
+      
+      /* Enable the TIM Capture/Compare 4  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+    
+    default:
+    break;
+  }
+
+  /* Enable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+   
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim); 
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Input Capture measurement on in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel : TIM Channels to be disabled
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+  
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {       
+      /* Disable the TIM Capture/Compare 1 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      /* Disable the TIM Capture/Compare 2 DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+    
+    case TIM_CHANNEL_3:
+    {
+      /* Disable the TIM Capture/Compare 3  DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC3);
+    }
+    break;
+    
+    case TIM_CHANNEL_4:
+    {
+      /* Disable the TIM Capture/Compare 4  DMA request */
+      __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC4);
+    }
+    break;
+    
+    default:
+    break;
+  }
+
+  /* Disable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+  
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim); 
+  
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM One Pulse signal generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  OutputChannel : TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Start(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Enable the Capture compare and the Input Capture channels 
+    (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
+    if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
+    if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output 
+    in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be enabled together 
+    
+    No need to enable the counter, it's enabled automatically by hardware 
+    (the counter starts in response to a stimulus and generate a pulse */
+  
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE); 
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM One Pulse signal generation.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  OutputChannel : TIM Channels to be disable.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Stop(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Disable the Capture compare and the Input Capture channels 
+  (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
+  if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
+  if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output 
+  in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be disabled together */
+  
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE); 
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+    
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim); 
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM One Pulse signal generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  OutputChannel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Enable the Capture compare and the Input Capture channels 
+    (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
+    if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
+    if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output 
+    in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be enabled together 
+    
+    No need to enable the counter, it's enabled automatically by hardware 
+    (the counter starts in response to a stimulus and generate a pulse */
+ 
+  /* Enable the TIM Capture/Compare 1 interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+  
+  /* Enable the TIM Capture/Compare 2 interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+  
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE); 
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE); 
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM One Pulse signal generation in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  OutputChannel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
+{
+  /* Disable the TIM Capture/Compare 1 interrupt */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);  
+  
+  /* Disable the TIM Capture/Compare 2 interrupt */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+  
+  /* Disable the Capture compare and the Input Capture channels 
+  (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
+  if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
+  if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output 
+  in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be disabled together */  
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE); 
+  TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+    
+  /* Disable the Peripheral */
+   __HAL_TIM_DISABLE(htim);  
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Encoder Interface.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+  
+  /* Enable the encoder interface channels */
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+      break; 
+    }
+    case TIM_CHANNEL_2:
+    { 
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE); 
+      break;
+    }  
+    default :
+    {
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+     break; 
+    }
+  }  
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Encoder Interface.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+    assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    
+   /* Disable the Input Capture channels 1 and 2
+    (in the EncoderInterface the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2) */ 
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+      break; 
+    }
+    case TIM_CHANNEL_2:
+    { 
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE); 
+      break;
+    }  
+    default :
+    {
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
+     break; 
+    }
+  }  
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Encoder Interface in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+  
+  /* Enable the encoder interface channels */
+  /* Enable the capture compare Interrupts 1 and/or 2 */
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+      break; 
+    }
+    case TIM_CHANNEL_2:
+    { 
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+      __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2); 
+      break;
+    }  
+    default :
+    {
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+     TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+     __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
+     __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC2);
+     break; 
+    }
+  }
+  
+  /* Enable the Peripheral */
+  __HAL_TIM_ENABLE(htim);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Encoder Interface in interrupt mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be disabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    
+  /* Disable the Input Capture channels 1 and 2
+    (in the EncoderInterface the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2) */ 
+  if(Channel == TIM_CHANNEL_1)
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE); 
+    
+    /* Disable the capture compare Interrupts 1 */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+  }  
+  else if(Channel == TIM_CHANNEL_2)
+  {  
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE); 
+    
+    /* Disable the capture compare Interrupts 2 */
+  __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+  }  
+  else
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE); 
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE); 
+    
+    /* Disable the capture compare Interrupts 1 and 2 */
+    __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC1);
+    __HAL_TIM_DISABLE_IT(htim, TIM_IT_CC2);
+  }
+    
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+  
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the TIM Encoder Interface in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @param  pData1: The destination Buffer address for IC1.
+  * @param  pData2: The destination Buffer address for IC2.
+  * @param  Length: The length of data to be transferred from TIM peripheral to memory.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData1, uint32_t *pData2, uint16_t Length)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+  
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((((pData1 == 0) || (pData2 == 0) )) && (Length > 0)) 
+    {
+      return HAL_ERROR;                                    
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }  
+   
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t )pData1, Length); 
+      
+      /* Enable the TIM Input Capture DMA request */      
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+            
+      /* Enable the Peripheral */
+      __HAL_TIM_ENABLE(htim);
+      
+      /* Enable the Capture compare channel */
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError;
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData2, Length);
+      
+      /* Enable the TIM Input Capture  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+     
+      /* Enable the Peripheral */
+      __HAL_TIM_ENABLE(htim);
+      
+      /* Enable the Capture compare channel */
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+    }
+    break;
+    
+    case TIM_CHANNEL_ALL:
+    {
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData1, Length);
+      
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError ;
+      
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData2, Length);
+          
+     /* Enable the Peripheral */
+      __HAL_TIM_ENABLE(htim);
+      
+      /* Enable the Capture compare channel */
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+      
+      /* Enable the TIM Input Capture  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
+      /* Enable the TIM Input Capture  DMA request */
+      __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+    }
+    break;
+    
+    default:
+    break;
+  }  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM Encoder Interface in DMA mode.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
+  
+  /* Disable the Input Capture channels 1 and 2
+    (in the EncoderInterface the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2) */ 
+  if(Channel == TIM_CHANNEL_1)
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE); 
+    
+    /* Disable the capture compare DMA Request 1 */
+    __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+  }  
+  else if(Channel == TIM_CHANNEL_2)
+  {  
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE); 
+    
+    /* Disable the capture compare DMA Request 2 */
+    __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+  }  
+  else
+  {
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE); 
+    TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE); 
+    
+    /* Disable the capture compare DMA Request 1 and 2 */
+    __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC1);
+    __HAL_TIM_DISABLE_DMA(htim, TIM_DMA_CC2);
+  }
+  
+  /* Disable the Peripheral */
+  __HAL_TIM_DISABLE(htim);
+  
+  /* Change the htim state */
+  htim->State = HAL_TIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Group3 Peripheral Control functions
+ *  @brief    Peripheral Control functions 
+ *
+@verbatim
+  ==============================================================================
+             ##### Peripheral Control functions #####
+  ==============================================================================
+ [..]
+   This section provides functions allowing to:
+      (+) Configure The Input Output channels for OC, PWM, IC or One Pulse mode. 
+      (+) Configure External Clock source.
+      (+) Configure Master and the Slave synchronization.
+      (+) Configure the DMA Burst Mode.
+      
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Initializes the TIM Output Compare Channels according to the specified
+  *         parameters in the TIM_OC_InitTypeDef.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sConfig: TIM Output Compare configuration structure
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected 
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel)
+{
+  /* Check the parameters */ 
+  assert_param(IS_TIM_CHANNELS(Channel)); 
+  assert_param(IS_TIM_OC_MODE(sConfig->OCMode));
+  assert_param(IS_TIM_OC_POLARITY(sConfig->OCPolarity));
+  assert_param(IS_TIM_FAST_STATE(sConfig->OCFastMode));
+  
+  /* Check input state */
+  __HAL_LOCK(htim); 
+  
+  htim->State = HAL_TIM_STATE_BUSY;
+  
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      /* Configure the TIM Channel 1 in Output Compare */
+      TIM_OC1_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      /* Configure the TIM Channel 2 in Output Compare */
+      TIM_OC2_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+    
+    case TIM_CHANNEL_3:
+    {
+       assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+      /* Configure the TIM Channel 3 in Output Compare */
+      TIM_OC3_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+    
+    case TIM_CHANNEL_4:
+    {
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+      /* Configure the TIM Channel 4 in Output Compare */
+      TIM_OC4_SetConfig(htim->Instance, sConfig);
+    }
+    break;
+    
+    default:
+    break;    
+  }
+  htim->State = HAL_TIM_STATE_READY;
+  
+  __HAL_UNLOCK(htim); 
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM Input Capture Channels according to the specified
+  *         parameters in the TIM_IC_InitTypeDef.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sConfig: TIM Input Capture configuration structure
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected 
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_IC_InitTypeDef* sConfig, uint32_t Channel)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_IC_POLARITY(sConfig->ICPolarity));
+  assert_param(IS_TIM_IC_SELECTION(sConfig->ICSelection));
+  assert_param(IS_TIM_IC_PRESCALER(sConfig->ICPrescaler));
+  assert_param(IS_TIM_IC_FILTER(sConfig->ICFilter));
+  
+  __HAL_LOCK(htim);
+  
+  htim->State = HAL_TIM_STATE_BUSY;
+  
+  if (Channel == TIM_CHANNEL_1)
+  {
+    /* TI1 Configuration */
+    TIM_TI1_SetConfig(htim->Instance,
+               sConfig->ICPolarity,
+               sConfig->ICSelection,
+               sConfig->ICFilter);
+               
+    /* Reset the IC1PSC Bits */
+    htim->Instance->CCMR1 &= ~TIM_CCMR1_IC1PSC;
+
+    /* Set the IC1PSC value */
+    htim->Instance->CCMR1 |= sConfig->ICPrescaler;
+  }
+  else if (Channel == TIM_CHANNEL_2)
+  {
+    /* TI2 Configuration */
+    assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    
+    TIM_TI2_SetConfig(htim->Instance, 
+                      sConfig->ICPolarity,
+                      sConfig->ICSelection,
+                      sConfig->ICFilter);
+               
+    /* Reset the IC2PSC Bits */
+    htim->Instance->CCMR1 &= ~TIM_CCMR1_IC2PSC;
+
+    /* Set the IC2PSC value */
+    htim->Instance->CCMR1 |= (sConfig->ICPrescaler << 8);
+  }
+  else if (Channel == TIM_CHANNEL_3)
+  {
+    /* TI3 Configuration */
+    assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+    
+    TIM_TI3_SetConfig(htim->Instance,  
+               sConfig->ICPolarity,
+               sConfig->ICSelection,
+               sConfig->ICFilter);
+               
+    /* Reset the IC3PSC Bits */
+    htim->Instance->CCMR2 &= ~TIM_CCMR2_IC3PSC;
+
+    /* Set the IC3PSC value */
+    htim->Instance->CCMR2 |= sConfig->ICPrescaler;
+  }
+  else
+  {
+    /* TI4 Configuration */
+    assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+    
+    TIM_TI4_SetConfig(htim->Instance, 
+               sConfig->ICPolarity,
+               sConfig->ICSelection,
+               sConfig->ICFilter);
+               
+    /* Reset the IC4PSC Bits */
+    htim->Instance->CCMR2 &= ~TIM_CCMR2_IC4PSC;
+
+    /* Set the IC4PSC value */
+    htim->Instance->CCMR2 |= (sConfig->ICPrescaler << 8);
+  }
+  
+  htim->State = HAL_TIM_STATE_READY;
+    
+  __HAL_UNLOCK(htim);
+  
+  return HAL_OK; 
+}
+
+/**
+  * @brief  Initializes the TIM PWM  channels according to the specified
+  *         parameters in the TIM_OC_InitTypeDef.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sConfig: TIM PWM configuration structure
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel)
+{
+  __HAL_LOCK(htim);
+  
+  /* Check the parameters */ 
+  assert_param(IS_TIM_CHANNELS(Channel)); 
+  assert_param(IS_TIM_PWM_MODE(sConfig->OCMode));
+  assert_param(IS_TIM_OC_POLARITY(sConfig->OCPolarity));
+  
+  htim->State = HAL_TIM_STATE_BUSY;
+    
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      /* Configure the Channel 1 in PWM mode */
+      TIM_OC1_SetConfig(htim->Instance, sConfig);
+      
+      /* Set the Preload enable bit for channel1 */
+      htim->Instance->CCMR1 |= TIM_CCMR1_OC1PE;
+      
+      /* Configure the Output Fast mode */
+      htim->Instance->CCMR1 &= ~TIM_CCMR1_OC1FE;
+      htim->Instance->CCMR1 |= sConfig->OCFastMode;
+    }
+    break;
+    
+    case TIM_CHANNEL_2:
+    {
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      /* Configure the Channel 2 in PWM mode */
+      TIM_OC2_SetConfig(htim->Instance, sConfig);
+      
+      /* Set the Preload enable bit for channel2 */
+      htim->Instance->CCMR1 |= TIM_CCMR1_OC2PE;
+      
+      /* Configure the Output Fast mode */
+      htim->Instance->CCMR1 &= ~TIM_CCMR1_OC2FE;
+      htim->Instance->CCMR1 |= sConfig->OCFastMode << 8;
+    }
+    break;
+    
+    case TIM_CHANNEL_3:
+    {
+      assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+      /* Configure the Channel 3 in PWM mode */
+      TIM_OC3_SetConfig(htim->Instance, sConfig);
+      
+      /* Set the Preload enable bit for channel3 */
+      htim->Instance->CCMR2 |= TIM_CCMR2_OC3PE;
+      
+     /* Configure the Output Fast mode */
+      htim->Instance->CCMR2 &= ~TIM_CCMR2_OC3FE;
+      htim->Instance->CCMR2 |= sConfig->OCFastMode;  
+    }
+    break;
+    
+    case TIM_CHANNEL_4:
+    {
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+      /* Configure the Channel 4 in PWM mode */
+      TIM_OC4_SetConfig(htim->Instance, sConfig);
+      
+      /* Set the Preload enable bit for channel4 */
+      htim->Instance->CCMR2 |= TIM_CCMR2_OC4PE;
+      
+     /* Configure the Output Fast mode */
+      htim->Instance->CCMR2 &= ~TIM_CCMR2_OC4FE;
+      htim->Instance->CCMR2 |= sConfig->OCFastMode << 8;  
+    }
+    break;
+    
+    default:
+    break;    
+  }
+  
+  htim->State = HAL_TIM_STATE_READY;
+    
+  __HAL_UNLOCK(htim);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TIM One Pulse Channels according to the specified
+  *         parameters in the TIM_OnePulse_InitTypeDef.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sConfig: TIM One Pulse configuration structure
+  * @param  OutputChannel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @param  InputChannel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim,  TIM_OnePulse_InitTypeDef* sConfig, uint32_t OutputChannel,  uint32_t InputChannel)
+{
+  TIM_OC_InitTypeDef temp1;
+  
+  /* Check the parameters */
+  assert_param(IS_TIM_OPM_CHANNELS(OutputChannel));
+  assert_param(IS_TIM_OPM_CHANNELS(InputChannel));
+
+  if(OutputChannel != InputChannel)  
+  {
+    __HAL_LOCK(htim);
+  
+    htim->State = HAL_TIM_STATE_BUSY;
+
+    /* Extract the Ouput compare configuration from sConfig structure */  
+    temp1.OCMode = sConfig->OCMode;
+    temp1.Pulse = sConfig->Pulse;
+    temp1.OCPolarity = sConfig->OCPolarity; 
+    
+    switch (OutputChannel)
+    {
+      case TIM_CHANNEL_1:
+      {
+        assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      
+        TIM_OC1_SetConfig(htim->Instance, &temp1); 
+      }
+      break;
+      case TIM_CHANNEL_2:
+      {
+        assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      
+        TIM_OC2_SetConfig(htim->Instance, &temp1);
+      }
+      break;
+      default:
+      break;  
+    } 
+    switch (InputChannel)
+    {
+      case TIM_CHANNEL_1:
+      {
+        assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      
+        TIM_TI1_SetConfig(htim->Instance, sConfig->ICPolarity,
+                        sConfig->ICSelection, sConfig->ICFilter);
+               
+        /* Reset the IC1PSC Bits */
+        htim->Instance->CCMR1 &= ~TIM_CCMR1_IC1PSC;
+
+        /* Select the Trigger source */
+        htim->Instance->SMCR &= ~TIM_SMCR_TS;
+        htim->Instance->SMCR |= TIM_TS_TI1FP1;
+      
+        /* Select the Slave Mode */      
+        htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+        htim->Instance->SMCR |= TIM_SLAVEMODE_TRIGGER;
+      }
+      break;
+      case TIM_CHANNEL_2:
+      {
+        assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      
+        TIM_TI2_SetConfig(htim->Instance, sConfig->ICPolarity,
+                 sConfig->ICSelection, sConfig->ICFilter);
+               
+        /* Reset the IC2PSC Bits */
+        htim->Instance->CCMR1 &= ~TIM_CCMR1_IC2PSC;
+
+        /* Select the Trigger source */
+        htim->Instance->SMCR &= ~TIM_SMCR_TS;
+        htim->Instance->SMCR |= TIM_TS_TI2FP2;
+      
+        /* Select the Slave Mode */      
+        htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+        htim->Instance->SMCR |= TIM_SLAVEMODE_TRIGGER;
+      }
+      break;
+    
+      default:
+      break;  
+    }
+  
+    htim->State = HAL_TIM_STATE_READY;
+    
+    __HAL_UNLOCK(htim);
+  
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Configure the DMA Burst to transfer Data from the memory to the TIM peripheral  
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  BurstBaseAddress: TIM Base address from when the DMA will starts the Data write.
+  *         This parameters can be on of the following values:
+  *            @arg TIM_DMABase_CR1  
+  *            @arg TIM_DMABase_CR2
+  *            @arg TIM_DMABase_SMCR
+  *            @arg TIM_DMABase_DIER
+  *            @arg TIM_DMABase_SR
+  *            @arg TIM_DMABase_EGR
+  *            @arg TIM_DMABase_CCMR1
+  *            @arg TIM_DMABase_CCMR2
+  *            @arg TIM_DMABase_CCER
+  *            @arg TIM_DMABase_CNT   
+  *            @arg TIM_DMABase_PSC   
+  *            @arg TIM_DMABase_ARR
+  *            @arg TIM_DMABase_CCR1
+  *            @arg TIM_DMABase_CCR2
+  *            @arg TIM_DMABase_CCR3  
+  *            @arg TIM_DMABase_CCR4
+  *            @arg TIM_DMABase_DCR
+  * @param  BurstRequestSrc: TIM DMA Request sources.
+  *         This parameters can be on of the following values:
+  *            @arg TIM_DMA_UPDATE: TIM update Interrupt source
+  *            @arg TIM_DMA_CC1: TIM Capture Compare 1 DMA source
+  *            @arg TIM_DMA_CC2: TIM Capture Compare 2 DMA source
+  *            @arg TIM_DMA_CC3: TIM Capture Compare 3 DMA source
+  *            @arg TIM_DMA_CC4: TIM Capture Compare 4 DMA source
+  *            @arg TIM_DMA_TRIGGER: TIM Trigger DMA source
+  * @param  BurstBuffer: The Buffer address.
+  * @param  BurstLength: DMA Burst length. This parameter can be one value
+  *         between TIM_DMABurstLength_1Transfer and TIM_DMABurstLength_18Transfers.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress, uint32_t BurstRequestSrc,
+                                              uint32_t* BurstBuffer, uint32_t  BurstLength)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMABURST_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_DMA_BASE(BurstBaseAddress));
+  assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
+  assert_param(IS_TIM_DMA_LENGTH(BurstLength));
+  
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((BurstBuffer == 0 ) && (BurstLength > 0)) 
+    {
+      return HAL_ERROR;                                    
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }
+  switch(BurstRequestSrc)
+  {
+    case TIM_DMA_UPDATE:
+    {  
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_UPDATE]->XferCpltCallback = TIM_DMAPeriodElapsedCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_UPDATE]->XferErrorCallback = HAL_TIM_DMAError ;
+  
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1); 
+    }
+    break;
+    case TIM_DMA_CC1:
+    {  
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+  
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);     
+    }
+    break;
+    case TIM_DMA_CC2:
+    {  
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError ;
+  
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);     
+    }
+    break;
+    case TIM_DMA_CC3:
+    {  
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = HAL_TIM_DMAError ;
+  
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);     
+    }
+    break;
+    case TIM_DMA_CC4:
+    {  
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = HAL_TIM_DMADelayPulseCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = HAL_TIM_DMAError ;
+  
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);     
+    }
+    break;
+    case TIM_DMA_TRIGGER:
+    {  
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_TRIGGER]->XferCpltCallback = TIM_DMATriggerCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_TRIGGER]->XferErrorCallback = HAL_TIM_DMAError ;
+  
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_TRIGGER], (uint32_t)BurstBuffer, (uint32_t)&htim->Instance->DMAR, ((BurstLength) >> 8) + 1);     
+    }
+    break;
+    default:
+    break;  
+  }
+   /* configure the DMA Burst Mode */
+   htim->Instance->DCR = BurstBaseAddress | BurstLength;  
+   
+   /* Enable the TIM DMA Request */
+   __HAL_TIM_ENABLE_DMA(htim, BurstRequestSrc);  
+   
+   htim->State = HAL_TIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the TIM DMA Burst mode 
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  BurstRequestSrc: TIM DMA Request sources to disable
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
+  
+  /* Disable the TIM Update DMA request */
+  __HAL_TIM_DISABLE_DMA(htim, BurstRequestSrc);
+      
+  /* Return function status */
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Configure the DMA Burst to transfer Data from the TIM peripheral to the memory 
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  BurstBaseAddress: TIM Base address from when the DMA will starts the Data read.
+  *         This parameters can be on of the following values:
+  *            @arg TIM_DMABase_CR1  
+  *            @arg TIM_DMABase_CR2
+  *            @arg TIM_DMABase_SMCR
+  *            @arg TIM_DMABase_DIER
+  *            @arg TIM_DMABase_SR
+  *            @arg TIM_DMABase_EGR
+  *            @arg TIM_DMABase_CCMR1
+  *            @arg TIM_DMABase_CCMR2
+  *            @arg TIM_DMABase_CCER
+  *            @arg TIM_DMABase_CNT   
+  *            @arg TIM_DMABase_PSC   
+  *            @arg TIM_DMABase_ARR
+  *            @arg TIM_DMABase_CCR1
+  *            @arg TIM_DMABase_CCR2
+  *            @arg TIM_DMABase_CCR3  
+  *            @arg TIM_DMABase_CCR4
+  *            @arg TIM_DMABase_DCR
+  * @param  BurstRequestSrc: TIM DMA Request sources.
+  *         This parameters can be on of the following values:
+  *            @arg TIM_DMA_UPDATE: TIM update Interrupt source
+  *            @arg TIM_DMA_CC1: TIM Capture Compare 1 DMA source
+  *            @arg TIM_DMA_CC2: TIM Capture Compare 2 DMA source
+  *            @arg TIM_DMA_CC3: TIM Capture Compare 3 DMA source
+  *            @arg TIM_DMA_CC4: TIM Capture Compare 4 DMA source
+  *            @arg TIM_DMA_TRIGGER: TIM Trigger DMA source
+  * @param  BurstBuffer: The Buffer address.
+  * @param  BurstLength: DMA Burst length. This parameter can be one value
+  *         between TIM_DMABurstLength_1Transfer and TIM_DMABurstLength_18Transfers.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress, uint32_t BurstRequestSrc,
+                                             uint32_t  *BurstBuffer, uint32_t  BurstLength)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMABURST_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_DMA_BASE(BurstBaseAddress));
+  assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
+  assert_param(IS_TIM_DMA_LENGTH(BurstLength));
+  
+  if((htim->State == HAL_TIM_STATE_BUSY))
+  {
+     return HAL_BUSY;
+  }
+  else if((htim->State == HAL_TIM_STATE_READY))
+  {
+    if((BurstBuffer == 0 ) && (BurstLength > 0)) 
+    {
+      return HAL_ERROR;                                    
+    }
+    else
+    {
+      htim->State = HAL_TIM_STATE_BUSY;
+    }
+  }  
+  switch(BurstRequestSrc)
+  {
+    case TIM_DMA_UPDATE:
+    {  
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_UPDATE]->XferCpltCallback = TIM_DMAPeriodElapsedCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_UPDATE]->XferErrorCallback = HAL_TIM_DMAError ;
+  
+      /* Enable the DMA Stream */
+       HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);     
+    }
+    break;
+    case TIM_DMA_CC1:
+    {  
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = HAL_TIM_DMAError ;
+  
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);      
+    }
+    break;
+    case TIM_DMA_CC2:
+    {  
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = HAL_TIM_DMAError ;
+  
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);     
+    }
+    break;
+    case TIM_DMA_CC3:
+    {  
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = HAL_TIM_DMAError ;
+  
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);      
+    }
+    break;
+    case TIM_DMA_CC4:
+    {  
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferCpltCallback = HAL_TIM_DMACaptureCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = HAL_TIM_DMAError ;
+  
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);      
+    }
+    break;
+    case TIM_DMA_TRIGGER:
+    {  
+      /* Set the DMA Period elapsed callback */
+      htim->hdma[TIM_DMA_ID_TRIGGER]->XferCpltCallback = TIM_DMATriggerCplt;
+     
+      /* Set the DMA error callback */
+      htim->hdma[TIM_DMA_ID_TRIGGER]->XferErrorCallback = HAL_TIM_DMAError ;
+  
+      /* Enable the DMA Stream */
+      HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_TRIGGER], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer, ((BurstLength) >> 8) + 1);      
+    }
+    break;
+    default:
+    break;  
+  }
+
+  /* configure the DMA Burst Mode */
+  htim->Instance->DCR = BurstBaseAddress | BurstLength;  
+  
+  /* Enable the TIM DMA Request */
+  __HAL_TIM_ENABLE_DMA(htim, BurstRequestSrc);
+  
+  htim->State = HAL_TIM_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stop the DMA burst reading 
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  BurstRequestSrc: TIM DMA Request sources to disable.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
+  
+  /* Disable the TIM Update DMA request */
+  __HAL_TIM_DISABLE_DMA(htim, BurstRequestSrc);
+      
+  /* Return function status */
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Generate a software event
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  EventSource: specifies the event source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_EventSource_Update: Timer update Event source
+  *            @arg TIM_EventSource_CC1: Timer Capture Compare 1 Event source
+  *            @arg TIM_EventSource_CC2: Timer Capture Compare 2 Event source
+  *            @arg TIM_EventSource_CC3: Timer Capture Compare 3 Event source
+  *            @arg TIM_EventSource_CC4: Timer Capture Compare 4 Event source  
+  *            @arg TIM_EventSource_Trigger: Timer Trigger Event source
+  * @note   TIM6 can only generate an update event. 
+  * @retval HAL status
+  */ 
+
+HAL_StatusTypeDef HAL_TIM_GenerateEvent(TIM_HandleTypeDef *htim, uint32_t EventSource)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_EVENT_SOURCE(EventSource));
+  
+  /* Process Locked */
+  __HAL_LOCK(htim);
+  
+  /* Change the TIM state */
+  htim->State = HAL_TIM_STATE_BUSY;
+  
+  /* Set the event sources */
+  htim->Instance->EGR = EventSource;
+  
+  /* Change the TIM state */
+  htim->State = HAL_TIM_STATE_READY;
+  
+  __HAL_UNLOCK(htim);
+  
+  /* Return function status */
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Configures the OCRef clear feature
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sClearInputConfig: pointer to a TIM_ClearInputConfigTypeDef structure that
+  *         contains the OCREF clear feature and parameters for the TIM peripheral. 
+  * @param  Channel: specifies the TIM Channel.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval HAL status
+  */ 
+HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim, TIM_ClearInputConfigTypeDef * sClearInputConfig, uint32_t Channel)
+{ 
+  /* Check the parameters */
+  assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_CHANNELS(Channel));
+  assert_param(IS_TIM_CLEARINPUT_SOURCE(sClearInputConfig->ClearInputSource));
+  assert_param(IS_TIM_CLEARINPUT_POLARITY(sClearInputConfig->ClearInputPolarity));
+  assert_param(IS_TIM_CLEARINPUT_PRESCALER(sClearInputConfig->ClearInputPrescaler));
+  assert_param(IS_TIM_CLEARINPUT_FILTER(sClearInputConfig->ClearInputFilter));
+   
+  /* Process Locked */
+  __HAL_LOCK(htim);
+  
+  htim->State = HAL_TIM_STATE_BUSY;
+  
+  if(sClearInputConfig->ClearInputSource == TIM_CLEARINPUTSOURCE_ETR)
+  {
+    TIM_ETR_SetConfig(htim->Instance, 
+                      sClearInputConfig->ClearInputPrescaler,
+                      sClearInputConfig->ClearInputPolarity,
+                      sClearInputConfig->ClearInputFilter);
+  }
+  
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {        
+      if(sClearInputConfig->ClearInputState != RESET)  
+      {
+        /* Enable the Ocref clear feature for Channel 1 */
+        htim->Instance->CCMR1 |= TIM_CCMR1_OC1CE;
+      }
+      else
+      {
+        /* Disable the Ocref clear feature for Channel 1 */
+        htim->Instance->CCMR1 &= ~TIM_CCMR1_OC1CE;      
+      }
+    }    
+    break;
+    case TIM_CHANNEL_2:    
+    { 
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance)); 
+      if(sClearInputConfig->ClearInputState != RESET)  
+      {
+        /* Enable the Ocref clear feature for Channel 2 */
+        htim->Instance->CCMR1 |= TIM_CCMR1_OC2CE;
+      }
+      else
+      {
+        /* Disable the Ocref clear feature for Channel 2 */
+        htim->Instance->CCMR1 &= ~TIM_CCMR1_OC2CE;      
+      }
+    } 
+    break;
+    case TIM_CHANNEL_3:   
+    {  
+      assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+      if(sClearInputConfig->ClearInputState != RESET)  
+      {
+        /* Enable the Ocref clear feature for Channel 3 */
+        htim->Instance->CCMR2 |= TIM_CCMR2_OC3CE;
+      }
+      else
+      {
+        /* Disable the Ocref clear feature for Channel 3 */
+        htim->Instance->CCMR2 &= ~TIM_CCMR2_OC3CE;      
+      }
+    } 
+    break;
+    case TIM_CHANNEL_4:    
+    {  
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+      if(sClearInputConfig->ClearInputState != RESET)  
+      {
+        /* Enable the Ocref clear feature for Channel 4 */
+        htim->Instance->CCMR2 |= TIM_CCMR2_OC4CE;
+      }
+      else
+      {
+        /* Disable the Ocref clear feature for Channel 4 */
+        htim->Instance->CCMR2 &= ~TIM_CCMR2_OC4CE;      
+      }
+    } 
+    break;
+    default:  
+    break;
+  } 
+
+  htim->State = HAL_TIM_STATE_READY;
+  
+  __HAL_UNLOCK(htim);
+  
+  return HAL_OK;  
+}  
+
+/**
+  * @brief   Configures the clock source to be used
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  sClockSourceConfig: pointer to a TIM_ClockConfigTypeDef structure that
+  *         contains the clock source information for the TIM peripheral. 
+  * @retval HAL status
+  */ 
+HAL_StatusTypeDef HAL_TIM_ConfigClockSource(TIM_HandleTypeDef *htim, TIM_ClockConfigTypeDef * sClockSourceConfig)    
+{
+  uint32_t tmpsmcr = 0;
+    
+  /* Process Locked */
+  __HAL_LOCK(htim);
+  
+  htim->State = HAL_TIM_STATE_BUSY;
+  
+  /* Check the parameters */
+  assert_param(IS_TIM_CLOCKSOURCE(sClockSourceConfig->ClockSource));
+  assert_param(IS_TIM_CLOCKPOLARITY(sClockSourceConfig->ClockPolarity));
+  assert_param(IS_TIM_CLOCKPRESCALER(sClockSourceConfig->ClockPrescaler));
+  assert_param(IS_TIM_CLOCKFILTER(sClockSourceConfig->ClockFilter));
+  
+  /* Reset the SMS, TS, ECE, ETPS and ETRF bits */
+  tmpsmcr = htim->Instance->SMCR;
+  tmpsmcr &= ~(TIM_SMCR_SMS | TIM_SMCR_TS);
+  tmpsmcr &= ~(TIM_SMCR_ETF | TIM_SMCR_ETPS | TIM_SMCR_ECE | TIM_SMCR_ETP);
+  htim->Instance->SMCR = tmpsmcr;
+  
+  switch (sClockSourceConfig->ClockSource)
+  {
+    case TIM_CLOCKSOURCE_INTERNAL:
+    { 
+      assert_param(IS_TIM_INSTANCE(htim->Instance));      
+      /* Disable slave mode to clock the prescaler directly with the internal clock */
+      htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+    }
+    break;
+    
+    case TIM_CLOCKSOURCE_ETRMODE1:
+    {
+      assert_param(IS_TIM_ETR_INSTANCE(htim->Instance));
+      /* Configure the ETR Clock source */
+      TIM_ETR_SetConfig(htim->Instance, 
+                        sClockSourceConfig->ClockPrescaler, 
+                        sClockSourceConfig->ClockPolarity, 
+                        sClockSourceConfig->ClockFilter);
+      /* Get the TIMx SMCR register value */
+      tmpsmcr = htim->Instance->SMCR;
+      /* Reset the SMS and TS Bits */
+      tmpsmcr &= ~(TIM_SMCR_SMS | TIM_SMCR_TS);
+      /* Select the External clock mode1 and the ETRF trigger */
+      tmpsmcr |= (TIM_SLAVEMODE_EXTERNAL1 | TIM_CLOCKSOURCE_ETRMODE1);
+      /* Write to TIMx SMCR */
+      htim->Instance->SMCR = tmpsmcr;
+    }
+    break;
+    
+    case TIM_CLOCKSOURCE_ETRMODE2:
+    {
+      assert_param(IS_TIM_ETR_INSTANCE(htim->Instance));
+      /* Configure the ETR Clock source */
+      TIM_ETR_SetConfig(htim->Instance, 
+                        sClockSourceConfig->ClockPrescaler, 
+                        sClockSourceConfig->ClockPolarity,
+                        sClockSourceConfig->ClockFilter);
+      /* Enable the External clock mode2 */
+      htim->Instance->SMCR |= TIM_SMCR_ECE;
+    }
+    break;
+    
+    case TIM_CLOCKSOURCE_TI1:
+    {
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      TIM_TI1_ConfigInputStage(htim->Instance, 
+                        sClockSourceConfig->ClockPolarity, 
+                        sClockSourceConfig->ClockFilter);
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_TI1);
+    }
+    break;
+    case TIM_CLOCKSOURCE_TI2:
+    {
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      TIM_TI2_ConfigInputStage(htim->Instance, 
+                        sClockSourceConfig->ClockPolarity, 
+                        sClockSourceConfig->ClockFilter);
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_TI2);
+    }
+    break;
+    case TIM_CLOCKSOURCE_TI1ED:
+    {
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      TIM_TI1_ConfigInputStage(htim->Instance, 
+                        sClockSourceConfig->ClockPolarity,
+                        sClockSourceConfig->ClockFilter);
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_TI1ED);
+    }
+    break;
+    case TIM_CLOCKSOURCE_ITR0:
+    {
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_ITR0);
+    }
+    break;
+    case TIM_CLOCKSOURCE_ITR1:
+    {
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_ITR1);
+    }
+    break;
+    case TIM_CLOCKSOURCE_ITR2:
+    {
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_ITR2);
+    }
+    break;
+    case TIM_CLOCKSOURCE_ITR3:
+    {
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      TIM_ITRx_SetConfig(htim->Instance, TIM_CLOCKSOURCE_ITR3);
+    }
+    break;
+    
+    default:
+    break;    
+  }
+  htim->State = HAL_TIM_STATE_READY;
+  
+  __HAL_UNLOCK(htim);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Selects the signal connected to the TI1 input: direct from CH1_input
+  *         or a XOR combination between CH1_input, CH2_input & CH3_input
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module..
+  * @param  TI1_Selection: Indicate whether or not channel 1 is connected to the
+  *         output of a XOR gate.
+  *         This parameter can be one of the following values:
+  *            @arg TIM_TI1SELECTION_CH1: The TIMx_CH1 pin is connected to TI1 input
+  *            @arg TIM_TI1SELECTION_XORCOMBINATION: The TIMx_CH1, CH2 and CH3
+  *            pins are connected to the TI1 input (XOR combination)
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_ConfigTI1Input(TIM_HandleTypeDef *htim, uint32_t TI1_Selection)
+{
+  uint32_t tmpcr2 = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_TIM_XOR_INSTANCE(htim->Instance)); 
+  assert_param(IS_TIM_TI1SELECTION(TI1_Selection));
+
+  /* Get the TIMx CR2 register value */
+  tmpcr2 = htim->Instance->CR2;
+
+  /* Reset the TI1 selection */
+  tmpcr2 &= ~TIM_CR2_TI1S;
+
+  /* Set the the TI1 selection */
+  tmpcr2 |= TI1_Selection;
+  
+  /* Write to TIMxCR2 */
+  htim->Instance->CR2 = tmpcr2;
+
+  return HAL_OK;
+}
+                                                
+/**
+  * @brief  Configures the TIM in Slave mode
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module..
+  * @param  sSlaveConfig: pointer to a TIM_SlaveConfigTypeDef structure that
+  *         contains the selected trigger (internal trigger input, filtered
+  *         timer input or external trigger input) and the ) and the Slave 
+  *         mode (Disable, Reset, Gated, Trigger, External clock mode 1). 
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchronization(TIM_HandleTypeDef *htim, TIM_SlaveConfigTypeDef * sSlaveConfig)
+{
+  uint32_t tmpsmcr = 0;
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_TIM_SLAVE_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_SLAVE_MODE(sSlaveConfig->SlaveMode));
+  assert_param(IS_TIM_TRIGGER_SELECTION(sSlaveConfig->InputTrigger));
+   
+  __HAL_LOCK(htim);
+  
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Get the TIMx SMCR register value */
+  tmpsmcr = htim->Instance->SMCR;
+
+  /* Reset the Trigger Selection Bits */
+  tmpsmcr &= ~TIM_SMCR_TS;
+  /* Set the Input Trigger source */
+  tmpsmcr |= sSlaveConfig->InputTrigger;
+
+  /* Reset the slave mode Bits */
+  tmpsmcr &= ~TIM_SMCR_SMS;
+  /* Set the slave mode */
+  tmpsmcr |= sSlaveConfig->SlaveMode;
+
+  /* Write to TIMx SMCR */
+  htim->Instance->SMCR = tmpsmcr;
+  
+  /* Configure the trigger prescaler, filter, and polarity */
+  switch (sSlaveConfig->InputTrigger)
+  {
+  case TIM_TS_ETRF:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_ETR_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERPRESCALER(sSlaveConfig->TriggerPrescaler));
+      assert_param(IS_TIM_TRIGGERPOLARITY(sSlaveConfig->TriggerPolarity));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+      /* Configure the ETR Trigger source */
+      TIM_ETR_SetConfig(htim->Instance, 
+                        sSlaveConfig->TriggerPrescaler, 
+                        sSlaveConfig->TriggerPolarity, 
+                        sSlaveConfig->TriggerFilter);
+    }
+    break;
+    
+  case TIM_TS_TI1F_ED:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+      
+      /* Disable the Channel 1: Reset the CC1E Bit */
+      tmpccer = htim->Instance->CCER;
+      htim->Instance->CCER &= ~TIM_CCER_CC1E;
+      tmpccmr1 = htim->Instance->CCMR1;    
+      
+      /* Set the filter */
+      tmpccmr1 &= ~TIM_CCMR1_IC1F;
+      tmpccmr1 |= ((sSlaveConfig->TriggerFilter) << 4);
+      
+      /* Write to TIMx CCMR1 and CCER registers */
+      htim->Instance->CCMR1 = tmpccmr1;
+      htim->Instance->CCER = tmpccer;                               
+                               
+    }
+    break;
+    
+  case TIM_TS_TI1FP1:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERPOLARITY(sSlaveConfig->TriggerPolarity));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+
+      /* Configure TI1 Filter and Polarity */
+      TIM_TI1_ConfigInputStage(htim->Instance,
+                               sSlaveConfig->TriggerPolarity,
+                               sSlaveConfig->TriggerFilter);
+    }
+    break;
+    
+  case TIM_TS_TI2FP2:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      assert_param(IS_TIM_TRIGGERPOLARITY(sSlaveConfig->TriggerPolarity));
+      assert_param(IS_TIM_TRIGGERFILTER(sSlaveConfig->TriggerFilter));
+      
+      /* Configure TI2 Filter and Polarity */
+      TIM_TI2_ConfigInputStage(htim->Instance,
+                                sSlaveConfig->TriggerPolarity,
+                                sSlaveConfig->TriggerFilter);
+    }
+    break;
+    
+  case TIM_TS_ITR0:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+    
+  case TIM_TS_ITR1:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+    
+  case TIM_TS_ITR2:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+    
+  case TIM_TS_ITR3:
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+    }
+    break;
+       
+  default:
+    break;
+  }
+  
+  htim->State = HAL_TIM_STATE_READY;
+     
+  __HAL_UNLOCK(htim);  
+  
+  return HAL_OK;
+} 
+
+/**
+  * @brief  Read the captured value from Capture Compare unit
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module..
+  * @param  Channel: TIM Channels to be enabled.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @retval Captured value
+  */
+uint32_t HAL_TIM_ReadCapturedValue(TIM_HandleTypeDef *htim, uint32_t Channel)
+{
+  uint32_t tmpreg = 0;
+  
+  __HAL_LOCK(htim);
+  
+  switch (Channel)
+  {
+    case TIM_CHANNEL_1:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+      
+      /* Return the capture 1 value */
+      tmpreg = htim->Instance->CCR1;
+      
+      break;
+    }
+    case TIM_CHANNEL_2:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      
+      /* Return the capture 2 value */
+      tmpreg = htim->Instance->CCR2;
+      
+      break;
+    }
+    
+    case TIM_CHANNEL_3:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC3_INSTANCE(htim->Instance));
+      
+      /* Return the capture 3 value */
+      tmpreg = htim->Instance->CCR3;
+      
+      break;
+    }
+    
+    case TIM_CHANNEL_4:
+    {
+      /* Check the parameters */
+      assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
+      
+      /* Return the capture 4 value */
+      tmpreg = htim->Instance->CCR4;
+      
+      break;
+    }
+    
+    default:
+    break;  
+  }
+     
+  __HAL_UNLOCK(htim);  
+  return tmpreg;
+}
+
+/**
+  * @}
+  */
+  
+/** @defgroup TIM_Group4 TIM Callbacks functions
+ *  @brief    TIM Callbacks functions 
+ *
+@verbatim
+  ==============================================================================
+                        ##### TIM Callbacks functions #####
+  ==============================================================================  
+ [..]  
+   This section provides TIM callback functions:
+   (+) Timer Period elapsed callback
+   (+) Timer Output Compare callback
+   (+) Timer Input capture callback
+   (+) Timer Trigger callback
+   (+) Timer Error callback
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Period elapsed callback in non blocking mode 
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the __HAL_TIM_PeriodElapsedCallback could be implemented in the user file
+   */
+  
+}
+/**
+  * @brief  Output Compare callback in non blocking mode 
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_OC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the __HAL_TIM_OC_DelayElapsedCallback could be implemented in the user file
+   */
+}
+/**
+  * @brief  Input Capture callback in non blocking mode 
+  * @param  htim: TIM IC handle
+  * @retval None
+  */
+__weak void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the __HAL_TIM_IC_CaptureCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  PWM Pulse finished callback in non blocking mode 
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_PWM_PulseFinishedCallback(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the __HAL_TIM_PWM_PulseFinishedCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Hall Trigger detection callback in non blocking mode 
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_TriggerCallback(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_TriggerCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Timer error callback in non blocking mode 
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval None
+  */
+__weak void HAL_TIM_ErrorCallback(TIM_HandleTypeDef *htim)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_TIM_ErrorCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Group5 Peripheral State functions 
+ *  @brief   Peripheral State functions 
+ *
+@verbatim   
+  ==============================================================================
+                      ##### Peripheral State functions #####
+  ==============================================================================  
+  [..]
+    This subsection permits to get in run-time the status of the peripheral 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the TIM Base state
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_Base_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM OC state
+  * @param  htim: TIM Ouput Compare handle
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_OC_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM PWM state
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_PWM_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM Input Capture state
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_IC_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM One Pulse Mode state
+  * @param  htim: TIM OPM handle
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_OnePulse_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @brief  Return the TIM Encoder Mode state
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @retval HAL state
+  */
+HAL_TIM_StateTypeDef HAL_TIM_Encoder_GetState(TIM_HandleTypeDef *htim)
+{
+  return htim->State;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Group6 TIM IRQ handler management 
+ *  @brief    IRQ handler management 
+ *
+@verbatim   
+  ==============================================================================
+                        ##### IRQ handler management #####
+  ==============================================================================  
+  [..]
+    This section provides Timer IRQ handler function.
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  This function handles TIM interrupts requests.
+  * @param  htim: TIM  handle
+  * @retval None
+  */
+void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
+{
+  /* Capture compare 1 event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC1) != RESET)
+  {
+    if(__HAL_TIM_GET_ITSTATUS(htim, TIM_IT_CC1) !=RESET)
+    {
+      {
+        __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC1);
+        htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
+        
+        /* Input capture event */
+        if((htim->Instance->CCMR1 & TIM_CCMR1_CC1S) != 0x00)
+        {
+          HAL_TIM_IC_CaptureCallback(htim);
+        }
+        /* Output compare event */
+        else
+        {
+          HAL_TIM_OC_DelayElapsedCallback(htim);
+          HAL_TIM_PWM_PulseFinishedCallback(htim);
+        }
+        htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+      }
+    }
+  }
+  /* Capture compare 2 event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC2) != RESET)
+  {
+    if(__HAL_TIM_GET_ITSTATUS(htim, TIM_IT_CC2) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC2);
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
+      /* Input capture event */
+      if((htim->Instance->CCMR1 & TIM_CCMR1_CC2S) != 0x00)
+      {          
+        HAL_TIM_IC_CaptureCallback(htim);
+      }
+      /* Output compare event */
+      else
+      {
+        HAL_TIM_OC_DelayElapsedCallback(htim);
+        HAL_TIM_PWM_PulseFinishedCallback(htim);
+      }
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+    }
+  }
+  /* Capture compare 3 event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC3) != RESET)
+  {
+    if(__HAL_TIM_GET_ITSTATUS(htim, TIM_IT_CC3) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC3);
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
+      /* Input capture event */
+      if((htim->Instance->CCMR2 & TIM_CCMR2_CC3S) != 0x00)
+      {          
+        HAL_TIM_IC_CaptureCallback(htim);
+      }
+      /* Output compare event */
+      else
+      {
+        HAL_TIM_OC_DelayElapsedCallback(htim);
+        HAL_TIM_PWM_PulseFinishedCallback(htim); 
+      }
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+    }
+  }
+  /* Capture compare 4 event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC4) != RESET)
+  {
+    if(__HAL_TIM_GET_ITSTATUS(htim, TIM_IT_CC4) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC4);
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
+      /* Input capture event */
+      if((htim->Instance->CCMR2 & TIM_CCMR2_CC4S) != 0x00)
+      {          
+        HAL_TIM_IC_CaptureCallback(htim);
+      }
+      /* Output compare event */
+      else
+      {
+        HAL_TIM_OC_DelayElapsedCallback(htim);
+        HAL_TIM_PWM_PulseFinishedCallback(htim);
+      }
+      htim->Channel = HAL_TIM_ACTIVE_CHANNEL_CLEARED;
+    }
+  }
+  /* TIM Update event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_UPDATE) != RESET)
+  {
+    if(__HAL_TIM_GET_ITSTATUS(htim, TIM_IT_UPDATE) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_UPDATE);
+      HAL_TIM_PeriodElapsedCallback(htim);
+    }
+  }
+  /* TIM Trigger detection event */
+  if(__HAL_TIM_GET_FLAG(htim, TIM_FLAG_TRIGGER) != RESET)
+  {
+    if(__HAL_TIM_GET_ITSTATUS(htim, TIM_IT_TRIGGER) !=RESET)
+    {
+      __HAL_TIM_CLEAR_IT(htim, TIM_IT_TRIGGER);
+      HAL_TIM_TriggerCallback(htim);
+    }
+  }
+}
+
+/**
+  * @brief  TIM DMA error callback 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void HAL_TIM_DMAError(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  htim->State= HAL_TIM_STATE_READY;
+   
+  HAL_TIM_ErrorCallback(htim);
+}
+
+/**
+  * @brief  TIM DMA Delay Pulse complete callback. 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void HAL_TIM_DMADelayPulseCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  htim->State= HAL_TIM_STATE_READY; 
+  
+  HAL_TIM_PWM_PulseFinishedCallback(htim);
+}
+/**
+  * @brief  TIM DMA Capture complete callback. 
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
+  * @retval None
+  */
+void HAL_TIM_DMACaptureCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+    
+   htim->State= HAL_TIM_STATE_READY; 
+    
+  HAL_TIM_IC_CaptureCallback(htim);
+
+}
+
+/**
+  * @}
+  */
+  
+
+/**
+  * @brief  TIM DMA Period Elapse complete callback. 
+  * @param  hdma: pointer to DMA handle.
+  * @retval None
+  */
+static void TIM_DMAPeriodElapsedCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  htim->State= HAL_TIM_STATE_READY;
+  
+  HAL_TIM_PeriodElapsedCallback(htim);
+}
+
+
+/**
+  * @brief  TIM DMA Trigger callback. 
+  * @param  hdma: pointer to DMA handle.
+  * @retval None
+  */
+static void TIM_DMATriggerCplt(DMA_HandleTypeDef *hdma)
+{
+  TIM_HandleTypeDef* htim = ( TIM_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;  
+  
+  htim->State= HAL_TIM_STATE_READY; 
+  
+  HAL_TIM_TriggerCallback(htim);
+}
+
+/**
+  * @brief  Time Base configuration
+  * @param  TIMx: TIM periheral
+  * @retval None
+  */
+static void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure)
+{
+  uint32_t tmpcr1 = 0;
+  tmpcr1 = TIMx->CR1;
+  
+  /* Set TIM Time Base Unit parameters ---------------------------------------*/
+  if(IS_TIM_CC3_INSTANCE(TIMx) != RESET)   
+  {
+    /* Select the Counter Mode */
+    tmpcr1 &= ~(TIM_CR1_DIR | TIM_CR1_CMS);
+    tmpcr1 |= Structure->CounterMode;
+  }
+ 
+  if(IS_TIM_CC1_INSTANCE(TIMx) != RESET)  
+  {
+    /* Set the clock division */
+    tmpcr1 &= ~TIM_CR1_CKD;
+    tmpcr1 |= (uint32_t)Structure->ClockDivision;
+  }
+
+  TIMx->CR1 = tmpcr1;
+
+  /* Set the Autoreload value */
+  TIMx->ARR = (uint32_t)Structure->Period ;
+ 
+  /* Set the Prescaler value */
+  TIMx->PSC = (uint32_t)Structure->Prescaler;
+
+  /* Generate an update event to reload the Prescaler value immediatly */
+  TIMx->EGR = TIM_EGR_UG;
+}
+
+/**
+  * @brief  Time Ouput Compare 1 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The ouput configuration structure
+  * @retval None
+  */
+static void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;  
+
+  /* Disable the Channel 1: Reset the CC1E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC1E;
+  
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 = TIMx->CR2;
+  
+  /* Get the TIMx CCMR1 register value */
+  tmpccmrx = TIMx->CCMR1;
+    
+  /* Reset the Output Compare Mode Bits */
+  tmpccmrx &= ~TIM_CCMR1_OC1M;
+  tmpccmrx &= ~TIM_CCMR1_CC1S;
+  /* Select the Output Compare Mode */
+  tmpccmrx |= OC_Config->OCMode;
+  
+  /* Reset the Output Polarity level */
+  tmpccer &= ~TIM_CCER_CC1P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= OC_Config->OCPolarity;
+
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+  
+  /* Write to TIMx CCMR1 */
+  TIMx->CCMR1 = tmpccmrx;
+  
+  /* Set the Capture Compare Register value */
+  TIMx->CCR1 = OC_Config->Pulse;
+  
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;  
+} 
+
+/**
+  * @brief  Time Ouput Compare 2 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The ouput configuration structure
+  * @retval None
+  */
+static void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;
+   
+  /* Disable the Channel 2: Reset the CC2E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC2E;
+  
+  /* Get the TIMx CCER register value */  
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 = TIMx->CR2;
+  
+  /* Get the TIMx CCMR1 register value */
+  tmpccmrx = TIMx->CCMR1;
+    
+  /* Reset the Output Compare mode and Capture/Compare selection Bits */
+  tmpccmrx &= ~TIM_CCMR1_OC2M;
+  tmpccmrx &= ~TIM_CCMR1_CC2S;
+  
+  /* Select the Output Compare Mode */
+  tmpccmrx |= (OC_Config->OCMode << 8);
+  
+  /* Reset the Output Polarity level */
+  tmpccer &= ~TIM_CCER_CC2P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (OC_Config->OCPolarity << 4);
+    
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+  
+  /* Write to TIMx CCMR1 */
+  TIMx->CCMR1 = tmpccmrx;
+  
+  /* Set the Capture Compare Register value */
+  TIMx->CCR2 = OC_Config->Pulse;
+  
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Time Ouput Compare 3 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The ouput configuration structure
+  * @retval None
+  */
+static void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;   
+
+  /* Disable the Channel 3: Reset the CC2E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC3E;
+  
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 = TIMx->CR2;
+  
+  /* Get the TIMx CCMR2 register value */
+  tmpccmrx = TIMx->CCMR2;
+    
+  /* Reset the Output Compare mode and Capture/Compare selection Bits */
+  tmpccmrx &= ~TIM_CCMR2_OC3M;
+  tmpccmrx &= ~TIM_CCMR2_CC3S;  
+  /* Select the Output Compare Mode */
+  tmpccmrx |= OC_Config->OCMode;
+  
+  /* Reset the Output Polarity level */
+  tmpccer &= ~TIM_CCER_CC3P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (OC_Config->OCPolarity << 8);
+    
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+  
+  /* Write to TIMx CCMR2 */
+  TIMx->CCMR2 = tmpccmrx;
+  
+  /* Set the Capture Compare Register value */
+  TIMx->CCR3 = OC_Config->Pulse;
+  
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Time Ouput Compare 4 configuration
+  * @param  TIMx to select the TIM peripheral
+  * @param  OC_Config: The ouput configuration structure
+  * @retval None
+  */
+static void TIM_OC4_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+{
+  uint32_t tmpccmrx = 0;
+  uint32_t tmpccer = 0;
+  uint32_t tmpcr2 = 0;
+
+  /* Disable the Channel 4: Reset the CC4E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC4E;
+  
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+  /* Get the TIMx CR2 register value */
+  tmpcr2 = TIMx->CR2;
+  
+  /* Get the TIMx CCMR2 register value */
+  tmpccmrx = TIMx->CCMR2;
+    
+  /* Reset the Output Compare mode and Capture/Compare selection Bits */
+  tmpccmrx &= ~TIM_CCMR2_OC4M;
+  tmpccmrx &= ~TIM_CCMR2_CC4S;
+  
+  /* Select the Output Compare Mode */
+  tmpccmrx |= (OC_Config->OCMode << 8);
+  
+  /* Reset the Output Polarity level */
+  tmpccer &= ~TIM_CCER_CC4P;
+  /* Set the Output Compare Polarity */
+  tmpccer |= (OC_Config->OCPolarity << 12);
+   
+  /* Write to TIMx CR2 */
+  TIMx->CR2 = tmpcr2;
+  
+  /* Write to TIMx CCMR2 */  
+  TIMx->CCMR2 = tmpccmrx;
+    
+  /* Set the Capture Compare Register value */
+  TIMx->CCR4 = OC_Config->Pulse;
+  
+  /* Write to TIMx CCER */
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the TI1 as Input.
+  * @param  TIMx to select the TIM peripheral.
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge  
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 1 is selected to be connected to IC1.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 1 is selected to be connected to IC2.
+  *            @arg TIM_ICSelection_TRC: TIM Input 1 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  */
+static void TIM_TI1_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+  
+  /* Disable the Channel 1: Reset the CC1E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC1E;
+  tmpccmr1 = TIMx->CCMR1;
+  tmpccer = TIMx->CCER;
+
+  /* Select the Input */
+  if(IS_TIM_CC2_INSTANCE(TIMx) != RESET)
+  {
+    tmpccmr1 &= ~TIM_CCMR1_CC1S;
+    tmpccmr1 |= TIM_ICSelection;
+  } 
+  else
+  {
+    tmpccmr1 &= ~TIM_CCMR1_CC1S;
+    tmpccmr1 |= TIM_CCMR1_CC1S_0;
+  }
+ 
+  /* Set the filter */
+  tmpccmr1 &= ~TIM_CCMR1_IC1F;
+  tmpccmr1 |= (TIM_ICFilter << 4);
+
+  /* Select the Polarity and set the CC1E Bit */
+  tmpccer &= ~(TIM_CCER_CC1P | TIM_CCER_CC1NP);
+  tmpccer |= TIM_ICPolarity;
+
+  /* Write to TIMx CCMR1 and CCER registers */
+  TIMx->CCMR1 = tmpccmr1;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the Polarity and Filter for TI1.
+  * @param  TIMx to select the TIM peripheral.
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  */
+static void TIM_TI1_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+  
+  /* Disable the Channel 1: Reset the CC1E Bit */
+  tmpccer = TIMx->CCER;
+  TIMx->CCER &= ~TIM_CCER_CC1E;
+  tmpccmr1 = TIMx->CCMR1;    
+  
+  /* Set the filter */
+  tmpccmr1 &= ~TIM_CCMR1_IC1F;
+  tmpccmr1 |= (TIM_ICFilter << 4);
+  
+  /* Select the Polarity and set the CC1E Bit */
+  tmpccer &= ~(TIM_CCER_CC1P | TIM_CCER_CC1NP);
+  tmpccer |= TIM_ICPolarity;
+  
+  /* Write to TIMx CCMR1 and CCER registers */
+  TIMx->CCMR1 = tmpccmr1;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the TI2 as Input.
+  * @param  TIMx to select the TIM peripheral
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge   
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 2 is selected to be connected to IC2.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 2 is selected to be connected to IC1.
+  *            @arg TIM_ICSelection_TRC: TIM Input 2 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  */
+static void TIM_TI2_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 2: Reset the CC2E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC2E;
+  tmpccmr1 = TIMx->CCMR1;
+  tmpccer = TIMx->CCER;
+  
+  /* Select the Input */
+  tmpccmr1 &= ~TIM_CCMR1_CC2S;
+  tmpccmr1 |= (TIM_ICSelection << 8);
+  
+  /* Set the filter */
+  tmpccmr1 &= ~TIM_CCMR1_IC2F;
+  tmpccmr1 |= (TIM_ICFilter << 12);
+
+  /* Select the Polarity and set the CC2E Bit */
+  tmpccer &= ~(TIM_CCER_CC2P | TIM_CCER_CC2NP);
+  tmpccer |= (TIM_ICPolarity << 4);
+
+  /* Write to TIMx CCMR1 and CCER registers */
+  TIMx->CCMR1 = tmpccmr1 ;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the Polarity and Filter for TI2.
+  * @param  TIMx to select the TIM peripheral.
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  */
+static void TIM_TI2_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr1 = 0;
+  uint32_t tmpccer = 0;
+  
+  /* Disable the Channel 2: Reset the CC2E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC2E;
+  tmpccmr1 = TIMx->CCMR1;
+  tmpccer = TIMx->CCER;
+  
+  /* Set the filter */
+  tmpccmr1 &= ~TIM_CCMR1_IC2F;
+  tmpccmr1 |= (TIM_ICFilter << 12);
+
+  /* Select the Polarity and set the CC2E Bit */
+  tmpccer &= ~(TIM_CCER_CC2P | TIM_CCER_CC2NP);
+  tmpccer |= (TIM_ICPolarity << 4);
+
+  /* Write to TIMx CCMR1 and CCER registers */
+  TIMx->CCMR1 = tmpccmr1 ;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the TI3 as Input.
+  * @param  TIMx to select the TIM peripheral
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge         
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 3 is selected to be connected to IC3.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 3 is selected to be connected to IC4.
+  *            @arg TIM_ICSelection_TRC: TIM Input 3 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  */
+static void TIM_TI3_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr2 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 3: Reset the CC3E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC3E;
+  tmpccmr2 = TIMx->CCMR2;
+  tmpccer = TIMx->CCER;
+
+  /* Select the Input */
+  tmpccmr2 &= ~TIM_CCMR2_CC3S;
+  tmpccmr2 |= TIM_ICSelection;
+
+  /* Set the filter */
+  tmpccmr2 &= ~TIM_CCMR2_IC3F;
+  tmpccmr2 |= (TIM_ICFilter << 4);
+
+  /* Select the Polarity and set the CC3E Bit */
+  tmpccer &= ~(TIM_CCER_CC3P | TIM_CCER_CC3NP);
+  tmpccer |= (TIM_ICPolarity << 8);
+
+  /* Write to TIMx CCMR2 and CCER registers */
+  TIMx->CCMR2 = tmpccmr2;
+  TIMx->CCER = tmpccer;
+}
+
+/**
+  * @brief  Configure the TI4 as Input.
+  * @param  TIMx to select the TIM peripheral
+  * @param  TIM_ICPolarity : The Input Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPolarity_Rising
+  *            @arg TIM_ICPolarity_Falling
+  *            @arg TIM_ICPolarity_BothEdge     
+  * @param  TIM_ICSelection: specifies the input to be used.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICSelection_DirectTI: TIM Input 4 is selected to be connected to IC4.
+  *            @arg TIM_ICSelection_IndirectTI: TIM Input 4 is selected to be connected to IC3.
+  *            @arg TIM_ICSelection_TRC: TIM Input 4 is selected to be connected to TRC.
+  * @param  TIM_ICFilter: Specifies the Input Capture Filter.
+  *          This parameter must be a value between 0x00 and 0x0F.
+  * @retval None
+  */
+static void TIM_TI4_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
+                       uint32_t TIM_ICFilter)
+{
+  uint32_t tmpccmr2 = 0;
+  uint32_t tmpccer = 0;
+
+  /* Disable the Channel 4: Reset the CC4E Bit */
+  TIMx->CCER &= ~TIM_CCER_CC4E;
+  tmpccmr2 = TIMx->CCMR2;
+  tmpccer = TIMx->CCER;
+
+  /* Select the Input */
+  tmpccmr2 &= ~TIM_CCMR2_CC4S;
+  tmpccmr2 |= (TIM_ICSelection << 8);
+
+  /* Set the filter */
+  tmpccmr2 &= ~TIM_CCMR2_IC4F;
+  tmpccmr2 |= (TIM_ICFilter << 12);
+
+  /* Select the Polarity and set the CC4E Bit */
+  tmpccer &= ~(TIM_CCER_CC4P | TIM_CCER_CC4NP);
+  tmpccer |= (TIM_ICPolarity << 12);
+
+  /* Write to TIMx CCMR2 and CCER registers */
+  TIMx->CCMR2 = tmpccmr2;
+  TIMx->CCER = tmpccer ;
+}
+
+/**
+  * @brief  Selects the Input Trigger source
+  * @param  TIMx to select the TIM peripheral
+  * @param  InputTriggerSource: The Input Trigger source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TS_ITR0: Internal Trigger 0
+  *            @arg TIM_TS_ITR1: Internal Trigger 1
+  *            @arg TIM_TS_ITR2: Internal Trigger 2
+  *            @arg TIM_TS_ITR3: Internal Trigger 3
+  *            @arg TIM_TS_TI1F_ED: TI1 Edge Detector
+  *            @arg TIM_TS_TI1FP1: Filtered Timer Input 1
+  *            @arg TIM_TS_TI2FP2: Filtered Timer Input 2
+  *            @arg TIM_TS_ETRF: External Trigger input
+  * @retval None
+  */
+static void TIM_ITRx_SetConfig(TIM_TypeDef *TIMx, uint16_t TIM_ITRx)
+{
+  uint32_t tmpsmcr = 0;
+  
+   /* Get the TIMx SMCR register value */
+   tmpsmcr = TIMx->SMCR;
+   /* Reset the TS Bits */
+   tmpsmcr &= ~TIM_SMCR_TS;
+   /* Set the Input Trigger source and the slave mode*/
+   tmpsmcr |= TIM_ITRx | TIM_SLAVEMODE_EXTERNAL1;
+   /* Write to TIMx SMCR */
+   TIMx->SMCR = tmpsmcr;
+}
+/**
+  * @brief  Configures the TIMx External Trigger (ETR).
+  * @param  TIMx to select the TIM peripheral
+  * @param  TIM_ExtTRGPrescaler: The external Trigger Prescaler.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ExtTRGPSC_DIV1: ETRP Prescaler OFF.
+  *            @arg TIM_ExtTRGPSC_DIV2: ETRP frequency divided by 2.
+  *            @arg TIM_ExtTRGPSC_DIV4: ETRP frequency divided by 4.
+  *            @arg TIM_ExtTRGPSC_DIV8: ETRP frequency divided by 8.
+  * @param  TIM_ExtTRGPolarity: The external Trigger Polarity.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ExtTRGPolarity_Inverted: active low or falling edge active.
+  *            @arg TIM_ExtTRGPolarity_NonInverted: active high or rising edge active.
+  * @param  ExtTRGFilter: External Trigger Filter.
+  *          This parameter must be a value between 0x00 and 0x0F
+  * @retval None
+  */
+static void TIM_ETR_SetConfig(TIM_TypeDef* TIMx, uint32_t TIM_ExtTRGPrescaler,
+                       uint32_t TIM_ExtTRGPolarity, uint32_t ExtTRGFilter)
+{
+  uint32_t tmpsmcr = 0;
+
+  tmpsmcr = TIMx->SMCR;
+
+  /* Reset the ETR Bits */
+  tmpsmcr &= ~(TIM_SMCR_ETF | TIM_SMCR_ETPS | TIM_SMCR_ECE | TIM_SMCR_ETP);
+
+  /* Set the Prescaler, the Filter value and the Polarity */
+  tmpsmcr |= (uint32_t)(TIM_ExtTRGPrescaler | (TIM_ExtTRGPolarity | (ExtTRGFilter << 8)));
+
+  /* Write to TIMx SMCR */
+  TIMx->SMCR = tmpsmcr;
+} 
+
+/**
+  * @brief  Enables or disables the TIM Capture Compare Channel x.
+  * @param  TIMx to select the TIM peripheral
+  * @param  Channel: specifies the TIM Channel
+  *          This parameter can be one of the following values:
+  *            @arg TIM_Channel_1: TIM Channel 1
+  *            @arg TIM_Channel_2: TIM Channel 2
+  *            @arg TIM_Channel_3: TIM Channel 3
+  *            @arg TIM_Channel_4: TIM Channel 4
+  * @param  ChannelState: specifies the TIM Channel CCxE bit new state.
+  *          This parameter can be: TIM_CCx_ENABLE or TIM_CCx_Disable. 
+  * @retval None
+  */
+static void TIM_CCxChannelCmd(TIM_TypeDef* TIMx, uint32_t Channel, uint32_t ChannelState)
+{
+  uint32_t tmp = 0;
+
+  /* Check the parameters */
+  assert_param(IS_TIM_CC1_INSTANCE(TIMx)); 
+  assert_param(IS_TIM_CHANNELS(Channel));
+
+  tmp = TIM_CCER_CC1E << Channel;
+
+  /* Reset the CCxE Bit */
+  TIMx->CCER &= ~tmp;
+
+  /* Set or reset the CCxE Bit */ 
+  TIMx->CCER |= (uint32_t)(ChannelState << Channel);
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_TIM_MODULE_ENABLED */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_tim.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_tim.h
@@ -1,0 +1,1293 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_tim.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of TIM HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_TIM_H
+#define __STM32L0xx_HAL_TIM_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup TIM
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+
+/** 
+  * @brief  TIM Time base Configuration Structure definition  
+  */
+typedef struct
+{
+  uint32_t Prescaler;         /*!< Specifies the prescaler value used to divide the TIM clock.
+                                   This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */
+
+  uint32_t CounterMode;       /*!< Specifies the counter mode.
+                                   This parameter can be a value of @ref TIM_Counter_Mode */
+
+  uint32_t Period;            /*!< Specifies the period value to be loaded into the active
+                                   Auto-Reload Register at the next update event.
+                                   This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF.  */ 
+
+  uint32_t ClockDivision;     /*!< Specifies the clock division.
+                                   This parameter can be a value of @ref TIM_ClockDivision */
+} TIM_Base_InitTypeDef;
+
+/** 
+  * @brief  TIM Output Compare Configuration Structure definition  
+  */
+
+typedef struct
+{                                 
+  uint32_t OCMode;        /*!< Specifies the TIM mode.
+                               This parameter can be a value of @ref TIM_Output_Compare_and_PWM_modes */
+
+  uint32_t Pulse;         /*!< Specifies the pulse value to be loaded into the Capture Compare Register. 
+                               This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */                          
+
+  uint32_t OCPolarity;    /*!< Specifies the output polarity.
+                               This parameter can be a value of @ref TIM_Output_Compare_Polarity */
+  
+  uint32_t OCFastMode;   /*!< Specifies the Fast mode state.
+                               This parameter can be a value of @ref TIM_Output_Fast_State
+                               @note This parameter is valid only in PWM1 and PWM2 mode. */
+
+} TIM_OC_InitTypeDef;  
+
+/** 
+  * @brief  TIM One Pulse Mode Configuration Structure definition  
+  */
+typedef struct
+{                               
+  uint32_t OCMode;        /*!< Specifies the TIM mode.
+                               This parameter can be a value of @ref TIM_Output_Compare_and_PWM_modes */
+
+  uint32_t Pulse;         /*!< Specifies the pulse value to be loaded into the Capture Compare Register. 
+                               This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF */                          
+
+  uint32_t OCPolarity;    /*!< Specifies the output polarity.
+                               This parameter can be a value of @ref TIM_Output_Compare_Polarity */
+
+
+  uint32_t ICPolarity;    /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+  uint32_t ICSelection;   /*!< Specifies the input.
+                              This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+  uint32_t ICFilter;      /*!< Specifies the input capture filter.
+                              This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */  
+} TIM_OnePulse_InitTypeDef;  
+
+
+/** 
+  * @brief  TIM Input Capture Configuration Structure definition  
+  */
+
+typedef struct
+{                                  
+  uint32_t  ICPolarity;   /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+  uint32_t ICSelection;  /*!< Specifies the input.
+                              This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+  uint32_t ICPrescaler;  /*!< Specifies the Input Capture Prescaler.
+                              This parameter can be a value of @ref TIM_Input_Capture_Prescaler */
+
+  uint32_t ICFilter;     /*!< Specifies the input capture filter.
+                              This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+} TIM_IC_InitTypeDef;
+
+/** 
+  * @brief  TIM Encoder Configuration Structure definition  
+  */
+
+typedef struct
+{
+  uint32_t EncoderMode;   /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Encoder_Mode */
+                                  
+  uint32_t IC1Polarity;   /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+  uint32_t IC1Selection;  /*!< Specifies the input.
+                               This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+  uint32_t IC1Prescaler;  /*!< Specifies the Input Capture Prescaler.
+                               This parameter can be a value of @ref TIM_Input_Capture_Prescaler */
+
+  uint32_t IC1Filter;     /*!< Specifies the input capture filter.
+                               This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+                                  
+  uint32_t IC2Polarity;   /*!< Specifies the active edge of the input signal.
+                               This parameter can be a value of @ref TIM_Input_Capture_Polarity */
+
+  uint32_t IC2Selection;  /*!< Specifies the input.
+                              This parameter can be a value of @ref TIM_Input_Capture_Selection */
+
+  uint32_t IC2Prescaler;  /*!< Specifies the Input Capture Prescaler.
+                               This parameter can be a value of @ref TIM_Input_Capture_Prescaler */
+
+  uint32_t IC2Filter;     /*!< Specifies the input capture filter.
+                               This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */                                 
+} TIM_Encoder_InitTypeDef;
+
+/** 
+  * @brief  Clock Configuration Handle Structure definition  
+  */ 
+typedef struct
+{
+  uint32_t ClockSource;     /*!< TIM clock sources. 
+                                 This parameter can be a value of @ref TIM_Clock_Source */ 
+  uint32_t ClockPolarity;   /*!< TIM clock polarity. 
+                                 This parameter can be a value of @ref TIM_Clock_Polarity */
+  uint32_t ClockPrescaler;  /*!< TIM clock prescaler. 
+                                 This parameter can be a value of @ref TIM_Clock_Prescaler */
+  uint32_t ClockFilter;    /*!< TIM clock filter. 
+                                This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+}TIM_ClockConfigTypeDef;
+
+/** 
+  * @brief  Clear Input Configuration Handle Structure definition  
+  */ 
+typedef struct
+{ 
+  uint32_t ClearInputState;      /*!< TIM clear Input state. 
+                                      This parameter can be ENABLE or DISABLE */  
+  uint32_t ClearInputSource;     /*!< TIM clear Input sources. 
+                                      This parameter can be a value of @ref TIM_ClearInput_Source */ 
+  uint32_t ClearInputPolarity;   /*!< TIM Clear Input polarity. 
+                                      This parameter can be a value of @ref TIM_ClearInput_Polarity */
+  uint32_t ClearInputPrescaler;  /*!< TIM Clear Input prescaler. 
+                                      This parameter can be a value of @ref TIM_ClearInput_Prescaler */
+  uint32_t ClearInputFilter;    /*!< TIM Clear Input filter. 
+                                     This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+}TIM_ClearInputConfigTypeDef;
+
+/** 
+  * @brief  TIM Slave configuration Structure definition  
+  */ 
+typedef struct {
+  uint32_t  SlaveMode;         /*!< Slave mode selection. 
+                                  This parameter can be a value of @ref TIM_Slave_Mode */ 
+  uint32_t  InputTrigger;      /*!< Input Trigger source. 
+                                  This parameter can be a value of @ref TIM_Trigger_Selection */
+  uint32_t  TriggerPolarity;   /*!< Input Trigger polarity. 
+                                  This parameter can be a value of @ref TIM_Trigger_Polarity */
+  uint32_t  TriggerPrescaler;  /*!< Input trigger prescaler. 
+                                  This parameter can be a value of @ref TIM_Trigger_Prescaler */
+  uint32_t  TriggerFilter;     /*!< Input trigger filter. 
+                                  This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+
+}TIM_SlaveConfigTypeDef;
+
+/** 
+  * @brief  HAL State structures definition  
+  */ 
+typedef enum
+{
+  HAL_TIM_STATE_RESET             = 0x00,    /*!< Peripheral not yet initialized or disabled  */
+  HAL_TIM_STATE_READY             = 0x01,    /*!< Peripheral Initialized and ready for use    */
+  HAL_TIM_STATE_BUSY              = 0x02,    /*!< An internal process is ongoing              */    
+  HAL_TIM_STATE_TIMEOUT           = 0x03,    /*!< Timeout state                               */  
+  HAL_TIM_STATE_ERROR             = 0x04     /*!< Reception process is ongoing                */                                                                             
+}HAL_TIM_StateTypeDef;
+
+/** 
+  * @brief  HAL Active channel structures definition  
+  */ 
+typedef enum
+{
+  HAL_TIM_ACTIVE_CHANNEL_1        = 0x01,    /*!< The active channel is 1     */
+  HAL_TIM_ACTIVE_CHANNEL_2        = 0x02,    /*!< The active channel is 2     */
+  HAL_TIM_ACTIVE_CHANNEL_3        = 0x04,    /*!< The active channel is 3     */   
+  HAL_TIM_ACTIVE_CHANNEL_4        = 0x08,    /*!< The active channel is 4     */
+  HAL_TIM_ACTIVE_CHANNEL_CLEARED  = 0x00     /*!< All active channels cleared */    
+}HAL_TIM_ActiveChannel;
+
+/** 
+  * @brief  TIM Time Base Handle Structure definition  
+  */ 
+typedef struct
+{
+  TIM_TypeDef              *Instance;     /*!< Register base address             */ 
+  TIM_Base_InitTypeDef     Init;          /*!< TIM Time Base required parameters */
+  HAL_TIM_ActiveChannel    Channel;       /*!< Active channel                    */ 
+  DMA_HandleTypeDef        *hdma[7];      /*!< DMA Handlers array
+                                             This array is accessed by a @ref DMA_Handle_index */
+  HAL_LockTypeDef          Lock;          /*!< Locking object                    */
+__IO HAL_TIM_StateTypeDef  State;         /*!< TIM operation state               */  
+}TIM_HandleTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup TIM_Exported_Constants
+  * @{
+  */
+
+/** @defgroup TIM_Input_Channel_Polarity
+  * @{
+  */
+#define  TIM_INPUTCHANNELPOLARITY_RISING      ((uint32_t)0x00000000)            /*!< Polarity for TIx source */
+#define  TIM_INPUTCHANNELPOLARITY_FALLING     (TIM_CCER_CC1P)                   /*!< Polarity for TIx source */
+#define  TIM_INPUTCHANNELPOLARITY_BOTHEDGE    (TIM_CCER_CC1P | TIM_CCER_CC1NP)  /*!< Polarity for TIx source */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_ETR_Polarity
+  * @{
+  */
+#define TIM_ETRPOLARITY_INVERTED              (TIM_SMCR_ETP)                    /*!< Polarity for ETR source */ 
+#define TIM_ETRPOLARITY_NONINVERTED           ((uint32_t)0x0000)                /*!< Polarity for ETR source */ 
+/**
+  * @}
+  */
+
+/** @defgroup TIM_ETR_Prescaler
+  * @{
+  */                
+#define TIM_ETRPRESCALER_DIV1                 ((uint32_t)0x0000)                /*!< No prescaler is used */
+#define TIM_ETRPRESCALER_DIV2                 (TIM_SMCR_ETPS_0)                 /*!< ETR input source is divided by 2 */
+#define TIM_ETRPRESCALER_DIV4                 (TIM_SMCR_ETPS_1)                 /*!< ETR input source is divided by 4 */
+#define TIM_ETRPRESCALER_DIV8                 (TIM_SMCR_ETPS)                   /*!< ETR input source is divided by 8 */
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Counter_Mode
+  * @{
+  */
+#define TIM_COUNTERMODE_UP                 ((uint32_t)0x0000)
+#define TIM_COUNTERMODE_DOWN               TIM_CR1_DIR
+#define TIM_COUNTERMODE_CENTERALIGNED1     TIM_CR1_CMS_0
+#define TIM_COUNTERMODE_CENTERALIGNED2     TIM_CR1_CMS_1
+#define TIM_COUNTERMODE_CENTERALIGNED3     TIM_CR1_CMS
+
+#define IS_TIM_COUNTER_MODE(MODE) (((MODE) == TIM_COUNTERMODE_UP)              || \
+                                   ((MODE) == TIM_COUNTERMODE_DOWN)            || \
+                                   ((MODE) == TIM_COUNTERMODE_CENTERALIGNED1)  || \
+                                   ((MODE) == TIM_COUNTERMODE_CENTERALIGNED2)  || \
+                                   ((MODE) == TIM_COUNTERMODE_CENTERALIGNED3))
+/**
+  * @}
+  */ 
+  
+/** @defgroup TIM_ClockDivision
+  * @{
+  */
+#define TIM_CLOCKDIVISION_DIV1                       ((uint32_t)0x0000)
+#define TIM_CLOCKDIVISION_DIV2                       (TIM_CR1_CKD_0)
+#define TIM_CLOCKDIVISION_DIV4                       (TIM_CR1_CKD_1)
+
+#define IS_TIM_CLOCKDIVISION_DIV(DIV) (((DIV) == TIM_CLOCKDIVISION_DIV1) || \
+                                       ((DIV) == TIM_CLOCKDIVISION_DIV2) || \
+                                       ((DIV) == TIM_CLOCKDIVISION_DIV4))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_and_PWM_modes
+  * @{
+  */
+#define TIM_OCMODE_TIMING                   ((uint32_t)0x0000)
+#define TIM_OCMODE_ACTIVE                   (TIM_CCMR1_OC1M_0)
+#define TIM_OCMODE_INACTIVE                 (TIM_CCMR1_OC1M_1)
+#define TIM_OCMODE_TOGGLE                   (TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_1)
+#define TIM_OCMODE_PWM1                     (TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2)
+#define TIM_OCMODE_PWM2                     (TIM_CCMR1_OC1M)
+#define TIM_OCMODE_FORCED_ACTIVE            (TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_2)
+#define TIM_OCMODE_FORCED_INACTIVE          (TIM_CCMR1_OC1M_2)
+
+#define IS_TIM_PWM_MODE(MODE) (((MODE) == TIM_OCMODE_PWM1) || \
+                               ((MODE) == TIM_OCMODE_PWM2))
+                              
+#define IS_TIM_OC_MODE(MODE) (((MODE) == TIM_OCMODE_TIMING)       || \
+                          ((MODE) == TIM_OCMODE_ACTIVE)           || \
+                          ((MODE) == TIM_OCMODE_INACTIVE)         || \
+                          ((MODE) == TIM_OCMODE_TOGGLE)           || \
+                          ((MODE) == TIM_OCMODE_FORCED_ACTIVE)    || \
+                          ((MODE) == TIM_OCMODE_FORCED_INACTIVE))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Output_Compare_State
+  * @{
+  */
+#define TIM_OUTPUTSTATE_DISABLE            ((uint32_t)0x0000)
+#define TIM_OUTPUTSTATE_ENABLE             (TIM_CCER_CC1E)
+
+#define IS_TIM_OUTPUT_STATE(STATE) (((STATE) == TIM_OUTPUTSTATE_DISABLE) || \
+                                    ((STATE) == TIM_OUTPUTSTATE_ENABLE))
+/**
+  * @}
+  */ 
+/** @defgroup TIM_Output_Fast_State
+  * @{
+  */
+#define TIM_OCFAST_DISABLE                ((uint32_t)0x0000)
+#define TIM_OCFAST_ENABLE                 (TIM_CCMR1_OC1FE)
+
+#define IS_TIM_FAST_STATE(STATE) (((STATE) == TIM_OCFAST_DISABLE) || \
+                                  ((STATE) == TIM_OCFAST_ENABLE))
+/**
+  * @}
+  */ 
+/** @defgroup TIM_Output_Compare_N_State
+  * @{
+  */
+#define TIM_OUTPUTNSTATE_DISABLE            ((uint32_t)0x0000)
+#define TIM_OUTPUTNSTATE_ENABLE             (TIM_CCER_CC1NE)
+
+#define IS_TIM_OUTPUTN_STATE(STATE) (((STATE) == TIM_OUTPUTNSTATE_DISABLE) || \
+                                     ((STATE) == TIM_OUTPUTNSTATE_ENABLE))
+/**
+  * @}
+  */ 
+  
+/** @defgroup TIM_Output_Compare_Polarity
+  * @{
+  */
+#define TIM_OCPOLARITY_HIGH                ((uint32_t)0x0000)
+#define TIM_OCPOLARITY_LOW                 (TIM_CCER_CC1P)
+
+#define IS_TIM_OC_POLARITY(POLARITY) (((POLARITY) == TIM_OCPOLARITY_HIGH) || \
+                                      ((POLARITY) == TIM_OCPOLARITY_LOW))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Channel
+  * @{
+  */
+
+#define TIM_CHANNEL_1                      ((uint32_t)0x0000)
+#define TIM_CHANNEL_2                      ((uint32_t)0x0004)
+#define TIM_CHANNEL_3                      ((uint32_t)0x0008)
+#define TIM_CHANNEL_4                      ((uint32_t)0x000C)
+#define TIM_CHANNEL_ALL                    ((uint32_t)0x0018)
+                                 
+#define IS_TIM_CHANNELS(CHANNEL) (((CHANNEL) == TIM_CHANNEL_1) || \
+                                  ((CHANNEL) == TIM_CHANNEL_2) || \
+                                  ((CHANNEL) == TIM_CHANNEL_3) || \
+                                  ((CHANNEL) == TIM_CHANNEL_4) || \
+                                  ((CHANNEL) == TIM_CHANNEL_ALL))
+                                 
+#define IS_TIM_PWMI_CHANNELS(CHANNEL) (((CHANNEL) == TIM_CHANNEL_1) || \
+                                       ((CHANNEL) == TIM_CHANNEL_2))
+
+#define IS_TIM_OPM_CHANNELS(CHANNEL) (((CHANNEL) == TIM_CHANNEL_1) || \
+                                      ((CHANNEL) == TIM_CHANNEL_2))                                       
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Input_Capture_Polarity
+  * @{
+  */
+#define  TIM_ICPOLARITY_RISING             TIM_INPUTCHANNELPOLARITY_RISING
+#define  TIM_ICPOLARITY_FALLING            TIM_INPUTCHANNELPOLARITY_FALLING
+#define  TIM_ICPOLARITY_BOTHEDGE           TIM_INPUTCHANNELPOLARITY_BOTHEDGE
+    
+#define IS_TIM_IC_POLARITY(POLARITY) (((POLARITY) == TIM_ICPOLARITY_RISING)   || \
+                                      ((POLARITY) == TIM_ICPOLARITY_FALLING)  || \
+                                      ((POLARITY) == TIM_ICPOLARITY_BOTHEDGE))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Input_Capture_Selection
+  * @{
+  */
+#define TIM_ICSELECTION_DIRECTTI           (TIM_CCMR1_CC1S_0)   /*!< TIM Input 1, 2, 3 or 4 is selected to be 
+                                                                     connected to IC1, IC2, IC3 or IC4, respectively */
+#define TIM_ICSELECTION_INDIRECTTI         (TIM_CCMR1_CC1S_1)   /*!< TIM Input 1, 2, 3 or 4 is selected to be
+                                                                     connected to IC2, IC1, IC4 or IC3, respectively */
+#define TIM_ICSELECTION_TRC                (TIM_CCMR1_CC1S)     /*!< TIM Input 1, 2, 3 or 4 is selected to be connected to TRC */
+
+#define IS_TIM_IC_SELECTION(SELECTION) (((SELECTION) == TIM_ICSELECTION_DIRECTTI) || \
+                                        ((SELECTION) == TIM_ICSELECTION_INDIRECTTI) || \
+                                        ((SELECTION) == TIM_ICSELECTION_TRC))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Input_Capture_Prescaler
+  * @{
+  */
+#define TIM_ICPSC_DIV1                     ((uint32_t)0x0000)       /*!< Capture performed each time an edge is detected on the capture input */
+#define TIM_ICPSC_DIV2                     (TIM_CCMR1_IC1PSC_0)     /*!< Capture performed once every 2 events */
+#define TIM_ICPSC_DIV4                     (TIM_CCMR1_IC1PSC_1)     /*!< Capture performed once every 4 events */
+#define TIM_ICPSC_DIV8                     (TIM_CCMR1_IC1PSC)       /*!< Capture performed once every 8 events */
+
+#define IS_TIM_IC_PRESCALER(PRESCALER) (((PRESCALER) == TIM_ICPSC_DIV1) || \
+                                        ((PRESCALER) == TIM_ICPSC_DIV2) || \
+                                        ((PRESCALER) == TIM_ICPSC_DIV4) || \
+                                        ((PRESCALER) == TIM_ICPSC_DIV8))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_One_Pulse_Mode
+  * @{
+  */
+#define TIM_OPMODE_SINGLE                  (TIM_CR1_OPM)
+#define TIM_OPMODE_REPETITIVE              ((uint32_t)0x0000)
+#define IS_TIM_OPM_MODE(MODE) (((MODE) == TIM_OPMODE_SINGLE) || \
+                               ((MODE) == TIM_OPMODE_REPETITIVE))
+/**
+  * @}
+  */ 
+/** @defgroup TIM_Encoder_Mode
+  * @{
+  */ 
+#define TIM_ENCODERMODE_TI1                (TIM_SMCR_SMS_0)
+#define TIM_ENCODERMODE_TI2                (TIM_SMCR_SMS_1)
+#define TIM_ENCODERMODE_TI12               (TIM_SMCR_SMS_1 | TIM_SMCR_SMS_0)
+#define IS_TIM_ENCODER_MODE(MODE) (((MODE) == TIM_ENCODERMODE_TI1) || \
+                                   ((MODE) == TIM_ENCODERMODE_TI2) || \
+                                   ((MODE) == TIM_ENCODERMODE_TI12))   
+/**
+  * @}
+  */   
+/** @defgroup TIM_Interrupt_definition
+  * @{
+  */ 
+#define TIM_IT_UPDATE           (TIM_DIER_UIE)
+#define TIM_IT_CC1              (TIM_DIER_CC1IE)
+#define TIM_IT_CC2              (TIM_DIER_CC2IE)
+#define TIM_IT_CC3              (TIM_DIER_CC3IE)
+#define TIM_IT_CC4              (TIM_DIER_CC4IE)
+#define TIM_IT_TRIGGER          (TIM_DIER_TIE)
+
+#define IS_TIM_IT(IT) ((((IT) & 0xFFFFFFA0) == 0x00000000) && ((IT) != 0x00000000))
+
+#define IS_TIM_GET_IT(IT) (((IT) == TIM_IT_UPDATE)  || \
+                           ((IT) == TIM_IT_CC1)     || \
+                           ((IT) == TIM_IT_CC2)     || \
+                           ((IT) == TIM_IT_CC3)     || \
+                           ((IT) == TIM_IT_CC4)     || \
+                           ((IT) == TIM_IT_TRIGGER))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_DMA_sources
+  * @{
+  */
+#define TIM_DMA_UPDATE                     (TIM_DIER_UDE)
+#define TIM_DMA_CC1                        (TIM_DIER_CC1DE)
+#define TIM_DMA_CC2                        (TIM_DIER_CC2DE)
+#define TIM_DMA_CC3                        (TIM_DIER_CC3DE)
+#define TIM_DMA_CC4                        (TIM_DIER_CC4DE)
+#define TIM_DMA_TRIGGER                    (TIM_DIER_TDE)
+#define IS_TIM_DMA_SOURCE(SOURCE) ((((SOURCE) & 0xFFFFA0FF) == 0x00000000) && ((SOURCE) != 0x00000000))
+
+/**
+  * @}
+  */
+    
+/** @defgroup TIM_Event_Source
+  * @{
+  */
+#define TIM_EventSource_Update              TIM_EGR_UG  
+#define TIM_EventSource_CC1                 TIM_EGR_CC1G
+#define TIM_EventSource_CC2                 TIM_EGR_CC2G
+#define TIM_EventSource_CC3                 TIM_EGR_CC3G
+#define TIM_EventSource_CC4                 TIM_EGR_CC4G
+#define TIM_EventSource_Trigger             TIM_EGR_TG    
+#define IS_TIM_EVENT_SOURCE(SOURCE) ((((SOURCE) & 0xFFFFFFA0) == 0x00000000) && ((SOURCE) != 0x00000000))                                          
+  
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Flag_definition
+  * @{
+  */                                
+#define TIM_FLAG_UPDATE                    (TIM_SR_UIF)
+#define TIM_FLAG_CC1                       (TIM_SR_CC1IF)
+#define TIM_FLAG_CC2                       (TIM_SR_CC2IF)
+#define TIM_FLAG_CC3                       (TIM_SR_CC3IF)
+#define TIM_FLAG_CC4                       (TIM_SR_CC4IF)
+#define TIM_FLAG_TRIGGER                   (TIM_SR_TIF)
+#define TIM_FLAG_CC1OF                     (TIM_SR_CC1OF)
+#define TIM_FLAG_CC2OF                     (TIM_SR_CC2OF)
+#define TIM_FLAG_CC3OF                     (TIM_SR_CC3OF)
+#define TIM_FLAG_CC4OF                     (TIM_SR_CC4OF)
+
+#define IS_TIM_FLAG(FLAG) (((FLAG) == TIM_FLAG_UPDATE) || \
+                           ((FLAG) == TIM_FLAG_CC1)     || \
+                           ((FLAG) == TIM_FLAG_CC2)     || \
+                           ((FLAG) == TIM_FLAG_CC3)     || \
+                           ((FLAG) == TIM_FLAG_CC4)     || \
+                           ((FLAG) == TIM_FLAG_TRIGGER) || \
+                           ((FLAG) == TIM_FLAG_CC1OF)   || \
+                           ((FLAG) == TIM_FLAG_CC2OF)   || \
+                           ((FLAG) == TIM_FLAG_CC3OF)   || \
+                           ((FLAG) == TIM_FLAG_CC4OF))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Clock_Source
+  * @{
+  */ 
+#define	TIM_CLOCKSOURCE_ETRMODE2    (TIM_SMCR_ETPS_1) 
+#define	TIM_CLOCKSOURCE_INTERNAL    (TIM_SMCR_ETPS_0) 
+#define	TIM_CLOCKSOURCE_ITR0        ((uint32_t)0x0000)
+#define	TIM_CLOCKSOURCE_ITR1        (TIM_SMCR_TS_0)
+#define	TIM_CLOCKSOURCE_ITR2        (TIM_SMCR_TS_1)
+#define	TIM_CLOCKSOURCE_ITR3        (TIM_SMCR_TS_0 | TIM_SMCR_TS_1)
+#define	TIM_CLOCKSOURCE_TI1ED       (TIM_SMCR_TS_2)
+#define	TIM_CLOCKSOURCE_TI1         (TIM_SMCR_TS_0 | TIM_SMCR_TS_2)
+#define	TIM_CLOCKSOURCE_TI2         (TIM_SMCR_TS_1 | TIM_SMCR_TS_2)
+#define	TIM_CLOCKSOURCE_ETRMODE1    (TIM_SMCR_TS)
+
+#define IS_TIM_CLOCKSOURCE(CLOCK) (((CLOCK) == TIM_CLOCKSOURCE_INTERNAL) || \
+                                   ((CLOCK) == TIM_CLOCKSOURCE_ETRMODE2) || \
+                                   ((CLOCK) == TIM_CLOCKSOURCE_ITR0)     || \
+                                   ((CLOCK) == TIM_CLOCKSOURCE_ITR1)     || \
+                                   ((CLOCK) == TIM_CLOCKSOURCE_ITR2)     || \
+                                   ((CLOCK) == TIM_CLOCKSOURCE_ITR3)     || \
+                                   ((CLOCK) == TIM_CLOCKSOURCE_TI1ED)    || \
+                                   ((CLOCK) == TIM_CLOCKSOURCE_TI1)      || \
+                                   ((CLOCK) == TIM_CLOCKSOURCE_TI2)      || \
+                                   ((CLOCK) == TIM_CLOCKSOURCE_ETRMODE1))
+/**
+  * @}
+  */   
+
+/** @defgroup TIM_Clock_Polarity
+  * @{
+  */
+#define TIM_CLOCKPOLARITY_INVERTED           TIM_ETRPOLARITY_INVERTED          /*!< Polarity for ETRx clock sources */ 
+#define TIM_CLOCKPOLARITY_NONINVERTED        TIM_ETRPOLARITY_NONINVERTED       /*!< Polarity for ETRx clock sources */ 
+#define TIM_CLOCKPOLARITY_RISING             TIM_INPUTCHANNELPOLARITY_RISING   /*!< Polarity for TIx clock sources */ 
+#define TIM_CLOCKPOLARITY_FALLING            TIM_INPUTCHANNELPOLARITY_FALLING   /*!< Polarity for TIx clock sources */ 
+#define TIM_CLOCKPOLARITY_BOTHEDGE           TIM_INPUTCHANNELPOLARITY_BOTHEDGE  /*!< Polarity for TIx clock sources */ 
+
+#define IS_TIM_CLOCKPOLARITY(POLARITY) (((POLARITY) == TIM_CLOCKPOLARITY_INVERTED)    || \
+                                        ((POLARITY) == TIM_CLOCKPOLARITY_NONINVERTED) || \
+                                        ((POLARITY) == TIM_CLOCKPOLARITY_RISING)      || \
+                                        ((POLARITY) == TIM_CLOCKPOLARITY_FALLING)     || \
+                                        ((POLARITY) == TIM_CLOCKPOLARITY_BOTHEDGE))
+/**
+  * @}
+  */
+/** @defgroup TIM_Clock_Prescaler
+  * @{
+  */                
+#define TIM_CLOCKPRESCALER_DIV1                 TIM_ETRPRESCALER_DIV1     /*!< No prescaler is used */
+#define TIM_CLOCKPRESCALER_DIV2                 TIM_ETRPRESCALER_DIV2     /*!< Prescaler for External ETR Clock: Capture performed once every 2 events. */
+#define TIM_CLOCKPRESCALER_DIV4                 TIM_ETRPRESCALER_DIV4     /*!< Prescaler for External ETR Clock: Capture performed once every 4 events. */
+#define TIM_CLOCKPRESCALER_DIV8                 TIM_ETRPRESCALER_DIV8     /*!< Prescaler for External ETR Clock: Capture performed once every 8 events. */
+
+#define IS_TIM_CLOCKPRESCALER(PRESCALER) (((PRESCALER) == TIM_CLOCKPRESCALER_DIV1) || \
+                                          ((PRESCALER) == TIM_CLOCKPRESCALER_DIV2) || \
+                                          ((PRESCALER) == TIM_CLOCKPRESCALER_DIV4) || \
+                                          ((PRESCALER) == TIM_CLOCKPRESCALER_DIV8)) 
+/**
+  * @}
+  */ 
+  
+/** @defgroup TIM_Clock_Filter
+  * @{
+  */
+#define IS_TIM_CLOCKFILTER(ICFILTER)      ((ICFILTER) <= 0xF)
+/**
+  * @}
+  */
+
+/** @defgroup TIM_ClearInput_Source
+  * @{
+  */
+#define TIM_CLEARINPUTSOURCE_ETR           ((uint32_t)0x0001) 
+#define TIM_CLEARINPUTSOURCE_NONE          ((uint32_t)0x0000)
+
+#define IS_TIM_CLEARINPUT_SOURCE(SOURCE)  (((SOURCE) == TIM_CLEARINPUTSOURCE_NONE) || \
+                                         ((SOURCE) == TIM_CLEARINPUTSOURCE_ETR)) 
+/**
+  * @}
+  */
+
+/** @defgroup TIM_ClearInput_Polarity
+  * @{
+  */
+#define TIM_CLEARINPUTPOLARITY_INVERTED           TIM_ETRPOLARITY_INVERTED                    /*!< Polarity for ETRx pin */ 
+#define TIM_CLEARINPUTPOLARITY_NONINVERTED        TIM_ETRPOLARITY_NONINVERTED                 /*!< Polarity for ETRx pin */ 
+#define IS_TIM_CLEARINPUT_POLARITY(POLARITY)   (((POLARITY) == TIM_CLEARINPUTPOLARITY_INVERTED) || \
+                                               ((POLARITY) == TIM_CLEARINPUTPOLARITY_NONINVERTED))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_ClearInput_Prescaler
+  * @{
+  */
+#define TIM_CLEARINPUTPRESCALER_DIV1                    TIM_ETRPRESCALER_DIV1      /*!< No prescaler is used */
+#define TIM_CLEARINPUTPRESCALER_DIV2                    TIM_ETRPRESCALER_DIV2      /*!< Prescaler for External ETR pin: Capture performed once every 2 events. */
+#define TIM_CLEARINPUTPRESCALER_DIV4                    TIM_ETRPRESCALER_DIV4      /*!< Prescaler for External ETR pin: Capture performed once every 4 events. */
+#define TIM_CLEARINPUTPRESCALER_DIV8                    TIM_ETRPRESCALER_DIV8        /*!< Prescaler for External ETR pin: Capture performed once every 8 events. */
+#define IS_TIM_CLEARINPUT_PRESCALER(PRESCALER)   (((PRESCALER) == TIM_CLEARINPUTPRESCALER_DIV1) || \
+                                                 ((PRESCALER) == TIM_CLEARINPUTPRESCALER_DIV2) || \
+                                                 ((PRESCALER) == TIM_CLEARINPUTPRESCALER_DIV4) || \
+                                                 ((PRESCALER) == TIM_CLEARINPUTPRESCALER_DIV8))
+/**
+  * @}
+  */
+  
+/** @defgroup TIM_ClearInput_Filter
+  * @{
+  */
+#define IS_TIM_CLEARINPUT_FILTER(ICFILTER) ((ICFILTER) <= 0xF) 
+/**
+  * @}
+  */ 
+
+  
+/** @defgroup TIM_Master_Mode_Selection
+  * @{
+  */  
+#define	TIM_TRGO_RESET            ((uint32_t)0x0000)             
+#define	TIM_TRGO_ENABLE           (TIM_CR2_MMS_0)           
+#define	TIM_TRGO_UPDATE           (TIM_CR2_MMS_1)             
+#define	TIM_TRGO_OC1              ((TIM_CR2_MMS_1 | TIM_CR2_MMS_0))    
+#define	TIM_TRGO_OC1REF           (TIM_CR2_MMS_2)           
+#define	TIM_TRGO_OC2REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_0))          
+#define	TIM_TRGO_OC3REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_1))           
+#define	TIM_TRGO_OC4REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_1 | TIM_CR2_MMS_0))   
+
+#define IS_TIM_TRGO_SOURCE(SOURCE) (((SOURCE) == TIM_TRGO_RESET) || \
+                                    ((SOURCE) == TIM_TRGO_ENABLE) || \
+                                    ((SOURCE) == TIM_TRGO_UPDATE) || \
+                                    ((SOURCE) == TIM_TRGO_OC1) || \
+                                    ((SOURCE) == TIM_TRGO_OC1REF) || \
+                                    ((SOURCE) == TIM_TRGO_OC2REF) || \
+                                    ((SOURCE) == TIM_TRGO_OC3REF) || \
+                                    ((SOURCE) == TIM_TRGO_OC4REF))
+      
+   
+/**
+  * @}
+  */ 
+/** @defgroup TIM_Slave_Mode
+  * @{
+  */
+#define TIM_SLAVEMODE_DISABLE              ((uint32_t)0x0000)
+#define TIM_SLAVEMODE_RESET                ((uint32_t)0x0004)
+#define TIM_SLAVEMODE_GATED                ((uint32_t)0x0005)
+#define TIM_SLAVEMODE_TRIGGER              ((uint32_t)0x0006)
+#define TIM_SLAVEMODE_EXTERNAL1            ((uint32_t)0x0007)
+
+#define IS_TIM_SLAVE_MODE(MODE) (((MODE) == TIM_SLAVEMODE_DISABLE) || \
+                                 ((MODE) == TIM_SLAVEMODE_GATED) || \
+                                 ((MODE) == TIM_SLAVEMODE_RESET) || \
+                                 ((MODE) == TIM_SLAVEMODE_TRIGGER) || \
+                                 ((MODE) == TIM_SLAVEMODE_EXTERNAL1))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Master_Slave_Mode
+  * @{
+  */
+
+#define TIM_MASTERSLAVEMODE_ENABLE          ((uint32_t)0x0080)
+#define TIM_MASTERSLAVEMODE_DISABLE         ((uint32_t)0x0000)
+#define IS_TIM_MSM_STATE(STATE) (((STATE) == TIM_MASTERSLAVEMODE_ENABLE) || \
+                                 ((STATE) == TIM_MASTERSLAVEMODE_DISABLE))
+/**
+  * @}
+  */ 
+/** @defgroup TIM_Trigger_Selection
+  * @{
+  */
+#define TIM_TS_ITR0                        ((uint32_t)0x0000)
+#define TIM_TS_ITR1                        ((uint32_t)0x0010)
+#define TIM_TS_ITR2                        ((uint32_t)0x0020)
+#define TIM_TS_ITR3                        ((uint32_t)0x0030)
+#define TIM_TS_TI1F_ED                     ((uint32_t)0x0040)
+#define TIM_TS_TI1FP1                      ((uint32_t)0x0050)
+#define TIM_TS_TI2FP2                      ((uint32_t)0x0060)
+#define TIM_TS_ETRF                        ((uint32_t)0x0070)
+#define TIM_TS_NONE                        ((uint32_t)0xFFFF)
+#define IS_TIM_TRIGGER_SELECTION(SELECTION) (((SELECTION) == TIM_TS_ITR0) || \
+                                             ((SELECTION) == TIM_TS_ITR1) || \
+                                             ((SELECTION) == TIM_TS_ITR2) || \
+                                             ((SELECTION) == TIM_TS_ITR3) || \
+                                             ((SELECTION) == TIM_TS_TI1F_ED) || \
+                                             ((SELECTION) == TIM_TS_TI1FP1) || \
+                                             ((SELECTION) == TIM_TS_TI2FP2) || \
+                                             ((SELECTION) == TIM_TS_ETRF))
+#define IS_TIM_INTERNAL_TRIGGER_SELECTION(SELECTION) (((SELECTION) == TIM_TS_ITR0) || \
+                                                      ((SELECTION) == TIM_TS_ITR1) || \
+                                                      ((SELECTION) == TIM_TS_ITR2) || \
+                                                      ((SELECTION) == TIM_TS_ITR3))
+#define IS_TIM_INTERNAL_TRIGGEREVENT_SELECTION(SELECTION) (((SELECTION) == TIM_TS_ITR0) || \
+                                                           ((SELECTION) == TIM_TS_ITR1) || \
+                                                           ((SELECTION) == TIM_TS_ITR2) || \
+                                                           ((SELECTION) == TIM_TS_ITR3) || \
+                                                           ((SELECTION) == TIM_TS_NONE))
+/**
+  * @}
+  */  
+
+/** @defgroup TIM_Trigger_Polarity
+  * @{
+  */
+#define TIM_TRIGGERPOLARITY_INVERTED           TIM_ETRPOLARITY_INVERTED      /*!< Polarity for ETRx trigger sources */ 
+#define TIM_TRIGGERPOLARITY_NONINVERTED        TIM_ETRPOLARITY_NONINVERTED   /*!< Polarity for ETRx trigger sources */ 
+#define TIM_TRIGGERPOLARITY_RISING             TIM_INPUTCHANNELPOLARITY_RISING        /*!< Polarity for TIxFPx or TI1_ED trigger sources */ 
+#define TIM_TRIGGERPOLARITY_FALLING            TIM_INPUTCHANNELPOLARITY_FALLING       /*!< Polarity for TIxFPx or TI1_ED trigger sources */ 
+#define TIM_TRIGGERPOLARITY_BOTHEDGE           TIM_INPUTCHANNELPOLARITY_BOTHEDGE      /*!< Polarity for TIxFPx or TI1_ED trigger sources */ 
+
+#define IS_TIM_TRIGGERPOLARITY(POLARITY)     (((POLARITY) == TIM_TRIGGERPOLARITY_INVERTED   ) || \
+                                              ((POLARITY) == TIM_TRIGGERPOLARITY_NONINVERTED) || \
+                                              ((POLARITY) == TIM_TRIGGERPOLARITY_RISING     ) || \
+                                              ((POLARITY) == TIM_TRIGGERPOLARITY_FALLING    ) || \
+                                              ((POLARITY) == TIM_TRIGGERPOLARITY_BOTHEDGE   ))
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Trigger_Prescaler
+  * @{
+  */                
+#define TIM_TRIGGERPRESCALER_DIV1             TIM_ETRPRESCALER_DIV1     /*!< No prescaler is used */
+#define TIM_TRIGGERPRESCALER_DIV2             TIM_ETRPRESCALER_DIV2     /*!< Prescaler for External ETR Trigger: Capture performed once every 2 events. */
+#define TIM_TRIGGERPRESCALER_DIV4             TIM_ETRPRESCALER_DIV4     /*!< Prescaler for External ETR Trigger: Capture performed once every 4 events. */
+#define TIM_TRIGGERPRESCALER_DIV8             TIM_ETRPRESCALER_DIV8     /*!< Prescaler for External ETR Trigger: Capture performed once every 8 events. */
+
+#define IS_TIM_TRIGGERPRESCALER(PRESCALER)  (((PRESCALER) == TIM_TRIGGERPRESCALER_DIV1) || \
+                                             ((PRESCALER) == TIM_TRIGGERPRESCALER_DIV2) || \
+                                             ((PRESCALER) == TIM_TRIGGERPRESCALER_DIV4) || \
+                                             ((PRESCALER) == TIM_TRIGGERPRESCALER_DIV8)) 
+/**
+  * @}
+  */
+
+/** @defgroup TIM_Trigger_Filter
+  * @{
+  */
+#define IS_TIM_TRIGGERFILTER(ICFILTER)     ((ICFILTER) <= 0xF) 
+/**
+  * @}
+  */  
+
+  /** @defgroup TIM_TI1_Selection
+  * @{
+  */
+#define TIM_TI1SELECTION_CH1                ((uint32_t)0x0000)
+#define TIM_TI1SELECTION_XORCOMBINATION     (TIM_CR2_TI1S)
+
+#define IS_TIM_TI1SELECTION(TI1SELECTION)   (((TI1SELECTION) == TIM_TI1SELECTION_CH1) || \
+                                             ((TI1SELECTION) == TIM_TI1SELECTION_XORCOMBINATION))
+/**
+  * @}
+  */ 
+  
+/** @defgroup TIM_DMA_Base_address
+  * @{
+  */
+#define TIM_DMABase_CR1                    (0x00000000)
+#define TIM_DMABase_CR2                    (0x00000001)
+#define TIM_DMABase_SMCR                   (0x00000002)
+#define TIM_DMABase_DIER                   (0x00000003)
+#define TIM_DMABase_SR                     (0x00000004)
+#define TIM_DMABase_EGR                    (0x00000005)
+#define TIM_DMABase_CCMR1                  (0x00000006)
+#define TIM_DMABase_CCMR2                  (0x00000007)
+#define TIM_DMABase_CCER                   (0x00000008)
+#define TIM_DMABase_CNT                    (0x00000009)
+#define TIM_DMABase_PSC                    (0x0000000A)
+#define TIM_DMABase_ARR                    (0x0000000B)
+#define TIM_DMABase_CCR1                   (0x0000000D)
+#define TIM_DMABase_CCR2                   (0x0000000E)
+#define TIM_DMABase_CCR3                   (0x0000000F)
+#define TIM_DMABase_CCR4                   (0x00000010)
+#define TIM_DMABase_DCR                    (0x00000012)
+#define TIM_DMABase_OR                     (0x00000013)
+#define IS_TIM_DMA_BASE(BASE) (((BASE) == TIM_DMABase_CR1) || \
+                               ((BASE) == TIM_DMABase_CR2) || \
+                               ((BASE) == TIM_DMABase_SMCR) || \
+                               ((BASE) == TIM_DMABase_DIER) || \
+                               ((BASE) == TIM_DMABase_SR) || \
+                               ((BASE) == TIM_DMABase_EGR) || \
+                               ((BASE) == TIM_DMABase_CCMR1) || \
+                               ((BASE) == TIM_DMABase_CCMR2) || \
+                               ((BASE) == TIM_DMABase_CCER) || \
+                               ((BASE) == TIM_DMABase_CNT) || \
+                               ((BASE) == TIM_DMABase_PSC) || \
+                               ((BASE) == TIM_DMABase_ARR) || \
+                               ((BASE) == TIM_DMABase_CCR1) || \
+                               ((BASE) == TIM_DMABase_CCR2) || \
+                               ((BASE) == TIM_DMABase_CCR3) || \
+                               ((BASE) == TIM_DMABase_CCR4) || \
+                               ((BASE) == TIM_DMABase_DCR) || \
+                               ((BASE) == TIM_DMABase_OR))                     
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_DMA_Burst_Length
+  * @{
+  */
+#define TIM_DMABurstLength_1Transfer           (0x00000000)
+#define TIM_DMABurstLength_2Transfers          (0x00000100)
+#define TIM_DMABurstLength_3Transfers          (0x00000200)
+#define TIM_DMABurstLength_4Transfers          (0x00000300)
+#define TIM_DMABurstLength_5Transfers          (0x00000400)
+#define TIM_DMABurstLength_6Transfers          (0x00000500)
+#define TIM_DMABurstLength_7Transfers          (0x00000600)
+#define TIM_DMABurstLength_8Transfers          (0x00000700)
+#define TIM_DMABurstLength_9Transfers          (0x00000800)
+#define TIM_DMABurstLength_10Transfers         (0x00000900)
+#define TIM_DMABurstLength_11Transfers         (0x00000A00)
+#define TIM_DMABurstLength_12Transfers         (0x00000B00)
+#define TIM_DMABurstLength_13Transfers         (0x00000C00)
+#define TIM_DMABurstLength_14Transfers         (0x00000D00)
+#define TIM_DMABurstLength_15Transfers         (0x00000E00)
+#define TIM_DMABurstLength_16Transfers         (0x00000F00)
+#define TIM_DMABurstLength_17Transfers         (0x00001000)
+#define TIM_DMABurstLength_18Transfers         (0x00001100)
+#define IS_TIM_DMA_LENGTH(LENGTH) (((LENGTH) == TIM_DMABurstLength_1Transfer) || \
+                                   ((LENGTH) == TIM_DMABurstLength_2Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_3Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_4Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_5Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_6Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_7Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_8Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_9Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_10Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_11Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_12Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_13Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_14Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_15Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_16Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_17Transfers) || \
+                                   ((LENGTH) == TIM_DMABurstLength_18Transfers))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIM_Input_Capture_Filer_Value
+  * @{
+  */
+#define IS_TIM_IC_FILTER(ICFILTER) ((ICFILTER) <= 0xF) 
+/**
+  * @}
+  */ 
+
+/** @defgroup DMA_Handle_index
+  * @{
+  */
+#define TIM_DMA_ID_UPDATE                ((uint16_t) 0x0)       /*!< Index of the DMA handle used for Update DMA requests */
+#define TIM_DMA_ID_CC1                   ((uint16_t) 0x1)       /*!< Index of the DMA handle used for Capture/Compare 1 DMA requests */
+#define TIM_DMA_ID_CC2                   ((uint16_t) 0x2)       /*!< Index of the DMA handle used for Capture/Compare 2 DMA requests */
+#define TIM_DMA_ID_CC3                   ((uint16_t) 0x3)       /*!< Index of the DMA handle used for Capture/Compare 3 DMA requests */
+#define TIM_DMA_ID_CC4                   ((uint16_t) 0x4)       /*!< Index of the DMA handle used for Capture/Compare 4 DMA requests */
+#define TIM_DMA_ID_TRIGGER               ((uint16_t) 0x5)       /*!< Index of the DMA handle used for Trigger DMA requests */
+/**
+  * @}
+  */ 
+
+/** @defgroup Channel_CC_State
+  * @{
+  */
+#define TIM_CCx_ENABLE                   ((uint32_t)0x0001)
+#define TIM_CCx_DISABLE                  ((uint32_t)0x0000)
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */   
+  
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup TIM_Exported_Macro
+  * @{
+  */
+
+/** @brief Reset UART handle state
+  * @param  __HANDLE__: TIM handle
+  * @retval None
+  */
+#define __HAL_TIM_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_TIM_STATE_RESET)
+
+/**
+  * @brief  Enable the TIM peripheral.
+  * @param  __HANDLE__: TIM handle
+  * @retval None
+ */
+#define __HAL_TIM_ENABLE(__HANDLE__)                 ((__HANDLE__)->Instance->CR1|=(TIM_CR1_CEN))
+
+/* The counter of a timer instance is disabled only if all the CCx channels have
+   been disabled */
+#define CCER_CCxE_MASK ((uint32_t)(TIM_CCER_CC1E | TIM_CCER_CC2E | TIM_CCER_CC3E | TIM_CCER_CC4E))
+
+/**
+  * @brief  Disable the TIM peripheral.
+  * @param  __HANDLE__: TIM handle
+  * @retval None
+  */
+#define __HAL_TIM_DISABLE(__HANDLE__) \
+                        do { \
+                          if (((__HANDLE__)->Instance->CCER & CCER_CCxE_MASK) == 0) \
+                          { \
+                            (__HANDLE__)->Instance->CR1 &= ~(TIM_CR1_CEN); \
+                          } \
+                        } while(0) 
+
+#define __HAL_TIM_ENABLE_IT(__HANDLE__, __INTERRUPT__)    ((__HANDLE__)->Instance->DIER |= (__INTERRUPT__))
+#define __HAL_TIM_ENABLE_DMA(__HANDLE__, __DMA__)         ((__HANDLE__)->Instance->DIER |= (__DMA__))
+#define __HAL_TIM_DISABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->DIER &= ~(__INTERRUPT__))
+#define __HAL_TIM_DISABLE_DMA(__HANDLE__, __DMA__)        ((__HANDLE__)->Instance->DIER &= ~(__DMA__))
+#define __HAL_TIM_GET_FLAG(__HANDLE__, __FLAG__)          (((__HANDLE__)->Instance->SR &(__FLAG__)) == (__FLAG__))
+#define __HAL_TIM_CLEAR_FLAG(__HANDLE__, __FLAG__)        ((__HANDLE__)->Instance->SR = ~(__FLAG__))
+
+#define __HAL_TIM_GET_ITSTATUS(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->DIER & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+#define __HAL_TIM_CLEAR_IT(__HANDLE__, __INTERRUPT__)     ((__HANDLE__)->Instance->SR = ~(__INTERRUPT__))
+
+#define __HAL_TIM_DIRECTION_STATUS(__HANDLE__)            (((__HANDLE__)->Instance->CR1 &(TIM_CR1_DIR)) == (TIM_CR1_DIR))
+#define __HAL_TIM_PRESCALER(__HANDLE__, __PRESC__)        ((__HANDLE__)->Instance->PSC = (__PRESC__))
+
+#define __HAL_TIM_SetICPrescalerValue(__HANDLE__, __CHANNEL__, __ICPSC__) \
+(((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCMR1 |= (__ICPSC__)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCMR1 |= ((__ICPSC__) << 8)) :\
+ ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCMR2 |= (__ICPSC__)) :\
+ ((__HANDLE__)->Instance->CCMR2 |= ((__ICPSC__) << 8)))
+
+#define __HAL_TIM_ResetICPrescalerValue(__HANDLE__, __CHANNEL__) \
+(((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCMR1 &= (uint16_t)~TIM_CCMR1_IC1PSC) :\
+ ((__CHANNEL__) == TIM_CHANNEL_2) ? ((__HANDLE__)->Instance->CCMR1 &= (uint16_t)~TIM_CCMR1_IC2PSC) :\
+ ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCMR2 &= (uint16_t)~TIM_CCMR2_IC3PSC) :\
+ ((__HANDLE__)->Instance->CCMR2 &= (uint16_t)~TIM_CCMR2_IC4PSC))
+                          
+/**
+  * @brief  Sets the TIM Capture Compare Register value on runtime without
+  *         calling another time ConfigChannel function.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CHANNEL__ : TIM Channels to be configured.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  __COMPARE__: specifies the Capture Compare register new value.
+  * @retval None
+  */
+#define __HAL_TIM_SetCompare(__HANDLE__, __CHANNEL__, __COMPARE__) \
+(*(__IO uint32_t *)(&((__HANDLE__)->Instance->CCR1) + ((__CHANNEL__) >> 2)) = (__COMPARE__))
+
+/**
+  * @brief  Gets the TIM Capture Compare Register value on runtime
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CHANNEL__ : TIM Channel associated with the capture compare register
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: get capture/compare 1 register value
+  *            @arg TIM_CHANNEL_2: get capture/compare 2 register value
+  *            @arg TIM_CHANNEL_3: get capture/compare 3 register value
+  *            @arg TIM_CHANNEL_4: get capture/compare 4 register value
+  * @retval None
+  */
+#define __HAL_TIM_GetCompare(__HANDLE__, __CHANNEL__) \
+  (*(__IO uint32_t *)(&((__HANDLE__)->Instance->CCR1) + ((__CHANNEL__) >> 2)))
+
+/**
+  * @brief  Sets the TIM Counter Register value on runtime.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __COUNTER__: specifies the Counter register new value.
+  * @retval None
+  */
+#define __HAL_TIM_SetCounter(__HANDLE__, __COUNTER__)  ((__HANDLE__)->Instance->CNT = (__COUNTER__))
+
+/**
+  * @brief  Gets the TIM Counter Register value on runtime.
+  * @param  __HANDLE__: TIM handle.
+  * @retval None
+  */
+#define __HAL_TIM_GetCounter(__HANDLE__) ((__HANDLE__)->Instance->CNT)
+
+/**
+  * @brief  Sets the TIM Autoreload Register value on runtime without calling 
+  *         another time any Init function.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __AUTORELOAD__: specifies the Counter register new value.
+  * @retval None
+  */
+#define __HAL_TIM_SetAutoreload(__HANDLE__, __AUTORELOAD__) \
+                        do{                                                    \
+                              (__HANDLE__)->Instance->ARR = (__AUTORELOAD__);  \
+                              (__HANDLE__)->Init.Period = (__AUTORELOAD__);    \
+                          } while(0)
+/**
+  * @brief  Gets the TIM Autoreload Register value on runtime
+  * @param  __HANDLE__: TIM handle.
+  * @retval None
+  */
+#define __HAL_TIM_GetAutoreload(__HANDLE__) ((__HANDLE__)->Instance->ARR)
+
+/**
+  * @brief  Sets the TIM Clock Division value on runtime without calling 
+  *         another time any Init function. 
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CKD__: specifies the clock division value.
+  *          This parameter can be one of the following value:
+  *            @arg TIM_CLOCKDIVISION_DIV1
+  *            @arg TIM_CLOCKDIVISION_DIV2
+  *            @arg TIM_CLOCKDIVISION_DIV4
+  * @retval None
+  */
+#define __HAL_TIM_SetClockDivision(__HANDLE__, __CKD__) \
+                        do{                                                    \
+                              (__HANDLE__)->Instance->CR1 &= (uint16_t)(~TIM_CR1_CKD);  \
+                              (__HANDLE__)->Instance->CR1 |= (__CKD__);                   \
+                              (__HANDLE__)->Init.ClockDivision = (__CKD__);             \
+                          } while(0)
+/**
+  * @brief  Gets the TIM Clock Division value on runtime
+  * @param  __HANDLE__: TIM handle.
+  * @retval None
+  */
+#define __HAL_TIM_GetClockDivision(__HANDLE__) ((__HANDLE__)->Instance->CR1 & TIM_CR1_CKD)
+
+/**
+  * @brief  Sets the TIM Input Capture prescaler on runtime without calling 
+  *         another time HAL_TIM_IC_ConfigChannel() function.
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CHANNEL__ : TIM Channels to be configured.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
+  * @param  __ICPSC__: specifies the Input Capture4 prescaler new value.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_ICPSC_DIV1: no prescaler
+  *            @arg TIM_ICPSC_DIV2: capture is done once every 2 events
+  *            @arg TIM_ICPSC_DIV4: capture is done once every 4 events
+  *            @arg TIM_ICPSC_DIV8: capture is done once every 8 events
+  * @retval None
+  */
+#define __HAL_TIM_SetICPrescaler(__HANDLE__, __CHANNEL__, __ICPSC__) \
+                        do{                                                    \
+                              __HAL_TIM_ResetICPrescalerValue((__HANDLE__), (__CHANNEL__));  \
+                              __HAL_TIM_SetICPrescalerValue((__HANDLE__), (__CHANNEL__), (__ICPSC__)); \
+                          } while(0)
+
+/**
+  * @brief  Gets the TIM Input Capture prescaler on runtime
+  * @param  __HANDLE__: TIM handle.
+  * @param  __CHANNEL__ : TIM Channels to be configured.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CHANNEL_1: get input capture 1 prescaler value
+  *            @arg TIM_CHANNEL_2: get input capture 2 prescaler value
+  *            @arg TIM_CHANNEL_3: get input capture 3 prescaler value
+  *            @arg TIM_CHANNEL_4: get input capture 4 prescaler value
+  * @retval None
+  */
+#define __HAL_TIM_GetICPrescaler(__HANDLE__, __CHANNEL__)  \
+  (((__CHANNEL__) == TIM_CHANNEL_1) ? ((__HANDLE__)->Instance->CCMR1 & TIM_CCMR1_IC1PSC) :\
+   ((__CHANNEL__) == TIM_CHANNEL_2) ? (((__HANDLE__)->Instance->CCMR1 & TIM_CCMR1_IC2PSC) >> 8) :\
+   ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->Instance->CCMR2 & TIM_CCMR2_IC3PSC) :\
+   (((__HANDLE__)->Instance->CCMR2 & TIM_CCMR2_IC4PSC)) >> 8)
+   
+
+/**
+  * @}
+  */   
+     
+/* Include TIM HAL Extension module */
+#include "stm32l0xx_hal_tim_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/* Time Base functions ********************************************************/
+HAL_StatusTypeDef HAL_TIM_Base_Init(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_Base_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_Base_Start(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_Base_Stop(TIM_HandleTypeDef *htim);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_Base_Start_IT(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_Base_Stop_IT(TIM_HandleTypeDef *htim);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_Base_Stop_DMA(TIM_HandleTypeDef *htim);
+
+/* Timer Output Compare functions **********************************************/
+HAL_StatusTypeDef HAL_TIM_OC_Init(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_OC_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_OC_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_OC_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_OC_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_OC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_OC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_OC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+
+/* Timer PWM functions *********************************************************/
+HAL_StatusTypeDef HAL_TIM_PWM_Init(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_PWM_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_PWM_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_PWM_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_PWM_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_PWM_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_PWM_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+
+/* Timer Input Capture functions ***********************************************/
+HAL_StatusTypeDef HAL_TIM_IC_Init(TIM_HandleTypeDef *htim);
+HAL_StatusTypeDef HAL_TIM_IC_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_IC_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_IC_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_IC_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_IC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_IC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_IC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+
+/* Timer One Pulse functions ***************************************************/
+HAL_StatusTypeDef HAL_TIM_OnePulse_Init(TIM_HandleTypeDef *htim, uint32_t OnePulseMode);
+HAL_StatusTypeDef HAL_TIM_OnePulse_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_OnePulse_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_OnePulse_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Start(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+HAL_StatusTypeDef HAL_TIM_OnePulse_Stop(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_OnePulse_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+
+/* Timer Encoder functions *****************************************************/
+HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_InitTypeDef* sConfig);
+HAL_StatusTypeDef HAL_TIM_Encoder_DeInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim);
+void HAL_TIM_Encoder_MspDeInit(TIM_HandleTypeDef *htim);
+/* Blocking mode: Polling */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: Interrupt */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
+/* Non-Blocking mode: DMA */
+HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData1, uint32_t *pData2, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_Encoder_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+
+/* Interrupt Handler functions  **********************************************/
+void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim);
+
+/* Control functions  *********************************************************/
+HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_IC_InitTypeDef* sConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OnePulse_InitTypeDef* sConfig, uint32_t OutputChannel,  uint32_t InputChannel);
+HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim, TIM_ClearInputConfigTypeDef * sClearInputConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_ConfigClockSource(TIM_HandleTypeDef *htim, TIM_ClockConfigTypeDef * sClockSourceConfig);    
+HAL_StatusTypeDef HAL_TIM_ConfigTI1Input(TIM_HandleTypeDef *htim, uint32_t TI1_Selection);
+HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchronization(TIM_HandleTypeDef *htim, TIM_SlaveConfigTypeDef * sSlaveConfig);
+HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress, uint32_t BurstRequestSrc, \
+                                              uint32_t  *BurstBuffer, uint32_t  BurstLength);
+HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc);
+HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress, uint32_t BurstRequestSrc, \
+                                              uint32_t  *BurstBuffer, uint32_t  BurstLength);
+HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc);
+HAL_StatusTypeDef HAL_TIM_GenerateEvent(TIM_HandleTypeDef *htim, uint32_t EventSource);
+uint32_t HAL_TIM_ReadCapturedValue(TIM_HandleTypeDef *htim, uint32_t Channel);
+
+/* Callback in non blocking modes (Interrupt and DMA) *************************/
+void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_OC_DelayElapsedCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_PWM_PulseFinishedCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_TriggerCallback(TIM_HandleTypeDef *htim);
+void HAL_TIM_ErrorCallback(TIM_HandleTypeDef *htim);
+
+/* Peripheral State functions  **************************************************/
+HAL_TIM_StateTypeDef HAL_TIM_Base_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_OC_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_PWM_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_IC_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_OnePulse_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_Encoder_GetState(TIM_HandleTypeDef *htim);
+void HAL_TIM_DMADelayPulseCplt(DMA_HandleTypeDef *hdma);
+void HAL_TIM_DMAError(DMA_HandleTypeDef *hdma);
+void HAL_TIM_DMACaptureCplt(DMA_HandleTypeDef *hdma);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_TIM_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_tim_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_tim_ex.c
@@ -1,0 +1,240 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_tim_ex.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   TIM HAL module driver.
+  * @brief   This file provides firmware functions to manage the following 
+  *          functionalities of the Timer (TIM) peripheral:
+  *           + Time Hall Sensor Interface Initialization
+  *           + Time Hall Sensor Interface Start
+  *           + Time Master and Slave synchronization configuration
+  @verbatim 
+================================================================================
+          ##### TIM specific features integration #####
+================================================================================
+           
+    [..] The Timer features include: 
+         (#) 16-bit up, down, up/down auto-reload counter.
+         (#) 16-bit programmable prescaler allowing dividing (also on the fly) the counter clock
+             frequency either by any factor between 1 and 65536.
+         (#) Up to 4 independent channels for:
+           Input Capture
+           Output Compare
+           PWM generation (Edge and Center-aligned Mode)
+           One-pulse mode output
+         (#) Synchronization circuit to control the timer with external signals and to interconnect
+            several timers together.
+         (#) Supports incremental (quadrature) encoder and hall-sensor circuitry for positioning
+           purposes               
+   
+            ##### How to use this driver #####
+================================================================================
+    [..]
+     (#) Enable the TIM interface clock using 
+         __TIMx_CLK_ENABLE(); 
+       
+     (#) TIM pins configuration
+          (++) Enable the clock for the TIM GPIOs using the following function:
+              __GPIOx_CLK_ENABLE();   
+          (++) Configure these TIM pins in Alternate function mode using HAL_GPIO_Init();  
+
+     (#) The external Clock can be configured, if needed (the default clock is the internal clock from the APBx), 
+         using the following function:
+         HAL_TIM_ConfigClockSource, the clock configuration should be done before any start function.
+  
+     (#) Configure the TIM in the desired operating mode using one of the 
+         configuration function of this driver:
+          (++) HAL_TIMEx_MasterConfigSynchronization() to configure the peripheral in master mode.
+
+     (#) Remap the Timer I/O using HAL_TIMEx_RemapConfig() API.
+
+  
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup TIMEx 
+  * @brief TIMEx HAL module driver
+  * @{
+  */
+
+#ifdef HAL_TIM_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/   
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup TIMEx_Private_Functions
+  * @{
+  */
+
+
+/** @defgroup TIMEx_Group1 Peripheral Control functions
+ *  @brief   	Peripheral Control functions 
+ *
+@verbatim   
+ ===============================================================================
+             ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Configure Master and the Slave synchronization.
+      
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configures the TIM in master mode.
+  * @param  htim: TIM handle.   
+  * @param  sMasterConfig: pointer to a TIM_MasterConfigTypeDef structure that
+  *         contains the selected trigger output (TRGO) and the Master/Slave 
+  *         mode. 
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_MasterConfigSynchronization(TIM_HandleTypeDef *htim, TIM_MasterConfigTypeDef * sMasterConfig)
+{
+  /* Check the parameters */
+  assert_param(IS_TIM_MASTER_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_TRGO_SOURCE(sMasterConfig->MasterOutputTrigger));
+  assert_param(IS_TIM_MSM_STATE(sMasterConfig->MasterSlaveMode));
+  
+  __HAL_LOCK(htim);
+  
+  /* Change the handler state */
+  htim->State = HAL_TIM_STATE_BUSY;
+
+  /* Reset the MMS Bits */
+  htim->Instance->CR2 &= ~TIM_CR2_MMS;
+  /* Select the TRGO source */
+  htim->Instance->CR2 |= sMasterConfig->MasterOutputTrigger;
+
+  /* Reset the MSM Bit */
+  htim->Instance->SMCR &= ~TIM_SMCR_MSM;
+  /* Set or Reset the MSM Bit */
+  htim->Instance->SMCR |= sMasterConfig->MasterSlaveMode;
+
+  htim->State = HAL_TIM_STATE_READY;
+  
+  __HAL_UNLOCK(htim);
+  
+  return HAL_OK;
+}  
+
+/**
+  * @brief  Configures the TIM2, TIM21 and TIM22 Remapping input capabilities.
+  * @param  htim: pointer to a TIM_HandleTypeDef structure that contains
+  *                the configuration information for TIM module.
+  * @param  TIM_Remap: specifies the TIM input remapping source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM2_ETR_GPIO: TIM2  ETR is connected to GPIO (default)
+  *            @arg TIM2_ETR_HSI48: TIM2  ETR is connected to HSI48
+  *            @arg TIM2_ETR_LSE: TIM2  ETR is connected to LSE
+  *            @arg TIM2_ETR_COMP2_OUT: TIM2  ETR is connected to COMP2 output
+  *            @arg TIM2_ETR_COMP1_OUT: TIM2  ETR is connected to COMP1 output
+  *            @arg TIM2_TI4_GPIO1: TIM2  TI4 is connected to GPIO1(default)
+  *            @arg TIM2_TI4_COMP1: TIM2  TI4 is connected to COMP1
+  *            @arg TIM2_TI4_COMP2: TIM2  TI4 is connected to COMP2
+  *            @arg TIM2_TI4_GPIO2: TIM2  TI4 is connected to GPIO2
+  *            @arg TIM21_ETR_GPIO: TIM21 ETR is connected to GPIO(default)
+  *            @arg TIM21_ETR_COMP2_OUT: TIM21 ETR is connected to COMP2 output
+  *            @arg TIM21_ETR_COMP1_OUT: TIM21 ETR is connected to COMP1 output
+  *            @arg TIM21_ETR_LSE: TIM21 ETR is connected to LSE
+  *            @arg TIM21_TI1_MCO: TIM21 TI1 is connected to MCO
+  *            @arg TIM21_TI1_RTC_WKUT_IT: TIM21 TI1 is connected to RTC WAKEUP interrupt
+  *            @arg TIM21_TI1_HSE_RTC: TIM21 TI1 is connected to HSE_RTC 
+  *            @arg TIM21_TI1_MSI: TIM21 TI1 is connected to MSI clock
+  *            @arg TIM21_TI1_LSE: TIM21 TI1 is connected to LSE
+  *            @arg TIM21_TI1_LSI: TIM21 TI1 is connected to LSI  
+  *            @arg TIM21_TI1_COMP1_OUT: TIM21 TI1 is connected to COMP1_OUT
+  *            @arg TIM21_TI1_GPIO: TIM21 TI1 is connected to GPIO(default)
+  *            @arg TIM21_TI2_GPIO: TIM21 TI2 is connected to GPIO(default)
+  *            @arg TIM21_TI2_COMP2_OUT: TIM21 TI2 is connected to COMP2 output
+  *            @arg TIM22_ETR_LSE: TIM22 ETR is connected to LSE
+  *            @arg TIM22_ETR_COMP2_OUT: TIM22 ETR is connected to COMP2 output
+  *            @arg TIM22_ETR_COMP1_OUT: TIM22 ETR is connected to COMP1 output
+  *            @arg TIM22_ETR_GPIO: TIM22 ETR is connected to GPIO(default)  
+  *            @arg TIM22_TI1_GPIO1: TIM22 TI1 is connected to GPIO(default)
+  *            @arg TIM22_TI1_COMP2_OUT: TIM22 TI1 is connected to COMP2 output 
+  *            @arg TIM22_TI1_COMP1_OUT: TIM22 TI1 is connected to COMP1 output
+  *            @arg TIM22_TI1_GPIO2: TIM22 TI1 is connected to GPIO 
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap)
+{
+  __HAL_LOCK(htim);
+    
+  /* Check parameters */
+  assert_param(IS_TIM_REMAP_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_REMAP(Remap));
+  
+  /* Change the handler state */
+  htim->State = HAL_TIM_STATE_BUSY;
+  
+  /* Set the Timer remapping configuration */
+  htim->Instance->OR &=  (uint32_t)(Remap >> 16);
+  htim->Instance->OR |=  Remap;
+  
+  /* Change the handler state */
+  htim->State = HAL_TIM_STATE_READY;
+  
+  __HAL_UNLOCK(htim);  
+  
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_TIM_MODULE_ENABLED */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_tim_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_tim_ex.h
@@ -1,0 +1,197 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_tim_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of TIM HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_TIM_EX_H
+#define __STM32L0xx_HAL_TIM_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL
+  * @{
+  */
+
+/** @addtogroup TIMEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+
+/** 
+  * @brief  TIM Master configuration Structure definition  
+  */ 
+typedef struct {
+  uint32_t  MasterOutputTrigger;   /*!< Trigger output (TRGO) selection 
+                                      This parameter can be a value of @ref TIMEx_Master_Mode_Selection */ 
+  uint32_t  MasterSlaveMode;       /*!< Master/slave mode selection 
+                                      This parameter can be a value of @ref TIM_Master_Slave_Mode */
+}TIM_MasterConfigTypeDef;
+
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup TIMEx_Exported_Constants
+  * @{
+  */
+
+/** @defgroup TIMEx_Master_Mode_Selection
+  * @{
+  */  
+#define	TIM_TRGO_RESET            ((uint32_t)0x0000)             
+#define	TIM_TRGO_ENABLE           (TIM_CR2_MMS_0)           
+#define	TIM_TRGO_UPDATE           (TIM_CR2_MMS_1)             
+#define	TIM_TRGO_OC1              ((TIM_CR2_MMS_1 | TIM_CR2_MMS_0))    
+#define	TIM_TRGO_OC1REF           (TIM_CR2_MMS_2)           
+#define	TIM_TRGO_OC2REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_0))          
+#define	TIM_TRGO_OC3REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_1))           
+#define	TIM_TRGO_OC4REF           ((TIM_CR2_MMS_2 | TIM_CR2_MMS_1 | TIM_CR2_MMS_0))   
+
+#define IS_TIM_TRGO_SOURCE(SOURCE) (((SOURCE) == TIM_TRGO_RESET) || \
+                                    ((SOURCE) == TIM_TRGO_ENABLE) || \
+                                    ((SOURCE) == TIM_TRGO_UPDATE) || \
+                                    ((SOURCE) == TIM_TRGO_OC1) || \
+                                    ((SOURCE) == TIM_TRGO_OC1REF) || \
+                                    ((SOURCE) == TIM_TRGO_OC2REF) || \
+                                    ((SOURCE) == TIM_TRGO_OC3REF) || \
+                                    ((SOURCE) == TIM_TRGO_OC4REF))      
+   
+/**
+  * @}
+  */ 
+
+/** @defgroup TIMEx_Remap
+  * @{
+  */
+
+#define TIM2_ETR_GPIO                     ((uint32_t)0xFFF80000)
+#define TIM2_ETR_HSI48                    ((uint32_t)0xFFF80004)
+#define TIM2_ETR_LSE                      ((uint32_t)0xFFF80005)
+#define TIM2_ETR_COMP2_OUT                ((uint32_t)0xFFF80006)
+#define TIM2_ETR_COMP1_OUT                ((uint32_t)0xFFF80007)
+#define TIM2_TI4_GPIO1                    ((uint32_t)0xFFE70000)
+#define TIM2_TI4_COMP2                    ((uint32_t)0xFFE70008)
+#define TIM2_TI4_COMP1                    ((uint32_t)0xFFE70010)
+#define TIM2_TI4_GPIO2                    ((uint32_t)0xFFE70018)
+#define TIM21_ETR_GPIO                    ((uint32_t)0xFFF40000)
+#define TIM21_ETR_COMP2_OUT               ((uint32_t)0xFFF40001)
+#define TIM21_ETR_COMP1_OUT               ((uint32_t)0xFFF40002)
+#define TIM21_ETR_LSE                     ((uint32_t)0xFFF40003)
+#define TIM21_TI1_MCO                     ((uint32_t)0xFFE3001C)
+#define TIM21_TI1_RTC_WKUT_IT             ((uint32_t)0xFFE30004)
+#define TIM21_TI1_HSE_RTC                 ((uint32_t)0xFFE30008)
+#define TIM21_TI1_MSI                     ((uint32_t)0xFFE3000C)
+#define TIM21_TI1_LSE                     ((uint32_t)0xFFE30010)
+#define TIM21_TI1_LSI                     ((uint32_t)0xFFE30014)
+#define TIM21_TI1_COMP1_OUT               ((uint32_t)0xFFE30018)
+#define TIM21_TI1_GPIO                    ((uint32_t)0xFFE30000)
+#define TIM21_TI2_GPIO                    ((uint32_t)0xFFDF0000)
+#define TIM21_TI2_COMP2_OUT               ((uint32_t)0xFFDF0020)
+#define TIM22_ETR_LSE                     ((uint32_t)0xFFFC0000)
+#define TIM22_ETR_COMP2_OUT               ((uint32_t)0xFFFC0001)
+#define TIM22_ETR_COMP1_OUT               ((uint32_t)0xFFFC0002)
+#define TIM22_ETR_GPIO                    ((uint32_t)0xFFFC0003)
+#define TIM22_TI1_GPIO1                   ((uint32_t)0xFFF70000)
+#define TIM22_TI1_COMP2_OUT               ((uint32_t)0xFFF70004)
+#define TIM22_TI1_COMP1_OUT               ((uint32_t)0xFFF70008)
+#define TIM22_TI1_GPIO2                   ((uint32_t)0xFFF7000C)
+
+
+#define IS_TIM_REMAP(TIM_REMAP)  (((TIM_REMAP) == TIM2_ETR_GPIO          )|| \
+                                  ((TIM_REMAP) == TIM2_ETR_HSI48         )|| \
+                                  ((TIM_REMAP) == TIM2_ETR_LSE           )|| \
+                                  ((TIM_REMAP) == TIM2_ETR_COMP2_OUT     )|| \
+                                  ((TIM_REMAP) == TIM2_ETR_COMP1_OUT     )|| \
+                                  ((TIM_REMAP) == TIM2_TI4_GPIO1         )|| \
+                                  ((TIM_REMAP) == TIM2_TI4_COMP1         )|| \
+                                  ((TIM_REMAP) == TIM2_TI4_COMP2         )|| \
+                                  ((TIM_REMAP) == TIM2_TI4_GPIO2         )|| \
+                                  ((TIM_REMAP) == TIM21_ETR_GPIO         )|| \
+                                  ((TIM_REMAP) == TIM21_ETR_COMP2_OUT    )|| \
+                                  ((TIM_REMAP) == TIM21_ETR_COMP1_OUT    )|| \
+                                  ((TIM_REMAP) == TIM21_ETR_LSE          )|| \
+                                  ((TIM_REMAP) == TIM21_TI1_MCO          )|| \
+                                  ((TIM_REMAP) == TIM21_TI1_RTC_WKUT_IT  )|| \
+                                  ((TIM_REMAP) == TIM21_TI1_HSE_RTC      )|| \
+                                  ((TIM_REMAP) == TIM21_TI1_MSI          )|| \
+                                  ((TIM_REMAP) == TIM21_TI1_LSE          )|| \
+                                  ((TIM_REMAP) == TIM21_TI1_LSI          )|| \
+                                  ((TIM_REMAP) == TIM21_TI1_COMP1_OUT    )|| \
+                                  ((TIM_REMAP) == TIM21_TI1_GPIO         )|| \
+                                  ((TIM_REMAP) == TIM21_TI2_GPIO         )|| \
+                                  ((TIM_REMAP) == TIM21_TI2_COMP2_OUT    )|| \
+                                  ((TIM_REMAP) == TIM22_ETR_LSE         )|| \
+                                  ((TIM_REMAP) == TIM22_ETR_COMP2_OUT   )|| \
+                                  ((TIM_REMAP) == TIM22_ETR_COMP1_OUT   )|| \
+                                  ((TIM_REMAP) == TIM22_ETR_GPIO        )|| \
+                                  ((TIM_REMAP) == TIM22_TI1_GPIO1       )|| \
+                                  ((TIM_REMAP) == TIM22_TI1_COMP2_OUT   )|| \
+                                  ((TIM_REMAP) == TIM22_TI1_COMP1_OUT   )|| \
+                                  ((TIM_REMAP) == TIM22_TI1_GPIO2       ))
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */   
+  
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+/* Control functions  ***********************************************************/
+HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap);
+HAL_StatusTypeDef HAL_TIMEx_MasterConfigSynchronization(TIM_HandleTypeDef *htim, TIM_MasterConfigTypeDef * sMasterConfig);
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_TIM_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_tsc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_tsc.c
@@ -1,0 +1,766 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_tsc.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   This file provides firmware functions to manage the following 
+  *          functionalities of the Touch Sensing Controller (TSC) peripheral:
+  *           + Initialization and DeInitialization
+  *           + Channel IOs, Shield IOs and Sampling IOs configuration
+  *           + Start and Stop an acquisition
+  *           + Read acquisition result
+  *           + Interrupts and flags management
+  *         
+  @verbatim
+================================================================================
+                       ##### TSC specific features #####
+================================================================================
+  [..]
+  (#) Proven and robust surface charge transfer acquisition principle
+    
+  (#) Supports up to 3 capacitive sensing channels per group
+    
+  (#) Capacitive sensing channels can be acquired in parallel offering a very good
+      response time
+      
+  (#) Spread spectrum feature to improve system robustness in noisy environments
+   
+  (#) Full hardware management of the charge transfer acquisition sequence
+   
+  (#) Programmable charge transfer frequency
+   
+  (#) Programmable sampling capacitor I/O pin
+   
+  (#) Programmable channel I/O pin
+   
+  (#) Programmable max count value to avoid long acquisition when a channel is faulty
+   
+  (#) Dedicated end of acquisition and max count error flags with interrupt capability
+   
+  (#) One sampling capacitor for up to 3 capacitive sensing channels to reduce the system
+      components
+   
+  (#) Compatible with proximity, touchkey, linear and rotary touch sensor implementation
+
+   
+                          ##### How to use this driver #####
+================================================================================
+  [..]
+    (#) Enable the TSC interface clock using __TSC_CLK_ENABLE() macro.
+
+    (#) GPIO pins configuration
+      (++) Enable the clock for the TSC GPIOs using __GPIOx_CLK_ENABLE() macro.
+      (++) Configure the TSC pins used as sampling IOs in alternate function output Open-Drain mode,
+           and TSC pins used as channel/shield IOs in alternate function output Push-Pull mode
+           using HAL_GPIO_Init() function.
+      (++) Configure the alternate function on all the TSC pins using HAL_xxxx() function.
+
+    (#) Interrupts configuration
+      (++) Configure the NVIC (if the interrupt model is used) using HAL_xxx() function.
+
+    (#) TSC configuration
+      (++) Configure all TSC parameters and used TSC IOs using HAL_TSC_Init() function.
+
+  *** Acquisition sequence ***
+  ===================================
+  [..]
+    (+) Discharge all IOs using HAL_TSC_IODischarge() function.
+    (+) Wait a certain time allowing a good discharge of all capacitors. This delay depends
+        of the sampling capacitor and electrodes design.
+    (+) Select the channel IOs to be acquired using HAL_TSC_IOConfig() function.
+    (+) Launch the acquisition using either HAL_TSC_Start() or HAL_TSC_Start_IT() function.
+        If the synchronized mode is selected, the acquisition will start as soon as the signal
+        is received on the synchro pin.
+    (+) Wait the end of acquisition using either HAL_TSC_PollForAcquisition() or
+        HAL_TSC_GetState() function or using WFI instruction for example.
+    (+) Check the group acquisition status using HAL_TSC_GroupGetStatus() function.
+    (+) Read the acquisition value using HAL_TSC_GroupGetValue() function.
+      
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup TSC
+  * @brief HAL TSC module driver
+  * @{
+  */
+
+#ifdef HAL_TSC_MODULE_ENABLED
+    
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static uint32_t TSC_extract_groups(uint32_t iomask);
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup TSC_Private_Functions
+  * @{
+  */ 
+
+/** @defgroup TSC_Group1 Initialization/de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the TSC.
+      (+) De-initialize the TSC.
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the TSC peripheral according to the specified parameters 
+  *         in the TSC_InitTypeDef structure.           
+  * @param  htsc: TSC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TSC_Init(TSC_HandleTypeDef* htsc)
+{
+  /* Check TSC handle allocation */
+  if (htsc == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
+  assert_param(IS_TSC_CTPH(htsc->Init.CTPulseHighLength));
+  assert_param(IS_TSC_CTPL(htsc->Init.CTPulseLowLength));
+  assert_param(IS_TSC_SS(htsc->Init.SpreadSpectrum));
+  assert_param(IS_TSC_SSD(htsc->Init.SpreadSpectrumDeviation));
+  assert_param(IS_TSC_SS_PRESC(htsc->Init.SpreadSpectrumPrescaler));
+  assert_param(IS_TSC_PG_PRESC(htsc->Init.PulseGeneratorPrescaler));
+  assert_param(IS_TSC_MCV(htsc->Init.MaxCountValue));
+  assert_param(IS_TSC_IODEF(htsc->Init.IODefaultMode));
+  assert_param(IS_TSC_SYNC_POL(htsc->Init.SynchroPinPolarity));
+  assert_param(IS_TSC_ACQ_MODE(htsc->Init.AcquisitionMode));
+  assert_param(IS_TSC_MCE_IT(htsc->Init.MaxCountInterrupt));
+    
+  /* Initialize the TSC state */
+  htsc->State = HAL_TSC_STATE_BUSY;
+
+  /* Init the low level hardware : GPIO, CLOCK, CORTEX */
+  HAL_TSC_MspInit(htsc);
+
+  /*--------------------------------------------------------------------------*/  
+  /* Set TSC parameters */
+
+  /* Enable TSC */
+  htsc->Instance->CR = TSC_CR_TSCE;
+  
+  /* Set all functions */
+  htsc->Instance->CR |= (htsc->Init.CTPulseHighLength |
+                         htsc->Init.CTPulseLowLength |
+                         (uint32_t)(htsc->Init.SpreadSpectrumDeviation << 17) |
+                         htsc->Init.SpreadSpectrumPrescaler |
+                         htsc->Init.PulseGeneratorPrescaler |
+                         htsc->Init.MaxCountValue |
+                         htsc->Init.IODefaultMode |
+                         htsc->Init.SynchroPinPolarity |
+                         htsc->Init.AcquisitionMode);
+
+  /* Spread spectrum */
+  if (htsc->Init.SpreadSpectrum == ENABLE)
+  {
+    htsc->Instance->CR |= TSC_CR_SSE;
+  }
+  
+  /* Disable Schmitt trigger hysteresis on all used TSC IOs */
+  htsc->Instance->IOHCR = (uint32_t)(~(htsc->Init.ChannelIOs | htsc->Init.ShieldIOs | htsc->Init.SamplingIOs));
+
+  /* Set channel and shield IOs */
+  htsc->Instance->IOCCR = (htsc->Init.ChannelIOs | htsc->Init.ShieldIOs);
+  
+  /* Set sampling IOs */
+  htsc->Instance->IOSCR = htsc->Init.SamplingIOs;
+  
+  /* Set the groups to be acquired */
+  htsc->Instance->IOGCSR = TSC_extract_groups(htsc->Init.ChannelIOs);
+  
+  /* Clear interrupts */
+  htsc->Instance->IER &= (uint32_t)(~(TSC_IT_EOA | TSC_IT_MCE));
+  
+  /* Clear flags */
+  htsc->Instance->ICR |= (TSC_FLAG_EOA | TSC_FLAG_MCE);
+
+  /*--------------------------------------------------------------------------*/
+  
+  /* Initialize the TSC state */
+  htsc->State = HAL_TSC_STATE_READY;
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deinitializes the TSC peripheral registers to their default reset values.
+  * @param  htsc: TSC handle  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TSC_DeInit(TSC_HandleTypeDef* htsc)
+{
+  /* Check TSC handle allocation */
+  if (htsc == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
+   
+  /* Change TSC state */
+  htsc->State = HAL_TSC_STATE_BUSY;
+ 
+  /* DeInit the low level hardware */
+  HAL_TSC_MspDeInit(htsc);
+  
+  /* Change TSC state */
+  htsc->State = HAL_TSC_STATE_RESET;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(htsc);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the TSC MSP.
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.  
+  * @retval None
+  */
+__weak void HAL_TSC_MspInit(TSC_HandleTypeDef* htsc)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TSC_MspInit could be implemented in the user file.
+   */ 
+}
+
+/**
+  * @brief  DeInitializes the TSC MSP.
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.  
+  * @retval None
+  */
+__weak void HAL_TSC_MspDeInit(TSC_HandleTypeDef* htsc)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TSC_MspDeInit could be implemented in the user file.
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_TSC_Group2 IO operation functions
+ *  @brief    IO operation functions 
+ *
+@verbatim   
+ ===============================================================================
+             ##### I/O Operation functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Start acquisition in polling mode.
+      (+) Start acquisition in interrupt mode.
+      (+) Stop conversion in polling mode.
+      (+) Stop conversion in interrupt mode.
+      (+) Get group acquisition status.
+      (+) Get group acquisition value.
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Starts the acquisition.
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TSC_Start(TSC_HandleTypeDef* htsc)
+{
+  /* Check the parameters */
+  assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
+  
+  /* Process locked */
+  __HAL_LOCK(htsc);
+  
+  /* Change TSC state */
+  htsc->State = HAL_TSC_STATE_BUSY;
+
+  /* Clear interrupts */
+  __HAL_TSC_DISABLE_IT(htsc, (TSC_IT_EOA | TSC_IT_MCE));
+
+  /* Clear flags */
+  __HAL_TSC_CLEAR_FLAG(htsc, (TSC_FLAG_EOA | TSC_FLAG_MCE));
+
+  /* Stop discharging the IOs */
+  __HAL_TSC_SET_IODEF_INFLOAT(htsc);
+  
+  /* Launch the acquisition */
+  __HAL_TSC_START_ACQ(htsc);
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(htsc);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables the interrupt and starts the acquisition
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_TSC_Start_IT(TSC_HandleTypeDef* htsc)
+{
+  /* Check the parameters */
+  assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
+  assert_param(IS_TSC_MCE_IT(htsc->Init.MaxCountInterrupt));
+
+  /* Process locked */
+  __HAL_LOCK(htsc);
+  
+  /* Change TSC state */
+  htsc->State = HAL_TSC_STATE_BUSY;
+  
+  /* Enable end of acquisition interrupt */
+  __HAL_TSC_ENABLE_IT(htsc, TSC_IT_EOA);
+
+  /* Enable max count error interrupt (optional) */
+  if (htsc->Init.MaxCountInterrupt == ENABLE)
+  {
+    __HAL_TSC_ENABLE_IT(htsc, TSC_IT_MCE);
+  }
+  else
+  {
+    __HAL_TSC_DISABLE_IT(htsc, TSC_IT_MCE);
+  }
+
+  /* Clear flags */
+  __HAL_TSC_CLEAR_FLAG(htsc, (TSC_FLAG_EOA | TSC_FLAG_MCE));
+  
+  /* Stop discharging the IOs */
+  __HAL_TSC_SET_IODEF_INFLOAT(htsc);
+  
+  /* Launch the acquisition */
+  __HAL_TSC_START_ACQ(htsc);
+
+  /* Process unlocked */
+  __HAL_UNLOCK(htsc);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the acquisition previously launched in polling mode
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TSC_Stop(TSC_HandleTypeDef* htsc)
+{
+  /* Check the parameters */
+  assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(htsc);
+  
+  /* Stop the acquisition */
+  __HAL_TSC_STOP_ACQ(htsc);
+
+  /* Clear flags */
+  __HAL_TSC_CLEAR_FLAG(htsc, (TSC_FLAG_EOA | TSC_FLAG_MCE));
+  
+  /* Change TSC state */
+  htsc->State = HAL_TSC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(htsc);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Stops the acquisition previously launched in interrupt mode
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TSC_Stop_IT(TSC_HandleTypeDef* htsc)
+{
+  /* Check the parameters */
+  assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(htsc);
+  
+  /* Stop the acquisition */
+  __HAL_TSC_STOP_ACQ(htsc);
+  
+  /* Disable interrupts */
+  __HAL_TSC_DISABLE_IT(htsc, (TSC_IT_EOA | TSC_IT_MCE));
+
+  /* Clear flags */
+  __HAL_TSC_CLEAR_FLAG(htsc, (TSC_FLAG_EOA | TSC_FLAG_MCE));
+  
+  /* Change TSC state */
+  htsc->State = HAL_TSC_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(htsc);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Gets the acquisition status for a group
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.
+  * @param  gx_index: Index of the group
+  * @retval Group status
+  */
+TSC_GroupStatusTypeDef HAL_TSC_GroupGetStatus(TSC_HandleTypeDef* htsc, uint32_t gx_index)
+{
+  /* Check the parameters */
+  assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
+  assert_param(IS_GROUP_INDEX(gx_index));
+
+  /* Return the group status */ 
+  return(__HAL_TSC_GET_GROUP_STATUS(htsc, gx_index));
+}
+
+/**
+  * @brief  Gets the acquisition measure for a group
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.
+  * @param  gx_index: Index of the group
+  * @retval Acquisition measure
+  */
+uint32_t HAL_TSC_GroupGetValue(TSC_HandleTypeDef* htsc, uint32_t gx_index)
+{       
+  /* Check the parameters */
+  assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
+  assert_param(IS_GROUP_INDEX(gx_index));
+
+  /* Return the group acquisition counter */ 
+  return htsc->Instance->IOGXCR[gx_index];
+}
+
+/**
+  * @}
+  */
+  
+/** @defgroup HAL_TSC_Group3 Peripheral Control functions
+ *  @brief    Peripheral Control functions 
+ *
+@verbatim   
+ ===============================================================================
+             ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]  This section provides functions allowing to:
+      (+) Configure TSC IOs
+      (+) Discharge TSC IOs
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configures TSC IOs
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.
+  * @param  config: pointer to the configuration structure.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TSC_IOConfig(TSC_HandleTypeDef* htsc, TSC_IOConfigTypeDef* config)
+{
+  /* Check the parameters */
+  assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
+ 
+  /* Process locked */
+  __HAL_LOCK(htsc);
+
+  /* Stop acquisition */
+  __HAL_TSC_STOP_ACQ(htsc);
+
+  /* Disable Schmitt trigger hysteresis on all used TSC IOs */
+  htsc->Instance->IOHCR = (uint32_t)(~(config->ChannelIOs | config->ShieldIOs | config->SamplingIOs));
+
+  /* Set channel and shield IOs */
+  htsc->Instance->IOCCR = (config->ChannelIOs | config->ShieldIOs);
+  
+  /* Set sampling IOs */
+  htsc->Instance->IOSCR = config->SamplingIOs;
+  
+  /* Set groups to be acquired */
+  htsc->Instance->IOGCSR = TSC_extract_groups(config->ChannelIOs);
+    
+  /* Process unlocked */
+  __HAL_UNLOCK(htsc);
+  
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Discharge TSC IOs
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.
+  * @param  choice: enable or disable
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_TSC_IODischarge(TSC_HandleTypeDef* htsc, uint32_t choice)
+{       
+  /* Check the parameters */
+  assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(htsc);
+  
+  if (choice == ENABLE)
+  {
+    __HAL_TSC_SET_IODEF_OUTPPLOW(htsc);
+  }
+  else
+  {
+    __HAL_TSC_SET_IODEF_INFLOAT(htsc);
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(htsc);
+  
+  /* Return the group acquisition counter */ 
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup HAL_TSC_Group4 State functions
+ *  @brief   State functions 
+ *
+@verbatim   
+ ===============================================================================
+            ##### State functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides functions allowing to
+      (+) Get TSC state.
+      (+) Poll for acquisition completed.
+      (+) Handles TSC interrupt request.
+         
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the TSC state
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.
+  * @retval HAL state
+  */
+HAL_TSC_StateTypeDef HAL_TSC_GetState(TSC_HandleTypeDef* htsc)
+{
+  /* Check the parameters */
+  assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
+  
+  if (htsc->State == HAL_TSC_STATE_BUSY)
+  {
+    /* Check end of acquisition flag */
+    if (__HAL_TSC_GET_FLAG(htsc, TSC_FLAG_EOA) != RESET)
+    {
+      /* Check max count error flag */
+      if (__HAL_TSC_GET_FLAG(htsc, TSC_FLAG_MCE) != RESET)
+      {
+        /* Change TSC state */
+        htsc->State = HAL_TSC_STATE_ERROR;
+      }
+      else
+      {
+        /* Change TSC state */
+        htsc->State = HAL_TSC_STATE_READY;
+      }
+    }
+  }
+  
+  /* Return TSC state */
+  return htsc->State;
+}
+
+/**
+  * @brief  Start acquisition and wait until completion
+  * @note   There is no need of a timeout parameter as the max count error is already
+  *         managed by the TSC peripheral.
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.
+  * @retval HAL state
+  */
+HAL_StatusTypeDef HAL_TSC_PollForAcquisition(TSC_HandleTypeDef* htsc)
+{
+  /* Check the parameters */
+  assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(htsc);
+  
+  /* Check end of acquisition */
+  while (HAL_TSC_GetState(htsc) == HAL_TSC_STATE_BUSY)
+  {
+    /* The timeout (max count error) is managed by the TSC peripheral itself. */
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(htsc);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles TSC interrupt request  
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.
+  * @retval None
+  */
+void HAL_TSC_IRQHandler(TSC_HandleTypeDef* htsc)
+{
+  /* Check the parameters */
+  assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
+
+  /* Check if the end of acquisition occured */
+  if (__HAL_TSC_GET_FLAG(htsc, TSC_FLAG_EOA) != RESET)
+  {
+    /* Clear EOA flag */
+    __HAL_TSC_CLEAR_FLAG(htsc, TSC_FLAG_EOA);
+  }
+  
+  /* Check if max count error occured */
+  if (__HAL_TSC_GET_FLAG(htsc, TSC_FLAG_MCE) != RESET)
+  {
+    /* Clear MCE flag */
+    __HAL_TSC_CLEAR_FLAG(htsc, TSC_FLAG_MCE);
+    /* Change TSC state */
+    htsc->State = HAL_TSC_STATE_ERROR;
+    /* Conversion completed callback */
+    HAL_TSC_ErrorCallback(htsc);
+  }
+  else
+  {
+    /* Change TSC state */
+    htsc->State = HAL_TSC_STATE_READY;
+    /* Conversion completed callback */
+    HAL_TSC_ConvCpltCallback(htsc);
+  }
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  Acquisition completed callback in non blocking mode 
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.
+  * @retval None
+  */
+__weak void HAL_TSC_ConvCpltCallback(TSC_HandleTypeDef* htsc)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TSC_ConvCpltCallback could be implemented in the user file.
+   */
+}
+
+/**
+  * @brief  Error callback in non blocking mode
+  * @param  htsc: pointer to a TSC_HandleTypeDef structure that contains
+  *         the configuration information for the specified TSC.
+  * @retval None
+  */
+__weak void HAL_TSC_ErrorCallback(TSC_HandleTypeDef* htsc)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_TSC_ErrorCallback could be implemented in the user file.
+   */
+}
+
+/**
+  * @brief  Utility function used to set the acquired groups mask
+  * @param  iomask: Channels IOs mask
+  * @retval Acquired groups mask
+  */
+static uint32_t TSC_extract_groups(uint32_t iomask)
+{
+  uint32_t groups = 0;
+  uint32_t idx;
+  
+  for (idx = 0; idx < TSC_NB_OF_GROUPS; idx++)
+  {
+    if ((iomask & ((uint32_t)0x0F << (idx * 4))) != RESET)
+    {
+      groups |= ((uint32_t)1 << idx);
+    }
+  }
+  
+  return groups;
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_TSC_MODULE_ENABLED */
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_tsc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_tsc.h
@@ -1,0 +1,586 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_tsc.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   This file contains all the functions prototypes for the TSC firmware 
+  *          library.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_TSC_H
+#define __STM32L0xx_TSC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup TSC
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+   
+/** 
+  * @brief TSC state structure definition  
+  */ 
+typedef enum
+{
+  HAL_TSC_STATE_RESET  = 0x00, /*!< TSC registers have their reset value */
+  HAL_TSC_STATE_READY  = 0x01, /*!< TSC registers are initialized or acquisition is completed with success */
+  HAL_TSC_STATE_BUSY   = 0x02, /*!< TSC initialization or acquisition is on-going */
+  HAL_TSC_STATE_ERROR  = 0x03  /*!< Acquisition is completed with max count error */
+} HAL_TSC_StateTypeDef;
+
+/** 
+  * @brief TSC group status structure definition  
+  */ 
+typedef enum
+{
+  TSC_GROUP_ONGOING   = 0x00, /*!< Acquisition on group is on-going or not started */
+  TSC_GROUP_COMPLETED = 0x01  /*!< Acquisition on group is completed with success (no max count error) */
+} TSC_GroupStatusTypeDef;
+
+/** 
+  * @brief TSC init structure definition  
+  */ 
+typedef struct
+{
+  uint32_t CTPulseHighLength;       /*!< Charge-transfer high pulse length */
+  uint32_t CTPulseLowLength;        /*!< Charge-transfer low pulse length */
+  uint32_t SpreadSpectrum;          /*!< Spread spectrum activation */
+  uint32_t SpreadSpectrumDeviation; /*!< Spread spectrum deviation */
+  uint32_t SpreadSpectrumPrescaler; /*!< Spread spectrum prescaler */
+  uint32_t PulseGeneratorPrescaler; /*!< Pulse generator prescaler */
+  uint32_t MaxCountValue;           /*!< Max count value */
+  uint32_t IODefaultMode;           /*!< IO default mode */
+  uint32_t SynchroPinPolarity;      /*!< Synchro pin polarity */
+  uint32_t AcquisitionMode;         /*!< Acquisition mode */
+  uint32_t MaxCountInterrupt;       /*!< Max count interrupt activation */
+  uint32_t ChannelIOs;              /*!< Channel IOs mask */
+  uint32_t ShieldIOs;               /*!< Shield IOs mask */
+  uint32_t SamplingIOs;             /*!< Sampling IOs mask */
+} TSC_InitTypeDef;
+
+/** 
+  * @brief TSC IOs configuration structure definition  
+  */ 
+typedef struct
+{
+  uint32_t ChannelIOs;  /*!< Channel IOs mask */
+  uint32_t ShieldIOs;   /*!< Shield IOs mask */
+  uint32_t SamplingIOs; /*!< Sampling IOs mask */
+} TSC_IOConfigTypeDef;
+
+/** 
+  * @brief  TSC handle Structure definition  
+  */ 
+typedef struct
+{
+  TSC_TypeDef               *Instance; /*!< Register base address */
+  TSC_InitTypeDef           Init;      /*!< Initialization parameters */
+  __IO HAL_TSC_StateTypeDef State;     /*!< Peripheral state */
+  HAL_LockTypeDef           Lock;      /*!< Lock feature */
+} TSC_HandleTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup TSC_Exported_Constants
+  * @{
+  */ 
+
+#define IS_TSC_ALL_INSTANCE(PERIPH) ((PERIPH) == TSC)
+
+#define TSC_CTPH_1CYCLE   ((uint32_t)((uint32_t) 0 << 28))
+#define TSC_CTPH_2CYCLES  ((uint32_t)((uint32_t) 1 << 28))
+#define TSC_CTPH_3CYCLES  ((uint32_t)((uint32_t) 2 << 28))
+#define TSC_CTPH_4CYCLES  ((uint32_t)((uint32_t) 3 << 28))
+#define TSC_CTPH_5CYCLES  ((uint32_t)((uint32_t) 4 << 28))
+#define TSC_CTPH_6CYCLES  ((uint32_t)((uint32_t) 5 << 28))
+#define TSC_CTPH_7CYCLES  ((uint32_t)((uint32_t) 6 << 28))
+#define TSC_CTPH_8CYCLES  ((uint32_t)((uint32_t) 7 << 28))
+#define TSC_CTPH_9CYCLES  ((uint32_t)((uint32_t) 8 << 28))
+#define TSC_CTPH_10CYCLES ((uint32_t)((uint32_t) 9 << 28))
+#define TSC_CTPH_11CYCLES ((uint32_t)((uint32_t)10 << 28))
+#define TSC_CTPH_12CYCLES ((uint32_t)((uint32_t)11 << 28))
+#define TSC_CTPH_13CYCLES ((uint32_t)((uint32_t)12 << 28))
+#define TSC_CTPH_14CYCLES ((uint32_t)((uint32_t)13 << 28))
+#define TSC_CTPH_15CYCLES ((uint32_t)((uint32_t)14 << 28))
+#define TSC_CTPH_16CYCLES ((uint32_t)((uint32_t)15 << 28))
+#define IS_TSC_CTPH(VAL) (((VAL) == TSC_CTPH_1CYCLE) || \
+                          ((VAL) == TSC_CTPH_2CYCLES) || \
+                          ((VAL) == TSC_CTPH_3CYCLES) || \
+                          ((VAL) == TSC_CTPH_4CYCLES) || \
+                          ((VAL) == TSC_CTPH_5CYCLES) || \
+                          ((VAL) == TSC_CTPH_6CYCLES) || \
+                          ((VAL) == TSC_CTPH_7CYCLES) || \
+                          ((VAL) == TSC_CTPH_8CYCLES) || \
+                          ((VAL) == TSC_CTPH_9CYCLES) || \
+                          ((VAL) == TSC_CTPH_10CYCLES) || \
+                          ((VAL) == TSC_CTPH_11CYCLES) || \
+                          ((VAL) == TSC_CTPH_12CYCLES) || \
+                          ((VAL) == TSC_CTPH_13CYCLES) || \
+                          ((VAL) == TSC_CTPH_14CYCLES) || \
+                          ((VAL) == TSC_CTPH_15CYCLES) || \
+                          ((VAL) == TSC_CTPH_16CYCLES))
+
+#define TSC_CTPL_1CYCLE   ((uint32_t)((uint32_t) 0 << 24))
+#define TSC_CTPL_2CYCLES  ((uint32_t)((uint32_t) 1 << 24))
+#define TSC_CTPL_3CYCLES  ((uint32_t)((uint32_t) 2 << 24))
+#define TSC_CTPL_4CYCLES  ((uint32_t)((uint32_t) 3 << 24))
+#define TSC_CTPL_5CYCLES  ((uint32_t)((uint32_t) 4 << 24))
+#define TSC_CTPL_6CYCLES  ((uint32_t)((uint32_t) 5 << 24))
+#define TSC_CTPL_7CYCLES  ((uint32_t)((uint32_t) 6 << 24))
+#define TSC_CTPL_8CYCLES  ((uint32_t)((uint32_t) 7 << 24))
+#define TSC_CTPL_9CYCLES  ((uint32_t)((uint32_t) 8 << 24))
+#define TSC_CTPL_10CYCLES ((uint32_t)((uint32_t) 9 << 24))
+#define TSC_CTPL_11CYCLES ((uint32_t)((uint32_t)10 << 24))
+#define TSC_CTPL_12CYCLES ((uint32_t)((uint32_t)11 << 24))
+#define TSC_CTPL_13CYCLES ((uint32_t)((uint32_t)12 << 24))
+#define TSC_CTPL_14CYCLES ((uint32_t)((uint32_t)13 << 24))
+#define TSC_CTPL_15CYCLES ((uint32_t)((uint32_t)14 << 24))
+#define TSC_CTPL_16CYCLES ((uint32_t)((uint32_t)15 << 24))
+#define IS_TSC_CTPL(VAL) (((VAL) == TSC_CTPL_1CYCLE) || \
+                          ((VAL) == TSC_CTPL_2CYCLES) || \
+                          ((VAL) == TSC_CTPL_3CYCLES) || \
+                          ((VAL) == TSC_CTPL_4CYCLES) || \
+                          ((VAL) == TSC_CTPL_5CYCLES) || \
+                          ((VAL) == TSC_CTPL_6CYCLES) || \
+                          ((VAL) == TSC_CTPL_7CYCLES) || \
+                          ((VAL) == TSC_CTPL_8CYCLES) || \
+                          ((VAL) == TSC_CTPL_9CYCLES) || \
+                          ((VAL) == TSC_CTPL_10CYCLES) || \
+                          ((VAL) == TSC_CTPL_11CYCLES) || \
+                          ((VAL) == TSC_CTPL_12CYCLES) || \
+                          ((VAL) == TSC_CTPL_13CYCLES) || \
+                          ((VAL) == TSC_CTPL_14CYCLES) || \
+                          ((VAL) == TSC_CTPL_15CYCLES) || \
+                          ((VAL) == TSC_CTPL_16CYCLES))
+
+#define IS_TSC_SS(VAL) (((VAL) == DISABLE) || ((VAL) == ENABLE))
+
+#define IS_TSC_SSD(VAL) (((VAL) == 0) || (((VAL) > 0) && ((VAL) < 128)))
+
+#define TSC_SS_PRESC_DIV1 ((uint32_t)0)  
+#define TSC_SS_PRESC_DIV2  (TSC_CR_SSPSC) 
+#define IS_TSC_SS_PRESC(VAL) (((VAL) == TSC_SS_PRESC_DIV1) || ((VAL) == TSC_SS_PRESC_DIV2))
+
+#define TSC_PG_PRESC_DIV1   ((uint32_t)(0 << 12))
+#define TSC_PG_PRESC_DIV2   ((uint32_t)(1 << 12))
+#define TSC_PG_PRESC_DIV4   ((uint32_t)(2 << 12))
+#define TSC_PG_PRESC_DIV8   ((uint32_t)(3 << 12))
+#define TSC_PG_PRESC_DIV16  ((uint32_t)(4 << 12))
+#define TSC_PG_PRESC_DIV32  ((uint32_t)(5 << 12))
+#define TSC_PG_PRESC_DIV64  ((uint32_t)(6 << 12))
+#define TSC_PG_PRESC_DIV128 ((uint32_t)(7 << 12))
+#define IS_TSC_PG_PRESC(VAL) (((VAL) == TSC_PG_PRESC_DIV1) || \
+                              ((VAL) == TSC_PG_PRESC_DIV2) || \
+                              ((VAL) == TSC_PG_PRESC_DIV4) || \
+                              ((VAL) == TSC_PG_PRESC_DIV8) || \
+                              ((VAL) == TSC_PG_PRESC_DIV16) || \
+                              ((VAL) == TSC_PG_PRESC_DIV32) || \
+                              ((VAL) == TSC_PG_PRESC_DIV64) || \
+                              ((VAL) == TSC_PG_PRESC_DIV128))
+
+#define TSC_MCV_255   ((uint32_t)(0 << 5))
+#define TSC_MCV_511   ((uint32_t)(1 << 5))
+#define TSC_MCV_1023  ((uint32_t)(2 << 5))
+#define TSC_MCV_2047  ((uint32_t)(3 << 5))
+#define TSC_MCV_4095  ((uint32_t)(4 << 5))
+#define TSC_MCV_8191  ((uint32_t)(5 << 5))
+#define TSC_MCV_16383 ((uint32_t)(6 << 5))
+#define IS_TSC_MCV(VAL) (((VAL) == TSC_MCV_255) || \
+                         ((VAL) == TSC_MCV_511) || \
+                         ((VAL) == TSC_MCV_1023) || \
+                         ((VAL) == TSC_MCV_2047) || \
+                         ((VAL) == TSC_MCV_4095) || \
+                         ((VAL) == TSC_MCV_8191) || \
+                         ((VAL) == TSC_MCV_16383))
+
+#define TSC_IODEF_OUT_PP_LOW ((uint32_t)0)
+#define TSC_IODEF_IN_FLOAT   (TSC_CR_IODEF)
+#define IS_TSC_IODEF(VAL) (((VAL) == TSC_IODEF_OUT_PP_LOW) || ((VAL) == TSC_IODEF_IN_FLOAT))
+
+#define TSC_SYNC_POL_FALL      ((uint32_t)0)
+#define TSC_SYNC_POL_RISE_HIGH (TSC_CR_SYNCPOL)
+#define IS_TSC_SYNC_POL(VAL) (((VAL) == TSC_SYNC_POL_FALL) || ((VAL) == TSC_SYNC_POL_RISE_HIGH))
+
+#define TSC_ACQ_MODE_NORMAL  ((uint32_t)0)
+#define TSC_ACQ_MODE_SYNCHRO (TSC_CR_AM)
+#define IS_TSC_ACQ_MODE(VAL) (((VAL) == TSC_ACQ_MODE_NORMAL) || ((VAL) == TSC_ACQ_MODE_SYNCHRO))
+
+#define TSC_IOMODE_UNUSED   ((uint32_t)0)
+#define TSC_IOMODE_CHANNEL  ((uint32_t)1)
+#define TSC_IOMODE_SHIELD   ((uint32_t)2)
+#define TSC_IOMODE_SAMPLING ((uint32_t)3)
+#define IS_TSC_IOMODE(VAL) (((VAL) == TSC_IOMODE_UNUSED) || \
+                            ((VAL) == TSC_IOMODE_CHANNEL) || \
+                            ((VAL) == TSC_IOMODE_SHIELD) || \
+                            ((VAL) == TSC_IOMODE_SAMPLING))
+
+/** @defgroup TSC_interrupts_definition
+  * @{
+  */
+#define TSC_IT_EOA ((uint32_t)TSC_IER_EOAIE)  
+#define TSC_IT_MCE ((uint32_t)TSC_IER_MCEIE) 
+#define IS_TSC_MCE_IT(VAL) (((VAL) == DISABLE) || ((VAL) == ENABLE))
+/**
+  * @}
+  */ 
+
+/** @defgroup TSC_flags_definition
+  * @{
+  */ 
+#define TSC_FLAG_EOA ((uint32_t)TSC_ISR_EOAF)
+#define TSC_FLAG_MCE ((uint32_t)TSC_ISR_MCEF)
+/**
+  * @}
+  */
+
+#define TSC_NB_OF_GROUPS (8)
+
+#define TSC_GROUP1 ((uint32_t)0x00000001)
+#define TSC_GROUP2 ((uint32_t)0x00000002)
+#define TSC_GROUP3 ((uint32_t)0x00000004)
+#define TSC_GROUP4 ((uint32_t)0x00000008)
+#define TSC_GROUP5 ((uint32_t)0x00000010)
+#define TSC_GROUP6 ((uint32_t)0x00000020)
+#define TSC_GROUP7 ((uint32_t)0x00000040)
+#define TSC_GROUP8 ((uint32_t)0x00000080)
+#define TSC_ALL_GROUPS ((uint32_t)0x000000FF)
+
+#define TSC_GROUP1_IDX ((uint32_t)0)
+#define TSC_GROUP2_IDX ((uint32_t)1)
+#define TSC_GROUP3_IDX ((uint32_t)2)
+#define TSC_GROUP4_IDX ((uint32_t)3)
+#define TSC_GROUP5_IDX ((uint32_t)4)
+#define TSC_GROUP6_IDX ((uint32_t)5)
+#define TSC_GROUP7_IDX ((uint32_t)6)
+#define TSC_GROUP8_IDX ((uint32_t)7)
+#define IS_GROUP_INDEX(VAL) (((VAL) == 0) || (((VAL) > 0) && ((VAL) < TSC_NB_OF_GROUPS)))
+
+#define TSC_GROUP1_IO1 ((uint32_t)0x00000001)
+#define TSC_GROUP1_IO2 ((uint32_t)0x00000002)
+#define TSC_GROUP1_IO3 ((uint32_t)0x00000004)
+#define TSC_GROUP1_IO4 ((uint32_t)0x00000008)
+#define TSC_GROUP1_ALL_IOS ((uint32_t)0x0000000F)
+
+#define TSC_GROUP2_IO1 ((uint32_t)0x00000010)
+#define TSC_GROUP2_IO2 ((uint32_t)0x00000020)
+#define TSC_GROUP2_IO3 ((uint32_t)0x00000040)
+#define TSC_GROUP2_IO4 ((uint32_t)0x00000080)
+#define TSC_GROUP2_ALL_IOS ((uint32_t)0x000000F0)
+
+#define TSC_GROUP3_IO1 ((uint32_t)0x00000100)
+#define TSC_GROUP3_IO2 ((uint32_t)0x00000200)
+#define TSC_GROUP3_IO3 ((uint32_t)0x00000400)
+#define TSC_GROUP3_IO4 ((uint32_t)0x00000800)
+#define TSC_GROUP3_ALL_IOS ((uint32_t)0x00000F00)
+
+#define TSC_GROUP4_IO1 ((uint32_t)0x00001000)
+#define TSC_GROUP4_IO2 ((uint32_t)0x00002000)
+#define TSC_GROUP4_IO3 ((uint32_t)0x00004000)
+#define TSC_GROUP4_IO4 ((uint32_t)0x00008000)
+#define TSC_GROUP4_ALL_IOS ((uint32_t)0x0000F000)
+
+#define TSC_GROUP5_IO1 ((uint32_t)0x00010000)
+#define TSC_GROUP5_IO2 ((uint32_t)0x00020000)
+#define TSC_GROUP5_IO3 ((uint32_t)0x00040000)
+#define TSC_GROUP5_IO4 ((uint32_t)0x00080000)
+#define TSC_GROUP5_ALL_IOS ((uint32_t)0x000F0000)
+
+#define TSC_GROUP6_IO1 ((uint32_t)0x00100000)
+#define TSC_GROUP6_IO2 ((uint32_t)0x00200000)
+#define TSC_GROUP6_IO3 ((uint32_t)0x00400000)
+#define TSC_GROUP6_IO4 ((uint32_t)0x00800000)
+#define TSC_GROUP6_ALL_IOS ((uint32_t)0x00F00000)
+
+#define TSC_GROUP7_IO1 ((uint32_t)0x01000000)
+#define TSC_GROUP7_IO2 ((uint32_t)0x02000000)
+#define TSC_GROUP7_IO3 ((uint32_t)0x04000000)
+#define TSC_GROUP7_IO4 ((uint32_t)0x08000000)
+#define TSC_GROUP7_ALL_IOS ((uint32_t)0x0F000000)
+
+#define TSC_GROUP8_IO1 ((uint32_t)0x10000000)
+#define TSC_GROUP8_IO2 ((uint32_t)0x20000000)
+#define TSC_GROUP8_IO3 ((uint32_t)0x40000000)
+#define TSC_GROUP8_IO4 ((uint32_t)0x80000000)
+#define TSC_GROUP8_ALL_IOS ((uint32_t)0xF0000000)
+
+#define TSC_ALL_GROUPS_ALL_IOS ((uint32_t)0xFFFFFFFF)
+
+/**
+  * @}
+  */ 
+
+/* Exported macro ------------------------------------------------------------*/
+
+/** @brief Reset TSC handle state
+  * @param  __HANDLE__: TSC handle
+  * @retval None
+  */
+#define __HAL_TSC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_TSC_STATE_RESET)
+
+/**
+  * @brief Enable the TSC peripheral.
+  * @param  __HANDLE__: TSC handle
+  * @retval None
+  */
+#define __HAL_TSC_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR |= TSC_CR_TSCE)
+
+/**
+  * @brief Disable the TSC peripheral.
+  * @param  __HANDLE__: TSC handle
+  * @retval None
+  */
+#define __HAL_TSC_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR &= (uint32_t)(~TSC_CR_TSCE))
+
+/**
+  * @brief Start acquisition
+  * @param  __HANDLE__: TSC handle
+  * @retval None
+  */
+#define __HAL_TSC_START_ACQ(__HANDLE__) ((__HANDLE__)->Instance->CR |= TSC_CR_START)
+
+/**
+  * @brief Stop acquisition
+  * @param  __HANDLE__: TSC handle
+  * @retval None
+  */
+#define __HAL_TSC_STOP_ACQ(__HANDLE__) ((__HANDLE__)->Instance->CR &= (uint32_t)(~TSC_CR_START))
+
+/**
+  * @brief Set IO default mode to output push-pull low
+  * @param  __HANDLE__: TSC handle
+  * @retval None
+  */
+#define __HAL_TSC_SET_IODEF_OUTPPLOW(__HANDLE__) ((__HANDLE__)->Instance->CR &= (uint32_t)(~TSC_CR_IODEF))
+
+/**
+  * @brief Set IO default mode to input floating
+  * @param  __HANDLE__: TSC handle
+  * @retval None
+  */
+#define __HAL_TSC_SET_IODEF_INFLOAT(__HANDLE__) ((__HANDLE__)->Instance->CR |= TSC_CR_IODEF)
+
+/**
+  * @brief Set synchronization polarity to falling edge
+  * @param  __HANDLE__: TSC handle
+  * @retval None
+  */
+#define __HAL_TSC_SET_SYNC_POL_FALL(__HANDLE__) ((__HANDLE__)->Instance->CR &= (uint32_t)(~TSC_CR_SYNCPOL))
+
+/**
+  * @brief Set synchronization polarity to rising edge and high level
+  * @param  __HANDLE__: TSC handle
+  * @retval None
+  */
+#define __HAL_TSC_SET_SYNC_POL_RISE_HIGH(__HANDLE__) ((__HANDLE__)->Instance->CR |= TSC_CR_SYNCPOL)
+
+/**
+  * @brief Enable TSC interrupt.
+  * @param  __HANDLE__: TSC handle
+  * @param  __INTERRUPT__: TSC interrupt
+  * @retval None
+  */
+#define __HAL_TSC_ENABLE_IT(__HANDLE__, __INTERRUPT__) ((__HANDLE__)->Instance->IER |= (__INTERRUPT__))
+
+/**
+  * @brief Disable TSC interrupt.
+  * @param  __HANDLE__: TSC handle
+  * @param  __INTERRUPT__: TSC interrupt
+  * @retval None
+  */
+#define __HAL_TSC_DISABLE_IT(__HANDLE__, __INTERRUPT__) ((__HANDLE__)->Instance->IER &= (uint32_t)(~(__INTERRUPT__)))
+
+/** @brief Check if the specified TSC interrupt source is enabled or disabled.
+  * @param  __HANDLE__: TSC Handle
+  * @param  __INTERRUPT__: TSC interrupt
+  * @retval SET or RESET
+  */
+#define __HAL_TSC_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->IER & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+
+/**
+  * @brief Get the selected TSC's flag status.
+  * @param  __HANDLE__: TSC handle
+  * @param  __FLAG__: TSC flag
+  * @retval SET or RESET
+  */
+#define __HAL_TSC_GET_FLAG(__HANDLE__, __FLAG__) ((((__HANDLE__)->Instance->ISR & (__FLAG__)) == (__FLAG__)) ? SET : RESET)
+
+/**
+  * @brief Clear the TSC's pending flag.
+  * @param  __HANDLE__: TSC handle
+  * @param  __FLAG__: TSC flag
+  * @retval None
+  */
+#define __HAL_TSC_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ICR = (__FLAG__))
+
+/**
+  * @brief Enable schmitt trigger hysteresis on a group of IOs
+  * @param  __HANDLE__: TSC handle
+  * @param  __GX_IOY_MASK__: IOs mask
+  * @retval None
+  */
+#define __HAL_TSC_ENABLE_HYSTERESIS(__HANDLE__, __GX_IOY_MASK__) ((__HANDLE__)->Instance->IOHCR |= (__GX_IOY_MASK__))
+
+/**
+  * @brief Disable schmitt trigger hysteresis on a group of IOs
+  * @param  __HANDLE__: TSC handle
+  * @param  __GX_IOY_MASK__: IOs mask
+  * @retval None
+  */
+#define __HAL_TSC_DISABLE_HYSTERESIS(__HANDLE__, __GX_IOY_MASK__) ((__HANDLE__)->Instance->IOHCR &= (uint32_t)(~(__GX_IOY_MASK__)))
+
+/**
+  * @brief Open analog switch on a group of IOs
+  * @param  __HANDLE__: TSC handle
+  * @param  __GX_IOY_MASK__: IOs mask
+  * @retval None
+  */
+#define __HAL_TSC_OPEN_ANALOG_SWITCH(__HANDLE__, __GX_IOY_MASK__) ((__HANDLE__)->Instance->IOASCR &= (uint32_t)(~(__GX_IOY_MASK__)))
+
+/**
+  * @brief Close analog switch on a group of IOs
+  * @param  __HANDLE__: TSC handle
+  * @param  __GX_IOY_MASK__: IOs mask
+  * @retval None
+  */
+#define __HAL_TSC_CLOSE_ANALOG_SWITCH(__HANDLE__, __GX_IOY_MASK__) ((__HANDLE__)->Instance->IOASCR |= (__GX_IOY_MASK__))
+
+/**
+  * @brief Enable a group of IOs in channel mode
+  * @param  __HANDLE__: TSC handle
+  * @param  __GX_IOY_MASK__: IOs mask
+  * @retval None
+  */
+#define __HAL_TSC_ENABLE_CHANNEL(__HANDLE__, __GX_IOY_MASK__) ((__HANDLE__)->Instance->IOCCR |= (__GX_IOY_MASK__))
+
+/**
+  * @brief Disable a group of channel IOs
+  * @param  __HANDLE__: TSC handle
+  * @param  __GX_IOY_MASK__: IOs mask
+  * @retval None
+  */
+#define __HAL_TSC_DISABLE_CHANNEL(__HANDLE__, __GX_IOY_MASK__) ((__HANDLE__)->Instance->IOCCR &= (uint32_t)(~(__GX_IOY_MASK__)))
+
+/**
+  * @brief Enable a group of IOs in sampling mode
+  * @param  __HANDLE__: TSC handle
+  * @param  __GX_IOY_MASK__: IOs mask
+  * @retval None
+  */
+#define __HAL_TSC_ENABLE_SAMPLING(__HANDLE__, __GX_IOY_MASK__) ((__HANDLE__)->Instance->IOSCR |= (__GX_IOY_MASK__))
+
+/**
+  * @brief Disable a group of sampling IOs
+  * @param  __HANDLE__: TSC handle
+  * @param  __GX_IOY_MASK__: IOs mask
+  * @retval None
+  */
+#define __HAL_TSC_DISABLE_SAMPLING(__HANDLE__, __GX_IOY_MASK__) ((__HANDLE__)->Instance->IOSCR &= (uint32_t)(~(__GX_IOY_MASK__)))
+
+/**
+  * @brief Enable acquisition groups
+  * @param  __HANDLE__: TSC handle
+  * @param  __GX_MASK__: Groups mask
+  * @retval None
+  */
+#define __HAL_TSC_ENABLE_GROUP(__HANDLE__, __GX_MASK__) ((__HANDLE__)->Instance->IOGCSR |= (__GX_MASK__))
+
+/**
+  * @brief Disable acquisition groups
+  * @param  __HANDLE__: TSC handle
+  * @param  __GX_MASK__: Groups mask
+  * @retval None
+  */
+#define __HAL_TSC_DISABLE_GROUP(__HANDLE__, __GX_MASK__) ((__HANDLE__)->Instance->IOGCSR &= (uint32_t)(~(__GX_MASK__)))
+
+/** @brief Gets acquisition group status
+  * @param  __HANDLE__: TSC Handle
+  * @param  __GX_INDEX__: Group index
+  * @retval SET or RESET
+  */
+#define __HAL_TSC_GET_GROUP_STATUS(__HANDLE__, __GX_INDEX__) \
+((((__HANDLE__)->Instance->IOGCSR & (uint32_t)((uint32_t)1 << ((__GX_INDEX__) + (uint32_t)16))) == (uint32_t)((uint32_t)1 << ((__GX_INDEX__) + (uint32_t)16))) ? TSC_GROUP_COMPLETED : TSC_GROUP_ONGOING)
+
+/* Exported functions --------------------------------------------------------*/  
+
+/* Initialization and de-initialization functions *****************************/
+HAL_StatusTypeDef HAL_TSC_Init(TSC_HandleTypeDef* htsc);
+HAL_StatusTypeDef HAL_TSC_DeInit(TSC_HandleTypeDef *htsc);
+void HAL_TSC_MspInit(TSC_HandleTypeDef* htsc);
+void HAL_TSC_MspDeInit(TSC_HandleTypeDef* htsc);
+
+/* IO operation functions *****************************************************/
+HAL_StatusTypeDef HAL_TSC_Start(TSC_HandleTypeDef* htsc);
+HAL_StatusTypeDef HAL_TSC_Start_IT(TSC_HandleTypeDef* htsc);
+HAL_StatusTypeDef HAL_TSC_Stop(TSC_HandleTypeDef* htsc);
+HAL_StatusTypeDef HAL_TSC_Stop_IT(TSC_HandleTypeDef* htsc);
+TSC_GroupStatusTypeDef HAL_TSC_GroupGetStatus(TSC_HandleTypeDef* htsc, uint32_t gx_index);
+uint32_t HAL_TSC_GroupGetValue(TSC_HandleTypeDef* htsc, uint32_t gx_index);
+
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef HAL_TSC_IOConfig(TSC_HandleTypeDef* htsc, TSC_IOConfigTypeDef* config);
+HAL_StatusTypeDef HAL_TSC_IODischarge(TSC_HandleTypeDef* htsc, uint32_t choice);
+
+/* Peripheral State and Error functions ***************************************/
+HAL_TSC_StateTypeDef HAL_TSC_GetState(TSC_HandleTypeDef* htsc);
+HAL_StatusTypeDef HAL_TSC_PollForAcquisition(TSC_HandleTypeDef* htsc);
+void HAL_TSC_IRQHandler(TSC_HandleTypeDef* htsc);
+
+/* Callback functions *********************************************************/
+void HAL_TSC_ConvCpltCallback(TSC_HandleTypeDef* htsc);
+void HAL_TSC_ErrorCallback(TSC_HandleTypeDef* htsc);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__STM32L0xx_TSC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_uart.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_uart.c
@@ -1,0 +1,1981 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_uart.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   UART HAL module driver.
+  *
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Universal Asynchronous Receiver Transmitter Peripheral (UART).
+  *           + Initialization and de-initialization methods
+  *           + IO operation methods
+  *           + Peripheral Control methods
+  *
+  @verbatim
+ ===============================================================================
+                        ##### How to use this driver #####
+ ===============================================================================
+  [..]
+    The UART HAL driver can be used as follows:
+    
+    (#) Declare a UART_HandleTypeDef handle structure.
+  
+    (#) Initialize the UART low level resources by implementing the HAL_UART_MspInit() API:
+        (##) Enable the USARTx interface clock.
+        (##) UART pins configuration:
+            (+++) Enable the clock for the UART GPIOs.
+            (+++) Configure these UART pins as alternate function pull-up.
+        (##) NVIC configuration if you need to use interrupt process (HAL_UART_Transmit_IT()
+             and HAL_UART_Receive_IT() APIs):
+            (+++) Configure the USARTx interrupt priority.
+            (+++) Enable the NVIC USART IRQ handle.
+
+        (##) DMA Configuration if you need to use DMA process (HAL_UART_Transmit_DMA()
+             and HAL_UART_Receive_DMA() APIs):
+            (+++) Declare a DMA handle structure for the Tx/Rx stream.
+            (+++) Enable the DMAx interface clock.
+            (+++) Configure the declared DMA handle structure with the required 
+                  Tx/Rx parameters.                
+            (+++) Configure the DMA Tx/Rx Stream.
+            (+++) Associate the initialized DMA handle to the UART DMA Tx/Rx handle.
+            (+++) Configure the priority and enable the NVIC for the transfer complete 
+                  interrupt on the DMA Tx/Rx Stream.
+
+    (#) Program the Baud Rate, Word Length, Stop Bit, Parity, Hardware 
+        flow control and Mode(Receiver/Transmitter) in the Init structure.
+
+    (#) For the UART asynchronous mode, initialize the UART registers by calling
+        the HAL_UART_Init() API.
+
+    (#) For the UART Half duplex mode, initialize the UART registers by calling 
+        the HAL_HalfDuplex_Init() API.
+
+    (#) For the LIN mode, initialize the UART registers by calling the HAL_LIN_Init() API.
+
+    (#) For the Multi-Processor mode, initialize the UART registers by calling 
+        the HAL_MultiProcessor_Init() API.
+
+     [..] 
+       (@) The specific UART interrupts (Transmission complete interrupt, 
+            RXNE interrupt and Error Interrupts) will be managed using the macros
+            __HAL_UART_ENABLE_IT() and __HAL_UART_DISABLE_IT() inside the transmit 
+            and receive process.
+
+     [..] 
+       (@) These APIs (HAL_UART_Init() and HAL_HalfDuplex_Init()) configure also the 
+            low level Hardware GPIO, CLOCK, CORTEX...etc) by calling the customed 
+            HAL_UART_MspInit() API.
+
+     [..] 
+        Three operation modes are available within this driver :
+
+     *** Polling mode IO operation ***
+     =================================
+     [..]    
+       (+) Send an amount of data in blocking mode using HAL_UART_Transmit() 
+       (+) Receive an amount of data in blocking mode using HAL_UART_Receive()
+       
+     *** Interrupt mode IO operation ***
+     ===================================
+     [..]
+       (+) Send an amount of data in non blocking mode using HAL_UART_Transmit_IT() 
+       (+) At transmission end of half transfer HAL_UART_TxHalfCpltCallback is executed and user can 
+            add his own code by customization of function pointer HAL_UART_TxHalfCpltCallback 
+       (+) At transmission end of transfer HAL_UART_TxCpltCallback is executed and user can 
+            add his own code by customization of function pointer HAL_UART_TxCpltCallback
+       (+) Receive an amount of data in non blocking mode using HAL_UART_Receive_IT() 
+       (+) At reception end of half transfer HAL_UART_RxHalfCpltCallback is executed and user can 
+            add his own code by customization of function pointer HAL_UART_RxHalfCpltCallback 
+       (+) At reception end of transfer HAL_UART_RxCpltCallback is executed and user can 
+            add his own code by customization of function pointer HAL_UART_RxCpltCallback
+       (+) In case of transfer Error, HAL_UART_ErrorCallback() function is executed and user can 
+            add his own code by customization of function pointer HAL_UART_ErrorCallback
+
+     *** DMA mode IO operation ***
+     ==============================
+     [..] 
+       (+) Send an amount of data in non blocking mode (DMA) using HAL_UART_Transmit_DMA() 
+       (+) At transmission end of half transfer HAL_UART_TxHalfCpltCallback is executed and user can 
+            add his own code by customization of function pointer HAL_UART_TxHalfCpltCallback 
+       (+) At transmission end of transfer HAL_UART_TxCpltCallback is executed and user can 
+            add his own code by customization of function pointer HAL_UART_TxCpltCallback
+       (+) Receive an amount of data in non blocking mode (DMA) using HAL_UART_Receive_DMA() 
+       (+) At reception end of half transfer HAL_UART_RxHalfCpltCallback is executed and user can 
+            add his own code by customization of function pointer HAL_UART_RxHalfCpltCallback 
+       (+) At reception end of transfer HAL_UART_RxCpltCallback is executed and user can 
+            add his own code by customization of function pointer HAL_UART_RxCpltCallback
+       (+) In case of transfer Error, HAL_UART_ErrorCallback() function is executed and user can 
+            add his own code by customization of function pointer HAL_UART_ErrorCallback
+       (+) Pause the DMA Transfer using HAL_UART_DMAPause()
+       (+) Resume the DMA Transfer using HAL_UART_DMAResume()
+       (+) Stop the DMA Transfer using HAL_UART_DMAStop()
+
+     *** UART HAL driver macros list ***
+     =============================================
+     [..]
+       Below the list of most used macros in UART HAL driver.
+
+      (+) __HAL_UART_ENABLE: Enable the UART peripheral 
+      (+) __HAL_UART_DISABLE: Disable the UART peripheral
+      (+) __HAL_UART_GET_FLAG : Check whether the specified UART flag is set or not
+      (+) __HAL_UART_CLEAR_FLAG : Clear the specified UART pending flag
+      (+) __HAL_UART_ENABLE_IT: Enable the specified UART interrupt
+      (+) __HAL_UART_DISABLE_IT: Disable the specified UART interrupt
+
+     [..]
+       (@) You can refer to the UART HAL driver header file for more useful macros 
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup UART 
+  * @brief UART module driver
+  * @{
+  */
+#ifdef HAL_UART_MODULE_ENABLED
+    
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define UART_TIMEOUT_VALUE       ((uint32_t) 22000)
+#define UART_CR1_FIELDS  ((uint32_t)(USART_CR1_M | USART_CR1_PCE | USART_CR1_PS | \
+                                     USART_CR1_TE | USART_CR1_RE | USART_CR1_OVER8))
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void UART_DMATransmitCplt(DMA_HandleTypeDef *hdma);
+static void UART_DMATxHalfCplt(DMA_HandleTypeDef *hdma);
+static void UART_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
+static void UART_DMARxHalfCplt(DMA_HandleTypeDef *hdma);
+static void UART_DMAError(DMA_HandleTypeDef *hdma); 
+static HAL_StatusTypeDef UART_Transmit_IT(UART_HandleTypeDef *huart);
+static HAL_StatusTypeDef UART_Receive_IT(UART_HandleTypeDef *huart);
+
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup UART_Private_Functions
+  * @{
+  */
+
+/** @defgroup UART_Group1 Initialization/de-initialization methods 
+  *  @brief    Initialization and Configuration functions 
+  *
+@verbatim    
+===============================================================================
+            ##### Initialization and Configuration functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to initialize the USARTx or the UARTy 
+    in asynchronous mode.
+      (+) For the asynchronous mode only these parameters can be configured: 
+        (++) Baud Rate
+        (++) Word Length 
+        (++) Stop Bit
+        (++) Parity: If the parity is enabled, then the MSB bit of the data written
+             in the data register is transmitted but is changed by the parity bit.
+             Depending on the frame length defined by the M bit (8-bits or 9-bits),
+             the possible UART frame formats are as listed in the following table:
+   +-----------------------------------------------------------------------+
+   |  M1 bit |  M0 bit |  PCE bit  |            USART frame                |
+   |---------|---------|-----------|---------------------------------------|
+   |    0    |    0    |    0      |    | SB |    8 bit data   | STB |     |
+   |---------|---------|-----------|---------------------------------------|
+   |    0    |    0    |    1      |    | SB | 7 bit data | PB | STB |     |
+   |---------|---------|-----------|---------------------------------------|
+   |    0    |    1    |    0      |    | SB |    9 bit data   | STB |     |
+   |---------|---------|-----------|---------------------------------------|
+   |    0    |    1    |    1      |    | SB | 8 bit data | PB | STB |     |
+   |---------|---------|-----------|---------------------------------------|
+   |    1    |    0    |    0      |    | SB |    7 bit data   | STB |     |
+   |---------|---------|-----------|---------------------------------------|
+   |    1    |    0    |    1      |    | SB | 6 bit data | PB | STB |     |
+   +-----------------------------------------------------------------------+
+        (++) Hardware flow control
+        (++) Receiver/transmitter modes
+        (++) Over Sampling Method
+        (++) One-Bit Sampling Method
+      (+) For the asynchronous mode, the following advanced features can be configured as well:
+        (++) TX and/or RX pin level inversion
+        (++) data logical level inversion
+        (++) RX and TX pins swap
+        (++) RX overrun detection disabling
+        (++) DMA disabling on RX error
+        (++) MSB first on communication line
+        (++) auto Baud rate detection
+    [..]
+    The HAL_UART_Init(), HAL_HalfDuplex_Init(), HAL_LIN_Init()and HAL_MultiProcessorEx_Init()API 
+    follow respectively the UART asynchronous, UART Half duplex, UART LIN mode
+    and UART multiprocessor mode mode configuration procedures (details for the procedures
+    are available in reference manual).
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Initializes the UART mode according to the specified
+  *         parameters in the UART_InitTypeDef and creates the associated handle .
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Init(UART_HandleTypeDef *huart)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  if(huart->Init.HwFlowCtl != UART_HWCONTROL_NONE)
+  {
+    /* Check the parameters */
+    assert_param(IS_UART_HWFLOW_INSTANCE(huart->Instance));
+  }
+  else
+  {
+    /* Check the parameters */
+    assert_param(IS_UART_INSTANCE(huart->Instance));
+  }
+  
+  if(huart->State == HAL_UART_STATE_RESET)
+  {  
+    /* Init the low level hardware : GPIO, CLOCK, CORTEX */
+    HAL_UART_MspInit(huart);
+  }
+  
+  huart->State = HAL_UART_STATE_BUSY;  
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+  
+  /* Set the UART Communication parameters */
+  UART_SetConfig(huart);
+  
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+  
+  /* In asynchronous mode, the following bits must be kept cleared: 
+  - LINEN and CLKEN bits in the USART_CR2 register,
+  - SCEN, HDSEL and IREN  bits in the USART_CR3 register.*/
+  huart->Instance->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN); 
+  huart->Instance->CR3 &= ~(USART_CR3_SCEN | USART_CR3_HDSEL | USART_CR3_IREN); 
+    
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+  
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+/**
+  * @brief Initializes the half-duplex mode according to the specified
+  *         parameters in the UART_InitTypeDef and creates the associated handle .
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HalfDuplex_Init(UART_HandleTypeDef *huart)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  if(huart->State == HAL_UART_STATE_RESET)
+  {   
+    /* Init the low level hardware : GPIO, CLOCK, CORTEX */
+    HAL_UART_MspInit(huart);
+  }
+  
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+  
+  /* Set the UART Communication parameters */
+  UART_SetConfig(huart);
+  
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+  
+  /* In half-duplex mode, the following bits must be kept cleared: 
+  - LINEN and CLKEN bits in the USART_CR2 register,
+  - SCEN and IREN bits in the USART_CR3 register.*/
+  huart->Instance->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN);
+  huart->Instance->CR3 &= ~(USART_CR3_IREN | USART_CR3_SCEN);
+  
+  /* Enable the Half-Duplex mode by setting the HDSEL bit in the CR3 register */
+  huart->Instance->CR3 |= USART_CR3_HDSEL;
+  
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+  
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+/**
+  * @brief Initializes the LIN mode according to the specified
+  *         parameters in the UART_InitTypeDef and creates the associated handle .
+  * @param huart: uart handle
+  * @param BreakDetectLength: specifies the LIN break detection length.
+  *        This parameter can be one of the following values:
+  *          @arg UART_LINBREAKDETECTLENGTH_10B: 10-bit break detection
+  *          @arg UART_LINBREAKDETECTLENGTH_11B: 11-bit break detection
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LIN_Init(UART_HandleTypeDef *huart, uint32_t BreakDetectLength)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+  /* Check the Break detection length parameter */
+  assert_param(IS_UART_LIN_BREAK_DETECT_LENGTH(BreakDetectLength));
+  
+  /* LIN mode limited to 16-bit oversampling only */
+  if(huart->Init.OverSampling == UART_OVERSAMPLING_8)
+  {
+    return HAL_ERROR;
+  }
+  
+  if(huart->State == HAL_UART_STATE_RESET)
+  {   
+    /* Init the low level hardware : GPIO, CLOCK, CORTEX */
+    HAL_UART_MspInit(huart);
+  }
+  
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+  
+  /* Set the UART Communication parameters */
+  UART_SetConfig(huart);
+  
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+  
+  /* In LIN mode, the following bits must be kept cleared: 
+  - LINEN and CLKEN bits in the USART_CR2 register,
+  - SCEN and IREN bits in the USART_CR3 register.*/
+  huart->Instance->CR2 &= ~(USART_CR2_CLKEN);
+  huart->Instance->CR3 &= ~(USART_CR3_HDSEL | USART_CR3_IREN | USART_CR3_SCEN);
+  
+  /* Enable the LIN mode by setting the LINEN bit in the CR2 register */
+  huart->Instance->CR2 |= USART_CR2_LINEN;
+  
+  /* Set the USART LIN Break detection length. */
+  MODIFY_REG(huart->Instance->CR2, USART_CR2_LBDL, BreakDetectLength);
+  
+    /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+  
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+/**
+  * @brief Initializes the multiprocessor mode according to the specified
+  *         parameters in the UART_InitTypeDef and creates the associated handle.
+  * @param huart: UART handle   
+  * @param Address: UART node address (4-, 6-, 7- or 8-bit long)
+  * @param WakeUpMethod: specifies the UART wakeup method.
+  *        This parameter can be one of the following values:
+  *          @arg UART_WAKEUPMETHOD_IDLELINE: WakeUp by an idle line detection
+  *          @arg UART_WAKEUPMETHOD_ADDRESSMARK: WakeUp by an address mark
+  * @note  If the user resorts to idle line detection wake up, the Address parameter
+  *        is useless and ignored by the initialization function.               
+  * @note  If the user resorts to address mark wake up, the address length detection 
+  *        is configured by default to 4 bits only. For the UART to be able to 
+  *        manage 6-, 7- or 8-bit long addresses detection, the API
+  *        HAL_MultiProcessorEx_AddressLength_Set() must be called after 
+  *        HAL_MultiProcessor_Init().                      
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_MultiProcessor_Init(UART_HandleTypeDef *huart, uint8_t Address, uint32_t WakeUpMethod)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the wake up method parameter */
+  assert_param(IS_UART_WAKEUPMETHOD(WakeUpMethod));
+  
+  if(huart->State == HAL_UART_STATE_RESET)
+  {   
+    /* Init the low level hardware : GPIO, CLOCK */
+    HAL_UART_MspInit(huart);
+  }
+  
+  huart->State = HAL_UART_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+  
+  /* Set the UART Communication parameters */
+  UART_SetConfig(huart);
+  
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+  
+  /* In multiprocessor mode, the following bits must be kept cleared: 
+  - LINEN and CLKEN bits in the USART_CR2 register,
+  - SCEN, HDSEL and IREN  bits in the USART_CR3 register. */
+  huart->Instance->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN);
+  huart->Instance->CR3 &= ~(USART_CR3_SCEN | USART_CR3_HDSEL | USART_CR3_IREN);
+  
+  if (WakeUpMethod == UART_WAKEUPMETHOD_ADDRESSMARK)
+  {
+    /* If address mark wake up method is chosen, set the USART address node */
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_ADD, ((uint32_t)Address << UART_CR2_ADDRESS_LSB_POS));
+  }
+  
+  /* Set the wake up method by setting the WAKE bit in the CR1 register */
+  MODIFY_REG(huart->Instance->CR1, USART_CR1_WAKE, WakeUpMethod);
+  
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart); 
+  
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+/**
+  * @brief DeInitializes the UART peripheral 
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_DeInit(UART_HandleTypeDef *huart)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+  
+  /* Check the parameters */
+  assert_param(IS_UART_INSTANCE(huart->Instance));
+
+  huart->State = HAL_UART_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+  
+  huart->Instance->CR1 = 0x0;
+  huart->Instance->CR2 = 0x0;
+  huart->Instance->CR3 = 0x0;
+  
+  /* DeInit the low level hardware */
+  HAL_UART_MspDeInit(huart);
+
+  huart->ErrorCode = HAL_UART_ERROR_NONE;
+  huart->State = HAL_UART_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(huart);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief UART MSP Init
+  * @param huart: uart handle
+  * @retval None
+  */
+ __weak void HAL_UART_MspInit(UART_HandleTypeDef *huart)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UART_MspInit can be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief UART MSP DeInit
+  * @param huart: uart handle
+  * @retval None
+  */
+ __weak void HAL_UART_MspDeInit(UART_HandleTypeDef *huart)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UART_MspDeInit can be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup UART_Group2 IO operation functions 
+  *  @brief UART Transmit/Receive functions 
+  *
+@verbatim   
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    This subsection provides a set of functions allowing to manage the UART asynchronous
+    and Half duplex data transfers.
+
+    (#) There are two mode of transfer:
+       (+) Blocking mode: The communication is performed in polling mode. 
+            The HAL status of all data processing is returned by the same function 
+            after finishing transfer.  
+       (+) No-Blocking mode: The communication is performed using Interrupts 
+           or DMA, These API's return the HAL status.
+           The end of the data processing will be indicated through the 
+           dedicated UART IRQ when using Interrupt mode or the DMA IRQ when 
+           using DMA mode.
+           The HAL_UART_TxCpltCallback(), HAL_UART_RxCpltCallback() user callbacks 
+           will be executed respectivelly at the end of the transmit or Receive process
+           The HAL_UART_ErrorCallback()user callback will be executed when a communication error is detected
+
+    (#) Blocking mode API's are :
+        (+) HAL_UART_Transmit()
+        (+) HAL_UART_Receive() 
+        
+    (#) Non-Blocking mode API's with Interrupt are :
+        (+) HAL_UART_Transmit_IT()
+        (+) HAL_UART_Receive_IT()
+        (+) HAL_UART_IRQHandler()
+        (+) UART_Transmit_IT()
+        (+) UART_Receive_IT()
+
+    (#) No-Blocking mode API's with DMA are :
+        (+) HAL_UART_Transmit_DMA()
+        (+) HAL_UART_Receive_DMA()
+        (+) HAL_UART_DMAPause()
+        (+) HAL_UART_DMAResume()
+        (+) HAL_UART_DMAStop()
+
+    (#) A set of Transfer Complete Callbacks are provided in No_Blocking mode:
+        (+) HAL_UART_TxHalfCpltCallback()
+        (+) HAL_UART_TxCpltCallback()
+        (+) HAL_UART_RxHalfCpltCallback()
+        (+) HAL_UART_RxCpltCallback()
+        (+) HAL_UART_ErrorCallback()
+
+    -@- In the Half duplex communication, it is forbidden to run the transmit 
+        and receive process in parallel, the UART state HAL_UART_STATE_BUSY_TX_RX can't be useful.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Send an amount of data in blocking mode 
+  * @param huart: uart handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be sent
+  * @param Timeout : Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+   uint16_t* tmp;
+
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_RX))
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a non-blocking receive process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_RX) 
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+
+    huart->TxXferSize = Size;
+    huart->TxXferCount = Size;
+    while(huart->TxXferCount > 0)
+    {
+      huart->TxXferCount--;
+        if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_TXE, RESET, Timeout) != HAL_OK)  
+        { 
+          return HAL_TIMEOUT;
+        }
+      if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+      {
+        tmp = (uint16_t*) pData;
+        huart->Instance->TDR = (*tmp & (uint16_t)0x01FF);
+        pData += 2;
+      }
+      else
+      {
+        huart->Instance->TDR = (*pData++ & (uint8_t)0xFF);
+      }
+    }
+    if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_TC, RESET, Timeout) != HAL_OK)  
+    { 
+      return HAL_TIMEOUT;
+    }
+    /* Check if a non-blocking receive Process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX_RX) 
+    {
+      huart->State = HAL_UART_STATE_BUSY_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_READY;
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in blocking mode 
+  * @param huart: uart handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @param Timeout : Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+{
+  uint16_t* tmp;
+  uint16_t uhMask;
+
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_TX))
+  {
+    if((pData == NULL ) || (Size == 0))
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a non-blocking transmit process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX)
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_RX;
+    }
+
+    huart->RxXferSize = Size; 
+    huart->RxXferCount = Size;
+
+    /* Computation of UART mask to apply to RDR register */
+    __HAL_UART_MASK_COMPUTATION(huart);
+    uhMask = huart->Mask;
+
+    /* as long as data have to be received */
+    while(huart->RxXferCount > 0)
+    {
+      huart->RxXferCount--;
+        if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_RXNE, RESET, Timeout) != HAL_OK)  
+        {
+          return HAL_TIMEOUT;
+        }
+      if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+      {
+        tmp = (uint16_t*) pData ;
+        *tmp = (uint16_t)(huart->Instance->RDR & uhMask);
+        pData +=2; 
+      }
+      else
+      {
+        *pData++ = (uint8_t)(huart->Instance->RDR & (uint8_t)uhMask); 
+      }
+    }
+
+    /* Check if a non-blocking transmit Process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX_RX) 
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_READY;
+    }
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Send an amount of data in interrupt mode 
+  * @param huart: uart handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{  
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_RX))
+  {
+    if((pData == NULL ) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(huart);
+    
+    huart->pTxBuffPtr = pData;
+    huart->TxXferSize = Size;
+    huart->TxXferCount = Size;
+    
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a receive process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_RX) 
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+    
+    /* Enable the UART Parity Error Interrupt */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_PE);
+    
+    /* Enable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_ERR);
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);    
+
+    /* Enable the UART Transmit data register empty Interrupt */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;   
+  }
+}
+
+/**
+  * @brief Receive an amount of data in interrupt mode 
+  * @param huart: uart handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_TX))
+  {
+    if((pData == NULL ) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->pRxBuffPtr = pData;
+    huart->RxXferSize = Size;
+    huart->RxXferCount = Size;
+
+    /* Computation of UART mask to apply to RDR register */
+    __HAL_UART_MASK_COMPUTATION(huart);
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a transmit process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX) 
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_RX;
+    }
+
+    /* Enable the UART Parity Error Interrupt */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_PE);
+
+    /* Enable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_ERR);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    /* Enable the UART Data Register not empty Interrupt */
+    __HAL_UART_ENABLE_IT(huart, UART_IT_RXNE);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief Send an amount of data in DMA mode 
+  * @param huart: uart handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  uint32_t *tmp;
+  
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_RX))
+  {
+    if((pData == NULL ) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(huart);
+    
+    huart->pTxBuffPtr = pData;
+    huart->TxXferSize = Size;
+    huart->TxXferCount = Size; 
+    
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a receive process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_RX) 
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+    
+    /* Set the UART DMA transfert complete callback */
+    huart->hdmatx->XferCpltCallback = UART_DMATransmitCplt;
+    
+    /* Set the UART DMA Half transfer complete callback */
+    huart->hdmatx->XferHalfCpltCallback = UART_DMATxHalfCplt;
+    
+    /* Set the DMA error callback */
+    huart->hdmatx->XferErrorCallback = UART_DMAError;
+
+    /* Enable the UART transmit DMA Stream */
+    tmp = (uint32_t*)&pData;
+    HAL_DMA_Start_IT(huart->hdmatx, *(uint32_t*)tmp, (uint32_t)&huart->Instance->TDR, Size);
+    
+    /* Enable the DMA transfer for transmit request by setting the DMAT bit
+       in the UART CR3 register */
+    huart->Instance->CR3 |= USART_CR3_DMAT;
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;   
+  }
+}
+
+/**
+  * @brief Receive an amount of data in DMA mode 
+  * @param huart: uart handle
+  * @param pData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @note   When the UART parity is enabled (PCE = 1) the data received contain the parity bit.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_Receive_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  uint32_t *tmp;
+  
+  if((huart->State == HAL_UART_STATE_READY) || (huart->State == HAL_UART_STATE_BUSY_TX))
+  {
+    if((pData == NULL ) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    
+    /* Process Locked */
+    __HAL_LOCK(huart);
+    
+    huart->pRxBuffPtr = pData;
+    huart->RxXferSize = Size;
+    
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    /* Check if a transmit process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX) 
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX_RX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_BUSY_RX;
+    }
+    
+    /* Set the UART DMA transfert complete callback */
+    huart->hdmarx->XferCpltCallback = UART_DMAReceiveCplt;
+    
+    /* Set the UART DMA Half transfer complete callback */
+    huart->hdmarx->XferHalfCpltCallback = UART_DMARxHalfCplt;
+    
+    /* Set the DMA error callback */
+    huart->hdmarx->XferErrorCallback = UART_DMAError;
+
+    /* Enable the DMA Stream */
+    tmp = (uint32_t*)&pData;
+    HAL_DMA_Start_IT(huart->hdmarx, (uint32_t)&huart->Instance->RDR, *(uint32_t*)tmp, Size);
+
+    /* Enable the DMA transfer for the receiver request by setting the DMAR bit 
+       in the UART CR3 register */
+     huart->Instance->CR3 |= USART_CR3_DMAR;
+    
+     /* Process Unlocked */
+     __HAL_UNLOCK(huart);
+     
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief Pauses the DMA Transfer.
+  * @param huart: UART handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_UART_DMAPause(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+  
+  if(huart->State == HAL_UART_STATE_BUSY_TX)
+  {
+    /* Disable the UART DMA Tx request */
+    huart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAT);
+  }
+  else if(huart->State == HAL_UART_STATE_BUSY_RX)
+  {
+    /* Disable the UART DMA Rx request */
+    huart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAR);
+  }
+  else if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+  {
+    /* Disable the UART DMA Tx request */
+    huart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAT);
+    /* Disable the UART DMA Rx request */
+    huart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAR);
+  }
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK; 
+}
+
+/**
+  * @brief Resumes the DMA Transfer.
+  * @param huart: UART handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_UART_DMAResume(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  if(huart->State == HAL_UART_STATE_BUSY_TX)
+  {
+    /* Enable the UART DMA Tx request */
+    huart->Instance->CR3 |= USART_CR3_DMAT;
+  }
+  else if(huart->State == HAL_UART_STATE_BUSY_RX)
+  {
+    /* Clear the Overrun flag before resumming the Rx transfer*/
+    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
+    
+    /* Enable the UART DMA Rx request */
+    huart->Instance->CR3 |= USART_CR3_DMAR;
+  }
+  else if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+  {
+    /* Clear the Overrun flag before resumming the Rx transfer*/
+    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
+    
+    /* Enable the UART DMA Rx request  before the DMA Tx request */
+    huart->Instance->CR3 |= USART_CR3_DMAR;
+    
+    /* Enable the UART DMA Tx request */
+    huart->Instance->CR3 |= USART_CR3_DMAT;
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Stops the DMA Transfer.
+  * @param huart: UART handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_UART_DMAStop(UART_HandleTypeDef *huart)
+{
+  /* The Lock is not implemented on this API to allow the user application
+     to call the HAL UART API under callbacks HAL_UART_TxCpltCallback() / HAL_UART_RxCpltCallback():
+     when calling HAL_DMA_Abort() API the DMA TX/RX Transfer complete interrupt is generated
+     and the correspond call back is executed HAL_UART_TxCpltCallback() / HAL_UART_RxCpltCallback()
+     */
+  
+  /* Disable the UART Tx/Rx DMA requests */
+  huart->Instance->CR3 &= ~USART_CR3_DMAT;
+  huart->Instance->CR3 &= ~USART_CR3_DMAR;
+  
+  /* Abort the UART DMA tx channel */
+  if(huart->hdmatx != NULL)
+  {
+    HAL_DMA_Abort(huart->hdmatx);
+  }
+  /* Abort the UART DMA rx channel */
+  if(huart->hdmarx != NULL)
+  {
+    HAL_DMA_Abort(huart->hdmarx);
+  }
+  
+  huart->State = HAL_UART_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief This function handles UART interrupt request.
+  * @param huart: uart handle
+  * @retval None
+  */
+void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
+{
+  /* UART parity error interrupt occurred ------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_PE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_PE) != RESET))
+  { 
+    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_PEF);
+    
+    huart->ErrorCode |= HAL_UART_ERROR_PE;
+    /* Set the UART state ready to be able to start again the process */
+    huart->State = HAL_UART_STATE_READY;
+  }
+  
+  /* UART frame error interrupt occured --------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_FE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET))
+  { 
+    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_FEF);
+    
+    huart->ErrorCode |= HAL_UART_ERROR_FE;
+    /* Set the UART state ready to be able to start again the process */
+    huart->State = HAL_UART_STATE_READY;
+  }
+  
+  /* UART noise error interrupt occured --------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_NE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET))
+  { 
+    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_NEF);
+    
+    huart->ErrorCode |= HAL_UART_ERROR_NE;
+    /* Set the UART state ready to be able to start again the process */
+    huart->State = HAL_UART_STATE_READY;
+  }
+  
+  /* UART Over-Run interrupt occured -----------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET))
+  { 
+    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
+    
+    huart->ErrorCode |= HAL_UART_ERROR_ORE;
+    /* Set the UART state ready to be able to start again the process */
+    huart->State = HAL_UART_STATE_READY;
+  }
+
+   /* Call UART Error Call back function if need be --------------------------*/
+  if(huart->ErrorCode != HAL_UART_ERROR_NONE)
+  {
+    HAL_UART_ErrorCallback(huart);
+  }
+
+  /* UART Wake Up interrupt occured ------------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_WUF) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_WUF) != RESET))
+  { 
+    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_WUF);
+    /* Set the UART state ready to be able to start again the process */
+    huart->State = HAL_UART_STATE_READY;
+    HAL_UARTEx_WakeupCallback(huart);
+  }
+  
+  /* UART in mode Receiver ---------------------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) && (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET))
+  { 
+    UART_Receive_IT(huart);
+  }
+  
+  /* UART in mode Transmitter ------------------------------------------------*/
+  if((__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) &&(__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TXE) != RESET))
+  {
+    UART_Transmit_IT(huart);
+  }
+
+  if(huart->ErrorCode != HAL_UART_ERROR_NONE)
+  {
+    HAL_UART_ErrorCallback(huart);
+  }
+}
+
+/**
+  * @brief Tx Transfer completed callbacks
+  * @param huart: uart handle
+  * @retval None
+  */
+ __weak void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_UART_TxCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  Tx Half Transfer completed callbacks.
+  * @param  huart: UART handle
+  * @retval None
+  */
+ __weak void HAL_UART_TxHalfCpltCallback(UART_HandleTypeDef *huart)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_UART_TxCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief Rx Transfer completed callbacks
+  * @param huart: uart handle
+  * @retval None
+  */
+__weak void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_UART_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Rx Half Transfer completed callbacks.
+  * @param  huart: UART handle
+  * @retval None
+  */
+__weak void HAL_UART_RxHalfCpltCallback(UART_HandleTypeDef *huart)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_UART_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief UART error callbacks
+  * @param huart: uart handle
+  * @retval None
+  */
+ __weak void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UART_ErrorCallback can be implemented in the user file
+   */ 
+}
+
+
+/**
+  * @}
+  */
+
+/** @defgroup UART_Group3 Peripheral Control funtions 
+  *  @brief   UART control functions 
+  *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to control the UART.
+     (+) HAL_MultiProcessor_EnableMuteMode() API enables mute mode
+     (+) HAL_MultiProcessor_DisableMuteMode() API disables mute mode
+     (+) HAL_MultiProcessor_EnterMuteMode() API enters mute mode
+     (+) HAL_HalfDuplex_EnableTransmitter() API enables the transmitter
+     (+) HAL_HalfDuplex_EnableReceiver() API enables the receiver
+     (+) HAL_UART_GetState() API is helpful to check in run-time the state of the UART peripheral
+     (+) HAL_UART_GetError()API is helpful to check in run-time the error state of the UART peripheral
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Enable UART in mute mode (doesn't mean UART enters mute mode;
+  * to enter mute mode, HAL_MultiProcessor_EnterMuteMode() API must be called)
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_MultiProcessor_EnableMuteMode(UART_HandleTypeDef *huart)
+{  
+  /* Process Locked */
+  __HAL_LOCK(huart);
+  
+  huart->State = HAL_UART_STATE_BUSY;
+  
+  /* Enable USART mute mode by setting the MME bit in the CR1 register */
+  huart->Instance->CR1 |= USART_CR1_MME;
+  
+  huart->State = HAL_UART_STATE_READY;
+  
+  return (UART_CheckIdleState(huart));
+}
+
+/**
+  * @brief Disable UART mute mode (doesn't mean it actually wakes up the software,
+  * as it may not have been in mute mode at this very moment).
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_MultiProcessor_DisableMuteMode(UART_HandleTypeDef *huart)
+{ 
+  /* Process Locked */
+  __HAL_LOCK(huart);
+  
+  huart->State = HAL_UART_STATE_BUSY;
+  
+   /* Disable USART mute mode by clearing the MME bit in the CR1 register */
+  huart->Instance->CR1 &= ~(USART_CR1_MME);
+  
+  huart->State = HAL_UART_STATE_READY;
+  
+  return (UART_CheckIdleState(huart));
+}
+
+/**
+  * @brief Enter UART mute mode (means UART actually enters mute mode).
+  * To exit from mute mode, HAL_MultiProcessor_DisableMuteMode() API must be called. 
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+void HAL_MultiProcessor_EnterMuteMode(UART_HandleTypeDef *huart)
+{    
+  __HAL_UART_SEND_REQ(huart, UART_MUTE_MODE_REQUEST);
+}
+
+/**
+  * @brief  Enables the UART transmitter and disables the UART receiver.
+  * @param  huart: UART handle
+  * @retval HAL status
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_HalfDuplex_EnableTransmitter(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Clear TE and RE bits */
+  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TE | USART_CR1_RE));
+  /* Enable the USART's transmit interface by setting the TE bit in the USART CR1 register */
+  SET_BIT(huart->Instance->CR1, USART_CR1_TE);
+
+  huart->State = HAL_UART_STATE_READY;
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables the UART receiver and disables the UART transmitter.
+  * @param  huart: UART handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_HalfDuplex_EnableReceiver(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Clear TE and RE bits */
+  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TE | USART_CR1_RE));
+  /* Enable the USART's receive interface by setting the RE bit in the USART CR1 register */
+  SET_BIT(huart->Instance->CR1, USART_CR1_RE);
+
+  huart->State = HAL_UART_STATE_READY;
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Transmits break characters.
+  * @param  huart: pointer to a UART_HandleTypeDef structure that contains
+  *                the configuration information for the specified UART module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_LIN_SendBreak(UART_HandleTypeDef *huart)
+{
+  /* Check the parameters */
+  assert_param(IS_UART_INSTANCE(huart->Instance));
+  
+  /* Process Locked */
+  __HAL_LOCK(huart);
+  
+  huart->State = HAL_UART_STATE_BUSY;
+  
+  /* Send break characters */
+  huart->Instance->RQR |= USART_RQR_SBKRQ;
+ 
+  huart->State = HAL_UART_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+  
+  return HAL_OK; 
+}
+
+/**
+  * @brief return the UART state
+  * @param huart: uart handle
+  * @retval HAL state
+  */
+HAL_UART_StateTypeDef HAL_UART_GetState(UART_HandleTypeDef *huart)
+{
+  return huart->State;
+}
+
+/**
+* @brief  Return the UART error code
+* @param  huart : pointer to a UART_HandleTypeDef structure that contains
+  *              the configuration information for the specified UART.
+* @retval UART Error Code
+*/
+uint32_t HAL_UART_GetError(UART_HandleTypeDef *huart)
+{
+  return huart->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief DMA UART transmit process complete callback 
+  * @param hdma: DMA handle
+  * @retval None
+  */
+static void UART_DMATransmitCplt(DMA_HandleTypeDef *hdma)     
+{
+  UART_HandleTypeDef* huart = ( UART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  /* DMA Normal mode*/  
+  if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+  {
+    huart->TxXferCount = 0;
+    
+    /* Disable the DMA transfer for transmit request by setting the DMAT bit
+    in the UART CR3 register */
+    huart->Instance->CR3 &= (uint32_t)~((uint32_t)USART_CR3_DMAT);
+    
+    /* Wait for UART TC Flag */
+    if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_TC, RESET, UART_TIMEOUT_VALUE) != HAL_OK)
+    {
+      /* Timeout Occured */ 
+      huart->State = HAL_UART_STATE_TIMEOUT;
+      HAL_UART_ErrorCallback(huart);
+    }
+    else
+    {
+      /* No Timeout */
+      /* Check if a receive process is ongoing or not */
+      if(huart->State == HAL_UART_STATE_BUSY_TX_RX)
+      {
+        huart->State = HAL_UART_STATE_BUSY_RX;
+      }
+      else
+      {
+        huart->State = HAL_UART_STATE_READY;
+      }
+      HAL_UART_TxCpltCallback(huart);
+    }
+  }
+  /* DMA Circular mode */
+  else
+  {
+    HAL_UART_TxCpltCallback(huart);
+  }
+}
+
+/**
+  * @brief DMA UART transmit process half complete callback 
+  * @param hdma : DMA handle
+  * @retval None
+  */
+static void UART_DMATxHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  UART_HandleTypeDef* huart = (UART_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  HAL_UART_TxHalfCpltCallback(huart);
+}
+
+/**
+  * @brief DMA UART receive process complete callback 
+  * @param hdma: DMA handle
+  * @retval None
+  */
+static void UART_DMAReceiveCplt(DMA_HandleTypeDef *hdma)  
+{
+  UART_HandleTypeDef* huart = ( UART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  
+  /* DMA Normal mode*/
+  if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+  {
+    huart->RxXferCount = 0;
+    
+    /* Disable the DMA transfer for the receiver request by setting the DMAR bit 
+    in the UART CR3 register */
+    huart->Instance->CR3 &= (uint32_t)~((uint32_t)USART_CR3_DMAR);
+    
+    /* Check if a transmit Process is ongoing or not */
+    if(huart->State == HAL_UART_STATE_BUSY_TX_RX) 
+    {
+      huart->State = HAL_UART_STATE_BUSY_TX;
+    }
+    else
+    {
+      huart->State = HAL_UART_STATE_READY;
+    }
+  }
+  HAL_UART_RxCpltCallback(huart);
+}
+
+/**
+  * @brief DMA UART receive process half complete callback 
+  * @param hdma : DMA handle
+  * @retval None
+  */
+static void UART_DMARxHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  UART_HandleTypeDef* huart = (UART_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  HAL_UART_RxHalfCpltCallback(huart); 
+}
+
+/**
+  * @brief DMA UART communication error callback 
+  * @param hdma: DMA handle
+  * @retval None
+  */
+static void UART_DMAError(DMA_HandleTypeDef *hdma)   
+{
+  UART_HandleTypeDef* huart = ( UART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  huart->RxXferCount = 0;
+  huart->TxXferCount = 0;
+  huart->State= HAL_UART_STATE_READY;
+  huart->ErrorCode |= HAL_UART_ERROR_DMA;
+  HAL_UART_ErrorCallback(huart);
+}
+
+/**
+  * @brief Send an amount of data in interrupt mode 
+  *         Function called under interruption only, once
+  *         interruptions have been enabled by HAL_UART_Transmit_IT()
+  * @param  huart: UART handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef UART_Transmit_IT(UART_HandleTypeDef *huart)
+{
+  uint16_t* tmp;
+
+  if ((huart->State == HAL_UART_STATE_BUSY_TX) || (huart->State == HAL_UART_STATE_BUSY_TX_RX))
+  {
+    if(huart->TxXferCount == 0)
+    {
+      /* Disable the UART TXE Interrupt */
+      __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
+
+      /* Check if a receive Process is ongoing or not */
+      if(huart->State == HAL_UART_STATE_BUSY_TX_RX) 
+      {
+        huart->State = HAL_UART_STATE_BUSY_RX;
+      }
+      else
+      {
+        /* Disable the UART Parity Error Interrupt */
+        __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
+        
+        /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+        __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
+        
+        huart->State = HAL_UART_STATE_READY;
+      }
+      
+      /* Wait on TC flag to be able to start a second transfer */
+      if(UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_TC, RESET, UART_TIMEOUT_VALUE) != HAL_OK)
+      { 
+        return HAL_TIMEOUT;
+      }
+
+      HAL_UART_TxCpltCallback(huart);
+
+      return HAL_OK;
+    }
+    else
+    {
+      if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+      {
+        tmp = (uint16_t*) huart->pTxBuffPtr;
+        huart->Instance->TDR = (*tmp & (uint16_t)0x01FF);
+        huart->pTxBuffPtr += 2;
+      } 
+      else
+      {
+        huart->Instance->TDR = (uint8_t)(*huart->pTxBuffPtr++ & (uint8_t)0xFF);
+      }
+
+      huart->TxXferCount--;
+  
+      return HAL_OK;
+    }
+  }
+  else
+  {
+    return HAL_BUSY;   
+  }
+}
+
+/**
+  * @brief Receive an amount of data in interrupt mode 
+  *         Function called under interruption only, once
+  *         interruptions have been enabled by HAL_UART_Receive_IT()
+  * @param  huart: UART handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef UART_Receive_IT(UART_HandleTypeDef *huart)
+{
+  uint16_t* tmp;
+  uint16_t uhMask = huart->Mask;
+
+  if((huart->State == HAL_UART_STATE_BUSY_RX) || (huart->State == HAL_UART_STATE_BUSY_TX_RX))
+  {
+    if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+    {
+      tmp = (uint16_t*) huart->pRxBuffPtr ;
+      *tmp = (uint16_t)(huart->Instance->RDR & uhMask);
+      huart->pRxBuffPtr +=2;
+    }
+    else
+    {
+      *huart->pRxBuffPtr++ = (uint8_t)(huart->Instance->RDR & (uint8_t)uhMask); 
+    }
+
+    if(--huart->RxXferCount == 0)
+    {
+      while(HAL_IS_BIT_SET(huart->Instance->ISR, UART_FLAG_RXNE))
+      {
+      }
+      __HAL_UART_DISABLE_IT(huart, UART_IT_RXNE);
+
+      /* Check if a transmit Process is ongoing or not */
+      if(huart->State == HAL_UART_STATE_BUSY_TX_RX) 
+      {
+        huart->State = HAL_UART_STATE_BUSY_TX;
+      }
+      else
+      {
+        /* Disable the UART Parity Error Interrupt */
+        __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
+
+        /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+        __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
+
+        huart->State = HAL_UART_STATE_READY;
+      }
+      HAL_UART_RxCpltCallback(huart);
+      return HAL_OK;
+    }
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief Configure the UART peripheral 
+  * @param huart: uart handle
+  * @retval None
+  */
+void UART_SetConfig(UART_HandleTypeDef *huart)
+{
+  uint32_t tmpreg = 0x00000000;
+  uint32_t clocksource = 0x00000000;
+  uint16_t brrtemp = 0x0000;
+  uint16_t usartdiv = 0x0000;
+  
+  /* Check the parameters */ 
+  assert_param(IS_UART_BAUDRATE(huart->Init.BaudRate));  
+  assert_param(IS_UART_WORD_LENGTH(huart->Init.WordLength));
+  assert_param(IS_UART_STOPBITS(huart->Init.StopBits));
+  assert_param(IS_UART_PARITY(huart->Init.Parity));
+  assert_param(IS_UART_MODE(huart->Init.Mode));
+  assert_param(IS_UART_HARDWARE_FLOW_CONTROL(huart->Init.HwFlowCtl));
+  assert_param(IS_UART_ONEBIT_SAMPLING(huart->Init.OneBitSampling)); 
+
+  /*-------------------------- USART CR1 Configuration -----------------------*/
+  /* Clear M, PCE, PS, TE, RE and OVER8 bits and configure       
+   *  the UART Word Length, Parity, Mode and oversampling: 
+   *  set the M bits according to huart->Init.WordLength value 
+   *  set PCE and PS bits according to huart->Init.Parity value
+   *  set TE and RE bits according to huart->Init.Mode value
+   *  set OVER8 bit according to huart->Init.OverSampling value */
+  tmpreg = (uint32_t)huart->Init.WordLength | huart->Init.Parity | huart->Init.Mode | huart->Init.OverSampling ;
+  MODIFY_REG(huart->Instance->CR1, UART_CR1_FIELDS, tmpreg);
+
+  /*-------------------------- USART CR2 Configuration -----------------------*/
+  /* Configure the UART Stop Bits: Set STOP[13:12] bits according 
+   * to huart->Init.StopBits value */
+  MODIFY_REG(huart->Instance->CR2, USART_CR2_STOP, huart->Init.StopBits);
+  
+  /*-------------------------- USART CR3 Configuration -----------------------*/
+  /* Configure 
+   * - UART HardWare Flow Control: set CTSE and RTSE bits according 
+   *   to huart->Init.HwFlowCtl value 
+   * - one-bit sampling method versus three samples' majority rule according
+   *   to huart->Init.OneBitSampling */
+  tmpreg = (uint32_t)huart->Init.HwFlowCtl | huart->Init.OneBitSampling ;
+  MODIFY_REG(huart->Instance->CR3, (USART_CR3_RTSE | USART_CR3_CTSE | USART_CR3_ONEBIT), tmpreg);
+  
+  /*-------------------------- USART BRR Configuration -----------------------*/
+  __HAL_UART_GETCLOCKSOURCE(huart, clocksource);
+  
+  /* Check LPUART instace */
+  if(huart->Instance == LPUART1)
+  {
+    switch (clocksource)
+    {
+    case UART_CLOCKSOURCE_PCLK1: 
+      huart->Instance->BRR = (uint32_t)(__DIV_LPUART(HAL_RCC_GetPCLK1Freq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_HSI: 
+      huart->Instance->BRR = (uint32_t)(__DIV_LPUART(HSI_VALUE, huart->Init.BaudRate)); 
+      break; 
+    case UART_CLOCKSOURCE_SYSCLK:  
+      huart->Instance->BRR = (uint32_t)(__DIV_LPUART(HAL_RCC_GetSysClockFreq(), huart->Init.BaudRate));
+      break;  
+    case UART_CLOCKSOURCE_LSE:
+      huart->Instance->BRR = (uint32_t)(__DIV_LPUART(LSE_VALUE, huart->Init.BaudRate)); 
+      break;
+    default:
+      break;
+    }
+  }
+  /* Check the UART Over Sampling 8 to set Baud Rate Register */
+  else if (huart->Init.OverSampling == UART_OVERSAMPLING_8)
+  { 
+    switch (clocksource)
+    {
+    case UART_CLOCKSOURCE_PCLK1:
+      usartdiv = (uint32_t)(__DIV_SAMPLING8(HAL_RCC_GetPCLK1Freq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_PCLK2:
+      usartdiv = (uint32_t)(__DIV_SAMPLING8(HAL_RCC_GetPCLK2Freq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_HSI:
+      usartdiv = (uint32_t)(__DIV_SAMPLING8(HSI_VALUE, huart->Init.BaudRate)); 
+      break;
+    case UART_CLOCKSOURCE_SYSCLK:
+      huart->Instance->BRR = (uint32_t)(__DIV_SAMPLING8(HAL_RCC_GetSysClockFreq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_LSE:
+      usartdiv = (uint32_t)(__DIV_SAMPLING8(LSE_VALUE, huart->Init.BaudRate)); 
+      break;
+    default:
+      break;
+    }
+    
+    brrtemp = usartdiv & 0xFFF0;
+    brrtemp |= (uint16_t)((uint16_t)(usartdiv & (uint16_t)0x000F) >> (uint16_t)1);
+    huart->Instance->BRR = brrtemp;
+  }
+  else
+  {
+    switch (clocksource)
+    {
+    case UART_CLOCKSOURCE_PCLK1: 
+      huart->Instance->BRR = (uint32_t)(__DIV_SAMPLING16(HAL_RCC_GetPCLK1Freq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_PCLK2: 
+      huart->Instance->BRR = (uint32_t)(__DIV_SAMPLING16(HAL_RCC_GetPCLK2Freq(), huart->Init.BaudRate));
+      break;
+    case UART_CLOCKSOURCE_HSI: 
+      huart->Instance->BRR = (uint32_t)(__DIV_SAMPLING16(HSI_VALUE, huart->Init.BaudRate)); 
+      break; 
+    case UART_CLOCKSOURCE_SYSCLK:  
+      huart->Instance->BRR = (uint32_t)(__DIV_SAMPLING16(HAL_RCC_GetSysClockFreq(), huart->Init.BaudRate));
+      break;  
+    case UART_CLOCKSOURCE_LSE:
+      huart->Instance->BRR = (uint32_t)(__DIV_SAMPLING16(LSE_VALUE, huart->Init.BaudRate)); 
+      break;
+    default:
+      break;
+    }
+  }
+}
+
+/**
+  * @brief Check the UART Idle State
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart)
+{
+  /* Check if the Transmitter is enabled */
+  if((huart->Instance->CR1 & USART_CR1_TE) == USART_CR1_TE)
+  {
+    /* Wait until TEACK flag is set */
+    if(UART_WaitOnFlagUntilTimeout(huart, USART_ISR_TEACK, RESET, UART_TIMEOUT_VALUE) != HAL_OK)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+  /* Check if the Receiver is enabled */
+  if((huart->Instance->CR1 & USART_CR1_RE) == USART_CR1_RE)
+  {
+    /* Wait until REACK flag is set */
+    if(UART_WaitOnFlagUntilTimeout(huart, USART_ISR_REACK, RESET, UART_TIMEOUT_VALUE) != HAL_OK)
+    { 
+      return HAL_TIMEOUT;
+    }
+  }
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+  
+  /* Initialize the UART state*/
+  huart->ErrorCode = HAL_UART_ERROR_NONE;
+  huart->State= HAL_UART_STATE_READY;
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief Configure the UART peripheral advanced feautures 
+  * @param huart: uart handle  
+  * @retval None
+  */
+void UART_AdvFeatureConfig(UART_HandleTypeDef *huart)
+{
+  /* Check whether the set of advanced features to configure is properly set */ 
+  assert_param(IS_UART_ADVFEATURE_INIT(huart->AdvancedInit.AdvFeatureInit));
+  
+  /* if required, configure TX pin active level inversion */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_TXINVERT_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_TXINV(huart->AdvancedInit.TxPinLevelInvert));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_TXINV, huart->AdvancedInit.TxPinLevelInvert);
+  }
+  
+  /* if required, configure RX pin active level inversion */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_RXINVERT_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_RXINV(huart->AdvancedInit.RxPinLevelInvert));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_RXINV, huart->AdvancedInit.RxPinLevelInvert);
+  }
+  
+  /* if required, configure data inversion */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_DATAINVERT_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_DATAINV(huart->AdvancedInit.DataInvert));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_DATAINV, huart->AdvancedInit.DataInvert);
+  }
+  
+  /* if required, configure RX/TX pins swap */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_SWAP_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_SWAP(huart->AdvancedInit.Swap));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_SWAP, huart->AdvancedInit.Swap);
+  }
+  
+  /* if required, configure RX overrun detection disabling */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_RXOVERRUNDISABLE_INIT))
+  {
+    assert_param(IS_UART_OVERRUN(huart->AdvancedInit.OverrunDisable));  
+    MODIFY_REG(huart->Instance->CR3, USART_CR3_OVRDIS, huart->AdvancedInit.OverrunDisable);
+  }
+  
+  /* if required, configure DMA disabling on reception error */
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_DMADISABLEONERROR_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_DMAONRXERROR(huart->AdvancedInit.DMADisableonRxError));   
+    MODIFY_REG(huart->Instance->CR3, USART_CR3_DDRE, huart->AdvancedInit.DMADisableonRxError);
+  }
+  
+  /* if required, configure auto Baud rate detection scheme */              
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_AUTOBAUDRATE_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_AUTOBAUDRATE(huart->AdvancedInit.AutoBaudRateEnable));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_ABREN, huart->AdvancedInit.AutoBaudRateEnable);
+    /* set auto Baudrate detection parameters if detection is enabled */
+    if(huart->AdvancedInit.AutoBaudRateEnable == UART_ADVFEATURE_AUTOBAUDRATE_ENABLE)
+    {
+      assert_param(IS_UART_ADVFEATURE_AUTOBAUDRATEMODE(huart->AdvancedInit.AutoBaudRateMode));
+      MODIFY_REG(huart->Instance->CR2, USART_CR2_ABRMODE, huart->AdvancedInit.AutoBaudRateMode);
+    }
+  }
+  
+  /* if required, configure MSB first on communication line */  
+  if(HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_MSBFIRST_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_MSBFIRST(huart->AdvancedInit.MSBFirst));   
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_MSBFIRST, huart->AdvancedInit.MSBFirst);
+  }
+}
+
+/**
+  * @brief  This function handles UART Communication Timeout.
+  * @param  huart: UART handle
+  * @param  Flag: specifies the UART flag to check.
+  * @param  Status: The new Flag status (SET or RESET).
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_t Flag, FlagStatus Status, uint32_t Timeout)
+{
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+  
+  /* Wait until flag is set */
+  if(Status == RESET)
+  {    
+    while(__HAL_UART_GET_FLAG(huart, Flag) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+          __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_RXNE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
+          
+          huart->State= HAL_UART_STATE_TIMEOUT;
+          
+          /* Process Unlocked */
+          __HAL_UNLOCK(huart);
+          
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    while(__HAL_UART_GET_FLAG(huart, Flag) != RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+          __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_RXNE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_PE);
+          __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
+          
+          huart->State= HAL_UART_STATE_TIMEOUT;
+          
+          /* Process Unlocked */
+          __HAL_UNLOCK(huart);
+          
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  return HAL_OK;      
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_UART_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_uart.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_uart.h
@@ -1,0 +1,1054 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_uart.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of UART HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_UART_H
+#define __STM32L0xx_HAL_UART_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup UART
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+
+/** 
+  * @brief UART Init Structure definition  
+  */ 
+typedef struct
+{
+  uint32_t BaudRate;                  /*!< This member configures the UART communication baud rate.
+                                           The baud rate register is computed using the following formula:
+                                           - If oversampling is 16 or in LIN mode,
+                                              Baud Rate Register = ((PCLKx) / ((huart->Init.BaudRate)))
+                                           - If oversampling is 8,
+                                              Baud Rate Register[15:4] = ((2 * PCLKx) / ((huart->Init.BaudRate)))[15:4]  
+                                              Baud Rate Register[3] =  0
+                                              Baud Rate Register[2:0] =  (((2 * PCLKx) / ((huart->Init.BaudRate)))[3:0]) >> 1      */
+
+  uint32_t WordLength;                /*!< Specifies the number of data bits transmitted or received in a frame.
+                                           This parameter can be a value of @ref UARTEx_Word_Length */
+
+  uint32_t StopBits;                  /*!< Specifies the number of stop bits transmitted.
+                                           This parameter can be a value of @ref UART_Stop_Bits */
+
+  uint32_t Parity;                    /*!< Specifies the parity mode.
+                                           This parameter can be a value of @ref UART_Parity
+                                           @note When parity is enabled, the computed parity is inserted
+                                                 at the MSB position of the transmitted data (9th bit when
+                                                 the word length is set to 9 data bits; 8th bit when the
+                                                 word length is set to 8 data bits). */
+ 
+  uint32_t Mode;                      /*!< Specifies wether the Receive or Transmit mode is enabled or disabled.
+                                           This parameter can be a value of @ref UART_Mode */
+
+  uint32_t HwFlowCtl;                 /*!< Specifies wether the hardware flow control mode is enabled
+                                           or disabled.
+                                           This parameter can be a value of @ref UART_Hardware_Flow_Control */
+  
+  uint32_t OverSampling;              /*!< Specifies wether the Over sampling 8 is enabled or disabled, to achieve higher speed (up to fPCLK/8).
+                                           This parameter can be a value of @ref UART_Over_Sampling */  
+                                           
+  uint32_t OneBitSampling;            /*!< Specifies wether a single sample or three samples' majority vote is selected.
+                                           Selecting the single sample method increases the receiver tolerance to clock
+                                           deviations. This parameter can be a value of @ref UART_OneBit_Sampling */                                                 
+}UART_InitTypeDef;
+
+/** 
+  * @brief  UART Advanced Features initalization structure definition  
+  */
+typedef struct                                      
+{
+  uint32_t AdvFeatureInit;        /*!< Specifies which advanced UART features is initialized. Several
+                                       Advanced Features may be initialized at the same time .
+                                       This parameter can be a value of @ref UART_Advanced_Features_Initialization_Type */
+  
+  uint32_t TxPinLevelInvert;      /*!< Specifies whether the TX pin active level is inverted.
+                                       This parameter can be a value of @ref UART_Tx_Inv  */
+                                           
+  uint32_t RxPinLevelInvert;      /*!< Specifies whether the RX pin active level is inverted.
+                                       This parameter can be a value of @ref UART_Rx_Inv  */
+
+  uint32_t DataInvert;            /*!< Specifies whether data are inverted (positive/direct logic
+                                       vs negative/inverted logic).
+                                       This parameter can be a value of @ref UART_Data_Inv */
+                                       
+  uint32_t Swap;                  /*!< Specifies whether TX and RX pins are swapped.   
+                                       This parameter can be a value of @ref UART_Rx_Tx_Swap */
+                                       
+  uint32_t OverrunDisable;        /*!< Specifies whether the reception overrun detection is disabled.   
+                                       This parameter can be a value of @ref UART_Overrun_Disable */
+                                       
+  uint32_t DMADisableonRxError;   /*!< Specifies whether the DMA is disabled in case of reception error.     
+                                       This parameter can be a value of @ref UART_DMA_Disable_on_Rx_Error */
+                                       
+  uint32_t AutoBaudRateEnable;    /*!< Specifies whether auto Baud rate detection is enabled.     
+                                       This parameter can be a value of @ref UART_AutoBaudRate_Enable */  
+                                       
+  uint32_t AutoBaudRateMode;      /*!< If auto Baud rate detection is enabled, specifies how the rate 
+                                       detection is carried out.     
+                                       This parameter can be a value of @ref UARTEx_AutoBaud_Rate_Mode */ 
+                                    
+  uint32_t MSBFirst;              /*!< Specifies whether MSB is sent first on UART line.      
+                                       This parameter can be a value of @ref UART_MSB_First */
+} UART_AdvFeatureInitTypeDef;
+
+/** 
+  * @brief HAL UART State structures definition  
+  */ 
+typedef enum
+{
+  HAL_UART_STATE_RESET             = 0x00,    /*!< Peripheral Reset state                             */
+  HAL_UART_STATE_READY             = 0x01,    /*!< Peripheral Initialized and ready for use           */
+  HAL_UART_STATE_BUSY              = 0x02,    /*!< an internal process is ongoing                     */
+  HAL_UART_STATE_BUSY_TX           = 0x12,    /*!< Data Transmission process is ongoing               */
+  HAL_UART_STATE_BUSY_RX           = 0x22,    /*!< Data Reception process is ongoing                  */
+  HAL_UART_STATE_BUSY_TX_RX        = 0x32,    /*!< Data Transmission and Reception process is ongoing */
+  HAL_UART_STATE_TIMEOUT           = 0x03,    /*!< Timeout state                                      */
+  HAL_UART_STATE_ERROR             = 0x04     /*!< Error                                              */
+}HAL_UART_StateTypeDef;
+
+/** 
+  * @brief  HAL UART Error Code structure definition  
+  */ 
+typedef enum
+{
+  HAL_UART_ERROR_NONE      = 0x00,    /*!< No error            */
+  HAL_UART_ERROR_PE        = 0x01,    /*!< Parity error        */
+  HAL_UART_ERROR_NE        = 0x02,    /*!< Noise error         */
+  HAL_UART_ERROR_FE        = 0x04,    /*!< frame error         */
+  HAL_UART_ERROR_ORE       = 0x08,    /*!< Overrun error       */
+  HAL_UART_ERROR_DMA       = 0x10     /*!< DMA transfer error  */
+}HAL_UART_ErrorTypeDef;
+
+/**
+  * @brief UART clock sources definition
+  */
+typedef enum
+{
+  UART_CLOCKSOURCE_PCLK1      = 0x00,    /*!< PCLK1 clock source  */
+  UART_CLOCKSOURCE_PCLK2      = 0x01,    /*!< PCLK2 clock source  */
+  UART_CLOCKSOURCE_HSI        = 0x02,    /*!< HSI clock source    */
+  UART_CLOCKSOURCE_SYSCLK     = 0x04,    /*!< SYSCLK clock source */
+  UART_CLOCKSOURCE_LSE        = 0x08     /*!< LSE clock source     */
+}UART_ClockSourceTypeDef;
+
+/** 
+  * @brief  UART handle Structure definition  
+  */  
+typedef struct
+{
+  USART_TypeDef            *Instance;        /* UART registers base address        */
+
+  UART_InitTypeDef         Init;             /* UART communication parameters      */
+
+  UART_AdvFeatureInitTypeDef AdvancedInit;   /* UART Advanced Features initialization parameters */
+
+  uint8_t                  *pTxBuffPtr;      /* Pointer to UART Tx transfer Buffer */
+
+  uint16_t                 TxXferSize;       /* UART Tx Transfer size              */
+
+  uint16_t                 TxXferCount;      /* UART Tx Transfer Counter           */
+
+  uint8_t                  *pRxBuffPtr;      /* Pointer to UART Rx transfer Buffer */
+
+  uint16_t                 RxXferSize;       /* UART Rx Transfer size              */
+
+  uint16_t                 RxXferCount;      /* UART Rx Transfer Counter           */
+
+  uint16_t                 Mask;             /* UART Rx RDR register mask          */
+
+  DMA_HandleTypeDef        *hdmatx;          /* UART Tx DMA Handle parameters      */
+
+  DMA_HandleTypeDef        *hdmarx;          /* UART Rx DMA Handle parameters      */
+
+  HAL_LockTypeDef           Lock;            /* Locking object                     */
+
+  __IO HAL_UART_StateTypeDef    State;       /* UART communication state           */
+
+  __IO HAL_UART_ErrorTypeDef    ErrorCode;   /* UART Error code                    */
+
+}UART_HandleTypeDef;
+
+  
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup UART_Exported_Constants
+  * @{
+  */
+
+/** @defgroup UART_Stop_Bits
+  * @{
+  */
+#define UART_STOPBITS_1                     ((uint32_t)0x0000)
+#define UART_STOPBITS_2                     ((uint32_t)USART_CR2_STOP_1)
+#define IS_UART_STOPBITS(STOPBITS) (((STOPBITS) == UART_STOPBITS_1) || \
+                                    ((STOPBITS) == UART_STOPBITS_2))
+/**
+  * @}
+  */ 
+
+/** @defgroup UART_Parity
+  * @{
+  */ 
+#define UART_PARITY_NONE                    ((uint32_t)0x0000)
+#define UART_PARITY_EVEN                    ((uint32_t)USART_CR1_PCE)
+#define UART_PARITY_ODD                     ((uint32_t)(USART_CR1_PCE | USART_CR1_PS)) 
+#define IS_UART_PARITY(PARITY) (((PARITY) == UART_PARITY_NONE) || \
+                                ((PARITY) == UART_PARITY_EVEN) || \
+                                ((PARITY) == UART_PARITY_ODD))
+/**
+  * @}
+  */ 
+
+/** @defgroup UART_Hardware_Flow_Control
+  * @{
+  */ 
+#define UART_HWCONTROL_NONE                  ((uint32_t)0x0000)
+#define UART_HWCONTROL_RTS                   ((uint32_t)USART_CR3_RTSE)
+#define UART_HWCONTROL_CTS                   ((uint32_t)USART_CR3_CTSE)
+#define UART_HWCONTROL_RTS_CTS               ((uint32_t)(USART_CR3_RTSE | USART_CR3_CTSE))
+#define IS_UART_HARDWARE_FLOW_CONTROL(CONTROL)\
+                              (((CONTROL) == UART_HWCONTROL_NONE) || \
+                               ((CONTROL) == UART_HWCONTROL_RTS) || \
+                               ((CONTROL) == UART_HWCONTROL_CTS) || \
+                               ((CONTROL) == UART_HWCONTROL_RTS_CTS))
+/**
+  * @}
+  */
+
+/** @defgroup UART_Mode
+  * @{
+  */ 
+#define UART_MODE_RX                        ((uint32_t)USART_CR1_RE)
+#define UART_MODE_TX                        ((uint32_t)USART_CR1_TE)
+#define UART_MODE_TX_RX                     ((uint32_t)(USART_CR1_TE |USART_CR1_RE))
+#define IS_UART_MODE(MODE) ((((MODE) & (~((uint32_t)(UART_MODE_TX_RX)))) == (uint32_t)0x00) && ((MODE) != (uint32_t)0x00))
+/**
+  * @}
+  */
+    
+ /** @defgroup UART_State
+  * @{
+  */ 
+#define UART_STATE_DISABLE                  ((uint32_t)0x0000)
+#define UART_STATE_ENABLE                   ((uint32_t)USART_CR1_UE)
+#define IS_UART_STATE(STATE) (((STATE) == UART_STATE_DISABLE) || \
+                              ((STATE) == UART_STATE_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup UART_Over_Sampling
+  * @{
+  */
+#define UART_OVERSAMPLING_16                    ((uint32_t)0x0000)
+#define UART_OVERSAMPLING_8                     ((uint32_t)USART_CR1_OVER8)
+#define IS_UART_OVERSAMPLING(SAMPLING) (((SAMPLING) == UART_OVERSAMPLING_16) || \
+                                        ((SAMPLING) == UART_OVERSAMPLING_8))
+/**
+  * @}
+  */ 
+
+/** @defgroup UART_OneBit_Sampling
+  * @{
+  */
+#define UART_ONEBIT_SAMPLING_DISABLED   ((uint32_t)0x0000)
+#define UART_ONEBIT_SAMPLING_ENABLED    ((uint32_t)USART_CR3_ONEBIT)
+#define IS_UART_ONEBIT_SAMPLING(ONEBIT) (((ONEBIT) == UART_ONEBIT_SAMPLING_DISABLED) || \
+                                         ((ONEBIT) == UART_ONEBIT_SAMPLING_ENABLED))
+/**
+  * @}
+  */  
+  
+
+/** @defgroup UART_Receiver_TimeOut
+  * @{
+  */
+#define UART_RECEIVER_TIMEOUT_DISABLE   ((uint32_t)0x00000000)
+#define UART_RECEIVER_TIMEOUT_ENABLE    ((uint32_t)USART_CR2_RTOEN)
+#define IS_UART_RECEIVER_TIMEOUT(TIMEOUT) (((TIMEOUT) == UART_RECEIVER_TIMEOUT_DISABLE) || \
+                                           ((TIMEOUT) == UART_RECEIVER_TIMEOUT_ENABLE))
+/**
+  * @}
+  */ 
+
+/** @defgroup UART_LIN
+  * @{
+  */
+#define UART_LIN_DISABLE            ((uint32_t)0x00000000)
+#define UART_LIN_ENABLE             ((uint32_t)USART_CR2_LINEN)
+#define IS_UART_LIN(LIN)            (((LIN) == UART_LIN_DISABLE) || \
+                                     ((LIN) == UART_LIN_ENABLE))
+/**
+  * @}
+  */ 
+  
+/** @defgroup UART_LIN_Break_Detection
+  * @{
+  */
+#define UART_LINBREAKDETECTLENGTH_10B            ((uint32_t)0x00000000)
+#define UART_LINBREAKDETECTLENGTH_11B            ((uint32_t)USART_CR2_LBDL)
+#define IS_UART_LIN_BREAK_DETECT_LENGTH(LENGTH) (((LENGTH) == UART_LINBREAKDETECTLENGTH_10B) || \
+                                                 ((LENGTH) == UART_LINBREAKDETECTLENGTH_11B))
+/**
+  * @}
+  */ 
+  
+ 
+
+/** @defgroup UART_One_Bit
+  * @{
+  */
+#define UART_ONE_BIT_SAMPLE_DISABLED          ((uint32_t)0x00000000)
+#define UART_ONE_BIT_SAMPLE_ENABLED           ((uint32_t)USART_CR3_ONEBIT)
+#define IS_UART_ONEBIT_SAMPLE(ONEBIT)         (((ONEBIT) == UART_ONE_BIT_SAMPLE_DISABLED) || \
+                                                  ((ONEBIT) == UART_ONE_BIT_SAMPLE_ENABLED))
+/**
+  * @}
+  */  
+  
+/** @defgroup UART_DMA_Tx
+  * @{
+  */
+#define UART_DMA_TX_DISABLE          ((uint32_t)0x00000000)
+#define UART_DMA_TX_ENABLE           ((uint32_t)USART_CR3_DMAT)
+#define IS_UART_DMA_TX(DMATX)         (((DMATX) == UART_DMA_TX_DISABLE) || \
+                                       ((DMATX) == UART_DMA_TX_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup UART_DMA_Rx
+  * @{
+  */
+#define UART_DMA_RX_DISABLE           ((uint32_t)0x0000)
+#define UART_DMA_RX_ENABLE            ((uint32_t)USART_CR3_DMAR)
+#define IS_UART_DMA_RX(DMARX)         (((DMARX) == UART_DMA_RX_DISABLE) || \
+                                       ((DMARX) == UART_DMA_RX_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup UART_Half_Duplex_Selection
+  * @{
+  */
+#define UART_HALF_DUPLEX_DISABLE          ((uint32_t)0x0000)
+#define UART_HALF_DUPLEX_ENABLE           ((uint32_t)USART_CR3_HDSEL)
+#define IS_UART_HALF_DUPLEX(HDSEL)         (((HDSEL) == UART_HALF_DUPLEX_DISABLE) || \
+                                            ((HDSEL) == UART_HALF_DUPLEX_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup UART_Flags
+  *        Elements values convention: 0xXXXX
+  *           - 0xXXXX  : Flag mask in the ISR register
+  * @{
+  */
+#define UART_FLAG_REACK                     ((uint32_t)0x00400000)
+#define UART_FLAG_TEACK                     ((uint32_t)0x00200000)  
+#define UART_FLAG_WUF                       ((uint32_t)0x00100000)
+#define UART_FLAG_RWU                       ((uint32_t)0x00080000)
+#define UART_FLAG_SBKF                      ((uint32_t)0x00040000
+#define UART_FLAG_CMF                       ((uint32_t)0x00020000)
+#define UART_FLAG_BUSY                      ((uint32_t)0x00010000)
+#define UART_FLAG_ABRF                      ((uint32_t)0x00008000)  
+#define UART_FLAG_ABRE                      ((uint32_t)0x00004000)
+#define UART_FLAG_EOBF                      ((uint32_t)0x00001000)
+#define UART_FLAG_RTOF                      ((uint32_t)0x00000800)
+#define UART_FLAG_CTS                       ((uint32_t)0x00000400)
+#define UART_FLAG_CTSIF                     ((uint32_t)0x00000200)
+#define UART_FLAG_LBDF                      ((uint32_t)0x00000100)
+#define UART_FLAG_TXE                       ((uint32_t)0x00000080)
+#define UART_FLAG_TC                        ((uint32_t)0x00000040)
+#define UART_FLAG_RXNE                      ((uint32_t)0x00000020)
+#define UART_FLAG_IDLE                      ((uint32_t)0x00000010)
+#define UART_FLAG_ORE                       ((uint32_t)0x00000008)
+#define UART_FLAG_NE                        ((uint32_t)0x00000004)
+#define UART_FLAG_FE                        ((uint32_t)0x00000002)
+#define UART_FLAG_PE                        ((uint32_t)0x00000001)
+/**
+  * @}
+  */ 
+
+/** @defgroup UART_Interrupt_definition
+  *        Elements values convention: 0000ZZZZ0XXYYYYYb
+  *           - YYYYY  : Interrupt source position in the XX register (5bits)
+  *           - XX  : Interrupt source register (2bits)
+  *                 - 01: CR1 register
+  *                 - 10: CR2 register
+  *                 - 11: CR3 register
+  *           - ZZZZ  : Flag position in the ISR register(4bits)
+  * @{
+  */
+#define UART_IT_PE                          ((uint32_t)0x0028)
+#define UART_IT_TXE                         ((uint32_t)0x0727)
+#define UART_IT_TC                          ((uint32_t)0x0626)
+#define UART_IT_RXNE                        ((uint32_t)0x0525)
+#define UART_IT_IDLE                        ((uint32_t)0x0424)
+#define UART_IT_LBD                         ((uint32_t)0x0846)
+#define UART_IT_CTS                         ((uint32_t)0x096A)
+#define UART_IT_CM                          ((uint32_t)0x142E)
+#define UART_IT_WUF                         ((uint32_t)0x1476)
+
+/**       Elements values convention: 000000000XXYYYYYb
+  *           - YYYYY  : Interrupt source position in the XX register (5bits)
+  *           - XX  : Interrupt source register (2bits)
+  *                 - 01: CR1 register
+  *                 - 10: CR2 register
+  *                 - 11: CR3 register
+  */
+#define UART_IT_ERR                         ((uint32_t)0x0060)
+
+/**       Elements values convention: 0000ZZZZ00000000b
+  *           - ZZZZ  : Flag position in the ISR register(4bits)
+  */
+#define UART_IT_ORE                         ((uint32_t)0x0300)
+#define UART_IT_NE                          ((uint32_t)0x0200)
+#define UART_IT_FE                          ((uint32_t)0x0100)
+/**
+  * @}
+  */
+
+/** @defgroup UART_IT_CLEAR_Flags
+  * @{
+  */
+#define UART_CLEAR_PEF                       USART_ICR_PECF            /*!< Parity Error Clear Flag */          
+#define UART_CLEAR_FEF                       USART_ICR_FECF            /*!< Framing Error Clear Flag */         
+#define UART_CLEAR_NEF                       USART_ICR_NCF             /*!< Noise detected Clear Flag */        
+#define UART_CLEAR_OREF                      USART_ICR_ORECF           /*!< OverRun Error Clear Flag */         
+#define UART_CLEAR_IDLEF                     USART_ICR_IDLECF          /*!< IDLE line detected Clear Flag */    
+#define UART_CLEAR_TCF                       USART_ICR_TCCF            /*!< Transmission Complete Clear Flag */ 
+#define UART_CLEAR_LBDF                      USART_ICR_LBDCF           /*!< LIN Break Detection Clear Flag */   
+#define UART_CLEAR_CTSF                      USART_ICR_CTSCF           /*!< CTS Interrupt Clear Flag */         
+#define UART_CLEAR_RTOF                      USART_ICR_RTOCF           /*!< Receiver Time Out Clear Flag */     
+#define UART_CLEAR_EOBF                      USART_ICR_EOBCF           /*!< End Of Block Clear Flag */          
+#define UART_CLEAR_CMF                       USART_ICR_CMCF            /*!< Character Match Clear Flag */       
+#define UART_CLEAR_WUF                       USART_ICR_WUCF            /*!< Wake Up from stop mode Clear Flag */
+/**
+  * @}
+  */
+
+/** @defgroup UART_Request_Parameters
+  * @{
+  */
+#define UART_AUTOBAUD_REQUEST            ((uint32_t)USART_RQR_ABRRQ)        /*!< Auto-Baud Rate Request */     
+#define UART_SENDBREAK_REQUEST           ((uint32_t)USART_RQR_SBKRQ)        /*!< Send Break Request */         
+#define UART_MUTE_MODE_REQUEST           ((uint32_t)USART_RQR_MMRQ)         /*!< Mute Mode Request */          
+#define UART_RXDATA_FLUSH_REQUEST        ((uint32_t)USART_RQR_RXFRQ)        /*!< Receive Data flush Request */ 
+#define UART_TXDATA_FLUSH_REQUEST        ((uint32_t)USART_RQR_TXFRQ)        /*!< Transmit data flush Request */
+#define IS_UART_REQUEST_PARAMETER(PARAM) (((PARAM) == UART_AUTOBAUD_REQUEST) || \
+                                          ((PARAM) == UART_SENDBREAK_REQUEST) || \
+                                          ((PARAM) == UART_MUTE_MODE_REQUEST) || \
+                                          ((PARAM) == UART_RXDATA_FLUSH_REQUEST) || \
+                                          ((PARAM) == UART_TXDATA_FLUSH_REQUEST))
+/**
+  * @}
+  */
+
+/** @defgroup UART_Advanced_Features_Initialization_Type
+  * @{
+  */
+#define UART_ADVFEATURE_NO_INIT                 ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_TXINVERT_INIT           ((uint32_t)0x00000001)
+#define UART_ADVFEATURE_RXINVERT_INIT           ((uint32_t)0x00000002)
+#define UART_ADVFEATURE_DATAINVERT_INIT         ((uint32_t)0x00000004)
+#define UART_ADVFEATURE_SWAP_INIT               ((uint32_t)0x00000008)
+#define UART_ADVFEATURE_RXOVERRUNDISABLE_INIT   ((uint32_t)0x00000010)
+#define UART_ADVFEATURE_DMADISABLEONERROR_INIT  ((uint32_t)0x00000020)
+#define UART_ADVFEATURE_AUTOBAUDRATE_INIT       ((uint32_t)0x00000040)
+#define UART_ADVFEATURE_MSBFIRST_INIT           ((uint32_t)0x00000080)
+#define IS_UART_ADVFEATURE_INIT(INIT)           ((INIT) <= (UART_ADVFEATURE_NO_INIT | \
+                                                            UART_ADVFEATURE_TXINVERT_INIT | \
+                                                            UART_ADVFEATURE_RXINVERT_INIT | \
+                                                            UART_ADVFEATURE_DATAINVERT_INIT | \
+                                                            UART_ADVFEATURE_SWAP_INIT | \
+                                                            UART_ADVFEATURE_RXOVERRUNDISABLE_INIT | \
+                                                            UART_ADVFEATURE_DMADISABLEONERROR_INIT   | \
+                                                            UART_ADVFEATURE_AUTOBAUDRATE_INIT | \
+                                                            UART_ADVFEATURE_MSBFIRST_INIT))
+/**
+  * @}
+  */
+
+/** @defgroup UART_Tx_Inv
+  * @{
+  */
+#define UART_ADVFEATURE_TXINV_DISABLE   ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_TXINV_ENABLE    ((uint32_t)USART_CR2_TXINV)
+#define IS_UART_ADVFEATURE_TXINV(TXINV) (((TXINV) == UART_ADVFEATURE_TXINV_DISABLE) || \
+                                         ((TXINV) == UART_ADVFEATURE_TXINV_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup UART_Rx_Inv
+  * @{
+  */
+#define UART_ADVFEATURE_RXINV_DISABLE   ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_RXINV_ENABLE    ((uint32_t)USART_CR2_RXINV)
+#define IS_UART_ADVFEATURE_RXINV(RXINV) (((RXINV) == UART_ADVFEATURE_RXINV_DISABLE) || \
+                                         ((RXINV) == UART_ADVFEATURE_RXINV_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup UART_Data_Inv
+  * @{
+  */
+#define UART_ADVFEATURE_DATAINV_DISABLE     ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_DATAINV_ENABLE      ((uint32_t)USART_CR2_DATAINV)
+#define IS_UART_ADVFEATURE_DATAINV(DATAINV) (((DATAINV) == UART_ADVFEATURE_DATAINV_DISABLE) || \
+                                             ((DATAINV) == UART_ADVFEATURE_DATAINV_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup UART_Rx_Tx_Swap
+  * @{
+  */
+#define UART_ADVFEATURE_SWAP_DISABLE   ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_SWAP_ENABLE    ((uint32_t)USART_CR2_SWAP)
+#define IS_UART_ADVFEATURE_SWAP(SWAP) (((SWAP) == UART_ADVFEATURE_SWAP_DISABLE) || \
+                                       ((SWAP) == UART_ADVFEATURE_SWAP_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup UART_Overrun_Disable
+  * @{
+  */
+#define UART_ADVFEATURE_OVERRUN_ENABLE   ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_OVERRUN_DISABLE  ((uint32_t)USART_CR3_OVRDIS)
+#define IS_UART_OVERRUN(OVERRUN)         (((OVERRUN) == UART_ADVFEATURE_OVERRUN_ENABLE) || \
+                                          ((OVERRUN) == UART_ADVFEATURE_OVERRUN_DISABLE))
+/**
+  * @}
+  */
+
+/** @defgroup UART_AutoBaudRate_Enable
+  * @{
+  */
+#define UART_ADVFEATURE_AUTOBAUDRATE_DISABLE           ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_AUTOBAUDRATE_ENABLE            ((uint32_t)USART_CR2_ABREN)
+#define IS_UART_ADVFEATURE_AUTOBAUDRATE(AUTOBAUDRATE)  (((AUTOBAUDRATE) == UART_ADVFEATURE_AUTOBAUDRATE_DISABLE) || \
+                                                        ((AUTOBAUDRATE) == UART_ADVFEATURE_AUTOBAUDRATE_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup UART_DMA_Disable_on_Rx_Error
+  * @{
+  */
+#define UART_ADVFEATURE_DMA_ENABLEONRXERROR       ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_DMA_DISABLEONRXERROR      ((uint32_t)USART_CR3_DDRE)
+#define IS_UART_ADVFEATURE_DMAONRXERROR(DMA)      (((DMA) == UART_ADVFEATURE_DMA_ENABLEONRXERROR) || \
+                                                   ((DMA) == UART_ADVFEATURE_DMA_DISABLEONRXERROR))
+/**
+  * @}
+  */
+
+/** @defgroup UART_MSB_First
+  * @{
+  */
+#define UART_ADVFEATURE_MSBFIRST_DISABLE      ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_MSBFIRST_ENABLE       ((uint32_t)USART_CR2_MSBFIRST)
+#define IS_UART_ADVFEATURE_MSBFIRST(MSBFIRST) (((MSBFIRST) == UART_ADVFEATURE_MSBFIRST_DISABLE) || \
+                                               ((MSBFIRST) == UART_ADVFEATURE_MSBFIRST_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup UART_Stop_Mode_Enable
+  * @{
+  */
+#define UART_ADVFEATURE_STOPMODE_DISABLE      ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_STOPMODE_ENABLE       ((uint32_t)USART_CR1_UESM)
+#define IS_UART_ADVFEATURE_STOPMODE(STOPMODE) (((STOPMODE) == UART_ADVFEATURE_STOPMODE_DISABLE) || \
+                                               ((STOPMODE) == UART_ADVFEATURE_STOPMODE_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup UART_Mute_Mode
+  * @{
+  */
+#define UART_ADVFEATURE_MUTEMODE_DISABLE    ((uint32_t)0x00000000)
+#define UART_ADVFEATURE_MUTEMODE_ENABLE    ((uint32_t)USART_CR1_MME)
+#define IS_UART_MUTE_MODE(MUTE)           (((MUTE) == UART_ADVFEATURE_MUTEMODE_DISABLE) || \
+                                           ((MUTE) == UART_ADVFEATURE_MUTEMODE_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup UART_CR2_ADDRESS_LSBPOS
+  * @{
+  */
+#define UART_CR2_ADDRESS_LSB_POS            ((uint32_t) 24)
+/**
+  * @}
+  */
+
+/** @defgroup UART_WakeUp_from_Stop_Selection
+  * @{
+  */
+#define UART_WAKEUP_ON_ADDRESS           ((uint32_t)0x0000)
+#define UART_WAKEUP_ON_STARTBIT          ((uint32_t)USART_CR3_WUS_1)
+#define UART_WAKEUP_ON_READDATA_NONEMPTY ((uint32_t)USART_CR3_WUS)
+#define IS_UART_WAKEUP_SELECTION(WAKE)   (((WAKE) == UART_WAKEUP_ON_ADDRESS) || \
+                                          ((WAKE) == UART_WAKEUP_ON_STARTBIT) || \
+                                          ((WAKE) == UART_WAKEUP_ON_READDATA_NONEMPTY))
+/**
+  * @}
+  */
+
+/** @defgroup UART_DriverEnable_Polarity
+  * @{
+  */
+#define UART_DE_POLARITY_HIGH            ((uint32_t)0x00000000)
+#define UART_DE_POLARITY_LOW             ((uint32_t)USART_CR3_DEP)
+#define IS_UART_DE_POLARITY(POLARITY)    (((POLARITY) == UART_DE_POLARITY_HIGH) || \
+                                          ((POLARITY) == UART_DE_POLARITY_LOW))
+/**
+  * @}
+  */
+
+/** @defgroup UART_CR1_DEAT_ADDRESS_LSBPOS
+  * @{
+  */
+#define UART_CR1_DEAT_ADDRESS_LSB_POS            ((uint32_t) 21)
+/**
+  * @}
+  */
+
+/** @defgroup UART_CR1_DEDT_ADDRESS_LSBPOS
+  * @{
+  */
+#define UART_CR1_DEDT_ADDRESS_LSB_POS            ((uint32_t) 16)
+/**
+  * @}
+  */
+
+/** @defgroup UART_Interruption_Mask
+  * @{
+  */
+#define UART_IT_MASK                             ((uint32_t)0x001F)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup UART_Exported_Macros
+  * @{
+  */
+
+/** @brief Reset UART handle state
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance which can be USART1, USART2 or LPUART.
+  * @retval None
+  */
+#define __HAL_UART_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_UART_STATE_RESET)
+
+/** @brief  Checks whether the specified UART flag is set or not.
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         This parameter can be USART1, USART2 or LPUART.
+  * @param  __FLAG__: specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg UART_FLAG_REACK: Receive enable ackowledge flag
+  *            @arg UART_FLAG_TEACK: Transmit enable ackowledge flag
+  *            @arg UART_FLAG_WUF:   Wake up from stop mode flag
+  *            @arg UART_FLAG_RWU:   Receiver wake up flag (is the UART in mute mode)
+  *            @arg UART_FLAG_SBKF:  Send Break flag
+  *            @arg UART_FLAG_CMF:   Character match flag
+  *            @arg UART_FLAG_BUSY:  Busy flag
+  *            @arg UART_FLAG_ABRF:  Auto Baud rate detection flag
+  *            @arg UART_FLAG_ABRE:  Auto Baud rate detection error flag
+  *            @arg UART_FLAG_EOBF:  End of block flag   
+  *            @arg UART_FLAG_RTOF:  Receiver timeout flag                     
+  *            @arg UART_FLAG_CTS:   CTS Change flag (not available for UART4 and UART5)
+  *            @arg UART_FLAG_LBD:   LIN Break detection flag
+  *            @arg UART_FLAG_TXE:   Transmit data register empty flag
+  *            @arg UART_FLAG_TC:    Transmission Complete flag
+  *            @arg UART_FLAG_RXNE:  Receive data register not empty flag
+  *            @arg UART_FLAG_IDLE:  Idle Line detection flag
+  *            @arg UART_FLAG_ORE:   OverRun Error flag
+  *            @arg UART_FLAG_NE:    Noise Error flag
+  *            @arg UART_FLAG_FE:    Framing Error flag
+  *            @arg UART_FLAG_PE:    Parity Error flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_UART_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->ISR & (__FLAG__)) == (__FLAG__))
+
+/** @brief  Enables the specified UART interrupt.
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         This parameter can be USART1, USART2 or LPUART.
+  * @param  __INTERRUPT__: specifies the UART interrupt source to enable.
+  *          This parameter can be one of the following values:
+  *            @arg UART_IT_WUF:  Wakeup from stop mode interrupt
+  *            @arg UART_IT_CM:   Character match interrupt
+  *            @arg UART_IT_CTS:  CTS change interrupt
+  *            @arg UART_IT_LBD:  LIN Break detection interrupt
+  *            @arg UART_IT_TXE:  Transmit Data Register empty interrupt
+  *            @arg UART_IT_TC:   Transmission complete interrupt
+  *            @arg UART_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg UART_IT_IDLE: Idle line detection interrupt
+  *            @arg UART_IT_PE:   Parity Error interrupt
+  *            @arg UART_IT_ERR:  Error interrupt(Frame error, noise error, overrun error)
+  * @retval None
+  */
+#define __HAL_UART_ENABLE_IT(__HANDLE__, __INTERRUPT__)   (((((uint8_t)(__INTERRUPT__)) >> 5) == 1)? ((__HANDLE__)->Instance->CR1 |= (1 << ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                       ((((uint8_t)(__INTERRUPT__)) >> 5) == 2)? ((__HANDLE__)->Instance->CR2 |= (1 << ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                       ((__HANDLE__)->Instance->CR3 |= (1 << ((__INTERRUPT__) & UART_IT_MASK))))
+
+/** @brief  Disables the specified UART interrupt.
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         This parameter can be USART1, USART2 or LPUART.
+  * @param  __INTERRUPT__: specifies the UART interrupt source to disable.
+  *          This parameter can be one of the following values:
+  *            @arg UART_IT_WUF:  Wakeup from stop mode interrupt
+  *            @arg UART_IT_CM:   Character match interrupt            
+  *            @arg UART_IT_CTS:  CTS change interrupt
+  *            @arg UART_IT_LBD:  LIN Break detection interrupt
+  *            @arg UART_IT_TXE:  Transmit Data Register empty interrupt
+  *            @arg UART_IT_TC:   Transmission complete interrupt
+  *            @arg UART_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg UART_IT_IDLE: Idle line detection interrupt
+  *            @arg UART_IT_PE:   Parity Error interrupt
+  *            @arg UART_IT_ERR:  Error interrupt(Frame error, noise error, overrun error)
+  * @retval None
+  */
+#define __HAL_UART_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (((((uint8_t)(__INTERRUPT__)) >> 5) == 1)? ((__HANDLE__)->Instance->CR1 &= ~ ((uint32_t)1 << ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                       ((((uint8_t)(__INTERRUPT__)) >> 5) == 2)? ((__HANDLE__)->Instance->CR2 &= ~ ((uint32_t)1 << ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                       ((__HANDLE__)->Instance->CR3 &= ~ ((uint32_t)1 << ((__INTERRUPT__) & UART_IT_MASK))))
+
+/** @brief  Checks whether the specified UART interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         This parameter can be USART1, USART2 or LPUART.
+  * @param  __IT__: specifies the UART interrupt to check.
+  *          This parameter can be one of the following values:
+  *            @arg UART_IT_WUF:  Wakeup from stop mode interrupt
+  *            @arg UART_IT_CM:   Character match interrupt              
+  *            @arg UART_IT_CTS:  CTS change interrupt (not available for UART4 and UART5)
+  *            @arg UART_IT_LBD:  LIN Break detection interrupt
+  *            @arg UART_IT_TXE:  Transmit Data Register empty interrupt
+  *            @arg UART_IT_TC:   Transmission complete interrupt
+  *            @arg UART_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg UART_IT_IDLE: Idle line detection interrupt
+  *            @arg UART_IT_ORE:  OverRun Error interrupt
+  *            @arg UART_IT_NE:   Noise Error interrupt
+  *            @arg UART_IT_FE:   Framing Error interrupt
+  *            @arg UART_IT_PE:   Parity Error interrupt  
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_UART_GET_IT(__HANDLE__, __IT__) ((__HANDLE__)->Instance->ISR & ((uint32_t)1 << ((__IT__)>> 0x08)))
+
+/** @brief  Checks whether the specified UART interrupt source is enabled.
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         This parameter can be USART1, USART2 or LPUART.
+  * @param  __IT__: specifies the UART interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg UART_IT_CTS: CTS change interrupt (not available for UART4 and UART5)
+  *            @arg UART_IT_LBD: LIN Break detection interrupt
+  *            @arg UART_IT_TXE: Transmit Data Register empty interrupt
+  *            @arg UART_IT_TC:  Transmission complete interrupt
+  *            @arg UART_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg UART_IT_IDLE: Idle line detection interrupt
+  *            @arg UART_IT_ORE: OverRun Error interrupt
+  *            @arg UART_IT_NE: Noise Error interrupt
+  *            @arg UART_IT_FE: Framing Error interrupt
+  *            @arg UART_IT_PE: Parity Error interrupt  
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_UART_GET_IT_SOURCE(__HANDLE__, __IT__) ((((((uint8_t)(__IT__)) >> 5) == 1)? (__HANDLE__)->Instance->CR1:(((((uint8_t)(__IT__)) >> 5) == 2)? \
+                                                       (__HANDLE__)->Instance->CR2 : (__HANDLE__)->Instance->CR3)) & ((uint32_t)1 << (((uint16_t)(__IT__)) & UART_IT_MASK)))
+
+/** @brief  Clears the specified UART ISR flag, in setting the proper ICR register flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         This parameter can be USART1, USART2 or LPUART.
+  * @param  __IT_CLEAR__: specifies the interrupt clear register flag that needs to be set
+  *                       to clear the corresponding interrupt
+  *          This parameter can be one of the following values:
+  *            @arg UART_CLEAR_PEF: Parity Error Clear Flag
+  *            @arg UART_CLEAR_FEF: Framing Error Clear Flag
+  *            @arg UART_CLEAR_NEF: Noise detected Clear Flag
+  *            @arg UART_CLEAR_OREF: OverRun Error Clear Flag
+  *            @arg UART_CLEAR_IDLEF: IDLE line detected Clear Flag
+  *            @arg UART_CLEAR_TCF: Transmission Complete Clear Flag
+  *            @arg UART_CLEAR_LBDF: LIN Break Detection Clear Flag
+  *            @arg UART_CLEAR_CTSF: CTS Interrupt Clear Flag
+  *            @arg UART_CLEAR_RTOF: Receiver Time Out Clear Flag
+  *            @arg UART_CLEAR_EOBF: End Of Block Clear Flag
+  *            @arg UART_CLEAR_CMF: Character Match Clear Flag
+  *            @arg UART_CLEAR_WUF:  Wake Up from stop mode Clear Flag
+  * @retval None
+  */
+#define __HAL_UART_CLEAR_IT(__HANDLE__, __IT_CLEAR__) ((__HANDLE__)->Instance->ICR = (uint32_t)(__IT_CLEAR__))
+
+/** @brief  Set a specific UART request flag.
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         This parameter can be USART1, USART2 or LPUART.
+  * @param  __REQ__: specifies the request flag to set
+  *          This parameter can be one of the following values:
+  *            @arg UART_AUTOBAUD_REQUEST: Auto-Baud Rate Request
+  *            @arg UART_SENDBREAK_REQUEST: Send Break Request
+  *            @arg UART_MUTE_MODE_REQUEST: Mute Mode Request
+  *            @arg UART_RXDATA_FLUSH_REQUEST: Receive Data flush Request
+  *            @arg UART_TXDATA_FLUSH_REQUEST: Transmit data flush Request
+  * @retval None
+  */
+#define __HAL_UART_SEND_REQ(__HANDLE__, __REQ__) ((__HANDLE__)->Instance->RQR |= (uint16_t)(__REQ__))
+
+/** @brief  Enable UART
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance can be USART1, USART2 or LPUART.
+  * @retval None
+  */ 
+#define __HAL_UART_ENABLE(__HANDLE__)                   ((__HANDLE__)->Instance->CR1 |=  USART_CR1_UE)
+
+/** @brief  Disable UART
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance can be USART1, USART2 or LPUART.
+  * @retval None
+  */
+#define __HAL_UART_DISABLE(__HANDLE__)                  ((__HANDLE__)->Instance->CR1 &=  ~USART_CR1_UE)
+
+/** @brief  Enable CTS flow control 
+  *         This macro allows to enable CTS hardware flow control for a given UART instance, 
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying CTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e __HAL_UART_ENABLE(__HANDLE__)).                                                                                                                  
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance can be USART1, USART2 or LPUART.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_CTS_ENABLE(__HANDLE__)        \
+  do{                                                      \
+    SET_BIT((__HANDLE__)->Instance->CR3, USART_CR3_CTSE);  \
+    (__HANDLE__)->Init.HwFlowCtl |= USART_CR3_CTSE;        \
+  } while(0)
+
+/** @brief  Disable CTS flow control 
+  *         This macro allows to disable CTS hardware flow control for a given UART instance, 
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying CTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e __HAL_UART_ENABLE(__HANDLE__)). 
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance can be USART1, USART2 or LPUART.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_CTS_DISABLE(__HANDLE__)        \
+  do{                                                       \
+    CLEAR_BIT((__HANDLE__)->Instance->CR3, USART_CR3_CTSE); \
+    (__HANDLE__)->Init.HwFlowCtl &= ~(USART_CR3_CTSE);      \
+  } while(0)
+
+/** @brief  Enable RTS flow control 
+  *         This macro allows to enable RTS hardware flow control for a given UART instance, 
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying RTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e __HAL_UART_ENABLE(__HANDLE__)). 
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance can be USART1, USART2 or LPUART.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_RTS_ENABLE(__HANDLE__)       \
+  do{                                                     \
+    SET_BIT((__HANDLE__)->Instance->CR3, USART_CR3_RTSE); \
+    (__HANDLE__)->Init.HwFlowCtl |= USART_CR3_RTSE;       \
+  } while(0)
+
+/** @brief  Disable RTS flow control 
+  *         This macro allows to disable RTS hardware flow control for a given UART instance, 
+  *         without need to call HAL_UART_Init() function.
+  *         As involving direct access to UART registers, usage of this macro should be fully endorsed by user.
+  * @note   As macro is expected to be used for modifying RTS Hw flow control feature activation, without need
+  *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
+  *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
+  *           - macro could only be called when corresponding UART instance is disabled (i.e __HAL_UART_DISABLE(__HANDLE__))
+  *             and should be followed by an Enable macro (i.e __HAL_UART_ENABLE(__HANDLE__)). 
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance can be USART1, USART2 or LPUART.
+  * @retval None
+  */
+#define __HAL_UART_HWCONTROL_RTS_DISABLE(__HANDLE__)       \
+  do{                                                      \
+    CLEAR_BIT((__HANDLE__)->Instance->CR3, USART_CR3_RTSE);\
+    (__HANDLE__)->Init.HwFlowCtl &= ~(USART_CR3_RTSE);     \
+  } while(0)
+
+
+/** @brief  BRR division operation to set BRR register with LPUART
+  * @param  _PCLK_: LPUART clock
+  * @param  _BAUD_: Baud rate set by the user
+  * @retval Division result
+  */
+#define __DIV_LPUART(_PCLK_, _BAUD_)                (((_PCLK_)*256)/((_BAUD_)))
+
+/** @brief  BRR division operation to set BRR register in 8-bit oversampling mode
+  * @param  _PCLK_: UART clock
+  * @param  _BAUD_: Baud rate set by the user
+  * @retval Division result
+  */
+#define __DIV_SAMPLING8(_PCLK_, _BAUD_)             (((_PCLK_)*2)/((_BAUD_)))
+
+/** @brief  BRR division operation to set BRR register in 16-bit oversampling mode
+  * @param  _PCLK_: UART clock
+  * @param  _BAUD_: Baud rate set by the user
+  * @retval Division result
+  */
+#define __DIV_SAMPLING16(_PCLK_, _BAUD_)             (((_PCLK_))/((_BAUD_)))
+
+/** @brief  Check UART Baud rate
+  * @param  BAUDRATE: Baudrate specified by the user
+  *         The maximum Baud Rate is derived from the maximum clock on L0 (i.e. 32 MHz) 
+  *         divided by the smallest oversampling used on the USART (i.e. 8) 
+  * @retval Test result (TRUE or FALSE).
+  */
+#define IS_UART_BAUDRATE(BAUDRATE) ((BAUDRATE) < 4000001)
+
+/** @brief  Check UART byte address
+  * @param  ADDRESS: UART 8-bit address for wake-up process scheme
+  * @retval Test result (TRUE or FALSE). 
+  */ 
+#define IS_UART_7B_ADDRESS(ADDRESS) ((ADDRESS) <= 0x7F)
+
+/** @brief  Check UART 4-bit address
+  * @param  ADDRESS: UART 4-bit address for wake-up process scheme
+  * @retval Test result (TRUE or FALSE). 
+  */ 
+#define IS_UART_4B_ADDRESS(ADDRESS) ((ADDRESS) <= 0xF)
+
+/** @brief  Check UART assertion time
+  * @param  TIME: 5-bit value assertion time
+  * @retval Test result (TRUE or FALSE). 
+  */ 
+#define IS_UART_ASSERTIONTIME(TIME)    ((TIME) <= 0x1F)
+
+/** @brief  Check UART deassertion time
+  * @param  TIME: 5-bit value deassertion time
+  * @retval Test result (TRUE or FALSE). 
+  */
+#define IS_UART_DEASSERTIONTIME(TIME) ((TIME) <= 0x1F)
+
+/**
+  * @}
+  */
+/* Include UART HAL Extension module */
+#include "stm32l0xx_hal_uart_ex.h"
+/* Exported functions --------------------------------------------------------*/
+/* Initialization/de-initialization functions  ********************************/
+HAL_StatusTypeDef HAL_UART_Init(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_HalfDuplex_Init(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_LIN_Init(UART_HandleTypeDef *huart, uint32_t BreakDetectLength);
+HAL_StatusTypeDef HAL_MultiProcessor_Init(UART_HandleTypeDef *huart, uint8_t Address, uint32_t WakeUpMethod);
+HAL_StatusTypeDef HAL_UART_DeInit (UART_HandleTypeDef *huart);
+void HAL_UART_MspInit(UART_HandleTypeDef *huart);
+void HAL_UART_MspDeInit(UART_HandleTypeDef *huart);
+
+/* IO operation functions *****************************************************/
+HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UART_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UART_Receive_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UART_DMAPause(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_UART_DMAResume(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_UART_DMAStop(UART_HandleTypeDef *huart);
+void HAL_UART_IRQHandler(UART_HandleTypeDef *huart);
+void HAL_UART_TxHalfCpltCallback(UART_HandleTypeDef *huart);
+void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart);
+void HAL_UART_RxHalfCpltCallback(UART_HandleTypeDef *huart);
+void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart);
+void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart);
+
+/* Peripheral Control and State functions  ************************************/
+HAL_StatusTypeDef HAL_MultiProcessor_EnableMuteMode(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_MultiProcessor_DisableMuteMode(UART_HandleTypeDef *huart);
+void HAL_MultiProcessor_EnterMuteMode(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_HalfDuplex_EnableTransmitter(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_HalfDuplex_EnableReceiver(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_LIN_SendBreak(UART_HandleTypeDef *huart);
+HAL_UART_StateTypeDef HAL_UART_GetState(UART_HandleTypeDef *huart);
+uint32_t HAL_UART_GetError(UART_HandleTypeDef *huart);
+
+/* Non-User functions  ********************************************************/
+void UART_SetConfig(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
+void UART_AdvFeatureConfig(UART_HandleTypeDef *huart);
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_UART_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_uart_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_uart_ex.c
@@ -1,0 +1,440 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_uart_ex.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Extended UART HAL module driver.
+  *    
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Inter Integrated Circuit (UART) peripheral:
+  *           + Extended Control methods
+  *         
+  @verbatim
+  ==============================================================================
+               ##### UART peripheral extended features  #####
+  ==============================================================================
+           
+  [..] Comparing to other previous devices, the UART interface for STM32L0XX
+       devices contains the following additional features
+       
+       (+) Possibility to disable or enable Analog Noise Filter
+       (+) Use of a configured Digital Noise Filter
+       (+) Disable or enable wakeup from Stop mode
+   
+                     ##### How to use this driver #####
+  ==============================================================================
+  [..] This driver provides functions to configure Noise Filter
+  
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup UARTEx
+  * @brief UARTEx module driver
+  * @{
+  */
+
+#ifdef HAL_UART_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define UART_REACK_TIMEOUT       ((uint32_t) 1000)
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void UART_Wakeup_AddressConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection);
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup UARTEX_Private_Functions
+  * @{
+  */
+
+/** @defgroup UARTEx_Group1 Extended Initialization/de-initialization functions
+  * @brief    Extended Initialization and Configuration Functions
+
+  *
+@verbatim    
+===============================================================================
+            ##### Initialization and Configuration functions #####
+ ===============================================================================  
+    [..]
+    The HAL_RS485Ex_Init() API follows respectively the UART RS485 mode 
+    configuration procedures (details for the procedures are available in reference manual).
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Initializes the RS485 Driver enable feature according to the specified
+  *         parameters in the UART_InitTypeDef and creates the associated handle .
+  * @param huart: uart handle
+  * @param Polarity: select the driver enable polarity
+  *        This parameter can be one of the following values:
+  *          @arg UART_DE_POLARITY_HIGH: DE signal is active high
+  *          @arg UART_DE_POLARITY_LOW: DE signal is active low
+  * @param AssertionTime: Driver Enable assertion time
+  *                         5-bit value defining the time between the activation of the DE (Driver Enable)
+  *                         signal and the beginning of the start bit. It is expressed in sample time
+  *                         units (1/8 or 1/16 bit time, depending on the oversampling rate)         
+  * @param DeassertionTime: Driver Enable deassertion time          
+  *                         5-bit value defining the time between the end of the last stop bit, in a
+  *                         transmitted message, and the de-activation of the DE (Driver Enable) signal.
+  *                         It is expressed in sample time units (1/8 or 1/16 bit time, depending on the
+  *                         oversampling rate).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RS485Ex_Init(UART_HandleTypeDef *huart, uint32_t Polarity, uint32_t AssertionTime, uint32_t DeassertionTime)
+{
+  uint32_t temp = 0x0;
+  
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the Driver Enable polarity */
+  assert_param(IS_UART_DE_POLARITY(Polarity));
+  
+  /* Check the Driver Enable assertion time */
+  assert_param(IS_UART_ASSERTIONTIME(AssertionTime));
+  
+  /* Check the Driver Enable deassertion time */
+  assert_param(IS_UART_DEASSERTIONTIME(DeassertionTime));
+  
+  if(huart->State == HAL_UART_STATE_RESET)
+  {   
+    /* Init the low level hardware : GPIO, CLOCK, CORTEX */
+    HAL_UART_MspInit(huart);
+  }
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+  
+  /* Set the UART Communication parameters */
+  UART_SetConfig(huart);
+  
+  if(huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+  
+  /* Enable the Driver Enable mode by setting the DEM bit in the CR3 register */
+  huart->Instance->CR3 |= USART_CR3_DEM;
+  
+  /* Set the Driver Enable polarity */
+  MODIFY_REG(huart->Instance->CR3, USART_CR3_DEP, Polarity);
+  
+  /* Set the Driver Enable assertion and deassertion times */
+  temp = (AssertionTime << UART_CR1_DEAT_ADDRESS_LSB_POS);
+  temp |= (DeassertionTime << UART_CR1_DEDT_ADDRESS_LSB_POS);
+  MODIFY_REG(huart->Instance->CR1, (USART_CR1_DEDT|USART_CR1_DEAT), temp);
+  
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+  
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+/**
+  * @brief UART wakeup from Stop mode callback
+  * @param huart: uart handle
+  * @retval None
+  */
+ __weak void HAL_UARTEx_WakeupCallback(UART_HandleTypeDef *huart)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UART_WakeupCallback can be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+  
+/** @defgroup UARTEX_Group2 Peripheral Control functions 
+ *  @brief   management functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control funtions #####
+ ===============================================================================  
+    [..] This section provides functions allowing to:
+     (+) UART_AdvFeatureConfig() API optionally configures the UART advanced features 
+     (+) HAL_MultiProcessorEx_AddressLength_Set() API optionally sets the UART node address
+         detection length to more than 4 bits for multiprocessor address mark wake up.
+     (+) HAL_UARTEx_EnableStopMode() API enables the UART to wake up the MCU from stop mode   
+     (+) HAL_UARTEx_DisableStopMode() API disables the above functionality
+     (+) HAL_UARTEx_EnableClockStopMode() API enables the UART HSI clock during stop mode   
+     (+) HAL_UARTEx_DisableClockStopMode() API disables the above functionality   
+     (+) UART_Wakeup_AddressConfig() API configures the wake-up from stop mode parameters
+
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief Enable UART Stop Mode
+  * The UART is able to wake up the MCU from Stop mode as long as UART clock is HSI or LSE
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_EnableStopMode(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+  
+  huart->State = HAL_UART_STATE_BUSY;
+  
+  /* Set the USART UESM bit */
+  huart->Instance->CR1 |= USART_CR1_UESM;
+  
+  huart->State = HAL_UART_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+  
+  return HAL_OK; 
+}
+
+/**
+  * @brief Enable UART Clock in Stop Mode
+  * The UART keeps the Clock ON during Stop mode
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_EnableClockStopMode(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+  
+  huart->State = HAL_UART_STATE_BUSY;
+  
+  /* Set the USART UESM bit */
+  huart->Instance->CR3 |= USART_CR3_UCESM;
+  
+  huart->State = HAL_UART_STATE_READY;
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+  
+  return HAL_OK; 
+}
+
+/**
+  * @brief Disable UART Stop Mode 
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_DisableStopMode(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  huart->State = HAL_UART_STATE_BUSY; 
+
+  /* Clear USART UESM bit */
+  huart->Instance->CR1 &= ~(USART_CR1_UESM);
+  
+  huart->State = HAL_UART_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Disable UART Clock in Stop Mode 
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_DisableClockStopMode(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Clear USART UESM bit */
+  huart->Instance->CR3 &= ~(USART_CR3_UCESM);
+
+  huart->State = HAL_UART_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Set Wakeup from Stop mode interrupt flag selection
+  * @param huart: uart handle, 
+  * @param WakeUpSelection: address match, Start Bit detection or RXNE bit status.
+  * This parameter can be one of the following values:
+  *      @arg UART_WAKEUP_ON_ADDRESS
+  *      @arg UART_WAKEUP_ON_STARTBIT
+  *      @arg UART_WAKEUP_ON_READDATA_NONEMPTY
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_StopModeWakeUpSourceConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection)
+{
+  /* Check the wake-up selection parameter */
+  assert_param(IS_UART_WAKEUP_SELECTION(WakeUpSelection.WakeUpEvent));
+
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  huart->State = HAL_UART_STATE_BUSY;
+
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+
+  /* Set the wake-up selection scheme */
+  MODIFY_REG(huart->Instance->CR3, USART_CR3_WUS, WakeUpSelection.WakeUpEvent);
+
+  if(WakeUpSelection.WakeUpEvent == UART_WAKEUP_ON_ADDRESS)
+  {
+    UART_Wakeup_AddressConfig(huart, WakeUpSelection);
+  }
+
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart);
+
+  /* Wait until REACK flag is set before moving huart->State to Ready */
+  if(UART_WaitOnFlagUntilTimeout(huart, USART_ISR_REACK, RESET, UART_REACK_TIMEOUT) != HAL_OK)
+  {
+    return HAL_TIMEOUT;
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  /* Initialize the UART state*/
+  huart->ErrorCode = HAL_UART_ERROR_NONE;
+  huart->State= HAL_UART_STATE_READY;
+
+  return HAL_OK;
+}
+/**
+  * @brief By default in multiprocessor mode, when the wake up method is set 
+  *        to address mark, the UART handles only 4-bit long addresses detection. 
+  *        This API allows to enable longer addresses detection (6-, 7- or 8-bit
+  *        long):
+  *        - 6-bit address detection in 7-bit data mode
+  *        - 7-bit address detection in 8-bit data mode
+  *        - 8-bit address detection in 9-bit data mode
+  * @param huart: UART handle
+  * @param AddressLength: this parameter can be one of the following values:
+  *          @arg UART_ADDRESS_DETECT_4B: 4-bit long address
+  *          @arg UART_ADDRESS_DETECT_7B: 6-, 7- or 8-bit long address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_MultiProcessorEx_AddressLength_Set(UART_HandleTypeDef *huart, uint32_t AddressLength)
+{
+  /* Check the UART handle allocation */
+  if(huart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the address length parameter */
+  assert_param(IS_UART_ADDRESSLENGTH_DETECT(AddressLength));
+  
+  huart->State = HAL_UART_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_UART_DISABLE(huart);
+  
+  /* Set the address length */
+  MODIFY_REG(huart->Instance->CR2, USART_CR2_ADDM7, AddressLength);
+  
+  /* Enable the Peripheral */
+  __HAL_UART_ENABLE(huart); 
+  
+  /* TEACK and/or REACK to check before moving huart->State to Ready */
+  return (UART_CheckIdleState(huart));
+}
+
+/**
+  * @}
+  */  
+
+/**
+  * @brief Initializes the UART wake-up from stop mode parameters when triggered by address detection.
+  * @param huart: uart handle
+  * @param WakeUpSelection: UART wake up from stop mode parameters
+  * @retval HAL status
+  */                        
+static void UART_Wakeup_AddressConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection)
+{
+  assert_param(IS_UART_ADDRESSLENGTH_DETECT(WakeUpSelection.AddressLength));
+  if(WakeUpSelection.AddressLength == UART_ADDRESS_DETECT_4B)
+  {
+    assert_param(IS_UART_4B_ADDRESS(WakeUpSelection.Address));
+  }
+  else
+  {
+    assert_param(IS_UART_7B_ADDRESS(WakeUpSelection.Address));
+  }
+
+  /* Set the USART address length */
+  MODIFY_REG(huart->Instance->CR2, USART_CR2_ADDM7, WakeUpSelection.AddressLength);
+
+  /* Set the USART address node */
+  MODIFY_REG(huart->Instance->CR2, USART_CR2_ADD, ((uint32_t)WakeUpSelection.Address << UART_CR2_ADDRESS_LSB_POS));
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_UART_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_uart_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_uart_ex.h
@@ -1,0 +1,292 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_uart_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of UART HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_UART_EX_H
+#define __STM32L0xx_HAL_UART_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup UARTEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** 
+  * @brief  UART wake up from stop mode parameters
+  */
+typedef struct
+{
+  uint32_t WakeUpEvent;        /*!< Specifies which event will activat the Wakeup from Stop mode flag (WUF).
+                                    This parameter can be a value of @ref UART_WakeUp_from_Stop_Selection.
+                                    If set to UART_WAKEUP_ON_ADDRESS, the two other fields below must
+                                    be filled up. */
+  
+  uint16_t AddressLength;      /*!< Specifies whether the address is 4 or 7-bit long.
+                                    This parameter can be a value of @ref UARTEx_WakeUp_Address_Length  */
+
+  uint8_t Address;             /*!< UART/USART node address (7-bit long max) */
+} UART_WakeUpTypeDef;
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup UARTEx_Extended_Exported_Constants
+  * @{
+  */
+  
+/** @defgroup UARTEx_Word_Length
+  * @{
+  */
+#define UART_WORDLENGTH_7B                  ((uint32_t)USART_CR1_M_1)
+#define UART_WORDLENGTH_8B                  ((uint32_t)0x0000)
+#define UART_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M_0)
+#define IS_UART_WORD_LENGTH(LENGTH) (((LENGTH) == UART_WORDLENGTH_7B) || \
+                                     ((LENGTH) == UART_WORDLENGTH_8B) || \
+                                     ((LENGTH) == UART_WORDLENGTH_9B))
+/**
+  * @}
+  */
+
+/** @defgroup UARTEx_AutoBaud_Rate_Mode
+  * @{
+  */
+#define UART_ADVFEATURE_AUTOBAUDRATE_ONSTARTBIT    ((uint32_t)0x0000)
+#define UART_ADVFEATURE_AUTOBAUDRATE_ONFALLINGEDGE ((uint32_t)USART_CR2_ABRMODE_0)
+#define UART_ADVFEATURE_AUTOBAUDRATE_ON0X7FFRAME   ((uint32_t)USART_CR2_ABRMODE_1)
+#define UART_ADVFEATURE_AUTOBAUDRATE_ON0X55FRAME   ((uint32_t)USART_CR2_ABRMODE)
+#define IS_UART_ADVFEATURE_AUTOBAUDRATEMODE(MODE)  (((MODE) == UART_ADVFEATURE_AUTOBAUDRATE_ONSTARTBIT) || \
+                                                    ((MODE) == UART_ADVFEATURE_AUTOBAUDRATE_ONFALLINGEDGE) || \
+                                                    ((MODE) == UART_ADVFEATURE_AUTOBAUDRATE_ON0X7FFRAME) || \
+                                                    ((MODE) == UART_ADVFEATURE_AUTOBAUDRATE_ON0X55FRAME))
+/**
+  * @}
+  */  
+  
+/** @defgroup UARTEx_WakeUp_Address_Length
+  * @{
+  */
+#define UART_ADDRESS_DETECT_4B                ((uint32_t)0x00000000)
+#define UART_ADDRESS_DETECT_7B                ((uint32_t)USART_CR2_ADDM7)
+#define IS_UART_ADDRESSLENGTH_DETECT(ADDRESS) (((ADDRESS) == UART_ADDRESS_DETECT_4B) || \
+                                               ((ADDRESS) == UART_ADDRESS_DETECT_7B))
+/**
+  * @}
+  */  
+
+  
+/** @defgroup UARTEx_WakeUp_Methods
+  * @{
+  */
+#define UART_WAKEUPMETHOD_IDLELINE                ((uint32_t)0x00000000)
+#define UART_WAKEUPMETHOD_ADDRESSMARK             ((uint32_t)USART_CR1_WAKE)
+#define IS_UART_WAKEUPMETHOD(WAKEUP) (((WAKEUP) == UART_WAKEUPMETHOD_IDLELINE) || \
+                                       ((WAKEUP) == UART_WAKEUPMETHOD_ADDRESSMARK))
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */  
+  
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup UARTEx_Extended_Exported_Macros
+  * @{
+  */
+           
+/** @brief  Reports the UART clock source.
+  * @param  __HANDLE__: specifies the UART Handle
+  * @param  __CLOCKSOURCE__ : output variable   
+  * @retval UART clocking source, written in __CLOCKSOURCE__.
+  */
+#define __HAL_UART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__) \
+  do {                                                        \
+    if((__HANDLE__)->Instance == USART1)                      \
+    {                                                         \
+       switch(__HAL_RCC_GET_USART1_SOURCE())                  \
+       {                                                      \
+        case RCC_USART1CLKSOURCE_PCLK2:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK2;         \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART1CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if((__HANDLE__)->Instance == USART2)                 \
+    {                                                         \
+       switch(__HAL_RCC_GET_USART2_SOURCE())                  \
+       {                                                      \
+        case RCC_USART2CLKSOURCE_PCLK1:                       \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_HSI:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_SYSCLK:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_USART2CLKSOURCE_LSE:                         \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+    else if((__HANDLE__)->Instance == LPUART1)                \
+    {                                                         \
+       switch(__HAL_RCC_GET_LPUART1_SOURCE())                 \
+       {                                                      \
+        case RCC_LPUART1CLKSOURCE_PCLK1:                      \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_PCLK1;         \
+          break;                                              \
+        case RCC_LPUART1CLKSOURCE_HSI:                        \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_HSI;           \
+          break;                                              \
+        case RCC_LPUART1CLKSOURCE_SYSCLK:                     \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_SYSCLK;        \
+          break;                                              \
+        case RCC_LPUART1CLKSOURCE_LSE:                        \
+          (__CLOCKSOURCE__) = UART_CLOCKSOURCE_LSE;           \
+          break;                                              \
+        default:                                              \
+          break;                                              \
+       }                                                      \
+    }                                                         \
+  } while(0)
+
+/** @brief  Reports the UART mask to apply to retrieve the received data
+  *         according to the word length and to the parity bits activation.
+  *         If PCE = 1, the parity bit is not included in the data extracted
+  *         by the reception API().
+  *         This masking operation is not carried out in the case of
+  *         DMA transfers.        
+  * @param  __HANDLE__: specifies the UART Handle
+  * @param  __MASK__ : output variable   
+  * @retval mask to apply to UART RDR register value.
+  */
+#define __HAL_UART_MASK_COMPUTATION(__HANDLE__)                       \
+  do {                                                                \
+  if ((__HANDLE__)->Init.WordLength == UART_WORDLENGTH_9B)            \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == UART_PARITY_NONE)               \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x01FF ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x00FF ;                                 \
+     }                                                                \
+  }                                                                   \
+  else if ((__HANDLE__)->Init.WordLength == UART_WORDLENGTH_8B)       \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == UART_PARITY_NONE)               \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x00FF ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x007F ;                                 \
+     }                                                                \
+  }                                                                   \
+  else if ((__HANDLE__)->Init.WordLength == UART_WORDLENGTH_7B)       \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == UART_PARITY_NONE)               \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x007F ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x003F ;                                 \
+     }                                                                \
+  }                                                                   \
+} while(0)
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/* Initialization/de-initialization functions  ********************************/
+HAL_StatusTypeDef HAL_RS485Ex_Init(UART_HandleTypeDef *huart, uint32_t Polarity, uint32_t AssertionTime, uint32_t DeassertionTime);
+
+/* IO operation functions *****************************************************/
+/* Peripheral Control functions  **********************************************/
+HAL_StatusTypeDef HAL_UARTEx_StopModeWakeUpSourceConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection);
+HAL_StatusTypeDef HAL_UARTEx_EnableStopMode(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_UARTEx_EnableClockStopMode(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_UARTEx_DisableStopMode(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_UARTEx_DisableClockStopMode(UART_HandleTypeDef *huart);
+void HAL_UARTEx_WakeupCallback(UART_HandleTypeDef *huart);
+/* Aliases for inter STM32 series compatibility */
+#define HAL_UART_WakeupCallback         HAL_UARTEx_WakeupCallback
+
+/* Peripheral State functions  ************************************************/
+HAL_StatusTypeDef HAL_MultiProcessorEx_AddressLength_Set(UART_HandleTypeDef *huart, uint32_t AddressLength);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_UART_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_usart.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_usart.c
@@ -1,0 +1,1722 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_usart.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   USART HAL module driver.
+  *
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Universal Synchronous/Asynchronous Receiver Transmitter
+  *          Peripheral (USART).
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral Control functions
+  *           
+  @verbatim       
+ ===============================================================================
+                        ##### How to use this driver #####
+ ===============================================================================
+    [..]
+      The USART HAL driver can be used as follows:
+
+      (#) Declare a USART_HandleTypeDef handle structure.
+      (#) Initialize the USART low level resources by implement the HAL_USART_MspInit ()API:
+          (##) Enable the USARTx interface clock.
+          (##) USART pins configuration:
+              (+++) Enable the clock for the USART GPIOs.
+              (+++) Configure these USART pins as alternate function pull-up.
+          (##) NVIC configuration if you need to use interrupt process (HAL_USART_Transmit_IT(),
+                HAL_USART_Receive_IT() and HAL_USART_TransmitReceive_IT() APIs):
+              (+++) Configure the USARTx interrupt priority.
+              (+++) Enable the NVIC USART IRQ handle.
+              (@) The specific USART interrupts (Transmission complete interrupt, 
+                  RXNE interrupt and Error Interrupts) will be managed using the macros
+                  __HAL_USART_ENABLE_IT() and __HAL_USART_DISABLE_IT() inside the transmit and receive process.
+          (##) DMA Configuration if you need to use DMA process (HAL_USART_Transmit_DMA()
+               HAL_USART_Receive_IT() and HAL_USART_TransmitReceive_IT() APIs):
+              (+++) Declare a DMA handle structure for the Tx/Rx stream.
+              (+++) Enable the DMAx interface clock.
+              (+++) Configure the declared DMA handle structure with the required Tx/Rx parameters.
+              (+++) Configure the DMA Tx/Rx Stream.
+              (+++) Associate the initilalized DMA handle to the USART DMA Tx/Rx handle.
+              (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx/Rx Stream.
+
+      (#) Program the Baud Rate, Word Length, Stop Bit, Parity, Hardware 
+          flow control and Mode(Receiver/Transmitter) in the husart Init structure.
+
+      (#) Initialize the USART registers by calling the HAL_USART_Init() API:
+          (+) These API's configures also the low level Hardware GPIO, CLOCK, CORTEX...etc)
+              by calling the customed HAL_USART_MspInit(&husart) API.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup USART 
+  * @brief USART Synchronous module driver
+  * @{
+  */
+#ifdef HAL_USART_MODULE_ENABLED
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+#define DUMMY_DATA                             ((uint16_t) 0xFFFF)
+#define TEACK_REACK_TIMEOUT                    ((uint32_t) 1000)
+#define HAL_USART_TXDMA_TIMEOUTVALUE           ((uint32_t) 22000)
+
+
+#define USART_CR1_FIELDS        ((uint32_t)(USART_CR1_M | USART_CR1_PCE | \
+                            USART_CR1_PS | USART_CR1_TE | USART_CR1_RE))
+#define USART_CR2_FIELDS       ((uint32_t)(USART_CR2_CPHA | USART_CR2_CPOL | \
+                            USART_CR2_CLKEN | USART_CR2_LBCL | USART_CR2_STOP))
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+static void USART_DMATransmitCplt(DMA_HandleTypeDef *hdma);
+static void USART_DMATxHalfCplt(DMA_HandleTypeDef *hdma);
+static void USART_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
+static void USART_DMARxHalfCplt(DMA_HandleTypeDef *hdma);
+static void USART_DMAError(DMA_HandleTypeDef *hdma); 
+static HAL_StatusTypeDef USART_WaitOnFlagUntilTimeout(USART_HandleTypeDef *husart, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
+static void USART_SetConfig (USART_HandleTypeDef *husart);
+static HAL_StatusTypeDef USART_CheckIdleState(USART_HandleTypeDef *husart);
+static HAL_StatusTypeDef USART_Transmit_IT(USART_HandleTypeDef *husart);
+static HAL_StatusTypeDef USART_Receive_IT(USART_HandleTypeDef *husart);
+static HAL_StatusTypeDef USART_TransmitReceive_IT(USART_HandleTypeDef *husart);
+/* Private functions ---------------------------------------------------------*/
+
+
+/** @defgroup USART_Private_Functions
+  * @{
+  */
+
+/** @defgroup USART_Group1 USART Initialization/de-initialization functions 
+  *  @brief    Initialization and Configuration functions 
+  *
+@verbatim
+ ===============================================================================
+            ##### Initialization and Configuration functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to initialize the USART 
+    in asynchronous and in synchronous modes.
+      (+) For the asynchronous mode only these parameters can be configured: 
+        (++) Baud Rate
+        (++) Word Length 
+        (++) Stop Bit
+        (++) Parity: If the parity is enabled, then the MSB bit of the data written
+             in the data register is transmitted but is changed by the parity bit.
+             Depending on the frame length defined by the M bit (8-bits or 9-bits),
+             the possible USART frame formats are as listed in the following table:
+   +-------------------------------------------------------------+
+   |  M0 bit |  PCE bit  |            USART frame                |
+   |---------------------|---------------------------------------|
+   |    0    |    0      |    | SB | 8 bit data | STB |          |
+   |---------|-----------|---------------------------------------|
+   |    0    |    1      |    | SB | 7 bit data | PB | STB |     |
+   |---------|-----------|---------------------------------------|
+   |    1    |    0      |    | SB | 9 bit data | STB |          |
+   |---------|-----------|---------------------------------------|
+   |    1    |    1      |    | SB | 8 bit data | PB | STB |     |
+   +-------------------------------------------------------------+
+        (++) USART polarity
+        (++) USART phase
+        (++) USART LastBit
+        (++) Receiver/transmitter modes
+
+    [..]
+    The HAL_USART_Init() function follows the USART  synchronous configuration 
+    procedure (details for the procedure are available in reference manual (RM0329)).
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the USART mode according to the specified
+  *         parameters in the USART_InitTypeDef and create the associated handle.
+  * @param  husart: USART handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_USART_Init(USART_HandleTypeDef *husart)
+{
+  /* Check the USART handle allocation */
+  if(husart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_USART_INSTANCE(husart->Instance));
+
+  if(husart->State == HAL_USART_STATE_RESET)
+  {
+    /* Init the low level hardware : GPIO, CLOCK, CORTEX */
+    HAL_USART_MspInit(husart);
+  }
+  
+  husart->State = HAL_USART_STATE_BUSY;
+  
+  /* Disable the Peripheral */
+  __HAL_USART_DISABLE(husart);
+  
+  /* Set the Usart Communication parameters */
+  USART_SetConfig(husart);
+  
+  /* In Synchronous mode, the following bits must be kept cleared: 
+  - LINEN bit in the USART_CR2 register
+  - HDSEL, SCEN and IREN bits in the USART_CR3 register.*/
+  husart->Instance->CR2 &= ~USART_CR2_LINEN;
+  husart->Instance->CR3 &= ~(USART_CR3_SCEN | USART_CR3_HDSEL | USART_CR3_IREN);
+  
+  /* Enable the Peripharal */
+  __HAL_USART_ENABLE(husart);
+  
+  /* TEACK and/or REACK to check before moving husart->State to Ready */
+  return (USART_CheckIdleState(husart));
+}
+
+/**
+  * @brief  DeInitializes the USART peripheral.
+  * @param  husart: USART handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_USART_DeInit(USART_HandleTypeDef *husart)
+{
+   /* Check the USART handle allocation */
+  if(husart == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_USART_INSTANCE(husart->Instance));
+
+  husart->State = HAL_USART_STATE_BUSY;
+  
+  husart->Instance->CR1 = 0x0;
+  husart->Instance->CR2 = 0x0;
+  husart->Instance->CR3 = 0x0;
+  
+  /* DeInit the low level hardware */
+  HAL_USART_MspDeInit(husart);
+
+  husart->ErrorCode = HAL_USART_ERROR_NONE;
+  husart->State = HAL_USART_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(husart);
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  USART MSP Init.
+  * @param  husart: USART handle
+  * @retval None
+  */
+ __weak void HAL_USART_MspInit(USART_HandleTypeDef *husart)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_USART_MspInit could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @brief  USART MSP DeInit.
+  * @param  husart: USART handle
+  * @retval None
+  */
+ __weak void HAL_USART_MspDeInit(USART_HandleTypeDef *husart)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_USART_MspDeInit could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup USART_Group2 IO operation functions 
+  *  @brief   USART Transmit and Receive functions 
+  *
+@verbatim
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+  [..]
+    This subsection provides a set of functions allowing to manage the USART synchronous
+    data transfers.
+      
+    [..] The USART supports master mode only: it cannot receive or send data related to an input
+         clock (SCLK is always an output).
+
+    (#) There are two modes of transfer:
+       (++) Blocking mode: The communication is performed in polling mode. 
+            The HAL status of all data processing is returned by the same function 
+            after finishing transfer.  
+       (++) No-Blocking mode: The communication is performed using Interrupts 
+           or DMA, These API's return the HAL status.
+           The end of the data processing will be indicated through the 
+           dedicated USART IRQ when using Interrupt mode or the DMA IRQ when 
+           using DMA mode.
+           The HAL_USART_TxCpltCallback(), HAL_USART_RxCpltCallback() and HAL_USART_TxRxCpltCallback() user callbacks 
+           will be executed respectivelly at the end of the transmit or Receive process
+           The HAL_USART_ErrorCallback()user callback will be executed when a communication error is detected.
+
+    (#) Blocking mode API's are :
+        (++) HAL_USART_Transmit()in simplex mode
+        (++) HAL_USART_Receive() in full duplex receive only
+        (++) HAL_USART_TransmitReceive() in full duplex mode
+        
+    (#) Non-Blocking mode API's with Interrupt are :
+        (++) HAL_USART_Transmit_IT()in simplex mode
+        (++) HAL_USART_Receive_IT() in full duplex receive only
+        (++) HAL_USART_TransmitReceive_IT()in full duplex mode
+        (++) HAL_USART_IRQHandler()
+
+    (#) No-Blocking mode functions with DMA are :
+        (++) HAL_USART_Transmit_DMA()in simplex mode
+        (++) HAL_USART_Receive_DMA() in full duplex receive only
+        (++) HAL_USART_TransmitReceive_DMA() in full duplex mode
+        (++) HAL_USART_DMAPause()
+        (++) HAL_USART_DMAResume()
+        (++) HAL_USART_DMAStop()
+
+    (#) A set of Transfer Complete Callbacks are provided in No_Blocking mode:
+        (++) HAL_USART_TxCpltCallback()
+        (++) HAL_USART_RxCpltCallback()
+        (++) HAL_USART_TxHalfCpltCallback()
+        (++) HAL_USART_RxHalfCpltCallback()
+        (++) HAL_USART_ErrorCallback()
+        (++) HAL_USART_TxRxCpltCallback()
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Simplex Send an amount of data in blocking mode  
+  * @param  husart: USART handle
+  * @param  pTxData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @param Timeout : Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, uint8_t *pTxData, uint16_t Size, uint32_t Timeout)
+{
+  uint16_t* tmp;
+
+  if(husart->State == HAL_USART_STATE_READY)
+  {
+    if((pTxData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(husart);
+
+    husart->ErrorCode = HAL_USART_ERROR_NONE;
+    husart->State = HAL_USART_STATE_BUSY_TX;
+
+    husart->TxXferSize = Size;
+    husart->TxXferCount = Size;
+    
+    /* Check the remaining data to be sent */
+    while(husart->TxXferCount > 0)
+    {
+      husart->TxXferCount--;
+      if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TXE, RESET, Timeout) != HAL_OK)
+        {
+          return HAL_TIMEOUT;
+        }
+      if((husart->Init.WordLength == USART_WORDLENGTH_9B) && (husart->Init.Parity == USART_PARITY_NONE))
+      {
+        tmp = (uint16_t*) pTxData;
+        husart->Instance->TDR = (*tmp & (uint16_t)0x01FF);
+        pTxData += 2;
+      } 
+      else
+      {
+        husart->Instance->TDR = (*pTxData++ & (uint8_t)0xFF);
+      }
+    }
+
+    if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TC, RESET, Timeout) != HAL_OK)
+    { 
+      return HAL_TIMEOUT;
+    }
+
+    husart->State = HAL_USART_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(husart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in blocking mode 
+  *        To receive synchronous data, dummy data are simultaneously transmitted  
+  * @param husart: USART handle
+  * @param pRxData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @param Timeout : Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_USART_Receive(USART_HandleTypeDef *husart, uint8_t *pRxData, uint16_t Size, uint32_t Timeout)
+{
+  uint16_t* tmp;
+  uint16_t uhMask;
+  
+  if(husart->State == HAL_USART_STATE_READY)
+  {
+    if((pRxData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;
+    }
+    /* Process Locked */
+    __HAL_LOCK(husart);
+
+    husart->ErrorCode = HAL_USART_ERROR_NONE;
+    husart->State = HAL_USART_STATE_BUSY_RX;
+
+    husart->RxXferSize = Size;
+    husart->RxXferCount = Size;
+    
+    /* Computation of USART mask to apply to RDR register */
+    __HAL_USART_MASK_COMPUTATION(husart);
+    uhMask = husart->Mask;
+    
+    /* as long as data have to be received */
+    while(husart->RxXferCount > 0)
+    {
+      husart->RxXferCount--;
+      
+      /* Wait until TXE flag is set to send dummy byte in order to generate the 
+      * clock for the slave to send data.
+       * Whatever the frame length (7, 8 or 9-bit long), the same dummy value 
+       * can be written for all the cases. */
+      if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TXE, RESET, Timeout) != HAL_OK)
+      {            
+        return HAL_TIMEOUT;  
+      }
+      husart->Instance->TDR = (DUMMY_DATA & (uint16_t)0x0FF);         
+        
+      /* Wait for RXNE Flag */
+      if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+      {            
+        return HAL_TIMEOUT;
+      }
+      
+      if((husart->Init.WordLength == USART_WORDLENGTH_9B) && (husart->Init.Parity == USART_PARITY_NONE))
+      {
+        tmp = (uint16_t*) pRxData ;
+        *tmp = (uint16_t)(husart->Instance->RDR & uhMask);
+        pRxData +=2;        
+      } 
+      else
+      {
+        *pRxData++ = (uint8_t)(husart->Instance->RDR & (uint8_t)uhMask);  
+      }
+    }
+
+    husart->State = HAL_USART_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(husart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Full-Duplex Send and Receive an amount of data in blocking mode 
+  * @param husart: USART handle
+  * @param pTxData: pointer to TX data buffer
+  * @param pRxData: pointer to RX data buffer
+  * @param Size: amount of data to be sent (same amount to be received)
+  * @param Timeout : Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size, uint32_t Timeout)
+{
+  uint16_t* tmp;
+  uint16_t uhMask;
+  
+  if(husart->State == HAL_USART_STATE_READY)
+  {
+    if((pTxData == NULL) || (pRxData == NULL) || (Size == 0)) 
+    {
+      return  HAL_ERROR;
+    }
+    /* Process Locked */
+    __HAL_LOCK(husart);
+    
+    husart->ErrorCode = HAL_USART_ERROR_NONE;
+    husart->State = HAL_USART_STATE_BUSY_RX;
+    
+    husart->RxXferSize = Size;
+    husart->TxXferSize = Size;
+    husart->TxXferCount = Size;
+    husart->RxXferCount = Size;
+    
+    /* Computation of USART mask to apply to RDR register */
+    __HAL_USART_MASK_COMPUTATION(husart);
+    uhMask = husart->Mask;
+    
+    /* Check the remain data to be sent */
+    while(husart->TxXferCount > 0)
+    {
+      husart->TxXferCount--;
+      husart->RxXferCount--;
+      
+      /* Wait until TXE flag is set to send data */
+      if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TXE, RESET, Timeout) != HAL_OK)
+      {            
+        return HAL_TIMEOUT;
+      }
+      if((husart->Init.WordLength == USART_WORDLENGTH_9B) && (husart->Init.Parity == USART_PARITY_NONE))
+      {
+        tmp = (uint16_t*) pTxData;
+        husart->Instance->TDR = (*tmp & uhMask);
+        pTxData += 2;
+      }
+      else
+      {
+        husart->Instance->TDR = (*pTxData++ & (uint8_t)uhMask);         
+      }   
+      
+      /* Wait for RXNE Flag */
+      if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_RXNE, RESET, Timeout) != HAL_OK)
+      {            
+        return HAL_TIMEOUT;
+      }
+      
+      if((husart->Init.WordLength == USART_WORDLENGTH_9B) && (husart->Init.Parity == USART_PARITY_NONE))
+      {
+        tmp = (uint16_t*) pRxData ;
+        *tmp = (uint16_t)(husart->Instance->RDR & uhMask);
+        pRxData +=2;        
+      } 
+      else
+      {
+        *pRxData++ = (uint8_t)(husart->Instance->RDR & (uint8_t)uhMask);  
+      }
+    }
+    
+    husart->State = HAL_USART_STATE_READY;
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(husart);
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Send an amount of data in interrupt mode 
+  * @param  husart: USART handle
+  * @param  pTxData: Pointer to data buffer
+  * @param  Size: Amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_USART_Transmit_IT(USART_HandleTypeDef *husart, uint8_t *pTxData, uint16_t Size)
+{
+  if(husart->State == HAL_USART_STATE_READY)
+  {
+    if((pTxData == NULL ) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(husart);
+
+    husart->pTxBuffPtr = pTxData;
+    husart->TxXferSize = Size;
+    husart->TxXferCount = Size;
+
+    husart->ErrorCode = HAL_USART_ERROR_NONE;
+    husart->State = HAL_USART_STATE_BUSY_TX;
+
+    /* The USART Error Interrupts: (Frame error, noise error, overrun error) 
+    are not managed by the USART Transmit Process to avoid the overrun interrupt
+    when the usart mode is configured for transmit and receive "USART_MODE_TX_RX"
+    to benefit for the frame error and noise interrupts the usart mode should be 
+    configured only for transmit "USART_MODE_TX" */
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(husart);
+
+    /* Enable the USART Transmit Complete Interrupt */
+    __HAL_USART_ENABLE_IT(husart, USART_IT_TXE);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in blocking mode 
+  *        To receive synchronous data, dummy data are simultaneously transmitted  
+  * @param husart: usart handle
+  * @param pRxData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_USART_Receive_IT(USART_HandleTypeDef *husart, uint8_t *pRxData, uint16_t Size)
+{
+  if(husart->State == HAL_USART_STATE_READY)
+  {
+    if((pRxData == NULL ) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    /* Process Locked */
+    __HAL_LOCK(husart);
+
+    husart->pRxBuffPtr = pRxData;
+    husart->RxXferSize = Size;
+    husart->RxXferCount = Size;
+
+    __HAL_USART_MASK_COMPUTATION(husart);
+    
+    husart->ErrorCode = HAL_USART_ERROR_NONE;
+    husart->State = HAL_USART_STATE_BUSY_RX;
+    
+    /* Enable the USART Parity Error Interrupt */
+    __HAL_USART_ENABLE_IT(husart, USART_IT_PE);
+
+    /* Enable the USART Error Interrupt: (Frame error, noise error, overrun error) */
+    __HAL_USART_ENABLE_IT(husart, USART_IT_ERR);
+
+    /* Enable the USART Data Register not empty Interrupt */
+    __HAL_USART_ENABLE_IT(husart, USART_IT_RXNE); 
+    
+    /* Process Unlocked */
+    __HAL_UNLOCK(husart);
+
+    /* Send dummy byte in order to generate the clock for the Slave to send the next data */
+    if(husart->Init.WordLength == USART_WORDLENGTH_9B)
+    {
+      husart->Instance->TDR = (DUMMY_DATA & (uint16_t)0x01FF); 
+    } 
+    else
+    {
+      husart->Instance->TDR = (DUMMY_DATA & (uint16_t)0x00FF);
+    }
+    
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Full-Duplex Send and Receive an amount of data in interrupt mode 
+  * @param husart: USART handle
+  * @param pTxData: pointer to TX data buffer
+  * @param pRxData: pointer to RX data buffer
+  * @param Size: amount of data to be sent (same amount to be received)   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, uint8_t *pTxData, uint8_t *pRxData,  uint16_t Size)
+{
+  if(husart->State == HAL_USART_STATE_READY)
+  {
+    if((pTxData == NULL) || (pRxData == NULL) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    /* Process Locked */
+    __HAL_LOCK(husart);
+
+    husart->pRxBuffPtr = pRxData;
+    husart->RxXferSize = Size;
+    husart->RxXferCount = Size;
+    husart->pTxBuffPtr = pTxData;
+    husart->TxXferSize = Size;
+    husart->TxXferCount = Size;
+    
+    /* Computation of USART mask to apply to RDR register */
+    __HAL_USART_MASK_COMPUTATION(husart);
+
+    husart->ErrorCode = HAL_USART_ERROR_NONE;
+    husart->State = HAL_USART_STATE_BUSY_TX_RX;
+
+    /* Enable the USART Data Register not empty Interrupt */
+    __HAL_USART_ENABLE_IT(husart, USART_IT_RXNE); 
+
+    /* Enable the USART Parity Error Interrupt */
+    __HAL_USART_ENABLE_IT(husart, USART_IT_PE);
+
+    /* Enable the USART Error Interrupt: (Frame error, noise error, overrun error) */
+    __HAL_USART_ENABLE_IT(husart, USART_IT_ERR);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(husart);
+
+    /* Enable the USART Transmit Complete Interrupt */
+    __HAL_USART_ENABLE_IT(husart, USART_IT_TXE);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief Send an amount of data in DMA mode 
+  * @param husart: USART handle
+  * @param pTxData: pointer to data buffer
+  * @param Size: amount of data to be sent
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_USART_Transmit_DMA(USART_HandleTypeDef *husart, uint8_t *pTxData, uint16_t Size)
+{
+  uint32_t *tmp;
+  
+  if(husart->State == HAL_USART_STATE_READY)
+  {
+    if((pTxData == NULL ) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    /* Process Locked */
+    __HAL_LOCK(husart);  
+
+    husart->pTxBuffPtr = pTxData;
+    husart->TxXferSize = Size;
+    husart->TxXferCount = Size;
+
+    husart->ErrorCode = HAL_USART_ERROR_NONE;
+    husart->State = HAL_USART_STATE_BUSY_TX;
+
+    /* Set the USART DMA transfer complete callback */
+    husart->hdmatx->XferCpltCallback = USART_DMATransmitCplt;
+
+    /* Set the USART DMA Half transfer complete callback */
+    husart->hdmatx->XferHalfCpltCallback = USART_DMATxHalfCplt;
+
+    /* Set the DMA error callback */
+    husart->hdmatx->XferErrorCallback = USART_DMAError;
+
+    /* Enable the USART transmit DMA channel */
+    tmp = (uint32_t*)&pTxData;
+    HAL_DMA_Start_IT(husart->hdmatx, *(uint32_t*)tmp, (uint32_t)&husart->Instance->TDR, Size);
+
+    /* Enable the DMA transfer for transmit request by setting the DMAT bit
+       in the USART CR3 register */
+    husart->Instance->CR3 |= USART_CR3_DMAT;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(husart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in DMA mode 
+  * @param husart: USART handle
+  * @param pRxData: pointer to data buffer
+  * @param Size: amount of data to be received
+  * @note   When the USART parity is enabled (PCE = 1), the received data contain 
+  *         the parity bit (MSB position)
+  * @retval HAL status
+  * @note The USART DMA transmit stream must be configured in order to generate the clock for the slave.
+  */
+HAL_StatusTypeDef HAL_USART_Receive_DMA(USART_HandleTypeDef *husart, uint8_t *pRxData, uint16_t Size)
+{
+  uint32_t *tmp;
+  
+  if(husart->State == HAL_USART_STATE_READY)
+  {
+    if((pRxData == NULL ) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+
+    /* Process Locked */
+    __HAL_LOCK(husart);
+
+    husart->pRxBuffPtr = pRxData;
+    husart->RxXferSize = Size;
+    husart->pTxBuffPtr = pRxData;
+    husart->TxXferSize = Size;
+
+    husart->ErrorCode = HAL_USART_ERROR_NONE;
+    husart->State = HAL_USART_STATE_BUSY_RX;
+
+    /* Set the USART DMA Rx transfer complete callback */
+    husart->hdmarx->XferCpltCallback = USART_DMAReceiveCplt;
+
+    /* Set the USART DMA Half transfer complete callback */
+    husart->hdmarx->XferHalfCpltCallback = USART_DMARxHalfCplt;
+
+    /* Set the USART DMA Rx transfer error callback */
+    husart->hdmarx->XferErrorCallback = USART_DMAError;
+
+    /* Enable the USART receive DMA Stream */
+    tmp = (uint32_t*)&pRxData;
+    HAL_DMA_Start_IT(husart->hdmarx, (uint32_t)&husart->Instance->RDR, *(uint32_t*)tmp, Size);
+
+    /* Enable the USART transmit DMA channel: the transmit channel is used in order
+       to generate in the non-blocking mode the clock to the slave device, 
+       this mode isn't a simplex receive mode but a full-duplex receive mode */
+    tmp = (uint32_t*)&pRxData;
+    HAL_DMA_Start_IT(husart->hdmatx, *(uint32_t*)tmp, (uint32_t)&husart->Instance->TDR, Size);
+    
+    /* Clear the Overrun flag just before enabling the DMA Rx request: mandatory for the second transfer
+    when using the USART in circular mode */
+    __HAL_USART_CLEAR_IT(husart, USART_CLEAR_OREF);
+    
+    /* Enable the DMA transfer for the receiver request by setting the DMAR bit 
+       in the USART CR3 register */
+    husart->Instance->CR3 |= USART_CR3_DMAR;
+
+    /* Enable the DMA transfer for transmit request by setting the DMAT bit
+       in the USART CR3 register */
+    husart->Instance->CR3 |= USART_CR3_DMAT;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(husart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Full-Duplex Transmit Receive an amount of data in non blocking mode 
+  * @param husart: usart handle
+  * @param pTxData: pointer to TX data buffer
+  * @param pRxData: pointer to RX data buffer
+  * @param Size: amount of data to be received/sent
+  * @note   When the USART parity is enabled (PCE = 1) the data received contain the parity bit.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_USART_TransmitReceive_DMA(USART_HandleTypeDef *husart, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size)
+{
+  uint32_t *tmp;
+  
+  if(husart->State == HAL_USART_STATE_READY)
+  {
+    if((pTxData == NULL) || (pRxData == NULL) || (Size == 0)) 
+    {
+      return HAL_ERROR;
+    }
+    /* Process Locked */
+    __HAL_LOCK(husart);
+
+    husart->pRxBuffPtr = pRxData;
+    husart->RxXferSize = Size;
+    husart->pTxBuffPtr = pTxData;
+    husart->TxXferSize = Size;
+
+    husart->ErrorCode = HAL_USART_ERROR_NONE;
+    husart->State = HAL_USART_STATE_BUSY_TX_RX;
+
+    /* Set the USART DMA Rx transfer complete callback */
+    husart->hdmarx->XferCpltCallback = USART_DMAReceiveCplt;
+
+    /* Set the USART DMA Half transfer complete callback */
+    husart->hdmarx->XferHalfCpltCallback = USART_DMARxHalfCplt;
+
+    /* Set the USART DMA Tx transfer complete callback */
+    husart->hdmatx->XferCpltCallback = USART_DMATransmitCplt;
+
+    /* Set the USART DMA Half transfer complete callback */
+    husart->hdmatx->XferHalfCpltCallback = USART_DMATxHalfCplt;
+
+    /* Set the USART DMA Tx transfer error callback */
+    husart->hdmatx->XferErrorCallback = USART_DMAError;
+
+    /* Set the USART DMA Rx transfer error callback */
+    husart->hdmarx->XferErrorCallback = USART_DMAError;
+
+    /* Enable the USART receive DMA Stream */
+    tmp = (uint32_t*)&pRxData;
+    HAL_DMA_Start_IT(husart->hdmarx, (uint32_t)&husart->Instance->RDR, *(uint32_t*)tmp, Size);
+
+    /* Enable the USART transmit DMA Stream */
+    tmp = (uint32_t*)&pTxData;
+    HAL_DMA_Start_IT(husart->hdmatx, *(uint32_t*)tmp, (uint32_t)&husart->Instance->TDR, Size);
+    
+   /* Clear the Overrun flag: mandatory for the second transfer in circular mode */
+    __HAL_USART_CLEAR_IT(husart, USART_CLEAR_OREF);
+    
+    /* Enable the DMA transfer for the receiver request by setting the DMAR bit 
+       in the USART CR3 register */
+    husart->Instance->CR3 |= USART_CR3_DMAR;
+
+    /* Enable the DMA transfer for transmit request by setting the DMAT bit
+       in the USART CR3 register */
+    husart->Instance->CR3 |= USART_CR3_DMAT;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(husart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Pauses the DMA Transfer.
+  * @param husart: USART handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_USART_DMAPause(USART_HandleTypeDef *husart)
+{
+  /* Process Locked */
+  __HAL_LOCK(husart);
+
+  /* Disable the USART DMA Tx request */
+  husart->Instance->CR3 &= (uint32_t)(~USART_CR3_DMAT);
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(husart);
+
+  return HAL_OK; 
+}
+
+/**
+  * @brief Resumes the DMA Transfer.
+  * @param husart: USART handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_USART_DMAResume(USART_HandleTypeDef *husart)
+{
+  /* Process Locked */
+  __HAL_LOCK(husart);
+ 
+  /* Enable the USART DMA Tx request */
+   husart->Instance->CR3 |= USART_CR3_DMAT;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(husart);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief Stops the DMA Transfer.
+  * @param husart: USART handle
+  * @retval None
+  */
+HAL_StatusTypeDef HAL_USART_DMAStop(USART_HandleTypeDef *husart)
+{
+ /* The Lock is not implemented on this API to allow the user application
+     to call the HAL USART API under callbacks HAL_USART_TxCpltCallback() / HAL_USART_RxCpltCallback():
+     when calling HAL_DMA_Abort() API the DMA TX/RX Transfer complete interrupt is generated
+     and the correspond call back is executed HAL_USART_TxCpltCallback() / HAL_USART_RxCpltCallback()
+     */
+
+  /* Abort the USART DMA tx Stream */
+  if(husart->hdmatx != NULL)
+  {
+    HAL_DMA_Abort(husart->hdmatx);
+  }
+  /* Abort the USART DMA rx Stream */
+  if(husart->hdmarx != NULL)
+  {
+    HAL_DMA_Abort(husart->hdmarx);
+  }
+  
+  /* Disable the USART Tx/Rx DMA requests */
+  husart->Instance->CR3 &= ~USART_CR3_DMAT;
+  husart->Instance->CR3 &= ~USART_CR3_DMAR;
+
+  husart->State = HAL_USART_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles USART interrupt request.
+  * @param  husart: USART handle
+  * @retval None
+  */
+void HAL_USART_IRQHandler(USART_HandleTypeDef *husart)
+{
+  
+  /* USART parity error interrupt occured ------------------------------------*/
+  if((__HAL_USART_GET_IT(husart, USART_IT_PE) != RESET) && (__HAL_USART_GET_IT_SOURCE(husart, USART_IT_PE) != RESET))
+  { 
+    __HAL_USART_CLEAR_IT(husart, USART_IT_PE);
+    husart->ErrorCode |= HAL_USART_ERROR_PE;
+    /* Set the USART state ready to be able to start again the process */
+    husart->State = HAL_USART_STATE_READY;
+  }
+  
+  /* USART frame error interrupt occured -------------------------------------*/
+  if((__HAL_USART_GET_IT(husart, USART_IT_FE) != RESET) && (__HAL_USART_GET_IT_SOURCE(husart, USART_IT_ERR) != RESET))
+  { 
+    __HAL_USART_CLEAR_IT(husart, USART_IT_FE);
+    husart->ErrorCode |= HAL_USART_ERROR_FE;
+    /* Set the USART state ready to be able to start again the process */
+    husart->State = HAL_USART_STATE_READY;
+  }
+  
+  /* USART noise error interrupt occured -------------------------------------*/
+  if((__HAL_USART_GET_IT(husart, USART_IT_NE) != RESET) && (__HAL_USART_GET_IT_SOURCE(husart, USART_IT_ERR) != RESET))
+  { 
+    __HAL_USART_CLEAR_IT(husart, USART_IT_NE);
+    husart->ErrorCode |= HAL_USART_ERROR_NE;
+    /* Set the USART state ready to be able to start again the process */
+    husart->State = HAL_USART_STATE_READY;
+  }
+  
+  /* USART Over-Run interrupt occured ----------------------------------------*/
+  if((__HAL_USART_GET_IT(husart, USART_IT_ORE) != RESET) && (__HAL_USART_GET_IT_SOURCE(husart, USART_IT_ERR) != RESET))
+  { 
+    __HAL_USART_CLEAR_IT(husart, USART_IT_ORE);
+    husart->ErrorCode |= HAL_USART_ERROR_ORE;
+    /* Set the USART state ready to be able to start again the process */
+    husart->State = HAL_USART_STATE_READY;
+  }
+ 
+   /* Call USART Error Call back function if need be --------------------------*/
+  if(husart->ErrorCode != HAL_USART_ERROR_NONE)
+  {
+    HAL_USART_ErrorCallback(husart);
+  }  
+ 
+  /* USART in mode Receiver --------------------------------------------------*/
+  if((__HAL_USART_GET_IT(husart, USART_IT_RXNE) != RESET) && (__HAL_USART_GET_IT_SOURCE(husart, USART_IT_RXNE) != RESET))
+  {
+    if(husart->State == HAL_USART_STATE_BUSY_RX)
+    {
+      USART_Receive_IT(husart);
+    }
+    else
+    {
+      USART_TransmitReceive_IT(husart);
+    }
+  }
+  
+  /* USART in mode Transmitter -----------------------------------------------*/
+  if((__HAL_USART_GET_IT(husart, USART_IT_TXE) != RESET) &&(__HAL_USART_GET_IT_SOURCE(husart, USART_IT_TXE) != RESET))
+  {    
+    if(husart->State == HAL_USART_STATE_BUSY_TX)
+    {
+      USART_Transmit_IT(husart);
+    }
+    else
+    {
+      USART_TransmitReceive_IT(husart);
+    }
+  }
+}
+
+/**
+  * @brief  Tx Transfer completed callbacks.
+  * @param  husart: USART handle
+  * @retval None
+  */
+ __weak void HAL_USART_TxCpltCallback(USART_HandleTypeDef *husart)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_USART_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Tx Half Transfer completed callbacks.
+  * @param  husart: USART handle
+  * @retval None
+  */
+ __weak void HAL_USART_TxHalfCpltCallback(USART_HandleTypeDef *husart)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_USART_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Rx Transfer completed callbacks.
+  * @param  husart: USART handle
+  * @retval None
+  */
+__weak void HAL_USART_RxCpltCallback(USART_HandleTypeDef *husart)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_USART_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Rx Half Transfer completed callbacks.
+  * @param  husart: USART handle
+  * @retval None
+  */
+__weak void HAL_USART_RxHalfCpltCallback(USART_HandleTypeDef *husart)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_USART_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Tx/Rx Transfers completed callback for the non-blocking process.
+  * @param  husart: USART handle
+  * @retval None
+  */
+__weak void HAL_USART_TxRxCpltCallback(USART_HandleTypeDef *husart)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_USART_TxCpltCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  USART error callbacks.
+  * @param  husart: USART handle
+  * @retval None
+  */
+ __weak void HAL_USART_ErrorCallback(USART_HandleTypeDef *husart)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_USART_ErrorCallback could be implemented in the user file
+   */ 
+}
+  
+/**
+  * @}
+  */
+
+/** @defgroup USART_Group3 Peripheral State functions 
+  *  @brief   USART State functions 
+  *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to control the USART.
+     (+) HAL_USART_GetState() API can be helpful to check in run-time the state of the USART peripheral. 
+     (+) HAL_USART_GetError() API can be helpful to check in run-time the Error Code of the USART peripheral. 
+     (+) USART_SetConfig() API is used to set the USART communication parameters.
+     (+) USART_CheckIdleState() APi ensures that TEACK and/or REACK bits are set after initialization
+      
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the USART state.
+  * @param  husart: USART handle
+  * @retval HAL state
+  */
+HAL_USART_StateTypeDef HAL_USART_GetState(USART_HandleTypeDef *husart)
+{
+  return husart->State;
+}
+
+/**
+  * @brief  Return the USART error code
+  * @param  husart : pointer to a USART_HandleTypeDef structure that contains
+  *              the configuration information for the specified USART.
+  * @retval USART Error Code
+  */
+uint32_t HAL_USART_GetError(USART_HandleTypeDef *husart)
+{
+  return husart->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  This function handles USART Communication Timeout.
+  * @param  husart: USART handle
+  * @param  Flag: specifies the USART flag to check.
+  * @param  Status: The new Flag status (SET or RESET).
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef USART_WaitOnFlagUntilTimeout(USART_HandleTypeDef *husart, uint32_t Flag, FlagStatus Status, uint32_t Timeout)  
+{
+  uint32_t tickstart = 0x00;
+  tickstart = HAL_GetTick();
+
+  /* Wait until flag is set */
+  if(Status == RESET)
+  {
+    while(__HAL_USART_GET_FLAG(husart, Flag) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+          __HAL_USART_DISABLE_IT(husart, USART_IT_TXE);
+          __HAL_USART_DISABLE_IT(husart, USART_IT_RXNE);
+          __HAL_USART_DISABLE_IT(husart, USART_IT_PE);
+          __HAL_USART_DISABLE_IT(husart, USART_IT_ERR);
+
+          husart->State= HAL_USART_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(husart);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    while(__HAL_USART_GET_FLAG(husart, Flag) != RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0)||((HAL_GetTick() - tickstart ) > Timeout))
+        {
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+          __HAL_USART_DISABLE_IT(husart, USART_IT_TXE);
+          __HAL_USART_DISABLE_IT(husart, USART_IT_RXNE);
+          __HAL_USART_DISABLE_IT(husart, USART_IT_PE);
+          __HAL_USART_DISABLE_IT(husart, USART_IT_ERR);
+
+          husart->State= HAL_USART_STATE_READY;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(husart);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  DMA USART transmit process complete callback. 
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void USART_DMATransmitCplt(DMA_HandleTypeDef *hdma)
+{
+  USART_HandleTypeDef* husart = ( USART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  /* DMA Normal mode */
+  if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+  {
+    
+    husart->TxXferCount = 0;
+    if(husart->State == HAL_USART_STATE_BUSY_TX)
+    {
+      /* Wait for USART TC Flag */
+      if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TC, RESET, HAL_USART_TXDMA_TIMEOUTVALUE) != HAL_OK)
+      {
+        /* Timeout Occured */ 
+        husart->State = HAL_USART_STATE_TIMEOUT;
+        HAL_USART_ErrorCallback(husart);
+      }
+      else
+      {
+        /* No Timeout */
+        /* Disable the DMA transfer for transmit request by setting the DMAT bit
+        in the USART CR3 register */
+        husart->Instance->CR3 &= ~(USART_CR3_DMAT);
+        husart->State= HAL_USART_STATE_READY;
+      }
+    }
+  }
+  /* DMA Circular mode */
+  else
+  {
+    if(husart->State == HAL_USART_STATE_BUSY_TX)
+    {
+      HAL_USART_TxCpltCallback(husart);
+    }
+  }
+}
+
+/**
+  * @brief DMA USART transmit process half complete callback 
+  * @param hdma : DMA handle
+  * @retval None
+  */
+static void USART_DMATxHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  USART_HandleTypeDef* husart = (USART_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  HAL_USART_TxHalfCpltCallback(husart);
+}
+
+/**
+  * @brief  DMA USART receive process complete callback. 
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void USART_DMAReceiveCplt(DMA_HandleTypeDef *hdma)   
+{
+  USART_HandleTypeDef* husart = ( USART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+  /* DMA Normal mode */
+  if((hdma->Instance->CCR & DMA_CCR_CIRC) == 0)
+  {
+    husart->RxXferCount = 0;
+    husart->State= HAL_USART_STATE_READY;
+    if(husart->State == HAL_USART_STATE_BUSY_RX)
+    {
+      /* Disable the DMA transfer for the Transmit/receiver requests by setting the DMAT/DMAR bit 
+         in the USART CR3 register */
+      husart->Instance->CR3 &= ~(USART_CR3_DMAR);
+
+      HAL_USART_RxCpltCallback(husart);
+    }
+    /* the usart state is HAL_USART_STATE_BUSY_TX_RX*/
+    else
+    {
+      /* Disable the DMA transfer for the Transmit/receiver requests by setting the DMAT/DMAR bit 
+         in the USART CR3 register */
+      husart->Instance->CR3 &= ~(USART_CR3_DMAR);
+      husart->Instance->CR3 &= ~(USART_CR3_DMAT);
+
+      HAL_USART_TxRxCpltCallback(husart);
+    }
+  }
+  /* DMA circular mode */
+  else
+  {
+    if(husart->State == HAL_USART_STATE_BUSY_RX)
+    {
+      HAL_USART_RxCpltCallback(husart);
+    }
+    /* the usart state is HAL_USART_STATE_BUSY_TX_RX*/
+    else
+    {
+      HAL_USART_TxRxCpltCallback(husart);
+    }
+  }
+}
+
+/**
+  * @brief DMA USART receive process half complete callback 
+  * @param hdma : DMA handle
+  * @retval None
+  */
+static void USART_DMARxHalfCplt(DMA_HandleTypeDef *hdma)
+{
+  USART_HandleTypeDef* husart = (USART_HandleTypeDef*)((DMA_HandleTypeDef*)hdma)->Parent;
+
+  HAL_USART_RxHalfCpltCallback(husart); 
+}
+
+/**
+  * @brief  DMA USART communication error callback. 
+  * @param  hdma: DMA handle
+  * @retval None
+  */
+static void USART_DMAError(DMA_HandleTypeDef *hdma)   
+{
+  USART_HandleTypeDef* husart = ( USART_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
+
+  husart->RxXferCount = 0;
+  husart->TxXferCount = 0;
+  husart->ErrorCode |= HAL_USART_ERROR_DMA;
+  husart->State= HAL_USART_STATE_READY;
+  
+  HAL_USART_ErrorCallback(husart);
+}
+
+/**
+  * @brief  Simplex Send an amount of data in non-blocking mode.
+  *         Function called under interruption only, once
+  *         interruptions have been enabled by HAL_USART_Transmit_IT() 
+  * @param  husart: USART handle
+  * @retval HAL status
+  * @note   The USART errors are not managed to avoid the overrun error.
+  */
+static HAL_StatusTypeDef USART_Transmit_IT(USART_HandleTypeDef *husart)
+{
+  uint16_t* tmp;
+ 
+  if(husart->State == HAL_USART_STATE_BUSY_TX)
+  {
+    if(husart->Init.WordLength == USART_WORDLENGTH_9B)
+    {
+      tmp = (uint16_t*) husart->pTxBuffPtr;
+      husart->Instance->TDR = (uint16_t)(*tmp & (uint16_t)0x01FF);
+      if(husart->Init.Parity == USART_PARITY_NONE)
+      {
+        husart->pTxBuffPtr += 2;
+      }
+      else
+      {
+        husart->pTxBuffPtr += 1;
+      }
+    } 
+    else
+    { 
+      husart->Instance->TDR = (uint8_t)(*husart->pTxBuffPtr++ & (uint8_t)0x00FF);
+    }
+    
+    if(--husart->TxXferCount == 0)
+    {
+      /* Disable the USART Transmit data register empty Interrupt */
+      __HAL_USART_DISABLE_IT(husart, USART_IT_TXE);
+
+      /* Disable the USART Error Interrupt: (Frame error, noise error, overrun error) */
+      __HAL_USART_DISABLE_IT(husart, USART_IT_ERR);
+
+
+      if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TC, RESET, HAL_USART_TXDMA_TIMEOUTVALUE) != HAL_OK)
+      { 
+        return HAL_TIMEOUT;
+      }
+      husart->State = HAL_USART_STATE_READY;
+      
+      HAL_USART_TxCpltCallback(husart);
+
+      return HAL_OK;
+    }
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Simplex Receive an amount of data in non-blocking mode.
+  *         Function called under interruption only, once
+  *         interruptions have been enabled by HAL_USART_Receive_IT()    
+  * @param  husart: USART handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef USART_Receive_IT(USART_HandleTypeDef *husart)
+{
+  uint16_t* tmp;
+  uint16_t uhMask = husart->Mask; 
+
+  if(husart->State == HAL_USART_STATE_BUSY_RX)
+  {
+
+    if((husart->Init.WordLength == USART_WORDLENGTH_9B) && (husart->Init.Parity == USART_PARITY_NONE))
+    {
+      tmp = (uint16_t*) husart->pRxBuffPtr;
+      *tmp = (uint16_t)(husart->Instance->RDR & uhMask);
+      husart->pRxBuffPtr += 2;
+    } 
+    else
+    {
+      *husart->pRxBuffPtr++ = (uint8_t)(husart->Instance->RDR & (uint8_t)uhMask);       
+    }
+      /* Send dummy byte in order to generate the clock for the Slave to Send the next data */
+      husart->Instance->TDR = (DUMMY_DATA & (uint16_t)0x00FF);       
+    
+    if(--husart->RxXferCount == 0)
+    { 
+      /* Wait for RXNE Flag */
+      if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_RXNE, RESET, HAL_USART_TXDMA_TIMEOUTVALUE) != HAL_OK)
+      {            
+        return HAL_TIMEOUT;
+      }
+
+      __HAL_USART_DISABLE_IT(husart, USART_IT_RXNE);      
+
+      /* Disable the USART Parity Error Interrupt */
+      __HAL_USART_DISABLE_IT(husart, USART_IT_PE);
+        
+      /* Disable the USART Error Interrupt: (Frame error, noise error, overrun error) */
+      __HAL_USART_DISABLE_IT(husart, USART_IT_ERR);
+        
+      husart->State = HAL_USART_STATE_READY;
+
+
+      HAL_USART_RxCpltCallback(husart);
+      
+      return HAL_OK;
+    }
+
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief  Full-Duplex Send receive an amount of data in full-duplex mode (non-blocking).
+  *         Function called under interruption only, once
+  *         interruptions have been enabled by HAL_USART_TransmitReceive_IT()     
+  * @param  husart: USART handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef USART_TransmitReceive_IT(USART_HandleTypeDef *husart)
+{
+  uint16_t* tmp;
+  uint16_t uhMask = husart->Mask; 
+
+  if(husart->State == HAL_USART_STATE_BUSY_TX_RX)
+  {
+    if(husart->TxXferCount != 0x00)
+    {
+      if(__HAL_USART_GET_FLAG(husart, USART_FLAG_TC) != RESET)
+      {
+        if((husart->Init.WordLength == USART_WORDLENGTH_9B) && (husart->Init.Parity == USART_PARITY_NONE))
+        {
+          tmp = (uint16_t*) husart->pTxBuffPtr;
+          husart->Instance->TDR = (uint16_t)(*tmp & uhMask);
+          husart->pTxBuffPtr += 2;
+        } 
+        else
+        {
+          husart->Instance->TDR = (uint8_t)(*husart->pTxBuffPtr++ & (uint8_t)uhMask);
+        }
+        husart->TxXferCount--;
+
+        /* Check the latest data transmitted */
+        if(husart->TxXferCount == 0)
+        {
+           __HAL_USART_DISABLE_IT(husart, USART_IT_TXE);
+        }
+      }
+    }
+
+    if(husart->RxXferCount != 0x00)
+    {
+      if(__HAL_USART_GET_FLAG(husart, USART_FLAG_RXNE) != RESET)
+      {
+        if((husart->Init.WordLength == USART_WORDLENGTH_9B) && (husart->Init.Parity == USART_PARITY_NONE))
+        {
+          tmp = (uint16_t*) husart->pRxBuffPtr;
+          *tmp = (uint16_t)(husart->Instance->RDR & uhMask);
+          husart->pRxBuffPtr += 2;          
+        } 
+        else
+        {
+          *husart->pRxBuffPtr++ = (uint8_t)(husart->Instance->RDR & (uint8_t)uhMask);
+        }
+        husart->RxXferCount--;
+      }
+    }
+
+    /* Check the latest data received */
+    if(husart->RxXferCount == 0)
+    {
+      __HAL_USART_DISABLE_IT(husart, USART_IT_RXNE);
+
+      /* Disable the USART Parity Error Interrupt */
+      __HAL_USART_DISABLE_IT(husart, USART_IT_PE);
+
+      /* Disable the USART Error Interrupt: (Frame error, noise error, overrun error) */
+      __HAL_USART_DISABLE_IT(husart, USART_IT_ERR);
+
+      husart->State = HAL_USART_STATE_READY;
+
+      HAL_USART_TxRxCpltCallback(husart);
+
+      return HAL_OK;
+    }
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(husart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY; 
+  }
+}
+
+/**
+  * @brief Configure the USART peripheral 
+  * @param husart: USART handle
+  * @retval None
+  */
+static void USART_SetConfig(USART_HandleTypeDef *husart)
+{
+  uint32_t tmpreg      = 0x0;
+  uint32_t clocksource = 0x0;
+  
+  /* Check the parameters */
+  assert_param(IS_USART_INSTANCE(husart->Instance));
+  assert_param(IS_USART_POLARITY(husart->Init.CLKPolarity));
+  assert_param(IS_USART_PHASE(husart->Init.CLKPhase));
+  assert_param(IS_USART_LASTBIT(husart->Init.CLKLastBit));
+  assert_param(IS_USART_BAUDRATE(husart->Init.BaudRate));  
+  assert_param(IS_USART_WORD_LENGTH(husart->Init.WordLength));
+  assert_param(IS_USART_STOPBITS(husart->Init.StopBits));
+  assert_param(IS_USART_PARITY(husart->Init.Parity));
+  assert_param(IS_USART_MODE(husart->Init.Mode));
+
+  /*-------------------------- USART CR1 Configuration -----------------------*/
+   /* Clear M, PCE, PS, TE and RE bits and configure       
+   *  the USART Word Length, Parity, Mode and oversampling: 
+   *  set the M bits according to husart->Init.WordLength value 
+   *  set PCE and PS bits according to husart->Init.Parity value
+   *  set TE and RE bits according to husart->Init.Mode value */
+  tmpreg = (uint32_t)husart->Init.WordLength | husart->Init.Parity | husart->Init.Mode ;
+  MODIFY_REG(husart->Instance->CR1, USART_CR1_FIELDS, tmpreg);
+  
+  /*---------------------------- USART CR2 Configuration ---------------------*/
+  /* Clear and configure the USART Clock, CPOL, CPHA, LBCL and STOP bits:
+   * set CPOL bit according to husart->Init.CLKPolarity value
+   * set CPHA bit according to husart->Init.CLKPhase value
+   * set LBCL bit according to husart->Init.CLKLastBit value
+   * set STOP[13:12] bits according to husart->Init.StopBits value */
+  tmpreg = (uint32_t)(USART_CLOCK_ENABLED); 
+  tmpreg |= (uint32_t)(husart->Init.CLKPolarity | husart->Init.CLKPhase);
+  tmpreg |= (uint32_t)(husart->Init.CLKLastBit | husart->Init.StopBits);
+  MODIFY_REG(husart->Instance->CR2, USART_CR2_FIELDS, tmpreg);
+
+  /*-------------------------- USART CR3 Configuration -----------------------*/
+  /* no CR3 register configuration                                            */
+
+  /*-------------------------- USART BRR Configuration -----------------------*/
+  __HAL_USART_GETCLOCKSOURCE(husart, clocksource);
+  switch (clocksource)
+  {
+  case USART_CLOCKSOURCE_PCLK1: 
+    husart->Instance->BRR = (uint16_t)(HAL_RCC_GetPCLK1Freq() / husart->Init.BaudRate);
+    break;
+  case USART_CLOCKSOURCE_PCLK2: 
+    husart->Instance->BRR = (uint16_t)(HAL_RCC_GetPCLK2Freq() / husart->Init.BaudRate);
+    break;
+  case USART_CLOCKSOURCE_HSI: 
+    husart->Instance->BRR = (uint16_t)(HSI_VALUE / husart->Init.BaudRate); 
+    break; 
+  case USART_CLOCKSOURCE_SYSCLK:  
+    husart->Instance->BRR = (uint16_t)(HAL_RCC_GetSysClockFreq() / husart->Init.BaudRate);
+    break;  
+  case USART_CLOCKSOURCE_LSE:                
+    husart->Instance->BRR = (uint16_t)(LSE_VALUE / husart->Init.BaudRate); 
+    break;
+  default:
+    break;    
+  } 
+}
+
+/**
+  * @brief Check the USART Idle State
+  * @param husart: USART handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef USART_CheckIdleState(USART_HandleTypeDef *husart)
+{
+   /* Initialize the USART ErrorCode */
+  husart->ErrorCode = HAL_USART_ERROR_NONE;
+  
+  /* Check if the Transmitter is enabled */
+  if((husart->Instance->CR1 & USART_CR1_TE) == USART_CR1_TE)
+  {
+    /* Wait until TEACK flag is set */
+    if(USART_WaitOnFlagUntilTimeout(husart, USART_ISR_TEACK, RESET, TEACK_REACK_TIMEOUT) != HAL_OK)  
+    { 
+      husart->State= HAL_USART_STATE_TIMEOUT;      
+      return HAL_TIMEOUT;
+    } 
+  }
+  /* Check if the Receiver is enabled */
+  if((husart->Instance->CR1 & USART_CR1_RE) == USART_CR1_RE)
+  {
+    /* Wait until REACK flag is set */
+    if(USART_WaitOnFlagUntilTimeout(husart, USART_ISR_REACK, RESET, TEACK_REACK_TIMEOUT) != HAL_OK)  
+    { 
+      husart->State= HAL_USART_STATE_TIMEOUT;       
+      return HAL_TIMEOUT;
+    }
+  }
+  
+  /* Process Unlocked */
+  __HAL_UNLOCK(husart);
+        
+  /* Initialize the USART state*/
+  husart->State= HAL_USART_STATE_READY;
+  
+  return HAL_OK;  
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_USART_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_usart.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_usart.h
@@ -1,0 +1,557 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_usart.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of USART HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  * Unless required by applicable law or agreed to in writing, software 
+  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_USART_H
+#define __STM32L0xx_HAL_USART_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup USART
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/ 
+/** 
+  * @brief USART Init Structure definition  
+  */ 
+typedef struct
+{
+  uint32_t BaudRate;                  /*!< This member configures the Usart communication baud rate.
+                                           The baud rate is computed using the following formula:
+                                              Baud Rate Register = ((PCLKx) / ((huart->Init.BaudRate))) */
+
+  uint32_t WordLength;                /*!< Specifies the number of data bits transmitted or received in a frame.
+                                           This parameter can be a value of @ref USARTEx_Word_Length */
+
+  uint32_t StopBits;                  /*!< Specifies the number of stop bits transmitted.
+                                           This parameter can be a value of @ref USART_Stop_Bits */
+
+  uint32_t Parity;                   /*!< Specifies the parity mode.
+                                           This parameter can be a value of @ref USART_Parity
+                                           @note When parity is enabled, the computed parity is inserted
+                                                 at the MSB position of the transmitted data (9th bit when
+                                                 the word length is set to 9 data bits; 8th bit when the
+                                                 word length is set to 8 data bits). */
+ 
+  uint32_t Mode;                      /*!< Specifies wether the Receive or Transmit mode is enabled or disabled.
+                                           This parameter can be a value of @ref USART_Mode */
+
+  uint32_t CLKPolarity;               /*!< Specifies the steady state of the serial clock.
+                                           This parameter can be a value of @ref USART_Clock_Polarity */
+
+  uint32_t CLKPhase;                  /*!< Specifies the clock transition on which the bit capture is made.
+                                           This parameter can be a value of @ref USART_Clock_Phase */
+
+  uint32_t CLKLastBit;                /*!< Specifies whether the clock pulse corresponding to the last transmitted
+                                           data bit (MSB) has to be output on the SCLK pin in synchronous mode.
+                                           This parameter can be a value of @ref USART_Last_Bit */
+}USART_InitTypeDef;
+
+/** 
+  * @brief HAL State structures definition  
+  */ 
+typedef enum
+{
+  HAL_USART_STATE_RESET             = 0x00,    /*!< Peripheral Reset state */  
+  HAL_USART_STATE_READY             = 0x01,    /*!< Peripheral Initialized and ready for use */
+  HAL_USART_STATE_BUSY              = 0x02,    /*!< an internal process is ongoing */   
+  HAL_USART_STATE_BUSY_TX           = 0x12,    /*!< Data Transmission process is ongoing */ 
+  HAL_USART_STATE_BUSY_RX           = 0x22,    /*!< Data Reception process is ongoing */
+  HAL_USART_STATE_BUSY_TX_RX        = 0x32,    /*!< Data Transmission Reception process is ongoing */
+  HAL_USART_STATE_TIMEOUT           = 0x03,    /*!< Timeout state */
+  HAL_USART_STATE_ERROR             = 0x04     /*!< Error */      
+}HAL_USART_StateTypeDef;
+
+/** 
+  * @brief  HAL USART Error Code structure definition  
+  */ 
+typedef enum
+{
+  HAL_USART_ERROR_NONE      = 0x00,    /*!< No error            */
+  HAL_USART_ERROR_PE        = 0x01,    /*!< Parity error        */
+  HAL_USART_ERROR_NE        = 0x02,    /*!< Noise error         */
+  HAL_USART_ERROR_FE        = 0x04,    /*!< frame error         */
+  HAL_USART_ERROR_ORE       = 0x08,    /*!< Overrun error       */
+  HAL_USART_ERROR_DMA       = 0x10     /*!< DMA transfer error  */
+}HAL_USART_ErrorTypeDef;
+
+/** 
+  * @brief  USART clock sources definitions
+  */
+typedef enum
+{
+  USART_CLOCKSOURCE_PCLK1      = 0x00,    /*!< PCLK1 clock source  */
+  USART_CLOCKSOURCE_PCLK2      = 0x01,    /*!< PCLK2 clock source  */
+  USART_CLOCKSOURCE_HSI        = 0x02,    /*!< HSI clock source    */
+  USART_CLOCKSOURCE_SYSCLK     = 0x04,    /*!< SYSCLK clock source */
+  USART_CLOCKSOURCE_LSE        = 0x08     /*!< LSE clock source     */
+}USART_ClockSourceTypeDef;
+
+
+/** 
+  * @brief  HAL USART Error Code structure definition  
+  */ 
+
+/** 
+  * @brief  USART handle Structure definition  
+  */  
+typedef struct
+{
+  USART_TypeDef                 *Instance;        /*!<  USART registers base address        */
+
+  USART_InitTypeDef             Init;             /*!<  Usart communication parameters      */
+  
+  uint8_t                       *pTxBuffPtr;      /*!<  Pointer to Usart Tx transfer Buffer */
+  
+  uint16_t                      TxXferSize;       /*!<  Usart Tx Transfer size              */
+  
+  __IO uint16_t                 TxXferCount;      /*!<  Usart Tx Transfer Counter           */
+  
+  uint8_t                       *pRxBuffPtr;      /*!<  Pointer to Usart Rx transfer Buffer */
+  
+  uint16_t                      RxXferSize;       /*!<  Usart Rx Transfer size              */
+  
+  __IO uint16_t                 RxXferCount;      /*!<  Usart Rx Transfer Counter           */
+
+  uint16_t                      Mask;             /* USART Rx RDR register mask             */  
+  
+  DMA_HandleTypeDef             *hdmatx;          /*!<  Usart Tx DMA Handle parameters      */
+    
+  DMA_HandleTypeDef             *hdmarx;          /*!<  Usart Rx DMA Handle parameters      */
+  
+  HAL_LockTypeDef                Lock;            /*!<  Locking object                      */
+  
+  __IO HAL_USART_StateTypeDef    State;           /*!<  Usart communication state           */
+  
+  __IO HAL_USART_ErrorTypeDef    ErrorCode;       /*!<  USART Error code                    */
+  
+}USART_HandleTypeDef;
+
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup USART_Exported_Constants
+  * @{
+  */
+
+/** @defgroup USART_Stop_Bits
+  * @{
+  */
+#define USART_STOPBITS_1                     ((uint32_t)0x0000)
+#define USART_STOPBITS_0_5                   ((uint32_t)USART_CR2_STOP_0)
+#define USART_STOPBITS_2                     ((uint32_t)USART_CR2_STOP_1)
+#define USART_STOPBITS_1_5                   ((uint32_t)(USART_CR2_STOP_0 | USART_CR2_STOP_1))
+#define IS_USART_STOPBITS(STOPBITS) (((STOPBITS) == USART_STOPBITS_1) || \
+                                         ((STOPBITS) == USART_STOPBITS_0_5) || \
+                                         ((STOPBITS) == USART_STOPBITS_1_5) || \
+                                         ((STOPBITS) == USART_STOPBITS_2))
+/**
+  * @}
+  */ 
+
+/** @defgroup USART_Parity
+  * @{
+  */ 
+#define USART_PARITY_NONE                    ((uint32_t)0x0000)
+#define USART_PARITY_EVEN                    ((uint32_t)USART_CR1_PCE)
+#define USART_PARITY_ODD                     ((uint32_t)(USART_CR1_PCE | USART_CR1_PS)) 
+#define IS_USART_PARITY(PARITY) (((PARITY) == USART_PARITY_NONE) || \
+                                     ((PARITY) == USART_PARITY_EVEN) || \
+                                     ((PARITY) == USART_PARITY_ODD))
+/**
+  * @}
+  */ 
+
+/** @defgroup USART_Mode
+  * @{
+  */ 
+#define USART_MODE_RX                        ((uint32_t)USART_CR1_RE)
+#define USART_MODE_TX                        ((uint32_t)USART_CR1_TE)
+#define USART_MODE_TX_RX                     ((uint32_t)(USART_CR1_TE |USART_CR1_RE))
+#define IS_USART_MODE(MODE) ((((MODE) & (uint32_t)0xFFFFFFF3) == 0x00) && ((MODE) != (uint32_t)0x00))
+/**
+  * @}
+  */
+    
+/** @defgroup USART_Clock
+  * @{
+  */ 
+#define USART_CLOCK_DISABLED                 ((uint32_t)0x0000)
+#define USART_CLOCK_ENABLED                  ((uint32_t)USART_CR2_CLKEN)
+#define IS_USART_CLOCK(CLOCK)      (((CLOCK) == USART_CLOCK_DISABLED) || \
+                                   ((CLOCK) == USART_CLOCK_ENABLED))
+/**
+  * @}
+  */ 
+
+/** @defgroup USART_Clock_Polarity
+  * @{
+  */
+#define USART_POLARITY_LOW                   ((uint32_t)0x0000)
+#define USART_POLARITY_HIGH                  ((uint32_t)USART_CR2_CPOL)
+#define IS_USART_POLARITY(CPOL) (((CPOL) == USART_POLARITY_LOW) || ((CPOL) == USART_POLARITY_HIGH))
+/**
+  * @}
+  */ 
+
+/** @defgroup USART_Clock_Phase
+  * @{
+  */
+#define USART_PHASE_1EDGE                    ((uint32_t)0x0000)
+#define USART_PHASE_2EDGE                    ((uint32_t)USART_CR2_CPHA)
+#define IS_USART_PHASE(CPHA) (((CPHA) == USART_PHASE_1EDGE) || ((CPHA) == USART_PHASE_2EDGE))
+/**
+  * @}
+  */
+
+/** @defgroup USART_Last_Bit
+  * @{
+  */
+#define USART_LASTBIT_DISABLE                ((uint32_t)0x0000)
+#define USART_LASTBIT_ENABLE                 ((uint32_t)USART_CR2_LBCL)
+#define IS_USART_LASTBIT(LASTBIT) (((LASTBIT) == USART_LASTBIT_DISABLE) || \
+                                       ((LASTBIT) == USART_LASTBIT_ENABLE))
+/**
+  * @}
+  */
+
+
+/** @defgroup USART_Flags
+  *        Elements values convention: 0xXXXX
+  *           - 0xXXXX  : Flag mask in the ISR register
+  * @{
+  */
+#define USART_FLAG_REACK                     ((uint32_t)0x00400000)
+#define USART_FLAG_TEACK                     ((uint32_t)0x00200000)  
+#define USART_FLAG_BUSY                      ((uint32_t)0x00010000)
+#define USART_FLAG_CTS                       ((uint32_t)0x00000400)
+#define USART_FLAG_CTSIF                     ((uint32_t)0x00000200)
+#define USART_FLAG_LBDF                      ((uint32_t)0x00000100)
+#define USART_FLAG_TXE                       ((uint32_t)0x00000080)
+#define USART_FLAG_TC                        ((uint32_t)0x00000040)
+#define USART_FLAG_RXNE                      ((uint32_t)0x00000020)
+#define USART_FLAG_IDLE                      ((uint32_t)0x00000010)
+#define USART_FLAG_ORE                       ((uint32_t)0x00000008)
+#define USART_FLAG_NE                        ((uint32_t)0x00000004)
+#define USART_FLAG_FE                        ((uint32_t)0x00000002)
+#define USART_FLAG_PE                        ((uint32_t)0x00000001)
+/**
+  * @}
+  */
+
+/** @defgroup USART_Interrupt_definition
+  *        Elements values convention: 0000ZZZZ0XXYYYYYb
+  *           - YYYYY  : Interrupt source position in the XX register (5bits)
+  *           - XX  : Interrupt source register (2bits)
+  *                 - 01: CR1 register
+  *                 - 10: CR2 register
+  *                 - 11: CR3 register
+  *           - ZZZZ  : Flag position in the ISR register(4bits)
+  * @{
+  */
+  
+#define USART_IT_PE                          ((uint16_t)0x0028)
+#define USART_IT_TXE                         ((uint16_t)0x0727)
+#define USART_IT_TC                          ((uint16_t)0x0626)
+#define USART_IT_RXNE                        ((uint16_t)0x0525)
+#define USART_IT_IDLE                        ((uint16_t)0x0424)
+#define USART_IT_ERR                         ((uint16_t)0x0060)
+
+#define USART_IT_ORE                         ((uint16_t)0x0300)
+#define USART_IT_NE                          ((uint16_t)0x0200)
+#define USART_IT_FE                          ((uint16_t)0x0100)
+/**
+  * @}
+  */
+
+/** @defgroup USART_IT_CLEAR_Flags
+  * @{
+  */
+#define USART_CLEAR_PEF                       USART_ICR_PECF            /*!< Parity Error Clear Flag */          
+#define USART_CLEAR_FEF                       USART_ICR_FECF            /*!< Framing Error Clear Flag */         
+#define USART_CLEAR_NEF                       USART_ICR_NCF             /*!< Noise detected Clear Flag */        
+#define USART_CLEAR_OREF                      USART_ICR_ORECF           /*!< OverRun Error Clear Flag */         
+#define USART_CLEAR_IDLEF                     USART_ICR_IDLECF          /*!< IDLE line detected Clear Flag */    
+#define USART_CLEAR_TCF                       USART_ICR_TCCF            /*!< Transmission Complete Clear Flag */ 
+#define USART_CLEAR_CTSF                      USART_ICR_CTSCF           /*!< CTS Interrupt Clear Flag */         
+/**
+  * @}
+  */ 
+
+/** @defgroup USART_Request_Parameters
+  * @{
+  */
+#define USART_RXDATA_FLUSH_REQUEST        ((uint32_t)USART_RQR_RXFRQ)        /*!< Receive Data flush Request */ 
+#define USART_TXDATA_FLUSH_REQUEST        ((uint32_t)USART_RQR_TXFRQ)        /*!< Transmit data flush Request */
+#define IS_USART_REQUEST_PARAMETER(PARAM) (((PARAM) == USART_RXDATA_FLUSH_REQUEST) || \
+                                           ((PARAM) == USART_TXDATA_FLUSH_REQUEST))   
+/**
+  * @}
+  */
+
+/** @defgroup USART_Interruption_Mask
+  * @{
+  */  
+#define USART_IT_MASK                             ((uint16_t)0x001F)  
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+    
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup USART_Exported_Macros
+  * @{
+  */
+/** @brief Reset USART handle state
+  * @param  __HANDLE__: specifies the UART Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @retval None
+  */
+#define __HAL_USART_RESET_HANDLE_STATE(__HANDLE__)  ((__HANDLE__)->State = HAL_USART_STATE_RESET)
+
+/** @brief  Checks whether the specified USART flag is set or not.
+  * @param  __HANDLE__: specifies the USART Handle which can be USART1 or USART2.
+  * @param  __FLAG__: specifies the flag to check.
+  *        This parameter can be one of the following values:
+  *            @arg USART_FLAG_REACK: Receive enable ackowledge flag
+  *            @arg USART_FLAG_TEACK: Transmit enable ackowledge flag
+  *            @arg USART_FLAG_BUSY:  Busy flag                  
+  *            @arg USART_FLAG_CTS:   CTS Change flag         
+  *            @arg USART_FLAG_TXE:   Transmit data register empty flag
+  *            @arg USART_FLAG_TC:    Transmission Complete flag
+  *            @arg USART_FLAG_RXNE:  Receive data register not empty flag
+  *            @arg USART_FLAG_IDLE:  Idle Line detection flag
+  *            @arg USART_FLAG_ORE:   OverRun Error flag
+  *            @arg USART_FLAG_NE:    Noise Error flag
+  *            @arg USART_FLAG_FE:    Framing Error flag
+  *            @arg USART_FLAG_PE:    Parity Error flag
+  * @retval The new state of __FLAG__ (TRUE or FALSE).
+  */
+#define __HAL_USART_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->ISR & (__FLAG__)) == (__FLAG__))
+
+
+/** @brief  Enables the specified USART interrupt.
+  * @param  __HANDLE__: specifies the USART Handle which can be USART1 or USART2.
+  * @param  __INTERRUPT__: specifies the USART interrupt source to enable.
+  *          This parameter can be one of the following values:
+  *            @arg USART_IT_TXE:  Transmit Data Register empty interrupt
+  *            @arg USART_IT_TC:   Transmission complete interrupt
+  *            @arg USART_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg USART_IT_IDLE: Idle line detection interrupt
+  *            @arg USART_IT_PE:   Parity Error interrupt
+  *            @arg USART_IT_ERR:  Error interrupt(Frame error, noise error, overrun error)
+  * @retval None
+  */
+#define __HAL_USART_ENABLE_IT(__HANDLE__, __INTERRUPT__)(((((uint8_t)(__INTERRUPT__)) >> 5) == 1)? ((__HANDLE__)->Instance->CR1 |= (1 << ((__INTERRUPT__) & USART_IT_MASK))): \
+                                                        ((((uint8_t)(__INTERRUPT__)) >> 5) == 2)? ((__HANDLE__)->Instance->CR2 |= (1 << ((__INTERRUPT__) & USART_IT_MASK))): \
+                                                        ((__HANDLE__)->Instance->CR3 |= (1 << ((__INTERRUPT__) & USART_IT_MASK))))
+
+/** @brief  Disables the specified USART interrupt.
+  * @param  __HANDLE__: specifies the USART Handle which can be USART1 or USART2.
+  * @param  __INTERRUPT__: specifies the USART interrupt source to disable.
+  *          This parameter can be one of the following values:
+  *            @arg USART_IT_TXE:  Transmit Data Register empty interrupt
+  *            @arg USART_IT_TC:   Transmission complete interrupt
+  *            @arg USART_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg USART_IT_IDLE: Idle line detection interrupt
+  *            @arg USART_IT_PE:   Parity Error interrupt
+  *            @arg USART_IT_ERR:  Error interrupt(Frame error, noise error, overrun error)
+  * @retval None
+  */
+#define __HAL_USART_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (((((uint8_t)(__INTERRUPT__)) >> 5) == 1)? ((__HANDLE__)->Instance->CR1 &= ~ ((uint32_t)1 << ((__INTERRUPT__) & USART_IT_MASK))): \
+                                                        ((((uint8_t)(__INTERRUPT__)) >> 5) == 2)? ((__HANDLE__)->Instance->CR2 &= ~ ((uint32_t)1 << ((__INTERRUPT__) & USART_IT_MASK))): \
+                                                        ((__HANDLE__)->Instance->CR3 &= ~ ((uint32_t)1 << ((__INTERRUPT__) & USART_IT_MASK))))
+
+/** @brief  Checks whether the specified USART interrupt has occurred or not.
+  * @param  __HANDLE__: specifies the USART Handle which can be USART1 or USART2.
+  * @param  __IT__: specifies the USART interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg USART_IT_TXE: Transmit Data Register empty interrupt
+  *            @arg USART_IT_TC:  Transmission complete interrupt
+  *            @arg USART_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg USART_IT_IDLE: Idle line detection interrupt
+  *            @arg USART_IT_ORE: OverRun Error interrupt
+  *            @arg USART_IT_NE: Noise Error interrupt
+  *            @arg USART_IT_FE: Framing Error interrupt
+  *            @arg USART_IT_PE: Parity Error interrupt
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_USART_GET_IT(__HANDLE__, __IT__) ((__HANDLE__)->Instance->ISR & ((uint32_t)1 << ((__IT__)>> 0x08))) 
+
+/** @brief  Checks whether the specified USART interrupt source is enabled.
+  * @param  __HANDLE__: specifies the USART Handle which can be USART1 or USART2.
+  * @param  __IT__: specifies the USART interrupt source to check.
+  *          This parameter can be one of the following values:
+  *            @arg USART_IT_TXE: Transmit Data Register empty interrupt
+  *            @arg USART_IT_TC:  Transmission complete interrupt
+  *            @arg USART_IT_RXNE: Receive Data register not empty interrupt
+  *            @arg USART_IT_IDLE: Idle line detection interrupt
+  *            @arg USART_IT_ORE: OverRun Error interrupt
+  *            @arg USART_IT_NE: Noise Error interrupt
+  *            @arg USART_IT_FE: Framing Error interrupt
+  *            @arg USART_IT_PE: Parity Error interrupt
+  * @retval The new state of __IT__ (TRUE or FALSE).
+  */
+#define __HAL_USART_GET_IT_SOURCE(__HANDLE__, __IT__) ((((((uint8_t)(__IT__)) >> 5) == 1)? (__HANDLE__)->Instance->CR1:(((((uint8_t)(__IT__)) >> 5) == 2)? \
+                                                   (__HANDLE__)->Instance->CR2 : (__HANDLE__)->Instance->CR3)) & ((uint32_t)1 << \
+                                                   (((uint16_t)(__IT__)) & USART_IT_MASK)))
+
+
+/** @brief  Clears the specified USART ISR flag, in setting the proper ICR register flag.
+  * @param  __HANDLE__: specifies the USART Handle which can be USART1 or USART2.
+  * @param  __IT_CLEAR__: specifies the interrupt clear register flag that needs to be set
+  *                       to clear the corresponding interrupt
+  *          This parameter can be one of the following values:
+  *            @arg USART_CLEAR_PEF: Parity Error Clear Flag
+  *            @arg USART_CLEAR_FEF: Framing Error Clear Flag
+  *            @arg USART_CLEAR_NEF: Noise detected Clear Flag
+  *            @arg USART_CLEAR_OREF: OverRun Error Clear Flag
+  *            @arg USART_CLEAR_IDLEF: IDLE line detected Clear Flag
+  *            @arg USART_CLEAR_TCF: Transmission Complete Clear Flag 
+  *            @arg USART_CLEAR_CTSF: CTS Interrupt Clear Flag
+  * @retval None
+  */
+#define __HAL_USART_CLEAR_IT(__HANDLE__, __IT_CLEAR__) ((__HANDLE__)->Instance->ICR = (uint32_t)(__IT_CLEAR__)) 
+
+/** @brief  Set a specific USART request flag.
+  * @param  __HANDLE__: specifies the USART Handle which can be USART1 or USART2.
+  * @param  __REQ__: specifies the request flag to set
+  *          This parameter can be one of the following values:
+  *            @arg USART_RXDATA_FLUSH_REQUEST: Receive Data flush Request 
+  *            @arg USART_TXDATA_FLUSH_REQUEST: Transmit data flush Request 
+  *
+  * @retval None
+  */ 
+#define __HAL_USART_SEND_REQ(__HANDLE__, __REQ__) ((__HANDLE__)->Instance->RQR |= (uint16_t)(__REQ__)) 
+
+/** @brief  Enable USART
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @retval None
+  */ 
+#define __HAL_USART_ENABLE(__HANDLE__)               ((__HANDLE__)->Instance->CR1 |=  USART_CR1_UE)
+
+/** @brief  Disable USART
+  * @param  __HANDLE__: specifies the USART Handle.
+  *         The Handle Instance which can be USART1 or USART2.
+  * @retval None
+  */ 
+#define __HAL_USART_DISABLE(__HANDLE__)              ((__HANDLE__)->Instance->CR1 &=  ~USART_CR1_UE)
+  
+
+/** @brief  Check USART Baud rate
+  * @param  BAUDRATE: Baudrate specified by the user
+  *         The maximum Baud Rate is derived from the maximum clock on L0 (i.e. 32 MHz) 
+  *         divided by the smallest oversampling used on the USART (i.e. 8) 
+  * @retval Test result (TRUE or FALSE).
+  */
+#define IS_USART_BAUDRATE(BAUDRATE) ((BAUDRATE) < 4000001)
+
+/**
+  * @}
+  */
+      
+/* Include UART HAL Extension module */
+#include "stm32l0xx_hal_usart_ex.h"
+/* Exported functions --------------------------------------------------------*/
+
+/* Initialization/de-initialization functions  ********************************/
+HAL_StatusTypeDef HAL_USART_Init(USART_HandleTypeDef *husart);
+HAL_StatusTypeDef HAL_USART_DeInit(USART_HandleTypeDef *husart);
+void HAL_USART_MspInit(USART_HandleTypeDef *husart);
+void HAL_USART_MspDeInit(USART_HandleTypeDef *husart);
+void HAL_USART_SetConfig(USART_HandleTypeDef *husart);
+/* IO operation functions *****************************************************/
+HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, uint8_t *pTxData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_USART_Receive(USART_HandleTypeDef *husart, uint8_t *pRxData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_USART_Transmit_IT(USART_HandleTypeDef *husart, uint8_t *pTxData, uint16_t Size);
+HAL_StatusTypeDef HAL_USART_Receive_IT(USART_HandleTypeDef *husart, uint8_t *pRxData, uint16_t Size);
+HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, uint8_t *pTxData, uint8_t *pRxData,  uint16_t Size);
+HAL_StatusTypeDef HAL_USART_Transmit_DMA(USART_HandleTypeDef *husart, uint8_t *pTxData, uint16_t Size);
+HAL_StatusTypeDef HAL_USART_Receive_DMA(USART_HandleTypeDef *husart, uint8_t *pRxData, uint16_t Size);
+HAL_StatusTypeDef HAL_USART_TransmitReceive_DMA(USART_HandleTypeDef *husart, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size);
+HAL_StatusTypeDef HAL_USART_DMAPause(USART_HandleTypeDef *husart);
+HAL_StatusTypeDef HAL_USART_DMAResume(USART_HandleTypeDef *husart);
+HAL_StatusTypeDef HAL_USART_DMAStop(USART_HandleTypeDef *husart);
+void HAL_USART_IRQHandler(USART_HandleTypeDef *husart);
+void HAL_USART_TxCpltCallback(USART_HandleTypeDef *husart);
+void HAL_USART_TxHalfCpltCallback(USART_HandleTypeDef *husart);
+void HAL_USART_RxCpltCallback(USART_HandleTypeDef *husart);
+void HAL_USART_RxHalfCpltCallback(USART_HandleTypeDef *husart);
+void HAL_USART_TxRxCpltCallback(USART_HandleTypeDef *husart);
+void HAL_USART_ErrorCallback(USART_HandleTypeDef *husart);
+
+/* Peripheral State functions  ************************************************/
+HAL_USART_StateTypeDef HAL_USART_GetState(USART_HandleTypeDef *husart);
+uint32_t               HAL_USART_GetError(USART_HandleTypeDef *husart);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_USART_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_usart_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_usart_ex.h
@@ -1,0 +1,206 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_usart_ex.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of USART HAL Extension module.
+  ******************************************************************************
+  * @attention
+  *                               
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_USART_EX_H
+#define __STM32L0xx_HAL_USART_EX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup USARTEx
+  * @{
+  */ 
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup USARTEx_Exported_Constants
+  * @{
+  */
+  
+/** @defgroup USARTEx_Word_Length
+  * @{
+  */
+#define USART_WORDLENGTH_7B                  ((uint32_t)USART_CR1_M_1)
+#define USART_WORDLENGTH_8B                  ((uint32_t)0x00000000)
+#define USART_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M_0)
+#define IS_USART_WORD_LENGTH(LENGTH) (((LENGTH) == USART_WORDLENGTH_7B) || \
+                                      ((LENGTH) == USART_WORDLENGTH_8B) || \
+                                      ((LENGTH) == USART_WORDLENGTH_9B))                                 
+/**
+  * @}
+  */  
+  
+/**
+  * @}
+  */  
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup USARTEx_Extended_Exported_Macros
+  * @{
+  */
+
+/** @brief  Reports the USART clock source.
+  * @param  __HANDLE__: specifies the USART Handle
+  * @param  __CLOCKSOURCE__ : output variable   
+  * @retval the USART clocking source, written in __CLOCKSOURCE__.
+  */
+#define __HAL_USART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__) \
+  do {                                                         \
+    if((__HANDLE__)->Instance == USART1)                       \
+    {                                                          \
+       switch(__HAL_RCC_GET_USART1_SOURCE())                   \
+       {                                                       \
+        case RCC_USART1CLKSOURCE_PCLK2:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PCLK2;         \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_HSI;           \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_SYSCLK:                       \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_SYSCLK;        \
+          break;                                               \
+        case RCC_USART1CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_LSE;           \
+          break;                                               \
+        default:                                               \
+          break;                                               \
+       }                                                       \
+    }                                                          \
+    else if((__HANDLE__)->Instance == USART2)                  \
+    {                                                          \
+       switch(__HAL_RCC_GET_USART2_SOURCE())                   \
+       {                                                       \
+        case RCC_USART2CLKSOURCE_PCLK1:                        \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_PCLK1;         \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_HSI:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_HSI;           \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_SYSCLK:                       \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_SYSCLK;        \
+          break;                                               \
+        case RCC_USART2CLKSOURCE_LSE:                          \
+          (__CLOCKSOURCE__) = USART_CLOCKSOURCE_LSE;           \
+          break;                                               \
+        default:                                               \
+          break;                                               \
+       }                                                       \
+    }                                                          \
+  } while(0)
+
+/** @brief  Reports the USART mask to apply to retrieve the received data
+  *         according to the word length and to the parity bits activation.
+  *         If PCE = 1, the parity bit is not included in the data extracted
+  *         by the reception API().
+  *         This masking operation is not carried out in the case of
+  *         DMA transfers.    
+  * @param  __HANDLE__: specifies the USART Handle
+  * @param  __MASK__ : output variable   
+  * @retval mask to apply to USART RDR register value.
+  */  
+#define __HAL_USART_MASK_COMPUTATION(__HANDLE__)                      \
+  do {                                                                \
+  if ((__HANDLE__)->Init.WordLength == USART_WORDLENGTH_9B)           \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == USART_PARITY_NONE)              \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x01FF ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x00FF ;                                 \
+     }                                                                \
+  }                                                                   \
+  else if ((__HANDLE__)->Init.WordLength == USART_WORDLENGTH_8B)      \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == USART_PARITY_NONE)              \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x00FF ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x007F ;                                 \
+     }                                                                \
+  }                                                                   \
+  else if ((__HANDLE__)->Init.WordLength == USART_WORDLENGTH_7B)      \
+  {                                                                   \
+     if ((__HANDLE__)->Init.Parity == USART_PARITY_NONE)              \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x007F ;                                 \
+     }                                                                \
+     else                                                             \
+     {                                                                \
+        (__HANDLE__)->Mask = 0x003F ;                                 \
+     }                                                                \
+  }                                                                   \
+} while(0)
+
+/**
+  * @}
+  */   
+
+/* Exported functions --------------------------------------------------------*/
+/* Initialization/de-initialization methods  **********************************/
+/* IO operation methods *******************************************************/
+/* Peripheral Control methods  ************************************************/
+/* Peripheral State methods  **************************************************/
+
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_USART_EX_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_wwdg.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_wwdg.c
@@ -1,0 +1,461 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_wwdg.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   WWDG HAL module driver.
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Window Watchdog (WWDG) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + IO operation functions
+  *           + Peripheral State functions        
+  @verbatim
+  ==============================================================================
+                      ##### WWDG specific features #####
+  ==============================================================================
+  [..] 
+    Once enabled the WWDG generates a system reset on expiry of a programmed
+       time period, unless the program refreshes the counter (downcounter)
+       before reaching 0x3F value (i.e. a reset is generated when the counter
+       value rolls over from 0x40 to 0x3F).
+
+        (+) An MCU reset is also generated if the counter value is refreshed
+            before the counter has reached the refresh window value. This
+            implies that the counter must be refreshed in a limited window.
+        (+) Once enabled the WWDG cannot be disabled except by a system reset.
+        (+) WWDGRST flag in RCC_CSR register can be used to inform when a WWDG
+            reset occurs.               
+        (+) The WWDG counter input clock is derived from the APB clock divided
+            by a programmable prescaler.
+        (+) WWDG counter clock = PCLK1 / Prescaler
+            WWDG timeout = (WWDG counter clock) * (counter value) 
+        (+) Min-max timeout value @32 MHz(PCLK1): ~128.0 us / ~65.54 ms
+
+
+                     ##### How to use this driver #####
+  ==============================================================================
+  [..]
+    (+) Enable WWDG APB1 clock using __WWDG_CLK_ENABLE().
+    (+) Set the WWDG prescaler, refresh window and counter value
+        using HAL_WWDG_Init() function.
+    (+) Start the WWDG using HAL_WWDG_Start() function.
+        When the WWDG is enabled the counter value should be configured to
+        a value greater than 0x40 to prevent generating an immediate reset.
+    (+) Optionally you can enable the Early Wakeup Interrupt (EWI) which is
+        generated when the counter reaches 0x40, and then start the WWDG using
+        HAL_WWDG_Start_IT().
+        Once enabled, EWI interrupt cannot be disabled except by a system reset.
+    (+) Then the application program must refresh the WWDG counter at regular
+        intervals during normal operation to prevent an MCU reset, using
+        HAL_WWDG_Refresh() function. This operation must occur only when
+        the counter is lower than the refresh window value already programmed.
+        
+     *** WWDG HAL driver macros list ***
+     ==================================
+     [..]
+       Below the list of most used macros in WWDG HAL driver.
+       
+      (+) __HAL_WWDG_ENABLE: Enable the WWDG peripheral 
+      (+) __HAL_WWDG_GET_FLAG: Get the selected WWDG's flag status
+      (+) __HAL_WWDG_CLEAR_FLAG: Clear the WWDG's pending flags 
+      (+) __HAL_WWDG_ENABLE_IT:  Enables the WWDG early wakeup interrupt  
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup WWDG 
+  * @brief WWDG HAL module driver.
+  * @{
+  */
+
+#ifdef HAL_WWDG_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup WWDG_Private_Functions
+  * @{
+  */
+
+/** @defgroup WWDG_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions.
+ *
+@verbatim
+  ==============================================================================
+          ##### Initialization and de-initialization functions #####
+  ==============================================================================
+  [..]  
+    This section provides functions allowing to:
+      (+) Initialize the WWDG according to the specified parameters
+          in the WWDG_InitTypeDef and create the associated handle
+      (+) DeInitialize the WWDG peripheral
+      (+) Initialize the WWDG MSP
+      (+) DeInitialize the WWDG MSP
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the WWDG according to the specified
+  *         parameters in the WWDG_InitTypeDef and creates the associated handle.
+  * @param  hwwdg: pointer to a WWDG_HandleTypeDef structure that contains
+  *              the configuration information for the specified WWDG module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_WWDG_Init(WWDG_HandleTypeDef *hwwdg)
+{
+  uint32_t tmp = 0;
+
+  /* Check the WWDG handle allocation */
+  if(hwwdg == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_WWDG_ALL_INSTANCE(hwwdg->Instance));
+  assert_param(IS_WWDG_PRESCALER(hwwdg->Init.Prescaler));
+  assert_param(IS_WWDG_WINDOW(hwwdg->Init.Window));
+  assert_param(IS_WWDG_COUNTER(hwwdg->Init.Counter));
+  
+  if(hwwdg->State == HAL_WWDG_STATE_RESET)
+  {
+    /* Init the low level hardware */
+    HAL_WWDG_MspInit(hwwdg);
+  }
+
+  /* Change WWDG peripheral state */
+  hwwdg->State = HAL_WWDG_STATE_BUSY;
+
+  /* Set WWDG Prescaler and Window */
+  /* Get the CFR register value */
+  tmp = hwwdg->Instance->CFR;
+
+  /* Clear WDGTB[1:0] and W[6:0] bits */
+  tmp &= ((uint32_t)~(WWDG_CFR_WDGTB | WWDG_CFR_W));
+
+  /* Prepare the WWDG Prescaler and Window parameters */
+  tmp |= hwwdg->Init.Prescaler | hwwdg->Init.Window;
+
+  /* Write to WWDG CFR */
+  hwwdg->Instance->CFR = tmp;
+
+  /* Set WWDG Counter */
+  /* Get the CR register value */
+  tmp = hwwdg->Instance->CR;
+
+  /* Clear T[6:0] bits */
+  tmp &= (uint32_t)~((uint32_t)WWDG_CR_T);
+
+  /* Prepare the WWDG Counter parameter */
+  tmp |= (hwwdg->Init.Counter);
+
+  /* Write to WWDG CR */
+  hwwdg->Instance->CR = tmp;  
+
+  /* Change WWDG peripheral state */
+  hwwdg->State = HAL_WWDG_STATE_READY;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  DeInitializes the WWDG peripheral.
+  * @param  hwwdg: pointer to a WWDG_HandleTypeDef structure that contains
+  *              the configuration information for the specified WWDG module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_WWDG_DeInit(WWDG_HandleTypeDef *hwwdg)
+{
+  /* Check the parameters */
+  assert_param(IS_WWDG_ALL_INSTANCE(hwwdg->Instance));
+
+  /* Change WWDG peripheral state */
+  hwwdg->State = HAL_WWDG_STATE_BUSY;
+
+  /* DeInit the low level hardware */
+  HAL_WWDG_MspDeInit(hwwdg);
+
+  /* Reset WWDG Control register */
+  hwwdg->Instance->CR  = (uint32_t)0x0000007F;
+
+  /* Reset WWDG Configuration register */
+  hwwdg->Instance->CFR = (uint32_t)0x0000007F;
+
+  /* Reset WWDG Status register */
+  hwwdg->Instance->SR  = 0; 
+
+  /* Change WWDG peripheral state */
+  hwwdg->State = HAL_WWDG_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(hwwdg);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the WWDG MSP.
+  * @param  hwwdg: pointer to a WWDG_HandleTypeDef structure that contains
+  *              the configuration information for the specified WWDG module.
+  * @retval None
+  */
+__weak void HAL_WWDG_MspInit(WWDG_HandleTypeDef *hwwdg)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_WWDG_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes the WWDG MSP.
+  * @param  hwwdg: pointer to a WWDG_HandleTypeDef structure that contains
+  *              the configuration information for the specified WWDG module.
+  * @retval None
+  */
+__weak void HAL_WWDG_MspDeInit(WWDG_HandleTypeDef *hwwdg)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_WWDG_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup WWDG_Group2 IO operation functions 
+ *  @brief    IO operation functions 
+ *
+@verbatim
+  ==============================================================================
+                      ##### IO operation functions #####
+  ==============================================================================  
+  [..]  
+    This section provides functions allowing to:
+      (+) Start the WWDG.
+      (+) Refresh the WWDG.
+      (+) Handle WWDG interrupt request.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Starts the WWDG.
+  * @param  hwwdg: pointer to a WWDG_HandleTypeDef structure that contains
+  *              the configuration information for the specified WWDG module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_WWDG_Start(WWDG_HandleTypeDef *hwwdg)
+{
+  /* Process Locked */
+  __HAL_LOCK(hwwdg); 
+
+  /* Change WWDG peripheral state */
+  hwwdg->State = HAL_WWDG_STATE_BUSY;
+
+  /* Enable the peripheral */
+  __HAL_WWDG_ENABLE(hwwdg);
+
+  /* Change WWDG peripheral state */
+  hwwdg->State = HAL_WWDG_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hwwdg);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Starts the WWDG with interrupt enabled.
+  * @param  hwwdg: pointer to a WWDG_HandleTypeDef structure that contains
+  *              the configuration information for the specified WWDG module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_WWDG_Start_IT(WWDG_HandleTypeDef *hwwdg)
+{
+  /* Process Locked */
+  __HAL_LOCK(hwwdg);
+
+  /* Change WWDG peripheral state */
+  hwwdg->State = HAL_WWDG_STATE_BUSY;
+
+  /* Enable the Early Wakeup Interrupt */
+  __HAL_WWDG_ENABLE_IT(WWDG_IT_EWI);
+
+  /* Enable the peripheral */
+  __HAL_WWDG_ENABLE(hwwdg);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Refreshes the WWDG.
+  * @param  hwwdg: pointer to a WWDG_HandleTypeDef structure that contains
+  *              the configuration information for the specified WWDG module.
+  * @param  Counter: value of counter to put in WWDG counter
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_WWDG_Refresh(WWDG_HandleTypeDef *hwwdg, uint32_t Counter)
+{
+  /* Process Locked */
+  __HAL_LOCK(hwwdg);
+
+  /* Change WWDG peripheral state */
+  hwwdg->State = HAL_WWDG_STATE_BUSY;
+
+  /* Check the parameters */
+  assert_param(IS_WWDG_COUNTER(Counter));
+
+  /* Write to WWDG CR the WWDG Counter value to refresh with */
+  MODIFY_REG(hwwdg->Instance->CR, (uint32_t)WWDG_CR_T, Counter);
+  
+  /* Change WWDG peripheral state */
+  hwwdg->State = HAL_WWDG_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hwwdg);
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles WWDG interrupt request.
+  * @note   The Early Wakeup Interrupt (EWI) can be used if specific safety operations
+  *         or data logging must be performed before the actual reset is generated.
+  *         The EWI interrupt is enabled using __HAL_WWDG_ENABLE_IT() macro.
+  *         When the downcounter reaches the value 0x40, and EWI interrupt is
+  *         generated and the corresponding Interrupt Service Routine (ISR) can
+  *         be used to trigger specific actions (such as communications or data
+  *         logging), before resetting the device.
+  * @param  hwwdg: pointer to a WWDG_HandleTypeDef structure that contains
+  *              the configuration information for the specified WWDG module.
+  * @retval None
+  */
+void HAL_WWDG_IRQHandler(WWDG_HandleTypeDef *hwwdg)
+{
+  /* WWDG Early Wakeup Interrupt occurred */
+  if(__HAL_WWDG_GET_FLAG(hwwdg, WWDG_FLAG_EWIF) != RESET)
+  {
+    /* Early Wakeup callback */ 
+    HAL_WWDG_WakeupCallback(hwwdg);
+
+    /* Change WWDG peripheral state */
+    hwwdg->State = HAL_WWDG_STATE_READY;
+
+    /* Clear the WWDG Data Ready flag */
+    __HAL_WWDG_CLEAR_IT(hwwdg, WWDG_FLAG_EWIF);
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hwwdg);
+  }
+}
+
+/**
+  * @brief  Early Wakeup WWDG callback.
+  * @param  hwwdg: pointer to a WWDG_HandleTypeDef structure that contains
+  *              the configuration information for the specified WWDG module.
+  * @retval None
+  */
+__weak void HAL_WWDG_WakeupCallback(WWDG_HandleTypeDef* hwwdg)
+{
+  /* NOTE: This function Should not be modified, when the callback is needed,
+           the HAL_WWDG_WakeupCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup WWDG_Group3 Peripheral State functions 
+ *  @brief    Peripheral State functions.
+ *
+@verbatim
+  ==============================================================================
+                      ##### Peripheral State functions #####
+  ==============================================================================  
+    [..]
+    This subsection permits to get in run-time the status of the peripheral
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the WWDG state.
+  * @param  hwwdg: pointer to a WWDG_HandleTypeDef structure that contains
+  *              the configuration information for the specified WWDG module.
+  * @retval HAL state
+  */
+HAL_WWDG_StateTypeDef HAL_WWDG_GetState(WWDG_HandleTypeDef *hwwdg)
+{
+  return hwwdg->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_WWDG_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_wwdg.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/stm32l0xx_hal_wwdg.h
@@ -1,0 +1,293 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx_hal_wwdg.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   Header file of WWDG HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L0xx_HAL_WWDG_H
+#define __STM32L0xx_HAL_WWDG_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l0xx_hal_def.h"
+
+/** @addtogroup STM32L0xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup WWDG
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** @defgroup WWDG_Exported_Types WWDG Exported Types
+  * @{
+  */
+   
+/**
+  * @brief  WWDG HAL State Structure definition
+  */
+typedef enum
+{
+  HAL_WWDG_STATE_RESET     = 0x00,  /*!< WWDG not yet initialized or disabled */
+  HAL_WWDG_STATE_READY     = 0x01,  /*!< WWDG initialized and ready for use   */
+  HAL_WWDG_STATE_BUSY      = 0x02,  /*!< WWDG internal process is ongoing     */
+  HAL_WWDG_STATE_TIMEOUT   = 0x03,  /*!< WWDG timeout state                   */
+  HAL_WWDG_STATE_ERROR     = 0x04   /*!< WWDG error state                     */
+}HAL_WWDG_StateTypeDef;
+
+/** 
+  * @brief  WWDG Init structure definition
+  */
+typedef struct
+{
+  uint32_t Prescaler;  /*!< Specifies the prescaler value of the WWDG.
+                            This parameter can be a value of @ref WWDG_Prescaler */
+
+  uint32_t Window;     /*!< Specifies the WWDG window value to be compared to the downcounter.
+                            This parameter must be a number lower than Max_Data = 0x80 */
+
+  uint32_t Counter;    /*!< Specifies the WWDG free-running downcounter  value.
+                            This parameter must be a number between Min_Data = 0x40 and Max_Data = 0x7F */
+
+}WWDG_InitTypeDef;
+
+/**
+  * @brief  WWDG handle Structure definition
+  */
+typedef struct
+{
+  WWDG_TypeDef                 *Instance;  /*!< Register base address    */
+
+  WWDG_InitTypeDef             Init;       /*!< WWDG required parameters */
+
+  HAL_LockTypeDef              Lock;       /*!< WWDG locking object      */
+
+  __IO HAL_WWDG_StateTypeDef   State;      /*!< WWDG communication state */
+
+}WWDG_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup WWDG_Exported_Constants WWDG Exported Constants
+  * @{
+  */
+
+/** @defgroup WWDG_BitAddress_AliasRegion WWDG BitAddress AliasRegion
+  * @brief WWDG registers bit address in the alias region
+  * @{
+  */
+
+/* --- CFR Register ---*/
+/* Alias word address of EWI bit */
+#define CFR_BASE   (uint32_t)(WWDG_BASE + 0x04)
+
+/**
+  * @}
+  */
+
+/** @defgroup WWDG_Interrupt_definition WWDG Interrupt definition
+  * @{
+  */
+#define WWDG_IT_EWI   ((uint32_t)WWDG_CFR_EWI)
+
+#define IS_WWDG_IT(__IT__) ((__IT__) == WWDG_IT_EWI)
+
+/**
+  * @}
+  */
+
+/** @defgroup WWDG_Flag_definition WWDG Flag definition
+  * @brief WWDG Flag definition
+  * @{
+  */
+#define WWDG_FLAG_EWIF   ((uint32_t)WWDG_SR_EWIF)  /*!< Early wakeup interrupt flag */
+
+#define IS_WWDG_FLAG(__FLAG__) ((__FLAG__) == WWDG_FLAG_EWIF)) 
+
+/**
+  * @}
+  */
+
+/** @defgroup WWDG_Prescaler WWDG Prescaler
+  * @{
+  */
+#define WWDG_PRESCALER_1   ((uint32_t)0x00000000)  /*!< WWDG counter clock = (PCLK1/4096)/1 */
+#define WWDG_PRESCALER_2   ((uint32_t)WWDG_CFR_WDGTB0)  /*!< WWDG counter clock = (PCLK1/4096)/2 */
+#define WWDG_PRESCALER_4   ((uint32_t)WWDG_CFR_WDGTB1)  /*!< WWDG counter clock = (PCLK1/4096)/4 */
+#define WWDG_PRESCALER_8   ((uint32_t)WWDG_CFR_WDGTB)  /*!< WWDG counter clock = (PCLK1/4096)/8 */
+
+#define IS_WWDG_PRESCALER(__PRESCALER__) (((__PRESCALER__) == WWDG_PRESCALER_1) || \
+                                          ((__PRESCALER__) == WWDG_PRESCALER_2) || \
+                                          ((__PRESCALER__) == WWDG_PRESCALER_4) || \
+                                          ((__PRESCALER__) == WWDG_PRESCALER_8))
+
+/**
+  * @}
+  */
+
+/** @defgroup WWDG_Window WWDG Window
+  * @{
+  */
+#define IS_WWDG_WINDOW(__WINDOW__) ((__WINDOW__) <= 0x7F)
+
+/**
+  * @}
+  */
+
+/** @defgroup WWDG_Counter WWDG Counter
+  * @{
+  */
+#define IS_WWDG_COUNTER(__COUNTER__) (((__COUNTER__) >= 0x40) && ((__COUNTER__) <= 0x7F))
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup WWDG_Exported_Macros WWDG Exported Macros
+  * @{
+  */
+
+/** @brief Reset WWDG handle state
+  * @param  __HANDLE__: WWDG handle
+  * @retval None
+  */
+#define __HAL_WWDG_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_WWDG_STATE_RESET)
+
+/**
+  * @brief  Enables the WWDG peripheral.
+  * @param  __HANDLE__: WWDG handle
+  * @retval None
+  */
+#define __HAL_WWDG_ENABLE(__HANDLE__)               SET_BIT((__HANDLE__)->Instance->CR, WWDG_CR_WDGA)
+
+/**
+  * @brief  Gets the selected WWDG's flag status.
+  * @param  __HANDLE__: WWDG handle
+  * @param  __FLAG__: specifies the flag to check.
+  *         This parameter can be one of the following values:
+  *            @arg WWDG_FLAG_EWIF: Early wakeup interrupt flag
+  * @retval The new state of WWDG_FLAG (SET or RESET).
+  */
+#define __HAL_WWDG_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR & (__FLAG__)) == (__FLAG__))
+
+/**
+  * @brief  Clears the WWDG's pending flags.
+  * @param  __HANDLE__: WWDG handle
+  * @param  __FLAG__: specifies the flag to clear.
+  *         This parameter can be one of the following values:
+  *            @arg WWDG_FLAG_EWIF: Early wakeup interrupt flag
+  * @retval None
+  */
+#define __HAL_WWDG_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) = ~(__FLAG__))
+
+/**
+  * @brief  Enables the WWDG early wakeup interrupt.
+  * @param  __INTERRUPT__: specifies the interrupt to enable.
+  *         This parameter can be one of the following values:
+  *            @arg WWDG_IT_EWI: Early wakeup interrupt
+  * @note   Once enabled this interrupt cannot be disabled except by a system reset.
+  * @retval None
+  */
+#define __HAL_WWDG_ENABLE_IT(__INTERRUPT__) (*(__IO uint32_t *) CFR_BASE |= (__INTERRUPT__))
+
+/** @brief  Clear the WWDG's interrupt pending bits
+  *         bits to clear the selected interrupt pending bits.
+  * @param  __HANDLE__: WWDG handle
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear.
+  *         This parameter can be one of the following values:
+  *            @arg WWDG_FLAG_EWIF: Early wakeup interrupt flag
+  */
+#define __HAL_WWDG_CLEAR_IT(__HANDLE__, __INTERRUPT__) __HAL_WWDG_CLEAR_FLAG((__HANDLE__), (__INTERRUPT__))
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup WWDG_Exported_Functions
+  * @{
+  */
+
+/* Initialization/de-initialization functions  **********************************/
+HAL_StatusTypeDef HAL_WWDG_Init(WWDG_HandleTypeDef *hwwdg);
+HAL_StatusTypeDef HAL_WWDG_DeInit(WWDG_HandleTypeDef *hwwdg);
+void HAL_WWDG_MspInit(WWDG_HandleTypeDef *hwwdg);
+void HAL_WWDG_MspDeInit(WWDG_HandleTypeDef *hwwdg);
+void HAL_WWDG_WakeupCallback(WWDG_HandleTypeDef* hwwdg);
+
+/* I/O operation functions ******************************************************/
+HAL_StatusTypeDef HAL_WWDG_Start(WWDG_HandleTypeDef *hwwdg);
+HAL_StatusTypeDef HAL_WWDG_Start_IT(WWDG_HandleTypeDef *hwwdg);
+HAL_StatusTypeDef HAL_WWDG_Refresh(WWDG_HandleTypeDef *hwwdg, uint32_t Counter);
+void HAL_WWDG_IRQHandler(WWDG_HandleTypeDef *hwwdg);
+
+/* Peripheral State functions  **************************************************/
+HAL_WWDG_StateTypeDef HAL_WWDG_GetState(WWDG_HandleTypeDef *hwwdg);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L0xx_HAL_WWDG_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/system_stm32l0xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/system_stm32l0xx.c
@@ -1,0 +1,469 @@
+/**
+  ******************************************************************************
+  * @file    system_stm32l0xx.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   CMSIS Cortex-M0+ Device Peripheral Access Layer System Source File.
+  *
+  *   This file provides two functions and one global variable to be called from
+  *   user application:
+  *      - SystemInit(): This function is called at startup just after reset and
+  *                      before branch to main program. This call is made inside
+  *                      the "startup_stm32l0xx.s" file.
+  *
+  *      - SystemCoreClock variable: Contains the core clock (HCLK), it can be used
+  *                                  by the user application to setup the SysTick
+  *                                  timer or configure other parameters.
+  *
+  *      - SystemCoreClockUpdate(): Updates the variable SystemCoreClock and must
+  *                                 be called whenever the core clock is changed
+  *                                 during program execution.
+  *
+  * This file configures the system clock as follows:
+  *-----------------------------------------------------------------------------
+  * System clock source                | 1- PLL_HSE_EXTC        | 3- PLL_HSI
+  *                                    | (external 8 MHz clock) | (internal 16 MHz)
+  *                                    | 2- PLL_HSE_XTAL        |
+  *                                    | (external 8 MHz xtal)  |
+  *-----------------------------------------------------------------------------
+  * SYSCLK(MHz)                        | 32                     | 32
+  *-----------------------------------------------------------------------------
+  * AHBCLK (MHz)                       | 32                     | 32
+  *-----------------------------------------------------------------------------
+  * APB1CLK (MHz)                      | 32                     | 32
+  *-----------------------------------------------------------------------------
+  * APB2CLK (MHz)                      | 32                     | 32
+  *-----------------------------------------------------------------------------
+  * USB capable (48 MHz precise clock) | YES                    | YES
+  *-----------------------------------------------------------------------------
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32l0xx_system
+  * @{
+  */
+
+/** @addtogroup STM32L0xx_System_Private_Includes
+  * @{
+  */
+
+#include "stm32l0xx.h"
+
+#if !defined  (HSE_VALUE)
+  #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
+#endif /* HSE_VALUE */
+
+#if !defined  (MSI_VALUE)
+  #define MSI_VALUE    ((uint32_t)2000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* MSI_VALUE */
+
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)16000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32L0xx_System_Private_TypesDefinitions
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32L0xx_System_Private_Defines
+  * @{
+  */
+/************************* Miscellaneous Configuration ************************/
+
+/*!< Uncomment the following line if you need to relocate your vector Table in
+     Internal SRAM. */
+/* #define VECT_TAB_SRAM */
+#define VECT_TAB_OFFSET  0x00 /*!< Vector Table base offset field.
+                                   This value must be a multiple of 0x200. */
+/******************************************************************************/
+/**
+  * @}
+  */
+
+/** @addtogroup STM32L0xx_System_Private_Macros
+  * @{
+  */
+
+/* Select the clock sources (other than HSI) to start with (0=OFF, 1=ON) */
+#define USE_PLL_HSE_EXTC (1) /* Use external clock */
+#define USE_PLL_HSE_XTAL (1) /* Use external xtal */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32L0xx_System_Private_Variables
+  * @{
+  */
+  /* This variable is updated in three ways:
+      1) by calling CMSIS function SystemCoreClockUpdate()
+      2) by calling HAL API function HAL_RCC_GetHCLKFreq()
+      3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
+         Note: If you use this function to configure the system clock; then there
+               is no need to call the 2 first functions listed above, since SystemCoreClock
+               variable is updated automatically.
+  */
+  uint32_t SystemCoreClock = 32000000;
+__IO const uint8_t AHBPrescTable[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9};
+__IO const uint8_t PLLMulTable[9] = {3, 4, 6, 8, 12, 16, 24, 32, 48};
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32L0xx_System_Private_FunctionPrototypes
+  * @{
+  */
+
+#if (USE_PLL_HSE_XTAL != 0) || (USE_PLL_HSE_EXTC != 0)
+uint8_t SetSysClock_PLL_HSE(uint8_t bypass);
+#endif
+
+uint8_t SetSysClock_PLL_HSI(void);
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32L0xx_System_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Setup the microcontroller system.
+  * @param  None
+  * @retval None
+  */
+void SystemInit (void)
+{
+/*!< Set MSION bit */
+  RCC->CR |= (uint32_t)0x00000100;
+
+  /*!< Reset SW[1:0], HPRE[3:0], PPRE1[2:0], PPRE2[2:0], MCOSEL[2:0] and MCOPRE[2:0] bits */
+  RCC->CFGR &= (uint32_t) 0x88FF400C;
+
+  /*!< Reset HSION, HSIDIVEN, HSEON, CSSON and PLLON bits */
+  RCC->CR &= (uint32_t)0xFEF6FFF6;
+
+  /*!< Reset HSI48ON  bit */
+  RCC->CRRCR &= (uint32_t)0xFFFFFFFE;
+
+  /*!< Reset HSEBYP bit */
+  RCC->CR &= (uint32_t)0xFFFBFFFF;
+
+  /*!< Reset PLLSRC, PLLMUL[3:0] and PLLDIV[1:0] bits */
+  RCC->CFGR &= (uint32_t)0xFF02FFFF;
+
+  /*!< Disable all interrupts */
+  RCC->CIER = 0x00000000;
+
+  /* Configure the Vector Table location add offset address ------------------*/
+#ifdef VECT_TAB_SRAM
+  SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
+#else
+  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+#endif
+
+  /* Configure the Cube driver */
+  HAL_Init();
+
+  /* Configure the System clock source, PLL Multiplier and Divider factors,
+     AHB/APBx prescalers and Flash settings */
+  SetSysClock();
+}
+
+/**
+  * @brief  Update SystemCoreClock according to Clock Register Values
+  *         The SystemCoreClock variable contains the core clock (HCLK), it can
+  *         be used by the user application to setup the SysTick timer or configure
+  *         other parameters.
+  *
+  * @note   Each time the core clock (HCLK) changes, this function must be called
+  *         to update SystemCoreClock variable value. Otherwise, any configuration
+  *         based on this variable will be incorrect.
+  *
+  * @note   - The system frequency computed by this function is not the real
+  *           frequency in the chip. It is calculated based on the predefined
+  *           constant and the selected clock source:
+  *
+  *           - If SYSCLK source is MSI, SystemCoreClock will contain the MSI
+  *             value as defined by the MSI range.
+  *
+  *           - If SYSCLK source is HSI, SystemCoreClock will contain the HSI_VALUE(*)
+  *
+  *           - If SYSCLK source is HSE, SystemCoreClock will contain the HSE_VALUE(**)
+  *
+  *           - If SYSCLK source is PLL, SystemCoreClock will contain the HSE_VALUE(**)
+  *             or HSI_VALUE(*) multiplied/divided by the PLL factors.
+  *
+  *         (*) HSI_VALUE is a constant defined in stm32l0xx_hal.h file (default value
+  *             16 MHz) but the real value may vary depending on the variations
+  *             in voltage and temperature.
+  *
+  *         (**) HSE_VALUE is a constant defined in stm32l0xx_hal.h file (default value
+  *              8 MHz), user has to ensure that HSE_VALUE is same as the real
+  *              frequency of the crystal used. Otherwise, this function may
+  *              have wrong result.
+  *
+  *         - The result of this function could be not correct when using fractional
+  *           value for HSE crystal.
+  * @param  None
+  * @retval None
+  */
+void SystemCoreClockUpdate (void)
+{
+  uint32_t tmp = 0, pllmul = 0, plldiv = 0, pllsource = 0, msirange = 0;
+
+  /* Get SYSCLK source -------------------------------------------------------*/
+  tmp = RCC->CFGR & RCC_CFGR_SWS;
+
+  switch (tmp)
+  {
+    case 0x00:  /* MSI used as system clock */
+      SystemCoreClock = ((1 <<((RCC->ICSCR & RCC_ICSCR_MSIRANGE)>>13 ))* 64000);
+      break;
+    case 0x04:  /* HSI used as system clock */
+      SystemCoreClock = HSI_VALUE;
+      break;
+    case 0x08:  /* HSE used as system clock */
+      SystemCoreClock = HSE_VALUE;
+      break;
+    case 0x0C:  /* PLL used as system clock */
+      /* Get PLL clock source and multiplication factor ----------------------*/
+      pllmul = RCC->CFGR & RCC_CFGR_PLLMUL;
+      plldiv = RCC->CFGR & RCC_CFGR_PLLDIV;
+      pllmul = PLLMulTable[(pllmul >> 18)];
+      plldiv = (plldiv >> 22) + 1;
+
+      pllsource = RCC->CFGR & RCC_CFGR_PLLSRC;
+
+      if (pllsource == 0x00)
+      {
+        /* HSI oscillator clock selected as PLL clock entry */
+        SystemCoreClock = (((HSI_VALUE) * pllmul) / plldiv);
+      }
+      else
+      {
+        /* HSE selected as PLL clock entry */
+        SystemCoreClock = (((HSE_VALUE) * pllmul) / plldiv);
+      }
+      break;
+    default: /* MSI used as system clock */
+      msirange = (RCC->ICSCR & RCC_ICSCR_MSIRANGE) >> 13;
+      SystemCoreClock = (32768 * (1 << (msirange + 1)));
+      break;
+  }
+  /* Compute HCLK clock frequency --------------------------------------------*/
+  /* Get HCLK prescaler */
+  tmp = AHBPrescTable[((RCC->CFGR & RCC_CFGR_HPRE) >> 4)];
+  /* HCLK clock frequency */
+  SystemCoreClock >>= tmp;
+}
+
+/**
+  * @brief  Configures the System clock source, PLL Multiplier and Divider factors,
+  *               AHB/APBx prescalers and Flash settings
+  * @note   This function should be called only once the RCC clock configuration
+  *         is reset to the default reset state (done in SystemInit() function).
+  * @param  None
+  * @retval None
+  */
+void SetSysClock(void)
+{
+  /* 1- Try to start with HSE and external clock */
+#if USE_PLL_HSE_EXTC != 0
+  if (SetSysClock_PLL_HSE(1) == 0)
+#endif
+  {
+    /* 2- If fail try to start with HSE and external xtal */
+    #if USE_PLL_HSE_XTAL != 0
+    if (SetSysClock_PLL_HSE(0) == 0)
+    #endif
+    {
+      /* 3- If fail start with HSI clock */
+      if (SetSysClock_PLL_HSI() == 0)
+      {
+        while(1)
+        {
+          // [TODO] Put something here to tell the user that a problem occured...
+        }
+      }
+    }
+  }
+
+  /* Output clock on MCO1 pin(PA8) for debugging purpose */
+  //HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_SYSCLK, RCC_MCODIV_1);
+  //HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_HSI48, RCC_MCODIV_1);
+}
+
+#if (USE_PLL_HSE_XTAL != 0) || (USE_PLL_HSE_EXTC != 0)
+/******************************************************************************/
+/*            PLL (clocked by HSE) used as System clock source                */
+/******************************************************************************/
+uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
+{
+  RCC_ClkInitTypeDef RCC_ClkInitStruct;
+  RCC_OscInitTypeDef RCC_OscInitStruct;
+
+  /* Used to gain time after DeepSleep in case HSI is used */
+  if (__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) != RESET)
+  {
+    return 0;
+  }
+
+  /* The voltage scaling allows optimizing the power consumption when the device is
+     clocked below the maximum system frequency, to update the voltage scaling value
+     regarding system frequency refer to product datasheet. */
+  __PWR_CLK_ENABLE();
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+
+  /* Enable HSE and HSI48 oscillators and activate PLL with HSE as source */
+  RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSI48;
+  if (bypass == 0)
+  {
+    RCC_OscInitStruct.HSEState          = RCC_HSE_ON; /* External 8 MHz xtal on OSC_IN/OSC_OUT */
+  }
+  else
+  {
+    RCC_OscInitStruct.HSEState          = RCC_HSE_BYPASS; /* External 8 MHz clock on OSC_IN */
+  }
+  RCC_OscInitStruct.HSIState            = RCC_HSI_OFF;
+  RCC_OscInitStruct.HSI48State          = RCC_HSI48_ON; /* For USB and RNG clock */
+  // PLLCLK = (8 MHz * 8)/2 = 32 MHz
+  RCC_OscInitStruct.PLL.PLLState        = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource       = RCC_PLLSOURCE_HSE;
+  RCC_OscInitStruct.PLL.PLLMUL          = RCC_PLLMUL_8;
+  RCC_OscInitStruct.PLL.PLLDIV          = RCC_PLLDIV_2;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
+  {
+    return 0; // FAIL
+  }
+
+  /* Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2 clocks dividers */
+  RCC_ClkInitStruct.ClockType      = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
+  RCC_ClkInitStruct.SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK; // 32 MHz
+  RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;         // 32 MHz
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;           // 32 MHz
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;           // 32 MHz
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1) != HAL_OK)
+  {
+    return 0; // FAIL
+  }
+
+  /* Output clock on MCO1 pin(PA8) for debugging purpose */
+  //if (bypass == 0)
+  //  HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_HSE, RCC_MCODIV_2); // 4 MHz
+  //else
+  //  HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_HSE, RCC_MCODIV_1); // 8 MHz
+
+  return 1; // OK
+}
+#endif
+
+/******************************************************************************/
+/*            PLL (clocked by HSI) used as System clock source                */
+/******************************************************************************/
+uint8_t SetSysClock_PLL_HSI(void)
+{
+  RCC_ClkInitTypeDef RCC_ClkInitStruct;
+  RCC_OscInitTypeDef RCC_OscInitStruct;
+
+  /* The voltage scaling allows optimizing the power consumption when the device is
+     clocked below the maximum system frequency, to update the voltage scaling value
+     regarding system frequency refer to product datasheet. */
+  __PWR_CLK_ENABLE();
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+
+  /* Enable HSI and HSI48 oscillators and activate PLL with HSI as source */
+  RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_HSI48;
+  RCC_OscInitStruct.HSEState            = RCC_HSE_OFF;
+  RCC_OscInitStruct.HSIState            = RCC_HSI_ON;
+  RCC_OscInitStruct.HSI48State          = RCC_HSI48_ON; /* For USB and RNG clock */
+  // PLLCLK = (16 MHz * 4)/2 = 32 MHz
+  RCC_OscInitStruct.PLL.PLLState        = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource       = RCC_PLLSOURCE_HSI;
+  RCC_OscInitStruct.PLL.PLLMUL          = RCC_PLLMUL_4;
+  RCC_OscInitStruct.PLL.PLLDIV          = RCC_PLLDIV_2;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
+  {
+    return 0; // FAIL
+  }
+
+  /* Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2 clocks dividers */
+  RCC_ClkInitStruct.ClockType      = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
+  RCC_ClkInitStruct.SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK; // 32 MHz
+  RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;         // 32 MHz
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;           // 32 MHz
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;           // 32 MHz
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1) != HAL_OK)
+  {
+    return 0; // FAIL
+  }
+
+  /* Output clock on MCO1 pin(PA8) for debugging purpose */
+  //HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_HSI, RCC_MCODIV_1); // 16 MHz
+
+  return 1; // OK
+}
+
+/* Used for the different timeouts in the HAL */
+void SysTick_Handler(void)
+{
+  HAL_IncTick();
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/system_stm32l0xx.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_DISCO_L053C8/system_stm32l0xx.h
@@ -1,0 +1,123 @@
+/**
+  ******************************************************************************
+  * @file    system_stm32l0xx.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    18-June-2014
+  * @brief   CMSIS Cortex-M0+ Device Peripheral Access Layer System Header File.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32l0xx_system
+  * @{
+  */
+
+/**
+  * @brief Define to prevent recursive inclusion
+  */
+#ifndef __SYSTEM_STM32L0XX_H
+#define __SYSTEM_STM32L0XX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/** @addtogroup STM32L0xx_System_Includes
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+
+/** @addtogroup STM32L0xx_System_Exported_types
+  * @{
+  */
+  /* This variable is updated in three ways:
+      1) by calling CMSIS function SystemCoreClockUpdate()
+      2) by calling HAL API function HAL_RCC_GetSysClockFreq()
+      3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
+         Note: If you use this function to configure the system clock; then there
+               is no need to call the 2 first functions listed above, since SystemCoreClock
+               variable is updated automatically.
+  */
+extern uint32_t SystemCoreClock;          /*!< System Clock Frequency (Core Clock) */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32L0xx_System_Exported_Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32L0xx_System_Exported_Macros
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup STM32L0xx_System_Exported_Functions
+  * @{
+  */
+
+extern void SystemInit(void);
+extern void SystemCoreClockUpdate(void);
+extern void SetSysClock(void);
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__SYSTEM_STM32L0XX_H */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/PeripheralNames.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/PeripheralNames.h
@@ -1,0 +1,77 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#ifndef MBED_PERIPHERALNAMES_H
+#define MBED_PERIPHERALNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    ADC_1 = (int)ADC1_BASE
+} ADCName;
+
+typedef enum {
+    DAC_1 = (int)DAC_BASE
+} DACName;
+
+typedef enum {
+    UART_1   = (int)USART1_BASE,
+    UART_2   = (int)USART2_BASE,
+    LPUART_1 = (int)LPUART1_BASE
+} UARTName;
+
+#define STDIO_UART_TX  PA_2
+#define STDIO_UART_RX  PA_3
+#define STDIO_UART     UART_2
+
+typedef enum {
+    SPI_1 = (int)SPI1_BASE,
+    SPI_2 = (int)SPI2_BASE
+} SPIName;
+
+typedef enum {
+    I2C_1 = (int)I2C1_BASE,
+    I2C_2 = (int)I2C2_BASE
+} I2CName;
+
+typedef enum {
+    PWM_2  = (int)TIM2_BASE,
+    PWM_21 = (int)TIM21_BASE,
+    PWM_22 = (int)TIM22_BASE
+} PWMName;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/PinNames.h
@@ -1,0 +1,183 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// See stm32l0xx_hal_gpio.h and stm32l0xx_hal_gpio_ex.h for values of MODE, PUPD and AFNUM
+#define STM_PIN_DATA(MODE, PUPD, AFNUM)  ((int)(((AFNUM) << 7) | ((PUPD) << 4) | ((MODE) << 0)))
+#define STM_PIN_MODE(X)   (((X) >> 0) & 0x0F)
+#define STM_PIN_PUPD(X)   (((X) >> 4) & 0x07)
+#define STM_PIN_AFNUM(X)  (((X) >> 7) & 0x0F)
+#define STM_MODE_INPUT              (0)
+#define STM_MODE_OUTPUT_PP          (1)
+#define STM_MODE_OUTPUT_OD          (2)
+#define STM_MODE_AF_PP              (3)
+#define STM_MODE_AF_OD              (4)
+#define STM_MODE_ANALOG             (5)
+#define STM_MODE_IT_RISING          (6)
+#define STM_MODE_IT_FALLING         (7)
+#define STM_MODE_IT_RISING_FALLING  (8)
+#define STM_MODE_EVT_RISING         (9)
+#define STM_MODE_EVT_FALLING        (10)
+#define STM_MODE_EVT_RISING_FALLING (11)
+#define STM_MODE_IT_EVT_RESET       (12)
+
+// High nibble = port number (0=A, 1=B, 2=C, 3=D, 4=E, 5=F, 6=G, 7=H)
+// Low nibble  = pin number
+#define STM_PORT(X) (((uint32_t)(X) >> 4) & 0xF)
+#define STM_PIN(X)  ((uint32_t)(X) & 0xF)
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+typedef enum {
+    PA_0  = 0x00,
+    PA_1  = 0x01,
+    PA_2  = 0x02,
+    PA_3  = 0x03,
+    PA_4  = 0x04,
+    PA_5  = 0x05,
+    PA_6  = 0x06,
+    PA_7  = 0x07,
+    PA_8  = 0x08,
+    PA_9  = 0x09,
+    PA_10 = 0x0A,
+    PA_11 = 0x0B,
+    PA_12 = 0x0C,
+    PA_13 = 0x0D,
+    PA_14 = 0x0E,
+    PA_15 = 0x0F,
+
+    PB_0  = 0x10,
+    PB_1  = 0x11,
+    PB_2  = 0x12,
+    PB_3  = 0x13,
+    PB_4  = 0x14,
+    PB_5  = 0x15,
+    PB_6  = 0x16,
+    PB_7  = 0x17,
+    PB_8  = 0x18,
+    PB_9  = 0x19,
+    PB_10 = 0x1A,
+    PB_11 = 0x1B,
+    PB_12 = 0x1C,
+    PB_13 = 0x1D,
+    PB_14 = 0x1E,
+    PB_15 = 0x1F,
+
+    PC_0  = 0x20,
+    PC_1  = 0x21,
+    PC_2  = 0x22,
+    PC_3  = 0x23,
+    PC_4  = 0x24,
+    PC_5  = 0x25,
+    PC_6  = 0x26,
+    PC_7  = 0x27,
+    PC_8  = 0x28,
+    PC_9  = 0x29,
+    PC_10 = 0x2A,
+    PC_11 = 0x2B,
+    PC_12 = 0x2C,
+    PC_13 = 0x2D,
+    PC_14 = 0x2E,
+    PC_15 = 0x2F,
+
+    PD_2  = 0x32,
+
+    PH_0  = 0x70,
+    PH_1  = 0x71,
+
+    // Arduino connector namings
+    A0          = PA_0,
+    A1          = PA_1,
+    A2          = PA_4,
+    A3          = PB_0,
+    A4          = PC_1,
+    A5          = PC_0,
+    D0          = PA_3,
+    D1          = PA_2,
+    D2          = PA_10,
+    D3          = PB_3,
+    D4          = PB_5,
+    D5          = PB_4,
+    D6          = PB_10,
+    D7          = PA_8,
+    D8          = PA_9,
+    D9          = PC_7,
+    D10         = PB_6,
+    D11         = PA_7,
+    D12         = PA_6,
+    D13         = PA_5,
+    D14         = PB_9,
+    D15         = PB_8,
+
+    // Generic signals namings
+    LED1        = PB_4,
+    LED2        = PA_5,
+    LED3        = PB_4,
+    LED4        = PA_5,
+    USER_BUTTON = PA_0,
+    SERIAL_TX   = PA_9,
+    SERIAL_RX   = PA_10,
+    USBTX       = PA_9,
+    USBRX       = PA_10,
+    I2C_SCL     = PB_8,
+    I2C_SDA     = PB_9,
+    SPI_MOSI    = PB_14,
+    SPI_MISO    = PB_15,
+    SPI_SCK     = PB_13,
+    SPI_CS      = PB_12,
+    PWM_OUT     = PB_3,
+
+    // Not connected
+    NC = (int)0xFFFFFFFF
+} PinName;
+
+typedef enum {
+    PullNone  = 0,
+    PullUp    = 1,
+    PullDown  = 2,
+    OpenDrain = 3,
+    PullDefault = PullNone
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/PortNames.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/PortNames.h
@@ -1,0 +1,48 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#ifndef MBED_PORTNAMES_H
+#define MBED_PORTNAMES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PortA = 0,
+    PortB = 1,
+    PortC = 2,
+    PortD = 3,
+    PortH = 7
+} PortName;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/analogin_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/analogin_api.c
@@ -1,0 +1,191 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "mbed_assert.h"
+#include "analogin_api.h"
+
+#if DEVICE_ANALOGIN
+
+#include "wait_api.h"
+#include "cmsis.h"
+#include "pinmap.h"
+
+static const PinMap PinMap_ADC[] = {
+    {PA_0, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN0
+    {PA_1, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN1
+    {PA_2, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN2
+    {PA_3, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN3
+    {PA_4, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN4
+    {PA_5, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN5
+    {PA_6, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN6
+    {PA_7, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN7
+    {PB_0, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN8
+    {PB_1, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN9
+    {PC_0, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN10
+    {PC_1, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN11
+    {PC_2, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN12
+    {PC_3, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN13
+    {PC_4, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN14
+    {PC_5, ADC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // ADC1_IN15
+    {NC,   NC,    0}
+};
+
+ADC_HandleTypeDef AdcHandle;
+
+int adc_inited = 0;
+
+void analogin_init(analogin_t *obj, PinName pin) {
+    // Get the peripheral name from the pin and assign it to the object
+    obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
+    MBED_ASSERT(obj->adc != (ADCName)NC);
+
+    // Configure GPIO
+    pinmap_pinout(pin, PinMap_ADC);
+
+    // Save pin number for the read function
+    obj->pin = pin;
+
+    // The ADC initialization is done once
+    if (adc_inited == 0) {
+        adc_inited = 1;
+
+        AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
+
+        // Enable ADC clock
+        __ADC1_CLK_ENABLE();
+
+        // Configure ADC
+        AdcHandle.Init.OversamplingMode      = DISABLE;
+        AdcHandle.Init.ClockPrescaler        = ADC_CLOCKPRESCALER_PCLK_DIV1;
+        AdcHandle.Init.Resolution            = ADC_RESOLUTION12b;
+        AdcHandle.Init.SamplingTime          = ADC_SAMPLETIME_41CYCLES_5;
+        AdcHandle.Init.ScanDirection         = ADC_SCAN_DIRECTION_UPWARD;
+        AdcHandle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
+        AdcHandle.Init.ContinuousConvMode    = DISABLE;
+        AdcHandle.Init.DiscontinuousConvMode = DISABLE;
+        AdcHandle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIG_EDGE_NONE;
+        AdcHandle.Init.ExternalTrigConv      = ADC_EXTERNALTRIG0_T6_TRGO; // Not used here
+        AdcHandle.Init.DMAContinuousRequests = DISABLE;
+        AdcHandle.Init.EOCSelection          = EOC_SINGLE_CONV;
+        AdcHandle.Init.Overrun               = OVR_DATA_OVERWRITTEN;
+        AdcHandle.Init.LowPowerAutoWait      = ENABLE;
+        AdcHandle.Init.LowPowerFrequencyMode = DISABLE; // To be enabled only if ADC clock < 2.8 MHz
+        AdcHandle.Init.LowPowerAutoOff       = DISABLE;
+        HAL_ADC_Init(&AdcHandle);
+        
+        // Calibration
+        HAL_ADCEx_Calibration_Start(&AdcHandle, ADC_SINGLE_ENDED);
+        
+        __HAL_ADC_ENABLE(&AdcHandle);
+    }
+}
+
+static inline uint16_t adc_read(analogin_t *obj) {
+    ADC_ChannelConfTypeDef sConfig;
+
+    AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
+
+    // Configure ADC channel
+    switch (obj->pin) {
+        case PA_0:
+            sConfig.Channel = ADC_CHANNEL_0;
+            break;
+        case PA_1:
+            sConfig.Channel = ADC_CHANNEL_1;
+            break;
+        case PA_2:
+            sConfig.Channel = ADC_CHANNEL_2;
+            break;
+        case PA_3:
+            sConfig.Channel = ADC_CHANNEL_3;
+            break;
+        case PA_4:
+            sConfig.Channel = ADC_CHANNEL_4;
+            break;
+        case PA_5:
+            sConfig.Channel = ADC_CHANNEL_5;
+            break;
+        case PA_6:
+            sConfig.Channel = ADC_CHANNEL_6;
+            break;
+        case PA_7:
+            sConfig.Channel = ADC_CHANNEL_7;
+            break;
+        case PB_0:
+            sConfig.Channel = ADC_CHANNEL_8;
+            break;
+        case PB_1:
+            sConfig.Channel = ADC_CHANNEL_9;
+            break;
+        case PC_0:
+            sConfig.Channel = ADC_CHANNEL_10;
+            break;
+        case PC_1:
+            sConfig.Channel = ADC_CHANNEL_11;
+            break;
+        case PC_2:
+            sConfig.Channel = ADC_CHANNEL_12;
+            break;
+        case PC_3:
+            sConfig.Channel = ADC_CHANNEL_13;
+            break;
+        case PC_4:
+            sConfig.Channel = ADC_CHANNEL_14;
+            break;
+        case PC_5:
+            sConfig.Channel = ADC_CHANNEL_15;
+            break;
+        default:
+            return 0;
+    }
+
+    ADC1->CHSELR = 0; // [TODO] Workaround. To be removed after Cube driver is corrected.
+    HAL_ADC_ConfigChannel(&AdcHandle, &sConfig);
+
+    HAL_ADC_Start(&AdcHandle); // Start conversion
+
+    // Wait end of conversion and get value
+    if (HAL_ADC_PollForConversion(&AdcHandle, 10) == HAL_OK) {
+        return (HAL_ADC_GetValue(&AdcHandle));
+    } else {
+        return 0;
+    }
+}
+
+uint16_t analogin_read_u16(analogin_t *obj) {
+    uint16_t value = adc_read(obj);
+    // 12-bit to 16-bit conversion
+    value = ((value << 4) & (uint16_t)0xFFF0) | ((value >> 8) & (uint16_t)0x000F);
+    return value;
+}
+
+float analogin_read(analogin_t *obj) {
+    uint16_t value = adc_read(obj);
+    return (float)value * (1.0f / (float)0xFFF); // 12 bits range
+}
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/analogout_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/analogout_api.c
@@ -1,0 +1,119 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "mbed_assert.h"
+#include "analogout_api.h"
+
+#if DEVICE_ANALOGOUT
+
+#include "cmsis.h"
+#include "pinmap.h"
+#include "mbed_error.h"
+
+#define DAC_RANGE (0xFFF) // 12 bits
+
+static const PinMap PinMap_DAC[] = {
+    {PA_4, DAC_1, STM_PIN_DATA(STM_MODE_ANALOG, GPIO_NOPULL, 0)}, // DAC_OUT
+    {NC,   NC,    0}
+};
+
+static DAC_HandleTypeDef DacHandle;
+
+void analogout_init(dac_t *obj, PinName pin) {
+    DAC_ChannelConfTypeDef sConfig;
+
+    DacHandle.Instance = DAC;
+
+    // Get the peripheral name (DAC_1, ...) from the pin and assign it to the object
+    obj->dac = (DACName)pinmap_peripheral(pin, PinMap_DAC);
+    MBED_ASSERT(obj->dac != (DACName)NC);
+
+    // Configure GPIO
+    pinmap_pinout(pin, PinMap_DAC);
+
+    // Save the channel for future use
+    obj->pin = pin;
+
+    // Enable DAC clock
+    __DAC_CLK_ENABLE();
+
+    // Configure DAC
+    sConfig.DAC_Trigger      = DAC_TRIGGER_NONE;
+    sConfig.DAC_OutputBuffer = DAC_OUTPUTBUFFER_DISABLE;
+
+    HAL_DAC_ConfigChannel(&DacHandle, &sConfig, DAC_CHANNEL_1);
+
+    analogout_write_u16(obj, 0);
+}
+
+void analogout_free(dac_t *obj) {
+    // Reset DAC and disable clock
+    __DAC_FORCE_RESET();
+    __DAC_RELEASE_RESET();
+    __DAC_CLK_DISABLE();
+
+    // Configure GPIO
+    pin_function(obj->pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+}
+
+static inline void dac_write(dac_t *obj, uint16_t value) {
+    HAL_DAC_SetValue(&DacHandle, DAC_CHANNEL_1, DAC_ALIGN_12B_R, value);
+    HAL_DAC_Start(&DacHandle, DAC_CHANNEL_1);
+}
+
+static inline int dac_read(dac_t *obj) {
+    return (int)HAL_DAC_GetValue(&DacHandle, DAC_CHANNEL_1);
+}
+
+void analogout_write(dac_t *obj, float value) {
+    if (value < 0.0f) {
+        dac_write(obj, 0); // Min value
+    } else if (value > 1.0f) {
+        dac_write(obj, (uint16_t)DAC_RANGE); // Max value
+    } else {
+        dac_write(obj, (uint16_t)(value * (float)DAC_RANGE));
+    }
+}
+
+void analogout_write_u16(dac_t *obj, uint16_t value) {
+    if (value > (uint16_t)DAC_RANGE) {
+        dac_write(obj, (uint16_t)DAC_RANGE); // Max value
+    } else {
+        dac_write(obj, value);
+    }
+}
+
+float analogout_read(dac_t *obj) {
+    uint32_t value = dac_read(obj);
+    return (float)((float)value * (1.0f / (float)DAC_RANGE));
+}
+
+uint16_t analogout_read_u16(dac_t *obj) {
+    return (uint16_t)dac_read(obj);
+}
+
+#endif // DEVICE_ANALOGOUT

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/device.h
@@ -1,0 +1,70 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+#define DEVICE_PORTIN           1
+#define DEVICE_PORTOUT          1
+#define DEVICE_PORTINOUT        1
+
+#define DEVICE_INTERRUPTIN      1
+
+#define DEVICE_ANALOGIN         1
+#define DEVICE_ANALOGOUT        1
+
+#define DEVICE_SERIAL           1
+
+#define DEVICE_I2C              1
+#define DEVICE_I2CSLAVE         1
+
+#define DEVICE_SPI              1
+#define DEVICE_SPISLAVE         1
+
+#define DEVICE_RTC              1
+
+#define DEVICE_PWMOUT           1
+
+#define DEVICE_SLEEP            1
+
+//=======================================
+
+#define DEVICE_SEMIHOST         0
+#define DEVICE_LOCALFILESYSTEM  0
+#define DEVICE_ID_LENGTH       24
+
+#define DEVICE_DEBUG_AWARENESS  0
+
+#define DEVICE_STDIO_MESSAGES   1
+
+#define DEVICE_ERROR_RED        0
+
+#include "objects.h"
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/gpio_api.c
@@ -1,0 +1,73 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include "mbed_assert.h"
+#include "gpio_api.h"
+#include "pinmap.h"
+#include "mbed_error.h"
+
+extern uint32_t Set_GPIO_Clock(uint32_t port_idx);
+
+uint32_t gpio_set(PinName pin) {
+    MBED_ASSERT(pin != (PinName)NC);
+
+    pin_function(pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    return (uint32_t)(1 << ((uint32_t)pin & 0xF)); // Return the pin mask
+}
+
+void gpio_init(gpio_t *obj, PinName pin) {
+    obj->pin = pin;
+    if (pin == (PinName)NC)
+        return;
+
+    uint32_t port_index = STM_PORT(pin);
+
+    // Enable GPIO clock
+    uint32_t gpio_add = Set_GPIO_Clock(port_index);
+    GPIO_TypeDef *gpio = (GPIO_TypeDef *)gpio_add;
+
+    // Fill GPIO object structure for future use
+    obj->mask    = gpio_set(pin);
+    obj->reg_in  = &gpio->IDR;
+    obj->reg_set = &gpio->BSRR;
+    obj->reg_clr = &gpio->BRR;
+}
+
+void gpio_mode(gpio_t *obj, PinMode mode) {
+    pin_mode(obj->pin, mode);
+}
+
+void gpio_dir(gpio_t *obj, PinDirection direction) {
+    MBED_ASSERT(obj->pin != (PinName)NC);
+    if (direction == PIN_OUTPUT) {
+        pin_function(obj->pin, STM_PIN_DATA(STM_MODE_OUTPUT_PP, GPIO_NOPULL, 0));
+    } else { // PIN_INPUT
+        pin_function(obj->pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    }
+}

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/gpio_irq_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/gpio_irq_api.c
@@ -1,0 +1,201 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include <stddef.h>
+#include "cmsis.h"
+#include "gpio_irq_api.h"
+#include "pinmap.h"
+#include "mbed_error.h"
+
+#define EDGE_NONE (0)
+#define EDGE_RISE (1)
+#define EDGE_FALL (2)
+#define EDGE_BOTH (3)
+
+#define CHANNEL_NUM (3)
+
+static uint32_t channel_ids[CHANNEL_NUM]  = {0, 0, 0};
+static uint32_t channel_gpio[CHANNEL_NUM] = {0, 0, 0};
+static uint32_t channel_pin[CHANNEL_NUM]  = {0, 0, 0};
+
+static gpio_irq_handler irq_handler;
+
+static void handle_interrupt_in(uint32_t irq_index) {
+    // Retrieve the gpio and pin that generate the irq
+    GPIO_TypeDef *gpio = (GPIO_TypeDef *)(channel_gpio[irq_index]);
+    uint32_t pin = (uint32_t)(1 << channel_pin[irq_index]);
+
+    // Clear interrupt flag
+    if (__HAL_GPIO_EXTI_GET_FLAG(pin) != RESET) {
+        __HAL_GPIO_EXTI_CLEAR_FLAG(pin);
+    }
+
+    if (channel_ids[irq_index] == 0) return;
+
+    // Check which edge has generated the irq
+    if ((gpio->IDR & pin) == 0) {
+        irq_handler(channel_ids[irq_index], IRQ_FALL);
+    } else  {
+        irq_handler(channel_ids[irq_index], IRQ_RISE);
+    }
+}
+
+// The irq_index is passed to the function
+// EXTI lines 0 to 1
+static void gpio_irq0(void) {
+    handle_interrupt_in(0);
+}
+// EXTI lines 2 to 3
+static void gpio_irq1(void) {
+    handle_interrupt_in(1);
+}
+// EXTI lines 4 to 15
+static void gpio_irq2(void) {
+    handle_interrupt_in(2);
+}
+
+extern uint32_t Set_GPIO_Clock(uint32_t port_idx);
+
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id) {
+    IRQn_Type irq_n = (IRQn_Type)0;
+    uint32_t vector = 0;
+    uint32_t irq_index;
+
+    if (pin == NC) return -1;
+
+    uint32_t port_index = STM_PORT(pin);
+    uint32_t pin_index  = STM_PIN(pin);
+
+    // Select irq number and interrupt routine
+    if ((pin_index == 0) || (pin_index == 1)) {
+        irq_n = EXTI0_1_IRQn;
+        vector = (uint32_t)&gpio_irq0;
+        irq_index = 0;
+    } else if ((pin_index == 2) || (pin_index == 3)) {
+        irq_n = EXTI2_3_IRQn;
+        vector = (uint32_t)&gpio_irq1;
+        irq_index = 1;
+    } else if ((pin_index > 3) && (pin_index < 16)) {
+        irq_n = EXTI4_15_IRQn;
+        vector = (uint32_t)&gpio_irq2;
+        irq_index = 2;
+    } else {
+        error("InterruptIn error: pin not supported.\n");
+        return -1;
+    }
+
+    // Enable GPIO clock
+    uint32_t gpio_add = Set_GPIO_Clock(port_index);
+
+    // Configure GPIO
+    pin_function(pin, STM_PIN_DATA(STM_MODE_IT_FALLING, GPIO_NOPULL, 0));
+
+    // Enable EXTI interrupt
+    NVIC_SetVector(irq_n, vector);
+    NVIC_EnableIRQ(irq_n);
+
+    // Save informations for future use
+    obj->irq_n = irq_n;
+    obj->irq_index = irq_index;
+    obj->event = EDGE_NONE;
+    obj->pin = pin;
+    channel_ids[irq_index] = id;
+    channel_gpio[irq_index] = gpio_add;
+    channel_pin[irq_index] = pin_index;
+
+    irq_handler = handler;
+
+    return 0;
+}
+
+void gpio_irq_free(gpio_irq_t *obj) {
+    channel_ids[obj->irq_index] = 0;
+    channel_gpio[obj->irq_index] = 0;
+    channel_pin[obj->irq_index] = 0;
+    // Disable EXTI line
+    pin_function(obj->pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    obj->event = EDGE_NONE;
+}
+
+void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
+{
+    uint32_t mode = STM_MODE_IT_EVT_RESET;
+    uint32_t pull = GPIO_NOPULL;
+
+    if (enable) {
+        if (event == IRQ_RISE) {
+            if ((obj->event == EDGE_FALL) || (obj->event == EDGE_BOTH)) {
+                mode = STM_MODE_IT_RISING_FALLING;
+                obj->event = EDGE_BOTH;
+            } else { // NONE or RISE
+                mode = STM_MODE_IT_RISING;
+                obj->event = EDGE_RISE;
+            }
+        }
+        if (event == IRQ_FALL) {
+            if ((obj->event == EDGE_RISE) || (obj->event == EDGE_BOTH)) {
+                mode = STM_MODE_IT_RISING_FALLING;
+                obj->event = EDGE_BOTH;
+            } else { // NONE or FALL
+                mode = STM_MODE_IT_FALLING;
+                obj->event = EDGE_FALL;
+            }
+        }
+    } else { // Disable
+        if (event == IRQ_RISE) {
+            if ((obj->event == EDGE_FALL) || (obj->event == EDGE_BOTH)) {
+                mode = STM_MODE_IT_FALLING;
+                obj->event = EDGE_FALL;
+            } else { // NONE or RISE
+                mode = STM_MODE_IT_EVT_RESET;
+                obj->event = EDGE_NONE;
+            }
+        }
+        if (event == IRQ_FALL) {
+            if ((obj->event == EDGE_RISE) || (obj->event == EDGE_BOTH)) {
+                mode = STM_MODE_IT_RISING;
+                obj->event = EDGE_RISE;
+            } else { // NONE or FALL
+                mode = STM_MODE_IT_EVT_RESET;
+                obj->event = EDGE_NONE;
+            }
+        }
+    }
+
+    pin_function(obj->pin, STM_PIN_DATA(mode, pull, 0));
+}
+
+void gpio_irq_enable(gpio_irq_t *obj) {
+    NVIC_EnableIRQ(obj->irq_n);
+}
+
+void gpio_irq_disable(gpio_irq_t *obj) {
+    NVIC_DisableIRQ(obj->irq_n);
+    obj->event = EDGE_NONE;
+}

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/gpio_object.h
@@ -1,0 +1,69 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#ifndef MBED_GPIO_OBJECT_H
+#define MBED_GPIO_OBJECT_H
+
+#include "mbed_assert.h"
+#include "cmsis.h"
+#include "PortNames.h"
+#include "PeripheralNames.h"
+#include "PinNames.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    PinName  pin;
+    uint32_t mask;
+    __IO uint16_t *reg_in;
+    __IO uint32_t *reg_set;
+    __IO uint16_t *reg_clr;
+} gpio_t;
+
+static inline void gpio_write(gpio_t *obj, int value) {
+    MBED_ASSERT(obj->pin != (PinName)NC);
+    if (value) {
+        *obj->reg_set = obj->mask;
+    } else {
+        *obj->reg_clr = obj->mask;
+    }
+}
+
+static inline int gpio_read(gpio_t *obj) {
+    MBED_ASSERT(obj->pin != (PinName)NC);
+    return ((*obj->reg_in & obj->mask) ? 1 : 0);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/i2c_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/i2c_api.c
@@ -1,0 +1,394 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include "mbed_assert.h"
+#include "i2c_api.h"
+
+#if DEVICE_I2C
+
+#include "cmsis.h"
+#include "pinmap.h"
+#include "mbed_error.h"
+
+/* Timeout values for flags and events waiting loops. These timeouts are
+   not based on accurate values, they just guarantee that the application will
+   not remain stuck if the I2C communication is corrupted. */
+#define FLAG_TIMEOUT ((int)0x1000)
+#define LONG_TIMEOUT ((int)0x8000)
+
+static const PinMap PinMap_I2C_SDA[] = {
+    {PB_7,  I2C_1, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF1_I2C1)},
+    {PB_9,  I2C_1, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF4_I2C1)},
+    {PB_11, I2C_2, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF6_I2C2)},
+    {PB_14, I2C_2, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF5_I2C2)},
+    {NC,    NC,    0}
+};
+
+static const PinMap PinMap_I2C_SCL[] = {
+    {PB_6,  I2C_1, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF1_I2C1)},
+    {PB_8,  I2C_1, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF4_I2C1)},
+    {PB_10, I2C_2, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF6_I2C2)},
+    {PB_13, I2C_2, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_NOPULL, GPIO_AF5_I2C2)},
+    {NC,    NC,    0}
+};
+
+I2C_HandleTypeDef I2cHandle;
+
+int i2c1_inited = 0;
+int i2c2_inited = 0;
+
+void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
+    // Determine the I2C to use
+    I2CName i2c_sda = (I2CName)pinmap_peripheral(sda, PinMap_I2C_SDA);
+    I2CName i2c_scl = (I2CName)pinmap_peripheral(scl, PinMap_I2C_SCL);
+
+    obj->i2c = (I2CName)pinmap_merge(i2c_sda, i2c_scl);
+    MBED_ASSERT(obj->i2c != (I2CName)NC);
+
+    // Enable I2C1 clock and pinout if not done
+    if ((obj->i2c == I2C_1)&& !i2c1_inited) {
+        i2c1_inited = 1;
+        __HAL_RCC_I2C1_CONFIG(RCC_I2C1CLKSOURCE_SYSCLK);
+        __I2C1_CLK_ENABLE();
+        // Configure I2C pins
+        pinmap_pinout(sda, PinMap_I2C_SDA);
+        pinmap_pinout(scl, PinMap_I2C_SCL);
+        pin_mode(sda, OpenDrain);
+        pin_mode(scl, OpenDrain);
+    }
+    // Enable I2C2 clock and pinout if not done
+    if ((obj->i2c == I2C_2)&& !i2c2_inited) {
+        i2c2_inited = 1;
+        __I2C2_CLK_ENABLE();
+        // Configure I2C pins
+        pinmap_pinout(sda, PinMap_I2C_SDA);
+        pinmap_pinout(scl, PinMap_I2C_SCL);
+        pin_mode(sda, OpenDrain);
+        pin_mode(scl, OpenDrain);
+    }
+
+    // Reset to clear pending flags if any
+    i2c_reset(obj);
+
+    // I2C configuration
+    i2c_frequency(obj, 100000); // 100 kHz per default
+}
+
+void i2c_frequency(i2c_t *obj, int hz) {
+    MBED_ASSERT((hz == 100000) || (hz == 400000) || (hz == 1000000));
+    I2cHandle.Instance = (I2C_TypeDef *)(obj->i2c);
+    int timeout;
+
+    // wait before init
+    timeout = LONG_TIMEOUT;
+    while((__HAL_I2C_GET_FLAG(&I2cHandle, I2C_FLAG_BUSY)) && (timeout-- != 0));
+
+    // Common settings: I2C clock = 32 MHz, Analog filter = ON, Digital filter coefficient = 0
+    switch (hz) {
+        case 100000:
+            I2cHandle.Init.Timing = 0x20602938; // Standard mode with Rise Time = 400ns and Fall Time = 100ns
+            break;
+        case 400000:
+            I2cHandle.Init.Timing = 0x00B0122A; // Fast mode with Rise Time = 250ns and Fall Time = 100ns
+            break;
+        case 1000000:
+            I2cHandle.Init.Timing = 0x0030040E; // Fast mode Plus with Rise Time = 60ns and Fall Time = 100ns
+            break;
+        default:
+            break;
+    }
+
+    // I2C configuration
+    I2cHandle.Init.AddressingMode   = I2C_ADDRESSINGMODE_7BIT;
+    I2cHandle.Init.DualAddressMode  = I2C_DUALADDRESS_DISABLED;
+    I2cHandle.Init.GeneralCallMode  = I2C_GENERALCALL_DISABLED;
+    I2cHandle.Init.NoStretchMode    = I2C_NOSTRETCH_DISABLED;
+    I2cHandle.Init.OwnAddress1      = 0;
+    I2cHandle.Init.OwnAddress2      = 0;
+    I2cHandle.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
+    HAL_I2C_Init(&I2cHandle);
+}
+
+inline int i2c_start(i2c_t *obj) {
+    I2C_TypeDef *i2c = (I2C_TypeDef *)(obj->i2c);
+    int timeout;
+
+    I2cHandle.Instance = (I2C_TypeDef *)(obj->i2c);
+
+    // Clear Acknowledge failure flag
+    __HAL_I2C_CLEAR_FLAG(&I2cHandle, I2C_FLAG_AF);
+
+    // Generate the START condition
+    i2c->CR2 |= I2C_CR2_START;
+
+    // Wait the START condition has been correctly sent
+    timeout = FLAG_TIMEOUT;
+    while (__HAL_I2C_GET_FLAG(&I2cHandle, I2C_FLAG_BUSY) == RESET) {
+        if ((timeout--) == 0) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+inline int i2c_stop(i2c_t *obj) {
+    I2C_TypeDef *i2c = (I2C_TypeDef *)(obj->i2c);
+
+    // Generate the STOP condition
+    i2c->CR2 |= I2C_CR2_STOP;
+
+    return 0;
+}
+
+int i2c_read(i2c_t *obj, int address, char *data, int length, int stop) {
+    I2C_TypeDef *i2c = (I2C_TypeDef *)(obj->i2c);
+    I2cHandle.Instance = (I2C_TypeDef *)(obj->i2c);
+    int timeout;
+    int count;
+    int value;
+
+    /* update CR2 register */
+    i2c->CR2 = (i2c->CR2 & (uint32_t)~((uint32_t)(I2C_CR2_SADD | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_AUTOEND | I2C_CR2_RD_WRN | I2C_CR2_START | I2C_CR2_STOP)))
+               | (uint32_t)(((uint32_t)address & I2C_CR2_SADD) | (((uint32_t)length << 16) & I2C_CR2_NBYTES) | (uint32_t)I2C_SOFTEND_MODE | (uint32_t)I2C_GENERATE_START_READ);
+
+    // Read all bytes
+    for (count = 0; count < length; count++) {
+        value = i2c_byte_read(obj, 0);
+        data[count] = (char)value;
+    }
+
+    // Wait transfer complete
+    timeout = FLAG_TIMEOUT;
+    while (__HAL_I2C_GET_FLAG(&I2cHandle, I2C_FLAG_TC) == RESET) {
+        timeout--;
+        if (timeout == 0) {
+            return -1;
+        }
+    }
+
+    __HAL_I2C_CLEAR_FLAG(&I2cHandle, I2C_FLAG_TC);
+
+    // If not repeated start, send stop.
+    if (stop) {
+        i2c_stop(obj);
+        /* Wait until STOPF flag is set */
+        timeout = FLAG_TIMEOUT;
+        while (__HAL_I2C_GET_FLAG(&I2cHandle, I2C_FLAG_STOPF) == RESET) {
+            timeout--;
+            if (timeout == 0) {
+                return -1;
+            }
+        }
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(&I2cHandle, I2C_FLAG_STOPF);
+    }
+
+    return length;
+}
+
+int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop) {
+    I2C_TypeDef *i2c = (I2C_TypeDef *)(obj->i2c);
+    I2cHandle.Instance = (I2C_TypeDef *)(obj->i2c);
+    int timeout;
+    int count;
+
+    /* update CR2 register */
+    i2c->CR2 = (i2c->CR2 & (uint32_t)~((uint32_t)(I2C_CR2_SADD | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_AUTOEND | I2C_CR2_RD_WRN | I2C_CR2_START | I2C_CR2_STOP)))
+               | (uint32_t)(((uint32_t)address & I2C_CR2_SADD) | (((uint32_t)length << 16) & I2C_CR2_NBYTES) | (uint32_t)I2C_SOFTEND_MODE | (uint32_t)I2C_GENERATE_START_WRITE);
+
+    for (count = 0; count < length; count++) {
+        i2c_byte_write(obj, data[count]);
+    }
+
+    // Wait transfer complete
+    timeout = FLAG_TIMEOUT;
+    while (__HAL_I2C_GET_FLAG(&I2cHandle, I2C_FLAG_TC) == RESET) {
+        timeout--;
+        if (timeout == 0) {
+            return -1;
+        }
+    }
+
+    __HAL_I2C_CLEAR_FLAG(&I2cHandle, I2C_FLAG_TC);
+
+    // If not repeated start, send stop.
+    if (stop) {
+        i2c_stop(obj);
+        /* Wait until STOPF flag is set */
+        timeout = FLAG_TIMEOUT;
+        while (__HAL_I2C_GET_FLAG(&I2cHandle, I2C_FLAG_STOPF) == RESET) {
+            timeout--;
+            if (timeout == 0) {
+                return -1;
+            }
+        }
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(&I2cHandle, I2C_FLAG_STOPF);
+    }
+
+    return count;
+}
+
+int i2c_byte_read(i2c_t *obj, int last) {
+    I2C_TypeDef *i2c = (I2C_TypeDef *)(obj->i2c);
+    int timeout;
+
+    // Wait until the byte is received
+    timeout = FLAG_TIMEOUT;
+    while (__HAL_I2C_GET_FLAG(&I2cHandle, I2C_FLAG_RXNE) == RESET) {
+        if ((timeout--) == 0) {
+            return -1;
+        }
+    }
+
+    return (int)i2c->RXDR;
+}
+
+int i2c_byte_write(i2c_t *obj, int data) {
+    I2C_TypeDef *i2c = (I2C_TypeDef *)(obj->i2c);
+    int timeout;
+
+    // Wait until the previous byte is transmitted
+    timeout = FLAG_TIMEOUT;
+    while (__HAL_I2C_GET_FLAG(&I2cHandle, I2C_FLAG_TXIS) == RESET) {
+        if ((timeout--) == 0) {
+            return 0;
+        }
+    }
+
+    i2c->TXDR = (uint8_t)data;
+
+    return 1;
+}
+
+void i2c_reset(i2c_t *obj) {
+    int timeout;
+	
+    // wait before reset
+    timeout = LONG_TIMEOUT;
+    while((__HAL_I2C_GET_FLAG(&I2cHandle, I2C_FLAG_BUSY)) && (timeout-- != 0));
+
+    if (obj->i2c == I2C_1) {
+        __I2C1_FORCE_RESET();
+        __I2C1_RELEASE_RESET();
+    }
+    if (obj->i2c == I2C_2) {
+        __I2C2_FORCE_RESET();
+        __I2C2_RELEASE_RESET();
+    }
+}
+
+#if DEVICE_I2CSLAVE
+
+void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask) {
+    I2C_TypeDef *i2c = (I2C_TypeDef *)(obj->i2c);
+    uint16_t tmpreg;
+
+    // disable
+    i2c->OAR1 &= (uint32_t)(~I2C_OAR1_OA1EN);
+    // Get the old register value
+    tmpreg = i2c->OAR1;
+    // Reset address bits
+    tmpreg &= 0xFC00;
+    // Set new address
+    tmpreg |= (uint16_t)((uint16_t)address & (uint16_t)0x00FE); // 7-bits
+    // Store the new register value
+    i2c->OAR1 = tmpreg;
+    // enable
+    i2c->OAR1 |= I2C_OAR1_OA1EN;
+}
+
+void i2c_slave_mode(i2c_t *obj, int enable_slave) {
+
+    I2C_TypeDef *i2c = (I2C_TypeDef *)(obj->i2c);
+    uint16_t tmpreg;
+
+    // Get the old register value
+    tmpreg = i2c->OAR1;
+
+    // Enable / disable slave
+    if (enable_slave == 1) {
+        tmpreg |= I2C_OAR1_OA1EN;
+    } else {
+        tmpreg &= (uint32_t)(~I2C_OAR1_OA1EN);
+    }
+
+    // Set new mode
+    i2c->OAR1 = tmpreg;
+
+}
+
+// See I2CSlave.h
+#define NoData         0 // the slave has not been addressed
+#define ReadAddressed  1 // the master has requested a read from this slave (slave = transmitter)
+#define WriteGeneral   2 // the master is writing to all slave
+#define WriteAddressed 3 // the master is writing to this slave (slave = receiver)
+
+int i2c_slave_receive(i2c_t *obj) {
+    I2cHandle.Instance = (I2C_TypeDef *)(obj->i2c);
+    int retValue = NoData;
+
+    if (__HAL_I2C_GET_FLAG(&I2cHandle, I2C_FLAG_BUSY) == 1) {
+        if (__HAL_I2C_GET_FLAG(&I2cHandle, I2C_FLAG_ADDR) == 1) {
+            if (__HAL_I2C_GET_FLAG(&I2cHandle, I2C_FLAG_DIR) == 1)
+                retValue = ReadAddressed;
+            else
+                retValue = WriteAddressed;
+            __HAL_I2C_CLEAR_FLAG(&I2cHandle, I2C_FLAG_ADDR);
+        }
+    }
+
+    return (retValue);
+}
+
+int i2c_slave_read(i2c_t *obj, char *data, int length) {
+    char size = 0;
+
+    while (size < length) data[size++] = (char)i2c_byte_read(obj, 0);
+
+    return size;
+}
+
+int i2c_slave_write(i2c_t *obj, const char *data, int length) {
+    char size = 0;
+    I2cHandle.Instance = (I2C_TypeDef *)(obj->i2c);
+
+    do {
+        i2c_byte_write(obj, data[size]);
+        size++;
+    } while (size < length);
+
+    return size;
+}
+
+
+#endif // DEVICE_I2CSLAVE
+
+#endif // DEVICE_I2C

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/mbed_overrides.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/mbed_overrides.c
@@ -1,0 +1,34 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "cmsis.h"
+
+// This function is called after RAM initialization and before main.
+void mbed_sdk_init() {
+    // Update the SystemCoreClock variable.
+    SystemCoreClockUpdate();
+}

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/objects.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/objects.h
@@ -1,0 +1,109 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#ifndef MBED_OBJECTS_H
+#define MBED_OBJECTS_H
+
+#include "cmsis.h"
+#include "PortNames.h"
+#include "PeripheralNames.h"
+#include "PinNames.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct gpio_irq_s {
+    IRQn_Type irq_n;
+    uint32_t irq_index;
+    uint32_t event;
+    PinName pin;
+};
+
+struct port_s {
+    PortName port;
+    uint32_t mask;
+    PinDirection direction;
+    __IO uint16_t *reg_in;
+    __IO uint16_t *reg_out;
+};
+
+struct analogin_s {
+    ADCName adc;
+    PinName pin;
+};
+
+struct dac_s {
+    DACName dac;
+    PinName pin;
+};
+
+struct serial_s {
+    UARTName uart;
+    int index; // Used by irq
+    uint32_t baudrate;
+    uint32_t databits;
+    uint32_t stopbits;
+    uint32_t parity;
+    PinName  pin_tx;
+    PinName  pin_rx;
+};
+
+struct spi_s {
+    SPIName spi;
+    uint32_t bits;
+    uint32_t cpol;
+    uint32_t cpha;
+    uint32_t mode;
+    uint32_t nss;
+    uint32_t br_presc;
+    PinName  pin_miso;
+    PinName  pin_mosi;
+    PinName  pin_sclk;
+    PinName  pin_ssel;
+};
+
+struct i2c_s {
+    I2CName  i2c;
+};
+
+struct pwmout_s {
+    PWMName pwm;
+    PinName pin;
+    uint32_t period;
+    uint32_t pulse;
+};
+
+#include "gpio_object.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/pinmap.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/pinmap.c
@@ -1,0 +1,138 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include "mbed_assert.h"
+#include "pinmap.h"
+#include "PortNames.h"
+#include "mbed_error.h"
+
+// GPIO mode look-up table
+static const uint32_t gpio_mode[13] = {
+    0x00000000, //  0 = GPIO_MODE_INPUT
+    0x00000001, //  1 = GPIO_MODE_OUTPUT_PP
+    0x00000011, //  2 = GPIO_MODE_OUTPUT_OD
+    0x00000002, //  3 = GPIO_MODE_AF_PP
+    0x00000012, //  4 = GPIO_MODE_AF_OD
+    0x00000003, //  5 = GPIO_MODE_ANALOG
+    0x10110000, //  6 = GPIO_MODE_IT_RISING
+    0x10210000, //  7 = GPIO_MODE_IT_FALLING
+    0x10310000, //  8 = GPIO_MODE_IT_RISING_FALLING
+    0x10120000, //  9 = GPIO_MODE_EVT_RISING
+    0x10220000, // 10 = GPIO_MODE_EVT_FALLING
+    0x10320000, // 11 = GPIO_MODE_EVT_RISING_FALLING
+    0x10000000  // 12 = Reset IT and EVT (not in STM32Cube HAL)
+};
+
+// Enable GPIO clock and return GPIO base address
+uint32_t Set_GPIO_Clock(uint32_t port_idx) {
+    uint32_t gpio_add = 0;
+    switch (port_idx) {
+        case PortA:
+            gpio_add = GPIOA_BASE;
+            __GPIOA_CLK_ENABLE();
+            break;
+        case PortB:
+            gpio_add = GPIOB_BASE;
+            __GPIOB_CLK_ENABLE();
+            break;
+        case PortC:
+            gpio_add = GPIOC_BASE;
+            __GPIOC_CLK_ENABLE();
+            break;
+        case PortD:
+            gpio_add = GPIOD_BASE;
+            __GPIOD_CLK_ENABLE();
+            break;
+        case PortH:
+            gpio_add = GPIOH_BASE;
+            __GPIOH_CLK_ENABLE();
+            break;
+        default:
+            error("Pinmap error: wrong port number.");
+            break;
+    }
+    return gpio_add;
+}
+
+/**
+ * Configure pin (mode, speed, output type and pull-up/pull-down)
+ */
+void pin_function(PinName pin, int data) {
+    MBED_ASSERT(pin != (PinName)NC);
+    // Get the pin informations
+    uint32_t mode  = STM_PIN_MODE(data);
+    uint32_t pupd  = STM_PIN_PUPD(data);
+    uint32_t afnum = STM_PIN_AFNUM(data);
+
+    uint32_t port_index = STM_PORT(pin);
+    uint32_t pin_index  = STM_PIN(pin);
+
+    // Enable GPIO clock
+    uint32_t gpio_add = Set_GPIO_Clock(port_index);
+    GPIO_TypeDef *gpio = (GPIO_TypeDef *)gpio_add;
+
+    // Configure GPIO
+    GPIO_InitTypeDef GPIO_InitStructure;
+    GPIO_InitStructure.Pin       = (uint32_t)(1 << pin_index);
+    GPIO_InitStructure.Mode      = gpio_mode[mode];
+    GPIO_InitStructure.Pull      = pupd;
+    GPIO_InitStructure.Speed     = GPIO_SPEED_HIGH;
+    GPIO_InitStructure.Alternate = afnum;
+    HAL_GPIO_Init(gpio, &GPIO_InitStructure);
+
+    // [TODO] Disconnect JTAG-DP + SW-DP signals.
+    // Warning: Need to reconnect under reset
+    //if ((pin == PA_13) || (pin == PA_14)) {
+    //
+    //}
+    //if ((pin == PA_15) || (pin == PB_3) || (pin == PB_4)) {
+    //
+    //}
+}
+
+/**
+ * Configure pin pull-up/pull-down
+ */
+void pin_mode(PinName pin, PinMode mode) {
+    MBED_ASSERT(pin != (PinName)NC);
+    uint32_t port_index = STM_PORT(pin);
+    uint32_t pin_index  = STM_PIN(pin);
+
+    // Enable GPIO clock
+    uint32_t gpio_add = Set_GPIO_Clock(port_index);
+    GPIO_TypeDef *gpio = (GPIO_TypeDef *)gpio_add;
+
+    // Configure pull-up/pull-down resistors
+    uint32_t pupd = (uint32_t)mode;
+    if (pupd > 2)
+        pupd = 0; // Open-drain = No pull-up/No pull-down
+    gpio->PUPDR &= (uint32_t)(~(GPIO_PUPDR_PUPD0 << (pin_index * 2)));
+    gpio->PUPDR |= (uint32_t)(pupd << (pin_index * 2));
+
+}

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/port_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/port_api.c
@@ -1,0 +1,97 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include "port_api.h"
+#include "pinmap.h"
+#include "gpio_api.h"
+#include "mbed_error.h"
+
+#if DEVICE_PORTIN || DEVICE_PORTOUT
+
+extern uint32_t Set_GPIO_Clock(uint32_t port_idx);
+
+// high nibble = port number (0=A, 1=B, 2=C, 3=D, 4=E, 5=F, ...)
+// low nibble  = pin number
+PinName port_pin(PortName port, int pin_n) {
+    return (PinName)(pin_n + (port << 4));
+}
+
+void port_init(port_t *obj, PortName port, int mask, PinDirection dir) {
+    uint32_t port_index = (uint32_t)port;
+
+    // Enable GPIO clock
+    uint32_t gpio_add = Set_GPIO_Clock(port_index);
+    GPIO_TypeDef *gpio = (GPIO_TypeDef *)gpio_add;
+
+    // Fill PORT object structure for future use
+    obj->port      = port;
+    obj->mask      = mask;
+    obj->direction = dir;
+    obj->reg_in    = &gpio->IDR;
+    obj->reg_out   = &gpio->ODR;
+
+    port_dir(obj, dir);
+}
+
+void port_dir(port_t *obj, PinDirection dir) {
+    uint32_t i;
+    obj->direction = dir;
+    for (i = 0; i < 16; i++) { // Process all pins
+        if (obj->mask & (1 << i)) { // If the pin is used
+            if (dir == PIN_OUTPUT) {
+                pin_function(port_pin(obj->port, i), STM_PIN_DATA(STM_MODE_OUTPUT_PP, GPIO_NOPULL, 0));
+            } else { // PIN_INPUT
+                pin_function(port_pin(obj->port, i), STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+            }
+        }
+    }
+}
+
+void port_mode(port_t *obj, PinMode mode) {
+    uint32_t i;
+    for (i = 0; i < 16; i++) { // Process all pins
+        if (obj->mask & (1 << i)) { // If the pin is used
+            pin_mode(port_pin(obj->port, i), mode);
+        }
+    }
+}
+
+void port_write(port_t *obj, int value) {
+    *obj->reg_out = (*obj->reg_out & ~obj->mask) | (value & obj->mask);
+}
+
+int port_read(port_t *obj) {
+    if (obj->direction == PIN_OUTPUT) {
+        return (*obj->reg_out & obj->mask);
+    } else { // PIN_INPUT
+        return (*obj->reg_in & obj->mask);
+    }
+}
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/pwmout_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/pwmout_api.c
@@ -1,0 +1,203 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include "pwmout_api.h"
+
+#if DEVICE_PWMOUT
+
+#include "cmsis.h"
+#include "pinmap.h"
+#include "mbed_error.h"
+
+// TIM21 cannot be used because already used by the us_ticker
+static const PinMap PinMap_PWM[] = {
+    {PA_0,  PWM_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM2)},  // TIM2_CH1
+    {PA_1,  PWM_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM2)},  // TIM2_CH2
+//  {PA_2,  PWM_21, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_TIM21)}, // TIM21_CH1
+//  {PA_2,  PWM_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM2)},  // TIM2_CH3 - used by STDIO TX
+//  {PA_3,  PWM_21, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_TIM21)}, // TIM21_CH2
+//  {PA_3,  PWM_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM2)},  // TIM2_CH4 - used by STDIO RX
+    {PA_5,  PWM_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF5_TIM2)},  // TIM2_CH1 - used also to drive the LED
+    {PA_6,  PWM_22, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF5_TIM22)}, // TIM22_CH1
+    {PA_7,  PWM_22, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF5_TIM22)}, // TIM22_CH2
+    {PA_15, PWM_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF5_TIM2)},  // TIM2_CH1
+    {PB_3,  PWM_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM2)},  // TIM2_CH2
+    {PB_4,  PWM_22, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_TIM22)}, // TIM22_CH1
+    {PB_5,  PWM_22, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_TIM22)}, // TIM22_CH2
+    {PB_10, PWM_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM2)},  // TIM2_CH3
+    {PB_11, PWM_2,  STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_TIM2)},  // TIM2_CH4
+//  {PB_13, PWM_21, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF6_TIM21)}, // TIM21_CH1
+//  {PB_14, PWM_21, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF6_TIM21)}, // TIM21_CH2
+    {PC_6,  PWM_22, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_TIM22)}, // TIM22_CH1
+    {PC_7,  PWM_22, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_TIM22)}, // TIM22_CH2
+    {NC,    NC,     0}
+};
+
+static TIM_HandleTypeDef TimHandle;
+
+void pwmout_init(pwmout_t* obj, PinName pin) {
+    // Get the peripheral name from the pin and assign it to the object
+    obj->pwm = (PWMName)pinmap_peripheral(pin, PinMap_PWM);
+
+    if (obj->pwm == (PWMName)NC) {
+        error("PWM error: pinout mapping failed.");
+    }
+
+    // Enable TIM clock
+    if (obj->pwm == PWM_2) __TIM2_CLK_ENABLE();
+    if (obj->pwm == PWM_21) __TIM21_CLK_ENABLE();
+    if (obj->pwm == PWM_22) __TIM22_CLK_ENABLE();
+
+    // Configure GPIO
+    pinmap_pinout(pin, PinMap_PWM);
+
+    obj->pin = pin;
+    obj->period = 0;
+    obj->pulse = 0;
+
+    pwmout_period_us(obj, 20000); // 20 ms per default
+}
+
+void pwmout_free(pwmout_t* obj) {
+    // Configure GPIO
+    pin_function(obj->pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+}
+
+void pwmout_write(pwmout_t* obj, float value) {
+    TIM_OC_InitTypeDef sConfig;
+    int channel = 0;
+
+    TimHandle.Instance = (TIM_TypeDef *)(obj->pwm);
+
+    if (value < (float)0.0) {
+        value = 0.0;
+    } else if (value > (float)1.0) {
+        value = 1.0;
+    }
+
+    obj->pulse = (uint32_t)((float)obj->period * value);
+
+    // Configure channels
+    sConfig.OCMode       = TIM_OCMODE_PWM1;
+    sConfig.Pulse        = obj->pulse;
+    sConfig.OCPolarity   = TIM_OCPOLARITY_HIGH;
+    sConfig.OCFastMode   = TIM_OCFAST_ENABLE;
+
+    switch (obj->pin) {
+        // Channels 1
+        case PA_0:
+//      case PA_2:
+        case PA_5:
+        case PA_6:
+        case PA_15:
+        case PB_4:
+//      case PB_13:
+        case PC_6:
+            channel = TIM_CHANNEL_1;
+            break;
+        // Channels 2
+        case PA_1:
+//      case PA_3:
+        case PA_7:
+        case PB_3:
+        case PB_5:
+//      case PB_14:
+        case PC_7:
+            channel = TIM_CHANNEL_2;
+            break;
+        // Channels 3
+        case PA_2:
+        case PB_10:
+            channel = TIM_CHANNEL_3;
+            break;
+        // Channels 4
+        case PA_3:
+        case PB_11:
+            channel = TIM_CHANNEL_4;
+            break;
+        default:
+            return;
+    }
+
+    HAL_TIM_PWM_ConfigChannel(&TimHandle, &sConfig, channel);
+    HAL_TIM_PWM_Start(&TimHandle, channel);
+}
+
+float pwmout_read(pwmout_t* obj) {
+    float value = 0;
+    if (obj->period > 0) {
+        value = (float)(obj->pulse) / (float)(obj->period);
+    }
+    return ((value > (float)1.0) ? (float)(1.0) : (value));
+}
+
+void pwmout_period(pwmout_t* obj, float seconds) {
+    pwmout_period_us(obj, seconds * 1000000.0f);
+}
+
+void pwmout_period_ms(pwmout_t* obj, int ms) {
+    pwmout_period_us(obj, ms * 1000);
+}
+
+void pwmout_period_us(pwmout_t* obj, int us) {
+    TimHandle.Instance = (TIM_TypeDef *)(obj->pwm);
+
+    float dc = pwmout_read(obj);
+
+    __HAL_TIM_DISABLE(&TimHandle);
+
+    TimHandle.Init.Period        = us - 1;
+    TimHandle.Init.Prescaler     = (uint16_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimHandle.Init.ClockDivision = 0;
+    TimHandle.Init.CounterMode   = TIM_COUNTERMODE_UP;
+    HAL_TIM_PWM_Init(&TimHandle);
+
+    // Set duty cycle again
+    pwmout_write(obj, dc);
+
+    // Save for future use
+    obj->period = us;
+
+    __HAL_TIM_ENABLE(&TimHandle);
+}
+
+void pwmout_pulsewidth(pwmout_t* obj, float seconds) {
+    pwmout_pulsewidth_us(obj, seconds * 1000000.0f);
+}
+
+void pwmout_pulsewidth_ms(pwmout_t* obj, int ms) {
+    pwmout_pulsewidth_us(obj, ms * 1000);
+}
+
+void pwmout_pulsewidth_us(pwmout_t* obj, int us) {
+    float value = (float)us / (float)obj->period;
+    pwmout_write(obj, value);
+}
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/rtc_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/rtc_api.c
@@ -1,0 +1,198 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include "rtc_api.h"
+
+#if DEVICE_RTC
+
+#include "mbed_error.h"
+
+static int rtc_inited = 0;
+
+static RTC_HandleTypeDef RtcHandle;
+
+void rtc_init(void) {
+    RCC_OscInitTypeDef RCC_OscInitStruct;
+    uint32_t rtc_freq = 0;
+
+    if (rtc_inited) return;
+    rtc_inited = 1;
+
+    RtcHandle.Instance = RTC;
+
+    // Enable Power clock
+    __PWR_CLK_ENABLE();
+
+    // Enable access to Backup domain
+    HAL_PWR_EnableBkUpAccess();
+
+    // Reset Backup domain
+    __HAL_RCC_BACKUPRESET_FORCE();
+    __HAL_RCC_BACKUPRESET_RELEASE();
+
+    // Enable LSE Oscillator
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
+    RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; /* Mandatory, otherwise the PLL is reconfigured! */
+    RCC_OscInitStruct.LSEState       = RCC_LSE_ON; /* External 32.768 kHz clock on OSC_IN/OSC_OUT */
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK) {
+        // Connect LSE to RTC
+        __HAL_RCC_RTC_CLKPRESCALER(RCC_RTCCLKSOURCE_LSE);
+        __HAL_RCC_RTC_CONFIG(RCC_RTCCLKSOURCE_LSE);
+        rtc_freq = LSE_VALUE;
+    } else {
+        // Enable LSI clock
+        RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI | RCC_OSCILLATORTYPE_LSE;
+        RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // Mandatory, otherwise the PLL is reconfigured!
+        RCC_OscInitStruct.LSEState       = RCC_LSE_OFF;
+        RCC_OscInitStruct.LSIState       = RCC_LSI_ON;
+        if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+            error("RTC error: LSI clock initialization failed.");
+        }
+        // Connect LSI to RTC
+        __HAL_RCC_RTC_CLKPRESCALER(RCC_RTCCLKSOURCE_LSI);
+        __HAL_RCC_RTC_CONFIG(RCC_RTCCLKSOURCE_LSI);
+        // [TODO] This value is LSI typical value. To be measured precisely using a timer input capture
+        rtc_freq = 32000;
+    }
+
+    // Enable RTC
+    __HAL_RCC_RTC_ENABLE();
+
+    RtcHandle.Init.HourFormat     = RTC_HOURFORMAT_24;
+    RtcHandle.Init.AsynchPrediv   = 127;
+    RtcHandle.Init.SynchPrediv    = (rtc_freq / 128) - 1;
+    RtcHandle.Init.OutPut         = RTC_OUTPUT_DISABLE;
+    RtcHandle.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
+    RtcHandle.Init.OutPutType     = RTC_OUTPUT_TYPE_OPENDRAIN;
+
+    if (HAL_RTC_Init(&RtcHandle) != HAL_OK) {
+        error("RTC error: RTC initialization failed.");
+    }
+}
+
+void rtc_free(void) {
+    // Enable Power clock
+    __PWR_CLK_ENABLE();
+
+    // Enable access to Backup domain
+    HAL_PWR_EnableBkUpAccess();
+
+    // Reset Backup domain
+    __HAL_RCC_BACKUPRESET_FORCE();
+    __HAL_RCC_BACKUPRESET_RELEASE();
+
+    // Disable access to Backup domain
+    HAL_PWR_DisableBkUpAccess();
+
+    // Disable LSI and LSE clocks
+    RCC_OscInitTypeDef RCC_OscInitStruct;
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI | RCC_OSCILLATORTYPE_LSE;
+    RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE;
+    RCC_OscInitStruct.LSIState       = RCC_LSI_OFF;
+    RCC_OscInitStruct.LSEState       = RCC_LSE_OFF;
+    HAL_RCC_OscConfig(&RCC_OscInitStruct);
+
+    rtc_inited = 0;
+}
+
+int rtc_isenabled(void) {
+    return rtc_inited;
+}
+
+/*
+ RTC Registers
+   RTC_WeekDay 1=monday, 2=tuesday, ..., 7=sunday
+   RTC_Month   1=january, 2=february, ..., 12=december
+   RTC_Date    day of the month 1-31
+   RTC_Year    year 0-99
+ struct tm
+   tm_sec      seconds after the minute 0-61
+   tm_min      minutes after the hour 0-59
+   tm_hour     hours since midnight 0-23
+   tm_mday     day of the month 1-31
+   tm_mon      months since January 0-11
+   tm_year     years since 1900
+   tm_wday     days since Sunday 0-6
+   tm_yday     days since January 1 0-365
+   tm_isdst    Daylight Saving Time flag
+*/
+time_t rtc_read(void) {
+    RTC_DateTypeDef dateStruct;
+    RTC_TimeTypeDef timeStruct;
+    struct tm timeinfo;
+
+    RtcHandle.Instance = RTC;
+
+    // Read actual date and time
+    // Warning: the time must be read first!
+    HAL_RTC_GetTime(&RtcHandle, &timeStruct, FORMAT_BIN);
+    HAL_RTC_GetDate(&RtcHandle, &dateStruct, FORMAT_BIN);
+
+    // Setup a tm structure based on the RTC
+    timeinfo.tm_wday = dateStruct.WeekDay;
+    timeinfo.tm_mon  = dateStruct.Month - 1;
+    timeinfo.tm_mday = dateStruct.Date;
+    timeinfo.tm_year = dateStruct.Year + 100;
+    timeinfo.tm_hour = timeStruct.Hours;
+    timeinfo.tm_min  = timeStruct.Minutes;
+    timeinfo.tm_sec  = timeStruct.Seconds;
+
+    // Convert to timestamp
+    time_t t = mktime(&timeinfo);
+
+    return t;
+}
+
+void rtc_write(time_t t) {
+    RTC_DateTypeDef dateStruct;
+    RTC_TimeTypeDef timeStruct;
+
+    RtcHandle.Instance = RTC;
+
+    // Convert the time into a tm
+    struct tm *timeinfo = localtime(&t);
+
+    // Fill RTC structures
+    dateStruct.WeekDay        = timeinfo->tm_wday;
+    dateStruct.Month          = timeinfo->tm_mon + 1;
+    dateStruct.Date           = timeinfo->tm_mday;
+    dateStruct.Year           = timeinfo->tm_year - 100;
+    timeStruct.Hours          = timeinfo->tm_hour;
+    timeStruct.Minutes        = timeinfo->tm_min;
+    timeStruct.Seconds        = timeinfo->tm_sec;
+    timeStruct.TimeFormat     = RTC_HOURFORMAT12_PM;
+    timeStruct.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
+    timeStruct.StoreOperation = RTC_STOREOPERATION_RESET;
+
+    // Change the RTC current date/time
+    HAL_RTC_SetDate(&RtcHandle, &dateStruct, FORMAT_BIN);
+    HAL_RTC_SetTime(&RtcHandle, &timeStruct, FORMAT_BIN);
+}
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/serial_api.c
@@ -1,0 +1,351 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include "mbed_assert.h"
+#include "serial_api.h"
+
+#if DEVICE_SERIAL
+
+#include "cmsis.h"
+#include "pinmap.h"
+#include <string.h>
+
+static const PinMap PinMap_UART_TX[] = {
+    {PA_2,  UART_2,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_USART2)},
+    {PA_9,  UART_1,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_USART1)},
+    {PA_14, UART_2,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_USART2)}, // Warning: this pin is used by SWCLK
+    {PB_6,  UART_1,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_USART1)},
+    {PB_10, LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_LPUART1)},
+    {PC_4,  LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_LPUART1)},
+    {PC_10, LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_LPUART1)},
+    {NC,    NC,       0}
+};
+
+static const PinMap PinMap_UART_RX[] = {
+    {PA_3,  UART_2,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_USART2)},
+    {PA_10, UART_1,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_USART1)},
+    {PA_15, UART_2,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_USART2)},
+    {PB_7,  UART_1,   STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_USART1)},
+    {PB_11, LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF4_LPUART1)},
+    {PC_5,  LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_LPUART1)},
+    {PC_11, LPUART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_LPUART1)},
+    {NC,    NC,      0}
+};
+
+#define UART_NUM (3)
+
+static uint32_t serial_irq_ids[UART_NUM] = {0, 0, 0};
+
+static uart_irq_handler irq_handler;
+
+UART_HandleTypeDef UartHandle;
+
+int stdio_uart_inited = 0;
+serial_t stdio_uart;
+
+static void init_uart(serial_t *obj) {
+    UartHandle.Instance = (USART_TypeDef *)(obj->uart);
+
+    // [TODO] Workaround to be removed after HAL driver is corrected
+    if (obj->uart == LPUART_1) {
+        UartHandle.Init.BaudRate = obj->baudrate >> 1;
+    } else {
+        UartHandle.Init.BaudRate = obj->baudrate;
+    }
+    UartHandle.Init.WordLength = obj->databits;
+    UartHandle.Init.StopBits   = obj->stopbits;
+    UartHandle.Init.Parity     = obj->parity;
+    UartHandle.Init.HwFlowCtl  = UART_HWCONTROL_NONE;
+
+    if (obj->pin_rx == NC) {
+        UartHandle.Init.Mode = UART_MODE_TX;
+    } else if (obj->pin_tx == NC) {
+        UartHandle.Init.Mode = UART_MODE_RX;
+    } else {
+        UartHandle.Init.Mode = UART_MODE_TX_RX;
+    }
+
+    // Disable the reception overrun detection
+    UartHandle.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_RXOVERRUNDISABLE_INIT;
+    UartHandle.AdvancedInit.OverrunDisable = UART_ADVFEATURE_OVERRUN_DISABLE;
+    
+    HAL_UART_Init(&UartHandle);
+}
+
+void serial_init(serial_t *obj, PinName tx, PinName rx) {
+    // Determine the UART to use (UART_1, UART_2, ...)
+    UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
+    UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
+
+    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
+    obj->uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
+    MBED_ASSERT(obj->uart != (UARTName)NC);
+
+    // Enable UART clock
+    if (obj->uart == UART_1) {
+        __USART1_CLK_ENABLE();
+        obj->index = 0;
+    }
+
+    if (obj->uart == UART_2) {
+        __USART2_CLK_ENABLE();
+        obj->index = 1;
+    }
+
+    if (obj->uart == LPUART_1) {
+        __LPUART1_CLK_ENABLE();
+        obj->index = 2;
+    }
+
+    // Configure the UART pins
+    pinmap_pinout(tx, PinMap_UART_TX);
+    pinmap_pinout(rx, PinMap_UART_RX);
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
+
+    // Configure UART
+    obj->baudrate = 9600;
+    obj->databits = UART_WORDLENGTH_8B;
+    obj->stopbits = UART_STOPBITS_1;
+    obj->parity   = UART_PARITY_NONE;
+    obj->pin_tx   = tx;
+    obj->pin_rx   = rx;
+
+    init_uart(obj);
+
+    // For stdio management
+    if (obj->uart == STDIO_UART) {
+        stdio_uart_inited = 1;
+        memcpy(&stdio_uart, obj, sizeof(serial_t));
+    }
+}
+
+void serial_free(serial_t *obj) {
+    // Reset UART and disable clock
+    if (obj->uart == UART_1) {
+        __USART1_FORCE_RESET();
+        __USART1_RELEASE_RESET();
+        __USART1_CLK_DISABLE();
+    }
+
+    if (obj->uart == UART_2) {
+        __USART2_FORCE_RESET();
+        __USART2_RELEASE_RESET();
+        __USART2_CLK_DISABLE();
+    }
+
+    if (obj->uart == LPUART_1) {
+        __LPUART1_FORCE_RESET();
+        __LPUART1_RELEASE_RESET();
+        __LPUART1_CLK_DISABLE();
+    }
+
+    // Configure GPIOs
+    pin_function(obj->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    pin_function(obj->pin_rx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+
+    serial_irq_ids[obj->index] = 0;
+}
+
+void serial_baud(serial_t *obj, int baudrate) {
+    obj->baudrate = baudrate;
+    init_uart(obj);
+}
+
+void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits) {
+    if (data_bits == 9) {
+        obj->databits = UART_WORDLENGTH_9B;
+    } else {
+        obj->databits = UART_WORDLENGTH_8B;
+    }
+
+    switch (parity) {
+        case ParityOdd:
+        case ParityForced0:
+            obj->parity = UART_PARITY_ODD;
+            break;
+        case ParityEven:
+        case ParityForced1:
+            obj->parity = UART_PARITY_EVEN;
+            break;
+        default: // ParityNone
+            obj->parity = UART_PARITY_NONE;
+            break;
+    }
+
+    if (stop_bits == 2) {
+        obj->stopbits = UART_STOPBITS_2;
+    } else {
+        obj->stopbits = UART_STOPBITS_1;
+    }
+
+    init_uart(obj);
+}
+
+/******************************************************************************
+ * INTERRUPTS HANDLING
+ ******************************************************************************/
+
+static void uart_irq(UARTName name, int id) {
+    UartHandle.Instance = (USART_TypeDef *)name;
+    if (serial_irq_ids[id] != 0) {
+        if (__HAL_UART_GET_FLAG(&UartHandle, UART_FLAG_TC) != RESET) {
+            irq_handler(serial_irq_ids[id], TxIrq);
+            __HAL_UART_CLEAR_IT(&UartHandle, UART_CLEAR_TCF);
+        }
+        if (__HAL_UART_GET_FLAG(&UartHandle, UART_FLAG_RXNE) != RESET) {
+            irq_handler(serial_irq_ids[id], RxIrq);
+            volatile uint32_t tmpval = UartHandle.Instance->RDR; // Clear RXNE bit
+        }
+    }
+}
+
+static void uart1_irq(void) {
+    uart_irq(UART_1, 0);
+}
+
+static void uart2_irq(void) {
+    uart_irq(UART_2, 1);
+}
+
+static void lpuart1_irq(void) {
+    uart_irq(LPUART_1, 2);
+}
+
+void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id) {
+    irq_handler = handler;
+    serial_irq_ids[obj->index] = id;
+}
+
+void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable) {
+    IRQn_Type irq_n = (IRQn_Type)0;
+    uint32_t vector = 0;
+
+    UartHandle.Instance = (USART_TypeDef *)(obj->uart);
+
+    if (obj->uart == UART_1) {
+        irq_n = USART1_IRQn;
+        vector = (uint32_t)&uart1_irq;
+    }
+
+    if (obj->uart == UART_2) {
+        irq_n = USART2_IRQn;
+        vector = (uint32_t)&uart2_irq;
+    }
+
+    if (obj->uart == LPUART_1) {
+        irq_n = RNG_LPUART1_IRQn;
+        vector = (uint32_t)&lpuart1_irq;
+    }
+
+    if (enable) {
+
+        if (irq == RxIrq) {
+            __HAL_UART_ENABLE_IT(&UartHandle, UART_IT_RXNE);
+        } else { // TxIrq
+            __HAL_UART_ENABLE_IT(&UartHandle, UART_IT_TC);
+        }
+
+        NVIC_SetVector(irq_n, vector);
+        NVIC_EnableIRQ(irq_n);
+
+    } else { // disable
+
+        int all_disabled = 0;
+
+        if (irq == RxIrq) {
+            __HAL_UART_DISABLE_IT(&UartHandle, UART_IT_RXNE);
+            // Check if TxIrq is disabled too
+            if ((UartHandle.Instance->CR1 & USART_CR1_TCIE) == 0) all_disabled = 1;
+        } else { // TxIrq
+            __HAL_UART_DISABLE_IT(&UartHandle, UART_IT_TC);
+            // Check if RxIrq is disabled too
+            if ((UartHandle.Instance->CR1 & USART_CR1_RXNEIE) == 0) all_disabled = 1;
+        }
+
+        if (all_disabled) NVIC_DisableIRQ(irq_n);
+
+    }
+}
+
+/******************************************************************************
+ * READ/WRITE
+ ******************************************************************************/
+
+int serial_getc(serial_t *obj) {
+    USART_TypeDef *uart = (USART_TypeDef *)(obj->uart);
+    while (!serial_readable(obj));
+    return (int)(uart->RDR & (uint32_t)0xFF);
+}
+
+void serial_putc(serial_t *obj, int c) {
+    USART_TypeDef *uart = (USART_TypeDef *)(obj->uart);
+    while (!serial_writable(obj));
+    uart->TDR = (uint32_t)(c & (uint32_t)0xFF);
+}
+
+int serial_readable(serial_t *obj) {
+    int status;
+    UartHandle.Instance = (USART_TypeDef *)(obj->uart);
+    // Check if data is received
+    status = ((__HAL_UART_GET_FLAG(&UartHandle, UART_FLAG_RXNE) != RESET) ? 1 : 0);
+    return status;
+}
+
+int serial_writable(serial_t *obj) {
+    int status;
+    UartHandle.Instance = (USART_TypeDef *)(obj->uart);
+    // Check if data is transmitted
+    status = ((__HAL_UART_GET_FLAG(&UartHandle, UART_FLAG_TXE) != RESET) ? 1 : 0);
+    return status;
+}
+
+void serial_clear(serial_t *obj) {
+    UartHandle.Instance = (USART_TypeDef *)(obj->uart);
+    __HAL_UART_CLEAR_IT(&UartHandle, UART_CLEAR_TCF);
+    __HAL_UART_SEND_REQ(&UartHandle, UART_RXDATA_FLUSH_REQUEST);
+}
+
+void serial_pinout_tx(PinName tx) {
+    pinmap_pinout(tx, PinMap_UART_TX);
+}
+
+void serial_break_set(serial_t *obj) {
+    UartHandle.Instance = (USART_TypeDef *)(obj->uart);
+    __HAL_UART_SEND_REQ(&UartHandle, UART_SENDBREAK_REQUEST);
+}
+
+void serial_break_clear(serial_t *obj) {
+}
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/sleep.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/sleep.c
@@ -1,0 +1,65 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include "sleep_api.h"
+
+#if DEVICE_SLEEP
+
+#include "cmsis.h"
+
+static TIM_HandleTypeDef TimMasterHandle;
+
+void sleep(void) {
+    // Disable us_ticker update interrupt
+    TimMasterHandle.Instance = TIM21;
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_UPDATE);
+
+    // Request to enter SLEEP mode
+    HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
+
+    // Re-enable us_ticker update interrupt
+    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_UPDATE);
+}
+
+void deepsleep(void) {
+    // Disable us_ticker update interrupt
+    TimMasterHandle.Instance = TIM21;
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_UPDATE);
+
+    // Request to enter STOP mode with regulator in low power mode
+    HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
+
+    // After wake-up from STOP reconfigure the PLL
+    SetSysClock();
+
+    // Re-enable us_ticker update interrupt
+    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_UPDATE);
+}
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/spi_api.c
@@ -1,0 +1,287 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include "mbed_assert.h"
+#include "spi_api.h"
+
+#if DEVICE_SPI
+
+#include <math.h>
+#include "cmsis.h"
+#include "pinmap.h"
+
+static const PinMap PinMap_SPI_MOSI[] = {
+    {PA_7,  SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_SPI1)},
+    {PA_12, SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_SPI1)},
+    {PB_5,  SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_SPI1)},
+    {PB_15, SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_SPI2)},
+    {PC_3,  SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_SPI2)},
+    {NC,    NC,    0}
+};
+
+static const PinMap PinMap_SPI_MISO[] = {
+    {PA_6,  SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_SPI1)},
+    {PA_11, SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_SPI1)},
+    {PB_4,  SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_SPI1)},
+    {PB_14, SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_SPI2)},
+    {PC_2,  SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF2_SPI2)},
+    {NC,    NC,    0}
+};
+
+static const PinMap PinMap_SPI_SCLK[] = {
+    {PA_5,  SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_SPI1)},
+    {PB_3,  SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_SPI1)},
+    {PB_10, SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF5_SPI2)},
+    {PB_13, SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_SPI2)},
+    {NC,    NC,    0}
+};
+
+static const PinMap PinMap_SPI_SSEL[] = {
+    {PA_4,  SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_SPI1)},
+    {PA_15, SPI_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_SPI1)},
+    {PB_9,  SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF5_SPI2)},
+    {PB_12, SPI_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF0_SPI2)},
+    {NC,    NC,    0}
+};
+
+static SPI_HandleTypeDef SpiHandle;
+
+static void init_spi(spi_t *obj) {
+    SpiHandle.Instance = (SPI_TypeDef *)(obj->spi);
+
+    __HAL_SPI_DISABLE(&SpiHandle);
+
+    SpiHandle.Init.Mode              = obj->mode;
+    SpiHandle.Init.BaudRatePrescaler = obj->br_presc;
+    SpiHandle.Init.Direction         = SPI_DIRECTION_2LINES;
+    SpiHandle.Init.CLKPhase          = obj->cpha;
+    SpiHandle.Init.CLKPolarity       = obj->cpol;
+    SpiHandle.Init.CRCCalculation    = SPI_CRCCALCULATION_DISABLED;
+    SpiHandle.Init.CRCPolynomial     = 7;
+    SpiHandle.Init.DataSize          = obj->bits;
+    SpiHandle.Init.FirstBit          = SPI_FIRSTBIT_MSB;
+    SpiHandle.Init.NSS               = obj->nss;
+    SpiHandle.Init.TIMode            = SPI_TIMODE_DISABLED;
+
+    HAL_SPI_Init(&SpiHandle);
+
+    __HAL_SPI_ENABLE(&SpiHandle);
+}
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
+    // Determine the SPI to use
+    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
+    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+
+    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
+    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
+
+    obj->spi = (SPIName)pinmap_merge(spi_data, spi_cntl);
+    MBED_ASSERT(obj->spi != (SPIName)NC);
+
+    // Enable SPI clock
+    if (obj->spi == SPI_1) {
+        __SPI1_CLK_ENABLE();
+    }
+    if (obj->spi == SPI_2) {
+        __SPI2_CLK_ENABLE();
+    }
+
+    // Configure the SPI pins
+    pinmap_pinout(mosi, PinMap_SPI_MOSI);
+    pinmap_pinout(miso, PinMap_SPI_MISO);
+    pinmap_pinout(sclk, PinMap_SPI_SCLK);
+
+    // Save new values
+    obj->bits = SPI_DATASIZE_8BIT;
+    obj->cpol = SPI_POLARITY_LOW;
+    obj->cpha = SPI_PHASE_1EDGE;
+    obj->br_presc = SPI_BAUDRATEPRESCALER_256;
+
+    obj->pin_miso = miso;
+    obj->pin_mosi = mosi;
+    obj->pin_sclk = sclk;
+    obj->pin_ssel = ssel;
+
+    if (ssel == NC) { // SW NSS Master mode
+        obj->mode = SPI_MODE_MASTER;
+        obj->nss = SPI_NSS_SOFT;
+    } else { // Slave
+        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+        obj->mode = SPI_MODE_SLAVE;
+        obj->nss = SPI_NSS_HARD_INPUT;
+    }
+
+    init_spi(obj);
+}
+
+void spi_free(spi_t *obj) {
+    // Reset SPI and disable clock
+    if (obj->spi == SPI_1) {
+        __SPI1_FORCE_RESET();
+        __SPI1_RELEASE_RESET();
+        __SPI1_CLK_DISABLE();
+    }
+
+    if (obj->spi == SPI_2) {
+        __SPI2_FORCE_RESET();
+        __SPI2_RELEASE_RESET();
+        __SPI2_CLK_DISABLE();
+    }
+
+    // Configure GPIO
+    pin_function(obj->pin_miso, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    pin_function(obj->pin_mosi, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    pin_function(obj->pin_sclk, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    pin_function(obj->pin_ssel, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+}
+
+void spi_format(spi_t *obj, int bits, int mode, int slave) {
+    // Save new values
+    if (bits == 16) {
+        obj->bits = SPI_DATASIZE_16BIT;
+    } else {
+        obj->bits = SPI_DATASIZE_8BIT;
+    }
+
+    switch (mode) {
+        case 0:
+            obj->cpol = SPI_POLARITY_LOW;
+            obj->cpha = SPI_PHASE_1EDGE;
+            break;
+        case 1:
+            obj->cpol = SPI_POLARITY_LOW;
+            obj->cpha = SPI_PHASE_2EDGE;
+            break;
+        case 2:
+            obj->cpol = SPI_POLARITY_HIGH;
+            obj->cpha = SPI_PHASE_1EDGE;
+            break;
+        default:
+            obj->cpol = SPI_POLARITY_HIGH;
+            obj->cpha = SPI_PHASE_2EDGE;
+            break;
+    }
+
+    if (slave == 0) {
+        obj->mode = SPI_MODE_MASTER;
+        obj->nss = SPI_NSS_SOFT;
+    } else {
+        obj->mode = SPI_MODE_SLAVE;
+        obj->nss = SPI_NSS_HARD_INPUT;
+    }
+
+    init_spi(obj);
+}
+
+void spi_frequency(spi_t *obj, int hz) {
+    // Note: The frequencies are obtained with SPI1 clock = 32 MHz (APB2 clock)
+    if (hz < 250000) {
+        obj->br_presc = SPI_BAUDRATEPRESCALER_256; // 125 kHz
+    } else if ((hz >= 250000) && (hz < 500000)) {
+        obj->br_presc = SPI_BAUDRATEPRESCALER_128; // 250 kHz
+    } else if ((hz >= 500000) && (hz < 1000000)) {
+        obj->br_presc = SPI_BAUDRATEPRESCALER_64; // 500 kHz
+    } else if ((hz >= 1000000) && (hz < 2000000)) {
+        obj->br_presc = SPI_BAUDRATEPRESCALER_32; // 1 MHz
+    } else if ((hz >= 2000000) && (hz < 4000000)) {
+        obj->br_presc = SPI_BAUDRATEPRESCALER_16; // 2 MHz
+    } else if ((hz >= 4000000) && (hz < 8000000)) {
+        obj->br_presc = SPI_BAUDRATEPRESCALER_8; // 4 MHz
+    } else if ((hz >= 8000000) && (hz < 16000000)) {
+        obj->br_presc = SPI_BAUDRATEPRESCALER_4; // 8 MHz
+    } else { // >= 16000000
+        obj->br_presc = SPI_BAUDRATEPRESCALER_2; // 16 MHz
+    }
+    init_spi(obj);
+}
+
+static inline int ssp_readable(spi_t *obj) {
+    int status;
+    SpiHandle.Instance = (SPI_TypeDef *)(obj->spi);
+    // Check if data is received
+    status = ((__HAL_SPI_GET_FLAG(&SpiHandle, SPI_FLAG_RXNE) != RESET) ? 1 : 0);
+    return status;
+}
+
+static inline int ssp_writeable(spi_t *obj) {
+    int status;
+    SpiHandle.Instance = (SPI_TypeDef *)(obj->spi);
+    // Check if data is transmitted
+    status = ((__HAL_SPI_GET_FLAG(&SpiHandle, SPI_FLAG_TXE) != RESET) ? 1 : 0);
+    return status;
+}
+
+static inline void ssp_write(spi_t *obj, int value) {
+    SPI_TypeDef *spi = (SPI_TypeDef *)(obj->spi);
+    while (!ssp_writeable(obj));
+    spi->DR = (uint16_t)value;
+}
+
+static inline int ssp_read(spi_t *obj) {
+    SPI_TypeDef *spi = (SPI_TypeDef *)(obj->spi);
+    while (!ssp_readable(obj));
+    return (int)spi->DR;
+}
+
+static inline int ssp_busy(spi_t *obj) {
+    int status;
+    SpiHandle.Instance = (SPI_TypeDef *)(obj->spi);
+    status = ((__HAL_SPI_GET_FLAG(&SpiHandle, SPI_FLAG_BSY) != RESET) ? 1 : 0);
+    return status;
+}
+
+int spi_master_write(spi_t *obj, int value) {
+    ssp_write(obj, value);
+    return ssp_read(obj);
+}
+
+int spi_slave_receive(spi_t *obj) {
+    return (ssp_readable(obj) ? 1 : 0);
+};
+
+int spi_slave_read(spi_t *obj) {
+    SPI_TypeDef *spi = (SPI_TypeDef *)(obj->spi);
+    while (!ssp_readable(obj));
+    return (int)spi->DR;
+}
+
+void spi_slave_write(spi_t *obj, int value) {
+    SPI_TypeDef *spi = (SPI_TypeDef *)(obj->spi);
+    while (!ssp_writeable(obj));
+    spi->DR = (uint16_t)value;
+}
+
+int spi_busy(spi_t *obj) {
+    return ssp_busy(obj);
+}
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/us_ticker.c
@@ -1,0 +1,151 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2014, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <stddef.h>
+#include "us_ticker_api.h"
+#include "PeripheralNames.h"
+
+// Timer selection:
+#define TIM_MST      TIM21
+#define TIM_MST_IRQ  TIM21_IRQn
+#define TIM_MST_RCC  __TIM21_CLK_ENABLE()
+
+static TIM_HandleTypeDef TimMasterHandle;
+
+static int      us_ticker_inited = 0;
+static volatile uint32_t SlaveCounter = 0;
+static volatile uint32_t oc_int_part = 0;
+static volatile uint16_t oc_rem_part = 0;
+
+void set_compare(uint16_t count) {
+    // Set new output compare value
+    __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_1, count);
+    // Enable IT
+    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC1);
+}
+
+static void tim_irq_handler(void) {
+    uint16_t cval = TIM_MST->CNT;
+
+    // Clear Update interrupt flag
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE) == SET) {
+        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE);
+        SlaveCounter++;
+    }
+
+    // Clear CC1 interrupt flag
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC1);
+        if (oc_rem_part > 0) {
+            set_compare(oc_rem_part); // Finish the remaining time left
+            oc_rem_part = 0;
+        } else {
+            if (oc_int_part > 0) {
+                set_compare(0xFFFF);
+                oc_rem_part = cval; // To finish the counter loop the next time
+                oc_int_part--;
+            } else {
+                us_ticker_irq_handler();
+            }
+        }
+    }
+}
+
+void us_ticker_init(void) {
+    if (us_ticker_inited) return;
+    us_ticker_inited = 1;
+
+    // Enable timer clock
+    TIM_MST_RCC;
+
+    // Configure time base
+    TimMasterHandle.Instance = TIM_MST;
+    TimMasterHandle.Init.Period        = 0xFFFF;
+    TimMasterHandle.Init.Prescaler     = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.ClockDivision = 0;
+    TimMasterHandle.Init.CounterMode   = TIM_COUNTERMODE_UP;
+    HAL_TIM_Base_Init(&TimMasterHandle);
+
+    // Configure interrupts
+    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_UPDATE);
+
+    // Update interrupt used for 32-bit counter
+    // Output compare interrupt used for timeout feature
+    NVIC_SetVector(TIM_MST_IRQ, (uint32_t)tim_irq_handler);
+    NVIC_EnableIRQ(TIM_MST_IRQ);
+
+    // Enable timer
+    HAL_TIM_Base_Start(&TimMasterHandle);
+}
+
+uint32_t us_ticker_read() {
+    uint32_t counter, counter2;
+    if (!us_ticker_inited) us_ticker_init();
+    // A situation might appear when Master overflows right after Slave is read and before the
+    // new (overflowed) value of Master is read. Which would make the code below consider the
+    // previous (incorrect) value of Slave and the new value of Master, which would return a
+    // value in the past. Avoid this by computing consecutive values of the timer until they
+    // are properly ordered.
+    counter = (uint32_t)(SlaveCounter << 16);
+    counter += TIM_MST->CNT;
+    while (1) {
+        counter2 = (uint32_t)(SlaveCounter << 16);
+        counter2 += TIM_MST->CNT;
+        if (counter2 > counter) {
+            break;
+        }
+        counter = counter2;
+    }
+    return counter2;
+}
+
+void us_ticker_set_interrupt(timestamp_t timestamp) {
+    int delta = (int)((uint32_t)timestamp - us_ticker_read());
+    uint16_t cval = TIM_MST->CNT;
+
+    if (delta <= 0) { // This event was in the past
+        us_ticker_irq_handler();
+    } else {
+        oc_int_part = (uint32_t)(delta >> 16);
+        oc_rem_part = (uint16_t)(delta & 0xFFFF);
+        if (oc_rem_part <= (0xFFFF - cval)) {
+            set_compare(cval + oc_rem_part);
+            oc_rem_part = 0;
+        } else {
+            set_compare(0xFFFF);
+            oc_rem_part = oc_rem_part - (0xFFFF - cval);
+        }
+    }
+}
+
+void us_ticker_disable_interrupt(void) {
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC1);
+}
+
+void us_ticker_clear_interrupt(void) {
+    __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC1);
+}

--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -747,6 +747,14 @@ class DISCO_F429ZI(Target):
         self.supported_toolchains = ["GCC_ARM"]
         self.default_toolchain = "GCC_ARM"
 
+class DISCO_L053C8(Target):
+    def __init__(self):
+        Target.__init__(self)
+        self.core = "Cortex-M0+"
+        self.extra_labels = ['STM', 'STM32L0', 'STM32L053C8']
+        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
+        self.default_toolchain = "uARM"
+
 # Get a single instance for each target
 TARGETS = [
     LPC2368(),
@@ -809,6 +817,7 @@ TARGETS = [
     MTS_GAMBIT(),
     ARCH_MAX(),
     DISCO_F429ZI(),
+    DISCO_L053C8(),
 ]
 
 # Map each target name to its unique instance


### PR DESCRIPTION
Tested this with `workspace_tools\build.py -m DISCO_L053C8 -t GCC_ARM` and build was successful. I have included the drivers from STM32Cube_FW_L0_V1.1.0 whereas the Nucleo L053R8 is using STM32Cube_FW_L0_V1.0.0  
