### PR TITLE
Update RTX_Conf_CM.c

### DIFF
--- a/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
@@ -33,7 +33,7 @@
  *---------------------------------------------------------------------------*/
 
 #include "cmsis_os.h"
-
+#include "toolchain.h"
 
 /*----------------------------------------------------------------------------
  *      RTX User configuration part BEGIN
@@ -247,7 +247,7 @@
 /*----------------------------------------------------------------------------
  *      OS Idle daemon
  *---------------------------------------------------------------------------*/
-void os_idle_demon (void) {
+WEAK void os_idle_demon (void) {
   /* The idle demon is a system thread, running when no other thread is      */
   /* ready to run.                                                           */
 


### PR DESCRIPTION
RTOS: RTX - Idle task weak symbol

Changed os_idle_demon() to a weak symbol so that it can be overridden in the main program.
