### PR TITLE
Unification of wait functions

### DIFF
--- a/hal/common/mbed_wait_api_no_rtos.c
+++ b/hal/common/mbed_wait_api_no_rtos.c
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// This implementation of the wait functions will be compiled only
+// if the RTOS is not present.
+#ifndef MBED_CONF_RTOS_PRESENT
+
 #include "wait_api.h"
 #include "us_ticker_api.h"
 
@@ -28,3 +33,6 @@ void wait_us(int us) {
     uint32_t start = us_ticker_read();
     while ((us_ticker_read() - start) < (uint32_t)us);
 }
+
+#endif // #ifndef MBED_CONF_RTOS_PRESENT
+

--- a/hal/common/mbed_wait_api_rtos.cpp
+++ b/hal/common/mbed_wait_api_rtos.cpp
@@ -1,0 +1,56 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This implementation of the wait functions will be compiled only
+// if the RTOS is present.
+#ifdef MBED_CONF_RTOS_PRESENT
+
+#include "wait_api.h"
+#include "us_ticker_api.h"
+#include "rtos.h"
+#include "critical.h"
+
+void wait(float s) {
+    wait_us(s * 1000000.0f);
+}
+
+void wait_ms(int ms) {
+    wait_us(ms * 1000);
+}
+
+// Wait for the given number of microseconds using a hardware timer
+// in a busy wait loop
+static void wait_us_busy(int us) {
+    if (us > 0) {
+        uint32_t start = us_ticker_read();
+        while ((us_ticker_read() - start) < (uint32_t)us);
+    }
+}
+
+void wait_us(int us) {
+    // Use the RTOS to wait for millisecond delays if possible
+    int ms = us / 1000;
+    if ((ms > 0) && core_util_are_interrupts_enabled()) {
+        Thread::wait((uint32_t)ms);
+        us -= ms * 1000;
+    }
+    // Use busy waiting for sub-millisecond delays, or for the whole
+    // interval if interrupts are not enabled
+    wait_us_busy(us);
+}
+
+#endif // #if MBED_CONF_RTOS_PRESENT
+

--- a/hal/common/mbed_wait_api_rtos.cpp
+++ b/hal/common/mbed_wait_api_rtos.cpp
@@ -31,16 +31,8 @@ void wait_ms(int ms) {
     wait_us(ms * 1000);
 }
 
-// Wait for the given number of microseconds using a hardware timer
-// in a busy wait loop
-static void wait_us_busy(int us) {
-    if (us > 0) {
-        uint32_t start = us_ticker_read();
-        while ((us_ticker_read() - start) < (uint32_t)us);
-    }
-}
-
 void wait_us(int us) {
+    uint32_t start = us_ticker_read();
     // Use the RTOS to wait for millisecond delays if possible
     int ms = us / 1000;
     if ((ms > 0) && core_util_are_interrupts_enabled()) {
@@ -49,7 +41,9 @@ void wait_us(int us) {
     }
     // Use busy waiting for sub-millisecond delays, or for the whole
     // interval if interrupts are not enabled
-    wait_us_busy(us);
+    if (us > 0) {
+        while((us_ticker_read() - start) < (uint32_t)us);
+    }
 }
 
 #endif // #if MBED_CONF_RTOS_PRESENT


### PR DESCRIPTION
This commit adds two implementations for the mbed wait functions (wait,
wait_ms, wait_us):

- with the RTOS present, the wait functions will use `Thread::wait` for
  millisecond delays and a busy wait loop for sub-millisecond delays.
- with the RTOS not present, the wait functions will always use a busy
  wait loop.