### PR TITLE
Adding retries to the NIST test.

### DIFF
--- a/features/net/FEATURE_IPV4/TESTS/mbedmicro-net/nist_internet_time_service/main.cpp
+++ b/features/net/FEATURE_IPV4/TESTS/mbedmicro-net/nist_internet_time_service/main.cpp
@@ -8,55 +8,64 @@
 #include "greentea-client/test_env.h"
 
 namespace {
-    //const char *HTTP_SERVER_NAME = "utcnist.colorado.edu";
     const char *HTTP_SERVER_NAME = "pool.ntp.org";
     const int HTTP_SERVER_PORT = 123;
 }
 
 
 int main() {
-    GREENTEA_SETUP(20, "default_auto");
+    GREENTEA_SETUP(60, "default_auto");
 
     bool result = false;
     const time_t TIME1970 = 2208988800L;
-    int ntp_values[12] = {0};
+    int ntp_send_values[12] = {0};
+    int ntp_recv_values[12] = {0};
 
     EthernetInterface eth;
-    //eth.init(); //Use DHCP
     eth.connect();
     printf("UDP client IP Address is %s\n", eth.get_ip_address());
 
     UDPSocket sock;
     sock.open(&eth);
+    sock.set_timeout(15000);
 
     SocketAddress nist(&eth, HTTP_SERVER_NAME, HTTP_SERVER_PORT);
 
     printf("UDP: NIST server %s address: %s on port %d\r\n", HTTP_SERVER_NAME, nist.get_ip_address(), nist.get_port());
 
-    memset(ntp_values, 0x00, sizeof(ntp_values));
-    ntp_values[0] = '\x1b';
+    memset(ntp_send_values, 0x00, sizeof(ntp_send_values));
+    ntp_send_values[0] = '\x1b';
 
-    int ret_send = sock.sendto(nist, (void*)ntp_values, sizeof(ntp_values));
-    printf("UDP: Sent %d Bytes to NTP server \n", ret_send);
+    while(1) {
+        memset(ntp_recv_values, 0x00, sizeof(ntp_recv_values));
 
-    const int n = sock.recvfrom(&nist, (void*)ntp_values, sizeof(ntp_values));
+        int ret_send = sock.sendto(nist, (void*)ntp_send_values, sizeof(ntp_send_values));
+        printf("UDP: Sent %d Bytes to NTP server \n", ret_send);
 
-    printf("UDP: Recved from NTP server %d Bytes \n", n);
+        const int n = sock.recvfrom(&nist, (void*)ntp_recv_values, sizeof(ntp_recv_values));
 
-    if (n > 0 ) {
-        result = true;
+        printf("UDP: Recved from NTP server %d Bytes \n", n);
 
-        printf("UDP: Values returned by NTP server: \n");
-        for (size_t i=0; i < sizeof(ntp_values) / sizeof(ntp_values[0]); ++i) {
-            printf("\t[%02d] 0x%X", i, ntohl(ntp_values[i]));
+        if (n > 0) {
+            result = true;
 
-            if (i == 10) {
-                time_t timestamp = ntohl(ntp_values[i]) - TIME1970;
-                printf("\tNTP timestamp is %s", ctime(&timestamp));
-            } else {
-                printf("\n");
+            printf("UDP: Values returned by NTP server: \n");
+            for (size_t i=0; i < sizeof(ntp_recv_values) / sizeof(ntp_recv_values[0]); ++i) {
+                printf("\t[%02d] 0x%X", i, ntohl(ntp_recv_values[i]));
+
+                if (i == 10) {
+                    time_t timestamp = ntohl(ntp_recv_values[i]) - TIME1970;
+                    printf("\tNTP timestamp is %s", ctime(&timestamp));
+                } else {
+                    printf("\n");
+                }
             }
+
+            break;
         }
+
+        printf("Failed to receive data, retrying in 5 seconds...\n");
+        wait(5);
     }
 
     sock.close();


### PR DESCRIPTION
A UDP request to the NIST servers can fail to return data due to UDP
packet loss. Since packets are not guaranteed with UDP, this is a valid
failure and should not be treated as a test failure. The test should retry
the request in this case. This commit adds those retries.

This test sometimes fails in CI even when the actual PR can't cause the test to fail (#2393 is an example of this). This should help cut down on false failures.