### PR TITLE
Name of exit function in exit.c

### DIFF
--- a/libraries/mbed/common/exit.c
+++ b/libraries/mbed/common/exit.c
@@ -22,6 +22,8 @@
 #ifdef TOOLCHAIN_GCC_CW
 // TODO: Ideally, we would like to define directly "_ExitProcess"
 void mbed_exit(int return_code) {
+#elif defined TOOLCHAIN_GCC_ARM
+void _exit(int return_code) {
 #else
 void exit(int return_code) {
 #endif


### PR DESCRIPTION
Change the name of the exit function to _exit as suggested in clib documenation for all gcc_arm toolchains (GCC_ARM and CoIDE).

Please see issue #710 
