### PR TITLE
Potential fix for #646

### DIFF
--- a/libraries/mbed/common/us_ticker_api.c
+++ b/libraries/mbed/common/us_ticker_api.c
@@ -37,7 +37,7 @@ void us_ticker_irq_handler(void) {
             return;
         }
 
-        if ((int64_t)(head->timestamp - us_ticker_read()) <= 0) {
+        if ((int)(head->timestamp - us_ticker_read()) <= 0) {
             // This event was in the past:
             //      point to the following one and execute its handler
             ticker_event_t *p = head;


### PR DESCRIPTION
Here's the program I used to unit-test my solution.

``` C
#include <iostream>
#include <stdint.h>

using namespace std;

void test(uint64_t headTimestamp, uint32_t currentTimestmap)
{
    cout << "head: " << headTimestamp << " current: " << currentTimestmap << " ";

    int64_t check = (int)(headTimestamp - currentTimestmap);
    cout << "check: " << check << " ";
    if (check < 0) {
        cout << "elapsed" << endl;
    } else {
        cout << "NOT elapsed" << endl;
    }
}

int main()
{
    uint64_t headTimestamp;
    // uint64_t headTimestamp = 0xffffffff - 1;
    // test(headTimestamp, 0xffffffff);

    // headTimestamp = 0xffffffff;
    // test(headTimestamp, 0xffffffff);
    // headTimestamp = 0xffffffff + 2;
    // test(headTimestamp, 0xffffffff);
    // test(headTimestamp, 0x0);
    // test(headTimestamp, 0x1);
    // test(headTimestamp, 0x2);

    headTimestamp = 0x100000000ULL * 32 + 1;
    test(headTimestamp, 0xffffffff-1000);
    test(headTimestamp, 0xffffffff);
    test(headTimestamp, 0x0);
    test(headTimestamp, 0x1);
    test(headTimestamp, 0x2);
}
```
