### PR TITLE
Expose the network-socket API through mbed.h

### DIFF
--- a/features/FEATURE_CLIENT/mbed-client-classic/source/m2mconnectionhandlerpimpl.cpp
+++ b/features/FEATURE_CLIENT/mbed-client-classic/source/m2mconnectionhandlerpimpl.cpp
@@ -27,6 +27,7 @@
 #include "eventOS_scheduler.h"
 
 #include "mbed-trace/mbed_trace.h"
+#include "mbed.h"
 
 #define TRACE_GROUP "mClt"
 

--- a/features/net/network-socket/Socket.cpp
+++ b/features/net/network-socket/Socket.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "Socket.h"
+#include "mbed.h"
 
 Socket::Socket()
     : _stack(0)

--- a/features/net/network-socket/Socket.h
+++ b/features/net/network-socket/Socket.h
@@ -22,10 +22,6 @@
 #include "rtos/Mutex.h"
 #include "Callback.h"
 
-#ifndef NSAPI_NO_INCLUDE_MBED
-#include "mbed.h" // needed for backwards compatability
-#endif
-
 
 /** Abstract socket class
  */

--- a/features/net/network-socket/TCPServer.cpp
+++ b/features/net/network-socket/TCPServer.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "TCPServer.h"
-#include "Timer.h"
+#include "mbed.h"
 
 TCPServer::TCPServer()
     : _pending(0), _accept_sem(0)

--- a/features/net/network-socket/mbed_lib.json
+++ b/features/net/network-socket/mbed_lib.json
@@ -1,0 +1,6 @@
+{
+    "name": "nsapi",
+    "config": {
+        "present": 1
+    }
+}

--- a/features/net/network-socket/nsapi.h
+++ b/features/net/network-socket/nsapi.h
@@ -21,9 +21,6 @@
 // entry point for nsapi types
 #include "nsapi_types.h"
 
-// disable bug-compatible mbed inclusion
-#define NSAPI_NO_INCLUDE_MBED
-
 #ifdef __cplusplus
 
 // entry point for C++ api

--- a/hal/api/mbed.h
+++ b/hal/api/mbed.h
@@ -22,6 +22,10 @@
 #include "rtos/rtos.h"
 #endif
 
+#if MBED_CONF_NSAPI_PRESENT
+#include "network-socket/nsapi.h"
+#endif
+
 #include "toolchain.h"
 #include "platform.h"
 


### PR DESCRIPTION
Currently this uses the same mechanism used by the rtos to conditionally include the network-socket API. Perhaps this should be builtin to the config system?

Note: this does require that the bug-compatible inclusion of mbed.h be removed to avoid include-order issues, this may cause issues with existing examples. I will look into how this impacts mbed-os-example-client.

cc @sg-