### PR TITLE
Export RAM start/stop symbols on NRF51

### DIFF
--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_16K/nRF51822_QFAA.icf
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_16K/nRF51822_QFAA.icf
@@ -8,6 +8,8 @@ define symbol __ICFEDIT_region_ROM_start__ = 0x0001b0c0;
 define symbol __ICFEDIT_region_ROM_end__   = 0x0003FFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20002ef8;
 define symbol __ICFEDIT_region_RAM_end__   = 0x20003FFF;
+export symbol __ICFEDIT_region_RAM_start__;
+export symbol __ICFEDIT_region_RAM_end__;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x400;
 define symbol __ICFEDIT_size_heap__   = 0x900;

--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_32K/nRF51822_QFAA.icf
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_32K/nRF51822_QFAA.icf
@@ -8,6 +8,8 @@ define symbol __ICFEDIT_region_ROM_start__ = 0x0001b0c0;
 define symbol __ICFEDIT_region_ROM_end__   = 0x0003FFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20002ef8;
 define symbol __ICFEDIT_region_RAM_end__   = 0x20007FFF;
+export symbol __ICFEDIT_region_RAM_start__;
+export symbol __ICFEDIT_region_RAM_end__;
 /*-Sizes-*/
 /*Heap 1/4 of ram and stack 1/8*/
 define symbol __ICFEDIT_size_cstack__   = 0xc00;


### PR DESCRIPTION
The symbols __ICFEDIT_region_RAM_start__ and __ICFEDIT_region_RAM_end__ where not exported by IAR linker script for NRF51.

Those symbols are needed by the nordic SDK.

This patch should fix https://github.com/ARMmbed/mbed-os-example-ble/issues/8