### PR TITLE
[NUCLEO_F334R8] Update STM32Cube driver

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/TOOLCHAIN_ARM_MICRO/startup_stm32f334x8.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/TOOLCHAIN_ARM_MICRO/startup_stm32f334x8.s
@@ -1,8 +1,8 @@
 ;******************** (C) COPYRIGHT 2014 STMicroelectronics ********************
 ;* File Name          : startup_stm32f334x8.s
 ;* Author             : MCD Application Team
-;* Version            : V2.0.1
-;* Date               : 18-June-2014
+;* Version            : V2.1.0
+;* Date               : 12-Sept-2014
 ;* Description        : STM32F334x4/x6/x8 devices vector table for MDK-ARM_MICRO toolchain.
 ;*                      This module performs:
 ;*                      - Set the initial SP

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/TOOLCHAIN_ARM_STD/startup_stm32f334x8.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/TOOLCHAIN_ARM_STD/startup_stm32f334x8.s
@@ -1,8 +1,8 @@
 ;******************** (C) COPYRIGHT 2014 STMicroelectronics ********************
 ;* File Name          : startup_stm32f334x8.s
 ;* Author             : MCD Application Team
-;* Version            : V2.0.1
-;* Date               : 18-June-2014
+;* Version            : V2.1.0
+;* Date               : 12-Sept-2014
 ;* Description        : STM32F334x4/x6/x8 devices vector table for MDK-ARM_STD toolchain.
 ;*                      This module performs:
 ;*                      - Set the initial SP

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/hal_tick.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/hal_tick.c
@@ -1,0 +1,120 @@
+/**
+  ******************************************************************************
+  * @file    hal_tick.c
+  * @author  MCD Application Team
+  * @brief   Initialization of HAL tick
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+#include "hal_tick.h"
+
+TIM_HandleTypeDef TimMasterHandle;
+uint32_t PreviousVal = 0;
+
+void us_ticker_irq_handler(void);
+
+void timer_irq_handler(void) {
+    // Channel 1 for mbed timeout
+    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
+        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+        us_ticker_irq_handler();
+    }
+
+    // Channel 2 for HAL tick
+    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
+        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+            // Increment HAL variable
+            HAL_IncTick();
+            // Prepare next interrupt
+            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+            PreviousVal = val;
+#if 0 // For DEBUG only
+            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+#endif
+        }
+    }
+}
+
+// Reconfigure the HAL tick using a standard timer instead of systick.
+HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
+    // Enable timer clock
+    TIM_MST_RCC;
+
+    // Reset timer
+    TIM_MST_RESET_ON;
+    TIM_MST_RESET_OFF;
+  
+    // Configure time base
+    TimMasterHandle.Instance = TIM_MST;
+    TimMasterHandle.Init.Period            = 0xFFFFFFFF;
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
+    TimMasterHandle.Init.ClockDivision     = 0;
+    TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
+    TimMasterHandle.Init.RepetitionCounter = 0;
+    HAL_TIM_OC_Init(&TimMasterHandle);
+
+    NVIC_SetVector(TIM_MST_IRQ, (uint32_t)timer_irq_handler);
+    NVIC_EnableIRQ(TIM_MST_IRQ);
+
+    // Channel 1 for mbed timeout
+    HAL_TIM_OC_Start(&TimMasterHandle, TIM_CHANNEL_1);
+
+    // Channel 2 for HAL tick
+    HAL_TIM_OC_Start(&TimMasterHandle, TIM_CHANNEL_2);
+    PreviousVal = __HAL_TIM_GetCounter(&TimMasterHandle);
+    __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, PreviousVal + HAL_TICK_DELAY);
+    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+
+#if 0 // For DEBUG only
+    __GPIOB_CLK_ENABLE();
+    GPIO_InitTypeDef GPIO_InitStruct;
+    GPIO_InitStruct.Pin = GPIO_PIN_6;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Pull = GPIO_PULLUP;
+    GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
+    HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+#endif
+
+    return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */    
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/hal_tick.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/hal_tick.h
@@ -1,0 +1,60 @@
+/**
+  ******************************************************************************
+  * @file    hal_tick.h
+  * @author  MCD Application Team
+  * @brief   Initialization of HAL tick
+  ******************************************************************************  
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+#ifndef __HAL_TICK_H
+#define __HAL_TICK_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include "stm32f3xx.h"
+#include "cmsis_nvic.h"
+   
+#define TIM_MST      TIM2
+#define TIM_MST_IRQ  TIM2_IRQn
+#define TIM_MST_RCC  __TIM2_CLK_ENABLE()
+
+#define TIM_MST_RESET_ON   __TIM2_FORCE_RESET()
+#define TIM_MST_RESET_OFF  __TIM2_RELEASE_RESET()
+
+#define HAL_TICK_DELAY (1000) // 1 ms
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __HAL_TICK_H
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f334x8.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f334x8.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f334x8.h
   * @author  MCD Application Team
-  * @version V2.0.1
-  * @date    18-June-2014
+  * @version V2.1.0
+  * @date    12-Sept-2014
   * @brief   CMSIS STM32F334x4/STM32F334x6/STM32F334x8 Devices Peripheral Access Layer Header File.
   *
   *          This file contains:

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx.h
   * @author  MCD Application Team
-  * @version V2.0.1
-  * @date    18-June-2014
+  * @version V2.1.0
+  * @date    12-Sept-2014
   * @brief   CMSIS STM32F3xx Device Peripheral Access Layer Header File.           
   *            
   *          The file is the unique include file that the application programmer
@@ -68,20 +68,22 @@
    application 
   */
 
-#if !defined (STM32F301x8) && !defined (STM32F318xx) && \
-    !defined (STM32F302x8) && !defined (STM32F302xC) && \
-    !defined (STM32F303x8) &&                           \
-    !defined (STM32F303xC) && !defined (STM32F358xx) && \
-    !defined (STM32F373xC) && !defined (STM32F378xx) && \
-    !defined (STM32F334x8) && !defined (STM32F328xx)
+#if !defined (STM32F301x8) && !defined (STM32F302x8) && !defined (STM32F318xx) && \
+    !defined (STM32F302xC) && !defined (STM32F303xC) && !defined (STM32F358xx) && \
+    !defined (STM32F303x8) && !defined (STM32F334x8) && !defined (STM32F328xx) && \
+    !defined (STM32F302xE) && !defined (STM32F303xE) && !defined (STM32F398xx) && \
+    !defined (STM32F373xC) && !defined (STM32F378xx)
+    
   /* #define STM32F301x8 */   /*!< STM32F301K6, STM32F301K8, STM32F301C6, STM32F301C8,
                                    STM32F301R6 and STM32F301R8 Devices */
   /* #define STM32F302x8 */   /*!< STM32F302K6, STM32F302K8, STM32F302C6, STM32F302C8,
                                    STM32F302R6 and STM32F302R8 Devices */
   /* #define STM32F302xC */   /*!< STM32F302CB, STM32F302CC, STM32F302RB, STM32F302RC, STM32F302VB and STM32F302VC Devices */
+  /* #define STM32F302xE */   /*!< STM32F302CE, STM32F302RE, and STM32F302VE Devices */
   /* #define STM32F303x8 */   /*!< STM32F303K6, STM32F303K8, STM32F303C6, STM32F303C8, 
                                    STM32F303R6 and STM32F303R8 Devices */
   /* #define STM32F303xC */   /*!< STM32F303CB, STM32F303CC, STM32F303RB, STM32F303RC, STM32F303VB and STM32F303VC Devices */
+  /* #define STM32F303xE */   /*!< STM32F303RE, STM32F303VE and STM32F303ZE Devices */
   /* #define STM32F373xC */   /*!< STM32F373C8, STM32F373CB, STM32F373CC, STM32F373R8, STM32F373RB, STM32F373RC,
                                    STM32F373V8, STM32F373VB and STM32F373VC Devices */
 #define STM32F334x8           /*!< STM32F334C4, STM32F334C6, STM32F334C8, STM32F334R4, STM32F334R6 and STM32F334R8 Devices */
@@ -89,6 +91,7 @@
   /* #define STM32F328xx */   /*!< STM32F328C8, STM32F328R8: STM32F334x8 with regulator off: STM32F328xx Devices */
   /* #define STM32F358xx */   /*!< STM32F358CC, STM32F358RC, STM32F358VC: STM32F303xC with regulator off: STM32F358xx Devices */
   /* #define STM32F378xx */   /*!< STM32F378CC, STM32F378RC, STM32F378VC: STM32F373xC with regulator off: STM32F378xx Devices */
+  /* #define STM32F398xx */   /*!< STM32F398CE, STM32F398RE, STM32F398VE: STM32F303xE with regulator off: STM32F398xx Devices */
 #endif
    
 /*  Tip: To avoid modifying this file each time you need to switch between these
@@ -104,11 +107,11 @@
 #endif /* USE_HAL_DRIVER */
 
 /**
-  * @brief CMSIS Device version number V2.0.1
+  * @brief CMSIS Device version number V2.1.0
   */
 #define __STM32F3xx_CMSIS_DEVICE_VERSION_MAIN   (0x02) /*!< [31:24] main version */                                  
-#define __STM32F3xx_CMSIS_DEVICE_VERSION_SUB1   (0x00) /*!< [23:16] sub1 version */
-#define __STM32F3xx_CMSIS_DEVICE_VERSION_SUB2   (0x01) /*!< [15:8]  sub2 version */
+#define __STM32F3xx_CMSIS_DEVICE_VERSION_SUB1   (0x01) /*!< [23:16] sub1 version */
+#define __STM32F3xx_CMSIS_DEVICE_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
 #define __STM32F3xx_CMSIS_DEVICE_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
 #define __STM32F3xx_CMSIS_DEVICE_VERSION        ((__CMSIS_DEVICE_VERSION_MAIN     << 24)\
                                       |(__CMSIS_DEVICE_HAL_VERSION_SUB1 << 16)\
@@ -129,10 +132,14 @@
   #include "stm32f302x8.h"
 #elif defined(STM32F302xC)
   #include "stm32f302xc.h"
+#elif defined(STM32F302xE)
+  #include "stm32f302xe.h"
 #elif defined(STM32F303x8)
   #include "stm32f303x8.h"
 #elif defined(STM32F303xC)
   #include "stm32f303xc.h"
+#elif defined(STM32F303xE)
+  #include "stm32f303xe.h"
 #elif defined(STM32F373xC)
   #include "stm32f373xc.h"
 #elif defined(STM32F334x8)
@@ -145,6 +152,8 @@
   #include "stm32f358xx.h"
 #elif defined(STM32F378xx)
   #include "stm32f378xx.h"
+#elif defined(STM32F398xx)
+  #include "stm32f398xx.h"
 #else
  #error "Please select first the target STM32F3xx device used in your application (in stm32f3xx.h file)"
 #endif

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   HAL module driver.
   *          This is the common part of the HAL initialization
   *
@@ -57,7 +57,7 @@
   * @{
   */
 
-/** @defgroup HAL
+/** @defgroup HAL HAL module driver
   * @brief HAL module driver.
   * @{
   */
@@ -66,12 +66,15 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+/** @defgroup HAL_Private Constants
+  * @{
+  */
 /**
- * @brief STM32F3xx HAL Driver version number V1.0.1
+ * @brief STM32F3xx HAL Driver version number V1.1.0
    */
 #define __STM32F3xx_HAL_VERSION_MAIN   (0x01) /*!< [31:24] main version */
-#define __STM32F3xx_HAL_VERSION_SUB1   (0x00) /*!< [23:16] sub1 version */
-#define __STM32F3xx_HAL_VERSION_SUB2   (0x01) /*!< [15:8]  sub2 version */
+#define __STM32F3xx_HAL_VERSION_SUB1   (0x01) /*!< [23:16] sub1 version */
+#define __STM32F3xx_HAL_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
 #define __STM32F3xx_HAL_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
 #define __STM32F3xx_HAL_VERSION         ((__STM32F3xx_HAL_VERSION_MAIN << 24)\
                                         |(__STM32F3xx_HAL_VERSION_SUB1 << 16)\
@@ -79,18 +82,21 @@
                                         |(__STM32F3xx_HAL_VERSION_RC))
 
 #define IDCODE_DEVID_MASK    ((uint32_t)0x00000FFF)
-
+/**
+  * @}
+  */
+  
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 static __IO uint32_t uwTick;
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
 
-/** @defgroup HAL_Private_Functions
+/** @defgroup HAL_Exported_Functions HAL Exported Functions
   * @{
   */
 
-/** @defgroup HAL_Group1 Initialization and de-initialization Functions 
+/** @defgroup HAL_Exported_Functions_Group1 Initialization and de-initialization Functions 
  *  @brief    Initialization and de-initialization functions
  *
 @verbatim
@@ -140,7 +146,6 @@ static __IO uint32_t uwTick;
   *         the tick variable is incremented each 1ms in its ISR.
   *         
   * @note                  
-  * @param  None
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_Init(void)
@@ -167,7 +172,6 @@ HAL_StatusTypeDef HAL_Init(void)
   * @brief  This function de-Initializes common part of the HAL and stops the source
   *         of time base.
   *         This function is optional.
-  * @param  None
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_DeInit(void)
@@ -191,7 +195,6 @@ HAL_StatusTypeDef HAL_DeInit(void)
 
 /**
   * @brief  Initializes the MSP.
-  * @param  None
   * @retval None
   */
 __weak void HAL_MspInit(void)
@@ -203,7 +206,6 @@ __weak void HAL_MspInit(void)
 
 /**
   * @brief  DeInitializes the MSP.
-  * @param  None
   * @retval None
   */
 __weak void HAL_MspDeInit(void)
@@ -212,10 +214,6 @@ __weak void HAL_MspDeInit(void)
             the HAL_MspDeInit could be implemented in the user file
    */
 }
-
-/**
-  * @}
-  */
 
 /**
   * @brief  This function configures the source of the time base. 
@@ -246,7 +244,11 @@ __weak HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
   return HAL_OK;
 }
 
-/** @defgroup HAL_Group2 HAL Control functions 
+/**
+  * @}
+  */
+
+/** @defgroup HAL_Exported_Functions_Group2 HAL Control functions 
  *  @brief    HAL Control functions
  *
 @verbatim
@@ -277,7 +279,6 @@ __weak HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
   *         in Systick ISR.
   *         The function is declared as __Weak  to be overwritten  in case of other 
   *         implementations  in user file.
-  * @param  None
   * @retval None
   */
 __weak void HAL_IncTick(void)
@@ -289,7 +290,6 @@ __weak void HAL_IncTick(void)
   * @brief  Povides a tick value in millisecond.
   * @note   The function is declared as __Weak  to be overwritten  in case of other 
   *         implementations  in user file.
-  * @param  None
   * @retval tick value
   */
 __weak uint32_t HAL_GetTick(void)
@@ -324,7 +324,6 @@ __weak void HAL_Delay(__IO uint32_t Delay)
   *         is suspended.
   *         The function is declared as __Weak  to be overwritten  in case of other
   *         implementations  in user file.
-  * @param  None
   * @retval None
   */
 __weak void HAL_SuspendTick(void)
@@ -343,7 +342,6 @@ __weak void HAL_SuspendTick(void)
   *         is resumed.
   *         The function is declared as __Weak  to be overwritten  in case of other
   *         implementations  in user file.
-  * @param  None
   * @retval None
   */
 __weak void HAL_ResumeTick(void)
@@ -355,7 +353,6 @@ __weak void HAL_ResumeTick(void)
 
 /**
   * @brief  This function returns the HAL revision
-  * @param  None
   * @retval version : 0xXYZR (8bits for each decimal, R for RC)
   */
 uint32_t HAL_GetHalVersion(void)
@@ -365,7 +362,6 @@ uint32_t HAL_GetHalVersion(void)
 
 /**
   * @brief  Returns the device revision identifier.
-  * @param  None
   * @retval Device revision identifier
   */
 uint32_t HAL_GetREVID(void)
@@ -375,7 +371,6 @@ uint32_t HAL_GetREVID(void)
 
 /**
   * @brief  Returns the device identifier.
-  * @param  None
   * @retval Device identifier
   */
 uint32_t HAL_GetDEVID(void)
@@ -385,7 +380,6 @@ uint32_t HAL_GetDEVID(void)
 
 /**
   * @brief  Enable the Debug Module during SLEEP mode
-  * @param  None
   * @retval None
   */
 void HAL_EnableDBGSleepMode(void)
@@ -395,7 +389,6 @@ void HAL_EnableDBGSleepMode(void)
 
 /**
   * @brief  Disable the Debug Module during SLEEP mode
-  * @param  None
   * @retval None
   */
 void HAL_DisableDBGSleepMode(void)
@@ -405,7 +398,6 @@ void HAL_DisableDBGSleepMode(void)
 
 /**
   * @brief  Enable the Debug Module during STOP mode
-  * @param  None
   * @retval None
   */
 void HAL_EnableDBGStopMode(void)
@@ -415,7 +407,6 @@ void HAL_EnableDBGStopMode(void)
 
 /**
   * @brief  Disable the Debug Module during STOP mode
-  * @param  None
   * @retval None
   */
 void HAL_DisableDBGStopMode(void)
@@ -425,7 +416,6 @@ void HAL_DisableDBGStopMode(void)
 
 /**
   * @brief  Enable the Debug Module during STANDBY mode
-  * @param  None
   * @retval None
   */
 void HAL_EnableDBGStandbyMode(void)
@@ -435,7 +425,6 @@ void HAL_EnableDBGStandbyMode(void)
 
 /**
   * @brief  Disable the Debug Module during STANDBY mode
-  * @param  None
   * @retval None
   */
 void HAL_DisableDBGStandbyMode(void)

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   This file contains all the functions prototypes for the HAL 
   *          module driver.
   ******************************************************************************
@@ -57,8 +57,10 @@
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
-
-/** @defgroup SYSCFG_BitAddress_AliasRegion
+/** @defgroup HAL_Exported_Constants HAL Exported Constants
+  * @{
+  */
+/** @defgroup SYSCFG_BitAddress_AliasRegion SYSCFG registers bit address in the alias region
   * @brief SYSCFG registers bit address in the alias region
   * @{
   */
@@ -74,7 +76,7 @@
   */
 
 #if defined(SYSCFG_CFGR1_DMA_RMP)
-/** @defgroup HAL_DMA_Remapping
+/** @defgroup HAL_DMA_Remapping DMA Remapping
   *        Elements values convention: 0xXXYYYYYY
   *           - YYYYYY  : Position in the register
   *           - XX  : Register index
@@ -82,15 +84,15 @@
   *                 - 01: CFGR3 register in SYSCFG (not available on STM32F373xC/STM32F378xx devices)
   * @{
   */
-#define HAL_REMAPDMA_ADC24_DMA2_CH34         ((uint32_t)0x00000100) /*!< ADC24 DMA remap (STM32F303xB/C/E and STM32F358xx devices)
+#define HAL_REMAPDMA_ADC24_DMA2_CH34         ((uint32_t)0x00000100) /*!< ADC24 DMA remap (STM32F303xB/C/E, STM32F358xx and STM32F398xx devices)
                                                                           1: Remap (ADC24 DMA requests mapped on DMA2 channels 3 and 4) */
 #define HAL_REMAPDMA_TIM16_DMA1_CH6          ((uint32_t)0x00000800) /*!< TIM16 DMA request remap
                                                                          1: Remap (TIM16_CH1 and TIM16_UP DMA requests mapped on DMA1 channel 6) */
 #define HAL_REMAPDMA_TIM17_DMA1_CH7          ((uint32_t)0x00001000) /*!< TIM17 DMA request remap
                                                                          1: Remap (TIM17_CH1 and TIM17_UP DMA requests mapped on DMA1 channel 7) */
-#define HAL_REMAPDMA_TIM6_DAC1_CH1_DMA1_CH3  ((uint32_t)0x00002000) /*!< TIM6 and DAC channel1 DMA remap (STM32F303xB/C/E and STM32F358xx devices)
+#define HAL_REMAPDMA_TIM6_DAC1_CH1_DMA1_CH3  ((uint32_t)0x00002000) /*!< TIM6 and DAC channel1 DMA remap (STM32F303xB/C/E, STM32F358xx and STM32F398xx devices)
                                                                          1: Remap (TIM6_UP and DAC_CH1 DMA requests mapped on DMA1 channel 3) */
-#define HAL_REMAPDMA_TIM7_DAC1_CH2_DMA1_CH4  ((uint32_t)0x00004000) /*!< TIM7 and DAC channel2 DMA remap (STM32F303xB/C/E and STM32F358xx devices)
+#define HAL_REMAPDMA_TIM7_DAC1_CH2_DMA1_CH4  ((uint32_t)0x00004000) /*!< TIM7 and DAC channel2 DMA remap (STM32F303xB/C/E, STM32F358xx and STM32F398xx devices)
                                                                          1: Remap (TIM7_UP and DAC_CH2 DMA requests mapped on DMA1 channel 4) */
 #define HAL_REMAPDMA_DAC2_CH1_DMA1_CH5       ((uint32_t)0x00008000) /*!< DAC2 channel1 DMA remap (STM32F303x4/6/8 devices only)
                                                                          1: Remap (DAC2_CH1 DMA requests mapped on DMA1 channel 5) */
@@ -132,7 +134,7 @@
                                                                          11: Map on DMA1 channel 4 */
 #endif /* SYSCFG_CFGR3_DMA_RMP */
 
-#if defined(SYSCFG_CFGR3_DMA_RMP) && defined(SYSCFG_CFGR1_DMA_RMP)
+#if defined(SYSCFG_CFGR3_DMA_RMP)
 #define IS_HAL_REMAPDMA(RMP) ((((RMP) & HAL_REMAPDMA_ADC24_DMA2_CH34)         == HAL_REMAPDMA_ADC24_DMA2_CH34)         || \
                               (((RMP) & HAL_REMAPDMA_TIM16_DMA1_CH6)          == HAL_REMAPDMA_TIM16_DMA1_CH6)          || \
                               (((RMP) & HAL_REMAPDMA_TIM17_DMA1_CH7)          == HAL_REMAPDMA_TIM17_DMA1_CH7)          || \
@@ -154,7 +156,7 @@
                               (((RMP) & HAL_REMAPDMA_I2C1_TX_DMA1_CH4)        == HAL_REMAPDMA_I2C1_TX_DMA1_CH4)  || \
                               (((RMP) & HAL_REMAPDMA_ADC2_DMA1_CH2)           == HAL_REMAPDMA_ADC2_DMA1_CH2)     || \
                               (((RMP) & HAL_REMAPDMA_ADC2_DMA1_CH4)           == HAL_REMAPDMA_ADC2_DMA1_CH4))
-#elif defined(SYSCFG_CFGR1_DMA_RMP)
+#else
 #define IS_HAL_REMAPDMA(RMP) ((((RMP) & HAL_REMAPDMA_ADC24_DMA2_CH34)         == HAL_REMAPDMA_ADC24_DMA2_CH34)         || \
                               (((RMP) & HAL_REMAPDMA_TIM16_DMA1_CH6)          == HAL_REMAPDMA_TIM16_DMA1_CH6)          || \
                               (((RMP) & HAL_REMAPDMA_TIM17_DMA1_CH7)          == HAL_REMAPDMA_TIM17_DMA1_CH7)          || \
@@ -168,7 +170,7 @@
   */
 #endif /* SYSCFG_CFGR1_DMA_RMP */
 
-/** @defgroup HAL_Trigger_Remapping
+/** @defgroup HAL_Trigger_Remapping Trigger Remapping
   *        Elements values convention: 0xXXYYYYYY
   *           - YYYYYY  : Position in the register
   *           - XX  : Register index
@@ -192,9 +194,6 @@
 #define HAL_REMAPTRIGGER_DAC1_TRIG5        ((uint32_t)0x01020000)  /*!< DAC1_CH1 / DAC1_CH2 Trigger remap
                                                                         0: No remap
                                                                         1: Remap (DAC trigger is HRTIM1_DAC1_TRIG2) */
-#endif /* SYSCFG_CFGR3_TRIGGER_RMP */
-
-#if defined(SYSCFG_CFGR3_TRIGGER_RMP)
 #define IS_HAL_REMAPTRIGGER(RMP) ((((RMP) & HAL_REMAPTRIGGER_DAC1)       == HAL_REMAPTRIGGER_DAC1)       || \
                                   (((RMP) & HAL_REMAPTRIGGER_TIM1_ITR3)  == HAL_REMAPTRIGGER_TIM1_ITR3)  || \
                                   (((RMP) & HAL_REMAPTRIGGER_DAC1_TRIG3) == HAL_REMAPTRIGGER_DAC1_TRIG3) || \
@@ -207,7 +206,73 @@
   * @}
   */
 
-/** @defgroup HAL_FastModePlus_I2C
+#if defined (STM32F303xE) || defined (STM32F398xx)
+/** @defgroup HAL_ADC_Trigger_Remapping ADC Trigger Remapping
+  * @{
+  */
+#define HAL_REMAPADCTRIGGER_ADC12_EXT2        SYSCFG_CFGR4_ADC12_EXT2_RMP   /*!< Input trigger of ADC12 regular channel EXT2
+                                                                                 0: No remap (TIM1_CC3)
+                                                                                 1: Remap (TIM20_TRGO) */
+#define HAL_REMAPADCTRIGGER_ADC12_EXT3        SYSCFG_CFGR4_ADC12_EXT3_RMP   /*!< Input trigger of ADC12 regular channel EXT3
+                                                                                 0: No remap (TIM2_CC2)
+                                                                                 1: Remap (TIM20_TRGO2) */
+#define HAL_REMAPADCTRIGGER_ADC12_EXT5        SYSCFG_CFGR4_ADC12_EXT5_RMP   /*!< Input trigger of ADC12 regular channel EXT5
+                                                                                 0: No remap (TIM4_CC4)
+                                                                                 1: Remap (TIM20_CC1) */
+#define HAL_REMAPADCTRIGGER_ADC12_EXT13       SYSCFG_CFGR4_ADC12_EXT13_RMP  /*!< Input trigger of ADC12 regular channel EXT13
+                                                                                 0: No remap (TIM6_TRGO)
+                                                                                 1: Remap (TIM20_CC2) */
+#define HAL_REMAPADCTRIGGER_ADC12_EXT15       SYSCFG_CFGR4_ADC12_EXT15_RMP  /*!< Input trigger of ADC12 regular channel EXT15
+                                                                                 0: No remap (TIM3_CC4)
+                                                                                 1: Remap (TIM20_CC3) */
+#define HAL_REMAPADCTRIGGER_ADC12_JEXT3       SYSCFG_CFGR4_ADC12_JEXT3_RMP  /*!< Input trigger of ADC12 injected channel JEXT3
+                                                                                 0: No remap (TIM2_CC1)
+                                                                                 1: Remap (TIM20_TRGO) */
+#define HAL_REMAPADCTRIGGER_ADC12_JEXT6       SYSCFG_CFGR4_ADC12_JEXT6_RMP  /*!< Input trigger of ADC12 injected channel JEXT6
+                                                                                 0: No remap (EXTI line 15)
+                                                                                 1: Remap (TIM20_TRGO2) */
+#define HAL_REMAPADCTRIGGER_ADC12_JEXT13      SYSCFG_CFGR4_ADC12_JEXT13_RMP  /*!< Input trigger of ADC12 injected channel JEXT13
+                                                                                 0: No remap (TIM3_CC1)
+                                                                                 1: Remap (TIM20_CC4) */
+#define HAL_REMAPADCTRIGGER_ADC34_EXT5        SYSCFG_CFGR4_ADC34_EXT5_RMP   /*!< Input trigger of ADC34 regular channel EXT5
+                                                                                 0: No remap (EXTI line 2)
+                                                                                 1: Remap (TIM20_TRGO) */
+#define HAL_REMAPADCTRIGGER_ADC34_EXT6        SYSCFG_CFGR4_ADC34_EXT6_RMP   /*!< Input trigger of ADC34 regular channel EXT6
+                                                                                 0: No remap (TIM4_CC1)
+                                                                                 1: Remap (TIM20_TRGO2) */
+#define HAL_REMAPADCTRIGGER_ADC34_EXT15       SYSCFG_CFGR4_ADC34_EXT15_RMP  /*!< Input trigger of ADC34 regular channel EXT15
+                                                                                 0: No remap (TIM2_CC1)
+                                                                                 1: Remap (TIM20_CC1) */
+#define HAL_REMAPADCTRIGGER_ADC34_JEXT5       SYSCFG_CFGR4_ADC34_JEXT5_RMP  /*!< Input trigger of ADC34 injected channel JEXT5
+                                                                                 0: No remap (TIM4_CC3)
+                                                                                 1: Remap (TIM20_TRGO) */
+#define HAL_REMAPADCTRIGGER_ADC34_JEXT11      SYSCFG_CFGR4_ADC34_JEXT11_RMP /*!< Input trigger of ADC34 injected channel JEXT11
+                                                                                 0: No remap (TIM1_CC3)
+                                                                                 1: Remap (TIM20_TRGO2) */
+#define HAL_REMAPADCTRIGGER_ADC34_JEXT14      SYSCFG_CFGR4_ADC34_JEXT14_RMP /*!< Input trigger of ADC34 injected channel JEXT14
+                                                                                 0: No remap (TIM7_TRGO)
+                                                                                 1: Remap (TIM20_CC2) */
+
+#define IS_HAL_REMAPADCTRIGGER(RMP)  ((((RMP) & HAL_REMAPADCTRIGGER_ADC12_EXT2)   == HAL_REMAPADCTRIGGER_ADC12_EXT2)   || \
+                                      (((RMP) & HAL_REMAPADCTRIGGER_ADC12_EXT3)   == HAL_REMAPADCTRIGGER_ADC12_EXT3)   || \
+                                      (((RMP) & HAL_REMAPADCTRIGGER_ADC12_EXT5)   == HAL_REMAPADCTRIGGER_ADC12_EXT5)   || \
+                                      (((RMP) & HAL_REMAPADCTRIGGER_ADC12_EXT13)  == HAL_REMAPADCTRIGGER_ADC12_EXT13)  || \
+                                      (((RMP) & HAL_REMAPADCTRIGGER_ADC12_EXT15)  == HAL_REMAPADCTRIGGER_ADC12_EXT15)  || \
+                                      (((RMP) & HAL_REMAPADCTRIGGER_ADC12_JEXT3)  == HAL_REMAPADCTRIGGER_ADC12_JEXT3)  || \
+                                      (((RMP) & HAL_REMAPADCTRIGGER_ADC12_JEXT6)  == HAL_REMAPADCTRIGGER_ADC12_JEXT6)  || \
+                                      (((RMP) & HAL_REMAPADCTRIGGER_ADC12_JEXT13) == HAL_REMAPADCTRIGGER_ADC12_JEXT13) || \
+                                      (((RMP) & HAL_REMAPADCTRIGGER_ADC34_EXT5)   == HAL_REMAPADCTRIGGER_ADC34_EXT5)   || \
+                                      (((RMP) & HAL_REMAPADCTRIGGER_ADC34_EXT6)   == HAL_REMAPADCTRIGGER_ADC34_EXT6)   || \
+                                      (((RMP) & HAL_REMAPADCTRIGGER_ADC34_EXT15)  == HAL_REMAPADCTRIGGER_ADC34_EXT15)  || \
+                                      (((RMP) & HAL_REMAPADCTRIGGER_ADC34_JEXT5)  == HAL_REMAPADCTRIGGER_ADC34_JEXT5)  || \
+                                      (((RMP) & HAL_REMAPADCTRIGGER_ADC34_JEXT11) == HAL_REMAPADCTRIGGER_ADC34_JEXT11) || \
+                                      (((RMP) & HAL_REMAPADCTRIGGER_ADC34_JEXT14) == HAL_REMAPADCTRIGGER_ADC34_JEXT14))
+/**
+  * @}
+  */
+#endif /* STM32F303xE || STM32F398xx */
+
+/** @defgroup HAL_FastModePlus_I2C I2C Fast Mode Plus
   * @{
   */
 #if defined(SYSCFG_CFGR1_I2C1_FMP)
@@ -280,7 +345,7 @@
 
 #if defined(SYSCFG_RCR_PAGE0)
 /* CCM-SRAM defined */
-/** @defgroup HAL_Page_Write_Protection
+/** @defgroup HAL_Page_Write_Protection CCM RAM page write protection
   * @{
   */
 #define HAL_SYSCFG_WP_PAGE0                    (SYSCFG_RCR_PAGE0)  /*!< ICODE SRAM Write protection page 0 */
@@ -294,18 +359,30 @@
 #define HAL_SYSCFG_WP_PAGE6                    (SYSCFG_RCR_PAGE6)  /*!< ICODE SRAM Write protection page 6 */
 #define HAL_SYSCFG_WP_PAGE7                    (SYSCFG_RCR_PAGE7)  /*!< ICODE SRAM Write protection page 7 */
 #endif /* SYSCFG_RCR_PAGE4 */
+#if defined(SYSCFG_RCR_PAGE8)
+#define HAL_SYSCFG_WP_PAGE8                    (SYSCFG_RCR_PAGE8)  /*!< ICODE SRAM Write protection page 8 */
+#define HAL_SYSCFG_WP_PAGE9                    (SYSCFG_RCR_PAGE9)  /*!< ICODE SRAM Write protection page 9 */
+#define HAL_SYSCFG_WP_PAGE10                   (SYSCFG_RCR_PAGE10) /*!< ICODE SRAM Write protection page 10 */
+#define HAL_SYSCFG_WP_PAGE11                   (SYSCFG_RCR_PAGE11) /*!< ICODE SRAM Write protection page 11 */
+#define HAL_SYSCFG_WP_PAGE12                   (SYSCFG_RCR_PAGE12) /*!< ICODE SRAM Write protection page 12 */
+#define HAL_SYSCFG_WP_PAGE13                   (SYSCFG_RCR_PAGE13) /*!< ICODE SRAM Write protection page 13 */
+#define HAL_SYSCFG_WP_PAGE14                   (SYSCFG_RCR_PAGE14) /*!< ICODE SRAM Write protection page 14 */
+#define HAL_SYSCFG_WP_PAGE15                   (SYSCFG_RCR_PAGE15) /*!< ICODE SRAM Write protection page 15 */
+#endif /* SYSCFG_RCR_PAGE8 */
 
-#if defined(SYSCFG_RCR_PAGE4)
-#define IS_HAL_SYSCFG_WP_PAGE(__PAGE__)        (((__PAGE__) > 0) && ((__PAGE__) <= SYSCFG_RCR_PAGE7))
+#if defined(SYSCFG_RCR_PAGE8)
+#define IS_HAL_SYSCFG_WP_PAGE(__PAGE__)        (((__PAGE__) > 0) && ((__PAGE__) <= (uint32_t)0xFFFF))
+#elif defined(SYSCFG_RCR_PAGE4)
+#define IS_HAL_SYSCFG_WP_PAGE(__PAGE__)        (((__PAGE__) > 0) && ((__PAGE__) <= (uint32_t)0x00FF))
 #else
-#define IS_HAL_SYSCFG_WP_PAGE(__PAGE__)        (((__PAGE__) > 0) && ((__PAGE__) <= SYSCFG_RCR_PAGE3))
-#endif
+#define IS_HAL_SYSCFG_WP_PAGE(__PAGE__)        (((__PAGE__) > 0) && ((__PAGE__) <= (uint32_t)0x000F))
+#endif /* SYSCFG_RCR_PAGE8 */      
 /**
   * @}
   */
 #endif /* SYSCFG_RCR_PAGE0 */
 
-/** @defgroup HAL_SYSCFG_Interrupts
+/** @defgroup HAL_SYSCFG_Interrupts SYSCFG Interrupts
   * @{
   */
 #define HAL_SYSCFG_IT_FPU_IOC                  (SYSCFG_CFGR1_FPU_IE_0)  /*!< Floating Point Unit Invalid operation Interrupt */
@@ -325,32 +402,19 @@
 /**
   * @}
   */
-
+  
+/**
+ * @}
+ */ 
 
 /* Exported macro ------------------------------------------------------------*/
-
-/** @brief  Freeze/Unfreeze Peripherals in Debug mode 
+/** @defgroup HAL_Exported_Macros HAL Exported Macros
+  * @{
   */
-#if defined(DBGMCU_APB1_FZ_DBG_RTC_STOP)
-#define __HAL_FREEZE_RTC_DBGMCU()            (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_RTC_STOP))
-#define __HAL_UNFREEZE_RTC_DBGMCU()          (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_RTC_STOP))
-#endif /* DBGMCU_APB1_FZ_DBG_RTC_STOP */
 
-#if defined(DBGMCU_APB1_FZ_DBG_WWDG_STOP)
-#define __HAL_FREEZE_WWDG_DBGMCU()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_WWDG_STOP))
-#define __HAL_UNFREEZE_WWDG_DBGMCU()         (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_WWDG_STOP))
-#endif /* DBGMCU_APB1_FZ_DBG_WWDG_STOP */
-
-#if defined(DBGMCU_APB1_FZ_DBG_IWDG_STOP)
-#define __HAL_FREEZE_IWDG_DBGMCU()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_IWDG_STOP))
-#define __HAL_UNFREEZE_IWDG_DBGMCU()         (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_IWDG_STOP))
-#endif /* DBGMCU_APB1_FZ_DBG_IWDG_STOP */
-
-#if defined(DBGMCU_APB2_FZ_DBG_TIM1_STOP)
-#define __HAL_FREEZE_TIM1_DBGMCU()           (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM1_STOP))
-#define __HAL_UNFREEZE_TIM1_DBGMCU()           (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM1_STOP))
-#endif /* DBGMCU_APB2_FZ_DBG_TIM1_STOP */
-
+/** @defgroup Debug_MCU_APB1_Freeze Freeze/Unfreeze APB1 Peripherals in Debug mode
+  * @{
+  */
 #if defined(DBGMCU_APB1_FZ_DBG_TIM2_STOP)
 #define __HAL_FREEZE_TIM2_DBGMCU()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_TIM2_STOP))
 #define __HAL_UNFREEZE_TIM2_DBGMCU()         (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM2_STOP))
@@ -381,11 +445,6 @@
 #define __HAL_UNFREEZE_TIM7_DBGMCU()         (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM7_STOP))
 #endif /* DBGMCU_APB1_FZ_DBG_TIM7_STOP */
 
-#if defined(DBGMCU_APB2_FZ_DBG_TIM8_STOP)
-#define __HAL_FREEZE_TIM8_DBGMCU()           (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM8_STOP))
-#define __HAL_UNFREEZE_TIM8_DBGMCU()         (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM8_STOP))
-#endif /* DBGMCU_APB2_FZ_DBG_TIM8_STOP */
-
 #if defined(DBGMCU_APB1_FZ_DBG_TIM12_STOP)
 #define __HAL_FREEZE_TIM12_DBGMCU()          (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_TIM12_STOP))
 #define __HAL_UNFREEZE_TIM12_DBGMCU()        (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM12_STOP))
@@ -401,25 +460,25 @@
 #define __HAL_UNFREEZE_TIM14_DBGMCU()        (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM14_STOP))
 #endif /* DBGMCU_APB1_FZ_DBG_TIM14_STOP */
 
-#if defined(DBGMCU_APB2_FZ_DBG_TIM15_STOP)
-#define __HAL_FREEZE_TIM15_DBGMCU()          (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM15_STOP))
-#define __HAL_UNFREEZE_TIM15_DBGMCU()        (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM15_STOP))
-#endif /* DBGMCU_APB2_FZ_DBG_TIM15_STOP */
+#if defined(DBGMCU_APB1_FZ_DBG_TIM18_STOP)
+#define __HAL_FREEZE_TIM18_DBGMCU()          (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_TIM18_STOP))
+#define __HAL_UNFREEZE_TIM18_DBGMCU()        (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_TIM18_STOP))
+#endif /* DBGMCU_APB1_FZ_DBG_TIM14_STOP */
 
-#if defined(DBGMCU_APB2_FZ_DBG_TIM16_STOP)
-#define __HAL_FREEZE_TIM16_DBGMCU()          (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM16_STOP))
-#define __HAL_UNFREEZE_TIM16_DBGMCU()        (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM16_STOP))
-#endif /* DBGMCU_APB2_FZ_DBG_TIM16_STOP */
+#if defined(DBGMCU_APB1_FZ_DBG_RTC_STOP)
+#define __HAL_FREEZE_RTC_DBGMCU()            (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_RTC_STOP))
+#define __HAL_UNFREEZE_RTC_DBGMCU()          (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_RTC_STOP))
+#endif /* DBGMCU_APB1_FZ_DBG_RTC_STOP */
 
-#if defined(DBGMCU_APB2_FZ_DBG_TIM17_STOP)
-#define __HAL_FREEZE_TIM17_DBGMCU()          (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM17_STOP))
-#define __HAL_UNFREEZE_TIM17_DBGMCU()        (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM17_STOP))
-#endif /* DBGMCU_APB2_FZ_DBG_TIM17_STOP */
+#if defined(DBGMCU_APB1_FZ_DBG_WWDG_STOP)
+#define __HAL_FREEZE_WWDG_DBGMCU()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_WWDG_STOP))
+#define __HAL_UNFREEZE_WWDG_DBGMCU()         (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_WWDG_STOP))
+#endif /* DBGMCU_APB1_FZ_DBG_WWDG_STOP */
 
-#if defined(DBGMCU_APB2_FZ_DBG_TIM19_STOP)
-#define __HAL_FREEZE_TIM19_DBGMCU()          (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM19_STOP))
-#define __HAL_UNFREEZE_TIM19_DBGMCU()        (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM19_STOP))
-#endif /*  */
+#if defined(DBGMCU_APB1_FZ_DBG_IWDG_STOP)
+#define __HAL_FREEZE_IWDG_DBGMCU()           (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_IWDG_STOP))
+#define __HAL_UNFREEZE_IWDG_DBGMCU()         (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_IWDG_STOP))
+#endif /* DBGMCU_APB1_FZ_DBG_IWDG_STOP */
 
 #if defined(DBGMCU_APB1_FZ_DBG_I2C1_SMBUS_TIMEOUT)
 #define __HAL_FREEZE_I2C1_TIMEOUT_DBGMCU()   (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_I2C1_SMBUS_TIMEOUT))
@@ -440,8 +499,54 @@
 #define __HAL_FREEZE_CAN_DBGMCU()            (DBGMCU->APB1FZ |= (DBGMCU_APB1_FZ_DBG_CAN_STOP))
 #define __HAL_UNFREEZE_CAN_DBGMCU()          (DBGMCU->APB1FZ &= ~(DBGMCU_APB1_FZ_DBG_CAN_STOP))
 #endif /* DBGMCU_APB1_FZ_DBG_CAN_STOP */
+/**
+ * @}
+ */
+ 
+/** @defgroup Debug_MCU_APB2_Freeze Freeze/Unfreeze APB2 Peripherals in Debug mode
+  * @{
+  */
+#if defined(DBGMCU_APB2_FZ_DBG_TIM1_STOP)
+#define __HAL_FREEZE_TIM1_DBGMCU()           (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM1_STOP))
+#define __HAL_UNFREEZE_TIM1_DBGMCU()           (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM1_STOP))
+#endif /* DBGMCU_APB2_FZ_DBG_TIM1_STOP */
 
+#if defined(DBGMCU_APB2_FZ_DBG_TIM8_STOP)
+#define __HAL_FREEZE_TIM8_DBGMCU()           (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM8_STOP))
+#define __HAL_UNFREEZE_TIM8_DBGMCU()         (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM8_STOP))
+#endif /* DBGMCU_APB2_FZ_DBG_TIM8_STOP */
 
+#if defined(DBGMCU_APB2_FZ_DBG_TIM15_STOP)
+#define __HAL_FREEZE_TIM15_DBGMCU()          (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM15_STOP))
+#define __HAL_UNFREEZE_TIM15_DBGMCU()        (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM15_STOP))
+#endif /* DBGMCU_APB2_FZ_DBG_TIM15_STOP */
+
+#if defined(DBGMCU_APB2_FZ_DBG_TIM16_STOP)
+#define __HAL_FREEZE_TIM16_DBGMCU()          (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM16_STOP))
+#define __HAL_UNFREEZE_TIM16_DBGMCU()        (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM16_STOP))
+#endif /* DBGMCU_APB2_FZ_DBG_TIM16_STOP */
+
+#if defined(DBGMCU_APB2_FZ_DBG_TIM17_STOP)
+#define __HAL_FREEZE_TIM17_DBGMCU()          (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM17_STOP))
+#define __HAL_UNFREEZE_TIM17_DBGMCU()        (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM17_STOP))
+#endif /* DBGMCU_APB2_FZ_DBG_TIM17_STOP */
+
+#if defined(DBGMCU_APB2_FZ_DBG_TIM19_STOP)
+#define __HAL_FREEZE_TIM19_DBGMCU()          (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM19_STOP))
+#define __HAL_UNFREEZE_TIM19_DBGMCU()        (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM19_STOP))
+#endif /* DBGMCU_APB2_FZ_DBG_TIM19_STOP */
+
+#if defined(DBGMCU_APB2_FZ_DBG_TIM20_STOP)
+#define __HAL_FREEZE_TIM20_DBGMCU()          (DBGMCU->APB2FZ |= (DBGMCU_APB2_FZ_DBG_TIM19_STOP))
+#define __HAL_UNFREEZE_TIM20_DBGMCU()        (DBGMCU->APB2FZ &= ~(DBGMCU_APB2_FZ_DBG_TIM19_STOP))
+#endif /* DBGMCU_APB2_FZ_DBG_TIM20_STOP */
+/**
+ * @}
+ */
+
+/** @defgroup Memory_Mapping_Selection Memory Mapping Selection
+  * @{
+  */
 #if defined(SYSCFG_CFGR1_MEM_MODE)
 /** @brief  Main Flash memory mapped at 0x00000000
   */
@@ -464,6 +569,18 @@
                                             }while(0)
 #endif /* SYSCFG_CFGR1_MEM_MODE_0 && SYSCFG_CFGR1_MEM_MODE_1 */
 
+#if defined(SYSCFG_CFGR1_MEM_MODE_2)
+#define __HAL_FMC_BANK()         do {SYSCFG->CFGR1 &= ~(SYSCFG_CFGR1_MEM_MODE); \
+                                     SYSCFG->CFGR1 |= (SYSCFG_CFGR1_MEM_MODE_2); \
+                                    }while(0)
+#endif /* SYSCFG_CFGR1_MEM_MODE_2 */
+/**
+ * @}
+ */
+ 
+/** @defgroup Encoder_Mode Encoder Mode
+  * @{
+  */
 #if defined(SYSCFG_CFGR1_ENCODER_MODE)
 /** @brief  No Encoder mode
   */
@@ -493,7 +610,13 @@
                                              SYSCFG->CFGR1 |= (SYSCFG_CFGR1_ENCODER_MODE_0 | SYSCFG_CFGR1_ENCODER_MODE_1);  \
                                             }while(0)
 #endif /* SYSCFG_CFGR1_ENCODER_MODE_0 && SYSCFG_CFGR1_ENCODER_MODE_1 */
-
+/**
+ * @}
+ */
+ 
+/** @defgroup DMA_Remap_Enable DMA Remap Enable
+  * @{
+  */
 #if defined(SYSCFG_CFGR3_DMA_RMP) && defined(SYSCFG_CFGR1_DMA_RMP)
 /** @brief  DMA remapping enable/disable macros
   * @param __DMA_REMAP__: This parameter can be a value of @ref HAL_DMA_Remapping
@@ -519,7 +642,13 @@
                                                            SYSCFG->CFGR1 &= ~(__DMA_REMAP__);                               \
                                                          }while(0)
 #endif /* SYSCFG_CFGR3_DMA_RMP || SYSCFG_CFGR1_DMA_RMP */
-
+/**
+ * @}
+ */
+ 
+/** @defgroup I2C2_Fast_Mode_Plus_Enable I2C2 Fast Mode Plus Enable
+  * @{
+  */
 /** @brief  Fast mode Plus driving capability enable/disable macros
   * @param __FASTMODEPLUS__: This parameter can be a value of @ref HAL_FastModePlus_I2C
   */
@@ -530,7 +659,13 @@
 #define __HAL_SYSCFG_FASTMODEPLUS_DISABLE(__FASTMODEPLUS__) do {assert_param(IS_HAL_SYSCFG_FASTMODEPLUS_CONFIG((__FASTMODEPLUS__))); \
                                                                 SYSCFG->CFGR1 &= ~(__FASTMODEPLUS__);                                \
                                                                }while(0)
+/**
+ * @}
+ */
 
+/** @defgroup Floating_Point_Unit_Interrupts_Enable Floating Point Unit Interrupts Enable
+  * @{
+  */
 /** @brief  SYSCFG interrupt enable/disable macros
   * @param __INTERRUPT__: This parameter can be a value of @ref HAL_SYSCFG_Interrupts
   */
@@ -541,22 +676,40 @@
 #define __HAL_SYSCFG_INTERRUPT_DISABLE(__INTERRUPT__)       do {assert_param(IS_HAL_SYSCFG_INTERRUPT((__INTERRUPT__))); \
                                                                 SYSCFG->CFGR1 &= ~(__INTERRUPT__);                      \
                                                                }while(0)
-
+/**
+ * @}
+ */
+ 
 #if defined(SYSCFG_CFGR1_USB_IT_RMP)
+/** @defgroup USB_Interrupt_Remap USB Interrupt Remap
+  * @{
+  */ 
 /** @brief  USB interrupt remapping enable/disable macros
   */
 #define __HAL_REMAPINTERRUPT_USB_ENABLE()              (SYSCFG->CFGR1 |= (SYSCFG_CFGR1_USB_IT_RMP))
 #define __HAL_REMAPINTERRUPT_USB_DISABLE()             (SYSCFG->CFGR1 &= ~(SYSCFG_CFGR1_USB_IT_RMP))
+/**
+ * @}
+ */
 #endif /* SYSCFG_CFGR1_USB_IT_RMP */
-
+ 
 #if defined(SYSCFG_CFGR1_VBAT)
+/** @defgroup VBAT_Monitoring_Enable VBAT Monitoring Enable
+  * @{
+  */  
 /** @brief  SYSCFG interrupt enable/disable macros
   */
 #define __HAL_SYSCFG_VBAT_MONITORING_ENABLE()          (SYSCFG->CFGR1 |= (SYSCFG_CFGR1_VBAT))
 #define __HAL_SYSCFG_VBAT_MONITORING_DISABLE()         (SYSCFG->CFGR1 &= ~(SYSCFG_CFGR1_VBAT))
+/**
+ * @}
+ */
 #endif /* SYSCFG_CFGR1_VBAT */
-
+ 
 #if defined(SYSCFG_CFGR2_LOCKUP_LOCK)
+/** @defgroup Cortex_Lockup_Enable Cortex Lockup Enable
+  * @{
+  */
 /** @brief  SYSCFG Break Lockup lock
   *         Enables and locks the connection of Cortex-M4 LOCKUP (Hardfault) output to TIM1/15/16/17 Break input
   * @note   The selected configuration is locked and can be unlocked by system reset
@@ -564,9 +717,15 @@
 #define __HAL_SYSCFG_BREAK_LOCKUP_LOCK()   do {SYSCFG->CFGR2 &= ~(SYSCFG_CFGR2_LOCKUP_LOCK); \
                                                SYSCFG->CFGR2 |= SYSCFG_CFGR2_LOCKUP_LOCK;    \
                                               }while(0)
+/**
+ * @}
+ */
 #endif /* SYSCFG_CFGR2_LOCKUP_LOCK */
-
+ 
 #if defined(SYSCFG_CFGR2_PVD_LOCK)
+/** @defgroup PVD_Lock_Enable PVD Lock
+  * @{
+  */
 /** @brief  SYSCFG Break PVD lock
   *         Enables and locks the PVD connection with Timer1/8/15/16/17 Break Input, , as well as the PVDE and PLS[2:0] in the PWR_CR register
   * @note   The selected configuration is locked and can be unlocked by system reset
@@ -574,9 +733,15 @@
 #define __HAL_SYSCFG_BREAK_PVD_LOCK()      do {SYSCFG->CFGR2 &= ~(SYSCFG_CFGR2_PVD_LOCK); \
                                                SYSCFG->CFGR2 |= SYSCFG_CFGR2_PVD_LOCK;    \
                                               }while(0)
+/**
+ * @}
+ */
 #endif /* SYSCFG_CFGR2_PVD_LOCK */
 
 #if defined(SYSCFG_CFGR2_SRAM_PARITY_LOCK)
+/** @defgroup SRAM_Parity_Lock SRAM Parity Lock
+  * @{
+  */
 /** @brief  SYSCFG Break SRAM PARITY lock
   *         Enables and locks the SRAM_PARITY error signal with Break Input of TIMER1/8/15/16/17
   * @note   The selected configuration is locked and can be unlocked by system reset
@@ -584,8 +749,14 @@
 #define __HAL_SYSCFG_BREAK_SRAMPARITY_LOCK() do {SYSCFG->CFGR2 &= ~(SYSCFG_CFGR2_SRAM_PARITY_LOCK); \
                                                  SYSCFG->CFGR2 |= SYSCFG_CFGR2_SRAM_PARITY_LOCK;    \
                                                 }while(0)
+/**
+ * @}
+ */
 #endif /* SYSCFG_CFGR2_SRAM_PARITY_LOCK */
-
+ 
+/** @defgroup Trigger_Remapping_Enable Trigger Remapping Enable
+  * @{
+  */
 #if defined(SYSCFG_CFGR3_TRIGGER_RMP)
 /** @brief  Trigger remapping enable/disable macros
   * @param __TRIGGER_REMAP__: This parameter can be a value of @ref HAL_Trigger_Remapping
@@ -611,17 +782,47 @@
                                                            (SYSCFG->CFGR1 &= ~(__TRIGGER_REMAP__));                          \
                                                          }while(0)
 #endif /* SYSCFG_CFGR3_TRIGGER_RMP */
+/**
+ * @}
+ */
+ 
+#if defined (STM32F302xE) || defined (STM32F303xE) || defined (STM32F398xx)
+/** @defgroup ADC_Trigger_Remapping_Enable ADC Trigger Remapping Enable
+  * @{
+  */
+/** @brief  ADC trigger remapping enable/disable macros
+  * @param __ADCTRIGGER_REMAP__: This parameter can be a value of @ref HAL_ADC_Trigger_Remapping
+  */
+#define __HAL_REMAPADCTRIGGER_ENABLE(__ADCTRIGGER_REMAP__)   do {assert_param(IS_HAL_REMAPADCTRIGGER((__ADCTRIGGER_REMAP__)));   \
+                                                             (SYSCFG->CFGR4 |= (__ADCTRIGGER_REMAP__));                          \
+                                                         }while(0)
+#define __HAL_REMAPADCTRIGGER_DISABLE(__ADCTRIGGER_REMAP__)  do {assert_param(IS_HAL_REMAPADCTRIGGER((__ADCTRIGGER_REMAP__)));   \
+                                                             (SYSCFG->CFGR4 &= ~(__ADCTRIGGER_REMAP__));                         \
+                                                         }while(0)
+/**
+ * @}
+ */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
                                                            
 #if defined(SYSCFG_CFGR2_BYP_ADDR_PAR)
+/** @defgroup RAM_Parity_Check_Disable RAM Parity Check Disable
+  * @{
+  */
 /**
   * @brief  Parity check on RAM disable macro
   * @note   Disabling the parity check on RAM locks the configuration bit.
   *         To re-enable the parity check on RAM perform a system reset.
   */
 #define __HAL_SYSCFG_RAM_PARITYCHECK_DISABLE()         (*(__IO uint32_t *) CFGR2_BYPADDRPAR_BB = (uint32_t)0x00000001)
+/**
+ * @}
+ */
 #endif /* SYSCFG_CFGR2_BYP_ADDR_PAR */
-
+ 
 #if defined(SYSCFG_RCR_PAGE0)
+/** @defgroup CCM_RAM_Page_Write_Protection_Enable CCM RAM page write protection enable
+  * @{
+  */
 /** @brief  CCM RAM page write protection enable macro
   * @param __PAGE_WP__: This parameter can be a value of @ref HAL_Page_Write_Protection
   * @note   write protection can only be disabled by a system reset
@@ -629,18 +830,37 @@
 #define __HAL_SYSCFG_SRAM_WRP_ENABLE(__PAGE_WP__)      do {assert_param(IS_HAL_SYSCFG_WP_PAGE((__PAGE_WP__))); \
                                                            SYSCFG->RCR |= (__PAGE_WP__);                       \
                                                           }while(0)
+/**
+ * @}
+ */
 #endif /* SYSCFG_RCR_PAGE0 */
-
-
+ 
+/**
+ * @}
+ */ 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup HAL_Exported_Functions HAL Exported Functions
+  * @{
+  */
 
+/** @addtogroup HAL_Exported_Functions_Group1 Initialization and de-initialization Functions 
+ *  @brief    Initialization and de-initialization functions
+ * @{
+ */
 /* Initialization and de-initialization functions  ******************************/
 HAL_StatusTypeDef HAL_Init(void);
 HAL_StatusTypeDef HAL_DeInit(void);
 void HAL_MspInit(void);
 void HAL_MspDeInit(void);
 HAL_StatusTypeDef HAL_InitTick (uint32_t TickPriority);
-
+/**
+ * @}
+ */
+ 
+/** @addtogroup HAL_Exported_Functions_Group2 HAL Control functions 
+ *  @brief    HAL Control functions
+ * @{
+ */
 /* Peripheral Control functions  ************************************************/
 void     HAL_IncTick(void);
 void     HAL_Delay(__IO uint32_t Delay);
@@ -656,7 +876,13 @@ void     HAL_EnableDBGStopMode(void);
 void     HAL_DisableDBGStopMode(void);
 void     HAL_EnableDBGStandbyMode(void);
 void     HAL_DisableDBGStandbyMode(void);
+/**
+ * @}
+ */
 
+/**
+ * @}
+ */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_adc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_adc.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_adc.c
   * @author  MCD Application conversion
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   This file provides firmware functions to manage the following 
   *          functionalities of the Analog to Digital Convertor (ADC)
   *          peripheral:
@@ -192,8 +192,8 @@
   * @{
   */
 
-/** @defgroup ADC 
-  * @brief ADC driver modules
+/** @defgroup ADC ADC HAL module driver
+  * @brief ADC HAL module driver
   * @{
   */ 
 
@@ -204,13 +204,13 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
 
-/** @defgroup ADC_Private_Functions
+/** @defgroup ADC_Exported_Functions ADC Exported Functions
   * @{
   */ 
 
-/** @defgroup ADC_Group1 Initialization/de-initialization functions 
+/** @defgroup ADC_Exported_Functions_Group1 Initialization and de-initialization functions
  *  @brief    Initialization and Configuration functions 
  *
 @verbatim    
@@ -261,7 +261,7 @@ __weak HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef* hadc)
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
   
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
 
 /**
@@ -289,7 +289,7 @@ __weak HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef* hadc)
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
   
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
     
 /**
@@ -320,7 +320,7 @@ __weak void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc)
   * @}
   */
 
-/** @defgroup ADC_Group2 IO operation functions
+/** @defgroup ADC_Exported_Functions_Group2 Input and Output operation functions
  *  @brief    IO operation functions 
  *
 @verbatim   
@@ -355,7 +355,7 @@ __weak void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc)
 __weak HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef* hadc)
 {
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
 
 /**
@@ -378,7 +378,7 @@ __weak HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef* hadc)
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
   
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
 
 /**
@@ -393,7 +393,7 @@ __weak HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef* hadc, uint
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
   
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
 
 /**
@@ -415,7 +415,7 @@ __weak HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef* hadc, uint32_t 
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
   
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
 
 /**
@@ -436,7 +436,7 @@ __weak HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef* hadc)
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
   
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
 
 /**
@@ -460,7 +460,7 @@ __weak HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef* hadc)
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
   
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
 
 /**
@@ -483,7 +483,7 @@ __weak HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef* hadc, uint32_t* pD
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
   
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
 
 /**
@@ -505,7 +505,7 @@ __weak HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef* hadc)
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
   
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
 
 /**
@@ -590,7 +590,7 @@ __weak void HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc)
   * @}
   */
 
-/** @defgroup ADC_Group3 Peripheral Control functions
+/** @defgroup ADC_Exported_Functions_Group3 Peripheral Control functions
  *  @brief    Peripheral Control functions 
  *
 @verbatim   
@@ -634,7 +634,7 @@ __weak HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_Chan
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
   
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
 
 /**
@@ -657,14 +657,14 @@ __weak HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_An
   /*        Function content is located into file stm32f3xx_hal_adc_ex.c   */
   
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
 
 /**
   * @}
   */
 
-/** @defgroup ADC_Group4 ADC Peripheral State functions
+/** @defgroup ADC_Exported_Functions_Group4 Peripheral State functions
  *  @brief   ADC Peripheral State functions 
  *
 @verbatim   

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_adc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_adc.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_adc.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file containing functions prototypes of ADC HAL library.
   ******************************************************************************
   * @attention
@@ -56,7 +56,9 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/
-   
+/** @defgroup ADC_Exported_Types ADC Exported Types
+  * @{
+  */   
 /** 
   * @brief  HAL ADC state machine: ADC States structure definition  
   */ 
@@ -98,11 +100,14 @@ typedef struct __ADC_HandleTypeDef
 
   __IO uint32_t                 ErrorCode;              /*!< ADC Error code */
 }ADC_HandleTypeDef;
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
 /* Exported macros -----------------------------------------------------------*/
      
-/** @defgroup ADC_Exported_Macro
+/** @defgroup ADC_Exported_Macro ADC Exported Macros
   * @{
   */
 /** @brief  Reset ADC handle state
@@ -116,17 +121,31 @@ typedef struct __ADC_HandleTypeDef
   */ 
 
 
-/* Include ADC HAL Extension module */
+/* Include ADC HAL Extended module */
 #include "stm32f3xx_hal_adc_ex.h"
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup ADC_Exported_Functions ADC Exported Functions
+  * @{
+  */ 
+
+/** @addtogroup ADC_Exported_Functions_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ * @{
+ */ 
 /* Initialization and de-initialization functions  **********************************/
 HAL_StatusTypeDef       HAL_ADC_Init(ADC_HandleTypeDef* hadc);
 HAL_StatusTypeDef       HAL_ADC_DeInit(ADC_HandleTypeDef *hadc);
 void                    HAL_ADC_MspInit(ADC_HandleTypeDef* hadc);
 void                    HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc);
+/**
+  * @}
+  */
 
-/* IO operation functions  *****************************************************/
+/** @addtogroup ADC_Exported_Functions_Group2 Input and Output operation functions
+ *  @brief    IO operation functions 
+ * @{
+ */ 
 /* Blocking mode: Polling */
 HAL_StatusTypeDef       HAL_ADC_Start(ADC_HandleTypeDef* hadc);
 HAL_StatusTypeDef       HAL_ADC_Stop(ADC_HandleTypeDef* hadc);
@@ -150,15 +169,35 @@ void                    HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc);
 void                    HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc);
 void                    HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef* hadc);
 void                    HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc);
+/**
+  * @}
+  */
 
+/** @addtogroup ADC_Exported_Functions_Group3 Peripheral Control functions
+ *  @brief    Peripheral Control functions 
+ * @{
+ */ 
 /* Peripheral Control functions ***********************************************/
 HAL_StatusTypeDef       HAL_ADC_ConfigChannel(ADC_HandleTypeDef* hadc, ADC_ChannelConfTypeDef* sConfig);
 HAL_StatusTypeDef       HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef* hadc, ADC_AnalogWDGConfTypeDef* AnalogWDGConfig);
+/**
+  * @}
+  */
 
+/** @defgroup ADC_Exported_Functions_Group4 Peripheral State functions
+ *  @brief   ADC Peripheral State functions 
+ * @{
+ */ 
 /* Peripheral State functions *************************************************/
 HAL_ADC_StateTypeDef    HAL_ADC_GetState(ADC_HandleTypeDef* hadc);
 uint32_t                HAL_ADC_GetError(ADC_HandleTypeDef *hadc);
+/**
+  * @}
+  */
 
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_adc_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_adc_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_adc_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file containing functions prototypes of ADC HAL library.
   ******************************************************************************
   * @attention
@@ -50,14 +50,20 @@
   * @{
   */
 
-/** @addtogroup ADC
+/** @addtogroup ADCEx ADC Extended HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/
+/** @defgroup ADCEx_Exported_Types ADC Extented Exported Types
+  * @{
+  */
 struct __ADC_HandleTypeDef;
 
-#if defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8) || defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /**
   * @brief  Structure definition of ADC initialization and regular group  
   * @note   Parameters of this structure are shared within 2 scopes:
@@ -156,14 +162,15 @@ typedef struct
   uint32_t Rank;                   /*!< Specifies the rank in the regular group sequencer.
                                         This parameter can be a value of @ref ADCEx_regular_rank
                                         Note: In case of need to disable a channel or change order of conversion sequencer, rank containing a previous channel setting can be overwritten by the new channel setting (or parameter number of conversions can be adjusted) */
-  uint32_t SamplingTime;           /*!< Specifies the sampling time to be set for the selected channel.
+  uint32_t SamplingTime;           /*!< Sampling time value to be set for the selected channel.
                                         Unit: ADC clock cycles
-                                        Conversion time is addition of sampling time and processing time (12.5 ADC clock cycles at ADC resolution 12 bits, 10.5 cycles at 10 bits, 8.5 cycles at 8 bits, 6.5 cycles at 6 bits).
+                                        Conversion time is the addition of sampling time and processing time (12.5 ADC clock cycles at ADC resolution 12 bits, 10.5 cycles at 10 bits, 8.5 cycles at 8 bits, 6.5 cycles at 6 bits).
                                         This parameter can be a value of @ref ADCEx_sampling_times
                                         Caution: This parameter updates the parameter property of the channel, that can be used into regular and/or injected groups.
                                                  If this same channel has been previously configured in the other group (regular/injected), it will be updated to last setting.
-                                        Note: In case of usage of internal measurement channels (Vbat/VrefInt/TempSensor),
-                                              the recommended sampling time is at least 2.2us (sampling time setting to be chosen in function of ADC clock frequency) */
+                                        Note: In case of usage of internal measurement channels (VrefInt/Vbat/TempSensor),
+                                              sampling time constraints must be respected (sampling time can be adjusted in function of ADC clock frequency and sampling time setting)
+                                              Refer to device datasheet for timings values, parameters TS_vrefint, TS_vbat, TS_temp (values rough order: 2.2us min). */
   uint32_t SingleDiff;             /*!< Selection of single-ended or differential input.
                                         In differential mode: Differential measurement is between the selected channel 'i' (positive input) and channel 'i+1' (negative input).
                                                               Only channel 'i' has to be configured, channel 'i+1' is configured automatically.
@@ -206,14 +213,15 @@ typedef struct
   uint32_t InjectedRank;                  /*!< The rank in the regular group sequencer
                                                This parameter must be a value of @ref ADCEx_injected_rank
                                                Note: In case of need to disable a channel or change order of conversion sequencer, rank containing a previous channel setting can be overwritten by the new channel setting (or parameter number of conversions can be adjusted) */
-  uint32_t InjectedSamplingTime;          /*!< The sample time value to be set for the selected channel.
+  uint32_t InjectedSamplingTime;          /*!< Sampling time value to be set for the selected channel.
                                                Unit: ADC clock cycles
-                                               Conversion time is addition of sampling time and processing time (12.5 ADC clock cycles at ADC resolution 12 bits, 10.5 cycles at 10 bits, 8.5 cycles at 8 bits, 6.5 cycles at 6 bits).
+                                               Conversion time is the addition of sampling time and processing time (12.5 ADC clock cycles at ADC resolution 12 bits, 10.5 cycles at 10 bits, 8.5 cycles at 8 bits, 6.5 cycles at 6 bits).
                                                This parameter can be a value of @ref ADCEx_sampling_times
                                                Caution: This parameter updates the parameter property of the channel, that can be used into regular and/or injected groups.
                                                         If this same channel has been previously configured in the other group (regular/injected), it will be updated to last setting.
-                                               Note: In case of usage of internal measurement channels (Vbat/VrefInt/TempSensor),
-                                                     the recommended sampling time is at least 2.2us (sampling time setting to be chosen in function of ADC clock frequency) */ 
+                                               Note: In case of usage of internal measurement channels (VrefInt/Vbat/TempSensor),
+                                                     sampling time constraints must be respected (sampling time can be adjusted in function of ADC clock frequency and sampling time setting)
+                                                     Refer to device datasheet for timings values, parameters TS_vrefint, TS_vbat, TS_temp (values rough order: 2.2us min). */
   uint32_t InjectedSingleDiff;            /*!< Selection of single-ended or differential input.
                                                In differential mode: Differential measurement is between the selected channel 'i' (positive input) and channel 'i+1' (negative input).
                                                               Only channel 'i' has to be configured, channel 'i+1' is configured automatically.
@@ -323,7 +331,10 @@ typedef struct
                                    Delay range depends on selected resolution: from 1 to 12 clock cycles for 12 bits, from 1 to 10 clock cycles for 10 bits
                                                                                from 1 to 8 clock cycles for 8 bits, from 1 to 6 clock cycles for 6 bits     */
 }ADC_MultiModeTypeDef;
-#endif /* STM32F303xC || STM32F358xC || STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 || STM32F301x8 || STM32F318xx || STM32F302x8 */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
 #if defined(STM32F373xC) || defined(STM32F378xx)
 /** 
@@ -382,12 +393,15 @@ typedef struct
   uint32_t Rank;                   /*!< Specifies the rank in the regular group sequencer 
                                         This parameter can be a value of @ref ADCEx_regular_rank
                                         Note: In case of need to disable a channel or change order of conversion sequencer, rank containing a previous channel setting can be overwritten by the new channel setting (or parameter number of conversions can be adjusted) */
-  uint32_t SamplingTime;           /*!< Sample time value to be set for the selected channel.
+  uint32_t SamplingTime;           /*!< Sampling time value to be set for the selected channel.
                                         Unit: ADC clock cycles
-                                        Conversion time is addition of sampling time and processing time (12.5 ADC clock cycles at ADC resolution 12 bits).
+                                        Conversion time is the addition of sampling time and processing time (12.5 ADC clock cycles at ADC resolution 12 bits).
                                         This parameter can be a value of @ref ADCEx_sampling_times
-                                        Note: In case of usage of internal measurement channels Temperature Sensor,
-                                              the recommended sampling time is at least 17.1us (sampling time setting to be chosen in function of ADC clock frequency) */
+                                        Caution: This parameter updates the parameter property of the channel, that can be used into regular and/or injected groups.
+                                                 If this same channel has been previously configured in the other group (regular/injected), it will be updated to last setting.
+                                        Note: In case of usage of internal measurement channels (VrefInt/Vbat/TempSensor),
+                                              sampling time constraints must be respected (sampling time can be adjusted in function of ADC clock frequency and sampling time setting)
+                                              Refer to device datasheet for timings values, parameters TS_vrefint, TS_vbat, TS_temp (values rough order: 5us to 17.1us min). */
 }ADC_ChannelConfTypeDef;
 
 /** 
@@ -409,12 +423,15 @@ typedef struct
   uint32_t InjectedRank;                  /*!< Rank in the injected group sequencer
                                                This parameter must be a value of @ref ADCEx_injected_rank
                                                Note: In case of need to disable a channel or change order of conversion sequencer, rank containing a previous channel setting can be overwritten by the new channel setting (or parameter number of conversions can be adjusted) */
-  uint32_t InjectedSamplingTime;          /*!< Sample time value to be set for the selected channel.
+  uint32_t InjectedSamplingTime;          /*!< Sampling time value to be set for the selected channel.
                                                Unit: ADC clock cycles
                                                Conversion time is the addition of sampling time and processing time (12.5 ADC clock cycles at ADC resolution 12 bits).
                                                This parameter can be a value of @ref ADCEx_sampling_times
-                                               Note: In case of usage of internal measurement channels Temperature Sensor,
-                                                     the recommended sampling time is at least 17.1us (sampling time setting to be chosen in function of ADC clock frequency) */
+                                               Caution: This parameter updates the parameter property of the channel, that can be used into regular and/or injected groups.
+                                                        If this same channel has been previously configured in the other group (regular/injected), it will be updated to last setting.
+                                               Note: In case of usage of internal measurement channels (VrefInt/Vbat/TempSensor),
+                                                     sampling time constraints must be respected (sampling time can be adjusted in function of ADC clock frequency and sampling time setting)
+                                                     Refer to device datasheet for timings values, parameters TS_vrefint, TS_vbat, TS_temp (values rough order: 5us to 17.1us min). */
   uint32_t InjectedOffset;                /*!< Defines the offset to be subtracted from the raw converted data (for channels set on injected group only).
                                                Offset value must be a positive number.
                                                Depending of ADC resolution selected (12, 10, 8 or 6 bits),
@@ -470,15 +487,17 @@ typedef struct
   uint32_t WatchdogNumber;    /*!< Reserved for future use, can be set to 0 */
 }ADC_AnalogWDGConfTypeDef;
 #endif /* STM32F373xC || STM32F378xx */
-
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
 
-/** @defgroup ADCEx_Exported_Constants
+/** @defgroup ADCEx_Exported_Constants ADC Extended Exported Constants
   * @{
   */
 
-/** @defgroup ADCEx_Error_Code
+/** @defgroup ADCEx_Error_Code ADC Extended Error Code
   * @{
   */
 #define HAL_ADC_ERROR_NONE        ((uint32_t)0x00)   /*!< No error                                              */
@@ -491,18 +510,26 @@ typedef struct
   * @}
   */
 
-#if defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8) || defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
-/** @defgroup ADCEx_ClockPrescaler
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/** @defgroup ADCEx_ClockPrescaler ADC Extended Clock Prescaler
   * @{
   */
 #define ADC_CLOCK_ASYNC               ((uint32_t)0x00000000)          /*!< ADC asynchronous clock derived from ADC dedicated PLL */
 
-#if defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define ADC_CLOCK_SYNC_PCLK_DIV1      ((uint32_t)ADC12_CCR_CKMODE_0)  /*!< ADC synchronous clock derived from AHB clock without prescaler */
 #define ADC_CLOCK_SYNC_PCLK_DIV2      ((uint32_t)ADC12_CCR_CKMODE_1)  /*!< ADC synchronous clock derived from AHB clock divided by a prescaler of 2 */
 #define ADC_CLOCK_SYNC_PCLK_DIV4      ((uint32_t)ADC12_CCR_CKMODE)    /*!< ADC synchronous clock derived from AHB clock divided by a prescaler of 4 */
-#endif /* STM32F303xC || STM32F358xx || STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 */
-#if defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define ADC_CLOCK_SYNC_PCLK_DIV1      ((uint32_t)ADC1_CCR_CKMODE_0)   /*!< ADC synchronous clock derived from AHB clock without prescaler */
 #define ADC_CLOCK_SYNC_PCLK_DIV2      ((uint32_t)ADC1_CCR_CKMODE_1)   /*!< ADC synchronous clock derived from AHB clock divided by a prescaler of 2 */
 #define ADC_CLOCK_SYNC_PCLK_DIV4      ((uint32_t)ADC1_CCR_CKMODE)     /*!< ADC synchronous clock derived from AHB clock divided by a prescaler of 4 */
@@ -520,7 +547,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_Resolution
+/** @defgroup ADCEx_Resolution ADC Extended Resolution
   * @{
   */
 #define ADC_RESOLUTION12b      ((uint32_t)0x00000000)          /*!<  ADC 12-bit resolution */
@@ -539,7 +566,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_Data_align
+/** @defgroup ADCEx_Data_align ADC Extended Data Alignment
   * @{
   */
 #define ADC_DATAALIGN_RIGHT      ((uint32_t)0x00000000)
@@ -551,7 +578,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_Scan_mode
+/** @defgroup ADCEx_Scan_mode ADC Extended Scan Mode
   * @{
   */
 #define ADC_SCAN_DISABLE         ((uint32_t)0x00000000)
@@ -563,7 +590,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_External_trigger_edge_Regular
+/** @defgroup ADCEx_External_trigger_edge_Regular ADC Extended External trigger enable and polarity selection for regular channels
   * @{
   */
 #define ADC_EXTERNALTRIGCONVEDGE_NONE           ((uint32_t)0x00000000)
@@ -579,10 +606,11 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_External_trigger_source_Regular
+/** @defgroup ADCEx_External_trigger_source_Regular ADC Extended External trigger selection for regular group
   * @{
   */
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 /*!< List of external triggers with generic trigger name, independently of    */
 /* ADC target (caution: applies to other ADCs sharing the same common group), */
 /* sorted by trigger name:                                                    */
@@ -620,6 +648,40 @@ typedef struct
 
 #define ADC_SOFTWARE_START                  ((uint32_t)0x00000001)
 
+#if defined(STM32F303xE) || defined(STM32F398xx)
+/* ADC external triggers specific to device STM303xE: mask to differentiate   */
+/* standard triggers from specific timer 20, needed for reallocation of       */
+/* triggers common to ADC1&2/ADC3&4 and to avoind mixing with standard        */
+/* triggers without remap.                                                    */
+#define ADC_EXTERNALTRIGCONV_T20_MASK       0x1000
+
+/*!< List of external triggers specific to device STM303xE: using Timer20     */
+/* with ADC trigger input remap.                                              */
+/* To remap ADC trigger from other timers/ExtLine to timer20: use macro       */
+/* " __HAL_REMAPADCTRIGGER_ENABLE(...) " with parameters described below:     */
+
+/*!< External triggers of regular group for ADC1&ADC2 only, specific to       */
+/* device STM303xE: : using Timer20 with ADC trigger input remap              */
+#define ADC_EXTERNALTRIGCONV_T20_CC2        ADC_EXTERNALTRIGCONV_T6_TRGO /*!< Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_EXT13) */
+#define ADC_EXTERNALTRIGCONV_T20_CC3        ADC_EXTERNALTRIGCONV_T3_CC4  /*!< Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_EXT15) */
+
+/*!< External triggers of regular group for ADC3&ADC4 only, specific to       */
+/* device STM303xE: : using Timer20 with ADC trigger input remap              */
+/* None */
+
+/*!< External triggers of regular group for ADC1&ADC2, ADC3&ADC4, specific to */
+/* device STM303xE: : using Timer20 with ADC trigger input remap              */
+/* Note: Triggers affected to group ADC1_2 by default, redirected to group    */
+/*       ADC3_4 by driver when needed.                                        */
+#define ADC_EXTERNALTRIGCONV_T20_CC1        (ADC_EXTERNALTRIGCONV_T4_CC4 | ADC_EXTERNALTRIGCONV_T20_MASK) /*!< For ADC1&ADC2: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_EXT5) */
+                                                                                                          /*!< For ADC3&ADC4: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC34_EXT15) */
+#define ADC_EXTERNALTRIGCONV_T20_TRGO       (ADC_EXTERNALTRIGCONV_T1_CC3 | ADC_EXTERNALTRIGCONV_T20_MASK) /*!< For ADC1&ADC2: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_EXT2) */
+                                                                                                          /*!< For ADC3&ADC4: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC34_EXT5) */
+#define ADC_EXTERNALTRIGCONV_T20_TRGO2      (ADC_EXTERNALTRIGCONV_T2_CC2 | ADC_EXTERNALTRIGCONV_T20_MASK) /*!< For ADC1&ADC2: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_EXT3) */
+                                                                                                          /*!< For ADC3&ADC4: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC34_EXT6) */
+#endif /* STM32F303xE || STM32F398xx */
+
+#if defined(STM32F303xC) || defined(STM32F358xx)
 #define IS_ADC_EXTTRIG(REGTRIG) (((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC1)   || \
                                  ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC2)   || \
                                  ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC2)   || \
@@ -649,7 +711,47 @@ typedef struct
                                  ((REGTRIG) == ADC_SOFTWARE_START)              )
 #endif /* STM32F303xC || STM32F358xx */
 
-#if defined(STM32F302xC)
+#if defined(STM32F303xE) || defined(STM32F398xx)
+#define IS_ADC_EXTTRIG(REGTRIG) (((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC1)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC2)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC2)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_CC4)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_CC4)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T6_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_EXT_IT11)  || \
+                                                                                  \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC1)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC3)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_CC1)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_CC1)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T7_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T8_CC1)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_EXT_IT2)   || \
+                                                                                  \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC3)    || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO2)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T8_TRGO)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T8_TRGO2)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T15_TRGO)  || \
+                                                                                  \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T20_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T20_CC3)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T20_CC1)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T20_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T20_TRGO2) || \
+                                                                                  \
+                                 ((REGTRIG) == ADC_SOFTWARE_START)               )
+#endif /* STM32F303xE || STM32F398xx */
+
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC)
 /*!< List of external triggers with generic trigger name, independently of    */
 /* ADC target (caution: applies to other ADCs sharing the same common group), */
 /* sorted by trigger name:                                                    */
@@ -669,9 +771,49 @@ typedef struct
 #define ADC_EXTERNALTRIGCONV_T6_TRGO        ADC1_2_EXTERNALTRIG_T6_TRGO
 #define ADC_EXTERNALTRIGCONV_T15_TRGO       ADC1_2_EXTERNALTRIG_T15_TRGO
 #define ADC_EXTERNALTRIGCONV_EXT_IT11       ADC1_2_EXTERNALTRIG_EXT_IT11
-
 #define ADC_SOFTWARE_START                  ((uint32_t)0x00000001)
 
+#if defined(STM32F302xE)
+/* ADC external triggers specific to device STM302xE: mask to differentiate   */
+/* standard triggers from specific timer 20, needed for reallocation of       */
+/* triggers common to ADC1&2 and to avoind mixing with standard               */
+/* triggers without remap.                                                    */
+#define ADC_EXTERNALTRIGCONV_T20_MASK       0x1000
+
+/*!< List of external triggers specific to device STM302xE: using Timer20     */
+/* with ADC trigger input remap.                                              */
+/* To remap ADC trigger from other timers/ExtLine to timer20: use macro       */
+/* " __HAL_REMAPADCTRIGGER_ENABLE(...) " with parameters described below:     */
+
+/*!< External triggers of regular group for ADC1&ADC2 only, specific to       */
+/* device STM302xE: : using Timer20 with ADC trigger input remap              */
+#define ADC_EXTERNALTRIGCONV_T20_CC2        ADC_EXTERNALTRIGCONV_T6_TRGO /*!< Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_EXT13) */
+#define ADC_EXTERNALTRIGCONV_T20_CC3        ADC_EXTERNALTRIGCONV_T3_CC4  /*!< Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_EXT15) */
+#endif /* STM32F302xE */
+
+#if defined(STM32F302xE)
+#define IS_ADC_EXTTRIG(REGTRIG) (((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC1)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC3)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_CC2)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_CC4)   || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_EXT_IT11) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_TRGO2) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T2_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T4_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T6_TRGO)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T15_TRGO) || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T3_CC4)   || \
+                                                                                 \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T20_CC2)  || \
+                                 ((REGTRIG) == ADC_EXTERNALTRIGCONV_T20_CC3)  || \
+                                                                                 \
+                                 ((REGTRIG) == ADC_SOFTWARE_START)              )
+#endif /* STM32F302xE */
+
+#if defined(STM32F302xC)
 #define IS_ADC_EXTTRIG(REGTRIG) (((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC1)   || \
                                  ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC2)   || \
                                  ((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC3)   || \
@@ -689,6 +831,9 @@ typedef struct
                                                                                  \
                                  ((REGTRIG) == ADC_SOFTWARE_START)              )
 #endif /* STM32F302xC */
+
+#endif /* STM32F302xE || */
+       /* STM32F302xC    */
 
 #if defined(STM32F303x8) || defined(STM32F328xx)
 /*!< List of external triggers with generic trigger name, independently of    */
@@ -712,7 +857,6 @@ typedef struct
 #define ADC_EXTERNALTRIGCONV_T6_TRGO        ADC1_2_EXTERNALTRIG_T6_TRGO
 #define ADC_EXTERNALTRIGCONV_T15_TRGO       ADC1_2_EXTERNALTRIG_T15_TRGO
 #define ADC_EXTERNALTRIGCONV_EXT_IT11       ADC1_2_EXTERNALTRIG_EXT_IT11
-
 #define ADC_SOFTWARE_START                  ((uint32_t)0x00000001)
 
 #define IS_ADC_EXTTRIG(REGTRIG) (((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC1)   || \
@@ -755,7 +899,6 @@ typedef struct
 #define ADC_EXTERNALTRIGCONVHRTIM_TRG1      ADC1_2_EXTERNALTRIG_HRTIM_TRG1
 #define ADC_EXTERNALTRIGCONVHRTIM_TRG3      ADC1_2_EXTERNALTRIG_HRTIM_TRG3
 #define ADC_EXTERNALTRIGCONV_EXT_IT11       ADC1_2_EXTERNALTRIG_EXT_IT11
-
 #define ADC_SOFTWARE_START                  ((uint32_t)0x00000001)
 
 #define IS_ADC_EXTTRIG(REGTRIG) (((REGTRIG) == ADC_EXTERNALTRIGCONV_T1_CC1)    || \
@@ -776,7 +919,7 @@ typedef struct
                                  ((REGTRIG) == ADC_SOFTWARE_START)               )
 #endif /* STM32F334x8 */
 
-#if defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /* List of external triggers with generic trigger name, sorted by trigger     */
 /* name:                                                                      */
 
@@ -802,15 +945,16 @@ typedef struct
                                  ((REGTRIG) == ADC_EXTERNALTRIGCONV_T6_TRGO)  || \
                                  ((REGTRIG) == ADC_EXTERNALTRIGCONV_T15_TRGO) || \
                                  ((REGTRIG) == ADC_SOFTWARE_START)              )
-#endif /* STM32F301x8 || STM32F318xx || STM32F302x8 */
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
 /**
   * @}
   */
 
-/** @defgroup ADCEx_Internal_HAL_driver_Ext_trig_src_Regular
+/** @defgroup ADCEx_Internal_HAL_driver_Ext_trig_src_Regular ADC Extended External trigger selection for regular group (Used Internally)
   * @{
   */
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 /* List of external triggers for common groups ADC1&ADC2 and/or ADC3&ADC4:    */
 /* (used internally by HAL driver. To not use into HAL structure parameters)  */
 
@@ -849,26 +993,29 @@ typedef struct
 #define ADC3_4_EXTERNALTRIG_T7_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
 #define ADC3_4_EXTERNALTRIG_T15_TRGO         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
 #define ADC3_4_EXTERNALTRIG_T2_CC1           ((uint32_t)ADC_CFGR_EXTSEL)
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
-#if defined(STM32F302xC)
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC)
 /* List of external triggers of common group ADC1&ADC2:                       */
 /* (used internally by HAL driver. To not use into HAL structure parameters)  */
 #define ADC1_2_EXTERNALTRIG_T1_CC1           ((uint32_t)0x00000000)
 #define ADC1_2_EXTERNALTRIG_T1_CC2           ((uint32_t)ADC_CFGR_EXTSEL_0)
 #define ADC1_2_EXTERNALTRIG_T1_CC3           ((uint32_t)ADC_CFGR_EXTSEL_1)
-#define ADC1_2_EXTERNALTRIG_T2_CC2           ((uint32_t)(ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
-#define ADC1_2_EXTERNALTRIG_T3_TRGO          ((uint32_t)ADC_CFGR_EXTSEL_2)
-#define ADC1_2_EXTERNALTRIG_T4_CC4           ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
-#define ADC1_2_EXTERNALTRIG_EXT_IT11         ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
 #define ADC1_2_EXTERNALTRIG_T1_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_0))
 #define ADC1_2_EXTERNALTRIG_T1_TRGO2         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1))
+#define ADC1_2_EXTERNALTRIG_T2_CC2           ((uint32_t)(ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
 #define ADC1_2_EXTERNALTRIG_T2_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0))
+#define ADC1_2_EXTERNALTRIG_T3_CC4           ((uint32_t)ADC_CFGR_EXTSEL)
+#define ADC1_2_EXTERNALTRIG_T3_TRGO          ((uint32_t)ADC_CFGR_EXTSEL_2)
+#define ADC1_2_EXTERNALTRIG_T4_CC4           ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
 #define ADC1_2_EXTERNALTRIG_T4_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2))
 #define ADC1_2_EXTERNALTRIG_T6_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
 #define ADC1_2_EXTERNALTRIG_T15_TRGO         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
-#define ADC1_2_EXTERNALTRIG_T3_CC4           ((uint32_t)ADC_CFGR_EXTSEL)
-#endif /* STM32F302xC */
+#define ADC1_2_EXTERNALTRIG_EXT_IT11         ((uint32_t)(ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
+#endif /* STM32F302xE || */
+       /* STM32F302xC    */
 
 #if defined(STM32F303x8) || defined(STM32F328xx)
 /* List of external triggers of common group ADC1&ADC2:                       */
@@ -910,7 +1057,7 @@ typedef struct
 #define ADC1_2_EXTERNALTRIG_T3_CC4           ((uint32_t)ADC_CFGR_EXTSEL)
 #endif /* STM32F334x8 */
 
-#if defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /* List of external triggers of regular group for ADC1:                       */
 /* (used internally by HAL driver. To not use into HAL structure parameters)  */
 #define ADC1_EXTERNALTRIG_T1_CC1           ((uint32_t)0x00000000)
@@ -923,13 +1070,13 @@ typedef struct
 #define ADC1_EXTERNALTRIG_T6_TRGO          ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0))
 #define ADC1_EXTERNALTRIG_T15_TRGO         ((uint32_t)(ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1))
 #define ADC_SOFTWARE_START                 ((uint32_t)0x00000001)
-#endif /* STM32F301x8 || STM32F318xx || STM32F302x8 */
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
 /**
   * @}
   */
 
 
-/** @defgroup ADCEx_EOCSelection
+/** @defgroup ADCEx_EOCSelection ADC Extended End of Regular Sequence/Conversion 
   * @{
   */
 #define EOC_SINGLE_CONV         ((uint32_t) ADC_ISR_EOC)
@@ -943,7 +1090,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_Overrun
+/** @defgroup ADCEx_Overrun ADC Extended overrun
   * @{
   */
 #define OVR_DATA_OVERWRITTEN            ((uint32_t)0x00000000)   /*!< Default setting, to be used for compatibility with other STM32 devices */
@@ -955,7 +1102,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_channels
+/** @defgroup ADCEx_channels ADC Extended Channels
   * @{
   */
 /* Note: Depending on devices, some channels may not be available on package  */
@@ -1035,7 +1182,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_sampling_times
+/** @defgroup ADCEx_sampling_times ADC Extended Sampling Times
   * @{
   */
 #define ADC_SAMPLETIME_1CYCLE_5       ((uint32_t)0x00000000)                              /*!< Sampling time 1.5 ADC clock cycle */
@@ -1059,7 +1206,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_SingleDifferential
+/** @defgroup ADCEx_SingleDifferential ADC Extended Single-ended/Differential input mode
   * @{
   */
 #define ADC_SINGLE_ENDED                ((uint32_t)0x00000000)
@@ -1071,7 +1218,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_OffsetNumber
+/** @defgroup ADCEx_OffsetNumber ADC Extended Offset Number
   * @{
   */
 #define ADC_OFFSET_NONE               ((uint32_t)0x00)
@@ -1089,7 +1236,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_regular_rank
+/** @defgroup ADCEx_regular_rank ADC Extended Regular Channel Rank
   * @{
   */
 #define ADC_REGULAR_RANK_1    ((uint32_t)0x00000001)
@@ -1129,7 +1276,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_injected_rank
+/** @defgroup ADCEx_injected_rank ADC Extended Injected Channel Rank
   * @{
   */
 #define ADC_INJECTED_RANK_1    ((uint32_t)0x00000001)
@@ -1145,7 +1292,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_External_trigger_edge_Injected
+/** @defgroup ADCEx_External_trigger_edge_Injected External Trigger Edge of Injected Group
   * @{
   */
 #define ADC_EXTERNALTRIGINJECCONV_EDGE_NONE           ((uint32_t)0x00000000)
@@ -1161,10 +1308,11 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_External_trigger_source_Injected
+/** @defgroup ADCEx_External_trigger_source_Injected External Trigger Source of Injected Group
   * @{
   */
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 /* List of external triggers with generic trigger name, independently of ADC  */
 /* target (caution: applies to other ADCs sharing the same common group),     */
 /* sorted by trigger name:                                                    */
@@ -1200,6 +1348,31 @@ typedef struct
 
 #define ADC_INJECTED_SOFTWARE_START     ((uint32_t)0x00000001)
 
+#if defined(STM32F303xE) || defined(STM32F398xx)
+/*!< List of external triggers specific to device STM303xE: using Timer20     */
+/* with ADC trigger input remap.                                              */
+/* To remap ADC trigger from other timers/ExtLine to timer20: use macro       */
+/* " __HAL_REMAPADCTRIGGER_ENABLE(...) " with parameters described below:     */
+
+/*!< External triggers of injected group for ADC1&ADC2 only, specific to      */
+/* device STM303xE: : using Timer20 with ADC trigger input remap              */
+#define ADC_EXTERNALTRIGINJECCONV_T20_CC4        ADC_EXTERNALTRIGINJECCONV_T3_CC1  /*!< Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_JEXT13) */
+
+/*!< External triggers of injected group for ADC3&ADC4 only, specific to      */
+/* device STM303xE: : using Timer20 with ADC trigger input remap              */
+#define ADC_EXTERNALTRIGINJECCONV_T20_CC2        ADC_EXTERNALTRIGINJECCONV_T7_TRGO /*!< Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC34_JEXT14) */
+
+/*!< External triggers of regular group for ADC1&ADC2, ADC3&ADC4, specific to */
+/* device STM303xE: : using Timer20 with ADC trigger input remap              */
+/* Note: Triggers affected to group ADC1_2 by default, redirected to group    */
+/*       ADC3_4 by driver when needed.                                        */
+#define ADC_EXTERNALTRIGINJECCONV_T20_TRGO       (ADC_EXTERNALTRIGINJECCONV_T2_CC1 | ADC_EXTERNALTRIGCONV_T20_MASK)   /*!< For ADC1&ADC2: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_JEXT3) */
+                                                                                                                      /*!< For ADC3&ADC4: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC34_JEXT5) */
+#define ADC_EXTERNALTRIGINJECCONV_T20_TRGO2      (ADC_EXTERNALTRIGINJECCONV_EXT_IT15 | ADC_EXTERNALTRIGCONV_T20_MASK) /*!< For ADC1&ADC2: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_JEXT6) */
+                                                                                                                      /*!< For ADC3&ADC4: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC34_JEXT11) */
+#endif /* STM32F303xE || STM32F398xx */
+
+#if defined(STM32F303xC) || defined(STM32F358xx)
 #define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)   || \
                                       ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC1)   || \
                                       ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)   || \
@@ -1226,7 +1399,42 @@ typedef struct
                                       ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)          )
 #endif /* STM32F303xC || STM32F358xx */
 
-#if defined(STM32F302xC)
+#if defined(STM32F303xE) || defined(STM32F398xx)
+#define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC1)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T6_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_EXT_IT15)  || \
+                                                                                            \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_CC3)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T7_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_CC2)    || \
+                                                                                            \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO2)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC3)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T8_TRGO2)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T15_TRGO)  || \
+                                                                                            \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_CC2)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_TRGO2) || \
+                                                                                            \
+                                      ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)           )
+#endif /* STM32F303xE || STM32F398xx */
+
+#endif /* STM32F303xC || STM32F303xE || STM32F398xx || STM32F358xx */
+
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC)
 /*!< List of external triggers with generic trigger name, independently of    */
 /* ADC target (caution: applies to other ADCs sharing the same common group), */
 /* sorted by trigger name:                                                    */
@@ -1248,21 +1456,58 @@ typedef struct
 
 #define ADC_INJECTED_SOFTWARE_START     ((uint32_t)0x00000001)
 
-#define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO)  || \
-                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_CC4)   || \
-                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO)  || \
-                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)   || \
-                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)   || \
-                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO)  || \
-                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_EXT_IT15) || \
+#if defined(STM32F302xE)
+/*!< List of external triggers specific to device STM302xE: using Timer20     */
+/* with ADC trigger input remap.                                              */
+/* To remap ADC trigger from other timers/ExtLine to timer20: use macro       */
+/* " __HAL_REMAPADCTRIGGER_ENABLE(...) " with parameters described below:     */
+
+/*!< External triggers of injected group for ADC1&ADC2 only, specific to      */
+/* device STM302xE: : using Timer20 with ADC trigger input remap              */
+#define ADC_EXTERNALTRIGINJECCONV_T20_CC4        ADC_EXTERNALTRIGINJECCONV_T3_CC1  /*!< Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_JEXT13) */
+#define ADC_EXTERNALTRIGINJECCONV_T20_TRGO       (ADC_EXTERNALTRIGINJECCONV_T2_CC1 | ADC_EXTERNALTRIGCONV_T20_MASK)   /*!< For ADC1&ADC2: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_JEXT3) */
+#define ADC_EXTERNALTRIGINJECCONV_T20_TRGO2      (ADC_EXTERNALTRIGINJECCONV_EXT_IT15 | ADC_EXTERNALTRIGCONV_T20_MASK) /*!< For ADC1&ADC2: Remap trigger using macro __HAL_REMAPADCTRIGGER_ENABLE(HAL_REMAPADCTRIGGER_ADC12_JEXT6) */
+#endif /* STM32F302xE */
+
+#if defined(STM32F302xE)
+#define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO2)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC1)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC3)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)    || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T6_TRGO)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T15_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_EXT_IT15)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T20_TRGO2) || \
+                                      ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)             )
+#endif /* STM32F302xE */
+
+#if defined(STM32F302xC)
+#define IS_ADC_EXTTRIGINJEC(INJTRIG) (((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO)  || \
                                       ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T1_TRGO2) || \
-                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC3)   || \
-                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_CC1)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO)  || \
                                       ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC1)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC3)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_CC4)   || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T3_TRGO)  || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO)  || \
                                       ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T6_TRGO)  || \
                                       ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T15_TRGO) || \
+                                      ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_EXT_IT15) || \
                                       ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)          )
 #endif /* STM32F302xC */
+
+#endif /* STM32F302xE || */
+       /* STM32F302xC    */
 
 #if defined(STM32F303x8) || defined(STM32F328xx)
 /*!< List of external triggers with generic trigger name, independently of    */
@@ -1348,7 +1593,7 @@ typedef struct
                                       ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)            )
 #endif /* STM32F334x8 */
 
-#if defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /* List of external triggers with generic trigger name, sorted by trigger     */
 /* name:                                                                      */
 
@@ -1369,15 +1614,16 @@ typedef struct
                                       ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T6_TRGO)  || \
                                       ((INJTRIG) == ADC_EXTERNALTRIGINJECCONV_T15_TRGO) || \
                                       ((INJTRIG) == ADC_INJECTED_SOFTWARE_START)          )
-#endif /* STM32F301x8 || STM32F318xx || STM32F302x8 */
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
 /**
   * @}
   */
 
-/** @defgroup ADCEx_Internal_HAL_driver_Ext_trig_src_Injected
+/** @defgroup ADCEx_Internal_HAL_driver_Ext_trig_src_Injected ADC Extended External Trigger Source of Injected Group (Internal)
   * @{
   */
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 /* List of external triggers sorted of groups ADC1&ADC2 and/or ADC3&ADC4:     */
 /* (used internally by HAL driver. To not use into HAL structure parameters)  */
 
@@ -1412,6 +1658,11 @@ typedef struct
 #define ADC3_4_EXTERNALTRIGINJEC_T4_CC3     ((uint32_t)ADC_JSQR_JEXTSEL_1 | 0x10000)
 #define ADC3_4_EXTERNALTRIGINJEC_T8_CC2     ((uint32_t)(ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
 #define ADC3_4_EXTERNALTRIGINJEC_T8_CC4     ((uint32_t)ADC_JSQR_JEXTSEL_2)
+
+#if defined(STM32F303xE) || defined(STM32F398xx)
+#define ADC3_4_EXTERNALTRIGINJEC_T20_TRGO   ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0))
+#endif /* STM32F303xE || STM32F398xx */
+
 #define ADC3_4_EXTERNALTRIGINJEC_T4_CC4     ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
 #define ADC3_4_EXTERNALTRIGINJEC_T4_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0))
 #define ADC3_4_EXTERNALTRIGINJEC_T1_TRGO2   ((uint32_t)ADC_JSQR_JEXTSEL_3)
@@ -1422,9 +1673,11 @@ typedef struct
 #define ADC3_4_EXTERNALTRIGINJEC_T2_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0))
 #define ADC3_4_EXTERNALTRIGINJEC_T7_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
 #define ADC3_4_EXTERNALTRIGINJEC_T15_TRGO   ((uint32_t)ADC_JSQR_JEXTSEL)
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
-#if defined(STM32F302xC)
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC)
 /* List of external triggers of group ADC1&ADC2:                              */
 /* (used internally by HAL driver. To not use into HAL structure parameters)  */
 #define ADC1_2_EXTERNALTRIGINJEC_T1_TRGO    ((uint32_t)0x00000000)
@@ -1440,8 +1693,9 @@ typedef struct
 #define ADC1_2_EXTERNALTRIGINJEC_T3_CC1     ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0))
 #define ADC1_2_EXTERNALTRIGINJEC_T6_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
 #define ADC1_2_EXTERNALTRIGINJEC_T15_TRGO   ((uint32_t)ADC_JSQR_JEXTSEL)
-#endif /* STM32F302xC */
-
+#endif /* STM32F302xE || */
+       /* STM32F302xC    */
+      
 #if defined(STM32F303x8) || defined(STM32F328xx)
 /* List of external triggers of group ADC1&ADC2:                              */
 /* (used internally by HAL driver. To not use into HAL structure parameters)  */
@@ -1482,7 +1736,7 @@ typedef struct
 #define ADC1_2_EXTERNALTRIGINJEC_T15_TRGO    ((uint32_t)ADC_JSQR_JEXTSEL)
 #endif /* STM32F334x8 */
 
-#if defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /* List of external triggers of injected group for ADC1:                      */
 /* (used internally by HAL driver. To not use into HAL structure parameters)  */
 #define ADC1_EXTERNALTRIGINJEC_T1_TRGO    ((uint32_t)0x00000000)
@@ -1491,12 +1745,12 @@ typedef struct
 #define ADC1_EXTERNALTRIGINJEC_T1_TRGO2   ((uint32_t)ADC_JSQR_JEXTSEL_3)
 #define ADC1_EXTERNALTRIGINJEC_T6_TRGO    ((uint32_t)(ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1))
 #define ADC1_EXTERNALTRIGINJEC_T15_TRGO   ((uint32_t)ADC_JSQR_JEXTSEL)
-#endif /* STM32F301x8 || STM32F318xx || STM32F302x8 */
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
 /**
   * @}
   */
 
-/** @defgroup ADCEx_Common_mode
+/** @defgroup ADCEx_Common_mode ADC Extended Dual ADC Mode
   * @{
   */
 #define ADC_MODE_INDEPENDENT                  ((uint32_t)(0x00000000))
@@ -1519,7 +1773,7 @@ typedef struct
   */
 
 
-/** @defgroup ADCEx_Direct_memory_access_mode_for_multimode
+/** @defgroup ADCEx_Direct_memory_access_mode_for_multimode ADC Extended DMA Mode for Dual ADC Mode
   * @{
   */
 #define ADC_DMAACCESSMODE_DISABLED      ((uint32_t)0x00000000)         /*!< DMA multimode disabled: each ADC will use its own DMA channel */
@@ -1533,7 +1787,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_delay_between_2_sampling_phases
+/** @defgroup ADCEx_delay_between_2_sampling_phases ADC Extended Delay Between 2 Sampling Phases
   * @{
   */
 #define ADC_TWOSAMPLINGDELAY_1CYCLE     ((uint32_t)(0x00000000))
@@ -1565,7 +1819,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_analog_watchdog_number
+/** @defgroup ADCEx_analog_watchdog_number ADC Extended Analog Watchdog Selection
   * @{
   */
 #define ADC_ANALOGWATCHDOG_1                    ((uint32_t)0x00000001)
@@ -1579,7 +1833,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_analog_watchdog_mode
+/** @defgroup ADCEx_analog_watchdog_mode ADC Extended Analog Watchdog Mode
   * @{
   */
 #define ADC_ANALOGWATCHDOG_NONE                 ((uint32_t) 0x00000000)
@@ -1601,7 +1855,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADC_conversion_type
+/** @defgroup ADC_conversion_group ADC Conversion Group
   * @{
   */
 #define REGULAR_GROUP             ((uint32_t)(ADC_FLAG_EOC | ADC_FLAG_EOS))
@@ -1615,7 +1869,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_Event_type
+/** @defgroup ADCEx_Event_type ADC Extended Event Type
   * @{
   */
 #define AWD1_EVENT           ((uint32_t)ADC_FLAG_AWD1)  /*!< ADC Analog watchdog 1 event (main analog watchdog, present on all STM32 devices) */
@@ -1635,7 +1889,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_interrupts_definition
+/** @defgroup ADCEx_interrupts_definition ADC Extended Interrupts Definition
   * @{
   */
 #define ADC_IT_RDY           ADC_IER_RDY        /*!< ADC Ready (ADRDY) interrupt source */
@@ -1663,7 +1917,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_flags_definition
+/** @defgroup ADCEx_flags_definition ADC Extended Flags Definition
   * @{
   */
 #define ADC_FLAG_RDY           ADC_ISR_ADRD     /*!< ADC Ready (ADRDY) flag */
@@ -1700,10 +1954,12 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADC_multimode_bits
+/** @defgroup ADC_multimode_bits ADC Multimode Bits
   * @{
   */
-#if defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define ADC_CCR_MULTI             ADC12_CCR_MULTI        /*!< Multi ADC mode selection */
 #define ADC_CCR_MULTI_0           ADC12_CCR_MULTI_0      /*!< MULTI bit 0 */
 #define ADC_CCR_MULTI_1           ADC12_CCR_MULTI_1      /*!< MULTI bit 1 */
@@ -1725,9 +1981,11 @@ typedef struct
 #define ADC_CCR_VREFEN            ADC12_CCR_VREFEN       /*!< VREFINT enable */
 #define ADC_CCR_TSEN              ADC12_CCR_TSEN         /*!< Temperature sensor enable */
 #define ADC_CCR_VBATEN            ADC12_CCR_VBATEN       /*!< VBAT enable */
-#endif /* STM32F303xC || STM32F358xx || STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
 
-#if defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define ADC_CCR_MULTI             ADC1_CCR_MULTI        /*!< Multi ADC mode selection */
 #define ADC_CCR_MULTI_0           ADC1_CCR_MULTI_0      /*!< MULTI bit 0 */
 #define ADC_CCR_MULTI_1           ADC1_CCR_MULTI_1      /*!< MULTI bit 1 */
@@ -1749,20 +2007,14 @@ typedef struct
 #define ADC_CCR_VREFEN            ADC1_CCR_VREFEN       /*!< VREFINT enable */
 #define ADC_CCR_TSEN              ADC1_CCR_TSEN         /*!< Temperature sensor enable */
 #define ADC_CCR_VBATEN            ADC1_CCR_VBATEN       /*!< VBAT enable */
-#endif /* STM32F301x8 || STM32F318xx || STM32F302x8 */
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
 
 
 /**
   * @}
   */
 
-
-
-/**
-  * @}
-  */
-
-/** @defgroup ADCEx_range_verification
+/** @defgroup ADCEx_range_verification ADC Extended Range Verification
   * in function of ADC resolution selected (12, 10, 8 or 6 bits)
   * @{
   */
@@ -1775,7 +2027,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADC_injected_nb_conv_verification
+/** @defgroup ADC_injected_nb_conv_verification ADC Injected Conversion Number Verification
   * @{
   */
 #define IS_ADC_INJECTED_NB_CONV(LENGTH) (((LENGTH) >= ((uint32_t)1)) && ((LENGTH) <= ((uint32_t)4)))
@@ -1783,7 +2035,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADC_regular_nb_conv_verification
+/** @defgroup ADC_regular_nb_conv_verification ADC Regular Conversion Number Verification
   * @{
   */
 #define IS_ADC_REGULAR_NB_CONV(LENGTH) (((LENGTH) >= ((uint32_t)1)) && ((LENGTH) <= ((uint32_t)16)))
@@ -1791,7 +2043,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADC_regular_discontinuous_mode_number_verification
+/** @defgroup ADC_regular_discontinuous_mode_number_verification ADC Regular Discontinuous Mode NumberVerification
   * @{
   */
 #define IS_ADC_REGULAR_DISCONT_NUMBER(NUMBER) (((NUMBER) >= ((uint32_t)1)) && ((NUMBER) <= ((uint32_t)8)))
@@ -1799,7 +2051,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADC_calibration_factor_length_verification
+/** @defgroup ADC_calibration_factor_length_verification ADC Calibration Factor Length Verification
   * @{
   */
 /**
@@ -1811,11 +2063,14 @@ typedef struct
 /**
   * @}
   */
-#endif /* STM32F303xC || STM32F358xC || STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 || STM32F301x8 || STM32F318xx || STM32F302x8 */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
 
 #if defined(STM32F373xC) || defined(STM32F378xx)
-/** @defgroup ADCEx_Data_align
+/** @defgroup ADCEx_Data_align ADC Extended Data Alignment
   * @{
   */
 #define ADC_DATAALIGN_RIGHT      ((uint32_t)0x00000000)
@@ -1827,7 +2082,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_Scan_mode
+/** @defgroup ADCEx_Scan_mode ADC Extended Scan Mode
   * @{
   */
 #define ADC_SCAN_DISABLE         ((uint32_t)0x00000000)
@@ -1839,7 +2094,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_External_trigger_edge_Regular
+/** @defgroup ADCEx_External_trigger_edge_Regular ADC Extended External trigger enable for regular channels
   * @{
   */
 #define ADC_EXTERNALTRIGCONVEDGE_NONE           ((uint32_t)0x00000000)
@@ -1851,7 +2106,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_External_trigger_source_Regular
+/** @defgroup ADCEx_External_trigger_source_Regular ADC Extended External trigger selection for regular group
   * @{
   */
 /* List of external triggers with generic trigger name, sorted by trigger     */
@@ -1880,7 +2135,7 @@ typedef struct
   */
 
 
-/** @defgroup ADCEx_Internal_HAL_driver_Ext_trig_src_Regular
+/** @defgroup ADCEx_Internal_HAL_driver_Ext_trig_src_Regular ADC Extended External trigger selection for regular group (Used Internally)
   * @{
   */
 
@@ -1902,7 +2157,7 @@ typedef struct
   */
 
 
-/** @defgroup ADCEx_channels
+/** @defgroup ADCEx_channels ADC Extended Channels
   * @{
   */
 /* Note: Depending on devices, some channels may not be available on package  */
@@ -1954,7 +2209,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_sampling_times
+/** @defgroup ADCEx_sampling_times ADC Extended Sampling Times
   * @{
   */
 #define ADC_SAMPLETIME_1CYCLE_5       ((uint32_t)0x00000000)                            /*!< Sampling time 1.5 ADC clock cycle */
@@ -1978,7 +2233,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_sampling_times_all_channels
+/** @defgroup ADCEx_sampling_times_all_channels ADC Extended Sampling Times All Channels
   * @{
   */
 #define ADC_SAMPLETIME_ALLCHANNELS_SMPR2BIT2                                          \
@@ -2027,7 +2282,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_regular_rank
+/** @defgroup ADCEx_regular_rank ADC Extended Regular Channel Rank
   * @{
   */
 #define ADC_REGULAR_RANK_1    ((uint32_t)0x00000001)
@@ -2067,7 +2322,7 @@ typedef struct
   * @}
   */
        
-/** @defgroup ADCEx_injected_rank
+/** @defgroup ADCEx_injected_rank ADC Extended Injected Channel Rank
   * @{
   */
 #define ADC_INJECTED_RANK_1    ((uint32_t)0x00000001)
@@ -2083,7 +2338,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_External_trigger_edge_Injected
+/** @defgroup ADCEx_External_trigger_edge_Injected External Trigger Edge of Injected Group
   * @{
   */
 #define ADC_EXTERNALTRIGINJECCONV_EDGE_NONE           ((uint32_t)0x00000000)
@@ -2095,7 +2350,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_External_trigger_source_Injected
+/** @defgroup ADCEx_External_trigger_source_Injected External Trigger Source of Injected Group
   * @{
   */
 /* External triggers for injected groups of ADC1 */
@@ -2121,7 +2376,7 @@ typedef struct
   */
 
 
-/** @defgroup ADCEx_Internal_HAL_driver_Ext_trig_src_Injected
+/** @defgroup ADCEx_Internal_HAL_driver_Ext_trig_src_Injected ADC Extended External Trigger Source of Injected Group (Internal)
   * @{
   */
 
@@ -2141,7 +2396,7 @@ typedef struct
   */
 
 
-/** @defgroup ADCEx_analog_watchdog_mode
+/** @defgroup ADCEx_analog_watchdog_mode ADC Extended analog watchdog mode
   * @{
   */
 #define ADC_ANALOGWATCHDOG_NONE                 ((uint32_t)0x00000000)
@@ -2163,7 +2418,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADC_conversion_group
+/** @defgroup ADC_conversion_group ADC Conversion Group
   * @{
   */
 #define REGULAR_GROUP             ((uint32_t)(ADC_FLAG_EOC))
@@ -2177,7 +2432,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_Event_type
+/** @defgroup ADCEx_Event_type ADC Extended Event Type
   * @{
   */
 #define AWD_EVENT               ((uint32_t)ADC_FLAG_AWD)   /*!< ADC Analog watchdog event */
@@ -2187,7 +2442,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_interrupts_definition
+/** @defgroup ADCEx_interrupts_definition ADC Extended Interrupts Definition
   * @{
   */
 #define ADC_IT_EOC           ADC_CR1_EOCIE        /*!< ADC End of Regular Conversion interrupt source */
@@ -2202,7 +2457,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_flags_definition
+/** @defgroup ADCEx_flags_definition ADC Extended Flags Definition
   * @{
   */
 #define ADC_FLAG_AWD           ADC_SR_AWD      /*!< ADC Analog watchdog flag */
@@ -2224,7 +2479,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADCEx_range_verification
+/** @defgroup ADCEx_range_verification ADC Extended Range Verification
   * For a unique ADC resolution: 12 bits
   * @{
   */
@@ -2233,7 +2488,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADC_injected_nb_conv_verification
+/** @defgroup ADC_injected_nb_conv_verification ADC Injected Conversion Number Verification
   * @{
   */
 #define IS_ADC_INJECTED_NB_CONV(LENGTH) (((LENGTH) >= ((uint32_t)1)) && ((LENGTH) <= ((uint32_t)4)))
@@ -2241,7 +2496,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADC_regular_nb_conv_verification
+/** @defgroup ADC_regular_nb_conv_verification ADC Regular Conversion Number Verification
   * @{
   */
 #define IS_ADC_REGULAR_NB_CONV(LENGTH) (((LENGTH) >= ((uint32_t)1)) && ((LENGTH) <= ((uint32_t)16)))
@@ -2249,7 +2504,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADC_regular_discontinuous_mode_number_verification
+/** @defgroup ADC_regular_discontinuous_mode_number_verification ADC Regular Discontinuous Mode NumberVerification
   * @{
   */
 #define IS_ADC_REGULAR_DISCONT_NUMBER(NUMBER) (((NUMBER) >= ((uint32_t)1)) && ((NUMBER) <= ((uint32_t)8)))
@@ -2264,13 +2519,16 @@ typedef struct
 
 /* Exported macros -----------------------------------------------------------*/
 
-/** @addtogroup ADC_Exported_Macro
+/** @addtogroup ADC_Exported_Macro ADC Exported Macros
   * @{
   */
 /* Macro for internal HAL driver usage, and possibly can be used into code of */
 /* final user.                                                                */
 
-#if defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8) || defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /**
   * @brief Verification of ADC state: enabled or disabled
   * @param __HANDLE__: ADC handle
@@ -2383,8 +2641,10 @@ typedef struct
   * @retval None
   */
 #define __HAL_ADC_CLEAR_ERRORCODE(__HANDLE__) ((__HANDLE__)->ErrorCode = HAL_ADC_ERROR_NONE)
-#endif /* STM32F303xC || STM32F358xC || STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 || STM32F301x8 || STM32F318xx || STM32F302x8 */
-
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
       
 #if defined(STM32F373xC) || defined(STM32F378xx)
 /**
@@ -2473,10 +2733,13 @@ typedef struct
 /* Macro reserved for internal HAL driver usage, not intended to be used in   */
 /* code of final user.                                                        */
 
-/** @defgroup ADCEx_Exported_Macro_internal_HAL_driver
+/** @defgroup ADCEx_Exported_Macro_internal_HAL_driver ADC Extended Exported Macros (Internal)
   * @{
   */
-#if defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8) || defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 
 /**
   * @brief Set the ADC's sample time for Channels numbers between 0 and 9.
@@ -2632,6 +2895,9 @@ typedef struct
   * @param __EXT_TRIG_CONV__: External trigger selected for regular group.
   * @retval External trigger to be programmed into EXTSEL bits of CFGR register
   */
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+
 #if defined(STM32F303xC) || defined(STM32F358xx)
 #define __HAL_ADC_CFGR_EXTSEL(__HANDLE__, __EXT_TRIG_CONV__)                   \
  (( ((((__HANDLE__)->Instance) == ADC3) || (((__HANDLE__)->Instance) == ADC4)) \
@@ -2655,10 +2921,54 @@ typedef struct
    :                                                                           \
    (__EXT_TRIG_CONV__)                                                         \
  )
+#endif /* STM32F303xC || STM32F358xx */
+   
+#if defined(STM32F303xE) || defined(STM32F398xx)
+/* Note: Macro including external triggers specific to device STM303xE: using */
+/*       Timer20 with ADC trigger input remap.                                */
+#define __HAL_ADC_CFGR_EXTSEL(__HANDLE__, __EXT_TRIG_CONV__)                   \
+ (( ((((__HANDLE__)->Instance) == ADC3) || (((__HANDLE__)->Instance) == ADC4)) \
+  )?                                                                           \
+   ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T2_TRGO                     \
+     )?                                                                        \
+      (ADC3_4_EXTERNALTRIG_T2_TRGO)                                            \
+      :                                                                        \
+      ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T3_TRGO                  \
+        )?                                                                     \
+         (ADC3_4_EXTERNALTRIG_T3_TRGO)                                         \
+         :                                                                     \
+         ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T8_TRGO               \
+           )?                                                                  \
+            (ADC3_4_EXTERNALTRIG_T8_TRGO)                                      \
+            :                                                                  \
+            ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T20_CC1            \
+              )?                                                               \
+               (ADC3_4_EXTERNALTRIG_T2_CC1)                                    \
+               :                                                               \
+                ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T20_TRGO       \
+                  )?                                                           \
+                   (ADC3_4_EXTERNALTRIG_EXT_IT2)                               \
+                   :                                                           \
+                    ( ( (__EXT_TRIG_CONV__) == ADC_EXTERNALTRIGCONV_T20_TRGO2  \
+                      )?                                                       \
+                       (ADC3_4_EXTERNALTRIG_T4_CC1)                            \
+                       :                                                       \
+                       (__EXT_TRIG_CONV__)                                     \
+                  )                                                            \
+               )                                                               \
+            )                                                                  \
+         )                                                                     \
+      )                                                                        \
+   )                                                                           \
+   :                                                                           \
+   (__EXT_TRIG_CONV__ & (~ADC_EXTERNALTRIGCONV_T20_MASK))                      \
+ )
+#endif /* STM32F303xE || STM32F398xx */
 #else
 #define __HAL_ADC_CFGR_EXTSEL(__HANDLE__, __EXT_TRIG_CONV__)                   \
    (__EXT_TRIG_CONV__)
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
 /**
   * @brief For devices with 3 ADCs or more: Defines the external trigger source 
@@ -2675,6 +2985,7 @@ typedef struct
   * @param __EXT_TRIG_INJECTCONV__: External trigger selected for injected group
   * @retval External trigger to be programmed into JEXTSEL bits of JSQR register
   */
+#if defined(STM32F303xC) || defined(STM32F303xE) || defined(STM32F398xx) || defined(STM32F358xx)
 #if defined(STM32F303xC) || defined(STM32F358xx)
 #define __HAL_ADC_JSQR_JEXTSEL(__HANDLE__, __EXT_TRIG_INJECTCONV__)            \
  (( ((((__HANDLE__)->Instance) == ADC3) || (((__HANDLE__)->Instance) == ADC4)) \
@@ -2703,10 +3014,56 @@ typedef struct
    :                                                                           \
    (__EXT_TRIG_INJECTCONV__)                                                   \
  )
+#endif /* STM32F303xC || STM32F358xx */
+   
+#if defined(STM32F303xE) || defined(STM32F398xx)
+/* Note: Macro including external triggers specific to device STM303xE: using */
+/*       Timer20 with ADC trigger input remap.                                */
+#define __HAL_ADC_JSQR_JEXTSEL(__HANDLE__, __EXT_TRIG_INJECTCONV__)            \
+ (( ((((__HANDLE__)->Instance) == ADC3) || (((__HANDLE__)->Instance) == ADC4)) \
+  )?                                                                           \
+   ( ( (__EXT_TRIG_INJECTCONV__) == ADC_EXTERNALTRIGINJECCONV_T2_TRGO          \
+     )?                                                                        \
+      (ADC3_4_EXTERNALTRIGINJEC_T2_TRGO)                                       \
+      :                                                                        \
+      ( ( (__EXT_TRIG_INJECTCONV__) == ADC_EXTERNALTRIGINJECCONV_T4_TRGO       \
+        )?                                                                     \
+         (ADC3_4_EXTERNALTRIGINJEC_T4_TRGO)                                    \
+         :                                                                     \
+         ( ( (__EXT_TRIG_INJECTCONV__) == ADC_EXTERNALTRIGINJECCONV_T8_CC4     \
+           )?                                                                  \
+            (ADC3_4_EXTERNALTRIGINJEC_T8_CC4)                                  \
+            :                                                                  \
+            ( ( (__EXT_TRIG_INJECTCONV__) == ADC_EXTERNALTRIGINJECCONV_T4_CC3  \
+              )?                                                               \
+               (ADC3_4_EXTERNALTRIGINJEC_T4_CC3)                               \
+               :                                                               \
+                ( ( (__EXT_TRIG_INJECTCONV__)                                  \
+                                         == ADC_EXTERNALTRIGINJECCONV_T20_TRGO \
+                  )?                                                           \
+                   (ADC3_4_EXTERNALTRIGINJEC_T20_TRGO)                         \
+                   :                                                           \
+                    ( ( (__EXT_TRIG_INJECTCONV__)                              \
+                                       == ADC_EXTERNALTRIGINJECCONV_T20_TRGO2  \
+                      )?                                                       \
+                       (ADC3_4_EXTERNALTRIGINJEC_T1_CC3)                       \
+                       :                                                       \
+                       (__EXT_TRIG_INJECTCONV__)                               \
+                  )                                                            \
+               )                                                               \
+            )                                                                  \
+         )                                                                     \
+      )                                                                        \
+   )                                                                           \
+   :                                                                           \
+   (__EXT_TRIG_INJECTCONV__ & (~ADC_EXTERNALTRIGCONV_T20_MASK))                \
+ )
+#endif /* STM32F303xE || STM32F398xx */
 #else
 #define __HAL_ADC_JSQR_JEXTSEL(__HANDLE__, __EXT_TRIG_INJECTCONV__)            \
    (__EXT_TRIG_INJECTCONV__)
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
 /**
   * @brief Configure the channel number into offset OFRx register
@@ -2844,27 +3201,36 @@ typedef struct
   * @param __HANDLE__: ADC handle
   * @retval Common control register ADC1_2 or ADC3_4
   */
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 #define __HAL_ADC_COMMON_REGISTER(__HANDLE__)                                       \
      ( ( ((((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC2)) \
        )? (ADC1_2_COMMON) : (ADC3_4_COMMON)                                                           \
      )
-#endif /* STM32F303xC || STM32F358xx */
-#if defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8)
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+
+#if defined(STM32F302xE)                                                || \
+    defined(STM32F302xC)                                                || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define __HAL_ADC_COMMON_REGISTER(__HANDLE__)                                       \
      (ADC1_2_COMMON)
-#endif /* STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 */
-#if defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F303x8 || STM32F328xx || STM32F334x8    */
+       
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define __HAL_ADC_COMMON_REGISTER(__HANDLE__)                                       \
      (ADC1_COMMON)
-#endif /* STM32F301x8 || STM32F318xx || STM32F302x8 */
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
        
 /**
   * @brief Selection of ADC common register CCR bits MULTI[4:0]corresponding to the selected ADC (applicable for devices with several ADCs)
   * @param __HANDLE__: ADC handle
   * @retval None
   */
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 #define __HAL_ADC_COMMON_CCR_MULTI(__HANDLE__)                                   \
   ( ( ((((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC2)) \
     )?                                                                           \
@@ -2872,29 +3238,41 @@ typedef struct
      :                                                                           \
      (ADC3_4_COMMON->CCR & ADC34_CCR_MULTI)                                      \
   )
-#endif /* STM32F303xC || STM32F358xx */
-#if defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8)
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+    
+#if defined(STM32F302xE)                                                || \
+    defined(STM32F302xC)                                                || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define __HAL_ADC_COMMON_CCR_MULTI(__HANDLE__)                                   \
   (ADC1_2_COMMON->CCR & ADC12_CCR_MULTI)
-#endif /* STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 */
-#if defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F303x8 || STM32F328xx || STM32F334x8    */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define __HAL_ADC_COMMON_CCR_MULTI(__HANDLE__)                                   \
   (RESET)
-#endif /* STM32F301x8 || STM32F318xx || STM32F302x8 */
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
 
 /**
   * @brief Verification of condition for ADC start conversion: ADC must be in non-multimode, or multimode with handle of ADC master (applicable for devices with several ADCs)
   * @param __HANDLE__: ADC handle
   * @retval None
   */
-#if defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define __HAL_ADC_NONMULTIMODE_OR_MULTIMODEMASTER(__HANDLE__)                                   \
   ((__HAL_ADC_COMMON_CCR_MULTI(__HANDLE__) == RESET) || (IS_ADC_MULTIMODE_MASTER_INSTANCE((__HANDLE__)->Instance)))
-#endif /* STM32F303xC || STM32F358xC || STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 */
-#if defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define __HAL_ADC_NONMULTIMODE_OR_MULTIMODEMASTER(__HANDLE__)                                   \
   (!RESET)
-#endif /* STM32F301x8 || STM32F318xx || STM32F302x8 */
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
 
 /**
   * @brief Set handle of the other ADC sharing the same common register ADC1_2 or ADC3_4
@@ -2903,7 +3281,8 @@ typedef struct
   * @param __HANDLE_OTHER_ADC__: other ADC handle
   * @retval None
   */
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 #define __HAL_ADC_COMMON_ADC_OTHER(__HANDLE__, __HANDLE_OTHER_ADC__)           \
   ( ( ((__HANDLE__)->Instance == ADC1)                                         \
     )?                                                                         \
@@ -2921,13 +3300,17 @@ typedef struct
              )?                                                                \
               ((__HANDLE_OTHER_ADC__)->Instance = ADC3)                        \
               :                                                                \
-              ((__HANDLE_OTHER_ADC__)->Instance = NULL)                        \
+              ((__HANDLE_OTHER_ADC__)->Instance = HAL_NULL)                        \
            )                                                                   \
          )                                                                     \
      )                                                                         \
   )
-#endif /* STM32F303xC || STM32F358xx */
-#if defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8)
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+    
+#if defined(STM32F302xE)                                                || \
+    defined(STM32F302xC)                                                || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define __HAL_ADC_COMMON_ADC_OTHER(__HANDLE__, __HANDLE_OTHER_ADC__)           \
   ( ( ((__HANDLE__)->Instance == ADC1)                                         \
     )?                                                                         \
@@ -2935,11 +3318,14 @@ typedef struct
      :                                                                         \
      ((__HANDLE_OTHER_ADC__)->Instance = ADC1)                                 \
   )
-#endif /* STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 */
-#if defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F303x8 || STM32F328xx || STM32F334x8    */
+
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define __HAL_ADC_COMMON_ADC_OTHER(__HANDLE__, __HANDLE_OTHER_ADC__)           \
-  ((__HANDLE_OTHER_ADC__)->Instance = NULL)
-#endif /* STM32F301x8 || STM32F318xx || STM32F302x8 */
+  ((__HANDLE_OTHER_ADC__)->Instance = HAL_NULL)
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
 
 /**
   * @brief Set handle of the ADC slave associated to the ADC master
@@ -2948,7 +3334,8 @@ typedef struct
   * @param __HANDLE_SLAVE__: ADC slave handle
   * @retval None
   */
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 #define __HAL_ADC_MULTI_SLAVE(__HANDLE_MASTER__, __HANDLE_SLAVE__)             \
   ( ( ((__HANDLE_MASTER__)->Instance == ADC1)                                  \
     )?                                                                         \
@@ -2958,20 +3345,30 @@ typedef struct
        )?                                                                      \
         ((__HANDLE_SLAVE__)->Instance = ADC4)                                  \
         :                                                                      \
-        ((__HANDLE_SLAVE__)->Instance = NULL)                                  \
+        ((__HANDLE_SLAVE__)->Instance = HAL_NULL)                                  \
      )                                                                         \
   )
-#endif /* STM32F303xC || STM32F358xx */
-#if defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8)
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
+    
+#if defined(STM32F302xE)                                                || \
+    defined(STM32F302xC)                                                || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define __HAL_ADC_MULTI_SLAVE(__HANDLE_MASTER__, __HANDLE_SLAVE__)             \
   ( ( ((__HANDLE_MASTER__)->Instance == ADC1)                                  \
     )?                                                                         \
      ((__HANDLE_SLAVE__)->Instance = ADC2)                                     \
      :                                                                         \
-     ( NULL )                                                                  \
+     ( HAL_NULL )                                                                  \
   )
-#endif /* STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 */
-#endif /* STM32F303xC || STM32F358xC || STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 || STM32F301x8 || STM32F318xx || STM32F302x8 */
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F303x8 || STM32F328xx || STM32F334x8    */
+
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx */
 
 
 #if defined(STM32F373xC) || defined(STM32F378xx)
@@ -3153,18 +3550,31 @@ typedef struct
 
 
 /* Exported functions --------------------------------------------------------*/  
-
+/** @addtogroup ADCEx_Exported_Functions ADC Extended Exported Functions
+  * @{
+  */ 
           
 /* Initialization/de-initialization functions *********************************/
 
+/** @addtogroup ADCEx_Exported_Functions_Group2 Extended Input and Output operation functions
+  * @brief    Extended IO operation functions
+  * @{
+  */ 
 /* I/O operation functions ****************************************************/
 
 /* ADC calibration */
-#if defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8) || defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 HAL_StatusTypeDef       HAL_ADCEx_Calibration_Start(struct __ADC_HandleTypeDef* hadc, uint32_t SingleDiff);
 uint32_t        HAL_ADCEx_Calibration_GetValue(struct __ADC_HandleTypeDef *hadc, uint32_t SingleDiff);
 HAL_StatusTypeDef       HAL_ADCEx_Calibration_SetValue(struct __ADC_HandleTypeDef *hadc, uint32_t SingleDiff, uint32_t CalibrationFactor);
-#endif /* STM32F303xC || STM32F358xC || STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 || STM32F301x8 || STM32F318xx || STM32F302x8 */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
 #if defined(STM32F373xC) || defined(STM32F378xx)
 HAL_StatusTypeDef       HAL_ADCEx_Calibration_Start(struct __ADC_HandleTypeDef* hadc);
 #endif /* STM32F373xC || STM32F378xx */
@@ -3178,28 +3588,62 @@ HAL_StatusTypeDef       HAL_ADCEx_InjectedPollForConversion(struct __ADC_HandleT
 HAL_StatusTypeDef       HAL_ADCEx_InjectedStart_IT(struct __ADC_HandleTypeDef* hadc);
 HAL_StatusTypeDef       HAL_ADCEx_InjectedStop_IT(struct __ADC_HandleTypeDef* hadc);
      
-#if defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8) || defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) 
 /* ADC multimode */
 HAL_StatusTypeDef       HAL_ADCEx_MultiModeStart_DMA(struct __ADC_HandleTypeDef *hadc, uint32_t *pData, uint32_t Length);
 HAL_StatusTypeDef       HAL_ADCEx_MultiModeStop_DMA(struct __ADC_HandleTypeDef *hadc); 
 uint32_t                HAL_ADCEx_MultiModeGetValue(struct __ADC_HandleTypeDef *hadc);
-#endif /* STM32F303xC || STM32F358xC || STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 || STM32F301x8 || STM32F318xx || STM32F302x8 */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
 /* ADC retrieve conversion value intended to be used with polling or interruption */
 uint32_t                HAL_ADCEx_InjectedGetValue(struct __ADC_HandleTypeDef* hadc, uint32_t InjectedRank);
 
 /* ADC IRQHandler and Callbacks used in non-blocking modes (Interruption) */
 void                    HAL_ADCEx_InjectedConvCpltCallback(struct __ADC_HandleTypeDef* hadc);
-#if defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8) || defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 void                    HAL_ADCEx_InjectedQueueOverflowCallback(struct __ADC_HandleTypeDef* hadc);
-#endif /* STM32F303xC || STM32F358xC || STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 || STM32F301x8 || STM32F318xx || STM32F302x8 */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+/**
+  * @}
+  */
      
+/** @addtogroup ADCEx_Exported_Functions_Group3 Extended Peripheral Control functions
+  * @brief    Extended Peripheral Control functions
+  * @{
+  */ 
 /* Peripheral Control functions ***********************************************/
 HAL_StatusTypeDef       HAL_ADCEx_InjectedConfigChannel(struct __ADC_HandleTypeDef* hadc,ADC_InjectionConfTypeDef* sConfigInjected);
-#if defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8) || defined(STM32F301x8) || defined(STM32F318xx) || defined(STM32F302x8)
-HAL_StatusTypeDef       HAL_ADCEx_MultiModeConfigChannel(struct __ADC_HandleTypeDef *hadc, ADC_MultiModeTypeDef *multimode);
-#endif /* STM32F303xC || STM32F358xC || STM32F302xC || STM32F303x8 || STM32F328xx || STM32F334x8 || STM32F301x8 || STM32F318xx || STM32F302x8 */
 
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+HAL_StatusTypeDef       HAL_ADCEx_MultiModeConfigChannel(struct __ADC_HandleTypeDef *hadc, ADC_MultiModeTypeDef *multimode);
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
 /**
   * @}
   */ 
@@ -3212,7 +3656,7 @@ HAL_StatusTypeDef       HAL_ADCEx_MultiModeConfigChannel(struct __ADC_HandleType
 }
 #endif
 
-#endif /*__STM32F3xx_ADC_EX_H */
+#endif /*__STM32F3xx_ADC_H */
 
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_can.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_can.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_can.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   CAN HAL module driver.
   *
   *          This file provides firmware functions to manage the following 
@@ -107,17 +107,18 @@
   * @{
   */
 
-/** @defgroup CAN 
+/** @defgroup CAN CAN HAL module driver
   * @brief CAN driver modules
   * @{
   */ 
   
 #ifdef HAL_CAN_MODULE_ENABLED  
   
-#if defined(STM32F302x8) || defined(STM32F302xC) ||                         \
-    defined(STM32F303x8) || defined(STM32F303xC) || defined(STM32F373xC) || \
-    defined(STM32F334x8) ||                                                 \
-    defined(STM32F328xx) || defined(STM32F358xx) || defined(STM32F378xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F302x8)                                                 || \
+    defined(STM32F373xC) || defined(STM32F378xx)
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
@@ -126,13 +127,13 @@
 /* Private function prototypes -----------------------------------------------*/
 static HAL_StatusTypeDef CAN_Receive_IT(CAN_HandleTypeDef* hcan, uint8_t FIFONumber);
 static HAL_StatusTypeDef CAN_Transmit_IT(CAN_HandleTypeDef* hcan);
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
 
-/** @defgroup CAN_Private_Functions
+/** @defgroup CAN_Exported_Functions CAN Exported Functions
   * @{
   */
 
-/** @defgroup CAN_Group1 Initialization and de-initialization functions 
+/** @defgroup CAN_Exported_Functions_Group1 Initialization and de-initialization functions 
  *  @brief    Initialization and Configuration functions 
  *
 @verbatim    
@@ -160,7 +161,7 @@ HAL_StatusTypeDef HAL_CAN_Init(CAN_HandleTypeDef* hcan)
   uint32_t tickstart = 0;
   
   /* Check CAN handle */
-  if(hcan == NULL)
+  if(hcan == HAL_NULL)
   {
      return HAL_ERROR;
   }
@@ -430,7 +431,7 @@ HAL_StatusTypeDef HAL_CAN_ConfigFilter(CAN_HandleTypeDef* hcan, CAN_FilterConfTy
 HAL_StatusTypeDef HAL_CAN_DeInit(CAN_HandleTypeDef* hcan)
 {
   /* Check CAN handle */
-  if(hcan == NULL)
+  if(hcan == HAL_NULL)
   {
      return HAL_ERROR;
   }
@@ -484,7 +485,7 @@ __weak void HAL_CAN_MspDeInit(CAN_HandleTypeDef* hcan)
   * @}
   */
 
-/** @defgroup CAN_Group2 I/O operation functions
+/** @defgroup CAN_Exported_Functions_Group2 Input and Output operation functions
  *  @brief    I/O operation functions 
  *
 @verbatim   
@@ -1184,7 +1185,7 @@ __weak void HAL_CAN_ErrorCallback(CAN_HandleTypeDef *hcan)
   * @}
   */
 
-/** @defgroup CAN_Group3 Peripheral State and Error functions
+/** @defgroup CAN_Exported_Functions_Group3 Peripheral State and Error functions
  *  @brief   CAN Peripheral State functions 
  *
 @verbatim   
@@ -1227,6 +1228,13 @@ uint32_t HAL_CAN_GetError(CAN_HandleTypeDef *hcan)
   * @}
   */
 
+/**
+  * @}
+  */
+
+/** @defgroup CAN_Private_Functions CAN Private Functions
+ * @{
+ */
 /**
   * @brief  Initiates and transmits a CAN frame message.
   * @param  hcan: pointer to a CAN_HandleTypeDef structure that contains
@@ -1360,16 +1368,15 @@ static HAL_StatusTypeDef CAN_Receive_IT(CAN_HandleTypeDef* hcan, uint8_t FIFONum
 
   /* Return function status */
   return HAL_OK;
-}
-
+} 
 /**
-  * @}
-  */
-
-#endif /* defined(STM32F302x8) || defined(STM32F302xC) ||                         */
-       /* defined(STM32F303x8) || defined(STM32F303xC) || defined(STM32F373xC) || */
-       /* defined(STM32F334x8) ||                                                 */
-       /* defined(STM32F328xx) || defined(STM32F358xx) || defined(STM32F378xx)    */
+ * @}
+ */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F302x8                               || */
+       /* STM32F373xC || STM32F378xx                   */
 
 #endif /* HAL_CAN_MODULE_ENABLED */
 /**

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_can.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_can.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_can.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of CAN HAL module.
   ******************************************************************************
   * @attention
@@ -43,10 +43,11 @@
  extern "C" {
 #endif
 
-#if defined(STM32F302x8) || defined(STM32F302xC) ||                         \
-    defined(STM32F303x8) || defined(STM32F303xC) || defined(STM32F373xC) || \
-    defined(STM32F334x8) ||                                                 \
-    defined(STM32F328xx) || defined(STM32F358xx) || defined(STM32F378xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F302x8)                                                 || \
+    defined(STM32F373xC) || defined(STM32F378xx)
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f3xx_hal_def.h"
@@ -60,7 +61,9 @@
   */
 
 /* Exported types ------------------------------------------------------------*/
-
+/** @defgroup CAN_Exported_Types CAN Exported Types
+  * @{
+  */  
 /** 
   * @brief  HAL State structures definition  
   */ 
@@ -254,14 +257,16 @@ typedef struct
   __IO HAL_CAN_ErrorTypeDef   ErrorCode;  /*!< CAN Error code                 */
   
 }CAN_HandleTypeDef;
-
+/**
+  * @}
+  */
 /* Exported constants --------------------------------------------------------*/
 
-/** @defgroup CAN_Exported_Constants
+/** @defgroup CAN_Exported_Constants CAN Exported Constants
   * @{
   */
 
-/** @defgroup CAN_InitStatus 
+/** @defgroup CAN_InitStatus CAN initialization Status
   * @{
   */
 #define CAN_INITSTATUS_FAILED       ((uint32_t)0x00000000)  /*!< CAN initialization failed */
@@ -270,7 +275,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_operating_mode 
+/** @defgroup CAN_operating_mode CAN Operating Mode
   * @{
   */
 #define CAN_MODE_NORMAL             ((uint32_t)0x00000000)                     /*!< Normal mode   */
@@ -287,7 +292,7 @@ typedef struct
   */
 
 
-/** @defgroup CAN_synchronisation_jump_width 
+/** @defgroup CAN_synchronisation_jump_width CAN Synchronization Jump Width
   * @{
   */
 #define CAN_SJW_1TQ                 ((uint32_t)0x00000000)     /*!< 1 time quantum */
@@ -301,7 +306,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_time_quantum_in_bit_segment_1 
+/** @defgroup CAN_time_quantum_in_bit_segment_1 CAN Time Quantum in Bit Segment 1
   * @{
   */
 #define CAN_BS1_1TQ                 ((uint32_t)0x00000000)                                       /*!< 1 time quantum  */
@@ -326,7 +331,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_time_quantum_in_bit_segment_2 
+/** @defgroup CAN_time_quantum_in_bit_segment_2 CAN Time Quantum in Bit Segment 2
   * @{
   */
 #define CAN_BS2_1TQ                 ((uint32_t)0x00000000)                       /*!< 1 time quantum */
@@ -343,7 +348,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_clock_prescaler 
+/** @defgroup CAN_clock_prescaler CAN Clock Prescaler
   * @{
   */
 #define IS_CAN_PRESCALER(PRESCALER) (((PRESCALER) >= 1) && ((PRESCALER) <= 1024))
@@ -351,7 +356,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_filter_number 
+/** @defgroup CAN_filter_number CAN Filter Number
   * @{
   */
 #define IS_CAN_FILTER_NUMBER(NUMBER) ((NUMBER) <= 27)
@@ -359,7 +364,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_filter_mode 
+/** @defgroup CAN_filter_mode CAN Filter Mode
   * @{
   */
 #define CAN_FILTERMODE_IDMASK       ((uint8_t)0x00)  /*!< Identifier mask mode */
@@ -371,7 +376,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_filter_scale 
+/** @defgroup CAN_filter_scale CAN Filter Scale
   * @{
   */
 #define CAN_FILTERSCALE_16BIT       ((uint8_t)0x00)  /*!< Two 16-bit filters */
@@ -383,7 +388,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_filter_FIFO
+/** @defgroup CAN_filter_FIFO CAN Filter FIFO
   * @{
   */
 #define CAN_FILTER_FIFO0             ((uint8_t)0x00)  /*!< Filter FIFO 0 assignment for filter x */
@@ -399,7 +404,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_Start_bank_filter_for_slave_CAN 
+/** @defgroup CAN_Start_bank_filter_for_slave_CAN CAN Start Bank Filter For Slave CAN
   * @{
   */
 #define IS_CAN_BANKNUMBER(BANKNUMBER) ((BANKNUMBER) <= 28)
@@ -407,7 +412,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_Tx 
+/** @defgroup CAN_Tx CAN Tx
   * @{
   */
 #define IS_CAN_TRANSMITMAILBOX(TRANSMITMAILBOX) ((TRANSMITMAILBOX) <= ((uint8_t)0x02))
@@ -418,7 +423,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_identifier_type 
+/** @defgroup CAN_identifier_type CAN Identifier Type
   * @{
   */
 #define CAN_ID_STD             ((uint32_t)0x00000000)  /*!< Standard Id */
@@ -429,7 +434,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_remote_transmission_request 
+/** @defgroup CAN_remote_transmission_request CAN Remote Transmission Request
   * @{
   */
 #define CAN_RTR_DATA                ((uint32_t)0x00000000)  /*!< Data frame */
@@ -440,7 +445,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_transmit_constants 
+/** @defgroup CAN_transmit_constants CAN Transmit Constants
   * @{
   */
 #define CAN_TXSTATUS_FAILED         ((uint8_t)0x00)  /*!< CAN transmission failed */
@@ -452,7 +457,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_receive_FIFO_number_constants 
+/** @defgroup CAN_receive_FIFO_number_constants CAN Receive FIFO Number
   * @{
   */
 #define CAN_FIFO0                   ((uint8_t)0x00)  /*!< CAN FIFO 0 used to receive */
@@ -463,7 +468,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup CAN_flags 
+/** @defgroup CAN_flags CAN Flags
   * @{
   */
 /* If the flag is 0x3XXXXXXX, it means that it can be used with CAN_GetFlagStatus()
@@ -518,7 +523,7 @@ typedef struct
   */
 
   
-/** @defgroup CAN_interrupts 
+/** @defgroup CAN_interrupts CAN Interrupts
   * @{
   */ 
 #define CAN_IT_TME                  ((uint32_t)CAN_IER_TMEIE)   /*!< Transmit mailbox empty interrupt */
@@ -580,6 +585,9 @@ typedef struct
   */
 
 /* Exported macros -----------------------------------------------------------*/
+/** @defgroup CAN_Exported_Macro CAN Exported Macros
+  * @{
+  */
 
 /** @brief  Reset CAN handle state
   * @param  __HANDLE__: CAN handle.
@@ -732,16 +740,34 @@ typedef struct
   */
 #define __HAL_CAN_DBG_FREEZE(__HANDLE__, __NEWSTATE__) (((__NEWSTATE__) == ENABLE)? \
 ((__HANDLE__)->Instance->MCR |= CAN_MCR_DBF) : ((__HANDLE__)->Instance->MCR &= ~CAN_MCR_DBF)) 
-   
-/* Exported functions --------------------------------------------------------*/  
 
-/* Initialization and de-initialization functions *****************************/ 
+/**
+ * @}
+ */  
+ 
+/* Exported functions --------------------------------------------------------*/  
+/** @addtogroup CAN_Exported_Functions CAN Exported Functions
+  * @{
+  */
+  
+/** @defgroup CAN_Exported_Functions_Group1 Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions 
+ * @{
+ */
+/* addtogroup and de-initialization functions *****************************/ 
 HAL_StatusTypeDef HAL_CAN_Init(CAN_HandleTypeDef* hcan);
 HAL_StatusTypeDef HAL_CAN_ConfigFilter(CAN_HandleTypeDef* hcan, CAN_FilterConfTypeDef* sFilterConfig);
 HAL_StatusTypeDef HAL_CAN_DeInit(CAN_HandleTypeDef* hcan);
 void HAL_CAN_MspInit(CAN_HandleTypeDef* hcan);
 void HAL_CAN_MspDeInit(CAN_HandleTypeDef* hcan);
-
+/**
+ * @}
+ */ 
+ 
+/** @addtogroup CAN_Exported_Functions_Group2 Input and Output operation functions
+ *  @brief    I/O operation functions 
+ * @{
+ */
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef HAL_CAN_Transmit(CAN_HandleTypeDef *hcan, uint32_t Timeout);
 HAL_StatusTypeDef HAL_CAN_Transmit_IT(CAN_HandleTypeDef *hcan);
@@ -749,16 +775,29 @@ HAL_StatusTypeDef HAL_CAN_Receive(CAN_HandleTypeDef *hcan, uint8_t FIFONumber, u
 HAL_StatusTypeDef HAL_CAN_Receive_IT(CAN_HandleTypeDef *hcan, uint8_t FIFONumber);
 HAL_StatusTypeDef HAL_CAN_Sleep(CAN_HandleTypeDef *hcan);
 HAL_StatusTypeDef HAL_CAN_WakeUp(CAN_HandleTypeDef *hcan);
-
-/* Peripheral State and Error functions ***************************************/
 void HAL_CAN_IRQHandler(CAN_HandleTypeDef* hcan);
-uint32_t HAL_CAN_GetError(CAN_HandleTypeDef *hcan);
-HAL_CAN_StateTypeDef HAL_CAN_GetState(CAN_HandleTypeDef* hcan);
-
 void HAL_CAN_TxCpltCallback(CAN_HandleTypeDef* hcan);
 void HAL_CAN_RxCpltCallback(CAN_HandleTypeDef* hcan);
 void HAL_CAN_ErrorCallback(CAN_HandleTypeDef *hcan);
-
+/**
+ * @}
+ */ 
+ 
+/** @addtogroup CAN_Exported_Functions_Group3 Peripheral State and Error functions
+ *  @brief   CAN Peripheral State functions 
+ * @{
+ */
+/* Peripheral State and Error functions ***************************************/
+uint32_t HAL_CAN_GetError(CAN_HandleTypeDef *hcan);
+HAL_CAN_StateTypeDef HAL_CAN_GetState(CAN_HandleTypeDef* hcan);
+/**
+ * @}
+ */ 
+ 
+/**
+ * @}
+ */ 
+ 
 /**
   * @}
   */
@@ -767,10 +806,11 @@ void HAL_CAN_ErrorCallback(CAN_HandleTypeDef *hcan);
   * @}
   */
 
-#endif /* defined(STM32F302x8) || defined(STM32F302xC) ||                         */
-       /* defined(STM32F303x8) || defined(STM32F303xC) || defined(STM32F373xC) || */
-       /* defined(STM32F334x8) ||                                                 */
-       /* defined(STM32F328xx) || defined(STM32F358xx) || defined(STM32F378xx)    */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F302x8                               || */
+       /* STM32F373xC || STM32F378xx                   */
 
 #ifdef __cplusplus
 }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_cec.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_cec.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_cec.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   CEC HAL module driver.
   * 
   *          This file provides firmware functions to manage the following 
@@ -83,31 +83,37 @@
   * @{
   */
 
-/** @defgroup CEC 
-  * @brief HAL CEC module driver
-  * @{
-  */
 #ifdef HAL_CEC_MODULE_ENABLED
 
 #if defined(STM32F373xC) || defined(STM32F378xx)
+/** @defgroup CEC CEC HAL module driver
+  * @brief HAL CEC module driver
+  * @{
+  */
     
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+/** @defgroup CEC_Private CEC Private Constants
+  * @{
+  */
 #define CEC_CFGR_FIELDS     (CEC_CFGR_SFT | CEC_CFGR_RXTOL | CEC_CFGR_BRESTP \
                            | CEC_CFGR_BREGEN | CEC_CFGR_LBPEGEN | CEC_CFGR_SFTOPT \
                            | CEC_CFGR_BRDNOGEN | CEC_CFGR_OAR | CEC_CFGR_LSTN)
+/**
+ * @}
+ */ 
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 static HAL_StatusTypeDef CEC_Transmit_IT(CEC_HandleTypeDef *hcec);
 static HAL_StatusTypeDef CEC_Receive_IT(CEC_HandleTypeDef *hcec);
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
 
-/** @defgroup CEC_Private_Functions
+/** @defgroup CEC_Exported_Functions CEC Exported Functions
   * @{
   */
 
-/** @defgroup HAL_CEC_Group1 Initialization/de-initialization functions 
+/** @defgroup CEC_Exported_Functions_Group1 Initialization and de-initialization functions
   *  @brief    Initialization and Configuration functions 
   *
 @verbatim                                               
@@ -142,7 +148,7 @@ HAL_StatusTypeDef HAL_CEC_Init(CEC_HandleTypeDef *hcec)
   uint32_t tmpreg = 0x0;
   
   /* Check the CEC handle allocation */
-  if(hcec == NULL)
+  if(hcec == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -203,7 +209,7 @@ HAL_StatusTypeDef HAL_CEC_Init(CEC_HandleTypeDef *hcec)
 HAL_StatusTypeDef HAL_CEC_DeInit(CEC_HandleTypeDef *hcec)
 {
   /* Check the CEC handle allocation */
-  if(hcec == NULL)
+  if(hcec == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -255,7 +261,7 @@ HAL_StatusTypeDef HAL_CEC_DeInit(CEC_HandleTypeDef *hcec)
   * @}
   */
 
-/** @defgroup HAL_CEC_Group2 IO operation functions 
+/** @defgroup CEC_Exported_Functions_Group2 Input and Output operation functions 
   *  @brief CEC Transmit/Receive functions 
   *
 @verbatim   
@@ -318,7 +324,7 @@ HAL_StatusTypeDef HAL_CEC_Transmit(CEC_HandleTypeDef *hcec, uint8_t DestinationA
   if((hcec->State == HAL_CEC_STATE_READY) && (__HAL_CEC_GET_TRANSMISSION_START_FLAG(hcec) == RESET)) 
   {
     hcec->ErrorCode = HAL_CEC_ERROR_NONE;
-    if((pData == NULL) && (Size > 0)) 
+    if((pData == HAL_NULL) && (Size > 0)) 
     {
       hcec->State = HAL_CEC_STATE_ERROR;
       return  HAL_ERROR;                                    
@@ -466,7 +472,7 @@ HAL_StatusTypeDef HAL_CEC_Receive(CEC_HandleTypeDef *hcec, uint8_t *pData, uint3
   if (hcec->State == HAL_CEC_STATE_READY)
   { 
     hcec->ErrorCode = HAL_CEC_ERROR_NONE;
-    if (pData == NULL) 
+    if (pData == HAL_NULL) 
     {
       hcec->State = HAL_CEC_STATE_ERROR;
       return  HAL_ERROR;                                    
@@ -570,7 +576,7 @@ HAL_StatusTypeDef HAL_CEC_Transmit_IT(CEC_HandleTypeDef *hcec, uint8_t Destinati
   if (((hcec->State == HAL_CEC_STATE_READY) || (hcec->State == HAL_CEC_STATE_STANDBY_RX)) 
   &&   (__HAL_CEC_GET_TRANSMISSION_START_FLAG(hcec) == RESET)) 
   {    
-    if((pData == NULL) && (Size > 0)) 
+    if((pData == HAL_NULL) && (Size > 0)) 
     {
       hcec->State = HAL_CEC_STATE_ERROR;
       return  HAL_ERROR;                                    
@@ -700,7 +706,7 @@ HAL_StatusTypeDef HAL_CEC_Receive_IT(CEC_HandleTypeDef *hcec, uint8_t *pData)
 {  
   if(hcec->State == HAL_CEC_STATE_READY)
   {
-    if(pData == NULL) 
+    if(pData == HAL_NULL) 
     {
       hcec->State = HAL_CEC_STATE_ERROR;
       return HAL_ERROR;                                    
@@ -890,8 +896,62 @@ __weak void HAL_CEC_RxCpltCallback(CEC_HandleTypeDef *hcec)
    */ 
 }
 
+/**
+  * @}
+  */
+
+/** @defgroup CEC_Exported_Functions_Group3 Peripheral Control functions 
+  *  @brief   CEC control functions 
+  *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to control the CEC.
+     (+) HAL_CEC_GetState() API can be helpful to check in run-time the state of the CEC peripheral. 
+@endverbatim
+  * @{
+  */
+
+
+
+
 
 /**
+  * @brief return the CEC state
+  * @param hcec: CEC handle
+  * @retval HAL state
+  */
+HAL_CEC_StateTypeDef HAL_CEC_GetState(CEC_HandleTypeDef *hcec)
+{
+  return hcec->State;
+}
+
+/**
+* @brief  Return the CEC error code
+* @param  hcec : pointer to a CEC_HandleTypeDef structure that contains
+  *              the configuration information for the specified CEC.
+* @retval CEC Error Code
+*/
+uint32_t HAL_CEC_GetError(CEC_HandleTypeDef *hcec)
+{
+  return hcec->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @defgroup CEC_Private_Functions CEC Private Functions
+  * @{
+  */
+
+ /**
   * @brief Send data in interrupt mode 
   * @param hcec: CEC handle. 
   *         Function called under interruption only, once
@@ -1027,66 +1087,17 @@ static HAL_StatusTypeDef CEC_Receive_IT(CEC_HandleTypeDef *hcec)
   }
 }
 
-
-
+/**
+ * @}
+ */ 
+ 
 /**
   * @}
   */
 
-/** @defgroup HAL_CEC_Group3 Peripheral Control functions 
-  *  @brief   CEC control functions 
-  *
-@verbatim   
- ===============================================================================
-                      ##### Peripheral Control functions #####
- ===============================================================================  
-    [..]
-    This subsection provides a set of functions allowing to control the CEC.
-     (+) HAL_CEC_GetState() API can be helpful to check in run-time the state of the CEC peripheral. 
-@endverbatim
-  * @{
-  */
-
-
-
-
-
-/**
-  * @brief return the CEC state
-  * @param hcec: CEC handle
-  * @retval HAL state
-  */
-HAL_CEC_StateTypeDef HAL_CEC_GetState(CEC_HandleTypeDef *hcec)
-{
-  return hcec->State;
-}
-
-/**
-* @brief  Return the CEC error code
-* @param  hcec : pointer to a CEC_HandleTypeDef structure that contains
-  *              the configuration information for the specified CEC.
-* @retval CEC Error Code
-*/
-uint32_t HAL_CEC_GetError(CEC_HandleTypeDef *hcec)
-{
-  return hcec->ErrorCode;
-}
-
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
-  
 #endif /* defined(STM32F373xC) || defined(STM32F378xx) */
 
 #endif /* HAL_CEC_MODULE_ENABLED */
-/**
-  * @}
-  */
-
 /**
   * @}
   */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_cec.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_cec.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_cec.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of CEC HAL module.
   ******************************************************************************
   * @attention
@@ -56,7 +56,9 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
-
+/** @defgroup CEC_Exported_Types CEC Exported Types
+  * @{
+  */ 
 /** 
   * @brief CEC Init Structure definition  
   */ 
@@ -181,10 +183,12 @@ typedef struct
     
 }CEC_HandleTypeDef;
 
-
+/**
+ * @}
+ */ 
 
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup CEC_Exported_Constants
+/** @defgroup CEC_Exported_Constants CEC Exported Constants
   * @{
   */
      
@@ -327,7 +331,7 @@ typedef struct
   */  
   
 /* Exported macros -----------------------------------------------------------*/
-/** @defgroup CEC_Exported_Macros
+/** @defgroup CEC_Exported_Macros CEC Exported Macros
   * @{
   */
 
@@ -521,13 +525,27 @@ typedef struct
   */                       
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup CEC_Exported_Functions CEC Exported Functions
+  * @{
+  */
+  
+/** @addtogroup CEC_Exported_Functions_Group1 Initialization and de-initialization functions
+  *  @brief    Initialization and Configuration functions 
+  * @{
+  */
 /* Initialization and de-initialization functions  ****************************/
 HAL_StatusTypeDef HAL_CEC_Init(CEC_HandleTypeDef *hcec);
 HAL_StatusTypeDef HAL_CEC_DeInit(CEC_HandleTypeDef *hcec);
 void HAL_CEC_MspInit(CEC_HandleTypeDef *hcec);
 void HAL_CEC_MspDeInit(CEC_HandleTypeDef *hcec);
+/**
+  * @}
+  */
 
-
+/** @addtogroup CEC_Exported_Functions_Group2 Input and Output operation functions 
+  *  @brief CEC Transmit/Receive functions 
+  * @{
+  */
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef HAL_CEC_Transmit(CEC_HandleTypeDef *hcec, uint8_t DestinationAddress, uint8_t *pData, uint32_t Size, uint32_t Timeout);
 HAL_StatusTypeDef HAL_CEC_Receive(CEC_HandleTypeDef *hcec, uint8_t *pData, uint32_t Timeout);
@@ -537,12 +555,25 @@ void HAL_CEC_IRQHandler(CEC_HandleTypeDef *hcec);
 void HAL_CEC_TxCpltCallback(CEC_HandleTypeDef *hcec);
 void HAL_CEC_RxCpltCallback(CEC_HandleTypeDef *hcec);
 void HAL_CEC_ErrorCallback(CEC_HandleTypeDef *hcec);
+/**
+  * @}
+  */
 
-
+/** @defgroup CEC_Exported_Functions_Group3 Peripheral Control functions 
+  *  @brief   CEC control functions 
+  * @{
+  */
 /* Peripheral State and Error functions ***************************************/
 HAL_CEC_StateTypeDef HAL_CEC_GetState(CEC_HandleTypeDef *hcec);
 uint32_t HAL_CEC_GetError(CEC_HandleTypeDef *hcec);
+/**
+  * @}
+  */
 
+/**
+  * @}
+  */
+  
 /**
   * @}
   */ 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_comp.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_comp.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_comp.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   COMP HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -57,7 +57,7 @@
           (++) COMP_EXTI_LINE_COMP6_EVENT
           (++) COMP_EXTI_LINE_COMP7_EVENT
 
-[..] Table 1. COMP Inputs for the STM32F303xB/STM32F303xC devices
+[..] Table 1. COMP Inputs for the STM32F303xB/STM32F303xC/STM32F303xE devices
  +------------------------------------------------------------------------------------------+     
  |                 |                | COMP1 | COMP2 | COMP3 | COMP4 | COMP5 | COMP6 | COMP7 |
  |-----------------|----------------|---------------|---------------------------------------|
@@ -74,7 +74,7 @@
  |    Input        | IO2            |  ---  |  PA3  |  PD14 |  PE7  |  PB13 |  PB11 |  PC1  |
  +------------------------------------------------------------------------------------------+  
   
- [..] Table 2. COMP Outputs for the STM32F303xB/STM32F303xC devices
+ [..] Table 2. COMP Outputs for the STM32F303xB/STM32F303xC/STM32F303xE devices
  +-------------------------------------------------------+     
  | COMP1 | COMP2 | COMP3 | COMP4 | COMP5 | COMP6 | COMP7 |
  |-------|-------|-------|-------|-------|-------|-------|
@@ -114,15 +114,58 @@
  |  TIM3 OCREFCLR |  TIM3 OCREFCLR |  TIM15 BKIN    |  TIM15 IC2     |  TIM17 IC1     |  TIM4 IC4      |  TIM17 BKIN    |
  +----------------------------------------------------------------------------------------------------------------------+
 
- [..] Table 4. COMP Outputs blanking sources for the STM32F303xB/STM32F303xC devices
+ [..] Table 4. COMP Outputs redirection to embedded timers for the STM32F303xE devices
  +----------------------------------------------------------------------------------------------------------------------+
  |     COMP1      |     COMP2      |     COMP3      |     COMP4      |     COMP5      |     COMP6      |     COMP7      |
  |----------------|----------------|----------------|----------------|----------------|----------------|----------------|
- |  TIM1 OC5      |  TIM1 OC5      |  TIM1 OC5      |  TIM3 OC4      |  TIM3 OC3      |  TIM2 OC4      |  TIM1 OC5      |
+ |  TIM1 BKIN     |  TIM1 BKIN     |  TIM1 BKIN     |  TIM1 BKIN (1) |  TIM1 BKIN     |  TIM1 BKIN     |  TIM1 BKIN (1) |
  |                |                |                |                |                |                |                |
- |  TIM2 OC3      |  TIM2 OC3      |  --------      |  TIM8 OC5      |  TIM8 OC5      |  TIM8 OC5      |  TIM8 OC5      |
+ |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |
  |                |                |                |                |                |                |                |
- |  TIM3 OC3      |  TIM3 OC3      |  TIM2 OC4      |  TIM15 OC1     |  TIM8 BKIN     |  TIM15 OC2     |  TIM15 OC2     |
+ |  TIM8 BKIN     |  TIM8 BKIN     |  TIM8 BKIN     |  TIM8 BKIN (1) |  TIM8 BKIN     |  TIM8 BKIN     |  TIM8 BKIN (1) |
+ |                |                |                |                |                |                |                |
+ |  TIM8 BKIN2    |  TIM8 BKIN2    |  TIM8 BKIN2    |  TIM8 BKIN2    |  TIM8 BKIN2    |  TIM8 BKIN2    |  TIM8 BKIN2    |
+ |                |                |                |                |                |                |                |
+ |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |
+ |     +          |     +          |     +          |     +          |     +          |     +          |     +          |
+ |  TIM8BKIN2     |  TIM8BKIN2     |  TIM8BKIN2     |  TIM8BKIN2     |  TIM8BKIN2     |  TIM8BKIN2     |  TIM8BKIN2     |
+ |                |                |                |                |                |                |                |
+ |  TIM1 OCREFCLR |  TIM1 OCREFCLR |  TIM1 OCREFCLR |  TIM8 OCREFCLR |  TIM8 OCREFCLR |  TIM8 OCREFCLR |  TIM1 OCREFCLR |  
+ |                |                |                |                |                |                |                |
+ |  TIM1 IC1      |  TIM1 IC1      |  TIM2 OCREFCLR |  TIM3 IC3      |  TIM2 IC1      |  TIM2 IC2      |  TIM8 OCREFCLR |
+ |                |                |                |                |                |                |                |
+ |  TIM2 IC4      |  TIM2 IC4      |  TIM3 IC2      |  TIM3 OCREFCLR |  TIM3 OCREFCLR |  TIM2 OCREFCLR |  TIM2 IC3      |
+ |                |                |                |                |                |                |                |
+ |  TIM2 OCREFCLR |  TIM2 OCREFCLR |  TIM4 IC1      |  TIM4 IC2      |  TIM4 IC3      |  TIM16 OCREFCLR|  TIM1 IC2      |
+ |                |                |                |                |                |                |                |
+ |  TIM3 IC1      |  TIM3 IC1      |  TIM15 IC1     |  TIM15 OCREFCLR|  TIM16 BKIN    |  TIM16 IC1     |  TIM17 OCREFCLR|          
+ |                |                |                |                |                |                |                |
+ |  TIM3 OCREFCLR |  TIM3 OCREFCLR |  TIM15 BKIN    |  TIM15 IC2     |  TIM17 IC1     |  TIM4 IC4      |  TIM17 BKIN    |
+ |                |                |                |                |                |                |                |
+ |  TIM20 BKIN    |  TIM20 BKIN    |  TIM20 BKIN    |  TIM20 BKIN (1)|  TIM20 BKIN    |  TIM20 BKIN    |  TIM20 BKIN (1)|
+ |                |                |                |                |                |                |                |
+ |  TIM20 BKIN2   |  TIM20 BKIN2   |  TIM20 BKIN2   |  TIM20 BKIN2   |  TIM20 BKIN2   |  TIM20 BKIN2   |  TIM20 BKIN2   |
+ |                |                |                |                |                |                |                |
+ |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |  TIM1 BKIN2    |
+ |     +          |     +          |     +          |     +          |     +          |     +          |     +          |
+ |  TIM8 BKIN2    |  TIM8 BKIN2    |  TIM8 BKIN2    |  TIM8 BKIN2    |  TIM8 BKIN2    |  TIM8 BKIN2    |  TIM8 BKIN2    |
+ |     +          |     +          |     +          |     +          |     +          |     +          |     +          |
+ |  TIM20 BKIN2   |  TIM20 BKIN2   |  TIM20 BKIN2   |  TIM20 BKIN2   |  TIM20 BKIN2   |  TIM20 BKIN2   |  TIM20 BKIN2   |
+ |                |                |                |                |                |                |                |
+ +----------------------------------------------------------------------------------------------------------------------+
+ (1):This connection consists of connecting both GPIO and COMP output to TIM1/8/20 BRK input through an OR gate, instead
+     of connecting the GPIO to the TIM1/8/20 BRK input and the COMP output to the TIM1/8/20 BRK_ACTH input. The aim is to 
+     add a digital filter (3  bits) on the COMP output.
+
+ [..] Table 5. COMP Outputs blanking sources for the STM32F303xB/STM32F303xC/STM32F303xE devices
+ +----------------------------------------------------------------------------------------------------------------------+
+ |     COMP1      |     COMP2      |     COMP3      |     COMP4      |     COMP5      |     COMP6      |     COMP7      |
+ |----------------|----------------|----------------|----------------|----------------|----------------|----------------|
+ |  TIM1 OC5      |  TIM1 OC5      |  TIM1 OC5      |  TIM3 OC4      |  --------      |  TIM8 OC5      |  TIM1 OC5      |
+ |                |                |                |                |                |                |                |
+ |  TIM2 OC3      |  TIM2 OC3      |  --------      |  TIM8 OC5      |  TIM3 OC3      |  TIM2 OC4      |  TIM8 OC5      |
+ |                |                |                |                |                |                |                |
+ |  TIM3 OC3      |  TIM3 OC3      |  TIM2 OC4      |  TIM15 OC1     |  TIM8 OC5      |  TIM15 OC2     |  TIM15 OC2     |
  |                |                |                |                |                |                |                |
  +----------------------------------------------------------------------------------------------------------------------+
    
@@ -192,7 +235,7 @@
   * @{
   */
 
-/** @defgroup COMP 
+/** @defgroup COMP COMP HAL module driver
   * @brief COMP HAL module driver
   * @{
   */
@@ -204,13 +247,13 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
 
-/** @defgroup COMP_Private_Functions
+/** @defgroup COMP_Exported_Functions COMP Exported Functions
   * @{
   */
 
-/** @defgroup HAL_COMP_Group1 Initialization/de-initialization functions 
+/** @defgroup COMP_Exported_Functions_Group1 Initialization and de-initialization functions
  *  @brief    Initialization and Configuration functions 
  *
 @verbatim    
@@ -236,7 +279,7 @@ HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
   HAL_StatusTypeDef status = HAL_OK;
   
   /* Check the COMP handle allocation and lock status */
-  if((hcomp == NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != RESET))
+  if((hcomp == HAL_NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != RESET))
   {
     status = HAL_ERROR;
   }
@@ -299,7 +342,7 @@ HAL_StatusTypeDef HAL_COMP_DeInit(COMP_HandleTypeDef *hcomp)
   HAL_StatusTypeDef status = HAL_OK;
 
   /* Check the COMP handle allocation and lock status */
-  if((hcomp == NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != RESET))
+  if((hcomp == HAL_NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != RESET))
   {
     status = HAL_ERROR;
   }
@@ -328,7 +371,7 @@ HAL_StatusTypeDef HAL_COMP_DeInit(COMP_HandleTypeDef *hcomp)
 __weak void HAL_COMP_MspInit(COMP_HandleTypeDef *hcomp)
 {
   /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_COMP_MspInit could be implenetd in the user file
+            the HAL_COMP_MspInit could be implemented in the user file
    */
 }
 
@@ -348,7 +391,7 @@ __weak void HAL_COMP_MspDeInit(COMP_HandleTypeDef *hcomp)
   * @}
   */
 
-/** @defgroup HAL_COMP_Group2 I/O operation functions 
+/** @defgroup COMP_Exported_Functions_Group2 Input and Output operation functions 
  *  @brief   Data transfers functions 
  *
 @verbatim   
@@ -373,7 +416,7 @@ HAL_StatusTypeDef HAL_COMP_Start(COMP_HandleTypeDef *hcomp)
   HAL_StatusTypeDef status = HAL_OK;
   
   /* Check the COMP handle allocation and lock status */
-  if((hcomp == NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != RESET))
+  if((hcomp == HAL_NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != RESET))
   {
     status = HAL_ERROR;
   }
@@ -408,7 +451,7 @@ HAL_StatusTypeDef HAL_COMP_Stop(COMP_HandleTypeDef *hcomp)
   HAL_StatusTypeDef status = HAL_OK;
   
   /* Check the COMP handle allocation and lock status */
-  if((hcomp == NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != RESET))
+  if((hcomp == HAL_NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != RESET))
   {
     status = HAL_ERROR;
   }
@@ -443,6 +486,9 @@ HAL_StatusTypeDef HAL_COMP_Start_IT(COMP_HandleTypeDef *hcomp)
   HAL_StatusTypeDef status = HAL_OK;
   uint32_t extiline = 0;
   
+  /* Check the parameter */
+  assert_param(IS_COMP_TRIGGERMODE(hcomp->Init.TriggerMode));
+
   status = HAL_COMP_Start(hcomp);
   if(status == HAL_OK)
   {
@@ -516,7 +562,7 @@ void HAL_COMP_IRQHandler(COMP_HandleTypeDef *hcomp)
   * @}
   */
 
-/** @defgroup HAL_COMP_Group3 Peripheral Control functions 
+/** @defgroup COMP_Exported_Functions_Group3 Peripheral Control functions 
  *  @brief   management functions 
  *
 @verbatim   
@@ -541,7 +587,7 @@ HAL_StatusTypeDef HAL_COMP_Lock(COMP_HandleTypeDef *hcomp)
   HAL_StatusTypeDef status = HAL_OK;
 
   /* Check the COMP handle allocation and lock status */
-  if((hcomp == NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != RESET))
+  if((hcomp == HAL_NULL) || ((hcomp->State & COMP_STATE_BIT_LOCK) != RESET))
   {
     status = HAL_ERROR;
   }
@@ -610,7 +656,7 @@ __weak void HAL_COMP_TriggerCallback(COMP_HandleTypeDef *hcomp)
   * @}
   */
 
-/** @defgroup HAL_COMP_Group4 Peripheral State functions 
+/** @defgroup COMP_Exported_Functions_Group4 Peripheral State functions 
  *  @brief   Peripheral State functions 
  *
 @verbatim   
@@ -633,7 +679,7 @@ __weak void HAL_COMP_TriggerCallback(COMP_HandleTypeDef *hcomp)
 HAL_COMP_StateTypeDef HAL_COMP_GetState(COMP_HandleTypeDef *hcomp)
 {
   /* Check the COMP handle allocation */
-  if(hcomp == NULL)
+  if(hcomp == HAL_NULL)
   {
     return HAL_COMP_STATE_RESET;
   }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_comp.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_comp.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_comp.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of COMP HAL module.
   ******************************************************************************
   * @attention
@@ -55,7 +55,9 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
-
+/** @defgroup COMP_Exported_Types COMP Exported Types
+  * @{
+  */  
 /** 
   * @brief  COMP Init structure definition  
   */
@@ -122,12 +124,16 @@ typedef struct
   
 }COMP_HandleTypeDef;
 
+/**
+  * @}
+  */
+  
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup COMP_Exported_Constants
+/** @defgroup COMP_Exported_Constants COMP Exported Constants
   * @{
   */
 
-/** @defgroup COMP_OutputPolarity
+/** @defgroup COMP_OutputPolarity COMP Output Polarity
   * @{
   */
 #define COMP_OUTPUTPOL_NONINVERTED             ((uint32_t)0x00000000)  /*!< COMP output on GPIO isn't inverted */
@@ -138,7 +144,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup COMP_OutputLevel
+/** @defgroup COMP_OutputLevel COMP Output Level
   * @{
   */ 
 /* When output polarity is not inverted, comparator output is low when
@@ -151,7 +157,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup COMP_TriggerMode 
+/** @defgroup COMP_TriggerMode COMP Trigger Mode
   * @{
   */
 #define COMP_TRIGGERMODE_NONE                  ((uint32_t)0x00000000)   /*!< No External Interrupt trigger detection */
@@ -176,48 +182,89 @@ typedef struct
   */ 
   
 /* Exported macros -----------------------------------------------------------*/
+/** @defgroup COMP_Exported_Macros COMP Exported Macros
+  * @{
+  */
 
 /** @brief  Reset COMP handle state
   * @param  __HANDLE__: COMP handle.
   * @retval None
   */
 #define __HAL_COMP_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_COMP_STATE_RESET)
+/**
+  * @}
+  */ 
 
-/* Include COMP HAL Extension module */
+/* Include COMP HAL Extended module */
 #include "stm32f3xx_hal_comp_ex.h"
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup COMP_Exported_Functions COMP Exported Functions
+  * @{
+  */
 
+/** @addtogroup COMP_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions 
+ * @{
+ */
 /* Initialization and de-initialization functions  ****************************/
 HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp);
 HAL_StatusTypeDef HAL_COMP_DeInit (COMP_HandleTypeDef *hcomp);
 void HAL_COMP_MspInit(COMP_HandleTypeDef *hcomp);
 void HAL_COMP_MspDeInit(COMP_HandleTypeDef *hcomp);
+/**
+ * @}
+ */ 
 
+/** @addtogroup COMP_Exported_Functions_Group2 Input and Output operation functions
+ *  @brief   Data transfers functions 
+ * @{
+ */
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef HAL_COMP_Start(COMP_HandleTypeDef *hcomp);
 HAL_StatusTypeDef HAL_COMP_Stop(COMP_HandleTypeDef *hcomp);
 HAL_StatusTypeDef HAL_COMP_Start_IT(COMP_HandleTypeDef *hcomp);
 HAL_StatusTypeDef HAL_COMP_Stop_IT(COMP_HandleTypeDef *hcomp);
 void HAL_COMP_IRQHandler(COMP_HandleTypeDef *hcomp);
+/**
+  * @}
+  */ 
 
+/** @addtogroup COMP_Exported_Functions_Group3 Peripheral Control functions 
+ *  @brief   management functions 
+ * @{
+ */
 /* Peripheral Control functions ***********************************************/
 HAL_StatusTypeDef HAL_COMP_Lock(COMP_HandleTypeDef *hcomp);
 uint32_t HAL_COMP_GetOutputLevel(COMP_HandleTypeDef *hcomp);
 
 /* Callback in Interrupt mode */
 void HAL_COMP_TriggerCallback(COMP_HandleTypeDef *hcomp);
+/**
+  * @}
+  */ 
 
+/** @addtogroup COMP_Exported_Functions_Group4 Peripheral State functions 
+ *  @brief   Peripheral State functions 
+ * @{
+ */
 /* Peripheral State and Error functions ***************************************/
 HAL_COMP_StateTypeDef HAL_COMP_GetState(COMP_HandleTypeDef *hcomp);
-
 /**
   * @}
   */ 
 
 /**
   * @}
-  */ 
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 #ifdef __cplusplus
 }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_comp_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_comp_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_comp_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of COMP HAL Extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of COMP HAL Extended module.
   ******************************************************************************
   * @attention
   *
@@ -50,18 +50,19 @@
   * @{
   */
 
-/** @addtogroup COMPEx
+/** @defgroup COMPEx COMP Extended HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
 /* Exported constants --------------------------------------------------------*/
-/** @addtogroup COMPEx_Exported_Constants
+/** @defgroup COMPEx_Exported_Constants COMP Extended Exported Constants
   * @{
   */
 
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
-/** @defgroup COMPEx_InvertingInput  COMP_InvertingInput (STM32F302xC/STM32F303xC/STM32F358xx Product devices)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+   /** @defgroup COMPEx_InvertingInput  COMP Extended InvertingInput (STM32F302xE/STM32F303xE/STM32F398xx/STM32F302xC/STM32F303xC/STM32F358xx Product devices)
   * @{
   */
 #define COMP_INVERTINGINPUT_1_4VREFINT       ((uint32_t)0x00000000)                        /*!< 1/4 VREFINT connected to comparator inverting input */
@@ -91,7 +92,7 @@
   * @}
   */ 
 #elif defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
-/** @defgroup COMPEx_InvertingInput COMP_InvertingInput (STM32F301x8/STM32F302x8/STM32F318xx Product devices)
+/** @defgroup COMPEx_InvertingInput COMP Extended InvertingInput (STM32F301x8/STM32F302x8/STM32F318xx Product devices)
   * @{
   */
 #define COMP_INVERTINGINPUT_1_4VREFINT     ((uint32_t)0x00000000)                        /*!< 1/4 VREFINT connected to comparator inverting input */
@@ -114,7 +115,7 @@
   * @}
   */
 #elif defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
-/** @defgroup COMPEx_InvertingInput COMP_InvertingInput (STM32F303x8/STM32F334x8/STM32F328xx Product devices)
+/** @defgroup COMPEx_InvertingInput COMP Extended InvertingInput (STM32F303x8/STM32F334x8/STM32F328xx Product devices)
   * @{
   */
 #define COMP_INVERTINGINPUT_1_4VREFINT     ((uint32_t)0x00000000)                        /*!< 1/4 VREFINT connected to comparator inverting input */
@@ -142,7 +143,7 @@
   * @}
   */
 #elif defined(STM32F373xC) || defined(STM32F378xx)
-/** @defgroup COMPEx_InvertingInput COMP_InvertingInput (STM32F373xC/STM32F378xx Product devices)
+/** @defgroup COMPEx_InvertingInput COMP Extended InvertingInput (STM32F373xC/STM32F378xx Product devices)
   * @{
   */
 #define COMP_INVERTINGINPUT_1_4VREFINT  ((uint32_t)0x00000000)                        /*!< 1/4 VREFINT connected to comparator inverting input */
@@ -168,10 +169,11 @@
 /**
   * @}
   */
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx */
 
 #if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
-/** @defgroup COMPEx_NonInvertingInput  COMPEx_NonInvertingInput (STM32F302xC/STM32F303xC/STM32F358xx Product devices)
+/** @defgroup COMPEx_NonInvertingInput  COMP Extended NonInvertingInput (STM32F302xC/STM32F303xC/STM32F358xx Product devices)
   * @{
   */
 #define COMP_NONINVERTINGINPUT_IO1               ((uint32_t)0x00000000) /*!< I/O1 (PA1 for COMP1, PA7 for COMP2, PB14 for COMP3, 
@@ -200,7 +202,7 @@
   * @}
   */ 
 #elif defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
-/** @defgroup COMPEx_NonInvertingInput COMPEx_NonInvertingInput (STM32F301x8/STM32F302x8/STM32F318xx Product devices)
+/** @defgroup COMPEx_NonInvertingInput COMP Extended NonInvertingInput (STM32F301x8/STM32F302x8/STM32F318xx Product devices)
   * @{
   */
 #define COMP_NONINVERTINGINPUT_IO1               ((uint32_t)0x00000000) /*!< I/O1 (PA7 for COMP2, PB0 for COMP4, PB11 for COMP6)
@@ -223,7 +225,7 @@
   * @}
   */ 
 #elif defined(STM32F373xC) || defined(STM32F378xx)
-/** @defgroup COMPEx_NonInvertingInput COMPEx_NonInvertingInput (STM32F373xC/STM32F378xx Product devices)
+/** @defgroup COMPEx_NonInvertingInput COMP Extended NonInvertingInput (STM32F373xC/STM32F378xx Product devices)
   * @{
   */
 #define COMP_NONINVERTINGINPUT_IO1               ((uint32_t)0x00000000) /*!< I/O1 (PA1 for COMP1, PA3 for COMP2) 
@@ -245,8 +247,32 @@
 /**
   * @}
   */
+#elif defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+/** @defgroup COMPEx_NonInvertingInput  COMP Extended NonInvertingInput (STM32F302xE/STM32F303xE/STM32F398xx Product devices)
+  * @{
+  */
+#define COMP_NONINVERTINGINPUT_IO1             ((uint32_t)0x00000000)   /*!< I/O1 (PA1 for COMP1, PA7 for COMP2, PB14 for COMP3, 
+                                                                            PB0 for COMP4, PD12 for COMP5, PD11 for COMP6,
+                                                                            PA0 for COMP7) connected to comparator non inverting input */
+#define COMP_NONINVERTINGINPUT_DAC1SWITCHCLOSED COMP1_CSR_COMP1SW1      /*!< DAC ouput connected to comparator COMP1 non inverting input */
+
+#define IS_COMP_NONINVERTINGINPUT(INPUT) (((INPUT) == COMP_NONINVERTINGINPUT_IO1) || \
+                                          ((INPUT) == COMP_NONINVERTINGINPUT_DAC1SWITCHCLOSED))
+
+/* STM32F302xE/STM32F303xE/STM32F398xx devices comparator instances non inverting source values */
+#define IS_COMP_NONINVERTINGINPUT_INSTANCE(INSTANCE, INPUT)    \
+   ((((INSTANCE) == COMP1)  &&                                 \
+    (((INPUT) == COMP_NONINVERTINGINPUT_IO1)                || \
+     ((INPUT) == COMP_NONINVERTINGINPUT_DAC1SWITCHCLOSED)))    \
+    ||                                                         \
+    (((INPUT) == COMP_NONINVERTINGINPUT_IO1)))
+
+#define COMP_CSR_COMPxNONINSEL_MASK            (COMP1_CSR_COMP1SW1) /*!< COMP_CSR_COMPxNONINSEL mask */
+/**
+  * @}
+  */ 
 #else
-/** @defgroup COMPEx_NonInvertingInput COMPEx_NonInvertingInput (Other Product devices)
+/** @defgroup COMPEx_NonInvertingInput COMP Extended NonInvertingInput (Other Product devices)
   * @{
   */
 #define COMP_NONINVERTINGINPUT_IO1             ((uint32_t)0x00000000) /*!< I/O1 (PA7 for COMP2, PB0 for COMP4, PB11 for COMP6) 
@@ -262,8 +288,59 @@
   */
 #endif /* STM32F302xC || STM32F303xC || STM32F358xx */
 
-#if  defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
-/** @defgroup COMPEx_Output COMPEx_Output (STM32F302xC/STM32F303xC/STM32F358xx Product devices)
+#if  defined(STM32F302xC)
+/** @defgroup COMPEx_Output COMP Extended Output (STM32F302xC Product devices)
+  * @{
+  */
+#define COMP_OUTPUT_NONE                             ((uint32_t)0x00000000)   /*!< COMP output isn't connected to other peripherals */
+/* Output Redirection common for all comparators COMP1, COMP2, COMP4, COMP6 */
+#define COMP_OUTPUT_TIM1BKIN                         COMP_CSR_COMPxOUTSEL_0   /*!< COMP output connected to TIM1 Break Input (BKIN) */
+#define COMP_OUTPUT_TIM1BKIN2_BRK2                   ((uint32_t)0x00000800)   /*!< COMP output connected to TIM1 Break Input 2 (BKIN2) */
+#define COMP_OUTPUT_TIM1BKIN2                        ((uint32_t)0x00001400)   /*!< COMP output connected to TIM1 Break Input 2 */
+/* Output Redirection common for COMP1 and COMP2 */
+#define COMP_OUTPUT_TIM1OCREFCLR                      ((uint32_t)0x00001800)   /*!< COMP output connected to TIM1 OCREF Clear */
+#define COMP_OUTPUT_TIM1IC1                           ((uint32_t)0x00001C00)   /*!< COMP output connected to TIM1 Input Capture 1 */
+#define COMP_OUTPUT_TIM2IC4                           ((uint32_t)0x00002000)   /*!< COMP output connected to TIM2 Input Capture 4 */
+#define COMP_OUTPUT_TIM2OCREFCLR                      ((uint32_t)0x00002400)   /*!< COMP output connected to TIM2 OCREF Clear */
+#define COMP_OUTPUT_TIM3IC1                           ((uint32_t)0x00002800)   /*!< COMP output connected to TIM3 Input Capture 1 */
+/* Output Redirection common for COMP1,COMP2 and COMP4 */
+#define COMP_OUTPUT_TIM3OCREFCLR                      ((uint32_t)0x00002C00)   /*!< COMP output connected to TIM3 OCREF Clear */
+/* Output Redirection specific to COMP4 */
+#define COMP_OUTPUT_TIM3IC3                           ((uint32_t)0x00001800)   /*!< COMP output connected to TIM3 Input Capture 3 */
+#define COMP_OUTPUT_TIM15IC2                          ((uint32_t)0x00002000)   /*!< COMP output connected to TIM15 Input Capture 2 */
+#define COMP_OUTPUT_TIM4IC2                           ((uint32_t)0x00002400)   /*!< COMP output connected to TIM4 Input Capture 2 */
+#define COMP_OUTPUT_TIM15OCREFCLR                     ((uint32_t)0x00002800)   /*!< COMP output connected to TIM15 OCREF Clear */
+/* Output Redirection specific to COMP6 */
+#define COMP_OUTPUT_TIM2IC2                           ((uint32_t)0x00001800)   /*!< COMP output connected to TIM2 Input Capture 2 */
+#define COMP_OUTPUT_COMP6TIM2OCREFCLR                 ((uint32_t)0x00002000)   /*!< COMP6 output connected to TIM2 OCREF Clear */
+#define COMP_OUTPUT_TIM16OCREFCLR                     ((uint32_t)0x00002400)   /*!< COMP output connected to TIM16 OCREF Clear */
+#define COMP_OUTPUT_TIM16IC1                          ((uint32_t)0x00002800)   /*!< COMP output connected to TIM16 Input Capture 1 */
+#define COMP_OUTPUT_TIM4IC4                           ((uint32_t)0x00002C00)   /*!< COMP output connected to TIM4 Input Capture 4 */
+
+#define IS_COMP_OUTPUT(OUTPUT) (((OUTPUT) == COMP_OUTPUT_NONE)                || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1BKIN)            || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1BKIN2_BRK2)      || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1BKIN2)           || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1OCREFCLR)        || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1IC1)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM2IC4)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM2OCREFCLR)        || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM3IC1)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM3OCREFCLR)        || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM3IC3)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM15IC2)            || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM4IC2)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM15OCREFCLR)       || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM2IC2)             || \
+                                ((OUTPUT) == COMP_OUTPUT_COMP6TIM2OCREFCLR)   || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM16OCREFCLR)       || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM16IC1)            || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM4IC4))
+/**
+  * @}
+  */ 
+#elif  defined(STM32F303xC) || defined(STM32F358xx)
+/** @defgroup COMPEx_Output COMP Extended Output (STM32F303xC/STM32F358xx Product devices)
   * @{
   */
 #define COMP_OUTPUT_NONE                  ((uint32_t)0x00000000)   /*!< COMP output isn't connected to other peripherals */
@@ -353,7 +430,7 @@
   * @}
   */ 
 #elif defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
-/** @defgroup COMPEx_Output COMPEx_Output (STM32F301x8/STM32F302x8/STM32F318xx Product devices)
+/** @defgroup COMPEx_Output COMP Extended Output (STM32F301x8/STM32F302x8/STM32F318xx Product devices)
   * @{
   */
 #define COMP_OUTPUT_NONE                  ((uint32_t)0x00000000)   /*!< COMP output isn't connected to other peripherals */
@@ -391,7 +468,7 @@
   * @}
   */ 
 #elif  defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
-/** @defgroup COMPEx_Output COMPEx_Output (STM32F303x8/STM32F334x8/STM32F328xx Product devices)
+/** @defgroup COMPEx_Output COMP Extended Output (STM32F303x8/STM32F334x8/STM32F328xx Product devices)
   * @{
   */
 #define COMP_OUTPUT_NONE                  ((uint32_t)0x00000000)   /*!< COMP output isn't connected to other peripherals */
@@ -435,8 +512,8 @@
 /**
   * @}
   */ 
-#else
-/** @defgroup COMPEx_Output COMPEx_Output (STM32F373xC/STM32F378xx Product devices)
+#elif  defined(STM32F373xC) || defined(STM32F378xx)
+/** @defgroup COMPEx_Output COMP Extended Output (STM32F373xC/STM32F378xx Product devices)
   * @{
   */
 /* Output Redirection common for all comparators COMP1 and COMP2 */
@@ -468,10 +545,152 @@
 /**
   * @}
   */ 
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#elif defined(STM32F302xE)
+/** @defgroup COMPEx_Output COMP Extended Output (STM32F302xE Product devices)
+  * @{
+  */
+#define COMP_OUTPUT_NONE                             ((uint32_t)0x00000000)   /*!< COMP output isn't connected to other peripherals */
+/* Output Redirection common for all comparators COMP1, COMP2, COMP4, COMP6 */
+#define COMP_OUTPUT_TIM1BKIN                         COMP_CSR_COMPxOUTSEL_0   /*!< COMP output connected to TIM1 Break Input (BKIN) */
+#define COMP_OUTPUT_TIM1BKIN2_BRK2                   ((uint32_t)0x00000800)   /*!< COMP output connected to TIM1 Break Input 2 (BKIN2) */
+#define COMP_OUTPUT_TIM1BKIN2                        ((uint32_t)0x00001400)   /*!< COMP output connected to TIM1 Break Input 2 */
+/* Output Redirection common for COMP1 and COMP2 */
+#define COMP_OUTPUT_TIM1OCREFCLR                      ((uint32_t)0x00001800)   /*!< COMP output connected to TIM1 OCREF Clear */
+#define COMP_OUTPUT_TIM1IC1                           ((uint32_t)0x00001C00)   /*!< COMP output connected to TIM1 Input Capture 1 */
+#define COMP_OUTPUT_TIM2IC4                           ((uint32_t)0x00002000)   /*!< COMP output connected to TIM2 Input Capture 4 */
+#define COMP_OUTPUT_TIM2OCREFCLR                      ((uint32_t)0x00002400)   /*!< COMP output connected to TIM2 OCREF Clear */
+#define COMP_OUTPUT_TIM3IC1                           ((uint32_t)0x00002800)   /*!< COMP output connected to TIM3 Input Capture 1 */
+#define COMP_OUTPUT_TIM3OCREFCLR                      ((uint32_t)0x00002C00)   /*!< COMP output connected to TIM3 OCREF Clear */
+/* Output Redirection specific to COMP4 */
+#define COMP_OUTPUT_TIM3IC3                           ((uint32_t)0x00001800)   /*!< COMP output connected to TIM3 Input Capture 3 */
+#define COMP_OUTPUT_TIM15IC2                          ((uint32_t)0x00002000)   /*!< COMP output connected to TIM15 Input Capture 2 */
+#define COMP_OUTPUT_TIM4IC2                           ((uint32_t)0x00002400)   /*!< COMP output connected to TIM4 Input Capture 2 */
+#define COMP_OUTPUT_TIM15OCREFCLR                     ((uint32_t)0x00002800)   /*!< COMP output connected to TIM15 OCREF Clear */
+/* Output Redirection specific to COMP6 */
+#define COMP_OUTPUT_TIM2IC2                           ((uint32_t)0x00001800)   /*!< COMP output connected to TIM2 Input Capture 2 */
+#define COMP_OUTPUT_COMP6TIM2OCREFCLR                 ((uint32_t)0x00002000)   /*!< COMP output connected to TIM2 OCREF Clear */
+#define COMP_OUTPUT_TIM16OCREFCLR                     ((uint32_t)0x00002400)   /*!< COMP output connected to TIM16 OCREF Clear */
+#define COMP_OUTPUT_TIM16IC1                          ((uint32_t)0x00002800)   /*!< COMP output connected to TIM16 Input Capture 1 */
+#define COMP_OUTPUT_TIM4IC4                           ((uint32_t)0x00002C00)   /*!< COMP output connected to TIM4 Input Capture 4 */
+
+#define IS_COMP_OUTPUT(OUTPUT) (((OUTPUT) == COMP_OUTPUT_NONE)                || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1BKIN)            || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1BKIN2_BRK2)      || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1BKIN2)           || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1OCREFCLR)        || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1IC1)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM2IC4)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM2OCREFCLR)        || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM3IC1)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM3OCREFCLR)        || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM3IC3)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM15IC2)            || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM4IC2)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM15OCREFCLR)       || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM2IC2)             || \
+                                ((OUTPUT) == COMP_OUTPUT_COMP6TIM2OCREFCLR)   || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM16OCREFCLR)       || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM16IC1)            || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM4IC4))
+
+/**
+  * @}
+  */ 
+#elif defined(STM32F303xE) || defined(STM32F398xx)
+/** @defgroup COMPEx_Output COMP Extended Output (STM32F303xE/STM32F398xx Product devices)
+  * @{
+  */
+#define COMP_OUTPUT_NONE                             ((uint32_t)0x00000000)   /*!< COMP output isn't connected to other peripherals */
+/* Output Redirection common for all comparators COMP1...COMP7 */
+#define COMP_OUTPUT_TIM1BKIN                         COMP_CSR_COMPxOUTSEL_0   /*!< COMP output connected to TIM1 Break Input (BKIN) */
+#define COMP_OUTPUT_TIM1BKIN2                        ((uint32_t)0x00000800)   /*!< COMP output connected to TIM1 Break Input 2 (BKIN2) */
+#define COMP_OUTPUT_TIM8BKIN                         ((uint32_t)0x00000C00)   /*!< COMP output connected to TIM8 Break Input (BKIN) */
+#define COMP_OUTPUT_TIM8BKIN2                        ((uint32_t)0x00001000)   /*!< COMP output connected to TIM8 Break Input 2 (BKIN2) */
+#define COMP_OUTPUT_TIM1BKIN2_TIM8BKIN2              ((uint32_t)0x00001400)   /*!< COMP output connected to TIM1 Break Input 2 and TIM8 Break Input 2 */
+#define COMP_OUTPUT_TIM20BKIN                        ((uint32_t)0x00003000)   /*!< COMP output connected to TIM20 Break Input (BKIN) */
+#define COMP_OUTPUT_TIM20BKIN2                       ((uint32_t)0x00003400)   /*!< COMP output connected to TIM20 Break Input 2 (BKIN2) */
+#define COMP_OUTPUT_TIM1BKIN2_TIM8BKIN2_TIM20BKIN2   ((uint32_t)0x00003800)   /*!< COMP output connected to TIM1 Break Input 2, TIM8 Break Input 2 and TIM20 Break Input 2  */
+/* Output Redirection common for COMP1 and COMP2 */
+#define COMP_OUTPUT_TIM1OCREFCLR                      ((uint32_t)0x00001800)   /*!< COMP output connected to TIM1 OCREF Clear */
+#define COMP_OUTPUT_TIM1IC1                           ((uint32_t)0x00001C00)   /*!< COMP output connected to TIM1 Input Capture 1 */
+#define COMP_OUTPUT_TIM2IC4                           ((uint32_t)0x00002000)   /*!< COMP output connected to TIM2 Input Capture 4 */
+#define COMP_OUTPUT_TIM2OCREFCLR                      ((uint32_t)0x00002400)   /*!< COMP output connected to TIM2 OCREF Clear */
+#define COMP_OUTPUT_TIM3IC1                           ((uint32_t)0x00002800)   /*!< COMP output connected to TIM3 Input Capture 1 */
+#define COMP_OUTPUT_TIM3OCREFCLR                      ((uint32_t)0x00002C00)   /*!< COMP output connected to TIM3 OCREF Clear */
+/* Output Redirection specific to COMP2 */
+#define COMP_OUTPUT_TIM20OCREFCLR                     ((uint32_t)0x00003C00)   /*!< COMP output connected to TIM20 OCREF Clear */
+/* Output Redirection specific to COMP3 */
+#define COMP_OUTPUT_TIM4IC1                           ((uint32_t)0x00001C00)   /*!< COMP output connected to TIM4 Input Capture 1 */
+#define COMP_OUTPUT_TIM3IC2                           ((uint32_t)0x00002000)   /*!< COMP output connected to TIM3 Input Capture 2 */
+#define COMP_OUTPUT_TIM15IC1                          ((uint32_t)0x00002800)   /*!< COMP output connected to TIM15 Input Capture 1 */
+#define COMP_OUTPUT_TIM15BKIN                         ((uint32_t)0x00002C00)   /*!< COMP output connected to TIM15 Break Input (BKIN) */
+/* Output Redirection specific to COMP4 */
+#define COMP_OUTPUT_TIM3IC3                           ((uint32_t)0x00001800)   /*!< COMP output connected to TIM3 Input Capture 3 */
+#define COMP_OUTPUT_TIM8OCREFCLR                      ((uint32_t)0x00001C00)   /*!< COMP output connected to TIM8 OCREF Clear */
+#define COMP_OUTPUT_TIM15IC2                          ((uint32_t)0x00002000)   /*!< COMP output connected to TIM15 Input Capture 2 */
+#define COMP_OUTPUT_TIM4IC2                           ((uint32_t)0x00002400)   /*!< COMP output connected to TIM4 Input Capture 2 */
+#define COMP_OUTPUT_TIM15OCREFCLR                     ((uint32_t)0x00002800)   /*!< COMP output connected to TIM15 OCREF Clear */
+/* Output Redirection specific to COMP5 */
+#define COMP_OUTPUT_TIM2IC1                           ((uint32_t)0x00001800)   /*!< COMP output connected to TIM2 Input Capture 1 */
+#define COMP_OUTPUT_TIM17IC1                          ((uint32_t)0x00002000)   /*!< COMP output connected to TIM17 Input Capture 1 */
+#define COMP_OUTPUT_TIM4IC3                           ((uint32_t)0x00002400)   /*!< COMP output connected to TIM4 Input Capture 3 */
+#define COMP_OUTPUT_TIM16BKIN                         ((uint32_t)0x00002800)   /*!< COMP output connected to TIM16 Break Input (BKIN) */
+/* Output Redirection specific to COMP6 */
+#define COMP_OUTPUT_TIM2IC2                           ((uint32_t)0x00001800)   /*!< COMP output connected to TIM2 Input Capture 2 */
+#define COMP_OUTPUT_COMP6TIM2OCREFCLR                 ((uint32_t)0x00002000)   /*!< COMP output connected to TIM2 OCREF Clear */
+#define COMP_OUTPUT_TIM16OCREFCLR                     ((uint32_t)0x00002400)   /*!< COMP output connected to TIM16 OCREF Clear */
+#define COMP_OUTPUT_TIM16IC1                          ((uint32_t)0x00002800)   /*!< COMP output connected to TIM16 Input Capture 1 */
+#define COMP_OUTPUT_TIM4IC4                           ((uint32_t)0x00002C00)   /*!< COMP output connected to TIM4 Input Capture 4 */
+/* Output Redirection specific to COMP7 */
+#define COMP_OUTPUT_TIM2IC3                           ((uint32_t)0x00002000)   /*!< COMP output connected to TIM2 Input Capture 3 */
+#define COMP_OUTPUT_TIM1IC2                           ((uint32_t)0x00002400)   /*!< COMP output connected to TIM1 Input Capture 2 */
+#define COMP_OUTPUT_TIM17OCREFCLR                     ((uint32_t)0x00002800)   /*!< COMP output connected to TIM16 OCREF Clear */
+#define COMP_OUTPUT_TIM17BKIN                         ((uint32_t)0x00002C00)   /*!< COMP output connected to TIM16 Break Input (BKIN) */
+#define IS_COMP_OUTPUT(OUTPUT) (((OUTPUT) == COMP_OUTPUT_NONE)                || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1BKIN)            || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1IC1)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1OCREFCLR)        || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM2IC4)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM2OCREFCLR)        || \
+                                ((OUTPUT) == COMP_OUTPUT_COMP6TIM2OCREFCLR)   || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM3IC1)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM3OCREFCLR)        || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM20OCREFCLR)       || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM8BKIN)            || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1BKIN2)           || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM8BKIN2)           || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM2OCREFCLR)        || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1BKIN2_TIM8BKIN2) || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM20BKIN)           || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM20BKIN2)          || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1BKIN2_TIM8BKIN2_TIM20BKIN2) || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM3IC2)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM4IC1)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM15IC1)            || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM15BKIN)           || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM8OCREFCLR)        || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM3IC3)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM4IC1)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM15IC1)            || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM2IC1)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM4IC3)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM16BKIN)           || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM17IC1)            || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM2IC2)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM16IC1)            || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM4IC4)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM16OCREFCLR)       || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM2IC3)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM1IC2)             || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM17BKIN)           || \
+                                ((OUTPUT) == COMP_OUTPUT_TIM17OCREFCLR))
+/**
+  * @}
+  */ 
+#endif /* STM32F302xC */
 
 #if  defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
-/** @defgroup COMPEx_WindowMode COMPEx_WindowMode (STM32F302xC/STM32F303xC/STM32F358xx Product devices)
+/** @defgroup COMPEx_WindowMode COMP Extended WindowMode (STM32F302xC/STM32F303xC/STM32F358xx Product devices)
   * @{
   */
 #define COMP_WINDOWMODE_DISABLED               ((uint32_t)0x00000000)  /*!< Window mode disabled */
@@ -485,7 +704,7 @@
   * @}
   */
 #elif defined(STM32F373xC) || defined(STM32F378xx)
-/** @defgroup COMPEx_WindowMode COMPEx_WindowMode (STM32F373xC/STM32F378xx Product devices)
+/** @defgroup COMPEx_WindowMode COMP Extended WindowMode (STM32F373xC/STM32F378xx Product devices)
   * @{
   */
 #define COMP_WINDOWMODE_DISABLED               ((uint32_t)0x00000000)  /*!< Window mode disabled */
@@ -499,7 +718,7 @@
   * @}
   */
 #else
-/** @defgroup COMPEx_WindowMode COMPEx_WindowMode (Other Product devices)
+/** @defgroup COMPEx_WindowMode COMP Extended WindowMode (Other Product devices)
   * @{
   */
 #define COMP_WINDOWMODE_DISABLED               ((uint32_t)0x00000000)  /*!< Window mode disabled (not available) */
@@ -512,7 +731,7 @@
   */
 #endif /* STM32F302xC || STM32F303xC || STM32F358xx */
 
-/** @defgroup COMPEx_Mode
+/** @defgroup COMPEx_Mode COMP Extended Mode
   * @{
   */
 #if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
@@ -545,7 +764,7 @@
   * @}
   */
 
-/** @defgroup COMPEx_Hysteresis
+/** @defgroup COMPEx_Hysteresis COMP Extended Hysteresis
   * @{
   */
 #if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
@@ -579,7 +798,7 @@
 
 #if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
     defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
-/** @defgroup COMPEx_BlankingSrce  COMPEx_BlankingSrce (STM32F301x8/STM32F302x8/STM32F303x8/STM32F334x8/STM32F318xx/STM32F328xx Product devices)
+/** @defgroup COMPEx_BlankingSrce  COMP Extended Blanking Source (STM32F301x8/STM32F302x8/STM32F303x8/STM32F334x8/STM32F318xx/STM32F328xx Product devices)
   * @{
   */
 /* No blanking source can be selected for all comparators */
@@ -627,7 +846,7 @@
   * @}
   */
 
-/** @defgroup COMPEx_ExtiLineEvent COMPEx_ExtiLineEvent (STM32F301x8/STM32F302x8/STM32F303x8/STM32F334x8/STM32F318xx/STM32F328xx Product devices)
+/** @defgroup COMPEx_ExtiLineEvent COMP Extended EXTI Line Event (STM32F301x8/STM32F302x8/STM32F303x8/STM32F334x8/STM32F318xx/STM32F328xx Product devices)
   *        Elements values convention: XXXXZYYY
   *           - XXXX : Interrupt mask in the register list where Z equal 0x0
   *           - YYY : Interrupt mask in the register list where Z equal 0x1
@@ -648,8 +867,9 @@
 #endif /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
        /* STM32F303x8 || STM32F334x8 || STM32F328xx */
 
-#if defined(STM32F302xC)
-/** @defgroup COMPEx_BlankingSrce COMPEx_BlankingSrce (STM32F302xC Product devices)
+#if defined(STM32F302xE) ||\
+    defined(STM32F302xC)
+/** @defgroup COMPEx_BlankingSrce COMP Extended Blanking Source (STM32F302xE/STM32F302xC Product devices)
   * @{
   */
 /* No blanking source can be selected for all comparators */
@@ -659,13 +879,13 @@
 /* Blanking source common for COMP1 and COMP2 */
 #define COMP_BLANKINGSRCE_TIM2OC3              COMP_CSR_COMPxBLANKING_1  /*!< TIM2 OC3 selected as blanking source for compartor */
 /* Blanking source common for COMP1 and COMP2 */
-#define COMP_BLANKINGSRCE_TIM3OC3              (COMP_CSR_COMPxBLANKING_0|COMP_CSR_COMPxBLANKING_1)    /*!< TIM3 OC3 selected as blanking source for compartor */
+#define COMP_BLANKINGSRCE_TIM3OC3              (COMP_CSR_COMPxBLANKING_0|COMP_CSR_COMPxBLANKING_1)    /*!< TIM3 OC3 selected as blanking source for comparator */
 /* Blanking source for COMP4 */
-#define COMP_BLANKINGSRCE_TIM3OC4              COMP_CSR_COMPxBLANKING_0    /*!< TIM3 OC4 selected as blanking source for compartor */
-#define COMP_BLANKINGSRCE_TIM15OC1             (COMP_CSR_COMPxBLANKING_0|COMP_CSR_COMPxBLANKING_1)    /*!< TIM15 OC1 selected as blanking source for compartor */
+#define COMP_BLANKINGSRCE_TIM3OC4              COMP_CSR_COMPxBLANKING_0    /*!< TIM3 OC4 selected as blanking source for comparator */
+#define COMP_BLANKINGSRCE_TIM15OC1             (COMP_CSR_COMPxBLANKING_0|COMP_CSR_COMPxBLANKING_1)    /*!< TIM15 OC1 selected as blanking source for comparator */
 /* Blanking source for COMP6 */
-#define COMP_BLANKINGSRCE_TIM2OC4              (COMP_CSR_COMPxBLANKING_0|COMP_CSR_COMPxBLANKING_1)    /*!< TIM2 OC4 selected as blanking source for compartor */
-#define COMP_BLANKINGSRCE_TIM15OC2              COMP_CSR_COMPxBLANKING_2    /*!< TIM15 OC2 selected as blanking source for compartor */
+#define COMP_BLANKINGSRCE_TIM2OC4              (COMP_CSR_COMPxBLANKING_0|COMP_CSR_COMPxBLANKING_1)    /*!< TIM2 OC4 selected as blanking source for comparator */
+#define COMP_BLANKINGSRCE_TIM15OC2              COMP_CSR_COMPxBLANKING_2    /*!< TIM15 OC2 selected as blanking source for comparator */
 
 #define IS_COMP_BLANKINGSRCE(SOURCE) (((SOURCE) == COMP_BLANKINGSRCE_NONE)     || \
                                       ((SOURCE) == COMP_BLANKINGSRCE_TIM1OC5)  || \
@@ -676,7 +896,7 @@
                                       ((SOURCE) == COMP_BLANKINGSRCE_TIM15OC1) || \
                                       ((SOURCE) == COMP_BLANKINGSRCE_TIM15OC2))
 
-/* STM32F302xB/STM32F302xC devices comparator instances blanking source values */
+/* STM32F302xB/STM32F302xC/STM32F302xE devices comparator instances blanking source values */
 #define IS_COMP_BLANKINGSRCE_INSTANCE(INSTANCE, BLANKINGSRCE) \
    (((((INSTANCE) == COMP1) || ((INSTANCE) == COMP2))  &&     \
      (((BLANKINGSRCE) == COMP_BLANKINGSRCE_NONE)    ||        \
@@ -700,7 +920,7 @@
   * @}
   */
 
-/** @defgroup COMPEx_ExtiLineEvent COMPEx_ExtiLineEvent (STM32F302xC Product devices)
+/** @defgroup COMPEx_ExtiLineEvent COMP Extended EXTI Line Event (STM32F302xC Product devices)
   *        Elements values convention: XXXXZYYY
   *           - XXXX : Interrupt mask in the register list where Z equal 0x0
   *           - YYY : Interrupt mask in the register list where Z equal 0x1
@@ -719,29 +939,31 @@
 /**
   * @}
   */
-#endif /* STM32F302xC */
+#endif /* STM32F302xE || */
+       /* STM32F302xC    */
    
-#if defined(STM32F303xC) || defined(STM32F358xx)
-/** @defgroup COMPEx_BlankingSrce COMPEx_BlankingSrce (STM32F303xC/STM32F358xx Product devices)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+/** @defgroup COMPEx_BlankingSrce COMP Extended Blanking Source (STM32F303xE/STM32F398xx/STM32F303xC/STM32F358xx Product devices)
   * @{
   */
 /* No blanking source can be selected for all comparators */
 #define COMP_BLANKINGSRCE_NONE                 ((uint32_t)0x00000000)    /*!< No blanking source */
 /* Blanking source common for COMP1, COMP2, COMP3 and COMP7 */
-#define COMP_BLANKINGSRCE_TIM1OC5              COMP_CSR_COMPxBLANKING_0  /*!< TIM1 OC5 selected as blanking source for compartor */
+#define COMP_BLANKINGSRCE_TIM1OC5              COMP_CSR_COMPxBLANKING_0  /*!< TIM1 OC5 selected as blanking source for comparator */
 /* Blanking source common for COMP1 and COMP2 */
-#define COMP_BLANKINGSRCE_TIM2OC3              COMP_CSR_COMPxBLANKING_1  /*!< TIM2 OC5 selected as blanking source for compartor */
+#define COMP_BLANKINGSRCE_TIM2OC3              COMP_CSR_COMPxBLANKING_1  /*!< TIM2 OC5 selected as blanking source for comparator */
 /* Blanking source common for COMP1, COMP2 and COMP5 */
-#define COMP_BLANKINGSRCE_TIM3OC3              (COMP_CSR_COMPxBLANKING_0|COMP_CSR_COMPxBLANKING_1)    /*!< TIM2 OC3 selected as blanking source for compartor */
+#define COMP_BLANKINGSRCE_TIM3OC3              (COMP_CSR_COMPxBLANKING_0|COMP_CSR_COMPxBLANKING_1)    /*!< TIM2 OC3 selected as blanking source for comparator */
 /* Blanking source common for COMP3 and COMP6 */
-#define COMP_BLANKINGSRCE_TIM2OC4              (COMP_CSR_COMPxBLANKING_0|COMP_CSR_COMPxBLANKING_1)    /*!< TIM2 OC4 selected as blanking source for compartor */
+#define COMP_BLANKINGSRCE_TIM2OC4              (COMP_CSR_COMPxBLANKING_0|COMP_CSR_COMPxBLANKING_1)    /*!< TIM2 OC4 selected as blanking source for comparator */
 /* Blanking source common for COMP4, COMP5, COMP6 and COMP7 */
-#define COMP_BLANKINGSRCE_TIM8OC5              COMP_CSR_COMPxBLANKING_1  /*!< TIM8 OC5 selected as blanking source for compartor */
+#define COMP_BLANKINGSRCE_TIM8OC5              COMP_CSR_COMPxBLANKING_1  /*!< TIM8 OC5 selected as blanking source for comparator */
 /* Blanking source for COMP4 */
-#define COMP_BLANKINGSRCE_TIM3OC4              COMP_CSR_COMPxBLANKING_0  /*!< TIM3 OC4 selected as blanking source for compartor */
-#define COMP_BLANKINGSRCE_TIM15OC1             (COMP_CSR_COMPxBLANKING_0|COMP_CSR_COMPxBLANKING_1)    /*!< TIM15 OC1 selected as blanking source for compartor */
+#define COMP_BLANKINGSRCE_TIM3OC4              COMP_CSR_COMPxBLANKING_0  /*!< TIM3 OC4 selected as blanking source for comparator */
+#define COMP_BLANKINGSRCE_TIM15OC1             (COMP_CSR_COMPxBLANKING_0|COMP_CSR_COMPxBLANKING_1)    /*!< TIM15 OC1 selected as blanking source for comparator */
 /* Blanking source common for COMP6 and COMP7 */
-#define COMP_BLANKINGSRCE_TIM15OC2             COMP_CSR_COMPxBLANKING_2  /*!< TIM15 OC2 selected as blanking source for compartor */
+#define COMP_BLANKINGSRCE_TIM15OC2             COMP_CSR_COMPxBLANKING_2  /*!< TIM15 OC2 selected as blanking source for comparator */
 
 #define IS_COMP_BLANKINGSRCE(SOURCE) (((SOURCE) == COMP_BLANKINGSRCE_NONE)     || \
                                       ((SOURCE) == COMP_BLANKINGSRCE_TIM1OC5)  || \
@@ -753,7 +975,7 @@
                                       ((SOURCE) == COMP_BLANKINGSRCE_TIM15OC1) || \
                                       ((SOURCE) == COMP_BLANKINGSRCE_TIM15OC2))
 
-/* STM32F303xB/STM32F303xC/STM32F358xx devices comparator instances blanking source values */
+/* STM32F303xE/STM32F398xx/STM32F303xB/STM32F303xC/STM32F358xx devices comparator instances blanking source values */
 #define IS_COMP_BLANKINGSRCE_INSTANCE(INSTANCE, BLANKINGSRCE) \
    (((((INSTANCE) == COMP1) || ((INSTANCE) == COMP2))  &&     \
      (((BLANKINGSRCE) == COMP_BLANKINGSRCE_NONE)    ||        \
@@ -795,7 +1017,7 @@
   * @}
   */
 
-/** @defgroup COMPEx_ExtiLineEvent COMPEx_ExtiLineEvent (STM32F303xC/STM32F358xx Product devices)
+/** @defgroup COMPEx_ExtiLineEvent COMP Extended EXTI Line Event (STM32F303xE/STM32F398xx/STM32F303xC/STM32F358xx Product devices)
   *        Elements values convention: XXXXZYYY
   *           - XXXX : Interrupt mask in the register list where Z equal 0x0
   *           - YYY : Interrupt mask in the register list where Z equal 0x1
@@ -817,10 +1039,11 @@
 /**
   * @}
   */
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
 #if defined(STM32F373xC) ||defined(STM32F378xx)
-/** @defgroup COMPEx_BlankingSrce COMPEx_BlankingSrce (STM32F373xC/STM32F378xx Product devices)
+/** @defgroup COMPEx_BlankingSrce COMP Extended Blanking Source (STM32F373xC/STM32F378xx Product devices)
   * @{
   */
 /* No blanking source can be selected for all comparators */
@@ -839,7 +1062,7 @@
   * @}
   */
 
-/** @defgroup COMPEx_ExtiLineEvent COMPEx_ExtiLineEvent (STM32F373xC/STM32F378xx Product devices)
+/** @defgroup COMPEx_ExtiLineEvent COMP Extended EXTI Line Event (STM32F373xC/STM32F378xx Product devices)
   *        Elements values convention: XXXX0000
   *           - XXXX : Interrupt mask in the EMR/IMR/RTSR/FTSR register
   * @{   
@@ -874,6 +1097,9 @@
   */
 
 /* Exported macro ------------------------------------------------------------*/
+/** @defgroup USARTEx_Exported_Macros USART Extended Exported Macros
+  * @{
+  */
 #if defined(STM32F373xC) ||defined(STM32F378xx)
 /**
   * @brief  Checks whether the specified EXTI line flag is set or not.
@@ -1198,7 +1424,8 @@
 #endif /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
        /* STM32F303x8 || STM32F334x8 || STM32F328xx */
 
-#if defined(STM32F302xC)
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC)
 /**
   * @brief  Get the specified EXTI line for a comparator instance
   * @param  __INSTANCE__: specifies the COMP instance.
@@ -1208,9 +1435,11 @@
                                                 ((__INSTANCE__) == COMP2) ? COMP_EXTI_LINE_COMP2_EVENT : \
                                                 ((__INSTANCE__) == COMP4) ? COMP_EXTI_LINE_COMP4_EVENT : \
                                                 COMP_EXTI_LINE_COMP6_EVENT)
-#endif /* STM32F302xC */
+#endif /* STM32F302xE || */
+       /* STM32F302xC    */
    
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 /**
   * @brief  Get the specified EXTI line for a comparator instance
   * @param  __INSTANCE__: specifies the COMP instance.
@@ -1223,7 +1452,8 @@
                                                 ((__INSTANCE__) == COMP5) ? COMP_EXTI_LINE_COMP5_EVENT : \
                                                 ((__INSTANCE__) == COMP6) ? COMP_EXTI_LINE_COMP6_EVENT : \
                                                 COMP_EXTI_LINE_COMP7_EVENT)
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
                                                  
 #if defined(STM32F373xC) ||defined(STM32F378xx)
 /**
@@ -1235,7 +1465,10 @@
                                                 COMP_EXTI_LINE_COMP2_EVENT)
 #endif /* STM32F373xC || STM32F378xx */
 
-                                                 
+/**
+  * @}
+  */
+  
 /* Exported functions --------------------------------------------------------*/
 
 /* Initialization and de-initialization functions  ****************************/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_conf.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_conf.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_conf.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   HAL configuration file.
   ******************************************************************************
   * @attention
@@ -60,6 +60,10 @@
 #define HAL_DAC_MODULE_ENABLED
 #define HAL_DMA_MODULE_ENABLED
 #define HAL_FLASH_MODULE_ENABLED
+#define HAL_SRAM_MODULE_ENABLED
+#define HAL_NOR_MODULE_ENABLED
+#define HAL_NAND_MODULE_ENABLED
+#define HAL_PCCARD_MODULE_ENABLED
 #define HAL_GPIO_MODULE_ENABLED
 #define HAL_HRTIM_MODULE_ENABLED
 #define HAL_I2C_MODULE_ENABLED
@@ -212,6 +216,22 @@
  #include "stm32f3xx_hal_flash.h"
 #endif /* HAL_FLASH_MODULE_ENABLED */
 
+#ifdef HAL_SRAM_MODULE_ENABLED
+  #include "stm32f3xx_hal_sram.h"
+#endif /* HAL_SRAM_MODULE_ENABLED */
+
+#ifdef HAL_NOR_MODULE_ENABLED
+  #include "stm32f3xx_hal_nor.h"
+#endif /* HAL_NOR_MODULE_ENABLED */
+
+#ifdef HAL_NAND_MODULE_ENABLED
+  #include "stm32f3xx_hal_nand.h"
+#endif /* HAL_NAND_MODULE_ENABLED */
+
+#ifdef HAL_PCCARD_MODULE_ENABLED
+  #include "stm32f3xx_hal_pccard.h"
+#endif /* HAL_PCCARD_MODULE_ENABLED */ 
+  
 #ifdef HAL_HRTIM_MODULE_ENABLED
  #include "stm32f3xx_hal_hrtim.h"
 #endif /* HAL_HRTIM_MODULE_ENABLED */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_cortex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_cortex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_cortex.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   CORTEX HAL module driver.
   *
   *          This file provides firmware functions to manage the following
@@ -128,7 +128,7 @@
   * @{
   */
 
-/** @defgroup CORTEX
+/** @defgroup CORTEX CORTEX HAL module driver
   * @brief CORTEX HAL module driver
   * @{
   */
@@ -140,14 +140,14 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
 
-/** @defgroup CORTEX_Private_Functions
+/** @defgroup CORTEX_Exported_Functions CORTEX Exported Functions
   * @{
   */
 
 
-/** @defgroup HAL_CORTEX_Group1 Initialization/de-initialization functions
+/** @defgroup CORTEX_Exported_Functions_Group1 Initialization and de-initialization functions
  *  @brief    Initialization and Configuration functions
  *
 @verbatim
@@ -247,7 +247,6 @@ void HAL_NVIC_DisableIRQ(IRQn_Type IRQn)
 
 /**
   * @brief  Initiates a system reset request to reset the MCU.
-  * @param None
   * @retval None
   */
 void HAL_NVIC_SystemReset(void)
@@ -271,7 +270,7 @@ uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb)
   * @}
   */
 
-/** @defgroup HAL_CORTEX_Group2 Peripheral Control functions
+/** @defgroup CORTEX_Exported_Functions_Group2 Peripheral Control functions
  *  @brief   Cortex control functions
  *
 @verbatim
@@ -289,7 +288,6 @@ uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb)
 
 /**
   * @brief  Gets the priority grouping field from the NVIC Interrupt Controller.
-  * @param  None
   * @retval Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field)
   */
 uint32_t HAL_NVIC_GetPriorityGrouping(void)
@@ -393,7 +391,7 @@ uint32_t HAL_NVIC_GetActive(IRQn_Type IRQn)
 void HAL_SYSTICK_CLKSourceConfig(uint32_t CLKSource)
 {
   /* Check the parameters */
-  assert_param(IS_SYSTICK_CLKSOURCE(CLKSource));
+  assert_param(IS_SYSTICK_CLK_SOURCE(CLKSource));
   if (CLKSource == SYSTICK_CLKSOURCE_HCLK)
   {
     SysTick->CTRL |= SYSTICK_CLKSOURCE_HCLK;
@@ -406,7 +404,6 @@ void HAL_SYSTICK_CLKSourceConfig(uint32_t CLKSource)
 
 /**
   * @brief  This function handles SYSTICK interrupt request.
-  * @param  None
   * @retval None
   */
 void HAL_SYSTICK_IRQHandler(void)
@@ -416,7 +413,6 @@ void HAL_SYSTICK_IRQHandler(void)
 
 /**
   * @brief  SYSTICK callback.
-  * @param  None
   * @retval None
   */
 __weak void HAL_SYSTICK_Callback(void)

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_cortex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_cortex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_cortex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of CORTEX HAL module.
   ******************************************************************************
   * @attention
@@ -56,12 +56,11 @@
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
 
-/** @defgroup CORTEX_Exported_Constants
+/** @defgroup CORTEX_Exported_Constants CORTEX Exported Constants
   * @{
   */
 
-
-/** @defgroup CORTEX_Preemption_Priority_Group 
+/** @defgroup CORTEX_Preemption_Priority_Group CORTEX Preemption Priority Group
   * @{
   */
 
@@ -90,13 +89,13 @@
   * @}
   */
 
-/** @defgroup CORTEX_SysTick_clock_source 
+/** @defgroup CORTEX_SysTick_clock_source CORTEX _SysTick clock source 
   * @{
   */
 #define SYSTICK_CLKSOURCE_HCLK_DIV8    ((uint32_t)0x00000000)
 #define SYSTICK_CLKSOURCE_HCLK         ((uint32_t)0x00000004)
-#define IS_SYSTICK_CLKSOURCE(SOURCE) (((SOURCE) == SYSTICK_CLKSOURCE_HCLK) || \
-                                      ((SOURCE) == SYSTICK_CLKSOURCE_HCLK_DIV8))
+#define IS_SYSTICK_CLK_SOURCE(SOURCE) (((SOURCE) == SYSTICK_CLKSOURCE_HCLK) || \
+                                       ((SOURCE) == SYSTICK_CLKSOURCE_HCLK_DIV8))
 /**
   * @}
   */
@@ -107,7 +106,10 @@
 
 
 /* Exported Macros -----------------------------------------------------------*/
-
+/** @defgroup CORTEX_Exported_Macros CORTEX Exported Macros
+  * @{
+  */
+  
 /** @brief Configures the SysTick clock source.
   * @param __CLKSRC__: specifies the SysTick clock source.
   *   This parameter can be one of the following values:
@@ -124,9 +126,19 @@
                                  else                                          \
                                     SysTick->CTRL &= ~SYSTICK_CLKSOURCE_HCLK;  \
                                 } while(0)
-
-/* Exported macro ------------------------------------------------------------*/
+/**
+  * @}
+  */
+  
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup CORTEX_Exported_Functions CORTEX Exported Functions
+  * @{
+  */
+  
+/** @addtogroup CORTEX_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions
+ * @{
+ */
 /* Initialization and de-initialization functions *****************************/
 void HAL_NVIC_SetPriorityGrouping(uint32_t PriorityGroup);
 void HAL_NVIC_SetPriority(IRQn_Type IRQn, uint32_t PreemptPriority, uint32_t SubPriority);
@@ -134,7 +146,14 @@ void HAL_NVIC_EnableIRQ(IRQn_Type IRQn);
 void HAL_NVIC_DisableIRQ(IRQn_Type IRQn);
 void HAL_NVIC_SystemReset(void);
 uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb);
-
+/**
+  * @}
+  */
+  
+/** @addtogroup CORTEX_Exported_Functions_Group2 Peripheral Control functions
+ *  @brief   Cortex control functions
+ * @{
+ */
 /* Peripheral Control functions ***********************************************/
 uint32_t HAL_NVIC_GetPriorityGrouping(void);
 void HAL_NVIC_GetPriority(IRQn_Type IRQn, uint32_t PriorityGroup, uint32_t* pPreemptPriority, uint32_t* pSubPriority);
@@ -145,6 +164,13 @@ uint32_t HAL_NVIC_GetActive(IRQn_Type IRQn);
 void HAL_SYSTICK_CLKSourceConfig(uint32_t CLKSource);
 void HAL_SYSTICK_IRQHandler(void);
 void HAL_SYSTICK_Callback(void);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_crc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_crc.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_crc.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   CRC HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -68,7 +68,7 @@
   * @{
   */
 
-/** @defgroup CRC 
+/** @defgroup CRC CRC HAL module driver
   * @brief CRC HAL module driver.
   * @{
   */
@@ -80,14 +80,15 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
 static uint32_t CRC_Handle_8(CRC_HandleTypeDef *hcrc, uint8_t pBuffer[], uint32_t BufferLength);
 static uint32_t CRC_Handle_16(CRC_HandleTypeDef *hcrc, uint16_t pBuffer[], uint32_t BufferLength);
-/** @defgroup CRC_Private_Functions
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup CRC_Exported_Functions CRC Exported Functions
   * @{
   */
 
-/** @defgroup HAL_CRC_Group1 Initialization/de-initialization functions 
+/** @defgroup CRC_Exported_Functions_Group1 Initialization and de-initialization functions
  *  @brief    Initialization and Configuration functions. 
  *
 @verbatim    
@@ -114,7 +115,7 @@ static uint32_t CRC_Handle_16(CRC_HandleTypeDef *hcrc, uint16_t pBuffer[], uint3
 HAL_StatusTypeDef HAL_CRC_Init(CRC_HandleTypeDef *hcrc)
 {
   /* Check the CRC handle allocation */
-  if(hcrc == NULL)
+  if(hcrc == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -188,7 +189,7 @@ HAL_StatusTypeDef HAL_CRC_Init(CRC_HandleTypeDef *hcrc)
 HAL_StatusTypeDef HAL_CRC_DeInit(CRC_HandleTypeDef *hcrc)
 { 
   /* Check the CRC handle allocation */
-  if(hcrc == NULL)
+  if(hcrc == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -246,7 +247,7 @@ __weak void HAL_CRC_MspDeInit(CRC_HandleTypeDef *hcrc)
   * @}
   */
 
-/** @defgroup HAL_CRC_Group2 Peripheral Control functions 
+/** @defgroup CRC_Exported_Functions_Group2 Peripheral Control functions 
  *  @brief    management functions. 
  *
 @verbatim   
@@ -372,9 +373,48 @@ uint32_t HAL_CRC_Calculate(CRC_HandleTypeDef *hcrc, uint32_t pBuffer[], uint32_t
   /* Return the CRC computed value */ 
   return temp;
 }
+  
+/**
+  * @}
+  */
+
+/** @defgroup CRC_Exported_Functions_Group3 Peripheral State functions 
+ *  @brief    Peripheral State functions. 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral State functions #####
+ ===============================================================================  
+    [..]
+    This subsection permits to get in run-time the status of the peripheral 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Returns the CRC state.
+  * @param  hcrc: CRC handle
+  * @retval HAL state
+  */
+HAL_CRC_StateTypeDef HAL_CRC_GetState(CRC_HandleTypeDef *hcrc)
+{
+  return hcrc->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 
-
+/** @defgroup CRC_Private_Functions CRC Private Functions
+  * @{
+  */
 /**             
   * @brief  Enter 8-bit input data to the CRC calculator.
   *         Specific data handling to optimize processing time.  
@@ -445,39 +485,6 @@ static uint32_t CRC_Handle_16(CRC_HandleTypeDef *hcrc, uint16_t pBuffer[], uint3
   /* Return the CRC computed value */ 
   return hcrc->Instance->DR;
 }
-
-/**
-  * @}
-  */
-
-/** @defgroup HAL_CRC_Group3 Peripheral State functions 
- *  @brief    Peripheral State functions. 
- *
-@verbatim   
- ===============================================================================
-                      ##### Peripheral State functions #####
- ===============================================================================  
-    [..]
-    This subsection permits to get in run-time the status of the peripheral 
-    and the data flow.
-
-@endverbatim
-  * @{
-  */
-
-/**
-  * @brief  Returns the CRC state.
-  * @param  hcrc: CRC handle
-  * @retval HAL state
-  */
-HAL_CRC_StateTypeDef HAL_CRC_GetState(CRC_HandleTypeDef *hcrc)
-{
-  return hcrc->State;
-}
-
-/**
-  * @}
-  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_crc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_crc.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_crc.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of CRC HAL module.
   ******************************************************************************
   * @attention
@@ -55,7 +55,10 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
-
+/** @defgroup CRC_Exported_Types CRC Exported Types
+  * @{
+  */
+  
 /** 
   * @brief  CRC HAL State Structure definition  
   */ 
@@ -136,8 +139,15 @@ typedef struct
                                            must occur if InputBufferFormat is not one of the three values listed above  */ 
 }CRC_HandleTypeDef;
 
+/**
+  * @}
+  */
+  
 /* Exported constants --------------------------------------------------------*/
-
+/** @defgroup CRC_Exported_Constants CRC Exported Constants
+  * @{
+  */
+  
 /** @defgroup CRC_Default_Polynomial_Value    Default CRC generating polynomial
   * @{
   */
@@ -228,9 +238,13 @@ typedef struct
   * @}
   */   
 
+/**
+  * @}
+  */
+  
 /* Exported macros -----------------------------------------------------------*/
 
-/** @defgroup CRC_Exported_Macros
+/** @defgroup CRC_Exported_Macros CRC Exported Macros
   * @{
   */
 
@@ -260,27 +274,62 @@ typedef struct
   */
 
 
-/* Include CRC HAL Extension module */
+/* Include CRC HAL Extended module */
 #include "stm32f3xx_hal_crc_ex.h"
 
 /* Exported functions --------------------------------------------------------*/
-
+/** @addtogroup CRC_Exported_Functions CRC Exported Functions
+  * @{
+  */
+  
+/** @addtogroup CRC_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions. 
+ * @{
+ */
 /* Initialization and de-initialization functions  ****************************/
 HAL_StatusTypeDef HAL_CRC_Init(CRC_HandleTypeDef *hcrc);
 HAL_StatusTypeDef HAL_CRC_DeInit (CRC_HandleTypeDef *hcrc);
 void HAL_CRC_MspInit(CRC_HandleTypeDef *hcrc);
 void HAL_CRC_MspDeInit(CRC_HandleTypeDef *hcrc);
-/* Aliases for inter STM32 series compatibility */
-#define HAL_CRC_Input_Data_Reverse   HAL_CRCEx_Input_Data_Reverse
-#define HAL_CRC_Output_Data_Reverse  HAL_CRCEx_Output_Data_Reverse
-
+/**
+  * @}
+  */
+  
+/** @addtogroup CRC_Exported_Functions_Group2 Peripheral Control functions 
+ *  @brief    management functions. 
+ * @{
+ */
 /* Peripheral Control functions ***********************************************/
 uint32_t HAL_CRC_Accumulate(CRC_HandleTypeDef *hcrc, uint32_t pBuffer[], uint32_t BufferLength);
 uint32_t HAL_CRC_Calculate(CRC_HandleTypeDef *hcrc, uint32_t pBuffer[], uint32_t BufferLength);
-
+/**
+  * @}
+  */
+  
+/** @addtogroup CRC_Exported_Functions_Group3 Peripheral State functions 
+ *  @brief    Peripheral State functions. 
+ * @{
+ */
 /* Peripheral State and Error functions ***************************************/
 HAL_CRC_StateTypeDef HAL_CRC_GetState(CRC_HandleTypeDef *hcrc);
+/**
+  * @}
+  */
 
+/**
+  * @}
+  */
+
+  /** @defgroup HAL_CRC_Alias_Exported_Functions CRC aliases for Exported Functions 
+ * @{
+ */
+/* Aliases for inter STM32 series compatibility */
+#define HAL_CRC_Input_Data_Reverse   HAL_CRCEx_Input_Data_Reverse
+#define HAL_CRC_Output_Data_Reverse  HAL_CRCEx_Output_Data_Reverse
+/**
+  * @}
+  */
+  
 /**
   * @}
   */ 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_crc_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_crc_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_crc_ex.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Extended CRC HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -85,7 +85,7 @@
   * @{
   */
 
-/** @defgroup CRCEx
+/** @defgroup CRCEx CRC Extended HAL module driver
   * @brief CRC Extended HAL module driver
   * @{
   */
@@ -97,13 +97,13 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
 
-/** @defgroup CRCEx_Private_Functions
+/** @defgroup CRCEx_Exported_Functions CRC Extended Exported Functions
   * @{
   */
 
-/** @defgroup CRCEx_Group1 Extended Initialization/de-initialization functions
+/** @defgroup CRCEx_Exported_Functions_Group1 Extended Initialization and de-initialization functions
   * @brief    Extended Initialization and Configuration functions.
   *
 @verbatim    

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_crc_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_crc_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_crc_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of CRC HAL extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of CRC HAL Extended module.
   ******************************************************************************
   * @attention
   *
@@ -56,8 +56,11 @@
 
 /* Exported types ------------------------------------------------------------*/ 
 /* Exported constants --------------------------------------------------------*/
-
-/** @defgroup CRCEx_Input_Data_Inversion Input Data Inversion Modes
+/** @defgroup CRCEx_Exported_Constants CRC Extended Exported Constants
+  * @{
+  */
+  
+/** @defgroup CRCEx_Input_Data_Inversion CRC Extended Input Data Inversion Modes
   * @{
   */
 #define CRC_INPUTDATA_INVERSION_NONE              ((uint32_t)0x00000000)
@@ -73,7 +76,7 @@
   * @}
   */
 
-/** @defgroup CRCEx_Output_Data_Inversion Output Data Inversion Modes
+/** @defgroup CRCEx_Output_Data_Inversion CRC Extended Output Data Inversion Modes
   * @{
   */
 #define CRC_OUTPUTDATA_INVERSION_DISABLED         ((uint32_t)0x00000000)
@@ -84,10 +87,14 @@
 /**                                               
   * @}
   */
-
+  
+/**
+  * @}
+  */
+  
 /* Exported macro ------------------------------------------------------------*/
 
-/** @defgroup CRCEx_Exported_Macros
+/** @defgroup CRCEx_Exported_Macros CRC Extended Exported Macros
   * @{
   */
     
@@ -118,14 +125,28 @@
   */
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup CRCEx_Exported_Functions CRC Extended Exported Functions
+  * @{
+  */
+
+/** @addtogroup CRCEx_Exported_Functions_Group1 Extended Initialization and de-initialization functions
+  * @brief    Extended Initialization and Configuration functions.
+  * @{
+  */
 /* Initialization and de-initialization functions  ****************************/
 HAL_StatusTypeDef HAL_CRCEx_Polynomial_Set(CRC_HandleTypeDef *hcrc, uint32_t Pol, uint32_t PolyLength);
 HAL_StatusTypeDef HAL_CRCEx_Input_Data_Reverse(CRC_HandleTypeDef *hcrc, uint32_t InputReverseMode);
 HAL_StatusTypeDef HAL_CRCEx_Output_Data_Reverse(CRC_HandleTypeDef *hcrc, uint32_t OutputReverseMode);
+/**
+  * @}
+  */
 
 /* Peripheral Control functions ***********************************************/
 /* Peripheral State and Error functions ***************************************/
 
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_dac.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_dac.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_dac.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   This file provides firmware functions to manage the following 
   *          functionalities of the Digital-to-Analog Converter (DAC) peripheral: 
   *           + DAC channels configuration: trigger, output buffer, data format
@@ -206,8 +206,8 @@
   * @{
   */
 
-/** @defgroup DAC 
-  * @brief DAC driver modules
+/** @defgroup DAC DAC HAL module driver
+  * @brief DAC HAL module driver
   * @{
   */ 
  
@@ -219,13 +219,12 @@
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
     
-/* Private functions ---------------------------------------------------------*/
-
-/** @defgroup DAC_Private_Functions
+/* Exported functions ---------------------------------------------------------*/
+/** @defgroup DAC_Exported_Functions DAC Exported Functions
   * @{
   */
 
-/** @defgroup DAC_Group1 Initialization and de-initialization functions 
+/** @defgroup DAC_Exported_Functions_Group1 Initialization and de-initialization functions 
  *  @brief    Initialization and Configuration functions 
  *
 @verbatim    
@@ -250,7 +249,7 @@
 HAL_StatusTypeDef HAL_DAC_Init(DAC_HandleTypeDef* hdac)
 { 
   /* Check DAC handle */
-  if(hdac == NULL)
+  if(hdac == HAL_NULL)
   {
      return HAL_ERROR;
   }
@@ -285,7 +284,7 @@ HAL_StatusTypeDef HAL_DAC_Init(DAC_HandleTypeDef* hdac)
 HAL_StatusTypeDef HAL_DAC_DeInit(DAC_HandleTypeDef* hdac)
 {
   /* Check DAC handle */
-  if(hdac == NULL)
+  if(hdac == HAL_NULL)
   {
      return HAL_ERROR;
   }
@@ -342,7 +341,7 @@ __weak void HAL_DAC_MspDeInit(DAC_HandleTypeDef* hdac)
   * @}
   */
 
-/** @defgroup DAC_Group2 IO operation functions
+/** @defgroup DAC_Exported_Functions_Group2 Input and Output operation functions
  *  @brief    IO operation functions 
  *
 @verbatim   
@@ -379,7 +378,7 @@ __weak HAL_StatusTypeDef HAL_DAC_Start(DAC_HandleTypeDef* hdac, uint32_t channel
   /*        Function content is located into file stm32f3xx_hal_dac_ex.c  */
   
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
 
 /**
@@ -500,7 +499,7 @@ __weak uint32_t HAL_DACEx_DualGetValue(DAC_HandleTypeDef* hdac)
   * @}
   */
   
-/** @defgroup DAC_Group3 Peripheral Control functions
+/** @defgroup DAC_Exported_Functions_Group3 Peripheral Control functions
  *  @brief    Peripheral Control functions 
  *
 @verbatim   
@@ -576,7 +575,7 @@ __weak HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef* hdac, uint32_t chan
   /*        Function content is located into file stm32f3xx_hal_dac_ex.c  */
 
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
 
 __weak HAL_StatusTypeDef HAL_DACEx_DualSetValue(DAC_HandleTypeDef* hdac, uint32_t alignment, uint32_t data1, uint32_t data2)
@@ -585,19 +584,19 @@ __weak HAL_StatusTypeDef HAL_DACEx_DualSetValue(DAC_HandleTypeDef* hdac, uint32_
   /*        Function content is located into file stm32f3xx_hal_dac_ex.c  */
 
   /* Return function status */
-  return HAL_OK;
+  return HAL_ERROR;
 }
 
 /**
   * @}
   */
 
-/** @defgroup DAC_Group4 DAC Peripheral State functions
- *  @brief   DAC Peripheral State functions 
+/** @defgroup DAC_Exported_Functions_Group4 Peripheral State and Error functions
+ *  @brief   DAC Peripheral State and Error functions 
  *
 @verbatim   
   ==============================================================================
-            ##### DAC Peripheral State functions #####
+            ##### DAC Peripheral State and Error functions #####
   ==============================================================================  
     [..]
     This subsection provides functions allowing to
@@ -634,6 +633,10 @@ uint32_t HAL_DAC_GetError(DAC_HandleTypeDef *hdac)
 
 /**
   * @}
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group2 Input and Output operation functions
+  * @{
   */
 
 /**
@@ -689,6 +692,9 @@ __weak void HAL_DAC_DMAUnderrunCallbackCh1(DAC_HandleTypeDef *hdac)
    */
 }
 
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_dac.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_dac.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_dac.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of DAC HAL module.
   ******************************************************************************
   * @attention
@@ -50,11 +50,14 @@
   * @{
   */
 
-/** @addtogroup DAC
+/** @addtogroup DAC DAC HAL module driver
   * @{
   */
 
 /* Exported types ------------------------------------------------------------*/
+/** @defgroup DAC_Exported_Types DAC Exported Types
+  * @{
+  */
 
 /** 
   * @brief  HAL State structures definition  
@@ -101,10 +104,16 @@ typedef struct __DAC_HandleTypeDef
   __IO uint32_t               ErrorCode;     /*!< DAC Error code                    */
   
 }DAC_HandleTypeDef;
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
+/** @defgroup DAC_Exported_Constants DAC Exported Contants
+  * @{
+  */
 
-/** @defgroup DAC_Error_Code
+/** @defgroup DAC_Error_Code DAC Error Code
   * @{
   */
 #define  HAL_DAC_ERROR_NONE              0x00    /*!< No error                          */
@@ -115,7 +124,7 @@ typedef struct __DAC_HandleTypeDef
   * @}
   */
 
-/** @defgroup DAC_wave_generation 
+/** @defgroup DAC_wave_generation DAC wave generation
   * @{
   */
 #define DAC_WAVEGENERATION_NONE            ((uint32_t)0x00000000)
@@ -129,7 +138,7 @@ typedef struct __DAC_HandleTypeDef
   * @}
   */
 
-/** @defgroup DAC_lfsrunmask_triangleamplitude
+/** @defgroup DAC_lfsrunmask_triangleamplitude DAC lfsrunmask triangleamplitude
   * @{
   */
 #define DAC_LFSRUNMASK_BIT0                ((uint32_t)0x00000000) /*!< Unmask DAC channel LFSR bit0 for noise wave generation */
@@ -185,7 +194,7 @@ typedef struct __DAC_HandleTypeDef
   * @}
   */
 
-/** @defgroup DAC_output_buffer 
+/** @defgroup DAC_output_buffer DAC output buffer
   * @{
   */
 #define DAC_OUTPUTBUFFER_ENABLE            ((uint32_t)0x00000000)
@@ -197,7 +206,7 @@ typedef struct __DAC_HandleTypeDef
   * @}
   */
 
-/** @defgroup DAC_data_alignement 
+/** @defgroup DAC_data_alignement DAC data alignement
   * @{
   */
 #define DAC_ALIGN_12B_R                    ((uint32_t)0x00000000)
@@ -211,7 +220,7 @@ typedef struct __DAC_HandleTypeDef
   * @}
   */
 
-/** @defgroup DAC_wave_generation 
+/** @defgroup DAC_wave_generation DAC wave generation
   * @{
   */
 #define DAC_WAVE_NOISE                     ((uint32_t)DAC_CR_WAVE1_0)
@@ -223,7 +232,7 @@ typedef struct __DAC_HandleTypeDef
   * @}
   */
 
-/** @defgroup DAC_data 
+/** @defgroup DAC_data DAC data
   * @{
   */
 #define IS_DAC_DATA(DATA) ((DATA) <= 0xFFF0) 
@@ -231,7 +240,7 @@ typedef struct __DAC_HandleTypeDef
   * @}
   */
 
-/** @defgroup DAC_flags_definition 
+/** @defgroup DAC_flags_definition DAC flags definition
   * @{
   */ 
 #define DAC_FLAG_DMAUDR1                   ((uint32_t)DAC_SR_DMAUDR1)
@@ -243,7 +252,7 @@ typedef struct __DAC_HandleTypeDef
   * @}
   */
 
-/** @defgroup DAC_interrupts_definition 
+/** @defgroup DAC_interrupts_definition DAC interrupts definition
   * @{
   */ 
 #define DAC_IT_DMAUDR1                   ((uint32_t)DAC_CR_DMAUDRIE1)
@@ -257,7 +266,14 @@ typedef struct __DAC_HandleTypeDef
   * @}
   */
 
+/**
+  * @}
+  */
+
 /* Exported macros -----------------------------------------------------------*/
+/** @defgroup DAC_Exported_Macros DAC Exported Macros
+  * @{
+  */
 
 /** @brief Reset DAC handle state
   * @param  __HANDLE__: DAC handle.
@@ -294,36 +310,75 @@ typedef struct __DAC_HandleTypeDef
 /* Clear the DAC's flag */
 #define __HAL_DAC_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->SR) = (__FLAG__))
 
-/* Include DAC HAL Extension module */
+/**
+  * @}
+  */
+
+/* Include DAC HAL Extended module */
 #include "stm32f3xx_hal_dac_ex.h" 
 
 /* Exported functions --------------------------------------------------------*/  
+/** @addtogroup DAC_Exported_Functions DAC Exported Functions
+  * @{
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group1 Initialization and de-initialization functions 
+  * @{
+  */
 /* Initialization and de-initialization functions *****************************/ 
 HAL_StatusTypeDef HAL_DAC_Init(DAC_HandleTypeDef* hdac);
 HAL_StatusTypeDef HAL_DAC_DeInit(DAC_HandleTypeDef* hdac);
 void HAL_DAC_MspInit(DAC_HandleTypeDef* hdac);
 void HAL_DAC_MspDeInit(DAC_HandleTypeDef* hdac);
 
+/**
+  * @}
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef HAL_DAC_Start(DAC_HandleTypeDef* hdac, uint32_t channel);
 HAL_StatusTypeDef HAL_DAC_Stop(DAC_HandleTypeDef* hdac, uint32_t channel);
 HAL_StatusTypeDef HAL_DAC_Start_DMA(DAC_HandleTypeDef* hdac, uint32_t channel, uint32_t* pData, uint32_t Length, uint32_t alignment);
 HAL_StatusTypeDef HAL_DAC_Stop_DMA(DAC_HandleTypeDef* hdac, uint32_t channel);
 uint32_t HAL_DAC_GetValue(DAC_HandleTypeDef* hdac, uint32_t channel);
-
-/* Peripheral Control functions ***********************************************/
-HAL_StatusTypeDef HAL_DAC_ConfigChannel(DAC_HandleTypeDef* hdac, DAC_ChannelConfTypeDef* sConfig, uint32_t channel);
-HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef* hdac, uint32_t channel, uint32_t alignment, uint32_t data);
-
-/* Peripheral State and Error functions ***************************************/
-HAL_DAC_StateTypeDef HAL_DAC_GetState(DAC_HandleTypeDef* hdac);
 void HAL_DAC_IRQHandler(DAC_HandleTypeDef* hdac);
-uint32_t HAL_DAC_GetError(DAC_HandleTypeDef *hdac);
-
 void HAL_DAC_ConvCpltCallbackCh1(DAC_HandleTypeDef* hdac);
 void HAL_DAC_ConvHalfCpltCallbackCh1(DAC_HandleTypeDef* hdac);
 void HAL_DAC_ErrorCallbackCh1(DAC_HandleTypeDef *hdac);
 void HAL_DAC_DMAUnderrunCallbackCh1(DAC_HandleTypeDef *hdac);
+
+/**
+  * @}
+  */
+  
+/** @addtogroup DAC_Exported_Functions_Group3 Peripheral Control functions
+  * @{
+  */
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef HAL_DAC_ConfigChannel(DAC_HandleTypeDef* hdac, DAC_ChannelConfTypeDef* sConfig, uint32_t channel);
+HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef* hdac, uint32_t channel, uint32_t alignment, uint32_t data);
+
+/**
+  * @}
+  */
+
+/** @addtogroup DAC_Exported_Functions_Group4 Peripheral State and Error functions
+  * @{
+  */
+/* Peripheral State and Error functions ***************************************/
+HAL_DAC_StateTypeDef HAL_DAC_GetState(DAC_HandleTypeDef* hdac);
+uint32_t HAL_DAC_GetError(DAC_HandleTypeDef *hdac);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_dac_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_dac_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_dac_ex.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Extended DAC HAL module driver.
   *
   *          This file provides firmware functions to manage the following
@@ -50,37 +50,56 @@
   * @{
   */
 
-/** @addtogroup DAC
+#ifdef HAL_DAC_MODULE_ENABLED
+
+/** @defgroup DACEx DAC Extended HAL module driver
   * @brief DAC HAL module driver
   * @{
   */
-
-#ifdef HAL_DAC_MODULE_ENABLED
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-
+/** @defgroup DACEx_Private_Functions DAC Extended Private Functions
+  * @{
+  */
 static void DAC_DMAConvCpltCh1(DMA_HandleTypeDef *hdma);
 static void DAC_DMAErrorCh1(DMA_HandleTypeDef *hdma);
 static void DAC_DMAHalfConvCpltCh1(DMA_HandleTypeDef *hdma); 
 
-#if defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8) || defined(STM32F373xC) || defined(STM32F378xx) 
+#if defined(STM32F303xE) || defined(STM32F398xx)                         || \
+    defined(STM32F303xC) || defined(STM32F358xx)                         || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx) 
 /* DAC channel 2 is available on top of DAC channel 1 */
 static void DAC_DMAConvCpltCh2(DMA_HandleTypeDef *hdma);
 static void DAC_DMAErrorCh2(DMA_HandleTypeDef *hdma);
 static void DAC_DMAHalfConvCpltCh2(DMA_HandleTypeDef *hdma); 
-#endif /* STM32F303xC STM32F358xx STM32F303x8 STM32F328xx STM32F302xC STM32F334x8 STM32F373xC STM32F378xx */
+#endif /* STM32F303xE || STM32F398xx                || */
+       /* STM32F303xC || STM32F358xx                || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F373xC || STM32F378xx                   */
+/**
+  * @}
+  */
 
-/* Private functions ---------------------------------------------------------*/
+/**
+  * @}
+  */
 
-/** @addtogroup DAC_Private_Functions
+/** @addtogroup DAC DAC HAL module driver
+  * @brief DAC HAL module driver
+  * @{
+  */ 
+
+/* Exported functions ---------------------------------------------------------*/
+/** @addtogroup DAC_Exported_Functions DAC Exported Functions
   * @{
   */
 
-/** @defgroup DAC_Group3 Peripheral Control functions
+/** @addtogroup DAC_Exported_Functions_Group3 Peripheral Control functions
  *  @brief   	Peripheral Control functions 
  *
 @verbatim   
@@ -119,21 +138,24 @@ HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef* hdac, uint32_t channel, ui
   tmp = (uint32_t) (hdac->Instance);
 
 /* DAC 1 has 1 or 2 channels - no DAC2 */
-#if defined(STM32F302xC) ||  defined(STM32F302x8) || defined(STM32F301x8) ||  defined(STM32F318xx) || defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F328xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F373xC) || defined(STM32F378xx)
 /* DAC 1 has 2 channels 1 & 2 - DAC 2 has one channel 1 */
 
   if(channel == DAC_CHANNEL_1)
   {
     tmp += __HAL_DHR12R1_ALIGNEMENT(alignment);
   }
-
-#endif
-
+#if defined(STM32F303xE) || defined(STM32F398xx)                         || \
+    defined(STM32F303xC) || defined(STM32F358xx)                         || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
   else /* channel = DAC_CHANNEL_2  */
   {
     tmp += __HAL_DHR12R2_ALIGNEMENT(alignment);
   }
+#endif /* STM32F303xE || STM32F398xx                || */
+       /* STM32F303xC || STM32F358xx                || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
   /* Set the DAC channel1 selected data holding register */
   *(__IO uint32_t *) tmp = data;
@@ -146,7 +168,7 @@ HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef* hdac, uint32_t channel, ui
   * @}
   */
 
-/** @defgroup DAC_Group2 IO operation functions
+/** @addtogroup DAC_Exported_Functions_Group2 Input and Output operation functions
  *  @brief    IO operation functions 
  *
 @verbatim   
@@ -165,8 +187,10 @@ HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef* hdac, uint32_t channel, ui
   */
 
 /* DAC 1 has 2 channels 1 & 2 - DAC 2 has one channel 1 */
-#if  defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F373xC) || defined(STM32F378xx) || \
-     defined(STM32F303xC) || defined(STM32F358xx)
+#if  defined(STM32F303xE) || defined(STM32F398xx)                         || \
+     defined(STM32F303xC) || defined(STM32F358xx)                         || \
+     defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+     defined(STM32F373xC) || defined(STM32F378xx)
 /* DAC 1 has 2 channels 1 & 2 */
 
 /**
@@ -180,16 +204,6 @@ HAL_StatusTypeDef HAL_DAC_SetValue(DAC_HandleTypeDef* hdac, uint32_t channel, ui
   * @retval HAL status
   */
 
-/**
-  * @brief  Enables DAC and starts conversion of channel.
-  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
-  *         the configuration information for the specified DAC.
-  * @param  channel: The selected DAC channel. 
-  *          This parameter can be one of the following values:
-  *            @arg DAC_CHANNEL_1: DAC1 Channel1 selected
-  *            @arg DAC_CHANNEL_2: DAC1 Channel2 selected
-  * @retval HAL status
-  */
 HAL_StatusTypeDef HAL_DAC_Start(DAC_HandleTypeDef* hdac, uint32_t channel)
 {
   /* Check the parameters */
@@ -232,10 +246,26 @@ HAL_StatusTypeDef HAL_DAC_Start(DAC_HandleTypeDef* hdac, uint32_t channel)
   /* Return function status */
   return HAL_OK;
 }
-#endif
+#endif /* STM32F303xE || STM32F398xx                || */
+       /* STM32F303xC || STM32F358xx                || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
-#if defined(STM32F302xC) ||  defined(STM32F302x8) || defined(STM32F301x8) ||  defined(STM32F318xx)
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /* DAC 1 has 1 channels 1 */
+
+/**
+  * @brief  Enables DAC and starts conversion of channel.
+  * @param  hdac: pointer to a DAC_HandleTypeDef structure that contains
+  *         the configuration information for the specified DAC.
+  * @param  channel: The selected DAC channel. 
+  *          This parameter can be one of the following values:
+  *            @arg DAC_CHANNEL_1: DAC1 Channel1 selected
+  * @retval HAL status
+  */
+
 HAL_StatusTypeDef HAL_DAC_Start(DAC_HandleTypeDef* hdac, uint32_t channel)
 {
   /* Check the parameters */
@@ -266,11 +296,16 @@ HAL_StatusTypeDef HAL_DAC_Start(DAC_HandleTypeDef* hdac, uint32_t channel)
   /* Return function status */
   return HAL_OK;
 }
-#endif
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
 /* DAC 1 has 2 channels 1 & 2 - DAC 2 has one channel 1 */
-#if  defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F373xC) || defined(STM32F378xx) || defined(STM32F328xx) || \
-     defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx)                         || \
+    defined(STM32F303xC) || defined(STM32F358xx)                         || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
+    
 /* DAC 1 has 2 channels 1 & 2 */
 
 /**
@@ -404,10 +439,14 @@ HAL_StatusTypeDef HAL_DAC_Start_DMA(DAC_HandleTypeDef* hdac, uint32_t channel, u
   /* Return function status */
   return HAL_OK;
 }
+#endif /* STM32F303xE || STM32F398xx                || */
+       /* STM32F303xC || STM32F358xx                || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
-#endif
-
-#if defined(STM32F302xC) ||  defined(STM32F302x8) || defined(STM32F301x8) ||  defined(STM32F318xx)
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /* DAC 1 has 1 channels 1 */
 
 /**
@@ -488,11 +527,16 @@ HAL_StatusTypeDef HAL_DAC_Start_DMA(DAC_HandleTypeDef* hdac, uint32_t channel, u
   /* Return function status */
   return HAL_OK;
 }
-#endif
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
 /* DAC 1 has 2 channels 1 & 2 - DAC 2 has one channel 1 */
-#if  defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F373xC) || defined(STM32F378xx) ||  \
-     defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+#if  defined(STM32F303xE) || defined(STM32F398xx)                         || \
+     defined(STM32F303xC) || defined(STM32F358xx)                         || \
+     defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+     defined(STM32F373xC) || defined(STM32F378xx)
+     
 /* DAC 1 has 2 channels 1 & 2 */
 
 /**
@@ -533,9 +577,14 @@ uint32_t HAL_DAC_GetValue(DAC_HandleTypeDef* hdac, uint32_t channel)
   }
 }
 
-#endif
+#endif /* STM32F303xE || STM32F398xx                || */
+       /* STM32F303xC || STM32F358xx                || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
-#if defined(STM32F302x8) || defined(STM32F301x8) ||  defined(STM32F318xx)
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /* DAC 1 has 1 channel (channel 1)  */
 /**
   * @brief  Returns the last data output value of the selected DAC channel.
@@ -554,9 +603,13 @@ uint32_t HAL_DAC_GetValue(DAC_HandleTypeDef* hdac, uint32_t channel)
   /* Returns the DAC channel data output register value */
   return hdac->Instance->DOR1;
 }
-#endif
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /* DAC channel 2 is NOT available. Only DAC channel 1 is available */
 
 /**
@@ -587,9 +640,14 @@ void HAL_DAC_IRQHandler(struct __DAC_HandleTypeDef* hdac)
     HAL_DAC_DMAUnderrunCallbackCh1(hdac);
   }
 }
-#endif /* STM32F301x8 STM32F302x8 STM32F318xx */
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
-#if defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F303x8) || defined(STM32F328xx)|| defined(STM32F302xC) || defined(STM32F334x8) || defined(STM32F373xC) || defined(STM32F378xx) 
+#if  defined(STM32F303xE) || defined(STM32F398xx)                         || \
+     defined(STM32F303xC) || defined(STM32F358xx)                         || \
+     defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+     defined(STM32F373xC) || defined(STM32F378xx)
 /* DAC channel 2 is available on top of DAC channel 1 */
 
 /**
@@ -639,8 +697,14 @@ void HAL_DAC_IRQHandler(struct __DAC_HandleTypeDef* hdac)
     }
   }
 }
+#endif /* STM32F303xE || STM32F398xx                || */
+       /* STM32F303xC || STM32F358xx                || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
-#endif /* STM32F303xC STM32F358xx STM32F303x8 STM32F328xx STM32F302xC STM32F334x8 STM32F373xC STM32F378xx */
+/**
+  * @}
+  */
 
 /**
   * @}
@@ -650,16 +714,20 @@ void HAL_DAC_IRQHandler(struct __DAC_HandleTypeDef* hdac)
   * @}
   */
 
-/** @defgroup DACEx
+/** @addtogroup DACEx
   * @brief DACEx Extended HAL module driver
   * @{
   */
+/* Exported functions ---------------------------------------------------------*/
 
-/** @defgroup DACEx_Private_Functions
+/** @addtogroup DACEx_Exported_Functions DAC Extended Exported Functions
   * @{
   */
 
-#if  defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F373xC) || defined(STM32F378xx) || defined(STM32F303xC) || defined(STM32F358xx)
+#if  defined(STM32F303xE) || defined(STM32F398xx)                         || \
+     defined(STM32F303xC) || defined(STM32F358xx)                         || \
+     defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+     defined(STM32F373xC) || defined(STM32F378xx)
 /* DAC channel 2 is present in DAC 1 */
 /**
   * @brief  Set the specified data holding register value for dual DAC channel.
@@ -704,7 +772,10 @@ HAL_StatusTypeDef HAL_DACEx_DualSetValue(DAC_HandleTypeDef* hdac, uint32_t align
   /* Return function status */
   return HAL_OK;
 }
-#endif
+#endif /* STM32F303xE || STM32F398xx                || */
+       /* STM32F303xC || STM32F358xx                || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
 /**
   * @brief  Returns the last data output value of the selected DAC channel.
@@ -718,10 +789,17 @@ uint32_t HAL_DACEx_DualGetValue(DAC_HandleTypeDef* hdac)
 
   tmp |= hdac->Instance->DOR1;
 
-#if  defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F373xC) || defined(STM32F378xx) || defined(STM32F303xC) || defined(STM32F358xx)
+#if  defined(STM32F303xE) || defined(STM32F398xx)                         || \
+     defined(STM32F303xC) || defined(STM32F358xx)                         || \
+     defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+     defined(STM32F373xC) || defined(STM32F378xx)
 /* DAC channel 2 is present in DAC 1 */
   tmp |= hdac->Instance->DOR2 << 16;
-#endif
+#endif /* STM32F303xE || STM32F398xx                || */
+       /* STM32F303xC || STM32F358xx                || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F373xC || STM32F378xx                   */
+
   /* Returns the DAC channel data output register value */
   return tmp;
 }
@@ -920,7 +998,10 @@ static void DAC_DMAErrorCh1(DMA_HandleTypeDef *hdma)
   hdac->State= HAL_DAC_STATE_READY;
 }
 
-#if defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8) || defined(STM32F373xC) || defined(STM32F378xx)
+#if  defined(STM32F303xE) || defined(STM32F398xx)                         || \
+     defined(STM32F303xC) || defined(STM32F358xx)                         || \
+     defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+     defined(STM32F373xC) || defined(STM32F378xx)
 /* DAC channel 2 is available on top of DAC channel 1 */
 
 /**
@@ -965,7 +1046,10 @@ static void DAC_DMAErrorCh2(DMA_HandleTypeDef *hdma)
     
   hdac->State= HAL_DAC_STATE_READY;
 }
-#endif /* STM32F303xC STM32F358xx STM32F303x8 STM32F328xx STM32F334x8 STM32F373xC STM32F378xx */
+#endif /* STM32F303xE || STM32F398xx                || */
+       /* STM32F303xC || STM32F358xx                || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
 /**
   * @}
@@ -976,10 +1060,6 @@ static void DAC_DMAErrorCh2(DMA_HandleTypeDef *hdma)
   */
 
 #endif /* HAL_DAC_MODULE_ENABLED */
-/**
-  * @}
-  */
-
 /**
   * @}
   */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_dac_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_dac_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_dac_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of DAC HAL Extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of DAC HAL Extended module.
   ******************************************************************************
   * @attention
   *
@@ -50,13 +50,17 @@
   * @{
   */
 
-/** @addtogroup DACEx
+/** @addtogroup DACEx DAC Extended HAL module driver
   * @{
   */
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
-   /** @defgroup DACEx_trigger_selection
+/** @defgroup DACEx_Exported_Constants DAC Extended Exported Constants
+  * @{
+  */
+
+/** @defgroup DACEx_trigger_selection DAC Extended trigger selection
   * @{
   */
 
@@ -75,28 +79,11 @@
                                  ((TRIGGER) == DAC_TRIGGER_T15_TRGO) || \
                                  ((TRIGGER) == DAC_TRIGGER_EXT_IT9) || \
                                  ((TRIGGER) == DAC_TRIGGER_SOFTWARE))
-#endif /* STM32F301x8 STM32F318xx */
+#endif /* STM32F301x8 || STM32F318xx */
 
-#if defined(STM32F302x8)
-
-#define DAC_TRIGGER_NONE                   ((uint32_t)0x00000000) /*!< Conversion is automatic once the DAC1_DHRxxxx register 
-                                                                     has been loaded, and not by external trigger */
-#define DAC_TRIGGER_T6_TRGO                ((uint32_t)DAC_CR_TEN1) /*!< TIM6 TRGO selected as external conversion trigger for DAC channel */
-#define DAC_TRIGGER_T3_TRGO                ((uint32_t)(DAC_CR_TSEL1_0 | DAC_CR_TEN1)) /*!< TIM3 TRGO selected as external conversion trigger for DAC channel */                                                                       
-#define DAC_TRIGGER_T15_TRGO               ((uint32_t)(DAC_CR_TSEL1_1 | DAC_CR_TSEL1_0 | DAC_CR_TEN1)) /*!< TIM5 TRGO selected as external conversion trigger for DAC channel */
-#define DAC_TRIGGER_EXT_IT9                ((uint32_t)(DAC_CR_TSEL1_2 | DAC_CR_TSEL1_1 | DAC_CR_TEN1)) /*!< EXTI Line9 event selected as external conversion trigger for DAC channel */
-#define DAC_TRIGGER_SOFTWARE               ((uint32_t)(DAC_CR_TSEL1 | DAC_CR_TEN1)) /*!< Conversion started by software trigger for DAC channel */
-
-#define IS_DAC_TRIGGER(TRIGGER) (((TRIGGER) == DAC_TRIGGER_NONE) || \
-                                 ((TRIGGER) == DAC_TRIGGER_T3_TRGO) || \
-                                 ((TRIGGER) == DAC_TRIGGER_T15_TRGO) || \
-                                 ((TRIGGER) == DAC_TRIGGER_T6_TRGO) || \
-                                 ((TRIGGER) == DAC_TRIGGER_EXT_IT9) || \
-                                 ((TRIGGER) == DAC_TRIGGER_SOFTWARE))
-
-#endif /* STM32F302x8 */
-
-#if defined(STM32F302xC)
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC) || \
+    defined(STM32F302x8)
 
 #define DAC_TRIGGER_NONE                   ((uint32_t)0x00000000) /*!< Conversion is automatic once the DAC1_DHRxxxx register 
                                                                      has been loaded, and not by external trigger */
@@ -117,10 +104,12 @@
                                  ((TRIGGER) == DAC_TRIGGER_EXT_IT9) || \
                                  ((TRIGGER) == DAC_TRIGGER_SOFTWARE))
 
-#endif /* STM32F302xC */
+#endif /* STM32F302xE || */
+       /* STM32F302xC || */
+       /* STM32F302x8 */
 
-
-#if defined (STM32F303xC) || defined (STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 
 #define DAC_TRIGGER_NONE                   ((uint32_t)0x00000000) /*!< Conversion is automatic once the DAC1_DHRxxxx register 
                                                                      has been loaded, and not by external trigger */
@@ -146,10 +135,11 @@
                                  ((TRIGGER) == DAC_TRIGGER_T7_TRGO) || \
                                  ((TRIGGER) == DAC_TRIGGER_EXT_IT9) || \
                                  ((TRIGGER) == DAC_TRIGGER_SOFTWARE))
-#endif /* STM32F303xC || STM32F358xx  */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
 
-#if defined (STM32F303x8) || defined (STM32F328xx) 
+#if defined(STM32F303x8) || defined(STM32F328xx) 
 
 #define DAC_TRIGGER_NONE                   ((uint32_t)0x00000000) /*!< Conversion is automatic once the DAC1_DHRxxxx register 
                                                                      has been loaded, and not by external trigger */
@@ -174,7 +164,7 @@
 #endif /* STM32F303x8 || STM32F328xx */
 
 
-#if defined (STM32F373xC) || defined (STM32F378xx)
+#if defined(STM32F373xC) || defined(STM32F378xx)
  
 #define DAC_TRIGGER_NONE                   ((uint32_t)0x00000000) /*!< Conversion is automatic once the DAC1_DHRxxxx register 
                                                                      has been loaded, and not by external trigger */
@@ -234,26 +224,31 @@
                                  ((TRIGGER) == DAC_TRIGGER_EXT_IT9) || \
                                  ((TRIGGER) == DAC_TRIGGER_SOFTWARE))
 
-#endif /* STM32F334x8  */
+#endif /* STM32F334x8 */
 
 /**
   * @}
   */
 
-/** @defgroup DACEx_Channel_selection
+/** @defgroup DACEx_Channel_selection DAC Extended Channel selection
   * @{
   */
  
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define DAC_CHANNEL_1                      ((uint32_t)0x00000000)               /*!< DAC Channel 1 */
 /* Aliases for compatibility */
 #define DAC1_CHANNEL_1                     DAC_CHANNEL_1                        /*!< DAC1 Channel 1 */
 
 #define IS_DAC_CHANNEL(CHANNEL) ((CHANNEL) == DAC_CHANNEL_1)            
-#endif  /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+#endif  /* STM32F302xE                               || */
+        /* STM32F302xC                               || */
+        /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
 
-#if defined (STM32F303xC) || defined (STM32F358xx) || defined(STM32F302xC) 
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 #define DAC_CHANNEL_1                     ((uint32_t)0x00000000)       /*!< DAC Channel 1 */
 #define DAC_CHANNEL_2                     ((uint32_t)0x00000010)       /*!< DAC Channel 2 */
 /* Aliases for compatibility */
@@ -262,9 +257,11 @@
 
 #define IS_DAC_CHANNEL(CHANNEL) (((CHANNEL) == DAC_CHANNEL_1) || \
                                  ((CHANNEL) == DAC_CHANNEL_2))
-#endif /* STM32F303xC STM32F358xx STM32F302xC */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
    
-#if defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F373xC)|| defined (STM32F378xx) || defined (STM32F328xx)
+#if defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
 
 #define DAC_CHANNEL_1                     ((uint32_t)0x00000000)       /*!< DAC Channel 1 */
 #define DAC_CHANNEL_2                     ((uint32_t)0x00000010)       /*!< DAC Channel 2 */
@@ -276,16 +273,22 @@
 
 #define IS_DAC_CHANNEL(CHANNEL) (((CHANNEL) == DAC_CHANNEL_1) || \
                                  ((CHANNEL) == DAC_CHANNEL_2))
-#endif
+#endif /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F373xC || STM32F378xx                   */
    
 /**
   * @}
   */
 
+/**
+  * @}
+  */
 
- /* Exported macro ------------------------------------------------------------*/
-
-/* Extension features functions ***********************************************/
+/* Exported macro ------------------------------------------------------------*/
+/** @addtogroup DACEx_Exported_Functions DAC Extended Exported Functions
+  * @{
+  */
+/* Extended features functions ***********************************************/
 uint32_t HAL_DACEx_DualGetValue(DAC_HandleTypeDef* hdac);
 HAL_StatusTypeDef HAL_DACEx_DualSetValue(DAC_HandleTypeDef* hdac, uint32_t alignment, uint32_t data1, uint32_t data2);
 HAL_StatusTypeDef HAL_DACEx_TriangleWaveGenerate(DAC_HandleTypeDef* hdac, uint32_t channel, uint32_t Amplitude);
@@ -295,6 +298,10 @@ void HAL_DACEx_ConvCpltCallbackCh2(DAC_HandleTypeDef* hdac);
 void HAL_DACEx_ConvHalfCpltCallbackCh2(DAC_HandleTypeDef* hdac);
 void HAL_DACEx_ErrorCallbackCh2(DAC_HandleTypeDef *hdac);
 void HAL_DACEx_DMAUnderrunCallbackCh2(DAC_HandleTypeDef *hdac);
+
+/**
+  * @}
+  */
 
 /**
    * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_def.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_def.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_def.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   This file contains HAL common defines, enumeration, macros and 
   *          structures definitions. 
   ******************************************************************************
@@ -70,8 +70,8 @@ typedef enum
 } HAL_LockTypeDef;
 
 /* Exported macro ------------------------------------------------------------*/
-#ifndef NULL
-  #define NULL      (void *) 0
+#ifndef HAL_NULL
+  #define HAL_NULL      (void *) 0
 #endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFF
@@ -150,8 +150,6 @@ typedef enum
       #define __ALIGN_BEGIN    __align(4)  
     #elif defined (__ICCARM__)    /* IAR Compiler */
       #define __ALIGN_BEGIN 
-    #elif defined  (__TASKING__)  /* TASKING Compiler */
-      #define __ALIGN_BEGIN    __align(4) 
     #endif /* __CC_ARM */
   #endif /* __ALIGN_BEGIN */
 #endif /* __GNUC__ */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_dma.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_dma.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_dma.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   DMA HAL module driver.
   *    
   *         This file provides firmware functions to manage the following 
@@ -109,7 +109,7 @@
   * @{
   */
 
-/** @defgroup DMA 
+/** @defgroup DMA DMA HAL module driver
   * @brief DMA HAL module driver
   * @{
   */
@@ -118,19 +118,31 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+/** @defgroup DMA_Private_Defines DMA Private Define
+  * @{
+  */
 #define HAL_TIMEOUT_DMA_ABORT    ((uint32_t)1000)  /* 1s  */
+/**
+  * @}
+  */
+
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
+/** @defgroup DMA_Private_Functions DMA Private Functions
+  * @{
+  */
 static void DMA_SetConfig(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
+/**
+  * @}
+  */
 
-/* Private functions ---------------------------------------------------------*/
-
-/** @defgroup DMA_Private_Functions
+/* Exported functions ---------------------------------------------------------*/
+/** @defgroup DMA_Exported_Functions DMA Exported Functions
   * @{
   */
 
-/** @defgroup DMA_Group1 Initialization and de-initialization functions 
+/** @defgroup DMA_Exported_Functions_Group1 Initialization and de-initialization functions 
  *  @brief   Initialization and de-initialization functions 
  *
 @verbatim   
@@ -161,7 +173,7 @@ HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma)
   uint32_t tmp = 0;
   
   /* Check the DMA handle allocation */
-  if(hdma == NULL)
+  if(hdma == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -214,7 +226,7 @@ HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma)
 HAL_StatusTypeDef HAL_DMA_DeInit(DMA_HandleTypeDef *hdma)
 {
   /* Check the DMA handle allocation */
-  if(hdma == NULL)
+  if(hdma == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -264,7 +276,7 @@ HAL_StatusTypeDef HAL_DMA_DeInit(DMA_HandleTypeDef *hdma)
   * @}
   */
 
-/** @defgroup DMA_Group2 I/O operation functions 
+/** @defgroup DMA_Exported_Functions_Group2 Input and Output operation functions 
  *  @brief   I/O operation functions  
  *
 @verbatim   
@@ -519,7 +531,7 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
       /* Process Unlocked */
       __HAL_UNLOCK(hdma); 
     
-      if (hdma->XferErrorCallback != NULL)
+      if (hdma->XferErrorCallback != HAL_NULL)
       {
         /* Transfer error callback */
         hdma->XferErrorCallback(hdma);
@@ -544,7 +556,7 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
       /* Change DMA peripheral state */
       hdma->State = HAL_DMA_STATE_READY_HALF;
 
-      if(hdma->XferHalfCpltCallback != NULL)
+      if(hdma->XferHalfCpltCallback != HAL_NULL)
       {
         /* Half transfer callback */
         hdma->XferHalfCpltCallback(hdma);
@@ -574,7 +586,7 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
       /* Process Unlocked */
       __HAL_UNLOCK(hdma);
     
-      if(hdma->XferCpltCallback != NULL)
+      if(hdma->XferCpltCallback != HAL_NULL)
       {       
         /* Transfer complete callback */
         hdma->XferCpltCallback(hdma);
@@ -587,7 +599,7 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
   * @}
   */
 
-/** @defgroup DMA_Group3 Peripheral State functions
+/** @defgroup DMA_Exported_Functions_Group3 Peripheral State functions
  *  @brief    Peripheral State functions 
  *
 @verbatim   
@@ -627,6 +639,14 @@ uint32_t HAL_DMA_GetError(DMA_HandleTypeDef *hdma)
 
 /**
   * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup DMA_Private_Functions DMA Private Functions
+  * @{
   */
 
 /**

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_dma.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_dma.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_dma.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of DMA HAL module.
   ******************************************************************************
   * @attention
@@ -50,11 +50,14 @@
   * @{
   */
 
-/** @addtogroup DMA
+/** @addtogroup DMA DMA HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup DMA_Exported_Types DMA Exported Types
+  * @{
+  */
 
 /** 
   * @brief  DMA Configuration Structure definition  
@@ -146,14 +149,16 @@ typedef struct __DMA_HandleTypeDef
   __IO uint32_t              ErrorCode;                                                    /*!< DMA Error code                         */
   
 } DMA_HandleTypeDef;    
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
-
-/** @defgroup DMA_Exported_Constants
+/** @defgroup DMA_Exported_Constants DMA Exported Constants
   * @{
   */
 
-/** @defgroup DMA_Error_Code 
+/** @defgroup DMA_Error_Code  DMA Error Code
   * @{
   */ 
 #define HAL_DMA_ERROR_NONE      ((uint32_t)0x00000000)    /*!< No error             */
@@ -164,7 +169,7 @@ typedef struct __DMA_HandleTypeDef
   */
 
 
-/** @defgroup DMA_Data_transfer_direction 
+/** @defgroup DMA_Data_transfer_direction  DMA Data transfer direction
   * @{
   */ 
 #define DMA_PERIPH_TO_MEMORY         ((uint32_t)0x00000000)        /*!< Peripheral to memory direction */
@@ -178,7 +183,7 @@ typedef struct __DMA_HandleTypeDef
   * @}
   */
 
-/** @defgroup DMA_Data_buffer_size 
+/** @defgroup DMA_Data_buffer_size DMA Data buffer size
   * @{
   */ 
 #define IS_DMA_BUFFER_SIZE(SIZE) (((SIZE) >= 0x1) && ((SIZE) < 0x10000))
@@ -186,7 +191,7 @@ typedef struct __DMA_HandleTypeDef
   * @}
   */     
     
-/** @defgroup DMA_Peripheral_incremented_mode 
+/** @defgroup DMA_Peripheral_incremented_mode DMA Peripheral incremented mode
   * @{
   */ 
 #define DMA_PINC_ENABLE        ((uint32_t)DMA_CCR_PINC)  /*!< Peripheral increment mode Enable */
@@ -198,7 +203,7 @@ typedef struct __DMA_HandleTypeDef
   * @}
   */ 
 
-/** @defgroup DMA_Memory_incremented_mode 
+/** @defgroup DMA_Memory_incremented_mode DMA Memory incremented mode
   * @{
   */ 
 #define DMA_MINC_ENABLE         ((uint32_t)DMA_CCR_MINC)  /*!< Memory increment mode Enable  */
@@ -210,7 +215,7 @@ typedef struct __DMA_HandleTypeDef
   * @}
   */
 
-/** @defgroup DMA_Peripheral_data_size 
+/** @defgroup DMA_Peripheral_data_size DMA Peripheral data size
   * @{
   */ 
 #define DMA_PDATAALIGN_BYTE          ((uint32_t)0x00000000)       /*!< Peripheral data alignment : Byte     */
@@ -225,7 +230,7 @@ typedef struct __DMA_HandleTypeDef
   */ 
 
 
-/** @defgroup DMA_Memory_data_size
+/** @defgroup DMA_Memory_data_size DMA Memory data size
   * @{ 
   */
 #define DMA_MDATAALIGN_BYTE          ((uint32_t)0x00000000)       /*!< Memory data alignment : Byte     */
@@ -239,7 +244,7 @@ typedef struct __DMA_HandleTypeDef
   * @}
   */
 
-/** @defgroup DMA_mode 
+/** @defgroup DMA_mode DMA mode
   * @{
   */ 
 #define DMA_NORMAL         ((uint32_t)0x00000000)       /*!< Normal Mode                  */
@@ -251,7 +256,7 @@ typedef struct __DMA_HandleTypeDef
   * @}
   */
 
-/** @defgroup DMA_Priority_level 
+/** @defgroup DMA_Priority_level DMA Priority level
   * @{
   */
 #define DMA_PRIORITY_LOW             ((uint32_t)0x00000000)    /*!< Priority level : Low       */
@@ -268,7 +273,7 @@ typedef struct __DMA_HandleTypeDef
   */ 
 
 
-/** @defgroup DMA_interrupt_enable_definitions 
+/** @defgroup DMA_interrupt_enable_definitions DMA interrupt enable definitions
   * @{
   */
 
@@ -280,7 +285,7 @@ typedef struct __DMA_HandleTypeDef
   * @}
   */
 
-/** @defgroup DMA_flag_definitions 
+/** @defgroup DMA_flag_definitions DMA flag definitions
   * @{
   */ 
 
@@ -323,6 +328,9 @@ typedef struct __DMA_HandleTypeDef
   */
 
 /* Exported macros -----------------------------------------------------------*/
+/** @defgroup DMA_Exported_Macros DMA Exported Macros
+  * @{
+  */
 
 /** @brief  Reset DMA handle state
   * @param  __HANDLE__: DMA handle.
@@ -383,15 +391,32 @@ typedef struct __DMA_HandleTypeDef
   */
 #define __HAL_DMA_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)  ((((__HANDLE__)->Instance->CCR & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
 
-/* Include DMA HAL Extension module */
+/**
+  * @}
+  */
+
+/* Include DMA HAL Extended module */
 #include "stm32f3xx_hal_dma_ex.h"   
 
 /* Exported functions --------------------------------------------------------*/
-  
+/** @addtogroup DMA_Exported_Functions DMA Exported Functions
+  * @{
+  */
+
+/** @addtogroup DMA_Exported_Functions_Group1 Initialization and de-initialization functions 
+  * @{
+  */
 /* Initialization and de-initialization functions *****************************/
 HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma); 
 HAL_StatusTypeDef HAL_DMA_DeInit (DMA_HandleTypeDef *hdma);
 
+/**
+  * @}
+  */
+
+/** @addtogroup DMA_Exported_Functions_Group2 Input and Output operation functions 
+  * @{
+  */
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef HAL_DMA_Start (DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
 HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
@@ -399,9 +424,24 @@ HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma);
 HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, uint32_t CompleteLevel, uint32_t Timeout);
 void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma);
 
+/**
+  * @}
+  */
+
+/** @addtogroup DMA_Exported_Functions_Group3 Peripheral State functions
+  * @{
+  */
 /* Peripheral State and Error functions ***************************************/
 HAL_DMA_StateTypeDef HAL_DMA_GetState(DMA_HandleTypeDef *hdma);
 uint32_t             HAL_DMA_GetError(DMA_HandleTypeDef *hdma);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_dma_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_dma_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_dma_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of DMA HAL extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of DMA HAL Extended module.
   ******************************************************************************
   * @attention
   *
@@ -50,13 +50,16 @@
   * @{
   */
 
-/** @addtogroup DMAEx
+/** @addtogroup DMAEx DMA Extended HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
 /* Exported constants --------------------------------------------------------*/
-/* Exported macro ------------------------------------------------------------*/
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup DMAEx_Exported_Macros DMA Extended Exported Macros
+  * @{
+  */
 /* Interrupt & Flag management */
 
 /**
@@ -65,8 +68,10 @@
   * @retval The specified transfer complete flag index.
   */
 
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F373xC)
-/** @defgroup STM32F302xC_STM32F303xC_STM32F373xC Product devices
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
+/** @defgroup STM32F302xE_STM32F303xE_STM32F398xx_STM32F302xC_STM32F303xC_STM32F3058xx_STM32F373xC_STM32F378xx Product devices
   * @{
   */
 #define __HAL_DMA_GET_TC_FLAG_INDEX(__HANDLE__) \
@@ -126,10 +131,10 @@
   * @param  __HANDLE__: DMA handle
   * @param  __FLAG__: Get the specified flag.
   *          This parameter can be any combination of the following values:
-  *            @arg DMA_FLAG_TCIFx:  Transfer complete flag
-  *            @arg DMA_FLAG_HTIFx:  Half transfer complete flag
-  *            @arg DMA_FLAG_TEIFx:  Transfer error flag
-  *         Where x can be 0_4, 1_5, 2_6 or 3_7 to select the DMA Channel flag.   
+  *            @arg DMA_FLAG_TCx:  Transfer complete flag
+  *            @arg DMA_FLAG_HTx:  Half transfer complete flag
+  *            @arg DMA_FLAG_TEx:  Transfer error flag
+  *         Where x can be 0, 1, 2, 3, 4, 5, 6 or 7 to select the DMA Channel flag.   
   * @retval The state of FLAG (SET or RESET).
   */
 
@@ -142,10 +147,10 @@
   * @param  __HANDLE__: DMA handle
   * @param  __FLAG__: specifies the flag to clear.
   *          This parameter can be any combination of the following values:
-  *            @arg DMA_FLAG_TCIFx:  Transfer complete flag
-  *            @arg DMA_FLAG_HTIFx:  Half transfer complete flag
-  *            @arg DMA_FLAG_TEIFx:  Transfer error flag
-  *         Where x can be 0_4, 1_5, 2_6 or 3_7 to select the DMA Channel flag.   
+  *            @arg DMA_FLAG_TCx:  Transfer complete flag
+  *            @arg DMA_FLAG_HTx:  Half transfer complete flag
+  *            @arg DMA_FLAG_TEx:  Transfer error flag
+  *         Where x can be 0, 1, 2, 3, 4, 5, 6 or 7 to select the DMA Channel flag.   
   * @retval None
   */
 #define __HAL_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__) \
@@ -158,7 +163,7 @@
 
 #else
 
-/** @defgroup STM32F301x8_STM32F302x8_STM32F303x8_STM32F334x8 Product devices
+/** @defgroup STM32F301x8_STM32F302x8_STM32F318xx_STM32F303x8_STM32F334x8_STM32F328xx Product devices
   * @{
   */
 #define __HAL_DMA_GET_TC_FLAG_INDEX(__HANDLE__) \
@@ -203,10 +208,10 @@
   * @param  __HANDLE__: DMA handle
   * @param  __FLAG__: Get the specified flag.
   *          This parameter can be any combination of the following values:
-  *            @arg DMA_FLAG_TCIFx:  Transfer complete flag
-  *            @arg DMA_FLAG_HTIFx:  Half transfer complete flag
-  *            @arg DMA_FLAG_TEIFx:  Transfer error flag
-  *         Where x can be 0_4, 1_5, 2_6 or 3_7 to select the DMA Channel flag.   
+  *            @arg DMA_FLAG_TCx:  Transfer complete flag
+  *            @arg DMA_FLAG_HTx:  Half transfer complete flag
+  *            @arg DMA_FLAG_TEx:  Transfer error flag
+  *         Where x can be 0, 1, 2, 3, 4, 5, 6 or 7 to select the DMA Channel flag.   
   * @retval The state of FLAG (SET or RESET).
   */
 
@@ -217,10 +222,10 @@
   * @param  __HANDLE__: DMA handle
   * @param  __FLAG__: specifies the flag to clear.
   *          This parameter can be any combination of the following values:
-  *            @arg DMA_FLAG_TCIFx:  Transfer complete flag
-  *            @arg DMA_FLAG_HTIFx:  Half transfer complete flag
-  *            @arg DMA_FLAG_TEIFx:  Transfer error flag
-  *         Where x can be 0_4, 1_5, 2_6 or 3_7 to select the DMA Channel flag.   
+  *            @arg DMA_FLAG_TCx:  Transfer complete flag
+  *            @arg DMA_FLAG_HTx:  Half transfer complete flag
+  *            @arg DMA_FLAG_TEx:  Transfer error flag
+  *         Where x can be 0, 1, 2, 3, 4, 5, 6 or 7 to select the DMA Channel flag.   
   * @retval None
   */
 #define __HAL_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__) (DMA1->IFCR |= (__FLAG__))
@@ -233,6 +238,10 @@
   
 /**
   * @}
+  */
+
+/**
+  * @}
   */ 
 
 /**
@@ -241,7 +250,9 @@
 
 #ifdef __cplusplus
 }
-#endif
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
 #endif /* __STM32F3xx_HAL_DMA_H */
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_flash.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_flash.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_flash.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   FLASH HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -106,7 +106,7 @@
   * @{
   */
 
-/** @defgroup FLASH 
+/** @defgroup FLASH FLASH HAL module driver
   * @brief FLASH HAL module driver
   * @{
   */
@@ -115,47 +115,42 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+/** @defgroup FLASH_Private_Defines FLASH Private Define
+ * @{
+ */
 #define HAL_FLASH_TIMEOUT_VALUE   ((uint32_t)50000)/* 50 s */
+/**
+  * @}
+  */
+
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
+/** @defgroup FLASH_Private_Variables FLASH Private Variables
+ * @{
+ */
 /* Variables used for Erase pages under interruption*/
 FLASH_ProcessTypeDef pFlash;
+/**
+  * @}
+  */
 
 /* Private function prototypes -----------------------------------------------*/
-/* Erase operations */
-void                     FLASH_PageErase(uint32_t PageAddress);
-
+/** @defgroup FLASH_Private_Functions FLASH Private Functions
+ * @{
+ */
 /* Program operations */
-static void              FLASH_Program_HalfWord(uint32_t Address, uint16_t Data);
+static void FLASH_Program_HalfWord(uint32_t Address, uint16_t Data);
+static void FLASH_SetErrorCode(void);
+/**
+  * @}
+  */
 
-HAL_StatusTypeDef        FLASH_WaitForLastOperation(uint32_t Timeout);
-static void              FLASH_SetErrorCode(void);
-
-/* Private functions ---------------------------------------------------------*/
-
-/** @defgroup FLASH_Private_Functions
+/* Exported functions ---------------------------------------------------------*/
+/** @defgroup FLASH_Exported_Functions FLASH Exported Functions
   * @{
   */
   
-/** @defgroup HAL_FLASH_Group1 Initialization/de-initialization functions 
- *  @brief    Initialization and Configuration functions 
- *
-@verbatim    
- ===============================================================================
-              ##### Initialization and de-initialization functions #####
- ===============================================================================
-    [..]  This section provides functions allowing to:
- 
-@endverbatim
-  * @{
-  */
-
-
-/**
-  * @}
-  */  
-
-/** @defgroup HAL_FLASH_Group2 I/O operation functions 
+/** @defgroup FLASH_Exported_Functions_Group1 Input and Output operation functions 
  *  @brief   Data transfers functions 
  *
 @verbatim   
@@ -303,7 +298,6 @@ HAL_StatusTypeDef HAL_FLASH_Program_IT(uint32_t TypeProgram, uint32_t Address, u
 
 /**
   * @brief This function handles FLASH interrupt request.
-  * @param  None
   * @retval None
   */
 void HAL_FLASH_IRQHandler(void)
@@ -456,7 +450,7 @@ __weak void HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue)
   * @}
   */
 
-/** @defgroup HAL_FLASH_Group3 Peripheral Control functions 
+/** @defgroup FLASH_Exported_Functions_Group2 Peripheral Control functions 
  *  @brief   management functions 
  *
 @verbatim   
@@ -473,7 +467,6 @@ __weak void HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue)
 
 /**
   * @brief  Unlock the FLASH control register access
-  * @param  None
   * @retval HAL Status
   */
 HAL_StatusTypeDef HAL_FLASH_Unlock(void)
@@ -494,7 +487,6 @@ HAL_StatusTypeDef HAL_FLASH_Unlock(void)
 
 /**
   * @brief  Locks the FLASH control register access
-  * @param  None
   * @retval HAL Status
   */
 HAL_StatusTypeDef HAL_FLASH_Lock(void)
@@ -508,7 +500,6 @@ HAL_StatusTypeDef HAL_FLASH_Lock(void)
 
 /**
   * @brief  Unlock the FLASH Option Control Registers access.
-  * @param  None
   * @retval HAL Status
   */
 HAL_StatusTypeDef HAL_FLASH_OB_Unlock(void)
@@ -529,7 +520,6 @@ HAL_StatusTypeDef HAL_FLASH_OB_Unlock(void)
 
 /**
   * @brief  Lock the FLASH Option Control Registers access.
-  * @param  None
   * @retval HAL Status 
   */
 HAL_StatusTypeDef HAL_FLASH_OB_Lock(void)
@@ -542,7 +532,6 @@ HAL_StatusTypeDef HAL_FLASH_OB_Lock(void)
 
 /**
   * @brief  Launch the option byte loading.
-  * @param  None
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_FLASH_OB_Launch(void)
@@ -559,7 +548,7 @@ HAL_StatusTypeDef HAL_FLASH_OB_Launch(void)
   */
 
 
-/** @defgroup HAL_FLASH_Group4 Peripheral State functions 
+/** @defgroup FLASH_Exported_Functions_Group3 Peripheral State functions 
  *  @brief   Peripheral State functions 
  *
 @verbatim   
@@ -575,7 +564,6 @@ HAL_StatusTypeDef HAL_FLASH_OB_Launch(void)
 
 /**
   * @brief  Get the specific FLASH error flag.
-  * @param  None
   * @retval FLASH_ErrorCode: The returned value can be:
   *            @arg FLASH_ERROR_PG: FLASH Programming error flag 
   *            @arg FLASH_ERROR_WRP: FLASH Write protected error flag
@@ -589,6 +577,13 @@ FLASH_ErrorTypeDef HAL_FLASH_GetError(void)
   * @}
   */  
    
+/**
+  * @}
+  */
+
+/** @addtogroup FLASH_Private_Functions FLASH Private Functions
+ * @{
+ */
 /**
   * @brief  Program a half-word (16-bit) at a specified address.
   * @param  Address: specifies the address to be programmed.
@@ -662,7 +657,6 @@ void FLASH_PageErase(uint32_t PageAddress)
 
 /**
   * @brief  Set the specific FLASH error flag.
-  * @param  None
   * @retval None
   */
 static void FLASH_SetErrorCode(void)

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_flash.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_flash.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_flash.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of Flash HAL module.
   ******************************************************************************
   * @attention
@@ -50,12 +50,12 @@
   * @{
   */
 
-/** @addtogroup FLASH
+/** @addtogroup FLASH FLASH HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
-/** @defgroup FLASH_Exported_Types
+/** @defgroup FLASH_Exported_Types FLASH Exported Types
   * @{
   */  
 
@@ -152,8 +152,7 @@ typedef struct
   */
 
 /* Exported constants --------------------------------------------------------*/
-
-/** @defgroup FLASH_Exported_Constants
+/** @defgroup FLASH_Exported_Constants FLASH Exported Constants
   * @{
   */  
 
@@ -208,7 +207,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup FLASH_Latency 
+/** @defgroup FLASH_Latency FLASH Latency
   * @{
   */ 
 #define FLASH_LATENCY_0            ((uint8_t)0x0000)    /*!< FLASH Zero Latency cycle */
@@ -222,7 +221,7 @@ typedef struct
   * @}
   */ 
   
-/** @defgroup FLASH_OB_Data_Address 
+/** @defgroup FLASH_OB_Data_Address  FLASH Option Byte Data Address
   * @{
   */  
 #define IS_OB_DATA_ADDRESS(ADDRESS) (((ADDRESS) == 0x1FFFF804) || ((ADDRESS) == 0x1FFFF806)) 
@@ -230,7 +229,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup FLASH_OB_Read_Protection 
+/** @defgroup FLASH_OB_Read_Protection FLASH Option Byte Read Protection
   * @{
   */
 #define OB_RDP_LEVEL_0             ((uint8_t)0xAA)
@@ -244,7 +243,7 @@ typedef struct
   * @}
   */ 
   
-/** @defgroup FLASH_OB_IWatchdog 
+/** @defgroup FLASH_OB_IWatchdog FLASH Option Byte IWatchdog
   * @{
   */ 
 #define OB_IWDG_SW                 ((uint8_t)0x01)  /*!< Software IWDG selected */
@@ -254,7 +253,7 @@ typedef struct
   * @}
   */ 
   
-/** @defgroup FLASH_OB_nRST_STOP 
+/** @defgroup FLASH_OB_nRST_STOP FLASH Option Byte nRST STOP
   * @{
   */ 
 #define OB_STOP_NO_RST             ((uint8_t)0x02) /*!< No reset generated when entering in STOP */
@@ -264,7 +263,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup FLASH_OB_nRST_STDBY 
+/** @defgroup FLASH_OB_nRST_STDBY FLASH Option Byte nRST STDBY
   * @{
   */ 
 #define OB_STDBY_NO_RST            ((uint8_t)0x04) /*!< No reset generated when entering in STANDBY */
@@ -274,7 +273,7 @@ typedef struct
   * @}
   */    
 
-/** @defgroup FLASH_OB_BOOT1
+/** @defgroup FLASH_OB_BOOT1 FLASH Option Byte BOOT1
   * @{
   */
 #define OB_BOOT1_RESET             ((uint8_t)0x00) /*!< BOOT1 Reset */
@@ -284,7 +283,7 @@ typedef struct
   * @}
   */  
 
-/** @defgroup FLASH_OB_VDDA_Analog_Monitoring
+/** @defgroup FLASH_OB_VDDA_Analog_Monitoring FLASH Option Byte VDDA Analog Monitoring
   * @{
   */
 #define OB_VDDA_ANALOG_ON          ((uint8_t)0x20) /*!< Analog monitoring on VDDA Power source ON */
@@ -294,7 +293,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup FLASH_OB_SRAM_Parity_Enable 
+/** @defgroup FLASH_OB_SRAM_Parity_Enable FLASH Option Byte SRAM Parity Enable
   * @{
   */
 #define OB_SRAM_PARITY_SET         ((uint8_t)0x00) /*!< SRAM parity enable set */
@@ -304,7 +303,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup FLASH_OB_SDADC12_VDD_MONITOR
+/** @defgroup FLASH_OB_SDADC12_VDD_MONITOR FLASH Option Byte SDADC12 VDD MONITOR
   * @{
   */
 #define OB_SDADC12_VDD_MONITOR_SET        ((uint8_t)0x80) /*!< SDADC12_VDD power supply supervisor set */
@@ -314,7 +313,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup FLASH_Flag_definition
+/** @defgroup FLASH_Flag_definition FLASH Flag definition
   * @brief Flag definition
   * @{
   */ 
@@ -330,7 +329,7 @@ typedef struct
   * @}
   */
   
-/** @defgroup FLASH_Interrupt_definition 
+/** @defgroup FLASH_Interrupt_definition FLASH Interrupt definition
   * @brief FLASH Interrupt definition
   * @{
   */ 
@@ -341,7 +340,7 @@ typedef struct
   * @}
   */  
 
-/** @defgroup FLASH_Timeout_definition 
+/** @defgroup FLASH_Timeout_definition FLASH Timeout definition
   * @brief FLASH Timeout definition
   * @{
   */ 
@@ -356,7 +355,7 @@ typedef struct
   
 /* Exported macro ------------------------------------------------------------*/
 
-/** @defgroup FLASH_Macros
+/** @defgroup FLASH_Exported_Macros FLASH Exported Macros
  *  @brief macros to control FLASH features 
  *  @{
  */
@@ -371,37 +370,29 @@ typedef struct
 
 /**
   * @brief  Enable the FLASH prefetch buffer.
-  * @param  None
   * @retval None
   */ 
 #define __HAL_FLASH_PREFETCH_BUFFER_ENABLE()    (FLASH->ACR |= FLASH_ACR_PRFTBE)
 
 /**
   * @brief  Disable the FLASH prefetch buffer.
-  * @param  None
   * @retval None
   */
 #define __HAL_FLASH_PREFETCH_BUFFER_DISABLE()   (FLASH->ACR &= (~FLASH_ACR_PRFTBE))
 
 /**
   * @brief  Enable the FLASH half cycle access.
-  * @param  None
   * @retval None
   */
 #define __HAL_FLASH_HALF_CYCLE_ACCESS_ENABLE()  (FLASH->ACR |= FLASH_ACR_HLFCYA)
 
 /**
   * @brief  Disable the FLASH half cycle access.
-  * @param  None
   * @retval None
   */
 #define __HAL_FLASH_HALF_CYCLE_ACCESS_DISABLE() (FLASH->ACR &= (~FLASH_ACR_HLFCYA))
 
-/**
-  * @}
-  */  
-
-/** @defgroup FLASH_Interrupt
+/** @defgroup FLASH_Interrupt FLASH Interrupt
  *  @brief macros to handle FLASH interrupts
  * @{
  */ 
@@ -451,17 +442,23 @@ typedef struct
 
 /**
   * @}
+  */  
+
+/**
+  * @}
   */ 
 
-/* Include FLASH HAL Extension module */
+/* Include FLASH HAL Extended module */
 #include "stm32f3xx_hal_flash_ex.h"  
 
 /* Exported functions --------------------------------------------------------*/
-/** @defgroup FLASH_Exported_Functions
+/** @addtogroup FLASH_Exported_Functions FLASH Exported Functions
   * @{
-  */  
-
-/* Exported functions --------------------------------------------------------*/
+  */
+  
+/** @addtogroup FLASH_Exported_Functions_Group1 Input and Output operation functions
+  * @{
+  */
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef HAL_FLASH_Program(uint32_t TypeProgram, uint32_t Address, uint64_t Data);
 HAL_StatusTypeDef HAL_FLASH_Program_IT(uint32_t TypeProgram, uint32_t Address, uint64_t Data);
@@ -472,6 +469,13 @@ void              HAL_FLASH_IRQHandler(void);
 void       HAL_FLASH_EndOfOperationCallback(uint32_t ReturnValue);
 void       HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue);
 
+/**
+  * @}
+  */
+
+/** @addtogroup FLASH_Exported_Functions_Group2 Peripheral Control functions 
+  * @{
+  */
 /* Peripheral Control functions ***********************************************/
 HAL_StatusTypeDef HAL_FLASH_Unlock(void);
 HAL_StatusTypeDef HAL_FLASH_Lock(void);
@@ -480,9 +484,33 @@ HAL_StatusTypeDef HAL_FLASH_OB_Lock(void);
 /* Option bytes control */
 HAL_StatusTypeDef HAL_FLASH_OB_Launch(void);
 
+/**
+  * @}
+  */
+
+/** @addtogroup FLASH_Exported_Functions_Group3 Peripheral State functions 
+  * @{
+  */
 /* Peripheral State and Error functions ***************************************/
 FLASH_ErrorTypeDef HAL_FLASH_GetError(void);
 
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported Private function -------------------------------------------------*/
+/** @addtogroup FLASH_Exported_Private_Functions FLASH Exported Private Functions
+ * @{
+ */
+/* Erase operations */
+void                    FLASH_PageErase(uint32_t PageAddress);
+HAL_StatusTypeDef       FLASH_WaitForLastOperation(uint32_t Timeout);
+
+/* Program operations */
 /**
   * @}
   */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_flash_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_flash_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_flash_ex.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Extended FLASH HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -65,8 +65,8 @@
   * @{
   */
 
-/** @addtogroup FLASH
-  * @brief FLASH HAL module driver
+/** @addtogroup FLASHEx FLASH Extended HAL module driver
+  * @brief FLASH Extended HAL module driver
   * @{
   */
 
@@ -74,14 +74,30 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+/** @defgroup FLASHEx_Private_Defines FLASH Extended Private Define
+ * @{
+ */
 #define HAL_FLASH_TIMEOUT_VALUE   ((uint32_t)50000)/* 50 s */
+/**
+  * @}
+  */
+
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
+/** @defgroup FLASHEx_Private_Variables FLASH Extended Private Variables
+ * @{
+ */
 /* Variables used for Erase pages under interruption*/
 extern FLASH_ProcessTypeDef pFlash;
+/**
+  * @}
+  */
+
 /* Private function prototypes -----------------------------------------------*/
+/** @defgroup FLASHEx_Private_Functions FLASH Extended Private Functions
+ * @{
+ */
 /* Erase operations */
-extern void FLASH_PageErase(uint32_t PageAddress);
 static void              FLASH_MassErase(void);
 
 /* Option bytes control */
@@ -93,32 +109,16 @@ static HAL_StatusTypeDef FLASH_OB_ProgramData(uint32_t Address, uint8_t Data);
 static uint32_t          FLASH_OB_GetWRP(void);
 static FlagStatus        FLASH_OB_GetRDP(void);
 static uint8_t           FLASH_OB_GetUser(void);
-
-/* Private functions ---------------------------------------------------------*/
-extern HAL_StatusTypeDef FLASH_WaitForLastOperation(uint32_t Timeout);
-
-/** @addtogroup FLASH_Private_Functions
-  * @{
-  */
-
-/** @addtogroup FLASH_Group1 Initialization/de-initialization functions
-  * @brief      Initialization and Configuration functions
-  *
-@verbatim    
- ===============================================================================
-              ##### Initialization/de-initialization functions #####
- ===============================================================================
- 
-@endverbatim
-  * @{
-  */
-
-
 /**
   * @}
   */
 
-/** @addtogroup FLASH_Group2 I/O operation functions
+/* Exported functions ---------------------------------------------------------*/
+/** @defgroup FLASHEx_Exported_Functions FLASH Extended Exported Functions
+  * @{
+  */
+  
+/** @defgroup FLASHEx_Exported_Functions_Group1 Extended Input and Output operation functions
   * @brief      I/O operation functions
   *
 @verbatim   
@@ -272,7 +272,7 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit)
   * @}
   */
     
-/** @addtogroup FLASH_Group3 Peripheral Control functions
+/** @defgroup FLASHEx_Exported_Functions_Group2 Extended Peripheral Control functions
   * @brief      Peripheral Control functions
   *
 @verbatim   
@@ -293,7 +293,6 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit)
   *         The function HAL_FLASH_OB_Unlock() should be called before to unlock the options bytes
   *         The function HAL_FLASH_OB_Launch() should be called after to force the reload of the options bytes
   *         (system reset will occur)
-  * @param  None
   * @retval HAL status
   */
 
@@ -423,8 +422,15 @@ void HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit)
   */
 
 /**
+  * @}
+  */
+
+/** @addtogroup FLASHEx_Private_Functions FLASH Extended Private Functions
+ * @{
+ */
+
+/**
   * @brief  Mass erase of FLASH memory
-  * @param  None
   * 
   * @retval None
   */
@@ -437,6 +443,10 @@ static void FLASH_MassErase(void)
   SET_BIT(FLASH->CR, FLASH_CR_MER);
   SET_BIT(FLASH->CR, FLASH_CR_STRT);
 }
+
+/**
+  * @}
+  */
 
 /**
   * @brief  Enable the write protection of the desired pages
@@ -452,9 +462,13 @@ static HAL_StatusTypeDef FLASH_OB_EnableWRP(uint32_t WriteProtectPage)
 {
   HAL_StatusTypeDef status = HAL_OK;
   uint16_t WRP0_Data = 0xFFFF, WRP1_Data = 0xFFFF;
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F373xC) || defined(STM32F378xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
   uint16_t WRP2_Data = 0xFFFF, WRP3_Data = 0xFFFF;
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx || STM32F373xC || STM32F378xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F373xC || STM32F378xx                   */
   
   /* Check the parameters */
   assert_param(IS_OB_WRP(WriteProtectPage));
@@ -462,10 +476,17 @@ static HAL_StatusTypeDef FLASH_OB_EnableWRP(uint32_t WriteProtectPage)
   WriteProtectPage = (uint32_t)(~WriteProtectPage);
   WRP0_Data = (uint16_t)(WriteProtectPage & OB_WRP_PAGES0TO15MASK);
   WRP1_Data = (uint16_t)((WriteProtectPage & OB_WRP_PAGES16TO31MASK) >> 8);
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F373xC) || defined(STM32F378xx)
+#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
   WRP2_Data = (uint16_t)((WriteProtectPage & OB_WRP_PAGES32TO47MASK) >> 16);
   WRP3_Data = (uint16_t)((WriteProtectPage & OB_WRP_PAGES48TO127MASK) >> 24); 
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx || STM32F373xC || STM32F378xx */
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F373xC || STM32F378xx                   */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+  WRP2_Data = (uint16_t)((WriteProtectPage & OB_WRP_PAGES32TO47MASK) >> 16);
+  WRP3_Data = (uint16_t)((WriteProtectPage & OB_WRP_PAGES48TO255MASK) >> 24); 
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
 
   /* Wait for last operation to be completed */
   status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE);
@@ -493,7 +514,9 @@ static HAL_StatusTypeDef FLASH_OB_EnableWRP(uint32_t WriteProtectPage)
       status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE);
     }
           
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F373xC) || defined(STM32F378xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
     if((status == HAL_OK) && (WRP2_Data != 0xFF))
     {
       OB->WRP2 &= WRP2_Data;
@@ -509,7 +532,9 @@ static HAL_StatusTypeDef FLASH_OB_EnableWRP(uint32_t WriteProtectPage)
       /* Wait for last operation to be completed */
       status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE);
     }
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx || STM32F373xC || STM32F378xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
     /* if the program operation is completed, disable the OPTPG Bit */
     CLEAR_BIT(FLASH->CR, FLASH_CR_OPTPG);
@@ -533,19 +558,30 @@ static HAL_StatusTypeDef FLASH_OB_DisableWRP(uint32_t WriteProtectPage)
 {
   HAL_StatusTypeDef status = HAL_OK;
   uint16_t WRP0_Data = 0xFFFF, WRP1_Data = 0xFFFF;
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F373xC) || defined(STM32F378xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
   uint16_t WRP2_Data = 0xFFFF, WRP3_Data = 0xFFFF;
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx || STM32F373xC || STM32F378xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F373xC || STM32F378xx                   */
   
   /* Check the parameters */
   assert_param(IS_OB_WRP(WriteProtectPage));
 
   WRP0_Data = (uint16_t)(WriteProtectPage & OB_WRP_PAGES0TO15MASK);
   WRP1_Data = (uint16_t)((WriteProtectPage & OB_WRP_PAGES16TO31MASK) >> 8);
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F373xC) || defined(STM32F378xx)
+#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
   WRP2_Data = (uint16_t)((WriteProtectPage & OB_WRP_PAGES32TO47MASK) >> 16);
   WRP3_Data = (uint16_t)((WriteProtectPage & OB_WRP_PAGES48TO127MASK) >> 24); 
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx || STM32F373xC || STM32F378xx */
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F373xC || STM32F378xx                   */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+  WRP2_Data = (uint16_t)((WriteProtectPage & OB_WRP_PAGES32TO47MASK) >> 16);
+  WRP3_Data = (uint16_t)((WriteProtectPage & OB_WRP_PAGES48TO255MASK) >> 24); 
+#endif /* STM32F303xE || STM32F303xE || STM32F398xx */
     
   /* Wait for last operation to be completed */
   status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE);
@@ -573,7 +609,9 @@ static HAL_StatusTypeDef FLASH_OB_DisableWRP(uint32_t WriteProtectPage)
       status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE);
     }
           
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F373xC) || defined(STM32F378xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
     if((status == HAL_OK) && (WRP2_Data != 0xFF))
     {
       OB->WRP2 |= WRP2_Data;
@@ -589,7 +627,9 @@ static HAL_StatusTypeDef FLASH_OB_DisableWRP(uint32_t WriteProtectPage)
       /* Wait for last operation to be completed */
       status = FLASH_WaitForLastOperation((uint32_t)HAL_FLASH_TIMEOUT_VALUE);
     }
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx || STM32F373xC || STM32F378xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
     /* if the program operation is completed, disable the OPTPG Bit */
     CLEAR_BIT(FLASH->CR, FLASH_CR_OPTPG);
@@ -674,9 +714,16 @@ static HAL_StatusTypeDef FLASH_OB_UserConfig(uint8_t UserConfig)
     /* Enable the Option Bytes Programming operation */
     SET_BIT(FLASH->CR, FLASH_CR_OPTPG); 
            
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F302xC) || defined(STM32F303x8) || defined(STM32F303xC) || defined(STM32F318xx) || defined(STM32F334x8) || defined(STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8)                         || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
     OB->USER = (UserConfig | 0x88);
-#endif /* STM32F301x8 || STM32F302x8 || STM32F302xC || STM32F303xC || STM32F318xx || STM32F334x8 || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8                || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
 #if defined(STM32F373xC) || defined(STM32F378xx)
     OB->USER = (UserConfig | 0x08);
 #endif /* STM32F373xC || STM32F378xx */
@@ -734,7 +781,6 @@ static HAL_StatusTypeDef FLASH_OB_ProgramData(uint32_t Address, uint8_t Data)
 
 /**
   * @brief  Return the FLASH Write Protection Option Bytes value.
-  * @param  None
   * @retval The FLASH Write Protection Option Bytes value
   */
 static uint32_t FLASH_OB_GetWRP(void)
@@ -745,7 +791,6 @@ static uint32_t FLASH_OB_GetWRP(void)
 
 /**
   * @brief  Returns the FLASH Read Protection level.
-  * @param  None
   * @retval FLASH ReadOut Protection Status:
   *           - SET, when OB_RDP_Level_1 or OB_RDP_Level_2 is set
   *           - RESET, when OB_RDP_Level_0 is set
@@ -754,13 +799,16 @@ static FlagStatus FLASH_OB_GetRDP(void)
 {
   FlagStatus readstatus = RESET;
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
     defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) 
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
   if ((uint8_t)READ_BIT(FLASH->OBR, FLASH_OBR_RDPRT) != RESET)
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx ||                */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx                   */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+    
 #if defined(STM32F373xC) || defined(STM32F378xx)
   if ((uint8_t)READ_BIT(FLASH->OBR, (FLASH_OBR_LEVEL1_PROT | FLASH_OBR_LEVEL2_PROT)) != RESET)
 #endif /* STM32F373xC || STM32F378xx */
@@ -776,7 +824,6 @@ static FlagStatus FLASH_OB_GetRDP(void)
 
 /**
   * @brief  Return the FLASH User Option Byte value.
-  * @param  None
   * @retval The FLASH User Option Bytes values: IWDG_SW(Bit0), RST_STOP(Bit1), RST_STDBY(Bit2), BOOT1(Bit4),
   *         VDDA_Analog_Monitoring(Bit5) and SRAM_Parity_Enable(Bit6).
   *         And SDADC12_VDD_MONITOR(Bit7) for STM32F373 or STM32F378 . 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_flash_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_flash_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_flash_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of Flash HAL Extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of Flash HAL Extended module.
   ******************************************************************************
   * @attention
   *
@@ -50,20 +50,13 @@
   * @{
   */
 
-/** @addtogroup FLASHEx
+/** @addtogroup FLASHEx FLASH Extended HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
-/** @addtogroup FLASHEx_Exported_Types
-  * @{
-  */  
-/**
-  * @}
-  */
-
 /* Exported constants --------------------------------------------------------*/
-/** @addtogroup FLASHEx_Exported_Constants
+/** @defgroup FLASHEx_Exported_Constants FLASH Extended Exported Constants
   * @{
   */  
 #define FLASH_SIZE_DATA_REGISTER ((uint32_t)0x1FFFF7CC)
@@ -72,7 +65,7 @@
   * @}
   */
 
-/** @defgroup FLASHEx_Address
+/** @defgroup FLASHEx_Address FLASH Extended Address
   * @{
   */
 #if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
@@ -82,6 +75,10 @@
                                            ((ADDRESS) <= 0x0801FFFF) :  ((ADDRESS) <= 0x0800FFFF))))
 #endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
        /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+#define IS_FLASH_PROGRAM_ADDRESS(ADDRESS) (((ADDRESS) >= 0x08000000) && ((ADDRESS) <= 0x0807FFFF))
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
 
 #if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
     defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
@@ -94,7 +91,7 @@
   * @}
   */
 
-/** @defgroup FLASHEx_Nb_Pages
+/** @defgroup FLASHEx_Nb_Pages FLASH Extended Nb Pages
   * @{
   */
 #if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
@@ -104,6 +101,10 @@
                                             ((ADDRESS)+((NBPAGES)*FLASH_PAGE_SIZE)-1 <= 0x0800FFFF)))
 #endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
        /* STM32F373xC || STM32F378xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+#define IS_FLASH_NB_PAGES(ADDRESS,NBPAGES) ((ADDRESS)+((NBPAGES)*FLASH_PAGE_SIZE)-1 <= 0x0807FFFF)
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
 
 #if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
     defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
@@ -116,7 +117,7 @@
   * @}
   */
 
-/** @defgroup FLASHEx_OB_Write_Protection
+/** @defgroup FLASHEx_OB_Write_Protection FLASH Extended Option Bytes Write Protection
   * @{
   */
 #define OB_WRP_PAGES0TO1               ((uint32_t)0x00000001) /* Write protection of page 0 to 1 */
@@ -135,7 +136,9 @@
 #define OB_WRP_PAGES26TO27             ((uint32_t)0x00002000) /* Write protection of page 26 to 27 */
 #define OB_WRP_PAGES28TO29             ((uint32_t)0x00004000) /* Write protection of page 28 to 29 */
 #define OB_WRP_PAGES30TO31             ((uint32_t)0x00008000) /* Write protection of page 30 to 31 */
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F373xC) || defined(STM32F378xx)
+
+#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
 #define OB_WRP_PAGES32TO33             ((uint32_t)0x00010000) /* Write protection of page 32 to 33 */
 #define OB_WRP_PAGES34TO35             ((uint32_t)0x00020000) /* Write protection of page 34 to 35 */
 #define OB_WRP_PAGES36TO37             ((uint32_t)0x00040000) /* Write protection of page 36 to 37 */
@@ -152,29 +155,63 @@
 #define OB_WRP_PAGES58TO59             ((uint32_t)0x20000000) /* Write protection of page 58 to 59 */
 #define OB_WRP_PAGES60TO61             ((uint32_t)0x40000000) /* Write protection of page 60 to 61 */
 #define OB_WRP_PAGES62TO127            ((uint32_t)0x80000000) /* Write protection of page 62 to 127 */
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx || STM32F373xC || STM32F378xx */
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */ 
+       /* STM32F373xC || STM32F378xx                   */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+#define OB_WRP_PAGES32TO33             ((uint32_t)0x00010000) /* Write protection of page 32 to 33 */
+#define OB_WRP_PAGES34TO35             ((uint32_t)0x00020000) /* Write protection of page 34 to 35 */
+#define OB_WRP_PAGES36TO37             ((uint32_t)0x00040000) /* Write protection of page 36 to 37 */
+#define OB_WRP_PAGES38TO39             ((uint32_t)0x00080000) /* Write protection of page 38 to 39 */
+#define OB_WRP_PAGES40TO41             ((uint32_t)0x00100000) /* Write protection of page 40 to 41 */
+#define OB_WRP_PAGES42TO43             ((uint32_t)0x00200000) /* Write protection of page 42 to 43 */
+#define OB_WRP_PAGES44TO45             ((uint32_t)0x00400000) /* Write protection of page 44 to 45 */
+#define OB_WRP_PAGES46TO47             ((uint32_t)0x00800000) /* Write protection of page 46 to 47 */
+#define OB_WRP_PAGES48TO49             ((uint32_t)0x01000000) /* Write protection of page 48 to 49 */
+#define OB_WRP_PAGES50TO51             ((uint32_t)0x02000000) /* Write protection of page 50 to 51 */
+#define OB_WRP_PAGES52TO53             ((uint32_t)0x04000000) /* Write protection of page 52 to 53 */
+#define OB_WRP_PAGES54TO55             ((uint32_t)0x08000000) /* Write protection of page 54 to 55 */
+#define OB_WRP_PAGES56TO57             ((uint32_t)0x10000000) /* Write protection of page 56 to 57 */
+#define OB_WRP_PAGES58TO59             ((uint32_t)0x20000000) /* Write protection of page 58 to 59 */
+#define OB_WRP_PAGES60TO61             ((uint32_t)0x40000000) /* Write protection of page 60 to 61 */
+#define OB_WRP_PAGES62TO255            ((uint32_t)0x80000000) /* Write protection of page 62 to 255 */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
 
 #define OB_WRP_PAGES0TO15MASK          ((uint32_t)0x000000FF)
 #define OB_WRP_PAGES16TO31MASK         ((uint32_t)0x0000FF00)
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F373xC) || defined(STM32F378xx)
+
+#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
 #define OB_WRP_PAGES32TO47MASK         ((uint32_t)0x00FF0000)
 #define OB_WRP_PAGES48TO127MASK        ((uint32_t)0xFF000000)
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx || STM32F373xC || STM32F378xx */
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F373xC) || defined(STM32F378xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+#define OB_WRP_PAGES32TO47MASK         ((uint32_t)0x00FF0000)
+#define OB_WRP_PAGES48TO255MASK        ((uint32_t)0xFF000000)
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+
+#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
 #define OB_WRP_PAGES32TO47MASK         ((uint32_t)0x00FF0000)
 #define OB_WRP_PAGES48TO127MASK        ((uint32_t)0xFF000000)
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx || STM32F373xC || STM32F378xx */
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || defined(STM32F373xC) || defined(STM32F378xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
 #define OB_WRP_ALLPAGES                ((uint32_t)0xFFFFFFFF) /*!< Write protection of all pages */
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx || STM32F373xC || STM32F378xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
 #if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
     defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define OB_WRP_ALLPAGES                ((uint32_t)0x0000FFFF) /*!< Write protection of all pages */
 #endif /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
 
 #define IS_OB_WRP(PAGE) (((PAGE) != 0x0000000))
 /**
@@ -182,7 +219,7 @@
   */
 
 #if defined(STM32F373xC) || defined(STM32F378xx)
-/** @defgroup FLASHEx_OB_SDADC12_VDD_MONITOR
+/** @defgroup FLASHEx_OB_SDADC12_VDD_MONITOR FLASH Extended Option Bytes SDADC12 VDD MONITOR
   * @{
   */
 #define OB_SDACD_VDD_MONITOR_RESET           ((uint8_t)0x00) /*!< SDADC VDD Monitor reset */
@@ -199,15 +236,36 @@
 /* Exported macro ------------------------------------------------------------*/
 
 /* Exported functions --------------------------------------------------------*/
-
+/** @addtogroup FLASHEx_Exported_Functions FLASH Extended Exported Functions
+  * @{
+  */
+  
+/** @addtogroup FLASHEx_Exported_Functions_Group1 Extended Input and Output operation functions
+  * @{
+  */
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef  HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t *PageError);
 HAL_StatusTypeDef  HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit);
 
+/**
+  * @}
+  */
+    
+/** @addtogroup FLASHEx_Exported_Functions_Group2 Extended Peripheral Control functions
+  * @{
+  */
 /* Peripheral Control functions ***********************************************/
 HAL_StatusTypeDef  HAL_FLASHEx_OBErase(void);
 HAL_StatusTypeDef  HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit);
 void               HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_gpio.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_gpio.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_gpio.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   GPIO HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -135,7 +135,7 @@
   * @{
   */
 
-/** @defgroup GPIO GPIO
+/** @defgroup GPIO GPIO HAL module driver
   * @brief GPIO HAL module driver
   * @{
   */
@@ -145,6 +145,9 @@
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
+/** @defgroup GPIO_Private_Macros GPIO Private Macros
+ * @{
+ */
 #define GET_GPIO_SOURCE(__GPIOx__) \
 (((uint32_t)(__GPIOx__) == ((uint32_t)GPIOA_BASE))? 0U :\
  ((uint32_t)(__GPIOx__) == ((uint32_t)(GPIOA_BASE + 0x0400)))? 1U :\
@@ -162,15 +165,18 @@
 #define GPIO_OUTPUT_TYPE      ((uint32_t)0x00000010) 
 
 #define GPIO_NUMBER           ((uint32_t)16)
-/* Private variables ---------------------------------------------------------*/
-/* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
-
-/** @defgroup GPIO_Private_Functions
-  * @{
+/**
+  * @}
   */
 
-/** @defgroup HAL_GPIO_Group1 Initialization/de-initialization functions 
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
+/** @defgroup GPIO_Exported_Functions GPIO Exported Functions
+* @{
+*/
+
+/** @defgroup GPIO_Exported_Functions_Group1 Initialization and de-initialization functions
  *  @brief    Initialization and Configuration functions 
  *
 @verbatim    
@@ -366,7 +372,7 @@ void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
   * @}
   */
 
-/** @defgroup HAL_GPIO_Group2 IO operation functions 
+/** @defgroup GPIO_Exported_Functions_Group2 Input and Output operation functions 
  *  @brief   GPIO Read and Write 
  *
 @verbatim   
@@ -415,8 +421,8 @@ GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
   *          This parameter can be one of GPIO_PIN_x where x can be (0..15).
   * @param  PinState: specifies the value to be written to the selected bit.
   *          This parameter can be one of the GPIO_PinState enum values:
-  *            @arg GPIO_BIT_RESET: to clear the port pin
-  *            @arg GPIO_BIT_SET: to set the port pin
+  *            @arg GPIO_PIN_RESET: to clear the port pin
+  *            @arg GPIO_PIN_SET: to set the port pin
   * @retval None
   */
 void HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState)

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_gpio.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_gpio.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_gpio.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of GPIO HAL module.
   ******************************************************************************
   * @attention
@@ -50,11 +50,14 @@
   * @{
   */
 
-/** @addtogroup GPIO
+/** @addtogroup GPIO GPIO HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup GPIO_Exported_Types GPIO Exported Types
+  * @{
+  */
 
 /** 
   * @brief   GPIO Init structure definition  
@@ -87,13 +90,16 @@ typedef enum
 }GPIO_PinState;
 #define IS_GPIO_PIN_ACTION(ACTION) (((ACTION) == GPIO_PIN_RESET) || ((ACTION) == GPIO_PIN_SET))
 
-/* Exported constants --------------------------------------------------------*/
+/**
+  * @}
+  */
 
-/** @defgroup GPIO_Exported_Constants GPIO_Exported_Constants
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup GPIO_Exported_Constants GPIO Exported Constants
   * @{
   */
 
-/** @defgroup GPIO_pins_define GPIO_pins_define
+/** @defgroup GPIO_pins_define GPIO pins define
   * @{
   */
 #define GPIO_PIN_0                 ((uint16_t)0x0001)  /* Pin 0 selected    */
@@ -121,7 +127,7 @@ typedef enum
   * @}
   */
 
-/** @defgroup GPIO_mode_define GPIO_mode_define
+/** @defgroup GPIO_mode_define GPIO mode define
   * @brief GPIO Configuration Mode 
   *        Elements values convention: 0xX0yz00YZ
   *           - X  : GPIO mode or EXTI Mode
@@ -164,7 +170,7 @@ typedef enum
   * @}
   */
                                                          
-/** @defgroup GPIO_speed_define GPIO_speed_define
+/** @defgroup GPIO_speed_define GPIO speed define
   * @brief GPIO Output Maximum frequency
   * @{
   */  
@@ -178,7 +184,7 @@ typedef enum
   * @}
   */
 
- /** @defgroup GPIO_pull_define GPIO_pull_define
+ /** @defgroup GPIO_pull_define GPIO pull define
    * @brief GPIO Pull-Up or Pull-Down Activation
    * @{
    */  
@@ -196,7 +202,10 @@ typedef enum
   * @}
   */
 
-/* Exported macro ------------------------------------------------------------*/
+/* Exported macros -----------------------------------------------------------*/
+/** @defgroup GPIO_Exported_Macros GPIO Exported Macros
+  * @{
+  */
 
 /**
   * @brief  Checks whether the specified EXTI line flag is set or not.
@@ -238,14 +247,32 @@ typedef enum
   */
 #define __HAL_GPIO_EXTI_GENERATE_SWIT(__EXTI_LINE__) (EXTI->SWIER |= (__EXTI_LINE__))
 
-/* Include GPIO HAL Extension module */
+/**
+  * @}
+  */
+
+/* Include GPIO HAL Extended module */
 #include "stm32f3xx_hal_gpio_ex.h"
 
 /* Exported functions --------------------------------------------------------*/ 
+/** @addtogroup GPIO_Exported_Functions GPIO Exported Functions
+* @{
+*/
+
+/** @addtogroup GPIO_Exported_Functions_Group1 Initialization and de-initialization functions
+* @{
+*/
 /* Initialization and de-initialization functions *****************************/
 void              HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init);
 void              HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin);
 
+/**
+  * @}
+  */
+
+/** @addtogroup GPIO_Exported_Functions_Group2 Input and Output operation functions
+* @{
+*/
 /* IO operation functions *****************************************************/
 GPIO_PinState     HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
 void              HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState);
@@ -253,6 +280,14 @@ void              HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
 HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
 void              HAL_GPIO_EXTI_IRQHandler(uint16_t GPIO_Pin);
 void              HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_gpio_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_gpio_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_gpio_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of GPIO HAL Extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of GPIO HAL Extended module.
   ******************************************************************************
   * @attention
   *
@@ -50,24 +50,141 @@
   * @{
   */
 
-/** @addtogroup GPIOEx
+/** @addtogroup GPIOEx GPIO Extended HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/
 
 /* Exported constants --------------------------------------------------------*/
-
-/** @defgroup GPIOEx_Exported_Constants GPIOEx_Exported_Constants
+/** @defgroup GPIOEx_Exported_Constants GPIO Extended Exported Constants
   * @{
   */ 
   
-/** @defgroup GPIOEx_Alternate_function_selection GPIOEx_Alternate_function_selection
+/** @defgroup GPIOEx_Alternate_function_selection GPIO Extended Alternate function selection
   * @{
   */
   
-#if defined (STM32F302xC) || defined (STM32F303xC)
-/*------------------------- STM32F302xC/STM32F303xC---------------------------*/ 
+#if defined (STM32F302xC)
+/*---------------------------------- STM32F302xC ------------------------------*/
+/** 
+  * @brief   AF 0 selection  
+  */ 
+#define GPIO_AF0_RTC_50Hz      ((uint8_t)0x00)  /* RTC_50Hz Alternate Function mapping                       */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /* MCO (MCO1 and MCO2) Alternate Function mapping            */
+#define GPIO_AF0_TAMPER        ((uint8_t)0x00)  /* TAMPER (TAMPER_1 and TAMPER_2) Alternate Function mapping */
+#define GPIO_AF0_SWJ           ((uint8_t)0x00)  /* SWJ (SWD and JTAG) Alternate Function mapping             */
+#define GPIO_AF0_TRACE         ((uint8_t)0x00)  /* TRACE Alternate Function mapping                          */
+
+/** 
+  * @brief   AF 1 selection  
+  */ 
+#define GPIO_AF1_TIM2           ((uint8_t)0x01)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF1_TIM15          ((uint8_t)0x01)  /* TIM15 Alternate Function mapping */
+#define GPIO_AF1_TIM16          ((uint8_t)0x01)  /* TIM16 Alternate Function mapping */
+#define GPIO_AF1_TIM17          ((uint8_t)0x01)  /* TIM17 Alternate Function mapping */
+#define GPIO_AF1_EVENTOUT       ((uint8_t)0x01)  /* EVENTOUT Alternate Function mapping */
+/** 
+  * @brief   AF 2 selection  
+  */ 
+#define GPIO_AF2_TIM1           ((uint8_t)0x02)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF2_TIM2           ((uint8_t)0x02)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF2_TIM3           ((uint8_t)0x02)  /* TIM3 Alternate Function mapping */
+#define GPIO_AF2_TIM4           ((uint8_t)0x02)  /* TIM4 Alternate Function mapping */
+#define GPIO_AF2_TIM15          ((uint8_t)0x02)  /* TIM15 Alternate Function mapping */
+#define GPIO_AF2_COMP1          ((uint8_t)0x02)  /* COMP1 Alternate Function mapping */
+/** 
+  * @brief   AF 3 selection  
+  */ 
+#define GPIO_AF3_TSC           ((uint8_t)0x03)  /* TSC Alternate Function mapping  */
+#define GPIO_AF3_TIM15         ((uint8_t)0x03)  /* TIM15 Alternate Function mapping */
+
+/** 
+  * @brief   AF 4 selection  
+  */ 
+#define GPIO_AF4_TIM1          ((uint8_t)0x04)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF4_TIM16         ((uint8_t)0x04)  /* TIM16 Alternate Function mapping */
+#define GPIO_AF4_TIM17         ((uint8_t)0x04)  /* TIM17 Alternate Function mapping */
+#define GPIO_AF4_I2C1          ((uint8_t)0x04)  /* I2C1 Alternate Function mapping */
+#define GPIO_AF4_I2C2          ((uint8_t)0x04)  /* I2C2 Alternate Function mapping */
+
+/** 
+  * @brief   AF 5 selection  
+  */ 
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /* SPI1/I2S1 Alternate Function mapping */
+#define GPIO_AF5_SPI2          ((uint8_t)0x05)  /* SPI2/I2S2 Alternate Function mapping */
+#define GPIO_AF5_SPI3          ((uint8_t)0x05)  /* SPI3/I2S3 Alternate Function mapping */
+#define GPIO_AF5_I2S           ((uint8_t)0x05)  /* I2S Alternate Function mapping */
+#define GPIO_AF5_I2S2ext       ((uint8_t)0x05)  /* I2S2ext Alternate Function mapping */
+#define GPIO_AF5_IR            ((uint8_t)0x05)  /* IR Alternate Function mapping */
+#define GPIO_AF5_UART4         ((uint8_t)0x05)  /* UART4 Alternate Function mapping */
+#define GPIO_AF5_UART5         ((uint8_t)0x05)  /* UART5 Alternate Function mapping */
+/** 
+  * @brief   AF 6 selection  
+  */ 
+#define GPIO_AF6_SPI2          ((uint8_t)0x06)  /* SPI2/I2S2 Alternate Function mapping */
+#define GPIO_AF6_SPI3          ((uint8_t)0x06)  /* SPI3/I2S3 Alternate Function mapping */
+#define GPIO_AF6_I2S3ext       ((uint8_t)0x06)  /* I2S3ext Alternate Function mapping */
+#define GPIO_AF6_TIM1          ((uint8_t)0x06)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF6_IR            ((uint8_t)0x06)  /* IR Alternate Function mapping */
+
+/** 
+  * @brief   AF 7 selection  
+  */ 
+#define GPIO_AF7_USART1        ((uint8_t)0x07)  /* USART1 Alternate Function mapping  */
+#define GPIO_AF7_USART2        ((uint8_t)0x07)  /* USART2 Alternate Function mapping  */
+#define GPIO_AF7_USART3        ((uint8_t)0x07)  /* USART3 Alternate Function mapping  */
+#define GPIO_AF7_COMP6         ((uint8_t)0x07)  /* COMP6 Alternate Function mapping  */
+#define GPIO_AF7_CAN           ((uint8_t)0x07)  /* CAN Alternate Function mapping  */
+
+/** 
+  * @brief   AF 8 selection  
+  */ 
+#define GPIO_AF8_COMP1         ((uint8_t)0x08)  /* COMP1 Alternate Function mapping  */
+#define GPIO_AF8_COMP2         ((uint8_t)0x08)  /* COMP2 Alternate Function mapping  */
+#define GPIO_AF8_COMP4         ((uint8_t)0x08)  /* COMP4 Alternate Function mapping  */
+#define GPIO_AF8_COMP6         ((uint8_t)0x08)  /* COMP6 Alternate Function mapping  */
+
+/** 
+  * @brief   AF 9 selection 
+  */ 
+#define GPIO_AF9_CAN           ((uint8_t)0x09)  /* CAN Alternate Function mapping  */
+#define GPIO_AF9_TIM1          ((uint8_t)0x09)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF9_TIM15         ((uint8_t)0x09)  /* TIM15 Alternate Function mapping */
+
+/** 
+  * @brief   AF 10 selection  
+  */ 
+#define GPIO_AF10_TIM2           ((uint8_t)0xA)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF10_TIM3           ((uint8_t)0xA)  /* TIM3 Alternate Function mapping */
+#define GPIO_AF10_TIM4           ((uint8_t)0xA)  /* TIM4 Alternate Function mapping */
+#define GPIO_AF10_TIM17          ((uint8_t)0xA)  /* TIM17 Alternate Function mapping */
+/** 
+  * @brief   AF 11 selection  
+  */ 
+#define GPIO_AF11_TIM1           ((uint8_t)0x0B)  /* TIM1 Alternate Function mapping */
+
+/** 
+  * @brief   AF 12 selection  
+  */ 
+#define GPIO_AF12_TIM1            ((uint8_t)0xC)  /* TIM1 Alternate Function mapping */
+
+/** 
+  * @brief   AF 14 selection  
+  */
+
+#define GPIO_AF14_USB           ((uint8_t)0x0E)  /* USB Alternate Function mapping */
+/** 
+  * @brief   AF 15 selection  
+  */ 
+#define GPIO_AF15_EVENTOUT      ((uint8_t)0x0F)  /* EVENTOUT Alternate Function mapping */
+
+#define IS_GPIO_AF(AF)          (((AF) <= (uint8_t)0x0C) || ((AF) == (uint8_t)0x0E) || ((AF) == (uint8_t)0x0F))
+/*------------------------------------------------------------------------------------------*/
+#endif /* STM32F302xC */
+   
+#if defined (STM32F303xC)
+/*---------------------------------- STM32F303xC ------------------------------*/
 /** 
   * @brief   AF 0 selection  
   */ 
@@ -195,7 +312,415 @@
 
 #define IS_GPIO_AF(AF)          (((AF) <= (uint8_t)0x0C) || ((AF) == (uint8_t)0x0E) || ((AF) == (uint8_t)0x0F))
 /*------------------------------------------------------------------------------------------*/
-#endif /* STM32F302xC || STM32F303xC */
+#endif /* STM32F303xC */
+
+#if defined (STM32F303xE)
+/*---------------------------------- STM32F303xE ------------------------------*/
+/** 
+  * @brief   AF 0 selection  
+  */ 
+#define GPIO_AF0_RTC_50Hz      ((uint8_t)0x00)  /* RTC_50Hz Alternate Function mapping                       */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /* MCO (MCO1 and MCO2) Alternate Function mapping            */
+#define GPIO_AF0_TAMPER        ((uint8_t)0x00)  /* TAMPER (TAMPER_1 and TAMPER_2) Alternate Function mapping */
+#define GPIO_AF0_SWJ           ((uint8_t)0x00)  /* SWJ (SWD and JTAG) Alternate Function mapping             */
+#define GPIO_AF0_TRACE         ((uint8_t)0x00)  /* TRACE Alternate Function mapping                          */
+
+/** 
+  * @brief   AF 1 selection  
+  */ 
+#define GPIO_AF1_TIM2           ((uint8_t)0x01)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF1_TIM15          ((uint8_t)0x01)  /* TIM15 Alternate Function mapping */
+#define GPIO_AF1_TIM16          ((uint8_t)0x01)  /* TIM16 Alternate Function mapping */
+#define GPIO_AF1_TIM17          ((uint8_t)0x01)  /* TIM17 Alternate Function mapping */
+#define GPIO_AF1_EVENTOUT       ((uint8_t)0x01)  /* EVENTOUT Alternate Function mapping */
+
+/** 
+  * @brief   AF 2 selection  
+  */ 
+#define GPIO_AF2_TIM1           ((uint8_t)0x02)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF2_TIM2           ((uint8_t)0x02)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF2_TIM3           ((uint8_t)0x02)  /* TIM3 Alternate Function mapping */
+#define GPIO_AF2_TIM4           ((uint8_t)0x02)  /* TIM4 Alternate Function mapping */
+#define GPIO_AF2_TIM8           ((uint8_t)0x02)  /* TIM8 Alternate Function mapping */
+#define GPIO_AF2_TIM15          ((uint8_t)0x02)  /* TIM15 Alternate Function mapping */
+#define GPIO_AF2_COMP1          ((uint8_t)0x02)  /* COMP1 Alternate Function mapping */
+#define GPIO_AF2_I2C3           ((uint8_t)0x02)  /* I2C3 Alternate Function mapping */
+#define GPIO_AF2_TIM20          ((uint8_t)0x02)  /* TIM20 Alternate Function mapping */
+
+/** 
+  * @brief   AF 3 selection  
+  */ 
+#define GPIO_AF3_TSC           ((uint8_t)0x03)  /* TSC Alternate Function mapping  */
+#define GPIO_AF3_TIM8          ((uint8_t)0x03)  /* TIM8 Alternate Function mapping  */
+#define GPIO_AF3_COMP7         ((uint8_t)0x03)  /* COMP7 Alternate Function mapping */
+#define GPIO_AF3_TIM15         ((uint8_t)0x03)  /* TIM15 Alternate Function mapping */
+#define GPIO_AF3_I2C3          ((uint8_t)0x03)  /* I2C3 Alternate Function mapping */
+#define GPIO_AF3_TIM20         ((uint8_t)0x03)  /* TIM20 Alternate Function mapping */
+
+/** 
+  * @brief   AF 4 selection  
+  */ 
+#define GPIO_AF4_TIM1          ((uint8_t)0x04)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF4_TIM8          ((uint8_t)0x04)  /* TIM8 Alternate Function mapping */
+#define GPIO_AF4_TIM16         ((uint8_t)0x04)  /* TIM16 Alternate Function mapping */
+#define GPIO_AF4_TIM17         ((uint8_t)0x04)  /* TIM17 Alternate Function mapping */
+#define GPIO_AF4_I2C1          ((uint8_t)0x04)  /* I2C1 Alternate Function mapping */
+#define GPIO_AF4_I2C2          ((uint8_t)0x04)  /* I2C2 Alternate Function mapping */
+
+/** 
+  * @brief   AF 5 selection  
+  */ 
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /* SPI1 Alternate Function mapping */
+#define GPIO_AF5_SPI2          ((uint8_t)0x05)  /* SPI2/I2S2 Alternate Function mapping */
+#define GPIO_AF5_SPI3          ((uint8_t)0x05)  /* SPI3/I2S3 Alternate Function mapping */
+#define GPIO_AF5_I2S           ((uint8_t)0x05)  /* I2S Alternate Function mapping */
+#define GPIO_AF5_I2S2ext       ((uint8_t)0x05)  /* I2S2ext Alternate Function mapping */
+#define GPIO_AF5_TIM8          ((uint8_t)0x05)  /* TIM8 Alternate Function mapping */
+#define GPIO_AF5_IR            ((uint8_t)0x05)  /* IR Alternate Function mapping */
+#define GPIO_AF5_UART4         ((uint8_t)0x05)  /* UART4 Alternate Function mapping */
+#define GPIO_AF5_UART5         ((uint8_t)0x05)  /* UART5 Alternate Function mapping */
+#define GPIO_AF5_SPI4          ((uint8_t)0x05)  /* SPI4 Alternate Function mapping */
+
+/** 
+  * @brief   AF 6 selection  
+  */ 
+#define GPIO_AF6_SPI2          ((uint8_t)0x06)  /* SPI2/I2S2 Alternate Function mapping */
+#define GPIO_AF6_SPI3          ((uint8_t)0x06)  /* SPI3/I2S3 Alternate Function mapping */
+#define GPIO_AF6_I2S3ext       ((uint8_t)0x06)  /* I2S3ext Alternate Function mapping */
+#define GPIO_AF6_TIM1          ((uint8_t)0x06)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF6_TIM8          ((uint8_t)0x06)  /* TIM8 Alternate Function mapping */
+#define GPIO_AF6_IR            ((uint8_t)0x06)  /* IR Alternate Function mapping */
+#define GPIO_AF6_TIM20         ((uint8_t)0x06)  /* TIM20 Alternate Function mapping */
+
+/** 
+  * @brief   AF 7 selection  
+  */ 
+#define GPIO_AF7_USART1        ((uint8_t)0x07)  /* USART1 Alternate Function mapping  */
+#define GPIO_AF7_USART2        ((uint8_t)0x07)  /* USART2 Alternate Function mapping  */
+#define GPIO_AF7_USART3        ((uint8_t)0x07)  /* USART3 Alternate Function mapping  */
+#define GPIO_AF7_COMP3         ((uint8_t)0x07)  /* COMP3 Alternate Function mapping  */
+#define GPIO_AF7_COMP5         ((uint8_t)0x07)  /* COMP5 Alternate Function mapping  */
+#define GPIO_AF7_COMP6         ((uint8_t)0x07)  /* COMP6 Alternate Function mapping  */
+#define GPIO_AF7_CAN           ((uint8_t)0x07)  /* CAN Alternate Function mapping  */
+
+/** 
+  * @brief   AF 8 selection  
+  */ 
+#define GPIO_AF8_COMP1         ((uint8_t)0x08)  /* COMP1 Alternate Function mapping  */
+#define GPIO_AF8_COMP2         ((uint8_t)0x08)  /* COMP2 Alternate Function mapping  */
+#define GPIO_AF8_COMP3         ((uint8_t)0x08)  /* COMP3 Alternate Function mapping  */
+#define GPIO_AF8_COMP4         ((uint8_t)0x08)  /* COMP4 Alternate Function mapping  */
+#define GPIO_AF8_COMP5         ((uint8_t)0x08)  /* COMP5 Alternate Function mapping  */
+#define GPIO_AF8_COMP6         ((uint8_t)0x08)  /* COMP6 Alternate Function mapping  */
+#define GPIO_AF8_I2C3          ((uint8_t)0x08)  /* I2C3 Alternate Function mapping */
+
+/** 
+  * @brief   AF 9 selection 
+  */ 
+#define GPIO_AF9_CAN           ((uint8_t)0x09)  /* CAN Alternate Function mapping  */
+#define GPIO_AF9_TIM1          ((uint8_t)0x09)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF9_TIM8          ((uint8_t)0x09)  /* TIM8 Alternate Function mapping */
+#define GPIO_AF9_TIM15         ((uint8_t)0x09)  /* TIM15 Alternate Function mapping */
+
+/** 
+  * @brief   AF 10 selection  
+  */ 
+#define GPIO_AF10_TIM2           ((uint8_t)0xA)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF10_TIM3           ((uint8_t)0xA)  /* TIM3 Alternate Function mapping */
+#define GPIO_AF10_TIM4           ((uint8_t)0xA)  /* TIM4 Alternate Function mapping */
+#define GPIO_AF10_TIM8           ((uint8_t)0xA)  /* TIM8 Alternate Function mapping */
+#define GPIO_AF10_TIM17          ((uint8_t)0xA)  /* TIM17 Alternate Function mapping */
+/** 
+  * @brief   AF 11 selection  
+  */ 
+#define GPIO_AF11_TIM1           ((uint8_t)0x0B)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF11_TIM8           ((uint8_t)0x0B)  /* TIM8 Alternate Function mapping */
+
+/** 
+  * @brief   AF 12 selection  
+  */ 
+#define GPIO_AF12_TIM1            ((uint8_t)0xC)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF12_FMC             ((uint8_t)0xC)  /* FMC Alternate Function mapping                      */
+#define GPIO_AF12_SDIO            ((uint8_t)0xC)  /* SDIO Alternate Function mapping                     */
+
+/** 
+  * @brief   AF 14 selection  
+  */
+#define GPIO_AF14_USB           ((uint8_t)0x0E)  /* USB Alternate Function mapping */
+
+/** 
+  * @brief   AF 15 selection  
+  */ 
+#define GPIO_AF15_EVENTOUT      ((uint8_t)0x0F)  /* EVENTOUT Alternate Function mapping */
+
+#define IS_GPIO_AF(AF)          (((AF) <= (uint8_t)0x0C) || ((AF) == (uint8_t)0x0E) || ((AF) == (uint8_t)0x0F))
+/*------------------------------------------------------------------------------------------*/
+#endif /* STM32F303xE */
+
+#if defined (STM32F302xE)
+/*---------------------------------- STM32F302xE ------------------------------*/
+/** 
+  * @brief   AF 0 selection  
+  */ 
+#define GPIO_AF0_RTC_50Hz      ((uint8_t)0x00)  /* RTC_50Hz Alternate Function mapping                       */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /* MCO (MCO1 and MCO2) Alternate Function mapping            */
+#define GPIO_AF0_TAMPER        ((uint8_t)0x00)  /* TAMPER (TAMPER_1 and TAMPER_2) Alternate Function mapping */
+#define GPIO_AF0_SWJ           ((uint8_t)0x00)  /* SWJ (SWD and JTAG) Alternate Function mapping             */
+#define GPIO_AF0_TRACE         ((uint8_t)0x00)  /* TRACE Alternate Function mapping                          */
+
+/** 
+  * @brief   AF 1 selection  
+  */ 
+#define GPIO_AF1_TIM2           ((uint8_t)0x01)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF1_TIM15          ((uint8_t)0x01)  /* TIM15 Alternate Function mapping */
+#define GPIO_AF1_TIM16          ((uint8_t)0x01)  /* TIM16 Alternate Function mapping */
+#define GPIO_AF1_TIM17          ((uint8_t)0x01)  /* TIM17 Alternate Function mapping */
+#define GPIO_AF1_EVENTOUT       ((uint8_t)0x01)  /* EVENTOUT Alternate Function mapping */
+
+/** 
+  * @brief   AF 2 selection  
+  */ 
+#define GPIO_AF2_TIM1           ((uint8_t)0x02)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF2_TIM2           ((uint8_t)0x02)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF2_TIM3           ((uint8_t)0x02)  /* TIM3 Alternate Function mapping */
+#define GPIO_AF2_TIM4           ((uint8_t)0x02)  /* TIM4 Alternate Function mapping */
+#define GPIO_AF2_TIM15          ((uint8_t)0x02)  /* TIM15 Alternate Function mapping */
+#define GPIO_AF2_COMP1          ((uint8_t)0x02)  /* COMP1 Alternate Function mapping */
+#define GPIO_AF2_I2C3           ((uint8_t)0x02)  /* I2C3 Alternate Function mapping */
+
+/** 
+  * @brief   AF 3 selection  
+  */ 
+#define GPIO_AF3_TSC           ((uint8_t)0x03)  /* TSC Alternate Function mapping  */
+#define GPIO_AF3_TIM15         ((uint8_t)0x03)  /* TIM15 Alternate Function mapping */
+#define GPIO_AF3_I2C3          ((uint8_t)0x03)  /* I2C3 Alternate Function mapping */
+
+/** 
+  * @brief   AF 4 selection  
+  */ 
+#define GPIO_AF4_TIM1          ((uint8_t)0x04)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF4_TIM16         ((uint8_t)0x04)  /* TIM16 Alternate Function mapping */
+#define GPIO_AF4_TIM17         ((uint8_t)0x04)  /* TIM17 Alternate Function mapping */
+#define GPIO_AF4_I2C1          ((uint8_t)0x04)  /* I2C1 Alternate Function mapping */
+#define GPIO_AF4_I2C2          ((uint8_t)0x04)  /* I2C2 Alternate Function mapping */
+
+/** 
+  * @brief   AF 5 selection  
+  */ 
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /* SPI1 Alternate Function mapping */
+#define GPIO_AF5_SPI2          ((uint8_t)0x05)  /* SPI2/I2S2 Alternate Function mapping */
+#define GPIO_AF5_SPI3          ((uint8_t)0x05)  /* SPI3/I2S3 Alternate Function mapping */
+#define GPIO_AF5_I2S           ((uint8_t)0x05)  /* I2S Alternate Function mapping */
+#define GPIO_AF5_I2S2ext       ((uint8_t)0x05)  /* I2S2ext Alternate Function mapping */
+#define GPIO_AF5_IR            ((uint8_t)0x05)  /* IR Alternate Function mapping */
+#define GPIO_AF5_UART4         ((uint8_t)0x05)  /* UART4 Alternate Function mapping */
+#define GPIO_AF5_UART5         ((uint8_t)0x05)  /* UART5 Alternate Function mapping */
+#define GPIO_AF5_SPI4          ((uint8_t)0x05)  /* SPI4 Alternate Function mapping */
+
+/** 
+  * @brief   AF 6 selection  
+  */ 
+#define GPIO_AF6_SPI2          ((uint8_t)0x06)  /* SPI2/I2S2 Alternate Function mapping */
+#define GPIO_AF6_SPI3          ((uint8_t)0x06)  /* SPI3/I2S3 Alternate Function mapping */
+#define GPIO_AF6_I2S3ext       ((uint8_t)0x06)  /* I2S3ext Alternate Function mapping */
+#define GPIO_AF6_TIM1          ((uint8_t)0x06)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF6_IR            ((uint8_t)0x06)  /* IR Alternate Function mapping */
+
+/** 
+  * @brief   AF 7 selection  
+  */ 
+#define GPIO_AF7_USART1        ((uint8_t)0x07)  /* USART1 Alternate Function mapping  */
+#define GPIO_AF7_USART2        ((uint8_t)0x07)  /* USART2 Alternate Function mapping  */
+#define GPIO_AF7_USART3        ((uint8_t)0x07)  /* USART3 Alternate Function mapping  */
+#define GPIO_AF7_COMP6         ((uint8_t)0x07)  /* COMP6 Alternate Function mapping  */
+#define GPIO_AF7_CAN           ((uint8_t)0x07)  /* CAN Alternate Function mapping  */
+
+/** 
+  * @brief   AF 8 selection  
+  */ 
+#define GPIO_AF8_COMP1         ((uint8_t)0x08)  /* COMP1 Alternate Function mapping  */
+#define GPIO_AF8_COMP2         ((uint8_t)0x08)  /* COMP2 Alternate Function mapping  */
+#define GPIO_AF8_COMP4         ((uint8_t)0x08)  /* COMP4 Alternate Function mapping  */
+#define GPIO_AF8_COMP6         ((uint8_t)0x08)  /* COMP6 Alternate Function mapping  */
+#define GPIO_AF8_I2C3          ((uint8_t)0x08)  /* I2C3 Alternate Function mapping */
+
+/** 
+  * @brief   AF 9 selection 
+  */ 
+#define GPIO_AF9_CAN           ((uint8_t)0x09)  /* CAN Alternate Function mapping  */
+#define GPIO_AF9_TIM1          ((uint8_t)0x09)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF9_TIM15         ((uint8_t)0x09)  /* TIM15 Alternate Function mapping */
+
+/** 
+  * @brief   AF 10 selection  
+  */ 
+#define GPIO_AF10_TIM2           ((uint8_t)0xA)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF10_TIM3           ((uint8_t)0xA)  /* TIM3 Alternate Function mapping */
+#define GPIO_AF10_TIM4           ((uint8_t)0xA)  /* TIM4 Alternate Function mapping */
+#define GPIO_AF10_TIM17          ((uint8_t)0xA)  /* TIM17 Alternate Function mapping */
+/** 
+  * @brief   AF 11 selection  
+  */ 
+#define GPIO_AF11_TIM1           ((uint8_t)0x0B)  /* TIM1 Alternate Function mapping */
+
+/** 
+  * @brief   AF 12 selection  
+  */ 
+#define GPIO_AF12_TIM1            ((uint8_t)0xC)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF12_FMC             ((uint8_t)0xC)  /* FMC Alternate Function mapping                      */
+#define GPIO_AF12_SDIO            ((uint8_t)0xC)  /* SDIO Alternate Function mapping                     */
+
+/** 
+  * @brief   AF 14 selection  
+  */
+#define GPIO_AF14_USB           ((uint8_t)0x0E)  /* USB Alternate Function mapping */
+
+/** 
+  * @brief   AF 15 selection  
+  */ 
+#define GPIO_AF15_EVENTOUT      ((uint8_t)0x0F)  /* EVENTOUT Alternate Function mapping */
+
+#define IS_GPIO_AF(AF)          (((AF) <= (uint8_t)0x0C) || ((AF) == (uint8_t)0x0E) || ((AF) == (uint8_t)0x0F))
+/*------------------------------------------------------------------------------------------*/
+#endif /* STM32F302xE */
+
+#if defined (STM32F398xx)
+/*---------------------------------- STM32F398xx ------------------------------*/
+/** 
+  * @brief   AF 0 selection  
+  */ 
+#define GPIO_AF0_RTC_50Hz      ((uint8_t)0x00)  /* RTC_50Hz Alternate Function mapping                       */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /* MCO (MCO1 and MCO2) Alternate Function mapping            */
+#define GPIO_AF0_TAMPER        ((uint8_t)0x00)  /* TAMPER (TAMPER_1 and TAMPER_2) Alternate Function mapping */
+#define GPIO_AF0_SWJ           ((uint8_t)0x00)  /* SWJ (SWD and JTAG) Alternate Function mapping             */
+#define GPIO_AF0_TRACE         ((uint8_t)0x00)  /* TRACE Alternate Function mapping                          */
+
+/** 
+  * @brief   AF 1 selection  
+  */ 
+#define GPIO_AF1_TIM2           ((uint8_t)0x01)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF1_TIM15          ((uint8_t)0x01)  /* TIM15 Alternate Function mapping */
+#define GPIO_AF1_TIM16          ((uint8_t)0x01)  /* TIM16 Alternate Function mapping */
+#define GPIO_AF1_TIM17          ((uint8_t)0x01)  /* TIM17 Alternate Function mapping */
+#define GPIO_AF1_EVENTOUT       ((uint8_t)0x01)  /* EVENTOUT Alternate Function mapping */
+
+/** 
+  * @brief   AF 2 selection  
+  */ 
+#define GPIO_AF2_TIM1           ((uint8_t)0x02)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF2_TIM2           ((uint8_t)0x02)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF2_TIM3           ((uint8_t)0x02)  /* TIM3 Alternate Function mapping */
+#define GPIO_AF2_TIM4           ((uint8_t)0x02)  /* TIM4 Alternate Function mapping */
+#define GPIO_AF2_TIM8           ((uint8_t)0x02)  /* TIM8 Alternate Function mapping */
+#define GPIO_AF2_TIM15          ((uint8_t)0x02)  /* TIM15 Alternate Function mapping */
+#define GPIO_AF2_COMP1          ((uint8_t)0x02)  /* COMP1 Alternate Function mapping */
+#define GPIO_AF2_I2C3           ((uint8_t)0x02)  /* I2C3 Alternate Function mapping */
+#define GPIO_AF2_TIM20          ((uint8_t)0x02)  /* TIM20 Alternate Function mapping */
+
+/** 
+  * @brief   AF 3 selection  
+  */ 
+#define GPIO_AF3_TSC           ((uint8_t)0x03)  /* TSC Alternate Function mapping  */
+#define GPIO_AF3_TIM8          ((uint8_t)0x03)  /* TIM8 Alternate Function mapping  */
+#define GPIO_AF3_COMP7         ((uint8_t)0x03)  /* COMP7 Alternate Function mapping */
+#define GPIO_AF3_TIM15         ((uint8_t)0x03)  /* TIM15 Alternate Function mapping */
+#define GPIO_AF3_I2C3          ((uint8_t)0x03)  /* I2C3 Alternate Function mapping */
+#define GPIO_AF3_TIM20         ((uint8_t)0x03)  /* TIM20 Alternate Function mapping */
+
+/** 
+  * @brief   AF 4 selection  
+  */ 
+#define GPIO_AF4_TIM1          ((uint8_t)0x04)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF4_TIM8          ((uint8_t)0x04)  /* TIM8 Alternate Function mapping */
+#define GPIO_AF4_TIM16         ((uint8_t)0x04)  /* TIM16 Alternate Function mapping */
+#define GPIO_AF4_TIM17         ((uint8_t)0x04)  /* TIM17 Alternate Function mapping */
+#define GPIO_AF4_I2C1          ((uint8_t)0x04)  /* I2C1 Alternate Function mapping */
+#define GPIO_AF4_I2C2          ((uint8_t)0x04)  /* I2C2 Alternate Function mapping */
+
+/** 
+  * @brief   AF 5 selection  
+  */ 
+#define GPIO_AF5_SPI1          ((uint8_t)0x05)  /* SPI1 Alternate Function mapping */
+#define GPIO_AF5_SPI2          ((uint8_t)0x05)  /* SPI2/I2S2 Alternate Function mapping */
+#define GPIO_AF5_SPI3          ((uint8_t)0x05)  /* SPI3/I2S3 Alternate Function mapping */
+#define GPIO_AF5_I2S           ((uint8_t)0x05)  /* I2S Alternate Function mapping */
+#define GPIO_AF5_I2S2ext       ((uint8_t)0x05)  /* I2S2ext Alternate Function mapping */
+#define GPIO_AF5_TIM8          ((uint8_t)0x05)  /* TIM8 Alternate Function mapping */
+#define GPIO_AF5_IR            ((uint8_t)0x05)  /* IR Alternate Function mapping */
+#define GPIO_AF5_UART4         ((uint8_t)0x05)  /* UART4 Alternate Function mapping */
+#define GPIO_AF5_UART5         ((uint8_t)0x05)  /* UART5 Alternate Function mapping */
+#define GPIO_AF5_SPI4          ((uint8_t)0x05)  /* SPI4 Alternate Function mapping */
+
+/** 
+  * @brief   AF 6 selection  
+  */ 
+#define GPIO_AF6_SPI2          ((uint8_t)0x06)  /* SPI2/I2S2 Alternate Function mapping */
+#define GPIO_AF6_SPI3          ((uint8_t)0x06)  /* SPI3/I2S3 Alternate Function mapping */
+#define GPIO_AF6_I2S3ext       ((uint8_t)0x06)  /* I2S3ext Alternate Function mapping */
+#define GPIO_AF6_TIM1          ((uint8_t)0x06)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF6_TIM8          ((uint8_t)0x06)  /* TIM8 Alternate Function mapping */
+#define GPIO_AF6_IR            ((uint8_t)0x06)  /* IR Alternate Function mapping */
+#define GPIO_AF6_TIM20         ((uint8_t)0x06)  /* TIM20 Alternate Function mapping */
+
+/** 
+  * @brief   AF 7 selection  
+  */ 
+#define GPIO_AF7_USART1        ((uint8_t)0x07)  /* USART1 Alternate Function mapping  */
+#define GPIO_AF7_USART2        ((uint8_t)0x07)  /* USART2 Alternate Function mapping  */
+#define GPIO_AF7_USART3        ((uint8_t)0x07)  /* USART3 Alternate Function mapping  */
+#define GPIO_AF7_COMP3         ((uint8_t)0x07)  /* COMP3 Alternate Function mapping  */
+#define GPIO_AF7_COMP5         ((uint8_t)0x07)  /* COMP5 Alternate Function mapping  */
+#define GPIO_AF7_COMP6         ((uint8_t)0x07)  /* COMP6 Alternate Function mapping  */
+#define GPIO_AF7_CAN           ((uint8_t)0x07)  /* CAN Alternate Function mapping  */
+
+/** 
+  * @brief   AF 8 selection  
+  */ 
+#define GPIO_AF8_COMP1         ((uint8_t)0x08)  /* COMP1 Alternate Function mapping  */
+#define GPIO_AF8_COMP2         ((uint8_t)0x08)  /* COMP2 Alternate Function mapping  */
+#define GPIO_AF8_COMP3         ((uint8_t)0x08)  /* COMP3 Alternate Function mapping  */
+#define GPIO_AF8_COMP4         ((uint8_t)0x08)  /* COMP4 Alternate Function mapping  */
+#define GPIO_AF8_COMP5         ((uint8_t)0x08)  /* COMP5 Alternate Function mapping  */
+#define GPIO_AF8_COMP6         ((uint8_t)0x08)  /* COMP6 Alternate Function mapping  */
+#define GPIO_AF8_I2C3          ((uint8_t)0x08)  /* I2C3 Alternate Function mapping */
+
+/** 
+  * @brief   AF 9 selection 
+  */ 
+#define GPIO_AF9_CAN           ((uint8_t)0x09)  /* CAN Alternate Function mapping  */
+#define GPIO_AF9_TIM1          ((uint8_t)0x09)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF9_TIM8          ((uint8_t)0x09)  /* TIM8 Alternate Function mapping */
+#define GPIO_AF9_TIM15         ((uint8_t)0x09)  /* TIM15 Alternate Function mapping */
+
+/** 
+  * @brief   AF 10 selection  
+  */ 
+#define GPIO_AF10_TIM2           ((uint8_t)0xA)  /* TIM2 Alternate Function mapping */
+#define GPIO_AF10_TIM3           ((uint8_t)0xA)  /* TIM3 Alternate Function mapping */
+#define GPIO_AF10_TIM4           ((uint8_t)0xA)  /* TIM4 Alternate Function mapping */
+#define GPIO_AF10_TIM8           ((uint8_t)0xA)  /* TIM8 Alternate Function mapping */
+#define GPIO_AF10_TIM17          ((uint8_t)0xA)  /* TIM17 Alternate Function mapping */
+/** 
+  * @brief   AF 11 selection  
+  */ 
+#define GPIO_AF11_TIM1           ((uint8_t)0x0B)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF11_TIM8           ((uint8_t)0x0B)  /* TIM8 Alternate Function mapping */
+
+/** 
+  * @brief   AF 12 selection  
+  */ 
+#define GPIO_AF12_TIM1            ((uint8_t)0xC)  /* TIM1 Alternate Function mapping */
+#define GPIO_AF12_FMC             ((uint8_t)0xC)  /* FMC Alternate Function mapping                      */
+#define GPIO_AF12_SDIO            ((uint8_t)0xC)  /* SDIO Alternate Function mapping                     */
+
+/** 
+  * @brief   AF 15 selection  
+  */ 
+#define GPIO_AF15_EVENTOUT      ((uint8_t)0x0F)  /* EVENTOUT Alternate Function mapping */
+
+#define IS_GPIO_AF(AF)          (((AF) <= (uint8_t)0x0C) || ((AF) == (uint8_t)0x0F))
+/*------------------------------------------------------------------------------------------*/
+#endif /* STM32F398xx */
 
 #if defined (STM32F358xx)
 /*---------------------------------- STM32F358xx -------------------------------------------*/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_hrtim.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_hrtim.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_hrtim.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   TIM HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the High Resolution Timer (HRTIM) peripheral:
@@ -322,17 +322,20 @@
   * @{
   */
 
-/** @defgroup HRTIM 
-  * @brief HRTIM HAL module driver
-  * @{
-  */
-
 #ifdef HAL_HRTIM_MODULE_ENABLED
 
 #if defined(STM32F334x8)
 
+/** @defgroup HRTIM HRTIM HAL module driver
+  * @brief HRTIM HAL module driver
+  * @{
+  */
+
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+/** @defgroup HRTIM_Private_Defines HRTIM Private Define
+  * @{
+  */
 #define HRTIM_FLTR_FLTxEN (HRTIM_FLTR_FLT1EN |\
                            HRTIM_FLTR_FLT2EN |\
                            HRTIM_FLTR_FLT3EN |\
@@ -345,9 +348,15 @@
                                       HRTIM_TIMUPDATETRIGGER_TIMER_C |\
                                       HRTIM_TIMUPDATETRIGGER_TIMER_D |\
                                       HRTIM_TIMUPDATETRIGGER_TIMER_E)
+/**
+  * @}
+  */
 
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
+/** @defgroup HRTIM_Private_Variables HRTIM Private Variables
+  * @{
+  */
 static uint32_t TimerIdxToTimerId[] = 
 {
   HRTIM_TIMERID_TIMER_A,
@@ -357,9 +366,14 @@ static uint32_t TimerIdxToTimerId[] =
   HRTIM_TIMERID_TIMER_E,
   HRTIM_TIMERID_MASTER,
 };
+/**
+  * @}
+  */
 
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/** @defgroup HRTIM_Private_Functions HRTIM Private Functions
+  * @{
+  */
 static void HRTIM_MasterBase_Config(HRTIM_HandleTypeDef * hhrtim, 
                                     HRTIM_TimeBaseCfgTypeDef * pTimeBaseCfg);
 
@@ -427,12 +441,16 @@ static void HRTIM_DMATimerxCplt(DMA_HandleTypeDef *hdma);
 static void HRTIM_DMAError(DMA_HandleTypeDef *hdma);
 
 static void HRTIM_BurstDMACplt(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
 
-/** @defgroup HRTIM_Private_Functions
-* @{
-*/
+/* Exported functions ---------------------------------------------------------*/
+/** @defgroup HRTIM_Exported_Functions HRTIM Exported Functions
+  * @{
+  */
 
-/** @defgroup HAL_HRTIM_Group1 Initialization and de-initialization functions  
+/** @defgroup HRTIM_Exported_Functions_Group1 Initialization and de-initialization functions  
  *  @brief    Initialization and Configuration functions 
  *
 @verbatim    
@@ -463,7 +481,7 @@ HAL_StatusTypeDef HAL_HRTIM_Init(HRTIM_HandleTypeDef * hhrtim)
   uint32_t hrtim_mcr;
   
   /* Check the HRTIM handle allocation */
-  if(hhrtim == NULL)
+  if(hhrtim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -476,12 +494,12 @@ HAL_StatusTypeDef HAL_HRTIM_Init(HRTIM_HandleTypeDef * hhrtim)
   hhrtim->State = HAL_HRTIM_STATE_BUSY;
   
   /* Initialize the DMA handles */
-  hhrtim->hdmaMaster = (DMA_HandleTypeDef *)NULL;    
-  hhrtim->hdmaTimerA = (DMA_HandleTypeDef *)NULL;     
-  hhrtim->hdmaTimerB = (DMA_HandleTypeDef *)NULL;  
-  hhrtim->hdmaTimerC = (DMA_HandleTypeDef *)NULL;  
-  hhrtim->hdmaTimerD = (DMA_HandleTypeDef *)NULL;  
-  hhrtim->hdmaTimerE = (DMA_HandleTypeDef *)NULL;  
+  hhrtim->hdmaMaster = (DMA_HandleTypeDef *)HAL_NULL;    
+  hhrtim->hdmaTimerA = (DMA_HandleTypeDef *)HAL_NULL;     
+  hhrtim->hdmaTimerB = (DMA_HandleTypeDef *)HAL_NULL;  
+  hhrtim->hdmaTimerC = (DMA_HandleTypeDef *)HAL_NULL;  
+  hhrtim->hdmaTimerD = (DMA_HandleTypeDef *)HAL_NULL;  
+  hhrtim->hdmaTimerE = (DMA_HandleTypeDef *)HAL_NULL;  
   
   /* HRTIM output synchronization configuration (if required) */
   if ((hhrtim->Init.SyncOptions & HRTIM_SYNCOPTION_MASTER) != RESET)
@@ -562,7 +580,7 @@ HAL_StatusTypeDef HAL_HRTIM_Init(HRTIM_HandleTypeDef * hhrtim)
 HAL_StatusTypeDef HAL_HRTIM_DeInit (HRTIM_HandleTypeDef * hhrtim)
 {
   /* Check the HRTIM handle allocation */
-  if(hhrtim == NULL)
+  if(hhrtim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -806,7 +824,7 @@ HAL_StatusTypeDef HAL_HRTIM_TimeBaseConfig(HRTIM_HandleTypeDef *hhrtim,
   * @}
   */
 
-/** @defgroup HAL_HRTIM_Group2 Simple time base mode functions  
+/** @defgroup HRTIM_Exported_Functions_Group2 Simple time base mode functions  
  *  @brief    When à HRTIM timer operates in simple time base mode, the
  *            timer counter counts from 0 to the period value.
  *
@@ -1087,7 +1105,7 @@ HAL_StatusTypeDef HAL_HRTIM_SimpleBaseStart_DMA(HRTIM_HandleTypeDef * hhrtim,
   *                   @arg HRTIM_TIMERINDEX_TIMER_C for timer C
   *                   @arg HRTIM_TIMERINDEX_TIMER_D for timer D
   *                   @arg HRTIM_TIMERINDEX_TIMER_E for timer E
- * @retval HAL status
+  * @retval HAL status
   */
 HAL_StatusTypeDef HAL_HRTIM_SimpleBaseStop_DMA(HRTIM_HandleTypeDef * hhrtim,
                                               uint32_t TimerIdx)
@@ -1135,7 +1153,7 @@ HAL_StatusTypeDef HAL_HRTIM_SimpleBaseStop_DMA(HRTIM_HandleTypeDef * hhrtim,
   * @}
   */
 
-/** @defgroup HAL_HRTIM_Group3 Simple output compare mode functions  
+/** @defgroup HRTIM_Exported_Functions_Group3 Simple output compare mode functions  
  *  @brief    When a HRTIM timer operates in simple output compare mode
  *            the output level is set to a programmable value when a match 
  *            is found between the compare register and the counter.
@@ -1697,7 +1715,7 @@ HAL_StatusTypeDef HAL_HRTIM_SimpleOCStop_DMA(HRTIM_HandleTypeDef * hhrtim,
   * @}
   */
 
-/** @defgroup HAL_HRTIM_Group4 Simple PWM output mode functions  
+/** @defgroup HRTIM_Exported_Functions_Group4 Simple PWM output mode functions  
  *  @brief    When a HRTIM timer operates in simple PWM output mode 
  *            the output level is set to a programmable value when a match is
  *            found between the compare register and the counter and reset when
@@ -1752,6 +1770,8 @@ HAL_StatusTypeDef HAL_HRTIM_SimpleOCStop_DMA(HRTIM_HandleTypeDef * hhrtim,
   *       Output Set/Reset crossbar is set as follows:
   *         Ouput 1: SETx1R = CMP1, RSTx1R = PER
   *         Output 2: SETx2R = CMP2, RST2R = PER
+  * @note When Simple PWM mode is used the registers preload mechanism is 
+  *       enabled (otherwise the behavior is not guaranteed).
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_HRTIM_SimplePWMChannelConfig(HRTIM_HandleTypeDef * hhrtim,
@@ -1762,6 +1782,7 @@ HAL_StatusTypeDef HAL_HRTIM_SimplePWMChannelConfig(HRTIM_HandleTypeDef * hhrtim,
   uint32_t CompareUnit = 0xFFFFFFFF;
   HRTIM_CompareCfgTypeDef CompareCfg;
   HRTIM_OutputCfgTypeDef OutputCfg;
+  uint32_t hrtim_timcr;
 
   /* Check parameters */
   assert_param(IS_HRTIM_TIMER_OUTPUT(TimerIdx, PWMChannel));
@@ -1829,7 +1850,12 @@ HAL_StatusTypeDef HAL_HRTIM_SimplePWMChannelConfig(HRTIM_HandleTypeDef * hhrtim,
   HRTIM_OutputConfig(hhrtim,
                      TimerIdx,
                      PWMChannel,
-                     &OutputCfg);  
+                     &OutputCfg);
+  
+  /* Enable the registers preload mechanism */
+  hrtim_timcr   = hhrtim->Instance->sTimerxRegs[TimerIdx].TIMxCR;
+  hrtim_timcr |= HRTIM_TIMCR_PREEN;
+  hhrtim->Instance->sTimerxRegs[TimerIdx].TIMxCR  = hrtim_timcr;  
   
   hhrtim->State = HAL_HRTIM_STATE_READY;
   
@@ -2282,7 +2308,7 @@ HAL_StatusTypeDef HAL_HRTIM_SimplePWMStop_DMA(HRTIM_HandleTypeDef * hhrtim,
   * @}
   */
 
-/** @defgroup HAL_HRTIM_Group5 Simple input capture functions  
+/** @defgroup HRTIM_Exported_Functions_Group5 Simple input capture functions  
  *  @brief    When a HRTIM timer operates in simple input capture mode 
  *            the Capture Register (HRTIM_CPT1/2xR) is used to latch the
  *            value of the timer counter counter after a transition detected 
@@ -2785,7 +2811,7 @@ HAL_StatusTypeDef HAL_HRTIM_SimpleCaptureStop_DMA(HRTIM_HandleTypeDef * hhrtim,
   * @}
   */
 
-/** @defgroup HAL_HRTIM_Group6 Simple one pulse functions  
+/** @defgroup HRTIM_Exported_Functions_Group6 Simple one pulse functions  
  *  @brief    When a HRTIM timer operates in simple one pulse mode 
  *            the timer counter is started in response to transition detected 
  *            on a given external event input to generate a pulse with a 
@@ -3206,7 +3232,7 @@ HAL_StatusTypeDef HAL_HRTIM_SimpleOnePulseStop_IT(HRTIM_HandleTypeDef * hhrtim,
   * @}
   */
 
-/** @defgroup HAL_HRTIM_Group7 HRTIM configuration functions  
+/** @defgroup HRTIM_Exported_Functions_Group7 Configuration functions  
  *  @brief    Functions configuring the HRTIM resources shared by all the
  *            HRTIM timers operating in waveform mode.
  *
@@ -3698,7 +3724,7 @@ HAL_StatusTypeDef HAL_HRTIM_ADCTriggerConfig(HRTIM_HandleTypeDef * hhrtim,
   * @}
   */
 
-/** @defgroup HAL_HRTIM_Group8 HRTIM timer configuration and functions
+/** @defgroup HRTIM_Exported_Functions_Group8 Timer waveform configuration and functions
  *  @brief    Functions used to configure and control a HRTIM timer 
  *            operating in waveform mode.
  *
@@ -5394,7 +5420,7 @@ HAL_StatusTypeDef HAL_HRTIM_UpdateDisable(HRTIM_HandleTypeDef *hhrtim,
   * @}
   */
 
-/** @defgroup HAL_HRTIM_Group9 HRTIM peripheral state functions
+/** @defgroup HRTIM_Exported_Functions_Group9 Peripheral state functions
  *  @brief    Functions used to get HRTIM or HRTIM timer specific
  *            information.
  *
@@ -5809,7 +5835,7 @@ uint32_t HAL_HRTIM_GetIdlePushPullStatus(HRTIM_HandleTypeDef * hhrtim,
   * @}
   */
 
-/** @defgroup HAL_HRTIM_Group10 HRTIM interrupts handling
+/** @defgroup HRTIM_Exported_Functions_Group10 Interrupts handling
  *  @brief  Functions called when HRTIM generates an interrupt
  *          7 interrupts can be generated by the master timer:
  *            - Master timer registers update
@@ -6331,6 +6357,14 @@ __weak void HAL_HRTIM_ErrorCallback(HRTIM_HandleTypeDef *hhrtim)
 
 /**
   * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup HRTIM_Private_Functions HRTIM Private Functions
+  * @{
   */
 
 /**
@@ -7247,7 +7281,7 @@ static uint32_t HRTIM_GetDMAFromOCMode(HRTIM_HandleTypeDef * hhrtim,
 static DMA_HandleTypeDef * HRTIM_GetDMAHandleFromTimerIdx(HRTIM_HandleTypeDef * hhrtim,
                                                           uint32_t TimerIdx)
 {
-  DMA_HandleTypeDef * hdma = (DMA_HandleTypeDef *)NULL;
+  DMA_HandleTypeDef * hdma = (DMA_HandleTypeDef *)HAL_NULL;
   
   switch (TimerIdx)
   {
@@ -7888,12 +7922,12 @@ static void HRTIM_BurstDMACplt(DMA_HandleTypeDef *hdma)
   * @}
   */
 
-#endif /* STM32F334x8 */
-
-#endif /* HAL_HRTIM_MODULE_ENABLED */
 /**
   * @}
   */
+#endif /* STM32F334x8 */
+
+#endif /* HAL_HRTIM_MODULE_ENABLED */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_hrtim.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_hrtim.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_hrtim.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of HRTIM HAL module.
   ******************************************************************************
   * @attention
@@ -52,13 +52,29 @@
   * @{
   */
 
-/** @addtogroup HRTIM
+/** @addtogroup HRTIM HRTIM HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @addtogroup HRTIM_Exported_Constants HRTIM Exported Constants
+  * @{
+  */
+/** @defgroup HRTIM_Max_Timer HRTIM Max Timer
+  * @{
+  */
 #define MAX_HRTIM_TIMER 6
-   
+/**
+  * @}
+  */
+/**
+  * @}
+  */
+
+/** @defgroup HRTIM_Exported_Types HRTIM Exported Types
+  * @{
+  */
+
 /** 
   * @brief  HRTIM Configuration Structure definition - Time base related parameters
   */
@@ -393,7 +409,7 @@ typedef struct {
   */
 typedef struct {
   uint32_t Mode;           /*!< Specifies the burst mode operating mode
-                                This parameter can be a value of @ref HRTIM_Burst_Mode_Operating_mode */
+                                This parameter can be a value of @ref HRTIM_Burst_Mode_Operating_Mode */
   uint32_t ClockSource;    /*!< Specifies the burst mode clock source
                                 This parameter can be a value of @ref HRTIM_Burst_Mode_Clock_Source */
   uint32_t Prescaler;      /*!< Specifies the burst mode prescaler
@@ -418,13 +434,16 @@ typedef struct {
                               This parameter can be a value of @ref HRTIM_ADC_Trigger_Event  */
 } HRTIM_ADCTriggerCfgTypeDef;
 
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup HRTIM_Exported_Constants
+/** @defgroup HRTIM_Exported_Constants HRTIM Exported Constants
   * @{
   */
 
-/** @defgroup HRTIM_Timer_Index 
+/** @defgroup HRTIM_Timer_Index HRTIM Timer Index
   * @{
   * @brief Constants defining the timer indexes
   */
@@ -454,7 +473,7 @@ typedef struct {
   * @}
   */
     
-/** @defgroup HRTIM_Timer_identifier 
+/** @defgroup HRTIM_Timer_identifier HRTIM Timer identifier
   * @{
   * @brief Constants defining timer identifiers
   */ 
@@ -471,7 +490,7 @@ typedef struct {
  * @}
  */
     
-/** @defgroup HRTIM_Compare_Unit 
+/** @defgroup HRTIM_Compare_Unit HRTIM Compare Unit
   * @{
   * @brief Constants defining compare unit identifiers
   */  
@@ -489,7 +508,7 @@ typedef struct {
   * @}
   */
     
-/** @defgroup HRTIM_Capture_Unit 
+/** @defgroup HRTIM_Capture_Unit HRTIM Capture Unit
   * @{
   * @brief Constants defining capture unit identifiers
   */  
@@ -503,7 +522,7 @@ typedef struct {
   * @}
   */
  
-/** @defgroup HRTIM_Timer_Output 
+/** @defgroup HRTIM_Timer_Output HRTIM Timer Output
   * @{
   * @brief Constants defining timer output identifiers
   */  
@@ -544,7 +563,7 @@ typedef struct {
   * @}
   */
     
-/** @defgroup HRTIM_ADC_Trigger
+/** @defgroup HRTIM_ADC_Trigger HRTIM ADC Trigger
   * @{
   * @brief Constants defining ADC triggers identifiers
   */
@@ -562,7 +581,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_External_Event_Channels
+/** @defgroup HRTIM_External_Event_Channels HRTIM External Event Channels
   * @{
   * @brief Constants defining external event channel identifiers
   */
@@ -593,7 +612,7 @@ typedef struct {
   * @}
   */
     
-/** @defgroup HRTIM_Fault_Channel
+/** @defgroup HRTIM_Fault_Channel HRTIM Fault Channel
   * @{
   * @brief Constants defining fault channel identifiers
   */ 
@@ -614,7 +633,7 @@ typedef struct {
   */
 
 
- /** @defgroup HRTIM_Prescaler_Ratio 
+ /** @defgroup HRTIM_Prescaler_Ratio HRTIM Prescaler Ratio
   * @{
   * @brief Constants defining timer high-resolution clock prescaler ratio.
   */  
@@ -640,7 +659,7 @@ typedef struct {
   * @}
   */
   
-/** @defgroup HRTIM_Mode 
+/** @defgroup HRTIM_Mode HRTIM Mode
   * @{
   * @brief Constants defining timer counter operating mode.
   */  
@@ -661,7 +680,7 @@ typedef struct {
   * @}
   */
   
-/** @defgroup HRTIM_Half_Mode_Enable 
+/** @defgroup HRTIM_Half_Mode_Enable HRTIM Half Mode Enable
   * @{
   * @brief Constants defining half mode enabling status.
   */  
@@ -675,7 +694,7 @@ typedef struct {
   * @}
   */
               
-/** @defgroup HRTIM_Start_On_Sync_Input_Event 
+/** @defgroup HRTIM_Start_On_Sync_Input_Event HRTIM Start On Sync Input Event
   * @{
   * @brief Constants defining the timer behavior following the synchronization event
   */
@@ -689,7 +708,7 @@ typedef struct {
   * @}
   */
               
-/** @defgroup HRTIM_Reset_On_Sync_Input_Event 
+/** @defgroup HRTIM_Reset_On_Sync_Input_Event HRTIM Reset On Sync Input Event
   * @{
   * @brief Constants defining the timer behavior following the synchronization event
   */  
@@ -703,7 +722,7 @@ typedef struct {
   * @}
   */    
 
-/** @defgroup HRTIM_DAC_Synchronization 
+/** @defgroup HRTIM_DAC_Synchronization HRTIM DAC Synchronization
   * @{
   * @brief Constants defining on which output the DAC synchronization event is sent
   */ 
@@ -721,7 +740,7 @@ typedef struct {
   * @}
   */         
 
-/** @defgroup HRTIM_Register_Preload_Enable 
+/** @defgroup HRTIM_Register_Preload_Enable HRTIM Register Preload Enable
   * @{
   * @brief Constants defining whether a write access into a preloadable
   *        register is done into the active or the preload register.
@@ -736,7 +755,7 @@ typedef struct {
   * @}
   */   
 
-/** @defgroup HRTIM_Update_Gating 
+/** @defgroup HRTIM_Update_Gating HRTIM Update Gating
   * @{
   * @brief Constants defining how the update occurs relatively to the burst DMA 
   *        transaction and the external update request on update enable inputs 1 to 3.
@@ -770,7 +789,7 @@ typedef struct {
   * @}
   */ 
                   
-/** @defgroup HRTIM_Timer_Burst_Mode 
+/** @defgroup HRTIM_Timer_Burst_Mode HRTIM Timer Burst Mode
   * @{
   * @brief Constants defining how the timer behaves during a burst
             mode operation.
@@ -785,7 +804,7 @@ typedef struct {
   * @}
   */ 
 
-/** @defgroup HRTIM_Timer_Repetition_Update
+/** @defgroup HRTIM_Timer_Repetition_Update HRTIM Timer Repetition Update
   * @{
   * @brief Constants defining whether registers are updated when the timer
   *        repetition period is completed (either due to roll-over or
@@ -802,7 +821,7 @@ typedef struct {
   */
             
 
-/** @defgroup HRTIM_Timer_Push_Pull_Mode
+/** @defgroup HRTIM_Timer_Push_Pull_Mode HRTIM Timer Push Pull Mode
   * @{
   * @brief Constants defining whether or not the puhs-pull mode is enabled for
   *        a timer.
@@ -817,7 +836,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Timer_Fault_Enabling
+/** @defgroup HRTIM_Timer_Fault_Enabling HRTIM Timer Fault Enabling
   * @{
   * @brief Constants defining whether a faut channel is enabled for a timer
   */
@@ -834,7 +853,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Timer_Fault_Lock
+/** @defgroup HRTIM_Timer_Fault_Lock HRTIM Timer Fault Lock
   * @{
   * @brief Constants defining whether or not fault enabling bits are write 
   *        protected for a timer
@@ -849,7 +868,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Timer_Deadtime_Insertion
+/** @defgroup HRTIM_Timer_Deadtime_Insertion HRTIM Timer Deadtime Insertion
   * @{
   * @brief Constants defining whether or not fault the dead time insertion  
   *        feature is enabled for a timer
@@ -868,7 +887,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Timer_Delayed_Protection_Mode
+/** @defgroup HRTIM_Timer_Delayed_Protection_Mode HRTIM Timer Delayed Protection Mode
   * @{
   * @brief Constants defining all possible delayed protection modes 
   *        for a timer. Also definethe source and outputs on which the delayed 
@@ -900,7 +919,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Timer_Update_Trigger
+/** @defgroup HRTIM_Timer_Update_Trigger HRTIM Timer Update Trigger
   * @{
   * @brief Constants defining whether the registers update is done synchronously 
   *        with any other timer or master update
@@ -918,7 +937,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Timer_Reset_Trigger
+/** @defgroup HRTIM_Timer_Reset_Trigger HRTIM Timer Reset Trigger
   * @{
   * @brief Constants defining the events that can be selected to trigger the reset 
   *        of the timer counter
@@ -961,7 +980,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Timer_Reset_Update
+/** @defgroup HRTIM_Timer_Reset_Update HRTIM Timer Reset Update
   * @{
   * @brief Constants defining whether the register are updated upon Timerx 
   *        counter reset or roll-over to 0 after reaching the period value
@@ -977,7 +996,7 @@ typedef struct {
   * @}
   */
               
-/** @defgroup HRTIM_Compare_Unit_Auto_Delayed_Mode
+/** @defgroup HRTIM_Compare_Unit_Auto_Delayed_Mode HRTIM Compare Unit Auto Delayed Mode
   * @{
   * @brief Constants defining whether the compare register is behaving in 
   *        regular mode (compare match issued as soon as counter equal compare),
@@ -1011,7 +1030,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Simple_OC_Mode
+/** @defgroup HRTIM_Simple_OC_Mode HRTIM Simple OC Mode
   * @{
   * @brief Constants defining the behavior of the output signal when the timer
            operates in basic output compare mode
@@ -1028,7 +1047,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Output_Polarity
+/** @defgroup HRTIM_Output_Polarity HRTIM Output Polarity
   * @{
   * @brief Constants defining the polarity of a timer output
   */              
@@ -1042,7 +1061,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Output_Set_Source
+/** @defgroup HRTIM_Output_Set_Source HRTIM Output Set Source
   * @{
   * @brief Constants defining the events that can be selected to configure the
   *        set crossbar of a timer output
@@ -1117,7 +1136,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Output_Reset_Source
+/** @defgroup HRTIM_Output_Reset_Source HRTIM Output Reset Source
   * @{
   * @brief Constants defining the events that can be selected to configure the
   *        set crossbar of a timer output
@@ -1192,7 +1211,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Output_Idle_Mode
+/** @defgroup HRTIM_Output_Idle_Mode HRTIM Output Idle Mode
   * @{
   * @brief Constants defining whether or not the timer output transition to its 
            IDLE state when burst mode is entered
@@ -1207,7 +1226,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Output_IDLE_Level
+/** @defgroup HRTIM_Output_IDLE_Level HRTIM Output IDLE Level
   * @{
   * @brief Constants defining the output level when output is in IDLE state
   */  
@@ -1221,7 +1240,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Output_FAULT_Level
+/** @defgroup HRTIM_Output_FAULT_Level HRTIM Output FAULT Level
   * @{
   * @brief Constants defining the output level when output is in FAULT state
   */  
@@ -1239,13 +1258,13 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Output_Chopper_Mode_Enable
+/** @defgroup HRTIM_Output_Chopper_Mode_Enable HRTIM Output Chopper Mode Enable
   * @{
   * @brief Constants defining whether or not chopper mode is enabled for a timer
            output
   */  
-#define HRTIM_OUTPUTCHOPPERMODE_DISABLED   (uint32_t)0x00000000  /*!< The output is not affected by the fault input */
-#define HRTIM_OUTPUTCHOPPERMODE_ENABLED    (HRTIM_OUTR_CHP1)     /*!< Output at active level when in FAULT state */
+#define HRTIM_OUTPUTCHOPPERMODE_DISABLED   (uint32_t)0x00000000  /*!< Output signal is not altered  */
+#define HRTIM_OUTPUTCHOPPERMODE_ENABLED    (HRTIM_OUTR_CHP1)     /*!< Output signal is chopped by a carrier signal  */
 
 #define IS_HRTIM_OUTPUTCHOPPERMODE(OUTPUTCHOPPERMODE)\
               (((OUTPUTCHOPPERMODE) == HRTIM_OUTPUTCHOPPERMODE_DISABLED)  || \
@@ -1254,7 +1273,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Output_Burst_Mode_Entry_Delayed
+/** @defgroup HRTIM_Output_Burst_Mode_Entry_Delayed HRTIM Output Burst Mode Entry Delayed
   * @{
   * @brief Constants defining the idle mode entry is delayed by forcing a 
            deadtime insertion before switching the outputs to their idle state
@@ -1269,7 +1288,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Capture_Unit_Trigger
+/** @defgroup HRTIM_Capture_Unit_Trigger HRTIM Capture Unit Trigger
   * @{
   * @brief Constants defining the events that can be selected to trigger the 
   *        capture of the timing unit counter
@@ -1414,7 +1433,7 @@ typedef struct {
   * @}
   */   
 
-/** @defgroup HRTIM_Timer_External_Event_Filter
+/** @defgroup HRTIM_Timer_External_Event_Filter HRTIM Timer External Event Filter
   * @{
   * @brief Constants defining the event filtering apploed to external events
   *        by a timer
@@ -1457,7 +1476,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Timer_External_Event_Latch
+/** @defgroup HRTIM_Timer_External_Event_Latch HRTIM Timer External Event Latch
   * @{
   * @brief Constants defining whether or not the external event is
   *        memorized (latched) and generated as soon as the blanking period
@@ -1473,7 +1492,7 @@ typedef struct {
   * @}
   */
     
-/** @defgroup HRTIM_Deadtime_Prescaler_Ratio
+/** @defgroup HRTIM_Deadtime_Prescaler_Ratio HRTIM Deadtime Prescaler Ratio
   * @{
   * @brief Constants defining division ratio between the timer clock frequency 
   *        (fHRTIM) and the deadtime generator clock (fDTG)
@@ -1500,7 +1519,7 @@ typedef struct {
   * @}
   */
                   
-/** @defgroup HRTIM_Deadtime_Rising_Sign
+/** @defgroup HRTIM_Deadtime_Rising_Sign HRTIM Deadtime Rising Sign
   * @{
   * @brief Constants defining whether the deadtime is positive or negative
   *        (overlapping signal) on rising edge
@@ -1515,7 +1534,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Deadtime_Rising_Lock
+/** @defgroup HRTIM_Deadtime_Rising_Lock HRTIM Deadtime Rising Lock
   * @{
   * @brief Constants defining whether or not the deadtime (rising sign and
   *        value) is write protected
@@ -1530,7 +1549,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Deadtime_Rising_Sign_Lock
+/** @defgroup HRTIM_Deadtime_Rising_Sign_Lock HRTIM Deadtime Rising Sign Lock
   * @{
   * @brief Constants defining whether or not the deadtime rising sign is write
   *        protected
@@ -1545,7 +1564,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Deadtime_Falling_Sign
+/** @defgroup HRTIM_Deadtime_Falling_Sign HRTIM Deadtime Falling Sign
   * @{
   * @brief Constants defining whether the deadtime is positive or negative
   *        (overlapping signal) on falling edge
@@ -1560,7 +1579,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Deadtime_Falling_Lock
+/** @defgroup HRTIM_Deadtime_Falling_Lock HRTIM Deadtime Falling Lock
   * @{
   * @brief Constants defining whether or not the deadtime (falling sign and
   *        value) is write protected
@@ -1575,7 +1594,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Deadtime_Falling_Sign_Lock
+/** @defgroup HRTIM_Deadtime_Falling_Sign_Lock HRTIM Deadtime Falling Sign Lock
   * @{
   * @brief Constants defining whether or not the deadtime falling sign is write
   *        protected
@@ -1590,7 +1609,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Chopper_Frequency
+/** @defgroup HRTIM_Chopper_Frequency HRTIM Chopper Frequency
   * @{
   * @brief Constants defining the frequency of the generated high frequency carrier
   */
@@ -1632,7 +1651,7 @@ typedef struct {
   * @}
   */
   
-/** @defgroup HRTIM_Chopper_Duty_Cycle
+/** @defgroup HRTIM_Chopper_Duty_Cycle HRTIM Chopper Duty Cycle
   * @{
   * @brief Constants defining the duty cycle of the generated high frequency carrier
   *        Duty cycle can be adjusted by 1/8 step (from 0/8 up to 7/8)
@@ -1659,7 +1678,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Chopper_Start_Pulse_Width
+/** @defgroup HRTIM_Chopper_Start_Pulse_Width HRTIM Chopper Start Pulse Width
   * @{
   * @brief Constants defining the pulse width of the first pulse of the generated
   *        high frequency carrier
@@ -1702,7 +1721,7 @@ typedef struct {
   * @}
   */
                           
-/** @defgroup HRTIM_Synchronization_Options
+/** @defgroup HRTIM_Synchronization_Options HRTIM Synchronization Options
   * @{
   * @brief Constants defining the options for synchronizing multiple HRTIM 
   *        instances, as a master unit (generating a synchronization signal) 
@@ -1715,7 +1734,7 @@ typedef struct {
   * @}
   */
                     
-/** @defgroup HRTIM_Synchronization_Input_Source
+/** @defgroup HRTIM_Synchronization_Input_Source HRTIM Synchronization Input Source
   * @{
   * @brief Constants defining defining the synchronization input source
   */ 
@@ -1731,7 +1750,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Synchronization_Output_Source
+/** @defgroup HRTIM_Synchronization_Output_Source HRTIM Synchronization Output Source
   * @{
   * @brief Constants defining the source and event to be sent on the 
   *        synchronization outputs
@@ -1750,7 +1769,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Synchronization_Output_Polarity
+/** @defgroup HRTIM_Synchronization_Output_Polarity HRTIM Synchronization Output Polarity
   * @{
   * @brief Constants defining the routing and conditioning of the synchronization output event
   */ 
@@ -1766,7 +1785,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_External_Event_Sources
+/** @defgroup HRTIM_External_Event_Sources HRTIM External Event Sources
   * @{
   * @brief Constants defining available sources associated to external events
   */
@@ -1784,7 +1803,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_External_Event_Polarity
+/** @defgroup HRTIM_External_Event_Polarity HRTIM External Event Polarity
   * @{
   * @brief Constants defining the polarity of an external event
   */
@@ -1803,7 +1822,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_External_Event_Sensitivity
+/** @defgroup HRTIM_External_Event_Sensitivity HRTIM External Event Sensitivity
   * @{
   * @brief Constants defining the sensitivity (level-sensitive or edge-sensitive)
   *        of an external event
@@ -1822,7 +1841,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_External_Event_Fast_Mode
+/** @defgroup HRTIM_External_Event_Fast_Mode HRTIM External Event Fast Mode
   * @{
   * @brief Constants defining whether or not an external event is programmed in
            fast mode
@@ -1849,7 +1868,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_External_Event_Filter
+/** @defgroup HRTIM_External_Event_Filter HRTIM External Event Filter
   * @{
   * @brief Constants defining the frequency used to sample an external event 6
   *        input and the length (N) of the digital filter applied
@@ -1903,7 +1922,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup External_Event_Prescaler
+/** @defgroup HRTIM_External_Event_Prescaler HRTIM External Event Prescaler
   * @{
   * @brief Constants defining division ratio between the timer clock frequency 
   *        fHRTIM) and the external event signal sampling clock (fEEVS)
@@ -1923,7 +1942,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Fault_Sources
+/** @defgroup HRTIM_Fault_Sources HRTIM Fault Sources
   * @{
   * @brief Constants defining whether a faults is be triggered by any external 
   *        or internal fault source
@@ -1939,7 +1958,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Fault_Polarity
+/** @defgroup HRTIM_Fault_Polarity HRTIM Fault Polarity
   * @{
   * @brief Constants defining the polarity of a fault event
   */
@@ -1953,7 +1972,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Fault_Filter
+/** @defgroup HRTIM_Fault_Filter HRTIM Fault Filter
   * @{
   * @ brief Constants defining the frequency used to sample the fault input and
   *         the length (N) of the digital filter applied
@@ -1996,7 +2015,7 @@ typedef struct {
   * @}
   */
               
-/** @defgroup HRTIM_Fault_Lock
+/** @defgroup HRTIM_Fault_Lock HRTIM Fault Lock
   * @{
   * @brief Constants defining whether or not the fault programming bits are
            write protected
@@ -2011,7 +2030,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup External_Fault_Prescaler
+/** @defgroup HRTIM_External_Fault_Prescaler HRTIM External Fault Prescaler
   * @{
   * @brief Constants defining the division ratio between the timer clock 
   *        frequency (fHRTIM) and the fault signal sampling clock (fFLTS) used 
@@ -2031,7 +2050,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Burst_Mode_Operating_mode
+/** @defgroup HRTIM_Burst_Mode_Operating_Mode HRTIM Burst Mode Operating Mode
   * @{
   * @brief Constants defining if the burst mode is entered once or if it is 
   *        continuously operating
@@ -2046,7 +2065,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Burst_Mode_Clock_Source
+/** @defgroup HRTIM_Burst_Mode_Clock_Source HRTIM Burst Mode Clock Source
   * @{
   * @brief Constants defining the clock source for the burst mode counter
   */ 
@@ -2076,7 +2095,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Burst_Mode_Prescaler
+/** @defgroup HRTIM_Burst_Mode_Prescaler HRTIM Burst Mode Prescaler
   * @{
   * @brief Constants defining the prescaling ratio of the fHRTIM clock 
   *        for the burst mode controller
@@ -2119,7 +2138,7 @@ typedef struct {
   * @}
   */
                 
-/** @defgroup HRTIM_Burst_Mode_Register_Preload_Enable
+/** @defgroup HRTIM_Burst_Mode_Register_Preload_Enable HRTIM Burst Mode Register Preload Enable
   * @{
   * @brief Constants defining whether or not burst mode registers preload 
            mechanism is enabled, i.e. a write access into a preloadable register
@@ -2135,7 +2154,7 @@ typedef struct {
   * @}
   */
                 
-/** @defgroup HRTIM_Burst_Mode_Trigger
+/** @defgroup HRTIM_Burst_Mode_Trigger HRTIM Burst Mode Trigger
   * @{
   * @brief Constants defining the events that can be used tor trig the burst
   *        mode operation
@@ -2210,7 +2229,7 @@ typedef struct {
   * @}
   */
                 
-/** @defgroup HRTIM_ADC_Trigger_Update_Source
+/** @defgroup HRTIM_ADC_Trigger_Update_Source HRTIM ADC Trigger Update Source
   * @{
   * @brief constants defining the source triggering the update of the 
      HRTIM_ADCxR register (transfer from preload to active register).
@@ -2233,7 +2252,7 @@ typedef struct {
   * @}
   */
                 
-/** @defgroup HRTIM_ADC_Trigger_Event
+/** @defgroup HRTIM_ADC_Trigger_Event HRTIM ADC Trigger Event
   * @{
   * @brief constants defining the events triggering ADC conversion.
   *        HRTIM_ADCTRIGGEREVENT13_*: ADC Triggers 1 and 3
@@ -2311,7 +2330,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup DLL_Calibration_Rate 
+/** @defgroup HRTIM_DLL_Calibration_Rate HRTIM DLL Calibration Rate
   * @{
   * @brief Constants defining the DLL calibration periods (in micro seconds)
   */
@@ -2331,7 +2350,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup Burst_DMA_Registers_Update 
+/** @defgroup HRTIM_Burst_DMA_Registers_Update HRTIM Burst DMA Registers Update
   * @{
   * @brief Constants defining the registers that can be written during a burst
   *        DMA operation
@@ -2375,7 +2394,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup Burst_Mode_Control 
+/** @defgroup HRTIM_Burst_Mode_Control HRTIM Burst Mode Control
   * @{
   * @brief Constants used to enable or disable the burst mode controller
   */ 
@@ -2389,7 +2408,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup Fault_Mode_Control 
+/** @defgroup HRTIM_Fault_Mode_Control  HRTIM Fault Mode Control
   * @{
   * @brief Constants used to enable or disable a fault channel
   */ 
@@ -2403,7 +2422,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup Software_Timer_Update 
+/** @defgroup HRTIM_Software_Timer_Update HRTIM Software Timer Update
   * @{
   * @brief Constants used to force timer registers update
   */ 
@@ -2419,7 +2438,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup Software_Timer_Reset 
+/** @defgroup HRTIM_Software_Timer_Reset HRTIM Software Timer Reset
   * @{
   * @brief Constants used to force timer counter reset
   */ 
@@ -2435,7 +2454,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup Output_Level 
+/** @defgroup HRTIM_Output_Level HRTIM Output Level
   * @{
   * @brief Constants defining the level of a timer output
   */ 
@@ -2449,7 +2468,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup Output_State 
+/** @defgroup HRTIM_Output_State HRTIM Output State
   * @{
   * @brief Constants defining the state of a timer output
   */ 
@@ -2463,7 +2482,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup Burst_Mode_Status 
+/** @defgroup HRTIM_Burst_Mode_Status HRTIM Burst Mode Status
   * @{
   * @brief Constants defining the operating state of the burst mode controller
   */ 
@@ -2473,7 +2492,7 @@ typedef struct {
   * @}
   */
    
-/** @defgroup Current_Push_Pull_Status 
+/** @defgroup HRTIM_Current_Push_Pull_Status HRTIM Current Push Pull Status
   * @{
   * @brief Constants defining on which output the signal is currently applied
   *        in push-pull mode
@@ -2484,7 +2503,7 @@ typedef struct {
   * @}
   */
    
-/** @defgroup Idle_Push_Pull_Status 
+/** @defgroup HRTIM_Idle_Push_Pull_Status HRTIM Idle Push Pull Status
   * @{
   * @brief Constants defining on which output the signal was applied, in 
   *        push-pull mode balanced fault mode or delayed idle mode, when the 
@@ -2496,7 +2515,7 @@ typedef struct {
   * @}
   */
    
-/** @defgroup HRTIM_Common_Interrupt_Enable
+/** @defgroup HRTIM_Common_Interrupt_Enable HRTIM Common Interrupt Enable
   * @{
   */ 
 #define HRTIM_IT_NONE           (uint32_t)0x00000000  /*!< No interrupt enabled */
@@ -2515,7 +2534,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Master_Interrupt_Enable
+/** @defgroup HRTIM_Master_Interrupt_Enable HRTIM Master Interrupt Enable
   * @{
   */ 
 #define HRTIM_MASTER_IT_NONE         (uint32_t)0x00000000  /*!< No interrupt enabled */
@@ -2533,7 +2552,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Timing_Unit_Interrupt_Enable
+/** @defgroup HRTIM_Timing_Unit_Interrupt_Enable HRTIM Timing Unit Interrupt Enable
   * @{
   */ 
 #define HRTIM_TIM_IT_NONE       (uint32_t)0x00000000      /*!< No interrupt enabled */
@@ -2558,7 +2577,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Common_Interrupt_Flag
+/** @defgroup HRTIM_Common_Interrupt_Flag HRTIM Common Interrupt Flag
   * @{
   */ 
 #define HRTIM_FLAG_FLT1           HRTIM_ISR_FLT1    /*!< Fault 1 interrupt flag */
@@ -2574,7 +2593,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Master_Interrupt_Flag
+/** @defgroup HRTIM_Master_Interrupt_Flag HRTIM Master Interrupt Flag
   * @{
   */ 
 #define HRTIM_MASTER_FLAG_MCMP1        HRTIM_MISR_MCMP1    /*!< Master compare 1 interrupt flag */
@@ -2589,7 +2608,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Timing_Unit_Interrupt_Flag
+/** @defgroup HRTIM_Timing_Unit_Interrupt_Flag HRTIM Timing Unit Interrupt Flag
   * @{
   */ 
 #define HRTIM_TIM_FLAG_CMP1       HRTIM_TIMISR_CMP1      /*!< Timer compare 1 interrupt flag */
@@ -2611,7 +2630,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Master_DMA_Request_Enable
+/** @defgroup HRTIM_Master_DMA_Request_Enable HRTIM Master DMA Request Enable
   * @{
   */ 
 #define HRTIM_MASTER_DMA_NONE         (uint32_t)0x00000000   /*!< No DMA request enable */
@@ -2628,7 +2647,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup HRTIM_Timing_Unit_DMA_Request_Enable
+/** @defgroup HRTIM_Timing_Unit_DMA_Request_Enable HRTIM Timing Unit DMA Request Enable
   * @{
   */ 
 #define HRTIM_TIM_DMA_NONE       (uint32_t)0x00000000       /*!< No DMA request enable */
@@ -2653,19 +2672,14 @@ typedef struct {
   * @}
   */
                 
-/** @defgroup HRTIM_Instance_definition 
-  * @{
-  */ 
-#define IS_HRTIM_INSTANCE(INSTANCE) (INSTANCE) == HRTIM1)
-/**
-  * @}
-  */
-
 /**
   * @}
   */ 
   
 /* Exported macros -----------------------------------------------------------*/
+/** @defgroup HRTIM_Exported_Macros HRTIM Exported Macros
+  * @{
+  */
 
 /** @brief Reset HRTIM handle state
   * @param  __HANDLE__: HRTIM handle.
@@ -3110,10 +3124,21 @@ typedef struct {
          ((__COMPAREUNIT__) == HRTIM_COMPAREUNIT_2) ? ((__HANDLE__)->Instance->sTimerxRegs[(__TIMER__)].CMP2xR) :\
          ((__COMPAREUNIT__) == HRTIM_COMPAREUNIT_3) ? ((__HANDLE__)->Instance->sTimerxRegs[(__TIMER__)].CMP3xR) :\
          ((__HANDLE__)->Instance->sTimerxRegs[(__TIMER__)].CMP4xR)))
-        
-/* Exported functions --------------------------------------------------------*/
 
-/* HRTIM common functions  *****************************************************/
+/**
+  * @}
+  */ 
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup HRTIM_Exported_Functions HRTIM Exported Functions
+* @{
+*/
+
+/** @addtogroup HRTIM_Exported_Functions_Group1 Initialization and de-initialization functions  
+* @{
+*/
+
+/* Initialization and Configuration functions  ********************************/
 HAL_StatusTypeDef HAL_HRTIM_Init(HRTIM_HandleTypeDef *hhrtim);
 
 HAL_StatusTypeDef HAL_HRTIM_DeInit (HRTIM_HandleTypeDef *hhrtim);
@@ -3134,6 +3159,14 @@ HAL_StatusTypeDef HAL_HRTIM_DLLCalibrationStart_IT(HRTIM_HandleTypeDef *hhrtim,
  
 HAL_StatusTypeDef HAL_HRTIM_PollForDLLCalibration(HRTIM_HandleTypeDef *hhrtim,
                                                   uint32_t Timeout);
+
+/**
+  * @}
+  */
+
+/** @addtogroup HRTIM_Exported_Functions_Group2 Simple time base mode functions  
+* @{
+*/
 
 /* Simple time base related functions  *****************************************/
 HAL_StatusTypeDef HAL_HRTIM_SimpleBaseStart(HRTIM_HandleTypeDef *hhrtim,
@@ -3157,6 +3190,13 @@ HAL_StatusTypeDef HAL_HRTIM_SimpleBaseStart_DMA(HRTIM_HandleTypeDef *hhrtim,
 HAL_StatusTypeDef HAL_HRTIM_SimpleBaseStop_DMA(HRTIM_HandleTypeDef *hhrtim,
                                               uint32_t TimerIdx);
 
+/**
+  * @}
+  */
+
+/** @addtogroup HRTIM_Exported_Functions_Group3 Simple output compare mode functions  
+* @{
+*/
 /* Simple output compare related functions  ************************************/
 HAL_StatusTypeDef HAL_HRTIM_SimpleOCChannelConfig(HRTIM_HandleTypeDef *hhrtim,
                                                  uint32_t TimerIdx,
@@ -3190,6 +3230,13 @@ HAL_StatusTypeDef HAL_HRTIM_SimpleOCStop_DMA(HRTIM_HandleTypeDef *hhrtim,
                                             uint32_t TimerIdx,
                                             uint32_t OCChannel);
 
+/**
+  * @}
+  */
+
+/** @addtogroup HRTIM_Exported_Functions_Group4 Simple PWM output mode functions  
+* @{
+*/
 /* Simple PWM output related functions  ****************************************/
 HAL_StatusTypeDef HAL_HRTIM_SimplePWMChannelConfig(HRTIM_HandleTypeDef *hhrtim,
                                                   uint32_t TimerIdx,
@@ -3223,6 +3270,13 @@ HAL_StatusTypeDef HAL_HRTIM_SimplePWMStop_DMA(HRTIM_HandleTypeDef *hhrtim,
                                              uint32_t TimerIdx,
                                              uint32_t PWMChannel);
 
+/**
+  * @}
+  */
+
+/** @addtogroup HRTIM_Exported_Functions_Group5 Simple input capture functions  
+* @{
+*/
 /* Simple capture related functions  *******************************************/
 HAL_StatusTypeDef HAL_HRTIM_SimpleCaptureChannelConfig(HRTIM_HandleTypeDef *hhrtim,
                                                       uint32_t TimerIdx,
@@ -3256,6 +3310,13 @@ HAL_StatusTypeDef HAL_HRTIM_SimpleCaptureStop_DMA(HRTIM_HandleTypeDef *hhrtim,
                                                  uint32_t TimerIdx,
                                                  uint32_t CaptureChannel);
 
+/**
+  * @}
+  */
+
+/** @addtogroup HRTIM_Exported_Functions_Group6 Simple one pulse functions  
+* @{
+*/
 /* Simple one pulse related functions  *****************************************/
 HAL_StatusTypeDef HAL_HRTIM_SimpleOnePulseChannelConfig(HRTIM_HandleTypeDef *hhrtim,
                                                        uint32_t TimerIdx,
@@ -3278,6 +3339,45 @@ HAL_StatusTypeDef HAL_HRTIM_SimpleOnePulseStop_IT(HRTIM_HandleTypeDef *hhrtim,
                                                  uint32_t TimerIdx,
                                                  uint32_t OnePulseChannel);
 
+/**
+  * @}
+  */
+
+/** @addtogroup HRTIM_Exported_Functions_Group7 Configuration functions  
+* @{
+*/
+HAL_StatusTypeDef HAL_HRTIM_BurstModeConfig(HRTIM_HandleTypeDef *hhrtim,
+                                            HRTIM_BurstModeCfgTypeDef* pBurstModeCfg);
+
+HAL_StatusTypeDef HAL_HRTIM_EventConfig(HRTIM_HandleTypeDef *hhrtim,
+                                        uint32_t Event,
+                                        HRTIM_EventCfgTypeDef* pEventCfg);
+
+HAL_StatusTypeDef HAL_HRTIM_EventPrescalerConfig(HRTIM_HandleTypeDef *hhrtim,
+                                                 uint32_t Prescaler);
+ 
+HAL_StatusTypeDef HAL_HRTIM_FaultConfig(HRTIM_HandleTypeDef *hhrtim,
+                                        uint32_t Fault,
+                                        HRTIM_FaultCfgTypeDef* pFaultCfg);
+
+HAL_StatusTypeDef HAL_HRTIM_FaultPrescalerConfig(HRTIM_HandleTypeDef *hhrtim,
+                                                 uint32_t Prescaler);
+
+void HAL_HRTIM_FaultModeCtl(HRTIM_HandleTypeDef * hhrtim, 
+                            uint32_t Faults, 
+                            uint32_t Enable);
+
+HAL_StatusTypeDef HAL_HRTIM_ADCTriggerConfig(HRTIM_HandleTypeDef *hhrtim,
+                                             uint32_t ADCTrigger,
+                                             HRTIM_ADCTriggerCfgTypeDef* pADCTriggerCfg);
+
+/**
+  * @}
+  */
+
+/** @addtogroup HRTIM_Exported_Functions_Group8 Timer waveform configuration and functions
+* @{
+*/
 /* Waveform related functions *************************************************/
 HAL_StatusTypeDef HAL_HRTIM_WaveformTimerConfig(HRTIM_HandleTypeDef *hhrtim,
                                                 uint32_t TimerIdx,
@@ -3298,6 +3398,11 @@ HAL_StatusTypeDef HAL_HRTIM_WaveformOutputConfig(HRTIM_HandleTypeDef *hhrtim,
                                                  uint32_t Output,
                                                  HRTIM_OutputCfgTypeDef * pOutputCfg);
 
+HAL_StatusTypeDef HAL_HRTIM_WaveformSetOutputLevel(HRTIM_HandleTypeDef *hhrtim,
+                                                   uint32_t TimerIdx,
+                                                   uint32_t Output, 
+                                                   uint32_t OutputLevel);
+
 HAL_StatusTypeDef HAL_HRTIM_TimerEventFilteringConfig(HRTIM_HandleTypeDef *hhrtim,
                                                       uint32_t TimerIdx,
                                                       uint32_t Event,
@@ -3315,27 +3420,7 @@ HAL_StatusTypeDef HAL_HRTIM_BurstDMAConfig(HRTIM_HandleTypeDef *hhrtim,
                                            uint32_t TimerIdx,
                                            uint32_t RegistersToUpdate);
 
-HAL_StatusTypeDef HAL_HRTIM_BurstModeConfig(HRTIM_HandleTypeDef *hhrtim,
-                                            HRTIM_BurstModeCfgTypeDef* pBurstModeCfg);
-
-HAL_StatusTypeDef HAL_HRTIM_EventConfig(HRTIM_HandleTypeDef *hhrtim,
-                                        uint32_t Event,
-                                        HRTIM_EventCfgTypeDef* pEventCfg);
-
-HAL_StatusTypeDef HAL_HRTIM_EventPrescalerConfig(HRTIM_HandleTypeDef *hhrtim,
-                                                 uint32_t Prescaler);
  
-HAL_StatusTypeDef HAL_HRTIM_FaultConfig(HRTIM_HandleTypeDef *hhrtim,
-                                        uint32_t Fault,
-                                        HRTIM_FaultCfgTypeDef* pFaultCfg);
-
-HAL_StatusTypeDef HAL_HRTIM_FaultPrescalerConfig(HRTIM_HandleTypeDef *hhrtim,
-                                                 uint32_t Prescaler);
- 
-HAL_StatusTypeDef HAL_HRTIM_ADCTriggerConfig(HRTIM_HandleTypeDef *hhrtim,
-                                             uint32_t ADCTrigger,
-                                             HRTIM_ADCTriggerCfgTypeDef* pADCTriggerCfg);
-
 HAL_StatusTypeDef HAL_HRTIM_WaveformCounterStart(HRTIM_HandleTypeDef *hhrtim,
                                                  uint32_t Timers);
 
@@ -3362,18 +3447,10 @@ HAL_StatusTypeDef HAL_HRTIM_WaveformOutputStart(HRTIM_HandleTypeDef *hhrtim,
 HAL_StatusTypeDef HAL_HRTIM_WaveformOutputStop(HRTIM_HandleTypeDef *hhrtim,
                                                uint32_t OutputsToStop);
 
-/* IRQ handler */
-void HAL_HRTIM_IRQHandler(HRTIM_HandleTypeDef *hhrtim,
-                          uint32_t TimerIdx);
-
 HAL_StatusTypeDef HAL_HRTIM_BurstModeCtl(HRTIM_HandleTypeDef *hhrtim,
                                          uint32_t Enable);
 
 HAL_StatusTypeDef HAL_HRTIM_BurstModeSoftwareTrigger(HRTIM_HandleTypeDef *hhrtim);
-
-void HAL_HRTIM_FaultModeCtl(HRTIM_HandleTypeDef * hhrtim, 
-                            uint32_t Faults, 
-                            uint32_t Enable);
 
 HAL_StatusTypeDef HAL_HRTIM_SoftwareCapture(HRTIM_HandleTypeDef *hhrtim,
                                             uint32_t TimerIdx,
@@ -3385,7 +3462,10 @@ HAL_StatusTypeDef HAL_HRTIM_SoftwareUpdate(HRTIM_HandleTypeDef *hhrtim,
 HAL_StatusTypeDef HAL_HRTIM_SoftwareReset(HRTIM_HandleTypeDef *hhrtim,
                                           uint32_t Timers);
 
-HAL_HRTIM_StateTypeDef HAL_HRTIM_GetState(HRTIM_HandleTypeDef* hhrtim);
+HAL_StatusTypeDef HAL_HRTIM_BurstDMATransfer(HRTIM_HandleTypeDef *hhrtim,
+                                             uint32_t TimerIdx,
+                                             uint32_t BurstBufferAddress,
+                                             uint32_t BurstBufferLength);
 
 HAL_StatusTypeDef HAL_HRTIM_UpdateEnable(HRTIM_HandleTypeDef *hhrtim,
                                           uint32_t Timers);
@@ -3393,19 +3473,19 @@ HAL_StatusTypeDef HAL_HRTIM_UpdateEnable(HRTIM_HandleTypeDef *hhrtim,
 HAL_StatusTypeDef HAL_HRTIM_UpdateDisable(HRTIM_HandleTypeDef *hhrtim,
                                           uint32_t Timers);
 
-HAL_StatusTypeDef HAL_HRTIM_BurstDMATransfer(HRTIM_HandleTypeDef *hhrtim,
-                                             uint32_t TimerIdx,
-                                             uint32_t BurstBufferAddress,
-                                             uint32_t BurstBufferLength);
+/**
+  * @}
+  */
+
+/** @addtogroup HRTIM_Exported_Functions_Group9 Peripheral state functions
+* @{
+*/
+/* HRTIM peripheral state functions */
+HAL_HRTIM_StateTypeDef HAL_HRTIM_GetState(HRTIM_HandleTypeDef* hhrtim);
 
 uint32_t HAL_HRTIM_GetCapturedValue(HRTIM_HandleTypeDef *hhrtim,
                                     uint32_t TimerIdx,
                                     uint32_t CaptureUnit);
-
-HAL_StatusTypeDef HAL_HRTIM_WaveformSetOutputLevel(HRTIM_HandleTypeDef *hhrtim,
-                                                   uint32_t TimerIdx,
-                                                   uint32_t Output, 
-                                                   uint32_t OutputLevel);
 
 uint32_t HAL_HRTIM_WaveformGetOutputLevel(HRTIM_HandleTypeDef *hhrtim,
                                           uint32_t TimerIdx,
@@ -3426,6 +3506,17 @@ uint32_t HAL_HRTIM_GetCurrentPushPullStatus(HRTIM_HandleTypeDef *hhrtim,
 
 uint32_t HAL_HRTIM_GetIdlePushPullStatus(HRTIM_HandleTypeDef *hhrtim,
                                          uint32_t TimerIdx);
+
+/**
+  * @}
+  */
+
+/** @addtogroup HRTIM_Exported_Functions_Group10 Interrupts handling
+* @{
+*/
+/* IRQ handler */
+void HAL_HRTIM_IRQHandler(HRTIM_HandleTypeDef *hhrtim,
+                          uint32_t TimerIdx);
 
 /* HRTIM events related callback functions */
 void HAL_HRTIM_Fault1Callback(HRTIM_HandleTypeDef *hhrtim);
@@ -3470,6 +3561,14 @@ void HAL_HRTIM_Output2ResetCallback(HRTIM_HandleTypeDef *hhrtim,
 void HAL_HRTIM_BurstDMATransferCallback(HRTIM_HandleTypeDef *hhrtim,
                                                uint32_t TimerIdx);
 void HAL_HRTIM_ErrorCallback(HRTIM_HandleTypeDef *hhrtim);
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2c.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2c.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_i2c.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   I2C HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -186,7 +186,7 @@
   * @{
   */
 
-/** @defgroup I2C 
+/** @defgroup I2C I2C HAL module driver
   * @brief I2C HAL module driver
   * @{
   */
@@ -195,6 +195,10 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+
+/** @defgroup I2C_Private_Define I2C Private Define
+  * @{
+  */
 #define TIMING_CLEAR_MASK       ((uint32_t)0xF0FFFFFF)  /*<! I2C TIMING clear register Mask */
 #define I2C_TIMEOUT_ADDR    ((uint32_t)10000)  /* 10 s  */
 #define I2C_TIMEOUT_BUSY    ((uint32_t)25)     /* 25 ms */
@@ -205,10 +209,17 @@
 #define I2C_TIMEOUT_TCR     ((uint32_t)25)     /* 25 ms */
 #define I2C_TIMEOUT_TXIS    ((uint32_t)25)     /* 25 ms */
 #define I2C_TIMEOUT_FLAG    ((uint32_t)25)     /* 25 ms */
+/**
+  * @}
+  */ 
 
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
+
+/** @defgroup I2C_Private_Functions I2C Private Functions
+  * @{
+  */
 static void I2C_DMAMasterTransmitCplt(DMA_HandleTypeDef *hdma);
 static void I2C_DMAMasterReceiveCplt(DMA_HandleTypeDef *hdma);
 static void I2C_DMASlaveTransmitCplt(DMA_HandleTypeDef *hdma);
@@ -233,13 +244,17 @@ static HAL_StatusTypeDef I2C_SlaveTransmit_ISR(I2C_HandleTypeDef *hi2c);
 static HAL_StatusTypeDef I2C_SlaveReceive_ISR(I2C_HandleTypeDef *hi2c);
 
 static void I2C_TransferConfig(I2C_HandleTypeDef *hi2c,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request);
-/* Private functions ---------------------------------------------------------*/
+/**
+  * @}
+  */ 
+  
+/* Exported functions ---------------------------------------------------------*/
 
-/** @defgroup I2C_Private_Functions
+/** @defgroup I2C_Exported_Functions I2C Exported Functions
   * @{
   */
 
-/** @defgroup HAL_I2C_Group1 Initialization/de-initialization functions 
+/** @defgroup I2C_Exported_Functions_Group1 Initialization and de-initialization functions
  *  @brief    Initialization and Configuration functions 
  *
 @verbatim    
@@ -280,7 +295,7 @@ static void I2C_TransferConfig(I2C_HandleTypeDef *hi2c,  uint16_t DevAddress, ui
 HAL_StatusTypeDef HAL_I2C_Init(I2C_HandleTypeDef *hi2c)
 { 
   /* Check the I2C handle allocation */
-  if(hi2c == NULL)
+  if(hi2c == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -360,7 +375,7 @@ HAL_StatusTypeDef HAL_I2C_Init(I2C_HandleTypeDef *hi2c)
 HAL_StatusTypeDef HAL_I2C_DeInit(I2C_HandleTypeDef *hi2c)
 {
   /* Check the I2C handle allocation */
-  if(hi2c == NULL)
+  if(hi2c == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -415,7 +430,7 @@ HAL_StatusTypeDef HAL_I2C_DeInit(I2C_HandleTypeDef *hi2c)
   * @}
   */
 
-/** @defgroup HAL_I2C_Group2 I/O operation functions 
+/** @defgroup I2C_Exported_Functions_Group2 Input and Output operation functions 
  *  @brief   Data transfers functions 
  *
 @verbatim   
@@ -474,6 +489,10 @@ HAL_StatusTypeDef HAL_I2C_DeInit(I2C_HandleTypeDef *hi2c)
   * @{
   */
 
+/** @defgroup Blocking_mode_Polling Blocking mode Polling
+ * @{
+ */
+
 /**
   * @brief  Transmits in master mode an amount of data in blocking mode.
   * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
@@ -490,7 +509,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevA
 
   if(hi2c->State == HAL_I2C_STATE_READY)
   {    
-    if((pData == NULL ) || (Size == 0)) 
+    if((pData == HAL_NULL ) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -610,7 +629,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAd
 
   if(hi2c->State == HAL_I2C_STATE_READY)
   {    
-    if((pData == NULL ) || (Size == 0)) 
+    if((pData == HAL_NULL ) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -721,7 +740,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {    
-    if((pData == NULL ) || (Size == 0)) 
+    if((pData == HAL_NULL ) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -850,7 +869,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData,
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {  
-    if((pData == NULL ) || (Size == 0)) 
+    if((pData == HAL_NULL ) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -948,6 +967,13 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData,
     return HAL_BUSY; 
   } 
 }
+/**
+  * @}
+  */ 
+
+/** @addtogroup Non_Blocking_mode_Interrupt Non Blocking mode Interrupt
+ * @{
+ */
 
 /**
   * @brief  Transmit in master mode an amount of data in no-blocking mode with Interrupt
@@ -962,7 +988,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t D
 {   
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -1034,7 +1060,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t De
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -1104,7 +1130,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pD
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -1154,7 +1180,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pDa
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -1193,6 +1219,14 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pDa
 }
 
 /**
+  * @}
+  */ 
+
+/** @addtogroup Non_Blocking_mode_DMA Non Blocking mode DMA
+ * @{
+ */
+ 
+/**
   * @brief  Transmit in master mode an amount of data in no-blocking mode with DMA
   * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
   *                the configuration information for the specified I2C.
@@ -1205,7 +1239,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t 
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }     
@@ -1296,7 +1330,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t D
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }  
@@ -1376,7 +1410,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *p
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }   
@@ -1462,7 +1496,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pD
 {
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }   
@@ -1520,6 +1554,15 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pD
     return HAL_BUSY;
   }
 }
+
+/**
+  * @}
+  */ 
+
+/** @addtogroup Blocking_mode_Polling Blocking mode Polling
+ * @{
+ */
+   
 /**
   * @brief  Write an amount of data in blocking mode to a specific memory address
   * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
@@ -1541,7 +1584,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress
   
   if(hi2c->State == HAL_I2C_STATE_READY)
   { 
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -1684,7 +1727,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
   
   if(hi2c->State == HAL_I2C_STATE_READY)
   {    
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -1801,6 +1844,14 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
   }
 }
 /**
+  * @}
+  */ 
+
+/** @addtogroup Non_Blocking_mode_Interrupt Non Blocking mode Interrupt
+ * @{
+ */
+   
+/**
   * @brief  Write an amount of data in no-blocking mode with Interrupt to a specific memory address
   * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
   *                the configuration information for the specified I2C.
@@ -1818,7 +1869,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
   
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -1911,7 +1962,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddre
   
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -1984,6 +2035,15 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddre
     return HAL_BUSY; 
   }   
 }
+
+/**
+  * @}
+  */ 
+
+/** @addtogroup Non_Blocking_mode_DMA Non Blocking mode DMA
+ * @{
+ */ 
+ 
 /**
   * @brief  Write an amount of data in no-blocking mode with DMA to a specific memory address
   * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
@@ -2002,7 +2062,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
   
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -2111,7 +2171,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
   
   if(hi2c->State == HAL_I2C_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -2192,6 +2252,13 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
     return HAL_BUSY;
   }
 }
+/**
+  * @}
+  */ 
+
+/** @addtogroup Blocking_mode_Polling Blocking mode Polling
+ * @{
+ */
 
 /**
   * @brief  Checks if target device is ready for communication. 
@@ -2309,6 +2376,13 @@ HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
     return HAL_BUSY;
   }
 }
+/**
+  * @}
+  */
+
+/** @defgroup IRQ_Handler_and_Callbacks IRQ Handler and Callbacks
+ * @{
+ */   
 
 /**
   * @brief  This function handles I2C event interrupt request.
@@ -2494,7 +2568,11 @@ __weak void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c)
   * @}
   */
 
-/** @defgroup I2C_Group3 Peripheral State and Errors functions
+/**
+  * @}
+  */
+
+/** @defgroup I2C_Exported_Functions_Group3 Peripheral State and Errors functions
  *  @brief   Peripheral State and Errors functions
  *
 @verbatim   
@@ -2534,6 +2612,14 @@ uint32_t HAL_I2C_GetError(I2C_HandleTypeDef *hi2c)
   * @}
   */  
 
+/**
+  * @}
+  */   
+
+/** @addtogroup I2C_Private_Functions
+  * @{
+  */
+  
 /**
   * @brief  Handle Interrupt Flags Master Transmit Mode
   * @param  hi2c : Pointer to a I2C_HandleTypeDef structure that contains
@@ -3023,7 +3109,6 @@ static HAL_StatusTypeDef I2C_RequestMemoryRead(I2C_HandleTypeDef *hi2c, uint16_t
   
   return HAL_OK;
 }
-
 
 /**
   * @brief  DMA I2C master transmit process complete callback.
@@ -4061,10 +4146,6 @@ static void I2C_TransferConfig(I2C_HandleTypeDef *hi2c,  uint16_t DevAddress, ui
   /* update CR2 register */
   hi2c->Instance->CR2 = tmpreg;  
 }  
-
-/**
-  * @}
-  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2c.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2c.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_i2c.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of I2C HAL module.
   ******************************************************************************
   * @attention
@@ -55,9 +55,13 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup I2C_Exported_Types I2C Exported Types
+  * @{
+  */
 
-/** 
+/** @defgroup I2C_Configuration_Structure_definition I2C Configuration Structure definition
   * @brief  I2C Configuration Structure definition  
+  * @{
   */
 typedef struct
 {
@@ -89,8 +93,14 @@ typedef struct
 }I2C_InitTypeDef;
 
 /** 
-  * @brief  HAL State structures definition  
+  * @}
+  */
+
+/** @defgroup HAL_state_structure_definition HAL state structure definition
+  * @brief  HAL State structure definition  
+  * @{
   */ 
+
 typedef enum
 {
   HAL_I2C_STATE_RESET           = 0x00,  /*!< I2C not yet initialized or disabled         */
@@ -108,8 +118,14 @@ typedef enum
 }HAL_I2C_StateTypeDef;
 
 /** 
-  * @brief  HAL I2C Error Code structure definition  
+  * @}
+  */
+
+/** @defgroup I2C_Error_Code_structure_definition I2C Error Code structure definition
+  * @brief  I2C Error Code structure definition  
+  * @{
   */ 
+
 typedef enum
 {
   HAL_I2C_ERROR_NONE      = 0x00,    /*!< No error              */
@@ -123,8 +139,14 @@ typedef enum
 }HAL_I2C_ErrorTypeDef;
 
 /** 
-  * @brief  I2C handle Structure definition  
+  * @}
   */
+
+/** @defgroup I2C_handle_Structure_definition I2C handle Structure definition 
+  * @brief  I2C handle Structure definition  
+  * @{
+  */
+
 typedef struct
 {
   I2C_TypeDef                *Instance;  /*!< I2C registers base address     */
@@ -148,14 +170,20 @@ typedef struct
   __IO HAL_I2C_ErrorTypeDef  ErrorCode;  /* I2C Error code                   */
 
 }I2C_HandleTypeDef;
+/**
+  * @}
+  */
 
+/**
+  * @}
+  */  
 /* Exported constants --------------------------------------------------------*/
 
-/** @defgroup I2C_Exported_Constants
+/** @defgroup I2C_Exported_Constants I2C Exported Constants
   * @{
   */
 
-/** @defgroup I2C_addressing_mode
+/** @defgroup I2C_addressing_mode I2C addressing mode
   * @{
   */
 #define I2C_ADDRESSINGMODE_7BIT          ((uint32_t)0x00000001) 
@@ -167,7 +195,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup I2C_dual_addressing_mode 
+/** @defgroup I2C_dual_addressing_mode I2C dual addressing mode
   * @{
   */
 
@@ -180,7 +208,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup I2C_own_address2_masks
+/** @defgroup I2C_own_address2_masks I2C own address2 masks
   * @{
   */
 
@@ -205,7 +233,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup I2C_general_call_addressing_mode 
+/** @defgroup I2C_general_call_addressing_mode I2C general call addressing mode
   * @{
   */
 #define I2C_GENERALCALL_DISABLED        ((uint32_t)0x00000000)
@@ -217,7 +245,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup I2C_nostretch_mode 
+/** @defgroup I2C_nostretch_mode I2C nostretch mode
   * @{
   */
 #define I2C_NOSTRETCH_DISABLED          ((uint32_t)0x00000000)
@@ -229,7 +257,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup I2C_Memory_Address_Size 
+/** @defgroup I2C_Memory_Address_Size I2C Memory Address Size
   * @{
   */
 #define I2C_MEMADD_SIZE_8BIT            ((uint32_t)0x00000001)
@@ -241,7 +269,7 @@ typedef struct
   * @}
   */  
   
-/** @defgroup I2C_ReloadEndMode_definition 
+/** @defgroup I2C_ReloadEndMode_definition I2C ReloadEndMode definition
   * @{
   */
 
@@ -256,7 +284,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup I2C_StartStopMode_definition 
+/** @defgroup I2C_StartStopMode_definition I2C StartStopMode definition
   * @{
   */
 
@@ -274,7 +302,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup I2C_Interrupt_configuration_definition
+/** @defgroup I2C_Interrupt_configuration_definition I2C Interrupt configuration definition
   * @brief I2C Interrupt definition
   *        Elements values convention: 0xXXXXXXXX
   *           - XXXXXXXX  : Interrupt control mask
@@ -293,7 +321,7 @@ typedef struct
   */
 
 
-/** @defgroup I2C_Flag_definition 
+/** @defgroup I2C_Flag_definition I2C Flag definition
   * @{
   */ 
 
@@ -322,6 +350,10 @@ typedef struct
   */ 
   
 /* Exported macros -----------------------------------------------------------*/
+
+/** @defgroup I2C_Exported_Macros I2C Exported Macros
+  * @{
+  */
 
 /** @brief  Reset I2C handle state
   * @param  __HANDLE__: I2C handle.
@@ -424,18 +456,42 @@ typedef struct
 
 #define IS_I2C_OWN_ADDRESS1(ADDRESS1)   ((ADDRESS1) <= (uint32_t)0x000003FF)
 #define IS_I2C_OWN_ADDRESS2(ADDRESS2)   ((ADDRESS2) <= (uint16_t)0x00FF)
+/**
+  * @}
+  */ 
 
-/* Include I2C HAL Extension module */
+/* Include I2C HAL Extended module */
 #include "stm32f3xx_hal_i2c_ex.h"
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup I2C_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup I2C_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+  
 /* Initialization/de-initialization functions  **********************************/
 HAL_StatusTypeDef HAL_I2C_Init(I2C_HandleTypeDef *hi2c);
 HAL_StatusTypeDef HAL_I2C_DeInit (I2C_HandleTypeDef *hi2c);
 void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c);
 void HAL_I2C_MspDeInit(I2C_HandleTypeDef *hi2c);
 
+/**
+  * @}
+  */ 
+
+/** @addtogroup I2C_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
+   
 /* IO operation functions  *****************************************************/
+
+/** @addtogroup Blocking_mode_Polling Blocking mode Polling
+ * @{
+ */
+
  /******* Blocking mode: Polling */
 HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout);
 HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout);
@@ -445,6 +501,14 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress
 HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout);
 HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout);
 
+/**
+  * @}
+  */ 
+
+/** @addtogroup Non_Blocking_mode_Interrupt Non Blocking mode Interrupt
+ * @{
+ */
+   
  /******* Non-Blocking mode: Interrupt */
 HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
@@ -453,6 +517,13 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pDa
 HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
 
+/**
+  * @}
+  */ 
+
+/** @addtogroup Non_Blocking_mode_DMA Non Blocking mode DMA
+ * @{
+ */  
  /******* Non-Blocking mode: DMA */
 HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
@@ -460,7 +531,13 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *p
 HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+/**
+  * @}
+  */ 
 
+/** @addtogroup IRQ_Handler_and_Callbacks IRQ Handler and Callbacks
+ * @{
+ */   
  /******* I2C IRQHandler and Callbacks used in non blocking modes (Interrupt and DMA) */
 void HAL_I2C_EV_IRQHandler(I2C_HandleTypeDef *hi2c);
 void HAL_I2C_ER_IRQHandler(I2C_HandleTypeDef *hi2c);
@@ -472,10 +549,30 @@ void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c);
 void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c);
 void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c);
 
-/* Peripheral State functions  **************************************/
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
+/** @addtogroup I2C_Exported_Functions_Group3 Peripheral State and Errors functions
+  * @{
+  */
+  
+/* Peripheral State and Errors functions  **************************************/
 HAL_I2C_StateTypeDef HAL_I2C_GetState(I2C_HandleTypeDef *hi2c);
 uint32_t             HAL_I2C_GetError(I2C_HandleTypeDef *hi2c);
 
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
 /**
   * @}
   */ 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2c_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2c_ex.c
@@ -2,16 +2,16 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_i2c_ex.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   I2C Extension HAL module driver.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   I2C Extended HAL module driver.
   *          This file provides firmware functions to manage the following 
-  *          functionalities of I2C extension peripheral:
-  *           + Extension features functions
+  *          functionalities of I2C Extended peripheral:
+  *           + Extended features functions
   *         
   @verbatim
   ==============================================================================
-               ##### I2C peripheral extension features  #####
+               ##### I2C peripheral Extended features  #####
   ==============================================================================
            
   [..] Comparing to other previous devices, the I2C interface for STM32F3XX
@@ -68,7 +68,7 @@
   * @{
   */
 
-/** @defgroup I2CEx
+/** @defgroup I2CEx I2C Extended HAL module driver
   * @brief I2C Extended HAL module driver
   * @{
   */
@@ -82,17 +82,16 @@
 /* Private function prototypes -----------------------------------------------*/
 /* Private functions ---------------------------------------------------------*/
 
-/** @defgroup I2CEx_Private_Functions
+/** @defgroup I2CEx_Exported_Functions I2C Extended Exported Functions
   * @{
   */
 
-
-/** @defgroup I2CEx_Group1 Extended features functions
+/** @defgroup I2CEx_Exported_Functions_Group1 Extended features functions
   * @brief    Extended features functions
   *
 @verbatim   
  ===============================================================================
-                      ##### Extension features functions #####
+                      ##### Extended features functions #####
  ===============================================================================  
     [..] This section provides functions allowing to:
       (+) Configure Noise Filters 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2c_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2c_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_i2c_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of I2C HAL Extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of I2C HAL Extended module.
   ******************************************************************************
   * @attention
   *
@@ -50,18 +50,18 @@
   * @{
   */
 
-/** @addtogroup I2CEx
+/** @addtogroup I2CEx I2C Extended HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
 /* Exported constants --------------------------------------------------------*/
 
-/** @defgroup I2CEx_Exported_Constants
+/** @defgroup I2CEx_Exported_Constants I2C Extended Exported Constants
   * @{
   */
 
-/** @defgroup I2CEx_Analog_Filter
+/** @defgroup I2CEx_Analog_Filter I2C Extended Analog Filter
   * @{
   */
 #define I2C_ANALOGFILTER_ENABLED        ((uint32_t)0x00000000)
@@ -73,7 +73,7 @@
   * @}
   */
 
-/** @defgroup I2CEx_Digital_Filter
+/** @defgroup I2CEx_Digital_Filter I2C Extended Digital Filter
   * @{
   */
 #define IS_I2C_DIGITAL_FILTER(FILTER)   ((FILTER) <= 0x0000000F)
@@ -88,6 +88,14 @@
 /* Exported macro ------------------------------------------------------------*/
 /* Exported functions --------------------------------------------------------*/
 
+/** @addtogroup I2CEx_Exported_Functions I2C Extended Exported Functions
+  * @{
+  */
+
+/** @addtogroup I2CEx_Exported_Functions_Group1 Extended features functions
+  * @{
+  */
+  
 /* Peripheral Control functions  ************************************************/
 HAL_StatusTypeDef HAL_I2CEx_AnalogFilter_Config(I2C_HandleTypeDef *hi2c, uint32_t AnalogFilter);
 HAL_StatusTypeDef HAL_I2CEx_DigitalFilter_Config(I2C_HandleTypeDef *hi2c, uint32_t DigitalFilter);
@@ -102,6 +110,14 @@ HAL_StatusTypeDef HAL_I2CEx_DisableWakeUp (I2C_HandleTypeDef *hi2c);
   * @}
   */
   
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+    
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2s.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2s.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_i2s.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   I2S HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Integrated Interchip Sound (I2S) peripheral:
@@ -143,24 +143,26 @@
   * @{
   */
 
-/** @defgroup I2S 
+/** @defgroup I2S I2S HAL module driver
   * @brief I2S HAL module driver
   * @{
   */
 
 #ifdef HAL_I2S_MODULE_ENABLED
 
-#if defined(STM32F301x8) ||                         \
-    defined(STM32F302x8) || defined(STM32F302xC) || \
-    defined(STM32F303xC) || defined(STM32F373xC) || \
-    defined(STM32F318xx) ||                         \
-    defined(STM32F358xx) || defined(STM32F378xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
+/** @defgroup I2S_Private_Functions I2S Private Functions
+  * @{
+  */
 static void I2S_DMATxCplt(DMA_HandleTypeDef *hdma);
 static void I2S_DMATxHalfCplt(DMA_HandleTypeDef *hdma);
 static void I2S_DMARxCplt(DMA_HandleTypeDef *hdma);
@@ -169,14 +171,17 @@ static void I2S_DMAError(DMA_HandleTypeDef *hdma);
 static void I2S_Transmit_IT(I2S_HandleTypeDef *hi2s);
 static void I2S_Receive_IT(I2S_HandleTypeDef *hi2s);
 static HAL_StatusTypeDef I2S_WaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, uint32_t Flag, uint32_t State, uint32_t Timeout);
+/**
+  * @}
+  */
 
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
 
-/** @defgroup I2S_Private_Functions
+/** @defgroup I2S_Exported_Functions I2S Exported Functions
   * @{
   */
 
-/** @defgroup  I2S_Group1 Initialization and de-initialization functions 
+/** @defgroup  I2S_Exported_Functions_Group1 Initialization and de-initialization functions 
   *  @brief    Initialization and Configuration functions 
   *
 @verbatim    
@@ -208,7 +213,8 @@ static HAL_StatusTypeDef I2S_WaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, 
 /**
   * @brief Initializes the I2S according to the specified parameters 
   *         in the I2S_InitTypeDef and create the associated handle.
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @retval HAL status
   */
 __weak HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s)
@@ -223,13 +229,14 @@ __weak HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s)
            
 /**
   * @brief DeInitializes the I2S peripheral 
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_I2S_DeInit(I2S_HandleTypeDef *hi2s)
 {
   /* Check the I2S handle allocation */
-  if(hi2s == NULL)
+  if(hi2s == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -253,7 +260,8 @@ HAL_StatusTypeDef HAL_I2S_DeInit(I2S_HandleTypeDef *hi2s)
 
 /**
   * @brief I2S MSP Init
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @retval None
   */
  __weak void HAL_I2S_MspInit(I2S_HandleTypeDef *hi2s)
@@ -265,7 +273,8 @@ HAL_StatusTypeDef HAL_I2S_DeInit(I2S_HandleTypeDef *hi2s)
 
 /**
   * @brief I2S MSP DeInit
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @retval None
   */
  __weak void HAL_I2S_MspDeInit(I2S_HandleTypeDef *hi2s)
@@ -279,7 +288,7 @@ HAL_StatusTypeDef HAL_I2S_DeInit(I2S_HandleTypeDef *hi2s)
   * @}
   */
 
-/** @defgroup I2S_Group2 IO operation functions 
+/** @defgroup I2S_Exported_Functions_Group2 Input and Output operation functions 
   *  @brief Data transfers functions 
   *
 @verbatim   
@@ -290,7 +299,7 @@ HAL_StatusTypeDef HAL_I2S_DeInit(I2S_HandleTypeDef *hi2s)
     This subsection provides a set of functions allowing to manage the I2S data 
     transfers.
 
-    (#) There is two mode of transfer:
+    (#) There are two modes of transfer:
        (++) Blocking mode : The communication is performed in the polling mode. 
             The status of all data processing is returned by the same function 
             after finishing transfer.  
@@ -312,7 +321,7 @@ HAL_StatusTypeDef HAL_I2S_DeInit(I2S_HandleTypeDef *hi2s)
         (++) HAL_I2S_Transmit_DMA()
         (++) HAL_I2S_Receive_DMA()
 
-    (#) A set of Transfer Complete Callbacks are provided in No_Blocking mode:
+    (#) A set of Transfer Complete Callbacks are provided in non Blocking mode:
         (++) HAL_I2S_TxCpltCallback()
         (++) HAL_I2S_RxCpltCallback()
         (++) HAL_I2S_ErrorCallback()
@@ -323,7 +332,8 @@ HAL_StatusTypeDef HAL_I2S_DeInit(I2S_HandleTypeDef *hi2s)
 
 /**
   * @brief Transmit an amount of data in blocking mode
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @param pData: a 16-bit pointer to data buffer.
   * @param Size: number of data sample to be sent:
   * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
@@ -337,7 +347,7 @@ HAL_StatusTypeDef HAL_I2S_DeInit(I2S_HandleTypeDef *hi2s)
   */
 HAL_StatusTypeDef HAL_I2S_Transmit(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size, uint32_t Timeout)
 {
-  if((pData == NULL ) || (Size == 0)) 
+  if((pData == HAL_NULL ) || (Size == 0)) 
   {
     return  HAL_ERROR;                                    
   }
@@ -423,7 +433,8 @@ HAL_StatusTypeDef HAL_I2S_Transmit(I2S_HandleTypeDef *hi2s, uint16_t *pData, uin
 
 /**
   * @brief Receive an amount of data in blocking mode 
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @param pData: a 16-bit pointer to data buffer.
   * @param Size: number of data sample to be sent:
   * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
@@ -439,7 +450,7 @@ HAL_StatusTypeDef HAL_I2S_Transmit(I2S_HandleTypeDef *hi2s, uint16_t *pData, uin
   */
 HAL_StatusTypeDef HAL_I2S_Receive(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size, uint32_t Timeout)
 {
-  if((pData == NULL ) || (Size == 0)) 
+  if((pData == HAL_NULL ) || (Size == 0)) 
   {
     return  HAL_ERROR;                                    
   }
@@ -525,7 +536,8 @@ HAL_StatusTypeDef HAL_I2S_Receive(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint
 
 /**
   * @brief Transmit an amount of data in non-blocking mode with Interrupt
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @param pData: a 16-bit pointer to data buffer.
   * @param Size: number of data sample to be sent:
   * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
@@ -540,7 +552,7 @@ HAL_StatusTypeDef HAL_I2S_Transmit_IT(I2S_HandleTypeDef *hi2s, uint16_t *pData, 
 {
   if(hi2s->State == HAL_I2S_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -587,7 +599,8 @@ HAL_StatusTypeDef HAL_I2S_Transmit_IT(I2S_HandleTypeDef *hi2s, uint16_t *pData, 
 
 /**
   * @brief Receive an amount of data in non-blocking mode with Interrupt
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @param pData: a 16-bit pointer to the Receive data buffer.
   * @param Size: number of data sample to be sent:
   * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
@@ -604,7 +617,7 @@ HAL_StatusTypeDef HAL_I2S_Receive_IT(I2S_HandleTypeDef *hi2s, uint16_t *pData, u
 {
   if(hi2s->State == HAL_I2S_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -650,7 +663,8 @@ HAL_StatusTypeDef HAL_I2S_Receive_IT(I2S_HandleTypeDef *hi2s, uint16_t *pData, u
 
 /**
   * @brief Transmit an amount of data in non-blocking mode with DMA
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @param pData: a 16-bit pointer to the Transmit data buffer.
   * @param Size: number of data sample to be sent:
   * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
@@ -665,7 +679,7 @@ HAL_StatusTypeDef HAL_I2S_Transmit_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData,
 {
   uint32_t *tmp;
   
-  if((pData == NULL) || (Size == 0)) 
+  if((pData == HAL_NULL) || (Size == 0)) 
   {
     return  HAL_ERROR;                                    
   }
@@ -727,7 +741,8 @@ HAL_StatusTypeDef HAL_I2S_Transmit_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData,
 
 /**
   * @brief Receive an amount of data in non-blocking mode with DMA 
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @param pData: a 16-bit pointer to the Receive data buffer.
   * @param Size: number of data sample to be sent:
   * @note When a 16-bit data frame or a 16-bit data frame extended is selected during the I2S
@@ -742,7 +757,7 @@ HAL_StatusTypeDef HAL_I2S_Receive_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData, 
 {
   uint32_t *tmp;
   
-  if((pData == NULL) || (Size == 0)) 
+  if((pData == HAL_NULL) || (Size == 0)) 
   {
     return  HAL_ERROR;                                    
   } 
@@ -811,7 +826,8 @@ HAL_StatusTypeDef HAL_I2S_Receive_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData, 
 
 /**
   * @brief  This function handles I2S interrupt request.
-  * @param  hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @retval HAL status
   */
 void HAL_I2S_IRQHandler(I2S_HandleTypeDef *hi2s)
@@ -865,8 +881,20 @@ void HAL_I2S_IRQHandler(I2S_HandleTypeDef *hi2s)
 }
 
 /**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup I2S_Private_Functions I2S Private Functions
+  * @{
+  */
+/**
   * @brief This function handles I2S Communication Timeout.
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @param Flag: Flag checked
   * @param State: Value of the flag expected
   * @param Timeout: Duration of the timeout
@@ -896,10 +924,21 @@ static HAL_StatusTypeDef I2S_WaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, 
   
   return HAL_OK;      
 }
+/**
+  * @}
+  */
 
+/** @addtogroup I2S_Exported_Functions I2S Exported Functions
+  * @{
+  */
+
+/** @addtogroup  I2S_Exported_Functions_Group2 Input and Output operation functions 
+  * @{
+  */
 /**
   * @brief Tx Transfer Half completed callbacks
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @retval None
   */
  __weak void HAL_I2S_TxHalfCpltCallback(I2S_HandleTypeDef *hi2s)
@@ -911,7 +950,8 @@ static HAL_StatusTypeDef I2S_WaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, 
 
 /**
   * @brief Tx Transfer completed callbacks
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @retval None
   */
  __weak void HAL_I2S_TxCpltCallback(I2S_HandleTypeDef *hi2s)
@@ -923,7 +963,8 @@ static HAL_StatusTypeDef I2S_WaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, 
 
 /**
   * @brief Rx Transfer half completed callbacks
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @retval None
   */
 __weak void HAL_I2S_RxHalfCpltCallback(I2S_HandleTypeDef *hi2s)
@@ -935,7 +976,8 @@ __weak void HAL_I2S_RxHalfCpltCallback(I2S_HandleTypeDef *hi2s)
 
 /**
   * @brief Rx Transfer completed callbacks
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @retval None
   */
 __weak void HAL_I2S_RxCpltCallback(I2S_HandleTypeDef *hi2s)
@@ -947,7 +989,8 @@ __weak void HAL_I2S_RxCpltCallback(I2S_HandleTypeDef *hi2s)
 
 /**
   * @brief I2S error callbacks
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @retval None
   */
  __weak void HAL_I2S_ErrorCallback(I2S_HandleTypeDef *hi2s)
@@ -961,7 +1004,7 @@ __weak void HAL_I2S_RxCpltCallback(I2S_HandleTypeDef *hi2s)
   * @}
   */
 
-/** @defgroup I2S_Group3 Peripheral State and Errors functions 
+/** @defgroup I2S_Exported_Functions_Group3 Peripheral State and Errors functions 
   *  @brief   Peripheral State functions 
   *
 @verbatim   
@@ -969,7 +1012,7 @@ __weak void HAL_I2S_RxCpltCallback(I2S_HandleTypeDef *hi2s)
                       ##### Peripheral State and Errors functions #####
  ===============================================================================  
     [..]
-    This subsection permit to get in run-time the status of the peripheral 
+    This subsection permits to get in run-time the status of the peripheral 
     and the data flow.
 
 @endverbatim
@@ -978,7 +1021,8 @@ __weak void HAL_I2S_RxCpltCallback(I2S_HandleTypeDef *hi2s)
 
 /**
   * @brief  Return the I2S state
-  * @param  hi2s : I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @retval HAL state
   */
 HAL_I2S_StateTypeDef HAL_I2S_GetState(I2S_HandleTypeDef *hi2s)
@@ -988,14 +1032,14 @@ HAL_I2S_StateTypeDef HAL_I2S_GetState(I2S_HandleTypeDef *hi2s)
 
 /**
   * @brief  Return the I2S error code
-  * @param  hi2s : I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @retval I2S Error Code
   */
 HAL_I2S_ErrorTypeDef HAL_I2S_GetError(I2S_HandleTypeDef *hi2s)
 {
   return hi2s->ErrorCode;
 }
-
 /**
   * @}
   */  
@@ -1004,9 +1048,13 @@ HAL_I2S_ErrorTypeDef HAL_I2S_GetError(I2S_HandleTypeDef *hi2s)
   * @}
   */
 
+/** @addtogroup I2S_Private_Functions I2S Private Functions
+  * @{
+  */
 /**
   * @brief DMA I2S transmit process complete callback 
-  * @param hdma : DMA handle
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
   * @retval None
   */
 static void I2S_DMATxCplt(DMA_HandleTypeDef *hdma)   
@@ -1024,7 +1072,8 @@ static void I2S_DMATxCplt(DMA_HandleTypeDef *hdma)
 
 /**
   * @brief DMA I2S transmit process half complete callback 
-  * @param hdma : DMA handle
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
   * @retval None
   */
 static void I2S_DMATxHalfCplt(DMA_HandleTypeDef *hdma)
@@ -1036,7 +1085,8 @@ static void I2S_DMATxHalfCplt(DMA_HandleTypeDef *hdma)
 
 /**
   * @brief DMA I2S receive process complete callback 
-  * @param hdma : DMA handle
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
   * @retval None
   */
 static void I2S_DMARxCplt(DMA_HandleTypeDef *hdma)   
@@ -1053,7 +1103,8 @@ static void I2S_DMARxCplt(DMA_HandleTypeDef *hdma)
       
 /**
   * @brief DMA I2S receive process half complete callback 
-  * @param hdma : DMA handle
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
   * @retval None
   */
 static void I2S_DMARxHalfCplt(DMA_HandleTypeDef *hdma)
@@ -1065,7 +1116,8 @@ static void I2S_DMARxHalfCplt(DMA_HandleTypeDef *hdma)
 
 /**
   * @brief DMA I2S communication error callback 
-  * @param hdma : DMA handle
+  * @param  hdma: pointer to a DMA_HandleTypeDef structure that contains
+  *                the configuration information for the specified DMA module.
   * @retval None
   */
 static void I2S_DMAError(DMA_HandleTypeDef *hdma)   
@@ -1086,7 +1138,8 @@ static void I2S_DMAError(DMA_HandleTypeDef *hdma)
 
 /**
   * @brief Transmit an amount of data in non-blocking mode with Interrupt
-  * @param hi2s: I2S handle
+  * @param  hi2s: pointer to a I2S_HandleTypeDef structure that contains
+  *         the configuration information for I2S module
   * @retval None
   */
 static void I2S_Transmit_IT(I2S_HandleTypeDef *hi2s)
@@ -1099,6 +1152,7 @@ static void I2S_Transmit_IT(I2S_HandleTypeDef *hi2s)
   {
     /* Disable TXE and ERR interrupt */
     __HAL_I2S_DISABLE_IT(hi2s, (I2S_IT_TXE | I2S_IT_ERR));
+
     hi2s->State = HAL_I2S_STATE_READY;
     HAL_I2S_TxCpltCallback(hi2s);
   }
@@ -1119,16 +1173,19 @@ static void I2S_Receive_IT(I2S_HandleTypeDef *hi2s)
   {    
     /* Disable RXNE and ERR interrupt */
     __HAL_I2S_DISABLE_IT(hi2s, (I2S_IT_RXNE | I2S_IT_ERR));
+
     hi2s->State = HAL_I2S_STATE_READY;     
     HAL_I2S_RxCpltCallback(hi2s); 
   }
 }
+/**
+  * @}
+  */
 
-#endif /* defined(STM32F301x8) ||                         */
-       /* defined(STM32F302x8) || defined(STM32F302xC) || */
-       /* defined(STM32F303xC) || defined(STM32F373xC) || */
-       /* defined(STM32F318xx) ||                         */
-       /* defined(STM32F358xx) || defined(STM32F378xx)    */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
 #endif /* HAL_I2S_MODULE_ENABLED */
 /**

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2s.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2s.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_i2s.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of I2S HAL module.
   ******************************************************************************
   * @attention
@@ -43,11 +43,10 @@
  extern "C" {
 #endif
 
-#if defined(STM32F301x8) ||                         \
-    defined(STM32F302x8) || defined(STM32F302xC) || \
-    defined(STM32F303xC) || defined(STM32F373xC) || \
-    defined(STM32F318xx) ||                         \
-    defined(STM32F358xx) || defined(STM32F378xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f3xx_hal_def.h"  
@@ -56,11 +55,15 @@
   * @{
   */
 
-/** @addtogroup I2S
+/** @addtogroup I2S I2S HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup I2S_Exported_Types I2S Exported Types
+  * @{
+  */
+
 /** 
   * @brief I2S Init structure definition  
   */
@@ -158,14 +161,16 @@ typedef struct
   __IO HAL_I2S_ErrorTypeDef  ErrorCode;    /* I2S Error code                 */
 
 }I2S_HandleTypeDef;
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
-
-/** @defgroup I2S_Exported_Constants
+/** @defgroup I2S_Exported_Constants I2S Exported Constants
   * @{
   */
 
-/** @defgroup I2S_Clock_Source 
+/** @defgroup I2S_Clock_Source I2S Clock Source
   * @{
   */
 #define I2S_CLOCK_EXTERNAL                ((uint32_t)0x00000001)
@@ -177,7 +182,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup I2S_Mode 
+/** @defgroup I2S_Mode I2S Mode
   * @{
   */
 #define I2S_MODE_SLAVE_TX                ((uint32_t)0x00000000)
@@ -193,7 +198,7 @@ typedef struct
   * @}
   */
   
-/** @defgroup I2S_Standard 
+/** @defgroup I2S_Standard I2S Standard
   * @{
   */
 #define I2S_STANDARD_PHILIPS             ((uint32_t)0x00000000)
@@ -211,7 +216,7 @@ typedef struct
   * @}
   */
   
-/** @defgroup I2S_Data_Format 
+/** @defgroup I2S_Data_Format I2S Data Format
   * @{
   */
 #define I2S_DATAFORMAT_16B               ((uint32_t)0x00000000)
@@ -227,7 +232,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup I2S_MCLK_Output 
+/** @defgroup I2S_MCLK_Output I2S MCLK Output
   * @{
   */
 #define I2S_MCLKOUTPUT_ENABLE           ((uint32_t)SPI_I2SPR_MCKOE)
@@ -239,7 +244,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup I2S_Audio_Frequency 
+/** @defgroup I2S_Audio_Frequency I2S Audio Frequency
   * @{
   */
 #define I2S_AUDIOFREQ_192K               ((uint32_t)192000)
@@ -260,7 +265,7 @@ typedef struct
   * @}
   */
             
-/** @defgroup I2S_FullDuplex_Mode 
+/** @defgroup I2S_FullDuplex_Mode I2S Full Duplex Mode
   * @{
   */
 #define I2S_FULLDUPLEXMODE_DISABLE                   ((uint32_t)0x00000000)
@@ -272,7 +277,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup I2S_Clock_Polarity 
+/** @defgroup I2S_Clock_Polarity I2S Clock Polarity
   * @{
   */
 #define I2S_CPOL_LOW                    ((uint32_t)0x00000000)
@@ -284,7 +289,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup I2S_Interrupt_configuration_definition
+/** @defgroup I2S_Interrupt_configuration_definition I2S Interrupt configuration definition
   * @{
   */
 #define I2S_IT_TXE                      SPI_CR2_TXEIE
@@ -294,7 +299,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup I2S_Flag_definition 
+/** @defgroup I2S_Flag_definition I2S Flag definition
   * @{
   */ 
 #define I2S_FLAG_TXE                    SPI_SR_TXE
@@ -315,6 +320,9 @@ typedef struct
   */ 
   
 /* Exported macros -----------------------------------------------------------*/
+/** @defgroup I2S_Exported_Macros I2S Exported Macros
+  * @{
+  */
 
 /** @brief  Reset I2S handle state
   * @param  __HANDLE__: I2S handle.
@@ -379,18 +387,34 @@ typedef struct
   * @retval None
   */                                                                                                   
 #define __HAL_I2S_CLEAR_UDRFLAG(__HANDLE__)((__HANDLE__)->Instance->SR)    
+/**
+  * @}
+  */ 
                                   
-/* Include I2S HAL Extension module */
+/* Include I2S HAL Extended module */
 #include "stm32f3xx_hal_i2s_ex.h" 
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup I2S_Exported_Functions  I2S Exported Functions
+  * @{
+  */
+                                                
+/** @addtogroup I2S_Exported_Functions_Group1 Initialization and de-initialization functions 
+  * @{
+  */
 
 /* Initialization and de-initialization functions *****************************/
 HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s);
 HAL_StatusTypeDef HAL_I2S_DeInit (I2S_HandleTypeDef *hi2s);
 void HAL_I2S_MspInit(I2S_HandleTypeDef *hi2s);
 void HAL_I2S_MspDeInit(I2S_HandleTypeDef *hi2s);
+/**
+  * @}
+  */
 
+/** @addtogroup I2S_Exported_Functions_Group2 Input and Output operation functions 
+  * @{
+  */
 /* I/O operation functions  ***************************************************/
  /* Blocking mode: Polling */
 HAL_StatusTypeDef HAL_I2S_Transmit(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size, uint32_t Timeout);
@@ -405,16 +429,30 @@ void HAL_I2S_IRQHandler(I2S_HandleTypeDef *hi2s);
 HAL_StatusTypeDef HAL_I2S_Transmit_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_I2S_Receive_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pData, uint16_t Size);
 
-/* Peripheral Control and State functions  ************************************/
-HAL_I2S_StateTypeDef HAL_I2S_GetState(I2S_HandleTypeDef *hi2s);
-HAL_I2S_ErrorTypeDef HAL_I2S_GetError(I2S_HandleTypeDef *hi2s);
-
 /* Callbacks used in non blocking modes (Interrupt and DMA) *******************/
 void HAL_I2S_TxHalfCpltCallback(I2S_HandleTypeDef *hi2s);
 void HAL_I2S_TxCpltCallback(I2S_HandleTypeDef *hi2s);
 void HAL_I2S_RxHalfCpltCallback(I2S_HandleTypeDef *hi2s);
 void HAL_I2S_RxCpltCallback(I2S_HandleTypeDef *hi2s);
 void HAL_I2S_ErrorCallback(I2S_HandleTypeDef *hi2s);
+/**
+  * @}
+  */
+
+/** @addtogroup I2S_Exported_Functions_Group3 Peripheral State and Errors functions
+  * @{
+  */
+/* Peripheral Control and State functions  ************************************/
+HAL_I2S_StateTypeDef HAL_I2S_GetState(I2S_HandleTypeDef *hi2s);
+HAL_I2S_ErrorTypeDef HAL_I2S_GetError(I2S_HandleTypeDef *hi2s);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
 
 /**
   * @}
@@ -424,11 +462,10 @@ void HAL_I2S_ErrorCallback(I2S_HandleTypeDef *hi2s);
   * @}
   */
 
-#endif /* defined(STM32F301x8) ||                         */
-       /* defined(STM32F302x8) || defined(STM32F302xC) || */
-       /* defined(STM32F303xC) || defined(STM32F373xC) || */
-       /* defined(STM32F318xx) ||                         */
-       /* defined(STM32F358xx) || defined(STM32F378xx)    */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
 #ifdef __cplusplus
 }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2s_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2s_ex.c
@@ -2,23 +2,23 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_i2s_ex.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   I2S Extension HAL module driver.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   I2S Extended HAL module driver.
   *          This file provides firmware functions to manage the following 
-  *          functionalities of I2S extension peripheral:
-  *           + Extension features Functions
+  *          functionalities of I2S Extended peripheral:
+  *           + Extended features Functions
   *
   @verbatim
   ==============================================================================
-                    ##### I2S Extension features #####
+                    ##### I2S Extended features #####
   ============================================================================== 
  [..]
     (#) In I2S full duplex mode, each SPI peripheral is able to manage sending and receiving 
         data simultaneously using two data lines. Each SPI peripheral has an extended block 
         called I2Sxext ie. I2S2ext for SPI2 and I2S3ext for SPI3).
-    (#) The extension block is not a full SPI IP, it is used only as I2S slave to
-        implement full duplex mode. The extension block uses the same clock sources
+    (#) The Extended block is not a full SPI IP, it is used only as I2S slave to
+        implement full duplex mode. The Extended block uses the same clock sources
         as its master (refer to the following Figure).
 
                 +-----------------------+
@@ -122,46 +122,68 @@
   * @{
   */
 
-/** @addtogroup I2S
-  * @brief I2S HAL module driver
+#ifdef HAL_I2S_MODULE_ENABLED
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+
+/** @defgroup I2SEx I2S Extended HAL module driver
+  * @brief I2S Extended HAL module driver
   * @{
   */
 
-#ifdef HAL_I2S_MODULE_ENABLED
-
-#if defined(STM32F301x8) ||                         \
-    defined(STM32F302x8) || defined(STM32F302xC) || \
-    defined(STM32F303xC) || defined(STM32F373xC) || \
-    defined(STM32F318xx) || defined(STM32F358xx) || defined(STM32F378xx)
-
-#if defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
-
 /* Private typedef -----------------------------------------------------------*/
+/** @defgroup I2SEx_Private_Typedef I2S Extended Private Typedef
+  * @{
+  */
 typedef enum
 {
   I2S_USE_I2S      = 0x00,   /*!< I2Sx should be used           */
   I2S_USE_I2SEXT   = 0x01    /*!< I2Sx_ext should be used       */   
 }I2S_UseTypeDef;
+/**
+  * @}
+  */
 
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
+/** @defgroup I2SEx_Private_Functions I2S Extended Private Functions
+  * @{
+  */
 static void I2S_TxRxDMACplt(DMA_HandleTypeDef *hdma);
 static void I2S_TxRxDMAError(DMA_HandleTypeDef *hdma);
 static void I2S_FullDuplexTx_IT(I2S_HandleTypeDef *hi2s, I2S_UseTypeDef i2sUsed);
 static void I2S_FullDuplexRx_IT(I2S_HandleTypeDef *hi2s, I2S_UseTypeDef i2sUsed);
 static HAL_StatusTypeDef I2S_FullDuplexWaitFlagStateUntilTimeout(I2S_HandleTypeDef *hi2s, uint32_t Flag, 
                                                                  uint32_t State, uint32_t Timeout, I2S_UseTypeDef i2sUsed);
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+/**
+  * @}
+  */
 
-/* Private functions ---------------------------------------------------------*/
+/**
+  * @}
+  */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
 
-/** @addtogroup I2S_Private_Functions
+/* Exported functions ---------------------------------------------------------*/
+
+/** @addtogroup I2S I2S HAL module driver
   * @{
   */
 
-/** @addtogroup  I2S_Group1 Initialization and de-initialization functions
+/** @addtogroup I2S_Exported_Functions I2S Exported Functions
+  * @{
+  */
+
+/** @addtogroup  I2S_Exported_Functions_Group1 Initialization and de-initialization functions
   *  @brief    Initialization and Configuration functions
   *
 @verbatim
@@ -199,12 +221,14 @@ HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s)
 {
   uint16_t tmpreg = 0, i2sdiv = 2, i2sodd = 0, packetlength = 1;
   uint32_t tmp = 0, i2sclk = 0;
-#if defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
   RCC_PeriphCLKInitTypeDef rccperiphclkinit;
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
   
   /* Check the I2S handle allocation */
-  if(hi2s == NULL)
+  if(hi2s == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -257,7 +281,8 @@ HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s)
     }
     
     /* Get I2S source Clock frequency  ****************************************/
-#if defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
+#if defined (STM32F302xE) || defined (STM32F303xE) || defined (STM32F398xx) || \
+    defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
     rccperiphclkinit.PeriphClockSelection = RCC_PERIPHCLK_I2S;
 
     /* If an external I2S clock has to be used, the specific define should be set  
@@ -280,7 +305,8 @@ HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s)
       /* Get the I2S source clock value */
       i2sclk = HAL_RCC_GetSysClockFreq();
     }
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
 
 #if defined (STM32F373xC) || defined (STM32F378xx)
     if(hi2s->Instance == SPI1)
@@ -337,7 +363,8 @@ HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s)
   /* Write to SPIx I2SCFGR */  
   hi2s->Instance->I2SCFGR = tmpreg;
   
-#if defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
+#if defined (STM32F302xE) || defined (STM32F303xE) || defined (STM32F398xx) || \
+    defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
   if (hi2s->Init.FullDuplexMode == I2S_FULLDUPLEXMODE_ENABLE)
   {
     /* Clear I2SMOD, I2SE, I2SCFG, PCMSYNC, I2SSTD, CKPOL, DATLEN and CHLEN bits */
@@ -370,15 +397,24 @@ HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s)
     /* Write to SPIx I2SCFGR */  
     I2SxEXT(hi2s->Instance)->I2SCFGR = tmpreg;
   }
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
 
   hi2s->ErrorCode = HAL_I2S_ERROR_NONE;
   hi2s->State= HAL_I2S_STATE_READY;
   
   return HAL_OK;
 }
+/**
+  * @}
+  */
 
-#if defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
+#if defined (STM32F302xE) || defined (STM32F303xE) || defined (STM32F398xx) || \
+    defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
+/** @addtogroup  I2S_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
+
 /**
   * @brief  This function handles I2S/I2Sext interrupt requests in full-duplex mode.
   * @param  hi2s: I2S handle
@@ -508,13 +544,15 @@ __weak void HAL_I2S_TxRxCpltCallback(I2S_HandleTypeDef *hi2s)
             the HAL_I2S_TxRxCpltCallback could be implenetd in the user file
    */
 }
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
 
 /**
   * @}
   */
 
-/** @addtogroup HAL_I2S_Group2 Peripheral State functions
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
+
+/** @addtogroup I2S_Exported_Functions_Group3 Peripheral State and Errors functions
   *  @brief   Peripheral State functions
   *
   *
@@ -549,14 +587,16 @@ HAL_StatusTypeDef HAL_I2S_DMAPause(I2S_HandleTypeDef *hi2s)
     /* Pause the audio file playing by disabling the I2S DMA request */
     hi2s->Instance->CR2 &= (uint32_t)(~SPI_CR2_RXDMAEN);
   }
-#if defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
+#if defined (STM32F302xE) || defined (STM32F303xE) || defined (STM32F398xx) || \
+    defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
   else if(hi2s->State == HAL_I2S_STATE_BUSY_TX_RX)
   {
     /* Pause the audio file playing by disabling the I2S DMA request */
     hi2s->Instance->CR2 &= (uint32_t)(~(SPI_CR2_RXDMAEN | SPI_CR2_TXDMAEN));
     I2SxEXT(hi2s->Instance)->CR2 &= (uint32_t)(~(SPI_CR2_RXDMAEN | SPI_CR2_TXDMAEN));
   }
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
 
   /* Process Unlocked */
   __HAL_UNLOCK(hi2s);
@@ -584,7 +624,8 @@ HAL_StatusTypeDef HAL_I2S_DMAResume(I2S_HandleTypeDef *hi2s)
     /* Enable the I2S DMA request */
     hi2s->Instance->CR2 |= SPI_CR2_RXDMAEN;
   }
-#if defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
+#if defined (STM32F302xE) || defined (STM32F303xE) || defined (STM32F398xx) || \
+    defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
   else if(hi2s->State == HAL_I2S_STATE_BUSY_TX_RX)
   {
     /* Pause the audio file playing by disabling the I2S DMA request */
@@ -598,7 +639,8 @@ HAL_StatusTypeDef HAL_I2S_DMAResume(I2S_HandleTypeDef *hi2s)
       __HAL_I2SEXT_ENABLE(hi2s);
     }
   }
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
 
   /* If the I2S peripheral is still not enabled, enable it */
   if ((hi2s->Instance->I2SCFGR & SPI_I2SCFGR_I2SE) == 0)
@@ -639,7 +681,8 @@ HAL_StatusTypeDef HAL_I2S_DMAStop(I2S_HandleTypeDef *hi2s)
     /* Disable the I2S DMA Channel */
     HAL_DMA_Abort(hi2s->hdmarx);
   }
-#if defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
+#if defined (STM32F302xE) || defined (STM32F303xE) || defined (STM32F398xx) || \
+    defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
   else if(hi2s->State == HAL_I2S_STATE_BUSY_TX_RX)
   {
     /* Disable the I2S DMA requests */
@@ -653,7 +696,8 @@ HAL_StatusTypeDef HAL_I2S_DMAStop(I2S_HandleTypeDef *hi2s)
     /* Disable I2Sext peripheral */
     __HAL_I2SEXT_DISABLE(hi2s);
   }
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
 
   /* Disable I2S peripheral */
   __HAL_I2S_DISABLE(hi2s);
@@ -672,24 +716,29 @@ HAL_StatusTypeDef HAL_I2S_DMAStop(I2S_HandleTypeDef *hi2s)
 
 /**
   * @}
-  */
+  */  
 
-/** @defgroup I2SEx
+/**
+  * @}
+  */  
+
+#if defined (STM32F302xE) || defined (STM32F303xE) || defined (STM32F398xx) || \
+    defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
+/** @addtogroup I2SEx I2S Extended HAL module driver
   * @brief I2S Extended HAL module driver
   * @{
   */
 
-/** @defgroup I2SEx_Private_Functions
+/** @defgroup I2SEx_Exported_Functions I2S Extended Exported Functions
   * @{
   */
 
-#if defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
-/** @defgroup I2SEx_Group1 Extension features functions 
-  *  @brief   Extension features functions
+/** @defgroup I2SEx_Exported_Functions_Group1 Extended features functions 
+  *  @brief   Extended features functions
   *
 @verbatim   
  ===============================================================================
-                       ##### Extension features Functions #####
+                       ##### Extended features Functions #####
  ===============================================================================  
     [..]
     This subsection provides a set of functions allowing to manage the I2S data 
@@ -740,7 +789,7 @@ HAL_StatusTypeDef HAL_I2S_DMAStop(I2S_HandleTypeDef *hi2s)
   */
 HAL_StatusTypeDef HAL_I2SEx_TransmitReceive(I2S_HandleTypeDef *hi2s, uint16_t *pTxData, uint16_t *pRxData, uint16_t Size, uint32_t Timeout)
 {
-  if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0)) 
+  if((pTxData == HAL_NULL ) || (pRxData == HAL_NULL ) || (Size == 0)) 
   {
     return  HAL_ERROR;                                    
   }
@@ -979,7 +1028,7 @@ HAL_StatusTypeDef HAL_I2SEx_TransmitReceive_IT(I2S_HandleTypeDef *hi2s, uint16_t
 {
   if(hi2s->State == HAL_I2S_STATE_READY)
   {
-    if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0)) 
+    if((pTxData == HAL_NULL ) || (pRxData == HAL_NULL ) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -1127,7 +1176,7 @@ HAL_StatusTypeDef HAL_I2SEx_TransmitReceive_DMA(I2S_HandleTypeDef *hi2s, uint16_
 {
   uint32_t *tmp;
     
-  if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0)) 
+  if((pTxData == HAL_NULL ) || (pRxData == HAL_NULL ) || (Size == 0)) 
   {
     return  HAL_ERROR;                                    
   }
@@ -1255,6 +1304,10 @@ HAL_StatusTypeDef HAL_I2SEx_TransmitReceive_DMA(I2S_HandleTypeDef *hi2s, uint16_
 /**
   * @}
   */  
+
+/** @addtogroup I2SEx_Private_Functions I2S Extended Private Functions
+  * @{
+  */
 
 /**
   * @brief DMA I2S transmit receive process complete callback 
@@ -1480,27 +1533,22 @@ static HAL_StatusTypeDef I2S_FullDuplexWaitFlagStateUntilTimeout(I2S_HandleTypeD
   
   return HAL_OK;      
 }
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
-
 /**
   * @}
   */
 
 /**
   * @}
-  */
+  */  
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
 
-#endif /* defined(STM32F301x8) ||                         */
-       /* defined(STM32F302x8) || defined(STM32F302xC) || */
-       /* defined(STM32F303xC) || defined(STM32F373xC) || */
-       /* defined(STM32F318xx) ||                         */
-       /* defined(STM32F358xx) || defined(STM32F378xx)    */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
 #endif /* HAL_I2S_MODULE_ENABLED */
-
-/**
-  * @}
-  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2s_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_i2s_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_i2s_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of I2S HAL Extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of I2S HAL Extended module.
   ******************************************************************************
   * @attention
   *
@@ -43,11 +43,10 @@
  extern "C" {
 #endif
 
-#if defined(STM32F301x8) ||                         \
-    defined(STM32F302x8) || defined(STM32F302xC) || \
-    defined(STM32F303xC) || defined(STM32F373xC) || \
-    defined(STM32F318xx) ||                         \
-    defined(STM32F358xx) || defined(STM32F378xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f3xx_hal_def.h"  
@@ -56,14 +55,18 @@
   * @{
   */
 
-/** @addtogroup I2SEx
+/** @addtogroup I2SEx I2S Extended HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
 /* Exported constants --------------------------------------------------------*/  
-/* Exported macro ------------------------------------------------------------*/ 
-#if defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
+/* Exported macros ------------------------------------------------------------*/ 
+/** @defgroup I2SEx_Exported_Macros I2S Extended Exported Macros
+  * @{
+  */
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
 #define I2SxEXT(__INSTANCE__) ((__INSTANCE__) == (SPI2)? (SPI_TypeDef *)(I2S2ext_BASE): (SPI_TypeDef *)(I2S3ext_BASE))
 
 /** @brief  Enable or disable the specified I2SExt peripheral.
@@ -123,12 +126,25 @@
   * @retval None
   */                                                                                                   
 #define __HAL_I2SEXT_CLEAR_UDRFLAG(__HANDLE__)(I2SxEXT((__HANDLE__)->Instance)->SR)    
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
- 
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx */
+ /**
+  * @}
+  */
+
+
 /* Exported functions --------------------------------------------------------*/
 /* Initialization/de-initialization functions  ********************************/
+/** @addtogroup I2SEx_Exported_Functions I2S Extended Exported Functions
+  * @{
+  */
 
-#if defined (STM32F302xC) || defined (STM32F303xC) || defined (STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+/** @addtogroup I2SEx_Exported_Functions_Group1 Extended features functions 
+  * @{
+  */
+
 /* Extended features functions ************************************************/
  /* Blocking mode: Polling */
 HAL_StatusTypeDef HAL_I2SEx_TransmitReceive(I2S_HandleTypeDef *hi2s, uint16_t *pTxData, uint16_t *pRxData, uint16_t Size, uint32_t Timeout);
@@ -136,12 +152,44 @@ HAL_StatusTypeDef HAL_I2SEx_TransmitReceive(I2S_HandleTypeDef *hi2s, uint16_t *p
 HAL_StatusTypeDef HAL_I2SEx_TransmitReceive_IT(I2S_HandleTypeDef *hi2s, uint16_t *pTxData, uint16_t *pRxData, uint16_t Size);
 /* Non-Blocking mode: DMA */
 HAL_StatusTypeDef HAL_I2SEx_TransmitReceive_DMA(I2S_HandleTypeDef *hi2s, uint16_t *pTxData, uint16_t *pRxData, uint16_t Size);
+/**
+  * @}
+  */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx */
 
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup I2S I2S HAL module driver
+  * @{
+  */ 
+
+/** @addtogroup I2S_Exported_Functions I2S Exported Functions
+  * @{
+  */
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+/** @addtogroup  I2S_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
 /* I2S IRQHandler and Callbacks used in non blocking modes (Interrupt and DMA) */
 void HAL_I2S_FullDuplex_IRQHandler(I2S_HandleTypeDef *hi2s);
 void HAL_I2S_TxRxCpltCallback(I2S_HandleTypeDef *hi2s);
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+/**
+  * @}
+  */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx */
 
+/** @addtogroup I2S_Exported_Functions_Group3 Peripheral State and Errors functions
+  * @{
+  */
 /* Peripheral Control and State functions  ************************************/
 HAL_StatusTypeDef HAL_I2S_DMAPause(I2S_HandleTypeDef *hi2s);
 HAL_StatusTypeDef HAL_I2S_DMAResume(I2S_HandleTypeDef *hi2s);
@@ -155,11 +203,17 @@ HAL_StatusTypeDef HAL_I2S_DMAStop(I2S_HandleTypeDef *hi2s);
   * @}
   */
 
-#endif /* defined(STM32F301x8) ||                         */
-       /* defined(STM32F302x8) || defined(STM32F302xC) || */
-       /* defined(STM32F303xC) || defined(STM32F373xC) || */
-       /* defined(STM32F318xx) ||                         */
-       /* defined(STM32F358xx) || defined(STM32F378xx)    */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
 #ifdef __cplusplus
 }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_irda.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_irda.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_irda.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   IRDA HAL module driver.
   * 
   *          This file provides firmware functions to manage the following 
@@ -91,7 +91,7 @@
   * @{
   */
 
-/** @defgroup IRDA 
+/** @defgroup IRDA IRDA HAL module driver
   * @brief HAL IRDA module driver
   * @{
   */
@@ -99,14 +99,24 @@
     
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+/** @defgroup IRDA_Private_Constants   IRDA Private Constants
+  * @{
+  */
 #define TEACK_REACK_TIMEOUT            1000
 #define IRDA_TXDMA_TIMEOUTVALUE        22000
 #define IRDA_TIMEOUT_VALUE             22000
 #define IRDA_CR1_FIELDS  ((uint32_t)(USART_CR1_M | USART_CR1_PCE \
                                    | USART_CR1_PS | USART_CR1_TE | USART_CR1_RE))
+/**
+  * @}
+  */
+
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
+/** @defgroup IRDA_Private_Functions IRDA Private Functions
+  * @{
+  */
 static void IRDA_DMATransmitCplt(DMA_HandleTypeDef *hdma);
 static void IRDA_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
 static void IRDA_DMAError(DMA_HandleTypeDef *hdma); 
@@ -114,20 +124,24 @@ static HAL_StatusTypeDef IRDA_SetConfig(IRDA_HandleTypeDef *hirda);
 static HAL_StatusTypeDef IRDA_CheckIdleState(IRDA_HandleTypeDef *hirda);
 static HAL_StatusTypeDef IRDA_WaitOnFlagUntilTimeout(IRDA_HandleTypeDef *hirda, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
 static HAL_StatusTypeDef IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda);
+static HAL_StatusTypeDef IRDA_EndTransmit_IT(IRDA_HandleTypeDef *hirda);
 static HAL_StatusTypeDef IRDA_Receive_IT(IRDA_HandleTypeDef *hirda);
-/* Private functions ---------------------------------------------------------*/
+/**
+  * @}
+  */
+/* Exported functions ---------------------------------------------------------*/
 
-/** @defgroup IRDA_Private_Functions
+/** @defgroup IRDA_Exported_Functions IRDA Exported Functions
   * @{
   */
 
-/** @defgroup HAL_IRDA_Group1 Initialization/de-initialization functions 
+/** @defgroup IRDA_Exported_Functions_Group1 Initialization and de-initialization functions 
   *  @brief    Initialization and Configuration functions 
   *
 @verbatim    
-===============================================================================
+  ==============================================================================
             ##### Initialization and Configuration functions #####
- ===============================================================================  
+  ==============================================================================
     [..]
     This subsection provides a set of functions allowing to initialize the USARTx 
     in asynchronous IRDA mode.
@@ -178,7 +192,7 @@ static HAL_StatusTypeDef IRDA_Receive_IT(IRDA_HandleTypeDef *hirda);
 HAL_StatusTypeDef HAL_IRDA_Init(IRDA_HandleTypeDef *hirda)
 {
   /* Check the IRDA handle allocation */
-  if(hirda == NULL)
+  if(hirda == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -219,11 +233,6 @@ HAL_StatusTypeDef HAL_IRDA_Init(IRDA_HandleTypeDef *hirda)
   return (IRDA_CheckIdleState(hirda));
 }
 
-
-
-
-
-
 /**
   * @brief DeInitializes the IRDA peripheral 
   * @param hirda: IRDA handle
@@ -232,7 +241,7 @@ HAL_StatusTypeDef HAL_IRDA_Init(IRDA_HandleTypeDef *hirda)
 HAL_StatusTypeDef HAL_IRDA_DeInit(IRDA_HandleTypeDef *hirda)
 {
   /* Check the IRDA handle allocation */
-  if(hirda == NULL)
+  if(hirda == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -284,8 +293,8 @@ HAL_StatusTypeDef HAL_IRDA_DeInit(IRDA_HandleTypeDef *hirda)
   * @}
   */
 
-/** @defgroup HAL_IRDA_Group2 IO operation functions 
-  *  @brief IRDA Transmit/Receive functions 
+/** @defgroup IRDA_Exported_Functions_Group2 Input and Output operation functions 
+  *  @brief   IRDA Transmit and Receive functions 
   *
 @verbatim   
  ===============================================================================
@@ -345,7 +354,7 @@ HAL_StatusTypeDef HAL_IRDA_Transmit(IRDA_HandleTypeDef *hirda, uint8_t *pData, u
    
   if ((hirda->State == HAL_IRDA_STATE_READY) || (hirda->State == HAL_IRDA_STATE_BUSY_RX)) 
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -425,7 +434,7 @@ HAL_StatusTypeDef HAL_IRDA_Receive(IRDA_HandleTypeDef *hirda, uint8_t *pData, ui
   
   if ((hirda->State == HAL_IRDA_STATE_READY) || (hirda->State == HAL_IRDA_STATE_BUSY_TX))
   { 
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -503,7 +512,7 @@ HAL_StatusTypeDef HAL_IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData
 {
   if ((hirda->State == HAL_IRDA_STATE_READY) || (hirda->State == HAL_IRDA_STATE_BUSY_RX))
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;                                    
     }
@@ -553,7 +562,7 @@ HAL_StatusTypeDef HAL_IRDA_Receive_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData,
 {  
   if ((hirda->State == HAL_IRDA_STATE_READY) || (hirda->State == HAL_IRDA_STATE_BUSY_TX))
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;                                    
     }
@@ -612,7 +621,7 @@ HAL_StatusTypeDef HAL_IRDA_Transmit_DMA(IRDA_HandleTypeDef *hirda, uint8_t *pDat
   
   if ((hirda->State == HAL_IRDA_STATE_READY) || (hirda->State == HAL_IRDA_STATE_BUSY_RX))
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;                                    
     }
@@ -675,7 +684,7 @@ HAL_StatusTypeDef HAL_IRDA_Receive_DMA(IRDA_HandleTypeDef *hirda, uint8_t *pData
   
   if ((hirda->State == HAL_IRDA_STATE_READY) || (hirda->State == HAL_IRDA_STATE_BUSY_TX))
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;                                    
     }
@@ -789,7 +798,24 @@ void HAL_IRDA_IRQHandler(IRDA_HandleTypeDef *hirda)
     IRDA_Transmit_IT(hirda);
   } 
   
+  /* IRDA in mode Transmitter (transmission end) -----------------------------*/
+ if((__HAL_IRDA_GET_IT(hirda, IRDA_IT_TC) != RESET) &&(__HAL_IRDA_GET_IT_SOURCE(hirda, IRDA_IT_TC) != RESET))
+  {
+    IRDA_EndTransmit_IT(hirda);
+  }   
+  
 }
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */  
+
+/** @addtogroup IRDA_Private_Functions IRDA Private Functions
+  * @{
+  */
 
 /**
   * @brief DMA IRDA Tx transfer completed callback 
@@ -866,6 +892,17 @@ static void IRDA_DMAError(DMA_HandleTypeDef *hdma)
   hirda->ErrorCode |= HAL_IRDA_ERROR_DMA;
   HAL_IRDA_ErrorCallback(hirda);
 }
+/**
+  * @}
+  */
+
+/** @addtogroup IRDA_Exported_Functions IRDA Exported Functions
+  * @{
+  */
+  
+/** @addtogroup IRDA_Exported_Functions_Group2 Input and Output operation functions 
+  * @{
+  */
 
 /**
   * @brief Tx Transfer completed callback
@@ -904,6 +941,18 @@ __weak void HAL_IRDA_RxCpltCallback(IRDA_HandleTypeDef *hirda)
 }
 
 /**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+/** @addtogroup IRDA_Private_Functions IRDA Private Functions
+  * @{
+  */
+  
+/**
   * @brief Receive an amount of data in non blocking mode. 
   *         Function called under interruption only, once
   *         interruptions have been enabled by HAL_IRDA_Transmit_IT()      
@@ -922,40 +971,23 @@ static HAL_StatusTypeDef IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda)
       /* Disable the IRDA Transmit Data Register Empty Interrupt */
       __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_TXE);
       
-      if(hirda->State == HAL_IRDA_STATE_BUSY_TX_RX) 
-      {
-        hirda->State = HAL_IRDA_STATE_BUSY_RX;
-      }
-      else
-      {
-        /* Disable the IRDA Error Interrupt: (Frame error, noise error, overrun error) */
-        __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_ERR);
-      
-        hirda->State = HAL_IRDA_STATE_READY;
-      }
-
-      /* Wait on TC flag to be able to start a second transfer */
-      if(IRDA_WaitOnFlagUntilTimeout(hirda, IRDA_IT_TC, RESET, IRDA_TIMEOUT_VALUE) != HAL_OK)
-      { 
-        return HAL_TIMEOUT;
-      }
-      
-      HAL_IRDA_TxCpltCallback(hirda);
+      /* Enable the IRDA Transmit Complete Interrupt */    
+      __HAL_IRDA_ENABLE_IT(hirda, IRDA_IT_TC);
       
       return HAL_OK;
     }
     else
     {
       if ((hirda->Init.WordLength == IRDA_WORDLENGTH_9B) && (hirda->Init.Parity == IRDA_PARITY_NONE))
-        {
-          tmp = (uint16_t*) hirda->pTxBuffPtr;
-          hirda->Instance->TDR = (*tmp & (uint16_t)0x01FF);
-          hirda->pTxBuffPtr += 2;
-        }
-        else
-        {
-          hirda->Instance->TDR = (uint8_t)(*hirda->pTxBuffPtr++ & (uint8_t)0xFF); 
-        }
+      {
+        tmp = (uint16_t*) hirda->pTxBuffPtr;
+        hirda->Instance->TDR = (*tmp & (uint16_t)0x01FF);
+        hirda->pTxBuffPtr += 2;
+      }
+      else
+      {
+        hirda->Instance->TDR = (uint8_t)(*hirda->pTxBuffPtr++ & (uint8_t)0xFF); 
+      }
       hirda->TxXferCount--;
   
       return HAL_OK;
@@ -966,6 +998,36 @@ static HAL_StatusTypeDef IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda)
     return HAL_BUSY;   
   }
 }
+
+/**
+  * @brief  Wraps up transmission in non blocking mode.
+  * @param  hirda: pointer to a IRDA_HandleTypeDef structure that contains
+  *                the configuration information for the specified IRDA module.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef IRDA_EndTransmit_IT(IRDA_HandleTypeDef *hirda)
+{
+  /* Disable the IRDA Transmit Complete Interrupt */    
+  __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_TC);
+  
+  /* Check if a receive process is ongoing or not */
+  if(hirda->State == HAL_IRDA_STATE_BUSY_TX_RX) 
+  {
+    hirda->State = HAL_IRDA_STATE_BUSY_RX;
+  }
+  else
+  {
+    /* Disable the IRDA Error Interrupt: (Frame error, noise error, overrun error) */
+    __HAL_IRDA_DISABLE_IT(hirda, IRDA_IT_ERR);
+    
+    hirda->State = HAL_IRDA_STATE_READY;
+  }
+  
+  HAL_IRDA_TxCpltCallback(hirda);
+  
+  return HAL_OK;
+}
+
 
 /**
   * @brief Receive an amount of data in non blocking mode. 
@@ -1029,12 +1091,16 @@ static HAL_StatusTypeDef IRDA_Receive_IT(IRDA_HandleTypeDef *hirda)
   * @}
   */
 
-/** @defgroup HAL_IRDA_Group3 Peripheral Control functions 
+/** @addtogroup IRDA_Exported_Functions IRDA Exported Functions
+  * @{
+  */
+
+/** @defgroup IRDA_Exported_Functions_Group3 Peripheral State and Errors functions 
   *  @brief   IRDA control functions 
   *
 @verbatim   
  ===============================================================================
-                      ##### Peripheral Control functions #####
+                   ##### Peripheral State and Error functions #####
  ===============================================================================  
     [..]
     This subsection provides a set of functions allowing to control the IRDA.
@@ -1070,6 +1136,14 @@ uint32_t HAL_IRDA_GetError(IRDA_HandleTypeDef *hirda)
   */
 
 /**
+  * @}
+  */  
+
+/** @addtogroup IRDA_Private_Functions IRDA Private Functions
+  * @{
+  */
+  
+/**
   * @brief Configure the IRDA peripheral 
   * @param hirda: irda handle
   * @retval None
@@ -1087,9 +1161,6 @@ static HAL_StatusTypeDef IRDA_SetConfig(IRDA_HandleTypeDef *hirda)
   assert_param(IS_IRDA_TX_RX_MODE(hirda->Init.Mode));
   assert_param(IS_IRDA_PRESCALER(hirda->Init.Prescaler)); 
   assert_param(IS_IRDA_POWERMODE(hirda->Init.PowerMode)); 
-
-  
-
 
   /*-------------------------- USART CR1 Configuration -----------------------*/        
   /* Configure the IRDA Word Length, Parity and transfer Mode: 
@@ -1172,7 +1243,6 @@ static HAL_StatusTypeDef IRDA_CheckIdleState(IRDA_HandleTypeDef *hirda)
   
   return HAL_OK;
 }
-
 
 /**
   * @brief  Handle IRDA Communication Timeout.

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_irda.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_irda.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_irda.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of IRDA HAL module.
   ******************************************************************************
   * @attention
@@ -50,11 +50,14 @@
   * @{
   */
 
-/** @addtogroup IRDA
+/** @addtogroup IRDA IRDA HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup IRDA_Exported_Types IRDA Exported Types
+  * @{
+  */ 
 
 /** 
   * @brief IRDA Init Structure definition  
@@ -75,7 +78,7 @@ typedef struct
                                                  the word length is set to 9 data bits; 8th bit when the
                                                  word length is set to 8 data bits). */
  
-  uint16_t Mode;                      /*!< Specifies wether the Receive or Transmit mode is enabled or disabled.
+  uint16_t Mode;                      /*!< Specifies whether the Receive or Transmit mode is enabled or disabled.
                                            This parameter can be a value of @ref IRDA_Mode */
   
   uint8_t  Prescaler;                 /*!< Specifies the Prescaler value for dividing the UART/USART source clock
@@ -174,6 +177,10 @@ typedef enum
   IRDA_PRESCALER       = 0x04,  
   IRDA_POWERMODE       = 0x05
 }IRDA_ControlTypeDef;
+
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
 /** @defgroup IRDA_Exported_Constants  IRDA Exported Constants
@@ -370,9 +377,8 @@ typedef enum
  * @}
  */
 
-  
 /* Exported macros -----------------------------------------------------------*/
-/** @defgroup IRDA_Exported_Macros
+/** @defgroup IRDA_Exported_Macros IRDA Exported Macros
   * @{
   */
     
@@ -404,7 +410,6 @@ typedef enum
   * @retval The new state of __FLAG__ (TRUE or FALSE).
   */
 #define __HAL_IRDA_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->ISR & (__FLAG__)) == (__FLAG__))   
-
 
 /** @brief  Enables the specified IRDA interrupt.
   * @param  __HANDLE__: specifies the IRDA Handle.
@@ -546,16 +551,32 @@ typedef enum
  * @}
  */
 
-/* Include IRDA HAL Extension module */
+/* Include IRDA HAL Extended module */
 #include "stm32f3xx_hal_irda_ex.h"  
 
 /* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup IRDA_Exported_Functions IRDA Exported Functions
+  * @{
+  */
+  
+/** @addtogroup IRDA_Exported_Functions_Group1 Initialization and de-initialization functions 
+  * @{
+  */
+
 /* Initialization and de-initialization functions  ****************************/
 HAL_StatusTypeDef HAL_IRDA_Init(IRDA_HandleTypeDef *hirda);
 HAL_StatusTypeDef HAL_IRDA_DeInit(IRDA_HandleTypeDef *hirda);
 void HAL_IRDA_MspInit(IRDA_HandleTypeDef *hirda);
 void HAL_IRDA_MspDeInit(IRDA_HandleTypeDef *hirda);
 
+/**
+  * @}
+  */
+
+/** @addtogroup IRDA_Exported_Functions_Group2 Input and Output operation functions 
+  * @{
+  */
 
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef HAL_IRDA_Transmit(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size, uint32_t Timeout);
@@ -569,6 +590,14 @@ void HAL_IRDA_TxCpltCallback(IRDA_HandleTypeDef *hirda);
 void HAL_IRDA_RxCpltCallback(IRDA_HandleTypeDef *hirda);
 void HAL_IRDA_ErrorCallback(IRDA_HandleTypeDef *hirda);
 
+/**
+  * @}
+  */
+
+/** @addtogroup IRDA_Exported_Functions_Group3 Peripheral State and Errors functions
+  * @{
+  */
+
 /* Peripheral State and Error functions ***************************************/
 HAL_IRDA_StateTypeDef HAL_IRDA_GetState(IRDA_HandleTypeDef *hirda);
 uint32_t HAL_IRDA_GetError(IRDA_HandleTypeDef *hirda);
@@ -579,8 +608,15 @@ uint32_t HAL_IRDA_GetError(IRDA_HandleTypeDef *hirda);
 
 /**
   * @}
+  */
+
+/**
+  * @}
   */ 
-  
+
+/**
+  * @}
+  */
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_irda_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_irda_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_irda_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of IRDA HAL Extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of IRDA HAL Extended module.
   ******************************************************************************
   * @attention
   *                               
@@ -50,21 +50,22 @@
   * @{
   */
 
-/** @addtogroup IRDAEx
+/** @addtogroup IRDAEx IRDA Extended HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup IRDAEx_Exported_Constants
+/** @defgroup IRDAEx_Exported_Constants IRDA Extended Exported Constants
   * @{
   */
   
-/** @defgroup IRDAEx_Word_Length IRDA Word Length
+/** @defgroup IRDAEx_Word_Length IRDA Extended Word Length
   * @{
   */
-#if defined (STM32F301x8) || defined (STM32F302x8) || defined (STM32F334x8) \
- || defined (STM32F318xx)            
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F334x8)                                                 || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define IRDA_WORDLENGTH_7B                  ((uint32_t)USART_CR1_M1)
 #define IRDA_WORDLENGTH_8B                  ((uint32_t)0x00000000)
 #define IRDA_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M0)
@@ -76,7 +77,9 @@
 #define IRDA_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M)
 #define IS_IRDA_WORD_LENGTH(LENGTH) (((LENGTH) == IRDA_WORDLENGTH_8B) || \
                                      ((LENGTH) == IRDA_WORDLENGTH_9B))
-#endif                                     
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F334x8                               || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 /**
   * @}
   */
@@ -86,9 +89,9 @@
   * @}
   */  
   
-/* Exported macro ------------------------------------------------------------*/
+/* Exported macros -----------------------------------------------------------*/
 
-/** @defgroup IRDAEx_Exported_Macros
+/** @defgroup IRDAEx_Exported_Macros IRDA Extended Exported Macros
   * @{
   */
   
@@ -97,8 +100,8 @@
   * @param  __CLOCKSOURCE__ : output variable   
   * @retval IRDA clocking source, written in __CLOCKSOURCE__.
   */
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F303xE) \
- || defined(STM32F318xC) || defined(STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
 #define __HAL_IRDA_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__) \
   do {                                                        \
     if((__HANDLE__)->Instance == USART1)                      \
@@ -192,7 +195,7 @@
        }                                                      \
     }                                                         \
   } while(0)
-#elif defined(STM32F334x8) || defined(STM32F303x8) || defined(STM32F328xx) 
+#elif defined(STM32F303x8) || defined(STM32F334x8) ||defined(STM32F328xx) 
 #define __HAL_IRDA_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__) \
   do {                                                        \
     if((__HANDLE__)->Instance == USART1)                      \
@@ -308,7 +311,8 @@
        }                                                      \
     }                                                         \
   } while(0)
-#endif /* defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F303xE) || defined(STM32F318xC) || defined(STM32F358xx) */  
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */ 
   
   
 /** @brief  Computes the mask to apply to retrieve the received data
@@ -316,8 +320,9 @@
   * @param  __HANDLE__: specifies the IRDA Handle
   * @retval none
   */  
-#if defined (STM32F301x8) || defined (STM32F302x8) || defined (STM32F334x8) \
- || defined (STM32F318xx)    
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+    defined(STM32F334x8)
 #define __HAL_IRDA_MASK_COMPUTATION(__HANDLE__)                       \
   do {                                                                \
   if ((__HANDLE__)->Init.WordLength == IRDA_WORDLENGTH_9B)            \
@@ -380,8 +385,9 @@
      }                                                                \
   }                                                                   \
 } while(0) 
-#endif /* defined (STM32F301x8) || defined (STM32F302x8) || defined (STM32F334x8)
-          || defined (STM32F318xx)   */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+       /* STM32F334x8                                  */
 /**
   * @}
   */
@@ -391,7 +397,6 @@
 /* IO operation functions *****************************************************/
 /* Peripheral Control functions ***********************************************/
 /* Peripheral State and Error functions ***************************************/
-
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_iwdg.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_iwdg.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_iwdg.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   IWDG HAL module driver.
   *
   *          This file provides firmware functions to manage the following 
@@ -20,24 +20,18 @@
     [..]
     (+) The IWDG can be started by either software or hardware (configurable
         through option byte).
-
     (+) The IWDG is clocked by its own dedicated Low-Speed clock (LSI) and
         thus stays active even if the main clock fails.
-
     (+) Once the IWDG is started, the LSI is forced ON and cannot be disabled
         (LSI cannot be disabled too), and the counter starts counting down from 
         the reset value of 0xFFF. When it reaches the end of count value (0x000)
         a system reset is generated.
-
     (+) The IWDG counter should be refreshed at regular intervals, otherwise the
         watchdog generates an MCU reset when the counter reaches 0.          
-
     (+) The IWDG is implemented in the VDD voltage domain that is still functional
         in STOP and STANDBY mode (IWDG reset can wake-up from STANDBY).
-
     (+) IWDGRST flag in RCC_CSR register can be used to inform when an IWDG
         reset occurs.
-
     (+) Min-max timeout value @41KHz (LSI): ~0.1ms / ~25.5s
         The IWDG timeout may vary due to LSI frequency dispersion. STM32F30x
         devices provide the capability to measure the LSI frequency (LSI clock
@@ -119,7 +113,7 @@
   * @{
   */
 
-/** @defgroup IWDG 
+/** @defgroup IWDG IWDG HAL module driver
   * @brief IWDG HAL module driver.
   * @{
   */
@@ -128,17 +122,25 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
-#define HAL_IWDG_DEFAULT_TIMEOUT 1000
+
+/** @defgroup IWDG_Private_Defines IWDG Private Defines
+  * @{
+  */
+#define HAL_IWDG_DEFAULT_TIMEOUT (uint32_t)1000
+/**
+  * @}
+  */
+
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 /* Private functions ---------------------------------------------------------*/
 
-/** @defgroup IWDG_Private_Functions
+/** @defgroup IWDG_Exported_Functions IWDG Exported Functions
   * @{
   */
 
-/** @defgroup IWDG_Group1 Initialization functions 
+/** @defgroup IWDG_Exported_Functions_Group1 Initialization and de-initialization functions 
  *  @brief    Initialization and Configuration functions. 
  *
 @verbatim    
@@ -158,7 +160,8 @@
 /**
   * @brief  Initializes the IWDG according to the specified
   *         parameters in the IWDG_InitTypeDef and creates the associated handle.
-  * @param  hiwdg: IWDG handle
+  * @param  hiwdg: pointer to a IWDG_HandleTypeDef structure that contains
+  *                the configuration information for the specified IWDG module.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg)
@@ -166,7 +169,7 @@ HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg)
   uint32_t tickstart = 0;
 
   /* Check the IWDG handle allocation */
-  if(hiwdg == NULL)
+  if(hiwdg == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -178,9 +181,9 @@ HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg)
   assert_param(IS_IWDG_WINDOW(hiwdg->Init.Window));
 
   /* Check pending flag, if previous update not done, return error */
-  if((__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_PVU) != RESET)  &&
-     (__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_RVU) != RESET)  &&
-     (__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_WVU) != RESET))
+  if((__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_PVU) != RESET)
+     &&(__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_RVU) != RESET)
+     &&(__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_WVU) != RESET))
   {
     return HAL_ERROR;
   }
@@ -231,7 +234,8 @@ HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg)
 
 /**
   * @brief  Initializes the IWDG MSP.
-  * @param  hiwdg: IWDG handle
+  * @param  hiwdg: pointer to a IWDG_HandleTypeDef structure that contains
+  *                the configuration information for the specified IWDG module.
   * @retval None
   */
 __weak void HAL_IWDG_MspInit(IWDG_HandleTypeDef *hiwdg)
@@ -245,7 +249,7 @@ __weak void HAL_IWDG_MspInit(IWDG_HandleTypeDef *hiwdg)
   * @}
   */
 
-/** @defgroup IWDG_Group2 IO operation functions  
+/** @defgroup IWDG_Exported_Functions_Group2 Input and Output operation functions
  *  @brief   IO operation functions  
  *
 @verbatim   
@@ -262,7 +266,8 @@ __weak void HAL_IWDG_MspInit(IWDG_HandleTypeDef *hiwdg)
 
 /**
   * @brief  Starts the IWDG.
-  * @param  hiwdg: IWDG handle
+  * @param  hiwdg: pointer to a IWDG_HandleTypeDef structure that contains
+  *                the configuration information for the specified IWDG module.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_IWDG_Start(IWDG_HandleTypeDef *hiwdg)
@@ -287,9 +292,9 @@ HAL_StatusTypeDef HAL_IWDG_Start(IWDG_HandleTypeDef *hiwdg)
   tickstart = HAL_GetTick();
 
   /* Wait until PVU, RVU, WVU flag are RESET */
-  while( (__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_PVU) != RESET) &&
-         (__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_RVU) != RESET) &&
-         (__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_WVU) != RESET) )
+  while( (__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_PVU) != RESET)
+        &&(__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_RVU) != RESET)
+        &&(__HAL_IWDG_GET_FLAG(hiwdg, IWDG_FLAG_WVU) != RESET) )
   {
     if((HAL_GetTick()-tickstart) > HAL_IWDG_DEFAULT_TIMEOUT)
     { 
@@ -315,7 +320,8 @@ HAL_StatusTypeDef HAL_IWDG_Start(IWDG_HandleTypeDef *hiwdg)
 
 /**
   * @brief  Refreshes the IWDG.
-  * @param  hiwdg: IWDG handle
+  * @param  hiwdg: pointer to a IWDG_HandleTypeDef structure that contains
+  *                the configuration information for the specified IWDG module.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_IWDG_Refresh(IWDG_HandleTypeDef *hiwdg)
@@ -362,7 +368,7 @@ HAL_StatusTypeDef HAL_IWDG_Refresh(IWDG_HandleTypeDef *hiwdg)
   * @}
   */
 
-/** @defgroup IWDG_Group3 Peripheral State functions 
+/** @defgroup IWDG_Exported_Functions_Group3 Peripheral State functions
  *  @brief    Peripheral State functions. 
  *
 @verbatim   
@@ -379,7 +385,8 @@ HAL_StatusTypeDef HAL_IWDG_Refresh(IWDG_HandleTypeDef *hiwdg)
 
 /**
   * @brief  Returns the IWDG state.
-  * @param  hiwdg: IWDG handle
+  * @param  hiwdg: pointer to a IWDG_HandleTypeDef structure that contains
+  *                the configuration information for the specified IWDG module.
   * @retval HAL state
   */
 HAL_IWDG_StateTypeDef HAL_IWDG_GetState(IWDG_HandleTypeDef *hiwdg)

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_iwdg.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_iwdg.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_iwdg.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of IWDG HAL module.
   ******************************************************************************
   * @attention
@@ -50,11 +50,15 @@
   * @{
   */
 
-/** @addtogroup IWDG
+/** @addtogroup IWDG IWDG HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+
+/** @defgroup IWDG_Exported_Types IWDG Exported Types
+  * @{
+  */
 
 /** 
   * @brief  IWDG HAL State Structure definition  
@@ -100,12 +104,17 @@ typedef struct
 
 }IWDG_HandleTypeDef;
 
+/**
+  * @}
+  */
+
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup IWDG_Exported_Constants
+
+/** @defgroup IWDG_Exported_Constants IWDG Exported Constants
   * @{
   */
 
-/** @defgroup IWDG_Registers_BitMask
+/** @defgroup IWDG_Registers_BitMask IWDG Registers BitMask
   * @brief IWDG registers bit mask
   * @{
   */  
@@ -116,15 +125,15 @@ typedef struct
 #define KR_KEY_EWA              ((uint32_t)0x5555)  /*!< IWDG KR Write Access Enable  */
 #define KR_KEY_DWA              ((uint32_t)0x0000)  /*!< IWDG KR Write Access Disable */
 
-#define IS_IWDG_KR(KR) (((KR) == KR_KEY_RELOAD) || \
-                        ((KR) == KR_KEY_ENABLE))|| \
-                        ((KR) == KR_KEY_EWA))   || \
-                        ((KR) == KR_KEY_DWA))
+#define IS_IWDG_KR(__KR__) (((__KR__) == KR_KEY_RELOAD) || \
+                            ((__KR__) == KR_KEY_ENABLE))|| \
+                            ((__KR__) == KR_KEY_EWA))   || \
+                            ((__KR__) == KR_KEY_DWA))
 /**
   * @}
   */
   
-/** @defgroup IWDG_Flag_definition 
+/** @defgroup IWDG_Flag_definition IWDG Flag definition
   * @{
   */ 
 #define IWDG_FLAG_PVU    ((uint32_t)0x0001)  /*!< Watchdog counter prescaler value update Flag */
@@ -138,45 +147,45 @@ typedef struct
   * @}
   */
 
-/** @defgroup IWDG_Prescaler 
+/** @defgroup IWDG_Prescaler IWDG Prescaler
   * @{
   */ 
-#define IWDG_PRESCALER_4            ((uint8_t)0x00)  /*!< IWDG prescaler set to 4   */
-#define IWDG_PRESCALER_8            ((uint8_t)0x01)  /*!< IWDG prescaler set to 8   */
-#define IWDG_PRESCALER_16           ((uint8_t)0x02)  /*!< IWDG prescaler set to 16  */
-#define IWDG_PRESCALER_32           ((uint8_t)0x03)  /*!< IWDG prescaler set to 32  */
-#define IWDG_PRESCALER_64           ((uint8_t)0x04)  /*!< IWDG prescaler set to 64  */
-#define IWDG_PRESCALER_128          ((uint8_t)0x05)  /*!< IWDG prescaler set to 128 */
-#define IWDG_PRESCALER_256          ((uint8_t)0x06)  /*!< IWDG prescaler set to 256 */
+#define IWDG_PRESCALER_4            ((uint8_t)0x00)                         /*!< IWDG prescaler set to 4   */
+#define IWDG_PRESCALER_8            ((uint8_t)IWDG_PR_PR_0)                 /*!< IWDG prescaler set to 8   */
+#define IWDG_PRESCALER_16           ((uint8_t)IWDG_PR_PR_1)                 /*!< IWDG prescaler set to 16  */
+#define IWDG_PRESCALER_32           ((uint8_t)IWDG_PR_PR_1 | IWDG_PR_PR_0)  /*!< IWDG prescaler set to 32  */
+#define IWDG_PRESCALER_64           ((uint8_t)IWDG_PR_PR_2)                 /*!< IWDG prescaler set to 64  */
+#define IWDG_PRESCALER_128          ((uint8_t)IWDG_PR_PR_2 | IWDG_PR_PR_0)  /*!< IWDG prescaler set to 128 */
+#define IWDG_PRESCALER_256          ((uint8_t)IWDG_PR_PR_2 | IWDG_PR_PR_1)  /*!< IWDG prescaler set to 256 */
 
-#define IS_IWDG_PRESCALER(PRESCALER) (((PRESCALER) == IWDG_PRESCALER_4)  || \
-                                      ((PRESCALER) == IWDG_PRESCALER_8)  || \
-                                      ((PRESCALER) == IWDG_PRESCALER_16) || \
-                                      ((PRESCALER) == IWDG_PRESCALER_32) || \
-                                      ((PRESCALER) == IWDG_PRESCALER_64) || \
-                                      ((PRESCALER) == IWDG_PRESCALER_128)|| \
-                                      ((PRESCALER) == IWDG_PRESCALER_256))
+#define IS_IWDG_PRESCALER(__PRESCALER__) (((__PRESCALER__) == IWDG_PRESCALER_4)  || \
+                                          ((__PRESCALER__) == IWDG_PRESCALER_8)  || \
+                                          ((__PRESCALER__) == IWDG_PRESCALER_16) || \
+                                          ((__PRESCALER__) == IWDG_PRESCALER_32) || \
+                                          ((__PRESCALER__) == IWDG_PRESCALER_64) || \
+                                          ((__PRESCALER__) == IWDG_PRESCALER_128)|| \
+                                          ((__PRESCALER__) == IWDG_PRESCALER_256))
 
 /**
   * @}
   */
 
-/** @defgroup IWDG_Reload_Value 
+/** @defgroup IWDG_Reload_Value IWDG Reload Value
   * @{
   */ 
-#define IS_IWDG_RELOAD(RELOAD) ((RELOAD) <= 0xFFF)
+#define IS_IWDG_RELOAD(__RELOAD__) ((__RELOAD__) <= 0xFFF)
 /**
   * @}
   */
 
-/** @defgroup IWDG_CounterWindow_Value
+/** @defgroup IWDG_CounterWindow_Value IWDG CounterWindow Value
   * @{
   */
-#define IS_IWDG_WINDOW(VALUE) ((VALUE) <= 0xFFF)
+#define IS_IWDG_WINDOW(__VALUE__) ((__VALUE__) <= 0xFFF)
 /**
   * @}
   */ 
-/** @defgroup IWDG_Window option disable
+/** @defgroup IWDG_Window_option IWDG Window option
   * @{
   */
 #define IWDG_WINDOW_DISABLE    0xFFF
@@ -190,7 +199,7 @@ typedef struct
 
 /* Exported macros -----------------------------------------------------------*/
 
-/** @defgroup IWDG_Exported_Macro
+/** @defgroup IWDG_Exported_Macros IWDG Exported Macros
  * @{
  */
 
@@ -205,7 +214,7 @@ typedef struct
   * @param  __HANDLE__: IWDG handle
   * @retval None
   */
-#define __HAL_IWDG_START(__HANDLE__) ((__HANDLE__)->Instance->KR |=  KR_KEY_ENABLE)
+#define __HAL_IWDG_START(__HANDLE__) WRITE_REG((__HANDLE__)->Instance->KR, KR_KEY_ENABLE)
 
 /**
   * @brief  Reloads IWDG counter with value defined in the reload register
@@ -213,21 +222,21 @@ typedef struct
   * @param  __HANDLE__: IWDG handle
   * @retval None
   */
-#define __HAL_IWDG_RELOAD_COUNTER(__HANDLE__) (((__HANDLE__)->Instance->KR) |= KR_KEY_RELOAD)
+#define __HAL_IWDG_RELOAD_COUNTER(__HANDLE__) WRITE_REG((__HANDLE__)->Instance->KR, KR_KEY_RELOAD)
 
 /**
   * @brief  Enable write access to IWDG_PR, IWDG_RLR and IWDG_WINR registers.
   * @param  __HANDLE__: IWDG handle
   * @retval None
   */
-#define __HAL_IWDG_ENABLE_WRITE_ACCESS(__HANDLE__) (((__HANDLE__)->Instance->KR) |= KR_KEY_EWA)
+#define __HAL_IWDG_ENABLE_WRITE_ACCESS(__HANDLE__) WRITE_REG((__HANDLE__)->Instance->KR, KR_KEY_EWA)
 
 /**
   * @brief  Disable write access to IWDG_PR, IWDG_RLR and IWDG_WINR registers.
   * @param  __HANDLE__: IWDG handle
   * @retval None
   */
-#define __HAL_IWDG_DISABLE_WRITE_ACCESS(__HANDLE__) (((__HANDLE__)->Instance->KR) |= KR_KEY_DWA)
+#define __HAL_IWDG_DISABLE_WRITE_ACCESS(__HANDLE__) WRITE_REG((__HANDLE__)->Instance->KR, KR_KEY_DWA)
 
 /**
   * @brief  Gets the selected IWDG's flag status.
@@ -247,14 +256,35 @@ typedef struct
 
 /* Exported functions --------------------------------------------------------*/
 
+/** @addtogroup IWDG_Exported_Functions IWDG Exported Functions
+  * @{
+  */
+
+/** @addtogroup IWDG_Exported_Functions_Group1 Initialization and de-initialization functions 
+  * @{
+  */
 /* Initialization/de-initialization functions  ********************************/
 HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg);
 void HAL_IWDG_MspInit(IWDG_HandleTypeDef *hiwdg);
 
+/**
+  * @}
+  */
+  
+/** @addtogroup IWDG_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
 /* I/O operation functions ****************************************************/
 HAL_StatusTypeDef HAL_IWDG_Start(IWDG_HandleTypeDef *hiwdg);
 HAL_StatusTypeDef HAL_IWDG_Refresh(IWDG_HandleTypeDef *hiwdg);
 
+/**
+  * @}
+  */
+  
+/** @addtogroup IWDG_Exported_Functions_Group3 Peripheral State functions
+  * @{
+  */
 /* Peripheral State functions  ************************************************/
 HAL_IWDG_StateTypeDef HAL_IWDG_GetState(IWDG_HandleTypeDef *hiwdg);
 
@@ -266,6 +296,14 @@ HAL_IWDG_StateTypeDef HAL_IWDG_GetState(IWDG_HandleTypeDef *hiwdg);
   * @}
   */ 
 
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+  
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_nand.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_nand.c
@@ -1,0 +1,1069 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx_hal_nand.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   NAND HAL module driver.
+  *          This file provides a generic firmware to drive NAND memories mounted 
+  *          as external device.
+  *         
+  @verbatim
+  ==============================================================================
+                         ##### How to use this driver #####
+  ==============================================================================    
+    [..]
+      This driver is a generic layered driver which contains a set of APIs used to 
+      control NAND flash memories. It uses the FMC/FSMC layer functions to interface 
+      with NAND devices. This driver is used as follows:
+    
+      (+) NAND flash memory configuration sequence using the function HAL_NAND_Init() 
+          with control and timing parameters for both common and attribute spaces.
+            
+      (+) Read NAND flash memory maker and device IDs using the function
+          HAL_NAND_Read_ID(). The read information is stored in the NAND_ID_TypeDef 
+          structure declared by the function caller. 
+        
+      (+) Access NAND flash memory by read/write operations using the functions
+          HAL_NAND_Read_Page()/HAL_NAND_Read_SpareArea(), HAL_NAND_Write_Page()/HAL_NAND_Write_SpareArea()
+          to read/write page(s)/spare area(s). These functions use specific device 
+          information (Block, page size..) predefined by the user in the HAL_NAND_Info_TypeDef 
+          structure. The read/write address information is contained by the Nand_Address_Typedef
+          structure passed as parameter.
+        
+      (+) Perform NAND flash Reset chip operation using the function HAL_NAND_Reset().
+        
+      (+) Perform NAND flash erase block operation using the function HAL_NAND_Erase_Block().
+          The erase block address information is contained in the Nand_Address_Typedef 
+          structure passed as parameter.
+    
+      (+) Read the NAND flash status operation using the function HAL_NAND_Read_Status().
+        
+      (+) You can also control the NAND device by calling the control APIs HAL_NAND_ECC_Enable()/
+          HAL_NAND_ECC_Disable() to respectively enable/disable the ECC code correction
+          feature or the function HAL_NAND_GetECC() to get the ECC correction code. 
+       
+      (+) You can monitor the NAND device HAL state by calling the function
+          HAL_NAND_GetState()  
+
+    [..]
+      (@) This driver is a set of generic APIs which handle standard NAND flash operations.
+          If a NAND flash device contains different operations and/or implementations, 
+          it should be implemented separately.
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f3xx_hal.h"
+
+/** @addtogroup STM32F3xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup NAND NAND HAL module driver
+  * @brief NAND HAL module driver
+  * @{
+  */
+#ifdef HAL_NAND_MODULE_ENABLED
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/    
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
+
+/** @defgroup NAND_Exported_Functions NAND Exported Functions
+  * @{
+  */
+    
+/** @defgroup NAND_Exported_Functions_Group1 Initialization and de-initialization functions 
+  * @brief    Initialization and Configuration functions 
+  *
+  @verbatim    
+  ==============================================================================
+            ##### NAND Initialization and de-initialization functions #####
+  ==============================================================================
+  [..]  
+    This section provides functions allowing to initialize/de-initialize
+    the NAND memory
+  
+@endverbatim
+  * @{
+  */
+    
+/**
+  * @brief  Perform NAND memory Initialization sequence
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @param  ComSpace_Timing: pointer to Common space timing structure
+  * @param  AttSpace_Timing: pointer to Attribute space timing structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  HAL_NAND_Init(NAND_HandleTypeDef *hnand, FMC_NAND_PCC_TimingTypeDef *ComSpace_Timing, FMC_NAND_PCC_TimingTypeDef *AttSpace_Timing)
+{
+  /* Check the NAND handle state */
+  if(hnand == HAL_NULL)
+  {
+     return HAL_ERROR;
+  }
+
+  if(hnand->State == HAL_NAND_STATE_RESET)
+  {
+    /* Initialize the low level hardware (MSP) */
+    HAL_NAND_MspInit(hnand);
+  } 
+
+  /* Initialize NAND control Interface */
+  FMC_NAND_Init(hnand->Instance, &(hnand->Init));
+  
+  /* Initialize NAND common space timing Interface */  
+  FMC_NAND_CommonSpace_Timing_Init(hnand->Instance, ComSpace_Timing, hnand->Init.NandBank);
+  
+  /* Initialize NAND attribute space timing Interface */  
+  FMC_NAND_AttributeSpace_Timing_Init(hnand->Instance, AttSpace_Timing, hnand->Init.NandBank);
+  
+  /* Enable the NAND device */
+  __FMC_NAND_ENABLE(hnand->Instance, hnand->Init.NandBank);
+  
+  /* Update the NAND controller state */
+  hnand->State = HAL_NAND_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Perform NAND memory De-Initialization sequence
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NAND_DeInit(NAND_HandleTypeDef *hnand)  
+{
+  /* Initialize the low level hardware (MSP) */
+  HAL_NAND_MspDeInit(hnand);
+
+  /* Configure the NAND registers with their reset values */
+  FMC_NAND_DeInit(hnand->Instance, hnand->Init.NandBank);
+
+  /* Reset the NAND controller state */
+  hnand->State = HAL_NAND_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hnand);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  NAND MSP Init
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @retval None
+  */
+__weak void HAL_NAND_MspInit(NAND_HandleTypeDef *hnand)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_NAND_MspInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  NAND MSP DeInit
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @retval None
+  */
+__weak void HAL_NAND_MspDeInit(NAND_HandleTypeDef *hnand)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_NAND_MspDeInit could be implemented in the user file
+   */ 
+}
+
+
+/**
+  * @brief  This function handles NAND device interrupt request.
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @retval HAL status
+*/
+void HAL_NAND_IRQHandler(NAND_HandleTypeDef *hnand)
+{
+  /* Check NAND interrupt Rising edge flag */
+  if(__FMC_NAND_GET_FLAG(hnand->Instance, hnand->Init.NandBank, FMC_FLAG_RISING_EDGE))
+  {
+    /* NAND interrupt callback*/
+    HAL_NAND_ITCallback(hnand);
+  
+    /* Clear NAND interrupt Rising edge pending bit */
+    __FMC_NAND_CLEAR_FLAG(hnand->Instance, hnand->Init.NandBank, FMC_FLAG_RISING_EDGE);
+  }
+  
+  /* Check NAND interrupt Level flag */
+  if(__FMC_NAND_GET_FLAG(hnand->Instance, hnand->Init.NandBank, FMC_FLAG_LEVEL))
+  {
+    /* NAND interrupt callback*/
+    HAL_NAND_ITCallback(hnand);
+  
+    /* Clear NAND interrupt Level pending bit */
+    __FMC_NAND_CLEAR_FLAG(hnand->Instance, hnand->Init.NandBank, FMC_FLAG_LEVEL);
+  }
+
+  /* Check NAND interrupt Falling edge flag */
+  if(__FMC_NAND_GET_FLAG(hnand->Instance, hnand->Init.NandBank, FMC_FLAG_FALLING_EDGE))
+  {
+    /* NAND interrupt callback*/
+    HAL_NAND_ITCallback(hnand);
+  
+    /* Clear NAND interrupt Falling edge pending bit */
+    __FMC_NAND_CLEAR_FLAG(hnand->Instance, hnand->Init.NandBank, FMC_FLAG_FALLING_EDGE);
+  }
+  
+  /* Check NAND interrupt FIFO empty flag */
+  if(__FMC_NAND_GET_FLAG(hnand->Instance, hnand->Init.NandBank, FMC_FLAG_FEMPT))
+  {
+    /* NAND interrupt callback*/
+    HAL_NAND_ITCallback(hnand);
+  
+    /* Clear NAND interrupt FIFO empty pending bit */
+    __FMC_NAND_CLEAR_FLAG(hnand->Instance, hnand->Init.NandBank, FMC_FLAG_FEMPT);
+  }  
+
+}
+
+/**
+  * @brief  NAND interrupt feature callback
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @retval None
+  */
+__weak void HAL_NAND_ITCallback(NAND_HandleTypeDef *hnand)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_NAND_ITCallback could be implemented in the user file
+   */
+}
+ 
+/**
+  * @}
+  */
+  
+/** @defgroup NAND_Exported_Functions_Group2 Input and Output functions 
+  * @brief    Input Output and memory control functions 
+  *
+  @verbatim    
+  ==============================================================================
+                    ##### NAND Input and Output functions #####
+  ==============================================================================
+  [..]  
+    This section provides functions allowing to use and control the NAND 
+    memory
+  
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Read the NAND memory electronic signature
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @param  pNAND_ID: NAND ID structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NAND_Read_ID(NAND_HandleTypeDef *hnand, NAND_IDTypeDef *pNAND_ID)
+{
+  __IO uint32_t data = 0;
+  uint32_t deviceAddress = 0;
+
+  /* Process Locked */
+  __HAL_LOCK(hnand);  
+  
+  /* Check the NAND controller state */
+  if(hnand->State == HAL_NAND_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+  
+  /* Identify the device address */
+  if(hnand->Init.NandBank == FMC_NAND_BANK2)
+  {
+    deviceAddress = NAND_DEVICE1;
+  }
+  else
+  {
+    deviceAddress = NAND_DEVICE2;
+  }
+  
+  /* Update the NAND controller state */ 
+  hnand->State = HAL_NAND_STATE_BUSY;
+  
+  /* Send Read ID command sequence */ 	
+  *(__IO uint8_t *)((uint32_t)(deviceAddress | CMD_AREA))  = 0x90;
+  *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = 0x00;
+
+  /* Read the electronic signature from NAND flash */	
+  data = *(__IO uint32_t *)deviceAddress;
+  
+  /* Return the data read */
+  pNAND_ID->Maker_Id   = ADDR_1st_CYCLE(data);
+  pNAND_ID->Device_Id  = ADDR_2nd_CYCLE(data);
+  pNAND_ID->Third_Id   = ADDR_3rd_CYCLE(data);
+  pNAND_ID->Fourth_Id  = ADDR_4th_CYCLE(data);
+  
+  /* Update the NAND controller state */ 
+  hnand->State = HAL_NAND_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnand);   
+   
+  return HAL_OK;
+}
+
+/**
+  * @brief  NAND memory reset
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NAND_Reset(NAND_HandleTypeDef *hnand)
+{
+  uint32_t deviceAddress = 0;
+  
+  /* Process Locked */
+  __HAL_LOCK(hnand);
+    
+  /* Check the NAND controller state */
+  if(hnand->State == HAL_NAND_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+
+  /* Identify the device address */  
+  if(hnand->Init.NandBank == FMC_NAND_BANK2)
+  {
+    deviceAddress = NAND_DEVICE1;
+  }
+  else
+  {
+    deviceAddress = NAND_DEVICE2;
+  }  
+  
+  /* Update the NAND controller state */   
+  hnand->State = HAL_NAND_STATE_BUSY; 
+  
+  /* Send NAND reset command */  
+  *(__IO uint8_t *)((uint32_t)(deviceAddress | CMD_AREA)) = 0xFF;
+    
+  
+  /* Update the NAND controller state */   
+  hnand->State = HAL_NAND_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnand);    
+  
+  return HAL_OK;
+  
+}
+
+  
+/**
+  * @brief  Read Page(s) from NAND memory block 
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @param  pAddress : pointer to NAND address structure
+  * @param  pBuffer : pointer to destination read buffer
+  * @param  NumPageToRead : number of pages to read from block 
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NAND_Read_Page(NAND_HandleTypeDef *hnand, NAND_AddressTypedef *pAddress, uint8_t *pBuffer, uint32_t NumPageToRead)
+{   
+  __IO uint32_t index  = 0;
+  uint32_t deviceAddress = 0, size = 0, numPagesRead = 0, nandAddress = 0;
+  
+  /* Process Locked */
+  __HAL_LOCK(hnand); 
+  
+  /* Check the NAND controller state */
+  if(hnand->State == HAL_NAND_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+  
+  /* Identify the device address */
+  if(hnand->Init.NandBank == FMC_NAND_BANK2)
+  {
+    deviceAddress = NAND_DEVICE1;
+  }
+  else
+  {
+    deviceAddress = NAND_DEVICE2;
+  }
+
+  /* Update the NAND controller state */ 
+  hnand->State = HAL_NAND_STATE_BUSY;
+  
+  /* NAND raw address calculation */
+  nandAddress = ARRAY_ADDRESS(pAddress, hnand);
+  
+  /* Page(s) read loop */  
+  while((NumPageToRead != 0) && (nandAddress < ((hnand->Info.BlockSize) * (hnand->Info.PageSize) * (hnand->Info.ZoneSize))))
+  {	   
+    /* update the buffer size */
+    size = (hnand->Info.PageSize) + ((hnand->Info.PageSize) * numPagesRead);
+    
+    /* Send read page command sequence */
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | CMD_AREA)) = NAND_CMD_AREA_A;  
+   
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = 0x00; 
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_1st_CYCLE(nandAddress); 
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_2nd_CYCLE(nandAddress); 
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_3rd_CYCLE(nandAddress);
+  
+    /* for 512 and 1 GB devices, 4th cycle is required */    
+    if(hnand->Info.BlockNbr >= 1024)
+    {
+      *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_4th_CYCLE(nandAddress);
+    }
+  
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | CMD_AREA))  = 0x30;
+      
+    /* Get Data into Buffer */    
+    for(; index < size; index++)
+    {
+      *(uint8_t *)pBuffer++ = *(uint8_t *)deviceAddress;
+    }
+    
+    /* Increment read pages number */
+    numPagesRead++;
+    
+    /* Decrement pages to read */
+    NumPageToRead--;
+    
+    /* Increment the NAND address */
+    nandAddress = (uint32_t)(nandAddress + (hnand->Info.PageSize * 8));
+    
+  }
+  
+  /* Update the NAND controller state */ 
+  hnand->State = HAL_NAND_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnand);  
+    
+  return HAL_OK;
+
+}
+
+/**
+  * @brief  Write Page(s) to NAND memory block 
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @param  pAddress : pointer to NAND address structure
+  * @param  pBuffer : pointer to source buffer to write  
+  * @param  NumPageToWrite  : number of pages to write to block 
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NAND_Write_Page(NAND_HandleTypeDef *hnand, NAND_AddressTypedef *pAddress, uint8_t *pBuffer, uint32_t NumPageToWrite)
+{
+  __IO uint32_t index   = 0;
+  uint32_t timeout = 0;
+  uint32_t deviceAddress = 0, size = 0 , numPagesWritten = 0, nandAddress = 0;
+  
+  /* Process Locked */
+  __HAL_LOCK(hnand);  
+
+  /* Check the NAND controller state */
+  if(hnand->State == HAL_NAND_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+  
+  /* Identify the device address */
+  if(hnand->Init.NandBank == FMC_NAND_BANK2)
+  {
+    deviceAddress = NAND_DEVICE1;
+  }
+  else
+  {
+    deviceAddress = NAND_DEVICE2;
+  }
+  
+  /* Update the NAND controller state */ 
+  hnand->State = HAL_NAND_STATE_BUSY;
+  
+  /* NAND raw address calculation */
+  nandAddress = ARRAY_ADDRESS(pAddress, hnand);
+  
+  /* Page(s) write loop */
+  while((NumPageToWrite != 0) && (nandAddress < ((hnand->Info.BlockSize) * (hnand->Info.PageSize) * (hnand->Info.ZoneSize))))
+  {  
+    /* update the buffer size */
+    size = (hnand->Info.PageSize) + ((hnand->Info.PageSize) * numPagesWritten);
+ 
+    /* Send write page command sequence */
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | CMD_AREA)) = NAND_CMD_AREA_A;
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | CMD_AREA)) = 0x80;
+
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = 0x00;  
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_1st_CYCLE(nandAddress);  
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_2nd_CYCLE(nandAddress);  
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_3rd_CYCLE(nandAddress);
+  
+    /* for 512 and 1 GB devices, 4th cycle is required */     
+    if(hnand->Info.BlockNbr >= 1024)
+    {
+      *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_4th_CYCLE(nandAddress);
+    }
+  
+    /* Write data to memory */
+    for(; index < size; index++)
+    {
+      *(__IO uint8_t *)deviceAddress = *(uint8_t *)pBuffer++;
+    }
+   
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | CMD_AREA)) = 0x10;
+    
+    /* Read status until NAND is ready */
+    while(HAL_NAND_Read_Status(hnand) != NAND_READY)
+    {
+      /* Check for timeout value */
+      timeout = HAL_GetTick() + NAND_WRITE_TIMEOUT;
+    
+      if(HAL_GetTick() >= timeout)
+      {
+        return HAL_TIMEOUT; 
+      } 
+    }    
+ 
+    /* Increment written pages number */
+    numPagesWritten++;
+    
+    /* Decrement pages to write */
+    NumPageToWrite--;
+    
+    /* Increment the NAND address */
+    nandAddress = (uint32_t)(nandAddress + (hnand->Info.PageSize * 8));
+      
+  }
+  
+  /* Update the NAND controller state */ 
+  hnand->State = HAL_NAND_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnand);      
+  
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Read Spare area(s) from NAND memory 
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @param  pAddress : pointer to NAND address structure
+  * @param  pBuffer: pointer to source buffer to write  
+  * @param  NumSpareAreaToRead: Number of spare area to read  
+  * @retval HAL status
+*/
+HAL_StatusTypeDef HAL_NAND_Read_SpareArea(NAND_HandleTypeDef *hnand, NAND_AddressTypedef *pAddress, uint8_t *pBuffer, uint32_t NumSpareAreaToRead)
+{
+  __IO uint32_t index   = 0; 
+  uint32_t deviceAddress = 0, size = 0, numSpareAreaRead = 0, nandAddress = 0;
+  
+  /* Process Locked */
+  __HAL_LOCK(hnand);  
+  
+  /* Check the NAND controller state */
+  if(hnand->State == HAL_NAND_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+  
+  /* Identify the device address */
+  if(hnand->Init.NandBank == FMC_NAND_BANK2)
+  {
+    deviceAddress = NAND_DEVICE1;
+  }
+  else
+  {
+    deviceAddress = NAND_DEVICE2;
+  }
+  
+  /* Update the NAND controller state */
+  hnand->State = HAL_NAND_STATE_BUSY; 
+  
+  /* NAND raw address calculation */
+  nandAddress = ARRAY_ADDRESS(pAddress, hnand);    
+  
+  /* Spare area(s) read loop */ 
+  while((NumSpareAreaToRead != 0) && (nandAddress < ((hnand->Info.BlockSize) * (hnand->Info.SpareAreaSize) * (hnand->Info.ZoneSize))))
+  {     
+    
+    /* update the buffer size */
+    size = (hnand->Info.SpareAreaSize) + ((hnand->Info.SpareAreaSize) * numSpareAreaRead);
+    
+    /* Send read spare area command sequence */     
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | CMD_AREA)) = NAND_CMD_AREA_C;
+
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = 0x00; 
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_1st_CYCLE(nandAddress);     
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_2nd_CYCLE(nandAddress);     
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_3rd_CYCLE(nandAddress);
+  
+    /* for 512 and 1 GB devices, 4th cycle is required */    
+    if(hnand->Info.BlockNbr >= 1024)
+    {
+      *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_4th_CYCLE(nandAddress);
+    } 
+
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | CMD_AREA)) = 0x30;    
+    
+    /* Get Data into Buffer */
+    for ( ;index < size; index++)
+    {
+      *(uint8_t *)pBuffer++ = *(uint8_t *)deviceAddress;
+    }
+    
+    /* Increment read spare areas number */
+    numSpareAreaRead++;
+    
+    /* Decrement spare areas to read */
+    NumSpareAreaToRead--;
+    
+    /* Increment the NAND address */
+    nandAddress = (uint32_t)(nandAddress + (hnand->Info.SpareAreaSize));
+  }
+  
+  /* Update the NAND controller state */
+  hnand->State = HAL_NAND_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnand);     
+
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Write Spare area(s) to NAND memory 
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @param  pAddress : pointer to NAND address structure
+  * @param  pBuffer : pointer to source buffer to write  
+  * @param  NumSpareAreaTowrite  : number of spare areas to write to block
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NAND_Write_SpareArea(NAND_HandleTypeDef *hnand, NAND_AddressTypedef *pAddress, uint8_t *pBuffer, uint32_t NumSpareAreaTowrite)
+{
+  __IO uint32_t index = 0;
+  uint32_t timeout = 0;
+  uint32_t deviceAddress = 0, size = 0, numSpareAreaWritten = 0, nandAddress = 0;
+
+  /* Process Locked */
+  __HAL_LOCK(hnand); 
+  
+  /* Check the NAND controller state */
+  if(hnand->State == HAL_NAND_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+  
+  /* Identify the device address */
+  if(hnand->Init.NandBank == FMC_NAND_BANK2)
+  {
+    deviceAddress = NAND_DEVICE1;
+  }
+  else
+  {
+    deviceAddress = NAND_DEVICE2;
+  }
+  
+  /* Update the FMC_NAND controller state */
+  hnand->State = HAL_NAND_STATE_BUSY;
+
+  /* NAND raw address calculation */
+  nandAddress = ARRAY_ADDRESS(pAddress, hnand);  
+  
+  /* Spare area(s) write loop */
+  while((NumSpareAreaTowrite != 0) && (nandAddress < ((hnand->Info.BlockSize) * (hnand->Info.SpareAreaSize) * (hnand->Info.ZoneSize))))
+  {  
+    /* update the buffer size */
+    size = (hnand->Info.SpareAreaSize) + ((hnand->Info.SpareAreaSize) * numSpareAreaWritten);
+
+    /* Send write Spare area command sequence */
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | CMD_AREA)) = NAND_CMD_AREA_C;
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | CMD_AREA)) = 0x80;
+
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = 0x00;  
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_1st_CYCLE(nandAddress);  
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_2nd_CYCLE(nandAddress);  
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_3rd_CYCLE(nandAddress); 
+  
+    /* for 512 and 1 GB devices, 4th cycle is required */     
+    if(hnand->Info.BlockNbr >= 1024)
+    {
+      *(__IO uint8_t *)((uint32_t)(deviceAddress | ADDR_AREA)) = ADDR_4th_CYCLE(nandAddress);
+    }
+  
+    /* Write data to memory */
+    for(; index < size; index++)
+    {
+      *(__IO uint8_t *)deviceAddress = *(uint8_t *)pBuffer++;
+    }
+   
+    *(__IO uint8_t *)((uint32_t)(deviceAddress | CMD_AREA)) = 0x10;
+    
+   
+    /* Read status until NAND is ready */
+    while(HAL_NAND_Read_Status(hnand) != NAND_READY)
+    {
+      /* Check for timeout value */
+      timeout = HAL_GetTick() + NAND_WRITE_TIMEOUT;
+    
+      if(HAL_GetTick() >= timeout)
+      {
+        return HAL_TIMEOUT; 
+      } 
+    }
+
+    /* Increment written spare areas number */
+    numSpareAreaWritten++;
+    
+    /* Decrement spare areas to write */
+    NumSpareAreaTowrite--;
+    
+    /* Increment the NAND address */
+    nandAddress = (uint32_t)(nandAddress + (hnand->Info.PageSize));   
+      
+  }
+
+  /* Update the NAND controller state */
+  hnand->State = HAL_NAND_STATE_READY;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hnand);
+    
+  return HAL_OK;  
+}
+
+/**
+  * @brief  NAND memory Block erase 
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @param  pAddress : pointer to NAND address structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NAND_Erase_Block(NAND_HandleTypeDef *hnand, NAND_AddressTypedef *pAddress)
+{
+  uint32_t DeviceAddress = 0;
+  
+  /* Process Locked */
+  __HAL_LOCK(hnand);
+  
+  /* Check the NAND controller state */
+  if(hnand->State == HAL_NAND_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+  
+  /* Identify the device address */
+  if(hnand->Init.NandBank == FMC_NAND_BANK2)
+  {
+    DeviceAddress = NAND_DEVICE1;
+  }
+  else
+  {
+    DeviceAddress = NAND_DEVICE2;
+  }
+  
+  /* Update the NAND controller state */
+  hnand->State = HAL_NAND_STATE_BUSY;  
+  
+  /* Send Erase block command sequence */
+  *(__IO uint8_t *)((uint32_t)(DeviceAddress | CMD_AREA)) = 0x60;
+
+  *(__IO uint8_t *)((uint32_t)(DeviceAddress | ADDR_AREA)) = ADDR_1st_CYCLE(ARRAY_ADDRESS(pAddress, hnand));
+  *(__IO uint8_t *)((uint32_t)(DeviceAddress | ADDR_AREA)) = ADDR_2nd_CYCLE(ARRAY_ADDRESS(pAddress, hnand));
+  *(__IO uint8_t *)((uint32_t)(DeviceAddress | ADDR_AREA)) = ADDR_3rd_CYCLE(ARRAY_ADDRESS(pAddress, hnand));
+  
+  /* for 512 and 1 GB devices, 4th cycle is required */     
+  if(hnand->Info.BlockNbr >= 1024)
+  {
+    *(__IO uint8_t *)((uint32_t)(DeviceAddress | ADDR_AREA)) = ADDR_4th_CYCLE(ARRAY_ADDRESS(pAddress, hnand));
+  }  
+		
+  *(__IO uint8_t *)((uint32_t)(DeviceAddress | CMD_AREA)) = 0xD0; 
+  
+  /* Update the NAND controller state */
+  hnand->State = HAL_NAND_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnand);    
+  
+  return HAL_OK;  
+}
+
+
+/**
+  * @brief  NAND memory read status 
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @retval NAND status
+  */
+uint32_t HAL_NAND_Read_Status(NAND_HandleTypeDef *hnand)
+{
+  uint32_t data = 0;
+  uint32_t DeviceAddress = 0;
+  
+  /* Identify the device address */
+  if(hnand->Init.NandBank == FMC_NAND_BANK2)
+  {
+    DeviceAddress = NAND_DEVICE1;
+  }
+  else
+  {
+    DeviceAddress = NAND_DEVICE2;
+  } 
+
+  /* Send Read status operation command */
+  *(__IO uint8_t *)((uint32_t)(DeviceAddress | CMD_AREA)) = 0x70;
+  
+  /* Read status register data */
+  data = *(__IO uint8_t *)DeviceAddress;
+
+  /* Return the status */
+  if((data & NAND_ERROR) == NAND_ERROR)
+  {
+    return NAND_ERROR;
+  } 
+  else if((data & NAND_READY) == NAND_READY)
+  {
+    return NAND_READY;
+  }
+
+  return NAND_BUSY; 
+ 
+}
+
+/**
+  * @brief  Increment the NAND memory address
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @param pAddress: pointer to NAND adress structure
+  * @retval The new status of the increment address operation. It can be:
+  *           - NAND_VALID_ADDRESS: When the new address is valid address
+  *           - NAND_INVALID_ADDRESS: When the new address is invalid address
+  */
+uint32_t HAL_NAND_Address_Inc(NAND_HandleTypeDef *hnand, NAND_AddressTypedef *pAddress)
+{
+  uint32_t status = NAND_VALID_ADDRESS;
+ 
+  /* Increment page address */
+  pAddress->Page++;
+
+  /* Check NAND address is valid */
+  if(pAddress->Page == hnand->Info.BlockSize)
+  {
+    pAddress->Page = 0;
+    pAddress->Block++;
+    
+    if(pAddress->Block == hnand->Info.ZoneSize)
+    {
+      pAddress->Block = 0;
+      pAddress->Zone++;
+
+      if(pAddress->Zone == (hnand->Info.ZoneSize/ hnand->Info.BlockNbr))
+      {
+        status = NAND_INVALID_ADDRESS;
+      }
+    }
+  } 
+  
+  return (status);
+}
+
+
+/**
+  * @}
+  */
+
+/** @defgroup NAND_Exported_Functions_Group3 Peripheral Control functions 
+ *  @brief   management functions 
+ *
+@verbatim   
+  ==============================================================================
+                         ##### NAND Control functions #####
+  ==============================================================================  
+  [..]
+    This subsection provides a set of functions allowing to control dynamically
+    the NAND interface.
+
+@endverbatim
+  * @{
+  */ 
+
+    
+/**
+  * @brief  Enables dynamically NAND ECC feature.
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @retval HAL status
+  */    
+HAL_StatusTypeDef  HAL_NAND_ECC_Enable(NAND_HandleTypeDef *hnand)
+{
+  /* Check the NAND controller state */
+  if(hnand->State == HAL_NAND_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+
+  /* Update the NAND state */
+  hnand->State = HAL_NAND_STATE_BUSY;
+   
+  /* Enable ECC feature */
+  FMC_NAND_ECC_Enable(hnand->Instance, hnand->Init.NandBank);
+  
+  /* Update the NAND state */
+  hnand->State = HAL_NAND_STATE_READY;
+  
+  return HAL_OK;  
+}
+
+
+/**
+  * @brief  Disables dynamically FMC_NAND ECC feature.
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @retval HAL status
+  */  
+HAL_StatusTypeDef  HAL_NAND_ECC_Disable(NAND_HandleTypeDef *hnand)  
+{
+  /* Check the NAND controller state */
+  if(hnand->State == HAL_NAND_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+
+  /* Update the NAND state */
+  hnand->State = HAL_NAND_STATE_BUSY;
+    
+  /* Disable ECC feature */
+  FMC_NAND_ECC_Disable(hnand->Instance, hnand->Init.NandBank);
+  
+  /* Update the NAND state */
+  hnand->State = HAL_NAND_STATE_READY;
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Disables dynamically NAND ECC feature.
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @param  ECCval: pointer to ECC value 
+  * @param  Timeout: maximum timeout to wait    
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  HAL_NAND_GetECC(NAND_HandleTypeDef *hnand, uint32_t *ECCval, uint32_t Timeout)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+  
+  /* Check the NAND controller state */
+  if(hnand->State == HAL_NAND_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+  
+  /* Update the NAND state */
+  hnand->State = HAL_NAND_STATE_BUSY;  
+   
+  /* Get NAND ECC value */
+  status = FMC_NAND_GetECC(hnand->Instance, ECCval, hnand->Init.NandBank, Timeout);
+  
+  /* Update the NAND state */
+  hnand->State = HAL_NAND_STATE_READY;
+
+  return status;  
+}
+                      
+/**
+  * @}
+  */
+  
+    
+/** @defgroup NAND_Exported_Functions_Group4 Peripheral State functions 
+ *  @brief   Peripheral State functions 
+ *
+@verbatim   
+  ==============================================================================
+                         ##### NAND State functions #####
+  ==============================================================================  
+  [..]
+    This subsection permits to get in run-time the status of the NAND controller 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  return the NAND state
+  * @param  hnand: pointer to a NAND_HandleTypeDef structure that contains
+  *                the configuration information for NAND module.
+  * @retval HAL state
+  */
+HAL_NAND_StateTypeDef HAL_NAND_GetState(NAND_HandleTypeDef *hnand)
+{
+  return hnand->State;
+}
+
+/**
+  * @}
+  */  
+
+/**
+  * @}
+  */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+#endif /* HAL_NAND_MODULE_ENABLED  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_nand.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_nand.h
@@ -1,0 +1,286 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx_hal_nand.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of NAND HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F3xx_HAL_NAND_H
+#define __STM32F3xx_HAL_NAND_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+  #include "stm32f3xx_ll_fmc.h"
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+
+/** @addtogroup STM32F3xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup NAND
+  * @{
+  */ 
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+
+/* Exported typedef ----------------------------------------------------------*/
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup NAND_Exported_Types NAND Exported Types
+  * @{
+  */
+
+/** 
+  * @brief  HAL NAND State structures definition
+  */
+typedef enum
+{
+  HAL_NAND_STATE_RESET     = 0x00,  /*!< NAND not yet initialized or disabled */
+  HAL_NAND_STATE_READY     = 0x01,  /*!< NAND initialized and ready for use   */
+  HAL_NAND_STATE_BUSY      = 0x02,  /*!< NAND internal process is ongoing     */
+  HAL_NAND_STATE_ERROR     = 0x03   /*!< NAND error state                     */
+}HAL_NAND_StateTypeDef;
+   
+/** 
+  * @brief  NAND Memory electronic signature Structure definition
+  */
+typedef struct
+{
+  /*<! NAND memory electronic signature maker and device IDs */
+
+  uint8_t Maker_Id; 
+
+  uint8_t Device_Id;
+
+  uint8_t Third_Id;
+
+  uint8_t Fourth_Id;
+}NAND_IDTypeDef;
+
+/** 
+  * @brief  NAND Memory address Structure definition
+  */
+typedef struct 
+{
+  uint16_t Page;   /*!< NAND memory Page address  */
+
+  uint16_t Zone;   /*!< NAND memory Zone address  */
+
+  uint16_t Block;  /*!< NAND memory Block address */
+
+}NAND_AddressTypedef;
+
+/** 
+  * @brief  NAND Memory info Structure definition
+  */ 
+typedef struct
+{
+  uint32_t PageSize;       /*!< NAND memory page (without spare area) size measured in K. bytes */
+
+  uint32_t SpareAreaSize;  /*!< NAND memory spare area size measured in K. bytes                */
+
+  uint32_t BlockSize;      /*!< NAND memory block size number of pages                          */
+
+  uint32_t BlockNbr;       /*!< NAND memory number of blocks                                    */
+
+  uint32_t ZoneSize;       /*!< NAND memory zone size measured in number of blocks              */
+}NAND_InfoTypeDef;
+
+/** 
+  * @brief  NAND handle Structure definition
+  */   
+typedef struct
+{
+  FMC_NAND_TypeDef             *Instance;  /*!< Register base address                        */
+  
+  FMC_NAND_InitTypeDef         Init;       /*!< NAND device control configuration parameters */
+
+  HAL_LockTypeDef              Lock;       /*!< NAND locking object                          */
+
+  __IO HAL_NAND_StateTypeDef   State;      /*!< NAND device access state                     */
+
+  NAND_InfoTypeDef             Info;       /*!< NAND characteristic information structure    */
+}NAND_HandleTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup NAND_Exported_Constants NAND Exported Constants
+ * @{
+ */ 
+#define NAND_DEVICE1               ((uint32_t)0x70000000) 
+#define NAND_DEVICE2               ((uint32_t)0x80000000) 
+#define NAND_WRITE_TIMEOUT         ((uint32_t)0x01000000)
+
+#define CMD_AREA                   ((uint32_t)(1<<16))  /* A16 = CLE high */
+#define ADDR_AREA                  ((uint32_t)(1<<17))  /* A17 = ALE high */
+
+#define	NAND_CMD_AREA_A            ((uint8_t)0x00)
+#define	NAND_CMD_AREA_B            ((uint8_t)0x01)
+#define NAND_CMD_AREA_C            ((uint8_t)0x50)
+
+/* NAND memory status */
+#define NAND_VALID_ADDRESS         ((uint32_t)0x00000100)
+#define NAND_INVALID_ADDRESS       ((uint32_t)0x00000200)
+#define NAND_TIMEOUT_ERROR         ((uint32_t)0x00000400)
+#define NAND_BUSY                  ((uint32_t)0x00000000)
+#define NAND_ERROR                 ((uint32_t)0x00000001)
+#define NAND_READY                 ((uint32_t)0x00000040)
+
+/**
+  * @}
+  */
+  
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup NAND_Exported_Macros NAND Exported Macros
+ * @{
+ */ 
+
+/** @brief Reset NAND handle state
+  * @param  __HANDLE__: specifies the NAND handle.
+  * @retval None
+  */
+#define __HAL_NAND_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_NAND_STATE_RESET)
+
+/**
+  * @brief  NAND memory address computation.
+  * @param  __ADDRESS__: NAND memory address.
+  * @param  __HANDLE__ : NAND handle.
+  * @retval NAND Raw address value
+  */
+#define ARRAY_ADDRESS(__ADDRESS__ , __HANDLE__) ((__ADDRESS__)->Page + (((__ADDRESS__)->Block + (((__ADDRESS__)->Zone) * ((__HANDLE__)->Info.ZoneSize)))* ((__HANDLE__)->Info.BlockSize)))
+
+/**
+  * @brief  NAND memory address cycling.
+  * @param  __ADDRESS__: NAND memory address.
+  * @retval NAND address cycling value.
+  */
+#define ADDR_1st_CYCLE(__ADDRESS__)       (uint8_t)((__ADDRESS__)& 0xFF)               /* 1st addressing cycle */
+#define ADDR_2nd_CYCLE(__ADDRESS__)       (uint8_t)(((__ADDRESS__)& 0xFF00) >> 8)      /* 2nd addressing cycle */
+#define ADDR_3rd_CYCLE(__ADDRESS__)       (uint8_t)(((__ADDRESS__)& 0xFF0000) >> 16)   /* 3rd addressing cycle */
+#define ADDR_4th_CYCLE(__ADDRESS__)       (uint8_t)(((__ADDRESS__)& 0xFF000000) >> 24) /* 4th addressing cycle */
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup NAND_Exported_Functions NAND Exported Functions
+  * @{
+  */
+    
+/** @addtogroup NAND_Exported_Functions_Group1 Initialization and de-initialization functions 
+  * @{
+  */
+
+/* Initialization/de-initialization functions  ********************************/
+HAL_StatusTypeDef  HAL_NAND_Init(NAND_HandleTypeDef *hnand, FMC_NAND_PCC_TimingTypeDef *ComSpace_Timing, FMC_NAND_PCC_TimingTypeDef *AttSpace_Timing);
+HAL_StatusTypeDef  HAL_NAND_DeInit(NAND_HandleTypeDef *hnand);
+void        HAL_NAND_MspInit(NAND_HandleTypeDef *hnand);
+void        HAL_NAND_MspDeInit(NAND_HandleTypeDef *hnand);
+void               HAL_NAND_IRQHandler(NAND_HandleTypeDef *hnand);
+void        HAL_NAND_ITCallback(NAND_HandleTypeDef *hnand);
+
+/**
+  * @}
+  */
+  
+/** @addtogroup NAND_Exported_Functions_Group2 Input and Output functions 
+  * @{
+  */
+
+/* IO operation functions  ****************************************************/
+HAL_StatusTypeDef  HAL_NAND_Read_ID(NAND_HandleTypeDef *hnand, NAND_IDTypeDef *pNAND_ID);
+HAL_StatusTypeDef  HAL_NAND_Reset(NAND_HandleTypeDef *hnand);
+HAL_StatusTypeDef  HAL_NAND_Read_Page(NAND_HandleTypeDef *hnand, NAND_AddressTypedef *pAddress, uint8_t *pBuffer, uint32_t NumPageToRead);
+HAL_StatusTypeDef  HAL_NAND_Write_Page(NAND_HandleTypeDef *hnand, NAND_AddressTypedef *pAddress, uint8_t *pBuffer, uint32_t NumPageToWrite);
+HAL_StatusTypeDef  HAL_NAND_Read_SpareArea(NAND_HandleTypeDef *hnand, NAND_AddressTypedef *pAddress, uint8_t *pBuffer, uint32_t NumSpareAreaToRead);
+HAL_StatusTypeDef  HAL_NAND_Write_SpareArea(NAND_HandleTypeDef *hnand, NAND_AddressTypedef *pAddress, uint8_t *pBuffer, uint32_t NumSpareAreaTowrite);
+HAL_StatusTypeDef  HAL_NAND_Erase_Block(NAND_HandleTypeDef *hnand, NAND_AddressTypedef *pAddress);
+uint32_t           HAL_NAND_Read_Status(NAND_HandleTypeDef *hnand);
+uint32_t           HAL_NAND_Address_Inc(NAND_HandleTypeDef *hnand, NAND_AddressTypedef *pAddress);
+
+/**
+  * @}
+  */
+
+/** @addtogroup NAND_Exported_Functions_Group3 Peripheral Control functions 
+  * @{
+  */
+
+/* NAND Control functions  ****************************************************/
+HAL_StatusTypeDef  HAL_NAND_ECC_Enable(NAND_HandleTypeDef *hnand);
+HAL_StatusTypeDef  HAL_NAND_ECC_Disable(NAND_HandleTypeDef *hnand);
+HAL_StatusTypeDef  HAL_NAND_GetECC(NAND_HandleTypeDef *hnand, uint32_t *ECCval, uint32_t Timeout);
+
+/**
+  * @}
+  */
+    
+/** @defgroup NAND_Exported_Functions_Group4 Peripheral State functions 
+  * @{
+  */
+
+/* NAND State functions *******************************************************/
+HAL_NAND_StateTypeDef HAL_NAND_GetState(NAND_HandleTypeDef *hnand);
+uint32_t HAL_NAND_Read_Status(NAND_HandleTypeDef *hnand);
+
+/**
+  * @}
+  */
+    
+/**
+  * @}
+  */
+    
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F3xx_HAL_NAND_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_nor.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_nor.c
@@ -1,0 +1,838 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx_hal_nor.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   NOR HAL module driver.
+  *          This file provides a generic firmware to drive NOR memories mounted 
+  *          as external device.
+  *         
+  @verbatim
+  ==============================================================================
+                     ##### How to use this driver #####
+  ==============================================================================       
+    [..]
+      This driver is a generic layered driver which contains a set of APIs used to 
+      control NOR flash memories. It uses the FMC layer functions to interface 
+      with NOR devices. This driver is used as follows:
+    
+      (+) NOR flash memory configuration sequence using the function HAL_NOR_Init() 
+          with control and timing parameters for both normal and extended mode.
+            
+      (+) Read NOR flash memory manufacturer code and device IDs using the function
+          HAL_NOR_Read_ID(). The read information is stored in the NOR_ID_TypeDef 
+          structure declared by the function caller. 
+        
+      (+) Access NOR flash memory by read/write data unit operations using the functions
+          HAL_NOR_Read(), HAL_NOR_Program().
+        
+      (+) Perform NOR flash erase block/chip operations using the functions 
+          HAL_NOR_Erase_Block() and HAL_NOR_Erase_Chip().
+        
+      (+) Read the NOR flash CFI (common flash interface) IDs using the function
+          HAL_NOR_Read_CFI(). The read information is stored in the NOR_CFI_TypeDef
+          structure declared by the function caller.
+        
+      (+) You can also control the NOR device by calling the control APIs HAL_NOR_WriteOperation_Enable()/
+          HAL_NOR_WriteOperation_Disable() to respectively enable/disable the NOR write operation  
+       
+      (+) You can monitor the NOR device HAL state by calling the function
+          HAL_NOR_GetState() 
+    [..]
+     (@) This driver is a set of generic APIs which handle standard NOR flash operations.
+         If a NOR flash device contains different operations and/or implementations, 
+         it should be implemented separately.
+
+     *** NOR HAL driver macros list ***
+     ============================================= 
+     [..]
+       Below the list of most used macros in NOR HAL driver.
+       
+      (+) __NOR_WRITE : NOR memory write data to specified address
+
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f3xx_hal.h"
+
+/** @addtogroup STM32F3xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup NOR NOR HAL module driver
+  * @brief NOR HAL module driver
+  * @{
+  */
+#ifdef HAL_NOR_MODULE_ENABLED
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/** @defgroup NOR_Private_Variables NOR Private Variables
+ * @{
+ */
+static uint32_t uwNORAddress            = NOR_MEMORY_ADRESS1;
+static uint32_t uwNORMememoryDataWidth  = NOR_MEMORY_8B;
+/**
+  * @}
+  */
+
+/* Exported functions ---------------------------------------------------------*/
+
+/** @defgroup NOR_Exported_Functions NOR Exported Functions
+  * @{
+  */
+
+/** @defgroup NOR_Exported_Functions_Group1 Initialization and de-initialization functions 
+  * @brief    Initialization and Configuration functions 
+  *
+  @verbatim    
+  ==============================================================================
+           ##### NOR Initialization and de_initialization functions #####
+  ==============================================================================
+  [..]  
+    This section provides functions allowing to initialize/de-initialize
+    the NOR memory
+  
+@endverbatim
+  * @{
+  */
+    
+/**
+  * @brief  Perform the NOR memory Initialization sequence
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @param  Timing: pointer to NOR control timing structure 
+  * @param  ExtTiming: pointer to NOR extended mode timing structure    
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NOR_Init(NOR_HandleTypeDef *hnor, FMC_NORSRAM_TimingTypeDef *Timing, FMC_NORSRAM_TimingTypeDef *ExtTiming)
+{
+  /* Check the NOR handle parameter */
+  if(hnor == HAL_NULL)
+  {
+     return HAL_ERROR;
+  }
+  
+  if(hnor->State == HAL_NOR_STATE_RESET)
+  {
+    /* Initialize the low level hardware (MSP) */
+    HAL_NOR_MspInit(hnor);
+  }
+
+  /* Initialize NOR control Interface */
+  FMC_NORSRAM_Init(hnor->Instance, &(hnor->Init));
+
+  /* Initialize NOR timing Interface */
+  FMC_NORSRAM_Timing_Init(hnor->Instance, Timing, hnor->Init.NSBank); 
+
+  /* Initialize NOR extended mode timing Interface */
+  FMC_NORSRAM_Extended_Timing_Init(hnor->Extended, ExtTiming, hnor->Init.NSBank, hnor->Init.ExtendedMode);
+
+  /* Enable the NORSRAM device */
+  __FMC_NORSRAM_ENABLE(hnor->Instance, hnor->Init.NSBank);  
+
+  /* Initialize NOR address mapped by FMC */
+  if (hnor->Init.NSBank == FMC_NORSRAM_BANK1)
+  {
+    uwNORAddress = NOR_MEMORY_ADRESS1;
+  }
+  else if (hnor->Init.NSBank == FMC_NORSRAM_BANK2)
+  {
+    uwNORAddress = NOR_MEMORY_ADRESS2;
+  }
+  else if (hnor->Init.NSBank == FMC_NORSRAM_BANK3)
+  {
+    uwNORAddress = NOR_MEMORY_ADRESS3;
+  }
+  else
+  {
+    uwNORAddress = NOR_MEMORY_ADRESS4;
+  }
+
+  /* Initialize NOR Memory Data Width*/
+  if (hnor->Init.MemoryDataWidth == FMC_NORSRAM_MEM_BUS_WIDTH_8)
+  {
+    uwNORMememoryDataWidth = NOR_MEMORY_8B;
+  }
+  else
+  {
+    uwNORMememoryDataWidth = NOR_MEMORY_16B;
+  }
+
+  /* Check the NOR controller state */
+  hnor->State = HAL_NOR_STATE_READY; 
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Perform NOR memory De-Initialization sequence
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NOR_DeInit(NOR_HandleTypeDef *hnor)  
+{
+  /* De-Initialize the low level hardware (MSP) */
+  HAL_NOR_MspDeInit(hnor);
+ 
+  /* Configure the NOR registers with their reset values */
+  FMC_NORSRAM_DeInit(hnor->Instance, hnor->Extended, hnor->Init.NSBank);
+  
+  /* Update the NOR controller state */
+  hnor->State = HAL_NOR_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hnor);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  NOR MSP Init
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @retval None
+  */
+__weak void HAL_NOR_MspInit(NOR_HandleTypeDef *hnor)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_NOR_MspInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  NOR MSP DeInit
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @retval None
+  */
+__weak void HAL_NOR_MspDeInit(NOR_HandleTypeDef *hnor)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_NOR_MspDeInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  NOR BSP Wait fro Ready/Busy signal
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @param  Timeout: Maximum timeout value
+  * @retval None
+  */
+__weak void HAL_NOR_MspWait(NOR_HandleTypeDef *hnor, uint32_t Timeout)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_NOR_BspWait could be implemented in the user file
+   */ 
+}
+  
+/**
+  * @}
+  */
+
+/** @defgroup NOR_Exported_Functions_Group2 Input and Output functions 
+  * @brief    Input Output and memory control functions 
+  *
+  @verbatim    
+  ==============================================================================
+                ##### NOR Input and Output functions #####
+  ==============================================================================
+  [..]  
+    This section provides functions allowing to use and control the NOR memory
+  
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Read NOR flash IDs
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @param  pNOR_ID : pointer to NOR ID structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NOR_Read_ID(NOR_HandleTypeDef *hnor, NOR_IDTypeDef *pNOR_ID)
+{
+  /* Process Locked */
+  __HAL_LOCK(hnor);
+  
+  /* Check the NOR controller state */
+  if(hnor->State == HAL_NOR_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+    
+  /* Update the NOR controller state */
+  hnor->State = HAL_NOR_STATE_BUSY;
+  
+  /* Send read ID command */
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x0555), 0x00AA);
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x02AA), 0x0055);
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x0555), 0x0090);
+
+  /* Read the NOR IDs */
+  pNOR_ID->Manufacturer_Code = *(__IO uint16_t *) __NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, MC_ADDRESS);
+  pNOR_ID->Device_Code1      = *(__IO uint16_t *) __NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, DEVICE_CODE1_ADDR);
+  pNOR_ID->Device_Code2      = *(__IO uint16_t *) __NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, DEVICE_CODE2_ADDR);
+  pNOR_ID->Device_Code3      = *(__IO uint16_t *) __NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, DEVICE_CODE3_ADDR);
+  
+  /* Check the NOR controller state */
+  hnor->State = HAL_NOR_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnor);   
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Returns the NOR memory to Read mode.
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NOR_ReturnToReadMode(NOR_HandleTypeDef *hnor)
+{
+  /* Process Locked */
+  __HAL_LOCK(hnor);
+  
+  /* Check the NOR controller state */
+  if(hnor->State == HAL_NOR_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+  
+  __NOR_WRITE(uwNORAddress, 0x00F0);
+
+  /* Check the NOR controller state */
+  hnor->State = HAL_NOR_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnor);   
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Read data from NOR memory 
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @param  pAddress: pointer to Device address
+  * @param  pData : pointer to read data  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NOR_Read(NOR_HandleTypeDef *hnor, uint32_t *pAddress, uint16_t *pData)
+{
+  /* Process Locked */
+  __HAL_LOCK(hnor);
+  
+  /* Check the NOR controller state */
+  if(hnor->State == HAL_NOR_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+    
+  /* Update the NOR controller state */
+  hnor->State = HAL_NOR_STATE_BUSY;
+  
+  /* Send read data command */
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x00555), 0x00AA); 
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x002AA), 0x0055);  
+  __NOR_WRITE(pAddress, 0x00F0);
+
+  /* Read the data */
+  *pData = *(__IO uint32_t *)pAddress;
+  
+  /* Check the NOR controller state */
+  hnor->State = HAL_NOR_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnor);
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Program data to NOR memory 
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @param  pAddress: Device address
+  * @param  pData : pointer to the data to write   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NOR_Program(NOR_HandleTypeDef *hnor, uint32_t *pAddress, uint16_t *pData)
+{
+  /* Process Locked */
+  __HAL_LOCK(hnor);
+  
+  /* Check the NOR controller state */
+  if(hnor->State == HAL_NOR_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+    
+  /* Update the NOR controller state */
+  hnor->State = HAL_NOR_STATE_BUSY;
+  
+  /* Send program data command */
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x0555), 0x00AA);
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x02AA), 0x0055);
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x0555), 0x00A0);
+
+  /* Write the data */
+ __NOR_WRITE(pAddress, *pData);
+  
+  /* Check the NOR controller state */
+  hnor->State = HAL_NOR_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnor);
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Reads a block of data from the FMC NOR memory.
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @param  uwAddress: NOR memory internal address to read from.
+  * @param  pData: pointer to the buffer that receives the data read from the 
+  *         NOR memory.
+  * @param  uwBufferSize : number of Half word to read.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NOR_ReadBuffer(NOR_HandleTypeDef *hnor, uint32_t uwAddress, uint16_t *pData, uint32_t uwBufferSize)
+{
+  /* Process Locked */
+  __HAL_LOCK(hnor);
+  
+  /* Check the NOR controller state */
+  if(hnor->State == HAL_NOR_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+    
+  /* Update the NOR controller state */
+  hnor->State = HAL_NOR_STATE_BUSY;
+  
+  /* Send read data command */
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x00555), 0x00AA); 
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x002AA), 0x0055);  
+  __NOR_WRITE(uwAddress, 0x00F0);
+  
+  /* Read buffer */
+  while( uwBufferSize > 0) 
+  {
+    *pData++ = *(__IO uint16_t *)uwAddress;
+    uwAddress += 2;
+    uwBufferSize--;
+  } 
+  
+  /* Check the NOR controller state */
+  hnor->State = HAL_NOR_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnor);
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Writes a half-word buffer to the FMC NOR memory. This function 
+  *         must be used only with S29GL128P NOR memory. 
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @param  uwAddress: NOR memory internal address from which the data 
+  * @note   Some NOR memory need Address aligned to xx bytes (can be aligned to 
+  *          64 bytes boundary for example).
+  * @param  pData: pointer to source data buffer. 
+  * @param  uwBufferSize: number of Half words to write. 
+  * @note   The maximum buffer size allowed is NOR memory dependent
+  *         (can be 64 Bytes max for example).
+  * @retval HAL status
+  */ 
+HAL_StatusTypeDef HAL_NOR_ProgramBuffer(NOR_HandleTypeDef *hnor, uint32_t uwAddress, uint16_t *pData, uint32_t uwBufferSize)
+{
+  uint16_t * p_currentaddress;
+  uint16_t * p_endaddress;
+  uint32_t lastloadedaddress = 0;
+
+  /* Process Locked */
+  __HAL_LOCK(hnor);
+  
+  /* Check the NOR controller state */
+  if(hnor->State == HAL_NOR_STATE_BUSY)
+  {
+    return HAL_BUSY;
+  }
+    
+  /* Update the NOR controller state */
+  hnor->State = HAL_NOR_STATE_BUSY;
+  
+  /* Initialize variables */
+  p_currentaddress  = (uint16_t*)((uint32_t)(uwAddress));
+  p_endaddress      = p_currentaddress + (uwBufferSize-1);
+  lastloadedaddress = (uint32_t)(uwAddress);
+
+  /* Issue unlock command sequence */
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x0555), 0x00AA);
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x02AA), 0x0055); 
+
+  /* Write Buffer Load Command */
+  __NOR_WRITE((uint32_t)(p_currentaddress), 0x25); 
+  __NOR_WRITE((uint32_t)(p_currentaddress), (uwBufferSize-1)); 
+
+  /* Load Data into NOR Buffer */
+  while(p_currentaddress <= p_endaddress)
+  {
+    /* Store last loaded address & data value (for polling) */
+    lastloadedaddress = (uint32_t)p_currentaddress;
+ 
+    __NOR_WRITE(p_currentaddress, *pData++);
+
+    p_currentaddress++;
+  }
+
+  __NOR_WRITE((uint32_t)(lastloadedaddress), 0x29); 
+  
+  /* Check the NOR controller state */
+  hnor->State = HAL_NOR_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnor);
+  
+  return HAL_OK; 
+  
+}
+
+/**
+  * @brief  Erase the specified block of the NOR memory 
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @param  BlockAddress : Block to erase address 
+  * @param  Address: Device address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NOR_Erase_Block(NOR_HandleTypeDef *hnor, uint32_t BlockAddress, uint32_t Address)
+{
+  /* Process Locked */
+  __HAL_LOCK(hnor);
+  
+  /* Check the NOR controller state */
+  if(hnor->State == HAL_NOR_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+    
+  /* Update the NOR controller state */
+  hnor->State = HAL_NOR_STATE_BUSY;
+  
+  /* Send block erase command sequence */
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x0555), 0x00AA);
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x02AA), 0x0055);
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x0555), 0x0080);
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x0555), 0x00AA);
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x02AA), 0x0055);
+  __NOR_WRITE((uint32_t)(BlockAddress + Address), 0x30);
+
+  /* Check the NOR memory status and update the controller state */
+  hnor->State = HAL_NOR_STATE_READY;
+    
+  /* Process unlocked */
+  __HAL_UNLOCK(hnor);
+  
+  return HAL_OK;
+ 
+}
+
+/**
+  * @brief  Erase the entire NOR chip.
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @param  Address : Device address  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NOR_Erase_Chip(NOR_HandleTypeDef *hnor, uint32_t Address)
+{
+  /* Process Locked */
+  __HAL_LOCK(hnor);
+  
+  /* Check the NOR controller state */
+  if(hnor->State == HAL_NOR_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+    
+  /* Update the NOR controller state */
+  hnor->State = HAL_NOR_STATE_BUSY;  
+    
+  /* Send NOR chip erase command sequence */
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x0555), 0x00AA);
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x02AA), 0x0055);
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x0555), 0x0080);
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x0555), 0x00AA);
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x02AA), 0x0055);  
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x0555), 0x0010);
+  
+  /* Check the NOR memory status and update the controller state */
+  hnor->State = HAL_NOR_STATE_READY;
+    
+  /* Process unlocked */
+  __HAL_UNLOCK(hnor);
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Read NOR flash CFI IDs
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @param  pNOR_CFI : pointer to NOR CFI IDs structure  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NOR_Read_CFI(NOR_HandleTypeDef *hnor, NOR_CFITypeDef *pNOR_CFI)
+{
+  /* Process Locked */
+  __HAL_LOCK(hnor);
+  
+  /* Check the NOR controller state */
+  if(hnor->State == HAL_NOR_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+    
+  /* Update the NOR controller state */
+  hnor->State = HAL_NOR_STATE_BUSY;
+  
+  /* Send read CFI query command */
+  __NOR_WRITE(__NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, 0x0055), 0x0098);
+
+  /* read the NOR CFI information */
+  pNOR_CFI->CFI_1 = *(__IO uint16_t *) __NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, CFI1_ADDRESS);
+  pNOR_CFI->CFI_2 = *(__IO uint16_t *) __NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, CFI2_ADDRESS);
+  pNOR_CFI->CFI_3 = *(__IO uint16_t *) __NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, CFI3_ADDRESS);
+  pNOR_CFI->CFI_4 = *(__IO uint16_t *) __NOR_ADDR_SHIFT(uwNORAddress, uwNORMememoryDataWidth, CFI4_ADDRESS);
+
+  /* Check the NOR controller state */
+  hnor->State = HAL_NOR_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnor);
+  
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+  
+/** @defgroup NOR_Exported_Functions_Group3 Peripheral Control functions 
+ *  @brief   management functions 
+ *
+@verbatim   
+  ==============================================================================
+                        ##### NOR Control functions #####
+  ==============================================================================
+  [..]
+    This subsection provides a set of functions allowing to control dynamically
+    the NOR interface.
+
+@endverbatim
+  * @{
+  */
+    
+/**
+  * @brief  Enables dynamically NOR write operation.
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NOR_WriteOperation_Enable(NOR_HandleTypeDef *hnor)
+{
+  /* Process Locked */
+  __HAL_LOCK(hnor);
+
+  /* Enable write operation */
+  FMC_NORSRAM_WriteOperation_Enable(hnor->Instance, hnor->Init.NSBank); 
+  
+  /* Update the NOR controller state */
+  hnor->State = HAL_NOR_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnor); 
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Disables dynamically NOR write operation.
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_NOR_WriteOperation_Disable(NOR_HandleTypeDef *hnor)
+{
+  /* Process Locked */
+  __HAL_LOCK(hnor);
+
+  /* Update the SRAM controller state */
+  hnor->State = HAL_NOR_STATE_BUSY;
+    
+  /* Disable write operation */
+  FMC_NORSRAM_WriteOperation_Disable(hnor->Instance, hnor->Init.NSBank); 
+  
+  /* Update the NOR controller state */
+  hnor->State = HAL_NOR_STATE_PROTECTED;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hnor); 
+  
+  return HAL_OK;  
+}
+
+/**
+  * @}
+  */  
+  
+/** @defgroup NOR_Exported_Functions_Group4 Peripheral State functions 
+ *  @brief   Peripheral State functions 
+ *
+@verbatim   
+  ==============================================================================
+                      ##### NOR State functions #####
+  ==============================================================================  
+  [..]
+    This subsection permits to get in run-time the status of the NOR controller 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  return the NOR controller state
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.
+  * @retval NOR controller state
+  */
+HAL_NOR_StateTypeDef HAL_NOR_GetState(NOR_HandleTypeDef *hnor)
+{
+  return hnor->State;
+}
+
+/**
+  * @brief  Returns the NOR operation status.
+  * @param  hnor: pointer to a NOR_HandleTypeDef structure that contains
+  *                the configuration information for NOR module.   
+  * @param  Address: Device address
+  * @param  Timeout: NOR progamming Timeout
+  * @retval NOR_Status: The returned value can be: NOR_SUCCESS, NOR_ERROR
+  *         or NOR_TIMEOUT
+  */
+NOR_StatusTypedef HAL_NOR_GetStatus(NOR_HandleTypeDef *hnor, uint32_t Address, uint32_t Timeout)
+{ 
+  NOR_StatusTypedef status = NOR_ONGOING;
+  uint16_t tmpSR1 = 0, tmpSR2 = 0;
+  uint32_t timeout = 0;
+
+  /* Poll on NOR memory Ready/Busy signal ------------------------------------*/
+  HAL_NOR_MspWait(hnor, timeout);
+  
+  /* Get the NOR memory operation status -------------------------------------*/
+  while(status != NOR_SUCCESS)
+  {
+    /* Check for timeout value */
+    timeout = HAL_GetTick() + Timeout;
+    
+    if(HAL_GetTick() >= timeout)
+    {
+      status = NOR_TIMEOUT; 
+    }  
+    
+    /* Read NOR status register (DQ6 and DQ5) */
+    tmpSR1 = *(__IO uint16_t *)Address;
+    tmpSR2 = *(__IO uint16_t *)Address;
+
+    /* If DQ6 did not toggle between the two reads then return NOR_Success */
+    if((tmpSR1 & 0x0040) == (tmpSR2 & 0x0040)) 
+    {
+      return NOR_SUCCESS;
+    }
+    
+    if((tmpSR1 & 0x0020) == 0x0020)
+    {
+      return NOR_ONGOING;
+    }
+    
+    tmpSR1 = *(__IO uint16_t *)Address;
+    tmpSR2 = *(__IO uint16_t *)Address;
+
+    /* If DQ6 did not toggle between the two reads then return NOR_Success */
+    if((tmpSR1 & 0x0040) == (tmpSR2 & 0x0040)) 
+    {
+      return NOR_SUCCESS;
+    }
+    
+    if((tmpSR1 & 0x0020) == 0x0020)
+    {
+      return NOR_ERROR;
+    } 
+  }
+
+  /* Return the operation status */
+  return status;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+#endif /* HAL_NOR_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_nor.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_nor.h
@@ -1,0 +1,300 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx_hal_nor.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of NOR HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F3xx_HAL_NOR_H
+#define __STM32F3xx_HAL_NOR_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+  #include "stm32f3xx_ll_fmc.h"
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+
+/** @addtogroup STM32F3xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup NOR
+  * @{
+  */ 
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+
+/* Exported typedef ----------------------------------------------------------*/ 
+/** @defgroup NOR_Exported_Types NOR Exported Types
+  * @{
+  */
+
+/** 
+  * @brief  HAL SRAM State structures definition  
+  */ 
+typedef enum
+{  
+  HAL_NOR_STATE_RESET             = 0x00,  /*!< NOR not yet initialized or disabled  */
+  HAL_NOR_STATE_READY             = 0x01,  /*!< NOR initialized and ready for use    */
+  HAL_NOR_STATE_BUSY              = 0x02,  /*!< NOR internal processing is ongoing   */
+  HAL_NOR_STATE_ERROR             = 0x03,  /*!< NOR error state                      */ 
+  HAL_NOR_STATE_PROTECTED         = 0x04   /*!< NOR NORSRAM device write protected  */
+
+}HAL_NOR_StateTypeDef;    
+
+/**
+  * @brief  FMC NOR Status typedef
+  */
+typedef enum
+{
+  NOR_SUCCESS = 0,
+  NOR_ONGOING,
+  NOR_ERROR,
+  NOR_TIMEOUT
+
+}NOR_StatusTypedef; 
+
+/**
+  * @brief  FMC NOR ID typedef
+  */
+typedef struct
+{
+  uint16_t Manufacturer_Code;  /*!< Defines the device's manufacturer code used to identify the memory       */
+  
+  uint16_t Device_Code1;  
+  
+  uint16_t Device_Code2;                      
+        
+  uint16_t Device_Code3;       /*!< Defines the device's codes used to identify the memory. 
+                                    These codes can be accessed by performing read operations with specific 
+                                    control signals and addresses set.They can also be accessed by issuing 
+                                    an Auto Select command                                                   */    
+}NOR_IDTypeDef;
+
+/**
+  * @brief  FMC NOR CFI typedef
+  */
+typedef struct
+{
+  /*!< Defines the information stored in the memory's Common flash interface
+       which contains a description of various electrical and timing parameters, 
+       density information and functions supported by the memory                   */
+  
+  uint16_t CFI_1;            
+  
+  uint16_t CFI_2;          
+  
+  uint16_t CFI_3;                      
+  
+  uint16_t CFI_4;                     
+
+}NOR_CFITypeDef;
+
+/** 
+  * @brief  NOR handle Structure definition  
+  */ 
+typedef struct
+{
+  FMC_NORSRAM_TypeDef           *Instance;    /*!< Register base address                        */ 
+  
+  FMC_NORSRAM_EXTENDED_TypeDef  *Extended;    /*!< Extended mode register base address          */
+  
+  FMC_NORSRAM_InitTypeDef       Init;         /*!< NOR device control configuration parameters  */
+
+  HAL_LockTypeDef               Lock;         /*!< NOR locking object                           */ 
+  
+  __IO HAL_NOR_StateTypeDef     State;        /*!< NOR device access state                      */
+   
+}NOR_HandleTypeDef; 
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup NOR_Exported_Constants NOR Exported Constants
+  * @{
+  */
+/* NOR device IDs addresses */
+#define MC_ADDRESS               ((uint16_t)0x0000)
+#define DEVICE_CODE1_ADDR        ((uint16_t)0x0001)
+#define DEVICE_CODE2_ADDR        ((uint16_t)0x000E)
+#define DEVICE_CODE3_ADDR        ((uint16_t)0x000F)
+
+/* NOR CFI IDs addresses */
+#define CFI1_ADDRESS             ((uint16_t)0x61)
+#define CFI2_ADDRESS             ((uint16_t)0x62)
+#define CFI3_ADDRESS             ((uint16_t)0x63)
+#define CFI4_ADDRESS             ((uint16_t)0x64)
+
+/* NOR operation wait timeout */
+#define NOR_TMEOUT               ((uint16_t)0xFFFF)
+   
+/* NOR memory data width */
+#define NOR_MEMORY_8B            ((uint8_t)0x0)
+#define NOR_MEMORY_16B           ((uint8_t)0x1)
+
+/* NOR memory device read/write start address */
+#define NOR_MEMORY_ADRESS1       ((uint32_t)0x60000000)
+#define NOR_MEMORY_ADRESS2       ((uint32_t)0x64000000)
+#define NOR_MEMORY_ADRESS3       ((uint32_t)0x68000000)
+#define NOR_MEMORY_ADRESS4       ((uint32_t)0x6C000000)
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup NOR_Exported_Macros NOR Exported Macros
+  * @{
+  */
+
+/** @brief Reset NOR handle state
+  * @param  __HANDLE__: specifies the NOR handle.
+  * @retval None
+  */
+#define __HAL_NOR_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_NOR_STATE_RESET)
+
+/**
+  * @brief  NOR memory address shifting.
+  * @param  __NOR_ADDRESS: NOR base address 
+  * @param  __NOR_MEMORY_WIDTH_: NOR memory width
+  * @param  __ADDRESS__: NOR memory address 
+  * @retval NOR shifted address value
+  */
+#define __NOR_ADDR_SHIFT(__NOR_ADDRESS, __NOR_MEMORY_WIDTH_, __ADDRESS__)       \
+            ((uint32_t)(((__NOR_MEMORY_WIDTH_) == NOR_MEMORY_16B)?              \
+              ((uint32_t)((__NOR_ADDRESS) + (2 * (__ADDRESS__)))):              \
+              ((uint32_t)((__NOR_ADDRESS) + (__ADDRESS__)))))
+ 
+/**
+  * @brief  NOR memory write data to specified address.
+  * @param  __ADDRESS__: NOR memory address 
+  * @param  __DATA__: Data to write
+  * @retval None
+  */
+#define __NOR_WRITE(__ADDRESS__, __DATA__)  (*(__IO uint16_t *)((uint32_t)(__ADDRESS__)) = (__DATA__))
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup NOR_Exported_Functions NOR Exported Functions
+  * @{
+  */
+
+/** @addtogroup NOR_Exported_Functions_Group1 Initialization and de-initialization functions 
+  * @{
+  */
+
+/* Initialization/de-initialization functions  **********************************/  
+HAL_StatusTypeDef HAL_NOR_Init(NOR_HandleTypeDef *hnor, FMC_NORSRAM_TimingTypeDef *Timing, FMC_NORSRAM_TimingTypeDef *ExtTiming);
+HAL_StatusTypeDef HAL_NOR_DeInit(NOR_HandleTypeDef *hnor);
+void HAL_NOR_MspInit(NOR_HandleTypeDef *hnor);
+void HAL_NOR_MspDeInit(NOR_HandleTypeDef *hnor);
+void HAL_NOR_MspWait(NOR_HandleTypeDef *hnor, uint32_t Timeout);
+
+/**
+  * @}
+  */
+
+/** @addtogroup NOR_Exported_Functions_Group2 Input and Output functions 
+  * @{
+  */
+
+/* I/O operation functions  *****************************************************/
+HAL_StatusTypeDef HAL_NOR_Read_ID(NOR_HandleTypeDef *hnor, NOR_IDTypeDef *pNOR_ID);
+HAL_StatusTypeDef HAL_NOR_ReturnToReadMode(NOR_HandleTypeDef *hnor);
+HAL_StatusTypeDef HAL_NOR_Read(NOR_HandleTypeDef *hnor, uint32_t *pAddress, uint16_t *pData);
+HAL_StatusTypeDef HAL_NOR_Program(NOR_HandleTypeDef *hnor, uint32_t *pAddress, uint16_t *pData);
+
+HAL_StatusTypeDef HAL_NOR_ReadBuffer(NOR_HandleTypeDef *hnor, uint32_t uwAddress, uint16_t *pData, uint32_t uwBufferSize);
+HAL_StatusTypeDef HAL_NOR_ProgramBuffer(NOR_HandleTypeDef *hnor, uint32_t uwAddress, uint16_t *pData, uint32_t uwBufferSize);
+
+HAL_StatusTypeDef HAL_NOR_Erase_Block(NOR_HandleTypeDef *hnor, uint32_t BlockAddress, uint32_t Address);
+HAL_StatusTypeDef HAL_NOR_Erase_Chip(NOR_HandleTypeDef *hnor, uint32_t Address);
+HAL_StatusTypeDef HAL_NOR_Read_CFI(NOR_HandleTypeDef *hnor, NOR_CFITypeDef *pNOR_CFI);
+
+/**
+  * @}
+  */
+  
+/** @addtogroup NOR_Exported_Functions_Group3 Peripheral Control functions 
+  * @{
+  */
+
+/* NOR Control functions  *******************************************************/
+HAL_StatusTypeDef HAL_NOR_WriteOperation_Enable(NOR_HandleTypeDef *hnor);
+HAL_StatusTypeDef HAL_NOR_WriteOperation_Disable(NOR_HandleTypeDef *hnor);
+
+/**
+  * @}
+  */  
+  
+/** @addtogroup NOR_Exported_Functions_Group4 Peripheral State functions 
+  * @{
+  */
+
+/* NOR State functions **********************************************************/
+HAL_NOR_StateTypeDef HAL_NOR_GetState(NOR_HandleTypeDef *hnor);
+NOR_StatusTypedef HAL_NOR_GetStatus(NOR_HandleTypeDef *hnor, uint32_t Address, uint32_t Timeout);
+
+/**
+  * @}
+  */  
+
+/**
+  * @}
+  */  
+
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F3xx_HAL_NOR_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_opamp.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_opamp.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_opamp.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of OPAMP HAL module.
   ******************************************************************************
   * @attention
@@ -43,9 +43,10 @@
  extern "C" {
 #endif
 
-#if  defined (STM32F303xC) || defined (STM32F358xx) || defined (STM32F302xC) || \
-     defined (STM32F303x8) || defined (STM32F328xx) || defined (STM32F302x8) || \
-     defined (STM32F301x8) || defined (STM32F318xx) || defined (STM32F334x8)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) 
                   
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f3xx_hal_def.h"
@@ -59,6 +60,9 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup OPAMP_Exported_Types OPAMP Exported Types
+  * @{
+  */
 
 /** 
   * @brief  OPAMP Init structure definition  
@@ -80,7 +84,7 @@ typedef struct
 
   uint32_t NonInvertingInput;           /*!< Specifies the non inverting input of the opamp: 
                                              This parameter must be a value of @ref OPAMP_NonInvertingInput 
-                                             NonInvertingInput is either VP0, VP1, VP3 or VP4 */                                   
+                                             NonInvertingInput is either VP0, VP1, VP2 or VP3 */                                   
   
   uint32_t TimerControlledMuxmode;      /*!< Specifies if the Timer controlled Mux mode is enabled or disabled 
                                              This parameter must be a value of @ref OPAMP_TimerControlledMuxmode */
@@ -99,7 +103,7 @@ typedef struct
                                              TimerControlledMuxmode is enabled 
                                              i.e. when TimerControlledMuxmode is OPAMP_TIMERCONTROLLEDMUXMODE_ENABLE
                                              This parameter must be a value of @ref OPAMP_NonInvertingInputSecondary 
-                                             NonInvertingInput is either VP0, VP1, VP3 or VP3 */                                   
+                                             NonInvertingInput is either VP0, VP1, VP2 or VP3 */                                   
 
   uint32_t PgaConnect;                  /*!< Specifies the inverting pin in PGA mode 
                                              i.e. when mode is OPAMP_PGA_MODE 
@@ -113,7 +117,7 @@ typedef struct
                                                                                      
   uint32_t UserTrimming;                /*!< Specifies the trimming mode 
                                              This parameter must be a value of @ref OPAMP_UserTrimming 
-                                             UserTrimming is either factory or user timming */
+                                             UserTrimming is either factory or user trimming */
                                         
   uint32_t TrimmingValueP;              /*!< Specifies the offset trimming value (PMOS)
                                              i.e. when UserTrimming is OPAMP_TRIMMING_USER. 
@@ -143,7 +147,7 @@ typedef enum
 }HAL_OPAMP_StateTypeDef;
 
 /** 
-  * @brief PPP Handle Structure definition to @brief  OPAMP Handle Structure definition 
+  * @brief OPAMP Handle Structure definition to @brief  OPAMP Handle Structure definition 
   */ 
 typedef struct
 {
@@ -160,14 +164,17 @@ typedef struct
   */ 
 
 typedef  uint32_t OPAMP_TrimmingValueTypeDef;
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup OPAMP_Exported_Constants
+/** @defgroup OPAMP_Exported_Constants OPAMP Exported Constants
   * @{
   */
 
-/**
-  * CSR register Mask 
+/** @defgroup CSR_INIT CSR init register Mask 
+  * @{
   */
 /* Used for Init phase */
 #define OPAMP_CSR_UPDATE_PARAMETERS_INIT_MASK (OPAMP_CSR_TRIMOFFSETN | OPAMP_CSR_TRIMOFFSETP \
@@ -179,7 +186,7 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   * @}
   */         
 
-/** @defgroup OPAMP_Mode
+/** @defgroup OPAMP_Mode OPAMP Mode
   * @{
   */
 #define OPAMP_STANDALONE_MODE            ((uint32_t)0x00000000) /*!< standalone mode */
@@ -195,7 +202,7 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   * @}
   */                                        
                                                                              
-/** @defgroup OPAMP_NonInvertingInput
+/** @defgroup OPAMP_NonInvertingInput OPAMP Non Inverting Input
   * @{
   */
 
@@ -217,7 +224,7 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   * @}
   */
 
-/** @defgroup OPAMP_InvertingInput
+/** @defgroup OPAMP_InvertingInput OPAMP Inverting Input
   * @{
   */
 
@@ -231,7 +238,7 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   * @}
   */
 
-/** @defgroup OPAMP_TimerControlledMuxmode
+/** @defgroup OPAMP_TimerControlledMuxmode OPAMP Timer Controlled Mux mode
   * @{
   */
  #define OPAMP_TIMERCONTROLLEDMUXMODE_DISABLE ((uint32_t)0x00000000)    /*!< Timer controlled Mux mode disabled */
@@ -243,7 +250,7 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   * @}
   */
 
- /** @defgroup OPAMP_NonInvertingInputSecondary
+ /** @defgroup OPAMP_NonInvertingInputSecondary OPAMP Non Inverting Input Secondary
   * @{
   */
 
@@ -265,7 +272,7 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   * @}
   */
 
-/** @defgroup OPAMP_InvertingInputSecondary
+/** @defgroup OPAMP_InvertingInputSecondary OPAMP Inverting Input Secondary
   * @{
   */
 
@@ -281,7 +288,7 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   * @}
   */
 
-/** @defgroup OPAMP_PgaConnect
+/** @defgroup OPAMP_PgaConnect OPAMP Pga Connect
   * @{
   */
 
@@ -297,7 +304,7 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   */
 
 
-/** @defgroup OPAMP_PgaGain
+/** @defgroup OPAMP_PgaGain OPAMP Pga Gain
   * @{
   */
 
@@ -314,7 +321,7 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   * @}
   */
 
-/** @defgroup OPAMP_UserTrimming
+/** @defgroup OPAMP_UserTrimming OPAMP User Trimming
   * @{
   */
 
@@ -324,7 +331,7 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
 #define IS_OPAMP_TRIMMING(TRIMMING) (((TRIMMING) == OPAMP_TRIMMING_FACTORY) || \
                                      ((TRIMMING) == OPAMP_TRIMMING_USER))
 
-/** @defgroup OPAMP_FactoryTrimming
+/** @defgroup OPAMP_FactoryTrimming OPAMP Factory Trimming
   * @{
   */
 
@@ -341,7 +348,7 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   */ 
 
 
-/** @defgroup OPAMP_TrimmingValue
+/** @defgroup OPAMP_TrimmingValue OPAMP Trimming Value
   * @{
   */
 
@@ -353,7 +360,7 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   */ 
 
 
-/** @defgroup OPAMP_Input
+/** @defgroup OPAMP_Input OPAMP Input
   * @{
   */
 
@@ -367,7 +374,7 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   */
 
 
-/** @defgroup OPAMP_VREF
+/** @defgroup OPAMP_VREF OPAMP VREF
   * @{
   */
 
@@ -385,7 +392,7 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   * @}
   */ 
 
- /** @defgroup OPAMP_Vref2ADCforCalib
+ /** @defgroup OPAMP_Vref2ADCforCalib OPAMP Vref2ADCforCalib
   */
  
 #define OPAMP_VREF_NOTCONNECTEDTO_ADC          ((uint32_t)0x00000000) /*!< VREF not connected to ADC */
@@ -399,7 +406,14 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   * @}
   */ 
     
+ /**
+  * @}
+  */ 
+
 /* Exported macros -----------------------------------------------------------*/
+/** @defgroup OPAMP_Exported_Macros OPAMP Exported Macros
+  * @{
+  */
 
 /** @brief Reset OPAMP handle state
   * @param  __HANDLE__: OPAMP handle.
@@ -407,24 +421,59 @@ typedef  uint32_t OPAMP_TrimmingValueTypeDef;
   */
 #define __HAL_OPAMP_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_OPAMP_STATE_RESET)
 
-/* Include OPAMP HAL Extension module */
+/**
+  * @}
+  */ 
+
+/* Include OPAMP HAL Extended module */
 #include "stm32f3xx_hal_opamp_ex.h"
 
 /* Exported functions --------------------------------------------------------*/
+/** @defgroup OPAMP_Exported_Functions OPAMP Exported Functions
+  * @{
+  */
+
+/** @defgroup OPAMP_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
 
 /* Initialization/de-initialization functions  **********************************/
 HAL_StatusTypeDef HAL_OPAMP_Init(OPAMP_HandleTypeDef *hopamp);
 HAL_StatusTypeDef HAL_OPAMP_DeInit (OPAMP_HandleTypeDef *hopamp);
 void HAL_OPAMP_MspInit(OPAMP_HandleTypeDef *hopamp);
 void HAL_OPAMP_MspDeInit(OPAMP_HandleTypeDef *hopamp);
+/**
+  * @}
+  */
+
+
+/** @defgroup OPAMP_Exported_Functions_Group2 Input and Output operation functions 
+  * @{
+  */
 
 /* I/O operation functions  *****************************************************/
 HAL_StatusTypeDef HAL_OPAMP_Start(OPAMP_HandleTypeDef *hopamp);
 HAL_StatusTypeDef HAL_OPAMP_Stop(OPAMP_HandleTypeDef *hopamp);
 HAL_StatusTypeDef HAL_OPAMP_SelfCalibrate(OPAMP_HandleTypeDef *hopamp); 
 
+/**
+  * @}
+  */
+
+/** @defgroup OPAMP_Exported_Functions_Group3 Peripheral Control functions 
+  * @{
+  */
+
 /* Peripheral Control functions  ************************************************/
 HAL_StatusTypeDef HAL_OPAMP_Lock(OPAMP_HandleTypeDef *hopamp); 
+
+/**
+  * @}
+  */
+
+/** @defgroup OPAMP_Exported_Functions_Group4 Peripheral State functions 
+  * @{
+  */
 
 /* Peripheral State functions  **************************************************/
 HAL_OPAMP_StateTypeDef HAL_OPAMP_GetState(OPAMP_HandleTypeDef *hopamp);
@@ -432,14 +481,24 @@ OPAMP_TrimmingValueTypeDef HAL_OPAMP_GetTrimOffset (OPAMP_HandleTypeDef *hopamp,
 
 /**
   * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
   */ 
 
 /**
   * @}
   */ 
 
-#endif /* STM32F303xC  STM32F358xx STM32F302xC STM32F303x8 STM32F328xx 
-          STM32F302x8 STM32F301x8 STM32F318xx STM32F334x8 */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
 #ifdef __cplusplus
 }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_opamp_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_opamp_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_opamp_ex.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Extended OPAMP HAL module driver.
   *
   *          This file provides firmware functions to manage the following
@@ -49,7 +49,7 @@
   * @{
   */
 
-/** @defgroup OPAMPEx
+/** @defgroup OPAMPEx OPAMP Extended HAL module driver
   * @brief OPAMP Extended HAL module driver.
   * @{
   */
@@ -61,13 +61,14 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
 
-/** @defgroup OPAMPEx_Private_Functions
+/** @defgroup OPAMPEx_Exported_Functions OPAMP Extended Exported Functions
   * @{
   */
 
-/** @defgroup OPAMPEx_Group1 Extended I/O operation functions
+
+/** @defgroup OPAMPEx_Exported_Functions_Group1 Extended Input and Output operation functions
   * @brief    Extended Self calibration functions
   *
 @verbatim
@@ -80,7 +81,8 @@
   * @{
   */
 
-#if defined (STM32F302xC)
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC)
 /*  2 OPAMPS available */
 /*  2 OPAMPS can be calibrated in parallel */
 
@@ -104,8 +106,8 @@ HAL_StatusTypeDef HAL_OPAMPEx_SelfCalibrateAll(OPAMP_HandleTypeDef *hopamp1, OPA
 
   uint32_t delta;
 
-  if((hopamp1 == NULL) || (hopamp1->State == HAL_OPAMP_STATE_BUSYLOCKED) || \
-     (hopamp2 == NULL) || (hopamp2->State == HAL_OPAMP_STATE_BUSYLOCKED)) 
+  if((hopamp1 == HAL_NULL) || (hopamp1->State == HAL_OPAMP_STATE_BUSYLOCKED) || \
+     (hopamp2 == HAL_NULL) || (hopamp2->State == HAL_OPAMP_STATE_BUSYLOCKED)) 
   {
     status = HAL_ERROR;
   }
@@ -332,9 +334,11 @@ HAL_StatusTypeDef HAL_OPAMPEx_SelfCalibrateAll(OPAMP_HandleTypeDef *hopamp1, OPA
   
   return status;
 }
-#endif /* STM32F302xC */
+#endif /* STM32F302xE || */
+       /* STM32F302xC    */
 
-#if defined (STM32F303xC) || defined (STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 /*  4 OPAMPS available */
 /*  4 OPAMPS can be calibrated in parallel */
 
@@ -364,10 +368,10 @@ HAL_StatusTypeDef HAL_OPAMPEx_SelfCalibrateAll(OPAMP_HandleTypeDef *hopamp1, OPA
 
   uint32_t delta;
 
-  if((hopamp1 == NULL) || (hopamp1->State == HAL_OPAMP_STATE_BUSYLOCKED) || \
-     (hopamp2 == NULL) || (hopamp2->State == HAL_OPAMP_STATE_BUSYLOCKED) || \
-     (hopamp3 == NULL) || (hopamp3->State == HAL_OPAMP_STATE_BUSYLOCKED) || \
-     (hopamp4 == NULL) || (hopamp4->State == HAL_OPAMP_STATE_BUSYLOCKED)) 
+  if((hopamp1 == HAL_NULL) || (hopamp1->State == HAL_OPAMP_STATE_BUSYLOCKED) || \
+     (hopamp2 == HAL_NULL) || (hopamp2->State == HAL_OPAMP_STATE_BUSYLOCKED) || \
+     (hopamp3 == HAL_NULL) || (hopamp3->State == HAL_OPAMP_STATE_BUSYLOCKED) || \
+     (hopamp4 == HAL_NULL) || (hopamp4->State == HAL_OPAMP_STATE_BUSYLOCKED)) 
   {
     status = HAL_ERROR;
   }
@@ -657,7 +661,7 @@ HAL_StatusTypeDef HAL_OPAMPEx_SelfCalibrateAll(OPAMP_HandleTypeDef *hopamp1, OPA
       CLEAR_BIT (hopamp3->Instance->CSR, OPAMP_CSR_OPAMPxEN);
       CLEAR_BIT (hopamp4->Instance->CSR, OPAMP_CSR_OPAMPxEN);
 
-      /* Set normale operating mode back */
+      /* Set normal operating mode back */
       CLEAR_BIT(hopamp1->Instance->CSR, OPAMP_CSR_FORCEVP);
       CLEAR_BIT(hopamp2->Instance->CSR, OPAMP_CSR_FORCEVP);
       CLEAR_BIT(hopamp3->Instance->CSR, OPAMP_CSR_FORCEVP);
@@ -707,7 +711,12 @@ HAL_StatusTypeDef HAL_OPAMPEx_SelfCalibrateAll(OPAMP_HandleTypeDef *hopamp1, OPA
   
   return status;
 }
-#endif /* STM32F303xC  || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx  || */
+       /* STM32F303xC || STM32F358xx     */
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_opamp_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_opamp_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_opamp_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of OPAMP HAL Extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of OPAMP HAL Extended module.
   ******************************************************************************
   * @attention
   *
@@ -50,41 +50,44 @@
   * @{
   */
 
-/** @addtogroup OPAMPEx
+/** @addtogroup OPAMPEx OPAMP Extended HAL module driver
   * @{
   */
-
-
-
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
-
-/** @defgroup OPAMPEx_Exported_Constants
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup OPAMPEx_Exported_Functions OPAMP Extended Exported Functions
   * @{
   */
+
+/** @addtogroup OPAMPEx_Exported_Functions_Group1 Extended Input and Output operation functions
+  * @{
+  */
+
+/* I/O operation functions  *****************************************************/
+
+#if defined(STM32F302xE) || \
+    defined(STM32F302xC)
+
+HAL_StatusTypeDef HAL_OPAMPEx_SelfCalibrateAll(OPAMP_HandleTypeDef *hopamp1, OPAMP_HandleTypeDef *hopamp2); 
+
+#endif /* STM32F302xE || */
+       /* STM32F302xC    */
+
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx) 
+HAL_StatusTypeDef HAL_OPAMPEx_SelfCalibrateAll(OPAMP_HandleTypeDef *hopamp1, OPAMP_HandleTypeDef *hopamp2, OPAMP_HandleTypeDef *hopamp3, OPAMP_HandleTypeDef *hopamp4);
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
 /**
   * @}
   */
 
-/* Exported macro ------------------------------------------------------------*/
-/* Exported functions --------------------------------------------------------*/
-
-/* I/O operation functions  *****************************************************/
-
-#if defined (STM32F302xC)
-
-HAL_StatusTypeDef HAL_OPAMPEx_SelfCalibrateAll(OPAMP_HandleTypeDef *hopamp1, OPAMP_HandleTypeDef *hopamp2); 
-
-#endif /* STM32F302xC */
-
-#if defined (STM32F303xC) || defined (STM32F358xx) 
-
-HAL_StatusTypeDef HAL_OPAMPEx_SelfCalibrateAll(OPAMP_HandleTypeDef *hopamp1, OPAMP_HandleTypeDef *hopamp2, OPAMP_HandleTypeDef *hopamp3, OPAMP_HandleTypeDef *hopamp4);
-#endif /* STM32F303xC || STM32F358xx */
-
-/* Peripheral Control functions  ************************************************/
-
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pccard.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pccard.c
@@ -1,0 +1,725 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx_hal_pccard.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   PCCARD HAL module driver.
+  *          This file provides a generic firmware to drive PCCARD memories mounted 
+  *          as external device.
+  *         
+  @verbatim
+ ===============================================================================
+                        ##### How to use this driver #####
+ ===============================================================================  
+   [..]
+     This driver is a generic layered driver which contains a set of APIs used to 
+     control PCCARD/compact flash memories. It uses the FMC/FSMC layer functions 
+     to interface with PCCARD devices. This driver is used for:
+    
+    (+) PCCARD/compact flash memory configuration sequence using the function 
+        HAL_PCCARD_Init() with control and timing parameters for both common and 
+        attribute spaces.
+            
+    (+) Read PCCARD/compact flash memory maker and device IDs using the function
+        HAL_CF_Read_ID(). The read information is stored in the CompactFlash_ID 
+        structure declared by the function caller. 
+        
+    (+) Access PCCARD/compact flash memory by read/write operations using the functions
+        HAL_CF_Read_Sector()/HAL_CF_Write_Sector(), to read/write sector. 
+        
+    (+) Perform PCCARD/compact flash Reset chip operation using the function HAL_CF_Reset().
+        
+    (+) Perform PCCARD/compact flash erase sector operation using the function 
+        HAL_CF_Erase_Sector().
+    
+    (+) Read the PCCARD/compact flash status operation using the function HAL_CF_ReadStatus().
+     
+    (+) You can monitor the PCCARD/compact flash  device HAL state by calling the function
+        HAL_PCCARD_GetState()     
+        
+   [..]
+     (@) This driver is a set of generic APIs which handle standard PCCARD/compact flash 
+         operations. If a PCCARD/compact flash device contains different operations 
+         and/or implementations, it should be implemented separately.
+   
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f3xx_hal.h"
+
+/** @addtogroup STM32F3xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup PCCARD PCCARD HAL module driver
+  * @brief PCCARD HAL module driver
+  * @{
+  */
+#ifdef HAL_PCCARD_MODULE_ENABLED
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
+
+/** @defgroup PCCARD_Exported_Functions PCCARD Exported Functions
+  * @{
+  */
+
+/** @defgroup PCCARD_Exported_Functions_Group1 Initialization and de-initialization functions 
+  * @brief    Initialization and Configuration functions 
+  *
+  @verbatim    
+  ==============================================================================
+          ##### PCCARD Initialization and de-initialization functions #####
+  ==============================================================================
+  [..]  
+    This section provides functions allowing to initialize/de-initialize
+    the PCCARD memory
+  
+@endverbatim
+  * @{
+  */
+    
+/**
+  * @brief  Perform the PCCARD memory Initialization sequence
+  * @param  hpccard: pointer to a PCCARD_HandleTypeDef structure that contains
+  *                the configuration information for PCCARD module.
+  * @param  ComSpaceTiming: Common space timing structure
+  * @param  AttSpaceTiming: Attribute space timing structure
+  * @param  IOSpaceTiming: IO space timing structure     
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCCARD_Init(PCCARD_HandleTypeDef *hpccard, FMC_NAND_PCC_TimingTypeDef *ComSpaceTiming, FMC_NAND_PCC_TimingTypeDef *AttSpaceTiming, FMC_NAND_PCC_TimingTypeDef *IOSpaceTiming)
+{
+  /* Check the PCCARD controller state */
+  if(hpccard == HAL_NULL)
+  {
+     return HAL_ERROR;
+  }
+  
+  if(hpccard->State == HAL_PCCARD_STATE_RESET)
+  {  
+    /* Initialize the low level hardware (MSP) */
+    HAL_PCCARD_MspInit(hpccard);
+  }
+  
+  /* Initialize the PCCARD state */
+  hpccard->State = HAL_PCCARD_STATE_BUSY;    
+
+  /* Initialize PCCARD control Interface */
+  FMC_PCCARD_Init(hpccard->Instance, &(hpccard->Init));
+  
+  /* Init PCCARD common space timing Interface */
+  FMC_PCCARD_CommonSpace_Timing_Init(hpccard->Instance, ComSpaceTiming);
+  
+  /* Init PCCARD attribute space timing Interface */  
+  FMC_PCCARD_AttributeSpace_Timing_Init(hpccard->Instance, AttSpaceTiming);
+  
+  /* Init PCCARD IO space timing Interface */  
+  FMC_PCCARD_IOSpace_Timing_Init(hpccard->Instance, IOSpaceTiming);
+  
+  /* Enable the PCCARD device */
+  __FMC_PCCARD_ENABLE(hpccard->Instance); 
+  
+  /* Update the PCCARD state */
+  hpccard->State = HAL_PCCARD_STATE_READY;  
+  
+  return HAL_OK;
+
+}
+
+/**
+  * @brief  Perform the PCCARD memory De-initialization sequence
+  * @param  hpccard: pointer to a PCCARD_HandleTypeDef structure that contains
+  *                the configuration information for PCCARD module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  HAL_PCCARD_DeInit(PCCARD_HandleTypeDef *hpccard)
+{
+  /* De-Initialize the low level hardware (MSP) */
+  HAL_PCCARD_MspDeInit(hpccard);
+   
+  /* Configure the PCCARD registers with their reset values */
+  FMC_PCCARD_DeInit(hpccard->Instance);
+  
+  /* Update the PCCARD controller state */
+  hpccard->State = HAL_PCCARD_STATE_RESET;
+
+  /* Release Lock */
+  __HAL_UNLOCK(hpccard);
+
+  return HAL_OK; 
+}
+
+/**
+  * @brief  PCCARD MSP Init
+  * @param  hpccard: pointer to a PCCARD_HandleTypeDef structure that contains
+  *                the configuration information for PCCARD module.
+  * @retval None
+  */
+__weak void HAL_PCCARD_MspInit(PCCARD_HandleTypeDef *hpccard)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCCARD_MspInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  PCCARD MSP DeInit
+  * @param  hpccard: pointer to a PCCARD_HandleTypeDef structure that contains
+  *                the configuration information for PCCARD module.
+  * @retval None
+  */
+__weak void HAL_PCCARD_MspDeInit(PCCARD_HandleTypeDef *hpccard)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCCARD_MspDeInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup PCCARD_Exported_Functions_Group2 Input Output and memory functions 
+  * @brief    Input Output and memory control functions 
+  *
+  @verbatim    
+  ==============================================================================
+                ##### PCCARD Input Output and memory functions #####
+  ==============================================================================
+  [..]  
+    This section provides functions allowing to use and control the PCCARD memory
+  
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Read Compact Flash's ID.
+  * @param  hpccard: pointer to a PCCARD_HandleTypeDef structure that contains
+  *                the configuration information for PCCARD module.
+  * @param  CompactFlash_ID: Compact flash ID structure.  
+  * @param  pStatus: pointer to compact flash status         
+  * @retval HAL status
+  *   
+  */ 
+HAL_StatusTypeDef HAL_CF_Read_ID(PCCARD_HandleTypeDef *hpccard, uint8_t CompactFlash_ID[], uint8_t *pStatus)
+{
+  uint32_t timeout = 0xFFFF, index;
+  uint8_t status;
+  
+  /* Process Locked */
+  __HAL_LOCK(hpccard);  
+  
+  /* Check the PCCARD controller state */
+  if(hpccard->State == HAL_PCCARD_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+  
+  /* Update the PCCARD controller state */
+  hpccard->State = HAL_PCCARD_STATE_BUSY;
+  
+  /* Initialize the CF status */
+  *pStatus = CF_READY;  
+  
+  /* Send the Identify Command */
+  *(__IO uint16_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_STATUS_CMD)  = 0xECEC;
+    
+  /* Read CF IDs and timeout treatment */
+  do 
+  {
+     /* Read the CF status */
+     status = *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_STATUS_CMD_ALTERNATE);
+     
+     timeout--;
+  }while((status != 0x58) && timeout); 
+  
+  if(timeout == 0)
+  {
+    *pStatus = CF_TIMEOUT_ERROR;
+  }
+  else
+  {
+     /* Read CF ID bytes */
+    for(index = 0; index < 16; index++)
+    {
+      CompactFlash_ID[index] = *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_DATA);
+    }    
+  }
+  
+  /* Update the PCCARD controller state */
+  hpccard->State = HAL_PCCARD_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hpccard);  
+  
+  return HAL_OK;
+}
+   
+/**
+  * @brief  Read sector from PCCARD memory
+  * @param  hpccard: pointer to a PCCARD_HandleTypeDef structure that contains
+  *                the configuration information for PCCARD module.
+  * @param  pBuffer: pointer to destination read buffer
+  * @param  SectorAddress: Sector address to read
+  * @param  pStatus: pointer to CF status
+  * @retval HAL status
+  */    
+HAL_StatusTypeDef HAL_CF_Read_Sector(PCCARD_HandleTypeDef *hpccard, uint16_t *pBuffer, uint16_t SectorAddress, uint8_t *pStatus)
+{
+  uint32_t timeout = 0xFFFF, index = 0;
+  uint8_t status;
+
+  /* Process Locked */
+  __HAL_LOCK(hpccard);
+  
+  /* Check the PCCARD controller state */
+  if(hpccard->State == HAL_PCCARD_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+  
+  /* Update the PCCARD controller state */
+  hpccard->State = HAL_PCCARD_STATE_BUSY;
+
+  /* Initialize CF status */
+  *pStatus = CF_READY;
+
+  /* Set the parameters to write a sector */
+  *(__IO uint16_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_CYLINDER_HIGH) = (uint16_t)0x00;
+  *(__IO uint16_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_SECTOR_COUNT)  = ((uint16_t)0x0100 ) | ((uint16_t)SectorAddress);
+  *(__IO uint16_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_STATUS_CMD)    = (uint16_t)0xE4A0;  
+
+  do
+  {
+    /* wait till the Status = 0x80 */
+    status =  *(__IO uint16_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_STATUS_CMD_ALTERNATE);
+    timeout--;
+  }while((status == 0x80) && timeout);
+  
+  if(timeout == 0)
+  {
+    *pStatus = CF_TIMEOUT_ERROR;
+  }
+  
+  timeout = 0xFFFF;
+
+  do
+  {
+    /* wait till the Status = 0x58 */
+    status =  *(__IO uint16_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_STATUS_CMD_ALTERNATE);
+    timeout--;
+  }while((status != 0x58) && timeout);
+  
+  if(timeout == 0)
+  {
+    *pStatus = CF_TIMEOUT_ERROR;
+  }
+  
+  /* Read bytes */
+  for(; index < CF_SECTOR_SIZE; index++)
+  {
+    *(uint16_t *)pBuffer++ = *(uint16_t *)(CF_IO_SPACE_PRIMARY_ADDR);
+  } 
+
+  /* Update the PCCARD controller state */
+  hpccard->State = HAL_PCCARD_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hpccard);
+      
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Write sector to PCCARD memory
+  * @param  hpccard: pointer to a PCCARD_HandleTypeDef structure that contains
+  *                the configuration information for PCCARD module.
+  * @param  pBuffer: pointer to source write buffer
+  * @param  SectorAddress: Sector address to write
+  * @param  pStatus: pointer to CF status
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CF_Write_Sector(PCCARD_HandleTypeDef *hpccard, uint16_t *pBuffer, uint16_t SectorAddress,  uint8_t *pStatus)
+{
+  uint32_t timeout = 0xFFFF, index = 0;
+  uint8_t status;
+
+  /* Process Locked */
+  __HAL_LOCK(hpccard);  
+  
+  /* Check the PCCARD controller state */
+  if(hpccard->State == HAL_PCCARD_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+   
+  /* Update the PCCARD controller state */
+  hpccard->State = HAL_PCCARD_STATE_BUSY;
+    
+  /* Initialize CF status */
+  *pStatus = CF_READY;  
+    
+  /* Set the parameters to write a sector */
+  *(__IO uint16_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_CYLINDER_HIGH) = (uint16_t)0x00;
+  *(__IO uint16_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_SECTOR_COUNT)  = ((uint16_t)0x0100 ) | ((uint16_t)SectorAddress);
+  *(__IO uint16_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_STATUS_CMD)    = (uint16_t)0x30A0;
+  
+  do
+  {
+    /* Wait till the Status = 0x58 */
+    status =  *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_STATUS_CMD_ALTERNATE);
+    timeout--;
+  }while((status != 0x58) && timeout);
+  
+  if(timeout == 0)
+  {
+    *pStatus = CF_TIMEOUT_ERROR;
+  }
+  
+  /* Write bytes */
+  for(; index < CF_SECTOR_SIZE; index++)
+  {
+    *(uint16_t *)(CF_IO_SPACE_PRIMARY_ADDR) = *(uint16_t *)pBuffer++;
+  }
+
+  do
+  {
+    /* Wait till the Status = 0x50 */
+    status =  *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_STATUS_CMD_ALTERNATE);
+    timeout--;
+  }while((status != 0x50) && timeout);
+
+  if(timeout == 0)
+  {
+    *pStatus = CF_TIMEOUT_ERROR;
+  }  
+
+  /* Update the PCCARD controller state */
+  hpccard->State = HAL_PCCARD_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hpccard);  
+  
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Erase sector from PCCARD memory 
+  * @param  hpccard: pointer to a PCCARD_HandleTypeDef structure that contains
+  *                the configuration information for PCCARD module.
+  * @param  SectorAddress: Sector address to erase
+  * @param  pStatus: pointer to CF status
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  HAL_CF_Erase_Sector(PCCARD_HandleTypeDef *hpccard, uint16_t SectorAddress, uint8_t *pStatus)
+{
+  uint32_t timeout = 0x400;
+  uint8_t status;
+  
+  /* Process Locked */
+  __HAL_LOCK(hpccard);  
+  
+  /* Check the PCCARD controller state */
+  if(hpccard->State == HAL_PCCARD_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+
+  /* Update the PCCARD controller state */
+  hpccard->State = HAL_PCCARD_STATE_BUSY;
+  
+  /* Initialize CF status */ 
+  *pStatus = CF_READY;
+    
+  /* Set the parameters to write a sector */
+  *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_CYLINDER_LOW)  = 0x00;
+  *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_CYLINDER_HIGH) = 0x00;
+  *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_SECTOR_NUMBER) = SectorAddress;
+  *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_SECTOR_COUNT)  = 0x01;
+  *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_CARD_HEAD)     = 0xA0;
+  *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_STATUS_CMD)    = CF_ERASE_SECTOR_CMD;
+  
+  /* wait till the CF is ready */
+  status =  *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_STATUS_CMD_ALTERNATE);
+  
+  while((status != 0x50) && timeout)
+  {
+    status =  *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_STATUS_CMD_ALTERNATE);
+    timeout--;
+  } 
+  
+  if(timeout == 0)
+  {
+    *pStatus = CF_TIMEOUT_ERROR;
+  }
+  
+  /* Check the PCCARD controller state */
+  hpccard->State = HAL_PCCARD_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hpccard);   
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Reset the PCCARD memory 
+  * @param  hpccard: pointer to a PCCARD_HandleTypeDef structure that contains
+  *                the configuration information for PCCARD module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_CF_Reset(PCCARD_HandleTypeDef *hpccard)
+{
+
+  /* Process Locked */
+  __HAL_LOCK(hpccard);  
+  
+  /* Check the PCCARD controller state */
+  if(hpccard->State == HAL_PCCARD_STATE_BUSY)
+  {
+     return HAL_BUSY;
+  }
+
+  /* Provide an SW reset and Read and verify the:
+   - CF Configuration Option Register at address 0x98000200 --> 0x80
+   - Card Configuration and Status Register	at address 0x98000202 --> 0x00
+   - Pin Replacement Register  at address 0x98000204 --> 0x0C
+   - Socket and Copy Register at address 0x98000206 --> 0x00
+  */
+
+  /* Check the PCCARD controller state */
+  hpccard->State = HAL_PCCARD_STATE_BUSY;
+  
+  *(__IO uint8_t *)(0x98000202) = 0x01;
+    
+  /* Check the PCCARD controller state */
+  hpccard->State = HAL_PCCARD_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hpccard);  
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles PCCARD device interrupt request.
+  * @param  hpccard: pointer to a PCCARD_HandleTypeDef structure that contains
+  *                the configuration information for PCCARD module.
+  * @retval HAL status
+*/
+void HAL_PCCARD_IRQHandler(PCCARD_HandleTypeDef *hpccard)
+{
+  /* Check PCCARD interrupt Rising edge flag */
+  if(__FMC_PCCARD_GET_FLAG(hpccard->Instance, FMC_FLAG_RISING_EDGE))
+  {
+    /* PCCARD interrupt callback*/
+    HAL_PCCARD_ITCallback(hpccard);
+  
+    /* Clear PCCARD interrupt Rising edge pending bit */
+    __FMC_PCCARD_CLEAR_FLAG(hpccard->Instance, FMC_FLAG_RISING_EDGE);
+  }
+  
+  /* Check PCCARD interrupt Level flag */
+  if(__FMC_PCCARD_GET_FLAG(hpccard->Instance, FMC_FLAG_LEVEL))
+  {
+    /* PCCARD interrupt callback*/
+    HAL_PCCARD_ITCallback(hpccard);
+  
+    /* Clear PCCARD interrupt Level pending bit */
+    __FMC_PCCARD_CLEAR_FLAG(hpccard->Instance, FMC_FLAG_LEVEL);
+  }
+
+  /* Check PCCARD interrupt Falling edge flag */
+  if(__FMC_PCCARD_GET_FLAG(hpccard->Instance, FMC_FLAG_FALLING_EDGE))
+  {
+    /* PCCARD interrupt callback*/
+    HAL_PCCARD_ITCallback(hpccard);
+  
+    /* Clear PCCARD interrupt Falling edge pending bit */
+    __FMC_PCCARD_CLEAR_FLAG(hpccard->Instance, FMC_FLAG_FALLING_EDGE);
+  }
+  
+  /* Check PCCARD interrupt FIFO empty flag */
+  if(__FMC_PCCARD_GET_FLAG(hpccard->Instance, FMC_FLAG_FEMPT))
+  {
+    /* PCCARD interrupt callback*/
+    HAL_PCCARD_ITCallback(hpccard);
+  
+    /* Clear PCCARD interrupt FIFO empty pending bit */
+    __FMC_PCCARD_CLEAR_FLAG(hpccard->Instance, FMC_FLAG_FEMPT);
+  }  
+
+}
+
+/**
+  * @brief  PCCARD interrupt feature callback
+  * @param  hpccard: pointer to a PCCARD_HandleTypeDef structure that contains
+  *                the configuration information for PCCARD module.
+  * @retval None
+  */
+__weak void HAL_PCCARD_ITCallback(PCCARD_HandleTypeDef *hpccard)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_PCCARD_ITCallback could be implemented in the user file
+   */
+}
+  
+/**
+  * @}
+  */
+
+/** @defgroup PCCARD_Exported_Functions_Group3 Peripheral State functions 
+ *  @brief   Peripheral State functions 
+ *
+@verbatim   
+  ==============================================================================
+                   ##### PCCARD Peripheral State functions #####
+  ==============================================================================  
+  [..]
+    This subsection permits to get in run-time the status of the PCCARD controller 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */ 
+  
+/**
+  * @brief  return the PCCARD controller state
+  * @param  hpccard: pointer to a PCCARD_HandleTypeDef structure that contains
+  *                the configuration information for PCCARD module.
+  * @retval HAL state
+  */
+HAL_PCCARD_StateTypeDef HAL_PCCARD_GetState(PCCARD_HandleTypeDef *hpccard)
+{
+  return hpccard->State;
+}  
+ 
+/**
+  * @brief  Get the compact flash memory status
+  * @param  hpccard: pointer to a PCCARD_HandleTypeDef structure that contains
+  *                the configuration information for PCCARD module.       
+  * @retval New status of the CF operation. This parameter can be:
+  *          - CompactFlash_TIMEOUT_ERROR: when the previous operation generate 
+  *            a Timeout error
+  *          - CompactFlash_READY: when memory is ready for the next operation     
+  *                
+  */
+CF_StatusTypedef HAL_CF_GetStatus(PCCARD_HandleTypeDef *hpccard)
+{
+  uint32_t timeout = 0x1000000, status_CF;  
+  
+  /* Check the PCCARD controller state */
+  if(hpccard->State == HAL_PCCARD_STATE_BUSY)
+  {
+     return CF_ONGOING;
+  }
+
+  status_CF =  *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_STATUS_CMD_ALTERNATE);
+  
+  while((status_CF == CF_BUSY) && timeout)
+  {
+    status_CF =  *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_STATUS_CMD_ALTERNATE);
+    timeout--;
+  }
+
+  if(timeout == 0)
+  {          
+    status_CF =  CF_TIMEOUT_ERROR;      
+  }   
+
+  /* Return the operation status */
+  return (CF_StatusTypedef) status_CF;      
+}
+  
+/**
+  * @brief  Reads the Compact Flash memory status using the Read status command
+  * @param  hpccard: pointer to a PCCARD_HandleTypeDef structure that contains
+  *                the configuration information for PCCARD module.      
+  * @retval The status of the Compact Flash memory. This parameter can be:
+  *          - CompactFlash_BUSY: when memory is busy
+  *          - CompactFlash_READY: when memory is ready for the next operation    
+  *          - CompactFlash_ERROR: when the previous operation gererates error                
+  */
+CF_StatusTypedef HAL_CF_ReadStatus(PCCARD_HandleTypeDef *hpccard)
+{
+  uint8_t data = 0, status_CF = CF_BUSY;
+  
+  /* Check the PCCARD controller state */
+  if(hpccard->State == HAL_PCCARD_STATE_BUSY)
+  {
+     return CF_ONGOING;
+  } 
+
+  /* Read status operation */
+  data =  *(__IO uint8_t *)(CF_IO_SPACE_PRIMARY_ADDR | CF_STATUS_CMD_ALTERNATE);
+
+  if((data & CF_TIMEOUT_ERROR) == CF_TIMEOUT_ERROR)
+  {
+    status_CF = CF_TIMEOUT_ERROR;
+  } 
+  else if((data & CF_READY) == CF_READY)
+  {
+    status_CF = CF_READY;
+  }
+  
+  return (CF_StatusTypedef) status_CF;
+}  
+ 
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+#endif /* HAL_PCCARD_MODULE_ENABLED */  
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pccard.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pccard.h
@@ -1,0 +1,219 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx_hal_pccard.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of PCCARD HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F3xx_HAL_PCCARD_H
+#define __STM32F3xx_HAL_PCCARD_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+  #include "stm32f3xx_ll_fmc.h"
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+
+/** @addtogroup STM32F3xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup PCCARD
+  * @{
+  */ 
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+
+/* Exported typedef ----------------------------------------------------------*/
+/** @defgroup PCCARD_Exported_Types PCCARD Exported Types
+  * @{
+  */
+
+/** 
+  * @brief  HAL PCCARD State structures definition  
+  */ 
+typedef enum
+{
+  HAL_PCCARD_STATE_RESET     = 0x00,    /*!< PCCARD peripheral not yet initialized or disabled */
+  HAL_PCCARD_STATE_READY     = 0x01,    /*!< PCCARD peripheral ready                           */
+  HAL_PCCARD_STATE_BUSY      = 0x02,    /*!< PCCARD peripheral busy                            */   
+  HAL_PCCARD_STATE_ERROR     = 0x04     /*!< PCCARD peripheral error                           */
+}HAL_PCCARD_StateTypeDef;
+ 
+typedef enum
+{
+  CF_SUCCESS = 0,
+  CF_ONGOING,
+  CF_ERROR,
+  CF_TIMEOUT
+}CF_StatusTypedef;
+
+/** 
+  * @brief  FMC_PCCARD handle Structure definition  
+  */   
+typedef struct
+{
+  FMC_PCCARD_TypeDef           *Instance;              /*!< Register base address for PCCARD device          */
+  
+  FMC_PCCARD_InitTypeDef       Init;                   /*!< PCCARD device control configuration parameters   */
+
+  __IO HAL_PCCARD_StateTypeDef State;                  /*!< PCCARD device access state                       */
+   
+  HAL_LockTypeDef              Lock;                   /*!< PCCARD Lock                                      */ 
+ 
+}PCCARD_HandleTypeDef;
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup PCCARD_Exported_Constants PCCARD Exported Constants
+  * @{
+  */
+  
+#define CF_DEVICE_ADDRESS             ((uint32_t)0x90000000)
+#define CF_ATTRIBUTE_SPACE_ADDRESS    ((uint32_t)0x98000000)   /* Attribute space size to @0x9BFF FFFF */
+#define CF_COMMON_SPACE_ADDRESS       CF_DEVICE_ADDRESS        /* Common space size to @0x93FF FFFF    */
+#define CF_IO_SPACE_ADDRESS           ((uint32_t)0x9C000000)   /* IO space size to @0x9FFF FFFF        */
+#define CF_IO_SPACE_PRIMARY_ADDR      ((uint32_t)0x9C0001F0)   /* IO space size to @0x9FFF FFFF        */
+
+/* Compact Flash-ATA registers description */
+#define CF_DATA                       ((uint8_t)0x00)    /* Data register */
+#define CF_SECTOR_COUNT               ((uint8_t)0x02)    /* Sector Count register */
+#define CF_SECTOR_NUMBER              ((uint8_t)0x03)    /* Sector Number register */
+#define CF_CYLINDER_LOW               ((uint8_t)0x04)    /* Cylinder low register */
+#define CF_CYLINDER_HIGH              ((uint8_t)0x05)    /* Cylinder high register */
+#define CF_CARD_HEAD                  ((uint8_t)0x06)    /* Card/Head register */
+#define CF_STATUS_CMD                 ((uint8_t)0x07)    /* Status(read)/Command(write) register */
+#define CF_STATUS_CMD_ALTERNATE       ((uint8_t)0x0E)    /* Alternate Status(read)/Command(write) register */
+#define CF_COMMON_DATA_AREA           ((uint16_t)0x0400) /* Start of data area (for Common access only!) */
+
+/* Compact Flash-ATA commands */
+#define CF_READ_SECTOR_CMD            ((uint8_t)0x20)
+#define CF_WRITE_SECTOR_CMD           ((uint8_t)0x30)
+#define CF_ERASE_SECTOR_CMD           ((uint8_t)0xC0)
+#define CF_IDENTIFY_CMD               ((uint8_t)0xEC)
+
+/* Compact Flash status */
+#define CF_TIMEOUT_ERROR              ((uint8_t)0x60)
+#define CF_BUSY                       ((uint8_t)0x80)
+#define CF_PROGR                      ((uint8_t)0x01)
+#define CF_READY                      ((uint8_t)0x40)
+
+#define CF_SECTOR_SIZE                ((uint32_t)255)    /* In half words */ 
+ 
+/**
+  * @}
+  */ 
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup PCCARD_Exported_Macros PCCARD Exported Macros
+  * @{
+  */
+
+/** @brief Reset PCCARD handle state
+  * @param  __HANDLE__: specifies the PCCARD handle.
+  * @retval None
+  */
+#define __HAL_PCCARD_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_PCCARD_STATE_RESET)
+/**
+  * @}
+  */ 
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup PCCARD_Exported_Functions PCCARD Exported Functions
+  * @{
+  */
+
+/** @addtogroup PCCARD_Exported_Functions_Group1 Initialization and de-initialization functions 
+  * @{
+  */
+/* Initialization/de-initialization functions  **********************************/
+HAL_StatusTypeDef  HAL_PCCARD_Init(PCCARD_HandleTypeDef *hpccard, FMC_NAND_PCC_TimingTypeDef *ComSpaceTiming, FMC_NAND_PCC_TimingTypeDef *AttSpaceTiming, FMC_NAND_PCC_TimingTypeDef *IOSpaceTiming);
+HAL_StatusTypeDef  HAL_PCCARD_DeInit(PCCARD_HandleTypeDef *hpccard);   
+void HAL_PCCARD_MspInit(PCCARD_HandleTypeDef *hpccard);
+void HAL_PCCARD_MspDeInit(PCCARD_HandleTypeDef *hpccard);
+/**
+  * @}
+  */
+
+/** @addtogroup PCCARD_Exported_Functions_Group2 Input Output and memory functions 
+  * @{
+  */
+/* IO operation functions  *****************************************************/
+HAL_StatusTypeDef  HAL_CF_Read_ID(PCCARD_HandleTypeDef *hpccard, uint8_t CompactFlash_ID[], uint8_t *pStatus);
+HAL_StatusTypeDef  HAL_CF_Write_Sector(PCCARD_HandleTypeDef *hpccard, uint16_t *pBuffer, uint16_t SectorAddress,  uint8_t *pStatus);
+HAL_StatusTypeDef  HAL_CF_Read_Sector(PCCARD_HandleTypeDef *hpccard, uint16_t *pBuffer, uint16_t SectorAddress, uint8_t *pStatus);
+HAL_StatusTypeDef  HAL_CF_Erase_Sector(PCCARD_HandleTypeDef *hpccard, uint16_t SectorAddress, uint8_t *pStatus);
+HAL_StatusTypeDef  HAL_CF_Reset(PCCARD_HandleTypeDef *hpccard);
+void               HAL_PCCARD_IRQHandler(PCCARD_HandleTypeDef *hpccard);
+void        HAL_PCCARD_ITCallback(PCCARD_HandleTypeDef *hpccard);
+
+/**
+  * @}
+  */
+
+/** @defgroup PCCARD_Exported_Functions_Group3 Peripheral State functions 
+  * @{
+  */
+/* PCCARD State functions *******************************************************/
+HAL_PCCARD_StateTypeDef HAL_PCCARD_GetState(PCCARD_HandleTypeDef *hpccard);
+CF_StatusTypedef HAL_CF_GetStatus(PCCARD_HandleTypeDef *hpccard);
+CF_StatusTypedef HAL_CF_ReadStatus(PCCARD_HandleTypeDef *hpccard);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F3xx_HAL_PCCARD_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pcd.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pcd.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_pcd.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   PCD HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the USB Peripheral Controller:
@@ -78,31 +78,46 @@
   * @{
   */
 
-/** @defgroup PCD
+/** @defgroup PCD PCD HAL module driver
   * @brief PCD HAL module driver
   * @{
   */
 
 #ifdef HAL_PCD_MODULE_ENABLED
 
-#if defined(STM32F302x8) || defined(STM32F302xC) ||                         \
-    defined(STM32F303xC) || defined(STM32F373xC)
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F302x8)                         || \
+    defined(STM32F373xC)
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+
+/** @defgroup PCD_Private_Define PCD Private Define
+  * @{
+  */
 #define BTABLE_ADDRESS                  (0x000)  
+/**
+  * @}
+  */ 
+  
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
+/** @defgroup PCD_Private_Functions PCD Private Functions
+  * @{
+  */
 static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd);
-/* Private functions ---------------------------------------------------------*/
+/**
+  * @}
+  */ 
+/* Exported functions ---------------------------------------------------------*/
 
-
-/** @defgroup PCD_Private_Functions
+/** @defgroup PCD_Exported_Functions PCD Exported Functions
   * @{
   */
 
-/** @defgroup PCD_Group1 Initialization and de-initialization functions 
+/** @defgroup PCD_Exported_Functions_Group1 Initialization and de-initialization functions 
  *  @brief    Initialization and Configuration functions 
  *
 @verbatim
@@ -128,7 +143,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
   uint32_t wInterrupt_Mask = 0;
   
   /* Check the PCD handle allocation */
-  if(hpcd == NULL)
+  if(hpcd == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -199,7 +214,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
 HAL_StatusTypeDef HAL_PCD_DeInit(PCD_HandleTypeDef *hpcd)
 {
   /* Check the PCD handle allocation */
-  if(hpcd == NULL)
+  if(hpcd == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -245,7 +260,7 @@ __weak void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd)
   * @}
   */
 
-/** @defgroup PCD_Group2 IO operation functions 
+/** @defgroup PCD_Exported_Functions_Group2 Input and Output operation functions 
  *  @brief   Data transfers functions 
  *
 @verbatim   
@@ -294,7 +309,17 @@ HAL_StatusTypeDef HAL_PCD_Stop(PCD_HandleTypeDef *hpcd)
   __HAL_UNLOCK(hpcd); 
   return HAL_OK;
 }
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */  
 
+/** @addtogroup PCD_Private_Functions PCD Private Functions
+  * @{
+  */
 /**
   * @brief  This function handles PCD Endpoint interrupt request.
   * @param  hpcd: PCD handle
@@ -501,6 +526,18 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
   return HAL_OK;
 }
 /**
+  * @}
+  */
+
+/** @addtogroup PCD_Exported_Functions
+  * @{
+  */
+
+/** @defgroup PCD_Exported_Functions_Group2 Input and Output operation functions 
+ * @{
+ */    
+ 
+/**
   * @brief  This function handles PCD interrupt request.
   * @param  hpcd: PCD handle
   * @retval HAL status
@@ -584,7 +621,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
  __weak void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
 {
   /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_PCD_DataOutStageCallback could be implenetd in the user file
+            the HAL_PCD_DataOutStageCallback could be implemented in the user file
    */ 
 }
 
@@ -597,7 +634,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
  __weak void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
 {
   /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_PCD_DataInStageCallback could be implenetd in the user file
+            the HAL_PCD_DataInStageCallback could be implemented in the user file
    */ 
 }
 /**
@@ -608,7 +645,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
  __weak void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef *hpcd)
 {
   /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_PCD_SetupStageCallback could be implenetd in the user file
+            the HAL_PCD_SetupStageCallback could be implemented in the user file
    */ 
 }
 
@@ -620,7 +657,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
  __weak void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd)
 {
   /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_PCD_SOFCallback could be implenetd in the user file
+            the HAL_PCD_SOFCallback could be implemented in the user file
    */ 
 }
 
@@ -632,10 +669,9 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
  __weak void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
 {
   /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_PCD_ResetCallback could be implenetd in the user file
+            the HAL_PCD_ResetCallback could be implemented in the user file
    */ 
 }
-
 
 /**
   * @brief  Suspend event callbacks
@@ -645,7 +681,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
  __weak void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *hpcd)
 {
   /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_PCD_SuspendCallback could be implenetd in the user file
+            the HAL_PCD_SuspendCallback could be implemented in the user file
    */ 
 }
 
@@ -657,7 +693,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
  __weak void HAL_PCD_ResumeCallback(PCD_HandleTypeDef *hpcd)
 {
   /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_PCD_ResumeCallback could be implenetd in the user file
+            the HAL_PCD_ResumeCallback could be implemented in the user file
    */ 
 }
 
@@ -670,7 +706,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
  __weak void HAL_PCD_ISOOUTIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
 {
   /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_PCD_ISOOUTIncompleteCallback could be implenetd in the user file
+            the HAL_PCD_ISOOUTIncompleteCallback could be implemented in the user file
    */ 
 }
 
@@ -683,7 +719,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
  __weak void HAL_PCD_ISOINIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
 {
   /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_PCD_ISOINIncompleteCallback could be implenetd in the user file
+            the HAL_PCD_ISOINIncompleteCallback could be implemented in the user file
    */ 
 }
 
@@ -695,7 +731,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
  __weak void HAL_PCD_ConnectCallback(PCD_HandleTypeDef *hpcd)
 {
   /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_PCD_ConnectCallback could be implenetd in the user file
+            the HAL_PCD_ConnectCallback could be implemented in the user file
    */ 
 }
 
@@ -707,15 +743,14 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
  __weak void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd)
 {
   /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_PCD_DisconnectCallback could be implenetd in the user file
+            the HAL_PCD_DisconnectCallback could be implemented in the user file
    */ 
 }
-
 /**
   * @}
   */
   
-/** @defgroup PCD_Group3 Peripheral Control functions 
+/** @defgroup PCD_Exported_Functions_Group3 Peripheral Control functions 
  *  @brief   management functions 
  *
 @verbatim   
@@ -740,7 +775,7 @@ HAL_StatusTypeDef HAL_PCD_DevConnect(PCD_HandleTypeDef *hpcd)
   __HAL_LOCK(hpcd); 
   
   /* Enabling DP Pull-Down bit to Connect internal pull-up on USB DP line */
-   HAL_PCDEx_SetConnectionState (hpcd, 1);
+   HAL_PCDEx_SetConnectionState(hpcd, 1);
   
   __HAL_UNLOCK(hpcd); 
   return HAL_OK;
@@ -756,7 +791,7 @@ HAL_StatusTypeDef HAL_PCD_DevDisconnect(PCD_HandleTypeDef *hpcd)
   __HAL_LOCK(hpcd); 
   
   /* Disable DP Pull-Down bit*/
-  HAL_PCDEx_SetConnectionState (hpcd, 0);
+  HAL_PCDEx_SetConnectionState(hpcd, 0);
   
   __HAL_UNLOCK(hpcd); 
   return HAL_OK;
@@ -1217,7 +1252,7 @@ HAL_StatusTypeDef HAL_PCD_DeActiveRemoteWakeup(PCD_HandleTypeDef *hpcd)
   * @}
   */
   
-/** @defgroup PCD_Group4 Peripheral State functions 
+/** @defgroup PCD_Exported_Functions_Group4 Peripheral State functions 
  *  @brief   Peripheral State functions 
  *
 @verbatim   
@@ -1250,8 +1285,10 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd)
   * @}
   */
 
-#endif /* defined(STM32F302x8) || defined(STM32F302xC) ||                         */
-       /* defined(STM32F303xC) || defined(STM32F373xC)    */
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC || STM32F303xC || */
+       /* STM32F302x8                || */
+       /* STM32F373xC                   */
 
 #endif /* HAL_PCD_MODULE_ENABLED */
 /**

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pcd.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pcd.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_pcd.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of PCD HAL module.
   ******************************************************************************
   * @attention
@@ -43,8 +43,10 @@
  extern "C" {
 #endif
 
-#if defined(STM32F302x8) || defined(STM32F302xC) ||                         \
-    defined(STM32F303xC) || defined(STM32F373xC)
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F302x8)                         || \
+    defined(STM32F373xC)
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f3xx_hal_def.h"
@@ -58,6 +60,9 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup PCD_Exported_Types PCD Exported Types
+  * @{
+  */
 
    /** 
   * @brief  PCD State structures definition  
@@ -165,22 +170,26 @@ typedef struct
   PCD_TypeDef             *Instance;   /*!< Register base address              */ 
   PCD_InitTypeDef         Init;       /*!< PCD required parameters            */
   __IO uint8_t            USB_Address; /*!< USB Address            */  
-  PCD_EPTypeDef           IN_ep[5];  /*!< IN endpoint parameters             */
-  PCD_EPTypeDef           OUT_ep[5]; /*!< OUT endpoint parameters            */ 
+  PCD_EPTypeDef           IN_ep[8];  /*!< IN endpoint parameters             */
+  PCD_EPTypeDef           OUT_ep[8]; /*!< OUT endpoint parameters            */ 
   HAL_LockTypeDef         Lock;       /*!< PCD peripheral status              */
   __IO PCD_StateTypeDef   State;      /*!< PCD communication state            */
   uint32_t                Setup[12];  /*!< Setup packet buffer                */
   void                    *pData;      /*!< Pointer to upper stack Handler     */    
   
 } PCD_HandleTypeDef;
+
+/**
+  * @}
+  */ 
  
 #include "stm32f3xx_hal_pcd_ex.h"    
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup PCD_Exported_Constants
+/** @defgroup PCD_Exported_Constants PCD Exported Constants
   * @{
   */
 
-/** @defgroup USB_Core_Speed
+/** @defgroup USB_Core_Speed USB Core Speed
   * @{
   */
 #define PCD_SPEED_HIGH               0 /* Not Supported */
@@ -189,7 +198,7 @@ typedef struct
   * @}
   */
   
-  /** @defgroup USB_Core_PHY
+/** @defgroup USB_Core_PHY USB Core PHY
   * @{
   */
 #define PCD_PHY_EMBEDDED             2
@@ -197,7 +206,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup USB_EP0_MPS
+/** @defgroup USB_EP0_MPS USB EP0 MPS
   * @{
   */
 #define DEP0CTL_MPS_64                         0
@@ -213,7 +222,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup USB_EP_Type
+/** @defgroup USB_EP_Type USB EP Type
   * @{
   */
 #define PCD_EP_TYPE_CTRL                                 0
@@ -223,6 +232,10 @@ typedef struct
 /**
   * @}
   */ 
+
+/** @defgroup USB_ENDP USB ENDP
+  * @{
+  */
 
 #define PCD_ENDP0                             ((uint8_t)0)
 #define PCD_ENDP1                             ((uint8_t)1)
@@ -243,9 +256,13 @@ typedef struct
   * @}
   */ 
   
+/**
+  * @}
+  */   
+
 /* Exported macros -----------------------------------------------------------*/
 
-/** @defgroup PCD_Interrupt_Clock
+/** @defgroup PCD_Exported_Macros PCD Exported Macros
  *  @brief macros to handle interrupts and specific clock configurations
  * @{
  */
@@ -258,7 +275,35 @@ typedef struct
 #define __HAL_USB_EXTI_DISABLE_IT()                EXTI->IMR &= ~(USB_EXTI_LINE_WAKEUP)
 #define __HAL_USB_EXTI_GENERATE_SWIT(__EXTILINE__) (EXTI->SWIER |= (__EXTILINE__))
 
+#define __HAL_USB_EXTI_GET_FLAG()                  EXTI->PR & (USB_EXTI_LINE_WAKEUP)
+#define __HAL_USB_EXTI_CLEAR_FLAG()                EXTI->PR = USB_EXTI_LINE_WAKEUP
+
+#define __HAL_USB_EXTI_SET_RISING_EDGE_TRIGGER()   do {\
+                                                     EXTI->FTSR &= ~(USB_EXTI_LINE_WAKEUP);\
+                                                     EXTI->RTSR |= USB_EXTI_LINE_WAKEUP;\
+                                                   } while(0)
+
+#define __HAL_USB_EXTI_SET_FALLING_EDGE_TRIGGER()  do {\
+                                                     EXTI->FTSR |= (USB_EXTI_LINE_WAKEUP);\
+                                                     EXTI->RTSR &= ~(USB_EXTI_LINE_WAKEUP);\
+                                                   } while(0)
+
+#define __HAL_USB_EXTI_SET_FALLINGRISING_TRIGGER() do {\
+                                                     EXTI->RTSR &= ~(USB_EXTI_LINE_WAKEUP);\
+                                                     EXTI->FTSR &= ~(USB_EXTI_LINE_WAKEUP);\
+                                                     EXTI->RTSR |= USB_EXTI_LINE_WAKEUP;\
+                                                     EXTI->FTSR |= USB_EXTI_LINE_WAKEUP;\
+                                                   } while(0)
+/**
+  * @}
+  */                                                      
+
 /* Internal macros -----------------------------------------------------------*/
+
+/** @defgroup PCD_Private_Macros PCD Private Macros
+ *  @brief macros to handle interrupts and specific clock configurations
+  * @{
+  */
 
 /* SetENDPOINT */
 #define PCD_SET_ENDPOINT(USBx, bEpNum,wRegValue)  (*(&USBx->EP0R + bEpNum * 2)= (uint16_t)wRegValue)
@@ -646,12 +691,26 @@ typedef struct
 
 /* Exported functions --------------------------------------------------------*/
 
+/** @addtogroup PCD_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup PCD_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
 /* Initialization/de-initialization functions  **********************************/
 HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd);
 HAL_StatusTypeDef HAL_PCD_DeInit (PCD_HandleTypeDef *hpcd);
 void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd);
 void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd);
 
+/**
+  * @}
+  */
+
+/** @addtogroup PCD_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
 /* I/O operation functions  *****************************************************/
  /* Non-Blocking mode: Interrupt */
 HAL_StatusTypeDef HAL_PCD_Start(PCD_HandleTypeDef *hpcd);
@@ -670,6 +729,13 @@ void HAL_PCD_ISOINIncompleteCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum);
 void HAL_PCD_ConnectCallback(PCD_HandleTypeDef *hpcd);
 void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd);
 
+/**
+  * @}
+  */
+
+/** @addtogroup PCD_Exported_Functions_Group3 Peripheral Control functions
+  * @{
+  */
 /* Peripheral Control functions  ************************************************/
 HAL_StatusTypeDef HAL_PCD_DevConnect(PCD_HandleTypeDef *hpcd);
 HAL_StatusTypeDef HAL_PCD_DevDisconnect(PCD_HandleTypeDef *hpcd);
@@ -684,9 +750,22 @@ HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_ActiveRemoteWakeup(PCD_HandleTypeDef *hpcd);
 HAL_StatusTypeDef HAL_PCD_DeActiveRemoteWakeup(PCD_HandleTypeDef *hpcd);
+/**
+  * @}
+  */
+
+/** @addtogroup PCD_Exported_Functions_Group4 Peripheral State functions
+  * @{
+  */
 /* Peripheral State functions  **************************************************/
 PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
+/**
+  * @}
+  */
 
+/** @addtogroup PCDEx_Private_Functions PCD Extended Private Functions
+  * @{
+  */
 void PCD_WritePMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes);
 void PCD_ReadPMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes);
 /**
@@ -697,8 +776,17 @@ void PCD_ReadPMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, ui
   * @}
   */
 
-#endif /* defined(STM32F302x8) || defined(STM32F302xC) ||                         */
-       /* defined(STM32F303xC) || defined(STM32F373xC)    */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC || STM32F303xC || */
+       /* STM32F302x8                || */
+       /* STM32F373xC                   */
 
 #ifdef __cplusplus
 }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pcd_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pcd_ex.c
@@ -2,12 +2,12 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_pcd_ex.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Extended PCD HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the USB Peripheral Controller:
-  *           + Configururation of the PMA for EP
+  *           + Configuration of the PMA for EP
   *         
   ******************************************************************************
   * @attention
@@ -46,29 +46,30 @@
   * @{
   */
 
-/** @defgroup PCDEx
-  * @brief PCD HAL Extended module driver
+/** @defgroup PCDEx PCD Extended HAL module driver
+  * @brief PCDEx PCDEx Extended HAL module driver
   * @{
   */
 
 #ifdef HAL_PCD_MODULE_ENABLED
 
-#if defined(STM32F302x8) || defined(STM32F302xC) ||                         \
-    defined(STM32F303xC) || defined(STM32F373xC)
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F302x8)                         || \
+    defined(STM32F373xC)
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
 
-
-/** @defgroup PCD_Private_Functions
+/** @defgroup PCDEx_Exported_Functions PCD Extended Exported Functions
   * @{
   */
 
-/** @defgroup PCD_Group1 Initialization and de-initialization functions 
+/** @defgroup PCDEx_Exported_Functions_Group1 Extended Initialization and de-initialization functions 
  *  @brief    Initialization and Configuration functions 
  *
 @verbatim
@@ -81,7 +82,7 @@
 
 /**
   * @brief Configure PMA for EP
-  * @param  hpcd : PCD handle
+  * @param  hpcd: PCD handle
   * @param  ep_addr: endpoint address
   * @param  ep_kind: endpoint Kind
   *                @arg USB_SNG_BUF: Single Buffer used
@@ -133,10 +134,21 @@ HAL_StatusTypeDef  HAL_PCDEx_PMAConfig(PCD_HandleTypeDef *hpcd,
   
   return HAL_OK; 
 }
+/**
+  * @}
+  */ 
 
-#if defined(STM32F301x8) ||                         \
-    defined(STM32F303x8) || defined(STM32F303xC) || defined(STM32F373xC) || \
-    defined(STM32F334x8) || defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @}
+  */ 
+
+/** @defgroup PCDEx_Private_Functions PCD Extended Private Functions
+  * @{
+  */
+#if defined(STM32F303xC)                         || \
+    defined(STM32F303x8) || defined(STM32F334x8) || \
+    defined(STM32F301x8)                         || \
+    defined(STM32F373xC) || defined(STM32F378xx)
       
      
 /**
@@ -167,7 +179,7 @@ void PCD_WritePMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, u
 /**
   * @brief Copy a buffer from user memory area to packet memory area (PMA)
   * @param   USBx: USB peripheral instance register address.
-  * @param   pbUsrBuf    = pointer to user memory area.
+  * @param   pbUsrBuf: pointer to user memory area.
   * @param   wPMABufAddr: address into PMA.
   * @param   wNBytes: no. of bytes to be copied.
   * @retval None
@@ -184,10 +196,14 @@ void PCD_ReadPMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, ui
     pbUsrBuf++;
   }
 }
-#endif
+#endif /* STM32F303xC                || */
+       /* STM32F303x8 || STM32F334x8 || */
+       /* STM32F301x8                || */
+       /* STM32F373xC || STM32F378xx    */
 
-#if defined(STM32F302x8) || defined(STM32F302xC)
-         
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC)                         || \
+    defined(STM32F302x8) 
 /**
   * @brief Copy a buffer from user memory area to packet memory area (PMA)
   * @param   USBx: USB peripheral instance register address.
@@ -217,7 +233,7 @@ void PCD_WritePMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, u
 /**
   * @brief Copy a buffer from user memory area to packet memory area (PMA)
   * @param   USBx: USB peripheral instance register address.
-  * @param   pbUsrBuf    = pointer to user memory area.
+  * @param   pbUsrBuf: pointer to user memory area.
   * @param   wPMABufAddr: address into PMA.
   * @param   wNBytes: no. of bytes to be copied.
   * @retval None
@@ -234,8 +250,21 @@ void PCD_ReadPMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, ui
     pbUsrBuf++;
   }
 }
-#endif
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC                || */
+       /* STM32F302x8                   */
 
+/**
+  * @}
+  */ 
+
+/** @addtogroup PCDEx_Exported_Functions PCD Extended Exported Functions
+  * @{
+  */
+
+/** @addtogroup PCDEx_Exported_Functions_Group1 Extended Initialization and de-initialization functions 
+  * @{
+  */
 /**
   * @brief  Software Device Connection
   * @param  hpcd: PCD handle
@@ -248,17 +277,17 @@ void PCD_ReadPMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, ui
             the HAL_PCDEx_SetConnectionState could be implenetd in the user file
    */ 
 }
+/**
+  * @}
+  */ 
 
 /**
   * @}
   */
-
-/**
-  * @}
-  */
-
-#endif /* defined(STM32F302x8) || defined(STM32F302xC) || */
-       /* defined(STM32F303xC) || defined(STM32F373xC)    */
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC || STM32F303xC || */
+       /* STM32F302x8                || */
+       /* STM32F373xC                   */
 
 #endif /* HAL_PCD_MODULE_ENABLED */
 /**

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pcd_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pcd_ex.h
@@ -1,10 +1,10 @@
 /**
   ******************************************************************************
-  * @file    stm32f3xx_hal_pcd.h
+  * @file    stm32f3xx_hal_pcd_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of PCD HAL module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of PCD HAL Extended module.
   ******************************************************************************
   * @attention
   *
@@ -43,8 +43,10 @@
  extern "C" {
 #endif
 
-#if defined(STM32F302x8) || defined(STM32F302xC) ||                         \
-    defined(STM32F303xC) || defined(STM32F373xC)
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F302x8)                         || \
+    defined(STM32F373xC)
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f3xx_hal_def.h"
@@ -53,13 +55,16 @@
   * @{
   */
 
-/** @addtogroup PCD
+/** @addtogroup PCDEx
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
 /* Exported constants --------------------------------------------------------*/
 /* Exported macros -----------------------------------------------------------*/                                              
+/** @defgroup PCDEx_Exported_Macros PCD Extended Exported Macros
+  * @{
+  */
 /**
   * @brief  Gets address in an endpoint register.
   * @param  USBx: USB peripheral instance register address.
@@ -67,7 +72,8 @@
   * @retval None
   */
    
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F373xC)
+#if defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F373xC)
       
 #define PCD_EP_TX_ADDRESS(USBx, bEpNum) ((uint32_t *)((USBx->BTABLE+bEpNum*8)*2+     ((uint32_t)USBx + 0x400)))
 #define PCD_EP_TX_CNT(USBx, bEpNum) ((uint32_t *)((USBx->BTABLE+bEpNum*8+2)*2+  ((uint32_t)USBx + 0x400)))
@@ -79,10 +85,12 @@
     PCD_SET_EP_CNT_RX_REG(pdwReg, wCount);\
   }    
 
-#endif /* STM32F302xC || STM32F303xC || STM32F373xC */
+#endif /* STM32F302xC || STM32F303xC || */
+       /* STM32F373xC                   */
    
       
-#if defined(STM32F302x8) 
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302x8)
            
 #define PCD_EP_TX_ADDRESS(USBx, bEpNum) ((uint16_t *)((USBx->BTABLE+bEpNum*8)+     ((uint32_t)USBx + 0x400)))
 #define PCD_EP_TX_CNT(USBx, bEpNum) ((uint16_t *)((USBx->BTABLE+bEpNum*8+2)+  ((uint32_t)USBx + 0x400)))
@@ -94,9 +102,20 @@
     PCD_SET_EP_CNT_RX_REG(pdwReg, wCount);\
   }
 
-#endif /* STM32F302x8 */
-      
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302x8                   */
+/**
+  * @}
+  */ 
+
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup PCDEx_Exported_Functions PCD Extended Exported Functions
+  * @{
+  */
+/** @addtogroup PCDEx_Exported_Functions_Group1 Extended Initialization and de-initialization functions 
+ *  @brief    Initialization and Configuration functions
+  * @{
+  */
 HAL_StatusTypeDef HAL_PCDEx_PMAConfig(PCD_HandleTypeDef *hpcd, 
                                      uint16_t ep_addr,
                                      uint16_t ep_kind,
@@ -106,14 +125,24 @@ HAL_StatusTypeDef HAL_PCDEx_PMAConfig(PCD_HandleTypeDef *hpcd,
 
 /**
   * @}
+  */ 
+  
+/**
+  * @}
+  */ 
+
+/**
+  * @}
   */
 
 /**
   * @}
   */
 
-#endif /* defined(STM32F302x8) || defined(STM32F302xC) ||                         */
-       /* defined(STM32F303xC) || defined(STM32F373xC)    */
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC || STM32F303xC || */
+       /* STM32F302x8                || */
+       /* STM32F373xC                   */
 
 #ifdef __cplusplus
 }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pwr.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pwr.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_pwr.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   PWR HAL module driver.
   *
   *          This file provides firmware functions to manage the following
@@ -49,7 +49,7 @@
   * @{
   */
 
-/** @defgroup PWR
+/** @defgroup PWR PWR HAL module driver
   * @brief PWR HAL module driver
   * @{
   */
@@ -63,11 +63,11 @@
 /* Private function prototypes -----------------------------------------------*/
 /* Private functions ---------------------------------------------------------*/
 
-/** @defgroup PWR_Private_Functions
+/** @defgroup PWR_Exported_Functions PWR Exported Functions
   * @{
   */
 
-/** @defgroup HAL_PWR_Group1 Initialization and de-initialization functions 
+/** @defgroup PWR_Exported_Functions_Group1 Initialization and de-initialization functions 
   *  @brief    Initialization and de-initialization functions
   *
 @verbatim
@@ -89,7 +89,6 @@
 
 /**
   * @brief Deinitializes the HAL PWR peripheral registers to their default reset values.
-  * @param None
   * @retval None
   */
 void HAL_PWR_DeInit(void)
@@ -103,7 +102,6 @@ void HAL_PWR_DeInit(void)
   *         backup data registers and backup SRAM).
   * @note  If the HSE divided by 32 is used as the RTC clock, the
   *         Backup Domain Access should be kept enabled.
-  * @param None
   * @retval None
   */
 void HAL_PWR_EnableBkUpAccess(void)
@@ -116,7 +114,6 @@ void HAL_PWR_EnableBkUpAccess(void)
   *         backup data registers and backup SRAM).
   * @note  If the HSE divided by 32 is used as the RTC clock, the
   *         Backup Domain Access should be kept enabled.
-  * @param None
   * @retval None
   */
 void HAL_PWR_DisableBkUpAccess(void)
@@ -128,7 +125,7 @@ void HAL_PWR_DisableBkUpAccess(void)
   * @}
   */
 
-/** @defgroup HAL_PWR_Group2 Peripheral Control functions
+/** @defgroup PWR_Exported_Functions_Group2 Peripheral Control functions 
   *  @brief Low Power modes configuration functions
   *
 @verbatim
@@ -143,7 +140,7 @@ void HAL_PWR_DisableBkUpAccess(void)
           forced in input pull down configuration and is active on rising edges.
       (+) There are up to three WakeUp pins:
           WakeUp Pin 1 on PA.00.
-          WakeUp Pin 2 on PC.13 (STM32F303xC, only).
+          WakeUp Pin 2 on PC.13 (STM32F303xC, STM32F303xE only).
           WakeUp Pin 3 on PE.06.
 
     *** Main and Backup Regulators configuration ***
@@ -340,7 +337,6 @@ void HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry)
     __WFE();
     __WFE();
   }
-
 }
 
 /**
@@ -411,7 +407,6 @@ void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry)
   *            Alarm out, or RTC clock calibration out.
   *          - RTC_AF2 pin (PI8) if configured for tamper or time-stamp.
   *          - WKUP pin 1 (PA0) if enabled.
-  * @param  None
   * @retval None
   */
 void HAL_PWR_EnterSTANDBYMode(void)

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pwr.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pwr.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_pwr.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of PWR HAL module.
   ******************************************************************************
   * @attention
@@ -50,12 +50,15 @@
   * @{
   */
 
-/** @addtogroup PWR
+/** @addtogroup PWR PWR HAL Driver module
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
+/** @defgroup PWR_Alias_Exported_Constants PWR Alias Exported Constants
+  * @{
+  */ 
 /* ------------- PWR registers bit address in the alias region ---------------*/
 #define PWR_OFFSET               (PWR_BASE - PERIPH_BASE)
 
@@ -82,12 +85,15 @@
 /* Alias word address of EWUP3 bit */
 #define EWUP3_BitNumber          POSITION_VAL(PWR_CSR_EWUP3)
 #define CSR_EWUP3_BB             (PERIPH_BB_BASE + (CSR_OFFSET * 32) + (EWUP3_BitNumber * 4))
-
-/** @defgroup PWR_Exported_Constants
-  * @{
+/**
+  * @}
   */
 
-/** @defgroup PWR_WakeUp_Pins
+/** @defgroup PWR_Exported_Constants PWR Exported Constants
+  * @{
+  */ 
+
+/** @defgroup PWR_WakeUp_Pins PWR WakeUp Pins
   * @{
   */
 
@@ -101,7 +107,7 @@
   * @}
   */
 
-/** @defgroup PWR_Regulator_state_in_STOP_mode
+/** @defgroup PWR_Regulator_state_in_STOP_mode PWR Regulator state in STOP mode
   * @{
   */
 #define PWR_MAINREGULATOR_ON                        ((uint32_t)0x00000000)
@@ -113,7 +119,7 @@
   * @}
   */
 
-/** @defgroup PWR_SLEEP_mode_entry
+/** @defgroup PWR_SLEEP_mode_entry PWR SLEEP mode entry
   * @{
   */
 #define PWR_SLEEPENTRY_WFI              ((uint8_t)0x01)
@@ -123,7 +129,7 @@
   * @}
   */
 
-/** @defgroup PWR_STOP_mode_entry
+/** @defgroup PWR_STOP_mode_entry PWR STOP mode entry
   * @{
   */
 #define PWR_STOPENTRY_WFI               ((uint8_t)0x01)
@@ -133,7 +139,7 @@
   * @}
   */
 
-/** @defgroup PWR_Flag
+/** @defgroup PWR_Flag PWR Flag
   * @{
   */
 #define PWR_FLAG_WU                     PWR_CSR_WUF
@@ -153,7 +159,7 @@
   */
 
 /* Exported macro ------------------------------------------------------------*/
-/** @defgroup PWR_Exported_Macro
+/** @defgroup PWR_Exported_Macro PWR Exported Macro
   * @{
   */
 
@@ -189,23 +195,50 @@
   * @}
   */
 
-/* Include PWR HAL Extension module */
+/* Include PWR HAL Extended module */
 #include "stm32f3xx_hal_pwr_ex.h"
 
 /* Exported functions --------------------------------------------------------*/
 
+/** @addtogroup PWR_Exported_Functions PWR Exported Functions
+  * @{
+  */
+  
+/** @addtogroup PWR_Exported_Functions_Group1 Initialization and de-initialization functions 
+  * @{
+  */
+
 /* Initialization and de-initialization functions *****************************/
 void HAL_PWR_DeInit(void);
+
+/**
+  * @}
+  */
+
+/** @addtogroup PWR_Exported_Functions_Group2 Peripheral Control functions 
+  * @{
+  */
 
 /* Peripheral Control functions  **********************************************/
 void HAL_PWR_EnableBkUpAccess(void);
 void HAL_PWR_DisableBkUpAccess(void);
+
+/* WakeUp pins configuration functions ****************************************/
 void HAL_PWR_EnableWakeUpPin(uint32_t WakeUpPinx);
 void HAL_PWR_DisableWakeUpPin(uint32_t WakeUpPinx);
 
+/* Low Power modes configuration functions ************************************/
 void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry);
 void HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry);
 void HAL_PWR_EnterSTANDBYMode(void);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pwr_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_pwr_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_pwr_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of PWR HAL Extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of PWR HAL Extended module.
   ******************************************************************************
   * @attention
   *
@@ -55,10 +55,15 @@
   */
 
 /* Exported types ------------------------------------------------------------*/
-#if defined(STM32F301x8) ||                         \
-    defined(STM32F302x8) || defined(STM32F302xC) || \
-    defined(STM32F303x8) || defined(STM32F303xC) || defined(STM32F373xC) || \
-    defined(STM32F334x8)
+
+/** @defgroup PWREx_Exported_Types PWR Extended Exported Types
+ *  @{
+ */
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || \
+    defined(STM32F373xC) 
 /**
   * @brief  PWR PVD configuration structure definition
   */
@@ -70,21 +75,28 @@ typedef struct
   uint32_t Mode;       /*!< Mode: Specifies the operating mode for the selected pins.
                             This parameter can be a value of @ref PWREx_PVD_Mode */
 }PWR_PVDTypeDef;
-#endif /* STM32F301x8 || STM32F302x8 || STM32F302xC || */
-       /* STM32F303x8 || STM32F303xC */
-       /* STM32F373xC || STM32F334x8 */
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC || STM32F303xC || */
+       /* STM32F303x8 || STM32F334x8 || */
+       /* STM32F301x8 || STM32F302x8 || */
+       /* STM32F373xC                   */
+
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
-
-/** @defgroup PWREx_Exported_Constants
+/** @defgroup PWREx_Exported_Constants PWR Extended Exported Constants
   * @{
   */
 
-#if defined(STM32F301x8) ||                         \
-    defined(STM32F302x8) || defined(STM32F302xC) || \
-    defined(STM32F303x8) || defined(STM32F303xC) || defined(STM32F373xC) || \
-    defined(STM32F334x8)
-/** @defgroup PWREx_PVD_detection_level
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || \
+    defined(STM32F373xC)
+    
+/** @defgroup PWREx_PVD_detection_level PWR Extended PVD detection level
   * @{
   */
 #define PWR_PVDLEVEL_0                  PWR_CR_PLS_LEV0
@@ -103,27 +115,35 @@ typedef struct
   * @}
   */
 
-/** @defgroup PWREx_PVD_Mode
+/** @defgroup PWREx_PVD_Mode PWR Extended PVD Mode
   * @{
   */
-#define PWR_MODE_EVT                  ((uint32_t)0x00000000)   /*!< No Interrupt */
-#define PWR_MODE_IT_RISING            ((uint32_t)0x00000001)   /*!< External Interrupt Mode with Rising edge trigger detection */
-#define PWR_MODE_IT_FALLING           ((uint32_t)0x00000002)   /*!< External Interrupt Mode with Falling edge trigger detection */
-#define PWR_MODE_IT_RISING_FALLING    ((uint32_t)0x00000003)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection */
-#define IS_PWR_PVD_MODE(MODE) (((MODE) == PWR_MODE_EVT) || ((MODE) == PWR_MODE_IT_RISING)|| \
-                               ((MODE) == PWR_MODE_IT_FALLING) || ((MODE) == PWR_MODE_IT_RISING_FALLING))
+#define PWR_PVD_MODE_NORMAL                 ((uint32_t)0x00000000)   /*!< basic mode is used */
+#define PWR_PVD_MODE_IT_RISING              ((uint32_t)0x00010001)   /*!< External Interrupt Mode with Rising edge trigger detection */
+#define PWR_PVD_MODE_IT_FALLING             ((uint32_t)0x00010002)   /*!< External Interrupt Mode with Falling edge trigger detection */
+#define PWR_PVD_MODE_IT_RISING_FALLING      ((uint32_t)0x00010003)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection */
+#define PWR_PVD_MODE_EVENT_RISING           ((uint32_t)0x00020001)   /*!< Event Mode with Rising edge trigger detection */
+#define PWR_PVD_MODE_EVENT_FALLING          ((uint32_t)0x00020002)   /*!< Event Mode with Falling edge trigger detection */
+#define PWR_PVD_MODE_EVENT_RISING_FALLING   ((uint32_t)0x00020003)   /*!< Event Mode with Rising/Falling edge trigger detection */
+
+#define IS_PWR_PVD_MODE(MODE) (((MODE) == PWR_PVD_MODE_IT_RISING)|| ((MODE) == PWR_PVD_MODE_IT_FALLING) || \
+                              ((MODE) == PWR_PVD_MODE_IT_RISING_FALLING) || ((MODE) == PWR_PVD_MODE_EVENT_RISING) || \
+                              ((MODE) == PWR_PVD_MODE_EVENT_FALLING) || ((MODE) == PWR_PVD_MODE_EVENT_RISING_FALLING) || \
+                              ((MODE) == PWR_PVD_MODE_NORMAL))
 /**
   * @}
   */
 
 #define PWR_EXTI_LINE_PVD  ((uint32_t)0x00010000)  /*!< External interrupt line 16 Connected to the PVD EXTI Line */
 
-#endif /* STM32F301x8 || STM32F302x8 || STM32F302xC || */
-       /* STM32F303x8 || STM32F303xC */
-       /* STM32F373xC || STM32F334x8 */
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC || STM32F303xC || */
+       /* STM32F303x8 || STM32F334x8 || */
+       /* STM32F301x8 || STM32F302x8 || */
+       /* STM32F373xC                   */
 
 #if defined(STM32F373xC) || defined(STM32F378xx)
-/** @defgroup PWREx_SDADC_ANALOGx
+/** @defgroup PWREx_SDADC_ANALOGx PWR Extended SDADC ANALOGx
   * @{
   */
 #define PWR_SDADC_ANALOG1              ((uint32_t)PWR_CR_SDADC1EN)
@@ -142,61 +162,82 @@ typedef struct
   */
 
 /* Exported macro ------------------------------------------------------------*/
-/** @defgroup PWREx_Exported_Macros
+/** @defgroup PWREx_Exported_Macros PWR Extended Exported Macros
   * @{
   */
 
-#if defined(STM32F301x8) ||                         \
-    defined(STM32F302x8) || defined(STM32F302xC) || \
-    defined(STM32F303x8) || defined(STM32F303xC) || defined(STM32F373xC) || \
-    defined(STM32F334x8)
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || \
+    defined(STM32F373xC)
+    
 /**
-  * @brief Enable the PVD Exti Line.
-  * @param  __EXTILINE__: specifies the PVD EXTI sources to be enabled.
-  * This parameter can be:
-  *   @arg PWR_EXTI_LINE_PVD
+  * @brief Enable interrupt on PVD Exti Line 16.
   * @retval None.
   */
-#define __HAL_PVD_EXTI_ENABLE_IT(__EXTILINE__)  (EXTI->IMR |= (__EXTILINE__))
+#define __HAL_PWR_PVD_EXTI_ENABLE_IT()      (EXTI->IMR |= (PWR_EXTI_LINE_PVD))
 
 /**
-  * @brief Disable the PVD EXTI Line.
-  * @param  __EXTILINE__: specifies the PVD EXTI sources to be disabled.
-  * This parameter can be:
-  *  @arg PWR_EXTI_LINE_PVD
+  * @brief Disable interrupt on PVD Exti Line 16.
   * @retval None.
   */
-#define __HAL_PVD_EXTI_DISABLE_IT(__EXTILINE__)  (EXTI->IMR &= ~(__EXTILINE__))
+#define __HAL_PWR_PVD_EXTI_DISABLE_IT()     (EXTI->IMR &= ~(PWR_EXTI_LINE_PVD))
 
 /**
   * @brief Generate a Software interrupt on selected EXTI line.
-  * @param  __EXTILINE__: specifies the PVD EXTI sources to be disabled.
-  * This parameter can be:
-  *  @arg PWR_EXTI_LINE_PVD
-  * @retval None
+  * @retval None.
   */
-#define __HAL_PVD_EXTI_GENERATE_SWIT(__EXTILINE__) (EXTI->SWIER |= (__EXTILINE__))
+#define __HAL_PWR_PVD_EXTI_GENERATE_SWIT()  (EXTI->SWIER |= (PWR_EXTI_LINE_PVD))
+
+/**
+  * @brief Enable event on PVD Exti Line 16.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_ENABLE_EVENT()   (EXTI->EMR |= (PWR_EXTI_LINE_PVD))
+
+/**
+  * @brief Disable event on PVD Exti Line 16.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_DISABLE_EVENT()  (EXTI->EMR &= ~(PWR_EXTI_LINE_PVD))
+
+/**
+  * @brief  PVD EXTI line configuration: clear falling edge trigger and set rising edge.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_CLEAR_EGDE_TRIGGER()   EXTI->FTSR &= ~(PWR_EXTI_LINE_PVD); \
+                                                  EXTI->RTSR &= ~(PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief  PVD EXTI line configuration: set falling edge trigger.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_SET_FALLING_EGDE_TRIGGER()  EXTI->FTSR |= (PWR_EXTI_LINE_PVD)
+
+/**
+  * @brief  PVD EXTI line configuration: set rising edge trigger.
+  * @retval None.
+  */
+#define __HAL_PWR_PVD_EXTI_SET_RISING_EDGE_TRIGGER()   EXTI->RTSR |= (PWR_EXTI_LINE_PVD)
 
 /**
   * @brief Check whether the specified PVD EXTI interrupt flag is set or not.
-  * @param  __EXTILINE__: specifies the PVD EXTI sources to be cleared.
-  * This parameter can be:
-  *   @arg PWR_EXTI_LINE_PVD
   * @retval EXTI PVD Line Status.
   */
-#define __HAL_PVD_EXTI_GET_FLAG(__EXTILINE__)  (EXTI->PR & (__EXTILINE__))
+#define __HAL_PWR_PVD_EXTI_GET_FLAG()       (EXTI->PR & (PWR_EXTI_LINE_PVD))
 
 /**
   * @brief Clear the PVD EXTI flag.
-  * @param  __EXTILINE__: specifies the PVD EXTI sources to be cleared.
-  * This parameter can be:
-  *   @arg PWR_EXTI_LINE_PVD
   * @retval None.
   */
-#define __HAL_PVD_EXTI_CLEAR_FLAG(__EXTILINE__)  (EXTI->PR = (__EXTILINE__))
-#endif /* STM32F301x8 || STM32F302x8 || STM32F302xC || */
-       /* STM32F303x8 || STM32F303xC */
-       /* STM32F373xC || STM32F334x8 */
+#define __HAL_PWR_PVD_EXTI_CLEAR_FLAG()     (EXTI->PR = (PWR_EXTI_LINE_PVD))
+
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC || STM32F303xC || */
+       /* STM32F303x8 || STM32F334x8 || */
+       /* STM32F301x8 || STM32F302x8 || */
+       /* STM32F373xC                   */
 
 /**
   * @}
@@ -204,24 +245,42 @@ typedef struct
 
 /* Exported functions --------------------------------------------------------*/
 
-/* Peripheral Control functions ***********************************************/
-#if defined(STM32F301x8) ||                         \
-    defined(STM32F302x8) || defined(STM32F302xC) || \
-    defined(STM32F303x8) || defined(STM32F303xC) || defined(STM32F373xC) || \
-    defined(STM32F334x8)
+/** @addtogroup PWREx_Exported_Functions PWR Extended Exported Functions
+ *  @{
+ */
+
+/** @addtogroup PWREx_Exported_Functions_Group1 Peripheral Extended Control Functions
+  * @{
+  */
+/* Peripheral Extended control functions **************************************/
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || \
+    defined(STM32F373xC)
 void HAL_PWR_PVDConfig(PWR_PVDTypeDef *sConfigPVD);
 void HAL_PWR_EnablePVD(void);
 void HAL_PWR_DisablePVD(void);
 void HAL_PWR_PVD_IRQHandler(void);
 void HAL_PWR_PVDCallback(void);
-#endif /* STM32F301x8 || STM32F302x8 || STM32F302xC || */
-       /* STM32F303x8 || STM32F303xC */
-       /* STM32F373xC || STM32F334x8 */
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC || STM32F303xC || */
+       /* STM32F303x8 || STM32F334x8 || */
+       /* STM32F301x8 || STM32F302x8 || */
+       /* STM32F373xC                   */
 
 #if defined(STM32F373xC) || defined(STM32F378xx)
 void HAL_PWREx_EnableSDADCAnalog(uint32_t Analogx);
 void HAL_PWREx_DisableSDADCAnalog(uint32_t Analogx);
 #endif /* STM32F373xC || STM32F378xx */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_rcc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_rcc.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_rcc.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of RCC HAL module.
   ******************************************************************************
   * @attention
@@ -56,51 +56,9 @@
 
 /* Exported types ------------------------------------------------------------*/
 
-/**
-  * @brief  RCC PLL configuration structure definition
+/** @defgroup RCC_Exported_Types RCC Exported Types
+  * @{
   */
-typedef struct
-{
-  uint32_t PLLState;   /*!< PLLState: The new state of the PLL.
-                            This parameter can be a value of @ref RCC_PLL_Config */
-
-  uint32_t PLLSource;  /*!< PLLSource: PLL entry clock source.
-                            This parameter must be a value of @ref RCC_PLL_Clock_Source */
-
-  uint32_t PLLMUL;     /*!< PLLMUL: Multiplication factor for PLL VCO input clock
-                            This parameter must be a value of @ref RCC_PLL_Multiplication_Factor*/
-
-}RCC_PLLInitTypeDef;
-
-/**
-  * @brief  RCC Internal/External Oscillator (HSE, HSI, LSE and LSI) configuration structure definition
-  */
-typedef struct
-{
-  uint32_t OscillatorType;       /*!< The oscillators to be configured.
-                                      This parameter can be a value of @ref RCC_Oscillator_Type */
-
-  uint32_t HSEState;             /*!< The new state of the HSE.
-                                      This parameter can be a value of @ref RCC_HSE_Config */
-
-  uint32_t HSEPredivValue;       /*!<  The HSE predivision factor value.
-                                       This parameter can be a value of @ref RCC_HSE_Predivision_Factor */
-
-  uint32_t LSEState;             /*!<  The new state of the LSE.
-                                       This parameter can be a value of @ref RCC_LSE_Config */
-
-  uint32_t HSIState;             /*!< The new state of the HSI.
-                                      This parameter can be a value of @ref RCC_HSI_Config */
-
-  uint32_t HSICalibrationValue;  /*!< The calibration trimming value.
-                                      This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x1F */
-
-  uint32_t LSIState;             /*!<  The new state of the LSI.
-                                       This parameter can be a value of @ref RCC_LSI_Config */
-
-  RCC_PLLInitTypeDef PLL;        /*!< PLL structure parameters */
-
-}RCC_OscInitTypeDef;
 
 /**
   * @brief  RCC System, AHB and APB busses clock configuration structure definition
@@ -124,12 +82,16 @@ typedef struct
 
 }RCC_ClkInitTypeDef;
 
+/**
+  * @}
+  */
+  
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup RCC_Exported_Constants
+/** @defgroup RCC_Exported_Constants RCC Exported Constants
   * @{
   */
 
-/** @defgroup RCC_BitAddress_AliasRegion
+/** @defgroup RCC_BitAddress_AliasRegion RCC BitAddress AliasRegion
   * @brief RCC registers bit address in the alias region
   * @{
   */
@@ -194,6 +156,13 @@ typedef struct
 /* BDCR register byte 0 (Bits[7:0] base address */
 #define BDCR_BYTE0_ADDRESS        (PERIPH_BASE + RCC_BDCR_OFFSET)
 
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Timeout RCC Timeout
+  * @{
+  */  
 /* LSE state change timeout */
 #define LSE_TIMEOUT_VALUE          ((uint32_t)5000) /* 5 s    */
 
@@ -203,7 +172,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_Oscillator_Type
+/** @defgroup RCC_Oscillator_Type RCC Oscillator Type
   * @{
   */
 #define RCC_OSCILLATORTYPE_NONE            ((uint32_t)0x00000000)
@@ -221,7 +190,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_HSE_Config
+/** @defgroup RCC_HSE_Config RCC HSE Config
   * @{
   */
 #define RCC_HSE_OFF                      ((uint32_t)0x00000000)
@@ -234,41 +203,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_HSE_Predivision_Factor
-  * @{
-  */
-
-#define RCC_HSE_PREDIV_DIV1              RCC_CFGR2_PREDIV_DIV1
-#define RCC_HSE_PREDIV_DIV2              RCC_CFGR2_PREDIV_DIV2
-#define RCC_HSE_PREDIV_DIV3              RCC_CFGR2_PREDIV_DIV3
-#define RCC_HSE_PREDIV_DIV4              RCC_CFGR2_PREDIV_DIV4
-#define RCC_HSE_PREDIV_DIV5              RCC_CFGR2_PREDIV_DIV5
-#define RCC_HSE_PREDIV_DIV6              RCC_CFGR2_PREDIV_DIV6
-#define RCC_HSE_PREDIV_DIV7              RCC_CFGR2_PREDIV_DIV7
-#define RCC_HSE_PREDIV_DIV8              RCC_CFGR2_PREDIV_DIV8
-#define RCC_HSE_PREDIV_DIV9              RCC_CFGR2_PREDIV_DIV9
-#define RCC_HSE_PREDIV_DIV10             RCC_CFGR2_PREDIV_DIV10
-#define RCC_HSE_PREDIV_DIV11             RCC_CFGR2_PREDIV_DIV11
-#define RCC_HSE_PREDIV_DIV12             RCC_CFGR2_PREDIV_DIV12
-#define RCC_HSE_PREDIV_DIV13             RCC_CFGR2_PREDIV_DIV13
-#define RCC_HSE_PREDIV_DIV14             RCC_CFGR2_PREDIV_DIV14
-#define RCC_HSE_PREDIV_DIV15             RCC_CFGR2_PREDIV_DIV15
-#define RCC_HSE_PREDIV_DIV16             RCC_CFGR2_PREDIV_DIV16
-
-#define IS_RCC_HSE_PREDIV(DIV) (((DIV) == RCC_HSE_PREDIV_DIV1)  || ((DIV) == RCC_HSE_PREDIV_DIV2)  || \
-                                ((DIV) == RCC_HSE_PREDIV_DIV3)  || ((DIV) == RCC_HSE_PREDIV_DIV4)  || \
-                                ((DIV) == RCC_HSE_PREDIV_DIV5)  || ((DIV) == RCC_HSE_PREDIV_DIV6)  || \
-                                ((DIV) == RCC_HSE_PREDIV_DIV7)  || ((DIV) == RCC_HSE_PREDIV_DIV8)  || \
-                                ((DIV) == RCC_HSE_PREDIV_DIV9)  || ((DIV) == RCC_HSE_PREDIV_DIV10) || \
-                                ((DIV) == RCC_HSE_PREDIV_DIV11) || ((DIV) == RCC_HSE_PREDIV_DIV12) || \
-                                ((DIV) == RCC_HSE_PREDIV_DIV13) || ((DIV) == RCC_HSE_PREDIV_DIV14) || \
-                                ((DIV) == RCC_HSE_PREDIV_DIV15) || ((DIV) == RCC_HSE_PREDIV_DIV16))
-
-/**
-  * @}
-  */
-
-/** @defgroup RCC_LSE_Config
+/** @defgroup RCC_LSE_Config RCC_LSE_Config
   * @{
   */
 #define RCC_LSE_OFF                      ((uint32_t)0x00000000)
@@ -281,18 +216,22 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_HSI_Config
+/** @defgroup RCC_HSI_Config RCC HSI Config
   * @{
   */
 #define RCC_HSI_OFF                      ((uint32_t)0x00000000)
 #define RCC_HSI_ON                       ((uint32_t)0x00000001)
 
 #define IS_RCC_HSI(HSI) (((HSI) == RCC_HSI_OFF) || ((HSI) == RCC_HSI_ON))
+
+#define RCC_HSICALIBRATION_DEFAULT ((uint32_t)0x10) /* Default HSI calibration trimming value */
+
+#define IS_RCC_CALIBRATION_VALUE(__VALUE__) ((__VALUE__) <= 0x1F)
 /**
   * @}
   */
 
-/** @defgroup RCC_LSI_Config
+/** @defgroup RCC_LSI_Config RCC LSI Config
   * @{
   */
 #define RCC_LSI_OFF                      ((uint32_t)0x00000000)
@@ -303,7 +242,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_PLL_Config
+/** @defgroup RCC_PLL_Config RCC PLL Config
   * @{
   */
 #define RCC_PLL_NONE                     ((uint32_t)0x00000000)
@@ -315,7 +254,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_PLL_Multiplication_Factor
+/** @defgroup RCC_PLL_Multiplication_Factor RCC PLL Multiplication Factor
   * @{
   */
 #define RCC_PLL_MUL2                     RCC_CFGR_PLLMUL2
@@ -346,19 +285,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_PLL_Clock_Source
-  * @{
-  */
-#define RCC_PLLSOURCE_HSI                RCC_CFGR_PLLSRC_HSI_DIV2
-#define RCC_PLLSOURCE_HSE                RCC_CFGR_PLLSRC_HSE_PREDIV
-
-#define IS_RCC_PLLSOURCE(SOURCE) (((SOURCE) == RCC_PLLSOURCE_HSI) || \
-                                  ((SOURCE) == RCC_PLLSOURCE_HSE))
-/**
-  * @}
-  */
-
-/** @defgroup RCC_System_Clock_Type
+/** @defgroup RCC_System_Clock_Type RCC System Clock Type
   * @{
   */
 #define RCC_CLOCKTYPE_SYSCLK             ((uint32_t)0x00000001)
@@ -374,7 +301,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_System_Clock_Source
+/** @defgroup RCC_System_Clock_Source RCC System Clock Source
   * @{
   */
 #define RCC_SYSCLKSOURCE_HSI             RCC_CFGR_SW_HSI
@@ -388,7 +315,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_System_Clock_Source_Status
+/** @defgroup RCC_System_Clock_Source_Status RCC System Clock Source Status
   * @{
   */
 #define RCC_SYSCLKSOURCE_STATUS_HSI      RCC_CFGR_SWS_HSI
@@ -402,7 +329,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_AHB_Clock_Source
+/** @defgroup RCC_AHB_Clock_Source RCC AHB Clock Source
   * @{
   */
 #define RCC_SYSCLK_DIV1                  RCC_CFGR_HPRE_DIV1
@@ -424,7 +351,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_APB1_APB2_Clock_Source
+/** @defgroup RCC_APB1_APB2_Clock_Source RCC APB1 APB2 Clock Source
   * @{
   */
 #define RCC_HCLK_DIV1                    RCC_CFGR_PPRE1_DIV1
@@ -440,7 +367,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_RTC_Clock_Source
+/** @defgroup RCC_RTC_Clock_Source RCC RTC Clock Source
   * @{
   */
 #define RCC_RTCCLKSOURCE_NONE            RCC_BDCR_RTCSEL_NOCLOCK
@@ -456,7 +383,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_USART2_Clock_Source
+/** @defgroup RCC_USART2_Clock_Source RCC USART2 Clock Source
   * @{
   */
 #define RCC_USART2CLKSOURCE_PCLK1        RCC_CFGR3_USART2SW_PCLK
@@ -472,7 +399,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_USART3_Clock_Source
+/** @defgroup RCC_USART3_Clock_Source RCC USART3 Clock Source
   * @{
   */
 #define RCC_USART3CLKSOURCE_PCLK1        RCC_CFGR3_USART3SW_PCLK
@@ -488,7 +415,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_I2C1_Clock_Source
+/** @defgroup RCC_I2C1_Clock_Source RCC I2C1 Clock Source
   * @{
   */
 #define RCC_I2C1CLKSOURCE_HSI            RCC_CFGR3_I2C1SW_HSI
@@ -500,7 +427,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_MCOx_Index
+/** @defgroup RCC_MCOx_Index RCC MCOx Index
   * @{
   */
 #define RCC_MCO                          ((uint32_t)0x00000000)
@@ -510,29 +437,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCC_MCO_Clock_Source
-  * @{
-  */
-#define RCC_MCOSOURCE_NONE               RCC_CFGR_MCO_NOCLOCK
-#define RCC_MCOSOURCE_LSI                RCC_CFGR_MCO_LSI
-#define RCC_MCOSOURCE_LSE                RCC_CFGR_MCO_LSE
-#define RCC_MCOSOURCE_SYSCLK             RCC_CFGR_MCO_SYSCLK
-#define RCC_MCOSOURCE_HSI                RCC_CFGR_MCO_HSI
-#define RCC_MCOSOURCE_HSE                RCC_CFGR_MCO_HSE
-#define RCC_MCOSOURCE_PLLCLK_DIV2        RCC_CFGR_MCO_PLL
-
-#define IS_RCC_MCOSOURCE(SOURCE)  (((SOURCE) == RCC_MCOSOURCE_NONE)    || \
-                                   ((SOURCE) == RCC_MCOSOURCE_LSI)     || \
-                                   ((SOURCE) == RCC_MCOSOURCE_LSE)     || \
-                                   ((SOURCE) == RCC_MCOSOURCE_SYSCLK)  || \
-                                   ((SOURCE) == RCC_MCOSOURCE_HSI)     || \
-                                   ((SOURCE) == RCC_MCOSOURCE_HSE)     || \
-                                   ((SOURCE) == RCC_MCOSOURCE_PLLCLK_DIV2))
-/**
-  * @}
-  */
-
-/** @defgroup RCC_Interrupt 
+/** @defgroup RCC_Interrupt RCC Interrupt
   * @{
   */
 #define RCC_IT_LSIRDY                    ((uint32_t)0x00000001)
@@ -545,7 +450,7 @@ typedef struct
   * @}
   */  
   
-/** @defgroup RCC_Flag
+/** @defgroup RCC_Flag RCC Flag
   *        Elements values convention: 0XXYYYYYb
   *           - YYYYY  : Flag position in the register
   *           - XX  : Register index
@@ -580,16 +485,21 @@ typedef struct
   * @}
   */
 
-#define IS_RCC_CALIBRATION_VALUE(VALUE) ((VALUE) <= 0x1F)
 /**
   * @}
   */
 /* Exported macro ------------------------------------------------------------*/
 
-/** @brief  Enable or disable the AHB peripheral clock.
+/** @defgroup RCC_Exported_Macros RCC Exported Macros
+ * @{
+ */
+
+/** @defgroup RCC_AHB_Clock_Enable_Disable RCC AHB Clock Enable Disable
+  * @brief  Enable or disable the AHB peripheral clock.
   * @note   After reset, the peripheral clock (used for registers read/write access)
   *         is disabled and the application software has to enable this clock before
   *         using it.
+  * @{  
   */
 #define __GPIOA_CLK_ENABLE()         (RCC->AHBENR |= (RCC_AHBENR_GPIOAEN))
 #define __GPIOB_CLK_ENABLE()         (RCC->AHBENR |= (RCC_AHBENR_GPIOBEN))
@@ -612,11 +522,16 @@ typedef struct
 #define __SRAM_CLK_DISABLE()         (RCC->AHBENR &= ~(RCC_AHBENR_SRAMEN))
 #define __FLITF_CLK_DISABLE()        (RCC->AHBENR &= ~(RCC_AHBENR_FLITFEN))
 #define __TSC_CLK_DISABLE()          (RCC->AHBENR &= ~(RCC_AHBENR_TSCEN))
+/**
+  * @}
+  */
 
-/** @brief  Enable or disable the Low Speed APB (APB1) peripheral clock.
+/** @defgroup RCC_APB1_Clock_Enable_Disable RCC APB1 Clock Enable Disable
+  * @brief  Enable or disable the Low Speed APB (APB1) peripheral clock.
   * @note   After reset, the peripheral clock (used for registers read/write access)
   *         is disabled and the application software has to enable this clock before
   *         using it.
+  * @{   
   */
 #define __TIM2_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_TIM2EN))
 #define __TIM6_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_TIM6EN))
@@ -635,11 +550,16 @@ typedef struct
 #define __I2C1_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C1EN))
 #define __PWR_CLK_DISABLE()    (RCC->APB1ENR &= ~(RCC_APB1ENR_PWREN))
 #define __DAC1_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_DAC1EN))
-
-/** @brief  Enable or disable the High Speed APB (APB2) peripheral clock.
+/**
+  * @}
+  */
+  
+/** @defgroup RCC_APB2_Clock_Enable_Disable RCC APB2 Clock Enable Disable
+  * @brief  Enable or disable the High Speed APB (APB2) peripheral clock.
   * @note   After reset, the peripheral clock (used for registers read/write access)
   *         is disabled and the application software has to enable this clock before
   *         using it.
+  * @{   
   */
 #define __SYSCFG_CLK_ENABLE()  (RCC->APB2ENR |= (RCC_APB2ENR_SYSCFGEN))
 #define __TIM15_CLK_ENABLE()   (RCC->APB2ENR |= (RCC_APB2ENR_TIM15EN))
@@ -652,8 +572,13 @@ typedef struct
 #define __TIM16_CLK_DISABLE()  (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM16EN))
 #define __TIM17_CLK_DISABLE()  (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM17EN))
 #define __USART1_CLK_DISABLE() (RCC->APB2ENR &= ~(RCC_APB2ENR_USART1EN))
+/**
+  * @}
+  */
 
-/** @brief  Force or release AHB peripheral reset.
+/** @defgroup RCC_AHB_Force_Release_Reset RCC AHB Force Release Reset
+  * @brief  Force or release AHB peripheral reset.
+  * @{   
   */
 #define __AHB_FORCE_RESET()     (RCC->AHBRSTR = 0xFFFFFFFF)
 #define __GPIOA_FORCE_RESET()   (RCC->AHBRSTR |= (RCC_AHBRSTR_GPIOARST))
@@ -670,8 +595,13 @@ typedef struct
 #define __GPIOD_RELEASE_RESET() (RCC->AHBRSTR &= ~(RCC_AHBRSTR_GPIODRST))
 #define __GPIOF_RELEASE_RESET() (RCC->AHBRSTR &= ~(RCC_AHBRSTR_GPIOFRST))
 #define __TSC_RELEASE_RESET()   (RCC->AHBRSTR &= ~(RCC_AHBRSTR_TSCRST))
+/**
+  * @}
+  */
 
-/** @brief  Force or release APB1 peripheral reset.
+/** @defgroup RCC_APB1_Force_Release_Reset RCC APB1 Force Release Reset
+  * @brief  Force or release APB1 peripheral reset.
+  * @{   
   */
 #define __APB1_FORCE_RESET()     (RCC->APB1RSTR = 0xFFFFFFFF)
 #define __TIM2_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM2RST))
@@ -692,8 +622,13 @@ typedef struct
 #define __I2C1_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_I2C1RST))
 #define __PWR_RELEASE_RESET()    (RCC->APB1RSTR &= ~(RCC_APB1RSTR_PWRRST))
 #define __DAC1_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_DAC1RST))
+/**
+  * @}
+  */
 
-/** @brief  Force or release APB2 peripheral reset.
+/** @defgroup RCC_APB2_Force_Release_Reset RCC APB2 Force Release Reset
+  * @brief  Force or release APB2 peripheral reset.
+  * @{   
   */
 #define __APB2_FORCE_RESET()     (RCC->APB2RSTR = 0xFFFFFFFF)
 #define __SYSCFG_FORCE_RESET()   (RCC->APB2RSTR |= (RCC_APB2RSTR_SYSCFGRST))
@@ -708,6 +643,13 @@ typedef struct
 #define __TIM16_RELEASE_RESET()  (RCC->APB2RSTR &= ~(RCC_APB2RSTR_TIM16RST))
 #define __TIM17_RELEASE_RESET()  (RCC->APB2RSTR &= ~(RCC_APB2RSTR_TIM17RST))
 #define __USART1_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_USART1RST))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_HSI_Configuration RCC HSI Configuration
+  * @{   
+  */ 
 
 /** @brief  Macros to enable or disable the Internal High Speed oscillator (HSI).
   * @note   The HSI is stopped by hardware when entering STOP and STANDBY modes.
@@ -735,7 +677,13 @@ typedef struct
   */
 #define __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(__HSICalibrationValue__) \
                   MODIFY_REG(RCC->CR, RCC_CR_HSITRIM, (uint32_t)(__HSICalibrationValue__) << POSITION_VAL(RCC_CR_HSITRIM))
+/**
+  * @}
+  */
 
+/** @defgroup RCC_LSI_Configuration  RCC LSI Configuration
+  * @{   
+  */ 
 
 /** @brief  Macro to enable or disable the Internal Low Speed oscillator (LSI).
   * @note   After enabling the LSI, the application software should wait on
@@ -747,6 +695,13 @@ typedef struct
   */
 #define __HAL_RCC_LSI_ENABLE() (*(__IO uint32_t *)CSR_LSION_BB = ENABLE)
 #define __HAL_RCC_LSI_DISABLE() (*(__IO uint32_t *)CSR_LSION_BB = DISABLE)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_HSE_Configuration RCC HSE Configuration
+  * @{   
+  */ 
 
 /**
   * @brief  Macro to configure the External High Speed oscillator (HSE).
@@ -768,18 +723,13 @@ typedef struct
   *            @arg RCC_HSE_BYPASS: HSE oscillator bypassed with external clock
   */
 #define __HAL_RCC_HSE_CONFIG(__STATE__) (*(__IO uint8_t *)CR_BYTE2_ADDRESS = (__STATE__))
-
-/**
-  * @brief  Macro to configure the External High Speed oscillator (HSE) Predivision factor for PLL.
-  * @note   Predivision factor can not be changed if PLL is used as system clock
-  *         In this case, you have to select another source of the system clock, disable the PLL and
-  *         then change the HSE predivision factor.
-  * @param  __HSEPredivValue__: specifies the division value applied to HSE.
-  *         This parameter must be a number between RCC_HSE_PREDIV_DIV1 and RCC_HSE_PREDIV_DIV16.
+ /**
+  * @}
   */
-#define __HAL_RCC_HSE_PREDIV_CONFIG(__HSEPredivValue__) \
-                  MODIFY_REG(RCC->CFGR2, RCC_CFGR2_PREDIV, (uint32_t)(__HSEPredivValue__))
 
+/** @defgroup RCC_LSE_Configuration RCC LSE Configuration
+  * @{   
+  */   
 /**
   * @brief  Macro to configure the External Low Speed oscillator (LSE).
   * @note   As the LSE is in the Backup domain and write access is denied to
@@ -798,7 +748,13 @@ typedef struct
   */
 #define __HAL_RCC_LSE_CONFIG(__STATE__) \
                   MODIFY_REG(RCC->BDCR, RCC_BDCR_LSEON|RCC_BDCR_LSEBYP, (uint32_t)(__STATE__))
+/**
+  * @}
+  */
 
+/** @defgroup RCC_I2Cx_Clock_Config RCC I2Cx Clock Config
+  * @{   
+  */ 
 /** @brief Macro to configure the I2C1 clock (I2C1CLK).
   * @param  __I2C1CLKSource__: specifies the I2C1 clock source.
   *         This parameter can be one of the following values:
@@ -814,7 +770,14 @@ typedef struct
   *            @arg RCC_I2C1CLKSOURCE_SYSCLK: System Clock selected as I2C1 clock
   */
 #define __HAL_RCC_GET_I2C1_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_I2C1SW)))
+/**
+  * @}
+  */
 
+/** @defgroup RCC_USARTx_Clock_Config RCC USARTx Clock Config
+  * @{   
+  */ 
+    
 /** @brief Macro to configure the USART1 clock (USART1CLK).
   * @param  __USART1CLKSource__: specifies the USART1 clock source.
   *         This parameter can be one of the following values:
@@ -874,7 +837,13 @@ typedef struct
   *            @arg RCC_USART3CLKSOURCE_LSE: LSE selected as USART3 clock
   */
 #define __HAL_RCC_GET_USART3_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_USART3SW)))
+/**
+  * @}
+  */
 
+/** @defgroup RCC_RTC_Clock_Configuration RCC RTC Clock Configuration
+  * @{   
+  */ 
 /** @brief  Macros to enable or disable the the RTC clock.
   * @note   These macros must be used only after the RTC clock source was selected.
   */
@@ -914,6 +883,13 @@ typedef struct
   *            @arg RCC_RTCCLKSOURCE_HSE_DIV32: HSE clock divided by 32 selected as RTC clock
   */
 #define __HAL_RCC_GET_RTC_SOURCE() ((uint32_t)(READ_BIT(RCC->BDCR, RCC_BDCR_RTCSEL)))
+/**
+  * @}
+  */
+
+/** @defgroup RCC_Force_Release_Backup RCC Force Release Backup
+  * @{   
+  */ 
 
 /** @brief  Macro to force or release the Backup domain reset.
   * @note   These macros reset the RTC peripheral (including the backup registers)
@@ -922,6 +898,13 @@ typedef struct
   */
 #define __HAL_RCC_BACKUPRESET_FORCE() (*(__IO uint32_t *)BDCR_BDRST_BB = ENABLE)
 #define __HAL_RCC_BACKUPRESET_RELEASE() (*(__IO uint32_t *)BDCR_BDRST_BB = DISABLE)
+/**
+  * @}
+  */
+
+/** @defgroup RCC_PLL_Configuration RCC PLL Configuration
+  * @{   
+  */ 
 
 /** @brief  Macro to enable or disable the PLL.
   * @note   After enabling the PLL, the application software should wait on
@@ -932,22 +915,14 @@ typedef struct
   */
 #define __HAL_RCC_PLL_ENABLE() (*(__IO uint32_t *)CR_PLLON_BB = ENABLE)
 #define __HAL_RCC_PLL_DISABLE() (*(__IO uint32_t *)CR_PLLON_BB = DISABLE)
+/**
+  * @}
+  */                      
 
-/** @brief  Macro to configure the PLL clock source and multiplication factor.
-  * @note   This macro must be used only when the PLL is disabled.
-  *
-  * @param  __RCC_PLLSource__: specifies the PLL entry clock source.
-  *         This parameter can be one of the following values:
-  *            @arg RCC_PLLSOURCE_HSI: HSI oscillator clock selected as PLL clock entry
-  *            @arg RCC_PLLSOURCE_HSE: HSE oscillator clock selected as PLL clock entry
-  * @param  __PLLMUL__: specifies the multiplication factor for PLL VCO input clock
-  *         This parameter must be a number between RCC_PLL_MUL2 and RCC_PLL_MUL16.
-  *
-  */
-#define __HAL_RCC_PLL_CONFIG(__RCC_PLLSource__ , __PLLMUL__) \
-                  MODIFY_REG(RCC->CFGR, RCC_CFGR_PLLMUL | RCC_CFGR_PLLSRC, (uint32_t)((__PLLMUL__)|(__RCC_PLLSource__)))
+/** @defgroup RCC_Get_Clock_source RCC Get Clock source
+  * @{   
+  */ 
                       
-
 /** @brief  Macro to get the clock source used as system clock.
   * @retval The clock source used as system clock.
   *         The returned value can be one of the following value:
@@ -964,8 +939,11 @@ typedef struct
   *              - RCC_PLLSOURCE_HSE: HSE oscillator is used as PLL clock source.
   */
 #define __HAL_RCC_GET_PLL_OSCSOURCE() ((uint32_t)(READ_BIT(RCC->CFGR, RCC_CFGR_PLLSRC)))
+/**
+  * @}
+  */ 
 
-/** @defgroup RCC_Flags_Interrupts_Management
+/** @defgroup RCC_Flags_Interrupts_Management RCC Flags Interrupts Management
   * @brief macros to manage the specified RCC Flags and interrupts.
   * @{
   */
@@ -1052,16 +1030,36 @@ typedef struct
   * @}
   */
 
-/* Include RCC HAL Extension module */
+/**
+  * @}
+  */
+
+/* Include RCC HAL Extended module */
 #include "stm32f3xx_hal_rcc_ex.h"
 
 /* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup RCC_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup RCC_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
 
 /* Initialization and de-initialization functions  ***************************/
 void HAL_RCC_DeInit(void);
 HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef *RCC_OscInitStruct);
 HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef *RCC_ClkInitStruct, uint32_t FLatency);
 
+/**
+  * @}
+  */
+
+/** @addtogroup RCC_Exported_Functions_Group2 Peripheral Control functions
+  * @{
+  */
+  
 /* Peripheral Control functions  *********************************************/
 void     HAL_RCC_MCOConfig(uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_MCODiv);
 void     HAL_RCC_EnableCSS(void);
@@ -1078,6 +1076,14 @@ void HAL_RCC_NMI_IRQHandler(void);
 
 /* User Callbacks in non blocking mode (IT mode) */ 
 void HAL_RCC_CCSCallback(void);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_rcc_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_rcc_ex.c
@@ -2,11 +2,11 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_rcc_ex.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Extended RCC HAL module driver
   *          This file provides firmware functions to manage the following 
-  *          functionalities RCC extension peripheral:
+  *          functionalities RCC Extended peripheral:
   *           + Extended Clock Source configuration functions
   *  
   ******************************************************************************
@@ -46,7 +46,7 @@
   * @{
   */
 
-/** @defgroup RCCEx
+/** @defgroup RCCEx RCC Extended HAL module driver
   * @brief RCC Extended HAL module driver.
   * @{
   */
@@ -55,16 +55,39 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+/** @defgroup RCCEx_Private_Define RCC Extended Private Define
+  * @{
+  */
+#define HSE_TIMEOUT_VALUE          HSE_STARTUP_TIMEOUT
+#define HSI_TIMEOUT_VALUE          ((uint32_t)100)  /* 100 ms */
+#define LSI_TIMEOUT_VALUE          ((uint32_t)100)  /* 100 ms */
+#define PLL_TIMEOUT_VALUE          ((uint32_t)100)  /* 100 ms */
+#define CLOCKSWITCH_TIMEOUT_VALUE  ((uint32_t)5000) /* 5 s    */
+/**
+  * @}
+  */
+
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
-/* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/** @defgroup RCCEx_Private_Variables RCC Extented Private Variables
+  * @{
+  */
+const uint8_t PLLMULFactorTable[16] = { 2,  3,  4,  5,  6,  7,  8,  9,
+                                       10, 11, 12, 13, 14, 15, 16, 16};
+const uint8_t PredivFactorTable[16] = { 1, 2,  3,  4,  5,  6,  7,  8,
+                                         9,10, 11, 12, 13, 14, 15, 16};
+/**
+  * @}
+  */
 
-/** @defgroup RCCEx_Private_Functions
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
+
+/** @defgroup RCCEx_Exported_Functions RCC Extended Exported Functions
   * @{
   */
 
-/** @defgroup RCCEx_Group1 Extended Peripheral Control functions 
+/** @defgroup RCCEx_Exported_Functions_Group1 Extended Peripheral Control functions 
   * @brief    Extended Peripheral Control functions
   *
 @verbatim   
@@ -197,9 +220,10 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     __HAL_RCC_I2C1_CONFIG(PeriphClkInit->I2c1ClockSelection);
   }
 
-#if defined(STM32F302x8) || defined(STM32F302xC) || \
-    defined(STM32F303xC) || defined(STM32F373xC)
-
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F302x8)                         || \
+    defined(STM32F373xC)
   /*------------------------------ USB Configuration ------------------------*/ 
   if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_USB) == RCC_PERIPHCLK_USB)
   {
@@ -210,11 +234,14 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     __HAL_RCC_USB_CONFIG(PeriphClkInit->USBClockSelection);
   }
 
-#endif /* STM32F302x8 || STM32F302xC || */
-       /* STM32F303xC || STM32F373xC    */
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC || STM32F303xC || */
+       /* STM32F302x8                || */
+       /* STM32F373xC                   */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
     defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
     defined(STM32F373xC) || defined(STM32F378xx)
 
   /*------------------------------ I2C2 Configuration ------------------------*/ 
@@ -227,9 +254,13 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     __HAL_RCC_I2C2_CONFIG(PeriphClkInit->I2c2ClockSelection);
   }
 
-#endif
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+       /* STM32F373xC || STM32F378xx                   */
   
-#if defined(STM32F301x8) || defined(STM32F302x8) ||  defined(STM32F318xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 
   /*------------------------------ I2C3 Configuration ------------------------*/ 
   if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2C3) == RCC_PERIPHCLK_I2C3)
@@ -240,10 +271,11 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     /* Configure the I2C3 clock source */
     __HAL_RCC_I2C3_CONFIG(PeriphClkInit->I2c3ClockSelection);
   }
-
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
   
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
 
   /*------------------------------ UART4 Configuration ------------------------*/ 
   if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_UART4) == RCC_PERIPHCLK_UART4)
@@ -265,11 +297,12 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     __HAL_RCC_UART5_CONFIG(PeriphClkInit->Uart5ClockSelection);
   }
 
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
-    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
-
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
   /*------------------------------ I2S Configuration ------------------------*/ 
   if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_I2S) == RCC_PERIPHCLK_I2S)
   {
@@ -280,7 +313,9 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     __HAL_RCC_I2S_CONFIG(PeriphClkInit->I2sClockSelection);
   }
 
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx || STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
   
 #if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
       
@@ -296,7 +331,8 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
 
 #endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
   
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
     defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
       
   /*------------------------------ ADC1 & ADC2 clock Configuration -------------*/ 
@@ -309,10 +345,12 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     __HAL_RCC_ADC12_CONFIG(PeriphClkInit->Adc12ClockSelection);
   }
 
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx */    
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */    
   
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 
   /*------------------------------ ADC3 & ADC4 clock Configuration -------------*/ 
   if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_ADC34) == RCC_PERIPHCLK_ADC34)
@@ -324,7 +362,8 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     __HAL_RCC_ADC34_CONFIG(PeriphClkInit->Adc34ClockSelection);
   }
 
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
 #if defined(STM32F373xC) || defined(STM32F378xx)
       
@@ -340,9 +379,10 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
 
 #endif /* STM32F373xC || STM32F378xx */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
     defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 
   /*------------------------------ TIM1 clock Configuration ----------------*/ 
   if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_TIM1) == RCC_PERIPHCLK_TIM1)
@@ -354,11 +394,13 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     __HAL_RCC_TIM1_CONFIG(PeriphClkInit->Tim1ClockSelection);
   }
 
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
-
-#if defined(STM32F303xC) || defined(STM32F358xx)
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+  
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 
   /*------------------------------ TIM8 clock Configuration ----------------*/ 
   if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_TIM8) == RCC_PERIPHCLK_TIM8)
@@ -370,7 +412,8 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     __HAL_RCC_TIM8_CONFIG(PeriphClkInit->Tim8ClockSelection);
   }
 
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
 #if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 
@@ -444,6 +487,73 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
 
 #endif /* STM32F373xC || STM32F378xx */
   
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+  
+  /*------------------------------ TIM2 clock Configuration -------------------*/ 
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_TIM2) == RCC_PERIPHCLK_TIM2)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_TIM2CLKSOURCE(PeriphClkInit->Tim2ClockSelection));
+    
+    /* Configure the CEC clock source */
+    __HAL_RCC_TIM2_CONFIG(PeriphClkInit->Tim2ClockSelection);
+  }
+
+  /*------------------------------ TIM3 clock Configuration -------------------*/ 
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_TIM34) == RCC_PERIPHCLK_TIM34)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_TIM3CLKSOURCE(PeriphClkInit->Tim34ClockSelection));
+    
+    /* Configure the CEC clock source */
+    __HAL_RCC_TIM34_CONFIG(PeriphClkInit->Tim34ClockSelection);
+  }
+
+  /*------------------------------ TIM15 clock Configuration ------------------*/ 
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_TIM15) == RCC_PERIPHCLK_TIM15)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_TIM15CLKSOURCE(PeriphClkInit->Tim15ClockSelection));
+    
+    /* Configure the CEC clock source */
+    __HAL_RCC_TIM15_CONFIG(PeriphClkInit->Tim15ClockSelection);
+  }
+
+  /*------------------------------ TIM16 clock Configuration ------------------*/ 
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_TIM16) == RCC_PERIPHCLK_TIM16)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_TIM16CLKSOURCE(PeriphClkInit->Tim16ClockSelection));
+    
+    /* Configure the CEC clock source */
+    __HAL_RCC_TIM16_CONFIG(PeriphClkInit->Tim16ClockSelection);
+  }
+
+  /*------------------------------ TIM17 clock Configuration ------------------*/ 
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_TIM17) == RCC_PERIPHCLK_TIM17)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_TIM17CLKSOURCE(PeriphClkInit->Tim17ClockSelection));
+    
+    /* Configure the CEC clock source */
+    __HAL_RCC_TIM17_CONFIG(PeriphClkInit->Tim17ClockSelection);
+  }
+
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */  
+
+#if defined(STM32F303xE) || defined(STM32F398xx)
+  /*------------------------------ TIM20 clock Configuration ------------------*/ 
+  if(((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_TIM20) == RCC_PERIPHCLK_TIM20)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_TIM20CLKSOURCE(PeriphClkInit->Tim20ClockSelection));
+    
+    /* Configure the CEC clock source */
+    __HAL_RCC_TIM20_CONFIG(PeriphClkInit->Tim20ClockSelection);
+  }
+#endif /* STM32F303xE || STM32F398xx */  
+
+  
   return HAL_OK;
 }
 
@@ -473,36 +583,46 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
   /* Get the I2C1 clock configuration -----------------------------------------*/
   PeriphClkInit->I2c1ClockSelection = __HAL_RCC_GET_I2C1_SOURCE();
 
-#if defined(STM32F302x8) || defined(STM32F302xC) || \
-    defined(STM32F303xC) || defined(STM32F373xC)
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F302x8)                         || \
+    defined(STM32F373xC)
 
   PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_USB;
   /* Get the USB clock configuration -----------------------------------------*/
   PeriphClkInit->USBClockSelection = __HAL_RCC_GET_USB_SOURCE();
 
-#endif /* STM32F302x8 || STM32F302xC || */
-       /* STM32F303xC || STM32F373xC    */
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC || STM32F303xC || */
+       /* STM32F302x8                || */
+       /* STM32F373xC                   */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
     defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
     defined(STM32F373xC) || defined(STM32F378xx)
 
   PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_I2C2;
   /* Get the I2C2 clock configuration -----------------------------------------*/
   PeriphClkInit->I2c2ClockSelection = __HAL_RCC_GET_I2C2_SOURCE();
 
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx || STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F373xC || STM32F378xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+       /* STM32F373xC || STM32F378xx                   */
   
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 
   PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_I2C3;
   /* Get the I2C3 clock configuration -----------------------------------------*/
   PeriphClkInit->I2c3ClockSelection = __HAL_RCC_GET_I2C3_SOURCE();
 
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
   
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) ||defined(STM32F358xx)
 
   PeriphClkInit->PeriphClockSelection |= (RCC_PERIPHCLK_UART4  | RCC_PERIPHCLK_UART5);
   /* Get the UART4 clock configuration -----------------------------------------*/
@@ -510,16 +630,20 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
   /* Get the UART5 clock configuration -----------------------------------------*/
   PeriphClkInit->Uart5ClockSelection = __HAL_RCC_GET_UART5_SOURCE();
 
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
-    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 
   PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_I2S;
   /* Get the I2S clock configuration -----------------------------------------*/
   PeriphClkInit->I2sClockSelection = __HAL_RCC_GET_I2S_SOURCE();
 
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx || STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
   
 #if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
     defined(STM32F373xC) || defined(STM32F378xx)
@@ -528,37 +652,54 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
   /* Get the ADC1 clock configuration -----------------------------------------*/
   PeriphClkInit->Adc1ClockSelection = __HAL_RCC_GET_ADC1_SOURCE();
 
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx || STM32F373xC || STM32F378xx */
+#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
     defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 
   PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_ADC12;
   /* Get the ADC1 & ADC2 clock configuration -----------------------------------------*/
   PeriphClkInit->Adc12ClockSelection = __HAL_RCC_GET_ADC12_SOURCE();
 
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx  || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
 
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 
   PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_ADC34;
    /* Get the ADC3 & ADC4 clock configuration -----------------------------------------*/
   PeriphClkInit->Adc34ClockSelection = __HAL_RCC_GET_ADC34_SOURCE();
 
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
     defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 
   PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_TIM1;
   /* Get the TIM1 clock configuration -----------------------------------------*/
   PeriphClkInit->Tim1ClockSelection = __HAL_RCC_GET_TIM1_SOURCE();
 
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+  
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+
+  PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_TIM8;
+  /* Get the TIM8 clock configuration -----------------------------------------*/
+  PeriphClkInit->Tim8ClockSelection = __HAL_RCC_GET_TIM8_SOURCE();
+
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
 #if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 
@@ -571,14 +712,6 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
   PeriphClkInit->Tim17ClockSelection = __HAL_RCC_GET_TIM17_SOURCE();
 
 #endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
-
-#if defined(STM32F303xC) || defined(STM32F358xx)
-
-  PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_TIM8;
-  /* Get the TIM8 clock configuration -----------------------------------------*/
-  PeriphClkInit->Tim8ClockSelection = __HAL_RCC_GET_TIM8_SOURCE();
-
-#endif /* STM32F303xC || STM32F358xx */
 
 #if defined(STM32F334x8)
 
@@ -600,6 +733,568 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
 
 #endif /* STM32F373xC || STM32F378xx */
 
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+
+  PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_TIM2;
+  /* Get the TIM2 clock configuration -----------------------------------------*/
+  PeriphClkInit->Tim2ClockSelection = __HAL_RCC_GET_TIM2_SOURCE();
+
+  PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_TIM34;
+  /* Get the TIM3 clock configuration -----------------------------------------*/
+  PeriphClkInit->Tim34ClockSelection = __HAL_RCC_GET_TIM34_SOURCE();
+
+  PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_TIM15;
+  /* Get the TIM15 clock configuration -----------------------------------------*/
+  PeriphClkInit->Tim15ClockSelection = __HAL_RCC_GET_TIM15_SOURCE();
+
+  PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_TIM16;
+  /* Get the TIM16 clock configuration -----------------------------------------*/
+  PeriphClkInit->Tim16ClockSelection = __HAL_RCC_GET_TIM16_SOURCE();
+
+  PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_TIM17;
+  /* Get the TIM17 clock configuration -----------------------------------------*/
+  PeriphClkInit->Tim17ClockSelection = __HAL_RCC_GET_TIM17_SOURCE();
+
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+  
+#if defined (STM32F303xE) || defined(STM32F398xx)
+  PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_TIM20;
+  /* Get the TIM20 clock configuration -----------------------------------------*/
+  PeriphClkInit->Tim20ClockSelection = __HAL_RCC_GET_TIM20_SOURCE();
+#endif /* STM32F303xE || STM32F398xx */
+}
+
+/**
+  * @brief  Initializes the RCC Oscillators according to the specified parameters in the
+  *         RCC_OscInitTypeDef.
+  * @param  RCC_OscInitStruct: pointer to an RCC_OscInitTypeDef structure that
+  *         contains the configuration information for the RCC Oscillators.
+  * @note   The PLL is not disabled when used as system clock.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
+{
+  uint32_t tickstart = 0;
+
+  /* Check the parameters */
+  assert_param(RCC_OscInitStruct != HAL_NULL);
+  assert_param(IS_RCC_OSCILLATORTYPE(RCC_OscInitStruct->OscillatorType));
+  /*------------------------------- HSE Configuration ------------------------*/
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_HSE) == RCC_OSCILLATORTYPE_HSE)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_HSE(RCC_OscInitStruct->HSEState));
+    /* When the HSE is used as system clock or clock source for PLL in these cases HSE will not disabled */
+    if((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_HSE) ||
+       ((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_PLLCLK) && (__HAL_RCC_GET_PLL_OSCSOURCE() == RCC_PLLSOURCE_HSE)))
+    {
+      if((__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != RESET) && (RCC_OscInitStruct->HSEState != RCC_HSE_ON))
+      {
+        return HAL_ERROR;
+      }
+    }
+    else
+    {
+      /* Reset HSEON and HSEBYP bits before configuring the HSE --------------*/
+      __HAL_RCC_HSE_CONFIG(RCC_HSE_OFF);
+      
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      /* Wait till HSE is bypassed or disabled */
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != RESET)
+      {
+        if((HAL_GetTick()-tickstart) > HSE_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+
+      /* Set the new HSE configuration ---------------------------------------*/
+      __HAL_RCC_HSE_CONFIG(RCC_OscInitStruct->HSEState);
+
+#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
+      /* Configure the HSE predivision factor --------------------------------*/
+      __HAL_RCC_HSE_PREDIV_CONFIG(RCC_OscInitStruct->HSEPredivValue);
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+       /* STM32F373xC || STM32F378xx                   */
+
+      /* Check the HSE State */
+      if(RCC_OscInitStruct->HSEState == RCC_HSE_ON)
+      {
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+        
+        /* Wait till HSE is ready */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) == RESET)
+        {
+          if((HAL_GetTick()-tickstart) > HSE_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+      else
+      {
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+
+        /* Wait till HSE is bypassed or disabled */
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != RESET)
+        {
+          if((HAL_GetTick()-tickstart) > HSE_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+    }
+  }
+  /*----------------------------- HSI Configuration --------------------------*/
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_HSI) == RCC_OSCILLATORTYPE_HSI)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_HSI(RCC_OscInitStruct->HSIState));
+    assert_param(IS_RCC_CALIBRATION_VALUE(RCC_OscInitStruct->HSICalibrationValue));
+
+    /* Check if HSI is used as system clock or as PLL source when PLL is selected as system clock */    
+    if((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_HSI) ||
+       ((__HAL_RCC_GET_SYSCLK_SOURCE() == RCC_SYSCLKSOURCE_STATUS_PLLCLK) && (__HAL_RCC_GET_PLL_OSCSOURCE() == RCC_PLLSOURCE_HSI)))
+    {
+      /* When the HSI is used as system clock it is not allowed to be disabled */
+      if((__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) != RESET) && (RCC_OscInitStruct->HSIState != RCC_HSI_ON))
+      {
+        return HAL_ERROR;
+      }
+      /* Otherwise, just the calibration is allowed */
+      else
+      {
+        /* Adjusts the Internal High Speed oscillator (HSI) calibration value.*/
+        __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->HSICalibrationValue);
+      }
+    }
+    else
+    {
+      /* Check the HSI State */
+      if(RCC_OscInitStruct->HSIState != RCC_HSI_OFF)
+      {
+        /* Enable the Internal High Speed oscillator (HSI). */
+        __HAL_RCC_HSI_ENABLE();
+
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+
+        /* Wait till HSI is ready */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) == RESET)
+        {
+          if((HAL_GetTick()-tickstart) > HSI_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }      
+        } 
+
+        /* Adjusts the Internal High Speed oscillator (HSI) calibration value.*/
+        __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(RCC_OscInitStruct->HSICalibrationValue);
+      }
+      else
+      {
+        /* Disable the Internal High Speed oscillator (HSI). */
+        __HAL_RCC_HSI_DISABLE();
+
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+      
+        /* Wait till HSI is ready */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSIRDY) != RESET)
+        {
+          if((HAL_GetTick()-tickstart) > HSI_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+    }
+  }
+  /*------------------------------ LSI Configuration -------------------------*/
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_LSI) == RCC_OSCILLATORTYPE_LSI)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_LSI(RCC_OscInitStruct->LSIState));
+
+    /* Check the LSI State */
+    if(RCC_OscInitStruct->LSIState != RCC_LSI_OFF)
+    {
+      /* Enable the Internal Low Speed oscillator (LSI). */
+      __HAL_RCC_LSI_ENABLE();
+      
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      /* Wait till LSI is ready */  
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY) == RESET)
+      {
+        if((HAL_GetTick()-tickstart) > LSI_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+    else
+    {
+      /* Disable the Internal Low Speed oscillator (LSI). */
+      __HAL_RCC_LSI_DISABLE();
+      
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      /* Wait till LSI is ready */  
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY) != RESET)
+      {
+        if((HAL_GetTick()-tickstart) > LSI_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  /*------------------------------ LSE Configuration -------------------------*/
+  if(((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_LSE) == RCC_OSCILLATORTYPE_LSE)
+  {
+    /* Check the parameters */
+    assert_param(IS_RCC_LSE(RCC_OscInitStruct->LSEState));
+    
+    /* Enable Power Clock*/
+    __PWR_CLK_ENABLE();
+    
+    /* Enable write access to Backup domain */
+    SET_BIT(PWR->CR, PWR_CR_DBP);
+    
+    /* Wait for Backup domain Write protection disable */
+    tickstart = HAL_GetTick();
+    
+    while((PWR->CR & PWR_CR_DBP) == RESET)
+    {
+      if((HAL_GetTick()-tickstart) > DBP_TIMEOUT_VALUE)
+      {
+        return HAL_TIMEOUT;
+      }      
+    }
+
+    /* Reset LSEON and LSEBYP bits before configuring the LSE ----------------*/
+    __HAL_RCC_LSE_CONFIG(RCC_LSE_OFF);
+    
+    /* Get timeout */
+    tickstart = HAL_GetTick();
+      
+    /* Wait till LSE is ready */  
+    while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) != RESET)
+    {
+      if((HAL_GetTick()-tickstart) > LSE_TIMEOUT_VALUE)
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Set the new LSE configuration -----------------------------------------*/
+    __HAL_RCC_LSE_CONFIG(RCC_OscInitStruct->LSEState);
+    /* Check the LSE State */
+    if(RCC_OscInitStruct->LSEState == RCC_LSE_ON)
+    {
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      /* Wait till LSE is ready */  
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) == RESET)
+      {
+        if((HAL_GetTick()-tickstart) > LSE_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+    else
+    {
+      /* Get timeout */
+      tickstart = HAL_GetTick();
+      
+      /* Wait till LSE is ready */  
+      while(__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) != RESET)
+      {
+        if((HAL_GetTick()-tickstart) > LSE_TIMEOUT_VALUE)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  /*-------------------------------- PLL Configuration -----------------------*/
+  /* Check the parameters */
+  assert_param(IS_RCC_PLL(RCC_OscInitStruct->PLL.PLLState));
+  if ((RCC_OscInitStruct->PLL.PLLState) != RCC_PLL_NONE)
+  {
+    /* Check if the PLL is used as system clock or not */
+    if(__HAL_RCC_GET_SYSCLK_SOURCE() != RCC_SYSCLKSOURCE_STATUS_PLLCLK)
+    {
+      if((RCC_OscInitStruct->PLL.PLLState) == RCC_PLL_ON)
+      {
+        /* Check the parameters */
+        assert_param(IS_RCC_PLLSOURCE(RCC_OscInitStruct->PLL.PLLSource));
+        assert_param(IS_RCC_PLL_MUL(RCC_OscInitStruct->PLL.PLLMUL));
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+        assert_param(IS_RCC_PREDIV(RCC_OscInitStruct->PLL.PREDIV));
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+
+        /* Disable the main PLL. */
+        __HAL_RCC_PLL_DISABLE();
+
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+        
+        /* Wait till PLL is ready */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) != RESET)
+        {
+          if((HAL_GetTick()-tickstart) > PLL_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
+      /* Configure the main PLL clock source and multiplication factor. */
+      __HAL_RCC_PLL_CONFIG(RCC_OscInitStruct->PLL.PLLSource,
+                           RCC_OscInitStruct->PLL.PLLMUL);
+#else
+        /* Configure the main PLL clock source, predivider and multiplication factor. */
+        __HAL_RCC_PLL_CONFIG(RCC_OscInitStruct->PLL.PLLSource,
+                             RCC_OscInitStruct->PLL.PREDIV,
+                             RCC_OscInitStruct->PLL.PLLMUL);
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+       /* STM32F373xC || STM32F378xx                   */
+        
+        /* Enable the main PLL. */
+        __HAL_RCC_PLL_ENABLE();
+
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+      
+        /* Wait till PLL is ready */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) == RESET)
+        {
+          if((HAL_GetTick()-tickstart) > PLL_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+      else
+      {
+        /* Disable the main PLL. */
+        __HAL_RCC_PLL_DISABLE();
+        /* Get timeout */
+        tickstart = HAL_GetTick();
+      
+        /* Wait till PLL is ready */  
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_PLLRDY) != RESET)
+        {
+          if((HAL_GetTick()-tickstart) > PLL_TIMEOUT_VALUE)
+          {
+            return HAL_TIMEOUT;
+          }
+        }
+      }
+    }
+    else
+    {
+      return HAL_ERROR;
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the RCC_OscInitStruct according to the internal
+  * RCC configuration registers.
+  * @param  RCC_OscInitStruct: pointer to an RCC_OscInitTypeDef structure that
+  * will be configured.
+  * @retval None
+  */
+void HAL_RCC_GetOscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
+{
+  /* Check the parameters */
+  assert_param(RCC_OscInitStruct != HAL_NULL);
+
+  /* Set all possible values for the Oscillator type parameter ---------------*/
+  RCC_OscInitStruct->OscillatorType = RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_LSE | RCC_OSCILLATORTYPE_LSI;
+
+  /* Get the HSE configuration -----------------------------------------------*/
+  if((RCC->CR & RCC_CR_HSEBYP) == RCC_CR_HSEBYP)
+  {
+    RCC_OscInitStruct->HSEState = RCC_HSE_BYPASS;
+  }
+  else if((RCC->CR & RCC_CR_HSEON) == RCC_CR_HSEON)
+  {
+    RCC_OscInitStruct->HSEState = RCC_HSE_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->HSEState = RCC_HSE_OFF;
+  }
+  
+#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
+  RCC_OscInitStruct->HSEPredivValue = (uint32_t)(RCC->CFGR2 & RCC_CFGR2_PREDIV);
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+       /* STM32F373xC || STM32F378xx                   */
+
+  /* Get the HSI configuration -----------------------------------------------*/
+  if((RCC->CR & RCC_CR_HSION) == RCC_CR_HSION)
+  {
+    RCC_OscInitStruct->HSIState = RCC_HSI_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->HSIState = RCC_HSI_OFF;
+  }
+
+  RCC_OscInitStruct->HSICalibrationValue = (uint32_t)((RCC->CR &RCC_CR_HSITRIM) >> POSITION_VAL(RCC_CR_HSITRIM));
+
+  /* Get the LSE configuration -----------------------------------------------*/
+  if((RCC->BDCR & RCC_BDCR_LSEBYP) == RCC_BDCR_LSEBYP)
+  {
+    RCC_OscInitStruct->LSEState = RCC_LSE_BYPASS;
+  }
+  else if((RCC->BDCR & RCC_BDCR_LSEON) == RCC_BDCR_LSEON)
+  {
+    RCC_OscInitStruct->LSEState = RCC_LSE_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->LSEState = RCC_LSE_OFF;
+  }
+
+  /* Get the LSI configuration -----------------------------------------------*/
+  if((RCC->CSR & RCC_CSR_LSION) == RCC_CSR_LSION)
+  {
+    RCC_OscInitStruct->LSIState = RCC_LSI_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->LSIState = RCC_LSI_OFF;
+  }
+
+  /* Get the PLL configuration -----------------------------------------------*/
+  if((RCC->CR & RCC_CR_PLLON) == RCC_CR_PLLON)
+  {
+    RCC_OscInitStruct->PLL.PLLState = RCC_PLL_ON;
+  }
+  else
+  {
+    RCC_OscInitStruct->PLL.PLLState = RCC_PLL_OFF;
+  }
+  
+  RCC_OscInitStruct->PLL.PLLSource = (uint32_t)(RCC->CFGR & RCC_CFGR_PLLSRC);
+  RCC_OscInitStruct->PLL.PLLMUL = (uint32_t)(RCC->CFGR & RCC_CFGR_PLLMUL);
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+  RCC_OscInitStruct->PLL.PREDIV = (uint32_t)(RCC->CFGR2 & RCC_CFGR2_PREDIV);
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+}
+
+/**
+  * @brief  Returns the SYSCLK frequency
+  * @note   The system frequency computed by this function is not the real
+  *         frequency in the chip. It is calculated based on the predefined
+  *         constant and the selected clock source:
+  * @note     If SYSCLK source is HSI, function returns values based on HSI_VALUE(*)
+  * @note     If SYSCLK source is HSE, function returns values based on HSE_VALUE
+  *           divided by PREDIV factor(**)
+  * @note     If SYSCLK source is PLL, function returns values based on HSE_VALUE
+  *           divided by PREDIV factor(**) or HSI_VALUE(*) multiplied by the PLL factor.
+  * @note     (*) HSI_VALUE is a constant defined in stm32f3xx.h file (default value
+  *               8 MHz).
+  * @note     (**) HSE_VALUE is a constant defined in stm32f3xx.h file (default value
+  *                8 MHz), user has to ensure that HSE_VALUE is same as the real
+  *                frequency of the crystal used. Otherwise, this function may
+  *                have wrong result.
+  *
+  * @note   The result of this function could be not correct when using fractional
+  *         value for HSE crystal.
+  *
+  * @note   This function can be used by the user application to compute the
+  *         baudrate for the communication peripherals or configure other parameters.
+  *
+  * @note   Each time SYSCLK changes, this function must be called to update the
+  *         right SYSCLK value. Otherwise, any configuration based on this function will be incorrect.
+  *
+  * @retval SYSCLK frequency
+  */
+uint32_t HAL_RCC_GetSysClockFreq(void)
+{
+  uint32_t tmpreg = 0, prediv = 0, pllmul = 0, pllclk = 0;
+  uint32_t sysclockfreq = 0;
+  
+  tmpreg = RCC->CFGR;
+
+  /* Get SYSCLK source -------------------------------------------------------*/
+  switch (tmpreg & RCC_CFGR_SWS)
+  {
+  case RCC_SYSCLKSOURCE_STATUS_HSE:    /* HSE used as system clock  source */
+    sysclockfreq = HSE_VALUE;
+    break;
+
+  case RCC_SYSCLKSOURCE_STATUS_PLLCLK: /* PLL used as system clock  source */
+    pllmul = PLLMULFactorTable[(uint32_t)(tmpreg & RCC_CFGR_PLLMUL) >> POSITION_VAL(RCC_CFGR_PLLMUL)];
+    prediv = PredivFactorTable[(uint32_t)(RCC->CFGR2 & RCC_CFGR2_PREDIV) >> POSITION_VAL(RCC_CFGR2_PREDIV)];
+#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
+    if ((tmpreg & RCC_CFGR_PLLSRC) != RCC_PLLSOURCE_HSI)
+    {
+      /* HSE used as PLL clock source : PLLCLK = HSE/PREDIV * PLLMUL */
+      pllclk = (HSE_VALUE/prediv) * pllmul;
+    }
+    else
+    {
+      /* HSI used as PLL clock source : PLLCLK = HSI/2 * PLLMUL */
+      pllclk = (HSI_VALUE >> 1) * pllmul;
+    }
+#else
+    if ((tmpreg & RCC_CFGR_PLLSRC_HSE_PREDIV) == RCC_CFGR_PLLSRC_HSE_PREDIV)
+    {
+      /* HSE used as PLL clock source : PLLCLK = HSE/PREDIV * PLLMUL */
+      pllclk = (HSE_VALUE/prediv) * pllmul;
+    }
+    else
+    {
+      /* HSI used as PLL clock source : PLLCLK = HSI/PREDIV * PLLMUL */
+      pllclk = (HSI_VALUE/prediv) * pllmul;
+    }
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+       /* STM32F373xC || STM32F378xx                   */
+    sysclockfreq = pllclk;
+    break;
+
+  case RCC_SYSCLKSOURCE_STATUS_HSI:    /* HSI used as system clock source */
+  default:
+    sysclockfreq = HSI_VALUE;
+    break;
+  }
+  return sysclockfreq;
 }
 
 /**

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_rcc_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_rcc_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_rcc_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of RCC HAL Extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of RCC HAL Extended module.
   ******************************************************************************
   * @attention
   *
@@ -50,11 +50,117 @@
   * @{
   */
 
-/** @addtogroup RCC
+/** @addtogroup RCCEx
   * @{
   */
 
 /* Exported types ------------------------------------------------------------*/
+
+/** @defgroup RCCEx_Exported_Types RCC Extended Exported Types
+  * @{
+  */
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+/**
+  * @brief  RCC PLL configuration structure definition
+  */
+typedef struct
+{
+  uint32_t PLLState;   /*!< PLLState: The new state of the PLL.
+                            This parameter can be a value of @ref RCC_PLL_Config */
+
+  uint32_t PLLSource;  /*!< PLLSource: PLL entry clock source.
+                            This parameter must be a value of @ref RCCEx_PLL_Clock_Source */
+
+  uint32_t PLLMUL;     /*!< PLLMUL: Multiplication factor for PLL VCO input clock
+                            This parameter must be a value of @ref RCC_PLL_Multiplication_Factor*/
+
+  uint32_t PREDIV;     /*!< PREDIV: Predivision factor for PLL VCO input clock
+                            This parameter must be a value of @ref RCCEx_PLL_Prediv_Factor */
+
+}RCC_PLLInitTypeDef;
+
+/**
+  * @brief  RCC Internal/External Oscillator (HSE, HSI, LSE and LSI) configuration structure definition
+  */
+typedef struct
+{
+  uint32_t OscillatorType;       /*!< The oscillators to be configured.
+                                      This parameter can be a value of @ref RCC_Oscillator_Type */
+
+  uint32_t HSEState;             /*!< The new state of the HSE.
+                                      This parameter can be a value of @ref RCC_HSE_Config */
+
+  uint32_t LSEState;             /*!<  The new state of the LSE.
+                                       This parameter can be a value of @ref RCC_LSE_Config */
+
+  uint32_t HSIState;             /*!< The new state of the HSI.
+                                      This parameter can be a value of @ref RCC_HSI_Config */
+
+  uint32_t HSICalibrationValue;  /*!< The calibration trimming value.
+                                      This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x1F */
+
+  uint32_t LSIState;             /*!<  The new state of the LSI.
+                                       This parameter can be a value of @ref RCC_LSI_Config */
+
+  RCC_PLLInitTypeDef PLL;        /*!< PLL structure parameters */
+
+}RCC_OscInitTypeDef;
+
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+   
+#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
+/**
+  * @brief  RCC PLL configuration structure definition
+  */
+typedef struct
+{
+  uint32_t PLLState;   /*!< PLLState: The new state of the PLL.
+                            This parameter can be a value of @ref RCC_PLL_Config */
+
+  uint32_t PLLSource;  /*!< PLLSource: PLL entry clock source.
+                            This parameter must be a value of @ref RCCEx_PLL_Clock_Source */
+
+  uint32_t PLLMUL;     /*!< PLLMUL: Multiplication factor for PLL VCO input clock
+                            This parameter must be a value of @ref RCC_PLL_Multiplication_Factor*/
+
+}RCC_PLLInitTypeDef;
+
+/**
+  * @brief  RCC Internal/External Oscillator (HSE, HSI, LSE and LSI) configuration structure definition
+  */
+typedef struct
+{
+  uint32_t OscillatorType;       /*!< The oscillators to be configured.
+                                      This parameter can be a value of @ref RCC_Oscillator_Type */
+
+  uint32_t HSEState;             /*!< The new state of the HSE.
+                                      This parameter can be a value of @ref RCC_HSE_Config */
+
+  uint32_t HSEPredivValue;       /*!<  The HSE predivision factor value.
+                                       This parameter can be a value of @ref RCCEx_HSE_Predivision_Factor */
+
+  uint32_t LSEState;             /*!<  The new state of the LSE.
+                                       This parameter can be a value of @ref RCC_LSE_Config */
+
+  uint32_t HSIState;             /*!< The new state of the HSI.
+                                      This parameter can be a value of @ref RCC_HSI_Config */
+
+  uint32_t HSICalibrationValue;  /*!< The calibration trimming value.
+                                      This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x1F */
+
+  uint32_t LSIState;             /*!<  The new state of the LSI.
+                                       This parameter can be a value of @ref RCC_LSI_Config */
+
+  RCC_PLLInitTypeDef PLL;        /*!< PLL structure parameters */
+
+}RCC_OscInitTypeDef;
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+       /* STM32F373xC || STM32F378xx                   */
 
 /** 
   * @brief  RCC extended clocks structure definition  
@@ -253,6 +359,210 @@ typedef struct
 }RCC_PeriphCLKInitTypeDef;
 #endif /* STM32F303xC */
 
+#if defined(STM32F302xE)
+typedef struct
+{
+  uint32_t PeriphClockSelection; /*!< The Extended Clock to be configured.
+                                      This parameter can be a value of @ref RCCEx_Periph_Clock_Selection */
+
+  uint32_t RTCClockSelection;      /*!< Specifies RTC Clock Prescalers Selection 
+                                      This parameter can be a value of @ref RCC_RTC_Clock_Source */
+
+  uint32_t Usart1ClockSelection; /*!< USART1 clock source
+                                      This parameter can be a value of @ref RCCEx_USART1_Clock_Source */
+
+  uint32_t Usart2ClockSelection; /*!< USART2 clock source
+                                      This parameter can be a value of @ref RCC_USART2_Clock_Source */
+
+  uint32_t Usart3ClockSelection; /*!< USART3 clock source
+                                      This parameter can be a value of @ref RCC_USART3_Clock_Source */
+
+  uint32_t Uart4ClockSelection;  /*!< UART4 clock source
+                                      This parameter can be a value of @ref RCCEx_UART4_Clock_Source */
+
+  uint32_t Uart5ClockSelection;  /*!< UART5 clock source
+                                      This parameter can be a value of @ref RCCEx_UART5_Clock_Source */
+
+  uint32_t I2c1ClockSelection;   /*!< I2C1 clock source
+                                      This parameter can be a value of @ref RCC_I2C1_Clock_Source */
+
+  uint32_t I2c2ClockSelection;   /*!< I2C2 clock source
+                                      This parameter can be a value of @ref RCCEx_I2C2_Clock_Source */
+
+  uint32_t I2c3ClockSelection;   /*!< I2C3 clock source      
+                                      This parameter can be a value of @ref RCCEx_I2C3_Clock_Source */
+
+  uint32_t Adc12ClockSelection;  /*!< ADC1 & ADC2 clock source
+                                      This parameter can be a value of @ref RCCEx_ADC12_Clock_Source */
+
+  uint32_t I2sClockSelection;    /*!< I2S clock source
+                                      This parameter can be a value of @ref RCCEx_I2S_Clock_Source */
+
+  uint32_t Tim1ClockSelection;   /*!< TIM1 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM1_Clock_Source */
+
+  uint32_t Tim2ClockSelection;   /*!< TIM2 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM2_Clock_Source */
+
+  uint32_t Tim34ClockSelection;   /*!< TIM3 & TIM4 clock source
+                                       This parameter can be a value of @ref RCCEx_TIM34_Clock_Source */
+				       
+  uint32_t Tim15ClockSelection;  /*!< TIM15 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM15_Clock_Source */
+
+  uint32_t Tim16ClockSelection;  /*!< TIM16 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM16_Clock_Source */
+
+  uint32_t Tim17ClockSelection;  /*!< TIM17 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM17_Clock_Source */
+
+  uint32_t USBClockSelection;    /*!< USB clock source      
+                                      This parameter can be a value of @ref RCCEx_USB_Clock_Source */
+
+}RCC_PeriphCLKInitTypeDef;
+#endif /* STM32F302xE */
+
+#if defined(STM32F303xE)
+typedef struct
+{
+  uint32_t PeriphClockSelection; /*!< The Extended Clock to be configured.
+                                      This parameter can be a value of @ref RCCEx_Periph_Clock_Selection */
+
+  uint32_t RTCClockSelection;      /*!< Specifies RTC Clock Prescalers Selection 
+                                      This parameter can be a value of @ref RCC_RTC_Clock_Source */
+
+  uint32_t Usart1ClockSelection; /*!< USART1 clock source
+                                      This parameter can be a value of @ref RCCEx_USART1_Clock_Source */
+
+  uint32_t Usart2ClockSelection; /*!< USART2 clock source
+                                      This parameter can be a value of @ref RCC_USART2_Clock_Source */
+
+  uint32_t Usart3ClockSelection; /*!< USART3 clock source
+                                      This parameter can be a value of @ref RCC_USART3_Clock_Source */
+
+  uint32_t Uart4ClockSelection;  /*!< UART4 clock source
+                                      This parameter can be a value of @ref RCCEx_UART4_Clock_Source */
+
+  uint32_t Uart5ClockSelection;  /*!< UART5 clock source
+                                      This parameter can be a value of @ref RCCEx_UART5_Clock_Source */
+
+  uint32_t I2c1ClockSelection;   /*!< I2C1 clock source
+                                      This parameter can be a value of @ref RCC_I2C1_Clock_Source */
+
+  uint32_t I2c2ClockSelection;   /*!< I2C2 clock source
+                                      This parameter can be a value of @ref RCCEx_I2C2_Clock_Source */
+
+  uint32_t I2c3ClockSelection;   /*!< I2C3 clock source      
+                                      This parameter can be a value of @ref RCCEx_I2C3_Clock_Source */
+
+  uint32_t Adc12ClockSelection;  /*!< ADC1 & ADC2 clock source
+                                      This parameter can be a value of @ref RCCEx_ADC12_Clock_Source */
+
+  uint32_t Adc34ClockSelection;  /*!< ADC3 & ADC4 clock source
+                                      This parameter can be a value of @ref RCCEx_ADC34_Clock_Source */
+
+  uint32_t I2sClockSelection;    /*!< I2S clock source
+                                      This parameter can be a value of @ref RCCEx_I2S_Clock_Source */
+
+  uint32_t Tim1ClockSelection;   /*!< TIM1 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM1_Clock_Source */
+
+  uint32_t Tim2ClockSelection;   /*!< TIM2 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM2_Clock_Source */
+
+  uint32_t Tim34ClockSelection;   /*!< TIM3 & TIM4 clock source
+                                       This parameter can be a value of @ref RCCEx_TIM34_Clock_Source */
+
+  uint32_t Tim8ClockSelection;   /*!< TIM8 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM8_Clock_Source */
+
+  uint32_t Tim15ClockSelection;  /*!< TIM15 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM15_Clock_Source */
+
+  uint32_t Tim16ClockSelection;  /*!< TIM16 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM16_Clock_Source */
+
+  uint32_t Tim17ClockSelection;  /*!< TIM17 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM17_Clock_Source */
+
+  uint32_t Tim20ClockSelection;  /*!< TIM20 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM20_Clock_Source */
+
+  uint32_t USBClockSelection;    /*!< USB clock source      
+                                      This parameter can be a value of @ref RCCEx_USB_Clock_Source */
+
+}RCC_PeriphCLKInitTypeDef;
+#endif /* STM32F303xE */
+
+#if defined(STM32F398xx)
+typedef struct
+{
+  uint32_t PeriphClockSelection; /*!< The Extended Clock to be configured.
+                                      This parameter can be a value of @ref RCCEx_Periph_Clock_Selection */
+
+  uint32_t RTCClockSelection;      /*!< Specifies RTC Clock Prescalers Selection 
+                                      This parameter can be a value of @ref RCC_RTC_Clock_Source */
+
+  uint32_t Usart1ClockSelection; /*!< USART1 clock source
+                                      This parameter can be a value of @ref RCCEx_USART1_Clock_Source */
+
+  uint32_t Usart2ClockSelection; /*!< USART2 clock source
+                                      This parameter can be a value of @ref RCC_USART2_Clock_Source */
+
+  uint32_t Usart3ClockSelection; /*!< USART3 clock source
+                                      This parameter can be a value of @ref RCC_USART3_Clock_Source */
+
+  uint32_t Uart4ClockSelection;  /*!< UART4 clock source
+                                      This parameter can be a value of @ref RCCEx_UART4_Clock_Source */
+
+  uint32_t Uart5ClockSelection;  /*!< UART5 clock source
+                                      This parameter can be a value of @ref RCCEx_UART5_Clock_Source */
+
+  uint32_t I2c1ClockSelection;   /*!< I2C1 clock source
+                                      This parameter can be a value of @ref RCC_I2C1_Clock_Source */
+
+  uint32_t I2c2ClockSelection;   /*!< I2C2 clock source
+                                      This parameter can be a value of @ref RCCEx_I2C2_Clock_Source */
+
+  uint32_t I2c3ClockSelection;   /*!< I2C3 clock source      
+                                      This parameter can be a value of @ref RCCEx_I2C3_Clock_Source */
+
+  uint32_t Adc12ClockSelection;  /*!< ADC1 & ADC2 clock source
+                                      This parameter can be a value of @ref RCCEx_ADC12_Clock_Source */
+
+  uint32_t Adc34ClockSelection;  /*!< ADC3 & ADC4 clock source
+                                      This parameter can be a value of @ref RCCEx_ADC34_Clock_Source */
+
+  uint32_t I2sClockSelection;    /*!< I2S clock source
+                                      This parameter can be a value of @ref RCCEx_I2S_Clock_Source */
+
+  uint32_t Tim1ClockSelection;   /*!< TIM1 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM1_Clock_Source */
+
+  uint32_t Tim2ClockSelection;   /*!< TIM2 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM2_Clock_Source */
+
+  uint32_t Tim34ClockSelection;   /*!< TIM3 & TIM4 clock source
+                                       This parameter can be a value of @ref RCCEx_TIM34_Clock_Source */
+
+  uint32_t Tim8ClockSelection;   /*!< TIM8 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM8_Clock_Source */
+
+  uint32_t Tim15ClockSelection;  /*!< TIM15 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM15_Clock_Source */
+
+  uint32_t Tim16ClockSelection;  /*!< TIM16 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM16_Clock_Source */
+
+  uint32_t Tim17ClockSelection;  /*!< TIM17 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM17_Clock_Source */
+
+  uint32_t Tim20ClockSelection;  /*!< TIM20 clock source
+                                      This parameter can be a value of @ref RCCEx_TIM20_Clock_Source */
+
+}RCC_PeriphCLKInitTypeDef;
+#endif /* STM32F398xx */
+
 #if defined(STM32F358xx)
 typedef struct
 {
@@ -310,7 +620,7 @@ typedef struct
   uint32_t RTCClockSelection;      /*!< Specifies RTC Clock Prescalers Selection 
                                       This parameter can be a value of @ref RCC_RTC_Clock_Source */
 
-  uint32_t Usart1ClockSelection; /*!< USART1 clock source
+  uint32_t Usart1ClockSelection; /*!< USART1 clock source      
                                       This parameter can be a value of @ref RCCEx_USART1_Clock_Source */
 
   uint32_t Usart2ClockSelection; /*!< USART2 clock source      
@@ -340,7 +650,7 @@ typedef struct
   uint32_t RTCClockSelection;      /*!< Specifies RTC Clock Prescalers Selection 
                                       This parameter can be a value of @ref RCC_RTC_Clock_Source */
 
-  uint32_t Usart1ClockSelection; /*!< USART1 clock source      
+  uint32_t Usart1ClockSelection; /*!< USART1 clock source
                                       This parameter can be a value of @ref RCCEx_USART1_Clock_Source */
 
   uint32_t Usart2ClockSelection; /*!< USART2 clock source
@@ -374,7 +684,7 @@ typedef struct
                                       This parameter can be a value of @ref RCC_RTC_Clock_Source */
 
   uint32_t Usart1ClockSelection; /*!< USART1 clock source
-                                      This parameter can be a value of @ref RCCEx_USART1_Clock_Source */
+                                      This parameter can be a value of @ref RCC_USART1_Clock_Source */
 
   uint32_t Usart2ClockSelection; /*!< USART2 clock source
                                       This parameter can be a value of @ref RCC_USART2_Clock_Source */
@@ -469,12 +779,172 @@ typedef struct
 }RCC_PeriphCLKInitTypeDef;
 #endif /* STM32F378xx */
 
+/**
+  * @}
+  */
+
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup RCCEx_Exported_Constants
+/** @defgroup RCCEx_Exported_Constants RCC Extended Exported Constants
+  * @{
+  */
+#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F334x8)                                                 || \
+    defined(STM32F373xC) || defined(STM32F378xx)
+/** @defgroup RCCEx_MCO_Clock_Source RCC Extended MCO Clock Source
+  * @{
+  */
+#define RCC_MCOSOURCE_NONE               RCC_CFGR_MCO_NOCLOCK
+#define RCC_MCOSOURCE_LSI                RCC_CFGR_MCO_LSI
+#define RCC_MCOSOURCE_LSE                RCC_CFGR_MCO_LSE
+#define RCC_MCOSOURCE_SYSCLK             RCC_CFGR_MCO_SYSCLK
+#define RCC_MCOSOURCE_HSI                RCC_CFGR_MCO_HSI
+#define RCC_MCOSOURCE_HSE                RCC_CFGR_MCO_HSE
+#define RCC_MCOSOURCE_PLLCLK_DIV2        RCC_CFGR_MCO_PLL
+
+#define IS_RCC_MCOSOURCE(SOURCE)  (((SOURCE) == RCC_MCOSOURCE_NONE)    || \
+                                   ((SOURCE) == RCC_MCOSOURCE_LSI)     || \
+                                   ((SOURCE) == RCC_MCOSOURCE_LSE)     || \
+                                   ((SOURCE) == RCC_MCOSOURCE_SYSCLK)  || \
+                                   ((SOURCE) == RCC_MCOSOURCE_HSI)     || \
+                                   ((SOURCE) == RCC_MCOSOURCE_HSE)     || \
+                                   ((SOURCE) == RCC_MCOSOURCE_PLLCLK_DIV2))
+/**
+  * @}
+  */
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F334x8                                  */
+       /* STM32F373xC || STM32F378xx                   */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303x8) || defined(STM32F328xx) ||                         \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/** @defgroup RCCEx_MCO_Clock_Source RCC Extended MCO Clock Source
+  * @{
+  */
+#define RCC_MCOSOURCE_NONE               RCC_CFGR_MCO_NOCLOCK
+#define RCC_MCOSOURCE_LSI                RCC_CFGR_MCO_LSI
+#define RCC_MCOSOURCE_LSE                RCC_CFGR_MCO_LSE
+#define RCC_MCOSOURCE_SYSCLK             RCC_CFGR_MCO_SYSCLK
+#define RCC_MCOSOURCE_HSI                RCC_CFGR_MCO_HSI
+#define RCC_MCOSOURCE_HSE                RCC_CFGR_MCO_HSE
+#define RCC_MCOSOURCE_PLLCLK_DIV1        (RCC_CFGR_PLLNODIV | RCC_CFGR_MCO_PLL)
+#define RCC_MCOSOURCE_PLLCLK_DIV2        RCC_CFGR_MCO_PLL
+
+#define IS_RCC_MCOSOURCE(SOURCE)  (((SOURCE) == RCC_MCOSOURCE_NONE)        || \
+                                   ((SOURCE) == RCC_MCOSOURCE_LSI)         || \
+                                   ((SOURCE) == RCC_MCOSOURCE_LSE)         || \
+                                   ((SOURCE) == RCC_MCOSOURCE_SYSCLK)      || \
+                                   ((SOURCE) == RCC_MCOSOURCE_HSI)         || \
+                                   ((SOURCE) == RCC_MCOSOURCE_HSE)         || \
+                                   ((SOURCE) == RCC_MCOSOURCE_PLLCLK_DIV1) || \
+                                   ((SOURCE) == RCC_MCOSOURCE_PLLCLK_DIV2))
+/**
+  * @}
+  */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+       /* STM32F303x8 || STM32F328xx ||             */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+/** @defgroup RCCEx_PLL_Clock_Source RCC Extended PLL Clock Source
+  * @{
+  */
+#define RCC_PLLSOURCE_HSI                RCC_CFGR_PLLSRC_HSI_PREDIV
+#define RCC_PLLSOURCE_HSE                RCC_CFGR_PLLSRC_HSE_PREDIV
+
+#define IS_RCC_PLLSOURCE(SOURCE) (((SOURCE) == RCC_PLLSOURCE_HSI) || \
+                                  ((SOURCE) == RCC_PLLSOURCE_HSE))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_PLL_Prediv_Factor RCC Extended PLL Prediv Factor
+  * @{
+  */
+#define RCC_PREDIV_DIV1                  RCC_CFGR2_PREDIV_DIV1
+#define RCC_PREDIV_DIV2                  RCC_CFGR2_PREDIV_DIV2
+#define RCC_PREDIV_DIV3                  RCC_CFGR2_PREDIV_DIV3
+#define RCC_PREDIV_DIV4                  RCC_CFGR2_PREDIV_DIV4
+#define RCC_PREDIV_DIV5                  RCC_CFGR2_PREDIV_DIV5
+#define RCC_PREDIV_DIV6                  RCC_CFGR2_PREDIV_DIV6
+#define RCC_PREDIV_DIV7                  RCC_CFGR2_PREDIV_DIV7
+#define RCC_PREDIV_DIV8                  RCC_CFGR2_PREDIV_DIV8
+#define RCC_PREDIV_DIV9                  RCC_CFGR2_PREDIV_DIV9
+#define RCC_PREDIV_DIV10                 RCC_CFGR2_PREDIV_DIV10
+#define RCC_PREDIV_DIV11                 RCC_CFGR2_PREDIV_DIV11
+#define RCC_PREDIV_DIV12                 RCC_CFGR2_PREDIV_DIV12
+#define RCC_PREDIV_DIV13                 RCC_CFGR2_PREDIV_DIV13
+#define RCC_PREDIV_DIV14                 RCC_CFGR2_PREDIV_DIV14
+#define RCC_PREDIV_DIV15                 RCC_CFGR2_PREDIV_DIV15
+#define RCC_PREDIV_DIV16                 RCC_CFGR2_PREDIV_DIV16
+
+#define IS_RCC_PREDIV(PREDIV) (((PREDIV) == RCC_PREDIV_DIV1)  || ((PREDIV) == RCC_PREDIV_DIV2)   || \
+                               ((PREDIV) == RCC_PREDIV_DIV3)  || ((PREDIV) == RCC_PREDIV_DIV4)   || \
+                               ((PREDIV) == RCC_PREDIV_DIV5)  || ((PREDIV) == RCC_PREDIV_DIV6)   || \
+                               ((PREDIV) == RCC_PREDIV_DIV7)  || ((PREDIV) == RCC_PREDIV_DIV8)   || \
+                               ((PREDIV) == RCC_PREDIV_DIV9)  || ((PREDIV) == RCC_PREDIV_DIV10)  || \
+                               ((PREDIV) == RCC_PREDIV_DIV11) || ((PREDIV) == RCC_PREDIV_DIV12)  || \
+                               ((PREDIV) == RCC_PREDIV_DIV13) || ((PREDIV) == RCC_PREDIV_DIV14)  || \
+                               ((PREDIV) == RCC_PREDIV_DIV15) || ((PREDIV) == RCC_PREDIV_DIV16))
+/**
+  * @}
+  */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+
+#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
+/** @defgroup RCCEx_PLL_Clock_Source RCC Extended PLL Clock Source
+  * @{
+  */
+#define RCC_PLLSOURCE_HSI                RCC_CFGR_PLLSRC_HSI_DIV2
+#define RCC_PLLSOURCE_HSE                RCC_CFGR_PLLSRC_HSE_PREDIV
+
+#define IS_RCC_PLLSOURCE(SOURCE) (((SOURCE) == RCC_PLLSOURCE_HSI) || \
+                                  ((SOURCE) == RCC_PLLSOURCE_HSE))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_HSE_Predivision_Factor RCC Extended HSE Predivision Factor
   * @{
   */
 
-/** @defgroup RCCEx_Periph_Clock_Selection
+#define RCC_HSE_PREDIV_DIV1              RCC_CFGR2_PREDIV_DIV1
+#define RCC_HSE_PREDIV_DIV2              RCC_CFGR2_PREDIV_DIV2
+#define RCC_HSE_PREDIV_DIV3              RCC_CFGR2_PREDIV_DIV3
+#define RCC_HSE_PREDIV_DIV4              RCC_CFGR2_PREDIV_DIV4
+#define RCC_HSE_PREDIV_DIV5              RCC_CFGR2_PREDIV_DIV5
+#define RCC_HSE_PREDIV_DIV6              RCC_CFGR2_PREDIV_DIV6
+#define RCC_HSE_PREDIV_DIV7              RCC_CFGR2_PREDIV_DIV7
+#define RCC_HSE_PREDIV_DIV8              RCC_CFGR2_PREDIV_DIV8
+#define RCC_HSE_PREDIV_DIV9              RCC_CFGR2_PREDIV_DIV9
+#define RCC_HSE_PREDIV_DIV10             RCC_CFGR2_PREDIV_DIV10
+#define RCC_HSE_PREDIV_DIV11             RCC_CFGR2_PREDIV_DIV11
+#define RCC_HSE_PREDIV_DIV12             RCC_CFGR2_PREDIV_DIV12
+#define RCC_HSE_PREDIV_DIV13             RCC_CFGR2_PREDIV_DIV13
+#define RCC_HSE_PREDIV_DIV14             RCC_CFGR2_PREDIV_DIV14
+#define RCC_HSE_PREDIV_DIV15             RCC_CFGR2_PREDIV_DIV15
+#define RCC_HSE_PREDIV_DIV16             RCC_CFGR2_PREDIV_DIV16
+
+#define IS_RCC_HSE_PREDIV(DIV) (((DIV) == RCC_HSE_PREDIV_DIV1)  || ((DIV) == RCC_HSE_PREDIV_DIV2)  || \
+                                ((DIV) == RCC_HSE_PREDIV_DIV3)  || ((DIV) == RCC_HSE_PREDIV_DIV4)  || \
+                                ((DIV) == RCC_HSE_PREDIV_DIV5)  || ((DIV) == RCC_HSE_PREDIV_DIV6)  || \
+                                ((DIV) == RCC_HSE_PREDIV_DIV7)  || ((DIV) == RCC_HSE_PREDIV_DIV8)  || \
+                                ((DIV) == RCC_HSE_PREDIV_DIV9)  || ((DIV) == RCC_HSE_PREDIV_DIV10) || \
+                                ((DIV) == RCC_HSE_PREDIV_DIV11) || ((DIV) == RCC_HSE_PREDIV_DIV12) || \
+                                ((DIV) == RCC_HSE_PREDIV_DIV13) || ((DIV) == RCC_HSE_PREDIV_DIV14) || \
+                                ((DIV) == RCC_HSE_PREDIV_DIV15) || ((DIV) == RCC_HSE_PREDIV_DIV16))
+/**
+  * @}
+  */
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+       /* STM32F373xC || STM32F378xx                   */
+
+/** @defgroup RCCEx_Periph_Clock_Selection RCC Extended Periph Clock Selection
   * @{
   */
 #if defined(STM32F301x8) || defined(STM32F318xx)
@@ -571,6 +1041,106 @@ typedef struct
                                                      RCC_PERIPHCLK_TIM8   | RCC_PERIPHCLK_RTC    | \
                                                      RCC_PERIPHCLK_USB))
 #endif /* STM32F303xC */
+
+#if defined(STM32F302xE)
+#define RCC_PERIPHCLK_USART1           ((uint32_t)0x00000001)
+#define RCC_PERIPHCLK_USART2           ((uint32_t)0x00000002)
+#define RCC_PERIPHCLK_USART3           ((uint32_t)0x00000004)
+#define RCC_PERIPHCLK_UART4            ((uint32_t)0x00000008)
+#define RCC_PERIPHCLK_UART5            ((uint32_t)0x00000010)
+#define RCC_PERIPHCLK_I2C1             ((uint32_t)0x00000020)
+#define RCC_PERIPHCLK_I2C2             ((uint32_t)0x00000040)
+#define RCC_PERIPHCLK_ADC12            ((uint32_t)0x00000080)
+#define RCC_PERIPHCLK_I2S              ((uint32_t)0x00000200)
+#define RCC_PERIPHCLK_TIM1             ((uint32_t)0x00001000)
+#define RCC_PERIPHCLK_RTC              ((uint32_t)0x00010000)
+#define RCC_PERIPHCLK_USB              ((uint32_t)0x00020000)
+#define RCC_PERIPHCLK_I2C3             ((uint32_t)0x00040000)
+#define RCC_PERIPHCLK_TIM2             ((uint32_t)0x00100000)
+#define RCC_PERIPHCLK_TIM34            ((uint32_t)0x00200000)
+#define RCC_PERIPHCLK_TIM15            ((uint32_t)0x00400000)
+#define RCC_PERIPHCLK_TIM16            ((uint32_t)0x00800000)
+#define RCC_PERIPHCLK_TIM17            ((uint32_t)0x01000000)
+
+#define IS_RCC_PERIPHCLK(SELECTION) ((SELECTION) <= (RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_USART2 | RCC_PERIPHCLK_USART3 | \
+                                                     RCC_PERIPHCLK_UART4  | RCC_PERIPHCLK_UART5  | \
+                                                     RCC_PERIPHCLK_I2C1   | RCC_PERIPHCLK_I2C2   | \
+                                                     RCC_PERIPHCLK_ADC12  | RCC_PERIPHCLK_I2S    | \
+                                                     RCC_PERIPHCLK_TIM1   | RCC_PERIPHCLK_RTC    | \
+                                                     RCC_PERIPHCLK_USB    | RCC_PERIPHCLK_I2C3   | \
+                                                     RCC_PERIPHCLK_TIM2   | RCC_PERIPHCLK_TIM34  | \
+                                                     RCC_PERIPHCLK_TIM15  | RCC_PERIPHCLK_TIM16  | \
+                                                     RCC_PERIPHCLK_TIM17))
+#endif /* STM32F302xE */
+
+#if defined(STM32F303xE)
+#define RCC_PERIPHCLK_USART1           ((uint32_t)0x00000001)
+#define RCC_PERIPHCLK_USART2           ((uint32_t)0x00000002)
+#define RCC_PERIPHCLK_USART3           ((uint32_t)0x00000004)
+#define RCC_PERIPHCLK_UART4            ((uint32_t)0x00000008)
+#define RCC_PERIPHCLK_UART5            ((uint32_t)0x00000010)
+#define RCC_PERIPHCLK_I2C1             ((uint32_t)0x00000020)
+#define RCC_PERIPHCLK_I2C2             ((uint32_t)0x00000040)
+#define RCC_PERIPHCLK_ADC12            ((uint32_t)0x00000080)
+#define RCC_PERIPHCLK_ADC34            ((uint32_t)0x00000100)
+#define RCC_PERIPHCLK_I2S              ((uint32_t)0x00000200)
+#define RCC_PERIPHCLK_TIM1             ((uint32_t)0x00001000)
+#define RCC_PERIPHCLK_TIM8             ((uint32_t)0x00002000)
+#define RCC_PERIPHCLK_RTC              ((uint32_t)0x00010000)
+#define RCC_PERIPHCLK_USB              ((uint32_t)0x00020000)
+#define RCC_PERIPHCLK_I2C3             ((uint32_t)0x00040000)
+#define RCC_PERIPHCLK_TIM2             ((uint32_t)0x00100000)
+#define RCC_PERIPHCLK_TIM34            ((uint32_t)0x00200000)
+#define RCC_PERIPHCLK_TIM15            ((uint32_t)0x00400000)
+#define RCC_PERIPHCLK_TIM16            ((uint32_t)0x00800000)
+#define RCC_PERIPHCLK_TIM17            ((uint32_t)0x01000000)
+#define RCC_PERIPHCLK_TIM20            ((uint32_t)0x02000000)
+
+#define IS_RCC_PERIPHCLK(SELECTION) ((SELECTION) <= (RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_USART2 | RCC_PERIPHCLK_USART3 | \
+                                                     RCC_PERIPHCLK_UART4  | RCC_PERIPHCLK_UART5  | \
+                                                     RCC_PERIPHCLK_I2C1   | RCC_PERIPHCLK_I2C2   | \
+                                                     RCC_PERIPHCLK_ADC12  | RCC_PERIPHCLK_ADC34  | \
+                                                     RCC_PERIPHCLK_I2S    | RCC_PERIPHCLK_TIM1   | \
+                                                     RCC_PERIPHCLK_TIM8   | RCC_PERIPHCLK_RTC    | \
+                                                     RCC_PERIPHCLK_USB    | RCC_PERIPHCLK_I2C3   | \
+                                                     RCC_PERIPHCLK_TIM2   | RCC_PERIPHCLK_TIM34  | \
+                                                     RCC_PERIPHCLK_TIM15  | RCC_PERIPHCLK_TIM16  | \
+                                                     RCC_PERIPHCLK_TIM17  | RCC_PERIPHCLK_TIM20))
+#endif /* STM32F303xE */
+
+#if defined(STM32F398xx)
+#define RCC_PERIPHCLK_USART1           ((uint32_t)0x00000001)
+#define RCC_PERIPHCLK_USART2           ((uint32_t)0x00000002)
+#define RCC_PERIPHCLK_USART3           ((uint32_t)0x00000004)
+#define RCC_PERIPHCLK_UART4            ((uint32_t)0x00000008)
+#define RCC_PERIPHCLK_UART5            ((uint32_t)0x00000010)
+#define RCC_PERIPHCLK_I2C1             ((uint32_t)0x00000020)
+#define RCC_PERIPHCLK_I2C2             ((uint32_t)0x00000040)
+#define RCC_PERIPHCLK_ADC12            ((uint32_t)0x00000080)
+#define RCC_PERIPHCLK_ADC34            ((uint32_t)0x00000100)
+#define RCC_PERIPHCLK_I2S              ((uint32_t)0x00000200)
+#define RCC_PERIPHCLK_TIM1             ((uint32_t)0x00001000)
+#define RCC_PERIPHCLK_TIM8             ((uint32_t)0x00002000)
+#define RCC_PERIPHCLK_RTC              ((uint32_t)0x00010000)
+#define RCC_PERIPHCLK_I2C3             ((uint32_t)0x00040000)
+#define RCC_PERIPHCLK_TIM2             ((uint32_t)0x00100000)
+#define RCC_PERIPHCLK_TIM34            ((uint32_t)0x00200000)
+#define RCC_PERIPHCLK_TIM15            ((uint32_t)0x00400000)
+#define RCC_PERIPHCLK_TIM16            ((uint32_t)0x00800000)
+#define RCC_PERIPHCLK_TIM17            ((uint32_t)0x01000000)
+#define RCC_PERIPHCLK_TIM20            ((uint32_t)0x02000000)
+
+#define IS_RCC_PERIPHCLK(SELECTION) ((SELECTION) <= (RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_USART2 | RCC_PERIPHCLK_USART3 | \
+                                                     RCC_PERIPHCLK_UART4  | RCC_PERIPHCLK_UART5  | \
+                                                     RCC_PERIPHCLK_I2C1   | RCC_PERIPHCLK_I2C2   | \
+                                                     RCC_PERIPHCLK_ADC12  | RCC_PERIPHCLK_ADC34  | \
+                                                     RCC_PERIPHCLK_I2S    | RCC_PERIPHCLK_TIM1   | \
+                                                     RCC_PERIPHCLK_TIM8   | RCC_PERIPHCLK_RTC    | \
+                                                     RCC_PERIPHCLK_I2C3   | RCC_PERIPHCLK_TIM2   | \
+                                                     RCC_PERIPHCLK_TIM34  | RCC_PERIPHCLK_TIM15  | \
+                                                     RCC_PERIPHCLK_TIM16  | RCC_PERIPHCLK_TIM17  | \
+                                                     RCC_PERIPHCLK_TIM20))
+#endif /* STM32F398xx */
 
 #if defined(STM32F358xx)
 #define RCC_PERIPHCLK_USART1           ((uint32_t)0x00000001)
@@ -680,7 +1250,7 @@ typedef struct
 
 #if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 
-/** @defgroup RCCEx_USART1_Clock_Source
+/** @defgroup RCCEx_USART1_Clock_Source RCC Extended USART1 Clock Source
   * @{
   */
 #define RCC_USART1CLKSOURCE_PCLK2        RCC_CFGR3_USART1SW_PCLK
@@ -696,7 +1266,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_I2C2_Clock_Source
+/** @defgroup RCCEx_I2C2_Clock_Source RCC Extended I2C2 Clock Source
   * @{
   */
 #define RCC_I2C2CLKSOURCE_HSI            RCC_CFGR3_I2C2SW_HSI
@@ -708,7 +1278,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_I2C3_Clock_Source
+/** @defgroup RCCEx_I2C3_Clock_Source RCC Extended I2C3 Clock Source
   * @{
   */
 #define RCC_I2C3CLKSOURCE_HSI            RCC_CFGR3_I2C3SW_HSI
@@ -720,7 +1290,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_ADC1_Clock_Source
+/** @defgroup RCCEx_ADC1_Clock_Source RCC Extended ADC1 Clock Source
   * @{
   */
 #define RCC_ADC1PLLCLK_OFF               RCC_CFGR2_ADC1PRES_NO
@@ -748,7 +1318,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_I2S_Clock_Source
+/** @defgroup RCCEx_I2S_Clock_Source RCC Extended I2S Clock Source
   * @{
   */
 #define RCC_I2SCLKSOURCE_SYSCLK          RCC_CFGR_I2SSRC_SYSCLK
@@ -760,7 +1330,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_TIM1_Clock_Source
+/** @defgroup RCCEx_TIM1_Clock_Source RCC Extended TIM1 Clock Source
   * @{
   */
 #define RCC_TIM1CLK_HCLK                  RCC_CFGR3_TIM1SW_HCLK
@@ -772,7 +1342,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_TIM15_Clock_Source
+/** @defgroup RCCEx_TIM15_Clock_Source RCC Extended TIM15 Clock Source
   * @{
   */
 #define RCC_TIM15CLK_HCLK                 RCC_CFGR3_TIM15SW_HCLK
@@ -784,7 +1354,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_TIM16_Clock_Source
+/** @defgroup RCCEx_TIM16_Clock_Source RCC Extended TIM16 Clock Source
   * @{
   */
 #define RCC_TIM16CLK_HCLK                 RCC_CFGR3_TIM16SW_HCLK
@@ -796,7 +1366,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_TIM17_Clock_Source
+/** @defgroup RCCEx_TIM17_Clock_Source RCC Extended TIM17 Clock Source
   * @{
   */
 #define RCC_TIM17CLK_HCLK                 RCC_CFGR3_TIM17SW_HCLK
@@ -812,7 +1382,7 @@ typedef struct
 
 #if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
 
-/** @defgroup RCCEx_USART1_Clock_Source
+/** @defgroup RCCEx_USART1_Clock_Source RCC Extended USART1 Clock Source
   * @{
   */
 #define RCC_USART1CLKSOURCE_PCLK2        RCC_CFGR3_USART1SW_PCLK
@@ -828,7 +1398,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_I2C2_Clock_Source
+/** @defgroup RCCEx_I2C2_Clock_Source RCC Extended I2C2 Clock Source
   * @{
   */
 #define RCC_I2C2CLKSOURCE_HSI            RCC_CFGR3_I2C2SW_HSI
@@ -840,7 +1410,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_ADC12_Clock_Source
+/** @defgroup RCCEx_ADC12_Clock_Source RCC Extended ADC12 Clock Source
   * @{
   */
 
@@ -870,7 +1440,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_I2S_Clock_Source
+/** @defgroup RCCEx_I2S_Clock_Source RCC Extended I2S Clock Source
   * @{
   */
 #define RCC_I2SCLKSOURCE_SYSCLK          RCC_CFGR_I2SSRC_SYSCLK
@@ -881,7 +1451,7 @@ typedef struct
 /**
   * @}
   */
-/** @defgroup RCCEx_TIM1_Clock_Source
+/** @defgroup RCCEx_TIM1_Clock_Source RCC Extended TIM1 Clock Source
   * @{
   */
 #define RCC_TIM1CLK_HCLK                  RCC_CFGR3_TIM1SW_HCLK
@@ -893,7 +1463,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_UART4_Clock_Source
+/** @defgroup RCCEx_UART4_Clock_Source RCC Extended UART4 Clock Source
   * @{
   */
 #define RCC_UART4CLKSOURCE_PCLK1         RCC_CFGR3_UART4SW_PCLK
@@ -909,7 +1479,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_UART5_Clock_Source
+/** @defgroup RCCEx_UART5_Clock_Source RCC Extended UART5 Clock Source
   * @{
   */
 #define RCC_UART5CLKSOURCE_PCLK1         RCC_CFGR3_UART5SW_PCLK
@@ -927,9 +1497,9 @@ typedef struct
 
 #endif /* STM32F302xC || STM32F303xC || STM32F358xx */
 
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
 
-/** @defgroup RCCEx_USART1_Clock_Source
+/** @defgroup RCCEx_USART1_Clock_Source RCC Extended USART1 Clock Source
   * @{
   */
 #define RCC_USART1CLKSOURCE_PCLK2        RCC_CFGR3_USART1SW_PCLK
@@ -945,7 +1515,196 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_ADC34_Clock_Source
+/** @defgroup RCCEx_I2C2_Clock_Source RCC Extended I2C2 Clock Source
+  * @{
+  */
+#define RCC_I2C2CLKSOURCE_HSI            RCC_CFGR3_I2C2SW_HSI
+#define RCC_I2C2CLKSOURCE_SYSCLK         RCC_CFGR3_I2C2SW_SYSCLK
+
+#define IS_RCC_I2C2CLKSOURCE(SOURCE)  (((SOURCE) == RCC_I2C2CLKSOURCE_HSI) || \
+                                       ((SOURCE) == RCC_I2C2CLKSOURCE_SYSCLK))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_I2C3_Clock_Source RCC Extended I2C3 Clock Source
+  * @{
+  */
+#define RCC_I2C3CLKSOURCE_HSI            RCC_CFGR3_I2C3SW_HSI
+#define RCC_I2C3CLKSOURCE_SYSCLK         RCC_CFGR3_I2C3SW_SYSCLK
+
+#define IS_RCC_I2C3CLKSOURCE(SOURCE)  (((SOURCE) == RCC_I2C3CLKSOURCE_HSI) || \
+                                       ((SOURCE) == RCC_I2C3CLKSOURCE_SYSCLK))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_ADC12_Clock_Source RCC Extended ADC12 Clock Source
+  * @{
+  */
+
+/* ADC1 & ADC2 */
+#define RCC_ADC12PLLCLK_OFF              RCC_CFGR2_ADCPRE12_NO
+#define RCC_ADC12PLLCLK_DIV1             RCC_CFGR2_ADCPRE12_DIV1
+#define RCC_ADC12PLLCLK_DIV2             RCC_CFGR2_ADCPRE12_DIV2
+#define RCC_ADC12PLLCLK_DIV4             RCC_CFGR2_ADCPRE12_DIV4
+#define RCC_ADC12PLLCLK_DIV6             RCC_CFGR2_ADCPRE12_DIV6
+#define RCC_ADC12PLLCLK_DIV8             RCC_CFGR2_ADCPRE12_DIV8
+#define RCC_ADC12PLLCLK_DIV10            RCC_CFGR2_ADCPRE12_DIV10
+#define RCC_ADC12PLLCLK_DIV12            RCC_CFGR2_ADCPRE12_DIV12
+#define RCC_ADC12PLLCLK_DIV16            RCC_CFGR2_ADCPRE12_DIV16
+#define RCC_ADC12PLLCLK_DIV32            RCC_CFGR2_ADCPRE12_DIV32
+#define RCC_ADC12PLLCLK_DIV64            RCC_CFGR2_ADCPRE12_DIV64
+#define RCC_ADC12PLLCLK_DIV128           RCC_CFGR2_ADCPRE12_DIV128
+#define RCC_ADC12PLLCLK_DIV256           RCC_CFGR2_ADCPRE12_DIV256
+
+#define IS_RCC_ADC12PLLCLK_DIV(ADCCLK) (((ADCCLK) == RCC_ADC12PLLCLK_OFF)   || ((ADCCLK) == RCC_ADC12PLLCLK_DIV1)   || \
+                                        ((ADCCLK) == RCC_ADC12PLLCLK_DIV2)  || ((ADCCLK) == RCC_ADC12PLLCLK_DIV4)   || \
+                                        ((ADCCLK) == RCC_ADC12PLLCLK_DIV6)  || ((ADCCLK) == RCC_ADC12PLLCLK_DIV8)   || \
+                                        ((ADCCLK) == RCC_ADC12PLLCLK_DIV10) || ((ADCCLK) == RCC_ADC12PLLCLK_DIV12)  || \
+                                        ((ADCCLK) == RCC_ADC12PLLCLK_DIV16) || ((ADCCLK) == RCC_ADC12PLLCLK_DIV32)  || \
+                                        ((ADCCLK) == RCC_ADC12PLLCLK_DIV64) || ((ADCCLK) == RCC_ADC12PLLCLK_DIV128) || \
+                                        ((ADCCLK) == RCC_ADC12PLLCLK_DIV256))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_I2S_Clock_Source RCC Extended I2S Clock Source
+  * @{
+  */
+#define RCC_I2SCLKSOURCE_SYSCLK          RCC_CFGR_I2SSRC_SYSCLK
+#define RCC_I2SCLKSOURCE_EXT             RCC_CFGR_I2SSRC_EXT
+
+#define IS_RCC_I2SCLKSOURCE(SOURCE)  (((SOURCE) == RCC_I2SCLKSOURCE_SYSCLK) || \
+                                      ((SOURCE) == RCC_I2SCLKSOURCE_EXT))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_TIM1_Clock_Source RCC Extended TIM1 Clock Source
+  * @{
+  */
+#define RCC_TIM1CLK_HCLK                  RCC_CFGR3_TIM1SW_HCLK
+#define RCC_TIM1CLK_PLLCLK                RCC_CFGR3_TIM1SW_PLL
+
+#define IS_RCC_TIM1CLKSOURCE(SOURCE) (((SOURCE) == RCC_TIM1CLK_HCLK) || \
+                                      ((SOURCE) == RCC_TIM1CLK_PLLCLK))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_TIM2_Clock_Source RCC Extended TIM2 Clock Source
+  * @{
+  */
+#define RCC_TIM2CLK_HCLK                  RCC_CFGR3_TIM2SW_HCLK
+#define RCC_TIM2CLK_PLLCLK                RCC_CFGR3_TIM2SW_PLL
+
+#define IS_RCC_TIM2CLKSOURCE(SOURCE) (((SOURCE) == RCC_TIM2CLK_HCLK) || \
+                                      ((SOURCE) == RCC_TIM2CLK_PLLCLK))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_TIM34_Clock_Source RCC Extended TIM3 & TIM4 Clock Source
+  * @{
+  */
+#define RCC_TIM34CLK_HCLK                  RCC_CFGR3_TIM34SW_HCLK
+#define RCC_TIM34CLK_PLLCLK                RCC_CFGR3_TIM34SW_PLL
+
+#define IS_RCC_TIM3CLKSOURCE(SOURCE) (((SOURCE) == RCC_TIM34CLK_HCLK) || \
+                                      ((SOURCE) == RCC_TIM34CLK_PLLCLK))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_TIM15_Clock_Source RCC Extended TIM15 Clock Source
+  * @{
+  */
+#define RCC_TIM15CLK_HCLK                  RCC_CFGR3_TIM15SW_HCLK
+#define RCC_TIM15CLK_PLLCLK                RCC_CFGR3_TIM15SW_PLL
+
+#define IS_RCC_TIM15CLKSOURCE(SOURCE) (((SOURCE) == RCC_TIM15CLK_HCLK) || \
+                                      ((SOURCE) == RCC_TIM15CLK_PLLCLK))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_TIM16_Clock_Source RCC Extended TIM16 Clock Source
+  * @{
+  */
+#define RCC_TIM16CLK_HCLK                  RCC_CFGR3_TIM16SW_HCLK
+#define RCC_TIM16CLK_PLLCLK                RCC_CFGR3_TIM16SW_PLL
+
+#define IS_RCC_TIM16CLKSOURCE(SOURCE) (((SOURCE) == RCC_TIM16CLK_HCLK) || \
+                                      ((SOURCE) == RCC_TIM16CLK_PLLCLK))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_TIM17_Clock_Source RCC Extended TIM17 Clock Source
+  * @{
+  */
+#define RCC_TIM17CLK_HCLK                  RCC_CFGR3_TIM17SW_HCLK
+#define RCC_TIM17CLK_PLLCLK                RCC_CFGR3_TIM17SW_PLL
+
+#define IS_RCC_TIM17CLKSOURCE(SOURCE) (((SOURCE) == RCC_TIM17CLK_HCLK) || \
+                                      ((SOURCE) == RCC_TIM17CLK_PLLCLK))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_UART4_Clock_Source RCC Extended UART4 Clock Source
+  * @{
+  */
+#define RCC_UART4CLKSOURCE_PCLK1         RCC_CFGR3_UART4SW_PCLK
+#define RCC_UART4CLKSOURCE_SYSCLK        RCC_CFGR3_UART4SW_SYSCLK
+#define RCC_UART4CLKSOURCE_LSE           RCC_CFGR3_UART4SW_LSE
+#define RCC_UART4CLKSOURCE_HSI           RCC_CFGR3_UART4SW_HSI
+
+#define IS_RCC_UART4CLKSOURCE(SOURCE)  (((SOURCE) == RCC_UART4CLKSOURCE_PCLK1)  || \
+                                        ((SOURCE) == RCC_UART4CLKSOURCE_SYSCLK) || \
+                                        ((SOURCE) == RCC_UART4CLKSOURCE_LSE)    || \
+                                        ((SOURCE) == RCC_UART4CLKSOURCE_HSI))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_UART5_Clock_Source RCC Extended UART5 Clock Source
+  * @{
+  */
+#define RCC_UART5CLKSOURCE_PCLK1         RCC_CFGR3_UART5SW_PCLK
+#define RCC_UART5CLKSOURCE_SYSCLK        RCC_CFGR3_UART5SW_SYSCLK
+#define RCC_UART5CLKSOURCE_LSE           RCC_CFGR3_UART5SW_LSE
+#define RCC_UART5CLKSOURCE_HSI           RCC_CFGR3_UART5SW_HSI
+
+#define IS_RCC_UART5CLKSOURCE(SOURCE)  (((SOURCE) == RCC_UART5CLKSOURCE_PCLK1)  || \
+                                        ((SOURCE) == RCC_UART5CLKSOURCE_SYSCLK) || \
+                                        ((SOURCE) == RCC_UART5CLKSOURCE_LSE)    || \
+                                        ((SOURCE) == RCC_UART5CLKSOURCE_HSI))
+/**
+  * @}
+  */
+
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+
+#if defined(STM32F303xE) ||  defined(STM32F398xx)
+/** @defgroup RCCEx_TIM20_Clock_Source RCC Extended TIM20 Clock Source
+  * @{
+  */
+#define RCC_TIM20CLK_HCLK                  RCC_CFGR3_TIM20SW_HCLK
+#define RCC_TIM20CLK_PLLCLK                RCC_CFGR3_TIM20SW_PLL
+
+#define IS_RCC_TIM20CLKSOURCE(SOURCE) (((SOURCE) == RCC_TIM20CLK_HCLK) || \
+                                      ((SOURCE) == RCC_TIM20CLK_PLLCLK))
+/**
+  * @}
+  */
+#endif /* STM32F303xE || STM32F398xx */
+
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+
+/** @defgroup RCCEx_ADC34_Clock_Source RCC Extended ADC34 Clock Source
   * @{
   */
 
@@ -975,7 +1734,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_TIM8_Clock_Source
+/** @defgroup RCCEx_TIM8_Clock_Source RCC Extended TIM8 Clock Source
   * @{
   */
 #define RCC_TIM8CLK_HCLK                  RCC_CFGR3_TIM8SW_HCLK
@@ -987,11 +1746,11 @@ typedef struct
   * @}
   */
 
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xC || STM32F303xE || STM32F398xx || STM32F358xx */
 
 #if defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 
-/** @defgroup RCCEx_USART1_Clock_Source
+/** @defgroup RCCEx_USART1_Clock_Source RCC Extended USART1 Clock Source
   * @{
   */
 #define RCC_USART1CLKSOURCE_PCLK1        RCC_CFGR3_USART1SW_PCLK
@@ -1007,7 +1766,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_ADC12_Clock_Source
+/** @defgroup RCCEx_ADC12_Clock_Source RCC Extended ADC12 Clock Source
   * @{
   */
 /* ADC1 & ADC2 */
@@ -1036,7 +1795,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_TIM1_Clock_Source
+/** @defgroup RCCEx_TIM1_Clock_Source RCC Extended TIM1 Clock Source
   * @{
   */
 #define RCC_TIM1CLK_HCLK                  RCC_CFGR3_TIM1SW_HCLK
@@ -1052,7 +1811,7 @@ typedef struct
 
 #if defined(STM32F334x8)
 
-/** @defgroup RCCEx_HRTIM1_Clock_Source
+/** @defgroup RCCEx_HRTIM1_Clock_Source RCC Extended HRTIM1 Clock Source
   * @{
   */
 #define RCC_HRTIM1CLK_HCLK                RCC_CFGR3_HRTIM1SW_HCLK
@@ -1068,7 +1827,7 @@ typedef struct
 
 #if defined(STM32F373xC) || defined(STM32F378xx)
 
-/** @defgroup RCCEx_USART1_Clock_Source
+/** @defgroup RCCEx_USART1_Clock_Source  RCC Extended USART1 Clock Source
   * @{
   */
 #define RCC_USART1CLKSOURCE_PCLK2        RCC_CFGR3_USART1SW_PCLK
@@ -1084,7 +1843,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_I2C2_Clock_Source
+/** @defgroup RCCEx_I2C2_Clock_Source  RCC Extended I2C2 Clock Source
   * @{
   */
 #define RCC_I2C2CLKSOURCE_HSI            RCC_CFGR3_I2C2SW_HSI
@@ -1096,7 +1855,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_ADC1_Clock_Source
+/** @defgroup RCCEx_ADC1_Clock_Source  RCC Extended ADC1 Clock Source
   * @{
   */
 
@@ -1112,7 +1871,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_CEC_Clock_Source
+/** @defgroup RCCEx_CEC_Clock_Source RCC Extended CEC Clock Source
   * @{
   */
 #define RCC_CECCLKSOURCE_HSI             RCC_CFGR3_CECSW_HSI_DIV244
@@ -1124,7 +1883,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RCCEx_SDADC_Clock_Prescaler
+/** @defgroup RCCEx_SDADC_Clock_Prescaler RCC Extended SDADC Clock Prescaler
   * @{
   */
 #define RCC_SDADCSYSCLK_DIV1             RCC_CFGR_SDADCPRE_DIV1
@@ -1160,8 +1919,11 @@ typedef struct
 
 #endif /* STM32F373xC || STM32F378xx */
 
-#if defined(STM32F302x8) || defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F373xC)
-/** @defgroup RCCEx_USB_Clock_Source
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F302x8)                         || \
+    defined(STM32F373xC)
+/** @defgroup RCCEx_USB_Clock_Source  RCC Extended USB Clock Source
   * @{
   */
 #define RCC_USBPLLCLK_DIV1               RCC_CFGR_USBPRE_DIV1
@@ -1173,11 +1935,14 @@ typedef struct
   * @}
   */
 
-#endif /* STM32F302x8 || STM32F302xC || STM32F303xC || STM32F373xC */
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC || STM32F303xC || */
+       /* STM32F302x8                || */
+       /* STM32F373xC                   */
 
 #if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
     defined(STM32F373xC) || defined(STM32F378xx)
-/** @defgroup RCCEx_MCOx_Clock_Prescaler
+/** @defgroup RCCEx_MCOx_Clock_Prescaler RCC Extended MCOx Clock Prescaler
   * @{
   */
 #define RCC_MCO_NODIV                    ((uint32_t)0x00000000)
@@ -1186,13 +1951,14 @@ typedef struct
 /**
   * @}
   */
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
-       /* STM32F373xC || STM32F378xx */
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F373xC || STM32F378xx                   */
       
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 
-/** @defgroup RCCEx_MCOx_Clock_Prescaler
+/** @defgroup RCCEx_MCOx_Clock_Prescaler RCC Extended MCOx Clock Prescaler
   * @{
   */
 #define RCC_MCO_DIV1                     ((uint32_t)0x00000000)
@@ -1212,18 +1978,100 @@ typedef struct
   * @}
   */
 
-#endif /*  STM32F301x8 || STM32F302x8 || STM32F318xx || STM32F303x8 || STM32F334x8 || STM32F328xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
 /**
   * @}
   */
 
 /* Exported macro ------------------------------------------------------------*/
+/** @defgroup RCCEx_Exported_Macros RCC Extended Exported Macros
+ * @{
+ */
 
-/** @brief  Enable or disable the AHB peripheral clock.
+/** @defgroup RCCEx_PLL_Configuration RCC Extended PLL Configuration
+  * @{   
+  */ 
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+/** @brief  Macro to configure the PLL clock source, multiplication and division factors.
+  * @note   This macro must be used only when the PLL is disabled.
+  *
+  * @param  __RCC_PLLSource__: specifies the PLL entry clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_PLLSOURCE_HSI: HSI oscillator clock selected as PLL clock entry
+  *            @arg RCC_PLLSOURCE_HSE: HSE oscillator clock selected as PLL clock entry
+  * @param  __PREDIV__: specifies the predivider factor for PLL VCO input clock
+  *         This parameter must be a number between RCC_PREDIV_DIV1 and RCC_PREDIV_DIV16.
+  * @param  __PLLMUL__: specifies the multiplication factor for PLL VCO input clock
+  *         This parameter must be a number between RCC_PLL_MUL2 and RCC_PLL_MUL16.
+  *
+  */
+#define __HAL_RCC_PLL_CONFIG(__RCC_PLLSource__ , __PREDIV__, __PLLMUL__) \
+                  do { \
+                    MODIFY_REG(RCC->CFGR2, RCC_CFGR2_PREDIV, (__PREDIV__)); \
+                    MODIFY_REG(RCC->CFGR, RCC_CFGR_PLLMUL | RCC_CFGR_PLLSRC, (uint32_t)((__PLLMUL__)|(__RCC_PLLSource__))); \
+                  } while(0)
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+
+#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
+/** @brief  Macro to configure the PLL clock source and multiplication factor.
+  * @note   This macro must be used only when the PLL is disabled.
+  *
+  * @param  __RCC_PLLSource__: specifies the PLL entry clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_PLLSOURCE_HSI: HSI oscillator clock selected as PLL clock entry
+  *            @arg RCC_PLLSOURCE_HSE: HSE oscillator clock selected as PLL clock entry
+  * @param  __PLLMUL__: specifies the multiplication factor for PLL VCO input clock
+  *         This parameter must be a number between RCC_PLL_MUL2 and RCC_PLL_MUL16.
+  *
+  */
+#define __HAL_RCC_PLL_CONFIG(__RCC_PLLSource__ , __PLLMUL__) \
+                  MODIFY_REG(RCC->CFGR, RCC_CFGR_PLLMUL | RCC_CFGR_PLLSRC, (uint32_t)((__PLLMUL__)|(__RCC_PLLSource__)))
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+       /* STM32F373xC || STM32F378xx                   */
+/**
+  * @}
+  */ 
+                    
+#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)
+/** @defgroup RCCEx_HSE_Configuration RCC Extended HSE Configuration
+  * @{   
+  */ 
+
+/**
+  * @brief  Macro to configure the External High Speed oscillator (HSE) Predivision factor for PLL.
+  * @note   Predivision factor can not be changed if PLL is used as system clock
+  *         In this case, you have to select another source of the system clock, disable the PLL and
+  *         then change the HSE predivision factor.
+  * @param  __HSEPredivValue__: specifies the division value applied to HSE.
+  *         This parameter must be a number between RCC_HSE_PREDIV_DIV1 and RCC_HSE_PREDIV_DIV16.
+  */
+#define __HAL_RCC_HSE_PREDIV_CONFIG(__HSEPredivValue__) \
+                  MODIFY_REG(RCC->CFGR2, RCC_CFGR2_PREDIV, (uint32_t)(__HSEPredivValue__))
+/**
+  * @}
+  */
+#endif /* STM32F302xC || STM32F303xC || STM32F358xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+       /* STM32F373xC || STM32F378xx                   */
+                    
+/** @defgroup RCCEx_AHB_Clock_Enable_Disable RCC Extended AHB Clock Enable Disable
+  * @brief  Enable or disable the AHB peripheral clock.
   * @note   After reset, the peripheral clock (used for registers read/write access)
   *         is disabled and the application software has to enable this clock before
   *         using it.
+  * @{   
   */
 #if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define __ADC1_CLK_ENABLE()          (RCC->AHBENR |= (RCC_AHBENR_ADC1EN))
@@ -1231,7 +2079,8 @@ typedef struct
 #define __ADC1_CLK_DISABLE()         (RCC->AHBENR &= ~(RCC_AHBENR_ADC1EN))
 #endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
 
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
 #define __DMA2_CLK_ENABLE()          (RCC->AHBENR |= (RCC_AHBENR_DMA2EN))
 #define __GPIOE_CLK_ENABLE()         (RCC->AHBENR |= (RCC_AHBENR_GPIOEEN))
 #define __ADC12_CLK_ENABLE()         (RCC->AHBENR |= (RCC_AHBENR_ADC12EN))
@@ -1245,13 +2094,16 @@ typedef struct
 /* Aliases for STM32 F3 compatibility */
 #define __ADC1_CLK_DISABLE()          __ADC12_CLK_DISABLE()
 #define __ADC2_CLK_DISABLE()          __ADC12_CLK_DISABLE()
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
 
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 #define __ADC34_CLK_ENABLE()         (RCC->AHBENR |= (RCC_AHBENR_ADC34EN))
 
 #define __ADC34_CLK_DISABLE()        (RCC->AHBENR &= ~(RCC_AHBENR_ADC34EN))
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
 #if defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define __ADC12_CLK_ENABLE()         (RCC->AHBENR |= (RCC_AHBENR_ADC12EN))
@@ -1273,10 +2125,25 @@ typedef struct
 #define __GPIOE_CLK_DISABLE()        (RCC->AHBENR &= ~(RCC_AHBENR_GPIOEEN))
 #endif /* STM32F373xC || STM32F378xx */
 
-/** @brief  Enable or disable the Low Speed APB (APB1) peripheral clock.
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+#define __FMC_CLK_ENABLE()           (RCC->AHBENR |= (RCC_AHBENR_FMCEN))
+#define __GPIOG_CLK_ENABLE()         (RCC->AHBENR |= (RCC_AHBENR_GPIOGEN))
+#define __GPIOH_CLK_ENABLE()         (RCC->AHBENR |= (RCC_AHBENR_GPIOHEN))
+
+#define __FMC_CLK_DISABLE()           (RCC->AHBENR &= ~(RCC_AHBENR_FMCEN))
+#define __GPIOG_CLK_DISABLE()         (RCC->AHBENR &= ~(RCC_AHBENR_GPIOGEN))
+#define __GPIOH_CLK_DISABLE()         (RCC->AHBENR &= ~(RCC_AHBENR_GPIOHEN))
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_APB1_Clock_Enable_Disable RCC Extended APB1 Clock Enable Disable
+  * @brief  Enable or disable the Low Speed APB (APB1) peripheral clock.
   * @note   After reset, the peripheral clock (used for registers read/write access)
   *         is disabled and the application software has to enable this clock before
   *         using it.
+  * @{   
   */
 #if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define __SPI2_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_SPI2EN))
@@ -1290,7 +2157,8 @@ typedef struct
 #define __I2C3_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C3EN))
 #endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
 
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
 #define __TIM3_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_TIM3EN))
 #define __TIM4_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_TIM4EN))
 #define __SPI2_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_SPI2EN))
@@ -1306,7 +2174,8 @@ typedef struct
 #define __UART4_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_UART4EN))
 #define __UART5_CLK_DISABLE()  (RCC->APB1ENR &= ~(RCC_APB1ENR_UART5EN))
 #define __I2C2_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C2EN))
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
 
 #if defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define __TIM3_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_TIM3EN))
@@ -1344,20 +2213,29 @@ typedef struct
 #define __CEC_CLK_DISABLE()    (RCC->APB1ENR &= ~(RCC_APB1ENR_CECEN))
 #endif /* STM32F373xC || STM32F378xx */
 
-#if defined(STM32F303x8) || defined(STM32F303xC) || defined(STM32F358xx) || \
-    defined(STM32F334x8) || defined(STM32F328xx) || \
-    defined(STM32F373xC) || defined(STM32F378xx)      
+#if defined(STM32F303xE) || defined(STM32F398xx)                         || \
+    defined(STM32F303xC) || defined(STM32F358xx)                         || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F373xC) || defined(STM32F378xx)     
 #define __TIM7_CLK_ENABLE()    (RCC->APB1ENR |= (RCC_APB1ENR_TIM7EN))
 
 #define __TIM7_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM7EN))
-#endif /* STM32F303x8 || STM32F303xC || STM32F358xx || STM32F334x8 || STM32F328xx || STM32F373xC || STM32F378xx */
+#endif /* STM32F303xE || STM32F398xx                || */
+       /* STM32F303xC || STM32F358xx                || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
-#if defined(STM32F302x8) || defined(STM32F302xC) || \
-    defined(STM32F303xC) || defined(STM32F373xC)
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F302x8)                         || \
+    defined(STM32F373xC)
 #define __USB_CLK_ENABLE()     (RCC->APB1ENR |= (RCC_APB1ENR_USBEN))
 
 #define __USB_CLK_DISABLE()    (RCC->APB1ENR &= ~(RCC_APB1ENR_USBEN))
-#endif /* STM32F302x8 || STM32F302xC || STM32F303xC|| STM32F373xC */
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC || STM32F303xC || */
+       /* STM32F302x8                || */
+       /* STM32F373xC                   */
 
 #if !defined(STM32F301x8)
 #define __CAN_CLK_ENABLE()     (RCC->APB1ENR |= (RCC_APB1ENR_CANEN))
@@ -1365,22 +2243,37 @@ typedef struct
 #define __CAN_CLK_DISABLE()    (RCC->APB1ENR &= ~(RCC_APB1ENR_CANEN))
 #endif /* STM32F301x8*/
 
-/** @brief  Enable or disable the High Speed APB (APB2) peripheral clock.
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+#define __I2C3_CLK_ENABLE()          (RCC->APB1ENR |= (RCC_APB1ENR_I2C3EN))
+
+#define __I2C3_CLK_DISABLE()         (RCC->APB1ENR &= ~(RCC_APB1ENR_I2C3EN))
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+/**
+  * @}
+  */
+  
+/** @defgroup RCCEx_APB2_Clock_Enable_Disable RCC Extended APB2 Clock Enable Disable
+  * @brief  Enable or disable the High Speed APB (APB2) peripheral clock.
   * @note   After reset, the peripheral clock (used for registers read/write access)
   *         is disabled and the application software has to enable this clock before
   *         using it.
+  * @{   
   */
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
 #define __SPI1_CLK_ENABLE()    (RCC->APB2ENR |= (RCC_APB2ENR_SPI1EN))
 
 #define __SPI1_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI1EN))
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
 
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 #define __TIM8_CLK_ENABLE()    (RCC->APB2ENR |= (RCC_APB2ENR_TIM8EN))
 
 #define __TIM8_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM8EN))
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
 #if defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define __SPI1_CLK_ENABLE()    (RCC->APB2ENR |= (RCC_APB2ENR_SPI1EN))
@@ -1410,17 +2303,37 @@ typedef struct
 #define __SDADC3_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_SDADC3EN))
 #endif /* STM32F373xC || STM32F378xx */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
     defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define __TIM1_CLK_ENABLE()    (RCC->APB2ENR |= (RCC_APB2ENR_TIM1EN))
 
 #define __TIM1_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM1EN))
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
-/** @brief  Force or release AHB peripheral reset.
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+#define __SPI4_CLK_ENABLE()          (RCC->APB2ENR |= (RCC_APB2ENR_SPI4EN))
+
+#define __SPI4_CLK_DISABLE()         (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI4EN))
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+      
+#if defined(STM32F303xE) || defined(STM32F398xx)
+#define __TIM20_CLK_ENABLE()         (RCC->APB2ENR |= (RCC_APB2ENR_TIM20EN))
+
+#define __TIM20_CLK_DISABLE()        (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM20EN))
+#endif /* STM32F303xE || STM32F398xx */
+      
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_AHB_Force_Release_Reset RCC Extended AHB Force Release Reset
+  * @brief  Force or release AHB peripheral reset.
+  * @{   
   */
 #if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define __ADC1_FORCE_RESET()     (RCC->AHBRSTR |= (RCC_AHBRSTR_ADC1RST))
@@ -1428,7 +2341,8 @@ typedef struct
 #define __ADC1_RELEASE_RESET()  (RCC->AHBRSTR &= ~(RCC_AHBRSTR_ADC1RST))
 #endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
 
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
 #define __GPIOE_FORCE_RESET()    (RCC->AHBRSTR |= (RCC_AHBRSTR_GPIOERST))
 #define __ADC12_FORCE_RESET()    (RCC->AHBRSTR |= (RCC_AHBRSTR_ADC12RST))
 /* Aliases for STM32 F3 compatibility */
@@ -1440,13 +2354,16 @@ typedef struct
 /* Aliases for STM32 F3 compatibility */
 #define __ADC1_RELEASE_RESET()    __ADC12_RELEASE_RESET()
 #define __ADC2_RELEASE_RESET()    __ADC12_RELEASE_RESET()
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
 
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 #define __ADC34_FORCE_RESET()    (RCC->AHBRSTR |= (RCC_AHBRSTR_ADC34RST))
 
 #define __ADC34_RELEASE_RESET()  (RCC->AHBRSTR &= ~(RCC_AHBRSTR_ADC34RST))
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
 #if defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define __ADC12_FORCE_RESET()    (RCC->AHBRSTR |= (RCC_AHBRSTR_ADC12RST))
@@ -1466,7 +2383,22 @@ typedef struct
 #define __GPIOE_RELEASE_RESET() (RCC->AHBRSTR &= ~(RCC_AHBRSTR_GPIOERST))
 #endif /* STM32F373xC || STM32F378xx */
 
-/** @brief  Force or release APB1 peripheral reset.
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+#define __FMC_FORCE_RESET()            (RCC->AHBRSTR |= (RCC_AHBRSTR_FMCRST))
+#define __GPIOG_FORCE_RESET()          (RCC->AHBRSTR |= (RCC_AHBRSTR_GPIOGRST))
+#define __GPIOH_FORCE_RESET()          (RCC->AHBRSTR |= (RCC_AHBRSTR_GPIOHRST))
+
+#define __FMC_RELEASE_RESET()            (RCC->AHBRSTR &= ~(RCC_AHBRSTR_FMCRST))
+#define __GPIOG_RELEASE_RESET()          (RCC->AHBRSTR &= ~(RCC_AHBRSTR_GPIOGRST))
+#define __GPIOH_RELEASE_RESET()          (RCC->AHBRSTR &= ~(RCC_AHBRSTR_GPIOHRST))
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_APB1_Force_Release_Reset RCC Extended APB1 Force Release Reset
+  * @brief  Force or release APB1 peripheral reset.
+  * @{   
   */
 #if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define __SPI2_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_SPI2RST))
@@ -1480,7 +2412,8 @@ typedef struct
 #define __I2C3_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_I2C3RST))
 #endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
 
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
 #define __TIM3_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM3RST))
 #define __TIM4_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM4RST))
 #define __SPI2_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_SPI2RST))
@@ -1496,7 +2429,8 @@ typedef struct
 #define __UART4_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_UART4RST))
 #define __UART5_RELEASE_RESET()  (RCC->APB1RSTR &= ~(RCC_APB1RSTR_UART5RST))
 #define __I2C2_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_I2C2RST))
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx */
 
 #if defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define __TIM3_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM3RST))
@@ -1534,20 +2468,29 @@ typedef struct
 #define __CEC_RELEASE_RESET()    (RCC->APB1RSTR &= ~(RCC_APB1RSTR_CECRST))
 #endif /* STM32F373xC || STM32F378xx */
 
-#if defined(STM32F303x8) || defined(STM32F303xC) || defined(STM32F358xx) || \
-    defined(STM32F334x8) || defined(STM32F328xx) || \
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
     defined(STM32F373xC) || defined(STM32F378xx)      
 #define __TIM7_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_TIM7RST))
 
 #define __TIM7_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_TIM7RST))
-#endif /* STM32F303x8 || STM32F303xC || STM32F358xx || STM32F334x8 || STM32F328xx || STM32F373xC || STM32F378xx */
+#endif /* STM32F303xE || STM32F398xx                || */
+       /* STM32F303xC || STM32F358xx                || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
-#if defined(STM32F302x8) || defined(STM32F302xC) || \
-    defined(STM32F303xC) || defined(STM32F373xC)
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F302x8)                         || \
+    defined(STM32F373xC)
 #define __USB_FORCE_RESET()      (RCC->APB1RSTR |= (RCC_APB1RSTR_USBRST))
 
 #define __USB_RELEASE_RESET()    (RCC->APB1RSTR &= ~(RCC_APB1RSTR_USBRST))
-#endif /* STM32F302x8 || STM32F302xC || STM32F303xC|| STM32F373xC */
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC || STM32F303xC || */
+       /* STM32F302x8                || */
+       /* STM32F373xC                   */
 
 #if !defined(STM32F301x8)
 #define __CAN_FORCE_RESET()      (RCC->APB1RSTR |= (RCC_APB1RSTR_CANRST))
@@ -1555,19 +2498,34 @@ typedef struct
 #define __CAN_RELEASE_RESET()    (RCC->APB1RSTR &= ~(RCC_APB1RSTR_CANRST))
 #endif /* STM32F301x8*/
 
-/** @brief  Force or release APB2 peripheral reset.
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+#define __I2C3_FORCE_RESET()     (RCC->APB1RSTR |= (RCC_APB1RSTR_I2C3RST))
+
+#define __I2C3_RELEASE_RESET()   (RCC->APB1RSTR &= ~(RCC_APB1RSTR_I2C3RST))
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+/**
+  * @}
   */
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+
+/** @defgroup RCCEx_APB2_Force_Release_Reset RCC Extended APB2 Force Release Reset
+  * @brief  Force or release APB2 peripheral reset.
+  * @{   
+  */
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
 #define __SPI1_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI1RST))
 
 #define __SPI1_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SPI1RST))
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx */
 
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 #define __TIM8_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_TIM8RST))
 
 #define __TIM8_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_TIM8RST))
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
 #if defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define __SPI1_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI1RST))
@@ -1597,17 +2555,38 @@ typedef struct
 #define __SDADC3_RELEASE_RESET() (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SDADC3RST))
 #endif /* STM32F373xC || STM32F378xx */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
     defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define __TIM1_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_TIM1RST))
 
 #define __TIM1_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_TIM1RST))
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx    */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+#define __SPI4_FORCE_RESET()      (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI4RST))
+
+#define __SPI4_RELEASE_RESET()    (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SPI4RST))
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+
+#if defined(STM32F303xE) || defined(STM32F398xx)
+#define __TIM20_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_TIM20RST))
+
+#define __TIM20_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_TIM20RST))
+#endif /* STM32F303xE || STM32F398xx */
+
+/**
+  * @}
+  */
 
 #if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/** @defgroup RCCEx_I2Cx_Clock_Config RCC Extended I2Cx Clock Config
+  * @{   
+  */ 
 
 /** @brief  Macro to configure the I2C2 clock (I2C2CLK).
   * @param  __I2C2CLKSource__: specifies the I2C2 clock source.
@@ -1641,6 +2620,13 @@ typedef struct
   */
 #define __HAL_RCC_GET_I2C3_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_I2C3SW)))
 
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_TIMx_Clock_Config RCC Extended TIMx Clock Config
+  * @{   
+  */ 
 /** @brief  Macro to configure the TIM1 clock (TIM1CLK).
   * @param  __TIM1CLKSource__: specifies the TIM1 clock source.
   *         This parameter can be one of the following values:
@@ -1709,6 +2695,13 @@ typedef struct
   */
 #define __HAL_RCC_GET_TIM17_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_TIM17SW)))
 
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_I2Sx_Clock_Config RCC Extended I2Sx Clock Config
+  * @{   
+  */ 
 /** @brief  Macro to configure the I2S clock source (I2SCLK).
   * @note   This function must be called before enabling the I2S APB clock.
   * @param  __I2SCLKSource__: specifies the I2S clock source.
@@ -1727,6 +2720,13 @@ typedef struct
   *                                        used as I2S clock source
   */
 #define __HAL_RCC_GET_I2S_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR, RCC_CFGR_I2SSRC)))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_ADCx_Clock_Config RCC Extended ADCx Clock Config
+  * @{   
+  */ 
 
 /** @brief  Macro to configure the ADC1 clock (ADC1CLK).
   * @param  __ADC1CLKSource__: specifies the ADC1 clock source.
@@ -1765,10 +2765,17 @@ typedef struct
   *            @arg RCC_ADC1PLLCLK_DIV256: PLL clock divided by 256 selected as ADC1 clock
   */
 #define __HAL_RCC_GET_ADC1_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR2, RCC_CFGR2_ADC1PRES)))
+/**
+  * @}
+  */
 
 #endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
 
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+/** @defgroup RCCEx_I2Cx_Clock_Config RCC Extended I2Cx Clock Config
+  * @{   
+  */ 
 
 /** @brief  Macro to configure the I2C2 clock (I2C2CLK).
   * @param  __I2C2CLKSource__: specifies the I2C2 clock source.
@@ -1785,6 +2792,13 @@ typedef struct
   *            @arg RCC_I2C2CLKSOURCE_SYSCLK: System Clock selected as I2C2 clock
   */
 #define __HAL_RCC_GET_I2C2_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_I2C2SW)))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_ADCx_Clock_Config RCC Extended ADCx Clock Config
+  * @{   
+  */ 
 
 /** @brief  Macro to configure the ADC1 & ADC2 clock (ADC12CLK).
   * @param  __ADC12CLKSource__: specifies the ADC1 & ADC2 clock source.
@@ -1823,6 +2837,13 @@ typedef struct
   *            @arg RCC_ADC12PLLCLK_DIV256: PLL clock divided by 256 selected as ADC1 & ADC2 clock
   */
 #define __HAL_RCC_GET_ADC12_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR2, RCC_CFGR2_ADCPRE12)))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_TIMx_Clock_Config RCC Extended TIMx Clock Config
+  * @{   
+  */ 
 
 /** @brief  Macro to configure the TIM1 clock (TIM1CLK).
   * @param  __TIM1CLKSource__: specifies the TIM1 clock source.
@@ -1840,6 +2861,13 @@ typedef struct
   *            @arg RCC_TIM1CLKSOURCE_PLL: PLL Clock selected as TIM1 clock
   */
 #define __HAL_RCC_GET_TIM1_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_TIM1SW)))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_I2Sx_Clock_Config RCC Extended I2Sx Clock Config
+  * @{   
+  */ 
 
 /** @brief  Macro to configure the I2S clock source (I2SCLK).
   * @note   This function must be called before enabling the I2S APB clock.
@@ -1859,6 +2887,13 @@ typedef struct
   *                                        used as I2S clock source
   */
 #define __HAL_RCC_GET_I2S_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR, RCC_CFGR_I2SSRC)))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_UARTx_Clock_Config RCC Extended UARTx Clock Config
+  * @{   
+  */ 
 
 /** @brief  Macro to configure the UART4 clock (UART4CLK).
   * @param  __UART4CLKSource__: specifies the UART4 clock source.
@@ -1899,10 +2934,17 @@ typedef struct
   *            @arg RCC_UART5CLKSOURCE_LSE: LSE selected as UART5 clock
   */
 #define __HAL_RCC_GET_UART5_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_UART5SW)))
+/**
+  * @}
+  */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
 
-#endif /* STM32F302xC || STM32F303xC || STM32F358xx */
-
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+/** @defgroup RCCEx_ADCx_Clock_Config RCC Extended ADCx Clock Config
+  * @{   
+  */ 
 
 /** @brief  Macro to configure the ADC3 & ADC4 clock (ADC34CLK).
   * @param  __ADC34CLKSource__: specifies the ADC3 & ADC4 clock source.
@@ -1941,6 +2983,13 @@ typedef struct
   *            @arg RCC_ADC34PLLCLK_DIV256: PLL clock divided by 256 selected as ADC3 & ADC4 clock
   */
 #define __HAL_RCC_GET_ADC34_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR2, RCC_CFGR2_ADCPRE34)))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_TIMx_Clock_Config RCC Extended TIMx Clock Config
+  * @{   
+  */ 
 
 /** @brief  Macro to configure the TIM8 clock (TIM8CLK).
   * @param  __TIM8CLKSource__: specifies the TIM8 clock source.
@@ -1959,9 +3008,16 @@ typedef struct
   */
 #define __HAL_RCC_GET_TIM8_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_TIM8SW)))
 
-#endif /* STM32F303xC || STM32F358xx */
+/**
+  * @}
+  */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
 #if defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+/** @defgroup RCCEx_ADCx_Clock_Config RCC Extended ADCx Clock Config
+  * @{   
+  */ 
 
 /** @brief  Macro to configure the ADC1 & ADC2 clock (ADC12CLK).
   * @param  __ADC12CLKSource__: specifies the ADC1 & ADC2 clock source.
@@ -2000,7 +3056,13 @@ typedef struct
   *            @arg RCC_ADC12PLLCLK_DIV256: PLL clock divided by 256 selected as ADC1 & ADC2 clock
   */
 #define __HAL_RCC_GET_ADC12_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR2, RCC_CFGR2_ADCPRE12)))                    
-                    
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_TIMx_Clock_Config RCC Extended TIMx Clock Config
+  * @{   
+  */ 
 /** @brief  Macro to configure the TIM1 clock (TIM1CLK).
   * @param  __TIM1CLKSource__: specifies the TIM1 clock source.
   *         This parameter can be one of the following values:
@@ -2017,11 +3079,15 @@ typedef struct
   *            @arg RCC_TIM1CLKSOURCE_PLL: PLL Clock selected as TIM1 clock
   */
 #define __HAL_RCC_GET_TIM1_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_TIM1SW)))
-
+/**
+  * @}
+  */
 #endif /* STM32F303x8 || STM32F334x8 || STM32F328xx */
 
 #if defined(STM32F334x8)
-
+/** @defgroup RCCEx_HRTIMx_Clock_Config RCC Extended HRTIMx Clock Config
+  * @{   
+  */ 
 /** @brief  Macro to configure the HRTIM1 clock.
   * @param  __HRTIM1CLKSource__: specifies the HRTIM1 clock source.
   *         This parameter can be one of the following values:
@@ -2037,11 +3103,15 @@ typedef struct
   *            @arg RCC_HRTIM1CLKSOURCE_PLL: PLL Clock selected as HRTIM1 clock
   */
 #define __HAL_RCC_GET_HRTIM1_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_HRTIM1SW)))
-
+/**
+  * @}
+  */
 #endif /* STM32F334x8 */
 
 #if defined(STM32F373xC) || defined(STM32F378xx)
-
+/** @defgroup RCCEx_I2Cx_Clock_Config RCC Extended I2Cx Clock Config
+  * @{   
+  */ 
 /** @brief  Macro to configure the I2C2 clock (I2C2CLK).
   * @param  __I2C2CLKSource__: specifies the I2C2 clock source.
   *         This parameter can be one of the following values:
@@ -2057,7 +3127,13 @@ typedef struct
   *            @arg RCC_I2C2CLKSOURCE_SYSCLK: System Clock selected as I2C2 clock
   */
 #define __HAL_RCC_GET_I2C2_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_I2C2SW)))
+/**
+  * @}
+  */
 
+/** @defgroup RCCEx_ADCx_Clock_Config RCC Extended ADCx Clock Config
+  * @{   
+  */ 
 /** @brief  Macro to configure the ADC1 clock (ADC1CLK).
   * @param  __ADC1CLKSource__: specifies the ADC1 clock source.
   *          This parameter can be one of the following values:
@@ -2077,7 +3153,13 @@ typedef struct
   *            @arg RCC_ADC1PCLK2_DIV8: PCLK2 clock divided by 8 selected as ADC1 clock
   */
 #define __HAL_RCC_GET_ADC1_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR, RCC_CFGR_ADCPRE)))
+/**
+  * @}
+  */
 
+/** @defgroup RCCEx_SDADCx_Clock_Config RCC Extended SDADCx Clock Config
+  * @{   
+  */ 
 /** @brief  Macro to configure the SDADCx clock (SDADCxCLK).
   * @param  __SDADCPrescaler__: specifies the SDADCx system clock prescaler.
   *         This parameter can be one of the following values:
@@ -2123,7 +3205,13 @@ typedef struct
   *            @arg RCC_SDADCSYSCLK_DIV48: SYSCLK clock divided by 48 selected as SDADCx clock
   */
 #define __HAL_RCC_GET_SDADC_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR, RCC_CFGR_SDADCPRE)))
+/**
+  * @}
+  */
 
+/** @defgroup RCCEx_CECx_Clock_Config RCC Extended CECx Clock Config
+  * @{   
+  */ 
 /** @brief  Macro to configure the CEC clock.
   * @param  __CECCLKSource__: specifies the CEC clock source.
   *         This parameter can be one of the following values:
@@ -2139,11 +3227,20 @@ typedef struct
   *            @arg RCC_CECCLKSOURCE_LSE: LSE selected as CEC clock
   */
 #define __HAL_RCC_GET_CEC_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_CECSW)))
+/**
+  * @}
+  */
 
 #endif /* STM32F373xC || STM32F378xx */
 
-#if defined(STM32F302x8) || defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F373xC)
+#if defined(STM32F302xE) || defined(STM32F303xE) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || \
+    defined(STM32F302x8)                         || \
+    defined(STM32F373xC)
 
+/** @defgroup RCCEx_USBx_Clock_Config RCC Extended USBx Clock Config
+  * @{   
+  */ 
 /** @brief  Macro to configure the USB clock (USBCLK).
   * @param  __USBCLKSource__: specifies the USB clock source.
   *         This parameter can be one of the following values:
@@ -2159,12 +3256,22 @@ typedef struct
   *            @arg RCC_USBPLLCLK_DIV1_5: PLL Clock divided by 1.5 selected as USB clock
   */
 #define __HAL_RCC_GET_USB_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR, RCC_CFGR_USBPRE)))
+/**
+  * @}
+  */
 
-#endif /* STM32F302x8 || STM32F302xC || STM32F303xC || STM32F373xC */
+#endif /* STM32F302xE || STM32F303xE || */
+       /* STM32F302xC || STM32F303xC || */
+       /* STM32F302x8                || */
+       /* STM32F373xC                   */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 
+/** @defgroup RCCEx_MCOx_Clock_Config RCC Extended MCOx Clock Config
+  * @{   
+  */ 
 /** @brief macro to configure the MCO clock.
   * @param  __MCOCLKSource__: specifies the MCO clock source.
   *          This parameter can be one of the following values:
@@ -2180,21 +3287,183 @@ typedef struct
   */
 #define __HAL_RCC_MCO_CONFIG(__MCOCLKSource__, __MCODiv__) \
                  MODIFY_REG(RCC->CFGR, (RCC_CFGR_MCO | RCC_CFGR_MCOPRE), ((__MCOCLKSource__) | (__MCODiv__)))
+/**
+  * @}
+  */
 #else
+/** @defgroup RCCEx_MCOx_Clock_Config RCC Extended MCOx Clock Config
+  * @{   
+  */ 
 
 #define __HAL_RCC_MCO_CONFIG(__MCOCLKSource__, __MCODiv__) \
                  MODIFY_REG(RCC->CFGR, RCC_CFGR_MCO, (__MCOCLKSource__))
+/**
+  * @}
+  */
 
-#endif /*  STM32F301x8 || STM32F302x8 || STM32F318xx || STM32F303x8 || STM32F334x8 || STM32F328xx */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+
+/** @defgroup RCCEx_I2Cx_Clock_Config RCC Extended I2Cx Clock Config
+  * @{   
+  */ 
+/** @brief  Macro to configure the I2C3 clock (I2C3CLK).
+  * @param  __I2C3CLKSource__: specifies the I2C3 clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_I2C3CLKSOURCE_HSI: HSI selected as I2C3 clock
+  *            @arg RCC_I2C3CLKSOURCE_SYSCLK: System Clock selected as I2C3 clock
+  */
+#define __HAL_RCC_I2C3_CONFIG(__I2C3CLKSource__) \
+                  MODIFY_REG(RCC->CFGR3, RCC_CFGR3_I2C3SW, (uint32_t)(__I2C3CLKSource__))
+
+/** @brief  Macro to get the I2C3 clock source.
+  * @retval The clock source can be one of the following values:
+  *            @arg RCC_I2C3CLKSOURCE_HSI: HSI selected as I2C3 clock
+  *            @arg RCC_I2C3CLKSOURCE_SYSCLK: System Clock selected as I2C3 clock
+  */
+#define __HAL_RCC_GET_I2C3_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_I2C3SW)))
+/**
+  * @}
+  */
+
+/** @defgroup RCCEx_TIMx_Clock_Config RCC Extended TIMx Clock Config
+  * @{   
+  */ 
+/** @brief  Macro to configure the TIM2 clock (TIM2CLK).
+  * @param  __TIM2CLKSource__: specifies the TIM2 clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_TIM2CLK_HCLK: HCLK selected as TIM2 clock
+  *            @arg RCC_TIM2CLK_PLL: PLL Clock selected as TIM2 clock
+  */
+#define __HAL_RCC_TIM2_CONFIG(__TIM2CLKSource__) \
+                  MODIFY_REG(RCC->CFGR3, RCC_CFGR3_TIM2SW, (uint32_t)(__TIM2CLKSource__))
+
+/** @brief  Macro to get the TIM2 clock (TIM2CLK).
+  * @retval The clock source can be one of the following values:
+  *         This parameter can be one of the following values:
+  *            @arg RCC_TIM2CLK_HCLK: HCLK selected as TIM2 clock
+  *            @arg RCC_TIM2CLK_PLL: PLL Clock selected as TIM2 clock
+  */
+#define __HAL_RCC_GET_TIM2_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_TIM2SW)))
+                    
+/** @brief  Macro to configure the TIM3 & TIM4 clock (TIM34CLK).
+  * @param  __TIM3CLKSource__: specifies the TIM3 & TIM4 clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_TIM34CLK_HCLK: HCLK selected as TIM3 & TIM4 clock
+  *            @arg RCC_TIM34CLK_PLL: PLL Clock selected as TIM3 & TIM4 clock
+  */
+#define __HAL_RCC_TIM34_CONFIG(__TIM34CLKSource__) \
+                  MODIFY_REG(RCC->CFGR3, RCC_CFGR3_TIM34SW, (uint32_t)(__TIM34CLKSource__))
+
+/** @brief  Macro to get the TIM3 & TIM4 clock (TIM34CLK).
+  * @retval The clock source can be one of the following values:
+  *         This parameter can be one of the following values:
+  *            @arg RCC_TIM34CLK_HCLK: HCLK selected as TIM3 & TIM4 clock
+  *            @arg RCC_TIM34CLK_PLL: PLL Clock selected as TIM3 & TIM4 clock
+  */
+#define __HAL_RCC_GET_TIM34_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_TIM34SW)))
+
+/** @brief  Macro to configure the TIM15 clock (TIM15CLK).
+  * @param  __TIM15CLKSource__: specifies the TIM15 clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_TIM15CLK_HCLK: HCLK selected as TIM15 clock
+  *            @arg RCC_TIM15CLK_PLL: PLL Clock selected as TIM15 clock
+  */
+#define __HAL_RCC_TIM15_CONFIG(__TIM15CLKSource__) \
+                  MODIFY_REG(RCC->CFGR3, RCC_CFGR3_TIM15SW, (uint32_t)(__TIM15CLKSource__))
+
+/** @brief  Macro to get the TIM15 clock (TIM15CLK).
+  * @retval The clock source can be one of the following values:
+  *         This parameter can be one of the following values:
+  *            @arg RCC_TIM15CLK_HCLK: HCLK selected as TIM15 clock
+  *            @arg RCC_TIM15CLK_PLL: PLL Clock selected as TIM15 clock
+  */
+#define __HAL_RCC_GET_TIM15_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_TIM15SW)))
+
+/** @brief  Macro to configure the TIM16 clock (TIM16CLK).
+  * @param  __TIM16CLKSource__: specifies the TIM16 clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_TIM16CLK_HCLK: HCLK selected as TIM16 clock
+  *            @arg RCC_TIM16CLK_PLL: PLL Clock selected as TIM16 clock
+  */
+#define __HAL_RCC_TIM16_CONFIG(__TIM16CLKSource__) \
+                  MODIFY_REG(RCC->CFGR3, RCC_CFGR3_TIM16SW, (uint32_t)(__TIM16CLKSource__))
+
+/** @brief  Macro to get the TIM16 clock (TIM16CLK).
+  * @retval The clock source can be one of the following values:
+  *         This parameter can be one of the following values:
+  *            @arg RCC_TIM16CLK_HCLK: HCLK selected as TIM16 clock
+  *            @arg RCC_TIM16CLK_PLL: PLL Clock selected as TIM16 clock
+  */
+#define __HAL_RCC_GET_TIM16_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_TIM16SW)))
+ 
+/** @brief  Macro to configure the TIM17 clock (TIM17CLK).
+  * @param  __TIM17CLKSource__: specifies the TIM17 clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_TIM17CLK_HCLK: HCLK selected as TIM17 clock
+  *            @arg RCC_TIM17CLK_PLL: PLL Clock selected as TIM17 clock
+  */
+#define __HAL_RCC_TIM17_CONFIG(__TIM17CLKSource__) \
+                  MODIFY_REG(RCC->CFGR3, RCC_CFGR3_TIM17SW, (uint32_t)(__TIM17CLKSource__))
+
+/** @brief  Macro to get the TIM17 clock (TIM17CLK).
+  * @retval The clock source can be one of the following values:
+  *         This parameter can be one of the following values:
+  *            @arg RCC_TIM17CLK_HCLK: HCLK selected as TIM17 clock
+  *            @arg RCC_TIM17CLK_PLL: PLL Clock selected as TIM17 clock
+  */
+#define __HAL_RCC_GET_TIM17_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_TIM17SW)))
+                    
+/**
+  * @}
+  */
+                   
+#endif /* STM32f302xE || STM32f303xE || STM32F398xx */
+                    
+#if defined(STM32F303xE) || defined(STM32F398xx)
+/** @addtogroup RCCEx_TIMx_Clock_Config RCC Extended TIMx Clock Config 
+  * @{
+  */
+/** @brief  Macro to configure the TIM20 clock (TIM20CLK).
+  * @param  __TIM20CLKSource__: specifies the TIM20 clock source.
+  *         This parameter can be one of the following values:
+  *            @arg RCC_TIM20CLK_HCLK: HCLK selected as TIM20 clock
+  *            @arg RCC_TIM20CLK_PLL: PLL Clock selected as TIM20 clock
+  */
+#define __HAL_RCC_TIM20_CONFIG(__TIM20CLKSource__) \
+                  MODIFY_REG(RCC->CFGR3, RCC_CFGR3_TIM20SW, (uint32_t)(__TIM20CLKSource__))
+
+/** @brief  Macro to get the TIM20 clock (TIM20CLK).
+  * @retval The clock source can be one of the following values:
+  *         This parameter can be one of the following values:
+  *            @arg RCC_TIM20CLK_HCLK: HCLK selected as TIM20 clock
+  *            @arg RCC_TIM20CLK_PLL: PLL Clock selected as TIM20 clock
+  */
+#define __HAL_RCC_GET_TIM20_SOURCE() ((uint32_t)(READ_BIT(RCC->CFGR3, RCC_CFGR3_TIM20SW)))
+
+/**
+  * @}
+  */
+#endif /* STM32f303xE || STM32F398xx */
+
 
 /**
   * @}
   */
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup RCCEx_Exported_Functions RCC Extended Exported Functions
+  * @{
+  */
+
+/** @addtogroup RCCEx_Exported_Functions_Group1 Extended Peripheral Control functions 
+  * @{
+  */
 HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit);
 void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit);
-
 /**
   * @}
   */
@@ -2203,6 +3472,13 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit);
   * @}
   */
 
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_rtc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_rtc.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_rtc.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   RTC HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -183,7 +183,7 @@
   * @{
   */
 
-/** @defgroup RTC 
+/** @defgroup RTC RTC HAL module driver
   * @brief RTC HAL module driver
   * @{
   */
@@ -195,13 +195,13 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
 
-/** @defgroup RTC_Private_Functions
+/** @defgroup RTC_Exported_Functions RTC Exported Functions
   * @{
   */
   
-/** @defgroup RTC_Group1 Initialization and de-initialization functions 
+/** @defgroup RTC_Exported_Functions_Group1 Initialization and de-initialization functions 
  *  @brief    Initialization and Configuration functions 
  *
 @verbatim    
@@ -243,7 +243,7 @@
 HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc)
 {
   /* Check the RTC peripheral state */
-  if(hrtc == NULL)
+  if(hrtc == HAL_NULL)
   {
      return HAL_ERROR;
   }
@@ -436,7 +436,7 @@ __weak void HAL_RTC_MspDeInit(RTC_HandleTypeDef* hrtc)
   * @}
   */
 
-/** @defgroup RTC_Group2 RTC Time and Date functions
+/** @defgroup RTC_Exported_Functions_Group2 RTC Time and Date functions
  *  @brief   RTC Time and Date functions
  *
 @verbatim   
@@ -766,7 +766,7 @@ HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDat
   * @}
   */
 
-/** @defgroup RTC_Group3 RTC Alarm functions
+/** @defgroup RTC_Exported_Functions_Group3 RTC Alarm functions
  *  @brief   RTC Alarm functions
  *
 @verbatim   
@@ -1385,7 +1385,7 @@ HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t T
   * @}
   */
 
-/** @defgroup RTC_Group4 Peripheral Control functions 
+/** @defgroup RTC_Exported_Functions_Group4 Peripheral Control functions 
  *  @brief   Peripheral Control functions 
  *
 @verbatim   
@@ -1439,7 +1439,7 @@ HAL_StatusTypeDef HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc)
   * @}
   */
 
-/** @defgroup RTC_Group5 Peripheral State functions
+/** @defgroup RTC_Exported_Functions_Group5 Peripheral State functions
  *  @brief   Peripheral State functions 
  *
 @verbatim   
@@ -1467,6 +1467,14 @@ HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef* hrtc)
   * @}
   */
 
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Private_Functions RTC Private Functions
+  * @{
+  */
+    
 /**
   * @brief  Enters the RTC Initialization mode.
   * @note   The RTC Initialization mode is write protected, use the
@@ -1536,6 +1544,7 @@ uint8_t RTC_Bcd2ToByte(uint8_t Value)
   */
 
 #endif /* HAL_RTC_MODULE_ENABLED */
+
 /**
   * @}
   */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_rtc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_rtc.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_rtc.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of RTC HAL module.
   ******************************************************************************
   * @attention
@@ -50,11 +50,15 @@
   * @{
   */
 
-/** @addtogroup RTC
+/** @addtogroup RTC RTC HAL module driver
   * @{
   */
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup RTC_Exported_Types RTC Exported Types
+  * @{
+  */
+
 /** 
   * @brief  HAL State structures definition  
   */
@@ -178,12 +182,18 @@ typedef struct
   __IO HAL_RTCStateTypeDef  State;      /*!< Time communication state */
 
 }RTC_HandleTypeDef;
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup RTC_Exported_Constants
+/** @defgroup RTC_Exported_Constants RTC Exported Constants
   * @{
   */
 
+/** @defgroup RTC_Mask_Definition RTC Mask Definition
+  * @{
+  */
 /* Masks Definition */
 #define RTC_TR_RESERVED_MASK    ((uint32_t)0x007F7F7F)
 #define RTC_DR_RESERVED_MASK    ((uint32_t)0x00FFFF3F) 
@@ -196,8 +206,11 @@ typedef struct
                                             RTC_FLAG_RECALPF | RTC_FLAG_SHPF))
 
 #define RTC_TIMEOUT_VALUE  1000
+/**
+  * @}
+  */
   
-/** @defgroup RTC_Hour_Formats
+/** @defgroup RTC_Hour_Formats RTC Hour Formats
   * @{
   */
 #define RTC_HOURFORMAT_24              ((uint32_t)0x00000000)
@@ -209,7 +222,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_Output_Polarity_Definitions 
+/** @defgroup RTC_Output_Polarity_Definitions RTC Output Polarity Definitions
   * @{
   */
 #define RTC_OUTPUT_POLARITY_HIGH       ((uint32_t)0x00000000)
@@ -221,7 +234,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_Output_Type_ALARM_OUT
+/** @defgroup RTC_Output_Type_ALARM_OUT RTC Output Type ALARM OUT
   * @{
   */
 #define RTC_OUTPUT_TYPE_OPENDRAIN      ((uint32_t)0x00000000)
@@ -234,7 +247,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_Asynchronous_Predivider
+/** @defgroup RTC_Asynchronous_Predivider RTC Asynchronous Predivider
   * @{
   */
 #define IS_RTC_ASYNCH_PREDIV(PREDIV)   ((PREDIV) <= (uint32_t)0x7F)
@@ -242,8 +255,7 @@ typedef struct
   * @}
   */
 
-
-/** @defgroup RTC_Synchronous_Predivider
+/** @defgroup RTC_Synchronous_Predivider RTC Synchronous Predivider
   * @{
   */
 #define IS_RTC_SYNCH_PREDIV(PREDIV)    ((PREDIV) <= (uint32_t)0x7FFF)
@@ -251,7 +263,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_Time_Definitions
+/** @defgroup RTC_Time_Definitions RTC Time Definitions
   * @{
   */
 #define IS_RTC_HOUR12(HOUR)            (((HOUR) > (uint32_t)0) && ((HOUR) <= (uint32_t)12))
@@ -262,7 +274,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_AM_PM_Definitions
+/** @defgroup RTC_AM_PM_Definitions RTC AM PM Definitions
   * @{
   */
 #define RTC_HOURFORMAT12_AM            ((uint8_t)0x00)
@@ -273,7 +285,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_DayLightSaving_Definitions
+/** @defgroup RTC_DayLightSaving_Definitions RTC DayLightSaving Definitions
   * @{
   */
 #define RTC_DAYLIGHTSAVING_SUB1H       ((uint32_t)0x00020000)
@@ -287,7 +299,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_StoreOperation_Definitions 
+/** @defgroup RTC_StoreOperation_Definitions RTC StoreOperation Definitions
   * @{
   */
 #define RTC_STOREOPERATION_RESET        ((uint32_t)0x00000000)
@@ -299,7 +311,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_Input_parameter_format_definitions
+/** @defgroup RTC_Input_parameter_format_definitions RTC Input parameter format definitions
   * @{
   */
 #define FORMAT_BIN                      ((uint32_t)0x000000000)
@@ -310,7 +322,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_Year_Date_Definitions
+/** @defgroup RTC_Year_Date_Definitions RTC Year Date Definitions
   * @{
   */
 #define IS_RTC_YEAR(YEAR)              ((YEAR) <= (uint32_t)99)
@@ -318,7 +330,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_Month_Date_Definitions
+/** @defgroup RTC_Month_Date_Definitions RTC Month Date Definitions
   * @{
   */
 
@@ -342,7 +354,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_WeekDay_Definitions
+/** @defgroup RTC_WeekDay_Definitions RTC WeekDay Definitions
   * @{
   */
 #define RTC_WEEKDAY_MONDAY             ((uint8_t)0x01)
@@ -364,7 +376,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_Alarm_Definitions
+/** @defgroup RTC_Alarm_Definitions RTC Alarm Definitions
   * @{
   */
 #define IS_RTC_ALARM_DATE_WEEKDAY_DATE(DATE) (((DATE) >(uint32_t) 0) && ((DATE) <= (uint32_t)31))
@@ -379,8 +391,7 @@ typedef struct
   * @}
   */
 
-
-/** @defgroup RTC_AlarmDateWeekDay_Definitions
+/** @defgroup RTC_AlarmDateWeekDay_Definitions RTC AlarmDateWeekDay Definitions
   * @{
   */
 #define RTC_ALARMDATEWEEKDAYSEL_DATE      ((uint32_t)0x00000000)
@@ -392,8 +403,7 @@ typedef struct
   * @}
   */
 
-
-/** @defgroup RTC_AlarmMask_Definitions
+/** @defgroup RTC_AlarmMask_Definitions RTC AlarmMask Definitions
   * @{
   */
 #define RTC_ALARMMASK_NONE                ((uint32_t)0x00000000)
@@ -408,7 +418,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_Alarms_Definitions
+/** @defgroup RTC_Alarms_Definitions RTC Alarms Definitions
   * @{
   */
 #define RTC_ALARM_A                       RTC_CR_ALRAE
@@ -419,7 +429,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_Alarm_Sub_Seconds_Value
+/** @defgroup RTC_Alarm_Sub_Seconds_Value RTC Alarm Sub Seconds Value
   * @{
   */
 #define IS_RTC_ALARM_SUB_SECOND_VALUE(VALUE) ((VALUE) <= (uint32_t)0x00007FFF)
@@ -427,7 +437,7 @@ typedef struct
   * @}
   */
 
-  /** @defgroup RTC_Alarm_Sub_Seconds_Masks_Definitions
+  /** @defgroup RTC_Alarm_Sub_Seconds_Masks_Definitions RTC Alarm Sub Seconds Masks Definitions
   * @{
   */
 #define RTC_ALARMSUBSECONDMASK_ALL         ((uint32_t)0x00000000)  /*!< All Alarm SS fields are masked.
@@ -484,7 +494,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_Interrupts_Definitions
+/** @defgroup RTC_Interrupts_Definitions RTC Interrupts Definitions
   * @{
   */
 #define RTC_IT_TS                         ((uint32_t)0x00008000)
@@ -499,7 +509,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTC_Flags_Definitions
+/** @defgroup RTC_Flags_Definitions RTC Flags Definitions
   * @{
   */
 #define RTC_FLAG_RECALPF                  ((uint32_t)0x00010000)
@@ -527,6 +537,9 @@ typedef struct
   */
 
 /* Exported macros -----------------------------------------------------------*/
+/** @defgroup RTC_Exported_Macros RTC Exported Macros
+  * @{
+  */
 
 /** @brief  Reset RTC handle state
   * @param  __HANDLE__: RTC handle.
@@ -698,23 +711,47 @@ typedef struct
 /* alias define maintained for legacy */
 #define __HAL_RTC_CLEAR_FLAG   __HAL_RTC_EXTI_CLEAR_FLAG
 
-/* Include RTC HAL Extension module */
+/**
+  * @}
+  */
+
+/* Include RTC HAL Extended module */
 #include "stm32f3xx_hal_rtc_ex.h"
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup RTC_Exported_Functions RTC Exported Functions
+  * @{
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
 
 /* Initialization and de-initialization functions  ****************************/
 HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc);
 HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc);
 void              HAL_RTC_MspInit(RTC_HandleTypeDef *hrtc);
 void              HAL_RTC_MspDeInit(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group2 RTC Time and Date functions
+  * @{
+  */
 
 /* RTC Time and Date functions ************************************************/
 HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format);
 HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format);
 HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format);
 HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format);
+/**
+  * @}
+  */
 
+/** @addtogroup RTC_Exported_Functions_Group3 RTC Alarm functions
+  * @{
+  */
 /* RTC Alarm functions ********************************************************/
 HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format);
 HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format);
@@ -723,16 +760,41 @@ HAL_StatusTypeDef HAL_RTC_GetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
 void              HAL_RTC_AlarmIRQHandler(RTC_HandleTypeDef *hrtc);
 HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
 void              HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
 
+/** @addtogroup RTC_Exported_Functions_Group4 Peripheral Control functions
+  * @{
+  */  
 /* Peripheral Control functions ***********************************************/
 HAL_StatusTypeDef   HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc);
+/**
+  * @}
+  */
 
+/** @addtogroup RTC_Exported_Functions_Group5 Peripheral State functions
+  * @{
+  */  
 /* Peripheral State functions *************************************************/
 HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
 
+/**
+  * @}
+  */  
+
+/** @addtogroup RTC_Private_Functions
+  * @{
+  */    
 HAL_StatusTypeDef  RTC_EnterInitMode(RTC_HandleTypeDef* hrtc);
 uint8_t            RTC_ByteToBcd2(uint8_t Value);
 uint8_t            RTC_Bcd2ToByte(uint8_t Value);
+/**
+  * @}
+  */  
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_rtc_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_rtc_ex.c
@@ -2,16 +2,16 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_rtc_ex.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Extended RTC HAL module driver.
   *          This file provides firmware functions to manage the following 
-  *          functionalities of the Real Time Clock (RTC) Extension peripheral:
+  *          functionalities of the Real Time Clock (RTC) Extended peripheral:
   *           + RTC Time Stamp functions
   *           + RTC Tamper functions 
   *           + RTC Wake-up functions
-  *           + Extension Control functions
-  *           + Extension RTC features functions    
+  *           + Extended Control functions
+  *           + Extended RTC features functions    
   *
   @verbatim
   ==============================================================================
@@ -97,7 +97,7 @@
   * @{
   */
 
-/** @defgroup RTCEx
+/** @defgroup RTCEx RTC Extended HAL module driver
   * @brief RTC Extended HAL module driver
   * @{
   */
@@ -109,14 +109,14 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
 
-/** @defgroup RTCEx_Private_Functions
+/** @defgroup RTCEx_Exported_Functions RTC Extended Exported Functions
   * @{
   */
   
 
-/** @defgroup RTCEx_Group1 RTC TimeStamp and Tamper functions
+/** @defgroup RTCEx_Exported_Functions_Group1 RTC TimeStamp and Tamper functions
   * @brief    RTC TimeStamp and Tamper functions
   *
 @verbatim   
@@ -725,7 +725,7 @@ HAL_StatusTypeDef HAL_RTCEx_PollForTamper3Event(RTC_HandleTypeDef *hrtc, uint32_
   * @}
   */
   
-/** @defgroup RTCEx_Group2 RTC Wake-up functions
+/** @defgroup RTCEx_Exported_Functions_Group2 Extended Wake-up functions
   * @brief    RTC Wake-up functions
   *
 @verbatim   
@@ -1020,12 +1020,12 @@ HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uin
   */
 
 
-/** @defgroup RTCEx_Group3 Extended Peripheral Control functions
+/** @defgroup RTCEx_Exported_Functions_Group3 Extended Peripheral Control functions
   * @brief    Extended Peripheral Control functions
   *
 @verbatim   
  ===============================================================================
-              ##### Extension Peripheral Control functions #####
+              ##### Extended Peripheral Control functions #####
  ===============================================================================  
     [..]
     This subsection provides functions allowing to
@@ -1499,7 +1499,7 @@ HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef* hrtc)
   * @}
   */
 
-/** @defgroup RTCEx_Group4 Extended features functions
+/** @defgroup RTCEx_Exported_Functions_Group4 Extended features functions
   * @brief    Extended features functions
   *
 @verbatim   

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_rtc_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_rtc_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_rtc_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of RTC HAL Extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of RTC HAL Extended module.
   ******************************************************************************
   * @attention
   *
@@ -50,11 +50,15 @@
   * @{
   */
 
-/** @addtogroup RTCEx
+/** @addtogroup RTCEx RTC Extended HAL module driver
   * @{
   */
 
 /* Exported types ------------------------------------------------------------*/ 
+
+/** @defgroup RTCEx_Exported_Types RTC Extended Exported Types
+  * @{
+  */
 
 /**
   * @brief  RTC Tamper structure definition
@@ -82,13 +86,16 @@ typedef struct
   uint32_t TimeStampOnTamperDetection;  /*!< Specifies the TimeStampOnTamperDetection.
                                              This parameter can be a value of @ref RTCEx_Tamper_TimeStampOnTamperDetection_Definitions */
 }RTC_TamperTypeDef;
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup RTCEx_Exported_Constants
+/** @defgroup RTCEx_Exported_Constants RTC Extended Exported Constants
   * @{
   */
 
-/** @defgroup RTCEx_Output_selection_Definitions
+/** @defgroup RTCEx_Output_selection_Definitions RTC Extended Output Selection Definition
   * @{
   */
 #define RTC_OUTPUT_DISABLE             ((uint32_t)0x00000000)
@@ -104,7 +111,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Backup_Registers_Definitions
+/** @defgroup RTCEx_Backup_Registers_Definitions RTC Extended Backup Registers Definition
   * @{
   */
 #define RTC_BKP_DR0                       ((uint32_t)0x00000000)
@@ -147,7 +154,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Time_Stamp_Edges_definitions
+/** @defgroup RTCEx_Time_Stamp_Edges_definitions RTC Extended Time Stamp Edges definition
   * @{
   */
 #define RTC_TIMESTAMPEDGE_RISING          ((uint32_t)0x00000000)
@@ -159,7 +166,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Tamper_Pins_Definitions
+/** @defgroup RTCEx_Tamper_Pins_Definitions RTC Extended Tamper Pins Definition
   * @{
   */
 #define RTC_TAMPER_1                    RTC_TAFCR_TAMP1E
@@ -173,7 +180,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_TimeStamp_Pin_Selection
+/** @defgroup RTCEx_TimeStamp_Pin_Selections RTC Extended TimeStamp Pin Selection
   * @{
   */
 #define RTC_TIMESTAMPPIN_PC13              ((uint32_t)0x00000000)
@@ -183,7 +190,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Tamper_Trigger_Definitions
+/** @defgroup RTCEx_Tamper_Trigger_Definitions RTC Extended Tamper Trigger Definition
   * @{
   */
 #define RTC_TAMPERTRIGGER_RISINGEDGE       ((uint32_t)0x00000000)
@@ -200,7 +207,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Tamper_Filter_Definitions
+/** @defgroup RTCEx_Tamper_Filter_Definitions RTC Extended Tamper Filter Definition
   * @{
   */
 #define RTC_TAMPERFILTER_DISABLE   ((uint32_t)0x00000000)  /*!< Tamper filter is disabled */
@@ -220,7 +227,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Tamper_Sampling_Frequencies_Definitions 
+/** @defgroup RTCEx_Tamper_Sampling_Frequencies_Definitions RTC Extended Tamper Sampling Frequencies Definition  
   * @{
   */
 #define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV32768  ((uint32_t)0x00000000)  /*!< Each of the tamper inputs are sampled
@@ -252,7 +259,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Tamper_Pin_Precharge_Duration_Definitions
+/** @defgroup RTCEx_Tamper_Pin_Precharge_Duration_Definitions RTC Extended Tamper Pin Precharge Duration Definition
   * @{
   */
 #define RTC_TAMPERPRECHARGEDURATION_1RTCCLK ((uint32_t)0x00000000)  /*!< Tamper pins are pre-charged before
@@ -272,7 +279,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Tamper_TimeStampOnTamperDetection_Definitions
+/** @defgroup RTCEx_Tamper_TimeStampOnTamperDetection_Definitions RTC Extended Tamper TimeStampOnTamperDetection Definition
   * @{
   */
 #define RTC_TIMESTAMPONTAMPERDETECTION_ENABLE  ((uint32_t)RTC_TAFCR_TAMPTS)  /*!< TimeStamp on Tamper Detection event saved */
@@ -284,7 +291,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Tamper_Pull_UP_Definitions
+/** @defgroup RTCEx_Tamper_Pull_UP_Definitions RTC Extended Tamper Pull UP Definition
   * @{
   */
 #define RTC_TAMPER_PULLUP_ENABLE  ((uint32_t)0x00000000)            /*!< TimeStamp on Tamper Detection event saved */
@@ -296,7 +303,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Wakeup_Timer_Definitions
+/** @defgroup RTCEx_Wakeup_Timer_Definitions RTC Extended Wakeup Timer Definition
   * @{
   */
 #define RTC_WAKEUPCLOCK_RTCCLK_DIV16        ((uint32_t)0x00000000)
@@ -318,7 +325,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Smooth_calib_period_Definitions
+/** @defgroup RTCEx_Smooth_calib_period_Definitions RTC Extended Smooth calib period Definition
   * @{
   */
 #define RTC_SMOOTHCALIB_PERIOD_32SEC   ((uint32_t)0x00000000) /*!<  If RTCCLK = 32768 Hz, Smooth calibation
@@ -335,7 +342,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Smooth_calib_Plus_pulses_Definitions
+/** @defgroup RTCEx_Smooth_calib_Plus_pulses_Definitions RTC Extended Smooth calib Plus pulses Definition
   * @{
   */
 #define RTC_SMOOTHCALIB_PLUSPULSES_SET    ((uint32_t)0x00008000) /*!<  The number of RTCCLK pulses added
@@ -350,7 +357,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Smooth_calib_Minus_pulses_Definitions
+/** @defgroup RTCEx_Smooth_calib_Minus_pulses_Definitions RTC Extended Smooth calib Minus pulses Definition
   * @{
   */
 #define  IS_RTC_SMOOTH_CALIB_MINUS(VALUE) ((VALUE) <= 0x000001FF)
@@ -358,7 +365,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Add_1_Second_Parameter_Definitions
+/** @defgroup RTCEx_Add_1_Second_Parameter_Definition RTC Extended Add 1 Second Parameter Definition
   * @{
   */
 #define RTC_SHIFTADD1S_RESET      ((uint32_t)0x00000000)
@@ -370,7 +377,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup RTCEx_Substract_Fraction_Of_Second_Value
+/** @defgroup RTCEx_Substract_Fraction_Of_Second_Value RTC Extended Substract Fraction Of Second Value
   * @{
   */
 #define IS_RTC_SHIFT_SUBFS(FS) ((FS) <= 0x00007FFF)
@@ -378,7 +385,7 @@ typedef struct
   * @}
   */
 
- /** @defgroup RTCEx_Calib_Output_selection_Definitions
+ /** @defgroup RTCEx_Calib_Output_selection_Definitions RTC Extended Calib Output selection Definition
   * @{
   */
 #define RTC_CALIBOUTPUT_512HZ            ((uint32_t)0x00000000)
@@ -395,6 +402,9 @@ typedef struct
   */
 
 /* Exported macro ------------------------------------------------------------*/
+/** @defgroup RTCEx_Exported_Macros RTC Extended Exported Macros
+  * @{
+  */
 
 /**
   * @brief Enable the RTC WakeUp Timer peripheral.
@@ -593,8 +603,18 @@ typedef struct
   * @retval None
   */
 #define __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(__HANDLE__, __FLAG__)            ((__HANDLE__)->Instance->ISR) = (~(((__FLAG__) | RTC_ISR_INIT)& 0x0000FFFF)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT)) 
+/**
+  * @}
+  */
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup RTCEx_Exported_Functions RTC Extended Exported Functions
+  * @{
+  */
+
+/** @addtogroup RTCEx_Exported_Functions_Group1 RTC TimeStamp and Tamper functions
+ * @{
+ */ 
 
 /* RTC TimeStamp and Tamper functions *****************************************/
 HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin);
@@ -615,6 +635,13 @@ HAL_StatusTypeDef HAL_RTCEx_PollForTimeStampEvent(RTC_HandleTypeDef *hrtc, uint3
 HAL_StatusTypeDef HAL_RTCEx_PollForTamper1Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
 HAL_StatusTypeDef HAL_RTCEx_PollForTamper2Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
 HAL_StatusTypeDef HAL_RTCEx_PollForTamper3Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+/**
+  * @}
+  */
+
+/** @addtogroup RTCEx_Exported_Functions_Group2 Extended Wake-up functions
+ * @{
+ */ 
 
 /* RTC Wake-up functions ******************************************************/
 HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock);
@@ -624,8 +651,15 @@ uint32_t          HAL_RTCEx_GetWakeUpTimer(RTC_HandleTypeDef *hrtc);
 void              HAL_RTCEx_WakeUpTimerIRQHandler(RTC_HandleTypeDef *hrtc);
 void              HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef *hrtc);
 HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+/**
+  * @}
+  */
 
-/* Extension Control functions ************************************************/
+/** @addtogroup RTCEx_Exported_Functions_Group3 Extended Peripheral Control functions
+ * @{
+ */ 
+
+/* Extended Control functions ************************************************/
 void              HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister, uint32_t Data);
 uint32_t          HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister);
 
@@ -637,11 +671,24 @@ HAL_StatusTypeDef HAL_RTCEx_SetRefClock(RTC_HandleTypeDef *hrtc);
 HAL_StatusTypeDef HAL_RTCEx_DeactivateRefClock(RTC_HandleTypeDef *hrtc);
 HAL_StatusTypeDef HAL_RTCEx_EnableBypassShadow(RTC_HandleTypeDef *hrtc);
 HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
 
-/* Extension RTC features functions *******************************************/
+/* Extended RTC features functions *******************************************/
+/** @addtogroup RTCEx_Exported_Functions_Group4 Extended features functions
+ * @{
+ */ 
 void              HAL_RTCEx_AlarmBEventCallback(RTC_HandleTypeDef *hrtc); 
 HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
 
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_sdadc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_sdadc.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_sdadc.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   This file provides firmware functions to manage the following 
   *          functionalities of the Sigma-Delta Analog to Digital Convertor
   *          (SDADC) peripherals:
@@ -197,24 +197,34 @@
   * @{
   */
 
-/** @defgroup SDADC 
-  * @brief SDADC driver modules
+#ifdef HAL_SDADC_MODULE_ENABLED
+#if defined(STM32F373xC) || defined(STM32F378xx)
+/** @defgroup SDADC SDADC HAL module driver
+  * @brief SDADC HAL driver modules
   * @{
   */ 
 
-#ifdef HAL_SDADC_MODULE_ENABLED
-#if defined(STM32F373xC) || defined(STM32F378xx)
-    
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+/** @defgroup SDADC_Private_Define SDADC Private Define
+ * @{
+ */
 #define SDADC_TIMEOUT          200
 #define SDADC_CONFREG_OFFSET   0x00000020
 #define SDADC_JDATAR_CH_OFFSET 24
 #define SDADC_MSB_MASK         0xFFFF0000
 #define SDADC_LSB_MASK         0x0000FFFF
+/**
+  * @}
+  */
+
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
+/** @defgroup SDADC_Private_Functions SDADC Private Functions
+  * @{
+  */
+
 static HAL_StatusTypeDef SDADC_EnterInitMode(SDADC_HandleTypeDef* hsdadc);
 static void              SDADC_ExitInitMode(SDADC_HandleTypeDef* hsdadc);
 static uint32_t          SDADC_GetInjChannelsNbr(uint32_t Channels);
@@ -227,14 +237,17 @@ static void              SDADC_DMARegularConvCplt(DMA_HandleTypeDef *hdma);
 static void              SDADC_DMAInjectedHalfConvCplt(DMA_HandleTypeDef *hdma);
 static void              SDADC_DMAInjectedConvCplt(DMA_HandleTypeDef *hdma);
 static void              SDADC_DMAError(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
 
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
 
-/** @defgroup SDADC_Private_Functions
+/** @defgroup SDADC_Exported_Functions SDADC Exported Functions
   * @{
   */
 
-/** @defgroup SDADC_Group1 Initialization/de-initialization functions 
+/** @defgroup SDADC_Exported_Functions_Group1 Initialization and de-initialization functions
  *  @brief    Initialization and de-initialization functions 
  *
 @verbatim    
@@ -267,7 +280,7 @@ HAL_StatusTypeDef HAL_SDADC_Init(SDADC_HandleTypeDef* hsdadc)
   assert_param(IS_SDADC_VREF(hsdadc->Init.ReferenceVoltage));
   
   /* Check SDADC handle */
-  if(hsdadc == NULL)
+  if(hsdadc == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -330,7 +343,7 @@ HAL_StatusTypeDef HAL_SDADC_DeInit(SDADC_HandleTypeDef* hsdadc)
   assert_param(IS_SDADC_ALL_INSTANCE(hsdadc->Instance));
   
   /* Check SDADC handle */
-  if(hsdadc == NULL)
+  if(hsdadc == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -386,7 +399,7 @@ __weak void HAL_SDADC_MspDeInit(SDADC_HandleTypeDef* hsdadc)
   * @}
   */
 
-/** @defgroup SDADC_Group2 peripheral control functions
+/** @defgroup SDADC_Exported_Functions_Group2 peripheral control functions
  *  @brief    Peripheral control functions
  *
 @verbatim   
@@ -428,7 +441,7 @@ HAL_StatusTypeDef HAL_SDADC_PrepareChannelConfig(SDADC_HandleTypeDef *hsdadc,
   /* Check parameters */
   assert_param(IS_SDADC_ALL_INSTANCE(hsdadc->Instance));
   assert_param(IS_SDADC_CONF_INDEX(ConfIndex));
-  assert_param(ConfParamStruct != NULL);
+  assert_param(ConfParamStruct != HAL_NULL);
   assert_param(IS_SDADC_INPUT_MODE(ConfParamStruct->InputMode));
   assert_param(IS_SDADC_GAIN(ConfParamStruct->Gain));
   assert_param(IS_SDADC_COMMON_MODE(ConfParamStruct->CommonMode));
@@ -881,7 +894,7 @@ HAL_StatusTypeDef HAL_SDADC_InjectedMultiModeConfigChannel(SDADC_HandleTypeDef* 
   * @}
   */
 
-/** @defgroup SDADC_Group3 I/O operation functions
+/** @defgroup SDADC_Exported_Functions_Group3 Input and Output operation functions
  *  @brief    I/O operation Control functions 
  *
 @verbatim   
@@ -1266,7 +1279,7 @@ HAL_StatusTypeDef HAL_SDADC_Start_DMA(SDADC_HandleTypeDef *hsdadc, uint32_t *pDa
 
   /* Check parameters */
   assert_param(IS_SDADC_ALL_INSTANCE(hsdadc->Instance));
-  assert_param(pData != NULL);
+  assert_param(pData != HAL_NULL);
   assert_param(Length != 0);
 
   /* Check that DMA is not enabled for injected conversion */
@@ -1591,7 +1604,7 @@ HAL_StatusTypeDef HAL_SDADC_InjectedStart_DMA(SDADC_HandleTypeDef *hsdadc, uint3
 
   /* Check parameters */
   assert_param(IS_SDADC_ALL_INSTANCE(hsdadc->Instance));
-  assert_param(pData != NULL);
+  assert_param(pData != HAL_NULL);
   assert_param(Length != 0);
 
   /* Check that DMA is not enabled for regular conversion */
@@ -1704,7 +1717,7 @@ uint32_t HAL_SDADC_InjectedGetValue(SDADC_HandleTypeDef *hsdadc, uint32_t* Chann
 
   /* Check parameters */
   assert_param(IS_SDADC_ALL_INSTANCE(hsdadc->Instance));
-  assert_param(Channel != NULL);
+  assert_param(Channel != HAL_NULL);
 
   /* Read SDADC_JDATAR register and extract channel and conversion value */
   value = hsdadc->Instance->JDATAR;
@@ -1731,7 +1744,7 @@ HAL_StatusTypeDef HAL_SDADC_MultiModeStart_DMA(SDADC_HandleTypeDef* hsdadc, uint
 
   /* Check parameters */
   assert_param(IS_SDADC_ALL_INSTANCE(hsdadc->Instance));
-  assert_param(pData != NULL);
+  assert_param(pData != HAL_NULL);
   assert_param(Length != 0);
 
   /* Check instance is SDADC1 */
@@ -1887,7 +1900,7 @@ HAL_StatusTypeDef HAL_SDADC_InjectedMultiModeStart_DMA(SDADC_HandleTypeDef* hsda
 
   /* Check parameters */
   assert_param(IS_SDADC_ALL_INSTANCE(hsdadc->Instance));
-  assert_param(pData != NULL);
+  assert_param(pData != HAL_NULL);
   assert_param(Length != 0);
 
   /* Check instance is SDADC1 */
@@ -2279,7 +2292,7 @@ static void SDADC_DMAError(DMA_HandleTypeDef *hdma)
   * @}
   */
 
-/** @defgroup SDADC_Group4 SDADC Peripheral State functions
+/** @defgroup SDADC_Exported_Functions_Group4 Peripheral State functions
  *  @brief   SDADC Peripheral State functions 
  *
 @verbatim   
@@ -2622,12 +2635,12 @@ static HAL_StatusTypeDef SDADC_InjConvStop(SDADC_HandleTypeDef* hsdadc)
   * @}
   */
 
-#endif /* defined(STM32F373xC) || defined(STM32F378xx) */
-#endif /* HAL_SDADC_MODULE_ENABLED */
 /**
   * @}
   */ 
 
+#endif /* defined(STM32F373xC) || defined(STM32F378xx) */
+#endif /* HAL_SDADC_MODULE_ENABLED */
 /**
   * @}
   */ 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_sdadc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_sdadc.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_sdadc.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   This file contains all the functions prototypes for the SDADC
   *          firmware library.
   ******************************************************************************
@@ -58,6 +58,10 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/
+/** @defgroup SDADC_Exported_Types SDADC Exported Types
+  * @{
+  */
+
 
 /** 
   * @brief  HAL SDADC States definition  
@@ -124,7 +128,17 @@ typedef struct
                                 This parameter can be any value lower or equal to 0x00000FFF */
 }SDADC_ConfParamTypeDef;
 
-/** @defgroup SDADC_Idle_Low_Power_Mode 
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup SDADC_Exported_Constants SDADC Exported Constants
+  * @{
+  */
+
+/** @defgroup SDADC_Idle_Low_Power_Mode SDADC Idle Low Power Mode
   * @{
   */
 #define SDADC_LOWPOWER_NONE                  ((uint32_t)0x00000000)
@@ -137,7 +151,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_Fast_Conv_Mode 
+/** @defgroup SDADC_Fast_Conv_Mode SDADC Fast Conversion Mode
   * @{
   */
 #define SDADC_FAST_CONV_DISABLE              ((uint32_t)0x00000000)
@@ -148,7 +162,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_Slow_Clock_Mode 
+/** @defgroup SDADC_Slow_Clock_Mode SDADC Slow Clock Mode
   * @{
   */
 #define SDADC_SLOW_CLOCK_DISABLE             ((uint32_t)0x00000000)
@@ -159,7 +173,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_Reference_Voltage
+/** @defgroup SDADC_Reference_Voltage SDADC Reference Voltage
   * @{
   */
 #define SDADC_VREF_EXT                       ((uint32_t)0x00000000) /*!< The reference voltage is forced externally using VREF pin */
@@ -174,7 +188,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_ConfIndex
+/** @defgroup SDADC_ConfIndex SDADC Configuration Index
   * @{
   */
   
@@ -189,7 +203,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_InputMode
+/** @defgroup SDADC_InputMode SDADC Input Mode
   * @{
   */
 #define SDADC_INPUT_MODE_DIFF                ((uint32_t)0x00000000) /*!< Conversions are executed in differential mode */
@@ -203,7 +217,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_Gain 
+/** @defgroup SDADC_Gain SDADC Gain
   * @{
   */
 #define SDADC_GAIN_1                         ((uint32_t)0x00000000)  /*!< Gain equal to 1 */
@@ -224,7 +238,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_CommonMode
+/** @defgroup SDADC_CommonMode SDADC Common Mode
   * @{
   */
 #define SDADC_COMMON_MODE_VSSA               ((uint32_t)0x00000000) /*!< Select SDADC VSSA as common mode */
@@ -237,7 +251,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_Offset
+/** @defgroup SDADC_Offset SDADC Offset
   * @{
   */
 #define IS_SDADC_OFFSET_VALUE(VALUE) ((VALUE) <= 0x00000FFF)
@@ -245,7 +259,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_Channel_Selection
+/** @defgroup SDADC_Channel_Selection SDADC Channel Selection
   * @{
   */
 
@@ -285,7 +299,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_CalibrationSequence 
+/** @defgroup SDADC_CalibrationSequence SDADC Calibration Sequence
   * @{
   */ 
 #define SDADC_CALIBRATION_SEQ_1                   ((uint32_t)0x00000000) /*!< One calibration sequence to calculate offset of conf0 (OFFSET0[11:0]) */
@@ -299,7 +313,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_ContinuousMode 
+/** @defgroup SDADC_ContinuousMode SDADC Continuous Mode
   * @{
   */ 
 #define SDADC_CONTINUOUS_CONV_OFF            ((uint32_t)0x00000000) /*!< Conversion are not continuous */
@@ -311,7 +325,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_Trigger
+/** @defgroup SDADC_Trigger SDADC Trigger
   * @{
   */ 
 #define SDADC_SOFTWARE_TRIGGER               ((uint32_t)0x00000000) /*!< Software trigger */
@@ -328,7 +342,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_InjectedExtTrigger
+/** @defgroup SDADC_InjectedExtTrigger SDADC Injected External Trigger
   * @{
   */ 
 #define SDADC_EXT_TRIG_TIM13_CC1             ((uint32_t)0x00000000) /*!< Trigger source for SDADC1 */
@@ -376,7 +390,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_ExtTriggerEdge
+/** @defgroup SDADC_ExtTriggerEdge SDADC External Trigger Edge
   * @{
   */ 
 #define SDADC_EXT_TRIG_RISING_EDGE           SDADC_CR2_JEXTEN_0     /*!< External rising edge */
@@ -390,7 +404,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_InjectedDelay
+/** @defgroup SDADC_InjectedDelay SDADC Injected Conversion Delay
   * @{
   */ 
 #define SDADC_INJECTED_DELAY_NONE            ((uint32_t)0x00000000) /*!< No delay on injected conversion */
@@ -402,7 +416,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_MultimodeType
+/** @defgroup SDADC_MultimodeType SDADC Multimode Type
   * @{
   */ 
 #define SDADC_MULTIMODE_SDADC1_SDADC2        ((uint32_t)0x00000000) /*!< Get conversion values for SDADC1 and SDADC2 */
@@ -414,7 +428,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SDADC_ErrorCode
+/** @defgroup SDADC_ErrorCode SDADC Error Code
   * @{
   */ 
 #define SDADC_ERROR_NONE                     ((uint32_t)0x00000000) /*!< No error */
@@ -425,7 +439,14 @@ typedef struct
   * @}
   */
 
+/**
+  * @}
+  */
+
 /* Exported macros -----------------------------------------------------------*/  
+/** @defgroup SDADC_Exported_Macros SDADC Exported Macros
+ * @{
+ */
 
 /** @brief  Reset SDADC handle state
   * @param  __HANDLE__: SDADC handle.
@@ -433,13 +454,33 @@ typedef struct
   */
 #define __HAL_SDADC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_SDADC_STATE_RESET)
 
+/**
+  * @}
+  */
+
+
 /* Exported functions --------------------------------------------------------*/  
+/** @addtogroup SDADC_Exported_Functions SDADC Exported Functions
+  * @{
+  */
+
+/** @addtogroup SDADC_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
 
 /* Initialization and de-initialization functions *****************************/
 HAL_StatusTypeDef HAL_SDADC_Init(SDADC_HandleTypeDef *hsdadc);
 HAL_StatusTypeDef HAL_SDADC_DeInit(SDADC_HandleTypeDef *hsdadc);
 void HAL_SDADC_MspInit(SDADC_HandleTypeDef* hsdadc);
 void HAL_SDADC_MspDeInit(SDADC_HandleTypeDef* hsdadc);
+
+/**
+  * @}
+  */
+
+/** @addtogroup SDADC_Exported_Functions_Group2 peripheral control functions
+  * @{
+  */
 
 /* Peripheral Control functions ***********************************************/
 HAL_StatusTypeDef HAL_SDADC_PrepareChannelConfig(SDADC_HandleTypeDef *hsdadc, 
@@ -463,6 +504,14 @@ HAL_StatusTypeDef HAL_SDADC_SelectRegularTrigger(SDADC_HandleTypeDef *hsdadc, ui
 HAL_StatusTypeDef HAL_SDADC_SelectInjectedTrigger(SDADC_HandleTypeDef *hsdadc, uint32_t Trigger);
 HAL_StatusTypeDef HAL_SDADC_MultiModeConfigChannel(SDADC_HandleTypeDef* hsdadc, uint32_t MultimodeType);
 HAL_StatusTypeDef HAL_SDADC_InjectedMultiModeConfigChannel(SDADC_HandleTypeDef* hsdadc, uint32_t MultimodeType);
+
+/**
+  * @}
+  */
+
+/** @addtogroup SDADC_Exported_Functions_Group3 Input and Output operation functions
+  * @{
+  */
 
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef HAL_SDADC_CalibrationStart(SDADC_HandleTypeDef *hsdadc, uint32_t CalibrationSequence);
@@ -505,11 +554,27 @@ void HAL_SDADC_InjectedConvHalfCpltCallback(SDADC_HandleTypeDef* hsdadc);
 void HAL_SDADC_InjectedConvCpltCallback(SDADC_HandleTypeDef* hsdadc);
 void HAL_SDADC_ErrorCallback(SDADC_HandleTypeDef* hsdadc);
 
+/**
+  * @}
+  */
+
+/** @defgroup SDADC_Exported_Functions_Group4 Peripheral State functions
+  * @{
+  */
+
 /* Peripheral State and Error functions ***************************************/
 HAL_SDADC_StateTypeDef HAL_SDADC_GetState(SDADC_HandleTypeDef* hsdadc);
 uint32_t               HAL_SDADC_GetError(SDADC_HandleTypeDef* hsdadc);
 
 /* Private functions ---------------------------------------------------------*/  
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_smartcard.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_smartcard.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_smartcard.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of SMARTCARD HAL module.
   ******************************************************************************
   * @attention
@@ -55,6 +55,10 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup SMARTCARD_Exported_Types SMARTCARD Exported Types
+  * @{
+  */
+
 /** 
   * @brief SMARTCARD Init Structure definition  
   */ 
@@ -89,7 +93,7 @@ typedef struct
                                            data bit (MSB) has to be output on the SCLK pin in synchronous mode.
                                            This parameter can be a value of @ref SMARTCARD_Last_Bit */
                                              
-  uint16_t OneBitSampling;            /*!< Specifies wether a single sample or three samples' majority vote is selected.
+  uint16_t OneBitSampling;            /*!< Specifies whether a single sample or three samples' majority vote is selected.
                                            Selecting the single sample method increases the receiver tolerance to clock
                                            deviations. This parameter can be a value of @ref SMARTCARD_OneBit_Sampling. */
 
@@ -227,9 +231,12 @@ typedef enum
   SMARTCARD_CLOCKSOURCE_UNDEFINED = 0x10  /*!< undefined clock source */  
 }SMARTCARD_ClockSourceTypeDef;
 
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup SMARTCARD_Exported_Constants
+/** @defgroup SMARTCARD_Exported_Constants SMARTCARD Exported Constants
   * @{
   */
 
@@ -550,7 +557,7 @@ typedef enum
   */    
     
 /* Exported macros -----------------------------------------------------------*/
-/** @defgroup SMARTCARD_Exported_Macros
+/** @defgroup SMARTCARD_Exported_Macros SMARTCARD Exported Macros
   * @{
   */
 
@@ -735,17 +742,32 @@ typedef enum
   * @}
   */ 
 
-/* Include SMARTCARD HAL Extension module */
+/* Include SMARTCARD HAL Extended module */
 #include "stm32f3xx_hal_smartcard_ex.h"  
 
                                  
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup SMARTCARD_Exported_Functions SMARTCARD Exported Functions
+  * @{
+  */
+
+/** @addtogroup SMARTCARD_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+
 /* Initialization and de-initialization functions  ****************************/
 HAL_StatusTypeDef HAL_SMARTCARD_Init(SMARTCARD_HandleTypeDef *hsmartcard);
 HAL_StatusTypeDef HAL_SMARTCARD_DeInit(SMARTCARD_HandleTypeDef *hsmartcard);
 void HAL_SMARTCARD_MspInit(SMARTCARD_HandleTypeDef *hsmartcard);
 void HAL_SMARTCARD_MspDeInit(SMARTCARD_HandleTypeDef *hsmartcard);
 
+/**
+  * @}
+  */
+
+/** @addtogroup SMARTCARD_Exported_Functions_Group2 Input and Output operation functions 
+  * @{
+  */
 
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsmartcard, uint8_t *pData, uint16_t Size, uint32_t Timeout);
@@ -759,12 +781,25 @@ void HAL_SMARTCARD_TxCpltCallback(SMARTCARD_HandleTypeDef *hsmartcard);
 void HAL_SMARTCARD_RxCpltCallback(SMARTCARD_HandleTypeDef *hsmartcard);
 void HAL_SMARTCARD_ErrorCallback(SMARTCARD_HandleTypeDef *hsmartcard);
 
-/* Peripheral Control functions ***********************************************/
-void SMARTCARD_AdvFeatureConfig(SMARTCARD_HandleTypeDef *hsmartcard);
+/**
+  * @}
+  */  
+
+/** @defgroup SMARTCARD_Exported_Functions_Group3 Peripheral Control functions 
+  * @{
+  */
 
 /* Peripheral State and Error functions ***************************************/
 HAL_SMARTCARD_StateTypeDef HAL_SMARTCARD_GetState(SMARTCARD_HandleTypeDef *hsmartcard);
 uint32_t HAL_SMARTCARD_GetError(SMARTCARD_HandleTypeDef *hsmartcard);
+/**
+  * @}
+  */  
+
+/**
+  * @}
+  */  
+
 /**
   * @}
   */ 
@@ -772,7 +807,7 @@ uint32_t HAL_SMARTCARD_GetError(SMARTCARD_HandleTypeDef *hsmartcard);
 /**
   * @}
   */
-  
+ 
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_smartcard_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_smartcard_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_smartcard_ex.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   SMARTCARD HAL module driver.
   *
   *          This file provides extended firmware functions to manage the following 
@@ -64,7 +64,7 @@
   * @{
   */
 
-/** @defgroup SMARTCARDEx
+/** @defgroup SMARTCARDEx SMARTCARD Extended HAL module driver
   * @brief SMARTCARD Extended HAL module driver
   * @{
   */
@@ -75,15 +75,14 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
 
-/** @defgroup SMARTCARDEx_Private_Functions
+/* Exported functions ---------------------------------------------------------*/
+
+/** @defgroup SMARTCARDEx_Exported_Functions SMARTCARD Extended Exported Functions
   * @{
   */
 
-
-
-/** @defgroup SMARTCARDEx_Group1 Extended Peripheral Control functions
+/** @defgroup SMARTCARDEx_Exported_Functions_Group1 Extended Peripheral Control functions
   * @brief    Extended control functions
   *
 @verbatim   

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_smartcard_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_smartcard_ex.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_smartcard_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of SMARTCARD HAL module.
   ******************************************************************************
   * @attention
@@ -50,7 +50,7 @@
   * @{
   */
 
-/** @addtogroup SMARTCARDEx
+/** @addtogroup SMARTCARDEx SMARTCARD Extended HAL module driver
   * @{
   */ 
 
@@ -58,7 +58,7 @@
 /* Exported constants --------------------------------------------------------*/    
 /* Exported macro ------------------------------------------------------------*/
 
-/** @defgroup SMARTCARDEx_Exported_Macros
+/** @defgroup SMARTCARDEx_Exported_Macros SMARTCARD Extended Exported Macros
   * @{
   */
 
@@ -191,15 +191,30 @@
 
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup SMARTCARDEx_Exported_Functions SMARTCARD Extended Exported Functions
+  * @{
+  */
+
 /* Initialization and de-initialization functions  ****************************/
 /* IO operation functions *****************************************************/
 /* Peripheral Control functions ***********************************************/
+/** @addtogroup SMARTCARDEx_Exported_Functions_Group1 Extended Peripheral Control functions
+  * @{
+  */
 void HAL_SMARTCARDEx_BlockLength_Config(SMARTCARD_HandleTypeDef *hsmartcard, uint8_t BlockLength);
 void HAL_SMARTCARDEx_TimeOut_Config(SMARTCARD_HandleTypeDef *hsmartcard, uint32_t TimeOutValue);
 HAL_StatusTypeDef HAL_SMARTCARDEx_EnableReceiverTimeOut(SMARTCARD_HandleTypeDef *hsmartcard);
 HAL_StatusTypeDef HAL_SMARTCARDEx_DisableReceiverTimeOut(SMARTCARD_HandleTypeDef *hsmartcard);
 
 /* Peripheral State and Error functions ***************************************/
+
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_smbus.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_smbus.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_smbus.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   SMBUS HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -132,7 +132,7 @@
   * @{
   */
 
-/** @defgroup SMBUS
+/** @defgroup SMBUS SMBUS HAL module driver
   * @brief SMBUS HAL module driver
   * @{
   */
@@ -141,6 +141,9 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+/** @defgroup SMBUS_Private_Define SMBUS Private Define
+ * @{
+ */
 #define TIMING_CLEAR_MASK   ((uint32_t)0xF0FFFFFF)      /*<! SMBUS TIMING clear register Mask */
 #define HAL_TIMEOUT_ADDR    ((uint32_t)10000)           /* 10 s  */
 #define HAL_TIMEOUT_BUSY    ((uint32_t)25)              /* 25 ms */
@@ -151,13 +154,25 @@
 #define HAL_TIMEOUT_TCR     ((uint32_t)25)              /* 25 ms */
 #define HAL_TIMEOUT_TXIS    ((uint32_t)25)              /* 25 ms */
 #define MAX_NBYTE_SIZE      255
+/**
+  * @}
+  */
 
 /* Private macro -------------------------------------------------------------*/
+/** @defgroup SMBUS_Private_Macro SMBUS Private Macro
+ * @{
+ */
 #define __SMBUS_GET_ISR_REG(__HANDLE__) ((__HANDLE__)->Instance->ISR)
 #define __SMBUS_CHECK_FLAG(__ISR__, __FLAG__) ((((__ISR__) & ((__FLAG__) & SMBUS_FLAG_MASK)) == ((__FLAG__) & SMBUS_FLAG_MASK)))
+/**
+  * @}
+  */
 
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
+/** @defgroup SMBUS_Private_Functions SMBUS Private Functions
+  * @{
+  */
 static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout(SMBUS_HandleTypeDef *hsmbus, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
 
 static HAL_StatusTypeDef SMBUS_Enable_IRQ(SMBUS_HandleTypeDef *hsmbus, uint16_t InterruptRequest);
@@ -166,14 +181,17 @@ static HAL_StatusTypeDef SMBUS_Master_ISR(SMBUS_HandleTypeDef *hsmbus);
 static HAL_StatusTypeDef SMBUS_Slave_ISR(SMBUS_HandleTypeDef *hsmbus);
 
 static void SMBUS_TransferConfig(SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request);
+/**
+  * @}
+  */
 
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
 
-/** @defgroup SMBUS_Private_Functions
+/** @defgroup SMBUS_Exported_Functions SMBUS Exported Functions
   * @{
   */
 
-/** @defgroup HAL_SMBUS_Group1 Initialization and de-initialization functions
+/** @defgroup SMBUS_Exported_Functions_Group1 Initialization and de-initialization functions
  *  @brief    Initialization and Configuration functions 
  *
 @verbatim    
@@ -219,7 +237,7 @@ static void SMBUS_TransferConfig(SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddre
 HAL_StatusTypeDef HAL_SMBUS_Init(SMBUS_HandleTypeDef *hsmbus)
 { 
   /* Check the SMBUS handle allocation */
-  if(hsmbus == NULL)
+  if(hsmbus == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -318,7 +336,7 @@ HAL_StatusTypeDef HAL_SMBUS_Init(SMBUS_HandleTypeDef *hsmbus)
 HAL_StatusTypeDef HAL_SMBUS_DeInit(SMBUS_HandleTypeDef *hsmbus)
 {
   /* Check the SMBUS handle allocation */
-  if(hsmbus == NULL)
+  if(hsmbus == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -374,7 +392,7 @@ HAL_StatusTypeDef HAL_SMBUS_DeInit(SMBUS_HandleTypeDef *hsmbus)
   * @}
   */
 
-/** @defgroup HAL_SMBUS_Group2 IO operation functions
+/** @defgroup SMBUS_Exported_Functions_Group2 Input and Output operation functions
  *  @brief   Data transfers functions 
  *
 @verbatim   
@@ -417,6 +435,10 @@ HAL_StatusTypeDef HAL_SMBUS_DeInit(SMBUS_HandleTypeDef *hsmbus)
   * @{
   */
 
+/** @defgroup Non-Blocking_mode_Interrupt Non-Blocking mode Interrupt
+ * @{
+ */
+
 /**
   * @brief  Transmit in master/host SMBUS mode an amount of data in no-blocking mode with Interrupt
   * @param  hsmbus : Pointer to a SMBUS_HandleTypeDef structure that contains
@@ -446,7 +468,7 @@ HAL_StatusTypeDef HAL_SMBUS_Master_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint
 
     /* In case of Quick command, remove autoend mode */
     /* Manage the stop generation by software */
-    if(hsmbus->pBuffPtr == NULL)
+    if(hsmbus->pBuffPtr == HAL_NULL)
     {
       hsmbus->XferOptions &= ~SMBUS_AUTOEND_MODE;
     }
@@ -535,7 +557,7 @@ HAL_StatusTypeDef HAL_SMBUS_Master_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint1
     
     /* In case of Quick command, remove autoend mode */
     /* Manage the stop generation by software */
-    if(hsmbus->pBuffPtr == NULL)
+    if(hsmbus->pBuffPtr == HAL_NULL)
     {
       hsmbus->XferOptions &= ~SMBUS_AUTOEND_MODE;
     }
@@ -662,7 +684,7 @@ HAL_StatusTypeDef HAL_SMBUS_Slave_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint8
 
   if(hsmbus->State == HAL_SMBUS_STATE_LISTEN)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -676,6 +698,9 @@ HAL_StatusTypeDef HAL_SMBUS_Slave_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint8
     hsmbus->State |= HAL_SMBUS_STATE_SLAVE_BUSY_TX;
     hsmbus->ErrorCode = HAL_SMBUS_ERROR_NONE;
     
+    /* Set SBC bit to manage Acknowledge at each bit */
+    hsmbus->Instance->CR1 |= I2C_CR1_SBC;
+
     /* Enable Address Acknowledge */
     hsmbus->Instance->CR2 &= ~I2C_CR2_NACK;
 
@@ -750,7 +775,7 @@ HAL_StatusTypeDef HAL_SMBUS_Slave_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint8_
 
   if(hsmbus->State == HAL_SMBUS_STATE_LISTEN)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -764,6 +789,9 @@ HAL_StatusTypeDef HAL_SMBUS_Slave_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint8_
     hsmbus->State |= HAL_SMBUS_STATE_SLAVE_BUSY_RX;
     hsmbus->ErrorCode = HAL_SMBUS_ERROR_NONE;
     
+    /* Set SBC bit to manage Acknowledge at each bit */
+    hsmbus->Instance->CR1 |= I2C_CR1_SBC;
+
     /* Enable Address Acknowledge */
     hsmbus->Instance->CR2 &= ~I2C_CR2_NACK;
 
@@ -883,6 +911,14 @@ HAL_StatusTypeDef HAL_SMBUS_DisableAlert_IT(SMBUS_HandleTypeDef *hsmbus)
 
   return HAL_OK; 
 }
+
+/**
+  * @}
+  */
+
+/** @defgroup Blocking_mode_Polling Blocking mode Polling
+ * @{
+ */
 /**
   * @brief  Checks if target device is ready for communication. 
   * @note   This function is used with Memory devices
@@ -1000,6 +1036,13 @@ HAL_StatusTypeDef HAL_SMBUS_IsDeviceReady(SMBUS_HandleTypeDef *hsmbus, uint16_t 
     return HAL_BUSY;
   }
 }
+/**
+  * @}
+  */
+
+/** @defgroup IRQ_Handler_and_Callbacks IRQ Handler and Callbacks
+ * @{
+ */
 
 /**
   * @brief  This function handles SMBUS event interrupt request.
@@ -1124,9 +1167,14 @@ void HAL_SMBUS_ER_IRQHandler(SMBUS_HandleTypeDef *hsmbus)
     /* Do not Reset the the HAL state in case of ALERT error */
     if((hsmbus->ErrorCode & HAL_SMBUS_ERROR_ALERT) != HAL_SMBUS_ERROR_ALERT)
     {
-      /* Reset only HAL_SMBUS_STATE_SLAVE_BUSY_XX and HAL_SMBUS_STATE_MASTER_BUSY_XX */
-      /* keep HAL_SMBUS_STATE_LISTEN if set */
-      hsmbus->State &= ~((uint32_t)(HAL_SMBUS_STATE_MASTER_BUSY_RX | HAL_SMBUS_STATE_MASTER_BUSY_TX | HAL_SMBUS_STATE_SLAVE_BUSY_RX | HAL_SMBUS_STATE_SLAVE_BUSY_TX));
+      if(((hsmbus->State & HAL_SMBUS_STATE_SLAVE_BUSY_TX) == HAL_SMBUS_STATE_SLAVE_BUSY_TX)
+         || ((hsmbus->State & HAL_SMBUS_STATE_SLAVE_BUSY_RX) == HAL_SMBUS_STATE_SLAVE_BUSY_RX))
+      {
+        /* Reset only HAL_SMBUS_STATE_SLAVE_BUSY_XX */
+        /* keep HAL_SMBUS_STATE_LISTEN if set */
+        hsmbus->PreviousState = HAL_SMBUS_STATE_READY;
+        hsmbus->State = HAL_SMBUS_STATE_LISTEN;
+      }
     }
     
     /* Call the Error callback to prevent upper layer */
@@ -1230,7 +1278,11 @@ __weak void HAL_SMBUS_SlaveListenCpltCallback(SMBUS_HandleTypeDef *hsmbus)
   * @}
   */
 
-/** @defgroup HAL_SMBUS_Group3 Peripheral State and Errors functions 
+/**
+  * @}
+  */  
+
+/** @defgroup SMBUS_Exported_Functions_Group3 Peripheral State and Errors functions 
  *  @brief   Peripheral State and Errors functions 
  *
 @verbatim   
@@ -1269,6 +1321,15 @@ uint32_t HAL_SMBUS_GetError(SMBUS_HandleTypeDef *hsmbus)
 /**
   * @}
   */  
+
+/**
+  * @}
+  */  
+
+/** @addtogroup SMBUS_Private_Functions SMBUS Private Functions
+ *  @brief   Data transfers Private functions 
+  * @{
+  */
 
 /**
   * @brief  Interrupt Sub-Routine which handle the Interrupt Flags Master Mode
@@ -1423,7 +1484,7 @@ static HAL_StatusTypeDef SMBUS_Master_ISR(SMBUS_HandleTypeDef *hsmbus)
     if(hsmbus->XferCount == 0)
     {
       /* Specific use case for Quick command */
-      if(hsmbus->pBuffPtr == NULL)
+      if(hsmbus->pBuffPtr == HAL_NULL)
       {
         /* Generate a Stop command */
         hsmbus->Instance->CR2 |= I2C_CR2_STOP;
@@ -1509,7 +1570,7 @@ static HAL_StatusTypeDef SMBUS_Slave_ISR(SMBUS_HandleTypeDef *hsmbus)
 
       /* Disable RX/TX Interrupts, keep only ADDR Interrupt */
       SMBUS_Disable_IRQ(hsmbus, SMBUS_IT_RX | SMBUS_IT_TX);
-      
+
       /* Set ErrorCode corresponding to a Non-Acknowledge */
       hsmbus->ErrorCode |= HAL_SMBUS_ERROR_ACKF;
 
@@ -1885,7 +1946,6 @@ static void SMBUS_TransferConfig(SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddre
   /* update CR2 register */
   hsmbus->Instance->CR2 = tmpreg;  
 }  
-
 /**
   * @}
   */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_smbus.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_smbus.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_smbus.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of SMBUS HAL module.
   ******************************************************************************
   * @attention
@@ -55,6 +55,9 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup SMBUS_Exported_Types SMBUS Exported Types
+  * @{
+  */
 
 /** 
   * @brief  SMBUS Configuration Structure definition  
@@ -162,14 +165,17 @@ typedef struct
   __IO HAL_SMBUS_ErrorTypeDef  ErrorCode;       /*!< SMBUS Error code                   */
 
 }SMBUS_HandleTypeDef;
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
 
-/** @defgroup SMBUS_Exported_Constants
+/** @defgroup SMBUS_Exported_Constants SMBUS Exported Constants
   * @{
   */
 
-/** @defgroup SMBUS_Analog_Filter
+/** @defgroup SMBUS_Analog_Filter SMBUS Analog Filter
   * @{
   */
 #define SMBUS_ANALOGFILTER_ENABLED              ((uint32_t)0x00000000)
@@ -181,7 +187,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SMBUS_addressing_mode
+/** @defgroup SMBUS_addressing_mode SMBUS addressing mode
   * @{
   */
 #define SMBUS_ADDRESSINGMODE_7BIT               ((uint32_t)0x00000001) 
@@ -193,7 +199,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SMBUS_dual_addressing_mode 
+/** @defgroup SMBUS_dual_addressing_mode SMBUS dual addressing mode
   * @{
   */
 
@@ -206,7 +212,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SMBUS_own_address2_masks
+/** @defgroup SMBUS_own_address2_masks SMBUS own address2 masks
   * @{
   */
 
@@ -232,7 +238,7 @@ typedef struct
   */
 
 
-/** @defgroup SMBUS_general_call_addressing_mode 
+/** @defgroup SMBUS_general_call_addressing_mode  SMBUS general call addressing mode
   * @{
   */
 #define SMBUS_GENERALCALL_DISABLED              ((uint32_t)0x00000000)
@@ -244,7 +250,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SMBUS_nostretch_mode 
+/** @defgroup SMBUS_nostretch_mode SMBUS nostretch mode
   * @{
   */
 #define SMBUS_NOSTRETCH_DISABLED                ((uint32_t)0x00000000)
@@ -256,7 +262,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SMBUS_packet_error_check_mode
+/** @defgroup SMBUS_packet_error_check_mode SMBUS packet error check mode
   * @{
   */
 #define SMBUS_PEC_DISABLED                      ((uint32_t)0x00000000)
@@ -268,7 +274,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SMBUS_peripheral_mode
+/** @defgroup SMBUS_peripheral_mode SMBUS peripheral mode
   * @{
   */
 #define SMBUS_PERIPHERAL_MODE_SMBUS_HOST        (uint32_t)(I2C_CR1_SMBHEN)
@@ -282,7 +288,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SMBUS_ReloadEndMode_definition 
+/** @defgroup SMBUS_ReloadEndMode_definition  SMBUS ReloadEndMode definition
   * @{
   */
 
@@ -303,7 +309,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SMBUS_StartStopMode_definition 
+/** @defgroup SMBUS_StartStopMode_definition SMBUS StartStopMode definition
   * @{
   */
 
@@ -321,7 +327,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SMBUS_XferOptions_definition 
+/** @defgroup SMBUS_XferOptions_definition  SMBUS XferOptions definition
   * @{
   */
 
@@ -343,7 +349,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SMBUS_Interrupt_configuration_definition
+/** @defgroup SMBUS_Interrupt_configuration_definition SMBUS Interrupt configuration definition
   * @brief SMBUS Interrupt definition
   *        Elements values convention: 0xXXXXXXXX
   *           - XXXXXXXX  : Interrupt control mask
@@ -364,7 +370,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup SMBUS_Flag_definition 
+/** @defgroup SMBUS_Flag_definition SMBUS Flag definition
   * @brief Flag definition
   *        Elements values convention: 0xXXXXYYYY
   *           - XXXXXXXX  : Flag mask
@@ -396,7 +402,7 @@ typedef struct
   */
 
 /* Exported macros ------------------------------------------------------------*/
-/** @defgroup SMBUS_Exported_Macros
+/** @defgroup SMBUS_Exported_Macros SMBUS Exported Macros
   * @{
   */  
   
@@ -512,23 +518,41 @@ typedef struct
   */ 
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup SMBUS_Exported_Functions SMBUS Exported Functions
+  * @{
+  */
+
+/** @addtogroup SMBUS_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
+
 /* Initialization and de-initialization functions  **********************************/
 HAL_StatusTypeDef HAL_SMBUS_Init(SMBUS_HandleTypeDef *hsmbus);
 HAL_StatusTypeDef HAL_SMBUS_DeInit (SMBUS_HandleTypeDef *hsmbus);
 void HAL_SMBUS_MspInit(SMBUS_HandleTypeDef *hsmbus);
 void HAL_SMBUS_MspDeInit(SMBUS_HandleTypeDef *hsmbus);
 
-/* IO operation functions  *****************************************************/
-HAL_StatusTypeDef HAL_SMBUS_EnableAlert_IT(SMBUS_HandleTypeDef *hsmbus);
-HAL_StatusTypeDef HAL_SMBUS_DisableAlert_IT(SMBUS_HandleTypeDef *hsmbus);
-HAL_StatusTypeDef HAL_SMBUS_Slave_Listen_IT(SMBUS_HandleTypeDef *hsmbus);
-HAL_StatusTypeDef HAL_SMBUS_DisableListen_IT(SMBUS_HandleTypeDef *hsmbus);
-/* Aliases for new API and to insure inter STM32 series compatibility */
-#define HAL_SMBUS_EnableListen_IT   HAL_SMBUS_Slave_Listen_IT
+/**
+  * @}
+  */
 
+/** @addtogroup SMBUS_Exported_Functions_Group2 Input and Output operation functions
+  * @{
+  */
+
+/* IO operation functions  *****************************************************/
+/** @addtogroup Blocking_mode_Polling Blocking mode Polling
+ * @{
+ */
 /******* Blocking mode: Polling */
 HAL_StatusTypeDef HAL_SMBUS_IsDeviceReady(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout);
+/**
+  * @}
+  */
 
+/** @addtogroup Non-Blocking_mode_Interrupt Non-Blocking mode Interrupt
+ * @{
+ */
  /******* Non-Blocking mode: Interrupt */
 HAL_StatusTypeDef HAL_SMBUS_Master_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
 HAL_StatusTypeDef HAL_SMBUS_Master_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
@@ -536,6 +560,27 @@ HAL_StatusTypeDef HAL_SMBUS_Master_Abort_IT(SMBUS_HandleTypeDef *hsmbus, uint16_
 HAL_StatusTypeDef HAL_SMBUS_Slave_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
 HAL_StatusTypeDef HAL_SMBUS_Slave_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
 
+HAL_StatusTypeDef HAL_SMBUS_EnableAlert_IT(SMBUS_HandleTypeDef *hsmbus);
+HAL_StatusTypeDef HAL_SMBUS_DisableAlert_IT(SMBUS_HandleTypeDef *hsmbus);
+HAL_StatusTypeDef HAL_SMBUS_Slave_Listen_IT(SMBUS_HandleTypeDef *hsmbus);
+HAL_StatusTypeDef HAL_SMBUS_DisableListen_IT(SMBUS_HandleTypeDef *hsmbus);
+/** @defgroup Aliases_Exported_Functions Aliases for Exported Functions 
+ * @brief  Aliases for new API and to insure inter STM32 series compatibility
+ * @{
+ */
+/* Aliases for new API and to insure inter STM32 series compatibility */
+#define HAL_SMBUS_EnableListen_IT   HAL_SMBUS_Slave_Listen_IT
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup IRQ_Handler_and_Callbacks IRQ Handler and Callbacks
+ * @{
+ */
  /******* SMBUS IRQHandler and Callbacks used in non blocking modes (Interrupt) */
 void HAL_SMBUS_EV_IRQHandler(SMBUS_HandleTypeDef *hsmbus);
 void HAL_SMBUS_ER_IRQHandler(SMBUS_HandleTypeDef *hsmbus);
@@ -545,15 +590,39 @@ void HAL_SMBUS_SlaveTxCpltCallback(SMBUS_HandleTypeDef *hsmbus);
 void HAL_SMBUS_SlaveRxCpltCallback(SMBUS_HandleTypeDef *hsmbus);
 void HAL_SMBUS_SlaveAddrCallback(SMBUS_HandleTypeDef *hsmbus, uint8_t TransferDirection, uint16_t AddrMatchCode);
 void HAL_SMBUS_SlaveListenCpltCallback(SMBUS_HandleTypeDef *hsmbus);
+
+/** @addtogroup Aliases_Exported_Functions Aliases for Exported Functions 
+ * @brief  Aliases for new API and to insure inter STM32 series compatibility
+ * @{
+ */
 /* Aliases for new API and to insure inter STM32 series compatibility */
 #define HAL_SMBUS_AddrCallback         HAL_SMBUS_SlaveAddrCallback
 #define HAL_SMBUS_ListenCpltCallback   HAL_SMBUS_SlaveListenCpltCallback
+/**
+  * @}
+  */
 
 void HAL_SMBUS_ErrorCallback(SMBUS_HandleTypeDef *hsmbus);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup SMBUS_Exported_Functions_Group3 Peripheral State and Errors functions 
+  * @{
+  */
 
 /* Peripheral State and Errors functions  **************************************************/
 HAL_SMBUS_StateTypeDef HAL_SMBUS_GetState(SMBUS_HandleTypeDef *hsmbus);
 uint32_t               HAL_SMBUS_GetError(SMBUS_HandleTypeDef *hsmbus);
+
+/**
+  * @}
+  */
 
 /**
   * @}
@@ -563,6 +632,9 @@ uint32_t               HAL_SMBUS_GetError(SMBUS_HandleTypeDef *hsmbus);
   * @}
   */ 
   
+/**
+  * @}
+  */ 
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_spi.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_spi.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_spi.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   SPI HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -117,7 +117,7 @@
   * @{
   */
 
-/** @defgroup SPI 
+/** @defgroup SPI SPI HAL module driver
   * @brief SPI HAL module driver
   * @{
   */
@@ -125,14 +125,25 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+/** @defgroup SPI_Private_Define SPI Private Define
+ * @{
+ */
 #define SPI_DEFAULT_TIMEOUT 50
+/**
+  * @}
+  */
+
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-static void HAL_SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma);
-static void HAL_SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
-static void HAL_SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma);
-static void HAL_SPI_DMAError(DMA_HandleTypeDef *hdma);
+/** @defgroup SPI_Private_Functions SPI Private Functions
+  * @{
+  */
+
+static void SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma);
+static void SPI_DMAError(DMA_HandleTypeDef *hdma);
 static HAL_StatusTypeDef SPI_WaitFlagStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Flag, uint32_t State, uint32_t Timeout);
 static HAL_StatusTypeDef SPI_WaitFifoStateUntilTimeout(SPI_HandleTypeDef *hspi, uint32_t Flag, uint32_t State, uint32_t Timeout);
 static void SPI_TxISR_8BIT(struct __SPI_HandleTypeDef *hspi);
@@ -152,14 +163,17 @@ static void SPI_CloseRx_ISR(SPI_HandleTypeDef *hspi);
 static void SPI_CloseTx_ISR(SPI_HandleTypeDef *hspi);
 static HAL_StatusTypeDef SPI_EndRxTransaction(SPI_HandleTypeDef *hspi, uint32_t Timeout);
 static HAL_StatusTypeDef SPI_EndRxTxTransaction(SPI_HandleTypeDef *hspi, uint32_t Timeout);
+/**
+  * @}
+  */
 
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
 
-/** @defgroup SPI_Private_Functions
+/** @defgroup SPI_Exported_Functions SPI Exported Functions
   * @{
   */
 
-/** @defgroup HAL_SPI_Group1 Initialization/de-initialization functions 
+/** @defgroup SPI_Exported_Functions_Group1 Initialization and de-initialization functions
  *  @brief    Initialization and Configuration functions 
  *
 @verbatim    
@@ -205,12 +219,13 @@ HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi)
   uint32_t frxth;
   
   /* Check the SPI handle allocation */
-  if(hspi == NULL)
+  if(hspi == HAL_NULL)
   { 
     return HAL_ERROR;
   }
   
   /* Check the parameters */
+  assert_param(IS_SPI_ALL_INSTANCE(hspi->Instance));
   assert_param(IS_SPI_MODE(hspi->Init.Mode));
   assert_param(IS_SPI_DIRECTION(hspi->Init.Direction));
   assert_param(IS_SPI_DATASIZE(hspi->Init.DataSize));
@@ -299,10 +314,13 @@ HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi)
 HAL_StatusTypeDef HAL_SPI_DeInit(SPI_HandleTypeDef *hspi)
 {
   /* Check the SPI handle allocation */
-  if(hspi == NULL)
+  if(hspi == HAL_NULL)
   {
      return HAL_ERROR;
   }
+
+  /* Check the parameters */
+  assert_param(IS_SPI_ALL_INSTANCE(hspi->Instance));
 
   hspi->State = HAL_SPI_STATE_BUSY;
   
@@ -348,7 +366,7 @@ HAL_StatusTypeDef HAL_SPI_DeInit(SPI_HandleTypeDef *hspi)
   * @}
   */
 
-/** @defgroup HAL_SPI_Group2 I/O operation functions 
+/** @defgroup SPI_Exported_Functions_Group2 Input and Output operation functions 
  *  @brief   Data transfers functions 
  *
 @verbatim   
@@ -416,7 +434,7 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
     return HAL_BUSY;
   }
   
-  if((pData == NULL ) || (Size == 0))
+  if((pData == HAL_NULL ) || (Size == 0))
   {
     return HAL_ERROR;
   }
@@ -430,7 +448,7 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
   hspi->pTxBuffPtr  = pData;
   hspi->TxXferSize  = Size;
   hspi->TxXferCount = Size;
-  hspi->pRxBuffPtr  = NULL;
+  hspi->pRxBuffPtr  = HAL_NULL;
   hspi->RxXferSize  = 0;
   hspi->RxXferCount = 0;
 
@@ -547,7 +565,7 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
     return HAL_BUSY;
   }
   
-  if((pData == NULL ) || (Size == 0))
+  if((pData == HAL_NULL ) || (Size == 0))
   {
     return HAL_ERROR;
   }
@@ -567,7 +585,7 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
   hspi->pRxBuffPtr  = pData;
   hspi->RxXferSize  = Size;
   hspi->RxXferCount = Size;
-  hspi->pTxBuffPtr  = NULL;
+  hspi->pTxBuffPtr  = HAL_NULL;
   hspi->TxXferSize  = 0;
   hspi->TxXferCount = 0;
     
@@ -737,7 +755,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
     return HAL_BUSY;
   }
   
-  if((pTxData == NULL) || (pRxData == NULL) || (Size == 0))
+  if((pTxData == HAL_NULL) || (pRxData == HAL_NULL) || (Size == 0))
   {
     return HAL_ERROR;
   }
@@ -881,7 +899,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
   if(hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLED)
   {
     /* Wait until TXE flag */
-    if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_TXE, SPI_FLAG_TXE, Timeout) != HAL_OK)
+    if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, Timeout) != HAL_OK)
     {  
       /* Erreur on the CRC reception */
       hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
@@ -896,7 +914,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
       tmpreg = *(__IO uint8_t *)&hspi->Instance->DR;
       if(hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT)
       {
-        if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_TXE, SPI_FLAG_TXE, Timeout) != HAL_OK) 
+        if(SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SPI_FLAG_RXNE, Timeout) != HAL_OK) 
         {  
           /* Erreur on the CRC reception */
           hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
@@ -953,7 +971,7 @@ HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, u
   
   if(hspi->State == HAL_SPI_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0)) 
+    if((pData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -966,19 +984,19 @@ HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, u
     hspi->pTxBuffPtr  = pData;
     hspi->TxXferSize  = Size;
     hspi->TxXferCount = Size;
-    hspi->pRxBuffPtr  = NULL;
+    hspi->pRxBuffPtr  = HAL_NULL;
     hspi->RxXferSize  = 0;
     hspi->RxXferCount = 0;
 
     /* Set the function for IT treatement */
     if(hspi->Init.DataSize > SPI_DATASIZE_8BIT )
     {
-      hspi->RxISR = NULL;
+      hspi->RxISR = HAL_NULL;
       hspi->TxISR = SPI_TxISR_16BIT;
     }
     else
     {
-      hspi->RxISR = NULL;
+      hspi->RxISR = HAL_NULL;
       hspi->TxISR = SPI_TxISR_8BIT;
     }
     
@@ -1030,7 +1048,7 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
 {
   if(hspi->State == HAL_SPI_STATE_READY)
   {
-    if((pData == NULL) || (Size == 0))
+    if((pData == HAL_NULL) || (Size == 0))
     { 
       return  HAL_ERROR;                      
     }
@@ -1044,7 +1062,7 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
     hspi->pRxBuffPtr  = pData;
     hspi->RxXferSize  = Size;
     hspi->RxXferCount = Size;
-    hspi->pTxBuffPtr  = NULL;
+    hspi->pTxBuffPtr  = HAL_NULL;
     hspi->TxXferSize  = 0;
     hspi->TxXferCount = 0;
 
@@ -1076,14 +1094,14 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
       /* set fiforxthresold according the reception data lenght: 16 bit */
       CLEAR_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
       hspi->RxISR = SPI_RxISR_16BIT;
-      hspi->TxISR = NULL;
+      hspi->TxISR = HAL_NULL;
     }
     else
     {
       /* set fiforxthresold according the reception data lenght: 8 bit */
       SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
       hspi->RxISR = SPI_RxISR_8BIT;
-      hspi->TxISR = NULL;
+      hspi->TxISR = HAL_NULL;
     }
     
     /* Configure communication direction : 1Line */
@@ -1138,7 +1156,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *p
   if((hspi->State == HAL_SPI_STATE_READY) || \
      ((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES) && (hspi->State == HAL_SPI_STATE_BUSY_RX)))
   {
-    if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0)) 
+    if((pTxData == HAL_NULL ) || (pRxData == HAL_NULL ) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -1236,7 +1254,7 @@ HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, 
     return HAL_BUSY;
   }
   
-  if((pData == NULL) || (Size == 0))
+  if((pData == HAL_NULL) || (Size == 0))
   {
     return HAL_ERROR;
   }
@@ -1249,7 +1267,7 @@ HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, 
   hspi->pTxBuffPtr  = pData;
   hspi->TxXferSize  = Size;
   hspi->TxXferCount = Size;
-  hspi->pRxBuffPtr  = NULL;
+  hspi->pRxBuffPtr  = HAL_NULL;
   hspi->RxXferSize  = 0;
   hspi->RxXferCount = 0;
   
@@ -1266,10 +1284,10 @@ HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, 
   }
   
   /* Set the SPI TxDMA transfer complete callback */
-  hspi->hdmatx->XferCpltCallback = HAL_SPI_DMATransmitCplt;
+  hspi->hdmatx->XferCpltCallback = SPI_DMATransmitCplt;
   
   /* Set the DMA error callback */
-  hspi->hdmatx->XferErrorCallback = HAL_SPI_DMAError;
+  hspi->hdmatx->XferErrorCallback = SPI_DMAError;
   
   CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_LDMATX);
   /* packing mode is enabled only if the DMA setting is HALWORD */
@@ -1321,7 +1339,7 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
     return HAL_BUSY;
   }
   
-  if((pData == NULL) || (Size == 0))
+  if((pData == HAL_NULL) || (Size == 0))
   {
     return HAL_ERROR;
   }
@@ -1334,7 +1352,7 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
   hspi->pRxBuffPtr  = pData;
   hspi->RxXferSize  = Size;
   hspi->RxXferCount = Size;
-  hspi->pTxBuffPtr  = NULL;
+  hspi->pTxBuffPtr  = HAL_NULL;
   hspi->TxXferSize  = 0;
   hspi->TxXferCount = 0;
 
@@ -1381,10 +1399,10 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
   }
   
   /* Set the SPI Rx DMA transfer complete callback */
-  hspi->hdmarx->XferCpltCallback = HAL_SPI_DMAReceiveCplt;
+  hspi->hdmarx->XferCpltCallback = SPI_DMAReceiveCplt;
   
   /* Set the DMA error callback */
-  hspi->hdmarx->XferErrorCallback = HAL_SPI_DMAError;
+  hspi->hdmarx->XferErrorCallback = SPI_DMAError;
   
   /* Enable Rx DMA Request */  
   hspi->Instance->CR2 |= SPI_CR2_RXDMAEN;
@@ -1420,7 +1438,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
   if((hspi->State == HAL_SPI_STATE_READY) ||
      ((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES) && (hspi->State == HAL_SPI_STATE_BUSY_RX)))
   {
-    if((pTxData == NULL ) || (pRxData == NULL ) || (Size == 0)) 
+    if((pTxData == HAL_NULL ) || (pRxData == HAL_NULL ) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -1500,14 +1518,14 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
     the reception request (RXNE) */
     if(hspi->State == HAL_SPI_STATE_BUSY_RX)
     {
-      hspi->hdmarx->XferCpltCallback = HAL_SPI_DMAReceiveCplt;
+      hspi->hdmarx->XferCpltCallback = SPI_DMAReceiveCplt;
     }
     else
     {
-      hspi->hdmarx->XferCpltCallback = HAL_SPI_DMATransmitReceiveCplt;
+      hspi->hdmarx->XferCpltCallback = SPI_DMATransmitReceiveCplt;
     }
     /* Set the DMA error callback */
-    hspi->hdmarx->XferErrorCallback = HAL_SPI_DMAError;
+    hspi->hdmarx->XferErrorCallback = SPI_DMAError;
     
     /* Enable Rx DMA Request */  
     hspi->Instance->CR2 |= SPI_CR2_RXDMAEN;
@@ -1515,12 +1533,12 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
     /* Enable the Rx DMA channel */
     HAL_DMA_Start_IT(hspi->hdmarx, (uint32_t)&hspi->Instance->DR, (uint32_t) hspi->pRxBuffPtr, hspi->RxXferCount);
     
-    /* Set the SPI Tx DMA transfer complete callback as NULL because the communication closing
+    /* Set the SPI Tx DMA transfer complete callback as HAL_NULL because the communication closing
     is performed in DMA reception complete callback  */
-    hspi->hdmatx->XferCpltCallback = NULL;
+    hspi->hdmatx->XferCpltCallback = HAL_NULL;
     
     /* Set the DMA error callback */
-    hspi->hdmatx->XferErrorCallback = HAL_SPI_DMAError;
+    hspi->hdmatx->XferErrorCallback = SPI_DMAError;
     
     /* Enable the Tx DMA channel */
     HAL_DMA_Start_IT(hspi->hdmatx, (uint32_t)hspi->pTxBuffPtr, (uint32_t)&hspi->Instance->DR, hspi->TxXferCount);
@@ -1600,6 +1618,7 @@ void HAL_SPI_IRQHandler(SPI_HandleTypeDef *hspi)
     }
     
     __HAL_SPI_DISABLE_IT(hspi, SPI_IT_RXNE | SPI_IT_TXE | SPI_IT_ERR);
+    hspi->State = HAL_SPI_STATE_READY;
     HAL_SPI_ErrorCallback(hspi);
     
     return;
@@ -1611,7 +1630,7 @@ void HAL_SPI_IRQHandler(SPI_HandleTypeDef *hspi)
   * @param hdma : DMA handle
   * @retval None
   */
-static void HAL_SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma)   
+static void SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma)   
 {
   SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
 
@@ -1655,7 +1674,7 @@ static void HAL_SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma)
   * @param hdma : DMA handle
   * @retval None
   */
-static void HAL_SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma)   
+static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma)   
 {
   __IO uint16_t tmpreg;
   SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
@@ -1725,7 +1744,7 @@ static void HAL_SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
   * @retval None
   */
 
-static void HAL_SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma)   
+static void SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma)   
 {
   __IO int16_t tmpreg;
   SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
@@ -1791,7 +1810,7 @@ static void HAL_SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma)
   * @param hdma : DMA handle
   * @retval None
   */
-static void HAL_SPI_DMAError(DMA_HandleTypeDef *hdma)   
+static void SPI_DMAError(DMA_HandleTypeDef *hdma)   
 {
   SPI_HandleTypeDef* hspi = ( SPI_HandleTypeDef* )((DMA_HandleTypeDef* )hdma)->Parent;
   hspi->TxXferCount = 0;
@@ -1800,6 +1819,96 @@ static void HAL_SPI_DMAError(DMA_HandleTypeDef *hdma)
   hspi->State = HAL_SPI_STATE_READY;
   HAL_SPI_ErrorCallback(hspi);
 }
+
+/**
+  * @brief Tx Transfer completed callbacks
+  * @param hspi: SPI handle
+  * @retval None
+  */
+__weak void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SPI_TxCpltCallback could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @brief Rx Transfer completed callbacks
+  * @param hspi: SPI handle
+  * @retval None
+  */
+__weak void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SPI_RxCpltCallback could be implenetd in the user file
+   */
+}
+  
+/**
+  * @brief Tx and Rx Transfer completed callbacks
+  * @param hspi: SPI handle
+  * @retval None
+  */
+__weak void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SPI_TxRxCpltCallback could be implenetd in the user file
+   */
+}
+  
+/**
+  * @brief SPI error callbacks
+  * @param hspi: SPI handle
+  * @retval None
+  */
+ __weak void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SPI_ErrorCallback could be implenetd in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup SPI_Exported_Functions_Group3 Peripheral Control functions 
+  *  @brief   SPI control functions 
+ *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to control the SPI.
+     (+) HAL_SPI_GetState() API can be helpful to check in run-time the state of the SPI peripheral. 
+     (+) HAL_SPI_Ctl() API can be used to update the spi configuration (only one parameter)
+         without calling the HAL_SPI_Init() API
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the SPI state
+  * @param  hspi : SPI handle
+  * @retval HAL state
+  */
+HAL_SPI_StateTypeDef HAL_SPI_GetState(SPI_HandleTypeDef *hspi)
+{
+  return hspi->State;
+}
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup SPI_Private_Functions SPI Private Functions
+ *  @brief   Data transfers Private functions 
+  * @{
+  */
 
 /**
   * @brief  Rx Handler for Transmit and Receive in Interrupt mode
@@ -2275,11 +2384,10 @@ static void SPI_CloseRxTx_ISR(SPI_HandleTypeDef *hspi)
   /* Check the end of the transaction */
   SPI_EndRxTxTransaction(hspi,SPI_DEFAULT_TIMEOUT);
   
-  hspi->State = HAL_SPI_STATE_READY;
-  
   /* Check if CRC error occurred */
   if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_CRCERR) != RESET)
   {
+    hspi->State = HAL_SPI_STATE_READY;
     hspi->ErrorCode|= HAL_SPI_ERROR_CRC;
     __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
     HAL_SPI_ErrorCallback(hspi);
@@ -2290,15 +2398,18 @@ static void SPI_CloseRxTx_ISR(SPI_HandleTypeDef *hspi)
     {
       if(hspi->State == HAL_SPI_STATE_BUSY_RX)
       {
+      	hspi->State = HAL_SPI_STATE_READY;
         HAL_SPI_RxCpltCallback(hspi);
       }
       else
       {
+      	hspi->State = HAL_SPI_STATE_READY;
         HAL_SPI_TxRxCpltCallback(hspi);
       }      
     }
     else
     {
+      hspi->State = HAL_SPI_STATE_READY;
       HAL_SPI_ErrorCallback(hspi);
     }
   }
@@ -2368,90 +2479,8 @@ static void SPI_CloseTx_ISR(SPI_HandleTypeDef *hspi)
 }
 
 /**
-  * @brief Tx Transfer completed callbacks
-  * @param hspi: SPI handle
-  * @retval None
-  */
-__weak void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi)
-{
-  /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_SPI_TxCpltCallback could be implenetd in the user file
-   */ 
-}
-
-/**
-  * @brief Rx Transfer completed callbacks
-  * @param hspi: SPI handle
-  * @retval None
-  */
-__weak void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi)
-{
-  /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_SPI_RxCpltCallback could be implenetd in the user file
-   */
-}
-  
-/**
-  * @brief Tx and Rx Transfer completed callbacks
-  * @param hspi: SPI handle
-  * @retval None
-  */
-__weak void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi)
-{
-  /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_SPI_TxRxCpltCallback could be implenetd in the user file
-   */
-}
-  
-/**
-  * @brief SPI error callbacks
-  * @param hspi: SPI handle
-  * @retval None
-  */
- __weak void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi)
-{
-  /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_SPI_ErrorCallback could be implenetd in the user file
-   */ 
-}
-
-/**
   * @}
   */
-
-/** @defgroup HAL_SPI_Group3 Peripheral Control functions 
-  *  @brief   SPI control functions 
- *
-@verbatim   
- ===============================================================================
-                      ##### Peripheral Control functions #####
- ===============================================================================  
-    [..]
-    This subsection provides a set of functions allowing to control the SPI.
-     (+) HAL_SPI_GetState() API can be helpful to check in run-time the state of the SPI peripheral. 
-     (+) HAL_SPI_Ctl() API can be used to update the spi configuration (only one parameter)
-         without calling the HAL_SPI_Init() API
-@endverbatim
-  * @{
-  */
-
-/**
-  * @brief  Return the SPI state
-  * @param  hspi : SPI handle
-  * @retval HAL state
-  */
-HAL_SPI_StateTypeDef HAL_SPI_GetState(SPI_HandleTypeDef *hspi)
-{
-  return hspi->State;
-}
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
 
 #endif /* HAL_SPI_MODULE_ENABLED */
 /**

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_spi.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_spi.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_spi.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of SPI HAL module.
   ******************************************************************************
   * @attention
@@ -55,6 +55,9 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup SPI_Exported_Types SPI Exported Types
+  * @{
+  */
 
 /** 
   * @brief  SPI Configuration Structure definition  
@@ -179,13 +182,17 @@ typedef struct __SPI_HandleTypeDef
 
 }SPI_HandleTypeDef;
 
+/**
+  * @}
+  */
+
 /* Exported constants --------------------------------------------------------*/
 
-/** @defgroup SPI_Exported_Constants
+/** @defgroup SPI_Exported_Constants SPI Exported Constants
   * @{
   */
 
-/** @defgroup SPI_mode 
+/** @defgroup SPI_mode SPI mode
   * @{
   */  
 
@@ -197,7 +204,7 @@ typedef struct __SPI_HandleTypeDef
   * @}
   */
 
-/** @defgroup SPI_Direction 
+/** @defgroup SPI_Direction  SPI Direction
   * @{
   */
 #define SPI_DIRECTION_2LINES             ((uint32_t)0x00000000)
@@ -216,7 +223,7 @@ typedef struct __SPI_HandleTypeDef
   * @}
   */
   
-/** @defgroup SPI_data_size 
+/** @defgroup SPI_data_size SPI data size
   * @{
   */
 
@@ -251,7 +258,7 @@ typedef struct __SPI_HandleTypeDef
   * @}
   */ 
 
-/** @defgroup SPI_Clock_Polarity 
+/** @defgroup SPI_Clock_Polarity SPI Clock Polarity
   * @{
   */ 
 
@@ -263,7 +270,7 @@ typedef struct __SPI_HandleTypeDef
   * @}
   */
 
-/** @defgroup SPI_Clock_Phase 
+/** @defgroup SPI_Clock_Phase  SPI Clock Phase
   * @{
   */
 
@@ -275,7 +282,7 @@ typedef struct __SPI_HandleTypeDef
   * @}
   */
 
-/** @defgroup SPI_Slave_Select_management 
+/** @defgroup SPI_Slave_Select_management SPI Slave Select management
   * @{
   */ 
 
@@ -291,7 +298,7 @@ typedef struct __SPI_HandleTypeDef
   */
 
  
-/** @defgroup SPI_NSS pulse management 
+/** @defgroup SPI_NSS SPI NSS pulse management 
   * @{
   */ 
 #define SPI_NSS_PULSE_ENABLED           SPI_CR2_NSSP
@@ -305,7 +312,7 @@ typedef struct __SPI_HandleTypeDef
   */
 
    
-/** @defgroup SPI_BaudRate_Prescaler 
+/** @defgroup SPI_BaudRate_Prescaler SPI BaudRate Prescaler
   * @{
   */
 
@@ -329,7 +336,7 @@ typedef struct __SPI_HandleTypeDef
   * @}
   */ 
 
-/** @defgroup SPI_MSB_LSB_transmission 
+/** @defgroup SPI_MSB_LSB_transmission SPI MSB LSB transmission
   * @{
   */ 
 
@@ -341,7 +348,7 @@ typedef struct __SPI_HandleTypeDef
   * @}
   */
 
-/** @defgroup SPI_TI_mode 
+/** @defgroup SPI_TI_mode SPI TI mode
   * @{
   */
 
@@ -353,7 +360,7 @@ typedef struct __SPI_HandleTypeDef
   * @}
   */ 
   
-/** @defgroup SPI_CRC_Calculation 
+/** @defgroup SPI_CRC_Calculation SPI CRC Calculation
   * @{
   */
 
@@ -365,7 +372,7 @@ typedef struct __SPI_HandleTypeDef
   * @}
   */
 
-/** @defgroup SPI_CRC_length 
+/** @defgroup SPI_CRC_length SPI CRC length
   * @{
   * This parameter can be one of the following values:
   *     SPI_CRC_LENGTH_DATASIZE: aligned with the data size 
@@ -382,7 +389,7 @@ typedef struct __SPI_HandleTypeDef
   * @}
   */
   
-/** @defgroup SPI_FIFO_reception_threshold 
+/** @defgroup SPI_FIFO_reception_threshold SPI FIFO reception threshold
   * @{
   * This parameter can be one of the following values:
   *     SPI_RxFIFOThreshold_HF: RXNE event is generated if the FIFO 
@@ -398,7 +405,7 @@ typedef struct __SPI_HandleTypeDef
   * @}
   */
 
-/** @defgroup SPI_Interrupt_configuration_definition
+/** @defgroup SPI_Interrupt_configuration_definition SPI Interrupt configuration definition
   * @brief SPI Interrupt definition
   *        Elements values convention: 0xXXXXXXXX
   *           - XXXXXXXX  : Interrupt control mask
@@ -415,11 +422,12 @@ typedef struct __SPI_HandleTypeDef
   */
 
 
-/** @defgroup SPI_Flag_definition 
+/** @defgroup SPI_Flag_definition SPI Flag definition
   * @brief Flag definition
   *        Elements values convention: 0xXXXXYYYY
   *           - XXXX  : Flag register Index
   *           - YYYY  : Flag mask
+  * @{
   */ 
 #define SPI_FLAG_RXNE                   SPI_SR_RXNE		/* SPI status flag: Rx buffer not empty flag */
 #define SPI_FLAG_TXE                    SPI_SR_TXE		/* SPI status flag: Tx buffer empty flag */
@@ -439,9 +447,12 @@ typedef struct __SPI_HandleTypeDef
                       	   ((FLAG) == SPI_FLAG_FTLVL) || \
                       	   ((FLAG) == SPI_FLAG_FRLVL) || \
                       	   ((FLAG) == SPI_IT_FRE))
+/**
+  * @}
+  */
 
 
-/** @defgroup SPI_transmission_fifo_status_level 
+/** @defgroup SPI_transmission_fifo_status_level SPI transmission fifo status level
   * @{
   */ 
 
@@ -455,7 +466,7 @@ typedef struct __SPI_HandleTypeDef
   * @}
   */ 
 
-/** @defgroup SPI_reception_fifo_status_level 
+/** @defgroup SPI_reception_fifo_status_level SPI reception fifo status level
   * @{
   */ 
 #define SPI_FRLVL_EMPTY           ((uint16_t)0x0000)
@@ -473,6 +484,9 @@ typedef struct __SPI_HandleTypeDef
 
 
 /* Exported macros ------------------------------------------------------------*/
+/** @defgroup SPI_Exported_Macros SPI Exported Macros
+ * @{
+ */
 
 /** @brief  Reset SPI handle state
   * @param  __HANDLE__: SPI handle.
@@ -593,8 +607,18 @@ typedef struct __SPI_HandleTypeDef
 
                                                  
 #define IS_SPI_CRC_POLYNOMIAL(POLYNOMIAL) (((POLYNOMIAL) >= 0x1) && ((POLYNOMIAL) <= 0xFFFF))
+/**
+  * @}
+  */
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup SPI_Exported_Functions SPI Exported Functions
+  * @{
+  */
+
+/** @addtogroup SPI_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @{
+  */
 
 /* Initialization and de-initialization functions  ****************************/
 HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi);
@@ -602,6 +626,13 @@ HAL_StatusTypeDef HAL_SPI_InitExtended(SPI_HandleTypeDef *hspi);
 HAL_StatusTypeDef HAL_SPI_DeInit (SPI_HandleTypeDef *hspi);
 void HAL_SPI_MspInit(SPI_HandleTypeDef *hspi);
 void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi);
+/**
+  * @}
+  */
+
+/** @addtogroup SPI_Exported_Functions_Group2 Input and Output operation functions 
+  * @{
+  */
 
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout);
@@ -618,9 +649,23 @@ void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi);
 void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi);
 void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi);
 void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi);
+/**
+  * @}
+  */
+
+/** @addtogroup SPI_Exported_Functions_Group3 Peripheral Control functions 
+  * @{
+  */
 
 /* Peripheral State and Error functions ***************************************/
 HAL_SPI_StateTypeDef HAL_SPI_GetState(SPI_HandleTypeDef *hspi);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_sram.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_sram.c
@@ -1,0 +1,680 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx_hal_sram.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   SRAM HAL module driver.
+  *          This file provides a generic firmware to drive SRAM memories  
+  *          mounted as external device.
+  *         
+  @verbatim
+  ==============================================================================
+                          ##### How to use this driver #####
+  ==============================================================================  
+  [..]
+    This driver is a generic layered driver which contains a set of APIs used to 
+    control SRAM memories. It uses the FMC layer functions to interface 
+    with SRAM devices.  
+    The following sequence should be followed to configure the FMC/FSMC to interface
+    with SRAM/PSRAM memories: 
+      
+   (#) Declare a SRAM_HandleTypeDef handle structure, for example:
+          SRAM_HandleTypeDef  hsram; and: 
+          
+       (++) Fill the SRAM_HandleTypeDef handle "Init" field with the allowed 
+            values of the structure member.
+            
+       (++) Fill the SRAM_HandleTypeDef handle "Instance" field with a predefined 
+            base register instance for NOR or SRAM device 
+                         
+       (++) Fill the SRAM_HandleTypeDef handle "Extended" field with a predefined
+            base register instance for NOR or SRAM extended mode 
+             
+   (#) Declare two FMC_NORSRAM_TimingTypeDef structures, for both normal and extended 
+       mode timings; for example:
+          FMC_NORSRAM_TimingTypeDef  Timing and FMC_NORSRAM_TimingTypeDef  ExTiming;
+      and fill its fields with the allowed values of the structure member.
+      
+   (#) Initialize the SRAM Controller by calling the function HAL_SRAM_Init(). This function
+       performs the following sequence:
+          
+       (##) MSP hardware layer configuration using the function HAL_SRAM_MspInit()
+       (##) Control register configuration using the FMC NORSRAM interface function 
+            FMC_NORSRAM_Init()
+       (##) Timing register configuration using the FMC NORSRAM interface function 
+            FMC_NORSRAM_Timing_Init()
+       (##) Extended mode Timing register configuration using the FMC NORSRAM interface function 
+            FMC_NORSRAM_Extended_Timing_Init()
+       (##) Enable the SRAM device using the macro __FMC_NORSRAM_ENABLE()    
+
+   (#) At this stage you can perform read/write accesses from/to the memory connected 
+       to the NOR/SRAM Bank. You can perform either polling or DMA transfer using the
+       following APIs:
+       (++) HAL_SRAM_Read()/HAL_SRAM_Write() for polling read/write access
+       (++) HAL_SRAM_Read_DMA()/HAL_SRAM_Write_DMA() for DMA read/write transfer
+       
+   (#) You can also control the SRAM device by calling the control APIs HAL_SRAM_WriteOperation_Enable()/
+       HAL_SRAM_WriteOperation_Disable() to respectively enable/disable the SRAM write operation  
+       
+   (#) You can continuously monitor the SRAM device HAL state by calling the function
+       HAL_SRAM_GetState()              
+                             
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f3xx_hal.h"
+
+/** @addtogroup STM32F3xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup SRAM SRAM HAL module driver.
+  * @brief SRAM HAL module driver.
+  * @{
+  */
+#ifdef HAL_SRAM_MODULE_ENABLED
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/    
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
+
+/** @defgroup SRAM_Exported_Functions SRAM Exported Functions
+  * @{
+  */
+
+/** @defgroup SRAM_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @brief    Initialization and Configuration functions.
+  *
+  @verbatim    
+  ==============================================================================
+           ##### SRAM Initialization and de_initialization functions #####
+  ==============================================================================
+    [..]  This section provides functions allowing to initialize/de-initialize
+          the SRAM memory
+  
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Performs the SRAM device initialization sequence
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @param  Timing: Pointer to SRAM control timing structure 
+  * @param  ExtTiming: Pointer to SRAM extended mode timing structure  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SRAM_Init(SRAM_HandleTypeDef *hsram, FMC_NORSRAM_TimingTypeDef *Timing, FMC_NORSRAM_TimingTypeDef *ExtTiming)
+{ 
+  /* Check the SRAM handle parameter */
+  if(hsram == HAL_NULL)
+  {
+     return HAL_ERROR;
+  }
+  
+  if(hsram->State == HAL_SRAM_STATE_RESET)
+  {  
+    /* Initialize the low level hardware (MSP) */
+    HAL_SRAM_MspInit(hsram);
+  }
+  
+  /* Initialize SRAM control Interface */
+  FMC_NORSRAM_Init(hsram->Instance, &(hsram->Init));
+
+  /* Initialize SRAM timing Interface */
+  FMC_NORSRAM_Timing_Init(hsram->Instance, Timing, hsram->Init.NSBank); 
+
+  /* Initialize SRAM extended mode timing Interface */
+  FMC_NORSRAM_Extended_Timing_Init(hsram->Extended, ExtTiming, hsram->Init.NSBank,  hsram->Init.ExtendedMode);  
+  
+  /* Enable the NORSRAM device */
+  __FMC_NORSRAM_ENABLE(hsram->Instance, hsram->Init.NSBank); 
+  
+  return HAL_OK;
+}
+
+/**
+  * @brief  Performs the SRAM device De-initialization sequence.
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  HAL_SRAM_DeInit(SRAM_HandleTypeDef *hsram)
+{ 
+  /* De-Initialize the low level hardware (MSP) */
+  HAL_SRAM_MspDeInit(hsram);
+   
+  /* Configure the SRAM registers with their reset values */
+  FMC_NORSRAM_DeInit(hsram->Instance, hsram->Extended, hsram->Init.NSBank);
+
+  hsram->State = HAL_SRAM_STATE_RESET;
+  
+  /* Release Lock */
+  __HAL_UNLOCK(hsram);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  SRAM MSP Init.
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @retval None
+  */
+__weak void HAL_SRAM_MspInit(SRAM_HandleTypeDef *hsram)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SRAM_MspInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  SRAM MSP DeInit.
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @retval None
+  */
+__weak void HAL_SRAM_MspDeInit(SRAM_HandleTypeDef *hsram)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SRAM_MspDeInit could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  DMA transfer complete callback.
+  * @param  hdma: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @retval None
+  */
+__weak void HAL_SRAM_DMA_XferCpltCallback(DMA_HandleTypeDef *hdma)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SRAM_DMA_XferCpltCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @brief  DMA transfer complete error callback.
+  * @param  hdma: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @retval None
+  */
+__weak void HAL_SRAM_DMA_XferErrorCallback(DMA_HandleTypeDef *hdma)
+{
+  /* NOTE : This function Should not be modified, when the callback is needed,
+            the HAL_SRAM_DMA_XferErrorCallback could be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup SRAM_Exported_Functions_Group2 Input Output and memory control functions 
+  * @brief    Input Output and memory control functions 
+  *
+  @verbatim    
+  ==============================================================================
+                  ##### SRAM Input and Output functions #####
+  ==============================================================================
+  [..]  
+    This section provides functions allowing to use and control the SRAM memory
+  
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Reads 8-bit buffer from SRAM memory. 
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @param  pAddress: Pointer to read start address
+  * @param  pDstBuffer: Pointer to destination buffer  
+  * @param  BufferSize: Size of the buffer to read from memory
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SRAM_Read_8b(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint8_t *pDstBuffer, uint32_t BufferSize)
+{
+  __IO uint8_t * psramaddress = (uint8_t *)pAddress;
+  
+  /* Process Locked */
+  __HAL_LOCK(hsram);
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_BUSY;  
+  
+  /* Read data from memory */
+  for(; BufferSize != 0; BufferSize--)
+  {
+    *pDstBuffer = *(__IO uint8_t *)psramaddress;
+    pDstBuffer++;
+    psramaddress++;
+  }
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_READY;    
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hsram); 
+    
+  return HAL_OK;   
+}
+
+/**
+  * @brief  Writes 8-bit buffer to SRAM memory. 
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @param  pAddress: Pointer to write start address
+  * @param  pSrcBuffer: Pointer to source buffer to write  
+  * @param  BufferSize: Size of the buffer to write to memory
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SRAM_Write_8b(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint8_t *pSrcBuffer, uint32_t BufferSize)
+{
+  __IO uint8_t * psramaddress = (uint8_t *)pAddress;
+  
+  /* Check the SRAM controller state */
+  if(hsram->State == HAL_SRAM_STATE_PROTECTED)
+  {
+    return  HAL_ERROR; 
+  }
+  
+  /* Process Locked */
+  __HAL_LOCK(hsram);
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_BUSY; 
+
+  /* Write data to memory */
+  for(; BufferSize != 0; BufferSize--)
+  {
+    *(__IO uint8_t *)psramaddress = *pSrcBuffer; 
+    pSrcBuffer++;
+    psramaddress++;    
+  }    
+
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_READY; 
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hsram);
+    
+  return HAL_OK;   
+}
+
+/**
+  * @brief  Reads 16-bit buffer from SRAM memory. 
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @param  pAddress: Pointer to read start address
+  * @param  pDstBuffer: Pointer to destination buffer  
+  * @param  BufferSize: Size of the buffer to read from memory
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SRAM_Read_16b(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint16_t *pDstBuffer, uint32_t BufferSize)
+{
+  __IO uint16_t * psramaddress = (uint16_t *)pAddress;
+  
+  /* Process Locked */
+  __HAL_LOCK(hsram);
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_BUSY;  
+  
+  /* Read data from memory */
+  for(; BufferSize != 0; BufferSize--)
+  {
+    *pDstBuffer = *(__IO uint16_t *)psramaddress;
+    pDstBuffer++;
+    psramaddress++;
+  }
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_READY;    
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hsram); 
+    
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Writes 16-bit buffer to SRAM memory. 
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @param  pAddress: Pointer to write start address
+  * @param  pSrcBuffer: Pointer to source buffer to write  
+  * @param  BufferSize: Size of the buffer to write to memory
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SRAM_Write_16b(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint16_t *pSrcBuffer, uint32_t BufferSize)
+{
+  __IO uint16_t * psramaddress = (uint16_t *)pAddress; 
+  
+  /* Check the SRAM controller state */
+  if(hsram->State == HAL_SRAM_STATE_PROTECTED)
+  {
+    return  HAL_ERROR; 
+  }
+  
+  /* Process Locked */
+  __HAL_LOCK(hsram);
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_BUSY; 
+
+  /* Write data to memory */
+  for(; BufferSize != 0; BufferSize--)
+  {
+    *(__IO uint16_t *)psramaddress = *pSrcBuffer; 
+    pSrcBuffer++;
+    psramaddress++;    
+  }    
+
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_READY; 
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hsram);
+    
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Reads 32-bit buffer from SRAM memory. 
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @param  pAddress: Pointer to read start address
+  * @param  pDstBuffer: Pointer to destination buffer  
+  * @param  BufferSize: Size of the buffer to read from memory
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SRAM_Read_32b(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint32_t *pDstBuffer, uint32_t BufferSize)
+{
+  /* Process Locked */
+  __HAL_LOCK(hsram);
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_BUSY;  
+  
+  /* Read data from memory */
+  for(; BufferSize != 0; BufferSize--)
+  {
+    *pDstBuffer = *(__IO uint32_t *)pAddress;
+    pDstBuffer++;
+    pAddress++;
+  }
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_READY;    
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hsram); 
+    
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Writes 32-bit buffer to SRAM memory. 
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @param  pAddress: Pointer to write start address
+  * @param  pSrcBuffer: Pointer to source buffer to write  
+  * @param  BufferSize: Size of the buffer to write to memory
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SRAM_Write_32b(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint32_t *pSrcBuffer, uint32_t BufferSize)
+{
+  /* Check the SRAM controller state */
+  if(hsram->State == HAL_SRAM_STATE_PROTECTED)
+  {
+    return  HAL_ERROR; 
+  }
+  
+  /* Process Locked */
+  __HAL_LOCK(hsram);
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_BUSY; 
+
+  /* Write data to memory */
+  for(; BufferSize != 0; BufferSize--)
+  {
+    *(__IO uint32_t *)pAddress = *pSrcBuffer; 
+    pSrcBuffer++;
+    pAddress++;    
+  }    
+
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_READY; 
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hsram);
+    
+  return HAL_OK;   
+}
+
+/**
+  * @brief  Reads a Words data from the SRAM memory using DMA transfer.
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @param  pAddress: Pointer to read start address
+  * @param  pDstBuffer: Pointer to destination buffer  
+  * @param  BufferSize: Size of the buffer to read from memory
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SRAM_Read_DMA(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint32_t *pDstBuffer, uint32_t BufferSize)
+{
+  /* Process Locked */
+  __HAL_LOCK(hsram);  
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_BUSY;   
+  
+  /* Configure DMA user callbacks */
+  hsram->hdma->XferCpltCallback  = HAL_SRAM_DMA_XferCpltCallback;
+  hsram->hdma->XferErrorCallback = HAL_SRAM_DMA_XferErrorCallback;
+
+  /* Enable the DMA Stream */
+  HAL_DMA_Start_IT(hsram->hdma, (uint32_t)pAddress, (uint32_t)pDstBuffer, (uint32_t)BufferSize);
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_READY; 
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hsram);  
+  
+  return HAL_OK; 
+}
+
+/**
+  * @brief  Writes a Words data buffer to SRAM memory using DMA transfer.
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @param  pAddress: Pointer to write start address
+  * @param  pSrcBuffer: Pointer to source buffer to write  
+  * @param  BufferSize: Size of the buffer to write to memory
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SRAM_Write_DMA(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint32_t *pSrcBuffer, uint32_t BufferSize)
+{
+  /* Check the SRAM controller state */
+  if(hsram->State == HAL_SRAM_STATE_PROTECTED)
+  {
+    return  HAL_ERROR; 
+  }
+  
+  /* Process Locked */
+  __HAL_LOCK(hsram);
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_BUSY; 
+  
+  /* Configure DMA user callbacks */
+  hsram->hdma->XferCpltCallback  = HAL_SRAM_DMA_XferCpltCallback;
+  hsram->hdma->XferErrorCallback = HAL_SRAM_DMA_XferErrorCallback;
+
+  /* Enable the DMA Stream */
+  HAL_DMA_Start_IT(hsram->hdma, (uint32_t)pSrcBuffer, (uint32_t)pAddress, (uint32_t)BufferSize);
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_READY;  
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hsram);  
+  
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+  
+/** @defgroup SRAM_Exported_Functions_Group3 Control functions 
+ *  @brief   Control functions 
+ *
+@verbatim   
+  ==============================================================================
+                        ##### SRAM Control functions #####
+  ==============================================================================  
+  [..]
+    This subsection provides a set of functions allowing to control dynamically
+    the SRAM interface.
+
+@endverbatim
+  * @{
+  */
+    
+/**
+  * @brief  Enables dynamically SRAM write operation.
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SRAM_WriteOperation_Enable(SRAM_HandleTypeDef *hsram)
+{
+  /* Process Locked */
+  __HAL_LOCK(hsram);
+
+  /* Enable write operation */
+  FMC_NORSRAM_WriteOperation_Enable(hsram->Instance, hsram->Init.NSBank); 
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_READY;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hsram); 
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Disables dynamically SRAM write operation.
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SRAM_WriteOperation_Disable(SRAM_HandleTypeDef *hsram)
+{
+  /* Process Locked */
+  __HAL_LOCK(hsram);
+
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_BUSY;
+    
+  /* Disable write operation */
+  FMC_NORSRAM_WriteOperation_Disable(hsram->Instance, hsram->Init.NSBank); 
+  
+  /* Update the SRAM controller state */
+  hsram->State = HAL_SRAM_STATE_PROTECTED;
+  
+  /* Process unlocked */
+  __HAL_UNLOCK(hsram); 
+  
+  return HAL_OK;  
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup SRAM_Exported_Functions_Group4 Peripheral State functions 
+ *  @brief   Peripheral State functions 
+ *
+@verbatim   
+  ==============================================================================
+                      ##### SRAM State functions #####
+  ==============================================================================  
+  [..]
+    This subsection permits to get in run-time the status of the SRAM controller 
+    and the data flow.
+
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Returns the SRAM controller state
+  * @param  hsram: pointer to a SRAM_HandleTypeDef structure that contains
+  *                the configuration information for SRAM module.
+  * @retval HAL state
+  */
+HAL_SRAM_StateTypeDef HAL_SRAM_GetState(SRAM_HandleTypeDef *hsram)
+{
+  return hsram->State;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+#endif /* HAL_SRAM_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_sram.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_sram.h
@@ -1,0 +1,202 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx_hal_sram.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of SRAM HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F3xx_HAL_SRAM_H
+#define __STM32F3xx_HAL_SRAM_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+  #include "stm32f3xx_ll_fmc.h"
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+
+
+/** @addtogroup STM32F3xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup SRAM
+  * @{
+  */ 
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+
+/* Exported typedef ----------------------------------------------------------*/
+
+/** @defgroup SRAM_Exported_Types SRAM Exported Types
+  * @{
+  */
+/** 
+  * @brief  HAL SRAM State structures definition  
+  */ 
+typedef enum
+{
+  HAL_SRAM_STATE_RESET     = 0x00,  /*!< SRAM not yet initialized or disabled           */
+  HAL_SRAM_STATE_READY     = 0x01,  /*!< SRAM initialized and ready for use             */
+  HAL_SRAM_STATE_BUSY      = 0x02,  /*!< SRAM internal process is ongoing               */
+  HAL_SRAM_STATE_ERROR     = 0x03,  /*!< SRAM error state                               */
+  HAL_SRAM_STATE_PROTECTED = 0x04   /*!< SRAM peripheral NORSRAM device write protected */
+  
+}HAL_SRAM_StateTypeDef;
+
+/** 
+  * @brief  SRAM handle Structure definition  
+  */ 
+typedef struct
+{
+  FMC_NORSRAM_TypeDef           *Instance;  /*!< Register base address                        */ 
+  
+  FMC_NORSRAM_EXTENDED_TypeDef  *Extended;  /*!< Extended mode register base address          */
+  
+  FMC_NORSRAM_InitTypeDef       Init;       /*!< SRAM device control configuration parameters */
+
+  HAL_LockTypeDef               Lock;       /*!< SRAM locking object                          */ 
+  
+  __IO HAL_SRAM_StateTypeDef    State;      /*!< SRAM device access state                     */
+  
+  DMA_HandleTypeDef             *hdma;      /*!< Pointer DMA handler                          */
+  
+}SRAM_HandleTypeDef; 
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup SRAM_Exported_Macros SRAM Exported Macros
+ * @{
+ */
+
+/** @brief Reset SRAM handle state
+  * @param  __HANDLE__: SRAM handle
+  * @retval None
+  */
+#define __HAL_SRAM_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_SRAM_STATE_RESET)
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup SRAM_Exported_Functions SRAM Exported Functions
+  * @{
+  */
+
+/** @addtogroup SRAM_Exported_Functions_Group1 Initialization and de-initialization functions
+ * @{
+ */
+
+/* Initialization/de-initialization functions  ********************************/
+HAL_StatusTypeDef HAL_SRAM_Init(SRAM_HandleTypeDef *hsram, FMC_NORSRAM_TimingTypeDef *Timing, FMC_NORSRAM_TimingTypeDef *ExtTiming);
+HAL_StatusTypeDef HAL_SRAM_DeInit(SRAM_HandleTypeDef *hsram);
+void HAL_SRAM_MspInit(SRAM_HandleTypeDef *hsram);
+void HAL_SRAM_MspDeInit(SRAM_HandleTypeDef *hsram);
+
+void HAL_SRAM_DMA_XferCpltCallback(DMA_HandleTypeDef *hdma);
+void HAL_SRAM_DMA_XferErrorCallback(DMA_HandleTypeDef *hdma);
+
+/**
+  * @}
+  */
+
+/** @addtogroup SRAM_Exported_Functions_Group2 Input Output and memory control functions
+ * @{
+ */
+
+/* I/O operation functions  ***************************************************/
+HAL_StatusTypeDef HAL_SRAM_Read_8b(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint8_t *pDstBuffer, uint32_t BufferSize);
+HAL_StatusTypeDef HAL_SRAM_Write_8b(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint8_t *pSrcBuffer, uint32_t BufferSize);
+HAL_StatusTypeDef HAL_SRAM_Read_16b(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint16_t *pDstBuffer, uint32_t BufferSize);
+HAL_StatusTypeDef HAL_SRAM_Write_16b(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint16_t *pSrcBuffer, uint32_t BufferSize);
+HAL_StatusTypeDef HAL_SRAM_Read_32b(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint32_t *pDstBuffer, uint32_t BufferSize);
+HAL_StatusTypeDef HAL_SRAM_Write_32b(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint32_t *pSrcBuffer, uint32_t BufferSize);
+HAL_StatusTypeDef HAL_SRAM_Read_DMA(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint32_t *pDstBuffer, uint32_t BufferSize);
+HAL_StatusTypeDef HAL_SRAM_Write_DMA(SRAM_HandleTypeDef *hsram, uint32_t *pAddress, uint32_t *pSrcBuffer, uint32_t BufferSize);
+
+/**
+  * @}
+  */
+  
+/** @addtogroup SRAM_Exported_Functions_Group3 Control functions
+ * @{
+ */
+
+/* SRAM Control functions  ****************************************************/
+HAL_StatusTypeDef HAL_SRAM_WriteOperation_Enable(SRAM_HandleTypeDef *hsram);
+HAL_StatusTypeDef HAL_SRAM_WriteOperation_Disable(SRAM_HandleTypeDef *hsram);
+
+/**
+  * @}
+  */
+
+/** @addtogroup SRAM_Exported_Functions_Group4 Peripheral State functions
+ * @{
+ */
+
+/* SRAM Peripheral State functions ********************************************/
+HAL_SRAM_StateTypeDef HAL_SRAM_GetState(SRAM_HandleTypeDef *hsram);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F3xx_HAL_SRAM_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_tim.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_tim.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_tim.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   TIM HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Timer (TIM) peripheral:
@@ -132,7 +132,7 @@
   * @{
   */
 
-/** @defgroup TIM 
+/** @defgroup TIM TIM HAL module driver
   * @brief TIM HAL module driver
   * @{
   */
@@ -157,11 +157,11 @@ static void TIM_DMAPeriodElapsedCplt(DMA_HandleTypeDef *hdma);
 static void TIM_DMATriggerCplt(DMA_HandleTypeDef *hdma);
 /* Private functions ---------------------------------------------------------*/
 
-/** @defgroup TIM_Private_Functions
+/** @defgroup TIM_Exported_Functions TIM Exported Functions
   * @{
   */
 
-/** @defgroup TIM_Group1 Time Base functions 
+/** @defgroup TIM_Exported_Functions_Group1 Time Base functions 
  *  @brief    Time Base functions 
  *
 @verbatim    
@@ -191,7 +191,7 @@ static void TIM_DMATriggerCplt(DMA_HandleTypeDef *hdma);
 HAL_StatusTypeDef HAL_TIM_Base_Init(TIM_HandleTypeDef *htim)
 { 
   /* Check the TIM handle allocation */
-  if(htim == NULL)
+  if(htim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -429,7 +429,7 @@ HAL_StatusTypeDef HAL_TIM_Base_Stop_DMA(TIM_HandleTypeDef *htim)
   * @}
   */
   
-/** @defgroup TIM_Group2 Time Output Compare functions 
+/** @defgroup TIM_Exported_Functions_Group2 Time Output Compare functions 
  *  @brief    Time Output Compare functions 
  *
 @verbatim    
@@ -459,7 +459,7 @@ HAL_StatusTypeDef HAL_TIM_Base_Stop_DMA(TIM_HandleTypeDef *htim)
 HAL_StatusTypeDef HAL_TIM_OC_Init(TIM_HandleTypeDef* htim)
 {
   /* Check the TIM handle allocation */
-  if(htim == NULL)
+  if(htim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -926,7 +926,7 @@ HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
   * @}
   */
 
-/** @defgroup TIM_Group3 Time PWM functions 
+/** @defgroup TIM_Exported_Functions_Group3 Time PWM functions 
  *  @brief    Time PWM functions 
  *
 @verbatim    
@@ -956,7 +956,7 @@ HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
 HAL_StatusTypeDef HAL_TIM_PWM_Init(TIM_HandleTypeDef *htim)
 {
   /* Check the TIM handle allocation */
-  if(htim == NULL)
+  if(htim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -1426,7 +1426,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
   * @}
   */
 
-/** @defgroup TIM_Group4 Time Input Capture functions 
+/** @defgroup TIM_Exported_Functions_Group4 Time Input Capture functions 
  *  @brief    Time Input Capture functions 
  *
 @verbatim    
@@ -1456,7 +1456,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
 HAL_StatusTypeDef HAL_TIM_IC_Init(TIM_HandleTypeDef *htim)
 {
   /* Check the TIM handle allocation */
-  if(htim == NULL)
+  if(htim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -1888,7 +1888,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
   * @}
   */
 
-/** @defgroup TIM_Group5 Time One Pulse functions 
+/** @defgroup TIM_Exported_Functions_Group5 Time One Pulse functions 
  *  @brief    Time One Pulse functions 
  *
 @verbatim    
@@ -1922,7 +1922,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
 HAL_StatusTypeDef HAL_TIM_OnePulse_Init(TIM_HandleTypeDef *htim, uint32_t OnePulseMode)
 {
   /* Check the TIM handle allocation */
-  if(htim == NULL)
+  if(htim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -2155,7 +2155,7 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Out
   * @}
   */
 
-/** @defgroup TIM_Group6 Time Encoder functions 
+/** @defgroup TIM_Exported_Functions_Group6 Time Encoder functions 
  *  @brief    Time Encoder functions 
  *
 @verbatim    
@@ -2189,7 +2189,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_Ini
   uint32_t tmpccer = 0;
     
   /* Check the TIM handle allocation */
-  if(htim == NULL)
+  if(htim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -2668,7 +2668,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
 /**
   * @}
   */
-/** @defgroup TIM_Group7 TIM IRQ handler management 
+/** @defgroup TIM_Exported_Functions_Group7 TIM IRQ handler management 
  *  @brief    IRQ handler management 
  *
 @verbatim   
@@ -2817,7 +2817,7 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
   * @}
   */
 
-/** @defgroup TIM_Group8 Peripheral Control functions
+/** @defgroup TIM_Exported_Functions_Group8 Peripheral Control functions
  *  @brief   	Peripheral Control functions 
  *
 @verbatim   
@@ -4225,7 +4225,7 @@ uint32_t HAL_TIM_ReadCapturedValue(TIM_HandleTypeDef *htim, uint32_t Channel)
   * @}
   */
   
-/** @defgroup TIM_Group9 TIM Callbacks functions
+/** @defgroup TIM_Exported_Functions_Group9 TIM Callbacks functions
  *  @brief    TIM Callbacks functions 
  *
 @verbatim   
@@ -4319,7 +4319,7 @@ __weak void HAL_TIM_ErrorCallback(TIM_HandleTypeDef *htim)
   * @}
   */
 
-/** @defgroup TIM_Group10 Peripheral State functions 
+/** @defgroup TIM_Exported_Functions_Group10 Peripheral State functions 
  *  @brief   Peripheral State functions 
  *
 @verbatim   

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_tim.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_tim.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_tim.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of TIM HAL module.
   ******************************************************************************
   * @attention
@@ -55,6 +55,9 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup TIM_Exported_Types TIM Exported Types
+  * @{
+  */
 
 /** 
   * @brief  TIM Time base Configuration Structure definition  
@@ -292,12 +295,16 @@ typedef struct
   __IO HAL_TIM_StateTypeDef   State;         /*!< TIM operation state               */  
 }TIM_HandleTypeDef;
 
+/**
+  * @}
+  */
+
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup TIM_Exported_Constants
+/** @defgroup TIM_Exported_Constants TIM Exported Constants
   * @{
   */
 
-/** @defgroup TIM_Input_Channel_Polarity 
+/** @defgroup TIM_Input_Channel_Polarity TIM Input Channel polarity
   * @{
   */
 #define  TIM_INPUTCHANNELPOLARITY_RISING      ((uint32_t)0x00000000)            /*!< Polarity for TIx source */
@@ -307,7 +314,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup TIM_ETR_Polarity 
+/** @defgroup TIM_ETR_Polarity TIM ETR Polarity
   * @{
   */
 #define TIM_ETRPOLARITY_INVERTED              (TIM_SMCR_ETP)                    /*!< Polarity for ETR source */ 
@@ -316,7 +323,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup TIM_ETR_Prescaler 
+/** @defgroup TIM_ETR_Prescaler TIM ETR Prescaler
   * @{
   */                
 #define TIM_ETRPRESCALER_DIV1                 ((uint32_t)0x0000)                /*!< No prescaler is used */
@@ -327,7 +334,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup TIM_Counter_Mode 
+/** @defgroup TIM_Counter_Mode TIM Counter Mode
   * @{
   */
 
@@ -346,7 +353,7 @@ typedef struct
   * @}
   */ 
   
-/** @defgroup TIM_ClockDivision 
+/** @defgroup TIM_ClockDivision TIM Clock Division
   * @{
   */
 
@@ -361,7 +368,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup TIM_Output_Compare_State 
+/** @defgroup TIM_Output_Compare_State TIM Output Compare State
   * @{
   */
 
@@ -373,7 +380,7 @@ typedef struct
 /**
   * @}
   */ 
-/** @defgroup TIM_Output_Fast_State 
+/** @defgroup TIM_Output_Fast_State TIM Output Fast State
   * @{
   */
 #define TIM_OCFAST_DISABLE                ((uint32_t)0x0000)
@@ -384,7 +391,7 @@ typedef struct
 /**
   * @}
   */ 
-/** @defgroup TIM_Output_Compare_N_State
+/** @defgroup TIM_Output_Compare_N_State TIM Complementary Output Compare State
   * @{
   */
 
@@ -397,7 +404,7 @@ typedef struct
   * @}
   */ 
   
-/** @defgroup TIM_Output_Compare_Polarity 
+/** @defgroup TIM_Output_Compare_Polarity TIM Output Compare Polarity
   * @{
   */
 
@@ -410,7 +417,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup TIM_Output_Compare_N_Polarity 
+/** @defgroup TIM_Output_Compare_N_Polarity TIM Complementary Output Compare Polarity
   * @{
   */
   
@@ -423,7 +430,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup TIM_Output_Compare_Idle_State 
+/** @defgroup TIM_Output_Compare_Idle_State TIM Output Compare Idle State
   * @{
   */
 
@@ -435,7 +442,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup TIM_Output_Compare_N_Idle_State 
+/** @defgroup TIM_Output_Compare_N_Idle_State TIM Complementary Output Compare Idle State
   * @{
   */
 
@@ -449,7 +456,7 @@ typedef struct
 
 
 
-/** @defgroup TIM_Input_Capture_Polarity 
+/** @defgroup TIM_Input_Capture_Polarity TIM Input Capture Polarity
   * @{
   */
 
@@ -464,7 +471,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup TIM_Input_Capture_Selection 
+/** @defgroup TIM_Input_Capture_Selection TIM Input Capture Selection
   * @{
   */
 
@@ -481,7 +488,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup TIM_Input_Capture_Prescaler 
+/** @defgroup TIM_Input_Capture_Prescaler TIM Input Capture Prescaler
   * @{
   */
 
@@ -498,7 +505,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup TIM_One_Pulse_Mode 
+/** @defgroup TIM_One_Pulse_Mode TIM One Pulse Mode
   * @{
   */
 
@@ -509,7 +516,7 @@ typedef struct
 /**
   * @}
   */ 
-/** @defgroup TIM_Encoder_Mode 
+/** @defgroup TIM_Encoder_Mode TIM Encoder Mode
   * @{
   */ 
 #define TIM_ENCODERMODE_TI1                (TIM_SMCR_SMS_0)
@@ -521,7 +528,7 @@ typedef struct
 /**
   * @}
   */   
-/** @defgroup TIM_Interrupt_definition 
+/** @defgroup TIM_Interrupt_definition TIM interrupt Definition
   * @{
   */ 
 #define TIM_IT_UPDATE           (TIM_DIER_UIE)
@@ -549,7 +556,7 @@ typedef struct
 #define TIM_COMMUTATION_TRGI              (TIM_CR2_CCUS)
 #define TIM_COMMUTATION_SOFTWARE          ((uint32_t)0x0000)
 
-/** @defgroup TIM_DMA_sources 
+/** @defgroup TIM_DMA_sources TIM DMA Sources
   * @{
   */
 
@@ -566,7 +573,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup TIM_Flag_definition 
+/** @defgroup TIM_Flag_definition TIM Flag Definition
   * @{
   */ 
                                 
@@ -599,7 +606,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup TIM_Clock_Source 
+/** @defgroup TIM_Clock_Source TIM Clock Source
   * @{
   */ 
 #define	TIM_CLOCKSOURCE_ETRMODE2    (TIM_SMCR_ETPS_1) 
@@ -627,7 +634,7 @@ typedef struct
   * @}
   */   
 
-/** @defgroup TIM_Clock_Polarity 
+/** @defgroup TIM_Clock_Polarity TIM Clock Polarity
   * @{
   */
 #define TIM_CLOCKPOLARITY_INVERTED           TIM_ETRPOLARITY_INVERTED          /*!< Polarity for ETRx clock sources */ 
@@ -644,7 +651,7 @@ typedef struct
 /**
   * @}
   */
-/** @defgroup TIM_Clock_Prescaler 
+/** @defgroup TIM_Clock_Prescaler TIM Clock Prescaler
   * @{
   */                
 #define TIM_CLOCKPRESCALER_DIV1                 TIM_ETRPRESCALER_DIV1     /*!< No prescaler is used */
@@ -659,7 +666,7 @@ typedef struct
 /**
   * @}
   */ 
-/** @defgroup TIM_Clock_Filter
+/** @defgroup TIM_Clock_Filter TIM Clock Filter
   * @{
   */
 
@@ -668,7 +675,7 @@ typedef struct
   * @}
   */  
 
-/** @defgroup TIM_ClearInput_Polarity
+/** @defgroup TIM_ClearInput_Polarity TIM Clear Input Polarity
   * @{
   */
 #define TIM_CLEARINPUTPOLARITY_INVERTED           TIM_ETRPOLARITY_INVERTED                    /*!< Polarity for ETRx pin */ 
@@ -681,7 +688,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup TIM_ClearInput_Prescaler
+/** @defgroup TIM_ClearInput_Prescaler TIM Clear Input Prescaler
   * @{
   */
 #define TIM_CLEARINPUTPRESCALER_DIV1                    TIM_ETRPRESCALER_DIV1      /*!< No prescaler is used */
@@ -696,7 +703,7 @@ typedef struct
   * @}
   */
   
-/** @defgroup TIM_ClearInput_Filter
+/** @defgroup TIM_ClearInput_Filter TIM Clear Input Filter
   * @{
   */
 
@@ -705,7 +712,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup TIM_OSSR_Off_State_Selection_for_Run_mode_state
+/** @defgroup TIM_OSSR_Off_State_Selection_for_Run_mode_state TIM Off-state Selection for Run Mode
   * @{
   */  
 #define TIM_OSSR_ENABLE 	      (TIM_BDTR_OSSR)
@@ -717,7 +724,7 @@ typedef struct
   * @}
   */
   
-/** @defgroup TIM_OSSI_Off_State_Selection_for_Idle_mode_state 
+/** @defgroup TIM_OSSI_Off_State_Selection_for_Idle_mode_state TIM Off-state Selection for Idle Mode
   * @{
   */
 #define TIM_OSSI_ENABLE	 	    (TIM_BDTR_OSSI)
@@ -728,7 +735,7 @@ typedef struct
 /**
   * @}
   */
-/** @defgroup TIM_Lock_level 
+/** @defgroup TIM_Lock_level TIM Lock Configuration
   * @{
   */
 #define TIM_LOCKLEVEL_OFF	   ((uint32_t)0x0000)
@@ -743,7 +750,7 @@ typedef struct
 /**
   * @}
   */  
-/** @defgroup TIM_Break_Input_enable_disable 
+/** @defgroup TIM_Break_Input_enable_disable TIM Break Input Enable
   * @{
   */                         
 #define TIM_BREAK_ENABLE          (TIM_BDTR_BKE)
@@ -754,7 +761,7 @@ typedef struct
 /**
   * @}
   */
-/** @defgroup TIM_Break_Polarity 
+/** @defgroup TIM_Break_Polarity TIM Break Input Polarity
   * @{
   */
 #define TIM_BREAKPOLARITY_LOW        ((uint32_t)0x0000)
@@ -765,7 +772,7 @@ typedef struct
 /**
   * @}
   */
-/** @defgroup TIM_AOE_Bit_Set_Reset 
+/** @defgroup TIM_AOE_Bit_Set_Reset TIM Automatic Output Enable
   * @{
   */
 #define TIM_AUTOMATICOUTPUT_ENABLE           (TIM_BDTR_AOE)
@@ -777,7 +784,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup TIM_Master_Mode_Selection
+/** @defgroup TIM_Master_Mode_Selection TIM Master Mode Selection
   * @{
   */  
 #define	TIM_TRGO_RESET            ((uint32_t)0x0000)             
@@ -802,7 +809,7 @@ typedef struct
 /**
   * @}
   */   
-/** @defgroup TIM_Master_Slave_Mode 
+/** @defgroup TIM_Master_Slave_Mode TIM Master/Slave Mode
   * @{
   */
 
@@ -813,7 +820,7 @@ typedef struct
 /**
   * @}
   */ 
-/** @defgroup TIM_Trigger_Selection 
+/** @defgroup TIM_Trigger_Selection TIM Trigger Selection
   * @{
   */
 
@@ -847,7 +854,7 @@ typedef struct
   * @}
   */  
 
-/** @defgroup TIM_Trigger_Polarity 
+/** @defgroup TIM_Trigger_Polarity TIM Trigger Polarity
   * @{
   */
 #define TIM_TRIGGERPOLARITY_INVERTED           TIM_ETRPOLARITY_INVERTED      /*!< Polarity for ETRx trigger sources */ 
@@ -865,7 +872,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup TIM_Trigger_Prescaler 
+/** @defgroup TIM_Trigger_Prescaler TIM Trigger Prescaler
   * @{
   */                
 #define TIM_TRIGGERPRESCALER_DIV1             TIM_ETRPRESCALER_DIV1     /*!< No prescaler is used */
@@ -881,7 +888,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup TIM_Trigger_Filter
+/** @defgroup TIM_Trigger_Filter TIM Trigger Filter
   * @{
   */
 
@@ -890,7 +897,7 @@ typedef struct
   * @}
   */  
 
-  /** @defgroup TIM_TI1_Selection
+  /** @defgroup TIM_TI1_Selection TIM TI1 Input Selection
   * @{
   */
 
@@ -904,7 +911,7 @@ typedef struct
   * @}
   */  
 
-/** @defgroup TIM_DMA_Burst_Length 
+/** @defgroup TIM_DMA_Burst_Length TIM DMA Burst Length
   * @{
   */
 
@@ -948,7 +955,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup TIM_Input_Capture_Filer_Value 
+/** @defgroup TIM_Input_Capture_Filer_Value TIM Input Capture Value
   * @{
   */
 
@@ -957,7 +964,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup DMA_Handle_index 
+/** @defgroup DMA_Handle_index TIM DMA Handle Index
   * @{
   */
 #define TIM_DMA_ID_UPDATE                ((uint16_t) 0x0)       /*!< Index of the DMA handle used for Update DMA requests */
@@ -971,7 +978,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup Channel_CC_State 
+/** @defgroup Channel_CC_State TIM Capture/Compare Channel State
   * @{
   */
 #define TIM_CCx_ENABLE                   ((uint32_t)0x0001)
@@ -987,7 +994,7 @@ typedef struct
   */   
   
 /* Exported macros -----------------------------------------------------------*/
-/** @defgroup TIM_Exported_Macros
+/** @defgroup TIM_Exported_Macros TIM Exported Macros
   * @{
   */  
 
@@ -1179,14 +1186,46 @@ typedef struct
    (((__HANDLE__)->Instance->CCMR2 & TIM_CCMR2_IC4PSC)) >> 8)
     
 /**
+  * @brief  Set the Update Request Source (URS) bit of the TIMx_CR1 register
+  * @param  __HANDLE__: TIM handle.
+  * @note  When the USR bit of the TIMx_CR1 register is set, only counter 
+  *        overflow/underflow generates an update interrupt or DMA request (if
+  *        enabled)
+  * @retval None
+  */
+#define __HAL_TIM_URS_ENABLE(__HANDLE__) \
+    ((__HANDLE__)->Instance->CR1|= (TIM_CR1_URS))
+
+/**
+  * @brief  Reset the Update Request Source (URS) bit of the TIMx_CR1 register
+  * @param  __HANDLE__: TIM handle.
+  * @note  When the USR bit of the TIMx_CR1 register is reset, any of the 
+  *        following events generate an update interrupt or DMA request (if 
+  *        enabled):
+  *          – Counter overflow/underflow
+  *          – Setting the UG bit
+  *          – Update generation through the slave mode controller
+  * @retval None
+  */
+#define __HAL_TIM_URS_DISABLE(__HANDLE__) \
+      ((__HANDLE__)->Instance->CR1&=~(TIM_CR1_URS))
+
+/**
   * @}
   */
 
-/* Include TIM HAL Extension module */
+/* Include TIM HAL Extended module */
 #include "stm32f3xx_hal_tim_ex.h"
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup TIM_Exported_Functions TIM Exported Functions
+  * @{
+  */
 
+/** @addtogroup TIM_Exported_Functions_Group1 Time Base functions 
+ *  @brief    Time Base functions 
+ * @{
+ */
 /* Time Base functions ********************************************************/
 HAL_StatusTypeDef HAL_TIM_Base_Init(TIM_HandleTypeDef *htim);
 HAL_StatusTypeDef HAL_TIM_Base_DeInit(TIM_HandleTypeDef *htim);
@@ -1201,7 +1240,14 @@ HAL_StatusTypeDef HAL_TIM_Base_Stop_IT(TIM_HandleTypeDef *htim);
 /* Non-Blocking mode: DMA */
 HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pData, uint16_t Length);
 HAL_StatusTypeDef HAL_TIM_Base_Stop_DMA(TIM_HandleTypeDef *htim);
+/**
+  * @}
+  */
 
+/** @addtogroup TIM_Exported_Functions_Group2 Time Output Compare functions 
+ *  @brief    Time Output Compare functions 
+ * @{
+ */
 /* Timer Output Compare functions **********************************************/
 HAL_StatusTypeDef HAL_TIM_OC_Init(TIM_HandleTypeDef *htim);
 HAL_StatusTypeDef HAL_TIM_OC_DeInit(TIM_HandleTypeDef *htim);
@@ -1216,7 +1262,14 @@ HAL_StatusTypeDef HAL_TIM_OC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
 /* Non-Blocking mode: DMA */
 HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
 HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
-
+/**
+  * @}
+  */
+  
+/** @addtogroup TIM_Exported_Functions_Group3 Time PWM functions 
+ *  @brief    Time PWM functions 
+ * @{
+ */
 /* Timer PWM functions *********************************************************/
 HAL_StatusTypeDef HAL_TIM_PWM_Init(TIM_HandleTypeDef *htim);
 HAL_StatusTypeDef HAL_TIM_PWM_DeInit(TIM_HandleTypeDef *htim);
@@ -1231,7 +1284,14 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 /* Non-Blocking mode: DMA */
 HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
 HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
-
+/**
+  * @}
+  */
+  
+/** @addtogroup TIM_Exported_Functions_Group4 Time Input Capture functions 
+ *  @brief    Time Input Capture functions 
+ * @{
+ */
 /* Timer Input Capture functions ***********************************************/
 HAL_StatusTypeDef HAL_TIM_IC_Init(TIM_HandleTypeDef *htim);
 HAL_StatusTypeDef HAL_TIM_IC_DeInit(TIM_HandleTypeDef *htim);
@@ -1246,7 +1306,14 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
 /* Non-Blocking mode: DMA */
 HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
 HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
-
+/**
+  * @}
+  */
+  
+/** @addtogroup TIM_Exported_Functions_Group5 Time One Pulse functions 
+ *  @brief    Time One Pulse functions 
+ * @{
+ */
 /* Timer One Pulse functions ***************************************************/
 HAL_StatusTypeDef HAL_TIM_OnePulse_Init(TIM_HandleTypeDef *htim, uint32_t OnePulseMode);
 HAL_StatusTypeDef HAL_TIM_OnePulse_DeInit(TIM_HandleTypeDef *htim);
@@ -1258,17 +1325,17 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Stop(TIM_HandleTypeDef *htim, uint32_t Output
 /* Non-Blocking mode: Interrupt */
 HAL_StatusTypeDef HAL_TIM_OnePulse_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
 HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+/**
+  * @}
+  */
 
+/** @addtogroup TIM_Exported_Functions_Group6 Time Encoder functions 
+ *  @brief    Time Encoder functions 
+ * @{
+ */
 /* Timer Encoder functions *****************************************************/
 HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_InitTypeDef* sConfig);
 HAL_StatusTypeDef HAL_TIM_Encoder_DeInit(TIM_HandleTypeDef *htim);
-
-
-
-
-
-
-
 void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim);
 void HAL_TIM_Encoder_MspDeInit(TIM_HandleTypeDef *htim);
  /* Blocking mode: Polling */
@@ -1280,10 +1347,24 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Chan
 /* Non-Blocking mode: DMA */
 HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData1, uint32_t *pData2, uint16_t Length);
 HAL_StatusTypeDef HAL_TIM_Encoder_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+/**
+  * @}
+  */
 
+/** @addtogroup TIM_Exported_Functions_Group7 TIM IRQ handler management 
+ *  @brief    IRQ handler management 
+  * @{
+  */
 /* Interrupt Handler functions  **********************************************/
 void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim);
+/**
+  * @}
+  */
 
+/** @defgroup TIM_Exported_Functions_Group8 Peripheral Control functions
+ *  @brief   	Peripheral Control functions 
+  * @{
+  */
 /* Control functions  *********************************************************/
 HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel);
 HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef* sConfig, uint32_t Channel);
@@ -1301,7 +1382,14 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t B
 HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc);
 HAL_StatusTypeDef HAL_TIM_GenerateEvent(TIM_HandleTypeDef *htim, uint32_t EventSource);
 uint32_t HAL_TIM_ReadCapturedValue(TIM_HandleTypeDef *htim, uint32_t Channel);
+/**
+  * @}
+  */
 
+/** @defgroup TIM_Exported_Functions_Group9 TIM Callbacks functions
+ *  @brief    TIM Callbacks functions 
+  * @{
+  */
 /* Callback in non blocking modes (Interrupt and DMA) *************************/
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim);
 void HAL_TIM_OC_DelayElapsedCallback(TIM_HandleTypeDef *htim);
@@ -1309,7 +1397,14 @@ void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef *htim);
 void HAL_TIM_PWM_PulseFinishedCallback(TIM_HandleTypeDef *htim);
 void HAL_TIM_TriggerCallback(TIM_HandleTypeDef *htim);
 void HAL_TIM_ErrorCallback(TIM_HandleTypeDef *htim);
+/**
+  * @}
+  */
 
+/** @defgroup TIM_Exported_Functions_Group10 Peripheral State functions 
+ *  @brief   Peripheral State functions 
+ * @{
+ */
 /* Peripheral State functions  **************************************************/
 HAL_TIM_StateTypeDef HAL_TIM_Base_GetState(TIM_HandleTypeDef *htim);
 HAL_TIM_StateTypeDef HAL_TIM_OC_GetState(TIM_HandleTypeDef *htim);
@@ -1317,6 +1412,13 @@ HAL_TIM_StateTypeDef HAL_TIM_PWM_GetState(TIM_HandleTypeDef *htim);
 HAL_TIM_StateTypeDef HAL_TIM_IC_GetState(TIM_HandleTypeDef *htim);
 HAL_TIM_StateTypeDef HAL_TIM_OnePulse_GetState(TIM_HandleTypeDef *htim);
 HAL_TIM_StateTypeDef HAL_TIM_Encoder_GetState(TIM_HandleTypeDef *htim);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure);
 void TIM_TI1_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection, uint32_t TIM_ICFilter);
@@ -1332,12 +1434,9 @@ void HAL_TIM_DMAError(DMA_HandleTypeDef *hdma);
 void HAL_TIM_DMACaptureCplt(DMA_HandleTypeDef *hdma);
 void TIM_CCxChannelCmd(TIM_TypeDef* TIMx, uint32_t Channel, uint32_t ChannelState);
 
-
-
-
 /**
   * @}
-  */ 
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_tim_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_tim_ex.c
@@ -2,11 +2,11 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_tim_ex.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   TIM HAL module driver.
   *          This file provides firmware functions to manage the following 
-  *          functionalities of the Timer extension peripheral:
+  *          functionalities of the Timer Extended peripheral:
   *           + Time Hall Sensor Interface Initialization
   *           + Time Hall Sensor Interface Start
   *           + Time Complementary signal bread and dead time configuration  
@@ -19,7 +19,7 @@
                       ##### TIMER Extended features #####
   ==============================================================================
   [..] 
-    The Timer Extension features include: 
+    The Timer Extended features include: 
     (#) Complementary outputs with programmable dead-time for :
         (++) Output Compare
         (++) PWM generation (Edge and Center-aligned Mode)
@@ -61,7 +61,7 @@
              the commutation event).
 
      (#) Activate the TIM peripheral using one of the start functions: 
-           (++) Complementary Output Compare : HAL_TIMEx_OCN_Start(), HAL_TIMEx_OCN_Start_DMA(), HAL_TIMEx_OC_Start_IT()
+           (++) Complementary Output Compare : HAL_TIMEx_OCN_Start(), HAL_TIMEx_OCN_Start_DMA(), HAL_TIMEx_OCN_Start_IT()
            (++) Complementary PWM generation : HAL_TIMEx_PWMN_Start(), HAL_TIMEx_PWMN_Start_DMA(), HAL_TIMEx_PWMN_Start_IT()
            (++) Complementary One-pulse mode output : HAL_TIMEx_OnePulseN_Start(), HAL_TIMEx_OnePulseN_Start_IT()
            (++) Hall Sensor output : HAL_TIMEx_HallSensor_Start(), HAL_TIMEx_HallSensor_Start_DMA(), HAL_TIMEx_HallSensor_Start_IT().
@@ -105,7 +105,7 @@
   * @{
   */
 
-/** @defgroup TIMEx
+/** @defgroup TIMEx TIM Extended HAL module driver
   * @brief TIM Extended HAL module driver
   * @{
   */
@@ -114,36 +114,42 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) ||                         \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
     defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+      
 #define BDTR_BKF_SHIFT (16)
 #define BDTR_BK2F_SHIFT (20)
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx ||                */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx                   */
-
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+      
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) ||                        \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
     defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 static void TIM_OC5_SetConfig(TIM_TypeDef *TIMx,
                               TIM_OC_InitTypeDef *OC_Config);
 
 static void TIM_OC6_SetConfig(TIM_TypeDef *TIMx, 
                               TIM_OC_InitTypeDef *OC_Config);
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx ||                */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx                   */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
 static void TIM_CCxNChannelCmd(TIM_TypeDef* TIMx, uint32_t Channel, uint32_t ChannelNState);    
 
 /* Private functions ---------------------------------------------------------*/
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) ||                         \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
     defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /**
   * @brief  Timer Ouput Compare 5 configuration
   * @param  TIMx to select the TIM peripheral
@@ -250,15 +256,16 @@ static void TIM_OC6_SetConfig(TIM_TypeDef *TIMx,
   /* Write to TIMx CCER */
   TIMx->CCER = tmpccer;  
 } 
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx ||                */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx                   */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
-/** @defgroup TIMEx_Private_Functions
+/** @defgroup TIMEx_Exported_Functions TIM Extended Exported Functions
   * @{
   */
 
-/** @defgroup TIMEx_Group1 Timer Hall Sensor functions 
+/** @defgroup TIMEx_Exported_Functions_Group1 Extended Timer Hall Sensor functions 
   * @brief    Timer Hall Sensor functions
   *
 @verbatim    
@@ -290,7 +297,7 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Init(TIM_HandleTypeDef *htim, TIM_HallSen
   TIM_OC_InitTypeDef OC_Config;
     
   /* Check the TIM handle allocation */
-  if(htim == NULL)
+  if(htim == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -571,7 +578,7 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_DMA(TIM_HandleTypeDef *htim)
   * @}
   */
   
-/** @defgroup TIMEx_Group2 Timer Complementary Output Compare functions
+/** @defgroup TIMEx_Exported_Functions_Group2 Extended Timer Complementary Output Compare functions
   *  @brief   Timer Complementary Output Compare functions
   *
 @verbatim   
@@ -702,9 +709,12 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Chann
     break;
   } 
   
-     /* Enable the Capture compare channel N */
-     TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
-    
+  /* Enable the TIM Break interrupt */
+  __HAL_TIM_ENABLE_IT(htim, TIM_IT_BREAK);
+  
+  /* Enable the Capture compare channel N */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+  
   /* Enable the Main Ouput */
     __HAL_TIM_MOE_ENABLE(htim);
 
@@ -729,6 +739,8 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Chann
   */
 HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  uint32_t tmpccer = 0;
+
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel)); 
   
@@ -766,11 +778,18 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channe
     break; 
   }
     
-     /* Disable the Capture compare channel N */
-     TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+  /* Disable the Capture compare channel N */
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
     
+  /* Disable the TIM Break interrupt (only if no more channel is active) */
+  tmpccer = htim->Instance->CCER;
+  if ((tmpccer & (TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE)) == RESET)
+  {
+    __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
+  }
+
   /* Disable the Main Ouput */
-    __HAL_TIM_MOE_DISABLE(htim);
+  __HAL_TIM_MOE_DISABLE(htim);
 
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
@@ -967,7 +986,7 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Chann
   * @}
   */
   
-/** @defgroup TIMEx_Group3 Timer Complementary PWM functions
+/** @defgroup TIMEx_Exported_Functions_Group3 Extended Timer Complementary PWM functions
   * @brief    Timer Complementary PWM functions
   *
 @verbatim   
@@ -1136,6 +1155,8 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Chan
   */
 HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_IT (TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  uint32_t tmpccer = 0;
+
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel)); 
 
@@ -1173,11 +1194,15 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_IT (TIM_HandleTypeDef *htim, uint32_t Chan
     break; 
   }
   
-  /* Disable the TIM Break interrupt */
-  __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
-  
   /* Disable the complementary PWM output  */
   TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+  
+  /* Disable the TIM Break interrupt (only if no more channel is active) */
+  tmpccer = htim->Instance->CCER;
+  if ((tmpccer & (TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE)) == RESET)
+  {
+    __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
+  }
   
   /* Disable the Main Ouput */
   __HAL_TIM_MOE_DISABLE(htim);
@@ -1294,10 +1319,10 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
   }
 
   /* Enable the complementary PWM output  */
-     TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
     
   /* Enable the Main Ouput */
-    __HAL_TIM_MOE_ENABLE(htim);
+  __HAL_TIM_MOE_ENABLE(htim);
   
   /* Enable the Peripheral */
   __HAL_TIM_ENABLE(htim); 
@@ -1358,10 +1383,10 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
   } 
   
   /* Disable the complementary PWM output */
-    TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
      
   /* Disable the Main Ouput */
-    __HAL_TIM_MOE_DISABLE(htim);
+  __HAL_TIM_MOE_DISABLE(htim);
 
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim);
@@ -1377,7 +1402,7 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
   * @}
   */
   
-/** @defgroup TIMEx_Group4 Timer Complementary One Pulse functions
+/** @defgroup TIMEx_Exported_Functions_Group4 Extended Timer Complementary One Pulse functions
   * @brief    Timer Complementary One Pulse functions
   *
 @verbatim   
@@ -1437,10 +1462,10 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop(TIM_HandleTypeDef *htim, uint32_t Out
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel)); 
 
   /* Disable the complementary One Pulse output */
-    TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_DISABLE);
+  TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_DISABLE);
   
   /* Disable the Main Ouput */
-    __HAL_TIM_MOE_DISABLE(htim);
+  __HAL_TIM_MOE_DISABLE(htim);
   
   /* Disable the Peripheral */
   __HAL_TIM_DISABLE(htim); 
@@ -1508,7 +1533,7 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t 
   __HAL_TIM_MOE_DISABLE(htim);
   
   /* Disable the Peripheral */
-   __HAL_TIM_DISABLE(htim);  
+  __HAL_TIM_DISABLE(htim);  
   
   /* Return function status */
   return HAL_OK;
@@ -1519,7 +1544,7 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t 
 /**
   * @}
   */
-/** @defgroup TIMEx_Group5 Peripheral Control functions
+/** @defgroup TIMEx_Exported_Functions_Group5 Extended Peripheral Control functions
   * @brief    Peripheral Control functions
   *
 @verbatim   
@@ -1539,9 +1564,10 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t 
 @endverbatim
   * @{
   */
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) ||                         \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
     defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /**
   * @brief  Configure the TIM commutation event sequence.
   * @note: this function is mandatory to use the commutation event in order to 
@@ -2184,9 +2210,10 @@ HAL_StatusTypeDef HAL_TIMEx_MasterConfigSynchronization(TIM_HandleTypeDef *htim,
   
   return HAL_OK;
 } 
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx ||                */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx                   */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
 #if defined(STM32F373xC) || defined(STM32F378xx)
 /**
@@ -2226,16 +2253,17 @@ HAL_StatusTypeDef HAL_TIMEx_MasterConfigSynchronization(TIM_HandleTypeDef *htim,
 }
 #endif /* STM32F373xC || STM32F378xx */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) ||                         \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
     defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /**
   * @brief   Configures the Break feature, dead time, Lock level, OSSI/OSSR State
   *         and the AOE(automatic output enable).
   * @param  htim: TIM handle
   * @param  sBreakDeadTimeConfig: pointer to a TIM_ConfigBreakDeadConfigTypeDef structure that
   *         contains the BDTR Register configuration  information for the TIM peripheral. 
-  * @note   For STM32F302xC, STM32F303xC, STM32F358xx and STM32F303x8 two break inputs can be configured.
+  * @note   For STM32F302xC, STM32F303xC, STM32F358xx, STM32F303xE, STM32F398xx and STM32F303x8 two break inputs can be configured.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim, 
@@ -2248,6 +2276,7 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
   assert_param(IS_TIM_OSSR_STATE(sBreakDeadTimeConfig->OffStateRunMode));
   assert_param(IS_TIM_OSSI_STATE(sBreakDeadTimeConfig->OffStateIDLEMode));
   assert_param(IS_TIM_LOCK_LEVEL(sBreakDeadTimeConfig->LockLevel));
+  assert_param(IS_TIM_DEADTIME(sBreakDeadTimeConfig->DeadTime));
   assert_param(IS_TIM_BREAK_STATE(sBreakDeadTimeConfig->BreakState));
   assert_param(IS_TIM_BREAK_POLARITY(sBreakDeadTimeConfig->BreakPolarity));
   assert_param(IS_TIM_BREAK_FILTER(sBreakDeadTimeConfig->BreakFilter));
@@ -2308,9 +2337,10 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
   
   return HAL_OK;
 }
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx ||                */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx                   */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
 #if defined(STM32F373xC) || defined(STM32F378xx)
 /**
@@ -2329,6 +2359,7 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
   assert_param(IS_TIM_OSSR_STATE(sBreakDeadTimeConfig->OffStateRunMode));
   assert_param(IS_TIM_OSSI_STATE(sBreakDeadTimeConfig->OffStateIDLEMode));
   assert_param(IS_TIM_LOCK_LEVEL(sBreakDeadTimeConfig->LockLevel));
+  assert_param(IS_TIM_DEADTIME(sBreakDeadTimeConfig->DeadTime));
   assert_param(IS_TIM_BREAK_STATE(sBreakDeadTimeConfig->BreakState));
   assert_param(IS_TIM_BREAK_POLARITY(sBreakDeadTimeConfig->BreakPolarity));
   assert_param(IS_TIM_AUTOMATIC_OUTPUT_STATE(sBreakDeadTimeConfig->AutomaticOutput));
@@ -2357,7 +2388,48 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
 }
 #endif /* STM32F373xC || STM32F378xx */
 
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx)
+/**
+  * @brief  Configures the TIM1, TIM8, TIM16 and TIM20 Remapping input capabilities.
+  * @param  htim: TIM handle.
+  * @param  Remap1: specifies the first TIM remapping source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TIM1_ADC1_NONE: TIM1_ETR is not connected to any ADC1 AWD (analog watchdog)
+  *            @arg TIM_TIM1_ADC1_AWD1: TIM1_ETR is connected to ADC1 AWD1
+  *            @arg TIM_TIM1_ADC1_AWD2: TIM1_ETR is connected to ADC1 AWD2 
+  *            @arg TIM_TIM1_ADC1_AWD3: TIM1_ETR is connected to ADC1 AWD3 
+  *            @arg TIM_TIM8_ADC2_NONE: TIM8_ETR is not connected to any ADC2 AWD
+  *            @arg TIM_TIM8_ADC2_AWD1: TIM8_ETR is connected to ADC2 AWD1
+  *            @arg TIM_TIM8_ADC2_AWD2: TIM8_ETR is connected to ADC2 AWD2
+  *            @arg TIM_TIM8_ADC2_AWD3: TIM8_ETR is connected to ADC2 AWD3
+  *            @arg TIM_TIM16_GPIO: TIM16 TI1 is connected to GPIO
+  *            @arg TIM_TIM16_RTC: TIM16 TI1 is connected to RTC clock
+  *            @arg TIM_TIM16_HSE: TIM16 TI1 is connected to HSE/32
+  *            @arg TIM_TIM16_MCO: TIM16 TI1 is connected to MCO
+  *            @arg TIM_TIM20_ADC3_NONE: TIM20_ETR is not connected to any AWD (analog watchdog)
+  *            @arg TIM_TIM20_ADC3_AWD1: TIM20_ETR is connected to ADC3 AWD1
+  *            @arg TIM_TIM20_ADC3_AWD2: TIM20_ETR is connected to ADC3 AWD2
+  *            @arg TIM_TIM20_ADC3_AWD3: TIM20_ETR is connected to ADC3 AWD3
+  * @param  Remap2: specifies the  second TIMremapping source (if any).
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TIM1_ADC4_NONE: TIM1_ETR is not connected to any ADC4 AWD (analog watchdog)
+  *            @arg TIM_TIM1_ADC4_AWD1: TIM1_ETR is connected to ADC4 AWD1
+  *            @arg TIM_TIM1_ADC4_AWD2: TIM1_ETR is connected to ADC4 AWD2 
+  *            @arg TIM_TIM1_ADC4_AWD3: TIM1_ETR is connected to ADC4 AWD3 
+  *            @arg TIM_TIM8_ADC3_NONE: TIM8_ETR is not connected to any ADC3 AWD
+  *            @arg TIM_TIM8_ADC3_AWD1: TIM8_ETR is connected to ADC3 AWD1
+  *            @arg TIM_TIM8_ADC3_AWD2: TIM8_ETR is connected to ADC3 AWD2
+  *            @arg TIM_TIM8_ADC3_AWD3: TIM8_ETR is connected to ADC3 AWD3
+  *            @arg TIM_TIM16_NONE: Non significant value for TIM16
+  *            @arg TIM_TIM20_ADC4_NONE: TIM20_ETR is not connected to any ADC4 AWD
+  *            @arg TIM_TIM20_ADC4_AWD1: TIM20_ETR is connected to ADC4 AWD1
+  *            @arg TIM_TIM20_ADC4_AWD2: TIM20_ETR is connected to ADC4 AWD2
+  *            @arg TIM_TIM20_ADC4_AWD3: TIM20_ETR is connected to ADC4 AWD3
+  * @retval HAL status
+  */
+#else  /* STM32F303xC || STM32F358xx */  
 /**
   * @brief  Configures the TIM1, TIM8 and TIM16 Remapping input capabilities.
   * @param  htim: TIM handle.
@@ -2387,6 +2459,7 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
   *            @arg TIM_TIM8_ADC3_AWD3: TIM8_ETR is connected to ADC3 AWD3
   * @retval HAL status
   */
+#endif /* STM32F303xE || STM32F398xx || */
 HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap1, uint32_t Remap2)
 {
   __HAL_LOCK(htim);
@@ -2405,11 +2478,35 @@ HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap1
   
   return HAL_OK;
 }
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx || */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+
+#if defined(STM32F302xE)                                                 || \
+    defined(STM32F302xC)                                                 || \
     defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
     defined(STM32F373xC) || defined(STM32F378xx)
+#if defined(STM32F302xE)                                                 || \
+    defined(STM32F302xC)                                                 || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/**
+  * @brief  Configures the TIM1 and TIM16 Remapping input capabilities.
+  * @param  htim: TIM handle.
+  * @param  Remap: specifies the TIM remapping source.
+  *          This parameter can be one of the following values:
+  *            @arg TIM_TIM1_ADC1_NONE: TIM1_ETR is not connected to any AWD (analog watchdog)
+  *            @arg TIM_TIM1_ADC1_AWD1: TIM1_ETR is connected to ADC1 AWD1
+  *            @arg TIM_TIM1_ADC1_AWD2: TIM1_ETR is connected to ADC1 AWD2
+  *            @arg TIM_TIM1_ADC1_AWD3: TIM1_ETR is connected to ADC1 AWD3
+  *            @arg TIM_TIM16_GPIO: TIM16 TI1 is connected to GPIO
+  *            @arg TIM_TIM16_RTC: TIM16 TI1 is connected to RTC_clock
+  *            @arg TIM_TIM16_HSE: TIM16 TI1 is connected to HSE/32
+  *            @arg TIM_TIM16_MCO: TIM16 TI1 is connected to MCO
+  * @retval HAL status
+  */
+#else /* STM32F373xC || STM32F378xx */       
 /**
   * @brief  Configures the TIM2 and TIM14 Remapping input capabilities.
   * @param  htim: TIM handle.
@@ -2424,17 +2521,12 @@ HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap1
   *            @arg TIM_TIM14_RTC: TIM14 TI1 is connected to RTC_clock
   *            @arg TIM_TIM14_HSE: TIM14 TI1 is connected to HSE/32
   *            @arg TIM_TIM14_MCO: TIM14 TI1 is connected to MCO                              
-  *          STM32F303x8,STM32F334x8, STM32F328xx, STM32F301x8, STM32F302x8, STM32F318xx:
-  *            @arg TIM_TIM1_ADC1_NONE: TIM1_ETR is not connected to any AWD (analog watchdog)
-  *            @arg TIM_TIM1_ADC1_AWD1: TIM1_ETR is connected to ADC1 AWD1
-  *            @arg TIM_TIM1_ADC1_AWD2: TIM1_ETR is connected to ADC1 AWD2
-  *            @arg TIM_TIM1_ADC1_AWD3: TIM1_ETR is connected to ADC1 AWD3
-  *            @arg TIM_TIM16_GPIO: TIM16 TI1 is connected to GPIO
-  *            @arg TIM_TIM16_RTC: TIM16 TI1 is connected to RTC_clock
-  *            @arg TIM_TIM16_HSE: TIM16 TI1 is connected to HSE/32
-  *            @arg TIM_TIM16_MCO: TIM16 TI1 is connected to MCO
   * @retval HAL status
   */
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
 HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap)
 {
   __HAL_LOCK(htim);
@@ -2452,14 +2544,17 @@ HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap)
   
   return HAL_OK;
 }
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
        /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
-       /* STM32F373xC || STM32F378xx */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) ||                         \
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
     defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /**
   * @brief  Group channel 5 and channel 1, 2 or 3
   * @param  htim: TIM handle.
@@ -2494,24 +2589,24 @@ HAL_StatusTypeDef HAL_TIMEx_GroupChannel5(TIM_HandleTypeDef *htim, uint32_t OCRe
   
   return HAL_OK;
 }
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx ||                */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx                   */
-
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
 /**
   * @}
   */
 
-/** @defgroup TIMEx_Group6 Extension Callbacks functions 
-  * @brief    Extension Callbacks functions
+/** @defgroup TIMEx_Exported_Functions_Group6 Extended Callbacks functions 
+  * @brief    Extended Callbacks functions
   *
 @verbatim   
   ==============================================================================
-                    ##### Extension Callbacks functions #####
+                    ##### Extended Callbacks functions #####
   ==============================================================================  
   [..]  
-    This section provides Extension TIM callback functions:
+    This section provides Extended TIM callback functions:
     (+) Timer Commutation callback
     (+) Timer Break callback
 
@@ -2547,12 +2642,12 @@ __weak void HAL_TIMEx_BreakCallback(TIM_HandleTypeDef *htim)
   * @}
   */
 
-/** @defgroup TIMEx_Group7 Extension Peripheral State functions 
-  * @brief    Extension Peripheral State functions
+/** @defgroup TIMEx_Exported_Functions_Group7 Extended Peripheral State functions 
+  * @brief    Extended Peripheral State functions
   *
 @verbatim   
   ==============================================================================
-                ##### Extension Peripheral State functions #####
+                ##### Extended Peripheral State functions #####
   ==============================================================================  
   [..]
     This subsection permit to get in run-time the status of the peripheral 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_tim_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_tim_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_tim_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of TIM HAL Extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of TIM HAL Extended module.
   ******************************************************************************
   * @attention
   *
@@ -55,6 +55,9 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup TIMEx_Exported_Types TIM Extended Exported Types
+  * @{
+  */
 
 /** 
   * @brief  TIM Hall sensor Configuration Structure definition  
@@ -112,9 +115,10 @@ typedef struct
 
 #endif /* STM32F373xC || STM32F378xx */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) ||                        \
-    defined(STM32F302xC) || defined(STM32F303xC) ||defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /** 
   * @brief  TIM Break input(s) and Dead time configuration Structure definition  
   * @note   2 break inputs can be configured (BKIN and BKIN2) with configurable 
@@ -159,17 +163,21 @@ typedef struct {
   uint32_t  MasterSlaveMode;       /*!< Master/slave mode selection 
                                       This parameter can be a value of @ref TIM_Master_Slave_Mode */
 }TIM_MasterConfigTypeDef;
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx ||                */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx                   */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup TIMEx_Exported_Constants
+/** @defgroup TIMEx_Exported_Constants TIM Extended Exported Constants
   * @{
   */
 
 #if defined(STM32F373xC) || defined(STM32F378xx)
-/** @defgroup TIMEx_Channel
+/** @defgroup TIMEx_Channel TIM Extended Channel
   * @{
   */
 #define TIM_CHANNEL_1                      ((uint32_t)0x0000)
@@ -197,7 +205,7 @@ typedef struct {
   * @}
   */ 
 
-/** @defgroup TIMEx_Output_Compare_and_PWM_modes
+/** @defgroup TIMEx_Output_Compare_and_PWM_modes TIM Extended Output Compare and PWM Modes
   * @{
   */
 
@@ -223,7 +231,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup TIMEx_ClearInput_Source
+/** @defgroup TIMEx_ClearInput_Source TIM Extended Clear Input Source
   * @{
   */
 #define TIM_CLEARINPUTSOURCE_ETR           ((uint32_t)0x0001) 
@@ -235,7 +243,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup TIMEx_Slave_Mode
+/** @defgroup TIMEx_Slave_Mode TIM  Extended Slave Mode
   * @{
   */
 
@@ -254,7 +262,7 @@ typedef struct {
   * @}
   */ 
 
-/** @defgroup TIMEx_Event_Source
+/** @defgroup TIMEx_Event_Source TIM  Extended Event Source
   * @{
   */
 
@@ -272,7 +280,7 @@ typedef struct {
   * @}
   */ 
 
-/** @defgroup TIMEx_DMA_Base_address
+/** @defgroup TIMEx_DMA_Base_address TIM  Extended DMA BAse Address
   * @{
   */
 
@@ -321,10 +329,11 @@ typedef struct {
   */ 
 #endif /* STM32F373xC || STM32F378xx */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) ||                        \
-    defined(STM32F302xC) || defined(STM32F303xC) ||defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
-/** @defgroup TIMEx_Channel
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/** @defgroup TIMEx_Channel TIM  Extended Channel
   * @{
   */
 
@@ -357,7 +366,7 @@ typedef struct {
   * @}
   */ 
 
-/** @defgroup TIMEx_Output_Compare_and_PWM_modes
+/** @defgroup TIMEx_Output_Compare_and_PWM_modes TIM  Extended Output Compare and PWM Modes
   * @{
   */
 #define TIM_OCMODE_TIMING                   ((uint32_t)0x0000)
@@ -395,7 +404,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup TIMEx_ClearInput_Source
+/** @defgroup TIMEx_ClearInput_Source TIM  Extended Clear Input Source
   * @{
   */
 #define TIM_CLEARINPUTSOURCE_ETR            ((uint32_t)0x0001) 
@@ -409,7 +418,7 @@ typedef struct {
   * @}
   */
 
-/** @defgroup TIMEx_BreakInput_Filter
+/** @defgroup TIMEx_BreakInput_Filter TIM  Extended Break Input Filter
   * @{
   */
 
@@ -418,7 +427,7 @@ typedef struct {
   * @}
   */  
 
-/** @defgroup TIMEx_Break2_Input_enable_disable 
+/** @defgroup TIMEx_Break2_Input_enable_disable  TIMEX Break input 2 Enable
   * @{
   */                         
 #define TIM_BREAK2_DISABLE         ((uint32_t)0x00000000)
@@ -429,7 +438,7 @@ typedef struct {
 /**
   * @}
   */
-/** @defgroup TIMEx_Break2_Polarity 
+/** @defgroup TIMEx_Break2_Polarity TIM  Extended Break Input 2 Polarity
   * @{
   */
 #define TIM_BREAK2POLARITY_LOW        ((uint32_t)0x00000000)
@@ -441,7 +450,7 @@ typedef struct {
   * @}
   */
     
-/** @defgroup TIMEx_Master_Mode_Selection_2
+/** @defgroup TIMEx_Master_Mode_Selection_2 TIM  Extended Master Mode Selection 2 (TRGO2)
   * @{
   */  
 #define	TIM_TRGO2_RESET                          ((uint32_t)0x00000000)             
@@ -482,7 +491,7 @@ typedef struct {
   * @}
   */ 
 
-/** @defgroup TIMEx_Slave_Mode
+/** @defgroup TIMEx_Slave_Mode TIM  Extended Slave mode
   * @{
   */
 #define TIM_SLAVEMODE_DISABLE                ((uint32_t)0x0000)
@@ -502,7 +511,7 @@ typedef struct {
   * @}
   */ 
 
-/** @defgroup TIM_Event_Source 
+/** @defgroup TIM_Event_Source TIM  Extended Event Source
   * @{
   */
 
@@ -521,7 +530,7 @@ typedef struct {
   * @}
   */ 
 
-/** @defgroup TIM_DMA_Base_address 
+/** @defgroup TIM_DMA_Base_address TIM  Extended DMA Base Address
   * @{
   */
 
@@ -573,12 +582,16 @@ typedef struct {
 /**
   * @}
   */ 
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx ||                */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx                   */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 
-#if defined(STM32F302xC)
-/** @defgroup TIMEx_Remap 
+#if defined(STM32F302xE)                                                 || \
+    defined(STM32F302xC)                                                 || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/** @defgroup TIMEx_Remap TIM  Extended Remapping
   * @{
   */
 #define TIM_TIM1_ADC1_NONE                     (0x00000000) /* !< TIM1_ETR is not connected to any AWD (analog watchdog)*/
@@ -601,10 +614,13 @@ typedef struct {
 /**
   * @}
   */ 
-#endif /* STM32F302xC */
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
 
 #if defined(STM32F303xC) || defined(STM32F358xx)
-/** @defgroup TIMEx_Remap
+/** @defgroup TIMEx_Remap TIM  Extended Remapping 1
   * @{
   */
 #define TIM_TIM1_ADC1_NONE                     (0x00000000) /* !< TIM1_ETR is not connected to any AWD (analog watchdog)*/
@@ -636,7 +652,7 @@ typedef struct {
   * @}
   */ 
 
-/** @defgroup TIMEx_Remap2
+/** @defgroup TIMEx_Remap2 TIM  Extended Remapping 2
   * @{
   */
 #define TIM_TIM1_ADC4_NONE                     (0x00000000) /* !< TIM1_ETR is not connected to any AWD (analog watchdog)*/
@@ -663,8 +679,85 @@ typedef struct {
   */ 
 #endif /* STM32F303xC || STM32F358xx */
 
+#if defined(STM32F303xE) || defined(STM32F398xx)
+/** @defgroup TIMEx_Remap TIM  Extended Remapping 1
+  * @{
+  */
+#define TIM_TIM1_ADC1_NONE                     (0x00000000) /* !< TIM1_ETR is not connected to any AWD (analog watchdog)*/
+#define TIM_TIM1_ADC1_AWD1                     (0x00000001) /* !< TIM1_ETR is connected to ADC1 AWD1 */
+#define TIM_TIM1_ADC1_AWD2                     (0x00000002) /* !< TIM1_ETR is connected to ADC1 AWD2 */
+#define TIM_TIM1_ADC1_AWD3                     (0x00000003) /* !< TIM1_ETR is connected to ADC1 AWD3 */
+#define TIM_TIM8_ADC2_NONE                     (0x00000000) /* !< TIM8_ETR is not connected to any AWD (analog watchdog) */
+#define TIM_TIM8_ADC2_AWD1                     (0x00000001) /* !< TIM8_ETR is connected to ADC2 AWD1 */
+#define TIM_TIM8_ADC2_AWD2                     (0x00000002) /* !< TIM8_ETR is connected to ADC2 AWD2 */
+#define TIM_TIM8_ADC2_AWD3                     (0x00000003) /* !< TIM8_ETR is connected to ADC2 AWD3 */
+#define TIM_TIM16_GPIO                         (0x00000000) /* !< TIM16 TI1 is connected to GPIO */
+#define TIM_TIM16_RTC                          (0x00000001) /* !< TIM16 TI1 is connected to RTC_clock */
+#define TIM_TIM16_HSE                          (0x00000002) /* !< TIM16 TI1 is connected to HSE/32 */
+#define TIM_TIM16_MCO                          (0x00000003) /* !< TIM16 TI1 is connected to MCO */
+#define TIM_TIM20_ADC3_NONE                    (0x00000000) /* !< TIM20_ETR is not connected to any AWD (analog watchdog) */
+#define TIM_TIM20_ADC3_AWD1                    (0x00000001) /* !< TIM20_ETR is connected to ADC3 AWD1 */
+#define TIM_TIM20_ADC3_AWD2                    (0x00000002) /* !< TIM20_ETR is connected to ADC3 AWD2 */
+#define TIM_TIM20_ADC3_AWD3                    (0x00000003) /* !< TIM20_ETR is connected to ADC3 AWD3 */
+
+#define IS_TIM_REMAP(REMAP1)   (((REMAP1) == TIM_TIM1_ADC1_NONE) ||\
+                                ((REMAP1) == TIM_TIM1_ADC1_AWD1) ||\
+                                ((REMAP1) == TIM_TIM1_ADC1_AWD2) ||\
+                                ((REMAP1) == TIM_TIM1_ADC1_AWD3) ||\
+                                ((REMAP1) == TIM_TIM8_ADC2_NONE) ||\
+                                ((REMAP1) == TIM_TIM8_ADC2_AWD1) ||\
+                                ((REMAP1) == TIM_TIM8_ADC2_AWD2) ||\
+                                ((REMAP1) == TIM_TIM8_ADC2_AWD3) ||\
+                                ((REMAP1) == TIM_TIM16_GPIO)     ||\
+                                ((REMAP1) == TIM_TIM16_RTC)      ||\
+                                ((REMAP1) == TIM_TIM16_HSE)      ||\
+                                ((REMAP1) == TIM_TIM16_MCO)      ||\
+                                ((REMAP1) == TIM_TIM20_ADC3_NONE) ||\
+                                ((REMAP1) == TIM_TIM20_ADC3_AWD1) ||\
+                                ((REMAP1) == TIM_TIM20_ADC3_AWD2) ||\
+                                ((REMAP1) == TIM_TIM20_ADC3_AWD3))
+/**
+  * @}
+  */ 
+
+/** @defgroup TIMEx_Remap2 TIM  Extended Remapping 2
+  * @{
+  */
+#define TIM_TIM1_ADC4_NONE                     (0x00000000) /* !< TIM1_ETR is not connected to any AWD (analog watchdog)*/
+#define TIM_TIM1_ADC4_AWD1                     (0x00000004) /* !< TIM1_ETR is connected to ADC4 AWD1 */
+#define TIM_TIM1_ADC4_AWD2                     (0x00000008) /* !< TIM1_ETR is connected to ADC4 AWD2 */
+#define TIM_TIM1_ADC4_AWD3                     (0x0000000C) /* !< TIM1_ETR is connected to ADC4 AWD3 */
+#define TIM_TIM8_ADC3_NONE                     (0x00000000) /* !< TIM8_ETR is not connected to any AWD (analog watchdog) */
+#define TIM_TIM8_ADC3_AWD1                     (0x00000004) /* !< TIM8_ETR is connected to ADC3 AWD1 */
+#define TIM_TIM8_ADC3_AWD2                     (0x00000008) /* !< TIM8_ETR is connected to ADC3 AWD2 */
+#define TIM_TIM8_ADC3_AWD3                     (0x0000000C) /* !< TIM8_ETR is connected to ADC3 AWD3 */
+#define TIM_TIM16_NONE                         (0x00000000) /* !< Non significant value for TIM16 */
+#define TIM_TIM20_ADC4_NONE                    (0x00000000) /* !< TIM20_ETR is not connected to any AWD (analog watchdog) */
+#define TIM_TIM20_ADC4_AWD1                    (0x00000004) /* !< TIM20_ETR is connected to ADC4 AWD1 */
+#define TIM_TIM20_ADC4_AWD2                    (0x00000008) /* !< TIM20_ETR is connected to ADC4 AWD2 */
+#define TIM_TIM20_ADC4_AWD3                    (0x0000000C) /* !< TIM20_ETR is connected to ADC4 AWD3 */
+
+#define IS_TIM_REMAP2(REMAP2)  (((REMAP2) == TIM_TIM1_ADC4_NONE)  ||\
+                                ((REMAP2) == TIM_TIM1_ADC4_AWD1)  ||\
+                                ((REMAP2) == TIM_TIM1_ADC4_AWD2)  ||\
+                                ((REMAP2) == TIM_TIM1_ADC4_AWD3)  ||\
+                                ((REMAP2) == TIM_TIM8_ADC3_NONE)  ||\
+                                ((REMAP2) == TIM_TIM8_ADC3_AWD1)  ||\
+                                ((REMAP2) == TIM_TIM8_ADC3_AWD2)  ||\
+                                ((REMAP2) == TIM_TIM8_ADC3_AWD3)  ||\
+                                ((REMAP2) == TIM_TIM16_NONE)      ||\
+                                ((REMAP2) == TIM_TIM20_ADC4_NONE) ||\
+                                ((REMAP2) == TIM_TIM20_ADC4_AWD1) ||\
+                                ((REMAP2) == TIM_TIM20_ADC4_AWD2) ||\
+                                ((REMAP2) == TIM_TIM20_ADC4_AWD3))
+/**
+  * @}
+  */ 
+#endif /* STM32F303xE || STM32F398xx */
+
+
 #if defined(STM32F373xC) || defined(STM32F378xx)
-/** @defgroup TIMEx_Remap 
+/** @defgroup TIMEx_Remap TIM  Extended remapping 
   * @{
   */
 
@@ -691,54 +784,11 @@ typedef struct {
   */ 
 #endif /* STM32F373xC || STM32F378xx */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
-/** @defgroup TIMEx_Remap 
-  * @{
-  */
-#define TIM_TIM1_ADC1_NONE                     (0x00000000) /* !< TIM1_ETR is not connected to any AWD (analog watchdog)*/
-#define TIM_TIM1_ADC1_AWD1                     (0x00000001) /* !< TIM1_ETR is connected to ADC1 AWD1 */
-#define TIM_TIM1_ADC1_AWD2                     (0x00000002) /* !< TIM1_ETR is connected to ADC1 AWD2 */
-#define TIM_TIM1_ADC1_AWD3                     (0x00000003) /* !< TIM1_ETR is connected to ADC1 AWD3 */
-#define TIM_TIM16_GPIO                         (0x00000000) /* !< TIM16 TI1 is connected to GPIO */
-#define TIM_TIM16_RTC                          (0x00000001) /* !< TIM16 TI1 is connected to RTC_clock */
-#define TIM_TIM16_HSE                          (0x00000002) /* !< TIM16 TI1 is connected to HSE/32 */
-#define TIM_TIM16_MCO                          (0x00000003) /* !< TIM16 TI1 is connected to MCO */
-
-#define IS_TIM_REMAP(REMAP)    (((REMAP) == TIM_TIM1_ADC1_NONE) ||\
-                                ((REMAP) == TIM_TIM1_ADC1_AWD1) ||\
-                                ((REMAP) == TIM_TIM1_ADC1_AWD2) ||\
-                                ((REMAP) == TIM_TIM1_ADC1_AWD3) ||\
-                                ((REMAP) == TIM_TIM16_GPIO)     ||\
-                                ((REMAP) == TIM_TIM16_RTC)      ||\
-                                ((REMAP) == TIM_TIM16_HSE)      ||\
-                                ((REMAP) == TIM_TIM16_MCO))
-/**
-  * @}
-  */
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx */
-
-#if defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
-/** @defgroup TIMEx_Remap
-  * @{
-  */
-#define TIM_TIM1_ADC1_NONE                     (0x00000000) /* !< TIM1_ETR is not connected to any AWD (analog watchdog)*/
-#define TIM_TIM1_ADC1_AWD1                     (0x00000001) /* !< TIM1_ETR is connected to ADC1 AWD1 */
-#define TIM_TIM1_ADC1_AWD2                     (0x00000002) /* !< TIM1_ETR is connected to ADC1 AWD2 */
-#define TIM_TIM1_ADC1_AWD3                     (0x00000003) /* !< TIM1_ETR is connected to ADC1 AWD3 */
-
-#define IS_TIM_REMAP(REMAP)    (((REMAP) == TIM_TIM1_ADC1_NONE) ||\
-                                ((REMAP) == TIM_TIM1_ADC1_AWD1) ||\
-                                ((REMAP) == TIM_TIM1_ADC1_AWD2) ||\
-                                ((REMAP) == TIM_TIM1_ADC1_AWD3))
-/**
-  * @}
-  */
-#endif /* STM32F303x8 || STM32F334x8 || STM32F328xx */
-
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) ||                        \
-    defined(STM32F302xC) || defined(STM32F303xC) ||defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
-/** @defgroup TIMEx_Group_Channel5 
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
+/** @defgroup TIMEx_Group_Channel5 Group Channel 5 and Channel 1, 2 or 3
   * @{
   */
 #define TIM_GROUPCH5_NONE       (uint32_t)0x00000000  /* !< No effect of OC5REF on OC1REFC, OC2REFC and OC3REFC */
@@ -750,14 +800,28 @@ typedef struct {
 /**
   * @}
   */
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx ||                */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx                   */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+      
+/** @defgroup TIM_Clock_Filter TIM Clock Filter
+  * @{
+  */
+#define IS_TIM_DEADTIME(DEADTIME)      ((DEADTIME) <= 0xFF) 
+/**
+  * @}
+  */  
+
 /**
   * @}
   */ 
 
 /* Exported macro ------------------------------------------------------------*/
+/** @defgroup TIMEx_Exported_Macros TIM Extended Exported Macros
+  * @{
+  */  
+
 #if defined(STM32F373xC) || defined(STM32F378xx)
 /**
   * @brief  Sets the TIM Capture Compare Register value on runtime without
@@ -790,9 +854,10 @@ typedef struct {
   (*(__IO uint32_t *)(&((__HANDLE__)->Instance->CCR1) + ((__CHANNEL__) >> 2)))
 #endif /* STM32F373xC || STM32F378xx */
    
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) ||                        \
-    defined(STM32F302xC) || defined(STM32F303xC) ||defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 /**
   * @brief  Sets the TIM Capture Compare Register value on runtime without
   *         calling another time ConfigChannel function.
@@ -836,12 +901,23 @@ typedef struct {
  ((__CHANNEL__) == TIM_CHANNEL_4) ? ((__HANDLE__)->Instance->CCR4) :\
  ((__CHANNEL__) == TIM_CHANNEL_5) ? ((__HANDLE__)->Instance->CCR5) :\
  ((__HANDLE__)->Instance->CCR6))
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx ||                */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx                   */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+/**
+  * @}
+  */ 
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup TIMEx_Exported_Functions TIM Extended Exported Functions
+  * @{
+  */
 
+/** @addtogroup TIMEx_Exported_Functions_Group1 Extended Timer Hall Sensor functions 
+ *  @brief    Timer Hall Sensor functions
+ * @{
+ */
 /*  Timer Hall Sensor functions  **********************************************/
 HAL_StatusTypeDef HAL_TIMEx_HallSensor_Init(TIM_HandleTypeDef *htim, TIM_HallSensor_InitTypeDef* sConfig);
 HAL_StatusTypeDef HAL_TIMEx_HallSensor_DeInit(TIM_HandleTypeDef *htim);
@@ -858,7 +934,14 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_IT(TIM_HandleTypeDef *htim);
 /* Non-Blocking mode: DMA */
 HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pData, uint16_t Length);
 HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_DMA(TIM_HandleTypeDef *htim);
+/**
+  * @}
+  */
 
+/** @addtogroup TIMEx_Exported_Functions_Group2 Extended Timer Complementary Output Compare functions
+ *  @brief   Timer Complementary Output Compare functions
+ * @{
+ */
 /*  Timer Complementary Output Compare functions  *****************************/
 /* Blocking mode: Polling */
 HAL_StatusTypeDef HAL_TIMEx_OCN_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
@@ -871,7 +954,14 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channe
 /* Non-Blocking mode: DMA */
 HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
 HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+/**
+  * @}
+  */
 
+/** @addtogroup TIMEx_Exported_Functions_Group3 Extended Timer Complementary PWM functions
+ *  @brief    Timer Complementary PWM functions
+ * @{
+ */
 /*  Timer Complementary PWM functions  ****************************************/
 /* Blocking mode: Polling */
 HAL_StatusTypeDef HAL_TIMEx_PWMN_Start(TIM_HandleTypeDef *htim, uint32_t Channel);
@@ -883,7 +973,14 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Chann
 /* Non-Blocking mode: DMA */
 HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
 HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
+/**
+  * @}
+  */
 
+/** @addtogroup TIMEx_Exported_Functions_Group4 Extended Timer Complementary One Pulse functions
+ *  @brief    Timer Complementary One Pulse functions
+ * @{
+ */
 /*  Timer Complementary One Pulse functions  **********************************/
 /* Blocking mode: Polling */
 HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
@@ -892,42 +989,77 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop(TIM_HandleTypeDef *htim, uint32_t Out
 /* Non-Blocking mode: Interrupt */
 HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
 HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel);
+/**
+  * @}
+  */
 
-/* Extnsion Control functions  ************************************************/
+/** @addtogroup TIMEx_Exported_Functions_Group5 Extended Peripheral Control functions
+ *  @brief    Peripheral Control functions
+ * @{
+ */
+/* Extended Control functions  ************************************************/
 HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent(TIM_HandleTypeDef *htim, uint32_t  InputTrigger, uint32_t  CommutationSource);
 HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent_IT(TIM_HandleTypeDef *htim, uint32_t  InputTrigger, uint32_t  CommutationSource);
 HAL_StatusTypeDef HAL_TIMEx_ConfigCommutationEvent_DMA(TIM_HandleTypeDef *htim, uint32_t  InputTrigger, uint32_t  CommutationSource);
 HAL_StatusTypeDef HAL_TIMEx_MasterConfigSynchronization(TIM_HandleTypeDef *htim, TIM_MasterConfigTypeDef * sMasterConfig);
 HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim, TIM_BreakDeadTimeConfigTypeDef *sBreakDeadTimeConfig);
 
-#if defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303xC) || defined(STM32F358xx)
 HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap1, uint32_t Remap2);
-#endif /* STM32F303xC || STM32F358xx */
+#endif /* STM32F303xE || STM32F398xx || */
+       /* STM32F303xC || STM32F358xx    */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
+#if defined(STM32F302xE)                                                 || \
+    defined(STM32F302xC)                                                 || \
     defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || \
     defined(STM32F373xC) || defined(STM32F378xx)
 HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap);
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+#endif /* STM32F302xE                               || */
+       /* STM32F302xC                               || */
        /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
-       /* STM32F373xC || STM32F378xx */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx || */
+       /* STM32F373xC || STM32F378xx                   */
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) ||                        \
-    defined(STM32F302xC) || defined(STM32F303xC) ||defined(STM32F358xx) || \
-    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 HAL_StatusTypeDef HAL_TIMEx_GroupChannel5(TIM_HandleTypeDef *htim, uint32_t Channels);
-#endif /* STM32F301x8 || STM32F302x8 || STM32F318xx ||                */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
        /* STM32F302xC || STM32F303xC || STM32F358xx || */
-       /* STM32F303x8 || STM32F334x8 || STM32F328xx                   */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
+/**
+  * @}
+  */
 
-
-/* Extension Callback *********************************************************/
+/** @addtogroup TIMEx_Exported_Functions_Group6 Extended Callbacks functions 
+  * @brief    Extended Callbacks functions
+  * @{
+  */
+/* Extended Callback *********************************************************/
 void HAL_TIMEx_CommutationCallback(TIM_HandleTypeDef *htim);
 void HAL_TIMEx_BreakCallback(TIM_HandleTypeDef *htim);
 void HAL_TIMEx_DMACommutationCplt(DMA_HandleTypeDef *hdma);
+/**
+  * @}
+  */
 
-/* Extension Peripheral State functions  **************************************/
+/** @addtogroup TIMEx_Exported_Functions_Group7 Extended Peripheral State functions 
+  * @brief    Extended Peripheral State functions
+  * @{
+  */
+/* Extended Peripheral State functions  **************************************/
 HAL_TIM_StateTypeDef HAL_TIMEx_HallSensor_GetState(TIM_HandleTypeDef *htim);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */ 
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_tsc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_tsc.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_tsc.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   This file provides firmware functions to manage the following 
   *          functionalities of the Touch Sensing Controller (TSC) peripheral:
   *           + Initialization and DeInitialization
@@ -115,7 +115,7 @@
   * @{
   */
 
-/** @defgroup TSC
+/** @defgroup TSC HAL TSC module driver
   * @brief HAL TSC module driver
   * @{
   */
@@ -128,13 +128,13 @@
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 static uint32_t TSC_extract_groups(uint32_t iomask);
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
 
-/** @defgroup TSC_Private_Functions
+/** @defgroup TSC_Exported_Functions TSC Exported Functions
   * @{
   */ 
 
-/** @defgroup TSC_Group1 Initialization/de-initialization functions 
+/** @defgroup TSC_Exported_Functions_Group1 Initialization and de-initialization functions
  *  @brief    Initialization and Configuration functions 
  *
 @verbatim    
@@ -157,7 +157,7 @@ static uint32_t TSC_extract_groups(uint32_t iomask);
 HAL_StatusTypeDef HAL_TSC_Init(TSC_HandleTypeDef* htsc)
 {
   /* Check TSC handle allocation */
-  if (htsc == NULL)
+  if (htsc == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -240,7 +240,7 @@ HAL_StatusTypeDef HAL_TSC_Init(TSC_HandleTypeDef* htsc)
 HAL_StatusTypeDef HAL_TSC_DeInit(TSC_HandleTypeDef* htsc)
 {
   /* Check TSC handle allocation */
-  if (htsc == NULL)
+  if (htsc == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -294,7 +294,7 @@ __weak void HAL_TSC_MspDeInit(TSC_HandleTypeDef* htsc)
   * @}
   */
 
-/** @defgroup HAL_TSC_Group2 IO operation functions
+/** @defgroup TSC_Exported_Functions_Group2 Input and Output operation functions
  *  @brief    IO operation functions 
  *
 @verbatim   
@@ -496,7 +496,7 @@ uint32_t HAL_TSC_GroupGetValue(TSC_HandleTypeDef* htsc, uint32_t gx_index)
   * @}
   */
   
-/** @defgroup HAL_TSC_Group3 Peripheral Control functions
+/** @defgroup TSC_Exported_Functions_Group3 Peripheral Control functions
  *  @brief    Peripheral Control functions 
  *
 @verbatim   
@@ -582,7 +582,7 @@ HAL_StatusTypeDef HAL_TSC_IODischarge(TSC_HandleTypeDef* htsc, uint32_t choice)
   * @}
   */
 
-/** @defgroup HAL_TSC_Group4 State functions
+/** @defgroup TSC_Exported_Functions_Group4 Peripheral State functions
  *  @brief   State functions 
  *
 @verbatim   

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_tsc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_tsc.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_tsc.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   This file contains all the functions prototypes for the TSC firmware 
   *          library.
   ******************************************************************************
@@ -55,8 +55,11 @@
   * @{
   */ 
 
-/* Exported types ------------------------------------------------------------*/
-   
+/* Exported types ------------------------------------------------------------*/ 
+
+/** @defgroup TSC_Exported_Types TSC Exported Types
+  * @{
+  */
 /** 
   * @brief TSC state structure definition  
   */ 
@@ -119,9 +122,13 @@ typedef struct
   HAL_LockTypeDef           Lock;      /*!< Lock feature */
 } TSC_HandleTypeDef;
 
+/**
+  * @}
+  */
+
 /* Exported constants --------------------------------------------------------*/
 
-/** @defgroup TSC_Exported_Constants
+/** @defgroup TSC_Exported_Constants TSC Exported Constants
   * @{
   */ 
 
@@ -252,7 +259,7 @@ typedef struct
                             ((VAL) == TSC_IOMODE_SHIELD) || \
                             ((VAL) == TSC_IOMODE_SAMPLING))
 
-/** @defgroup TSC_interrupts_definition 
+/** @defgroup TSC_interrupts_definition TSC interrupts definition
   * @{
   */
 #define TSC_IT_EOA ((uint32_t)TSC_IER_EOAIE)  
@@ -262,7 +269,7 @@ typedef struct
   * @}
   */ 
 
-/** @defgroup TSC_flags_definition 
+/** @defgroup TSC_flags_definition TSC Flags Definition
   * @{
   */ 
 #define TSC_FLAG_EOA ((uint32_t)TSC_ISR_EOAF)
@@ -348,6 +355,9 @@ typedef struct
   */ 
 
 /* Exported macros -----------------------------------------------------------*/
+/** @defgroup TSC_Exported_Macros TSC Exported Macros
+ * @{
+ */
 
 /** @brief  Reset TSC handle state
   * @param  __HANDLE__: TSC handle.
@@ -538,14 +548,32 @@ typedef struct
 #define __HAL_TSC_GET_GROUP_STATUS(__HANDLE__, __GX_INDEX__) \
 ((((__HANDLE__)->Instance->IOGCSR & (uint32_t)((uint32_t)1 << ((__GX_INDEX__) + (uint32_t)16))) == (uint32_t)((uint32_t)1 << ((__GX_INDEX__) + (uint32_t)16))) ? TSC_GROUP_COMPLETED : TSC_GROUP_ONGOING)
 
+/**
+  * @}
+  */
+  
 /* Exported functions --------------------------------------------------------*/  
-
-/* Initialization and de-initialization functions *****************************/
+/** @addtogroup TSC_Exported_Functions TSC Exported Functions
+  * @{
+  */
+  
+/** @addtogroup TSC_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions 
+ *  @{
+ */
+ /* Initialization and de-initialization functions *****************************/
 HAL_StatusTypeDef HAL_TSC_Init(TSC_HandleTypeDef* htsc);
 HAL_StatusTypeDef HAL_TSC_DeInit(TSC_HandleTypeDef *htsc);
 void HAL_TSC_MspInit(TSC_HandleTypeDef* htsc);
 void HAL_TSC_MspDeInit(TSC_HandleTypeDef* htsc);
-
+/**
+  * @}
+  */
+  
+/** @addtogroup TSC_Exported_Functions_Group2 Input and Output operation functions
+ *  @brief    IO operation functions
+ *  @{
+ */
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef HAL_TSC_Start(TSC_HandleTypeDef* htsc);
 HAL_StatusTypeDef HAL_TSC_Start_IT(TSC_HandleTypeDef* htsc);
@@ -553,20 +581,41 @@ HAL_StatusTypeDef HAL_TSC_Stop(TSC_HandleTypeDef* htsc);
 HAL_StatusTypeDef HAL_TSC_Stop_IT(TSC_HandleTypeDef* htsc);
 TSC_GroupStatusTypeDef HAL_TSC_GroupGetStatus(TSC_HandleTypeDef* htsc, uint32_t gx_index);
 uint32_t HAL_TSC_GroupGetValue(TSC_HandleTypeDef* htsc, uint32_t gx_index);
-
+/**
+  * @}
+  */
+  
+/** @addtogroup TSC_Exported_Functions_Group3 Peripheral Control functions
+ *  @brief    Peripheral Control functions 
+ *  @{
+ */
 /* Peripheral Control functions ***********************************************/
 HAL_StatusTypeDef HAL_TSC_IOConfig(TSC_HandleTypeDef* htsc, TSC_IOConfigTypeDef* config);
 HAL_StatusTypeDef HAL_TSC_IODischarge(TSC_HandleTypeDef* htsc, uint32_t choice);
-
+/**
+  * @}
+  */
+  
+/** @addtogroup TSC_Exported_Functions_Group4 Peripheral State functions
+ *  @brief   State functions 
+ *  @{
+ */
 /* Peripheral State and Error functions ***************************************/
 HAL_TSC_StateTypeDef HAL_TSC_GetState(TSC_HandleTypeDef* htsc);
 HAL_StatusTypeDef HAL_TSC_PollForAcquisition(TSC_HandleTypeDef* htsc);
 void HAL_TSC_IRQHandler(TSC_HandleTypeDef* htsc);
+/**
+  * @}
+  */
+  
 
 /* Callback functions *********************************************************/
 void HAL_TSC_ConvCpltCallback(TSC_HandleTypeDef* htsc);
 void HAL_TSC_ErrorCallback(TSC_HandleTypeDef* htsc);
-
+/**
+  * @}
+  */
+  
 /**
   * @}
   */ 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_uart.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_uart.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_uart.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of UART HAL module.
   ******************************************************************************
   * @attention
@@ -55,6 +55,9 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup UART_Exported_Types UART Exported Types
+  * @{
+  */
 
 /** 
   * @brief UART Init Structure definition  
@@ -83,17 +86,17 @@ typedef struct
                                                  the word length is set to 9 data bits; 8th bit when the
                                                  word length is set to 8 data bits). */
  
-  uint32_t Mode;                      /*!< Specifies wether the Receive or Transmit mode is enabled or disabled.
+  uint32_t Mode;                      /*!< Specifies whether the Receive or Transmit mode is enabled or disabled.
                                            This parameter can be a value of @ref UART_Mode */
 
-  uint32_t HwFlowCtl;                 /*!< Specifies wether the hardware flow control mode is enabled
+  uint32_t HwFlowCtl;                 /*!< Specifies whether the hardware flow control mode is enabled
                                            or disabled.
                                            This parameter can be a value of @ref UART_Hardware_Flow_Control */
   
-  uint32_t OverSampling;              /*!< Specifies wether the Over sampling 8 is enabled or disabled, to achieve higher speed (up to fPCLK/8).
+  uint32_t OverSampling;              /*!< Specifies whether the Over sampling 8 is enabled or disabled, to achieve higher speed (up to fPCLK/8).
                                            This parameter can be a value of @ref UART_Over_Sampling */  
                                            
-  uint32_t OneBitSampling;            /*!< Specifies wether a single sample or three samples' majority vote is selected.
+  uint32_t OneBitSampling;            /*!< Specifies whether a single sample or three samples' majority vote is selected.
                                            Selecting the single sample method increases the receiver tolerance to clock
                                            deviations. This parameter can be a value of @ref UART_OneBit_Sampling. */                                                 
 }UART_InitTypeDef;
@@ -131,7 +134,7 @@ typedef struct
                                        
   uint32_t AutoBaudRateMode;      /*!< If auto Baud rate detection is enabled, specifies how the rate 
                                        detection is carried out.     
-                                       This parameter can be a value of @ref UARTEx_AutoBaud_Rate_Mode */
+                                       This parameter can be a value of @ref UART_AutoBaud_Rate_Mode */
                                     
   uint32_t MSBFirst;              /*!< Specifies whether MSB is sent first on UART line.      
                                        This parameter can be a value of @ref UART_MSB_First */
@@ -231,13 +234,12 @@ typedef struct
   
 }UART_HandleTypeDef;
 
+/**
+  * @}
+  */
 
-
-
-
-  
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup UART_Exported_Constants
+/** @defgroup UART_Exported_Constants UART Exported Constants
   * @{
   */
 
@@ -740,7 +742,7 @@ typedef struct
   */
 
 /* Exported macros -----------------------------------------------------------*/
-/** @defgroup UART_Exported_Macros
+/** @defgroup UART_Exported_Macros UART Exported Macros
   * @{
   */
   
@@ -959,14 +961,19 @@ typedef struct
   * @}
   */
 
-/* Include UART HAL Extension module */
+/* Include UART HAL Extended module */
 #include "stm32f3xx_hal_uart_ex.h"  
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup UART_Exported_Functions UART Exported Functions
+  * @{
+  */
+
+/** @addtogroup UART_Exported_Functions_Group1 Initialization and de-initialization functions
+  *  @brief    Initialization and Configuration functions 
+  * @{
+  */
 /* Initialization and de-initialization functions  ****************************/
-HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart);
-void UART_AdvFeatureConfig(UART_HandleTypeDef *huart);
-HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_UART_Init(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_HalfDuplex_Init(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_LIN_Init(UART_HandleTypeDef *huart, uint32_t BreakDetectLength);
@@ -974,12 +981,14 @@ HAL_StatusTypeDef HAL_MultiProcessor_Init(UART_HandleTypeDef *huart, uint8_t Add
 HAL_StatusTypeDef HAL_UART_DeInit (UART_HandleTypeDef *huart);
 void HAL_UART_MspInit(UART_HandleTypeDef *huart);
 void HAL_UART_MspDeInit(UART_HandleTypeDef *huart);
-HAL_StatusTypeDef HAL_MultiProcessor_EnableMuteMode(UART_HandleTypeDef *huart);
-HAL_StatusTypeDef HAL_MultiProcessor_DisableMuteMode(UART_HandleTypeDef *huart);
-void HAL_MultiProcessor_EnterMuteMode(UART_HandleTypeDef *huart);
-HAL_StatusTypeDef HAL_HalfDuplex_EnableTransmitter(UART_HandleTypeDef *huart);
-HAL_StatusTypeDef HAL_HalfDuplex_EnableReceiver(UART_HandleTypeDef *huart);
+/**
+  * @}
+  */
 
+/** @addtogroup UART_Exported_Functions_Group2 Input and Output operation functions 
+  *  @brief UART Transmit/Receive functions 
+  * @{
+  */
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout);
 HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout);
@@ -998,14 +1007,45 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart);
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart);
 void HAL_UART_WakeupCallback(UART_HandleTypeDef *huart);
 
-/* Peripheral Control functions ***********************************************/
-HAL_StatusTypeDef HAL_LIN_SendBreak(UART_HandleTypeDef *huart);
-void UART_Wakeup_AddressConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection);
 HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
+/**
+  * @}
+  */
 
+/** @addtogroup UART_Exported_Functions_Group3 Peripheral Control functions 
+  *  @brief   UART control functions 
+  * @{
+  */
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef HAL_MultiProcessor_EnableMuteMode(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_MultiProcessor_DisableMuteMode(UART_HandleTypeDef *huart);
+void HAL_MultiProcessor_EnterMuteMode(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_HalfDuplex_EnableTransmitter(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_HalfDuplex_EnableReceiver(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_LIN_SendBreak(UART_HandleTypeDef *huart);
+
+HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart);
+void UART_AdvFeatureConfig(UART_HandleTypeDef *huart);
+void UART_Wakeup_AddressConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection);  
+/**
+  * @}
+  */
+
+/** @addtogroup UART_Exported_Functions_Group4 Peripheral State and Error functions 
+  *  @brief   Peripheral State and Error functions 
+  * @{
+  */
 /* Peripheral State and Error functions ***************************************/
 HAL_UART_StateTypeDef HAL_UART_GetState(UART_HandleTypeDef *huart);
 uint32_t HAL_UART_GetError(UART_HandleTypeDef *huart);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_uart_ex.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_uart_ex.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_uart_ex.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Extended UART HAL module driver.
   *
   *          This file provides firmware functions to manage the following extended
@@ -63,7 +63,7 @@
   * @{
   */
 
-/** @defgroup UARTEx
+/** @defgroup UARTEx UART Extended HAL module driver
   * @brief UART Extended HAL module driver
   * @{
   */
@@ -74,13 +74,13 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/                                    
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
 
-/** @defgroup UARTEx_Private_Functions
+/** @defgroup UARTEx_Exported_Functions UART Extended Exported Functions
   * @{
   */
 
-/** @defgroup UARTEx_Group1 Extended Initialization/de-initialization functions
+/** @defgroup UARTEx_Exported_Functions_Group1 Extended Initialization and de-initialization functions
   * @brief    Extended Initialization and Configuration Functions
   *
 @verbatim    
@@ -161,7 +161,7 @@ HAL_StatusTypeDef HAL_RS485Ex_Init(UART_HandleTypeDef *huart, uint32_t UART_DEPo
   uint32_t temp = 0x0;
   
   /* Check the UART handle allocation */
-  if(huart == NULL)
+  if(huart == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -222,7 +222,7 @@ HAL_StatusTypeDef HAL_RS485Ex_Init(UART_HandleTypeDef *huart, uint32_t UART_DEPo
   * @}
   */
 
-/** @defgroup UARTEx_Group2 Extended Peripheral Control functions
+/** @defgroup UARTEx_Exported_Functions_Group2 Extended Peripheral Control functions
   * @brief    Extended Peripheral Control functions
   *
 @verbatim   
@@ -260,7 +260,7 @@ HAL_StatusTypeDef HAL_RS485Ex_Init(UART_HandleTypeDef *huart, uint32_t UART_DEPo
 HAL_StatusTypeDef HAL_MultiProcessorEx_AddressLength_Set(UART_HandleTypeDef *huart, uint32_t AddressLength)
 {
   /* Check the UART handle allocation */
-  if(huart == NULL)
+  if(huart == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -392,7 +392,7 @@ HAL_StatusTypeDef HAL_UARTEx_DisableStopMode(UART_HandleTypeDef *huart)
 /**
   * @}
   */
-
+  
 #endif /* HAL_UART_MODULE_ENABLED */
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_uart_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_uart_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_uart_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of UART HAL Extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of UART HAL Extended module.
   ******************************************************************************
   * @attention
   *                               
@@ -56,15 +56,16 @@
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup UARTEx_Exported_Constants
+/** @defgroup UARTEx_Exported_Constants UART Extented Exported Constants
   * @{
   */
   
-/** @defgroup UARTEx_Word_Length UART Word Length
+/** @defgroup UARTEx_Word_Length UART Extended Word Length
   * @{
   */
-#if defined (STM32F301x8) || defined (STM32F302x8) || defined (STM32F334x8) \
- || defined (STM32F318xx) || defined (STM32F303x8) || defined (STM32F328xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define UART_WORDLENGTH_7B                  ((uint32_t)USART_CR1_M1)
 #define UART_WORDLENGTH_8B                  ((uint32_t)0x00000000)
 #define UART_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M0)
@@ -76,7 +77,9 @@
 #define UART_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M)
 #define IS_UART_WORD_LENGTH(LENGTH) (((LENGTH) == UART_WORDLENGTH_8B) || \
                                      ((LENGTH) == UART_WORDLENGTH_9B))
-#endif                                     
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx   */
 /**
   * @}
   */ 
@@ -100,7 +103,7 @@
   
 /* Exported macro ------------------------------------------------------------*/
 
-/** @defgroup UARTEx_Exported_Macros
+/** @defgroup UARTEx_Exported_Macros UART Extended Exported Macros
   * @{
   */
            
@@ -109,7 +112,8 @@
   * @param  __CLOCKSOURCE__ : output variable   
   * @retval UART clocking source, written in __CLOCKSOURCE__.
   */
-#if defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx)
 #define __HAL_UART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__) \
   do {                                                        \
     if((__HANDLE__)->Instance == USART1)                      \
@@ -203,7 +207,7 @@
        }                                                      \
     }                                                         \
   } while(0)
-#elif defined(STM32F334x8) || defined(STM32F303x8) || defined(STM32F328xx)
+#elif defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define __HAL_UART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__) \
   do {                                                        \
     if((__HANDLE__)->Instance == USART1)                      \
@@ -319,7 +323,8 @@
        }                                                      \
     }                                                         \
   } while(0)
-#endif /* defined(STM32F302xC) || defined(STM32F303xC) || defined(STM32F358xx) */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F302xC || STM32F303xC || STM32F358xx    */
 
 
 /** @brief  Computes the UART mask to apply to retrieve the received data
@@ -331,8 +336,9 @@
   * @param  __HANDLE__: specifies the UART Handle
   * @retval none
   */  
-#if defined (STM32F301x8) || defined (STM32F302x8) || defined (STM32F334x8) \
- || defined (STM32F318xx) || defined (STM32F303x8) || defined (STM32F328xx)     
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx) || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define __HAL_UART_MASK_COMPUTATION(__HANDLE__)                       \
   do {                                                                \
   if ((__HANDLE__)->Init.WordLength == UART_WORDLENGTH_9B)            \
@@ -395,22 +401,44 @@
      }                                                                \
   }                                                                   \
 } while(0) 
-#endif /* defined (STM32F301x8) || defined (STM32F302x8) || defined (STM32F334x8) \
- || defined (STM32F318xx) || defined (STM32F303x8) || defined (STM32F328xx) */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F303x8 || STM32F334x8 || STM32F328xx || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 /**
   * @}
   */                                
 
 /* Exported functions --------------------------------------------------------*/
+/** @defgroup UARTEx_Exported_Functions UART Extended Exported Functions
+  * @{
+  */
+
+/** @defgroup UARTEx_Exported_Functions_Group1 Extended Initialization and de-initialization functions
+  * @brief    Extended Initialization and Configuration Functions
+  * @{
+  */
 /* Initialization and de-initialization functions  ****************************/
 HAL_StatusTypeDef HAL_RS485Ex_Init(UART_HandleTypeDef *huart, uint32_t UART_DEPolarity, uint32_t UART_DEAssertionTime, uint32_t UART_DEDeassertionTime);
-HAL_StatusTypeDef HAL_UARTEx_EnableStopMode(UART_HandleTypeDef *huart);
-HAL_StatusTypeDef HAL_UARTEx_DisableStopMode(UART_HandleTypeDef *huart);
-/* IO operation functions *****************************************************/
+/**
+  * @}
+  */   
+
+/** @defgroup UARTEx_Exported_Functions_Group2 Extended Peripheral Control functions
+  * @brief    Extended Peripheral Control functions
+  * @{
+  */
 /* Peripheral Control functions ***********************************************/
 HAL_StatusTypeDef HAL_UARTEx_StopModeWakeUpSourceConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection);
+HAL_StatusTypeDef HAL_UARTEx_EnableStopMode(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef HAL_UARTEx_DisableStopMode(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_MultiProcessorEx_AddressLength_Set(UART_HandleTypeDef *huart, uint32_t AddressLength);
-/* Peripheral State and Error functions ***************************************/
+/**
+  * @}
+  */   
+
+/**
+  * @}
+  */                                
 
 
 /**

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_usart.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_usart.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_usart.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   USART HAL module driver.
   *
   *          This file provides firmware functions to manage the following 
@@ -87,13 +87,16 @@
   * @{
   */
 
-/** @defgroup USART 
+/** @defgroup USART HAL USART Synchronous module driver
   * @brief HAL USART Synchronous module driver
   * @{
   */
 #ifdef HAL_USART_MODULE_ENABLED
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
+/** @defgroup UASRT_Private_Constants USART Private Constants
+  * @{
+  */
 #define DUMMY_DATA                  ((uint16_t) 0xFFFF)
 #define TEACK_REACK_TIMEOUT         ((uint32_t) 1000)
 #define USART_TXDMA_TIMEOUTVALUE            22000
@@ -102,6 +105,9 @@
                                       USART_CR1_TE | USART_CR1_RE))
 #define USART_CR2_FIELDS  ((uint32_t)(USART_CR2_CPHA | USART_CR2_CPOL | \
                                       USART_CR2_CLKEN | USART_CR2_LBCL | USART_CR2_STOP))
+/**
+  * @}
+  */
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
@@ -114,16 +120,17 @@ static HAL_StatusTypeDef USART_WaitOnFlagUntilTimeout(USART_HandleTypeDef *husar
 static HAL_StatusTypeDef USART_SetConfig(USART_HandleTypeDef *husart);
 static HAL_StatusTypeDef USART_CheckIdleState(USART_HandleTypeDef *husart);
 static HAL_StatusTypeDef USART_Transmit_IT(USART_HandleTypeDef *husart);
+static HAL_StatusTypeDef USART_EndTransmit_IT(USART_HandleTypeDef *husart);
 static HAL_StatusTypeDef USART_Receive_IT(USART_HandleTypeDef *husart);
 static HAL_StatusTypeDef USART_TransmitReceive_IT(USART_HandleTypeDef *husart);
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
 
 
-/** @defgroup USART_Private_Functions
+/** @defgroup USART_Exported_Functions USART Exported Functions
   * @{
   */
 
-/** @defgroup USART_Group1 USART Initialization/de-initialization functions 
+/** @defgroup USART_Exported_Functions_Group1 Initialization and de-initialization functions
   *  @brief    Initialization and Configuration functions 
   *
 @verbatim   
@@ -181,7 +188,7 @@ static HAL_StatusTypeDef USART_TransmitReceive_IT(USART_HandleTypeDef *husart);
 HAL_StatusTypeDef HAL_USART_Init(USART_HandleTypeDef *husart)
 {
   /* Check the USART handle allocation */
-  if(husart == NULL)
+  if(husart == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -227,7 +234,7 @@ HAL_StatusTypeDef HAL_USART_Init(USART_HandleTypeDef *husart)
 HAL_StatusTypeDef HAL_USART_DeInit(USART_HandleTypeDef *husart)
 {
    /* Check the USART handle allocation */
-  if(husart == NULL)
+  if(husart == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -281,7 +288,7 @@ HAL_StatusTypeDef HAL_USART_DeInit(USART_HandleTypeDef *husart)
   * @}
   */
 
-/** @defgroup HAL_USART_Group2 IO operation functions 
+/** @defgroup USART_Exported_Functions_Group2 Input and Output operation functions 
   *  @brief   USART Transmit/Receive functions 
   *
 @verbatim   
@@ -352,7 +359,7 @@ HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, uint8_t *pTxDa
     
   if(husart->State == HAL_USART_STATE_READY)
   { 
-    if((pTxData == NULL) || (Size == 0)) 
+    if((pTxData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -420,7 +427,7 @@ HAL_StatusTypeDef HAL_USART_Receive(USART_HandleTypeDef *husart, uint8_t *pRxDat
   
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pRxData == NULL) || (Size == 0)) 
+    if((pRxData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -499,7 +506,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, uint8_t
   
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pTxData == NULL) || (pRxData == NULL) || (Size == 0)) 
+    if((pTxData == HAL_NULL) || (pRxData == HAL_NULL) || (Size == 0)) 
     {
       return  HAL_ERROR;                                    
     }
@@ -582,7 +589,7 @@ HAL_StatusTypeDef HAL_USART_Transmit_IT(USART_HandleTypeDef *husart, uint8_t *pT
 {  
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pTxData == NULL) || (Size == 0)) 
+    if((pTxData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;                                    
     }
@@ -629,7 +636,7 @@ HAL_StatusTypeDef HAL_USART_Receive_IT(USART_HandleTypeDef *husart, uint8_t *pRx
 {
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pRxData == NULL) || (Size == 0)) 
+    if((pRxData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;                                    
     }
@@ -689,7 +696,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, uint
 
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pTxData == NULL) || (pRxData == NULL) || (Size == 0)) 
+    if((pTxData == HAL_NULL) || (pRxData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;                                    
     }
@@ -746,7 +753,7 @@ HAL_StatusTypeDef HAL_USART_Transmit_DMA(USART_HandleTypeDef *husart, uint8_t *p
   
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pTxData == NULL) || (Size == 0)) 
+    if((pTxData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR; 
     }
@@ -804,7 +811,7 @@ HAL_StatusTypeDef HAL_USART_Receive_DMA(USART_HandleTypeDef *husart, uint8_t *pR
   
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pRxData == NULL) || (Size == 0)) 
+    if((pRxData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;                                    
     }
@@ -873,7 +880,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_DMA(USART_HandleTypeDef *husart, uin
   
   if(husart->State == HAL_USART_STATE_READY)
   {
-    if((pTxData == NULL) || (pRxData == NULL) || (Size == 0)) 
+    if((pTxData == HAL_NULL) || (pRxData == HAL_NULL) || (Size == 0)) 
     {
       return HAL_ERROR;                                    
     }
@@ -1023,12 +1030,12 @@ HAL_StatusTypeDef HAL_USART_DMAStop(USART_HandleTypeDef *husart)
   husart->Instance->CR3 &= ~USART_CR3_DMAR;
 
   /* Abort the USART DMA tx channel */
-  if(husart->hdmatx != NULL)
+  if(husart->hdmatx != HAL_NULL)
   {
     HAL_DMA_Abort(husart->hdmatx);
   }
   /* Abort the USART DMA rx channel */
-  if(husart->hdmarx != NULL)
+  if(husart->hdmarx != HAL_NULL)
   {
     HAL_DMA_Abort(husart->hdmarx);
   }
@@ -1119,76 +1126,142 @@ void HAL_USART_IRQHandler(USART_HandleTypeDef *husart)
       USART_TransmitReceive_IT(husart);
     }
   }
+  
+  /* USART in mode Transmitter (transmission end) -----------------------------*/
+  if((__HAL_USART_GET_IT(husart, USART_IT_TC) != RESET) &&(__HAL_USART_GET_IT_SOURCE(husart, USART_IT_TC) != RESET))
+  {
+    USART_EndTransmit_IT(husart);
+  } 
 
 }
 
 
 /**
-  * @brief  This function handles USART Communication Timeout.
-  * @param  husart: USART handle
-  * @param  Flag: specifies the USART flag to check.
-  * @param  Status: The new Flag status (SET or RESET).
-  * @param  Timeout: Timeout duration
-  * @retval HAL status
+  * @brief Tx Transfer completed callbacks
+  * @param husart: usart handle
+  * @retval None
   */
-static HAL_StatusTypeDef USART_WaitOnFlagUntilTimeout(USART_HandleTypeDef *husart, uint32_t Flag, FlagStatus Status, uint32_t Timeout)  
+__weak void HAL_USART_TxCpltCallback(USART_HandleTypeDef *husart)
 {
-  uint32_t tickstart = HAL_GetTick();
-  
-  /* Wait until flag is set */
-  if(Status == RESET)
-  {    
-    while(__HAL_USART_GET_FLAG(husart, Flag) == RESET)
-    {
-      /* Check for the Timeout */
-      if(Timeout != HAL_MAX_DELAY)
-      {
-        if((Timeout == 0) || ((HAL_GetTick()-tickstart) > Timeout))
-        {
-          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
-          __HAL_USART_DISABLE_IT(husart, USART_IT_TXE);
-          __HAL_USART_DISABLE_IT(husart, USART_IT_RXNE);
-          __HAL_USART_DISABLE_IT(husart, USART_IT_PE);
-          __HAL_USART_DISABLE_IT(husart, USART_IT_ERR);
-          
-          husart->State= HAL_USART_STATE_TIMEOUT;
-          
-          /* Process Unlocked */
-          __HAL_UNLOCK(husart);
-          
-          return HAL_TIMEOUT;
-        }
-      }
-    }
-  }
-  else
-  {
-    while(__HAL_USART_GET_FLAG(husart, Flag) != RESET)
-    {
-      /* Check for the Timeout */
-      if(Timeout != HAL_MAX_DELAY)
-      {
-        if((Timeout == 0) || ((HAL_GetTick()-tickstart) > Timeout))
-        {
-          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
-          __HAL_USART_DISABLE_IT(husart, USART_IT_TXE);
-          __HAL_USART_DISABLE_IT(husart, USART_IT_RXNE);
-          __HAL_USART_DISABLE_IT(husart, USART_IT_PE);
-          __HAL_USART_DISABLE_IT(husart, USART_IT_ERR);
-    
-          husart->State= HAL_USART_STATE_TIMEOUT;
-          
-          /* Process Unlocked */
-          __HAL_UNLOCK(husart);
-        
-          return HAL_TIMEOUT;
-        }
-      }
-    }
-  }
-  return HAL_OK;      
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_USART_TxCpltCallback can be implemented in the user file
+   */ 
 }
 
+/**
+  * @brief  Tx Half Transfer completed callbacks.
+  * @param  husart: USART handle
+  * @retval None
+  */
+ __weak void HAL_USART_TxHalfCpltCallback(USART_HandleTypeDef *husart)
+{
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_USART_TxHalfCpltCallback can be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Rx Transfer completed callbacks.
+  * @param  husart: USART handle
+  * @retval None
+  */
+__weak void HAL_USART_RxCpltCallback(USART_HandleTypeDef *husart)
+{
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_USART_RxCpltCallback can be implemented in the user file
+   */
+}
+
+/**
+  * @brief Rx Half Transfer completed callbacks
+  * @param husart: usart handle
+  * @retval None
+  */
+__weak void HAL_USART_RxHalfCpltCallback(USART_HandleTypeDef *husart)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_USART_RxHalfCpltCallback can be implemented in the user file
+   */
+}
+
+/**
+  * @brief Tx/Rx Transfers completed callback for the non-blocking process
+  * @param husart: usart handle
+  * @retval None
+  */
+__weak void HAL_USART_TxRxCpltCallback(USART_HandleTypeDef *husart)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_USART_TxRxCpltCallback can be implemented in the user file
+   */
+}
+
+/**
+  * @brief USART error callbacks
+  * @param husart: usart handle
+  * @retval None
+  */
+__weak void HAL_USART_ErrorCallback(USART_HandleTypeDef *husart)
+{
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_USART_ErrorCallback can be implemented in the user file
+   */ 
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup USART_Exported_Functions_Group3 Peripheral Control functions 
+  *  @brief   USART control functions 
+  *
+@verbatim   
+ ===============================================================================
+                      ##### Peripheral Control functions #####
+ ===============================================================================  
+    [..]
+    This subsection provides a set of functions allowing to control the USART.
+     (+) HAL_USART_GetState() API can be helpful to check in run-time the state of the USART peripheral. 
+     (+) USART_CheckIdleState() APi ensures that TEACK and/or REACK bits are set after initialization
+      
+@endverbatim
+  * @{
+  */
+
+
+
+/**
+  * @brief return the USART state
+  * @param husart: USART handle
+  * @retval HAL state
+  */
+HAL_USART_StateTypeDef HAL_USART_GetState(USART_HandleTypeDef *husart)
+{
+  return husart->State;
+}
+
+/**
+  * @brief  Return the USART error code
+  * @param  husart : pointer to a USART_HandleTypeDef structure that contains
+  *              the configuration information for the specified USART.
+  * @retval USART Error Code
+  */
+uint32_t HAL_USART_GetError(USART_HandleTypeDef *husart)
+{
+  return husart->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+/** @defgroup USART_Private_Functions USART Private Functions
+ * @{
+ */
 
 /**
   * @brief DMA USART transmit process complete callback 
@@ -1292,77 +1365,185 @@ static void USART_DMAError(DMA_HandleTypeDef *hdma)
 }
 
 /**
-  * @brief Tx Transfer completed callbacks
-  * @param husart: usart handle
-  * @retval None
-  */
-__weak void HAL_USART_TxCpltCallback(USART_HandleTypeDef *husart)
-{
-  /* NOTE : This function should not be modified, when the callback is needed,
-            the HAL_USART_TxCpltCallback can be implemented in the user file
-   */ 
-}
-
-/**
-  * @brief  Tx Half Transfer completed callbacks.
+  * @brief  This function handles USART Communication Timeout.
   * @param  husart: USART handle
-  * @retval None
+  * @param  Flag: specifies the USART flag to check.
+  * @param  Status: The new Flag status (SET or RESET).
+  * @param  Timeout: Timeout duration
+  * @retval HAL status
   */
- __weak void HAL_USART_TxHalfCpltCallback(USART_HandleTypeDef *husart)
+static HAL_StatusTypeDef USART_WaitOnFlagUntilTimeout(USART_HandleTypeDef *husart, uint32_t Flag, FlagStatus Status, uint32_t Timeout)  
 {
-  /* NOTE: This function should not be modified, when the callback is needed,
-           the HAL_USART_TxHalfCpltCallback can be implemented in the user file
-   */
+  uint32_t tickstart = HAL_GetTick();
+  
+  /* Wait until flag is set */
+  if(Status == RESET)
+  {    
+    while(__HAL_USART_GET_FLAG(husart, Flag) == RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0) || ((HAL_GetTick()-tickstart) > Timeout))
+        {
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+          __HAL_USART_DISABLE_IT(husart, USART_IT_TXE);
+          __HAL_USART_DISABLE_IT(husart, USART_IT_RXNE);
+          __HAL_USART_DISABLE_IT(husart, USART_IT_PE);
+          __HAL_USART_DISABLE_IT(husart, USART_IT_ERR);
+          
+          husart->State= HAL_USART_STATE_TIMEOUT;
+          
+          /* Process Unlocked */
+          __HAL_UNLOCK(husart);
+          
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  else
+  {
+    while(__HAL_USART_GET_FLAG(husart, Flag) != RESET)
+    {
+      /* Check for the Timeout */
+      if(Timeout != HAL_MAX_DELAY)
+      {
+        if((Timeout == 0) || ((HAL_GetTick()-tickstart) > Timeout))
+        {
+          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+          __HAL_USART_DISABLE_IT(husart, USART_IT_TXE);
+          __HAL_USART_DISABLE_IT(husart, USART_IT_RXNE);
+          __HAL_USART_DISABLE_IT(husart, USART_IT_PE);
+          __HAL_USART_DISABLE_IT(husart, USART_IT_ERR);
+    
+          husart->State= HAL_USART_STATE_TIMEOUT;
+          
+          /* Process Unlocked */
+          __HAL_UNLOCK(husart);
+        
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+  return HAL_OK;      
 }
 
 /**
-  * @brief  Rx Transfer completed callbacks.
-  * @param  husart: USART handle
+  * @brief Configure the USART peripheral 
+  * @param husart: USART handle
   * @retval None
   */
-__weak void HAL_USART_RxCpltCallback(USART_HandleTypeDef *husart)
+static HAL_StatusTypeDef USART_SetConfig(USART_HandleTypeDef *husart)
 {
-  /* NOTE: This function should not be modified, when the callback is needed,
-           the HAL_USART_RxCpltCallback can be implemented in the user file
-   */
+  uint32_t tmpreg                      = 0x0;
+  USART_ClockSourceTypeDef clocksource = USART_CLOCKSOURCE_UNDEFINED;
+  HAL_StatusTypeDef ret                = HAL_OK;
+  
+  /* Check the parameters */
+  assert_param(IS_USART_POLARITY(husart->Init.CLKPolarity));
+  assert_param(IS_USART_PHASE(husart->Init.CLKPhase));
+  assert_param(IS_USART_LASTBIT(husart->Init.CLKLastBit));
+  assert_param(IS_USART_BAUDRATE(husart->Init.BaudRate));  
+  assert_param(IS_USART_WORD_LENGTH(husart->Init.WordLength));
+  assert_param(IS_USART_STOPBITS(husart->Init.StopBits));
+  assert_param(IS_USART_PARITY(husart->Init.Parity));
+  assert_param(IS_USART_MODE(husart->Init.Mode));
+ 
+
+  /*-------------------------- USART CR1 Configuration -----------------------*/
+   /* Clear M, PCE, PS, TE and RE bits and configure       
+   *  the USART Word Length, Parity and Mode: 
+   *  set the M bits according to husart->Init.WordLength value 
+   *  set PCE and PS bits according to husart->Init.Parity value
+   *  set TE and RE bits according to husart->Init.Mode value */
+  tmpreg = (uint32_t)husart->Init.WordLength | husart->Init.Parity | husart->Init.Mode;
+  MODIFY_REG(husart->Instance->CR1, USART_CR1_FIELDS, tmpreg);
+  
+  /*---------------------------- USART CR2 Configuration ---------------------*/
+  /* Clear and configure the USART Clock, CPOL, CPHA, LBCL and STOP bits:
+   * set CPOL bit according to husart->Init.CLKPolarity value
+   * set CPHA bit according to husart->Init.CLKPhase value
+   * set LBCL bit according to husart->Init.CLKLastBit value
+   * set STOP[13:12] bits according to husart->Init.StopBits value */
+  tmpreg = (uint32_t)(USART_CLOCK_ENABLED); 
+  tmpreg |= ((uint32_t)husart->Init.CLKPolarity | (uint32_t)husart->Init.CLKPhase);
+  tmpreg |= ((uint32_t)husart->Init.CLKLastBit | (uint32_t)husart->Init.StopBits);
+  MODIFY_REG(husart->Instance->CR2, USART_CR2_FIELDS, tmpreg);
+
+  /*-------------------------- USART CR3 Configuration -----------------------*/  
+  /* no CR3 register configuration                                            */
+
+  /*-------------------------- USART BRR Configuration -----------------------*/
+  __HAL_USART_GETCLOCKSOURCE(husart, clocksource);
+  switch (clocksource)
+  {
+    case USART_CLOCKSOURCE_PCLK1: 
+      husart->Instance->BRR = (uint16_t)(HAL_RCC_GetPCLK1Freq() / husart->Init.BaudRate);
+      break;
+    case USART_CLOCKSOURCE_PCLK2: 
+      husart->Instance->BRR = (uint16_t)(HAL_RCC_GetPCLK2Freq() / husart->Init.BaudRate);
+      break;
+    case USART_CLOCKSOURCE_HSI: 
+      husart->Instance->BRR = (uint16_t)(HSI_VALUE / husart->Init.BaudRate); 
+      break; 
+    case USART_CLOCKSOURCE_SYSCLK:  
+      husart->Instance->BRR = (uint16_t)(HAL_RCC_GetSysClockFreq() / husart->Init.BaudRate);
+      break;  
+    case USART_CLOCKSOURCE_LSE:                
+      husart->Instance->BRR = (uint16_t)(LSE_VALUE / husart->Init.BaudRate); 
+      break;      
+    case USART_CLOCKSOURCE_UNDEFINED:                
+    default:                
+      ret = HAL_ERROR; 
+      break;          
+  } 
+  
+  return ret; 
 }
+
+
 
 /**
-  * @brief Rx Half Transfer completed callbacks
-  * @param husart: usart handle
-  * @retval None
+  * @brief Check the USART Idle State
+  * @param husart: USART handle
+  * @retval HAL status
   */
-__weak void HAL_USART_RxHalfCpltCallback(USART_HandleTypeDef *husart)
+static HAL_StatusTypeDef USART_CheckIdleState(USART_HandleTypeDef *husart)
 {
-  /* NOTE : This function should not be modified, when the callback is needed,
-            the HAL_USART_RxHalfCpltCallback can be implemented in the user file
-   */
+  /* Initialize the USART ErrorCode */
+  husart->ErrorCode = HAL_USART_ERROR_NONE;
+  
+  /* Check if the Transmitter is enabled */
+  if((husart->Instance->CR1 & USART_CR1_TE) == USART_CR1_TE)
+  {
+    /* Wait until TEACK flag is set */
+    if(USART_WaitOnFlagUntilTimeout(husart, USART_ISR_TEACK, RESET, TEACK_REACK_TIMEOUT) != HAL_OK)  
+    { 
+      /* Timeout Occured */ 
+      return HAL_TIMEOUT;
+    } 
+  }
+  /* Check if the Receiver is enabled */
+  if((husart->Instance->CR1 & USART_CR1_RE) == USART_CR1_RE)
+  {
+    /* Wait until REACK flag is set */
+    if(USART_WaitOnFlagUntilTimeout(husart, USART_ISR_REACK, RESET, TEACK_REACK_TIMEOUT) != HAL_OK)  
+    { 
+      /* Timeout Occured */ 
+      return HAL_TIMEOUT;
+    }
+  }
+  
+  /* Initialize the USART state*/
+  husart->State= HAL_USART_STATE_READY;
+    
+  /* Process Unlocked */
+  __HAL_UNLOCK(husart);
+  
+  return HAL_OK;  
 }
-
-/**
-  * @brief Tx/Rx Transfers completed callback for the non-blocking process
-  * @param husart: usart handle
-  * @retval None
-  */
-__weak void HAL_USART_TxRxCpltCallback(USART_HandleTypeDef *husart)
-{
-  /* NOTE : This function should not be modified, when the callback is needed,
-            the HAL_USART_TxRxCpltCallback can be implemented in the user file
-   */
-}
-
-/**
-  * @brief USART error callbacks
-  * @param husart: usart handle
-  * @retval None
-  */
-__weak void HAL_USART_ErrorCallback(USART_HandleTypeDef *husart)
-{
-  /* NOTE : This function should not be modified, when the callback is needed,
-            the HAL_USART_ErrorCallback can be implemented in the user file
-   */ 
-}
-
 
 /**
   * @brief  Simplex Send an amount of data in non-blocking mode.
@@ -1384,16 +1565,8 @@ static HAL_StatusTypeDef USART_Transmit_IT(USART_HandleTypeDef *husart)
       /* Disable the USART Transmit Complete Interrupt */
       __HAL_USART_DISABLE_IT(husart, USART_IT_TXE);
         
-      /* Disable the USART Error Interrupt: (Frame error, noise error, overrun error) */
-      __HAL_USART_DISABLE_IT(husart, USART_IT_ERR);
-      
-      if(USART_WaitOnFlagUntilTimeout(husart, USART_FLAG_TC, RESET, USART_TIMEOUT_VALUE) != HAL_OK)
-      { 
-        return HAL_TIMEOUT;
-      }  
-      husart->State = HAL_USART_STATE_READY;
-      
-      HAL_USART_TxCpltCallback(husart);
+      /* Enable the USART Transmit Complete Interrupt */    
+      __HAL_USART_ENABLE_IT(husart, USART_IT_TC);
       
       return HAL_OK;
     }
@@ -1420,6 +1593,29 @@ static HAL_StatusTypeDef USART_Transmit_IT(USART_HandleTypeDef *husart)
     return HAL_BUSY;   
   }
 }
+
+
+/**
+  * @brief  Wraps up transmission in non blocking mode.
+  * @param  husart: pointer to a USART_HandleTypeDef structure that contains
+  *                the configuration information for the specified USART module.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef USART_EndTransmit_IT(USART_HandleTypeDef *husart)
+{
+  /* Disable the USART Transmit Complete Interrupt */    
+  __HAL_USART_DISABLE_IT(husart, USART_IT_TC);
+  
+  /* Disable the USART Error Interrupt: (Frame error, noise error, overrun error) */
+  __HAL_USART_DISABLE_IT(husart, USART_IT_ERR);
+    
+  husart->State = HAL_USART_STATE_READY;
+   
+  HAL_USART_TxCpltCallback(husart);
+  
+  return HAL_OK;
+}
+
 
 /**
   * @brief  Simplex Receive an amount of data in non-blocking mode.
@@ -1556,169 +1752,6 @@ static HAL_StatusTypeDef USART_TransmitReceive_IT(USART_HandleTypeDef *husart)
     return HAL_BUSY; 
   }
 }
-
-/**
-  * @}
-  */
-
-/** @defgroup HAL_USART_Group3 Peripheral Control functions 
-  *  @brief   USART control functions 
-  *
-@verbatim   
- ===============================================================================
-                      ##### Peripheral Control functions #####
- ===============================================================================  
-    [..]
-    This subsection provides a set of functions allowing to control the USART.
-     (+) HAL_USART_GetState() API can be helpful to check in run-time the state of the USART peripheral. 
-     (+) USART_SetConfig() API is used to set the USART communication parameters.
-     (+) USART_CheckIdleState() APi ensures that TEACK and/or REACK bits are set after initialization
-      
-@endverbatim
-  * @{
-  */
-
-
-
-/**
-  * @brief return the USART state
-  * @param husart: USART handle
-  * @retval HAL state
-  */
-HAL_USART_StateTypeDef HAL_USART_GetState(USART_HandleTypeDef *husart)
-{
-  return husart->State;
-}
-
-/**
-  * @brief  Return the USART error code
-  * @param  husart : pointer to a USART_HandleTypeDef structure that contains
-  *              the configuration information for the specified USART.
-  * @retval USART Error Code
-  */
-uint32_t HAL_USART_GetError(USART_HandleTypeDef *husart)
-{
-  return husart->ErrorCode;
-}
-
-/**
-  * @brief Configure the USART peripheral 
-  * @param husart: USART handle
-  * @retval None
-  */
-static HAL_StatusTypeDef USART_SetConfig(USART_HandleTypeDef *husart)
-{
-  uint32_t tmpreg                      = 0x0;
-  USART_ClockSourceTypeDef clocksource = USART_CLOCKSOURCE_UNDEFINED;
-  HAL_StatusTypeDef ret                = HAL_OK;
-  
-  /* Check the parameters */
-  assert_param(IS_USART_POLARITY(husart->Init.CLKPolarity));
-  assert_param(IS_USART_PHASE(husart->Init.CLKPhase));
-  assert_param(IS_USART_LASTBIT(husart->Init.CLKLastBit));
-  assert_param(IS_USART_BAUDRATE(husart->Init.BaudRate));  
-  assert_param(IS_USART_WORD_LENGTH(husart->Init.WordLength));
-  assert_param(IS_USART_STOPBITS(husart->Init.StopBits));
-  assert_param(IS_USART_PARITY(husart->Init.Parity));
-  assert_param(IS_USART_MODE(husart->Init.Mode));
- 
-
-  /*-------------------------- USART CR1 Configuration -----------------------*/
-   /* Clear M, PCE, PS, TE and RE bits and configure       
-   *  the USART Word Length, Parity and Mode: 
-   *  set the M bits according to husart->Init.WordLength value 
-   *  set PCE and PS bits according to husart->Init.Parity value
-   *  set TE and RE bits according to husart->Init.Mode value */
-  tmpreg = (uint32_t)husart->Init.WordLength | husart->Init.Parity | husart->Init.Mode;
-  MODIFY_REG(husart->Instance->CR1, USART_CR1_FIELDS, tmpreg);
-  
-  /*---------------------------- USART CR2 Configuration ---------------------*/
-  /* Clear and configure the USART Clock, CPOL, CPHA, LBCL and STOP bits:
-   * set CPOL bit according to husart->Init.CLKPolarity value
-   * set CPHA bit according to husart->Init.CLKPhase value
-   * set LBCL bit according to husart->Init.CLKLastBit value
-   * set STOP[13:12] bits according to husart->Init.StopBits value */
-  tmpreg = (uint32_t)(USART_CLOCK_ENABLED); 
-  tmpreg |= ((uint32_t)husart->Init.CLKPolarity | (uint32_t)husart->Init.CLKPhase);
-  tmpreg |= ((uint32_t)husart->Init.CLKLastBit | (uint32_t)husart->Init.StopBits);
-  MODIFY_REG(husart->Instance->CR2, USART_CR2_FIELDS, tmpreg);
-
-  /*-------------------------- USART CR3 Configuration -----------------------*/  
-  /* no CR3 register configuration                                            */
-
-  /*-------------------------- USART BRR Configuration -----------------------*/
-  __HAL_USART_GETCLOCKSOURCE(husart, clocksource);
-  switch (clocksource)
-  {
-    case USART_CLOCKSOURCE_PCLK1: 
-      husart->Instance->BRR = (uint16_t)(HAL_RCC_GetPCLK1Freq() / husart->Init.BaudRate);
-      break;
-    case USART_CLOCKSOURCE_PCLK2: 
-      husart->Instance->BRR = (uint16_t)(HAL_RCC_GetPCLK2Freq() / husart->Init.BaudRate);
-      break;
-    case USART_CLOCKSOURCE_HSI: 
-      husart->Instance->BRR = (uint16_t)(HSI_VALUE / husart->Init.BaudRate); 
-      break; 
-    case USART_CLOCKSOURCE_SYSCLK:  
-      husart->Instance->BRR = (uint16_t)(HAL_RCC_GetSysClockFreq() / husart->Init.BaudRate);
-      break;  
-    case USART_CLOCKSOURCE_LSE:                
-      husart->Instance->BRR = (uint16_t)(LSE_VALUE / husart->Init.BaudRate); 
-      break;      
-    case USART_CLOCKSOURCE_UNDEFINED:                
-    default:                
-      ret = HAL_ERROR; 
-      break;          
-  } 
-  
-  return ret; 
-}
-
-
-
-/**
-  * @brief Check the USART Idle State
-  * @param husart: USART handle
-  * @retval HAL status
-  */
-static HAL_StatusTypeDef USART_CheckIdleState(USART_HandleTypeDef *husart)
-{
-  /* Initialize the USART ErrorCode */
-  husart->ErrorCode = HAL_USART_ERROR_NONE;
-  
-  /* Check if the Transmitter is enabled */
-  if((husart->Instance->CR1 & USART_CR1_TE) == USART_CR1_TE)
-  {
-    /* Wait until TEACK flag is set */
-    if(USART_WaitOnFlagUntilTimeout(husart, USART_ISR_TEACK, RESET, TEACK_REACK_TIMEOUT) != HAL_OK)  
-    { 
-      /* Timeout Occured */ 
-      return HAL_TIMEOUT;
-    } 
-  }
-  /* Check if the Receiver is enabled */
-  if((husart->Instance->CR1 & USART_CR1_RE) == USART_CR1_RE)
-  {
-    /* Wait until REACK flag is set */
-    if(USART_WaitOnFlagUntilTimeout(husart, USART_ISR_REACK, RESET, TEACK_REACK_TIMEOUT) != HAL_OK)  
-    { 
-      /* Timeout Occured */ 
-      return HAL_TIMEOUT;
-    }
-  }
-  
-  /* Initialize the USART state*/
-  husart->State= HAL_USART_STATE_READY;
-    
-  /* Process Unlocked */
-  __HAL_UNLOCK(husart);
-  
-  return HAL_OK;  
-}
-
-/**
-  * @}
-  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_usart.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_usart.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_usart.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of USART HAL module.
   ******************************************************************************
   * @attention
@@ -55,6 +55,9 @@
   */ 
 
 /* Exported types ------------------------------------------------------------*/ 
+/** @defgroup USART_Exported_Types USART Exported Types
+  * @{
+  */
 
 /** 
   * @brief USART Init Structure definition  
@@ -78,7 +81,7 @@ typedef struct
                                                  the word length is set to 9 data bits; 8th bit when the
                                                  word length is set to 8 data bits). */
  
-  uint32_t Mode;                      /*!< Specifies wether the Receive or Transmit mode is enabled or disabled.
+  uint32_t Mode;                      /*!< Specifies whether the Receive or Transmit mode is enabled or disabled.
                                            This parameter can be a value of @ref USART_Mode */
                                            
   uint32_t CLKPolarity;               /*!< Specifies the steady state of the serial clock.
@@ -169,10 +172,13 @@ typedef struct
   
 }USART_HandleTypeDef;
 
+/**
+  * @}
+  */
 
 /* Exported constants --------------------------------------------------------*/
 
-/** @defgroup USART_Exported_Constants
+/** @defgroup USART_Exported_Constants USART Exported Constants
   * @{
   */
 
@@ -346,7 +352,7 @@ typedef struct
     
 /* Exported macros ------------------------------------------------------------*/
 
-/** @defgroup USART_Exported_Macros
+/** @defgroup USART_Exported_Macros USART Exported Macros
   * @{
   */  
   
@@ -498,17 +504,32 @@ typedef struct
   * @}
   */
  
-/* Include USART HAL Extension module */
+/* Include USART HAL Extended module */
 #include "stm32f3xx_hal_usart_ex.h"        
                                  
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup USART_Exported_Functions USART Exported Functions
+  * @{
+  */
 
+/** @addtogroup USART_Exported_Functions_Group1 Initialization and de-initialization functions
+  *  @brief    Initialization and Configuration functions 
+  * @{
+  */
 /* Initialization and de-initialization functions  ****************************/
 HAL_StatusTypeDef HAL_USART_Init(USART_HandleTypeDef *husart);
 HAL_StatusTypeDef HAL_USART_DeInit(USART_HandleTypeDef *husart);
 void HAL_USART_MspInit(USART_HandleTypeDef *husart);
 void HAL_USART_MspDeInit(USART_HandleTypeDef *husart);
 HAL_StatusTypeDef HAL_USART_CheckIdleState(USART_HandleTypeDef *husart);
+/**
+  * @}
+  */
+
+/** @defgroup USART_Exported_Functions_Group2 Input and Output operation functions 
+  *  @brief   USART Transmit/Receive functions 
+  * @{
+  */
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, uint8_t *pTxData, uint16_t Size, uint32_t Timeout);
 HAL_StatusTypeDef HAL_USART_Receive(USART_HandleTypeDef *husart, uint8_t *pRxData, uint16_t Size, uint32_t Timeout);
@@ -529,12 +550,26 @@ void HAL_USART_TxHalfCpltCallback(USART_HandleTypeDef *husart);
 void HAL_USART_RxHalfCpltCallback(USART_HandleTypeDef *husart);
 void HAL_USART_TxRxCpltCallback(USART_HandleTypeDef *husart);
 void HAL_USART_ErrorCallback(USART_HandleTypeDef *husart);
+/**
+  * @}
+  */
 
+/** @defgroup USART_Exported_Functions_Group3 Peripheral Control functions 
+  *  @brief   USART control functions 
+  * @{
+  */
 /* Peripheral Control functions ***********************************************/
 
 /* Peripheral State and Error functions ***************************************/
 HAL_USART_StateTypeDef HAL_USART_GetState(USART_HandleTypeDef *husart);
 uint32_t HAL_USART_GetError(USART_HandleTypeDef *husart);
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_usart_ex.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_usart_ex.h
@@ -2,9 +2,9 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_usart_ex.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
-  * @brief   Header file of USART HAL Extension module.
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of USART HAL Extended module.
   ******************************************************************************
   * @attention
   *                               
@@ -50,21 +50,22 @@
   * @{
   */
 
-/** @addtogroup USARTEx
+/** @defgroup USARTEx USART Extended HAL module driver
   * @{
   */ 
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup USARTEx_Exported_Constants
+/** @defgroup USARTEx_Exported_Constants USART Extended Exported Constants
   * @{
   */
   
-/** @defgroup USARTEx_Word_Length USART Word Length
+/** @defgroup USARTEx_Word_Length USART Extended Word Length
   * @{
   */
-#if defined (STM32F301x8) || defined (STM32F302x8) || defined (STM32F334x8) \
- || defined (STM32F318xx) 
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F334x8)                                                 || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define USART_WORDLENGTH_7B                  ((uint32_t)USART_CR1_M1)
 #define USART_WORDLENGTH_8B                  ((uint32_t)0x00000000)
 #define USART_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M0)
@@ -76,7 +77,9 @@
 #define USART_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M)
 #define IS_USART_WORD_LENGTH(LENGTH) (((LENGTH) == USART_WORDLENGTH_8B) || \
                                       ((LENGTH) == USART_WORDLENGTH_9B))
-#endif                                     
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F334x8                               || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 /**
   * @}
   */
@@ -90,7 +93,7 @@
   
 /* Exported macro ------------------------------------------------------------*/
 
-/** @defgroup USARTEx_Exported_Macros
+/** @defgroup USARTEx_Exported_Macros USART Extended Exported Macros
   * @{
   */
   
@@ -100,7 +103,7 @@
   * @param  __CLOCKSOURCE__ : output variable   
   * @retval the USART clocking source, written in __CLOCKSOURCE__.
   */
-#if defined(STM32F334x8) || defined(STM32F303x8) || defined(STM32F328xx)
+#if defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
 #define __HAL_USART_GETCLOCKSOURCE(__HANDLE__,__CLOCKSOURCE__) \
   do {                                                         \
     if((__HANDLE__)->Instance == USART1)                       \
@@ -216,7 +219,7 @@
        }                                                       \
     }                                                          \
   } while(0)  
-#endif  
+#endif /* STM32F303x8 || STM32F334x8 || STM32F328xx */
 
 /** @brief  Computes the USART mask to apply to retrieve the received data
   *         according to the word length and to the parity bits activation.
@@ -227,8 +230,9 @@
   * @param  __HANDLE__: specifies the USART Handle
   * @retval none
   */  
-#if defined (STM32F301x8) || defined (STM32F302x8) || defined (STM32F334x8) \
- || defined (STM32F318xx)    
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx) || \
+    defined(STM32F334x8)                                                 || \
+    defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx)
 #define __HAL_USART_MASK_COMPUTATION(__HANDLE__)                      \
   do {                                                                \
   if ((__HANDLE__)->Init.WordLength == USART_WORDLENGTH_9B)           \
@@ -291,8 +295,9 @@
      }                                                                \
   }                                                                   \
 } while(0) 
-#endif /* defined (STM32F301x8) || defined (STM32F302x8) || defined (STM32F334x8) \
- || defined (STM32F318xx)  */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx || */
+       /* STM32F334x8                               || */
+       /* STM32F301x8 || STM32F302x8 || STM32F318xx    */
 /**
   * @}
   */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_wwdg.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_wwdg.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_wwdg.c
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   WWDG HAL module driver.
   *
   *          This file provides firmware functions to manage the following 
@@ -89,7 +89,7 @@
   * @{
   */
 
-/** @defgroup WWDG 
+/** @defgroup WWDG WWDG HAL module driver.
   * @brief WWDG HAL module driver.
   * @{
   */
@@ -101,13 +101,13 @@
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions ---------------------------------------------------------*/
 
-/** @defgroup WWDG_Private_Functions
+/** @defgroup WWDG_Exported_Functions WWDG Exported Functions
   * @{
   */
 
-/** @defgroup HAL_WWDG_Group1 Initialization/de-initialization functions 
+/** @defgroup WWDG_Exported_Functions_Group1 Initialization and de-initialization functions
  *  @brief    Initialization and Configuration functions. 
  *
 @verbatim    
@@ -133,10 +133,8 @@
   */
 HAL_StatusTypeDef HAL_WWDG_Init(WWDG_HandleTypeDef *hwwdg)
 { 
-  uint32_t tmp = 0;
-
   /* Check the WWDG handle allocation */
-  if(hwwdg == NULL)
+  if(hwwdg == HAL_NULL)
   {
     return HAL_ERROR;
   }
@@ -157,33 +155,10 @@ HAL_StatusTypeDef HAL_WWDG_Init(WWDG_HandleTypeDef *hwwdg)
   hwwdg->State = HAL_WWDG_STATE_BUSY;
   
   /* Set WWDG Prescaler and Window */
-  /* Get the CFR register value */
-  tmp = hwwdg->Instance->CFR;
-  
-  /* Clear WDGTB[1:0] and W[6:0] bits */
-  tmp &= ((uint32_t)~(WWDG_CFR_WDGTB | WWDG_CFR_W));
-  
-  /* Prepare the WWDG Prescaler and Window parameters */
-  tmp |= hwwdg->Init.Prescaler | hwwdg->Init.Window;
-  
-  /* Write to WWDG CFR */
-  hwwdg->Instance->CFR = tmp;   
+  MODIFY_REG(hwwdg->Instance->CFR, (WWDG_CFR_WDGTB | WWDG_CFR_W), (hwwdg->Init.Prescaler | hwwdg->Init.Window));
  
   /* Set WWDG Counter */
-  /* Get the CR register value */
-  tmp = hwwdg->Instance->CR;
-  
-  /* Clear T[6:0] bits */
-  tmp &= ((uint32_t)~(WWDG_CR_T));
-  
-  /* Prepare the WWDG Counter parameter */
-  tmp |= (hwwdg->Init.Counter);  
-  
-  /* Write to WWDG CR */
-  hwwdg->Instance->CR = tmp;  
-   
-  /* Change WWDG peripheral state */
-  hwwdg->State = HAL_WWDG_STATE_READY;
+  MODIFY_REG(hwwdg->Instance->CR, WWDG_CR_T, hwwdg->Init.Counter);
   
   /* Return function status */
   return HAL_OK;
@@ -261,7 +236,7 @@ __weak void HAL_WWDG_WakeupCallback(WWDG_HandleTypeDef* hwwdg)
   * @}
   */
 
-/** @defgroup HAL_WWDG_Group2 I/O operation functions 
+/** @defgroup WWDG_Exported_Functions_Group2 Input and Output operation functions 
  *  @brief    I/O operation functions 
  *
 @verbatim   
@@ -286,19 +261,19 @@ HAL_StatusTypeDef HAL_WWDG_Start(WWDG_HandleTypeDef *hwwdg)
 {
   /* Process locked */
   __HAL_LOCK(hwwdg); 
-  
+
   /* Change WWDG peripheral state */  
   hwwdg->State = HAL_WWDG_STATE_BUSY;
-                  
+
   /* Enable the Peripheral */
   __HAL_WWDG_ENABLE(hwwdg);  
 
   /* Change WWDG peripheral state */    
   hwwdg->State = HAL_WWDG_STATE_READY; 
-                  
+
   /* Process unlocked */
   __HAL_UNLOCK(hwwdg);
-  
+
   /* Return function status */
   return HAL_OK;
 }
@@ -312,16 +287,16 @@ HAL_StatusTypeDef HAL_WWDG_Start_IT(WWDG_HandleTypeDef *hwwdg)
 {
   /* Process locked */
   __HAL_LOCK(hwwdg); 
-  
+
   /* Change WWDG peripheral state */  
   hwwdg->State = HAL_WWDG_STATE_BUSY;
 
   /* Enable the Early Wakeup Interrupt */ 
   __HAL_WWDG_ENABLE_IT(WWDG_IT_EWI);
-                  
+
   /* Enable the Peripheral */
   __HAL_WWDG_ENABLE(hwwdg);  
-  
+
   /* Return function status */
   return HAL_OK;
 }
@@ -391,7 +366,7 @@ void HAL_WWDG_IRQHandler(WWDG_HandleTypeDef *hwwdg)
   * @}
   */
 
-/** @defgroup HAL_WWDG_Group3 Peripheral State functions 
+/** @defgroup WWDG_Exported_Functions_Group3 Peripheral State functions 
  *  @brief    Peripheral State functions. 
  *
 @verbatim   

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_wwdg.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_hal_wwdg.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f3xx_hal_wwdg.h
   * @author  MCD Application Team
-  * @version V1.0.1
-  * @date    18-June-2014
+  * @version V1.1.0
+  * @date    12-Sept-2014
   * @brief   Header file of WWDG HAL module.
   ******************************************************************************
   * @attention
@@ -56,6 +56,9 @@
 
 /* Exported types ------------------------------------------------------------*/ 
 
+/** @defgroup WWDG_Exported_Types WWDG Exported Types
+  * @{
+  */
 /** 
   * @brief  WWDG HAL State Structure definition  
   */ 
@@ -100,13 +103,17 @@ typedef struct
 
 } WWDG_HandleTypeDef;
 
+/**
+  * @}
+  */
+
 /* Exported constants --------------------------------------------------------*/
 
-/** @defgroup WWDG_Exported_Constants
+/** @defgroup WWDG_Exported_Constants WWDG Exported Constants
   * @{
   */
 
-/** @defgroup WWDG_BitAddress_AliasRegion
+/** @defgroup WWDG_BitAddress_AliasRegion WWDG registers bit address in the alias region
   * @brief WWDG registers bit address in the alias region
   * @{
   */  
@@ -119,59 +126,60 @@ typedef struct
   * @}
   */
 
-/** @defgroup WWDG_Interrupt_definition 
+/** @defgroup WWDG_Interrupt_definition WWDG Interrupt definition 
+  * @brief WWDG registers bit address in the alias region
   * @{
   */ 
 #define WWDG_IT_EWI      ((uint32_t)WWDG_CFR_EWI)  
 
-#define IS_WWDG_IT(IT) ((IT) == WWDG_IT_EWI)
+#define IS_WWDG_IT(__IT__) ((__IT__) == WWDG_IT_EWI)
 
 /**
   * @}
   */
 
-/** @defgroup WWDG_Flag_definition 
+/** @defgroup WWDG_Flag_definition WWDG Flag definition
   * @brief WWDG Flag definition
   * @{
   */ 
-#define WWDG_FLAG_EWIF    ((uint32_t)0x0001)  /*!< Early Wakeup Interrupt Flag */
+#define WWDG_FLAG_EWIF    ((uint32_t)WWDG_SR_EWIF)  /*!< Early Wakeup Interrupt Flag */
 
-#define IS_WWDG_FLAG(FLAG)    ((FLAG) == WWDG_FLAG_EWIF)) 
+#define IS_WWDG_FLAG(__FLAG__)    ((__FLAG__) == WWDG_FLAG_EWIF)) 
 
 /**
   * @}
   */
 
-/** @defgroup WWDG_Prescaler 
+/** @defgroup WWDG_Prescaler WWDG Prescaler
   * @{
   */ 
 #define WWDG_PRESCALER_1    ((uint32_t)0x00000000)  /*!< WWDG counter clock = (PCLK1/4096)/1 */
-#define WWDG_PRESCALER_2    ((uint32_t)0x00000080)  /*!< WWDG counter clock = (PCLK1/4096)/2 */
-#define WWDG_PRESCALER_4    ((uint32_t)0x00000100)  /*!< WWDG counter clock = (PCLK1/4096)/4 */
-#define WWDG_PRESCALER_8    ((uint32_t)0x00000180)  /*!< WWDG counter clock = (PCLK1/4096)/8 */
+#define WWDG_PRESCALER_2    ((uint32_t)WWDG_CFR_WDGTB0)  /*!< WWDG counter clock = (PCLK1/4096)/2 */
+#define WWDG_PRESCALER_4    ((uint32_t)WWDG_CFR_WDGTB1)  /*!< WWDG counter clock = (PCLK1/4096)/4 */
+#define WWDG_PRESCALER_8    ((uint32_t)WWDG_CFR_WDGTB)  /*!< WWDG counter clock = (PCLK1/4096)/8 */
 
-#define IS_WWDG_PRESCALER(PRESCALER) (((PRESCALER) == WWDG_PRESCALER_1) || \
-                                      ((PRESCALER) == WWDG_PRESCALER_2) || \
-                                      ((PRESCALER) == WWDG_PRESCALER_4) || \
-                                      ((PRESCALER) == WWDG_PRESCALER_8))
-
-/**
-  * @}
-  */
-
-/** @defgroup WWDG_Window 
-  * @{
-  */ 
-#define IS_WWDG_WINDOW(WINDOW) ((WINDOW) <= 0x7F)
+#define IS_WWDG_PRESCALER(__PRESCALER__) (((__PRESCALER__) == WWDG_PRESCALER_1) || \
+                                          ((__PRESCALER__) == WWDG_PRESCALER_2) || \
+                                          ((__PRESCALER__) == WWDG_PRESCALER_4) || \
+                                          ((__PRESCALER__) == WWDG_PRESCALER_8))
 
 /**
   * @}
   */
 
-/** @defgroup WWDG_Counter 
+/** @defgroup WWDG_Window WWDG Window
   * @{
   */ 
-#define IS_WWDG_COUNTER(COUNTER) (((COUNTER) >= 0x40) && ((COUNTER) <= 0x7F))
+#define IS_WWDG_WINDOW(__WINDOW__) ((__WINDOW__) <= 0x7F)
+
+/**
+  * @}
+  */
+
+/** @defgroup WWDG_Counter WWDG Counter
+  * @{
+  */ 
+#define IS_WWDG_COUNTER(__COUNTER__) (((__COUNTER__) >= 0x40) && ((__COUNTER__) <= 0x7F))
 
 /**
   * @}
@@ -183,7 +191,7 @@ typedef struct
   
 /* Exported macros -----------------------------------------------------------*/
 
-/** @defgroup WWDG_Exported_Macros
+/** @defgroup WWDG_Exported_Macros WWDG Exported Macros
  * @{
  */
 
@@ -198,7 +206,7 @@ typedef struct
   * @param  __HANDLE__: WWDG handle
   * @retval None
   */
-#define __HAL_WWDG_ENABLE(__HANDLE__) ((__HANDLE__)->Instance->CR |=  WWDG_CR_WDGA)
+#define __HAL_WWDG_ENABLE(__HANDLE__) SET_BIT((__HANDLE__)->Instance->CR, WWDG_CR_WDGA)
 
 /**
   * @brief Get the selected WWDG's flag status.
@@ -227,11 +235,27 @@ typedef struct
   */
 #define __HAL_WWDG_ENABLE_IT(__INTERRUPT__) (*(__IO uint32_t *) CFR_BASE |= (__INTERRUPT__))
 
+/** @brief  Clear the WWDG's interrupt pending bits
+  *         bits to clear the selected interrupt pending bits.
+  * @param  __HANDLE__: WWDG handle
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear.
+  *         This parameter can be one of the following values:
+  *            @arg WWDG_FLAG_EWIF: Early wakeup interrupt flag
+  */
+#define __HAL_WWDG_CLEAR_IT(__HANDLE__, __INTERRUPT__) __HAL_WWDG_CLEAR_FLAG((__HANDLE__), (__INTERRUPT__))
 /**
   * @}
   */
 
 /* Exported functions --------------------------------------------------------*/
+/** @addtogroup WWDG_Exported_Functions WWDG Exported Functions
+  * @{
+  */
+
+/** @addtogroup WWDG_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions. 
+ * @{
+ */
 
 /* Initialization/de-initialization functions  **********************************/
 HAL_StatusTypeDef HAL_WWDG_Init(WWDG_HandleTypeDef *hwwdg);
@@ -239,15 +263,36 @@ HAL_StatusTypeDef HAL_WWDG_DeInit(WWDG_HandleTypeDef *hwwdg);
 void HAL_WWDG_MspInit(WWDG_HandleTypeDef *hwwdg);
 void HAL_WWDG_MspDeInit(WWDG_HandleTypeDef *hwwdg);
 void HAL_WWDG_WakeupCallback(WWDG_HandleTypeDef* hwwdg);
+/**
+  * @}
+  */
 
+/** @addtogroup WWDG_Exported_Functions_Group2 Input and Output operation functions 
+ *  @brief    I/O operation functions 
+ * @{
+ */
 /* I/O operation functions ******************************************************/
 HAL_StatusTypeDef HAL_WWDG_Start(WWDG_HandleTypeDef *hwwdg);
 HAL_StatusTypeDef HAL_WWDG_Start_IT(WWDG_HandleTypeDef *hwwdg);
 HAL_StatusTypeDef HAL_WWDG_Refresh(WWDG_HandleTypeDef *hwwdg, uint32_t Counter);
 void HAL_WWDG_IRQHandler(WWDG_HandleTypeDef *hwwdg);
+/**
+  * @}
+  */
 
+/** @addtogroup WWDG_Exported_Functions_Group3 Peripheral State functions 
+ *  @brief    Peripheral State functions. 
+ * @{
+ */
 /* Peripheral State functions  **************************************************/
 HAL_WWDG_StateTypeDef HAL_WWDG_GetState(WWDG_HandleTypeDef *hwwdg);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
 
 /**
   * @}

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_ll_fmc.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_ll_fmc.c
@@ -1,0 +1,920 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx_ll_fmc.c
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   FMC Low Layer HAL module driver.
+  *    
+  *          This file provides firmware functions to manage the following 
+  *          functionalities of the Flexible Memory Controller (FMC) peripheral memories:
+  *           + Initialization/de-initialization functions
+  *           + Peripheral Control functions 
+  *           + Peripheral State functions
+  *         
+  @verbatim
+  ==============================================================================
+                        ##### FMC peripheral features #####
+  ==============================================================================
+  [..] The Flexible memory controller (FMC) includes three memory controllers:
+       (+) The NOR/PSRAM memory controller
+       (+) The NAND/PC Card memory controller
+       
+  [..] The FMC functional block makes the interface with synchronous and asynchronous static
+       memories, and 16-bit PC memory cards. Its main purposes are:
+       (+) to translate AHB transactions into the appropriate external device protocol
+       (+) to meet the access time requirements of the external memory devices
+   
+  [..] All external memories share the addresses, data and control signals with the controller.
+       Each external device is accessed by means of a unique Chip Select. The FMC performs
+       only one access at a time to an external device.
+       The main features of the FMC controller are the following:
+        (+) Interface with static-memory mapped devices including:
+           (++) Static random access memory (SRAM)
+           (++) Read-only memory (ROM)
+           (++) NOR Flash memory/OneNAND Flash memory
+           (++) PSRAM (4 memory banks)
+           (++) 16-bit PC Card compatible devices
+           (++) Two banks of NAND Flash memory with ECC hardware to check up to 8 Kbytes of
+                data
+        (+) Independent Chip Select control for each memory bank
+        (+) Independent configuration for each memory bank
+                    
+  @endverbatim
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f3xx_hal.h"
+
+/** @addtogroup STM32F3xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup FMC 
+  * @brief FMC driver modules
+  * @{
+  */
+
+#if defined (HAL_SRAM_MODULE_ENABLED) || defined(HAL_NOR_MODULE_ENABLED) || defined(HAL_NAND_MODULE_ENABLED) || defined(HAL_PCCARD_MODULE_ENABLED)
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup FMC_Private_Functions
+  * @{
+  */
+
+/** @defgroup FMC_NORSRAM Controller functions
+  * @brief    NORSRAM Controller functions 
+  *
+  @verbatim 
+  ==============================================================================   
+                   ##### How to use NORSRAM device driver #####
+  ==============================================================================
+ 
+  [..] 
+    This driver contains a set of APIs to interface with the FMC NORSRAM banks in order
+    to run the NORSRAM external devices.
+      
+    (+) FMC NORSRAM bank reset using the function FMC_NORSRAM_DeInit() 
+    (+) FMC NORSRAM bank control configuration using the function FMC_NORSRAM_Init()
+    (+) FMC NORSRAM bank timing configuration using the function FMC_NORSRAM_Timing_Init()
+    (+) FMC NORSRAM bank extended timing configuration using the function 
+        FMC_NORSRAM_Extended_Timing_Init()
+    (+) FMC NORSRAM bank enable/disable write operation using the functions
+        FMC_NORSRAM_WriteOperation_Enable()/FMC_NORSRAM_WriteOperation_Disable()
+        
+
+@endverbatim
+  * @{
+  */
+       
+/** @defgroup FMC_NORSRAM_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @brief    Initialization and Configuration functions 
+  *
+  @verbatim    
+  ==============================================================================
+              ##### Initialization and de_initialization functions #####
+  ==============================================================================
+  [..]  
+    This section provides functions allowing to:
+    (+) Initialize and configure the FMC NORSRAM interface
+    (+) De-initialize the FMC NORSRAM interface 
+    (+) Configure the FMC clock and associated GPIOs    
+ 
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Initialize the FMC_NORSRAM device according to the specified
+  *         control parameters in the FMC_NORSRAM_InitTypeDef
+  * @param  Device: Pointer to NORSRAM device instance
+  * @param  Init: Pointer to NORSRAM Initialization structure   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  FMC_NORSRAM_Init(FMC_NORSRAM_TypeDef *Device, FMC_NORSRAM_InitTypeDef* Init)
+{ 
+  uint32_t tmpr = 0;
+    
+  /* Check the parameters */
+  assert_param(IS_FMC_NORSRAM_DEVICE(Device));
+  assert_param(IS_FMC_NORSRAM_BANK(Init->NSBank));
+  assert_param(IS_FMC_MUX(Init->DataAddressMux));
+  assert_param(IS_FMC_MEMORY(Init->MemoryType));
+  assert_param(IS_FMC_NORSRAM_MEMORY_WIDTH(Init->MemoryDataWidth));
+  assert_param(IS_FMC_BURSTMODE(Init->BurstAccessMode));
+  assert_param(IS_FMC_WAIT_POLARITY(Init->WaitSignalPolarity));
+  assert_param(IS_FMC_WRAP_MODE(Init->WrapMode));
+  assert_param(IS_FMC_WAIT_SIGNAL_ACTIVE(Init->WaitSignalActive));
+  assert_param(IS_FMC_WRITE_OPERATION(Init->WriteOperation));
+  assert_param(IS_FMC_WAITE_SIGNAL(Init->WaitSignal));
+  assert_param(IS_FMC_EXTENDED_MODE(Init->ExtendedMode));
+  assert_param(IS_FMC_ASYNWAIT(Init->AsynchronousWait));
+  assert_param(IS_FMC_WRITE_BURST(Init->WriteBurst));
+  assert_param(IS_FMC_CONTINOUS_CLOCK(Init->ContinuousClock)); 
+  
+  /* Set NORSRAM device control parameters */
+  tmpr = (uint32_t)(Init->DataAddressMux       |\
+                    Init->MemoryType           |\
+                    Init->MemoryDataWidth      |\
+                    Init->BurstAccessMode      |\
+                    Init->WaitSignalPolarity   |\
+                    Init->WrapMode             |\
+                    Init->WaitSignalActive     |\
+                    Init->WriteOperation       |\
+                    Init->WaitSignal           |\
+                    Init->ExtendedMode         |\
+                    Init->AsynchronousWait     |\
+                    Init->WriteBurst           |\
+                    Init->ContinuousClock
+                    );
+                    
+  if(Init->MemoryType == FMC_MEMORY_TYPE_NOR)
+  {
+    tmpr |= (uint32_t)FMC_NORSRAM_FLASH_ACCESS_ENABLE;
+  }
+  
+  Device->BTCR[Init->NSBank] = tmpr;
+
+  /* Configure synchronous mode when Continuous clock is enabled for bank2..4 */
+  if((Init->ContinuousClock == FMC_CONTINUOUS_CLOCK_SYNC_ASYNC) && (Init->NSBank != FMC_NORSRAM_BANK1))
+  { 
+    Init->BurstAccessMode = FMC_BURST_ACCESS_MODE_ENABLE; 
+    Device->BTCR[FMC_NORSRAM_BANK1] |= (uint32_t)(Init->BurstAccessMode  |\
+                                                  Init->ContinuousClock);                    
+  }                       
+  
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  DeInitialize the FMC_NORSRAM peripheral 
+  * @param  Device: Pointer to NORSRAM device instance
+  * @param  ExDevice: Pointer to NORSRAM extended mode device instance  
+  * @param  Bank: NORSRAM bank number  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef FMC_NORSRAM_DeInit(FMC_NORSRAM_TypeDef *Device, FMC_NORSRAM_EXTENDED_TypeDef *ExDevice, uint32_t Bank)
+{
+  /* Check the parameters */
+  assert_param(IS_FMC_NORSRAM_DEVICE(Device));
+  assert_param(IS_FMC_NORSRAM_EXTENDED_DEVICE(ExDevice));
+  assert_param(IS_FMC_NORSRAM_BANK(Bank));
+  
+  /* Disable the FMC_NORSRAM device */
+  __FMC_NORSRAM_DISABLE(Device, Bank);
+  
+  /* De-initialize the FMC_NORSRAM device */
+  /* FMC_NORSRAM_BANK1 */
+  if(Bank == FMC_NORSRAM_BANK1)
+  {
+    Device->BTCR[Bank] = 0x000030DB;    
+  }
+  /* FMC_NORSRAM_BANK2, FMC_NORSRAM_BANK3 or FMC_NORSRAM_BANK4 */
+  else
+  {   
+    Device->BTCR[Bank] = 0x000030D2; 
+  }
+  
+  Device->BTCR[Bank + 1] = 0x0FFFFFFF;
+  ExDevice->BWTR[Bank]   = 0x0FFFFFFF;
+   
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  Initialize the FMC_NORSRAM Timing according to the specified
+  *         parameters in the FMC_NORSRAM_TimingTypeDef
+  * @param  Device: Pointer to NORSRAM device instance
+  * @param  Timing: Pointer to NORSRAM Timing structure
+  * @param  Bank: NORSRAM bank number  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef FMC_NORSRAM_Timing_Init(FMC_NORSRAM_TypeDef *Device, FMC_NORSRAM_TimingTypeDef *Timing, uint32_t Bank)
+{
+  uint32_t tmpr = 0;
+  
+  /* Check the parameters */
+  assert_param(IS_FMC_NORSRAM_DEVICE(Device));
+  assert_param(IS_FMC_ADDRESS_SETUP_TIME(Timing->AddressSetupTime));
+  assert_param(IS_FMC_ADDRESS_HOLD_TIME(Timing->AddressHoldTime));
+  assert_param(IS_FMC_DATASETUP_TIME(Timing->DataSetupTime));
+  assert_param(IS_FMC_TURNAROUND_TIME(Timing->BusTurnAroundDuration));
+  assert_param(IS_FMC_CLK_DIV(Timing->CLKDivision));
+  assert_param(IS_FMC_DATA_LATENCY(Timing->DataLatency));
+  assert_param(IS_FMC_ACCESS_MODE(Timing->AccessMode));
+  assert_param(IS_FMC_NORSRAM_BANK(Bank));
+  
+  /* Set FMC_NORSRAM device timing parameters */  
+  tmpr = (uint32_t)(Timing->AddressSetupTime                  |\
+                   ((Timing->AddressHoldTime) << 4)          |\
+                   ((Timing->DataSetupTime) << 8)            |\
+                   ((Timing->BusTurnAroundDuration) << 16)   |\
+                   (((Timing->CLKDivision)-1) << 20)         |\
+                   (((Timing->DataLatency)-2) << 24)         |\
+                    (Timing->AccessMode)
+                    );
+  
+  Device->BTCR[Bank + 1] = tmpr;
+  
+  /* Configure Clock division value (in NORSRAM bank 1) when continuous clock is enabled */
+  if(HAL_IS_BIT_SET(Device->BTCR[FMC_NORSRAM_BANK1], FMC_BCR1_CCLKEN))
+  {
+    tmpr = (uint32_t)(Device->BTCR[FMC_NORSRAM_BANK1 + 1] & ~(((uint32_t)0x0F) << 20)); 
+    tmpr |= (uint32_t)(((Timing->CLKDivision)-1) << 20);
+    Device->BTCR[FMC_NORSRAM_BANK1 + 1] = tmpr;
+  }  
+  
+  return HAL_OK;   
+}
+
+/**
+  * @brief  Initialize the FMC_NORSRAM Extended mode Timing according to the specified
+  *         parameters in the FMC_NORSRAM_TimingTypeDef
+  * @param  Device: Pointer to NORSRAM device instance
+  * @param  Timing: Pointer to NORSRAM Timing structure
+  * @param  Bank: NORSRAM bank number  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef  FMC_NORSRAM_Extended_Timing_Init(FMC_NORSRAM_EXTENDED_TypeDef *Device, FMC_NORSRAM_TimingTypeDef *Timing, uint32_t Bank, uint32_t ExtendedMode)
+{  
+  /* Check the parameters */
+  assert_param(IS_FMC_EXTENDED_MODE(ExtendedMode));
+  
+  /* Set NORSRAM device timing register for write configuration, if extended mode is used */
+  if(ExtendedMode == FMC_EXTENDED_MODE_ENABLE)
+  {
+    /* Check the parameters */  
+    assert_param(IS_FMC_NORSRAM_EXTENDED_DEVICE(Device));  
+    assert_param(IS_FMC_ADDRESS_SETUP_TIME(Timing->AddressSetupTime));
+    assert_param(IS_FMC_ADDRESS_HOLD_TIME(Timing->AddressHoldTime));
+    assert_param(IS_FMC_DATASETUP_TIME(Timing->DataSetupTime));
+    assert_param(IS_FMC_TURNAROUND_TIME(Timing->BusTurnAroundDuration));
+    assert_param(IS_FMC_CLK_DIV(Timing->CLKDivision));
+    assert_param(IS_FMC_DATA_LATENCY(Timing->DataLatency));
+    assert_param(IS_FMC_ACCESS_MODE(Timing->AccessMode));
+    assert_param(IS_FMC_NORSRAM_BANK(Bank));  
+    
+    Device->BWTR[Bank] = (uint32_t)(Timing->AddressSetupTime                 |\
+                                   ((Timing->AddressHoldTime) << 4)          |\
+                                   ((Timing->DataSetupTime) << 8)            |\
+                                   ((Timing->BusTurnAroundDuration) << 16)   |\
+                                   (((Timing->CLKDivision)-1) << 20)         |\
+                                   (((Timing->DataLatency)-2) << 24)         |\
+                                   (Timing->AccessMode));
+  }
+  else                                        
+  {
+    Device->BWTR[Bank] = 0x0FFFFFFF;
+  }   
+  
+  return HAL_OK;  
+}
+
+
+/**
+  * @}
+  */
+  
+  
+/** @defgroup FMC_NORSRAM_Exported_Functions_Group3 Peripheral Control functions 
+ *  @brief   management functions 
+ *
+@verbatim   
+  ==============================================================================
+                      ##### FMC_NORSRAM Control functions #####
+  ==============================================================================  
+  [..]
+    This subsection provides a set of functions allowing to control dynamically
+    the FMC NORSRAM interface.
+
+@endverbatim
+  * @{
+  */
+    
+/**
+  * @brief  Enables dynamically FMC_NORSRAM write operation.
+  * @param  Device: Pointer to NORSRAM device instance
+  * @param  Bank: NORSRAM bank number   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef FMC_NORSRAM_WriteOperation_Enable(FMC_NORSRAM_TypeDef *Device, uint32_t Bank)
+{
+  /* Check the parameters */
+  assert_param(IS_FMC_NORSRAM_DEVICE(Device));
+  assert_param(IS_FMC_NORSRAM_BANK(Bank));
+  
+  /* Enable write operation */
+  Device->BTCR[Bank] |= FMC_WRITE_OPERATION_ENABLE; 
+
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Disables dynamically FMC_NORSRAM write operation.
+  * @param  Device: Pointer to NORSRAM device instance
+  * @param  Bank: NORSRAM bank number   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef FMC_NORSRAM_WriteOperation_Disable(FMC_NORSRAM_TypeDef *Device, uint32_t Bank)
+{ 
+  /* Check the parameters */
+  assert_param(IS_FMC_NORSRAM_DEVICE(Device));
+  assert_param(IS_FMC_NORSRAM_BANK(Bank));
+    
+  /* Disable write operation */
+  Device->BTCR[Bank] &= ~FMC_WRITE_OPERATION_ENABLE; 
+
+  return HAL_OK;  
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+  
+/** @defgroup FMC_NAND Controller functions
+  * @brief    NAND Controller functions 
+  *
+  @verbatim 
+  ==============================================================================
+                    ##### How to use NAND device driver #####
+  ==============================================================================
+  [..]
+    This driver contains a set of APIs to interface with the FMC NAND banks in order
+    to run the NAND external devices.
+  
+    (+) FMC NAND bank reset using the function FMC_NAND_DeInit() 
+    (+) FMC NAND bank control configuration using the function FMC_NAND_Init()
+    (+) FMC NAND bank common space timing configuration using the function 
+        FMC_NAND_CommonSpace_Timing_Init()
+    (+) FMC NAND bank attribute space timing configuration using the function 
+        FMC_NAND_AttributeSpace_Timing_Init()
+    (+) FMC NAND bank enable/disable ECC correction feature using the functions
+        FMC_NAND_ECC_Enable()/FMC_NAND_ECC_Disable()
+    (+) FMC NAND bank get ECC correction code using the function FMC_NAND_GetECC()    
+
+@endverbatim
+  * @{
+  */
+    
+/** @defgroup FMC_NAND_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+  ==============================================================================
+              ##### Initialization and de_initialization functions #####
+  ==============================================================================
+  [..]  
+    This section provides functions allowing to:
+    (+) Initialize and configure the FMC NAND interface
+    (+) De-initialize the FMC NAND interface 
+    (+) Configure the FMC clock and associated GPIOs
+        
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Initializes the FMC_NAND device according to the specified
+  *         control parameters in the FMC_NAND_HandleTypeDef
+  * @param  Device: Pointer to NAND device instance
+  * @param  Init: Pointer to NAND Initialization structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef FMC_NAND_Init(FMC_NAND_TypeDef *Device, FMC_NAND_InitTypeDef *Init)
+{
+  uint32_t tmppcr  = 0; 
+    
+  /* Check the parameters */
+  assert_param(IS_FMC_NAND_DEVICE(Device));
+  assert_param(IS_FMC_NAND_BANK(Init->NandBank));
+  assert_param(IS_FMC_WAIT_FEATURE(Init->Waitfeature));
+  assert_param(IS_FMC_NAND_MEMORY_WIDTH(Init->MemoryDataWidth));
+  assert_param(IS_FMC_ECC_STATE(Init->EccComputation));
+  assert_param(IS_FMC_ECCPAGE_SIZE(Init->ECCPageSize));
+  assert_param(IS_FMC_TCLR_TIME(Init->TCLRSetupTime));
+  assert_param(IS_FMC_TAR_TIME(Init->TARSetupTime));   
+
+  /* Set NAND device control parameters */
+  tmppcr = (uint32_t)(Init->Waitfeature                |\
+                      FMC_PCR_MEMORY_TYPE_NAND         |\
+                      Init->MemoryDataWidth            |\
+                      Init->EccComputation             |\
+                      Init->ECCPageSize                |\
+                      ((Init->TCLRSetupTime) << 9)     |\
+                      ((Init->TARSetupTime) << 13)
+                      );   
+  
+  if(Init->NandBank == FMC_NAND_BANK2)
+  {
+    /* NAND bank 2 registers configuration */
+    Device->PCR2  = tmppcr;
+  }
+  else
+  {
+    /* NAND bank 3 registers configuration */
+    Device->PCR3  = tmppcr;
+  }
+  
+  return HAL_OK;
+
+}
+
+/**
+  * @brief  Initializes the FMC_NAND Common space Timing according to the specified
+  *         parameters in the FMC_NAND_PCC_TimingTypeDef
+  * @param  Device: Pointer to NAND device instance
+  * @param  Timing: Pointer to NAND timing structure
+  * @param  Bank: NAND bank number   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef FMC_NAND_CommonSpace_Timing_Init(FMC_NAND_TypeDef *Device, FMC_NAND_PCC_TimingTypeDef *Timing, uint32_t Bank)
+{
+  uint32_t tmppmem = 0;  
+  
+  /* Check the parameters */
+  assert_param(IS_FMC_NAND_DEVICE(Device));
+  assert_param(IS_FMC_SETUP_TIME(Timing->SetupTime));
+  assert_param(IS_FMC_WAIT_TIME(Timing->WaitSetupTime));
+  assert_param(IS_FMC_HOLD_TIME(Timing->HoldSetupTime));
+  assert_param(IS_FMC_HIZ_TIME(Timing->HiZSetupTime));
+  assert_param(IS_FMC_NAND_BANK(Bank));
+  
+  /* Set FMC_NAND device timing parameters */
+  tmppmem = (uint32_t)(Timing->SetupTime                  |\
+                       ((Timing->WaitSetupTime) << 8)     |\
+                       ((Timing->HoldSetupTime) << 16)    |\
+                       ((Timing->HiZSetupTime) << 24)
+                       );
+                            
+  if(Bank == FMC_NAND_BANK2)
+  {
+    /* NAND bank 2 registers configuration */
+    Device->PMEM2 = tmppmem;
+  }
+  else
+  {
+    /* NAND bank 3 registers configuration */
+    Device->PMEM3 = tmppmem;
+  }  
+  
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Initializes the FMC_NAND Attribute space Timing according to the specified
+  *         parameters in the FMC_NAND_PCC_TimingTypeDef
+  * @param  Device: Pointer to NAND device instance
+  * @param  Timing: Pointer to NAND timing structure
+  * @param  Bank: NAND bank number 
+  * @retval HAL status
+  */
+HAL_StatusTypeDef FMC_NAND_AttributeSpace_Timing_Init(FMC_NAND_TypeDef *Device, FMC_NAND_PCC_TimingTypeDef *Timing, uint32_t Bank)
+{
+  uint32_t tmppatt = 0;  
+  
+  /* Check the parameters */ 
+  assert_param(IS_FMC_NAND_DEVICE(Device)); 
+  assert_param(IS_FMC_SETUP_TIME(Timing->SetupTime));
+  assert_param(IS_FMC_WAIT_TIME(Timing->WaitSetupTime));
+  assert_param(IS_FMC_HOLD_TIME(Timing->HoldSetupTime));
+  assert_param(IS_FMC_HIZ_TIME(Timing->HiZSetupTime));
+  assert_param(IS_FMC_NAND_BANK(Bank));
+  
+  /* Set FMC_NAND device timing parameters */
+  tmppatt = (uint32_t)(Timing->SetupTime                  |\
+                       ((Timing->WaitSetupTime) << 8)     |\
+                       ((Timing->HoldSetupTime) << 16)    |\
+                       ((Timing->HiZSetupTime) << 24)
+                       );
+                       
+  if(Bank == FMC_NAND_BANK2)
+  {
+    /* NAND bank 2 registers configuration */
+    Device->PATT2 = tmppatt;
+  }
+  else
+  {
+    /* NAND bank 3 registers configuration */
+    Device->PATT3 = tmppatt;
+  }   
+  
+  return HAL_OK;
+}
+
+
+/**
+  * @brief  DeInitializes the FMC_NAND device 
+  * @param  Device: Pointer to NAND device instance
+  * @param  Bank: NAND bank number
+  * @retval HAL status
+  */
+HAL_StatusTypeDef FMC_NAND_DeInit(FMC_NAND_TypeDef *Device, uint32_t Bank)
+{
+  /* Check the parameters */ 
+  assert_param(IS_FMC_NAND_DEVICE(Device)); 
+  assert_param(IS_FMC_NAND_BANK(Bank));
+      
+  /* Disable the NAND Bank */
+  __FMC_NAND_DISABLE(Device, Bank);
+ 
+  /* De-initialize the NAND Bank */
+  if(Bank == FMC_NAND_BANK2)
+  {
+    /* Set the FMC_NAND_BANK2 registers to their reset values */
+    Device->PCR2  = 0x00000018;
+    Device->SR2   = 0x00000040;
+    Device->PMEM2 = 0xFCFCFCFC;
+    Device->PATT2 = 0xFCFCFCFC;  
+  }
+  /* FMC_Bank3_NAND */  
+  else
+  {
+    /* Set the FMC_NAND_BANK3 registers to their reset values */
+    Device->PCR3  = 0x00000018;
+    Device->SR3   = 0x00000040;
+    Device->PMEM3 = 0xFCFCFCFC;
+    Device->PATT3 = 0xFCFCFCFC; 
+  }
+  
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+  
+  
+/** @defgroup FMC_NAND_Exported_Functions_Group3 Peripheral Control functions 
+ *  @brief   management functions 
+ *
+@verbatim   
+  ==============================================================================
+                       ##### FMC_NAND Control functions #####
+  ==============================================================================  
+  [..]
+    This subsection provides a set of functions allowing to control dynamically
+    the FMC NAND interface.
+
+@endverbatim
+  * @{
+  */ 
+
+    
+/**
+  * @brief  Enables dynamically FMC_NAND ECC feature.
+  * @param  Device: Pointer to NAND device instance
+  * @param  Bank: NAND bank number
+  * @retval HAL status
+  */    
+HAL_StatusTypeDef FMC_NAND_ECC_Enable(FMC_NAND_TypeDef *Device, uint32_t Bank)
+{
+  /* Check the parameters */ 
+  assert_param(IS_FMC_NAND_DEVICE(Device)); 
+  assert_param(IS_FMC_NAND_BANK(Bank));
+    
+  /* Enable ECC feature */
+  if(Bank == FMC_NAND_BANK2)
+  {
+    Device->PCR2 |= FMC_PCR2_ECCEN;
+  }
+  else
+  {
+    Device->PCR3 |= FMC_PCR3_ECCEN;
+  } 
+  
+  return HAL_OK;  
+}
+
+
+/**
+  * @brief  Disables dynamically FMC_NAND ECC feature.
+  * @param  Device: Pointer to NAND device instance
+  * @param  Bank: NAND bank number
+  * @retval HAL status
+  */  
+HAL_StatusTypeDef FMC_NAND_ECC_Disable(FMC_NAND_TypeDef *Device, uint32_t Bank)  
+{  
+  /* Check the parameters */ 
+  assert_param(IS_FMC_NAND_DEVICE(Device)); 
+  assert_param(IS_FMC_NAND_BANK(Bank));
+    
+  /* Disable ECC feature */
+  if(Bank == FMC_NAND_BANK2)
+  {
+    Device->PCR2 &= ~FMC_PCR2_ECCEN;
+  }
+  else
+  {
+    Device->PCR3 &= ~FMC_PCR3_ECCEN;
+  } 
+
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Disables dynamically FMC_NAND ECC feature.
+  * @param  Device: Pointer to NAND device instance
+  * @param  ECCval: Pointer to ECC value
+  * @param  Bank: NAND bank number
+  * @param  Timeout: Timeout wait value  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef FMC_NAND_GetECC(FMC_NAND_TypeDef *Device, uint32_t *ECCval, uint32_t Bank, uint32_t Timeout)
+{
+  uint32_t timeout = 0;
+
+  /* Check the parameters */ 
+  assert_param(IS_FMC_NAND_DEVICE(Device)); 
+  assert_param(IS_FMC_NAND_BANK(Bank));
+      
+  timeout = HAL_GetTick() + Timeout;
+  
+  /* Wait untill FIFO is empty */
+  while(__FMC_NAND_GET_FLAG(Device, Bank, FMC_FLAG_FEMPT))
+  {
+    /* Check for the Timeout */
+    if(Timeout != HAL_MAX_DELAY)
+    {
+      if(HAL_GetTick() >= timeout)
+      {
+        return HAL_TIMEOUT;
+      }
+    }  
+  }
+     
+  if(Bank == FMC_NAND_BANK2)
+  {    
+    /* Get the ECCR2 register value */
+    *ECCval = (uint32_t)Device->ECCR2;
+  }
+  else
+  {    
+    /* Get the ECCR3 register value */
+    *ECCval = (uint32_t)Device->ECCR3;
+  }
+
+  return HAL_OK;  
+}
+
+/**
+  * @}
+  */
+  
+/**
+  * @}
+  */
+    
+/** @defgroup FMC_PCCARD Controller functions
+  * @brief    PCCARD Controller functions 
+  *
+  @verbatim 
+  ==============================================================================  
+                    ##### How to use PCCARD device driver #####
+  ==============================================================================
+  [..]
+    This driver contains a set of APIs to interface with the FMC PCCARD bank in order
+    to run the PCCARD/compact flash external devices.
+  
+    (+) FMC PCCARD bank reset using the function FMC_PCCARD_DeInit() 
+    (+) FMC PCCARD bank control configuration using the function FMC_PCCARD_Init()
+    (+) FMC PCCARD bank common space timing configuration using the function 
+        FMC_PCCARD_CommonSpace_Timing_Init()
+    (+) FMC PCCARD bank attribute space timing configuration using the function 
+        FMC_PCCARD_AttributeSpace_Timing_Init()
+    (+) FMC PCCARD bank IO space timing configuration using the function 
+        FMC_PCCARD_IOSpace_Timing_Init()
+
+       
+@endverbatim
+  * @{
+  */
+  
+/** @defgroup FMC_PCCARD_Exported_Functions_Group1 Initialization and de-initialization functions
+ *  @brief    Initialization and Configuration functions 
+ *
+@verbatim    
+  ==============================================================================
+              ##### Initialization and de_initialization functions #####
+  ==============================================================================
+  [..]  
+    This section provides functions allowing to:
+    (+) Initialize and configure the FMC PCCARD interface
+    (+) De-initialize the FMC PCCARD interface 
+    (+) Configure the FMC clock and associated GPIOs
+        
+@endverbatim
+  * @{
+  */
+  
+/**
+  * @brief  Initializes the FMC_PCCARD device according to the specified
+  *         control parameters in the FMC_PCCARD_HandleTypeDef
+  * @param  Device: Pointer to PCCARD device instance
+  * @param  Init: Pointer to PCCARD Initialization structure   
+  * @retval HAL status
+  */
+HAL_StatusTypeDef FMC_PCCARD_Init(FMC_PCCARD_TypeDef *Device, FMC_PCCARD_InitTypeDef *Init)
+{
+  /* Check the parameters */ 
+  assert_param(IS_FMC_PCCARD_DEVICE(Device));
+  assert_param(IS_FMC_WAIT_FEATURE(Init->Waitfeature));
+  assert_param(IS_FMC_TCLR_TIME(Init->TCLRSetupTime));
+  assert_param(IS_FMC_TAR_TIME(Init->TARSetupTime));     
+  
+  /* Set FMC_PCCARD device control parameters */
+  Device->PCR4 = (uint32_t)(Init->Waitfeature               |\
+                            FMC_NAND_PCC_MEM_BUS_WIDTH_16   |\
+                            (Init->TCLRSetupTime << 9)      |\
+                            (Init->TARSetupTime << 13));
+  
+  return HAL_OK;
+
+}
+
+/**
+  * @brief  Initializes the FMC_PCCARD Common space Timing according to the specified
+  *         parameters in the FMC_NAND_PCC_TimingTypeDef
+  * @param  Device: Pointer to PCCARD device instance
+  * @param  Timing: Pointer to PCCARD timing structure 
+  * @retval HAL status
+  */
+HAL_StatusTypeDef FMC_PCCARD_CommonSpace_Timing_Init(FMC_PCCARD_TypeDef *Device, FMC_NAND_PCC_TimingTypeDef *Timing)
+{
+  /* Check the parameters */
+  assert_param(IS_FMC_PCCARD_DEVICE(Device));
+  assert_param(IS_FMC_SETUP_TIME(Timing->SetupTime));
+  assert_param(IS_FMC_WAIT_TIME(Timing->WaitSetupTime));
+  assert_param(IS_FMC_HOLD_TIME(Timing->HoldSetupTime));
+  assert_param(IS_FMC_HIZ_TIME(Timing->HiZSetupTime));
+
+  /* Set PCCARD timing parameters */
+  Device->PMEM4 = (uint32_t)((Timing->SetupTime                 |\
+                             ((Timing->WaitSetupTime) << 8)     |\
+                              (Timing->HoldSetupTime) << 16)    |\
+                              ((Timing->HiZSetupTime) << 24)
+                             ); 
+
+  return HAL_OK;  
+}
+
+/**
+  * @brief  Initializes the FMC_PCCARD Attribute space Timing according to the specified
+  *         parameters in the FMC_NAND_PCC_TimingTypeDef
+  * @param  Device: Pointer to PCCARD device instance
+  * @param  Timing: Pointer to PCCARD timing structure  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef FMC_PCCARD_AttributeSpace_Timing_Init(FMC_PCCARD_TypeDef *Device, FMC_NAND_PCC_TimingTypeDef *Timing)
+{
+  /* Check the parameters */ 
+  assert_param(IS_FMC_PCCARD_DEVICE(Device)); 
+  assert_param(IS_FMC_SETUP_TIME(Timing->SetupTime));
+  assert_param(IS_FMC_WAIT_TIME(Timing->WaitSetupTime));
+  assert_param(IS_FMC_HOLD_TIME(Timing->HoldSetupTime));
+  assert_param(IS_FMC_HIZ_TIME(Timing->HiZSetupTime));
+
+  /* Set PCCARD timing parameters */
+  Device->PATT4 = (uint32_t)((Timing->SetupTime                 |\
+                             ((Timing->WaitSetupTime) << 8)     |\
+                              (Timing->HoldSetupTime) << 16)    |\
+                              ((Timing->HiZSetupTime) << 24)
+                             );  
+                                        
+  return HAL_OK;
+}
+
+/**
+  * @brief  Initializes the FMC_PCCARD IO space Timing according to the specified
+  *         parameters in the FMC_NAND_PCC_TimingTypeDef
+  * @param  Device: Pointer to PCCARD device instance
+  * @param  Timing: Pointer to PCCARD timing structure  
+  * @retval HAL status
+  */
+HAL_StatusTypeDef FMC_PCCARD_IOSpace_Timing_Init(FMC_PCCARD_TypeDef *Device, FMC_NAND_PCC_TimingTypeDef *Timing)
+{
+  /* Check the parameters */  
+  assert_param(IS_FMC_PCCARD_DEVICE(Device));
+  assert_param(IS_FMC_SETUP_TIME(Timing->SetupTime));
+  assert_param(IS_FMC_WAIT_TIME(Timing->WaitSetupTime));
+  assert_param(IS_FMC_HOLD_TIME(Timing->HoldSetupTime));
+  assert_param(IS_FMC_HIZ_TIME(Timing->HiZSetupTime));
+
+  /* Set FMC_PCCARD device timing parameters */
+  Device->PIO4 = (uint32_t)((Timing->SetupTime                  |\
+                             ((Timing->WaitSetupTime) << 8)     |\
+                              (Timing->HoldSetupTime) << 16)    |\
+                              ((Timing->HiZSetupTime) << 24)
+                             );   
+  
+  return HAL_OK;
+}
+                                           
+/**
+  * @brief  DeInitializes the FMC_PCCARD device 
+  * @param  Device: Pointer to PCCARD device instance
+  * @retval HAL status
+  */
+HAL_StatusTypeDef FMC_PCCARD_DeInit(FMC_PCCARD_TypeDef *Device)
+{
+  /* Check the parameters */  
+  assert_param(IS_FMC_PCCARD_DEVICE(Device));
+    
+  /* Disable the FMC_PCCARD device */
+  __FMC_PCCARD_DISABLE(Device);
+  
+  /* De-initialize the FMC_PCCARD device */
+  Device->PCR4    = 0x00000018; 
+  Device->SR4     = 0x00000000;	
+  Device->PMEM4   = 0xFCFCFCFC;
+  Device->PATT4   = 0xFCFCFCFC;
+  Device->PIO4    = 0xFCFCFCFC;
+  
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+
+#endif /* HAL_FMC_MODULE_ENABLED */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_ll_fmc.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/stm32f3xx_ll_fmc.h
@@ -1,0 +1,956 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx_ll_fmc.h
+  * @author  MCD Application Team
+  * @version V1.1.0
+  * @date    12-Sept-2014
+  * @brief   Header file of FMC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2014 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32F3xx_LL_FMC_H
+#define __STM32F3xx_LL_FMC_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if defined(STM32F302xE) || defined(STM32F303xE) || defined(STM32F398xx)
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f3xx_hal_def.h"
+
+/** @addtogroup STM32F3xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup FMC
+  * @{
+  */ 
+
+/* Exported typedef ----------------------------------------------------------*/ 
+#define FMC_NORSRAM_TypeDef            FMC_Bank1_TypeDef
+#define FMC_NORSRAM_EXTENDED_TypeDef   FMC_Bank1E_TypeDef
+#define FMC_NAND_TypeDef               FMC_Bank2_3_TypeDef
+#define FMC_PCCARD_TypeDef             FMC_Bank4_TypeDef
+
+#define FMC_NORSRAM_DEVICE             FMC_Bank1            
+#define FMC_NORSRAM_EXTENDED_DEVICE    FMC_Bank1E   
+#define FMC_NAND_DEVICE                FMC_Bank2_3             
+#define FMC_PCCARD_DEVICE              FMC_Bank4             
+
+/** 
+  * @brief  FMC_NORSRAM Configuration Structure definition  
+  */ 
+typedef struct
+{
+  uint32_t NSBank;                       /*!< Specifies the NORSRAM memory device that will be used.
+                                              This parameter can be a value of @ref FMC_NORSRAM_Bank                     */  
+                                                    
+  uint32_t DataAddressMux;               /*!< Specifies whether the address and data values are
+                                              multiplexed on the data bus or not. 
+                                              This parameter can be a value of @ref FMC_Data_Address_Bus_Multiplexing    */
+  
+  uint32_t MemoryType;                   /*!< Specifies the type of external memory attached to
+                                              the corresponding memory device.
+                                              This parameter can be a value of @ref FMC_Memory_Type                      */
+                                              
+  uint32_t MemoryDataWidth;              /*!< Specifies the external memory device width.
+                                              This parameter can be a value of @ref FMC_NORSRAM_Data_Width               */
+  
+  uint32_t BurstAccessMode;              /*!< Enables or disables the burst access mode for Flash memory,
+                                              valid only with synchronous burst Flash memories.
+                                              This parameter can be a value of @ref FMC_Burst_Access_Mode                */
+                                               
+  uint32_t WaitSignalPolarity;           /*!< Specifies the wait signal polarity, valid only when accessing
+                                              the Flash memory in burst mode.
+                                              This parameter can be a value of @ref FMC_Wait_Signal_Polarity             */
+  
+  uint32_t WrapMode;                     /*!< Enables or disables the Wrapped burst access mode for Flash
+                                              memory, valid only when accessing Flash memories in burst mode.
+                                              This parameter can be a value of @ref FMC_Wrap_Mode                        */
+  
+  uint32_t WaitSignalActive;             /*!< Specifies if the wait signal is asserted by the memory one
+                                              clock cycle before the wait state or during the wait state,
+                                              valid only when accessing memories in burst mode. 
+                                              This parameter can be a value of @ref FMC_Wait_Timing                      */
+  
+  uint32_t WriteOperation;               /*!< Enables or disables the write operation in the selected device by the FMC. 
+                                              This parameter can be a value of @ref FMC_Write_Operation                  */
+  
+  uint32_t WaitSignal;                   /*!< Enables or disables the wait state insertion via wait
+                                              signal, valid for Flash memory access in burst mode. 
+                                              This parameter can be a value of @ref FMC_Wait_Signal                      */
+  
+  uint32_t ExtendedMode;                 /*!< Enables or disables the extended mode.
+                                              This parameter can be a value of @ref FMC_Extended_Mode                    */
+  
+  uint32_t AsynchronousWait;             /*!< Enables or disables wait signal during asynchronous transfers,
+                                              valid only with asynchronous Flash memories.
+                                              This parameter can be a value of @ref FMC_AsynchronousWait                 */
+  
+  uint32_t WriteBurst;                   /*!< Enables or disables the write burst operation.
+                                              This parameter can be a value of @ref FMC_Write_Burst                      */ 
+
+  uint32_t ContinuousClock;              /*!< Enables or disables the FMC clock output to external memory devices.
+                                              This parameter is only enabled through the FMC_BCR1 register, and don't care 
+                                              through FMC_BCR2..4 registers.
+                                              This parameter can be a value of @ref FMC_Continous_Clock                  */
+
+}FMC_NORSRAM_InitTypeDef;
+
+/** 
+  * @brief  FMC_NORSRAM Timing parameters structure definition  
+  */
+typedef struct
+{
+  uint32_t AddressSetupTime;             /*!< Defines the number of HCLK cycles to configure
+                                              the duration of the address setup time. 
+                                              This parameter can be a value between Min_Data = 0 and Max_Data = 15.
+                                              @note This parameter is not used with synchronous NOR Flash memories.      */
+  
+  uint32_t AddressHoldTime;              /*!< Defines the number of HCLK cycles to configure
+                                              the duration of the address hold time.
+                                              This parameter can be a value between Min_Data = 1 and Max_Data = 15. 
+                                              @note This parameter is not used with synchronous NOR Flash memories.      */
+  
+  uint32_t DataSetupTime;                /*!< Defines the number of HCLK cycles to configure
+                                              the duration of the data setup time.
+                                              This parameter can be a value between Min_Data = 1 and Max_Data = 255.
+                                              @note This parameter is used for SRAMs, ROMs and asynchronous multiplexed 
+                                              NOR Flash memories.                                                        */
+  
+  uint32_t BusTurnAroundDuration;        /*!< Defines the number of HCLK cycles to configure
+                                              the duration of the bus turnaround.
+                                              This parameter can be a value between Min_Data = 0 and Max_Data = 15.
+                                              @note This parameter is only used for multiplexed NOR Flash memories.      */
+  
+  uint32_t CLKDivision;                  /*!< Defines the period of CLK clock output signal, expressed in number of 
+                                              HCLK cycles. This parameter can be a value between Min_Data = 2 and Max_Data = 16.
+                                              @note This parameter is not used for asynchronous NOR Flash, SRAM or ROM 
+                                              accesses.                                                                  */
+  
+  uint32_t DataLatency;                  /*!< Defines the number of memory clock cycles to issue
+                                              to the memory before getting the first data.
+                                              The parameter value depends on the memory type as shown below:
+                                              - It must be set to 0 in case of a CRAM
+                                              - It is don't care in asynchronous NOR, SRAM or ROM accesses
+                                              - It may assume a value between Min_Data = 2 and Max_Data = 17 in NOR Flash memories
+                                                with synchronous burst mode enable                                       */
+  
+  uint32_t AccessMode;                   /*!< Specifies the asynchronous access mode. 
+                                              This parameter can be a value of @ref FMC_Access_Mode                      */
+
+}FMC_NORSRAM_TimingTypeDef;
+
+/** 
+  * @brief  FMC_NAND Configuration Structure definition  
+  */ 
+typedef struct
+{
+  uint32_t NandBank;               /*!< Specifies the NAND memory device that will be used.
+                                        This parameter can be a value of @ref FMC_NAND_Bank                    */           
+  
+  uint32_t Waitfeature;            /*!< Enables or disables the Wait feature for the NAND Memory device.
+                                        This parameter can be any value of @ref FMC_Wait_feature               */
+  
+  uint32_t MemoryDataWidth;        /*!< Specifies the external memory device width.
+                                        This parameter can be any value of @ref FMC_NAND_Data_Width            */
+  
+  uint32_t EccComputation;         /*!< Enables or disables the ECC computation.
+                                        This parameter can be any value of @ref FMC_ECC                        */
+  
+  uint32_t ECCPageSize;            /*!< Defines the page size for the extended ECC.
+                                        This parameter can be any value of @ref FMC_ECC_Page_Size              */
+  
+  uint32_t TCLRSetupTime;          /*!< Defines the number of HCLK cycles to configure the
+                                        delay between CLE low and RE low.
+                                        This parameter can be a value between Min_Data = 0 and Max_Data = 255  */
+  
+  uint32_t TARSetupTime;           /*!< Defines the number of HCLK cycles to configure the
+                                        delay between ALE low and RE low.
+                                        This parameter can be a number between Min_Data = 0 and Max_Data = 255 */
+                                     
+}FMC_NAND_InitTypeDef;  
+
+/** 
+  * @brief  FMC_NAND_PCCARD Timing parameters structure definition
+  */
+typedef struct
+{
+  uint32_t SetupTime;            /*!< Defines the number of HCLK cycles to setup address before
+                                      the command assertion for NAND-Flash read or write access
+                                      to common/Attribute or I/O memory space (depending on
+                                      the memory space timing to be configured).
+                                      This parameter can be a value between Min_Data = 0 and Max_Data = 255    */
+  
+  uint32_t WaitSetupTime;        /*!< Defines the minimum number of HCLK cycles to assert the
+                                      command for NAND-Flash read or write access to
+                                      common/Attribute or I/O memory space (depending on the
+                                      memory space timing to be configured). 
+                                      This parameter can be a number between Min_Data = 0 and Max_Data = 255   */
+  
+  uint32_t HoldSetupTime;        /*!< Defines the number of HCLK clock cycles to hold address
+                                      (and data for write access) after the command de-assertion
+                                      for NAND-Flash read or write access to common/Attribute
+                                      or I/O memory space (depending on the memory space timing
+                                      to be configured).
+                                      This parameter can be a number between Min_Data = 0 and Max_Data = 255   */
+  
+  uint32_t HiZSetupTime;         /*!< Defines the number of HCLK clock cycles during which the
+                                      data bus is kept in HiZ after the start of a NAND-Flash
+                                      write access to common/Attribute or I/O memory space (depending
+                                      on the memory space timing to be configured).
+                                      This parameter can be a number between Min_Data = 0 and Max_Data = 255   */
+  
+}FMC_NAND_PCC_TimingTypeDef;
+
+/** 
+  * @brief  FMC_NAND Configuration Structure definition  
+  */ 
+typedef struct
+{
+  uint32_t Waitfeature;            /*!< Enables or disables the Wait feature for the PCCARD Memory device.
+                                        This parameter can be any value of @ref FMC_Wait_feature               */
+  
+  uint32_t TCLRSetupTime;          /*!< Defines the number of HCLK cycles to configure the
+                                        delay between CLE low and RE low.
+                                        This parameter can be a value between Min_Data = 0 and Max_Data = 255  */
+  
+  uint32_t TARSetupTime;           /*!< Defines the number of HCLK cycles to configure the
+                                        delay between ALE low and RE low.
+                                        This parameter can be a number between Min_Data = 0 and Max_Data = 255 */
+                                     
+}FMC_PCCARD_InitTypeDef;  
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup FMC_NOR_SRAM_Controller 
+  * @{
+  */ 
+  
+/** @defgroup FMC_NORSRAM_Bank 
+  * @{
+  */
+#define FMC_NORSRAM_BANK1                       ((uint32_t)0x00000000)
+#define FMC_NORSRAM_BANK2                       ((uint32_t)0x00000002)
+#define FMC_NORSRAM_BANK3                       ((uint32_t)0x00000004)
+#define FMC_NORSRAM_BANK4                       ((uint32_t)0x00000006)
+
+#define IS_FMC_NORSRAM_BANK(BANK) (((BANK) == FMC_NORSRAM_BANK1) || \
+                                   ((BANK) == FMC_NORSRAM_BANK2) || \
+                                   ((BANK) == FMC_NORSRAM_BANK3) || \
+                                   ((BANK) == FMC_NORSRAM_BANK4))
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Data_Address_Bus_Multiplexing 
+  * @{
+  */
+#define FMC_DATA_ADDRESS_MUX_DISABLE            ((uint32_t)0x00000000)
+#define FMC_DATA_ADDRESS_MUX_ENABLE             ((uint32_t)0x00000002)
+
+#define IS_FMC_MUX(MUX) (((MUX) == FMC_DATA_ADDRESS_MUX_DISABLE) || \
+                         ((MUX) == FMC_DATA_ADDRESS_MUX_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Memory_Type 
+  * @{
+  */
+#define FMC_MEMORY_TYPE_SRAM                    ((uint32_t)0x00000000)
+#define FMC_MEMORY_TYPE_PSRAM                   ((uint32_t)0x00000004)
+#define FMC_MEMORY_TYPE_NOR                     ((uint32_t)0x00000008)
+
+#define IS_FMC_MEMORY(MEMORY) (((MEMORY) == FMC_MEMORY_TYPE_SRAM) || \
+                               ((MEMORY) == FMC_MEMORY_TYPE_PSRAM)|| \
+                               ((MEMORY) == FMC_MEMORY_TYPE_NOR))
+/**
+  * @}
+  */
+
+/** @defgroup FMC_NORSRAM_Data_Width 
+  * @{
+  */
+#define FMC_NORSRAM_MEM_BUS_WIDTH_8             ((uint32_t)0x00000000)
+#define FMC_NORSRAM_MEM_BUS_WIDTH_16            ((uint32_t)0x00000010)
+#define FMC_NORSRAM_MEM_BUS_WIDTH_32            ((uint32_t)0x00000020)
+
+#define IS_FMC_NORSRAM_MEMORY_WIDTH(WIDTH) (((WIDTH) == FMC_NORSRAM_MEM_BUS_WIDTH_8)  || \
+                                            ((WIDTH) == FMC_NORSRAM_MEM_BUS_WIDTH_16) || \
+                                            ((WIDTH) == FMC_NORSRAM_MEM_BUS_WIDTH_32))
+/**
+  * @}
+  */
+
+/** @defgroup FMC_NORSRAM_Flash_Access 
+  * @{
+  */
+#define FMC_NORSRAM_FLASH_ACCESS_ENABLE         ((uint32_t)0x00000040)
+#define FMC_NORSRAM_FLASH_ACCESS_DISABLE        ((uint32_t)0x00000000)
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Burst_Access_Mode 
+  * @{
+  */
+#define FMC_BURST_ACCESS_MODE_DISABLE           ((uint32_t)0x00000000) 
+#define FMC_BURST_ACCESS_MODE_ENABLE            ((uint32_t)0x00000100)
+
+#define IS_FMC_BURSTMODE(STATE) (((STATE) == FMC_BURST_ACCESS_MODE_DISABLE) || \
+                                 ((STATE) == FMC_BURST_ACCESS_MODE_ENABLE))
+/**
+  * @}
+  */
+    
+
+/** @defgroup FMC_Wait_Signal_Polarity 
+  * @{
+  */
+#define FMC_WAIT_SIGNAL_POLARITY_LOW            ((uint32_t)0x00000000)
+#define FMC_WAIT_SIGNAL_POLARITY_HIGH           ((uint32_t)0x00000200)
+
+#define IS_FMC_WAIT_POLARITY(POLARITY) (((POLARITY) == FMC_WAIT_SIGNAL_POLARITY_LOW) || \
+                                        ((POLARITY) == FMC_WAIT_SIGNAL_POLARITY_HIGH))
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Wrap_Mode 
+  * @{
+  */
+#define FMC_WRAP_MODE_DISABLE                   ((uint32_t)0x00000000)
+#define FMC_WRAP_MODE_ENABLE                    ((uint32_t)0x00000400)
+
+#define IS_FMC_WRAP_MODE(MODE) (((MODE) == FMC_WRAP_MODE_DISABLE) || \
+                                ((MODE) == FMC_WRAP_MODE_ENABLE)) 
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Wait_Timing 
+  * @{
+  */
+#define FMC_WAIT_TIMING_BEFORE_WS               ((uint32_t)0x00000000)
+#define FMC_WAIT_TIMING_DURING_WS               ((uint32_t)0x00000800)
+
+#define IS_FMC_WAIT_SIGNAL_ACTIVE(ACTIVE) (((ACTIVE) == FMC_WAIT_TIMING_BEFORE_WS) || \
+                                           ((ACTIVE) == FMC_WAIT_TIMING_DURING_WS)) 
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Write_Operation 
+  * @{
+  */
+#define FMC_WRITE_OPERATION_DISABLE             ((uint32_t)0x00000000)
+#define FMC_WRITE_OPERATION_ENABLE              ((uint32_t)0x00001000)
+
+#define IS_FMC_WRITE_OPERATION(OPERATION) (((OPERATION) == FMC_WRITE_OPERATION_DISABLE) || \
+                                           ((OPERATION) == FMC_WRITE_OPERATION_ENABLE))                       
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Wait_Signal 
+  * @{
+  */
+#define FMC_WAIT_SIGNAL_DISABLE                 ((uint32_t)0x00000000)
+#define FMC_WAIT_SIGNAL_ENABLE                  ((uint32_t)0x00002000)
+
+#define IS_FMC_WAITE_SIGNAL(SIGNAL) (((SIGNAL) == FMC_WAIT_SIGNAL_DISABLE) || \
+                                     ((SIGNAL) == FMC_WAIT_SIGNAL_ENABLE)) 
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Extended_Mode 
+  * @{
+  */
+#define FMC_EXTENDED_MODE_DISABLE               ((uint32_t)0x00000000)
+#define FMC_EXTENDED_MODE_ENABLE                ((uint32_t)0x00004000)
+
+#define IS_FMC_EXTENDED_MODE(MODE) (((MODE) == FMC_EXTENDED_MODE_DISABLE) || \
+                                    ((MODE) == FMC_EXTENDED_MODE_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup FMC_AsynchronousWait 
+  * @{
+  */
+#define FMC_ASYNCHRONOUS_WAIT_DISABLE           ((uint32_t)0x00000000)
+#define FMC_ASYNCHRONOUS_WAIT_ENABLE            ((uint32_t)0x00008000)
+
+#define IS_FMC_ASYNWAIT(STATE) (((STATE) == FMC_ASYNCHRONOUS_WAIT_DISABLE) || \
+                                ((STATE) == FMC_ASYNCHRONOUS_WAIT_ENABLE))
+/**
+  * @}
+  */  
+
+/** @defgroup FMC_Write_Burst 
+  * @{
+  */
+#define FMC_WRITE_BURST_DISABLE                 ((uint32_t)0x00000000)
+#define FMC_WRITE_BURST_ENABLE                  ((uint32_t)0x00080000)
+
+#define IS_FMC_WRITE_BURST(BURST) (((BURST) == FMC_WRITE_BURST_DISABLE) || \
+                                   ((BURST) == FMC_WRITE_BURST_ENABLE)) 
+/**
+  * @}
+  */
+  
+/** @defgroup FMC_Continous_Clock 
+  * @{
+  */
+#define FMC_CONTINUOUS_CLOCK_SYNC_ONLY          ((uint32_t)0x00000000)
+#define FMC_CONTINUOUS_CLOCK_SYNC_ASYNC         ((uint32_t)0x00100000)
+
+#define IS_FMC_CONTINOUS_CLOCK(CCLOCK) (((CCLOCK) == FMC_CONTINUOUS_CLOCK_SYNC_ONLY) || \
+                                        ((CCLOCK) == FMC_CONTINUOUS_CLOCK_SYNC_ASYNC)) 
+/**
+  * @}
+  */
+  
+/** @defgroup FMC_Address_Setup_Time 
+  * @{
+  */
+#define IS_FMC_ADDRESS_SETUP_TIME(TIME) ((TIME) <= 15)
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Address_Hold_Time 
+  * @{
+  */
+#define IS_FMC_ADDRESS_HOLD_TIME(TIME) (((TIME) > 0) && ((TIME) <= 15))
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Data_Setup_Time 
+  * @{
+  */
+#define IS_FMC_DATASETUP_TIME(TIME) (((TIME) > 0) && ((TIME) <= 255))
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Bus_Turn_around_Duration 
+  * @{
+  */
+#define IS_FMC_TURNAROUND_TIME(TIME) ((TIME) <= 15)
+/**
+  * @}
+  */
+
+/** @defgroup FMC_CLK_Division 
+  * @{
+  */
+#define IS_FMC_CLK_DIV(DIV) (((DIV) > 1) && ((DIV) <= 16))
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Data_Latency 
+  * @{
+  */
+#define IS_FMC_DATA_LATENCY(LATENCY) (((LATENCY) > 1) && ((LATENCY) <= 17))
+/**
+  * @}
+  */  
+
+/** @defgroup FMC_Access_Mode 
+  * @{
+  */
+#define FMC_ACCESS_MODE_A                        ((uint32_t)0x00000000)
+#define FMC_ACCESS_MODE_B                        ((uint32_t)0x10000000) 
+#define FMC_ACCESS_MODE_C                        ((uint32_t)0x20000000)
+#define FMC_ACCESS_MODE_D                        ((uint32_t)0x30000000)
+
+#define IS_FMC_ACCESS_MODE(MODE) (((MODE) == FMC_ACCESS_MODE_A) || \
+                                  ((MODE) == FMC_ACCESS_MODE_B) || \
+                                  ((MODE) == FMC_ACCESS_MODE_C) || \
+                                  ((MODE) == FMC_ACCESS_MODE_D))
+/**
+  * @}
+  */
+    
+/**
+  * @}
+  */  
+
+/** @defgroup FMC_NAND_Controller 
+  * @{
+  */
+
+/** @defgroup FMC_NAND_Bank 
+  * @{
+  */  
+#define FMC_NAND_BANK2                          ((uint32_t)0x00000010)
+#define FMC_NAND_BANK3                          ((uint32_t)0x00000100)
+
+#define IS_FMC_NAND_BANK(BANK) (((BANK) == FMC_NAND_BANK2) || \
+                                ((BANK) == FMC_NAND_BANK3))  
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Wait_feature 
+  * @{
+  */
+#define FMC_NAND_PCC_WAIT_FEATURE_DISABLE           ((uint32_t)0x00000000)
+#define FMC_NAND_PCC_WAIT_FEATURE_ENABLE            ((uint32_t)0x00000002)
+
+#define IS_FMC_WAIT_FEATURE(FEATURE) (((FEATURE) == FMC_NAND_PCC_WAIT_FEATURE_DISABLE) || \
+                                      ((FEATURE) == FMC_NAND_PCC_WAIT_FEATURE_ENABLE))                                              
+/**
+  * @}
+  */
+
+/** @defgroup FMC_PCR_Memory_Type 
+  * @{
+  */
+#define FMC_PCR_MEMORY_TYPE_PCCARD        ((uint32_t)0x00000000)
+#define FMC_PCR_MEMORY_TYPE_NAND          ((uint32_t)0x00000008)
+/**
+  * @}
+  */
+
+/** @defgroup FMC_NAND_Data_Width 
+  * @{
+  */
+#define FMC_NAND_PCC_MEM_BUS_WIDTH_8                ((uint32_t)0x00000000)
+#define FMC_NAND_PCC_MEM_BUS_WIDTH_16               ((uint32_t)0x00000010)
+
+#define IS_FMC_NAND_MEMORY_WIDTH(WIDTH) (((WIDTH) == FMC_NAND_PCC_MEM_BUS_WIDTH_8) || \
+                                         ((WIDTH) == FMC_NAND_PCC_MEM_BUS_WIDTH_16))
+/**
+  * @}
+  */
+
+/** @defgroup FMC_ECC 
+  * @{
+  */
+#define FMC_NAND_ECC_DISABLE                    ((uint32_t)0x00000000)
+#define FMC_NAND_ECC_ENABLE                     ((uint32_t)0x00000040)
+
+#define IS_FMC_ECC_STATE(STATE) (((STATE) == FMC_NAND_ECC_DISABLE) || \
+                                 ((STATE) == FMC_NAND_ECC_ENABLE))
+/**
+  * @}
+  */
+
+/** @defgroup FMC_ECC_Page_Size 
+  * @{
+  */
+#define FMC_NAND_ECC_PAGE_SIZE_256BYTE          ((uint32_t)0x00000000)
+#define FMC_NAND_ECC_PAGE_SIZE_512BYTE          ((uint32_t)0x00020000)
+#define FMC_NAND_ECC_PAGE_SIZE_1024BYTE         ((uint32_t)0x00040000)
+#define FMC_NAND_ECC_PAGE_SIZE_2048BYTE         ((uint32_t)0x00060000)
+#define FMC_NAND_ECC_PAGE_SIZE_4096BYTE         ((uint32_t)0x00080000)
+#define FMC_NAND_ECC_PAGE_SIZE_8192BYTE         ((uint32_t)0x000A0000)
+
+#define IS_FMC_ECCPAGE_SIZE(SIZE) (((SIZE) == FMC_NAND_ECC_PAGE_SIZE_256BYTE)  || \
+                                   ((SIZE) == FMC_NAND_ECC_PAGE_SIZE_512BYTE)  || \
+                                   ((SIZE) == FMC_NAND_ECC_PAGE_SIZE_1024BYTE) || \
+                                   ((SIZE) == FMC_NAND_ECC_PAGE_SIZE_2048BYTE) || \
+                                   ((SIZE) == FMC_NAND_ECC_PAGE_SIZE_4096BYTE) || \
+                                   ((SIZE) == FMC_NAND_ECC_PAGE_SIZE_8192BYTE))
+/**
+  * @}
+  */
+
+/** @defgroup FMC_TCLR_Setup_Time 
+  * @{
+  */
+#define IS_FMC_TCLR_TIME(TIME) ((TIME) <= 255)
+/**
+  * @}
+  */
+
+/** @defgroup FMC_TAR_Setup_Time 
+  * @{
+  */
+#define IS_FMC_TAR_TIME(TIME) ((TIME) <= 255)
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Setup_Time 
+  * @{
+  */
+#define IS_FMC_SETUP_TIME(TIME) ((TIME) <= 255)
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Wait_Setup_Time 
+  * @{
+  */
+#define IS_FMC_WAIT_TIME(TIME) ((TIME) <= 255)
+/**
+  * @}
+  */
+
+/** @defgroup FMC_Hold_Setup_Time 
+  * @{
+  */
+#define IS_FMC_HOLD_TIME(TIME) ((TIME) <= 255)
+/**
+  * @}
+  */
+
+/** @defgroup FMC_HiZ_Setup_Time 
+  * @{
+  */
+#define IS_FMC_HIZ_TIME(TIME) ((TIME) <= 255)
+/**
+  * @}
+  */  
+    
+/**
+  * @}
+  */  
+
+/** @defgroup FMC_NORSRAM_Device_Instance
+  * @{
+  */
+#define IS_FMC_NORSRAM_DEVICE(INSTANCE) ((INSTANCE) == FMC_NORSRAM_DEVICE)
+/**
+  * @}
+  */
+
+/** @defgroup FMC_NORSRAM_EXTENDED_Device_Instance
+  * @{
+  */
+#define IS_FMC_NORSRAM_EXTENDED_DEVICE(INSTANCE) ((INSTANCE) == FMC_NORSRAM_EXTENDED_DEVICE)
+/**
+  * @}
+  */
+  
+/** @defgroup FMC_NAND_Device_Instance
+  * @{
+  */
+#define IS_FMC_NAND_DEVICE(INSTANCE) ((INSTANCE) == FMC_NAND_DEVICE)
+/**
+  * @}
+  */  
+
+/** @defgroup FMC_PCCARD_Device_Instance
+  * @{
+  */
+#define IS_FMC_PCCARD_DEVICE(INSTANCE) ((INSTANCE) == FMC_PCCARD_DEVICE)
+
+/**
+  * @}
+  */ 
+
+/** @defgroup FMC_Interrupt_definition 
+  * @brief FMC Interrupt definition
+  * @{
+  */  
+#define FMC_IT_RISING_EDGE                ((uint32_t)0x00000008)
+#define FMC_IT_LEVEL                      ((uint32_t)0x00000010)
+#define FMC_IT_FALLING_EDGE               ((uint32_t)0x00000020)
+#define FMC_IT_REFRESH_ERROR              ((uint32_t)0x00004000)
+
+#define IS_FMC_IT(IT) ((((IT) & (uint32_t)0xFFFFBFC7) == 0x00000000) && ((IT) != 0x00000000))
+
+#define IS_FMC_GET_IT(IT) (((IT) == FMC_IT_RISING_EDGE)   || \
+                           ((IT) == FMC_IT_LEVEL)         || \
+                           ((IT) == FMC_IT_FALLING_EDGE)  || \
+                           ((IT) == FMC_IT_REFRESH_ERROR)) 
+/**
+  * @}
+  */
+    
+/** @defgroup FMC_Flag_definition 
+  * @brief FMC Flag definition
+  * @{
+  */ 
+#define FMC_FLAG_RISING_EDGE                    ((uint32_t)0x00000001)
+#define FMC_FLAG_LEVEL                          ((uint32_t)0x00000002)
+#define FMC_FLAG_FALLING_EDGE                   ((uint32_t)0x00000004)
+#define FMC_FLAG_FEMPT                          ((uint32_t)0x00000040)
+
+#define IS_FMC_GET_FLAG(FLAG) (((FLAG) == FMC_FLAG_RISING_EDGE)      || \
+                               ((FLAG) == FMC_FLAG_LEVEL)            || \
+                               ((FLAG) == FMC_FLAG_FALLING_EDGE)     || \
+                               ((FLAG) == FMC_FLAG_FEMPT))
+
+#define IS_FMC_CLEAR_FLAG(FLAG) ((((FLAG) & (uint32_t)0xFFFFFFF8) == 0x00000000) && ((FLAG) != 0x00000000))                               
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup FMC_NOR_Macros
+ *  @brief macros to handle NOR device enable/disable and read/write operations
+ *  @{
+ */
+ 
+/**
+  * @brief  Enable the NORSRAM device access.
+  * @param  __INSTANCE__: FMC_NORSRAM Instance
+  * @param  __BANK__: FMC_NORSRAM Bank     
+  * @retval None
+  */ 
+#define __FMC_NORSRAM_ENABLE(__INSTANCE__, __BANK__)  ((__INSTANCE__)->BTCR[(__BANK__)] |= FMC_BCR1_MBKEN)
+
+/**
+  * @brief  Disable the NORSRAM device access.
+  * @param  __INSTANCE__: FMC_NORSRAM Instance
+  * @param  __BANK__: FMC_NORSRAM Bank   
+  * @retval None
+  */ 
+#define __FMC_NORSRAM_DISABLE(__INSTANCE__, __BANK__) ((__INSTANCE__)->BTCR[(__BANK__)] &= ~FMC_BCR1_MBKEN)  
+
+/**
+  * @}
+  */ 
+
+/** @defgroup FMC_NAND_Macros
+ *  @brief macros to handle NAND device enable/disable
+ *  @{
+ */
+ 
+/**
+  * @brief  Enable the NAND device access.
+  * @param  __INSTANCE__: FMC_NAND Instance
+  * @param  __BANK__: FMC_NAND Bank    
+  * @retval None
+  */  
+#define __FMC_NAND_ENABLE(__INSTANCE__, __BANK__)  (((__BANK__) == FMC_NAND_BANK2)? ((__INSTANCE__)->PCR2 |= FMC_PCR2_PBKEN): \
+                                                    ((__INSTANCE__)->PCR3 |= FMC_PCR3_PBKEN))                                        
+
+/**
+  * @brief  Disable the NAND device access.
+  * @param  __INSTANCE__: FMC_NAND Instance
+  * @param  __BANK__: FMC_NAND Bank  
+  * @retval None
+  */                                          
+#define __FMC_NAND_DISABLE(__INSTANCE__, __BANK__) (((__BANK__) == FMC_NAND_BANK2)? ((__INSTANCE__)->PCR2 &= ~FMC_PCR2_PBKEN): \
+                                                   ((__INSTANCE__)->PCR3 &= ~FMC_PCR3_PBKEN))                                                                                
+/**
+  * @}
+  */ 
+  
+/** @defgroup FMC_PCCARD_Macros
+ *  @brief macros to handle SRAM read/write operations 
+ *  @{
+ */
+
+/**
+  * @brief  Enable the PCCARD device access.
+  * @param  __INSTANCE__: FMC_PCCARD Instance  
+  * @retval None
+  */ 
+#define __FMC_PCCARD_ENABLE(__INSTANCE__)  ((__INSTANCE__)->PCR4 |= FMC_PCR4_PBKEN)
+
+/**
+  * @brief  Disable the PCCARD device access.
+  * @param  __INSTANCE__: FMC_PCCARD Instance     
+  * @retval None
+  */ 
+#define __FMC_PCCARD_DISABLE(__INSTANCE__) ((__INSTANCE__)->PCR4 &= ~FMC_PCR4_PBKEN)
+/**
+  * @}
+  */
+  
+/** @defgroup FMC_Interrupt
+ *  @brief macros to handle FMC interrupts
+ * @{
+ */ 
+
+/**
+  * @brief  Enable the NAND device interrupt.
+  * @param  __INSTANCE__:  FMC_NAND Instance
+  * @param  __BANK__:      FMC_NAND Bank     
+  * @param  __INTERRUPT__: FMC_NAND interrupt 
+  *         This parameter can be any combination of the following values:
+  *            @arg FMC_IT_RISING_EDGE: Interrupt rising edge.
+  *            @arg FMC_IT_LEVEL: Interrupt level.
+  *            @arg FMC_IT_FALLING_EDGE: Interrupt falling edge.       
+  * @retval None
+  */  
+#define __FMC_NAND_ENABLE_IT(__INSTANCE__, __BANK__, __INTERRUPT__)  (((__BANK__) == FMC_NAND_BANK2)? ((__INSTANCE__)->SR2 |= (__INTERRUPT__)): \
+                                                                                                      ((__INSTANCE__)->SR3 |= (__INTERRUPT__)))
+
+/**
+  * @brief  Disable the NAND device interrupt.
+  * @param  __INSTANCE__:  FMC_NAND Instance
+  * @param  __BANK__:      FMC_NAND Bank    
+  * @param  __INTERRUPT__: FMC_NAND interrupt
+  *         This parameter can be any combination of the following values:
+  *            @arg FMC_IT_RISING_EDGE: Interrupt rising edge.
+  *            @arg FMC_IT_LEVEL: Interrupt level.
+  *            @arg FMC_IT_FALLING_EDGE: Interrupt falling edge.   
+  * @retval None
+  */
+#define __FMC_NAND_DISABLE_IT(__INSTANCE__, __BANK__, __INTERRUPT__)  (((__BANK__) == FMC_NAND_BANK2)? ((__INSTANCE__)->SR2 &= ~(__INTERRUPT__)): \
+                                                                                                      ((__INSTANCE__)->SR3 &= ~(__INTERRUPT__))) 
+                                                                                                                             
+/**
+  * @brief  Get flag status of the NAND device.
+  * @param  __INSTANCE__: FMC_NAND Instance
+  * @param  __BANK__:     FMC_NAND Bank      
+  * @param  __FLAG__: FMC_NAND flag
+  *         This parameter can be any combination of the following values:
+  *            @arg FMC_FLAG_RISING_EDGE: Interrupt rising edge flag.
+  *            @arg FMC_FLAG_LEVEL: Interrupt level edge flag.
+  *            @arg FMC_FLAG_FALLING_EDGE: Interrupt falling edge flag.
+  *            @arg FMC_FLAG_FEMPT: FIFO empty flag.   
+  * @retval The state of FLAG (SET or RESET).
+  */
+#define __FMC_NAND_GET_FLAG(__INSTANCE__, __BANK__, __FLAG__)  (((__BANK__) == FMC_NAND_BANK2)? (((__INSTANCE__)->SR2 &(__FLAG__)) == (__FLAG__)): \
+                                                                                                (((__INSTANCE__)->SR3 &(__FLAG__)) == (__FLAG__)))
+/**
+  * @brief  Clear flag status of the NAND device.
+  * @param  __INSTANCE__: FMC_NAND Instance  
+  * @param  __BANK__:     FMC_NAND Bank  
+  * @param  __FLAG__: FMC_NAND flag
+  *         This parameter can be any combination of the following values:
+  *            @arg FMC_FLAG_RISING_EDGE: Interrupt rising edge flag.
+  *            @arg FMC_FLAG_LEVEL: Interrupt level edge flag.
+  *            @arg FMC_FLAG_FALLING_EDGE: Interrupt falling edge flag.
+  *            @arg FMC_FLAG_FEMPT: FIFO empty flag.   
+  * @retval None
+  */
+#define __FMC_NAND_CLEAR_FLAG(__INSTANCE__, __BANK__, __FLAG__)  (((__BANK__) == FMC_NAND_BANK2)? ((__INSTANCE__)->SR2 &= ~(__FLAG__)): \
+                                                                                                  ((__INSTANCE__)->SR3 &= ~(__FLAG__))) 
+/**
+  * @brief  Enable the PCCARD device interrupt.
+  * @param  __INSTANCE__: FMC_PCCARD Instance  
+  * @param  __INTERRUPT__: FMC_PCCARD interrupt 
+  *         This parameter can be any combination of the following values:
+  *            @arg FMC_IT_RISING_EDGE: Interrupt rising edge.
+  *            @arg FMC_IT_LEVEL: Interrupt level.
+  *            @arg FMC_IT_FALLING_EDGE: Interrupt falling edge.       
+  * @retval None
+  */ 
+#define __FMC_PCCARD_ENABLE_IT(__INSTANCE__, __INTERRUPT__)  ((__INSTANCE__)->SR4 |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the PCCARD device interrupt.
+  * @param  __INSTANCE__: FMC_PCCARD Instance  
+  * @param  __INTERRUPT__: FMC_PCCARD interrupt 
+  *         This parameter can be any combination of the following values:
+  *            @arg FMC_IT_RISING_EDGE: Interrupt rising edge.
+  *            @arg FMC_IT_LEVEL: Interrupt level.
+  *            @arg FMC_IT_FALLING_EDGE: Interrupt falling edge.       
+  * @retval None
+  */ 
+#define __FMC_PCCARD_DISABLE_IT(__INSTANCE__, __INTERRUPT__)  ((__INSTANCE__)->SR4 &= ~(__INTERRUPT__)) 
+
+/**
+  * @brief  Get flag status of the PCCARD device.
+  * @param  __INSTANCE__: FMC_PCCARD Instance  
+  * @param  __FLAG__: FMC_PCCARD flag
+  *         This parameter can be any combination of the following values:
+  *            @arg  FMC_FLAG_RISING_EDGE: Interrupt rising edge flag.
+  *            @arg  FMC_FLAG_LEVEL: Interrupt level edge flag.
+  *            @arg  FMC_FLAG_FALLING_EDGE: Interrupt falling edge flag.
+  *            @arg  FMC_FLAG_FEMPT: FIFO empty flag.   
+  * @retval The state of FLAG (SET or RESET).
+  */
+#define __FMC_PCCARD_GET_FLAG(__INSTANCE__, __FLAG__)  (((__INSTANCE__)->SR4 &(__FLAG__)) == (__FLAG__))
+
+/**
+  * @brief  Clear flag status of the PCCARD device.
+  * @param  __INSTANCE__: FMC_PCCARD Instance  
+  * @param  __FLAG__: FMC_PCCARD flag
+  *         This parameter can be any combination of the following values:
+  *            @arg  FMC_FLAG_RISING_EDGE: Interrupt rising edge flag.
+  *            @arg  FMC_FLAG_LEVEL: Interrupt level edge flag.
+  *            @arg  FMC_FLAG_FALLING_EDGE: Interrupt falling edge flag.
+  *            @arg  FMC_FLAG_FEMPT: FIFO empty flag.   
+  * @retval None
+  */
+#define __FMC_PCCARD_CLEAR_FLAG(__INSTANCE__, __FLAG__)  ((__INSTANCE__)->SR4 &= ~(__FLAG__))
+ 
+/**
+  * @}
+  */ 
+
+/* Exported functions --------------------------------------------------------*/
+
+/* FMC_NORSRAM Controller functions *******************************************/
+/* Initialization/de-initialization functions */
+HAL_StatusTypeDef  FMC_NORSRAM_Init(FMC_NORSRAM_TypeDef *Device, FMC_NORSRAM_InitTypeDef *Init);
+HAL_StatusTypeDef  FMC_NORSRAM_Timing_Init(FMC_NORSRAM_TypeDef *Device, FMC_NORSRAM_TimingTypeDef *Timing, uint32_t Bank);
+HAL_StatusTypeDef  FMC_NORSRAM_Extended_Timing_Init(FMC_NORSRAM_EXTENDED_TypeDef *Device, FMC_NORSRAM_TimingTypeDef *Timing, uint32_t Bank, uint32_t ExtendedMode);
+HAL_StatusTypeDef  FMC_NORSRAM_DeInit(FMC_NORSRAM_TypeDef *Device, FMC_NORSRAM_EXTENDED_TypeDef *ExDevice, uint32_t Bank);
+
+/* FMC_NORSRAM Control functions */
+HAL_StatusTypeDef  FMC_NORSRAM_WriteOperation_Enable(FMC_NORSRAM_TypeDef *Device, uint32_t Bank);
+HAL_StatusTypeDef  FMC_NORSRAM_WriteOperation_Disable(FMC_NORSRAM_TypeDef *Device, uint32_t Bank);
+
+/* FMC_NAND Controller functions **********************************************/
+/* Initialization/de-initialization functions */
+HAL_StatusTypeDef  FMC_NAND_Init(FMC_NAND_TypeDef *Device, FMC_NAND_InitTypeDef *Init);
+HAL_StatusTypeDef  FMC_NAND_CommonSpace_Timing_Init(FMC_NAND_TypeDef *Device, FMC_NAND_PCC_TimingTypeDef *Timing, uint32_t Bank);
+HAL_StatusTypeDef  FMC_NAND_AttributeSpace_Timing_Init(FMC_NAND_TypeDef *Device, FMC_NAND_PCC_TimingTypeDef *Timing, uint32_t Bank);
+HAL_StatusTypeDef  FMC_NAND_DeInit(FMC_NAND_TypeDef *Device, uint32_t Bank);
+
+/* FMC_NAND Control functions */
+HAL_StatusTypeDef  FMC_NAND_ECC_Enable(FMC_NAND_TypeDef *Device, uint32_t Bank);
+HAL_StatusTypeDef  FMC_NAND_ECC_Disable(FMC_NAND_TypeDef *Device, uint32_t Bank);
+HAL_StatusTypeDef  FMC_NAND_GetECC(FMC_NAND_TypeDef *Device, uint32_t *ECCval, uint32_t Bank, uint32_t Timeout);
+
+/* FMC_PCCARD Controller functions ********************************************/
+/* Initialization/de-initialization functions */
+HAL_StatusTypeDef  FMC_PCCARD_Init(FMC_PCCARD_TypeDef *Device, FMC_PCCARD_InitTypeDef *Init);
+HAL_StatusTypeDef  FMC_PCCARD_CommonSpace_Timing_Init(FMC_PCCARD_TypeDef *Device, FMC_NAND_PCC_TimingTypeDef *Timing);
+HAL_StatusTypeDef  FMC_PCCARD_AttributeSpace_Timing_Init(FMC_PCCARD_TypeDef *Device, FMC_NAND_PCC_TimingTypeDef *Timing);
+HAL_StatusTypeDef  FMC_PCCARD_IOSpace_Timing_Init(FMC_PCCARD_TypeDef *Device, FMC_NAND_PCC_TimingTypeDef *Timing); 
+HAL_StatusTypeDef  FMC_PCCARD_DeInit(FMC_PCCARD_TypeDef *Device);
+
+#endif /* STM32F302xE || STM32F303xE || STM32F398xx */
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32F3xx_LL_FMC_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/system_stm32f3xx.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_NUCLEO_F334R8/system_stm32f3xx.h
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    system_stm32f3xx.h
   * @author  MCD Application Team
-  * @version V2.0.1
-  * @date    18-June-2014
+  * @version V2.1.0
+  * @date    12-Sept-2014
   * @brief   CMSIS Cortex-M4 Device System Source File for STM32F3xx devices.  
   ******************************************************************************
   * @attention

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F334R8/mbed_overrides.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F334R8/mbed_overrides.c
@@ -32,4 +32,6 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
+    // Need to restart HAL driver after the RAM is initialized
+    HAL_Init();
 }

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F334R8/sleep.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F334R8/sleep.c
@@ -33,14 +33,20 @@
 
 #include "cmsis.h"
 
+static TIM_HandleTypeDef TimMasterHandle;
+
 void sleep(void)
 {
-    // Stop HAL systick
-    HAL_SuspendTick();
+    TimMasterHandle.Instance = TIM2;
+
+    // Disable HAL tick interrupt
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+
     // Request to enter SLEEP mode
     HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
-    // Restart HAL systick
-    HAL_ResumeTick();
+
+    // Enable HAL tick interrupt
+    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
 }
 
 void deepsleep(void)

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F334R8/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F334R8/us_ticker.c
@@ -31,8 +31,6 @@
 
 // 32-bit timer selection
 #define TIM_MST      TIM2
-#define TIM_MST_IRQ  TIM2_IRQn
-#define TIM_MST_RCC  __TIM2_CLK_ENABLE()
 
 static TIM_HandleTypeDef TimMasterHandle;
 static int us_ticker_inited = 0;
@@ -42,26 +40,9 @@ void us_ticker_init(void)
     if (us_ticker_inited) return;
     us_ticker_inited = 1;
 
-    // Enable timer clock
-    TIM_MST_RCC;
-
-    // Update the SystemCoreClock variable
-    SystemCoreClockUpdate();
-
-    // Configure time base
     TimMasterHandle.Instance = TIM_MST;
-    TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
-    TimMasterHandle.Init.ClockDivision     = 0;
-    TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
-    TimMasterHandle.Init.RepetitionCounter = 0;
-    HAL_TIM_OC_Init(&TimMasterHandle);
 
-    NVIC_SetVector(TIM_MST_IRQ, (uint32_t)us_ticker_irq_handler);
-    NVIC_EnableIRQ(TIM_MST_IRQ);
-
-    // Enable timer
-    HAL_TIM_OC_Start(&TimMasterHandle, TIM_CHANNEL_1);
+    HAL_InitTick(0); // The passed value is not used  
 }
 
 uint32_t us_ticker_read()


### PR DESCRIPTION
- Same version as in NUCLEO_F302R8
- Fix issue #482 (IAR compilation)
- Compliant with mbed RTOS (Systick no more used)
