### PR TITLE
Add MBED_A27 test in the common list

### DIFF
--- a/libraries/tests/mbed/can_loopback/main.cpp
+++ b/libraries/tests/mbed/can_loopback/main.cpp
@@ -17,11 +17,13 @@ CAN can1(P5_9, P5_10);
       defined(TARGET_NUCLEO_F042K6) || defined(TARGET_NUCLEO_F334R8) || \
       defined(TARGET_NUCLEO_F303RE) || defined(TARGET_NUCLEO_F303K8) || \
       defined(TARGET_NUCLEO_F302R8) || defined(TARGET_NUCLEO_F446RE) || \
-      defined(TARGET_DISCO_F429ZI)  || defined(TARGET_NUCLEO_F103RB) || \
+      defined(TARGET_DISCO_F429ZI)  || \
       defined(TARGET_NUCLEO_F746ZG) || defined(TARGET_DISCO_L476VG)  || \
       defined(TARGET_NUCLEO_L476RG) || defined(TARGET_NUCLEO_L432KC)
 CAN can1(PA_11, PA_12);
 #elif defined(TARGET_DISCO_F469NI) || defined(TARGET_DISCO_F746NG)  || \
+			defined(TARGET_NUCLEO_F446ZE) || \
+			defined(TARGET_NUCLEO_F103RB) || \
       defined(TARGET_NUCLEO_F207ZG)
 CAN can1(PB_8, PB_9);
 #endif

--- a/tools/tests.py
+++ b/tools/tests.py
@@ -328,6 +328,18 @@ TESTS = [
         "DISCO_F746NG", "DISCO_L476VG", "NUCLEO_L476RG", "NUCLEO_L432KC"]
     },
     {
+        "id": "MBED_A28", "description": "CAN loopback test",
+        "source_dir": join(TEST_DIR, "mbed", "can_loopback"),
+        "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB],
+        "automated": True,
+        "duration": 20,
+        "mcu": ["B96B_F446VE",
+                "NUCLEO_F091RC", "NUCLEO_F072RB", "NUCLEO_F042K6", "NUCLEO_F334R8", "NUCLEO_F207ZG",
+        "NUCLEO_F303RE", "NUCLEO_F303K8", "NUCLEO_F302R8", "NUCLEO_F446RE","NUCLEO_F446ZE",
+        "DISCO_F469NI", "DISCO_F429ZI", "NUCLEO_F103RB", "NUCLEO_F746ZG",
+        "DISCO_F746NG", "DISCO_L476VG", "NUCLEO_L476RG", "NUCLEO_L432KC"]
+    },
+    {
         "id": "MBED_BLINKY", "description": "Blinky",
         "source_dir": join(TEST_DIR, "mbed", "blinky"),
         "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB],


### PR DESCRIPTION
MBED_A27 test doesn't need any peripheral
it can then be added in the common list