### PR TITLE
uvision - remove --cpp flag from exporters

### DIFF
--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -76,6 +76,8 @@ class Uvision4(Exporter):
         project_data['tool_specific']['uvision']['misc']['c_flags'].remove("--c99")
         # ARM_INC is by default as system inclusion, not required for exported project
         project_data['tool_specific']['uvision']['misc']['c_flags'].remove("-I \""+ARM_INC+"\"")
+        # cpp is not required as it's implicit for cpp files
+        project_data['tool_specific']['uvision']['misc']['c_flags'].remove("--cpp")
         project_data['tool_specific']['uvision']['misc']['ld_flags'] = self.toolchain.flags['ld']
 
         i = 0

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -71,8 +71,12 @@ class Uvision5(Exporter):
         project_data['tool_specific']['uvision5']['misc']['asm_flags'] = list(set(self.toolchain.flags['asm']))
         # cxx flags included, as uvision have them all in one tab
         project_data['tool_specific']['uvision5']['misc']['c_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['c'] + self.toolchain.flags['cxx']))
+        # ARM_INC is by default as system inclusion, not required for exported project
+        project_data['tool_specific']['uvision']['misc']['c_flags'].remove("-I \""+ARM_INC+"\"")
         # not compatible with c99 flag set in the template
         project_data['tool_specific']['uvision5']['misc']['c_flags'].remove("--c99")
+        # cpp is not required as it's implicit for cpp files
+        project_data['tool_specific']['uvision']['misc']['c_flags'].remove("--cpp")
         project_data['tool_specific']['uvision5']['misc']['ld_flags'] = self.toolchain.flags['ld']
 
         i = 0


### PR DESCRIPTION
The cpp files are by default compiled with --cpp. Including this flag, causing
C files compiled as C++ files. Thus we remove them. We could potentionally
remove it from cxx flags as well.

This was added just recently as flags unification. It's tricky to unify command line and IDE, as via cmd you can invoke separately asm/c/cxx, but in many IDE c/cxx are within the same tab. Therefore there are some limitations and we need to currently do exceptions for IDE, as in this PR. 

Fixes #1919 

@ohagendorf 
