### PR TITLE
Initialization steps in toolchains

### DIFF
--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -149,13 +149,21 @@ static inline int openmode_to_posix(int openmode) {
     return posix;
 }
 
+extern "C" WEAK void mbed_sdk_init(void);
+extern "C" WEAK void mbed_sdk_init(void) {
+}
+
 extern "C" FILEHANDLE PREFIX(_open)(const char* name, int openmode) {
     #if defined(__MICROLIB) && (__ARMCC_VERSION>5030000)
     // Before version 5.03, we were using a patched version of microlib with proper names
     // This is the workaround that the microlib author suggested us
     static int n = 0;
+    static int mbed_sdk_inited = 0;
+    if (!mbed_sdk_inited) {
+        mbed_sdk_inited = 1;
+        mbed_sdk_init();
+    }
     if (!std::strcmp(name, ":tt")) return n++;
-
     #else
     /* Use the posix convention that stdin,out,err are filehandles 0,1,2.
      */
@@ -515,10 +523,6 @@ extern "C" void software_init_hook(void)
 
 extern "C" WEAK void mbed_main(void);
 extern "C" WEAK void mbed_main(void) {
-}
-
-extern "C" WEAK void mbed_sdk_init(void);
-extern "C" WEAK void mbed_sdk_init(void) {
 }
 
 #if defined(TOOLCHAIN_ARM)

--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -510,7 +510,7 @@ extern "C" void software_init_hook(void)
         mbed_die();
     }
 #endif/* FEATURE_UVISOR */
-
+    mbed_sdk_init();
     software_init_hook_rtos();
 }
 #endif
@@ -541,7 +541,6 @@ extern "C" void _platform_post_stackheap_init (void) {
 extern "C" int __real_main(void);
 
 extern "C" int __wrap_main(void) {
-    mbed_sdk_init();
     mbed_main();
     return __real_main();
 }

--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -525,10 +525,14 @@ extern "C" WEAK void mbed_sdk_init(void) {
 extern "C" int $Super$$main(void);
 
 extern "C" int $Sub$$main(void) {
-    mbed_sdk_init();
     mbed_main();
     return $Super$$main();
 }
+
+extern "C" void _platform_post_stackheap_init (void) {
+    mbed_sdk_init();
+}
+
 #elif defined(TOOLCHAIN_GCC)
 extern "C" int __real_main(void);
 

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F0/mbed_overrides.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F0/mbed_overrides.c
@@ -31,8 +31,8 @@
 void mbed_sdk_init() {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
-
+#if !defined(TOOLCHAIN_GCC_ARM)
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
-
+#endif
 }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F0/pwmout_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F0/pwmout_api.c
@@ -162,9 +162,6 @@ void pwmout_period_us(pwmout_t* obj, int us) {
 
     __HAL_TIM_DISABLE(&TimHandle);
 
-    // Update the SystemCoreClock variable
-    SystemCoreClockUpdate();
-
     /* To make it simple, we use to possible prescaler values which lead to:
      * pwm unit = 1us, period/pulse can be from 1us to 65535us
      * or

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F1/mbed_overrides.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F1/mbed_overrides.c
@@ -32,6 +32,8 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
+#if !defined(TOOLCHAIN_GCC_ARM)
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
+#endif
 }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F1/pwmout_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F1/pwmout_api.c
@@ -152,9 +152,6 @@ void pwmout_period_us(pwmout_t* obj, int us)
 
     __HAL_TIM_DISABLE(&TimHandle);
 
-    // Update the SystemCoreClock variable
-    SystemCoreClockUpdate();
-
     /* To make it simple, we use to possible prescaler values which lead to:
      * pwm unit = 1us, period/pulse can be from 1us to 65535us
      * or

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/i2c_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/i2c_api.c
@@ -113,9 +113,6 @@ void i2c_frequency(i2c_t *obj, int hz)
     timeout = LONG_TIMEOUT;
     while ((__HAL_I2C_GET_FLAG(&I2cHandle, I2C_FLAG_BUSY)) && (timeout-- != 0));
 
-    // Update the SystemCoreClock variable.
-    SystemCoreClockUpdate();
-
     /*
        Values calculated with I2C_Timing_Configuration_V1.0.1.xls file (see AN4235)
        * Standard mode (up to 100 kHz)

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/mbed_overrides.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/mbed_overrides.c
@@ -32,6 +32,8 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
+#if !defined(TOOLCHAIN_GCC_ARM)
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
+#endif
 }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/pwmout_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/pwmout_api.c
@@ -159,9 +159,6 @@ void pwmout_period_us(pwmout_t* obj, int us)
 
     __HAL_TIM_DISABLE(&TimHandle);
 
-    // Update the SystemCoreClock variable
-    SystemCoreClockUpdate();
-
     /* To make it simple, we use to possible prescaler values which lead to:
      * pwm unit = 1us, period/pulse can be from 1us to 65535us
      * or

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/serial_api.c
@@ -82,9 +82,6 @@ static void init_uart(serial_t *obj)
         huart->Init.Mode = UART_MODE_TX_RX;
     }
 
-    /* uAMR & ARM: Call to UART init is done between reset of pre-initialized variables */
-    /* and before HAL Init. SystemCoreClock init required here */
-    SystemCoreClockUpdate();
 
     if (HAL_UART_Init(huart) != HAL_OK) {
         error("Cannot initialize UART\n");

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/mbed_overrides.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/mbed_overrides.c
@@ -33,8 +33,10 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
+#if !defined(TOOLCHAIN_GCC_ARM)
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
+#endif
 }
 
 /**

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
@@ -84,10 +84,6 @@ static void init_uart(serial_t *obj)
         huart->Init.Mode = UART_MODE_TX_RX;
     }
 
-    /* uAMR & ARM: Call to UART init is done between reset of pre-initialized variables */
-	  /* and before HAL Init. SystemCoreClock init required here */
-    SystemCoreClockUpdate();
-
     if (HAL_UART_Init(huart) != HAL_OK) {
         error("Cannot initialize UART\n");
     }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F7/mbed_overrides.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F7/mbed_overrides.c
@@ -35,8 +35,10 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
+#if !defined(TOOLCHAIN_GCC_ARM)
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
+#endif
 }
 
 

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F7/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F7/serial_api.c
@@ -67,9 +67,6 @@ static void init_uart(serial_t *obj)
         UartHandle.Init.Mode = UART_MODE_TX_RX;
     }
 
-    // Fix because HAL_RCC_GetHCLKFreq() don't update anymore SystemCoreClock
-    SystemCoreClockUpdate();
-
     if (HAL_UART_Init(&UartHandle) != HAL_OK) {
         error("Cannot initialize UART");
     }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L0/mbed_overrides.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L0/mbed_overrides.c
@@ -32,4 +32,8 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
+#if !defined(TOOLCHAIN_GCC_ARM)
+    // Need to restart HAL driver after the RAM is initialized
+    HAL_Init();
+#endif
 }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L1/mbed_overrides.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L1/mbed_overrides.c
