### PR TITLE
[HAL][KSDK] Fix first serial char not being sent

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/serial_api.c
@@ -75,6 +75,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
         stdio_uart_inited = 1;
         memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
+    while(!UART_HAL_IsTxDataRegEmpty(uart_addrs[obj->index]));
 }
 
 void serial_free(serial_t *obj) {


### PR DESCRIPTION
The K64F/K22F didn't send the first char. I don't know why exactly, but
any type of reading a status register seems to fix it. And this extra
line at least makes sense. Now it works correctly.
