### PR TITLE
[STM32F303RE] Fix initial SP on ARM and uARM

### DIFF
--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303RE/TOOLCHAIN_ARM_MICRO/startup_stm32f303xe.S
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303RE/TOOLCHAIN_ARM_MICRO/startup_stm32f303xe.S
@@ -51,7 +51,7 @@ Stack_Size      EQU     0x00000400
                 EXPORT  __initial_sp
                 
 Stack_Mem       SPACE   Stack_Size
-__initial_sp    EQU     0x20004000 ; Top of RAM
+__initial_sp    EQU     0x20010000 ; Top of RAM
 
 
 ; <h> Heap Configuration

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303RE/TOOLCHAIN_ARM_STD/startup_stm32f303xe.S
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303RE/TOOLCHAIN_ARM_STD/startup_stm32f303xe.S
@@ -39,7 +39,7 @@
 ;
 ;*******************************************************************************
 
-__initial_sp    EQU     0x20004000 ; Top of RAM
+__initial_sp    EQU     0x20010000 ; Top of RAM
 
                 PRESERVE8
                 THUMB


### PR DESCRIPTION
Fix issue #2327.

The RAM is correctly sized. Only the initial stack pointer was wrong. In IAR and GCC, it is handle automatically. The `INITIAL_SP` of the RTOS is correctly defined to `0x2001 0000`.