### PR TITLE
Exporter ds5 - add TOOLCHAIN

### DIFF
--- a/tools/export/ds5_5.py
+++ b/tools/export/ds5_5.py
@@ -20,6 +20,7 @@ from os.path import basename
 
 class DS5_5(Exporter):
     NAME = 'DS5'
+    TOOLCHAIN = 'ARM'
 
     TARGETS = [
         'LPC1768',


### PR DESCRIPTION
Required by exporters, as it's used by Exporter class. Set it to ARM toolchain for ds5

@toyowata @screamerbg 