### PR TITLE
Add the setting to use the mbed-os-example-client

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1628,7 +1628,7 @@
         "extra_labels": ["RENESAS", "MBRZA1H"],
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "inherits": ["Target"],
-        "macros": [" MBEDTLS_ENTROPY_HARDWARE_ALT "],
+        "macros": ["MBEDTLS_ENTROPY_HARDWARE_ALT"],
         "progen": {
             "target": "gr-peach",
             "iar": {

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1628,6 +1628,7 @@
         "extra_labels": ["RENESAS", "MBRZA1H"],
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "inherits": ["Target"],
+        "macros": [" MBEDTLS_ENTROPY_HARDWARE_ALT "],
         "progen": {
             "target": "gr-peach",
             "iar": {

--- a/hal/targets/hal/TARGET_RENESAS/TARGET_RZ_A1H/entropy_hardware_poll.c
+++ b/hal/targets/hal/TARGET_RENESAS/TARGET_RZ_A1H/entropy_hardware_poll.c
@@ -15,49 +15,31 @@
  */
 
 #include <stdlib.h>
-#include "mbed.h"
+#include "us_ticker_api.h"
 
-Timer t;
-static bool initialized = false;
-
-extern "C" {
-    
-int mbedtls_hardware_poll( void *data,
-                    unsigned char *output, size_t len, size_t *olen )
+int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
 {
-    #warning "Please update this function based on the security implementation on your platform"
-    
+    /* "Please update this function based on the security implementation on your platform" */
+
     uint32_t i;
-    
+
     *olen = 0;
-    
-    if(!initialized)
-    {
-        t.start();
-        initialized = true;
+
+    if (len == 0) {
+        return (0);
     }
-    
-    if (len == 0)
-    {
-        return( 0 );
-    }
-    
-    srand(t.read_us());
-    
-    for( i = 0; i < len; i++ )
-    {
+
+    srand(us_ticker_read());
+
+    for (i = 0; i < len; i++) {
         output[i] = rand() & 0xff;
-        
-        if( (i & 0x7)==0x07 )
-        {
-            srand(t.read_us());
+
+        if ((i & 0x7) == 0x07) {
+            srand(us_ticker_read());
         }
     }
-    
-    *olen = len;
-    
-    return( 0 );
-}
 
+    *olen = len;
+
+    return (0);
 }
-    

--- a/hal/targets/hal/TARGET_RENESAS/TARGET_RZ_A1H/entropy_hardware_poll.cpp
+++ b/hal/targets/hal/TARGET_RENESAS/TARGET_RZ_A1H/entropy_hardware_poll.cpp
@@ -1,0 +1,63 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include "mbed.h"
+
+Timer t;
+static bool initialized = false;
+
+extern "C" {
+    
+int mbedtls_hardware_poll( void *data,
+                    unsigned char *output, size_t len, size_t *olen )
+{
+    #warning "Please update this function based on the security implementation on your platform"
+    
+    uint32_t i;
+    
+    *olen = 0;
+    
+    if(!initialized)
+    {
+        t.start();
+        initialized = true;
+    }
+    
+    if (len == 0)
+    {
+        return( 0 );
+    }
+    
+    srand(t.read_us());
+    
+    for( i = 0; i < len; i++ )
+    {
+        output[i] = rand() & 0xff;
+        
+        if( (i & 0x7)==0x07 )
+        {
+            srand(t.read_us());
+        }
+    }
+    
+    *olen = len;
+    
+    return( 0 );
+}
+
+}
+    


### PR DESCRIPTION
By default, mbed-os-example-client can't be built for Renesas GR-PEACH, and This is the workaround for the issue.

There is no device unique ID to the GR-PEACH. Therefore, we implimented the following function.
- The value read by the Timer is set to a random seed.
- Put a random number into the entropy poll, and returns it.

Regards,
Tomo Yamanaka

