### PR TITLE
Remove problematic templated overloads on callback-based functions

### DIFF
--- a/features/net/network-socket/Socket.h
+++ b/features/net/network-socket/Socket.h
@@ -169,8 +169,13 @@ public:
      *  @param obj      Pointer to object to call method on
      *  @param method   Method to call on state change
      */
-    template <typename T, typename M>
-    void attach(T *obj, M method) {
+    template <typename T>
+    void attach(T *obj, void (T::*method)()) {
+        attach(mbed::Callback<void()>(obj, method));
+    }
+
+    template <typename T>
+    void attach(T *obj, void (*method)(T*)) {
         attach(mbed::Callback<void()>(obj, method));
     }
 

--- a/hal/api/CallChain.h
+++ b/hal/api/CallChain.h
@@ -88,8 +88,13 @@ public:
      *  @returns
      *  The function object created for 'obj' and 'method'
      */
-    template<typename T, typename M>
-    pFunctionPointer_t add(T *obj, M method) {
+    template <typename T>
+    pFunctionPointer_t add(T *obj, void (T::*method)()) {
+        return add(Callback<void()>(obj, method));
+    }
+
+    template <typename T>
+    pFunctionPointer_t add(T *obj, void (*method)(T*)) {
         return add(Callback<void()>(obj, method));
     }
 
@@ -110,8 +115,13 @@ public:
      *  @returns
      *  The function object created for 'tptr' and 'mptr'
      */
-    template<typename T, typename M>
-    pFunctionPointer_t add_front(T *obj, M method) {
+    template <typename T>
+    pFunctionPointer_t add_front(T *obj, void (T::*method)()) {
+        return add_front(Callback<void()>(obj, method));
+    }
+
+    template <typename T>
+    pFunctionPointer_t add_front(T *obj, void (*method)(T*)) {
         return add_front(Callback<void()>(obj, method));
     }
 

--- a/hal/api/InterruptIn.h
+++ b/hal/api/InterruptIn.h
@@ -89,8 +89,15 @@ public:
      *  @param obj pointer to the object to call the member function on
      *  @param method pointer to the member function to be called
      */
-    template<typename T, typename M>
-    void rise(T *obj, M method) {
+    template<typename T>
+    void rise(T *obj, void (T::*method)()) {
+        core_util_critical_section_enter();
+        rise(Callback<void()>(obj, method));
+        core_util_critical_section_exit();
+    }
+
+    template<typename T>
+    void rise(T *obj, void (*method)(T*)) {
         core_util_critical_section_enter();
         rise(Callback<void()>(obj, method));
         core_util_critical_section_exit();
@@ -107,8 +114,15 @@ public:
      *  @param obj pointer to the object to call the member function on
      *  @param method pointer to the member function to be called
      */
-    template<typename T, typename M>
-    void fall(T *obj, M method) {
+    template<typename T>
+    void fall(T *obj, void (T::*method)()) {
+        core_util_critical_section_enter();
+        fall(Callback<void()>(obj, method));
+        core_util_critical_section_exit();
+    }
+
+    template<typename T>
+    void fall(T *obj, void (*method)(T*)) {
         core_util_critical_section_enter();
         fall(Callback<void()>(obj, method));
         core_util_critical_section_exit();

--- a/hal/api/Ticker.h
+++ b/hal/api/Ticker.h
@@ -80,8 +80,13 @@ public:
      *  @param method pointer to the member function to be called
      *  @param t the time between calls in seconds
      */
-    template<typename T, typename M>
-    void attach(T *obj, M method, float t) {
+    template<typename T>
+    void attach(T *obj, void (T::*method)(), float t) {
+        attach(Callback<void()>(obj, method), t);
+    }
+
+    template<typename T>
+    void attach(T *obj, void (*method)(T*), float t) {
         attach(Callback<void()>(obj, method), t);
     }
 
@@ -101,8 +106,13 @@ public:
      *  @param mptr pointer to the member function to be called
      *  @param t the time between calls in micro-seconds
      */
-    template<typename T, typename M>
-    void attach_us(T *obj, M method, timestamp_t t) {
+    template<typename T>
+    void attach_us(T *obj, void (T::*method)(), float t) {
+        attach_us(Callback<void()>(obj, method), t);
+    }
+
+    template<typename T>
+    void attach_us(T *obj, void (*method)(T*), float t) {
         attach_us(Callback<void()>(obj, method), t);
     }
 

--- a/rtos/rtos/RtosTimer.h
+++ b/rtos/rtos/RtosTimer.h
@@ -62,8 +62,13 @@ public:
       @param   method    member function to be executed by this timer.
       @param   type      osTimerOnce for one-shot or osTimerPeriodic for periodic behaviour. (default: osTimerPeriodic)
     */
-    template <typename T, typename M>
-    RtosTimer(T *obj, M method, os_timer_type type=osTimerPeriodic) {
+    template <typename T>
+    RtosTimer(T *obj, void (T::*method)(), os_timer_type type=osTimerPeriodic) {
+        constructor(mbed::Callback<void()>(obj, method), type);
+    }
+
+    template <typename T>
+    RtosTimer(T *obj, void (*method)(T*), os_timer_type type=osTimerPeriodic) {
         constructor(mbed::Callback<void()>(obj, method), type);
     }
 

--- a/rtos/rtos/Thread.h
+++ b/rtos/rtos/Thread.h
@@ -156,8 +156,13 @@ public:
       @param   method         function to be executed by this thread.
       @return  status code that indicates the execution status of the function.
     */
-    template <typename T, typename M>
-    osStatus start(T *obj, M method) {
+    template <typename T>
+    osStatus start(T *obj, void (T::*method)()) {
+        return start(mbed::Callback<void()>(obj, method));
+    }
+
+    template <typename T>
+    osStatus start(T *obj, void (*method)(T*)) {
         return start(mbed::Callback<void()>(obj, method));
     }
 


### PR DESCRIPTION
**note: no API changes**

Before this commit, the following pattern was suggested as a shortcut
for writing callback-based functions overloaded based on arguments:

``` cpp
template <typename T, typename M>
void attach(T *obj, M method) {
    attach(Callback<void()>(obj, method);
}
```

Unfortunately, C++ did not fair well with this level of type-inference.

The initial problems were with variable-arity function. The M type would happily consume arguments during overload-resolution, only to fail during template-expansion. Removed from problematic functions, this bug was unfortunately easy to reintroduce (for example in the RtosTimer) since it is undectable without forcing the template to expand.

The latest problem is occuring during type-deduction of overloaded function pointers. The extra level of indirection with the templated-method parameter caused type-deduction to stop early, erroring with an ambiguity error. Even more unfortunate, this error is inconsistent, since some functions were unable to adopt the template-method pattern for the variable-arity issue mentioned earlier.

For example:

``` cpp
class Thing {
    void doit(int timeout);
    void doit();
};

Thing t;
serial.attach(&t, &Thing::doit); // perfectly fine
timer.attach(&t, &Thing::doit);  // ambiguity compile error
```

After running into these issues with this design pattern, the best path forward seems to be to simply remove the templated-method overloads. These have been replaced by the two explicit overloads for the existing callback arguments.

Note: Unless @pan- has a workaround up his sleeve, adding cv qualifiers to the callback overloads (see https://github.com/ARMmbed/mbed-os/pull/2190) may result in a large number of overloads to perfectly match all of the callback's constructors. It's a discussion for when we reach that point, but it does raise the question of it we should continue this overloading style.

cc @0xc0170, @pan-