### PR TITLE
Ensure that IG (Global) bit is reset in MAC address for K64F and others

### DIFF
--- a/libraries/mbed/common/mbed_interface.c
+++ b/libraries/mbed/common/mbed_interface.c
@@ -98,6 +98,7 @@ WEAK void mbed_mac_address(char *mac) {
             mac[i] = byte;
             p += 2;
         }
+        mac[0] &= ~0x01;    // reset the IG bit in the address; see IEE 802.3-2002, Section 3.2.3(b)
     } else {  // else return a default MAC
 #endif
         mac[0] = 0x00;

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/TARGET_MCU_K64F/TARGET_FRDM/mbed_overrides.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/TARGET_MCU_K64F/TARGET_FRDM/mbed_overrides.c
@@ -38,12 +38,12 @@ void mbed_mac_address(char *mac)
     uint32_t word0 = *(uint32_t *)0x40048060;
     // Fetch word 1
     // we only want bottom 16 bits of word1 (MAC bits 32-47)
-    // and bit 9 forced to 1, bit 8 forced to 0
+    // and bit 1 forced to 1, bit 0 forced to 0
     // Locally administered MAC, reduced conflicts
     // http://en.wikipedia.org/wiki/MAC_address
     uint32_t word1 = *(uint32_t *)0x4004805C;
-    word1 |= 0x00000200;
-    word1 &= 0x0000FEFF;
+    word1 |= 0x00000002;
+    word1 &= 0x0000FFFE;
     
     mac[0] = (word1 & 0x000000ff);
     mac[1] = (word1 & 0x0000ff00) >> 8;


### PR DESCRIPTION
I can't get a DHCP address because the MAC address chosen by the mbed library has the IG bit set. My DHCP server doesn't respond with an IP address.

Changing the resultant MAC address from the 0x03 to 0x02 allows me to get an IP address.

See IEE 802.3-2002, Section 3.2.3(b)

Here's a Wireshark analysis of the DHCP discover packet with the unmodified code:

![image](https://cloud.githubusercontent.com/assets/99482/4940832/36cba0ba-65de-11e4-8b19-23ea61be4ca0.png)
