### PR TITLE
Fixed IAR serial fgets fgetc

### DIFF
--- a/libraries/mbed/api/Stream.h
+++ b/libraries/mbed/api/Stream.h
@@ -21,6 +21,10 @@
 
 namespace mbed {
 
+extern void mbed_set_unbuffered_stream(FILE *_file);
+extern int mbed_getc(FILE *_file);
+extern char* mbed_gets(char *s, int size, FILE *_file);
+
 class Stream : public FileLike {
 
 public:

--- a/libraries/mbed/common/Stream.cpp
+++ b/libraries/mbed/common/Stream.cpp
@@ -24,11 +24,7 @@ Stream::Stream(const char *name) : FileLike(name), _file(NULL) {
     char buf[12]; /* :0x12345678 + null byte */
     std::sprintf(buf, ":%p", this);
     _file = std::fopen(buf, "w+");
-#if defined (__ICCARM__)
-    std::setvbuf(_file,buf,_IONBF,NULL);    
-#else
-    setbuf(_file, NULL);
-#endif
+    mbed_set_unbuffered_stream(_file);
 }
 
 Stream::~Stream() {
@@ -45,31 +41,11 @@ int Stream::puts(const char *s) {
 }
 int Stream::getc() {
     fflush(_file);
-#if defined (__ICCARM__)
-    int res = std::fgetc(_file);
-    if (res>=0){
-        _file->_Mode = (unsigned short)(_file->_Mode & ~ 0x1000);/* Unset read mode */
-        _file->_Rend = _file->_Wend;
-        _file->_Next = _file->_Wend;
-    }    
-    return res;
-#else    
-    return std::fgetc(_file);
-#endif    
+    return mbed_getc(_file);   
 }
 char* Stream::gets(char *s, int size) {
     fflush(_file);
-#if defined (__ICCARM__)
-    char *str = fgets(s,size,_file);
-    if (str!=NULL){
-        _file->_Mode = (unsigned short)(_file->_Mode & ~ 0x1000);/* Unset read mode */
-        _file->_Rend = _file->_Wend;
-        _file->_Next = _file->_Wend;
-    }
-    return str;
-#else    
-    return std::fgets(s,size,_file);
-#endif
+    return mbed_gets(s,size,_file);
 }
 
 int Stream::close() {

--- a/libraries/mbed/common/retarget.cpp
+++ b/libraries/mbed/common/retarget.cpp
@@ -480,3 +480,55 @@ extern "C" caddr_t _sbrk(int incr) {
     return (caddr_t) prev_heap;
 }
 #endif
+
+
+namespace mbed {
+
+void mbed_set_unbuffered_stream(FILE *_file) {
+#if defined (__ICCARM__)
+    char buf[2];
+    std::setvbuf(_file,buf,_IONBF,NULL);    
+#else
+    setbuf(_file, NULL);
+#endif
+}
+
+int mbed_getc(FILE *_file){
+#if defined (__ICCARM__)
+    /*This is only valid for unbuffered streams*/
+    int res = std::fgetc(_file);
+    if (res>=0){
+        _file->_Mode = (unsigned short)(_file->_Mode & ~ 0x1000);/* Unset read mode */
+        _file->_Rend = _file->_Wend;
+        _file->_Next = _file->_Wend;
+    }    
+    return res;
+#else    
+    return std::fgetc(_file);
+#endif   
+}
+
+char* mbed_gets(char*s, int size, FILE *_file){
+#if defined (__ICCARM__)
+    /*This is only valid for unbuffered streams*/
+    char *str = fgets(s,size,_file);
+    if (str!=NULL){
+        _file->_Mode = (unsigned short)(_file->_Mode & ~ 0x1000);/* Unset read mode */
+        _file->_Rend = _file->_Wend;
+        _file->_Next = _file->_Wend;
+    }
+    return str;
+#else    
+    return std::fgets(s,size,_file);
+#endif
+}
+
+} // namespace mbed
+
+
+
+
+
+
+
+


### PR DESCRIPTION
IAR's Dlib has some problems with unbuffered stream, however I found a workaround. setvbuf with these params generate a buffer with size 1. 
-        _file->_Mode = (unsigned short)(_file->_Mode & ~ 0x1000);/\* Unset read mode */
  Is to remove read mode from _file after read because writes will otherwise be blocked.
-        _file->_Rend = _file->_Wend;
-        _file->_Next = _file->_Wend;
  If this is not set the last char from fgets will be rewritten next time (saved in buffer). So for instance if you send a \n to end a string sequence it would be a double new line. The other new line would be written as start  of the next string.
