### PR TITLE
Fix behavior when mbed-os RTOS tests are build while the system is singlet hreaded.

### DIFF
--- a/TESTS/integration/threaded_blinky/main.cpp
+++ b/TESTS/integration/threaded_blinky/main.cpp
@@ -2,6 +2,10 @@
 #include "mbed.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 DigitalOut led1(LED1);
 
   

--- a/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
@@ -2,6 +2,10 @@
 #include "greentea-client/test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 /*
  * The stack size is defined in cmsis_os.h mainly dependent on the underlying toolchain and
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes

--- a/TESTS/mbedmicro-rtos-mbed/isr/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/isr/main.cpp
@@ -2,6 +2,10 @@
 #include "greentea-client/test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 #define QUEUE_SIZE              5
 #define THREAD_DELAY            250
 #define QUEUE_PUT_ISR_VALUE     128

--- a/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
@@ -2,6 +2,10 @@
 #include "greentea-client/test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 typedef struct {
     float    voltage;   /* AD result of measured voltage */
     float    current;   /* AD result of measured current */

--- a/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
@@ -2,6 +2,10 @@
 #include "greentea-client/test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 #define THREAD_DELAY     50
 #define SIGNALS_TO_EMIT  100
 

--- a/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
@@ -2,6 +2,10 @@
 #include "greentea-client/test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 typedef struct {
     float    voltage;   /* AD result of measured voltage */
     float    current;   /* AD result of measured current */

--- a/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
@@ -2,6 +2,10 @@
 #include "greentea-client/test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 #define THREAD_DELAY     75
 #define SEMAPHORE_SLOTS  2
 #define SEM_CHANGES      100

--- a/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
@@ -2,6 +2,10 @@
 #include "greentea-client/test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 #define SIGNAL_SET_VALUE    0x01
 const int SIGNALS_TO_EMIT = 100;
 const int SIGNAL_HANDLE_DELEY = 25;

--- a/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
@@ -6,6 +6,9 @@
 #include "SynchronizedIntegral.h"
 #include "LockGuard.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
 
 using namespace utest::v1;
 

--- a/TESTS/mbedmicro-rtos-mbed/timer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/timer/main.cpp
@@ -2,6 +2,10 @@
 #include "greentea-client/test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 DigitalOut LEDs[4] = {
     DigitalOut(LED1), DigitalOut(LED2), DigitalOut(LED3), DigitalOut(LED4)
 };


### PR DESCRIPTION
For mbed micro, if the MBED_RTOS_SINGLE_THREAD is defined then the
compilation of the test will fail with the info
    [NOT_SUPPORTED] test not supported

This patch bring this behavior to mbed-os tests using threads.
