### PR TITLE
Move target specific macros to mbed_config.h

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -504,5 +504,9 @@ class Config:
     # meant to be included to a C/C++ file. The content is returned as a string.
     # If 'fname' is given, the content is also written to the file called "fname".
     # WARNING: if 'fname' names an existing file, that file will be overwritten!
-    def get_config_data_header(self, fname = None):
-        return self.config_to_header(self.get_config_data(), fname)
+    def get_config_data_header(self, toolchain_macros=None, fname=None):
+        config_data = self.get_config_data()
+        if toolchain_macros:
+            macro_map = {symbol: ConfigMacro(symbol, "target", "library") for symbol in toolchain_macros}
+            config_data[1].update(macro_map)
+        return self.config_to_header(config_data, fname)

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -62,7 +62,6 @@ class Exporter(object):
             if self.config_header:
                 self._progen_flag_cache['c_flags'] += self.toolchain.get_config_option(self.config_header)
                 self._progen_flag_cache['cxx_flags'] += self.toolchain.get_config_option(self.config_header)
-                self._progen_flag_cache['asm_flags'] += self.toolchain.get_config_option(self.config_header)
         return self._progen_flag_cache
 
     def __scan_and_copy(self, src_path, trg_path):

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -191,11 +191,10 @@ class Exporter(object):
 
         # Loads the resources into the config system which might expand/modify resources based on config data
         self.resources = config.load_resources(resources)
-
         if hasattr(self, "MBED_CONFIG_HEADER_SUPPORTED") and self.MBED_CONFIG_HEADER_SUPPORTED :
             # Add the configuration file to the target directory
             self.config_header = self.toolchain.MBED_CONFIG_FILE_NAME
-            config.get_config_data_header(join(trg_path, self.config_header))
+            config.get_config_data_header(self.toolchain.get_symbols(), join(trg_path, self.config_header))
             self.config_macros = []
             self.resources.inc_dirs.append(".")
         else:
@@ -215,7 +214,10 @@ class Exporter(object):
         """ This function returns symbols which must be exported.
             Please add / overwrite symbols in each exporter separately
         """
-        symbols = self.toolchain.get_symbols() + self.config_macros
+        symbols = self.config_macros
+        if hasattr(self, "MBED_CONFIG_HEADER_SUPPORTED") and not(self.MBED_CONFIG_HEADER_SUPPORTED):
+            symbols.extend(self.toolchain.get_symbols())
+
         # We have extra symbols from e.g. libraries, we want to have them also added to export
         if add_extra_symbols:
             if self.extra_symbols is not None:


### PR DESCRIPTION
Fixes https://github.com/ARMmbed/mbed-os-example-client/issues/61. Prevents uvision armasm command from growing too long with -D defines for preprocessing.