### PR TITLE
Fix the clock setup for the K64 HEXIWEAR board

### DIFF
--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/TARGET_HEXIWEAR/fsl_clock_config.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/TARGET_HEXIWEAR/fsl_clock_config.c
@@ -106,7 +106,7 @@ const clock_config_t g_defaultClockConfigRun = {
 
             .pll0Config =
                 {
-                    .enableMode = 0U, .prdiv = 0x13U, .vdiv = 0x18U,
+                    .enableMode = 0U, .prdiv = 0x3U, .vdiv = 0x10U,
                 },
         },
     .simConfig =


### PR DESCRIPTION
Result: 26 OK

Completed in 427.14 sec

Build successes:
  * HEXIWEAR::IAR::DTCT_1
  * HEXIWEAR::IAR::EXAMPLE_1
  * HEXIWEAR::IAR::MBED
  * HEXIWEAR::IAR::MBED_10
  * HEXIWEAR::IAR::MBED_11
  * HEXIWEAR::IAR::MBED_12
  * HEXIWEAR::IAR::MBED_16
  * HEXIWEAR::IAR::MBED_2
  * HEXIWEAR::IAR::MBED_23
  * HEXIWEAR::IAR::MBED_24
  * HEXIWEAR::IAR::MBED_25
  * HEXIWEAR::IAR::MBED_26
  * HEXIWEAR::IAR::MBED_34
  * HEXIWEAR::IAR::MBED_37
  * HEXIWEAR::IAR::MBED_38
  * HEXIWEAR::IAR::MBED_A1
  * HEXIWEAR::IAR::MBED_A21
  * HEXIWEAR::IAR::MBED_A9
  * HEXIWEAR::IAR::MBED_BUSOUT
  * HEXIWEAR::IAR::RTOS
  * HEXIWEAR::IAR::RTOS_1
  * HEXIWEAR::IAR::RTOS_2
  * HEXIWEAR::IAR::RTOS_3
  * HEXIWEAR::IAR::RTOS_4
  * HEXIWEAR::IAR::RTOS_5
  * HEXIWEAR::IAR::RTOS_6
  * HEXIWEAR::IAR::RTOS_7
  * HEXIWEAR::IAR::RTOS_8
  * HEXIWEAR::IAR::RTX