### PR TITLE
[NUCLEO L053]fixed open drain for DigitalInOut

### DIFF
--- a/libraries/mbed/common/gpio.c
+++ b/libraries/mbed/common/gpio.c
@@ -29,7 +29,11 @@ static inline void _gpio_init_out(gpio_t* gpio, PinName pin, PinMode mode, int v
     gpio_init(gpio, pin);
     if (pin != NC) {
         gpio_write(gpio, value);
-        gpio_dir(gpio, PIN_OUTPUT);
+        if(mode == OpenDrain)
+            gpio_dir(gpio, PIN_OUTPUT_OD);
+        else{
+            gpio_dir(gpio, PIN_OUTPUT);
+        }
         gpio_mode(gpio, mode);
     }
 }

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L053R8/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L053R8/PinNames.h
@@ -62,7 +62,8 @@ extern "C" {
 
 typedef enum {
     PIN_INPUT,
-    PIN_OUTPUT
+    PIN_OUTPUT,
+    PIN_OUTPUT_OD
 } PinDirection;
 
 typedef enum {

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L053R8/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L053R8/gpio_api.c
@@ -71,6 +71,8 @@ void gpio_dir(gpio_t *obj, PinDirection direction)
     MBED_ASSERT(obj->pin != (PinName)NC);
     if (direction == PIN_OUTPUT) {
         pin_function(obj->pin, STM_PIN_DATA(STM_MODE_OUTPUT_PP, GPIO_NOPULL, 0));
+    } else if (direction == PIN_OUTPUT_OD){
+        pin_function(obj->pin, STM_PIN_DATA(STM_MODE_OUTPUT_OD, GPIO_NOPULL, 0));
     } else { // PIN_INPUT
         pin_function(obj->pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
     }


### PR DESCRIPTION
Added/fixed OpenDrain output type for Nucleo L053.

"OpenDrain" mode for DigitalInOut will generate pin with STM_MODE_OUTPUT_OD option.
Previously, using "OpenDrain" disabled Pullup/Pulldown only and the pin worked still as STM_MODE_OUTPUT_PP
