### PR TITLE
Include the EFM32GG_STK3700 in the release

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1682,7 +1682,7 @@
         "progen": {"target": "efm32gg-stk"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "forced_reset_timeout": 2,
-        "release_versions": ["2"]
+        "release_versions": ["2", "5"]
     },
     "EFM32LG_STK3600": {
         "inherits": ["Target"],


### PR DESCRIPTION
Set the mbed-os version 5 support flag for the EFM32GG_STK3700 so it
is tested and included in the upcoming release.