### PR TITLE
Synch - fix lwip-eth path

### DIFF
--- a/workspace_tools/synch.py
+++ b/workspace_tools/synch.py
@@ -56,7 +56,7 @@ OFFICIAL_CODE = (
     ("lwip-sys", LWIP_SOURCES+"/lwip-sys"),
     ("Socket"  , LWIP_SOURCES+"/Socket"),
 
-    ("lwip-eth"         , LWIP_SOURCES+"/lwip-eth"),
+    ("lwip-eth"         , ETH_SOURCES+"/lwip-eth"),
     ("EthernetInterface", ETH_SOURCES+"/EthernetInterface"),
 
     ("USBDevice", USB),


### PR DESCRIPTION
Fixes #1786 issue. lwip-eth is located in the ethernet sources ,not lwip (will be fixed later)

@screamerbg 
