### PR TITLE
[MTS_MDOT_F411RE] Fix startup to work with RTOS

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/TOOLCHAIN_GCC_ARM/STM32F411XE.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/TOOLCHAIN_GCC_ARM/STM32F411XE.ld
@@ -1,3 +1,5 @@
+/* Linker script for STM32F411 */
+
 /* Linker script to configure memory regions. */
 MEMORY
 { 
@@ -30,7 +32,6 @@ MEMORY
  *   __StackLimit
  *   __StackTop
  *   __stack
- *   _estack
  */
 ENTRY(Reset_Handler)
 
@@ -40,6 +41,7 @@ SECTIONS
     {
         KEEP(*(.isr_vector))
         *(.text*)
+
         KEEP(*(.init))
         KEEP(*(.fini))
 
@@ -75,12 +77,10 @@ SECTIONS
     __exidx_end = .;
 
     __etext = .;
-    _sidata = .;
 
     .data : AT (__etext)
     {
         __data_start__ = .;
-        _sdata = .;
         *(vtable)
         *(.data*)
 
@@ -109,7 +109,6 @@ SECTIONS
         . = ALIGN(4);
         /* All data end */
         __data_end__ = .;
-        _edata = .;
 
     } > RAM
 
@@ -117,12 +116,10 @@ SECTIONS
     {
         . = ALIGN(4);
         __bss_start__ = .;
-        _sbss = .;
         *(.bss*)
         *(COMMON)
         . = ALIGN(4);
         __bss_end__ = .;
-        _ebss = .;
     } > RAM
 
     .heap (COPY):
@@ -144,10 +141,10 @@ SECTIONS
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
     __StackTop = ORIGIN(RAM) + LENGTH(RAM);
-    _estack = __StackTop;
     __StackLimit = __StackTop - SIZEOF(.stack_dummy);
     PROVIDE(__stack = __StackTop);
 
     /* Check if data + heap + stack exceeds RAM limit */
     ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
 }
+

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/TOOLCHAIN_GCC_ARM/startup_stm32f411xe.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/TOOLCHAIN_GCC_ARM/startup_stm32f411xe.s
@@ -1,454 +1,297 @@
-/**
-  ******************************************************************************
-  * @file      startup_stm32f411xe.s
-  * @author    MCD Application Team
-  * @version   V2.1.0
-  * @date      19-June-2014
-  * @brief     STM32F411xExx Devices vector table for Atollic TrueSTUDIO toolchain. 
-  *            This module performs:
-  *                - Set the initial SP
-  *                - Set the initial PC == Reset_Handler,
-  *                - Set the vector table entries with the exceptions ISR address
-  *                - Branches to main in the C library (which eventually
-  *                  calls main()).
-  *            After Reset the Cortex-M4 processor is in Thread mode,
-  *            priority is Privileged, and the Stack is set to Main.
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; COPYRIGHT 2014 STMicroelectronics</center></h2>
-  *
-  * Redistribution and use in source and binary forms, with or without modification,
-  * are permitted provided that the following conditions are met:
-  *   1. Redistributions of source code must retain the above copyright notice,
-  *      this list of conditions and the following disclaimer.
-  *   2. Redistributions in binary form must reproduce the above copyright notice,
-  *      this list of conditions and the following disclaimer in the documentation
-  *      and/or other materials provided with the distribution.
-  *   3. Neither the name of STMicroelectronics nor the names of its contributors
-  *      may be used to endorse or promote products derived from this software
-  *      without specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  *
-  ******************************************************************************
-  */
-    
-  .syntax unified
-  .cpu cortex-m4
-  .fpu softvfp
-  .thumb
+/* File: startup_STM32F40x.S
+ * Purpose: startup file for Cortex-M4 devices. Should use with
+ *   GCC for ARM Embedded Processors
+ * Version: V1.4
+ * Date: 09 July 2012
+ *
+ * Copyright (c) 2011, 2012, ARM Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the ARM Limited nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL ARM LIMITED BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+    .syntax unified
+    .arch armv7-m
 
-.global  g_pfnVectors
-.global  Default_Handler
+    .section .stack
+    .align 3
+#ifdef __STACK_SIZE
+    .equ    Stack_Size, __STACK_SIZE
+#else
+    .equ    Stack_Size, 0xc00
+#endif
+    .globl    __StackTop
+    .globl    __StackLimit
+__StackLimit:
+    .space    Stack_Size
+    .size __StackLimit, . - __StackLimit
+__StackTop:
+    .size __StackTop, . - __StackTop
 
-/* start address for the initialization values of the .data section. 
-defined in linker script */
-.word  _sidata
-/* start address for the .data section. defined in linker script */  
-.word  _sdata
-/* end address for the .data section. defined in linker script */
-.word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
-/* stack used for SystemInit_ExtMemCtl; always internal RAM used */
+    .section .heap
+    .align 3
+#ifdef __HEAP_SIZE
+    .equ    Heap_Size, __HEAP_SIZE
+#else
+    .equ    Heap_Size, 0x400
+#endif
+    .globl    __HeapBase
+    .globl    __HeapLimit
+__HeapBase:
+    .if    Heap_Size
+    .space    Heap_Size
+    .endif
+    .size __HeapBase, . - __HeapBase
+__HeapLimit:
+    .size __HeapLimit, . - __HeapLimit
 
-/**
- * @brief  This is the code that gets called when the processor first
- *          starts execution following a reset event. Only the absolutely
- *          necessary set is performed, after which the application
- *          supplied main() routine is called. 
- * @param  None
- * @retval : None
-*/
+    .section .isr_vector
+    .align 2
+    .globl __isr_vector
+__isr_vector:
+    .long    __StackTop            /* Top of Stack */
+    .long    Reset_Handler         /* Reset Handler */
+    .long    NMI_Handler           /* NMI Handler */
+    .long    HardFault_Handler     /* Hard Fault Handler */
+    .long    MemManage_Handler     /* MPU Fault Handler */
+    .long    BusFault_Handler      /* Bus Fault Handler */
+    .long    UsageFault_Handler    /* Usage Fault Handler */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    SVC_Handler           /* SVCall Handler */
+    .long    DebugMon_Handler      /* Debug Monitor Handler */
+    .long    0                     /* Reserved */
+    .long    PendSV_Handler        /* PendSV Handler */
+    .long    SysTick_Handler       /* SysTick Handler */
 
-    .section  .text.Reset_Handler
-  .weak  Reset_Handler
-  .type  Reset_Handler, %function
-Reset_Handler:  
-  ldr   sp, =_estack    		 /* set stack pointer */
+    /* External interrupts */
+    .long     WWDG_IRQHandler               /* Window WatchDog */
+    .long     PVD_IRQHandler                /* PVD through EXTI Line detection */
+    .long     TAMP_STAMP_IRQHandler         /* Tamper and TimeStamps through the EXTI line */
+    .long     RTC_WKUP_IRQHandler           /* RTC Wakeup through the EXTI line */
+    .long     FLASH_IRQHandler              /* FLASH */
+    .long     RCC_IRQHandler                /* RCC */
+    .long     EXTI0_IRQHandler              /* EXTI Line0 */
+    .long     EXTI1_IRQHandler              /* EXTI Line1 */
+    .long     EXTI2_IRQHandler              /* EXTI Line2 */
+    .long     EXTI3_IRQHandler              /* EXTI Line3 */
+    .long     EXTI4_IRQHandler              /* EXTI Line4 */
+    .long     DMA1_Stream0_IRQHandler       /* DMA1 Stream 0 */
+    .long     DMA1_Stream1_IRQHandler       /* DMA1 Stream 1 */
+    .long     DMA1_Stream2_IRQHandler       /* DMA1 Stream 2 */
+    .long     DMA1_Stream3_IRQHandler       /* DMA1 Stream 3 */
+    .long     DMA1_Stream4_IRQHandler       /* DMA1 Stream 4 */
+    .long     DMA1_Stream5_IRQHandler       /* DMA1 Stream 5 */
+    .long     DMA1_Stream6_IRQHandler       /* DMA1 Stream 6 */
+    .long     ADC_IRQHandler                /* ADC1, ADC2 and ADC3s */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long     EXTI9_5_IRQHandler            /* External Line[9:5]s */
+    .long     TIM1_BRK_TIM9_IRQHandler      /* TIM1 Break and TIM9 */
+    .long     TIM1_UP_TIM10_IRQHandler      /* TIM1 Update and TIM10 */
+    .long     TIM1_TRG_COM_TIM11_IRQHandler /* TIM1 Trigger and Commutation and TIM11 */
+    .long     TIM1_CC_IRQHandler            /* TIM1 Capture Compare */
+    .long     TIM2_IRQHandler               /* TIM2 */
+    .long     TIM3_IRQHandler               /* TIM3 */
+    .long     TIM4_IRQHandler               /* TIM4 */
+    .long     I2C1_EV_IRQHandler            /* I2C1 Event */
+    .long     I2C1_ER_IRQHandler            /* I2C1 Error */
+    .long     I2C2_EV_IRQHandler            /* I2C2 Event */
+    .long     I2C2_ER_IRQHandler            /* I2C2 Error */
+    .long     SPI1_IRQHandler               /* SPI1 */
+    .long     SPI2_IRQHandler               /* SPI2 */
+    .long     USART1_IRQHandler             /* USART1 */
+    .long     USART2_IRQHandler             /* USART2 */
+    .long    0                     /* Reserved */
+    .long     EXTI15_10_IRQHandler          /* External Line[15:10]s */
+    .long     RTC_Alarm_IRQHandler          /* RTC Alarm (A and B) through EXTI Line */
+    .long     OTG_FS_WKUP_IRQHandler        /* USB OTG FS Wakeup through EXTI line */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long     DMA1_Stream7_IRQHandler       /* DMA1 Stream7 */
+    .long    0                     /* Reserved */
+    .long     SDIO_IRQHandler               /* SDIO */
+    .long     TIM5_IRQHandler               /* TIM5 */
+    .long     SPI3_IRQHandler               /* SPI3 */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long     DMA2_Stream0_IRQHandler       /* DMA2 Stream 0 */
+    .long     DMA2_Stream1_IRQHandler       /* DMA2 Stream 1 */
+    .long     DMA2_Stream2_IRQHandler       /* DMA2 Stream 2 */
+    .long     DMA2_Stream3_IRQHandler       /* DMA2 Stream 3 */
+    .long     DMA2_Stream4_IRQHandler       /* DMA2 Stream 4 */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long     OTG_FS_IRQHandler             /* USB OTG FS */
+    .long     DMA2_Stream5_IRQHandler       /* DMA2 Stream 5 */
+    .long     DMA2_Stream6_IRQHandler       /* DMA2 Stream 6 */
+    .long     DMA2_Stream7_IRQHandler       /* DMA2 Stream 7 */
+    .long     USART6_IRQHandler             /* USART6 */
+    .long     I2C3_EV_IRQHandler            /* I2C3 event */
+    .long     I2C3_ER_IRQHandler            /* I2C3 error */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long     FPU_IRQHandler                /* FPU */
+    .long     SPI4_IRQHandler                   /* SPI4 */ 
+    .long     SPI5_IRQHandler                   /* SPI5 */ 
 
-/* Copy the data segment initializers from flash to SRAM */  
-  movs  r1, #0
-  b  LoopCopyDataInit
+    .size    __isr_vector, . - __isr_vector
 
-CopyDataInit:
-  ldr  r3, =_sidata
-  ldr  r3, [r3, r1]
-  str  r3, [r0, r1]
-  adds  r1, r1, #4
-    
-LoopCopyDataInit:
-  ldr  r0, =_sdata
-  ldr  r3, =_edata
-  adds  r2, r0, r1
-  cmp  r2, r3
-  bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
+    .text
+    .thumb
+    .thumb_func
+    .align 2
+    .globl    Reset_Handler
+    .type    Reset_Handler, %function
+Reset_Handler:
+/*     Loop to copy data from read only memory to RAM. The ranges
+ *      of copy from/to are specified by following symbols evaluated in
+ *      linker script.
+ *      __etext: End of code section, i.e., begin of data sections to copy from.
+ *      __data_start__/__data_end__: RAM address range that data should be
+ *      copied to. Both must be aligned to 4 bytes boundary.  */
 
-/* Call the clock system intitialization function.*/
-  bl  SystemInit   
-/* Call static constructors */
-    bl __libc_init_array
-/* Call the application's entry point.*/
-  bl  main
-  bx  lr    
-.size  Reset_Handler, .-Reset_Handler
+    ldr    r1, =__etext
+    ldr    r2, =__data_start__
+    ldr    r3, =__data_end__
 
-/**
- * @brief  This is the code that gets called when the processor receives an 
- *         unexpected interrupt.  This simply enters an infinite loop, preserving
- *         the system state for examination by a debugger.
- * @param  None     
- * @retval None       
-*/
-    .section  .text.Default_Handler,"ax",%progbits
-Default_Handler:
-Infinite_Loop:
-  b  Infinite_Loop
-  .size  Default_Handler, .-Default_Handler
-/******************************************************************************
-*
-* The minimal vector table for a Cortex M3. Note that the proper constructs
-* must be placed on this to ensure that it ends up at physical address
-* 0x0000.0000.
-* 
-*******************************************************************************/
-   .section  .isr_vector,"a",%progbits
-  .type  g_pfnVectors, %object
-  .size  g_pfnVectors, .-g_pfnVectors
-    
-g_pfnVectors:
-  .word  _estack
-  .word  Reset_Handler
-  .word  NMI_Handler
-  .word  HardFault_Handler
-  .word  MemManage_Handler
-  .word  BusFault_Handler
-  .word  UsageFault_Handler
-  .word  0
-  .word  0
-  .word  0
-  .word  0
-  .word  SVC_Handler
-  .word  DebugMon_Handler
-  .word  0
-  .word  PendSV_Handler
-  .word  SysTick_Handler
-  
-  /* External Interrupts */
-  .word     WWDG_IRQHandler                   /* Window WatchDog              */                                        
-  .word     PVD_IRQHandler                    /* PVD through EXTI Line detection */                        
-  .word     TAMP_STAMP_IRQHandler             /* Tamper and TimeStamps through the EXTI line */            
-  .word     RTC_WKUP_IRQHandler               /* RTC Wakeup through the EXTI line */                      
-  .word     FLASH_IRQHandler                  /* FLASH                        */                                          
-  .word     RCC_IRQHandler                    /* RCC                          */                                            
-  .word     EXTI0_IRQHandler                  /* EXTI Line0                   */                        
-  .word     EXTI1_IRQHandler                  /* EXTI Line1                   */                          
-  .word     EXTI2_IRQHandler                  /* EXTI Line2                   */                          
-  .word     EXTI3_IRQHandler                  /* EXTI Line3                   */                          
-  .word     EXTI4_IRQHandler                  /* EXTI Line4                   */                          
-  .word     DMA1_Stream0_IRQHandler           /* DMA1 Stream 0                */                  
-  .word     DMA1_Stream1_IRQHandler           /* DMA1 Stream 1                */                   
-  .word     DMA1_Stream2_IRQHandler           /* DMA1 Stream 2                */                   
-  .word     DMA1_Stream3_IRQHandler           /* DMA1 Stream 3                */                   
-  .word     DMA1_Stream4_IRQHandler           /* DMA1 Stream 4                */                   
-  .word     DMA1_Stream5_IRQHandler           /* DMA1 Stream 5                */                   
-  .word     DMA1_Stream6_IRQHandler           /* DMA1 Stream 6                */                   
-  .word     ADC_IRQHandler                    /* ADC1, ADC2 and ADC3s         */                   
-  .word     0               				  /* Reserved                      */                         
-  .word     0              					  /* Reserved                     */                          
-  .word     0                                 /* Reserved                     */                          
-  .word     0                                 /* Reserved                     */                          
-  .word     EXTI9_5_IRQHandler                /* External Line[9:5]s          */                          
-  .word     TIM1_BRK_TIM9_IRQHandler          /* TIM1 Break and TIM9          */         
-  .word     TIM1_UP_TIM10_IRQHandler          /* TIM1 Update and TIM10        */         
-  .word     TIM1_TRG_COM_TIM11_IRQHandler     /* TIM1 Trigger and Commutation and TIM11 */
-  .word     TIM1_CC_IRQHandler                /* TIM1 Capture Compare         */                          
-  .word     TIM2_IRQHandler                   /* TIM2                         */                   
-  .word     TIM3_IRQHandler                   /* TIM3                         */                   
-  .word     TIM4_IRQHandler                   /* TIM4                         */                   
-  .word     I2C1_EV_IRQHandler                /* I2C1 Event                   */                          
-  .word     I2C1_ER_IRQHandler                /* I2C1 Error                   */                          
-  .word     I2C2_EV_IRQHandler                /* I2C2 Event                   */                          
-  .word     I2C2_ER_IRQHandler                /* I2C2 Error                   */                            
-  .word     SPI1_IRQHandler                   /* SPI1                         */                   
-  .word     SPI2_IRQHandler                   /* SPI2                         */                   
-  .word     USART1_IRQHandler                 /* USART1                       */                   
-  .word     USART2_IRQHandler                 /* USART2                       */                   
-  .word     0               				  /* Reserved                       */                   
-  .word     EXTI15_10_IRQHandler              /* External Line[15:10]s        */                          
-  .word     RTC_Alarm_IRQHandler              /* RTC Alarm (A and B) through EXTI Line */                 
-  .word     OTG_FS_WKUP_IRQHandler            /* USB OTG FS Wakeup through EXTI line */                       
-  .word     0                                 /* Reserved     				  */         
-  .word     0                                 /* Reserved       			  */         
-  .word     0                                 /* Reserved 					  */
-  .word     0                                 /* Reserved                     */                          
-  .word     DMA1_Stream7_IRQHandler           /* DMA1 Stream7                 */                          
-  .word     0                                 /* Reserved                     */                   
-  .word     SDIO_IRQHandler                   /* SDIO                         */                   
-  .word     TIM5_IRQHandler                   /* TIM5                         */                   
-  .word     SPI3_IRQHandler                   /* SPI3                         */                   
-  .word     0                                 /* Reserved                     */                   
-  .word     0                                 /* Reserved                     */                   
-  .word     0                                 /* Reserved                     */                   
-  .word     0                                 /* Reserved                     */
-  .word     DMA2_Stream0_IRQHandler           /* DMA2 Stream 0                */                   
-  .word     DMA2_Stream1_IRQHandler           /* DMA2 Stream 1                */                   
-  .word     DMA2_Stream2_IRQHandler           /* DMA2 Stream 2                */                   
-  .word     DMA2_Stream3_IRQHandler           /* DMA2 Stream 3                */                   
-  .word     DMA2_Stream4_IRQHandler           /* DMA2 Stream 4                */                   
-  .word     0                    			  /* Reserved                     */                   
-  .word     0              					  /* Reserved                     */                     
-  .word     0              					  /* Reserved                     */                          
-  .word     0             					  /* Reserved                     */                          
-  .word     0              					  /* Reserved                     */                          
-  .word     0              					  /* Reserved                     */                          
-  .word     OTG_FS_IRQHandler                 /* USB OTG FS                   */                   
-  .word     DMA2_Stream5_IRQHandler           /* DMA2 Stream 5                */                   
-  .word     DMA2_Stream6_IRQHandler           /* DMA2 Stream 6                */                   
-  .word     DMA2_Stream7_IRQHandler           /* DMA2 Stream 7                */                   
-  .word     USART6_IRQHandler                 /* USART6                       */                    
-  .word     I2C3_EV_IRQHandler                /* I2C3 event                   */                          
-  .word     I2C3_ER_IRQHandler                /* I2C3 error                   */                          
-  .word     0                                 /* Reserved                     */                   
-  .word     0                                 /* Reserved                     */                   
-  .word     0                                 /* Reserved                     */                         
-  .word     0                                 /* Reserved                     */                   
-  .word     0                                 /* Reserved                     */                   
-  .word     0                                 /* Reserved                     */                   
-  .word     0                                 /* Reserved                     */
-  .word     FPU_IRQHandler                    /* FPU                          */
-  .word     0                                 /* Reserved                     */                   
-  .word     0                                 /* Reserved                     */
-  .word     SPI4_IRQHandler                   /* SPI4                         */
-  .word     SPI5_IRQHandler                   /* SPI5                         */  
-                    
-/*******************************************************************************
-*
-* Provide weak aliases for each Exception handler to the Default_Handler. 
-* As they are weak aliases, any function with the same name will override 
-* this definition.
-* 
-*******************************************************************************/
-   .weak      NMI_Handler
-   .thumb_set NMI_Handler,Default_Handler
-  
-   .weak      HardFault_Handler
-   .thumb_set HardFault_Handler,Default_Handler
-  
-   .weak      MemManage_Handler
-   .thumb_set MemManage_Handler,Default_Handler
-  
-   .weak      BusFault_Handler
-   .thumb_set BusFault_Handler,Default_Handler
+.LC0:
+    cmp     r2, r3
+    ittt    lt
+    ldrlt   r0, [r1], #4
+    strlt   r0, [r2], #4
+    blt    .LC0
 
-   .weak      UsageFault_Handler
-   .thumb_set UsageFault_Handler,Default_Handler
+    ldr    r0, =SystemInit
+    blx    r0
+    ldr    r0, =_start
+    bx     r0
+    .pool
+    .size Reset_Handler, . - Reset_Handler
 
-   .weak      SVC_Handler
-   .thumb_set SVC_Handler,Default_Handler
+    .text
+/*    Macro to define default handlers. Default handler
+ *    will be weak symbol and just dead loops. They can be
+ *    overwritten by other handlers */
+    .macro    def_default_handler    handler_name
+    .align 1
+    .thumb_func
+    .weak    \handler_name
+    .type    \handler_name, %function
+\handler_name :
+    b    .
+    .size    \handler_name, . - \handler_name
+    .endm
 
-   .weak      DebugMon_Handler
-   .thumb_set DebugMon_Handler,Default_Handler
+    def_default_handler    NMI_Handler
+    def_default_handler    HardFault_Handler
+    def_default_handler    MemManage_Handler
+    def_default_handler    BusFault_Handler
+    def_default_handler    UsageFault_Handler
+    def_default_handler    SVC_Handler
+    def_default_handler    DebugMon_Handler
+    def_default_handler    PendSV_Handler
+    def_default_handler    SysTick_Handler
+    def_default_handler    Default_Handler
 
-   .weak      PendSV_Handler
-   .thumb_set PendSV_Handler,Default_Handler
+    .macro    def_irq_default_handler    handler_name
+    .weak     \handler_name
+    .set      \handler_name, Default_Handler
+    .endm
 
-   .weak      SysTick_Handler
-   .thumb_set SysTick_Handler,Default_Handler              
-  
-   .weak      WWDG_IRQHandler                   
-   .thumb_set WWDG_IRQHandler,Default_Handler      
-                  
-   .weak      PVD_IRQHandler      
-   .thumb_set PVD_IRQHandler,Default_Handler
-               
-   .weak      TAMP_STAMP_IRQHandler            
-   .thumb_set TAMP_STAMP_IRQHandler,Default_Handler
-            
-   .weak      RTC_WKUP_IRQHandler                  
-   .thumb_set RTC_WKUP_IRQHandler,Default_Handler
-            
-   .weak      FLASH_IRQHandler         
-   .thumb_set FLASH_IRQHandler,Default_Handler
-                  
-   .weak      RCC_IRQHandler      
-   .thumb_set RCC_IRQHandler,Default_Handler
-                  
-   .weak      EXTI0_IRQHandler         
-   .thumb_set EXTI0_IRQHandler,Default_Handler
-                  
-   .weak      EXTI1_IRQHandler         
-   .thumb_set EXTI1_IRQHandler,Default_Handler
-                     
-   .weak      EXTI2_IRQHandler         
-   .thumb_set EXTI2_IRQHandler,Default_Handler 
-                 
-   .weak      EXTI3_IRQHandler         
-   .thumb_set EXTI3_IRQHandler,Default_Handler
-                        
-   .weak      EXTI4_IRQHandler         
-   .thumb_set EXTI4_IRQHandler,Default_Handler
-                  
-   .weak      DMA1_Stream0_IRQHandler               
-   .thumb_set DMA1_Stream0_IRQHandler,Default_Handler
-         
-   .weak      DMA1_Stream1_IRQHandler               
-   .thumb_set DMA1_Stream1_IRQHandler,Default_Handler
-                  
-   .weak      DMA1_Stream2_IRQHandler               
-   .thumb_set DMA1_Stream2_IRQHandler,Default_Handler
-                  
-   .weak      DMA1_Stream3_IRQHandler               
-   .thumb_set DMA1_Stream3_IRQHandler,Default_Handler 
-                 
-   .weak      DMA1_Stream4_IRQHandler              
-   .thumb_set DMA1_Stream4_IRQHandler,Default_Handler
-                  
-   .weak      DMA1_Stream5_IRQHandler               
-   .thumb_set DMA1_Stream5_IRQHandler,Default_Handler
-                  
-   .weak      DMA1_Stream6_IRQHandler               
-   .thumb_set DMA1_Stream6_IRQHandler,Default_Handler
-                  
-   .weak      ADC_IRQHandler      
-   .thumb_set ADC_IRQHandler,Default_Handler
-            
-   .weak      EXTI9_5_IRQHandler   
-   .thumb_set EXTI9_5_IRQHandler,Default_Handler
-            
-   .weak      TIM1_BRK_TIM9_IRQHandler            
-   .thumb_set TIM1_BRK_TIM9_IRQHandler,Default_Handler
-            
-   .weak      TIM1_UP_TIM10_IRQHandler            
-   .thumb_set TIM1_UP_TIM10_IRQHandler,Default_Handler
-      
-   .weak      TIM1_TRG_COM_TIM11_IRQHandler      
-   .thumb_set TIM1_TRG_COM_TIM11_IRQHandler,Default_Handler
-      
-   .weak      TIM1_CC_IRQHandler   
-   .thumb_set TIM1_CC_IRQHandler,Default_Handler
-                  
-   .weak      TIM2_IRQHandler            
-   .thumb_set TIM2_IRQHandler,Default_Handler
-                  
-   .weak      TIM3_IRQHandler            
-   .thumb_set TIM3_IRQHandler,Default_Handler
-                  
-   .weak      TIM4_IRQHandler            
-   .thumb_set TIM4_IRQHandler,Default_Handler
-                  
-   .weak      I2C1_EV_IRQHandler   
-   .thumb_set I2C1_EV_IRQHandler,Default_Handler
-                     
-   .weak      I2C1_ER_IRQHandler   
-   .thumb_set I2C1_ER_IRQHandler,Default_Handler
-                     
-   .weak      I2C2_EV_IRQHandler   
-   .thumb_set I2C2_EV_IRQHandler,Default_Handler
-                  
-   .weak      I2C2_ER_IRQHandler   
-   .thumb_set I2C2_ER_IRQHandler,Default_Handler
-                           
-   .weak      SPI1_IRQHandler            
-   .thumb_set SPI1_IRQHandler,Default_Handler
-                        
-   .weak      SPI2_IRQHandler            
-   .thumb_set SPI2_IRQHandler,Default_Handler
-                  
-   .weak      USART1_IRQHandler      
-   .thumb_set USART1_IRQHandler,Default_Handler
-                     
-   .weak      USART2_IRQHandler      
-   .thumb_set USART2_IRQHandler,Default_Handler
-                                  
-   .weak      EXTI15_10_IRQHandler               
-   .thumb_set EXTI15_10_IRQHandler,Default_Handler
-               
-   .weak      RTC_Alarm_IRQHandler               
-   .thumb_set RTC_Alarm_IRQHandler,Default_Handler
-            
-   .weak      OTG_FS_WKUP_IRQHandler         
-   .thumb_set OTG_FS_WKUP_IRQHandler,Default_Handler
-            
-   .weak      DMA1_Stream7_IRQHandler               
-   .thumb_set DMA1_Stream7_IRQHandler,Default_Handler
-                     
-   .weak      SDIO_IRQHandler            
-   .thumb_set SDIO_IRQHandler,Default_Handler
-                     
-   .weak      TIM5_IRQHandler            
-   .thumb_set TIM5_IRQHandler,Default_Handler
-                     
-   .weak      SPI3_IRQHandler            
-   .thumb_set SPI3_IRQHandler,Default_Handler
-                     
-   .weak      DMA2_Stream0_IRQHandler               
-   .thumb_set DMA2_Stream0_IRQHandler,Default_Handler
-               
-   .weak      DMA2_Stream1_IRQHandler               
-   .thumb_set DMA2_Stream1_IRQHandler,Default_Handler
-                  
-   .weak      DMA2_Stream2_IRQHandler               
-   .thumb_set DMA2_Stream2_IRQHandler,Default_Handler
-            
-   .weak      DMA2_Stream3_IRQHandler               
-   .thumb_set DMA2_Stream3_IRQHandler,Default_Handler
-            
-   .weak      DMA2_Stream4_IRQHandler               
-   .thumb_set DMA2_Stream4_IRQHandler,Default_Handler
-            
-   .weak      OTG_FS_IRQHandler      
-   .thumb_set OTG_FS_IRQHandler,Default_Handler
-                     
-   .weak      DMA2_Stream5_IRQHandler               
-   .thumb_set DMA2_Stream5_IRQHandler,Default_Handler
-                  
-   .weak      DMA2_Stream6_IRQHandler               
-   .thumb_set DMA2_Stream6_IRQHandler,Default_Handler
-                  
-   .weak      DMA2_Stream7_IRQHandler               
-   .thumb_set DMA2_Stream7_IRQHandler,Default_Handler
-                  
-   .weak      USART6_IRQHandler      
-   .thumb_set USART6_IRQHandler,Default_Handler
-                        
-   .weak      I2C3_EV_IRQHandler   
-   .thumb_set I2C3_EV_IRQHandler,Default_Handler
-                        
-   .weak      I2C3_ER_IRQHandler   
-   .thumb_set I2C3_ER_IRQHandler,Default_Handler
-                        
-   .weak      FPU_IRQHandler                  
-   .thumb_set FPU_IRQHandler,Default_Handler  
+    def_irq_default_handler     WWDG_IRQHandler
+    def_irq_default_handler     PVD_IRQHandler
+    def_irq_default_handler     TAMP_STAMP_IRQHandler
+    def_irq_default_handler     RTC_WKUP_IRQHandler
+    def_irq_default_handler     FLASH_IRQHandler
+    def_irq_default_handler     RCC_IRQHandler
+    def_irq_default_handler     EXTI0_IRQHandler
+    def_irq_default_handler     EXTI1_IRQHandler
+    def_irq_default_handler     EXTI2_IRQHandler
+    def_irq_default_handler     EXTI3_IRQHandler
+    def_irq_default_handler     EXTI4_IRQHandler
+    def_irq_default_handler     DMA1_Stream0_IRQHandler
+    def_irq_default_handler     DMA1_Stream1_IRQHandler
+    def_irq_default_handler     DMA1_Stream2_IRQHandler
+    def_irq_default_handler     DMA1_Stream3_IRQHandler
+    def_irq_default_handler     DMA1_Stream4_IRQHandler
+    def_irq_default_handler     DMA1_Stream5_IRQHandler
+    def_irq_default_handler     DMA1_Stream6_IRQHandler
+    def_irq_default_handler     ADC_IRQHandler
+    def_irq_default_handler     EXTI9_5_IRQHandler
+    def_irq_default_handler     TIM1_BRK_TIM9_IRQHandler
+    def_irq_default_handler     TIM1_UP_TIM10_IRQHandler
+    def_irq_default_handler     TIM1_TRG_COM_TIM11_IRQHandler
+    def_irq_default_handler     TIM1_CC_IRQHandler
+    def_irq_default_handler     TIM2_IRQHandler
+    def_irq_default_handler     TIM3_IRQHandler
+    def_irq_default_handler     TIM4_IRQHandler
+    def_irq_default_handler     I2C1_EV_IRQHandler
+    def_irq_default_handler     I2C1_ER_IRQHandler
+    def_irq_default_handler     I2C2_EV_IRQHandler
+    def_irq_default_handler     I2C2_ER_IRQHandler
+    def_irq_default_handler     SPI1_IRQHandler
+    def_irq_default_handler     SPI2_IRQHandler
+    def_irq_default_handler     USART1_IRQHandler
+    def_irq_default_handler     USART2_IRQHandler
+    def_irq_default_handler     EXTI15_10_IRQHandler
+    def_irq_default_handler     RTC_Alarm_IRQHandler
+    def_irq_default_handler     OTG_FS_WKUP_IRQHandler
+    def_irq_default_handler     DMA1_Stream7_IRQHandler
+    def_irq_default_handler     SDIO_IRQHandler
+    def_irq_default_handler     TIM5_IRQHandler
+    def_irq_default_handler     SPI3_IRQHandler
+    def_irq_default_handler     DMA2_Stream0_IRQHandler
+    def_irq_default_handler     DMA2_Stream1_IRQHandler
+    def_irq_default_handler     DMA2_Stream2_IRQHandler
+    def_irq_default_handler     DMA2_Stream3_IRQHandler
+    def_irq_default_handler     DMA2_Stream4_IRQHandler
+    def_irq_default_handler     OTG_FS_IRQHandler
+    def_irq_default_handler     DMA2_Stream5_IRQHandler
+    def_irq_default_handler     DMA2_Stream6_IRQHandler
+    def_irq_default_handler     DMA2_Stream7_IRQHandler
+    def_irq_default_handler     USART6_IRQHandler
+    def_irq_default_handler     I2C3_EV_IRQHandler
+    def_irq_default_handler     I2C3_ER_IRQHandler
+    def_irq_default_handler     FPU_IRQHandler
+    def_irq_default_handler     SPI4_IRQHandler
+    def_irq_default_handler     SPI5_IRQHandler
+    def_irq_default_handler     DEF_IRQHandler
 
-   .weak      SPI4_IRQHandler                  
-   .thumb_set SPI4_IRQHandler,Default_Handler
-
-   .weak      SPI5_IRQHandler                  
-   .thumb_set SPI5_IRQHandler,Default_Handler    
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
-
+    .end


### PR DESCRIPTION
The old GCC startup skipped directly to main skipping some critical init sections for the RTOS.  @bcostm this issue is likely in more of the ST targets and I also noticed it potentially in the ARM toolchain.  I will create an issue for that.
