### PR TITLE
ARM toolchain - add support for small-build

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -81,6 +81,34 @@ class ARM(mbedToolchain):
         self.ar = join(ARM_BIN, "armar")
         self.elf2bin = join(ARM_BIN, "fromelf")
 
+        # Use latest gcc nanolib
+        if "big-build" in self.options:
+            use_microlib = False
+        elif "small-build" in self.options:
+            use_microlib = True
+        elif target.default_build == "standard":
+            use_microlib = False
+        elif target.default_build == "small":
+            use_microlib = True
+        else:
+            use_microlib = False
+
+        if use_microlib:
+            # Extend flags
+            self.flags['common'] += ["-D__MICROLIB, -DMBED_RTOS_SINGLE_THREAD"]
+            self.flags['c'] += ["--library_type=microlib"]
+            self.flags['ld'] += ["--library_type=microlib"]
+
+            # Run-time values
+            self.asm  += ["-D__MICROLIB"]
+            self.cc   += ["-D__MICROLIB", "--library_type=microlib"]
+            self.cppc += ["-D__MICROLIB", "--library_type=microlib"]
+            self.ld   += ["--library_type=microlib"]
+
+            # Only allow a single thread
+            self.cc += ["-DMBED_RTOS_SINGLE_THREAD"]
+            self.cppc += ["-DMBED_RTOS_SINGLE_THREAD"]
+
     def parse_dependencies(self, dep_path):
         dependencies = []
         for line in open(dep_path).readlines():


### PR DESCRIPTION
Same as for GCC, if small-build is selected, select microlib library. This
is currently duplicated from microlib. I assume we deprecate microlib toolchain, thus
duplication should be removed (regarding extending cc/asm flags by --microlib, etc).

Tested with nrf51 microbit:
```
python tools\make.py -m NRF51_MICROBIT -t ARM -n RTOS_1
Build Options: debug-info
Building project basic (NRF51_MICROBIT, ARM)
Scan: basic
Scan: mbed
Scan: rtos
Scan: env
Compile: main.cpp
[Error] main.cpp@6,0:  #35: #error directive: [NOT_SUPPORTED] test not supported
[ERROR] "C:\Code\git_repo\github\mbed\libraries\tests\rtos\mbed\basic\main.cpp", line 6: Error:  #35: #error directive: [NOT_SUPPORTED] test not supported
C:\Code\git_repo\github\mbed\libraries\tests\rtos\mbed\basic\main.cpp: 0 warnings, 1 error
```

Exported project contains also microlib configuration (tested for NRF51 MICROBIT), and K64F (not containing single thread as its full stdlib ``python tools\make.py -m K64F -t ARM -n RTOS_1``)

This PR assumes we got GCC and ARM toolchains and provide small std lib option. Not as it is uARM vs ARM.

@c1728p9 @sg- @pan- 