@@ -32,4 +32,8 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
+#if !defined(TOOLCHAIN_GCC_ARM)
+    // Need to restart HAL driver after the RAM is initialized
+    HAL_Init();
+#endif
 }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L1/pwmout_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L1/pwmout_api.c
@@ -166,8 +166,6 @@ void pwmout_period_us(pwmout_t* obj, int us)
 
     __HAL_TIM_DISABLE(&TimHandle);
 
-    SystemCoreClockUpdate();
-
     /* To make it simple, we use to possible prescaler values which lead to:
      * pwm unit = 1us, period/pulse can be from 1us to 65535us
      * or

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L1/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L1/serial_api.c
@@ -82,10 +82,6 @@ static void init_uart(serial_t *obj)
         huart->Init.Mode = UART_MODE_TX_RX;
     }
 
-    /* uAMR & ARM: Call to UART init is done between reset of pre-initialized variables */
-    /* and before HAL Init. SystemCoreClock init required here */
-    SystemCoreClockUpdate();
-
     if (HAL_UART_Init(huart) != HAL_OK) {
         error("Cannot initialize UART\n");
     }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L4/mbed_overrides.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L4/mbed_overrides.c
@@ -32,4 +32,8 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
+#if !defined(TOOLCHAIN_GCC_ARM)
+    // Need to restart HAL driver after the RAM is initialized
+    HAL_Init();
+#endif
 }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L4/pwmout_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L4/pwmout_api.c
@@ -167,8 +167,6 @@ void pwmout_period_us(pwmout_t* obj, int us)
 
     __HAL_TIM_DISABLE(&TimHandle);
 
-    SystemCoreClockUpdate();
-
     /* To make it simple, we use to possible prescaler values which lead to:
      * pwm unit = 1us, period/pulse can be from 1us to 65535us
      * or

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L4/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L4/serial_api.c
@@ -82,10 +82,6 @@ static void init_uart(serial_t *obj)
         huart->Init.Mode = UART_MODE_TX_RX;
     }
 
-    /* uAMR & ARM: Call to UART init is done between reset of pre-initialized variables */
-    /* and before HAL Init. SystemCoreClock init required here */
-    SystemCoreClockUpdate();
-
     if (HAL_UART_Init(huart) != HAL_OK) {
         error("Cannot initialize UART\n");
     }

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -746,6 +746,7 @@ void pre_main (void)
 __asm void __rt_entry (void) {
 
   IMPORT  __user_setup_stackheap
+  IMPORT  _platform_post_stackheap_init
   IMPORT  os_thread_def_main
   IMPORT  osKernelInitialize
 #ifdef __MBED_CMSIS_RTOS_CM
@@ -766,6 +767,7 @@ __asm void __rt_entry (void) {
   /* Ignore return value of __user_setup_stackheap since
    * this will be setup by set_stack_heap
    */
+  BL      _platform_post_stackheap_init
   BL      osKernelInitialize
 #ifdef __MBED_CMSIS_RTOS_CM
   BL      set_stack_heap


### PR DESCRIPTION
This PR is a follow-up of "Fix issue #2124: IAR no rtos #2129" for other tooochains.
jamike analysis explained that mbed_sdk_init needs to be called once at the right time (after ram initialization and before C++ object creation) - this PR aims to fulfill this same requirement for the supported toolchains (gcc / arm / µarm) and also in case of ARM + rtos configuration. 

Once this series is applied, few workarounds' can be removed from STM32 drivers.