### PR TITLE
[STM32F4xx] LowPowerTicker implementation

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_B96B_F446VE/device.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_B96B_F446VE/device.h
@@ -60,6 +60,8 @@
 
 #define DEVICE_CAN              1
 
+#define DEVICE_LOWPOWERTIMER    1
+
 //=======================================
 
 #define DEVICE_SEMIHOST         0

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/device.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/device.h
@@ -54,6 +54,8 @@
 
 #define DEVICE_SLEEP            1
 
+#define DEVICE_LOWPOWERTIMER    1
+
 //=======================================
 
 #define DEVICE_SEMIHOST         0

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F469NI/device.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F469NI/device.h
@@ -54,6 +54,8 @@
 
 #define DEVICE_SLEEP            1
 
+#define DEVICE_LOWPOWERTIMER    1
+
 //=======================================
 
 #define DEVICE_SEMIHOST         0

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/device.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/device.h
@@ -55,6 +55,8 @@
 
 #define DEVICE_SLEEP            1
 
+#define DEVICE_LOWPOWERTIMER    1
+
 //=======================================
 
 #define DEVICE_SEMIHOST         0

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F410RB/device.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F410RB/device.h
@@ -54,6 +54,8 @@
 
 #define DEVICE_SLEEP            1
 
+#define DEVICE_LOWPOWERTIMER    1
+
 //=======================================
 
 #define DEVICE_SEMIHOST         0

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F411RE/device.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F411RE/device.h
@@ -54,6 +54,8 @@
 
 #define DEVICE_SLEEP            1
 
+#define DEVICE_LOWPOWERTIMER    1
+
 //=======================================
 
 #define DEVICE_SEMIHOST         0

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446RE/device.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446RE/device.h
@@ -54,6 +54,8 @@
 
 #define DEVICE_SLEEP            1
 
+#define DEVICE_LOWPOWERTIMER    1
+
 //=======================================
 
 #define DEVICE_SEMIHOST         0

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/lp_ticker.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/lp_ticker.c
@@ -1,0 +1,49 @@
+#include "device.h"
+
+#if DEVICE_LOWPOWERTIMER
+
+#include "ticker_api.h"
+#include "lp_ticker_api.h"
+#include "rtc_api.h"
+#include "rtc_api_hal.h"
+
+static uint8_t lp_ticker_inited = 0;
+static uint32_t m_timestamp = 0;
+static uint32_t m_offset = 0;
+
+void lp_ticker_init() {
+    /*
+     * At this stage we don't have the users requested time.
+     * This is only to cover the API implementation.
+     */
+}
+
+uint32_t lp_ticker_read() {
+    /*
+     * Becuase our RTC has a periodic wake-up timer we just want to simply
+     * return the desired timestamp value to configure RTC exactly with the value
+     * provided by the user and to fulfill the mBed ticker architecture.
+     */
+    return m_timestamp;
+}
+
+void lp_ticker_set_interrupt(timestamp_t timestamp) {
+    m_offset = timestamp;
+
+    if (lp_ticker_inited) return;
+    lp_ticker_inited = 1;
+
+    rtc_periodic_ticker_init(timestamp);
+    rtc_set_irq_handler((uint32_t) lp_ticker_irq_handler);
+}
+
+void lp_ticker_disable_interrupt() {
+    lp_ticker_inited = 0;
+    rtc_periodic_ticker_disable_irq();
+}
+
+void lp_ticker_clear_interrupt() {
+    m_timestamp = m_offset;
+}
+
+#endif

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/rtc_api_hal.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/rtc_api_hal.h
@@ -1,0 +1,53 @@
+/* mbed Microcontroller Library
+*******************************************************************************
+* Copyright (c) 2016, STMicroelectronics
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+* 3. Neither the name of STMicroelectronics nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************
+*/
+
+#ifndef MBED_RTC_API_HAL_H
+#define MBED_RTC_API_HAL_H
+
+#include <stdint.h>
+#include "rtc_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Extend rtc_api.h
+ */
+void rtc_set_irq_handler(uint32_t handler);
+
+void rtc_periodic_ticker_init(uint32_t timestamp);
+void rtc_periodic_ticker_disable_irq();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
LowPowerTicker for STM32F4xx family is implemented using the RTC periodic unit
functionality. For more informations please follow this document:

www.st.com/resource/en/application_note/dm00025071.pdf

Supported platforms:

- NUCLEO_F411RE
- NUCLEO_F401RE
- NUCLEO_F410RB
- NUCLEO_F446RE
- DISCO_F429ZI
- DISCO_F469NI
- B96B_F446VE