### PR TITLE
STM32: Clear epComplete flag if a packet has been handled in the callback

### DIFF
--- a/libraries/USBDevice/USBDevice/USBHAL_STM32F4.cpp
+++ b/libraries/USBDevice/USBDevice/USBHAL_STM32F4.cpp
@@ -367,7 +367,7 @@ void USBHAL::usbisr(void) {
             else {
                 epComplete |= (1 << endpoint);
                 if ((instance->*(epCallback[endpoint - 2]))()) {
-                    epComplete &= (1 << endpoint);
+                    epComplete &= ~(1 << endpoint);
                 }
             }
         }


### PR DESCRIPTION
I'm not sure, what was an original idea behind these `USBHAL::EP1_OUT_callback` methods. But it looks like a typo for me.
Someone, please review. =]