### PR TITLE
Add ARDUINO to supported form factors of F429ZI

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -786,6 +786,7 @@
         "release_versions": ["2"]
     },
     "NUCLEO_F429ZI": {
+        "supported_form_factors": ["ARDUINO"],
         "inherits": ["Target"],
         "core": "Cortex-M4F",
         "default_toolchain": "ARM",


### PR DESCRIPTION
Add support for the arduino form factor in targets.json for the
NUCLEO_F429ZI.