### PR TITLE
Heap checking

### DIFF
--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -23,6 +23,8 @@
 #include "mbed_interface.h"
 #include "SingletonPtr.h"
 #include "PlatformMutex.h"
+#include "mbed_error.h"
+#include <stdlib.h>
 #if DEVICE_STDIO_MESSAGES
 #include <stdio.h>
 #endif
@@ -717,3 +719,34 @@ extern "C" void __env_unlock( struct _reent *_r )
 #endif
 
 } // namespace mbed
+
+void* operator new  ( std::size_t count )
+{
+    void *buffer = malloc(count);
+    if (NULL == buffer) {
+        error("Operator new out of memory\r\n");
+    }
+    return buffer;
+}
+
+void* operator new[]( std::size_t count )
+{
+    void *buffer = malloc(count);
+    if (NULL == buffer) {
+        error("Operator new[] out of memory\r\n");
+    }
+    return buffer;
+}
+
+void operator delete  ( void* ptr )
+{
+    if (ptr != NULL) {
+        free(ptr);
+    }
+}
+void operator delete[]( void* ptr )
+{
+    if (ptr != NULL) {
+        free(ptr);
+    }
+}

--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -68,6 +68,10 @@ extern const char __stdout_name[] = "/stdout";
 extern const char __stderr_name[] = "/stderr";
 #endif
 
+// Heap limits - only used if set
+unsigned char *mbed_heap_start = 0;
+uint32_t mbed_heap_size = 0;
+
 /* newlib has the filehandle field in the FILE struct as a short, so
  * we can't just return a Filehandle* from _open and instead have to
  * put it in a filehandles array and return the index into that array
@@ -585,6 +589,12 @@ extern "C" caddr_t _sbrk(int incr) {
 #else
     if (new_heap >= (unsigned char*)__get_MSP()) {
 #endif
+        errno = ENOMEM;
+        return (caddr_t)-1;
+    }
+
+    // Additional heap checking if set
+    if (mbed_heap_size && (new_heap >= mbed_heap_start + mbed_heap_size)) {
         errno = ENOMEM;
         return (caddr_t)-1;
     }

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -387,7 +387,7 @@ osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1U, 
 #define INITIAL_SP            (0x20003000UL)
 
 #elif defined(TARGET_K64F)
-#if defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED)
+#if defined(__GNUC__) && !defined(__CC_ARM)     /* GCC */
 extern uint32_t __StackTop[];
 #define INITIAL_SP            (__StackTop)
 #else

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -350,7 +350,12 @@ __attribute__((used)) void _mutex_release (OS_ID *mutex) {
 
 /* Main Thread definition */
 extern void pre_main (void);
+
+#if defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
+static uint32_t thread_stack_main[DEFAULT_STACK_SIZE / sizeof(uint32_t)];
+#else
 static uint32_t thread_stack_main[DEFAULT_STACK_SIZE * 2 / sizeof(uint32_t)];
+#endif
 osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1U, sizeof(thread_stack_main), thread_stack_main};
 
 // This define should be probably moved to the CMSIS layer

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -350,7 +350,8 @@ __attribute__((used)) void _mutex_release (OS_ID *mutex) {
 
 /* Main Thread definition */
 extern void pre_main (void);
-osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1U, 0U, NULL};
+static uint32_t thread_stack_main[DEFAULT_STACK_SIZE * 2 / sizeof(uint32_t)];
+osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1U, sizeof(thread_stack_main), thread_stack_main};
 
 // This define should be probably moved to the CMSIS layer
 #if   defined(TARGET_LPC1768)
@@ -545,28 +546,49 @@ extern uint32_t          __end__[];
 #define HEAP_START      (__end__)
 #elif defined(__ICCARM__)
 #pragma section="HEAP"
-#define HEAP_END  (void *)__section_end("HEAP")
+#pragma section="CSTACK"
 #endif
 
