### PR TITLE
[KL25Z] add 32KHz crystal clock setup 3 + minor RTC api changes

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/system_MKL25Z4.c
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/system_MKL25Z4.c
@@ -55,6 +55,12 @@
    2 ... Multipurpose Clock Generator (MCG) in Bypassed Low Power External (BLPE) mode
          Core clock/Bus clock derived directly from an external crystal 8MHz with no multiplication
          Core clock = 8MHz, BusClock = 8MHz
+   3 ... Multipurpose Clock Generator (MCG) in FLL Engaged External (FEE) mode
+         Reference clock source for MCG module is an external crystal 32.768kHz
+         Core clock = 47.97MHz, BusClock = 23.98MHz
+         This setup sets the RTC to be driven by the MCU clock directly without the need of an external source.
+         RTC register values are retained when MCU is reset although there will be a slight (mSec's)loss of time
+         accuracy durring the reset period. RTC will reset on power down. 
 */
 
 /*----------------------------------------------------------------------------
@@ -75,8 +81,12 @@
     #define CPU_INT_SLOW_CLK_HZ             32768u   /* Value of the slow internal oscillator clock frequency in Hz  */
     #define CPU_INT_FAST_CLK_HZ             4000000u /* Value of the fast internal oscillator clock frequency in Hz  */
     #define DEFAULT_SYSTEM_CLOCK            8000000u /* Default System clock value */
-#endif /* (CLOCK_SETUP == 2) */
-
+#elif (CLOCK_SETUP == 3)    
+    #define CPU_XTAL_CLK_HZ                 32768u   /* Value of the external crystal or oscillator clock frequency in Hz */
+    #define CPU_INT_SLOW_CLK_HZ             32768u   /* Value of the slow internal oscillator clock frequency in Hz  */
+    #define CPU_INT_FAST_CLK_HZ             4000000u /* Value of the fast internal oscillator clock frequency in Hz  */
+    #define DEFAULT_SYSTEM_CLOCK            47972352u /* Default System clock value */       
+#endif /* (CLOCK_SETUP == 3) */
 
 /* ----------------------------------------------------------------------------
    -- Core clock
@@ -183,7 +193,34 @@ void SystemInit (void) {
   MCG->C2 = (uint8_t)0x26U;
   while((MCG->S & 0x0CU) != 0x08U) {    /* Wait until external reference clock is selected as MCG output */
   }
