### PR TITLE
[tools] Fixed infinite loop in config scan due to list comparison error

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -444,7 +444,7 @@ class Config:
             self.add_config_files(resources.json_files)
 
             # Add features while we find new ones
-            features = self.get_features()
+            features = set(self.get_features())
             if features == prev_features:
                 break
 

--- a/tools/test/config_test/test28/mbed_app.json
+++ b/tools/test/config_test/test28/mbed_app.json
@@ -1,0 +1,17 @@
+{
+    "custom_targets": {
+        "test_target": {
+            "core": "Cortex-M0",
+            "extra_labels": [],
+            "features": [],
+            "default_build": "standard"
+        }
+    },
+    "target_overrides": {
+        "*": {
+            "target.features_add": ["UVISOR"],
+            "target.extra_labels_add": ["UVISOR_SUPPORTED"]
+        }
+    }
+}
+

--- a/tools/test/config_test/test28/test_data.py
+++ b/tools/test/config_test/test28/test_data.py
@@ -1,0 +1,8 @@
+# Testing when adding two features
+
+expected_results = {
+    "test_target": {
+        "desc": "test uvisor feature",
+        "expected_features": ["UVISOR"]
+    }
+}


### PR DESCRIPTION
Fixed infinite loop in config scan due to list comparison error.

Previously a scanning for config terminated on comparison of the feature set, however at some point the set was changed to a list. This resulted in non-deterministic failures based on list order.

Added a test specifically for the uvisor feature_add, which revealed the issue.

fixes https://github.com/mbedmicro/mbed/issues/2312
cc @AlessandroA