### PR TITLE
Sample Implementation of Revised PinMode Definition For KL25Z

### DIFF
--- a/libraries/mbed/hal/pinmap.h
+++ b/libraries/mbed/hal/pinmap.h
@@ -30,6 +30,7 @@ typedef struct {
 
 void pin_function(PinName pin, int function);
 void pin_mode    (PinName pin, PinMode mode);
+int pin_supports_mode(PinName pin, PinMode mode);
 
 uint32_t pinmap_peripheral(PinName pin, const PinMap* map);
 uint32_t pinmap_function(PinName pin, const PinMap* map);

--- a/libraries/mbed/hal/pinmode.h
+++ b/libraries/mbed/hal/pinmode.h
@@ -1,0 +1,7 @@
+typedef enum {
+    PullNone,
+    PullUp,
+    PullDown,
+    OpenDrain,
+    Repeater
+} PinMode;

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/PinNames.h
@@ -17,6 +17,7 @@
 #define MBED_PINNAMES_H
 
 #include "cmsis.h"
+#include "pinmode.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -240,12 +241,16 @@ typedef enum {
     NC = (int)0xFFFFFFFF
 } PinName;
 
-/* PullDown not available for KL25 */
-typedef enum {
-    PullNone = 0,
-    PullUp = 2,
-    PullDefault = PullUp
-} PinMode;
+static const int PinModes[] = {
+  0,    // PullNone bitmask
+  2,    // PullUp bitmask
+  -1,   // PullDown not supported
+  -1,   // OpenDrain not supported
+  -1    // Repeater not supported
+};
+
+static const PinMode PullDefault = PullUp;
+
 
 #ifdef __cplusplus
 }

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/pinmap.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/pinmap.c
@@ -29,11 +29,19 @@ void pin_function(PinName pin, int function) {
     *pin_pcr = (*pin_pcr & ~0x700) | (function << 8);
 }
 
+int pin_supports_mode(PinName pin, PinMode mode) {
+    // All pins support the same modes, no need to lookup per pin
+    // If the given mode is supported, return 0. Otherwise, return -1.
+    return PinModes[mode] != -1 ? 0 : -1 ;
+}
+
 void pin_mode(PinName pin, PinMode mode) {
     MBED_ASSERT(pin != (PinName)NC);
 
-    __IO uint32_t* pin_pcr = (__IO uint32_t*)(PORTA_BASE + pin);
+    if (pin_supports_mode(pin, mode) == 0) {
+        __IO uint32_t* pin_pcr = (__IO uint32_t*)(PORTA_BASE + pin);
 
-    // pin pullup bits: [1:0] -> 11 = (0x3)
-    *pin_pcr = (*pin_pcr & ~0x3) | mode;
+        // pin pullup bits: [1:0] -> 11 = (0x3)
+        *pin_pcr = (*pin_pcr & ~0x3) | PinModes[mode];
+    }
 }


### PR DESCRIPTION
**DO NOT MERGE**

The rest of the platforms will have to be updated too before this could be merged.

This is a sample implementation for the KL25Z of the changes I proposed in this issue: https://github.com/mbedmicro/mbed/issues/1064

I've made a few changes. I've moved the mentioned function `gpio_mode_supported` in the issue to the pinmap api as `int pin_supports_mode(PinName pin, PinMode mode);`. You can also configure an input pin to an unsupported mode, as all possible PinModes are now defined for all platforms. Right now it will simply ignore the request and leave the pin unchanged. However, you can proactively check if the pin supports a given PinMode by calling `pin_supports_mode`.

I've tested this with the KL25Z using the automated test suite and it passes all tests. I've also used a logic analyzer and I can see the "PullUp" and "PullNone" options changing the idle level of the pin.

I'd like to hear feedback on this change. How could this be better organized? Should the C++ API be changed as well to return information on (un)supported PinModes?