### PR TITLE
build_mbed_libs is now aware of the configuration

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -28,7 +28,7 @@ from time import time
 import fnmatch
 
 from tools.utils import mkdir, run_cmd, run_cmd_ext, NotSupportedException, ToolException, InvalidReleaseTargetException
-from tools.paths import MBED_TARGETS_PATH, MBED_LIBRARIES, MBED_API, MBED_HAL, MBED_COMMON
+from tools.paths import MBED_TARGETS_PATH, MBED_LIBRARIES, MBED_API, MBED_HAL, MBED_COMMON, MBED_CONFIG_FILE
 from tools.targets import TARGET_NAMES, TARGET_MAP
 from tools.libraries import Library
 from tools.toolchains import TOOLCHAIN_CLASSES
@@ -673,6 +673,12 @@ def build_mbed_libs(target, toolchain_name, options=None, verbose=False, clean=F
         toolchain.VERBOSE = verbose
         toolchain.jobs = jobs
         toolchain.build_all = clean
+
+        # Take into account the library configuration (MBED_CONFIG_FILE)
+        config = Config(target)
+        toolchain.config = config
+        config.add_config_files([MBED_CONFIG_FILE])
+        toolchain.set_config_data(toolchain.config.get_config_data())
 
         # Source and Build Paths
         BUILD_TARGET = join(MBED_LIBRARIES, "TARGET_" + target.name)

--- a/tools/paths.py
+++ b/tools/paths.py
@@ -40,6 +40,8 @@ MBED_TARGETS_PATH = join(MBED_BASE, "targets")
 
 MBED_LIBRARIES = join(BUILD_DIR, "mbed")
 
+MBED_CONFIG_FILE = join(ROOT, "mbed_lib.json")
+
 # Tests
 TEST_DIR = join(LIB_DIR, "tests")
 HOST_TESTS = join(ROOT, "tools", "host_tests")


### PR DESCRIPTION
Previously, build_mbed_libs didn't take into account the configuration.
This is a problem when doing a binary release, since mbed_lib.json
contains configuration data relevant to the binary release.