### PR TITLE
Increasing the heap for KL46Z for IAR.

### DIFF
--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/TOOLCHAIN_IAR/MKL46Z4.icf
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/TOOLCHAIN_IAR/MKL46Z4.icf
@@ -13,7 +13,7 @@ define symbol __ICFEDIT_region_RAM_end__   = 0x1fffffff;
 /*-Sizes-*/
 /*Heap 1/4 of ram and stack 1/8*/
 define symbol __ICFEDIT_size_cstack__ = 0x1000;
-define symbol __ICFEDIT_size_heap__   = 0x2000;
+define symbol __ICFEDIT_size_heap__   = 0x4000;
 /**** End of ICF editor section. ###ICF###*/
 
 define symbol __region_RAM2_start__ 		= 0x20000000;


### PR DESCRIPTION
The KL46Z passes all tests on all toolchains except the following when built with IAR: `tests-mbedmicro-rtos-mbed-threads`.

This is because the heap is becomes fully allocated. This commit increases the heap from 8K to 16K.

Please review @c1728p9 
FYI @sg- 