### PR TITLE
[RZ_A1H]Add the timer value wraparound processing to common wait processing

### DIFF
--- a/libraries/mbed/common/wait_api.c
+++ b/libraries/mbed/common/wait_api.c
@@ -16,6 +16,12 @@
 #include "wait_api.h"
 #include "us_ticker_api.h"
 
+#if defined(TARGET_RZ_A1H)
+#define EXPIRE_US (128849020)
+#else
+#define EXPIRE_US (0)
+#endif
+
 void wait(float s) {
     wait_us(s * 1000000.0f);
 }
@@ -26,5 +32,17 @@ void wait_ms(int ms) {
 
 void wait_us(int us) {
     uint32_t start = us_ticker_read();
-    while ((us_ticker_read() - start) < (uint32_t)us);
+    uint32_t expire_time = 0;
+    uint32_t now;
+#if (EXPIRE_US > 0)
+    uint32_t last  = start;
+#endif
+
+    do {
+        now = us_ticker_read();
+#if (EXPIRE_US > 0)
+        if ( last > now ) expire_time += EXPIRE_US;
+        last = now;
+#endif
+    } while ((now + expire_time - start) < (uint32_t)us);
 }

--- a/libraries/mbed/targets/hal/TARGET_RENESAS/TARGET_RZ_A1H/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_RENESAS/TARGET_RZ_A1H/us_ticker.c
@@ -39,9 +39,9 @@ void us_ticker_init(void) {
     
     /* set Counter Clock(us) */
     if (false == RZ_A1_IsClockMode0()) {
-        count_clock = (double)(CM1_RENESAS_RZ_A1_P0_CLK / US_TICKER_CLOCK_US_DEV);
+        count_clock = ((double)CM1_RENESAS_RZ_A1_P0_CLK / (double)US_TICKER_CLOCK_US_DEV);
     } else {
-        count_clock = (double)(CM0_RENESAS_RZ_A1_P0_CLK / US_TICKER_CLOCK_US_DEV);
+        count_clock = ((double)CM0_RENESAS_RZ_A1_P0_CLK / (double)US_TICKER_CLOCK_US_DEV);
     }
 
     /* Power Control for Peripherals      */


### PR DESCRIPTION
Hi,

We add the timer value wraparound processing to common wait processing.
Timer value wraparound operation had not been considered in common wait process.
By defining the EXPIRE_US non-zero value, wraparound operation is enabled.
The EXPIRE_US will be define the value of each vender-specific.
If EXPIRE_US is 0, the common wait process is same as before.
Please check the code.

And, fix a bug that us_ticker count clock will be truncated after the decimal point.

Regards,
Hamanaka