-#endif /* (CLOCK_SETUP == 2) */
+#elif (CLOCK_SETUP == 3)  
+/* SIM->SCGC5: PORTA=1 */
+  SIM->SCGC5 |= SIM_SCGC5_PORTA_MASK;   /* Enable clock gate for ports to enable pin routing */
+  /* SIM->CLKDIV1: OUTDIV1=0,??=0,??=0,??=0,??=0,??=0,??=0,??=0,??=0,??=0,OUTDIV4=1,??=0,??=0,??=0,??=0,??=0,??=0,??=0,??=0,??=0,??=0,??=0,??=0,??=0,??=0,??=0,??=0 */
+  SIM->CLKDIV1 = (SIM_CLKDIV1_OUTDIV1(0x00) | SIM_CLKDIV1_OUTDIV4(0x01)); /* Update system prescalers */
+  /* PORTA->PCR[3]: ISF=0,MUX=0 */
+  PORTA->PCR[3] &= (uint32_t)~(uint32_t)((PORT_PCR_ISF_MASK | PORT_PCR_MUX(0x07)));
+  /* PORTA->PCR[4]: ISF=0,MUX=0 */
+  PORTA->PCR[4] &= (uint32_t)~(uint32_t)((PORT_PCR_ISF_MASK | PORT_PCR_MUX(0x07)));
+  /* Switch to FEE Mode */
+  /* MCG->C2: LOCRE0=0,??=0,RANGE0=0,HGO0=0,EREFS0=1,LP=0,IRCS=0 */
+  MCG->C2 = (MCG_C2_RANGE0(0x00) | MCG_C2_EREFS0_MASK);
+  /* OSC0->CR: ERCLKEN=1,??=0,EREFSTEN=0,??=0,SC2P=0,SC4P=0,SC8P=0,SC16P=0 */
+  OSC0->CR = OSC_CR_ERCLKEN_MASK | OSC_CR_SC16P_MASK | OSC_CR_SC4P_MASK | OSC_CR_SC2P_MASK;
+  /* MCG->C1: CLKS=0,FRDIV=0,IREFS=0,IRCLKEN=1,IREFSTEN=0 */
+  MCG->C1 = (MCG_C1_CLKS(0x00) | MCG_C1_FRDIV(0x00) | MCG_C1_IRCLKEN_MASK);
+  /* MCG->C4: DMX32=1,DRST_DRS=1 */
+  MCG->C4 = (uint8_t)((MCG->C4 & (uint8_t)~(uint8_t)(
+            MCG_C4_DRST_DRS(0x02)
+           )) | (uint8_t)(
+            MCG_C4_DMX32_MASK |
+            MCG_C4_DRST_DRS(0x01)
+           ));
+  while((MCG->S & MCG_S_IREFST_MASK) != 0x00U) { /* Check that the source of the FLL reference clock is the external reference clock. */
+  }
+  while((MCG->S & 0x0CU) != 0x00U) {    /* Wait until output of the FLL is selected */
+  }          
+#endif /* (CLOCK_SETUP == 3) */
 }
 
 /* ----------------------------------------------------------------------------

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/rtc_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/rtc_api.c
@@ -27,12 +27,12 @@ static void init(void) {
     // Enable external crystal source if clock source is 32KHz
     if (extosc_frequency()==32768) {
         SIM->SOPT1 |= SIM_SOPT1_OSC32KSEL(OSC32KCLK);
-        }
-        else{
-            // If main clock is NOT 32KHz crystal, use external 32KHz clock source defined in PeripheralPins.c
-            SIM->SOPT1 |= SIM_SOPT1_OSC32KSEL(PinMap_RTC[0].peripheral);
-            pinmap_pinout(PinMap_RTC[0].pin, PinMap_RTC);        //Map RTC clk input (if not NC)
-            }
+    }
+    else{
+        // If main clock is NOT 32KHz crystal, use external 32KHz clock source defined in PeripheralPins.c
+        SIM->SOPT1 |= SIM_SOPT1_OSC32KSEL(PinMap_RTC[0].peripheral);
+        pinmap_pinout(PinMap_RTC[0].pin, PinMap_RTC);        //Map RTC clk input (if not NC)
+    }
 }
 
 void rtc_init(void) {

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/rtc_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/rtc_api.c
@@ -15,16 +15,24 @@
  */
 #include "rtc_api.h"
 #include "PeripheralPins.h"
+#include "clk_freqs.h"
 
 static void init(void) {
     // enable RTC clock
     SIM->SCGC6 |= SIM_SCGC6_RTC_MASK;
 
-    pinmap_pinout(PinMap_RTC[0].pin, PinMap_RTC);        //Map RTC clk input (if not NC)
-
     // select RTC clock source
     SIM->SOPT1 &= ~SIM_SOPT1_OSC32KSEL_MASK;
-    SIM->SOPT1 |= SIM_SOPT1_OSC32KSEL(PinMap_RTC[0].peripheral);
+    
+    // Enable external crystal source if clock source is 32KHz
+    if (extosc_frequency()==32768) {
+        SIM->SOPT1 |= SIM_SOPT1_OSC32KSEL(OSC32KCLK);
+        }
+        else{
+            // If main clock is NOT 32KHz crystal, use external 32KHz clock source defined in PeripheralPins.c
+            SIM->SOPT1 |= SIM_SOPT1_OSC32KSEL(PinMap_RTC[0].peripheral);
+            pinmap_pinout(PinMap_RTC[0].pin, PinMap_RTC);        //Map RTC clk input (if not NC)
+            }
 }
 
 void rtc_init(void) {


### PR DESCRIPTION
File system_MKL25Z4.c Adding clock setup 3.
32KHz crystal including internal loading capacitors.

File rtc.api.c Adding conditional code to detect if 32KHz (calculated) clock crystal is enabled to run the RTC from internal clock. If not 32KHz crystal or running on IRC the default FRDM SDA input is selected.

Extensively tested on various production boards and FRDM board.

The only issue encountered during testing is the USB function will not work at this clock rate due to prescaler restrictions.
The RTC registers are unchanged on reset, however there is a slight loss of accuracy during restart (1 - 2 mSec's).
