### PR TITLE
Hacked up support for AN10866 USB secondary loader

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X/TOOLCHAIN_ARM_STD/LPC1768.sct
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X/TOOLCHAIN_ARM_STD/LPC1768.sct
@@ -1,6 +1,11 @@
-
+#! armcc -E
+#ifdef SECONDARY_LOADER
+LR_IROM1 0x00002000 0x80000  {    ; load region size_region
+  ER_IROM1 0x00002000 0x80000  {  ; load address = execution address
+#else
 LR_IROM1 0x00000000 0x80000  {    ; load region size_region
   ER_IROM1 0x00000000 0x80000  {  ; load address = execution address
+#endif
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X/TOOLCHAIN_ARM_STD/startup_LPC17xx.S
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X/TOOLCHAIN_ARM_STD/startup_LPC17xx.S
@@ -82,10 +82,11 @@ __Vectors       DCD     __initial_sp              ; Top of Stack
                 DCD     PLL1_IRQHandler           ; 48: PLL1 Lock (USB PLL)
 
 
-                IF      :LNOT::DEF:NO_CRP
-                AREA    |.ARM.__at_0x02FC|, CODE, READONLY
-CRP_Key         DCD     0xFFFFFFFF
-                ENDIF
+; NOTE - DEFINING NO_CRP GENERATES ERROR A1185E: Symbol missing
+;                IF      :LNOT::DEF:NO_CRP
+;                AREA    |.ARM.__at_0x02FC|, CODE, READONLY
+;CRP_Key         DCD     0xFFFFFFFF
+;                ENDIF
 
 
                 AREA    |.text|, CODE, READONLY

--- a/workspace_tools/toolchains/arm.py
+++ b/workspace_tools/toolchains/arm.py
@@ -133,6 +133,7 @@ class ARM(mbedToolchain):
 
         if mem_map:
             args.extend(["--scatter", mem_map])
+            args.extend(['--predefine="-D%s"' % s for s in self.get_symbols()])
 
         if hasattr(self.target, "link_cmdline_hook"):
             args = self.target.link_cmdline_hook(self.__class__.__name__, args)


### PR DESCRIPTION
It looks like a bunch of people are trying to get mbed compiled code running on a bare metal mbed using the [AN10886](http://www.nxp.com/documents/application_note/AN10866.pdf) Secondary USB Bootloader.

Some aspects to make this work using the mbed build system already have been fixed (like [this](https://developer.mbed.org/questions/3022/MBED-code-fails-to-run-when-compiled-in-/))

But there are still some little tweaks to be made to make this work without hacking around.

I have mostly followed these instructions:
https://developer.mbed.org/users/hammerli22/notebook/crouching-landtiger-hidden-mbed/

I am still running into an issue when setting the NO_CRP predefine which I fixed by commenting the whole thing out. Any suggestions on what would be a more appropriate workaround?

Since the LPC1768 is so popular, would it make sense to create a bare metal LPC1768 target?