### PR TITLE
IAR RTOS support M0, M0+ and M4

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/TOOLCHAIN_IAR/MKL25Z4.icf
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/TOOLCHAIN_IAR/MKL25Z4.icf
@@ -12,7 +12,7 @@ define symbol __ICFEDIT_region_RAM_start__ = 0x1ffff0c0;
 define symbol __ICFEDIT_region_RAM_end__   = 0x1fffffff;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x400;
-define symbol __ICFEDIT_size_heap__   = 0x800;
+define symbol __ICFEDIT_size_heap__   = 0xA00;
 /**** End of ICF editor section. ###ICF###*/
 
 define symbol __region_RAM2_start__ 		= 0x20000000;

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC11UXX/TOOLCHAIN_IAR/TARGET_LPC11U24_401/LPC11U24.icf
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC11UXX/TOOLCHAIN_IAR/TARGET_LPC11U24_401/LPC11U24.icf
@@ -12,7 +12,7 @@ define symbol __ICFEDIT_region_RAM_start__   = 0x100000C0;
 define symbol __ICFEDIT_region_RAM_end__     = 0x10001FDF;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__   = 0x400;
-define symbol __ICFEDIT_size_heap__     = 0x800;
+define symbol __ICFEDIT_size_heap__     = 0xA00;
 /**** End of ICF editor section. ###ICF###*/
 
 define symbol __CRP_start__   = 0x000002FC;

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/TARGET_M0/TOOLCHAIN_IAR/HAL_CM0.s
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/TARGET_M0/TOOLCHAIN_IAR/HAL_CM0.s
@@ -1,0 +1,312 @@
+/*----------------------------------------------------------------------------
+ *      CMSIS-RTOS  -  RTX
+ *----------------------------------------------------------------------------
+ *      Name:    HAL_CM0.S
+ *      Purpose: Hardware Abstraction Layer for Cortex-M0
+ *      Rev.:    V4.70
+ *----------------------------------------------------------------------------
+ *
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+
+        NAME    HAL_CM0.S
+
+        #define TCB_TSTACK 36
+
+        EXTERN  os_flags
+        EXTERN  os_tsk
+        EXTERN  rt_alloc_box
+        EXTERN  rt_free_box
+        EXTERN  rt_stk_check
+        EXTERN  rt_pop_req
+        EXTERN  rt_systick
+        EXTERN  os_tick_irqack
+        EXTERN  SVC_Table
+        EXTERN  SVC_Count
+
+/*----------------------------------------------------------------------------
+ *      Functions
+ *---------------------------------------------------------------------------*/
+
+        SECTION .text:CODE:NOROOT(2)
+        THUMB
+
+/*--------------------------- rt_set_PSP ------------------------------------*/
+
+;       void rt_set_PSP (U32 stack);
+
+        PUBLIC  rt_set_PSP
+rt_set_PSP:
+
+        MSR     PSP,R0
+        BX      LR
+
+
+/*--------------------------- rt_get_PSP ------------------------------------*/
+
+;       U32 rt_get_PSP (void);
+
+        PUBLIC  rt_get_PSP
+rt_get_PSP:
+
+        MRS     R0,PSP
+        BX      LR
+
+
+/*--------------------------- os_set_env ------------------------------------*/
+
+;       void os_set_env (void);
+        /* Switch to Unprivileged/Privileged Thread mode, use PSP. */
+
+        PUBLIC  os_set_env
+os_set_env:
+
+        MOV     R0,SP                   /* PSP = MSP */
+        MSR     PSP,R0
+        LDR     R0,=os_flags
+        LDRB    R0,[R0]
+        LSLS    R0,#31
+        BNE     PrivilegedE
+        MOVS    R0,#0x03                /* Unprivileged Thread mode, use PSP */
+        MSR     CONTROL,R0
+        BX      LR
+PrivilegedE:
+        MOVS    R0,#0x02                /* Privileged Thread mode, use PSP */
+        MSR     CONTROL,R0
+        BX      LR
+
+
+/*--------------------------- _alloc_box ------------------------------------*/
+
+;      void *_alloc_box (void *box_mem);
+       /* Function wrapper for Unprivileged/Privileged mode. */
+
+        PUBLIC  _alloc_box
+_alloc_box:
+
+        LDR     R3,=rt_alloc_box
+        MOV     R12,R3
+        MRS     R3,IPSR
+        LSLS    R3,#24
+        BNE     PrivilegedA
+        MRS     R3,CONTROL
+        LSLS    R3,#31
+        BEQ     PrivilegedA
+        SVC     0
+        BX      LR
+PrivilegedA:
+        BX      R12
+
+
+/*--------------------------- _free_box -------------------------------------*/
+
+;       int _free_box (void *box_mem, void *box);
+        /* Function wrapper for Unprivileged/Privileged mode. */
+
+        PUBLIC  _free_box
+_free_box:
+
+        LDR     R3,=rt_free_box
+        MOV     R12,R3
+        MRS     R3,IPSR
+        LSLS    R3,#24
+        BNE     PrivilegedF
+        MRS     R3,CONTROL
+        LSLS    R3,#31
+        BEQ     PrivilegedF
+        SVC     0
+        BX      LR
+PrivilegedF:
+        BX      R12
+
+
+/*-------------------------- SVC_Handler ------------------------------------*/
+
+;       void SVC_Handler (void);
+
+        PUBLIC  SVC_Handler
+SVC_Handler:
+
+        MRS     R0,PSP                  /* Read PSP */
+        LDR     R1,[R0,#24]             /* Read Saved PC from Stack */
+        SUBS    R1,R1,#2                /* Point to SVC Instruction */
+        LDRB    R1,[R1]                 /* Load SVC Number */
+        CMP     R1,#0
+        BNE     SVC_User                /* User SVC Number > 0 */
+
+        MOV     LR,R4
+        LDMIA   R0,{R0-R3,R4}           /* Read R0-R3,R12 from stack */
+        MOV     R12,R4
+        MOV     R4,LR
+        BLX     R12                     /* Call SVC Function */
+
+        MRS     R3,PSP                  /* Read PSP */
+        STMIA   R3!,{R0-R2}             /* Store return values */
+
+        LDR     R3,=os_tsk
+        LDMIA   R3!,{R1,R2}             /* os_tsk.run, os_tsk.new */
+        CMP     R1,R2
+        BEQ     SVC_Exit                /* no task switch */
+
+        SUBS    R3,#8
+        CMP     R1,#0                   /* Runtask deleted? */
+        BEQ     SVC_Next
+
+        MRS     R0,PSP                  /* Read PSP */
+        SUBS    R0,R0,#32               /* Adjust Start Address */
+        STR     R0,[R1,#TCB_TSTACK]     /* Update os_tsk.run->tsk_stack */       
+        STMIA   R0!,{R4-R7}             /* Save old context (R4-R7) */
+        MOV     R4,R8
+        MOV     R5,R9
+        MOV     R6,R10
+        MOV     R7,R11
+        STMIA   R0!,{R4-R7}             /* Save old context (R8-R11) */
+
+        PUSH    {R2,R3}
+        BL      rt_stk_check            /* Check for Stack overflow */
+        POP     {R2,R3}
+
+SVC_Next:
+        STR     R2,[R3]                 /* os_tsk.run = os_tsk.new */
+
+        LDR     R0,[R2,#TCB_TSTACK]     /* os_tsk.new->tsk_stack */
+        ADDS    R0,R0,#16               /* Adjust Start Address */
+        LDMIA   R0!,{R4-R7}             /* Restore new Context (R8-R11) */
+        MOV     R8,R4
+        MOV     R9,R5
+        MOV     R10,R6
+        MOV     R11,R7
+        MSR     PSP,R0                  /* Write PSP */
+        SUBS    R0,R0,#32               /* Adjust Start Address */
+        LDMIA   R0!,{R4-R7}             /* Restore new Context (R4-R7) */
+
+SVC_Exit:
+        MOVS    R0,#~0xFFFFFFFD         /* Set EXC_RETURN value */
+        MVNS    R0,R0
+        BX      R0                      /* RETI to Thread Mode, use PSP */
+
+        /*------------------- User SVC ------------------------------*/
+
+SVC_User:
+        PUSH    {R4,LR}                 /* Save Registers */
+        LDR     R2,=SVC_Count
+        LDR     R2,[R2]
+        CMP     R1,R2
+        BHI     SVC_Done                /* Overflow */
+
+        LDR     R4,=SVC_Table-4
+        LSLS    R1,R1,#2
+        LDR     R4,[R4,R1]              /* Load SVC Function Address */
+        MOV     LR,R4
+
+        LDMIA   R0,{R0-R3,R4}           /* Read R0-R3,R12 from stack */
+        MOV     R12,R4
+        BLX     LR                      /* Call SVC Function */
+
+        MRS     R4,PSP                  /* Read PSP */
+        STMIA   R4!,{R0-R3}             /* Function return values */
+SVC_Done:
+        POP     {R4,PC}                 /* RETI */
+        
+
+/*-------------------------- PendSV_Handler ---------------------------------*/
+
+;       void PendSV_Handler (void);
+
+        PUBLIC  PendSV_Handler
+PendSV_Handler:
+
+        BL      rt_pop_req
+
+Sys_Switch:
+        LDR     R3,=os_tsk
+        LDMIA   R3!,{R1,R2}             /* os_tsk.run, os_tsk.new */
+        CMP     R1,R2
+        BEQ     Sys_Exit                /* no task switch */
+
+        SUBS    R3,#8
+
+        MRS     R0,PSP                  /* Read PSP */
+        SUBS    R0,R0,#32               /* Adjust Start Address */
+        STR     R0,[R1,#TCB_TSTACK]     /* Update os_tsk.run->tsk_stack */
+        STMIA   R0!,{R4-R7}             /* Save old context (R4-R7) */
+        MOV     R4,R8
+        MOV     R5,R9
+        MOV     R6,R10
+        MOV     R7,R11
+        STMIA   R0!,{R4-R7}             /* Save old context (R8-R11) */
+
+        PUSH    {R2,R3}
+        BL      rt_stk_check            /* Check for Stack overflow */
+        POP     {R2,R3}
+
+        STR     R2,[R3]                 /* os_tsk.run = os_tsk.new */
+
+        LDR     R0,[R2,#TCB_TSTACK]     /* os_tsk.new->tsk_stack */
+        ADDS    R0,R0,#16               /* Adjust Start Address */
+        LDMIA   R0!,{R4-R7}             /* Restore new Context (R8-R11) */
+        MOV     R8,R4
+        MOV     R9,R5
+        MOV     R10,R6
+        MOV     R11,R7
+        MSR     PSP,R0                  /* Write PSP */
+        SUBS    R0,R0,#32               /* Adjust Start Address */
+        LDMIA   R0!,{R4-R7}             /* Restore new Context (R4-R7) */
+
+Sys_Exit:
+        MOVS    R0,#~0xFFFFFFFD         /* Set EXC_RETURN value */
+        MVNS    R0,R0
+        BX      R0                      /* RETI to Thread Mode, use PSP */
+
+
+/*-------------------------- SysTick_Handler --------------------------------*/
+
+;       void SysTick_Handler (void);
+
+        PUBLIC  SysTick_Handler
+SysTick_Handler:
+
+        BL      rt_systick
+        B       Sys_Switch
+
+
+/*-------------------------- OS_Tick_Handler --------------------------------*/
+
+;       void OS_Tick_Handler (void);
+
+        PUBLIC  OS_Tick_Handler
+OS_Tick_Handler:
+
+        BL      os_tick_irqack
+        BL      rt_systick
+        B       Sys_Switch
+
+
+        END
+
+/*----------------------------------------------------------------------------
+ * end of file
+ *---------------------------------------------------------------------------*/

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/TARGET_M0/TOOLCHAIN_IAR/SVC_Table.s
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/TARGET_M0/TOOLCHAIN_IAR/SVC_Table.s
@@ -1,0 +1,58 @@
+;/*----------------------------------------------------------------------------
+; *      CMSIS-RTOS  -  RTX
+; *----------------------------------------------------------------------------
+; *      Name:    SVC_TABLE.S
+; *      Purpose: Pre-defined SVC Table for Cortex-M
+; *      Rev.:    V4.70
+; *----------------------------------------------------------------------------
+; *
+; * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+; * All rights reserved.
+; * Redistribution and use in source and binary forms, with or without
+; * modification, are permitted provided that the following conditions are met:
+; *  - Redistributions of source code must retain the above copyright
+; *    notice, this list of conditions and the following disclaimer.
+; *  - Redistributions in binary form must reproduce the above copyright
+; *    notice, this list of conditions and the following disclaimer in the
+; *    documentation and/or other materials provided with the distribution.
+; *  - Neither the name of ARM  nor the names of its contributors may be used 
+; *    to endorse or promote products derived from this software without 
+; *    specific prior written permission.
+; *
+; * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+; * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+; * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+; * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+; * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+; * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+; * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+; * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+; * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+; * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+; * POSSIBILITY OF SUCH DAMAGE.
+; *---------------------------------------------------------------------------*/
+
+
+                NAME    SVC_TABLE
+                SECTION .text:CONST (2)
+
+                PUBLIC  SVC_Count
+
+SVC_Cnt         EQU    (SVC_End-SVC_Table)/4
+SVC_Count       DCD     SVC_Cnt
+
+; Import user SVC functions here.
+;               IMPORT  __SVC_1
+
+                PUBLIC  SVC_Table
+SVC_Table
+; Insert user SVC functions here. SVC 0 used by RTL Kernel.
+;               DCD     __SVC_1                 ; user SVC function
+
+SVC_End
+
+                END
+
+/*----------------------------------------------------------------------------
+ * end of file
+ *---------------------------------------------------------------------------*/

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/TARGET_M0P/TOOLCHAIN_IAR/HAL_CM0.s
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/TARGET_M0P/TOOLCHAIN_IAR/HAL_CM0.s
@@ -1,0 +1,312 @@
+/*----------------------------------------------------------------------------
+ *      CMSIS-RTOS  -  RTX
+ *----------------------------------------------------------------------------
+ *      Name:    HAL_CM0.S
+ *      Purpose: Hardware Abstraction Layer for Cortex-M0
+ *      Rev.:    V4.70
+ *----------------------------------------------------------------------------
+ *
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+
+        NAME    HAL_CM0.S
+
+        #define TCB_TSTACK 36
+
+        EXTERN  os_flags
+        EXTERN  os_tsk
+        EXTERN  rt_alloc_box
+        EXTERN  rt_free_box
+        EXTERN  rt_stk_check
+        EXTERN  rt_pop_req
+        EXTERN  rt_systick
+        EXTERN  os_tick_irqack
+        EXTERN  SVC_Table
+        EXTERN  SVC_Count
+
+/*----------------------------------------------------------------------------
+ *      Functions
+ *---------------------------------------------------------------------------*/
+
+        SECTION .text:CODE:NOROOT(2)
+        THUMB
+
+/*--------------------------- rt_set_PSP ------------------------------------*/
+
+;       void rt_set_PSP (U32 stack);
+
+        PUBLIC  rt_set_PSP
+rt_set_PSP:
+
+        MSR     PSP,R0
+        BX      LR
+
+
+/*--------------------------- rt_get_PSP ------------------------------------*/
+
+;       U32 rt_get_PSP (void);
+
+        PUBLIC  rt_get_PSP
+rt_get_PSP:
+
+        MRS     R0,PSP
+        BX      LR
+
+
+/*--------------------------- os_set_env ------------------------------------*/
+
+;       void os_set_env (void);
+        /* Switch to Unprivileged/Privileged Thread mode, use PSP. */
+
+        PUBLIC  os_set_env
+os_set_env:
+
+        MOV     R0,SP                   /* PSP = MSP */
+        MSR     PSP,R0
+        LDR     R0,=os_flags
+        LDRB    R0,[R0]
+        LSLS    R0,#31
+        BNE     PrivilegedE
+        MOVS    R0,#0x03                /* Unprivileged Thread mode, use PSP */
+        MSR     CONTROL,R0
+        BX      LR
+PrivilegedE:
+        MOVS    R0,#0x02                /* Privileged Thread mode, use PSP */
+        MSR     CONTROL,R0
+        BX      LR
+
+
+/*--------------------------- _alloc_box ------------------------------------*/
+
+;      void *_alloc_box (void *box_mem);
+       /* Function wrapper for Unprivileged/Privileged mode. */
+
+        PUBLIC  _alloc_box
+_alloc_box:
+
+        LDR     R3,=rt_alloc_box
+        MOV     R12,R3
+        MRS     R3,IPSR
+        LSLS    R3,#24
+        BNE     PrivilegedA
+        MRS     R3,CONTROL
+        LSLS    R3,#31
+        BEQ     PrivilegedA
+        SVC     0
+        BX      LR
+PrivilegedA:
+        BX      R12
+
+
+/*--------------------------- _free_box -------------------------------------*/
+
+;       int _free_box (void *box_mem, void *box);
+        /* Function wrapper for Unprivileged/Privileged mode. */
+
+        PUBLIC  _free_box
+_free_box:
+
+        LDR     R3,=rt_free_box
+        MOV     R12,R3
+        MRS     R3,IPSR
+        LSLS    R3,#24
+        BNE     PrivilegedF
+        MRS     R3,CONTROL
+        LSLS    R3,#31
+        BEQ     PrivilegedF
+        SVC     0
+        BX      LR
+PrivilegedF:
+        BX      R12
+
+
+/*-------------------------- SVC_Handler ------------------------------------*/
+
+;       void SVC_Handler (void);
+
+        PUBLIC  SVC_Handler
+SVC_Handler:
+
+        MRS     R0,PSP                  /* Read PSP */
+        LDR     R1,[R0,#24]             /* Read Saved PC from Stack */
+        SUBS    R1,R1,#2                /* Point to SVC Instruction */
+        LDRB    R1,[R1]                 /* Load SVC Number */
+        CMP     R1,#0
+        BNE     SVC_User                /* User SVC Number > 0 */
+
+        MOV     LR,R4
+        LDMIA   R0,{R0-R3,R4}           /* Read R0-R3,R12 from stack */
+        MOV     R12,R4
+        MOV     R4,LR
+        BLX     R12                     /* Call SVC Function */
+
+        MRS     R3,PSP                  /* Read PSP */
+        STMIA   R3!,{R0-R2}             /* Store return values */
+
+        LDR     R3,=os_tsk
+        LDMIA   R3!,{R1,R2}             /* os_tsk.run, os_tsk.new */
+        CMP     R1,R2
+        BEQ     SVC_Exit                /* no task switch */
+
+        SUBS    R3,#8
+        CMP     R1,#0                   /* Runtask deleted? */
+        BEQ     SVC_Next
+
+        MRS     R0,PSP                  /* Read PSP */
+        SUBS    R0,R0,#32               /* Adjust Start Address */
+        STR     R0,[R1,#TCB_TSTACK]     /* Update os_tsk.run->tsk_stack */       
+        STMIA   R0!,{R4-R7}             /* Save old context (R4-R7) */
+        MOV     R4,R8
+        MOV     R5,R9
+        MOV     R6,R10
+        MOV     R7,R11
+        STMIA   R0!,{R4-R7}             /* Save old context (R8-R11) */
+
+        PUSH    {R2,R3}
+        BL      rt_stk_check            /* Check for Stack overflow */
+        POP     {R2,R3}
+
+SVC_Next:
+        STR     R2,[R3]                 /* os_tsk.run = os_tsk.new */
+
+        LDR     R0,[R2,#TCB_TSTACK]     /* os_tsk.new->tsk_stack */
+        ADDS    R0,R0,#16               /* Adjust Start Address */
+        LDMIA   R0!,{R4-R7}             /* Restore new Context (R8-R11) */
+        MOV     R8,R4
+        MOV     R9,R5
+        MOV     R10,R6
+        MOV     R11,R7
+        MSR     PSP,R0                  /* Write PSP */
+        SUBS    R0,R0,#32               /* Adjust Start Address */
+        LDMIA   R0!,{R4-R7}             /* Restore new Context (R4-R7) */
+
+SVC_Exit:
+        MOVS    R0,#~0xFFFFFFFD         /* Set EXC_RETURN value */
+        MVNS    R0,R0
+        BX      R0                      /* RETI to Thread Mode, use PSP */
+
+        /*------------------- User SVC ------------------------------*/
+
+SVC_User:
+        PUSH    {R4,LR}                 /* Save Registers */
+        LDR     R2,=SVC_Count
+        LDR     R2,[R2]
+        CMP     R1,R2
+        BHI     SVC_Done                /* Overflow */
+
+        LDR     R4,=SVC_Table-4
+        LSLS    R1,R1,#2
+        LDR     R4,[R4,R1]              /* Load SVC Function Address */
+        MOV     LR,R4
+
+        LDMIA   R0,{R0-R3,R4}           /* Read R0-R3,R12 from stack */
+        MOV     R12,R4
+        BLX     LR                      /* Call SVC Function */
+
+        MRS     R4,PSP                  /* Read PSP */
+        STMIA   R4!,{R0-R3}             /* Function return values */
+SVC_Done:
+        POP     {R4,PC}                 /* RETI */
+        
+
+/*-------------------------- PendSV_Handler ---------------------------------*/
+
+;       void PendSV_Handler (void);
+
+        PUBLIC  PendSV_Handler
+PendSV_Handler:
+
+        BL      rt_pop_req
+
+Sys_Switch:
+        LDR     R3,=os_tsk
+        LDMIA   R3!,{R1,R2}             /* os_tsk.run, os_tsk.new */
+        CMP     R1,R2
+        BEQ     Sys_Exit                /* no task switch */
+
+        SUBS    R3,#8
+
+        MRS     R0,PSP                  /* Read PSP */
+        SUBS    R0,R0,#32               /* Adjust Start Address */
+        STR     R0,[R1,#TCB_TSTACK]     /* Update os_tsk.run->tsk_stack */
+        STMIA   R0!,{R4-R7}             /* Save old context (R4-R7) */
+        MOV     R4,R8
+        MOV     R5,R9
+        MOV     R6,R10
+        MOV     R7,R11
+        STMIA   R0!,{R4-R7}             /* Save old context (R8-R11) */
+
+        PUSH    {R2,R3}
+        BL      rt_stk_check            /* Check for Stack overflow */
+        POP     {R2,R3}
+
+        STR     R2,[R3]                 /* os_tsk.run = os_tsk.new */
+
+        LDR     R0,[R2,#TCB_TSTACK]     /* os_tsk.new->tsk_stack */
+        ADDS    R0,R0,#16               /* Adjust Start Address */
+        LDMIA   R0!,{R4-R7}             /* Restore new Context (R8-R11) */
+        MOV     R8,R4
+        MOV     R9,R5
+        MOV     R10,R6
+        MOV     R11,R7
+        MSR     PSP,R0                  /* Write PSP */
+        SUBS    R0,R0,#32               /* Adjust Start Address */
+        LDMIA   R0!,{R4-R7}             /* Restore new Context (R4-R7) */
+
+Sys_Exit:
+        MOVS    R0,#~0xFFFFFFFD         /* Set EXC_RETURN value */
+        MVNS    R0,R0
+        BX      R0                      /* RETI to Thread Mode, use PSP */
+
+
+/*-------------------------- SysTick_Handler --------------------------------*/
+
+;       void SysTick_Handler (void);
+
+        PUBLIC  SysTick_Handler
+SysTick_Handler:
+
+        BL      rt_systick
+        B       Sys_Switch
+
+
+/*-------------------------- OS_Tick_Handler --------------------------------*/
+
+;       void OS_Tick_Handler (void);
+
+        PUBLIC  OS_Tick_Handler
+OS_Tick_Handler:
+
+        BL      os_tick_irqack
+        BL      rt_systick
+        B       Sys_Switch
+
+
+        END
+
+/*----------------------------------------------------------------------------
+ * end of file
+ *---------------------------------------------------------------------------*/

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/TARGET_M0P/TOOLCHAIN_IAR/SVC_Table.s
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/TARGET_M0P/TOOLCHAIN_IAR/SVC_Table.s
@@ -1,0 +1,58 @@
+;/*----------------------------------------------------------------------------
+; *      CMSIS-RTOS  -  RTX
+; *----------------------------------------------------------------------------
+; *      Name:    SVC_TABLE.S
+; *      Purpose: Pre-defined SVC Table for Cortex-M
+; *      Rev.:    V4.70
+; *----------------------------------------------------------------------------
+; *
+; * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+; * All rights reserved.
+; * Redistribution and use in source and binary forms, with or without
+; * modification, are permitted provided that the following conditions are met:
+; *  - Redistributions of source code must retain the above copyright
+; *    notice, this list of conditions and the following disclaimer.
+; *  - Redistributions in binary form must reproduce the above copyright
+; *    notice, this list of conditions and the following disclaimer in the
+; *    documentation and/or other materials provided with the distribution.
+; *  - Neither the name of ARM  nor the names of its contributors may be used 
+; *    to endorse or promote products derived from this software without 
+; *    specific prior written permission.
+; *
+; * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+; * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+; * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+; * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+; * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+; * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+; * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+; * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+; * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+; * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+; * POSSIBILITY OF SUCH DAMAGE.
+; *---------------------------------------------------------------------------*/
+
+
+                NAME    SVC_TABLE
+                SECTION .text:CONST (2)
+
+                PUBLIC  SVC_Count
+
+SVC_Cnt         EQU    (SVC_End-SVC_Table)/4
+SVC_Count       DCD     SVC_Cnt
+
+; Import user SVC functions here.
+;               IMPORT  __SVC_1
+
+                PUBLIC  SVC_Table
+SVC_Table
+; Insert user SVC functions here. SVC 0 used by RTL Kernel.
+;               DCD     __SVC_1                 ; user SVC function
+
+SVC_End
+
+                END
+
+/*----------------------------------------------------------------------------
+ * end of file
+ *---------------------------------------------------------------------------*/

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/TARGET_M4/TOOLCHAIN_IAR/HAL_CM4.s
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/TARGET_M4/TOOLCHAIN_IAR/HAL_CM4.s
@@ -1,0 +1,333 @@
+/*----------------------------------------------------------------------------
+ *      CMSIS-RTOS  -  RTX
+ *----------------------------------------------------------------------------
+ *      Name:    HAL_CM4.S
+ *      Purpose: Hardware Abstraction Layer for Cortex-M4
+ *      Rev.:    V4.70
+ *----------------------------------------------------------------------------
+ *
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+
+        NAME    HAL_CM4.S
+
+        #define TCB_STACKF 32
+        #define TCB_TSTACK 36
+
+        EXTERN  os_flags
+        EXTERN  os_tsk
+        EXTERN  rt_alloc_box
+        EXTERN  rt_free_box
+        EXTERN  rt_stk_check
+        EXTERN  rt_pop_req
+        EXTERN  rt_systick
+        EXTERN  os_tick_irqack
+        EXTERN  SVC_Table
+        EXTERN  SVC_Count
+
+/*----------------------------------------------------------------------------
+ *      Functions
+ *---------------------------------------------------------------------------*/
+
+        SECTION .text:CODE:NOROOT(2)
+        THUMB
+
+/*--------------------------- rt_set_PSP ------------------------------------*/
+
+;       void rt_set_PSP (U32 stack);
+
+        PUBLIC  rt_set_PSP
+rt_set_PSP:
+
+        MSR     PSP,R0
+        BX      LR
+
+
+/*--------------------------- rt_get_PSP ------------------------------------*/
+
+;       U32 rt_get_PSP (void);
+
+        PUBLIC  rt_get_PSP
+rt_get_PSP:
+
+        MRS     R0,PSP
+        BX      LR
+
+
+/*--------------------------- os_set_env ------------------------------------*/
+
+;       void os_set_env (void);
+        /* Switch to Unprivileged/Privileged Thread mode, use PSP. */
+
+        PUBLIC  os_set_env
+os_set_env:
+
+        MOV     R0,SP                   /* PSP = MSP */
+        MSR     PSP,R0
+        LDR     R0,=os_flags
+        LDRB    R0,[R0]
+        LSLS    R0,#31
+        ITE     NE
+        MOVNE   R0,#0x02                /* Privileged Thread mode, use PSP */
+        MOVEQ   R0,#0x03                /* Unprivileged Thread mode, use PSP */
+        MSR     CONTROL,R0
+        BX      LR
+
+
+/*--------------------------- _alloc_box ------------------------------------*/
+
+;      void *_alloc_box (void *box_mem);
+       /* Function wrapper for Unprivileged/Privileged mode. */
+
+        PUBLIC  _alloc_box
+_alloc_box:
+
+        LDR     R12,=rt_alloc_box
+        MRS     R3,IPSR
+        LSLS    R3,#24
+        IT      NE
+        BXNE    R12
+        MRS     R3,CONTROL
+        LSLS    R3,#31
+        IT      EQ
+        BXEQ    R12
+        SVC     0
+        BX      LR
+
+
+/*--------------------------- _free_box -------------------------------------*/
+
+;       int _free_box (void *box_mem, void *box);
+        /* Function wrapper for Unprivileged/Privileged mode. */
+
+        PUBLIC  _free_box
+_free_box:
+
+        LDR     R12,=rt_free_box
+        MRS     R3,IPSR
+        LSLS    R3,#24
+        IT      NE
+        BXNE    R12
+        MRS     R3,CONTROL
+        LSLS    R3,#31
+        IT      EQ
+        BXEQ    R12
+        SVC     0
+        BX      LR
+
+
+/*-------------------------- SVC_Handler ------------------------------------*/
+
+;       void SVC_Handler (void);
+
+        PUBLIC  SVC_Handler
+SVC_Handler:
+
+#ifdef IFX_XMC4XXX
+        PUBLIC  SVC_Handler_Veneer
+SVC_Handler_Veneer:
+#endif
+
+        MRS     R0,PSP                  /* Read PSP */
+        LDR     R1,[R0,#24]             /* Read Saved PC from Stack */
+        LDRB    R1,[R1,#-2]             /* Load SVC Number */
+        CBNZ    R1,SVC_User
+
+        LDM     R0,{R0-R3,R12}          /* Read R0-R3,R12 from stack */
+        PUSH    {R4,LR}                 /* Save EXC_RETURN */
+        BLX     R12                     /* Call SVC Function */
+        POP     {R4,LR}                 /* Restore EXC_RETURN */
+
+        MRS     R12,PSP                 /* Read PSP */
+        STM     R12,{R0-R2}             /* Store return values */
+
+        LDR     R3,=os_tsk
+        LDM     R3,{R1,R2}              /* os_tsk.run, os_tsk.new */
+        CMP     R1,R2
+#ifdef  IFX_XMC4XXX
+        ITT      EQ
+        PUSHEQ  {LR}
+        POPEQ   {PC}
+#else
+        IT      EQ
+        BXEQ    LR                      /* RETI, no task switch */
+#endif        
+
+        CBZ     R1,SVC_Next             /* Runtask deleted? */
+        TST     LR,#0x10                /* is it extended frame? */
+        ITTE    EQ
+        VSTMDBEQ R12!,{S16-S31}         /* yes, stack also VFP hi-regs */
+        MOVEQ   R0,#0x01                /* os_tsk->stack_frame val */
+        MOVNE   R0,#0x00
+        STRB    R0,[R1,#TCB_STACKF]     /* os_tsk.run->stack_frame = val */
+        STMDB   R12!,{R4-R11}           /* Save Old context */
+        STR     R12,[R1,#TCB_TSTACK]    /* Update os_tsk.run->tsk_stack */
+
+        PUSH    {R2,R3}
+        BL      rt_stk_check            /* Check for Stack overflow */
+        POP     {R2,R3}
+
+SVC_Next:
+        STR     R2,[R3]                 /* os_tsk.run = os_tsk.new */
+
+        LDR     R12,[R2,#TCB_TSTACK]    /* os_tsk.new->tsk_stack */
+        LDMIA   R12!,{R4-R11}           /* Restore New Context */
+        LDRB    R0,[R2,#TCB_STACKF]     /* Stack Frame */
+        CMP     R0,#0                   /* Basic/Extended Stack Frame */
+        ITTE    NE
+        VLDMIANE R12!,{S16-S31}         /* restore VFP hi-registers */
+        MVNNE   LR,#~0xFFFFFFED         /* set EXC_RETURN value */
+        MVNEQ   LR,#~0xFFFFFFFD
+        MSR     PSP,R12                 /* Write PSP */
+
+SVC_Exit:
+#ifdef  IFX_XMC4XXX
+        PUSH    {LR}
+        POP     {PC}
+#else
+        BX      LR
+#endif
+
+        /*------------------- User SVC ------------------------------*/
+
+SVC_User:
+        PUSH    {R4,LR}                 /* Save Registers */
+        LDR     R2,=SVC_Count
+        LDR     R2,[R2]
+        CMP     R1,R2
+        BHI     SVC_Done                /* Overflow */
+
+        LDR     R4,=SVC_Table-4
+        LDR     R4,[R4,R1,LSL #2]       /* Load SVC Function Address */
+
+        LDM     R0,{R0-R3,R12}          /* Read R0-R3,R12 from stack */
+        BLX     R4                      /* Call SVC Function */
+
+        MRS     R12,PSP
+        STM     R12,{R0-R3}             /* Function return values */
+SVC_Done:
+        POP     {R4,PC}                 /* RETI */
+        
+
+/*-------------------------- PendSV_Handler ---------------------------------*/
+
+;       void PendSV_Handler (void);
+
+        PUBLIC  PendSV_Handler
+PendSV_Handler:
+
+#ifdef  IFX_XMC4XXX
+        PUBLIC  PendSV_Handler_Veneer
+PendSV_Handler_Veneer:
+#endif
+
+        PUSH    {R4,LR}                 /* Save EXC_RETURN */
+        BL      rt_pop_req
+
+Sys_Switch:
+        POP     {R4,LR}                 /* Restore EXC_RETURN */
+
+        LDR     R3,=os_tsk
+        LDM     R3,{R1,R2}              /* os_tsk.run, os_tsk.new */
+        CMP     R1,R2
+#ifdef  IFX_XMC4XXX
+        ITT     EQ
+        PUSHEQ  {LR}
+        POPEQ   {PC}
+#else
+        IT      EQ
+        BXEQ    LR                      /* RETI, no task switch */
+#endif
+
+        MRS     R12,PSP                 /* Read PSP */
+        TST     LR,#0x10                /* is it extended frame? */
+        ITTE    EQ
+        VSTMDBEQ R12!,{S16-S31}         /* yes, stack also VFP hi-regs */
+        MOVEQ   R0,#0x01                /* os_tsk->stack_frame val */
+        MOVNE   R0,#0x00
+        STRB    R0,[R1,#TCB_STACKF]     /* os_tsk.run->stack_frame = val */
+        STMDB   R12!,{R4-R11}           /* Save Old context */
+        STR     R12,[R1,#TCB_TSTACK]    /* Update os_tsk.run->tsk_stack */
+
+        PUSH    {R2,R3}
+        BL      rt_stk_check            /* Check for Stack overflow */
+        POP     {R2,R3}
+
+        STR     R2,[R3]                 /* os_tsk.run = os_tsk.new */
+
+        LDR     R12,[R2,#TCB_TSTACK]    /* os_tsk.new->tsk_stack */
+        LDMIA   R12!,{R4-R11}           /* Restore New Context */
+        LDRB    R0,[R2,#TCB_STACKF]     /* Stack Frame */
+        CMP     R0,#0                   /* Basic/Extended Stack Frame */
+        ITTE    NE
+        VLDMIANE R12!,{S16-S31}         /* restore VFP hi-registers */
+        MVNNE   LR,#~0xFFFFFFED         /* set EXC_RETURN value */
+        MVNEQ   LR,#~0xFFFFFFFD
+        MSR     PSP,R12                 /* Write PSP */
+
+Sys_Exit:
+#ifdef  IFX_XMC4XXX
+        PUSH    {LR}
+        POP     {PC}
+#else
+        BX      LR                      /* Return to Thread Mode */
+#endif
+
+
+/*-------------------------- SysTick_Handler --------------------------------*/
+
+;       void SysTick_Handler (void);
+
+        PUBLIC  SysTick_Handler
+SysTick_Handler:
+#ifdef  IFX_XMC4XXX
+        PUBLIC  SysTick_Handler_Veneer
+SysTick_Handler_Veneer:
+#endif
+
+        PUSH    {R4,LR}                 /* Save EXC_RETURN */
+        BL      rt_systick
+        B       Sys_Switch
+
+
+/*-------------------------- OS_Tick_Handler --------------------------------*/
+
+;       void OS_Tick_Handler (void);
+
+        PUBLIC  OS_Tick_Handler
+OS_Tick_Handler:
+
+        PUSH    {R4,LR}                 /* Save EXC_RETURN */
+        BL      os_tick_irqack
+        BL      rt_systick
+        B       Sys_Switch
+
+
+        END
+
+/*----------------------------------------------------------------------------
+ * end of file
+ *---------------------------------------------------------------------------*/

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/TARGET_M4/TOOLCHAIN_IAR/SVC_Table.s
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/TARGET_M4/TOOLCHAIN_IAR/SVC_Table.s
@@ -1,0 +1,58 @@
+;/*----------------------------------------------------------------------------
+; *      CMSIS-RTOS  -  RTX
+; *----------------------------------------------------------------------------
+; *      Name:    SVC_TABLE.S
+; *      Purpose: Pre-defined SVC Table for Cortex-M
+; *      Rev.:    V4.70
+; *----------------------------------------------------------------------------
+; *
+; * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+; * All rights reserved.
+; * Redistribution and use in source and binary forms, with or without
+; * modification, are permitted provided that the following conditions are met:
+; *  - Redistributions of source code must retain the above copyright
+; *    notice, this list of conditions and the following disclaimer.
+; *  - Redistributions in binary form must reproduce the above copyright
+; *    notice, this list of conditions and the following disclaimer in the
+; *    documentation and/or other materials provided with the distribution.
+; *  - Neither the name of ARM  nor the names of its contributors may be used 
+; *    to endorse or promote products derived from this software without 
+; *    specific prior written permission.
+; *
+; * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+; * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+; * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+; * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+; * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+; * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+; * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+; * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+; * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+; * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+; * POSSIBILITY OF SUCH DAMAGE.
+; *---------------------------------------------------------------------------*/
+
+
+                NAME    SVC_TABLE
+                SECTION .text:CONST (2)
+
+                PUBLIC  SVC_Count
+
+SVC_Cnt         EQU    (SVC_End-SVC_Table)/4
+SVC_Count       DCD     SVC_Cnt
+
+; Import user SVC functions here.
+;               IMPORT  __SVC_1
+
+                PUBLIC  SVC_Table
+SVC_Table
+; Insert user SVC functions here. SVC 0 used by RTL Kernel.
+;               DCD     __SVC_1                 ; user SVC function
+
+SVC_End
+
+                END
+
+/*----------------------------------------------------------------------------
+ * end of file
+ *---------------------------------------------------------------------------*/


### PR DESCRIPTION
Added support for RTX m0,m0+ and M4. Increased the heap size (icf files) because the rtos basic example required it to work.
