### PR TITLE
Readable error when toolchain paths not set. Allow IAR and ARM toolchains to be set in user's PATH.

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -188,6 +188,23 @@ LEGACY_TOOLCHAIN_NAMES = {
 }
 
 
+def check_toolchain_path(function):
+    """Check if the path to toolchain is valid. Exit if not.
+    Use this function as a decorator.  Causes a system exit if the path does
+    not exist. Execute the function as normal if the path does exist.
+
+    Positional arguments:
+    function -- the function to decorate
+    """
+    def perform_check(self, *args, **kwargs):
+        if not exists(self.toolchain_path):
+            print('[ERROR] Toolchain path does not exist for %s.\n'
+                  'Current value: %s' % (self.name, self.toolchain_path))
+            sys.exit()
+        return function(self, *args, **kwargs)
+    return perform_check
+
+
 class mbedToolchain:
     # Verbose logging
     VERBOSE = True
@@ -702,6 +719,7 @@ class mbedToolchain:
 
     # THIS METHOD IS BEING CALLED BY THE MBED ONLINE BUILD SYSTEM
     # ANY CHANGE OF PARAMETERS OR RETURN VALUES WILL BREAK COMPATIBILITY
+    @check_toolchain_path
     def compile_sources(self, resources, build_path, inc_dirs=None):
         # Web IDE progress bar for project build
         files_to_compile = resources.s_sources + resources.c_sources + resources.cpp_sources
@@ -900,6 +918,7 @@ class mbedToolchain:
             else:
                 raise ToolException(_stderr)
 
+    @check_toolchain_path
     def build_library(self, objects, dir, name):
         needed_update = False
         lib = self.STD_LIB_NAME % name
@@ -911,6 +930,7 @@ class mbedToolchain:
 
         return needed_update
 
+    @check_toolchain_path
     def link_program(self, r, tmp_path, name):
         needed_update = False
         ext = 'bin'

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -198,9 +198,9 @@ def check_toolchain_path(function):
     """
     def perform_check(self, *args, **kwargs):
         if not exists(self.toolchain_path):
-            print('[ERROR] Toolchain path does not exist for %s.\n'
+            print('[ERROR] Toolchain path for %s does not exist.\n'
                   'Current value: %s' % (self.name, self.toolchain_path))
-            sys.exit()
+            sys.exit(-1)
         return function(self, *args, **kwargs)
     return perform_check
 

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -198,9 +198,9 @@ def check_toolchain_path(function):
     """
     def perform_check(self, *args, **kwargs):
         if not exists(self.toolchain_path):
-            print('[ERROR] Toolchain path for %s does not exist.\n'
-                  'Current value: %s' % (self.name, self.toolchain_path))
-            sys.exit(-1)
+            error_string = 'Could not find executable for %s.\n Currently ' \
+                           'set search path: %s'% (self.name, self.toolchain_path)
+            raise Exception(error_string)
         return function(self, *args, **kwargs)
     return perform_check
 

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -81,6 +81,8 @@ class ARM(mbedToolchain):
         self.ar = join(ARM_BIN, "armar")
         self.elf2bin = join(ARM_BIN, "fromelf")
 
+        self.toolchain_path = TOOLCHAIN_PATHS['ARM']
+
     def parse_dependencies(self, dep_path):
         dependencies = []
         for line in open(dep_path).readlines():

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -15,12 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import re
-from os.path import join, dirname, splitext, basename, exists
+from os.path import join, dirname, splitext, basename
+from distutils.spawn import find_executable
 
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool
 from tools.utils import mkdir
-import copy
 
 class ARM(mbedToolchain):
     LINKER_EXT = '.sct'
@@ -55,6 +55,11 @@ class ARM(mbedToolchain):
             cpu = "Cortex-M7.fp.sp"
         else:
             cpu = target.core
+
+        if not TOOLCHAIN_PATHS['ARM']:
+            exe = find_executable('armcc')
+            if exe:
+                TOOLCHAIN_PATHS['ARM'] = dirname(dirname(exe))
 
         ARM_BIN = join(TOOLCHAIN_PATHS['ARM'], "bin")
         ARM_INC = join(TOOLCHAIN_PATHS['ARM'], "include")

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -16,6 +16,7 @@ limitations under the License.
 """
 import re
 from os.path import join, basename, splitext, dirname, exists
+from distutils.spawn import find_executable
 
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool
@@ -110,7 +111,10 @@ class GCC(mbedToolchain):
         self.ar = join(tool_path, "arm-none-eabi-ar")
         self.elf2bin = join(tool_path, "arm-none-eabi-objcopy")
 
-        self.toolchain_path = tool_path
+        if tool_path:
+            self.toolchain_path = main_cc
+        else:
+            self.toolchain_path = find_executable("arm-none-eabi-gcc") or ''
 
     def parse_dependencies(self, dep_path):
         dependencies = []

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -110,6 +110,8 @@ class GCC(mbedToolchain):
         self.ar = join(tool_path, "arm-none-eabi-ar")
         self.elf2bin = join(tool_path, "arm-none-eabi-objcopy")
 
+        self.toolchain_path = tool_path
+
     def parse_dependencies(self, dep_path):
         dependencies = []
         buff = open(dep_path).readlines()

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -17,6 +17,7 @@ limitations under the License.
 import re
 from os import remove
 from os.path import join, exists, dirname, splitext, exists
+from distutils.spawn import find_executable
 
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool
@@ -50,6 +51,12 @@ class IAR(mbedToolchain):
             cpuchoice = "Cortex-M7"
         else:
             cpuchoice = target.core
+
+        if not TOOLCHAIN_PATHS['IAR']:
+            exe =  find_executable('iccarm')
+            if exe:
+                TOOLCHAIN_PATHS['IAR'] = dirname(dirname(exe))
+
         # flags_cmd are used only by our scripts, the project files have them already defined,
         # using this flags results in the errors (duplication)
         # asm accepts --cpu Core or --fpu FPU, not like c/c++ --cpu=Core

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -101,6 +101,8 @@ class IAR(mbedToolchain):
         self.ar = join(IAR_BIN, "iarchive")
         self.elf2bin = join(IAR_BIN, "ielftool")
 
+        self.toolchain_path = TOOLCHAIN_PATHS['IAR']
+
     def parse_dependencies(self, dep_path):
         return [(self.CHROOT if self.CHROOT else '')+path.strip() for path in open(dep_path).readlines()
                 if (path and not path.isspace())]


### PR DESCRIPTION
Fixes #2360.

New error:
[ERROR] Could not find executable for IAR.
Currently set search path: /default/path/that/doesnt/exist
(System exit before any build system calls)

@theotherjimmy  @0xc0170 @bridadan 