### PR TITLE
Add a c based re-entrant critical section API

### DIFF
--- a/hal/api/critical.h
+++ b/hal/api/critical.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MBED_UTIL_CRITICAL_H__
+#define __MBED_UTIL_CRITICAL_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Mark the start of a critical section
+  *
+  * This function should be called to mark the start of a critical section of code.
+  * \note
+  * NOTES:
+  * 1) The use of this style of critical section is targetted at C based implementations.
+  * 2) These critical sections can be nested.
+  * 3) The interrupt enable state on entry to the first critical section (of a nested set, or single
+  *    section) will be preserved on exit from the section.
+  * 4) This implementation will currently only work on code running in privileged mode.
+  */
+void core_util_critical_section_enter();
+
+/** Mark the end of a critical section
+  *
+  * This function should be called to mark the end of a critical section of code.
+  * \note
+  * NOTES:
+  * 1) The use of this style of critical section is targetted at C based implementations.
+  * 2) These critical sections can be nested.
+  * 3) The interrupt enable state on entry to the first critical section (of a nested set, or single
+  *    section) will be preserved on exit from the section.
+  * 4) This implementation will currently only work on code running in privileged mode.
+  */
+void core_util_critical_section_exit();
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+
+#endif // __MBED_UTIL_CRITICAL_H__

--- a/hal/common/critical.c
+++ b/hal/common/critical.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This critical section implementation is generic for mbed OS targets,
+// except Nordic ones
+#if defined(TARGET_LIKE_MBED) && !defined(TARGET_NORDIC)
+
+#include <stdint.h>
+#include <stddef.h>
+#include "cmsis.h"
+#include <assert.h>
+
+// Module include
+#include "critical.h"
+
+static volatile uint32_t interrupt_enable_counter = 0;
+static volatile uint32_t critical_primask = 0;
+
+void core_util_critical_section_enter()
+{
+    uint32_t primask = __get_PRIMASK(); /* get the current interrupt enabled state */
+    __disable_irq();
+
+    /* Save the interrupt enabled state as it was prior to any nested critical section lock use */
+    if (!interrupt_enable_counter) {
+        critical_primask = primask & 0x1;
+    }
+
+    /* If the interrupt_enable_counter overflows or we are in a nested critical section and interrupts
+       are enabled, then something has gone badly wrong thus assert an error.
+    */
+     assert(interrupt_enable_counter < UINT32_MAX); 
+    if (interrupt_enable_counter > 0) {
+        assert(primask & 0x1);
+    }
+    interrupt_enable_counter++;
+}
+
+void core_util_critical_section_exit()
+{
+    /* If critical_section_enter has not previously been called, do nothing */
+    if (interrupt_enable_counter) {
+
+        uint32_t primask = __get_PRIMASK(); /* get the current interrupt enabled state */
+
+        assert(primask & 0x1); /* Interrupts must be disabled on invoking an exit from a critical section */
+
+        interrupt_enable_counter--;
+
+        /* Only re-enable interrupts if we are exiting the last of the nested critical sections and
+           interrupts were enabled on entry to the first critical section.
+        */
+        if (!interrupt_enable_counter && !critical_primask) {
+            __enable_irq();
+        }
+    }
+}
+
+#endif // defined(TARGET_LIKE_MBED) && !defined(TARGET_NORDIC)

--- a/hal/common/critical_nordic.c
+++ b/hal/common/critical_nordic.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef TARGET_NORDIC
+
+#include <stdint.h>
+#include <stddef.h>
+#include "cmsis.h"
+#include <assert.h>
+#include <stdbool.h>
+#include <nrf_soc.h>
+#include <nrf_sdm.h>
+
+#include "critical.h"
+
+static volatile union {
+    uint32_t _PRIMASK_state;
+    uint8_t  _sd_state;
+} _state = { 0 } ;
+static volatile uint32_t _entry_count = 0;
+static volatile bool _use_softdevice_routine = false;
+
+void core_util_critical_section_enter()
+{
+    // if a critical section has already been entered, just update the counter
+    if (_entry_count) {
+        ++_entry_count;
+        return;
+    }
+
+    // in this path, a critical section has never been entered
+    uint32_t primask = __get_PRIMASK();
+
+    // if interrupts are enabled, try to use the soft device
+    uint8_t sd_enabled;
+    if ((primask == 0) && (sd_softdevice_is_enabled(&sd_enabled) == NRF_SUCCESS) && sd_enabled == 1) {
+        // if the soft device can be use, use it
+        sd_nvic_critical_region_enter(&_state._sd_state);
+        _use_softdevice_routine = true;
+    } else {
+        // if interrupts where enabled, disable them
+        if(primask == 0) {
+            __disable_irq();
+        }
+
+        // store the PRIMASK state, it will be restored at the end of the critical section
+        _state._PRIMASK_state = primask;
+        _use_softdevice_routine = false;
+    }
+
+    assert(_entry_count == 0); // entry count should always be equal to 0 at this point
+    ++_entry_count;
+}
+
+void core_util_critical_section_exit()
+{
+    assert(_entry_count > 0);
+    --_entry_count;
+
+    // If their is other segments which have entered the critical section, just leave
+    if (_entry_count) {
+        return;
+    }
+
+    // This is the last segment of the critical section, state should be restored as before entering
+    // the critical section
+    if (_use_softdevice_routine) {
+        sd_nvic_critical_region_exit(_state._sd_state);
+    } else {
+        __set_PRIMASK(_state._PRIMASK_state);
+    }
+}
+
+#endif //TARGET_NORDIC


### PR DESCRIPTION
This includes a generic critical section implementation, and nrf51
platforms specific implementation.

nrf51- this implementation will use sd_nvic_critical_region_enter if the
softdevice is enabled, otherwise it will use __disable_irq().
This implementation also allow a user to start a critical section while
interrupts are already disabled.

@sg- @c1728p9 
