### PR TITLE
Consistent default serial baud

### DIFF
--- a/hal/common/SerialBase.cpp
+++ b/hal/common/SerialBase.cpp
@@ -26,10 +26,11 @@ SerialBase::SerialBase(PinName tx, PinName rx) :
                                                  _thunk_irq(this), _tx_usage(DMA_USAGE_NEVER),
                                                  _rx_usage(DMA_USAGE_NEVER),
 #endif
-                                                _serial(), _baud(9600) {
+                                                _serial(), _baud(MBED_CONF_CORE_STDIO_BAUD_RATE) {
     // No lock needed in the constructor
 
     serial_init(&_serial, tx, rx);
+    serial_baud(&_serial, _baud);
     serial_irq_handler(&_serial, SerialBase::_irq_handler, (uint32_t)this);
 }
 


### PR DESCRIPTION
This commit changes the default baud of a new `Serial` or `SerialBase`
instance to the one defined by the core configuration
(`MBED_CONF_CORE_STDIO_BAUD_RATE`). This should ensure a consistent
behaviour of newly created `Serial` objects across all platforms.

Related to #2396.