### PR TITLE
Update progen to v0.9.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyserial
 IntelHex
 mbed-ls
 mbed-greentea
-project-generator>=0.8.11,<0.9.0
+project-generator>=0.9.3,<0.10.0
 Jinja2
 junit-xml
 requests

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name='mbed-tools',
       url='https://github.com/mbedmicro/mbed',
       packages=find_packages(),
       license=LICENSE,
-      install_requires=["PrettyTable>=0.7.2", "PySerial>=2.7", "IntelHex>=1.3", "colorama>=0.3.3", "Jinja2>=2.7.3", "project-generator>=0.8.11,<0.9.0", "junit-xml", "requests", "pyYAML"])
+      install_requires=["PrettyTable>=0.7.2", "PySerial>=2.7", "IntelHex>=1.3", "colorama>=0.3.3", "Jinja2>=2.7.3", "project-generator>=0.9.3,<0.10.0", "junit-xml", "requests", "pyYAML"])
 
 # Restore previous mbed_settings if needed
 if backup:

--- a/tools/export/iar_template.ewp.tmpl
+++ b/tools/export/iar_template.ewp.tmpl
@@ -402,7 +402,7 @@
         </option>
         <option>
           <name>IccAllowVLA</name>
-          <state>1</state>
+          <state>0</state>
         </option>
         <option>
           <name>IccCppDialect</name>


### PR DESCRIPTION
- IAR disable VLA in the template

progen v0.9.x brings templates for debuggers (currently only IAR supported, uvision coming soon), and some bugfixes, template for IAR as well which should fix extension in IAR as I have noticed is currently broken.

@bridadan @stevew817 please test (update progen to v0.9.x)
