### PR TITLE
Fix usage of custom targets in applications and tests

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -262,7 +262,7 @@ def build_library(src_paths, build_path, target, toolchain_name,
          dependencies_paths=None, options=None, name=None, clean=False, archive=True,
          notify=None, verbose=False, macros=None, inc_dirs=None, inc_dirs_ext=None,
          jobs=1, silent=False, report=None, properties=None, extra_verbose=False,
-         project_id=None):
+         project_id=None, config=None):
     """ src_path: the path of the source directory
     build_path: the path of the build directory
     target: ['LPC1768', 'LPC11U24', 'LPC2368']
@@ -284,7 +284,7 @@ def build_library(src_paths, build_path, target, toolchain_name,
         name = project_name
 
     # If the configuration object was not yet created, create it now
-    config = Config(target, src_paths)
+    config = config or Config(target, src_paths)
 
     # If the 'target' argument is a string, convert it to a target instance
     if isinstance(target, basestring):

--- a/tools/config.py
+++ b/tools/config.py
@@ -163,7 +163,7 @@ class Config:
     # If it does, it'll update the list of targets if need.
     # If found more than once, an exception is raised
     # top_level_dirs can be None (in this case, mbed_app_config.json will not be searched)
-    def __init__(self, target, top_level_dirs = []):
+    def __init__(self, target = None, top_level_dirs = []):
         app_config_location = None
         for s in (top_level_dirs or []):
             full_path = os.path.join(s, self.__mbed_app_config_name)
@@ -182,11 +182,16 @@ class Config:
         self.lib_config_data = {}
         # Make sure that each config is processed only once
         self.processed_configs = {}
-        self.target = target if isinstance(target, basestring) else target.name
-        self.target_labels = Target.get_target(self.target).get_labels()
+        self.set_target(target)
         self.added_features = set()
         self.removed_features = set()
         self.removed_unecessary_features = False
+
+    # Set the target used by the config system
+    def set_target(self, target):
+        if target is not None:
+            self.target = target if isinstance(target, basestring) else target.name
+            self.target_labels = Target.get_target(self.target).get_labels()
 
     # Add one or more configuration files
     def add_config_files(self, flist):

--- a/tools/make.py
+++ b/tools/make.py
@@ -60,12 +60,14 @@ if __name__ == '__main__':
     # After the configuration is created, the list of targets is automatically updated if needed and
     # the parsing can continue with a complete list of targets.
     # Step 1: parse only --source
-    parser = ArgumentParser()
+    parser = ArgumentParser(add_help = False)
     parser.add_argument("--source", dest="source_dir", type=argparse_filestring_type,
                        default=None, help="The source (input) directory", action="append")
     prev_options, rest = parser.parse_known_args()
     config = Config(top_level_dirs = prev_options.source_dir)
     # Step 2: parse the rest of the options
+    # We still add "--source" option to the arguments to give users a complete help text,
+    # but we don't use its value anymore
     parser = get_default_options_parser()
     group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument("-p",
@@ -123,6 +125,8 @@ if __name__ == '__main__':
                       default=None, help="Required peripherals")
     parser.add_argument("--dep", dest="dependencies",
                       default=None, help="Dependencies")
+    parser.add_argument("--source", dest="source_dir_not_used", type=argparse_filestring_type,
+                       default=None, help="The source (input) directory", action="append")
     parser.add_argument("--duration", type=int, dest="duration",
                       default=None, help="Duration of the test")
     parser.add_argument("--build", dest="build_dir",

--- a/tools/test.py
+++ b/tools/test.py
@@ -50,13 +50,15 @@ if __name__ == '__main__':
         # After the configuration is created, the list of targets is automatically updated if needed and
         # the parsing can continue with a complete list of targets.
         # Step 1: parse only --source
-        parser = ArgumentParser()
+        parser = ArgumentParser(add_help = False)
         parser.add_argument("--source", dest="source_dir",
                           type=argparse_filestring_type,
                             default=None, help="The source (input) directory (for sources other than tests). Defaults to current directory.", action="append")
         prev_options, rest = parser.parse_known_args()
         config = Config(top_level_dirs = prev_options.source_dir)
         # Step 2: parse the rest of the options
+        # We still add "--source" option to the arguments to give users a complete help text,
+        # but we don't use its value anymore
         parser = get_default_options_parser()
         
         parser.add_argument("-D",
@@ -70,6 +72,9 @@ if __name__ == '__main__':
                           default=0,
                           help="Number of concurrent jobs. Default: 0/auto (based on host machine's number of CPUs)")
 
+        parser.add_argument("--source", dest="source_dir_not_used",
+                          type=argparse_filestring_type,
+                            default=None, help="The source (input) directory (for sources other than tests). Defaults to current directory.", action="append")
 
         parser.add_argument("--build", dest="build_dir",
                           default=None, help="The build (output) directory")

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2044,7 +2044,7 @@ def norm_relative_path(path, start):
 def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
         options=None, clean=False, notify=None, verbose=False, jobs=1,
         macros=None, silent=False, report=None, properties=None,
-        continue_on_build_fail=False):
+        continue_on_build_fail=False, config=None):
     """Given the data structure from 'find_tests' and the typical build parameters,
     build all the tests
 
@@ -2081,7 +2081,8 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
                                      name=test_name,
                                      report=report,
                                      properties=properties,
-                                     verbose=verbose)
+                                     verbose=verbose,
+                                     config=config)
 
         except Exception, e:
             if not isinstance(e, NotSupportedException):


### PR DESCRIPTION
Commit 43e036d6 removed the ability to use custom targets (defined in
mbed_app.json) by restricting the type of the "target" argument to the
list of the known targets. The problem with this is that the
configuration system can dynamically add new custom targets to the list
of known targets. In order to do this, however, it needs the list of top
level source directories, so that it can look for a mbed_app.json file
in them. This commit fixes this problem by splitting argument parsing in
two steps:

1. in step 1, only '--source' is parsed.
2. the config object is created after this.
3. the rest of the command line options are parsed.
4. the config object created in step 2 is passed around to the various
   build functions (build_project, build_tests and so on) when needed.