### PR TITLE
add some of the build script dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(name='mbed-tools',
       maintainer_email=OWNER_EMAILS,
       url='https://github.com/mbedmicro/mbed',
       packages=find_packages(),
-      license=LICENSE)
+      license=LICENSE,
+      install_requires=["PrettyTable>=0.7.2", "PySerial>=2.7", "IntelHex>=1.3"])
 
 # Restore previous private_settings if needed
 if backup:


### PR DESCRIPTION
In the process of getting the tests building I needed to install these dependencies, and added them to setup.py.

Now you can do python setup.py install and they'll be installed automagically.
