### PR TITLE
Fix nrf51 stack on IAR.

### DIFF
--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_16K/nRF51822_QFAA.icf
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_16K/nRF51822_QFAA.icf
@@ -9,7 +9,7 @@ define symbol __ICFEDIT_region_ROM_end__   = 0x0003FFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20002ef8;
 define symbol __ICFEDIT_region_RAM_end__   = 0x20003FFF;
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x400;
+define symbol __ICFEDIT_size_cstack__ = 0x800;
 define symbol __ICFEDIT_size_heap__   = 0x900;
 /**** End of ICF editor section. ###ICF###*/
 

--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_32K/nRF51822_QFAA.icf
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_32K/nRF51822_QFAA.icf
@@ -10,7 +10,7 @@ define symbol __ICFEDIT_region_RAM_start__ = 0x20002ef8;
 define symbol __ICFEDIT_region_RAM_end__   = 0x20007FFF;
 /*-Sizes-*/
 /*Heap 1/4 of ram and stack 1/8*/
-define symbol __ICFEDIT_size_cstack__   = 0xc00;
+define symbol __ICFEDIT_size_cstack__   = 0x800;
 define symbol __ICFEDIT_size_heap__     = 0x1800;
 /**** End of ICF editor section. ###ICF###*/
 


### PR DESCRIPTION
While I was doing: https://github.com/ARMmbed/mbed-os/pull/2337 . 
I've discovered that the cstack definitions for IAR were not correct. 

This patch set the size of the cstack on NRF51 to 2048 bytes.