### PR TITLE
Fix KL05Z GCC_ARM linker script

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/TOOLCHAIN_GCC_ARM/MKL05Z4.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/TOOLCHAIN_GCC_ARM/MKL05Z4.ld
@@ -6,7 +6,7 @@ MEMORY
 {
   VECTORS (rx) : ORIGIN = 0x00000000, LENGTH = 0x00000410
   FLASH (rx) : ORIGIN = 0x00000410, LENGTH = 32K - 0x00000410
-  RAM (rwx) : ORIGIN = 0x1FFFFC00, LENGTH = 4K - 0xC0
+  RAM (rwx) : ORIGIN = 0x1FFFFCC0, LENGTH = 4K - 0xC0
 }
 
 /* Linker script to place sections and symbol values. Should be used together


### PR DESCRIPTION
Issue originally reported on mbed site here:
https://developer.mbed.org/questions/5695/FRDM-KL05z-hardfault-when-compiled-with-/

The RAM base address was incorrectly set to the beginning of RAM
instead of at a 0xC0 byte offset to reserve room for the interrupt
vectors. Without this fix, the global variables and the interrupt
vectors were occupying the same space in RAM once the user enabled the
timer interrupt.

The user who originally reported the issue on the mbed site has tested
this fix and verified that it corrected the hard fault issue that they
were encountering.
