### PR TITLE
Add debug symbols to release builds (all toolchains)

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -62,8 +62,8 @@ class ARM(mbedToolchain):
         if "save-asm" in self.options:
             self.flags['common'].extend(["--asm", "--interleave"])
 
+        self.flags['common'].append("-g")
         if "debug-info" in self.options:
-            self.flags['common'].append("-g")
             self.flags['c'].append("-O0")
         else:
             self.flags['c'].append("-O3")

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -83,8 +83,8 @@ class GCC(mbedToolchain):
         if "save-asm" in self.options:
             self.flags["common"].append("-save-temps")
 
+        self.flags["common"].append("-g")
         if "debug-info" in self.options:
-            self.flags["common"].append("-g")
             self.flags["common"].append("-O0")
         else:
             self.flags["common"].append("-O2")

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -81,8 +81,8 @@ class IAR(mbedToolchain):
             asm_flags_cmd += ["--fpu", "VFPv5"]
             c_flags_cmd.append("--fpu=VFPv5")
 
+        c_flags_cmd.append("-r")
         if "debug-info" in self.options:
-            c_flags_cmd.append("-r")
             c_flags_cmd.append("-On")
         else:
             c_flags_cmd.append("-Oh")


### PR DESCRIPTION
Add debug symbols to release builds in all toolchains. Including symbols in the builds significantly improves the debugging experience for all users because they can now relate the program execution to lines of source code rather than just plain assembly while using debugging tools such as GDB. This makes it significantly easier to identify bugs and issues in applications.
Note: Adding debug symbols will increase the size of the resulting elf file produced by the compiler, but should not have an impact in the binary that is flashed onto the target device.