### PR TITLE
[Tools] Add HTML report output to memap script

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -406,7 +406,10 @@ class MemapParser(object):
                 td_size_px = 4 * int(section_size)
                 #print td_size_px, module_size[section], total_section_size
                 color = self.html_section_color_map.get(section, "Silver")
-                td_str += "<td valign='top' bgcolor='%s' width='%dpx' height='55px' title='Section %s %d Bytes'></td>\n"% (color,
+                td_str += """
+                <td valign='top' bgcolor='%s' width='%dpx' height='55px' title='Section %s %d Bytes'>
+                </td>
+                """% (color,
                     td_size_px,
                     section,
                     module_size[section])

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -436,16 +436,16 @@ class MemapParser(object):
                     csv_module_section += [i+k]
                     csv_sizes += [self.modules[i][k]]
 
-            csv_module_section += ['total_static_ram']
+            csv_module_section += ['static_ram']
             csv_sizes += [subtotal['.data']+subtotal['.bss']]
 
-            csv_module_section += ['allocated_heap']
+            csv_module_section += ['heap']
             if subtotal['.heap'] == 0:
                 csv_sizes += ['unknown']
             else:
                 csv_sizes += [subtotal['.heap']]
 
-            csv_module_section += ['allocated_stack']
+            csv_module_section += ['stack']
             if subtotal['.stack'] == 0:
                 csv_sizes += ['unknown']
             else:

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -219,7 +219,7 @@ class mbedToolchain:
         "Cortex-M7" : ["__CORTEX_M7", "ARM_MATH_CM7", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
         "Cortex-A9" : ["__CORTEX_A9", "ARM_MATH_CA9", "__FPU_PRESENT", "__CMSIS_RTOS", "__EVAL", "__MBED_CMSIS_RTOS_CA9"],
     }
-    
+
     CORTEX_FPU_SYMBOLS = {
         "single" : ["__FPU_PRESENT=1"],
         "double" : ["__FPU_PRESENT=1"],
@@ -926,6 +926,10 @@ class mbedToolchain:
         # Write output to file in CSV format for the CI
         map_csv = splitext(map)[0] + "_map.csv"
         memap.generate_output('csv-ci', map_csv)
+
+        # Write output to file in HTML format for humans
+        map_htm = splitext(map)[0] + "_map.html"
+        memap.generate_output('html', map_htm)
 
         # Here we return memory statistics structure (constructed after
         # call to generate_output) which contains raw data in bytes


### PR DESCRIPTION
Changes:
* Add to memap script HTML formatted output for humans.
* Add memap HTML report to standard (with CSV and JSON) build directory output.
* This PR should be merged AFTER pull request: *[Tools] Replace in memap CSV report fields*, see #2161 

Example of report can be found [here](https://rawgit.com/PrzemekWirkus/1b0a737621348495d314935bcb567f72/raw/fa390c38fc4ba89b02001fbe0a3c4d2c09614c71/tests-integration-basic_map.html).
