### PR TITLE
print generally line feeds for every error prints

### DIFF
--- a/hal/common/board.c
+++ b/hal/common/board.c
@@ -85,6 +85,8 @@ void mbed_error_vfprintf(const char * format, va_list arg) {
         for (int i = 0; i < size; i++) {
             serial_putc(&stdio_uart, buffer[i]);
         }
+        serial_putc('\r');
+        serial_putc('\n');
     }
     core_util_critical_section_exit();
 #endif

--- a/hal/common/board.c
+++ b/hal/common/board.c
@@ -85,8 +85,8 @@ void mbed_error_vfprintf(const char * format, va_list arg) {
         for (int i = 0; i < size; i++) {
             serial_putc(&stdio_uart, buffer[i]);
         }
-        serial_putc('\r');
-        serial_putc('\n');
+        serial_putc(&stdio_uart, '\r');
+        serial_putc(&stdio_uart, '\n');
     }
     core_util_critical_section_exit();
 #endif


### PR DESCRIPTION
this safe a bit memory because we doesn't need to print line feeds for every `error(x)` -calls.
This also standardize that every error prints has proper line-feeds (CR+LF) which is needed by automation.

small side-effect: if `error()`is called with line feed(s) it prints now line feeds twice, but perhaps that is not the problem.

There is list of `error()` prints what we have currently:
https://gist.github.com/jupe/df248c195ecc4f484f06b61e9e8b12d3
NOTE: some of those doesn't have line feeds at all!

@geky @bridadan @0xc0170 @kjbracey-arm 
