### PR TITLE
[STM32F207ZG] Fix IAR memory init

### DIFF
--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/TOOLCHAIN_IAR/stm32f207xx.icf
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/TOOLCHAIN_IAR/stm32f207xx.icf
@@ -1,31 +1,31 @@
-/*###ICF### Section handled by ICF editor, don't touch! ****/
-/*-Editor annotation file-*/
-/* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
-/*-Specials-*/
-define symbol __ICFEDIT_intvec_start__ = 0x08000000;
-/*-Memory Regions-*/
-define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__   = 0x080FFFFF;
-define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__   = 0x20020000;
-/*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x400;
-define symbol __ICFEDIT_size_heap__   = 0x200;
-/**** End of ICF editor section. ###ICF###*/
+/* [ROM = 1024kb = 0x100000] */
+define symbol __intvec_start__     = 0x08000000;
+define symbol __region_ROM_start__ = 0x08000000;
+define symbol __region_ROM_end__   = 0x080FFFFF;
 
+/* [RAM = 128kb = 0x20000] Vector table dynamic copy: 97 vectors = 388 bytes (0x184) to be reserved in RAM */
+define symbol __NVIC_start__          = 0x20000000;
+define symbol __NVIC_end__            = 0x20000187; /*aligned on 8 bytes */
+define symbol __region_RAM_start__    = 0x20000188;
+define symbol __region_RAM_end__      = 0x2001FFFF;
 
+/* Memory regions */
 define memory mem with size = 4G;
-define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFEDIT_region_ROM_end__];
-define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
+define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
+define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 
-define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+/* Stack and Heap */
+/*Heap 1/4 of ram and stack 1/8*/
+define symbol __size_cstack__ = 0x4000;
+define symbol __size_heap__   = 0x8000;
+define block CSTACK    with alignment = 8, size = __size_cstack__   { };
+define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
-initialize by copy { readwrite };
+initialize by copy with packing = zeros { readwrite };
 do not initialize  { section .noinit };
 
-place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
+place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
-place in RAM_region   { readwrite,
-                        block CSTACK, block HEAP };
+place in RAM_region   { readwrite, block STACKHEAP };


### PR DESCRIPTION
The icf file was not align with other targets and they were no reserved space for NVIC vectors.

### common tests before the fix:
```
+---------+---------------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| Result  | Target              | Toolchain | Test ID     | Test Description                      | Elapsed Time (sec) | Timeout (sec) | Loops |
+---------+---------------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| OK      | NUCLEO_F207ZG[F079] | IAR       | DTCT_1      | Simple detect test                    |        0.52        |       10      |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | EXAMPLE_1   | /dev/null                             |        3.45        |       20      |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_10     | Hello World                           |        0.36        |       5       |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_11     | Ticker Int                            |       11.37        |       15      |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_12     | C++                                   |        1.35        |       10      |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_16     | RTC                                   |        4.6         |       20      |  1/1  |
| FAIL    | NUCLEO_F207ZG[F079] | IAR       | MBED_2      | stdio                                 |        5.34        |       20      |  0/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_23     | Ticker Int us                         |        11.4        |       15      |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_24     | Timeout Int us                        |       11.41        |       15      |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_25     | Time us                               |       11.37        |       15      |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_26     | Integer constant division             |        1.38        |       20      |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_34     | Ticker Two callbacks                  |       11.36        |       15      |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_37     | Serial NC RX                          |       11.91        |       20      |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_38     | Serial NC TX                          |       10.89        |       20      |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_A1     | Basic                                 |        1.34        |       20      |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_A21    | Call function before main (mbed_main) |        1.41        |       20      |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_A9     | Serial Echo at 115200                 |        6.51        |       20      |  1/1  |
| OK      | NUCLEO_F207ZG[F079] | IAR       | MBED_BUSOUT | BusOut                                |        2.26        |       15      |  1/1  |
| TIMEOUT | NUCLEO_F207ZG[F079] | IAR       | RTOS_1      | Basic thread                          |       30.28        |       15      |  0/1  |
| TIMEOUT | NUCLEO_F207ZG[F079] | IAR       | RTOS_2      | Mutex resource lock                   |       40.25        |       20      |  0/1  |
| TIMEOUT | NUCLEO_F207ZG[F079] | IAR       | RTOS_3      | Semaphore resource lock               |       40.25        |       20      |  0/1  |
| TIMEOUT | NUCLEO_F207ZG[F079] | IAR       | RTOS_4      | Signals messaging                     |       20.24        |       10      |  0/1  |
| TIMEOUT | NUCLEO_F207ZG[F079] | IAR       | RTOS_5      | Queue messaging                       |       20.27        |       10      |  0/1  |
| TIMEOUT | NUCLEO_F207ZG[F079] | IAR       | RTOS_6      | Mail messaging                        |       20.22        |       10      |  0/1  |
| TIMEOUT | NUCLEO_F207ZG[F079] | IAR       | RTOS_7      | Timer                                 |       30.24        |       15      |  0/1  |
| TIMEOUT | NUCLEO_F207ZG[F079] | IAR       | RTOS_8      | ISR (Queue)                           |       20.24        |       10      |  0/1  |
+---------+---------------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
Result: 1 FAIL / 17 OK / 8 TIMEOUT

Completed in 514.80 sec
```

### common tests after the fix:
```
+--------+---------------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| Result | Target              | Toolchain | Test ID     | Test Description                      | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------+---------------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| OK     | NUCLEO_F207ZG[F079] | IAR       | DTCT_1      | Simple detect test                    |        0.48        |       10      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | EXAMPLE_1   | /dev/null                             |        3.42        |       20      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_10     | Hello World                           |        0.37        |       5       |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_11     | Ticker Int                            |       11.38        |       15      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_12     | C++                                   |        1.37        |       10      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_16     | RTC                                   |        4.58        |       20      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_2      | stdio                                 |        0.77        |       20      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_23     | Ticker Int us                         |       11.37        |       15      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_24     | Timeout Int us                        |       11.44        |       15      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_25     | Time us                               |       11.38        |       15      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_26     | Integer constant division             |        1.38        |       20      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_34     | Ticker Two callbacks                  |       11.38        |       15      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_37     | Serial NC RX                          |       11.92        |       20      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_38     | Serial NC TX                          |       10.91        |       20      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_A1     | Basic                                 |        1.34        |       20      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_A21    | Call function before main (mbed_main) |        1.41        |       20      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_A9     | Serial Echo at 115200                 |        6.5         |       20      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | MBED_BUSOUT | BusOut                                |        2.26        |       15      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | RTOS_1      | Basic thread                          |       11.35        |       15      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | RTOS_2      | Mutex resource lock                   |       11.37        |       20      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | RTOS_3      | Semaphore resource lock               |        8.39        |       20      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | RTOS_4      | Signals messaging                     |        6.35        |       20      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | RTOS_5      | Queue messaging                       |        2.4         |       20      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | RTOS_6      | Mail messaging                        |        2.4         |       20      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | RTOS_7      | Timer                                 |       11.37        |       15      |  1/1  |
| OK     | NUCLEO_F207ZG[F079] | IAR       | RTOS_8      | ISR (Queue)                           |        6.37        |       20      |  1/1  |
+--------+---------------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
Result: 26 OK

Completed in 346.86 sec
```