-void set_main_stack(void) {
-    uint32_t interrupt_stack_size = ((uint32_t)OS_MAINSTKSIZE * 4);
+extern unsigned char *mbed_heap_start;
+extern uint32_t mbed_heap_size;
+
+unsigned char *mbed_stack_isr_start = 0;
+uint32_t mbed_stack_isr_size = 0;
+
+/*
+ * set_stack_heap purpose is to set the following variables:
+ * -mbed_heap_start
+ * -mbed_heap_size
+ * -mbed_stack_isr_start
+ * -mbed_stack_isr_size
+ */
+void set_stack_heap(void) {
+
 #if defined(__ICCARM__)
-	/* For IAR heap is defined  .icf file */
-	uint32_t main_stack_size = ((uint32_t)INITIAL_SP - (uint32_t)HEAP_END) - interrupt_stack_size;
+
+    // Fixed sized heap
+    mbed_heap_size = (uint32_t)__section_size("HEAP");
+    mbed_heap_start = (unsigned char*)__section_begin("HEAP");
+
+    // Fixed size ISR stack
+    mbed_stack_isr_size = (uint32_t)__section_size("CSTACK");
+    mbed_stack_isr_start = (unsigned char*)__section_begin("CSTACK");
+
 #else
-	/* For ARM , uARM, or GCC_ARM , heap can grow and reach main stack */
-    uint32_t heap_plus_stack_size = ((uint32_t)INITIAL_SP - (uint32_t)HEAP_START) - interrupt_stack_size;
-    // Main thread's stack is 1/4 of the heap
-    uint32_t main_stack_size = heap_plus_stack_size/4;
+
+    unsigned char *free_start = (unsigned char*)HEAP_START;
+    uint32_t free_size = ((uint32_t)INITIAL_SP - (uint32_t)HEAP_START);
+
+    // Interrupt stack -  reserve space at the end of the free block
+    mbed_stack_isr_size = (uint32_t)OS_MAINSTKSIZE * 4;
+    mbed_stack_isr_start = free_start + free_size - mbed_stack_isr_size;
+    free_size -= mbed_stack_isr_size;
+
+    // Heap - everything else
+    mbed_heap_size = free_size;
+    mbed_heap_start = free_start;
+
 #endif
-    // The main thread must be 4 byte aligned
-    uint32_t main_stack_start = ((uint32_t)INITIAL_SP - interrupt_stack_size - main_stack_size) & ~0x7;
-
-    // That is the bottom of the main stack block: no collision detection
-    os_thread_def_main.stack_pointer = (uint32_t*)main_stack_start;
-
-    // Leave OS_MAINSTKSIZE words for the scheduler and interrupts
-    os_thread_def_main.stacksize = main_stack_size;
 }
 
 #if defined (__CC_ARM)
@@ -580,7 +602,7 @@ void $Super$$__cpp_initialize__aeabi_(void);
 void _main_init (void) {
   osKernelInitialize();
 #ifdef __MBED_CMSIS_RTOS_CM
-  set_main_stack();
+  set_stack_heap();
 #endif
   osThreadCreate(&os_thread_def_main, NULL);
   osKernelStart();
@@ -602,15 +624,12 @@ void pre_main()
 
 #else
 
-void * armcc_heap_base;
-void * armcc_heap_top;
-
 int main(void);
 
 void pre_main (void)
 {
     singleton_mutex_id = osMutexCreate(osMutex(singleton_mutex));
-    __rt_lib_init((unsigned)armcc_heap_base, (unsigned)armcc_heap_top);
+    __rt_lib_init((unsigned)mbed_heap_start, (unsigned)(mbed_heap_start + mbed_heap_size));
     main();
 }
 
@@ -625,12 +644,10 @@ void pre_main (void)
 __asm void __rt_entry (void) {
 
   IMPORT  __user_setup_stackheap
-  IMPORT  armcc_heap_base
-  IMPORT  armcc_heap_top
   IMPORT  os_thread_def_main
   IMPORT  osKernelInitialize
 #ifdef __MBED_CMSIS_RTOS_CM
-  IMPORT  set_main_stack
+  IMPORT  set_stack_heap
 #endif
   IMPORT  osKernelStart
   IMPORT  osThreadCreate
@@ -644,13 +661,12 @@ __asm void __rt_entry (void) {
    * ARM Compiler ARM C and C++ Libraries and Floating-Point Support User Guide
    */
   BL      __user_setup_stackheap
-  LDR     R3,=armcc_heap_base
-  LDR     R4,=armcc_heap_top
-  STR     R0,[R3]
-  STR     R2,[R4]
+  /* Ignore return value of __user_setup_stackheap since
+   * this will be setup by set_stack_heap
+   */
   BL      osKernelInitialize
 #ifdef __MBED_CMSIS_RTOS_CM
-  BL      set_main_stack
+  BL      set_stack_heap
 #endif
   LDR     R0,=os_thread_def_main
   MOVS    R1,#0
@@ -688,7 +704,7 @@ __attribute__((naked)) void software_init_hook_rtos (void) {
   __asm (
     "bl   osKernelInitialize\n"
 #ifdef __MBED_CMSIS_RTOS_CM
-    "bl   set_main_stack\n"
+    "bl   set_stack_heap\n"
 #endif
     "ldr  r0,=os_thread_def_main\n"
     "movs r1,#0\n"
@@ -765,7 +781,7 @@ void __iar_program_start( void )
 #endif
   osKernelInitialize();
 #ifdef __MBED_CMSIS_RTOS_CM
-  set_main_stack();
+  set_stack_heap();
 #endif
   osThreadCreate(&os_thread_def_main, NULL);
   osKernelStart();


### PR DESCRIPTION
-Add checking so malloc actually returns 0 if it runs out of space for toolchains GCC_ARM and ARM. Toolchains IAR and uARM have a fixed size heap so this problem does not apply to them.
-Add a heap and stack test to make sure everything behaves as expected and to catch regressions.
-Turn on stack checking for all threads since heap and stack no longer overlap.
-Fix memory layout on KSDK2 causing heap and stack test to fail