### PR TITLE
[LPC11XX_11CXX] Fix SPI slave issue

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
@@ -67,11 +67,23 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
             LPC_SYSCON->SYSAHBCLKCTRL |= 1 << 11;
             LPC_SYSCON->SSP0CLKDIV = 0x01;
             LPC_SYSCON->PRESETCTRL |= 1 << 0;
+            if (sclk == P0_6) {
+                LPC_IOCON->SCK_LOC = 0x02;
+            }
+            else {
+                LPC_IOCON->SCK_LOC = 0x01;
+            }
             break;
         case SPI_1:
             LPC_SYSCON->SYSAHBCLKCTRL |= 1 << 18;
             LPC_SYSCON->SSP1CLKDIV = 0x01;
             LPC_SYSCON->PRESETCTRL |= 1 << 2;
+            LPC_IOCON->SCK1_LOC = 0x00;
+            LPC_IOCON->MISO1_LOC = 0x00;
+            LPC_IOCON->MOSI1_LOC = 0x00;
+            if (ssel != NC) {
+                LPC_IOCON->SSEL1_LOC = 0x00;
+            }
             break;
     }
     
@@ -192,11 +204,11 @@ int spi_master_write(spi_t *obj, int value) {
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ssp_readable(obj) ? (1) : (0);
 }
 
 int spi_slave_read(spi_t *obj) {
-    return obj->spi->DR;
+    return obj->spi->DR & 0xFFFF;
 }
 
 void spi_slave_write(spi_t *obj, int value) {

--- a/libraries/tests/mbed/spi_slave/main.cpp
+++ b/libraries/tests/mbed/spi_slave/main.cpp
@@ -8,6 +8,8 @@ SPISlave device(p12, p13, p15, p14);  // mosi, miso, sclk, ssel
 SPISlave device(P0_14, P0_15, P0_12, P0_13);    // mosi, miso, sclk, ssel
 #elif defined(TARGET_FF_ARDUINO)
 SPISlave device(D11, D12, D13, D10);       // mosi, miso, sclk, ssel
+#elif defined(TARGET_LPC1114)
+SPISlave device(dp2, dp1, dp6, dp25);            // mosi, miso, sclk, ssel
 #else
 SPISlave device(p5, p6, p7, p8);            // mosi, miso, sclk, ssel
 #endif


### PR DESCRIPTION
- Fix a bug reported here:
  https://developer.mbed.org/questions/4872/SPISlave-Class-dosnt-work-on-LPC1114/
- Add IOCON settings to enable proper pin functions
- Remove non-busy check in slave_receive() function, since the SSP/SPI
  is always in busy state when received a valid data according to the
  device user manual
- Add bit mask in spi_slave_read() function
- Add TARGET_LPC1114 pin config in SPI_SLAVE test
- Tested with LPC11U24 SPI master and LPC1114 SPI slave
