### PR TITLE
Adding clean support back to build_library

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -411,6 +411,12 @@ def build_library(src_paths, build_path, target, toolchain_name,
     else:
         tmp_path = build_path
 
+    # Clean the build directory
+    if clean:
+        if exists(tmp_path):
+            rmtree(tmp_path)
+    mkdir(tmp_path)
+
     # Pass all params to the unified prepare_toolchain()
     toolchain = prepare_toolchain(src_paths, target, toolchain_name,
         macros=macros, options=options, clean=clean, jobs=jobs,


### PR DESCRIPTION
At some point, the actual code that did the "clean" for build_library was
removed. This also affected building and cleaning tests. This adds this
capability back to the build API.

Please review @screamerbg 