### PR TITLE
Fix intermittent Thread::join bug

### DIFF
--- a/libraries/tests/rtos/mbed/semaphore/main.cpp
+++ b/libraries/tests/rtos/mbed/semaphore/main.cpp
@@ -40,7 +40,7 @@
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822)
-    #define STACK_SIZE 768
+    #define STACK_SIZE 512
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/rtos/rtos/Thread.h
+++ b/rtos/rtos/Thread.h
@@ -26,6 +26,7 @@
 #include "cmsis_os.h"
 #include "Callback.h"
 #include "toolchain.h"
+#include "Semaphore.h"
 
 namespace rtos {
 
@@ -275,11 +276,13 @@ private:
                      osPriority priority=osPriorityNormal,
                      uint32_t stack_size=DEFAULT_STACK_SIZE,
                      unsigned char *stack_pointer=NULL);
+    static void _thunk(const void * thread_ptr);
 
     mbed::Callback<void()> _task;
     osThreadId _tid;
     osThreadDef_t _thread_def;
     bool _dynamic_stack;
+    Semaphore _join_sem;
 };
 
 }


### PR DESCRIPTION
The function Thread::join determines if the thread the object it
represents has terminated by polling that threads TCB. This can
lead to problems since the RTOS frees the thread's TCB as soon as
the thread completes execution.

This patch updates the function Thread::join to use a semaphore to
determine when the thread finishes. This both avoids polling and
prevents a freed TCB from being accessed.