### PR TITLE
Added ultra low power mode VLLS0 + POR disabled to Freescale KLXX devices

### DIFF
--- a/libraries/mbed/hal/sleep_api.h
+++ b/libraries/mbed/hal/sleep_api.h
@@ -55,6 +55,22 @@ void sleep(void);
  */
 void deepsleep(void);
 
+
+/** Send the microcontroller to ultra deep sleep (VLLS0 with POR disabled)
+ *
+ * This processor is setup ready for deep sleep, and sent to sleep using __WFI(). This mode
+ * has the same sleep features as sleep plus it powers down all peripherals and clocks. All state
+ * is OFF.
+ *
+ * The processor can only be woken up by an external RESET or NMI interrupt.
+ *
+ * @note
+ *  The mbed interface semihosting is disconnected as part of going to sleep, and can not be restored.
+ * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
+ * able to access the LocalFileSystem
+ */
+void ultradeepsleep(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
On freescale KLXX devices we cannot reach lowest power consumption mode with `deepsleep()` api. This pull requests, adds a new api for these devices, called `ultradeepsleep()`.

This new api, set VLLS0 power mode and disables POR, ensuring the lowest power consumption mode. After that, only a hard RESET can wake the device up again.