### PR TITLE
Define stack size for RTOS tests when NRF52 is used.

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
@@ -23,7 +23,7 @@
 #define STACK_SIZE 768
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
 #define STACK_SIZE 1536
-#elif defined(TARGET_MCU_NRF51822)
+#elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
 #define STACK_SIZE 512
 #else
 #define STACK_SIZE DEFAULT_STACK_SIZE

--- a/TESTS/mbedmicro-rtos-mbed/isr/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/isr/main.cpp
@@ -26,7 +26,7 @@
     #define STACK_SIZE 768
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
-#elif defined(TARGET_MCU_NRF51822)
+#elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
     #define STACK_SIZE 512
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE

--- a/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
@@ -34,7 +34,7 @@ typedef struct {
     #define STACK_SIZE 768
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
-#elif defined(TARGET_MCU_NRF51822)
+#elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
     #define STACK_SIZE 512
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE

--- a/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
@@ -36,7 +36,7 @@
     #define STACK_SIZE 768
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
-#elif defined(TARGET_MCU_NRF51822)
+#elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
     #define STACK_SIZE 512
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE

--- a/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
@@ -34,7 +34,7 @@ typedef struct {
     #define STACK_SIZE 768
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
-#elif defined(TARGET_MCU_NRF51822)
+#elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
     #define STACK_SIZE 512
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE

--- a/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
@@ -39,7 +39,7 @@
     #define STACK_SIZE 768
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
-#elif defined(TARGET_MCU_NRF51822)
+#elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
     #define STACK_SIZE 512
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE

--- a/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
@@ -25,7 +25,7 @@ const int SIGNAL_HANDLE_DELEY = 25;
     #define STACK_SIZE 768
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
-#elif defined(TARGET_MCU_NRF51822)
+#elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
     #define STACK_SIZE 512
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE


### PR DESCRIPTION
This should help: https://github.com/mbedmicro/mbed/pull/2211
