### PR TITLE
Update rtc_api.c

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L4/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L4/rtc_api.c
@@ -51,6 +51,16 @@ void rtc_init(void)
 #endif
 
     RtcHandle.Instance = RTC;
+    
+    // Enable Power clock
+    __HAL_RCC_PWR_CLK_ENABLE();
+
+    // Enable access to Backup domain
+    HAL_PWR_EnableBkUpAccess();
+
+    // Reset Backup domain
+    __HAL_RCC_BACKUPRESET_FORCE();
+    __HAL_RCC_BACKUPRESET_RELEASE();
 
 #if !DEVICE_RTC_LSI
     // Enable LSE Oscillator
@@ -68,16 +78,6 @@ void rtc_init(void)
         error("Cannot initialize RTC with LSE\n");
     }
 #else
-    // Enable Power clock
-    __HAL_RCC_PWR_CLK_ENABLE();
-
-    // Enable access to Backup domain
-    HAL_PWR_EnableBkUpAccess();
-
-    // Reset Backup domain
-    __HAL_RCC_BACKUPRESET_FORCE();
-    __HAL_RCC_BACKUPRESET_RELEASE();
-
     // Enable LSI clock
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI | RCC_OSCILLATORTYPE_LSE;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // Mandatory, otherwise the PLL is reconfigured!


### PR DESCRIPTION
Since a recent change to this file (after revision 120) the deepsleep current level increased from 4-6uA to over 110uA.
This change puts the Power clock and Back up domain parts back where they were.
Now runs to specification as before using LSE.
But not sure why these would have been moved in the first place, there may other considerations ST have in mind.

One other minor consideration is the device.h file indicates  #define DEVICE_RTC_LSI          0
Personally I believe this should be #define DEVICE_RTC_LSE          1
by default and the RTC if/def's to suit. The LSI function is always available on this target whereas the external crystal may or may not be fitted in prototype or production scenarios. 
A user would set #define DEVICE_RTC_LSE          0 if they were not including the LSE crystal in their design.
 