### PR TITLE
LPC11U35_501 removed from uVision exporter targets

### DIFF
--- a/workspace_tools/export/uvision4.py
+++ b/workspace_tools/export/uvision4.py
@@ -50,7 +50,8 @@ class Uvision4(Exporter):
         'NUCLEO_L152RE',
         'UBLOX_C027',
         'LPC1549',
-        'LPC11U35_501',
+        # Removed as uvision4_lpc11u35_501.uvproj.tmpl is missing.
+        #'LPC11U35_501', 
         'NRF51822',
         'HRM1017',
         'ARCH_PRO',


### PR DESCRIPTION
uvision4_lpc11u35_501.uvproj.tmpl is missing so the export fails.

I am removing this so that the option to export is removed.

https://github.com/mbedmicro/mbed/commit/147b4a41af3e237a425683bd5040f07254d45c4a in this commit the test, which would have shown this problem, was removed and the broken exporter was re-enabled having been disabled in https://github.com/mbedmicro/mbed/commit/a5794b11078965c644d78d770eb129c1097877cf
