### PR TITLE
Fix docs/BUILDING.md error

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -444,7 +444,7 @@ Build successes:
 ```
 * We can print all 'programs' (test cases) ```make.py``` can build for us:
 ```
-$ python make.py
+$ python make.py -L
 .
 [  0] MBED_A1: Basic
 [  1] MBED_A2: Semihost file system


### PR DESCRIPTION
The description used in BUILDING.md does not work. It works with -L parameter