### PR TITLE
Enable FEATURE_IPV4 for the VK_RZ_A1H

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1652,7 +1652,8 @@
         "program_cycle_s": 2,
         "device_has": ["ANALOGIN", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "features": ["IPV4"],
-        "default_build": "standard"
+        "default_build": "standard",
+        "release_versions": ["2", "5"]
     },
     "MAXWSNENV": {
         "inherits": ["Target"],

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1651,6 +1651,7 @@
         },
         "program_cycle_s": 2,
         "device_has": ["ANALOGIN", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "features": ["IPV4"],
         "default_build": "standard"
     },
     "MAXWSNENV": {

--- a/hal/targets/cmsis/TARGET_RENESAS/TARGET_VK_RZ_A1H/TOOLCHAIN_IAR/startup_VKRZA1H.s
+++ b/hal/targets/cmsis/TARGET_RENESAS/TARGET_VK_RZ_A1H/TOOLCHAIN_IAR/startup_VKRZA1H.s
@@ -29,7 +29,7 @@
 
         SECTION .intvec:CODE:NOROOT(2)
 
-        PUBLIC  __vector
+        PUBLIC  __vector_core_a9
         PUBWEAK __iar_program_start
         PUBLIC  Undefined_Handler
         EXTERN  SWI_Handler
@@ -52,7 +52,7 @@
 __iar_init$$done:               ; The vector table is not needed
                                 ; until after copy initialization is done
 
-__vector:                       ; Make this a DATA label, so that stack usage
+__vector_core_a9:               ; Make this a DATA label, so that stack usage
                                 ; analysis doesn't consider it an uncalled fun
 
         ARM
@@ -95,7 +95,7 @@ FIQ_Addr:       DCD   FIQ_Handler
         EXTERN  SystemInit
         EXTERN  InitMemorySubsystem
         EXTERN  __cmain
-        REQUIRE __vector
+        REQUIRE __vector_core_a9
         EXTWEAK __iar_init_core
         EXTWEAK __iar_init_vfp
 
@@ -138,7 +138,7 @@ goToSleep:
   
   
 ;; Set Vector Base Address Register (VBAR) to point to this application's vector table
-    ldr     r0, =__vector
+    ldr     r0, =__vector_core_a9
     mcr     p15, 0, r0, c12, c0, 0
     
     

--- a/hal/targets/cmsis/TARGET_RENESAS/TARGET_VK_RZ_A1H/TOOLCHAIN_IAR/startup_VKRZA1H.s
+++ b/hal/targets/cmsis/TARGET_RENESAS/TARGET_VK_RZ_A1H/TOOLCHAIN_IAR/startup_VKRZA1H.s
@@ -30,7 +30,7 @@
         SECTION .intvec:CODE:NOROOT(2)
 
         PUBLIC  __vector
-        PUBLIC  __iar_program_start
+        PUBWEAK __iar_program_start
         PUBLIC  Undefined_Handler
         EXTERN  SWI_Handler
         PUBLIC  Prefetch_Handler


### PR DESCRIPTION
VK_RZ_A1H already has lwip support and restricting FEATURE_IPV4 is unnecessary.

should fix https://github.com/ARMmbed/mbed-os-example-client/issues/67
tested locally with [mbed-os-example-client](https://github.com/ARMmbed/mbed-os-example-client) and the [nsapi tests](https://developer.mbed.org/teams/NetworkSocketAPI/code/NSAPITests/#0d938ec9100c)

cc @sg-, @bulislaw
