### PR TITLE
Ignore cscope and vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,9 @@ debug.log
 # PyCharm
 *.idea
 
+# Cscope
+cscope.*
+
+# vim swap files
+*.swp
+


### PR DESCRIPTION
This can perhaps be added to my global ignores instead, however since project .gitignore contained other similar items added it here.

$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
nothing to commit, working directory clean
$ 
$ git status --ignored
On branch master
Your branch is up-to-date with 'origin/master'.
Ignored files:
  (use "git add -f <file>..." to include in what will be committed)

```
.gitignore.swp
libraries/cscope.in.out
libraries/cscope.out
libraries/cscope.po.out
```
