### PR TITLE
Fix possible overflow of NRF51 os tick.

### DIFF
--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/us_ticker.c
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/us_ticker.c
@@ -474,7 +474,7 @@ static void register_next_tick() {
     uint32_t current_counter = nrf_rtc_counter_get(COMMON_RTC_INSTANCE);
 
     // If an overflow occur, set the next tick in COUNTER + delta clock cycles
-    if (is_in_wrapped_range(previous_tick_cc_value, new_compare_value, current_counter) == false) {
+    if (is_in_wrapped_range(previous_tick_cc_value, new_compare_value, current_counter + 1) == false) {
         new_compare_value = current_counter + delta;
     }
     nrf_rtc_cc_set(COMMON_RTC_INSTANCE, OS_TICK_CC_CHANNEL, new_compare_value);


### PR DESCRIPTION
The RTC1 counter can increase while the new value for the CC register
used by the os tick is computed. As a result, when interrupts are enabled
again RTC1 counter and CC register value are equal. If these two values are
equal then the interrupt for the CC channel used by the OS tick will be
generated the next time the RTC counter reach that value.
In other words, the next OS tick will occur 131 seconds latter.

This issue possibly concern all NRF51 targets with 32K of RAM but is
only visible on NRF51_DK target when their is heavy BLE load.