### PR TITLE
Fix joining a terminated thread

### DIFF
--- a/rtos/rtos/Thread.cpp
+++ b/rtos/rtos/Thread.cpp
@@ -104,6 +104,9 @@ osStatus Thread::terminate() {
     ret = osThreadTerminate(_tid);
     _tid = (osThreadId)NULL;
 
+    // Wake threads joining the terminated thread
+    _join_sem.release();
+
     _mutex.unlock();
     return ret;
 }


### PR DESCRIPTION
When a thread is terminated signal the join semaphore so any threads
joining the terminated thread wake up as expected.