### PR TITLE
Backport fixes from nordic branches:

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1105,7 +1105,8 @@
             "toolchains": ["ARM_STD", "GCC_ARM"]
         },
         "program_cycle_s": 6,
-        "default_build": "small"
+        "default_build": "small",
+        "features": ["BLE"]
     },
     "MCU_NRF51_16K_BASE": {
         "inherits": ["MCU_NRF51"],

--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf.h
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf.h
@@ -1,48 +1,61 @@
-/* Copyright (c) 2013, Nordic Semiconductor ASA
+/*
+ * Copyright (c) Nordic Semiconductor ASA
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
  *
- *   * Redistributions of source code must retain the above copyright notice, this
- *     list of conditions and the following disclaimer.
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
  *
- *   * Redistributions in binary form must reproduce the above copyright notice,
- *     this list of conditions and the following disclaimer in the documentation
- *     and/or other materials provided with the distribution.
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
  *
- *   * Neither the name of Nordic Semiconductor ASA nor the names of its
- *     contributors may be used to endorse or promote products derived from
- *     this software without specific prior written permission.
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of other
+ *   contributors to this software may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
+
 #ifndef NRF_H
 #define NRF_H
 
-#ifndef _WIN32
-
-/* Family selection for main includes. NRF51 must be selected. */
-#ifdef NRF51
-    #include "nrf51.h"
-    #include "nrf51_bitfields.h"
+#if defined(_WIN32)
+    /* Do not include nrf51 specific files when building for PC host */
+#elif defined(__unix)
+    /* Do not include nrf51 specific files when building for PC host */
+#elif defined(__APPLE__)
+    /* Do not include nrf51 specific files when building for PC host */
 #else
-    #error "Device family must be defined. See nrf.h."
-#endif /* NRF51 */
 
-#include "compiler_abstraction.h"
+    /* Family selection for family includes. */
+    #if defined (NRF51)
+        #include "nrf51.h"
+        #include "nrf51_bitfields.h"
+        #include "nrf51_deprecated.h"
+    #elif defined (NRF52)
+        #include "nrf52.h"
+        #include "nrf52_bitfields.h"
+        #include "nrf51_to_nrf52.h"
+    #else
+        #error "Device family must be defined. See nrf.h."
+    #endif /* NRF51, NRF52 */
 
-#endif /* _WIN32 */
+    #include "compiler_abstraction.h"
+
+#endif /* _WIN32 || __unix || __APPLE__ */
 
 #endif /* NRF_H */
-

--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf51.h
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf51.h
@@ -1,56 +1,34 @@
-
-/****************************************************************************************************//**
- * @file     nRF51.h
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
  *
- * @brief    CMSIS Cortex-M0 Peripheral Access Layer Header File for
- *           nRF51 from Nordic Semiconductor.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
  *
- * @version  V522
- * @date     31. October 2014
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
  *
- * @note     Generated with SVDConv V2.81d
- *           from CMSIS SVD File 'nRF51.xml' Version 522,
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
  *
- * @par      Copyright (c) 2013, Nordic Semiconductor ASA
- *           All rights reserved.
- *
- *           Redistribution and use in source and binary forms, with or without
- *           modification, are permitted provided that the following conditions are met:
- *
- *           * Redistributions of source code must retain the above copyright notice, this
- *           list of conditions and the following disclaimer.
- *
- *           * Redistributions in binary form must reproduce the above copyright notice,
- *           this list of conditions and the following disclaimer in the documentation
- *           and/or other materials provided with the distribution.
- *
- *           * Neither the name of Nordic Semiconductor ASA nor the names of its
- *           contributors may be used to endorse or promote products derived from
- *           this software without specific prior written permission.
- *
- *           THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- *           AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- *           IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *           DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- *           FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- *           DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- *           SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *           CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- *           OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- *           OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of other
+ *   contributors to this software may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
  *
  *
- *******************************************************************************************************/
-
-
-
-/** @addtogroup Nordic Semiconductor
-  * @{
-  */
-
-/** @addtogroup nRF51
-  * @{
-  */
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
 
 #ifndef NRF51_H
 #define NRF51_H
@@ -71,7 +49,7 @@ typedef enum {
   DebugMonitor_IRQn             =  -4,              /*!<  12  Debug Monitor                                                    */
   PendSV_IRQn                   =  -2,              /*!<  14  Pendable request for system service                              */
   SysTick_IRQn                  =  -1,              /*!<  15  System Tick Timer                                                */
-/* ----------------------  nRF51 Specific Interrupt Numbers  ---------------------- */
+/* ----------------------  nrf51 Specific Interrupt Numbers  ---------------------- */
   POWER_CLOCK_IRQn              =   0,              /*!<   0  POWER_CLOCK                                                      */
   RADIO_IRQn                    =   1,              /*!<   1  RADIO                                                            */
   UART0_IRQn                    =   2,              /*!<   2  UART0                                                            */
@@ -117,7 +95,8 @@ typedef enum {
 /** @} */ /* End of group Configuration_of_CMSIS */
 
 #include "core_cm0.h"                               /*!< Cortex-M0 processor and core peripherals                              */
-#include "system_nrf51.h"                           /*!< nRF51 System                                                          */
+#include "system_nrf51.h"                           /*!< nrf51 System                                                          */
+
 
 /* ================================================================================ */
 /* ================       Device Specific Peripheral Section       ================ */
@@ -182,15 +161,6 @@ typedef struct {
   __IO uint32_t  EEP;                               /*!< Channel event end-point.                                              */
   __IO uint32_t  TEP;                               /*!< Channel task end-point.                                               */
 } PPI_CH_Type;
-
-typedef struct {
-  __I  uint32_t  PART;                              /*!< Part code                                                             */
-  __I  uint32_t  VARIANT;                           /*!< Part variant                                                          */
-  __I  uint32_t  PACKAGE;                           /*!< Package option                                                        */
-  __I  uint32_t  RAM;                               /*!< RAM variant                                                           */
-  __I  uint32_t  FLASH;                             /*!< Flash variant                                                         */
-  __I  uint32_t  RESERVED[3];                       /*!< Reserved                                                              */
-} FICR_INFO_Type;
 
 
 /* ================================================================================ */
@@ -301,27 +271,6 @@ typedef struct {                                    /*!< MPU Structure          
 
 
 /* ================================================================================ */
-/* ================                       PU                       ================ */
-/* ================================================================================ */
-
-
-/**
-  * @brief Patch unit. (PU)
-  */
-
-typedef struct {                                    /*!< PU Structure                                                          */
-  __I  uint32_t  RESERVED0[448];
-  __IO uint32_t  REPLACEADDR[8];                    /*!< Address of first instruction to replace.                              */
-  __I  uint32_t  RESERVED1[24];
-  __IO uint32_t  PATCHADDR[8];                      /*!< Relative address of patch instructions.                               */
-  __I  uint32_t  RESERVED2[24];
-  __IO uint32_t  PATCHEN;                           /*!< Patch enable register.                                                */
-  __IO uint32_t  PATCHENSET;                        /*!< Patch enable register.                                                */
-  __IO uint32_t  PATCHENCLR;                        /*!< Patch disable register.                                               */
-} NRF_PU_Type;
-
-
-/* ================================================================================ */
 /* ================                      AMLI                      ================ */
 /* ================================================================================ */
 
@@ -366,7 +315,7 @@ typedef struct {                                    /*!< RADIO Structure        
   __IO uint32_t  EVENTS_RSSIEND;                    /*!< Sampling of the receive signal strength complete. A new RSSI
                                                          sample is ready for readout at the RSSISAMPLE register.               */
   __I  uint32_t  RESERVED1[2];
-  __IO uint32_t  EVENTS_BCMATCH;                    /*!< Bit counter reached bit count value specified in BC register.         */
+  __IO uint32_t  EVENTS_BCMATCH;                    /*!< Bit counter reached bit count value specified in BCC register.        */
   __I  uint32_t  RESERVED2[53];
   __IO uint32_t  SHORTS;                            /*!< Shortcuts for the radio.                                              */
   __I  uint32_t  RESERVED3[64];
@@ -374,11 +323,11 @@ typedef struct {                                    /*!< RADIO Structure        
   __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
   __I  uint32_t  RESERVED4[61];
   __I  uint32_t  CRCSTATUS;                         /*!< CRC status of received packet.                                        */
-  __I  uint32_t  CD;                                /*!< Carrier detect.                                                       */
+  __I  uint32_t  RESERVED5;
   __I  uint32_t  RXMATCH;                           /*!< Received address.                                                     */
   __I  uint32_t  RXCRC;                             /*!< Received CRC.                                                         */
   __I  uint32_t  DAI;                               /*!< Device address match index.                                           */
-  __I  uint32_t  RESERVED5[60];
+  __I  uint32_t  RESERVED6[60];
   __IO uint32_t  PACKETPTR;                         /*!< Packet pointer. Decision point: START task.                           */
   __IO uint32_t  FREQUENCY;                         /*!< Frequency.                                                            */
   __IO uint32_t  TXPOWER;                           /*!< Output power.                                                         */
@@ -397,22 +346,22 @@ typedef struct {                                    /*!< RADIO Structure        
   __IO uint32_t  TEST;                              /*!< Test features enable register.                                        */
   __IO uint32_t  TIFS;                              /*!< Inter Frame Spacing in microseconds.                                  */
   __I  uint32_t  RSSISAMPLE;                        /*!< RSSI sample.                                                          */
-  __I  uint32_t  RESERVED6;
+  __I  uint32_t  RESERVED7;
   __I  uint32_t  STATE;                             /*!< Current radio state.                                                  */
   __IO uint32_t  DATAWHITEIV;                       /*!< Data whitening initial value.                                         */
-  __I  uint32_t  RESERVED7[2];
+  __I  uint32_t  RESERVED8[2];
   __IO uint32_t  BCC;                               /*!< Bit counter compare.                                                  */
-  __I  uint32_t  RESERVED8[39];
+  __I  uint32_t  RESERVED9[39];
   __IO uint32_t  DAB[8];                            /*!< Device address base segment.                                          */
   __IO uint32_t  DAP[8];                            /*!< Device address prefix.                                                */
   __IO uint32_t  DACNF;                             /*!< Device address match configuration.                                   */
-  __I  uint32_t  RESERVED9[56];
+  __I  uint32_t  RESERVED10[56];
   __IO uint32_t  OVERRIDE0;                         /*!< Trim value override register 0.                                       */
   __IO uint32_t  OVERRIDE1;                         /*!< Trim value override register 1.                                       */
   __IO uint32_t  OVERRIDE2;                         /*!< Trim value override register 2.                                       */
   __IO uint32_t  OVERRIDE3;                         /*!< Trim value override register 3.                                       */
   __IO uint32_t  OVERRIDE4;                         /*!< Trim value override register 4.                                       */
-  __I  uint32_t  RESERVED10[561];
+  __I  uint32_t  RESERVED11[561];
   __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
 } NRF_RADIO_Type;
 
@@ -571,39 +520,41 @@ typedef struct {                                    /*!< SPIS Structure         
   __O  uint32_t  TASKS_RELEASE;                     /*!< Release SPI semaphore.                                                */
   __I  uint32_t  RESERVED1[54];
   __IO uint32_t  EVENTS_END;                        /*!< Granted transaction completed.                                        */
-  __I  uint32_t  RESERVED2[8];
+  __I  uint32_t  RESERVED2[2];
+  __IO uint32_t  EVENTS_ENDRX;                      /*!< End of RXD buffer reached                                             */
+  __I  uint32_t  RESERVED3[5];
   __IO uint32_t  EVENTS_ACQUIRED;                   /*!< Semaphore acquired.                                                   */
-  __I  uint32_t  RESERVED3[53];
+  __I  uint32_t  RESERVED4[53];
   __IO uint32_t  SHORTS;                            /*!< Shortcuts for SPIS.                                                   */
-  __I  uint32_t  RESERVED4[64];
+  __I  uint32_t  RESERVED5[64];
   __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
   __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
-  __I  uint32_t  RESERVED5[61];
+  __I  uint32_t  RESERVED6[61];
   __I  uint32_t  SEMSTAT;                           /*!< Semaphore status.                                                     */
-  __I  uint32_t  RESERVED6[15];
+  __I  uint32_t  RESERVED7[15];
   __IO uint32_t  STATUS;                            /*!< Status from last transaction.                                         */
-  __I  uint32_t  RESERVED7[47];
+  __I  uint32_t  RESERVED8[47];
   __IO uint32_t  ENABLE;                            /*!< Enable SPIS.                                                          */
-  __I  uint32_t  RESERVED8;
+  __I  uint32_t  RESERVED9;
   __IO uint32_t  PSELSCK;                           /*!< Pin select for SCK.                                                   */
   __IO uint32_t  PSELMISO;                          /*!< Pin select for MISO.                                                  */
   __IO uint32_t  PSELMOSI;                          /*!< Pin select for MOSI.                                                  */
   __IO uint32_t  PSELCSN;                           /*!< Pin select for CSN.                                                   */
-  __I  uint32_t  RESERVED9[7];
+  __I  uint32_t  RESERVED10[7];
   __IO uint32_t  RXDPTR;                            /*!< RX data pointer.                                                      */
   __IO uint32_t  MAXRX;                             /*!< Maximum number of bytes in the receive buffer.                        */
   __I  uint32_t  AMOUNTRX;                          /*!< Number of bytes received in last granted transaction.                 */
-  __I  uint32_t  RESERVED10;
+  __I  uint32_t  RESERVED11;
   __IO uint32_t  TXDPTR;                            /*!< TX data pointer.                                                      */
   __IO uint32_t  MAXTX;                             /*!< Maximum number of bytes in the transmit buffer.                       */
   __I  uint32_t  AMOUNTTX;                          /*!< Number of bytes transmitted in last granted transaction.              */
-  __I  uint32_t  RESERVED11;
-  __IO uint32_t  CONFIG;                            /*!< Configuration register.                                               */
   __I  uint32_t  RESERVED12;
+  __IO uint32_t  CONFIG;                            /*!< Configuration register.                                               */
+  __I  uint32_t  RESERVED13;
   __IO uint32_t  DEF;                               /*!< Default character.                                                    */
-  __I  uint32_t  RESERVED13[24];
+  __I  uint32_t  RESERVED14[24];
   __IO uint32_t  ORC;                               /*!< Over-read character.                                                  */
-  __I  uint32_t  RESERVED14[654];
+  __I  uint32_t  RESERVED15[654];
   __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
 } NRF_SPIS_Type;
 
@@ -628,35 +579,28 @@ typedef struct {                                    /*!< SPIM Structure         
   __IO uint32_t  EVENTS_STOPPED;                    /*!< SPI transaction has stopped.                                          */
   __I  uint32_t  RESERVED3[2];
   __IO uint32_t  EVENTS_ENDRX;                      /*!< End of RXD buffer reached.                                            */
-  __I  uint32_t  RESERVED4;
-  __IO uint32_t  EVENTS_END;                        /*!< End of RXD buffer and TXD buffer reached.                             */
-  __I  uint32_t  RESERVED5;
+  __I  uint32_t  RESERVED4[3];
   __IO uint32_t  EVENTS_ENDTX;                      /*!< End of TXD buffer reached.                                            */
-  __I  uint32_t  RESERVED6[10];
+  __I  uint32_t  RESERVED5[10];
   __IO uint32_t  EVENTS_STARTED;                    /*!< Transaction started.                                                  */
-  __I  uint32_t  RESERVED7[44];
-  __IO uint32_t  SHORTS;                            /*!< Shortcuts for SPIM.                                                   */
-  __I  uint32_t  RESERVED8[64];
+  __I  uint32_t  RESERVED6[109];
   __IO uint32_t  INTENSET;                          /*!< Interrupt enable set register.                                        */
   __IO uint32_t  INTENCLR;                          /*!< Interrupt enable clear register.                                      */
-  __I  uint32_t  RESERVED9[125];
+  __I  uint32_t  RESERVED7[125];
   __IO uint32_t  ENABLE;                            /*!< Enable SPIM.                                                          */
-  __I  uint32_t  RESERVED10;
+  __I  uint32_t  RESERVED8;
   SPIM_PSEL_Type PSEL;                              /*!< Pin select configuration.                                             */
-  __I  uint32_t  RESERVED11;
-  __I  uint32_t  RXDDATA;                           /*!< RXD register.                                                         */
-  __IO uint32_t  TXDDATA;                           /*!< TXD register.                                                         */
-  __I  uint32_t  RESERVED12;
+  __I  uint32_t  RESERVED9[4];
   __IO uint32_t  FREQUENCY;                         /*!< SPI frequency.                                                        */
-  __I  uint32_t  RESERVED13[3];
+  __I  uint32_t  RESERVED10[3];
   SPIM_RXD_Type RXD;                                /*!< RXD EasyDMA configuration and status.                                 */
-  __I  uint32_t  RESERVED14;
+  __I  uint32_t  RESERVED11;
   SPIM_TXD_Type TXD;                                /*!< TXD EasyDMA configuration and status.                                 */
-  __I  uint32_t  RESERVED15;
+  __I  uint32_t  RESERVED12;
   __IO uint32_t  CONFIG;                            /*!< Configuration register.                                               */
-  __I  uint32_t  RESERVED16[26];
+  __I  uint32_t  RESERVED13[26];
   __IO uint32_t  ORC;                               /*!< Over-read character.                                                  */
-  __I  uint32_t  RESERVED17[654];
+  __I  uint32_t  RESERVED14[654];
   __IO uint32_t  POWER;                             /*!< Peripheral power control.                                             */
 } NRF_SPIM_Type;
 
@@ -1087,9 +1031,13 @@ typedef struct {                                    /*!< NVMC Structure         
   __I  uint32_t  READY;                             /*!< Ready flag.                                                           */
   __I  uint32_t  RESERVED1[64];
   __IO uint32_t  CONFIG;                            /*!< Configuration register.                                               */
-  __IO uint32_t  ERASEPAGE;                         /*!< Register for erasing a non-protected non-volatile memory page.        */
+
+  union {
+    __IO uint32_t  ERASEPCR1;                       /*!< Register for erasing a non-protected non-volatile memory page.        */
+    __IO uint32_t  ERASEPAGE;                       /*!< Register for erasing a non-protected non-volatile memory page.        */
+  };
   __IO uint32_t  ERASEALL;                          /*!< Register for erasing all non-volatile user memory.                    */
-  __IO uint32_t  ERASEPROTECTEDPAGE;                /*!< Register for erasing a protected non-volatile memory page.            */
+  __IO uint32_t  ERASEPCR0;                         /*!< Register for erasing a protected non-volatile memory page.            */
   __IO uint32_t  ERASEUICR;                         /*!< Register for start erasing User Information Congfiguration Registers. */
 } NRF_NVMC_Type;
 
@@ -1155,7 +1103,6 @@ typedef struct {                                    /*!< FICR Structure         
   __I  uint32_t  RESERVED5[10];
   __I  uint32_t  BLE_1MBIT[5];                      /*!< Override values for the OVERRIDEn registers in RADIO for BLE_1Mbit
                                                          mode.                                                                 */
-  FICR_INFO_Type INFO;                              /*!< Device info                                                           */
 } NRF_FICR_Type;
 
 
@@ -1174,7 +1121,13 @@ typedef struct {                                    /*!< UICR Structure         
   __IO uint32_t  XTALFREQ;                          /*!< Reset value for CLOCK XTALFREQ register.                              */
   __I  uint32_t  RESERVED0;
   __I  uint32_t  FWID;                              /*!< Firmware ID.                                                          */
-  __IO uint32_t  BOOTLOADERADDR;                    /*!< Bootloader start address.                                             */
+
+  union {
+    __IO uint32_t  NRFFW[15];                       /*!< Reserved for Nordic firmware design.                                  */
+    __IO uint32_t  BOOTLOADERADDR;                  /*!< Bootloader start address.                                             */
+  };
+  __IO uint32_t  NRFHW[12];                         /*!< Reserved for Nordic hardware design.                                  */
+  __IO uint32_t  CUSTOMER[32];                      /*!< Reserved for customer.                                                */
 } NRF_UICR_Type;
 
 
@@ -1226,7 +1179,6 @@ typedef struct {                                    /*!< GPIO Structure         
 #define NRF_POWER_BASE                  0x40000000UL
 #define NRF_CLOCK_BASE                  0x40000000UL
 #define NRF_MPU_BASE                    0x40000000UL
-#define NRF_PU_BASE                     0x40000000UL
 #define NRF_AMLI_BASE                   0x40000000UL
 #define NRF_RADIO_BASE                  0x40001000UL
 #define NRF_UART0_BASE                  0x40002000UL
@@ -1266,7 +1218,6 @@ typedef struct {                                    /*!< GPIO Structure         
 #define NRF_POWER                       ((NRF_POWER_Type          *) NRF_POWER_BASE)
 #define NRF_CLOCK                       ((NRF_CLOCK_Type          *) NRF_CLOCK_BASE)
 #define NRF_MPU                         ((NRF_MPU_Type            *) NRF_MPU_BASE)
-#define NRF_PU                          ((NRF_PU_Type             *) NRF_PU_BASE)
 #define NRF_AMLI                        ((NRF_AMLI_Type           *) NRF_AMLI_BASE)
 #define NRF_RADIO                       ((NRF_RADIO_Type          *) NRF_RADIO_BASE)
 #define NRF_UART0                       ((NRF_UART_Type           *) NRF_UART0_BASE)
@@ -1300,7 +1251,7 @@ typedef struct {                                    /*!< GPIO Structure         
 
 
 /** @} */ /* End of group Device_Peripheral_Registers */
-/** @} */ /* End of group nRF51 */
+/** @} */ /* End of group nrf51 */
 /** @} */ /* End of group Nordic Semiconductor */
 
 #ifdef __cplusplus
@@ -1308,5 +1259,4 @@ typedef struct {                                    /*!< GPIO Structure         
 #endif
 
 
-#endif  /* nRF51_H */
-
+#endif  /* nrf51_H */

--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf51_bitfields.h
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf51_bitfields.h
@@ -1,38 +1,38 @@
-/* Copyright (c) 2013, Nordic Semiconductor ASA
+/*
+ * Copyright (c) Nordic Semiconductor ASA
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
  *
- *   * Redistributions of source code must retain the above copyright notice, this
- *     list of conditions and the following disclaimer.
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
  *
- *   * Redistributions in binary form must reproduce the above copyright notice,
- *     this list of conditions and the following disclaimer in the documentation
- *     and/or other materials provided with the distribution.
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
  *
- *   * Neither the name of Nordic Semiconductor ASA nor the names of its
- *     contributors may be used to endorse or promote products derived from
- *     this software without specific prior written permission.
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of other
+ *   contributors to this software may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
 #ifndef __NRF51_BITS_H
 #define __NRF51_BITS_H
 
-/*lint ++flb "Enter library region */
-
-#include <core_cm0.h>
+/*lint ++flb "Enter library region" */
 
 /* Peripheral: AAR */
 /* Description: Accelerated Address Resolver. */
@@ -820,6 +820,7 @@
 #define AMLI_RAMPRI_AAR_RAM0_Pri12 (0xCUL) /*!< Priority 12. */
 #define AMLI_RAMPRI_AAR_RAM0_Pri14 (0xEUL) /*!< Priority 14. */
 
+
 /* Peripheral: CCM */
 /* Description: AES CCM Mode Encryption. */
 
@@ -1064,8 +1065,8 @@
 /* Bits 7..0 : External Xtal frequency selection. */
 #define CLOCK_XTALFREQ_XTALFREQ_Pos (0UL) /*!< Position of XTALFREQ field. */
 #define CLOCK_XTALFREQ_XTALFREQ_Msk (0xFFUL << CLOCK_XTALFREQ_XTALFREQ_Pos) /*!< Bit mask of XTALFREQ field. */
-#define CLOCK_XTALFREQ_XTALFREQ_16MHz (0xFFUL) /*!< 16MHz xtal is used as source for the HFCLK oscillator. */
 #define CLOCK_XTALFREQ_XTALFREQ_32MHz (0x00UL) /*!< 32MHz xtal is used as source for the HFCLK oscillator. */
+#define CLOCK_XTALFREQ_XTALFREQ_16MHz (0xFFUL) /*!< 16MHz xtal is used as source for the HFCLK oscillator. */
 
 
 /* Peripheral: ECB */
@@ -1124,8 +1125,8 @@
 /* Bits 7..0 : Pre-programmed factory code present. */
 #define FICR_PPFC_PPFC_Pos (0UL) /*!< Position of PPFC field. */
 #define FICR_PPFC_PPFC_Msk (0xFFUL << FICR_PPFC_PPFC_Pos) /*!< Bit mask of PPFC field. */
-#define FICR_PPFC_PPFC_NotPresent (0xFFUL) /*!< Not present. */
 #define FICR_PPFC_PPFC_Present (0x00UL) /*!< Present. */
+#define FICR_PPFC_PPFC_NotPresent (0xFFUL) /*!< Not present. */
 
 /* Register: FICR_CONFIGID */
 /* Description: Configuration identifier. */
@@ -1161,60 +1162,6 @@
 #define FICR_OVERRIDEEN_NRF_1MBIT_Msk (0x1UL << FICR_OVERRIDEEN_NRF_1MBIT_Pos) /*!< Bit mask of NRF_1MBIT field. */
 #define FICR_OVERRIDEEN_NRF_1MBIT_Override (0UL) /*!< Override the default values for NRF_1Mbit mode. */
 #define FICR_OVERRIDEEN_NRF_1MBIT_NotOverride (1UL) /*!< Do not override the default values for NRF_1Mbit mode. */
-
-/* Register: FICR_INFO_PART */
-/* Description: Part code */
-
-/* Bits 31..0 : Part code */
-#define FICR_INFO_PART_PART_Pos (0UL) /*!< Position of PART field. */
-#define FICR_INFO_PART_PART_Msk (0xFFFFFFFFUL << FICR_INFO_PART_PART_Pos) /*!< Bit mask of PART field. */
-#define FICR_INFO_PART_PART_N51822 (0x51822UL) /*!< nRF51822 */
-#define FICR_INFO_PART_PART_N51422 (0x51422UL) /*!< nRF51422 */
-#define FICR_INFO_PART_PART_Unspecified (0xFFFFFFFFUL) /*!< Unspecified */
-
-/* Register: FICR_INFO_VARIANT */
-/* Description: Part variant */
-
-/* Bits 31..0 : Part variant */
-#define FICR_INFO_VARIANT_VARIANT_Pos (0UL) /*!< Position of VARIANT field. */
-#define FICR_INFO_VARIANT_VARIANT_Msk (0xFFFFFFFFUL << FICR_INFO_VARIANT_VARIANT_Pos) /*!< Bit mask of VARIANT field. */
-#define FICR_INFO_VARIANT_VARIANT_nRF51C (0x1002UL) /*!< nRF51-C (XLR3) */
-#define FICR_INFO_VARIANT_VARIANT_nRF51D (0x1003UL) /*!< nRF51-D (L3) */
-#define FICR_INFO_VARIANT_VARIANT_nRF51E (0x1004UL) /*!< nRF51-E (XLR3P) */
-#define FICR_INFO_VARIANT_VARIANT_Unspecified (0xFFFFFFFFUL) /*!< Unspecified */
-
-/* Register: FICR_INFO_PACKAGE */
-/* Description: Package option */
-
-/* Bits 31..0 : Package option */
-#define FICR_INFO_PACKAGE_PACKAGE_Pos (0UL) /*!< Position of PACKAGE field. */
-#define FICR_INFO_PACKAGE_PACKAGE_Msk (0xFFFFFFFFUL << FICR_INFO_PACKAGE_PACKAGE_Pos) /*!< Bit mask of PACKAGE field. */
-#define FICR_INFO_PACKAGE_PACKAGE_QFN48 (0x0000UL) /*!< 48-pin QFN with 31 GPIO */
-#define FICR_INFO_PACKAGE_PACKAGE_nRF51CSP56A (0x1000UL) /*!< nRF51x22 CDxx - WLCSP 56 balls */
-#define FICR_INFO_PACKAGE_PACKAGE_nRF51CSP62A (0x1001UL) /*!< nRF51x22 CExx - WLCSP 62 balls */
-#define FICR_INFO_PACKAGE_PACKAGE_nRF51CSP62B (0x1002UL) /*!< nRF51x22 CFxx - WLCSP 62 balls */
-#define FICR_INFO_PACKAGE_PACKAGE_nRF51CSP62C (0x1003UL) /*!< nRF51x22 CTxx - WLCSP 62 balls */
-#define FICR_INFO_PACKAGE_PACKAGE_Unspecified (0xFFFFFFFFUL) /*!< Unspecified */
-
-/* Register: FICR_INFO_RAM */
-/* Description: RAM variant */
-
-/* Bits 31..0 : RAM variant */
-#define FICR_INFO_RAM_RAM_Pos (0UL) /*!< Position of RAM field. */
-#define FICR_INFO_RAM_RAM_Msk (0xFFFFFFFFUL << FICR_INFO_RAM_RAM_Pos) /*!< Bit mask of RAM field. */
-#define FICR_INFO_RAM_RAM_Unspecified (0xFFFFFFFFUL) /*!< Unspecified */
-#define FICR_INFO_RAM_RAM_K16 (16UL) /*!< 16 kByte RAM. */
-#define FICR_INFO_RAM_RAM_K32 (32UL) /*!< 32 kByte RAM. */
-
-/* Register: FICR_INFO_FLASH */
-/* Description: Flash variant */
-
-/* Bits 31..0 : Flash variant */
-#define FICR_INFO_FLASH_FLASH_Pos (0UL) /*!< Position of FLASH field. */
-#define FICR_INFO_FLASH_FLASH_Msk (0xFFFFFFFFUL << FICR_INFO_FLASH_FLASH_Pos) /*!< Bit mask of FLASH field. */
-#define FICR_INFO_FLASH_FLASH_Unspecified (0xFFFFFFFFUL) /*!< Unspecified */
-#define FICR_INFO_FLASH_FLASH_K128 (128UL) /*!< 128 kByte FLASH. */
-#define FICR_INFO_FLASH_FLASH_K256 (256UL) /*!< 256 kByte FLASH. */
 
 
 /* Peripheral: GPIO */
@@ -2846,6 +2793,7 @@
 /* Bits 17..16 : Effects on output when in Task mode, or events on input that generates an event. */
 #define GPIOTE_CONFIG_POLARITY_Pos (16UL) /*!< Position of POLARITY field. */
 #define GPIOTE_CONFIG_POLARITY_Msk (0x3UL << GPIOTE_CONFIG_POLARITY_Pos) /*!< Bit mask of POLARITY field. */
+#define GPIOTE_CONFIG_POLARITY_None (0x00UL) /*!< No task or event. */
 #define GPIOTE_CONFIG_POLARITY_LoToHi (0x01UL) /*!< Low to high. */
 #define GPIOTE_CONFIG_POLARITY_HiToLo (0x02UL) /*!< High to low. */
 #define GPIOTE_CONFIG_POLARITY_Toggle (0x03UL) /*!< Toggle. */
@@ -3720,30 +3668,44 @@
 /* Bit 18 : Reset from wake-up from OFF mode detected by entering into debug interface mode. */
 #define POWER_RESETREAS_DIF_Pos (18UL) /*!< Position of DIF field. */
 #define POWER_RESETREAS_DIF_Msk (0x1UL << POWER_RESETREAS_DIF_Pos) /*!< Bit mask of DIF field. */
+#define POWER_RESETREAS_DIF_NotDetected (0UL) /*!< Reset not detected. */
+#define POWER_RESETREAS_DIF_Detected (1UL) /*!< Reset detected. */
 
 /* Bit 17 : Reset from wake-up from OFF mode detected by the use of ANADETECT signal from LPCOMP. */
 #define POWER_RESETREAS_LPCOMP_Pos (17UL) /*!< Position of LPCOMP field. */
 #define POWER_RESETREAS_LPCOMP_Msk (0x1UL << POWER_RESETREAS_LPCOMP_Pos) /*!< Bit mask of LPCOMP field. */
+#define POWER_RESETREAS_LPCOMP_NotDetected (0UL) /*!< Reset not detected. */
+#define POWER_RESETREAS_LPCOMP_Detected (1UL) /*!< Reset detected. */
 
 /* Bit 16 : Reset from wake-up from OFF mode detected by the use of DETECT signal from GPIO. */
 #define POWER_RESETREAS_OFF_Pos (16UL) /*!< Position of OFF field. */
 #define POWER_RESETREAS_OFF_Msk (0x1UL << POWER_RESETREAS_OFF_Pos) /*!< Bit mask of OFF field. */
+#define POWER_RESETREAS_OFF_NotDetected (0UL) /*!< Reset not detected. */
+#define POWER_RESETREAS_OFF_Detected (1UL) /*!< Reset detected. */
 
 /* Bit 3 : Reset from CPU lock-up detected. */
 #define POWER_RESETREAS_LOCKUP_Pos (3UL) /*!< Position of LOCKUP field. */
 #define POWER_RESETREAS_LOCKUP_Msk (0x1UL << POWER_RESETREAS_LOCKUP_Pos) /*!< Bit mask of LOCKUP field. */
+#define POWER_RESETREAS_LOCKUP_NotDetected (0UL) /*!< Reset not detected. */
+#define POWER_RESETREAS_LOCKUP_Detected (1UL) /*!< Reset detected. */
 
 /* Bit 2 : Reset from AIRCR.SYSRESETREQ detected. */
 #define POWER_RESETREAS_SREQ_Pos (2UL) /*!< Position of SREQ field. */
 #define POWER_RESETREAS_SREQ_Msk (0x1UL << POWER_RESETREAS_SREQ_Pos) /*!< Bit mask of SREQ field. */
+#define POWER_RESETREAS_SREQ_NotDetected (0UL) /*!< Reset not detected. */
+#define POWER_RESETREAS_SREQ_Detected (1UL) /*!< Reset detected. */
 
 /* Bit 1 : Reset from watchdog detected. */
 #define POWER_RESETREAS_DOG_Pos (1UL) /*!< Position of DOG field. */
 #define POWER_RESETREAS_DOG_Msk (0x1UL << POWER_RESETREAS_DOG_Pos) /*!< Bit mask of DOG field. */
+#define POWER_RESETREAS_DOG_NotDetected (0UL) /*!< Reset not detected. */
+#define POWER_RESETREAS_DOG_Detected (1UL) /*!< Reset detected. */
 
 /* Bit 0 : Reset from pin-reset detected. */
 #define POWER_RESETREAS_RESETPIN_Pos (0UL) /*!< Position of RESETPIN field. */
 #define POWER_RESETREAS_RESETPIN_Msk (0x1UL << POWER_RESETREAS_RESETPIN_Pos) /*!< Bit mask of RESETPIN field. */
+#define POWER_RESETREAS_RESETPIN_NotDetected (0UL) /*!< Reset not detected. */
+#define POWER_RESETREAS_RESETPIN_Detected (1UL) /*!< Reset detected. */
 
 /* Register: POWER_RAMSTATUS */
 /* Description: Ram status register. */
@@ -4636,186 +4598,6 @@
 #define PPI_CHG_CH0_Included (1UL) /*!< Channel included. */
 
 
-/* Peripheral: PU */
-/* Description: Patch unit. */
-
-/* Register: PU_PATCHADDR */
-/* Description: Relative address of patch instructions. */
-
-/* Bits 24..0 : Relative address of patch instructions. */
-#define PU_PATCHADDR_PATCHADDR_Pos (0UL) /*!< Position of PATCHADDR field. */
-#define PU_PATCHADDR_PATCHADDR_Msk (0x1FFFFFFUL << PU_PATCHADDR_PATCHADDR_Pos) /*!< Bit mask of PATCHADDR field. */
-
-/* Register: PU_PATCHEN */
-/* Description: Patch enable register. */
-
-/* Bit 7 : Patch 7 enabled. */
-#define PU_PATCHEN_PATCH7_Pos (7UL) /*!< Position of PATCH7 field. */
-#define PU_PATCHEN_PATCH7_Msk (0x1UL << PU_PATCHEN_PATCH7_Pos) /*!< Bit mask of PATCH7 field. */
-#define PU_PATCHEN_PATCH7_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHEN_PATCH7_Enabled (1UL) /*!< Patch enabled. */
-
-/* Bit 6 : Patch 6 enabled. */
-#define PU_PATCHEN_PATCH6_Pos (6UL) /*!< Position of PATCH6 field. */
-#define PU_PATCHEN_PATCH6_Msk (0x1UL << PU_PATCHEN_PATCH6_Pos) /*!< Bit mask of PATCH6 field. */
-#define PU_PATCHEN_PATCH6_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHEN_PATCH6_Enabled (1UL) /*!< Patch enabled. */
-
-/* Bit 5 : Patch 5 enabled. */
-#define PU_PATCHEN_PATCH5_Pos (5UL) /*!< Position of PATCH5 field. */
-#define PU_PATCHEN_PATCH5_Msk (0x1UL << PU_PATCHEN_PATCH5_Pos) /*!< Bit mask of PATCH5 field. */
-#define PU_PATCHEN_PATCH5_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHEN_PATCH5_Enabled (1UL) /*!< Patch enabled. */
-
-/* Bit 4 : Patch 4 enabled. */
-#define PU_PATCHEN_PATCH4_Pos (4UL) /*!< Position of PATCH4 field. */
-#define PU_PATCHEN_PATCH4_Msk (0x1UL << PU_PATCHEN_PATCH4_Pos) /*!< Bit mask of PATCH4 field. */
-#define PU_PATCHEN_PATCH4_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHEN_PATCH4_Enabled (1UL) /*!< Patch enabled. */
-
-/* Bit 3 : Patch 3 enabled. */
-#define PU_PATCHEN_PATCH3_Pos (3UL) /*!< Position of PATCH3 field. */
-#define PU_PATCHEN_PATCH3_Msk (0x1UL << PU_PATCHEN_PATCH3_Pos) /*!< Bit mask of PATCH3 field. */
-#define PU_PATCHEN_PATCH3_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHEN_PATCH3_Enabled (1UL) /*!< Patch enabled. */
-
-/* Bit 2 : Patch 2 enabled. */
-#define PU_PATCHEN_PATCH2_Pos (2UL) /*!< Position of PATCH2 field. */
-#define PU_PATCHEN_PATCH2_Msk (0x1UL << PU_PATCHEN_PATCH2_Pos) /*!< Bit mask of PATCH2 field. */
-#define PU_PATCHEN_PATCH2_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHEN_PATCH2_Enabled (1UL) /*!< Patch enabled. */
-
-/* Bit 1 : Patch 1 enabled. */
-#define PU_PATCHEN_PATCH1_Pos (1UL) /*!< Position of PATCH1 field. */
-#define PU_PATCHEN_PATCH1_Msk (0x1UL << PU_PATCHEN_PATCH1_Pos) /*!< Bit mask of PATCH1 field. */
-#define PU_PATCHEN_PATCH1_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHEN_PATCH1_Enabled (1UL) /*!< Patch enabled. */
-
-/* Bit 0 : Patch 0 enabled. */
-#define PU_PATCHEN_PATCH0_Pos (0UL) /*!< Position of PATCH0 field. */
-#define PU_PATCHEN_PATCH0_Msk (0x1UL << PU_PATCHEN_PATCH0_Pos) /*!< Bit mask of PATCH0 field. */
-#define PU_PATCHEN_PATCH0_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHEN_PATCH0_Enabled (1UL) /*!< Patch enabled. */
-
-/* Register: PU_PATCHENSET */
-/* Description: Patch enable register. */
-
-/* Bit 7 : Patch 7 enabled. */
-#define PU_PATCHENSET_PATCH7_Pos (7UL) /*!< Position of PATCH7 field. */
-#define PU_PATCHENSET_PATCH7_Msk (0x1UL << PU_PATCHENSET_PATCH7_Pos) /*!< Bit mask of PATCH7 field. */
-#define PU_PATCHENSET_PATCH7_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENSET_PATCH7_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENSET_PATCH7_Set (1UL) /*!< Enable patch on write. */
-
-/* Bit 6 : Patch 6 enabled. */
-#define PU_PATCHENSET_PATCH6_Pos (6UL) /*!< Position of PATCH6 field. */
-#define PU_PATCHENSET_PATCH6_Msk (0x1UL << PU_PATCHENSET_PATCH6_Pos) /*!< Bit mask of PATCH6 field. */
-#define PU_PATCHENSET_PATCH6_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENSET_PATCH6_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENSET_PATCH6_Set (1UL) /*!< Enable patch on write. */
-
-/* Bit 5 : Patch 5 enabled. */
-#define PU_PATCHENSET_PATCH5_Pos (5UL) /*!< Position of PATCH5 field. */
-#define PU_PATCHENSET_PATCH5_Msk (0x1UL << PU_PATCHENSET_PATCH5_Pos) /*!< Bit mask of PATCH5 field. */
-#define PU_PATCHENSET_PATCH5_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENSET_PATCH5_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENSET_PATCH5_Set (1UL) /*!< Enable patch on write. */
-
-/* Bit 4 : Patch 4 enabled. */
-#define PU_PATCHENSET_PATCH4_Pos (4UL) /*!< Position of PATCH4 field. */
-#define PU_PATCHENSET_PATCH4_Msk (0x1UL << PU_PATCHENSET_PATCH4_Pos) /*!< Bit mask of PATCH4 field. */
-#define PU_PATCHENSET_PATCH4_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENSET_PATCH4_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENSET_PATCH4_Set (1UL) /*!< Enable patch on write. */
-
-/* Bit 3 : Patch 3 enabled. */
-#define PU_PATCHENSET_PATCH3_Pos (3UL) /*!< Position of PATCH3 field. */
-#define PU_PATCHENSET_PATCH3_Msk (0x1UL << PU_PATCHENSET_PATCH3_Pos) /*!< Bit mask of PATCH3 field. */
-#define PU_PATCHENSET_PATCH3_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENSET_PATCH3_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENSET_PATCH3_Set (1UL) /*!< Enable patch on write. */
-
-/* Bit 2 : Patch 2 enabled. */
-#define PU_PATCHENSET_PATCH2_Pos (2UL) /*!< Position of PATCH2 field. */
-#define PU_PATCHENSET_PATCH2_Msk (0x1UL << PU_PATCHENSET_PATCH2_Pos) /*!< Bit mask of PATCH2 field. */
-#define PU_PATCHENSET_PATCH2_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENSET_PATCH2_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENSET_PATCH2_Set (1UL) /*!< Enable patch on write. */
-
-/* Bit 1 : Patch 1 enabled. */
-#define PU_PATCHENSET_PATCH1_Pos (1UL) /*!< Position of PATCH1 field. */
-#define PU_PATCHENSET_PATCH1_Msk (0x1UL << PU_PATCHENSET_PATCH1_Pos) /*!< Bit mask of PATCH1 field. */
-#define PU_PATCHENSET_PATCH1_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENSET_PATCH1_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENSET_PATCH1_Set (1UL) /*!< Enable patch on write. */
-
-/* Bit 0 : Patch 0 enabled. */
-#define PU_PATCHENSET_PATCH0_Pos (0UL) /*!< Position of PATCH0 field. */
-#define PU_PATCHENSET_PATCH0_Msk (0x1UL << PU_PATCHENSET_PATCH0_Pos) /*!< Bit mask of PATCH0 field. */
-#define PU_PATCHENSET_PATCH0_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENSET_PATCH0_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENSET_PATCH0_Set (1UL) /*!< Enable patch on write. */
-
-/* Register: PU_PATCHENCLR */
-/* Description: Patch disable register. */
-
-/* Bit 7 : Patch 7 enabled. */
-#define PU_PATCHENCLR_PATCH7_Pos (7UL) /*!< Position of PATCH7 field. */
-#define PU_PATCHENCLR_PATCH7_Msk (0x1UL << PU_PATCHENCLR_PATCH7_Pos) /*!< Bit mask of PATCH7 field. */
-#define PU_PATCHENCLR_PATCH7_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENCLR_PATCH7_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENCLR_PATCH7_Clear (1UL) /*!< Disable patch on write. */
-
-/* Bit 6 : Patch 6 enabled. */
-#define PU_PATCHENCLR_PATCH6_Pos (6UL) /*!< Position of PATCH6 field. */
-#define PU_PATCHENCLR_PATCH6_Msk (0x1UL << PU_PATCHENCLR_PATCH6_Pos) /*!< Bit mask of PATCH6 field. */
-#define PU_PATCHENCLR_PATCH6_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENCLR_PATCH6_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENCLR_PATCH6_Clear (1UL) /*!< Disable patch on write. */
-
-/* Bit 5 : Patch 5 enabled. */
-#define PU_PATCHENCLR_PATCH5_Pos (5UL) /*!< Position of PATCH5 field. */
-#define PU_PATCHENCLR_PATCH5_Msk (0x1UL << PU_PATCHENCLR_PATCH5_Pos) /*!< Bit mask of PATCH5 field. */
-#define PU_PATCHENCLR_PATCH5_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENCLR_PATCH5_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENCLR_PATCH5_Clear (1UL) /*!< Disable patch on write. */
-
-/* Bit 4 : Patch 4 enabled. */
-#define PU_PATCHENCLR_PATCH4_Pos (4UL) /*!< Position of PATCH4 field. */
-#define PU_PATCHENCLR_PATCH4_Msk (0x1UL << PU_PATCHENCLR_PATCH4_Pos) /*!< Bit mask of PATCH4 field. */
-#define PU_PATCHENCLR_PATCH4_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENCLR_PATCH4_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENCLR_PATCH4_Clear (1UL) /*!< Disable patch on write. */
-
-/* Bit 3 : Patch 3 enabled. */
-#define PU_PATCHENCLR_PATCH3_Pos (3UL) /*!< Position of PATCH3 field. */
-#define PU_PATCHENCLR_PATCH3_Msk (0x1UL << PU_PATCHENCLR_PATCH3_Pos) /*!< Bit mask of PATCH3 field. */
-#define PU_PATCHENCLR_PATCH3_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENCLR_PATCH3_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENCLR_PATCH3_Clear (1UL) /*!< Disable patch on write. */
-
-/* Bit 2 : Patch 2 enabled. */
-#define PU_PATCHENCLR_PATCH2_Pos (2UL) /*!< Position of PATCH2 field. */
-#define PU_PATCHENCLR_PATCH2_Msk (0x1UL << PU_PATCHENCLR_PATCH2_Pos) /*!< Bit mask of PATCH2 field. */
-#define PU_PATCHENCLR_PATCH2_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENCLR_PATCH2_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENCLR_PATCH2_Clear (1UL) /*!< Disable patch on write. */
-
-/* Bit 1 : Patch 1 enabled. */
-#define PU_PATCHENCLR_PATCH1_Pos (1UL) /*!< Position of PATCH1 field. */
-#define PU_PATCHENCLR_PATCH1_Msk (0x1UL << PU_PATCHENCLR_PATCH1_Pos) /*!< Bit mask of PATCH1 field. */
-#define PU_PATCHENCLR_PATCH1_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENCLR_PATCH1_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENCLR_PATCH1_Clear (1UL) /*!< Disable patch on write. */
-
-/* Bit 0 : Patch 0 enabled. */
-#define PU_PATCHENCLR_PATCH0_Pos (0UL) /*!< Position of PATCH0 field. */
-#define PU_PATCHENCLR_PATCH0_Msk (0x1UL << PU_PATCHENCLR_PATCH0_Pos) /*!< Bit mask of PATCH0 field. */
-#define PU_PATCHENCLR_PATCH0_Disabled (0UL) /*!< Patch disabled. */
-#define PU_PATCHENCLR_PATCH0_Enabled (1UL) /*!< Patch enabled. */
-#define PU_PATCHENCLR_PATCH0_Clear (1UL) /*!< Disable patch on write. */
-
-
 /* Peripheral: QDEC */
 /* Description: Rotary decoder. */
 
@@ -5172,13 +4954,6 @@
 #define RADIO_CRCSTATUS_CRCSTATUS_CRCError (0UL) /*!< Packet received with CRC error. */
 #define RADIO_CRCSTATUS_CRCSTATUS_CRCOk (1UL) /*!< Packet received with CRC ok. */
 
-/* Register: RADIO_CD */
-/* Description: Carrier detect. */
-
-/* Bit 0 : Carrier detect. */
-#define RADIO_CD_CD_Pos (0UL) /*!< Position of CD field. */
-#define RADIO_CD_CD_Msk (0x1UL << RADIO_CD_CD_Pos) /*!< Bit mask of CD field. */
-
 /* Register: RADIO_RXMATCH */
 /* Description: Received address. */
 
@@ -5213,14 +4988,14 @@
 /* Bits 7..0 : Radio output power. Decision point: TXEN task. */
 #define RADIO_TXPOWER_TXPOWER_Pos (0UL) /*!< Position of TXPOWER field. */
 #define RADIO_TXPOWER_TXPOWER_Msk (0xFFUL << RADIO_TXPOWER_TXPOWER_Pos) /*!< Bit mask of TXPOWER field. */
-#define RADIO_TXPOWER_TXPOWER_Pos4dBm (0x04UL) /*!< +4dBm. */
 #define RADIO_TXPOWER_TXPOWER_0dBm (0x00UL) /*!< 0dBm. */
-#define RADIO_TXPOWER_TXPOWER_Neg4dBm (0xFCUL) /*!< -4dBm. */
-#define RADIO_TXPOWER_TXPOWER_Neg8dBm (0xF8UL) /*!< -8dBm. */
-#define RADIO_TXPOWER_TXPOWER_Neg12dBm (0xF4UL) /*!< -12dBm. */
-#define RADIO_TXPOWER_TXPOWER_Neg16dBm (0xF0UL) /*!< -16dBm. */
-#define RADIO_TXPOWER_TXPOWER_Neg20dBm (0xECUL) /*!< -20dBm. */
+#define RADIO_TXPOWER_TXPOWER_Pos4dBm (0x04UL) /*!< +4dBm. */
 #define RADIO_TXPOWER_TXPOWER_Neg30dBm (0xD8UL) /*!< -30dBm. */
+#define RADIO_TXPOWER_TXPOWER_Neg20dBm (0xECUL) /*!< -20dBm. */
+#define RADIO_TXPOWER_TXPOWER_Neg16dBm (0xF0UL) /*!< -16dBm. */
+#define RADIO_TXPOWER_TXPOWER_Neg12dBm (0xF4UL) /*!< -12dBm. */
+#define RADIO_TXPOWER_TXPOWER_Neg8dBm (0xF8UL) /*!< -8dBm. */
+#define RADIO_TXPOWER_TXPOWER_Neg4dBm (0xFCUL) /*!< -4dBm. */
 
 /* Register: RADIO_MODE */
 /* Description: Data rate and modulation. */
@@ -6000,15 +5775,6 @@
 /* Peripheral: SPIM */
 /* Description: SPI master with easyDMA 1. */
 
-/* Register: SPIM_SHORTS */
-/* Description: Shortcuts for SPIM. */
-
-/* Bit 17 : Shortcut between END event and START task. */
-#define SPIM_SHORTS_END_START_Pos (17UL) /*!< Position of END_START field. */
-#define SPIM_SHORTS_END_START_Msk (0x1UL << SPIM_SHORTS_END_START_Pos) /*!< Bit mask of END_START field. */
-#define SPIM_SHORTS_END_START_Disabled (0UL) /*!< Shortcut disabled. */
-#define SPIM_SHORTS_END_START_Enabled (1UL) /*!< Shortcut enabled. */
-
 /* Register: SPIM_INTENSET */
 /* Description: Interrupt enable set register. */
 
@@ -6025,13 +5791,6 @@
 #define SPIM_INTENSET_ENDTX_Disabled (0UL) /*!< Interrupt disabled. */
 #define SPIM_INTENSET_ENDTX_Enabled (1UL) /*!< Interrupt enabled. */
 #define SPIM_INTENSET_ENDTX_Set (1UL) /*!< Enable interrupt on write. */
-
-/* Bit 6 : Enable interrupt on END event. */
-#define SPIM_INTENSET_END_Pos (6UL) /*!< Position of END field. */
-#define SPIM_INTENSET_END_Msk (0x1UL << SPIM_INTENSET_END_Pos) /*!< Bit mask of END field. */
-#define SPIM_INTENSET_END_Disabled (0UL) /*!< Interrupt disabled. */
-#define SPIM_INTENSET_END_Enabled (1UL) /*!< Interrupt enabled. */
-#define SPIM_INTENSET_END_Set (1UL) /*!< Enable interrupt on write. */
 
 /* Bit 4 : Enable interrupt on ENDRX event. */
 #define SPIM_INTENSET_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
@@ -6064,13 +5823,6 @@
 #define SPIM_INTENCLR_ENDTX_Enabled (1UL) /*!< Interrupt enabled. */
 #define SPIM_INTENCLR_ENDTX_Clear (1UL) /*!< Disable interrupt on write. */
 
-/* Bit 6 : Disable interrupt on END event. */
-#define SPIM_INTENCLR_END_Pos (6UL) /*!< Position of END field. */
-#define SPIM_INTENCLR_END_Msk (0x1UL << SPIM_INTENCLR_END_Pos) /*!< Bit mask of END field. */
-#define SPIM_INTENCLR_END_Disabled (0UL) /*!< Interrupt disabled. */
-#define SPIM_INTENCLR_END_Enabled (1UL) /*!< Interrupt enabled. */
-#define SPIM_INTENCLR_END_Clear (1UL) /*!< Disable interrupt on write. */
-
 /* Bit 4 : Disable interrupt on ENDRX event. */
 #define SPIM_INTENCLR_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
 #define SPIM_INTENCLR_ENDRX_Msk (0x1UL << SPIM_INTENCLR_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
@@ -6094,20 +5846,6 @@
 #define SPIM_ENABLE_ENABLE_Disabled (0x00UL) /*!< Disabled SPIM. */
 #define SPIM_ENABLE_ENABLE_Enabled (0x07UL) /*!< Enable SPIM. */
 
-/* Register: SPIM_RXDDATA */
-/* Description: RXD register. */
-
-/* Bits 7..0 : RX data received. Double buffered. */
-#define SPIM_RXDDATA_RXD_Pos (0UL) /*!< Position of RXD field. */
-#define SPIM_RXDDATA_RXD_Msk (0xFFUL << SPIM_RXDDATA_RXD_Pos) /*!< Bit mask of RXD field. */
-
-/* Register: SPIM_TXDDATA */
-/* Description: TXD register. */
-
-/* Bits 7..0 : TX data to send. Double buffered. */
-#define SPIM_TXDDATA_TXD_Pos (0UL) /*!< Position of TXD field. */
-#define SPIM_TXDDATA_TXD_Msk (0xFFUL << SPIM_TXDDATA_TXD_Pos) /*!< Bit mask of TXD field. */
-
 /* Register: SPIM_FREQUENCY */
 /* Description: SPI frequency. */
 
@@ -6121,43 +5859,6 @@
 #define SPIM_FREQUENCY_FREQUENCY_M2 (0x20000000UL) /*!< 2 Mbps. */
 #define SPIM_FREQUENCY_FREQUENCY_M4 (0x40000000UL) /*!< 4 Mbps. */
 #define SPIM_FREQUENCY_FREQUENCY_M8 (0x80000000UL) /*!< 8 Mbps. */
-
-/* Register: SPIM_CONFIG */
-/* Description: Configuration register. */
-
-/* Bit 2 : Serial clock (SCK) polarity. */
-#define SPIM_CONFIG_CPOL_Pos (2UL) /*!< Position of CPOL field. */
-#define SPIM_CONFIG_CPOL_Msk (0x1UL << SPIM_CONFIG_CPOL_Pos) /*!< Bit mask of CPOL field. */
-#define SPIM_CONFIG_CPOL_ActiveHigh (0UL) /*!< Active high. */
-#define SPIM_CONFIG_CPOL_ActiveLow (1UL) /*!< Active low. */
-
-/* Bit 1 : Serial clock (SCK) phase. */
-#define SPIM_CONFIG_CPHA_Pos (1UL) /*!< Position of CPHA field. */
-#define SPIM_CONFIG_CPHA_Msk (0x1UL << SPIM_CONFIG_CPHA_Pos) /*!< Bit mask of CPHA field. */
-#define SPIM_CONFIG_CPHA_Leading (0UL) /*!< Sample on leading edge of the clock. Shift serial data on trailing edge. */
-#define SPIM_CONFIG_CPHA_Trailing (1UL) /*!< Sample on trailing edge of the clock. Shift serial data on leading edge. */
-
-/* Bit 0 : Bit order. */
-#define SPIM_CONFIG_ORDER_Pos (0UL) /*!< Position of ORDER field. */
-#define SPIM_CONFIG_ORDER_Msk (0x1UL << SPIM_CONFIG_ORDER_Pos) /*!< Bit mask of ORDER field. */
-#define SPIM_CONFIG_ORDER_MsbFirst (0UL) /*!< Most significant bit transmitted out first. */
-#define SPIM_CONFIG_ORDER_LsbFirst (1UL) /*!< Least significant bit transmitted out first. */
-
-/* Register: SPIM_ORC */
-/* Description: Over-read character. */
-
-/* Bits 7..0 : Over-read character. */
-#define SPIM_ORC_ORC_Pos (0UL) /*!< Position of ORC field. */
-#define SPIM_ORC_ORC_Msk (0xFFUL << SPIM_ORC_ORC_Pos) /*!< Bit mask of ORC field. */
-
-/* Register: SPIM_POWER */
-/* Description: Peripheral power control. */
-
-/* Bit 0 : Peripheral power control. */
-#define SPIM_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
-#define SPIM_POWER_POWER_Msk (0x1UL << SPIM_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
-#define SPIM_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
-#define SPIM_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
 
 /* Register: SPIM_RXD_PTR */
 /* Description: Data pointer. */
@@ -6201,6 +5902,43 @@
 #define SPIM_TXD_AMOUNT_AMOUNT_Pos (0UL) /*!< Position of AMOUNT field. */
 #define SPIM_TXD_AMOUNT_AMOUNT_Msk (0xFFUL << SPIM_TXD_AMOUNT_AMOUNT_Pos) /*!< Bit mask of AMOUNT field. */
 
+/* Register: SPIM_CONFIG */
+/* Description: Configuration register. */
+
+/* Bit 2 : Serial clock (SCK) polarity. */
+#define SPIM_CONFIG_CPOL_Pos (2UL) /*!< Position of CPOL field. */
+#define SPIM_CONFIG_CPOL_Msk (0x1UL << SPIM_CONFIG_CPOL_Pos) /*!< Bit mask of CPOL field. */
+#define SPIM_CONFIG_CPOL_ActiveHigh (0UL) /*!< Active high. */
+#define SPIM_CONFIG_CPOL_ActiveLow (1UL) /*!< Active low. */
+
+/* Bit 1 : Serial clock (SCK) phase. */
+#define SPIM_CONFIG_CPHA_Pos (1UL) /*!< Position of CPHA field. */
+#define SPIM_CONFIG_CPHA_Msk (0x1UL << SPIM_CONFIG_CPHA_Pos) /*!< Bit mask of CPHA field. */
+#define SPIM_CONFIG_CPHA_Leading (0UL) /*!< Sample on leading edge of the clock. Shift serial data on trailing edge. */
+#define SPIM_CONFIG_CPHA_Trailing (1UL) /*!< Sample on trailing edge of the clock. Shift serial data on leading edge. */
+
+/* Bit 0 : Bit order. */
+#define SPIM_CONFIG_ORDER_Pos (0UL) /*!< Position of ORDER field. */
+#define SPIM_CONFIG_ORDER_Msk (0x1UL << SPIM_CONFIG_ORDER_Pos) /*!< Bit mask of ORDER field. */
+#define SPIM_CONFIG_ORDER_MsbFirst (0UL) /*!< Most significant bit transmitted out first. */
+#define SPIM_CONFIG_ORDER_LsbFirst (1UL) /*!< Least significant bit transmitted out first. */
+
+/* Register: SPIM_ORC */
+/* Description: Over-read character. */
+
+/* Bits 7..0 : Over-read character. */
+#define SPIM_ORC_ORC_Pos (0UL) /*!< Position of ORC field. */
+#define SPIM_ORC_ORC_Msk (0xFFUL << SPIM_ORC_ORC_Pos) /*!< Bit mask of ORC field. */
+
+/* Register: SPIM_POWER */
+/* Description: Peripheral power control. */
+
+/* Bit 0 : Peripheral power control. */
+#define SPIM_POWER_POWER_Pos (0UL) /*!< Position of POWER field. */
+#define SPIM_POWER_POWER_Msk (0x1UL << SPIM_POWER_POWER_Pos) /*!< Bit mask of POWER field. */
+#define SPIM_POWER_POWER_Disabled (0UL) /*!< Module power disabled. */
+#define SPIM_POWER_POWER_Enabled (1UL) /*!< Module power enabled. */
+
 
 /* Peripheral: SPIS */
 /* Description: SPI slave 1. */
@@ -6224,6 +5962,13 @@
 #define SPIS_INTENSET_ACQUIRED_Enabled (1UL) /*!< Interrupt enabled. */
 #define SPIS_INTENSET_ACQUIRED_Set (1UL) /*!< Enable interrupt on write. */
 
+/* Bit 4 : enable interrupt on ENDRX event. */
+#define SPIS_INTENSET_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
+#define SPIS_INTENSET_ENDRX_Msk (0x1UL << SPIS_INTENSET_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define SPIS_INTENSET_ENDRX_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIS_INTENSET_ENDRX_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIS_INTENSET_ENDRX_Set (1UL) /*!< Enable interrupt on write. */
+
 /* Bit 1 : Enable interrupt on END event. */
 #define SPIS_INTENSET_END_Pos (1UL) /*!< Position of END field. */
 #define SPIS_INTENSET_END_Msk (0x1UL << SPIS_INTENSET_END_Pos) /*!< Bit mask of END field. */
@@ -6240,6 +5985,13 @@
 #define SPIS_INTENCLR_ACQUIRED_Disabled (0UL) /*!< Interrupt disabled. */
 #define SPIS_INTENCLR_ACQUIRED_Enabled (1UL) /*!< Interrupt enabled. */
 #define SPIS_INTENCLR_ACQUIRED_Clear (1UL) /*!< Disable interrupt on write. */
+
+/* Bit 4 : Disable interrupt on ENDRX event. */
+#define SPIS_INTENCLR_ENDRX_Pos (4UL) /*!< Position of ENDRX field. */
+#define SPIS_INTENCLR_ENDRX_Msk (0x1UL << SPIS_INTENCLR_ENDRX_Pos) /*!< Bit mask of ENDRX field. */
+#define SPIS_INTENCLR_ENDRX_Disabled (0UL) /*!< Interrupt disabled. */
+#define SPIS_INTENCLR_ENDRX_Enabled (1UL) /*!< Interrupt enabled. */
+#define SPIS_INTENCLR_ENDRX_Clear (1UL) /*!< Disable interrupt on write. */
 
 /* Bit 1 : Disable interrupt on END event. */
 #define SPIS_INTENCLR_END_Pos (1UL) /*!< Position of END field. */
@@ -6669,6 +6421,13 @@
 #define TWI_ERRORSRC_ANACK_Present (1UL) /*!< Error present. */
 #define TWI_ERRORSRC_ANACK_Clear (1UL) /*!< Clear error on write. */
 
+/* Bit 0 : Byte received in RXD register before read of the last received byte (data loss). */
+#define TWI_ERRORSRC_OVERRUN_Pos (0UL) /*!< Position of OVERRUN field. */
+#define TWI_ERRORSRC_OVERRUN_Msk (0x1UL << TWI_ERRORSRC_OVERRUN_Pos) /*!< Bit mask of OVERRUN field. */
+#define TWI_ERRORSRC_OVERRUN_NotPresent (0UL) /*!< Error not present. */
+#define TWI_ERRORSRC_OVERRUN_Present (1UL) /*!< Error present. */
+#define TWI_ERRORSRC_OVERRUN_Clear (1UL) /*!< Clear error on write. */
+
 /* Register: TWI_ENABLE */
 /* Description: Enable two-wire master. */
 
@@ -6725,13 +6484,13 @@
 /* Register: UART_SHORTS */
 /* Description: Shortcuts for UART. */
 
-/* Bit 4 : Shortcut between NCTS event and the STOPRX task. */
+/* Bit 4 : Shortcut between NCTS event and STOPRX task. */
 #define UART_SHORTS_NCTS_STOPRX_Pos (4UL) /*!< Position of NCTS_STOPRX field. */
 #define UART_SHORTS_NCTS_STOPRX_Msk (0x1UL << UART_SHORTS_NCTS_STOPRX_Pos) /*!< Bit mask of NCTS_STOPRX field. */
 #define UART_SHORTS_NCTS_STOPRX_Disabled (0UL) /*!< Shortcut disabled. */
 #define UART_SHORTS_NCTS_STOPRX_Enabled (1UL) /*!< Shortcut enabled. */
 
-/* Bit 3 : Shortcut between CTS event and the STARTRX task. */
+/* Bit 3 : Shortcut between CTS event and STARTRX task. */
 #define UART_SHORTS_CTS_STARTRX_Pos (3UL) /*!< Position of CTS_STARTRX field. */
 #define UART_SHORTS_CTS_STARTRX_Msk (0x1UL << UART_SHORTS_CTS_STARTRX_Pos) /*!< Bit mask of CTS_STARTRX field. */
 #define UART_SHORTS_CTS_STARTRX_Disabled (0UL) /*!< Shortcut disabled. */
@@ -6901,7 +6660,7 @@
 #define UART_BAUDRATE_BAUDRATE_Baud230400 (0x03AFB000UL) /*!< 230400 baud. */
 #define UART_BAUDRATE_BAUDRATE_Baud250000 (0x04000000UL) /*!< 250000 baud. */
 #define UART_BAUDRATE_BAUDRATE_Baud460800 (0x075F7000UL) /*!< 460800 baud. */
-#define UART_BAUDRATE_BAUDRATE_Baud921600 (0x0EBEDFA4UL) /*!< 921600 baud. */
+#define UART_BAUDRATE_BAUDRATE_Baud921600 (0x0EBED000UL) /*!< 921600 baud. */
 #define UART_BAUDRATE_BAUDRATE_Baud1M (0x10000000UL) /*!< 1M baud. */
 
 /* Register: UART_CONFIG */
@@ -6938,14 +6697,14 @@
 /* Bits 15..8 : Readback protect all code in the device. */
 #define UICR_RBPCONF_PALL_Pos (8UL) /*!< Position of PALL field. */
 #define UICR_RBPCONF_PALL_Msk (0xFFUL << UICR_RBPCONF_PALL_Pos) /*!< Bit mask of PALL field. */
-#define UICR_RBPCONF_PALL_Disabled (0xFFUL) /*!< Disabled. */
 #define UICR_RBPCONF_PALL_Enabled (0x00UL) /*!< Enabled. */
+#define UICR_RBPCONF_PALL_Disabled (0xFFUL) /*!< Disabled. */
 
 /* Bits 7..0 : Readback protect region 0. Will be ignored if pre-programmed factory code is present on the chip. */
 #define UICR_RBPCONF_PR0_Pos (0UL) /*!< Position of PR0 field. */
 #define UICR_RBPCONF_PR0_Msk (0xFFUL << UICR_RBPCONF_PR0_Pos) /*!< Bit mask of PR0 field. */
-#define UICR_RBPCONF_PR0_Disabled (0xFFUL) /*!< Disabled. */
 #define UICR_RBPCONF_PR0_Enabled (0x00UL) /*!< Enabled. */
+#define UICR_RBPCONF_PR0_Disabled (0xFFUL) /*!< Disabled. */
 
 /* Register: UICR_XTALFREQ */
 /* Description: Reset value for CLOCK XTALFREQ register. */
@@ -6953,8 +6712,8 @@
 /* Bits 7..0 : Reset value for CLOCK XTALFREQ register. */
 #define UICR_XTALFREQ_XTALFREQ_Pos (0UL) /*!< Position of XTALFREQ field. */
 #define UICR_XTALFREQ_XTALFREQ_Msk (0xFFUL << UICR_XTALFREQ_XTALFREQ_Pos) /*!< Bit mask of XTALFREQ field. */
-#define UICR_XTALFREQ_XTALFREQ_16MHz (0xFFUL) /*!< 16MHz Xtal is used. */
 #define UICR_XTALFREQ_XTALFREQ_32MHz (0x00UL) /*!< 32MHz Xtal is used. */
+#define UICR_XTALFREQ_XTALFREQ_16MHz (0xFFUL) /*!< 16MHz Xtal is used. */
 
 /* Register: UICR_FWID */
 /* Description: Firmware ID. */

--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf51_deprecated.h
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf51_deprecated.h
@@ -1,0 +1,440 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of other
+ *   contributors to this software may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef NRF51_DEPRECATED_H
+#define NRF51_DEPRECATED_H
+
+/*lint ++flb "Enter library region */
+
+/* This file is given to prevent your SW from not compiling with the updates made to nrf51.h and 
+ * nrf51_bitfields.h. The macros defined in this file were available previously. Do not use these
+ * macros on purpose. Use the ones defined in nrf51.h and nrf51_bitfields.h instead.
+ */
+
+/* NVMC */
+/* The register ERASEPROTECTEDPAGE is called ERASEPCR0 in the documentation. */
+#define ERASEPROTECTEDPAGE   ERASEPCR0
+
+ 
+/* LPCOMP */
+/* The interrupt ISR was renamed. Adding old name to the macros. */
+#define LPCOMP_COMP_IRQHandler      LPCOMP_IRQHandler
+#define LPCOMP_COMP_IRQn            LPCOMP_IRQn
+ 
+ 
+/* MPU */
+/* The field MPU.PERR0.LPCOMP_COMP was renamed. Added into deprecated in case somebody was using the macros defined for it. */
+#define MPU_PERR0_LPCOMP_COMP_Pos           MPU_PERR0_LPCOMP_Pos
+#define MPU_PERR0_LPCOMP_COMP_Msk           MPU_PERR0_LPCOMP_Msk
+#define MPU_PERR0_LPCOMP_COMP_InRegion1     MPU_PERR0_LPCOMP_InRegion1
+#define MPU_PERR0_LPCOMP_COMP_InRegion0     MPU_PERR0_LPCOMP_InRegion0
+ 
+ 
+/* POWER */
+/* The field POWER.RAMON.OFFRAM3 was eliminated. Added into deprecated in case somebody was using the macros defined for it. */
+#define POWER_RAMON_OFFRAM3_Pos         (19UL)                                  
+#define POWER_RAMON_OFFRAM3_Msk         (0x1UL << POWER_RAMON_OFFRAM3_Pos)      
+#define POWER_RAMON_OFFRAM3_RAM3Off     (0UL)                                   
+#define POWER_RAMON_OFFRAM3_RAM3On      (1UL)                                   
+/* The field POWER.RAMON.OFFRAM2 was eliminated. Added into deprecated in case somebody was using the macros defined for it. */
+#define POWER_RAMON_OFFRAM2_Pos         (18UL)                                  
+#define POWER_RAMON_OFFRAM2_Msk         (0x1UL << POWER_RAMON_OFFRAM2_Pos)      
+#define POWER_RAMON_OFFRAM2_RAM2Off     (0UL)                                   
+#define POWER_RAMON_OFFRAM2_RAM2On      (1UL)                                  
+/* The field POWER.RAMON.ONRAM3 was eliminated. Added into deprecated in case somebody was using the macros defined for it. */
+#define POWER_RAMON_ONRAM3_Pos          (3UL)                                  
+#define POWER_RAMON_ONRAM3_Msk          (0x1UL << POWER_RAMON_ONRAM3_Pos)      
+#define POWER_RAMON_ONRAM3_RAM3Off      (0UL)                                  
+#define POWER_RAMON_ONRAM3_RAM3On       (1UL)                                  
+/* The field POWER.RAMON.ONRAM2 was eliminated. Added into deprecated in case somebody was using the macros defined for it. */
+#define POWER_RAMON_ONRAM2_Pos          (2UL)                                  
+#define POWER_RAMON_ONRAM2_Msk          (0x1UL << POWER_RAMON_ONRAM2_Pos)       
+#define POWER_RAMON_ONRAM2_RAM2Off      (0UL)                                  
+#define POWER_RAMON_ONRAM2_RAM2On       (1UL)                                 
+
+ 
+/* RADIO */
+/* The enumerated value RADIO.TXPOWER.TXPOWER.Neg40dBm was renamed. Added into deprecated with the new macro name. */
+#define RADIO_TXPOWER_TXPOWER_Neg40dBm  RADIO_TXPOWER_TXPOWER_Neg30dBm      
+/* The name of the field SKIPADDR was corrected. Old macros added for compatibility. */
+#define RADIO_CRCCNF_SKIP_ADDR_Pos      RADIO_CRCCNF_SKIPADDR_Pos 
+#define RADIO_CRCCNF_SKIP_ADDR_Msk      RADIO_CRCCNF_SKIPADDR_Msk 
+#define RADIO_CRCCNF_SKIP_ADDR_Include  RADIO_CRCCNF_SKIPADDR_Include 
+#define RADIO_CRCCNF_SKIP_ADDR_Skip     RADIO_CRCCNF_SKIPADDR_Skip 
+/* The name of the field PLLLOCK was corrected. Old macros added for compatibility. */
+#define RADIO_TEST_PLL_LOCK_Pos         RADIO_TEST_PLLLOCK_Pos 
+#define RADIO_TEST_PLL_LOCK_Msk         RADIO_TEST_PLLLOCK_Msk 
+#define RADIO_TEST_PLL_LOCK_Disabled    RADIO_TEST_PLLLOCK_Disabled 
+#define RADIO_TEST_PLL_LOCK_Enabled     RADIO_TEST_PLLLOCK_Enabled 
+/* The name of the field CONSTCARRIER was corrected. Old macros added for compatibility. */
+#define RADIO_TEST_CONST_CARRIER_Pos        RADIO_TEST_CONSTCARRIER_Pos 
+#define RADIO_TEST_CONST_CARRIER_Msk        RADIO_TEST_CONSTCARRIER_Msk 
+#define RADIO_TEST_CONST_CARRIER_Disabled   RADIO_TEST_CONSTCARRIER_Disabled 
+#define RADIO_TEST_CONST_CARRIER_Enabled    RADIO_TEST_CONSTCARRIER_Enabled 
+
+
+/* FICR */
+/* The registers FICR.SIZERAMBLOCK0, FICR.SIZERAMBLOCK1, FICR.SIZERAMBLOCK2 and FICR.SIZERAMBLOCK3 were renamed into an array. */
+#define SIZERAMBLOCK0   SIZERAMBLOCKS                   
+#define SIZERAMBLOCK1   SIZERAMBLOCKS                   
+#define SIZERAMBLOCK2   SIZERAMBLOCK[2]                 /*!< Note that this macro will disapear when SIZERAMBLOCK array is eliminated. SIZERAMBLOCK is a deprecated array. */
+#define SIZERAMBLOCK3   SIZERAMBLOCK[3]                 /*!< Note that this macro will disapear when SIZERAMBLOCK array is eliminated. SIZERAMBLOCK is a deprecated array. */
+/* The registers FICR.DEVICEID0 and FICR.DEVICEID1 were renamed into an array. */
+#define DEVICEID0       DEVICEID[0]                     
+#define DEVICEID1       DEVICEID[1]                     
+/* The registers FICR.ER0, FICR.ER1, FICR.ER2 and FICR.ER3 were renamed into an array. */
+#define ER0             ER[0]                           
+#define ER1             ER[1]                          
+#define ER2             ER[2]                       
+#define ER3             ER[3]                      
+/* The registers FICR.IR0, FICR.IR1, FICR.IR2 and FICR.IR3 were renamed into an array. */
+#define IR0             IR[0]                         
+#define IR1             IR[1]                         
+#define IR2             IR[2]                         
+#define IR3             IR[3]                          
+/* The registers FICR.DEVICEADDR0 and FICR.DEVICEADDR1 were renamed into an array. */
+#define DEVICEADDR0     DEVICEADDR[0]                  
+#define DEVICEADDR1     DEVICEADDR[1]                  
+
+
+/* PPI */
+/* The tasks PPI.TASKS_CHGxEN and PPI.TASKS_CHGxDIS were renamed into an array of structs. */
+#define TASKS_CHG0EN     TASKS_CHG[0].EN                    
+#define TASKS_CHG0DIS    TASKS_CHG[0].DIS                  
+#define TASKS_CHG1EN     TASKS_CHG[1].EN                    
+#define TASKS_CHG1DIS    TASKS_CHG[1].DIS                  
+#define TASKS_CHG2EN     TASKS_CHG[2].EN                   
+#define TASKS_CHG2DIS    TASKS_CHG[2].DIS                  
+#define TASKS_CHG3EN     TASKS_CHG[3].EN                    
+#define TASKS_CHG3DIS    TASKS_CHG[3].DIS                  
+/* The registers PPI.CHx_EEP and PPI.CHx_TEP were renamed into an array of structs. */
+#define CH0_EEP          CH[0].EEP                          
+#define CH0_TEP          CH[0].TEP                          
+#define CH1_EEP          CH[1].EEP                         
+#define CH1_TEP          CH[1].TEP                         
+#define CH2_EEP          CH[2].EEP                          
+#define CH2_TEP          CH[2].TEP                         
+#define CH3_EEP          CH[3].EEP                          
+#define CH3_TEP          CH[3].TEP                         
+#define CH4_EEP          CH[4].EEP                         
+#define CH4_TEP          CH[4].TEP                         
+#define CH5_EEP          CH[5].EEP                          
+#define CH5_TEP          CH[5].TEP                          
+#define CH6_EEP          CH[6].EEP                          
+#define CH6_TEP          CH[6].TEP                         
+#define CH7_EEP          CH[7].EEP                          
+#define CH7_TEP          CH[7].TEP                          
+#define CH8_EEP          CH[8].EEP                         
+#define CH8_TEP          CH[8].TEP                          
+#define CH9_EEP          CH[9].EEP                          
+#define CH9_TEP          CH[9].TEP                          
+#define CH10_EEP         CH[10].EEP                         
+#define CH10_TEP         CH[10].TEP                         
+#define CH11_EEP         CH[11].EEP                         
+#define CH11_TEP         CH[11].TEP                         
+#define CH12_EEP         CH[12].EEP                         
+#define CH12_TEP         CH[12].TEP                         
+#define CH13_EEP         CH[13].EEP                         
+#define CH13_TEP         CH[13].TEP                         
+#define CH14_EEP         CH[14].EEP                         
+#define CH14_TEP         CH[14].TEP                         
+#define CH15_EEP         CH[15].EEP                         
+#define CH15_TEP         CH[15].TEP                        
+/* The registers PPI.CHG0, PPI.CHG1, PPI.CHG2 and PPI.CHG3 were renamed into an array. */
+#define CHG0             CHG[0]                            
+#define CHG1             CHG[1]                            
+#define CHG2             CHG[2]                             
+#define CHG3             CHG[3]                           
+/* All bitfield macros for the CHGx registers therefore changed name. */
+#define PPI_CHG0_CH15_Pos       PPI_CHG_CH15_Pos            
+#define PPI_CHG0_CH15_Msk       PPI_CHG_CH15_Msk            
+#define PPI_CHG0_CH15_Excluded  PPI_CHG_CH15_Excluded       
+#define PPI_CHG0_CH15_Included  PPI_CHG_CH15_Included       
+#define PPI_CHG0_CH14_Pos       PPI_CHG_CH14_Pos            
+#define PPI_CHG0_CH14_Msk       PPI_CHG_CH14_Msk           
+#define PPI_CHG0_CH14_Excluded  PPI_CHG_CH14_Excluded       
+#define PPI_CHG0_CH14_Included  PPI_CHG_CH14_Included       
+#define PPI_CHG0_CH13_Pos       PPI_CHG_CH13_Pos            
+#define PPI_CHG0_CH13_Msk       PPI_CHG_CH13_Msk            
+#define PPI_CHG0_CH13_Excluded  PPI_CHG_CH13_Excluded      
+#define PPI_CHG0_CH13_Included  PPI_CHG_CH13_Included       
+#define PPI_CHG0_CH12_Pos       PPI_CHG_CH12_Pos            
+#define PPI_CHG0_CH12_Msk       PPI_CHG_CH12_Msk            
+#define PPI_CHG0_CH12_Excluded  PPI_CHG_CH12_Excluded       
+#define PPI_CHG0_CH12_Included  PPI_CHG_CH12_Included       
+#define PPI_CHG0_CH11_Pos       PPI_CHG_CH11_Pos            
+#define PPI_CHG0_CH11_Msk       PPI_CHG_CH11_Msk            
+#define PPI_CHG0_CH11_Excluded  PPI_CHG_CH11_Excluded       
+#define PPI_CHG0_CH11_Included  PPI_CHG_CH11_Included       
+#define PPI_CHG0_CH10_Pos       PPI_CHG_CH10_Pos            
+#define PPI_CHG0_CH10_Msk       PPI_CHG_CH10_Msk            
+#define PPI_CHG0_CH10_Excluded  PPI_CHG_CH10_Excluded       
+#define PPI_CHG0_CH10_Included  PPI_CHG_CH10_Included       
+#define PPI_CHG0_CH9_Pos        PPI_CHG_CH9_Pos             
+#define PPI_CHG0_CH9_Msk        PPI_CHG_CH9_Msk             
+#define PPI_CHG0_CH9_Excluded   PPI_CHG_CH9_Excluded        
+#define PPI_CHG0_CH9_Included   PPI_CHG_CH9_Included        
+#define PPI_CHG0_CH8_Pos        PPI_CHG_CH8_Pos             
+#define PPI_CHG0_CH8_Msk        PPI_CHG_CH8_Msk             
+#define PPI_CHG0_CH8_Excluded   PPI_CHG_CH8_Excluded        
+#define PPI_CHG0_CH8_Included   PPI_CHG_CH8_Included        
+#define PPI_CHG0_CH7_Pos        PPI_CHG_CH7_Pos             
+#define PPI_CHG0_CH7_Msk        PPI_CHG_CH7_Msk             
+#define PPI_CHG0_CH7_Excluded   PPI_CHG_CH7_Excluded        
+#define PPI_CHG0_CH7_Included   PPI_CHG_CH7_Included        
+#define PPI_CHG0_CH6_Pos        PPI_CHG_CH6_Pos             
+#define PPI_CHG0_CH6_Msk        PPI_CHG_CH6_Msk             
+#define PPI_CHG0_CH6_Excluded   PPI_CHG_CH6_Excluded        
+#define PPI_CHG0_CH6_Included   PPI_CHG_CH6_Included        
+#define PPI_CHG0_CH5_Pos        PPI_CHG_CH5_Pos             
+#define PPI_CHG0_CH5_Msk        PPI_CHG_CH5_Msk             
+#define PPI_CHG0_CH5_Excluded   PPI_CHG_CH5_Excluded       
+#define PPI_CHG0_CH5_Included   PPI_CHG_CH5_Included        
+#define PPI_CHG0_CH4_Pos        PPI_CHG_CH4_Pos             
+#define PPI_CHG0_CH4_Msk        PPI_CHG_CH4_Msk             
+#define PPI_CHG0_CH4_Excluded   PPI_CHG_CH4_Excluded       
+#define PPI_CHG0_CH4_Included   PPI_CHG_CH4_Included       
+#define PPI_CHG0_CH3_Pos        PPI_CHG_CH3_Pos             
+#define PPI_CHG0_CH3_Msk        PPI_CHG_CH3_Msk            
+#define PPI_CHG0_CH3_Excluded   PPI_CHG_CH3_Excluded        
+#define PPI_CHG0_CH3_Included   PPI_CHG_CH3_Included       
+#define PPI_CHG0_CH2_Pos        PPI_CHG_CH2_Pos            
+#define PPI_CHG0_CH2_Msk        PPI_CHG_CH2_Msk             
+#define PPI_CHG0_CH2_Excluded   PPI_CHG_CH2_Excluded       
+#define PPI_CHG0_CH2_Included   PPI_CHG_CH2_Included       
+#define PPI_CHG0_CH1_Pos        PPI_CHG_CH1_Pos            
+#define PPI_CHG0_CH1_Msk        PPI_CHG_CH1_Msk            
+#define PPI_CHG0_CH1_Excluded   PPI_CHG_CH1_Excluded        
+#define PPI_CHG0_CH1_Included   PPI_CHG_CH1_Included       
+#define PPI_CHG0_CH0_Pos        PPI_CHG_CH0_Pos            
+#define PPI_CHG0_CH0_Msk        PPI_CHG_CH0_Msk            
+#define PPI_CHG0_CH0_Excluded   PPI_CHG_CH0_Excluded        
+#define PPI_CHG0_CH0_Included   PPI_CHG_CH0_Included       
+#define PPI_CHG1_CH15_Pos       PPI_CHG_CH15_Pos           
+#define PPI_CHG1_CH15_Msk       PPI_CHG_CH15_Msk           
+#define PPI_CHG1_CH15_Excluded  PPI_CHG_CH15_Excluded       
+#define PPI_CHG1_CH15_Included  PPI_CHG_CH15_Included      
+#define PPI_CHG1_CH14_Pos       PPI_CHG_CH14_Pos           
+#define PPI_CHG1_CH14_Msk       PPI_CHG_CH14_Msk            
+#define PPI_CHG1_CH14_Excluded  PPI_CHG_CH14_Excluded      
+#define PPI_CHG1_CH14_Included  PPI_CHG_CH14_Included       
+#define PPI_CHG1_CH13_Pos       PPI_CHG_CH13_Pos           
+#define PPI_CHG1_CH13_Msk       PPI_CHG_CH13_Msk            
+#define PPI_CHG1_CH13_Excluded  PPI_CHG_CH13_Excluded      
+#define PPI_CHG1_CH13_Included  PPI_CHG_CH13_Included      
+#define PPI_CHG1_CH12_Pos       PPI_CHG_CH12_Pos            
+#define PPI_CHG1_CH12_Msk       PPI_CHG_CH12_Msk           
+#define PPI_CHG1_CH12_Excluded  PPI_CHG_CH12_Excluded      
+#define PPI_CHG1_CH12_Included  PPI_CHG_CH12_Included      
+#define PPI_CHG1_CH11_Pos       PPI_CHG_CH11_Pos            
+#define PPI_CHG1_CH11_Msk       PPI_CHG_CH11_Msk           
+#define PPI_CHG1_CH11_Excluded  PPI_CHG_CH11_Excluded      
+#define PPI_CHG1_CH11_Included  PPI_CHG_CH11_Included      
+#define PPI_CHG1_CH10_Pos       PPI_CHG_CH10_Pos           
+#define PPI_CHG1_CH10_Msk       PPI_CHG_CH10_Msk            
+#define PPI_CHG1_CH10_Excluded  PPI_CHG_CH10_Excluded      
+#define PPI_CHG1_CH10_Included  PPI_CHG_CH10_Included      
+#define PPI_CHG1_CH9_Pos        PPI_CHG_CH9_Pos            
+#define PPI_CHG1_CH9_Msk        PPI_CHG_CH9_Msk            
+#define PPI_CHG1_CH9_Excluded   PPI_CHG_CH9_Excluded       
+#define PPI_CHG1_CH9_Included   PPI_CHG_CH9_Included       
+#define PPI_CHG1_CH8_Pos        PPI_CHG_CH8_Pos            
+#define PPI_CHG1_CH8_Msk        PPI_CHG_CH8_Msk            
+#define PPI_CHG1_CH8_Excluded   PPI_CHG_CH8_Excluded       
+#define PPI_CHG1_CH8_Included   PPI_CHG_CH8_Included       
+#define PPI_CHG1_CH7_Pos        PPI_CHG_CH7_Pos             
+#define PPI_CHG1_CH7_Msk        PPI_CHG_CH7_Msk            
+#define PPI_CHG1_CH7_Excluded   PPI_CHG_CH7_Excluded        
+#define PPI_CHG1_CH7_Included   PPI_CHG_CH7_Included       
+#define PPI_CHG1_CH6_Pos        PPI_CHG_CH6_Pos             
+#define PPI_CHG1_CH6_Msk        PPI_CHG_CH6_Msk            
+#define PPI_CHG1_CH6_Excluded   PPI_CHG_CH6_Excluded       
+#define PPI_CHG1_CH6_Included   PPI_CHG_CH6_Included       
+#define PPI_CHG1_CH5_Pos        PPI_CHG_CH5_Pos             
+#define PPI_CHG1_CH5_Msk        PPI_CHG_CH5_Msk             
+#define PPI_CHG1_CH5_Excluded   PPI_CHG_CH5_Excluded       
+#define PPI_CHG1_CH5_Included   PPI_CHG_CH5_Included        
+#define PPI_CHG1_CH4_Pos        PPI_CHG_CH4_Pos             
+#define PPI_CHG1_CH4_Msk        PPI_CHG_CH4_Msk             
+#define PPI_CHG1_CH4_Excluded   PPI_CHG_CH4_Excluded        
+#define PPI_CHG1_CH4_Included   PPI_CHG_CH4_Included        
+#define PPI_CHG1_CH3_Pos        PPI_CHG_CH3_Pos            
+#define PPI_CHG1_CH3_Msk        PPI_CHG_CH3_Msk             
+#define PPI_CHG1_CH3_Excluded   PPI_CHG_CH3_Excluded        
+#define PPI_CHG1_CH3_Included   PPI_CHG_CH3_Included       
+#define PPI_CHG1_CH2_Pos        PPI_CHG_CH2_Pos            
+#define PPI_CHG1_CH2_Msk        PPI_CHG_CH2_Msk             
+#define PPI_CHG1_CH2_Excluded   PPI_CHG_CH2_Excluded        
+#define PPI_CHG1_CH2_Included   PPI_CHG_CH2_Included        
+#define PPI_CHG1_CH1_Pos        PPI_CHG_CH1_Pos             
+#define PPI_CHG1_CH1_Msk        PPI_CHG_CH1_Msk            
+#define PPI_CHG1_CH1_Excluded   PPI_CHG_CH1_Excluded        
+#define PPI_CHG1_CH1_Included   PPI_CHG_CH1_Included       
+#define PPI_CHG1_CH0_Pos        PPI_CHG_CH0_Pos             
+#define PPI_CHG1_CH0_Msk        PPI_CHG_CH0_Msk            
+#define PPI_CHG1_CH0_Excluded   PPI_CHG_CH0_Excluded       
+#define PPI_CHG1_CH0_Included   PPI_CHG_CH0_Included       
+#define PPI_CHG2_CH15_Pos       PPI_CHG_CH15_Pos           
+#define PPI_CHG2_CH15_Msk       PPI_CHG_CH15_Msk            
+#define PPI_CHG2_CH15_Excluded  PPI_CHG_CH15_Excluded      
+#define PPI_CHG2_CH15_Included  PPI_CHG_CH15_Included      
+#define PPI_CHG2_CH14_Pos       PPI_CHG_CH14_Pos           
+#define PPI_CHG2_CH14_Msk       PPI_CHG_CH14_Msk           
+#define PPI_CHG2_CH14_Excluded  PPI_CHG_CH14_Excluded       
+#define PPI_CHG2_CH14_Included  PPI_CHG_CH14_Included      
+#define PPI_CHG2_CH13_Pos       PPI_CHG_CH13_Pos           
+#define PPI_CHG2_CH13_Msk       PPI_CHG_CH13_Msk            
+#define PPI_CHG2_CH13_Excluded  PPI_CHG_CH13_Excluded       
+#define PPI_CHG2_CH13_Included  PPI_CHG_CH13_Included      
+#define PPI_CHG2_CH12_Pos       PPI_CHG_CH12_Pos            
+#define PPI_CHG2_CH12_Msk       PPI_CHG_CH12_Msk            
+#define PPI_CHG2_CH12_Excluded  PPI_CHG_CH12_Excluded      
+#define PPI_CHG2_CH12_Included  PPI_CHG_CH12_Included       
+#define PPI_CHG2_CH11_Pos       PPI_CHG_CH11_Pos           
+#define PPI_CHG2_CH11_Msk       PPI_CHG_CH11_Msk           
+#define PPI_CHG2_CH11_Excluded  PPI_CHG_CH11_Excluded       
+#define PPI_CHG2_CH11_Included  PPI_CHG_CH11_Included       
+#define PPI_CHG2_CH10_Pos       PPI_CHG_CH10_Pos            
+#define PPI_CHG2_CH10_Msk       PPI_CHG_CH10_Msk            
+#define PPI_CHG2_CH10_Excluded  PPI_CHG_CH10_Excluded      
+#define PPI_CHG2_CH10_Included  PPI_CHG_CH10_Included      
+#define PPI_CHG2_CH9_Pos        PPI_CHG_CH9_Pos            
+#define PPI_CHG2_CH9_Msk        PPI_CHG_CH9_Msk            
+#define PPI_CHG2_CH9_Excluded   PPI_CHG_CH9_Excluded        
+#define PPI_CHG2_CH9_Included   PPI_CHG_CH9_Included       
+#define PPI_CHG2_CH8_Pos        PPI_CHG_CH8_Pos            
+#define PPI_CHG2_CH8_Msk        PPI_CHG_CH8_Msk            
+#define PPI_CHG2_CH8_Excluded   PPI_CHG_CH8_Excluded       
+#define PPI_CHG2_CH8_Included   PPI_CHG_CH8_Included        
+#define PPI_CHG2_CH7_Pos        PPI_CHG_CH7_Pos            
+#define PPI_CHG2_CH7_Msk        PPI_CHG_CH7_Msk            
+#define PPI_CHG2_CH7_Excluded   PPI_CHG_CH7_Excluded       
+#define PPI_CHG2_CH7_Included   PPI_CHG_CH7_Included       
+#define PPI_CHG2_CH6_Pos        PPI_CHG_CH6_Pos            
+#define PPI_CHG2_CH6_Msk        PPI_CHG_CH6_Msk            
+#define PPI_CHG2_CH6_Excluded   PPI_CHG_CH6_Excluded       
+#define PPI_CHG2_CH6_Included   PPI_CHG_CH6_Included       
+#define PPI_CHG2_CH5_Pos        PPI_CHG_CH5_Pos            
+#define PPI_CHG2_CH5_Msk        PPI_CHG_CH5_Msk            
+#define PPI_CHG2_CH5_Excluded   PPI_CHG_CH5_Excluded       
+#define PPI_CHG2_CH5_Included   PPI_CHG_CH5_Included        
+#define PPI_CHG2_CH4_Pos        PPI_CHG_CH4_Pos             
+#define PPI_CHG2_CH4_Msk        PPI_CHG_CH4_Msk             
+#define PPI_CHG2_CH4_Excluded   PPI_CHG_CH4_Excluded        
+#define PPI_CHG2_CH4_Included   PPI_CHG_CH4_Included       
+#define PPI_CHG2_CH3_Pos        PPI_CHG_CH3_Pos            
+#define PPI_CHG2_CH3_Msk        PPI_CHG_CH3_Msk            
+#define PPI_CHG2_CH3_Excluded   PPI_CHG_CH3_Excluded       
+#define PPI_CHG2_CH3_Included   PPI_CHG_CH3_Included       
+#define PPI_CHG2_CH2_Pos        PPI_CHG_CH2_Pos            
+#define PPI_CHG2_CH2_Msk        PPI_CHG_CH2_Msk           
+#define PPI_CHG2_CH2_Excluded   PPI_CHG_CH2_Excluded       
+#define PPI_CHG2_CH2_Included   PPI_CHG_CH2_Included       
+#define PPI_CHG2_CH1_Pos        PPI_CHG_CH1_Pos             
+#define PPI_CHG2_CH1_Msk        PPI_CHG_CH1_Msk             
+#define PPI_CHG2_CH1_Excluded   PPI_CHG_CH1_Excluded       
+#define PPI_CHG2_CH1_Included   PPI_CHG_CH1_Included       
+#define PPI_CHG2_CH0_Pos        PPI_CHG_CH0_Pos            
+#define PPI_CHG2_CH0_Msk        PPI_CHG_CH0_Msk            
+#define PPI_CHG2_CH0_Excluded   PPI_CHG_CH0_Excluded       
+#define PPI_CHG2_CH0_Included   PPI_CHG_CH0_Included        
+#define PPI_CHG3_CH15_Pos       PPI_CHG_CH15_Pos           
+#define PPI_CHG3_CH15_Msk       PPI_CHG_CH15_Msk           
+#define PPI_CHG3_CH15_Excluded  PPI_CHG_CH15_Excluded     
+#define PPI_CHG3_CH15_Included  PPI_CHG_CH15_Included      
+#define PPI_CHG3_CH14_Pos       PPI_CHG_CH14_Pos          
+#define PPI_CHG3_CH14_Msk       PPI_CHG_CH14_Msk           
+#define PPI_CHG3_CH14_Excluded  PPI_CHG_CH14_Excluded      
+#define PPI_CHG3_CH14_Included  PPI_CHG_CH14_Included       
+#define PPI_CHG3_CH13_Pos       PPI_CHG_CH13_Pos           
+#define PPI_CHG3_CH13_Msk       PPI_CHG_CH13_Msk            
+#define PPI_CHG3_CH13_Excluded  PPI_CHG_CH13_Excluded      
+#define PPI_CHG3_CH13_Included  PPI_CHG_CH13_Included      
+#define PPI_CHG3_CH12_Pos       PPI_CHG_CH12_Pos            
+#define PPI_CHG3_CH12_Msk       PPI_CHG_CH12_Msk            
+#define PPI_CHG3_CH12_Excluded  PPI_CHG_CH12_Excluded       
+#define PPI_CHG3_CH12_Included  PPI_CHG_CH12_Included       
+#define PPI_CHG3_CH11_Pos       PPI_CHG_CH11_Pos            
+#define PPI_CHG3_CH11_Msk       PPI_CHG_CH11_Msk            
+#define PPI_CHG3_CH11_Excluded  PPI_CHG_CH11_Excluded      
+#define PPI_CHG3_CH11_Included  PPI_CHG_CH11_Included       
+#define PPI_CHG3_CH10_Pos       PPI_CHG_CH10_Pos            
+#define PPI_CHG3_CH10_Msk       PPI_CHG_CH10_Msk            
+#define PPI_CHG3_CH10_Excluded  PPI_CHG_CH10_Excluded      
+#define PPI_CHG3_CH10_Included  PPI_CHG_CH10_Included      
+#define PPI_CHG3_CH9_Pos        PPI_CHG_CH9_Pos            
+#define PPI_CHG3_CH9_Msk        PPI_CHG_CH9_Msk            
+#define PPI_CHG3_CH9_Excluded   PPI_CHG_CH9_Excluded       
+#define PPI_CHG3_CH9_Included   PPI_CHG_CH9_Included       
+#define PPI_CHG3_CH8_Pos        PPI_CHG_CH8_Pos            
+#define PPI_CHG3_CH8_Msk        PPI_CHG_CH8_Msk             
+#define PPI_CHG3_CH8_Excluded   PPI_CHG_CH8_Excluded       
+#define PPI_CHG3_CH8_Included   PPI_CHG_CH8_Included       
+#define PPI_CHG3_CH7_Pos        PPI_CHG_CH7_Pos             
+#define PPI_CHG3_CH7_Msk        PPI_CHG_CH7_Msk            
+#define PPI_CHG3_CH7_Excluded   PPI_CHG_CH7_Excluded        
+#define PPI_CHG3_CH7_Included   PPI_CHG_CH7_Included       
+#define PPI_CHG3_CH6_Pos        PPI_CHG_CH6_Pos             
+#define PPI_CHG3_CH6_Msk        PPI_CHG_CH6_Msk             
+#define PPI_CHG3_CH6_Excluded   PPI_CHG_CH6_Excluded       
+#define PPI_CHG3_CH6_Included   PPI_CHG_CH6_Included        
+#define PPI_CHG3_CH5_Pos        PPI_CHG_CH5_Pos             
+#define PPI_CHG3_CH5_Msk        PPI_CHG_CH5_Msk             
+#define PPI_CHG3_CH5_Excluded   PPI_CHG_CH5_Excluded        
+#define PPI_CHG3_CH5_Included   PPI_CHG_CH5_Included       
+#define PPI_CHG3_CH4_Pos        PPI_CHG_CH4_Pos             
+#define PPI_CHG3_CH4_Msk        PPI_CHG_CH4_Msk            
+#define PPI_CHG3_CH4_Excluded   PPI_CHG_CH4_Excluded        
+#define PPI_CHG3_CH4_Included   PPI_CHG_CH4_Included        
+#define PPI_CHG3_CH3_Pos        PPI_CHG_CH3_Pos             
+#define PPI_CHG3_CH3_Msk        PPI_CHG_CH3_Msk            
+#define PPI_CHG3_CH3_Excluded   PPI_CHG_CH3_Excluded        
+#define PPI_CHG3_CH3_Included   PPI_CHG_CH3_Included        
+#define PPI_CHG3_CH2_Pos        PPI_CHG_CH2_Pos             
+#define PPI_CHG3_CH2_Msk        PPI_CHG_CH2_Msk             
+#define PPI_CHG3_CH2_Excluded   PPI_CHG_CH2_Excluded        
+#define PPI_CHG3_CH2_Included   PPI_CHG_CH2_Included       
+#define PPI_CHG3_CH1_Pos        PPI_CHG_CH1_Pos             
+#define PPI_CHG3_CH1_Msk        PPI_CHG_CH1_Msk             
+#define PPI_CHG3_CH1_Excluded   PPI_CHG_CH1_Excluded        
+#define PPI_CHG3_CH1_Included   PPI_CHG_CH1_Included        
+#define PPI_CHG3_CH0_Pos        PPI_CHG_CH0_Pos             
+#define PPI_CHG3_CH0_Msk        PPI_CHG_CH0_Msk             
+#define PPI_CHG3_CH0_Excluded   PPI_CHG_CH0_Excluded        
+#define PPI_CHG3_CH0_Included   PPI_CHG_CH0_Included        
+
+
+
+/*lint --flb "Leave library region" */
+
+#endif /* NRF51_DEPRECATED_H */
+


### PR DESCRIPTION
- enable feature BLE in the targets.json. This fix was done a long time
  ago in the nordic branch. Without it, it is not possible to compile BLE
  examples.
- nrf headers synchronized with the one in BLE implementation. This is a
  short term fix. The nordic branches use a single nrf SDK and does not
  have duplicate headers. Once this branch will be integrated, there will
  be no more issues around duplicate headers.

References for files:
- [targets.json](https://github.com/ARMmbed/mbed-nordic/blob/nordic_sdk_integration/hal/targets.json#L1130)
- [nrf.h](https://github.com/ARMmbed/mbed-os/blob/epr-16.06/features/FEATURE_BLE/ble/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf51-sdk/source/nordic_sdk/components/device/nrf51.h)
- [nrf51.h](https://github.com/ARMmbed/mbed-os/blob/epr-16.06/features/FEATURE_BLE/ble/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf51-sdk/source/nordic_sdk/components/device/nrf51.h)
- [nrf51_bitfields.h](https://github.com/ARMmbed/mbed-os/blob/epr-16.06/features/FEATURE_BLE/ble/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf51-sdk/source/nordic_sdk/components/device/nrf51_bitfields.h)
- [nrf51_deprecated.h](https://github.com/ARMmbed/mbed-os/blob/epr-16.06/features/FEATURE_BLE/ble/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf51-sdk/source/nordic_sdk/components/device/nrf51_deprecated.h)
