### PR TITLE
Fixing Static EthernetInterface IP

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/TARGET_KPSDK_CODE/common/phyksz8081/fsl_phy_driver.h
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/TARGET_KPSDK_CODE/common/phyksz8081/fsl_phy_driver.h
@@ -58,7 +58,7 @@ typedef enum _phy_status
 /*! @brief Defines the ENET timeout.*/
 typedef enum _phy_timeout
 {
-    kPhyTimeout = 0x10000, /*!< ENET resets timeout.*/
+    kPhyTimeout = 0x800, /*!< ENET resets timeout: 0x800 represents around 2 seconds */
 } phy_timeout_t;
 
 /*! @brief Defines the PHY register.*/

--- a/libraries/net/eth/EthernetInterface/EthernetInterface.cpp
+++ b/libraries/net/eth/EthernetInterface/EthernetInterface.cpp
@@ -22,6 +22,7 @@
 #include "lwip/netif.h"
 #include "netif/etharp.h"
 #include "lwip/dhcp.h"
+#include "lwip/dns.h"
 #include "eth_arch.h"
 #include "lwip/tcpip.h"
 
@@ -33,8 +34,10 @@ static struct netif netif;
 static char mac_addr[19];
 static char ip_addr[17] = "\0";
 static char gateway[17] = "\0";
+static char dns_addr[17] = "\0";
 static char networkmask[17] = "\0";
 static bool use_dhcp = false;
+static bool set_dns = false;
 
 static Semaphore tcpip_inited(0);
 static Semaphore netif_linked(0);
@@ -69,7 +72,6 @@ static int init_netif(ip_addr_t *ipaddr, ip_addr_t *netmask, ip_addr_t *gw) {
         return -1;
     }
     netif_set_default(&netif);
-    
     netif_set_link_callback  (&netif, netif_link_callback);
     netif_set_status_callback(&netif, netif_status_callback);
     return 0;
@@ -92,12 +94,15 @@ int EthernetInterface::init() {
     return init_netif(NULL, NULL, NULL);
 }
 
-int EthernetInterface::init(const char* ip, const char* mask, const char* gateway) {
+int EthernetInterface::init(const char* ip, const char* mask, const char* gateway, const char * dns) {
     use_dhcp = false;
     
     set_mac_address();
     strcpy(ip_addr, ip);
-    
+    if (dns != NULL) {
+        set_dns = true;
+        strcpy(dns_addr, dns);
+    }
     ip_addr_t ip_n, mask_n, gateway_n;
     inet_aton(ip, &ip_n);
     inet_aton(mask, &mask_n);
@@ -117,11 +122,22 @@ int EthernetInterface::connect(unsigned int timeout_ms) {
         inited = netif_up.wait(timeout_ms);
     } else {
         netif_set_up(&netif);
-        
         // Wait for the link up
-        inited = netif_linked.wait(timeout_ms);
+        Timer timeout;
+        timeout.start();
+        while(timeout.read_ms() < timeout_ms) {
+            if (netif.flags & NETIF_FLAG_LINK_UP) {
+                inited = 1;
+                break;
+            }
+        }
+        if (set_dns) {
+            ip_addr_t dns_n;
+            inet_aton(dns_addr, &dns_n);
+            dns_setserver(0, &dns_n);
+        }
     }
-    
+
     return (inited > 0) ? (0) : (-1);
 }
 

--- a/libraries/net/eth/EthernetInterface/EthernetInterface.h
+++ b/libraries/net/eth/EthernetInterface/EthernetInterface.h
@@ -45,7 +45,7 @@ public:
   * \param gateway the gateway to use
   * \return 0 on success, a negative number on failure
   */
-  static int init(const char* ip, const char* mask, const char* gateway);
+  static int init(const char* ip, const char* mask, const char* gateway, const char * dns = NULL);
 
   /** Connect
   * Bring the interface up, start DHCP if needed.


### PR DESCRIPTION
When trying to add a static IP to the EthernetInterface I found that it wasn't possible, due to a lengthy timeout in the K64F phy drivers and a race condition exhibited by the EthernetInterface class itself.

I changed the timeout in the driver and proposed a fix for the EthernetInterface lock up.