### PR TITLE
uvision - fix INC dir

### DIFF
--- a/workspace_tools/export/uvision4.py
+++ b/workspace_tools/export/uvision4.py
@@ -67,11 +67,11 @@ class Uvision4(Exporter):
 
         # get flags from toolchain and apply
         project_data['tool_specific']['uvision']['misc'] = {}
-        project_data['tool_specific']['uvision']['misc']['asm_flags'] = self.toolchain.flags['common'] + self.toolchain.flags['asm']
-        project_data['tool_specific']['uvision']['misc']['c_flags'] = self.toolchain.flags['common'] + self.toolchain.flags['c']
+        project_data['tool_specific']['uvision']['misc']['asm_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['asm']))
+        project_data['tool_specific']['uvision']['misc']['c_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['c']))
         # not compatible with c99 flag set in the template
         project_data['tool_specific']['uvision']['misc']['c_flags'].remove("--c99")
-        project_data['tool_specific']['uvision']['misc']['cxx_flags'] = self.toolchain.flags['common'] + self.toolchain.flags['ld']
+        project_data['tool_specific']['uvision']['misc']['cxx_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['ld']))
         project_data['tool_specific']['uvision']['misc']['ld_flags'] = self.toolchain.flags['ld']
 
         i = 0

--- a/workspace_tools/export/uvision5.py
+++ b/workspace_tools/export/uvision5.py
@@ -64,6 +64,16 @@ class Uvision5(Exporter):
 
         project_data['tool_specific'] = {}
         project_data['tool_specific'].update(tool_specific)
+
+        # get flags from toolchain and apply
+        project_data['tool_specific']['uvision5']['misc'] = {}
+        project_data['tool_specific']['uvision5']['misc']['asm_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['asm']))
+        project_data['tool_specific']['uvision5']['misc']['c_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['c']))
+        # not compatible with c99 flag set in the template
+        project_data['tool_specific']['uvision5']['misc']['c_flags'].remove("--c99")
+        project_data['tool_specific']['uvision5']['misc']['cxx_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['ld']))
+        project_data['tool_specific']['uvision5']['misc']['ld_flags'] = self.toolchain.flags['ld']
+
         i = 0
         for macro in project_data['common']['macros']:
             # armasm does not like floating numbers in macros, timestamp to int

--- a/workspace_tools/toolchains/arm.py
+++ b/workspace_tools/toolchains/arm.py
@@ -34,8 +34,8 @@ class ARM(mbedToolchain):
     DEFAULT_FLAGS = {
         'common': ["--apcs=interwork",
             "--brief_diagnostics"],
-        'asm': ['-I%s' % ARM_INC],
-        'c': ["-c", "--gnu", "-Otime", "--restrict", "--multibyte_chars", "--split_sections", "--md", "--no_depend_system_headers", '-I%s' % ARM_INC,
+        'asm': ['-I"%s"' % ARM_INC],
+        'c': ["-c", "--gnu", "-Otime", "--restrict", "--multibyte_chars", "--split_sections", "--md", "--no_depend_system_headers", '-I"%s"' % ARM_INC,
             "--c99", "-D__ASSERT_MSG" ],
         'cxx': ["--cpp", "--no_rtti", "-D__ASSERT_MSG"],
         'ld': [],


### PR DESCRIPTION
The path for INC might be with spaces, uvision does not handle it well,
thus wrapping around ""

Tested with uvision installed in "Program Files" folder
