### PR TITLE
[USBDevice] Fix for https://github.com/mbedmicro/mbed/issues/690

### DIFF
--- a/libraries/USBDevice/USBDevice/USBDevice.cpp
+++ b/libraries/USBDevice/USBDevice/USBDevice.cpp
@@ -187,7 +187,7 @@ bool USBDevice::controlOut(void)
     /* Check we should be transferring data OUT */
     if (transfer.direction != HOST_TO_DEVICE)
     {
-#if defined(TARGET_KL25Z) | defined(TARGET_KL46Z) | defined(TARGET_K20D5M) | defined(TARGET_K64F)
+#if defined(TARGET_KL25Z) | defined(TARGET_KL46Z) | defined(TARGET_K20D5M) | defined(TARGET_K64F) | defined(TARGET_K22F)
         /*
          * We seem to have a pending device-to-host transfer.  The host must have
          * sent a new control request without waiting for us to finish processing

--- a/libraries/USBDevice/USBDevice/USBEndpoints.h
+++ b/libraries/USBDevice/USBDevice/USBEndpoints.h
@@ -41,7 +41,7 @@ typedef enum {
 #include "USBEndpoints_LPC17_LPC23.h"
 #elif defined(TARGET_LPC11UXX) || defined(TARGET_LPC1347) || defined (TARGET_LPC11U6X) || defined (TARGET_LPC1549)
 #include "USBEndpoints_LPC11U.h"
-#elif defined(TARGET_KL25Z) | defined(TARGET_KL46Z) | defined(TARGET_K20D50M) | defined(TARGET_K64F)
+#elif defined(TARGET_KL25Z) | defined(TARGET_KL46Z) | defined(TARGET_K20D50M) | defined(TARGET_K64F) | defined(TARGET_K22F)
 #include "USBEndpoints_KL25Z.h"
 #elif defined (TARGET_STM32F4)
 #include "USBEndpoints_STM32F4.h"

--- a/libraries/USBDevice/USBDevice/USBHAL_KL25Z.cpp
+++ b/libraries/USBDevice/USBDevice/USBHAL_KL25Z.cpp
@@ -16,7 +16,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#if defined(TARGET_KL25Z) | defined(TARGET_KL46Z) | defined(TARGET_K20D50M) | defined(TARGET_K64F)
+#if defined(TARGET_KL25Z) | defined(TARGET_KL46Z) | defined(TARGET_K20D50M) | defined(TARGET_K64F) | defined(TARGET_K22F)
 
 #include "USBHAL.h"
 
@@ -121,9 +121,9 @@ USBHAL::USBHAL(void) {
     epCallback[28] = &USBHAL::EP15_OUT_callback;
     epCallback[29] = &USBHAL::EP15_IN_callback;
 
-
     // choose usb src as PLL
-    SIM->SOPT2 |= (SIM_SOPT2_USBSRC_MASK | SIM_SOPT2_PLLFLLSEL_MASK);
+    SIM->SOPT2 &= ~SIM_SOPT2_PLLFLLSEL_MASK;
+    SIM->SOPT2 |= (SIM_SOPT2_USBSRC_MASK | (1 << SIM_SOPT2_PLLFLLSEL_SHIFT));
 
     // enable OTG clock
     SIM->SCGC4 |= SIM_SCGC4_USBOTG_MASK;


### PR DESCRIPTION
In the old K64F register .h file (same for K22F),
SIM_SOPT2_PLLFLLSEL_MASK was incorrectly set as a 1-bit field, like it
was in the KLXX devices, while it now is a 2-bit field. This has been
fixed in the current register maps, however the USB clock was set by
taking the entire mask, while only the first bit needs to be set.

This is now fixed by using the SHIFT definition, and should work also on
other Freescale targets (verified on K64, K22 and KL25)

Also the sooner you decide on my other pull request the sooner they can be automatically merged again ;)
