### PR TITLE
Added a baud argument for (Raw)Serial objects

### DIFF
--- a/drivers/RawSerial.cpp
+++ b/drivers/RawSerial.cpp
@@ -23,7 +23,7 @@
 
 namespace mbed {
 
-RawSerial::RawSerial(PinName tx, PinName rx) : SerialBase(tx, rx) {
+RawSerial::RawSerial(PinName tx, PinName rx, int baud) : SerialBase(tx, rx, baud) {
     // No lock needed in the constructor
 }
 

--- a/drivers/RawSerial.h
+++ b/drivers/RawSerial.h
@@ -50,15 +50,16 @@ namespace mbed {
 class RawSerial: public SerialBase {
 
 public:
-    /** Create a RawSerial port, connected to the specified transmit and receive pins
+    /** Create a RawSerial port, connected to the specified transmit and receive pins, with the specified baud.
      *
      *  @param tx Transmit pin
      *  @param rx Receive pin
+     *  @param baud The baud rate of the serial port (optional, defaults to MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE)
      *
      *  @note
      *    Either tx or rx may be specified as NC if unused
      */
-    RawSerial(PinName tx, PinName rx);
+    RawSerial(PinName tx, PinName rx, int baud = MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE);
 
     /** Write a char to the serial port
      *

--- a/drivers/Serial.cpp
+++ b/drivers/Serial.cpp
@@ -20,7 +20,10 @@
 
 namespace mbed {
 
-Serial::Serial(PinName tx, PinName rx, const char *name) : SerialBase(tx, rx), Stream(name) {
+Serial::Serial(PinName tx, PinName rx, const char *name, int baud) : SerialBase(tx, rx, baud), Stream(name) {
+}
+
+Serial::Serial(PinName tx, PinName rx, int baud): SerialBase(tx, rx, baud), Stream(NULL) {
 }
 
 int Serial::_getc() {

--- a/drivers/Serial.h
+++ b/drivers/Serial.h
@@ -59,11 +59,25 @@ public:
      *
      *  @param tx Transmit pin
      *  @param rx Receive pin
+     *  @param name The name of the stream associated with this serial port (optional)
+     *  @param baud The baud rate of the serial port (optional, defaults to MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE)
      *
      *  @note
      *    Either tx or rx may be specified as NC if unused
      */
-    Serial(PinName tx, PinName rx, const char *name=NULL);
+    Serial(PinName tx, PinName rx, const char *name=NULL, int baud = MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE);
+
+
+    /** Create a Serial port, connected to the specified transmit and receive pins, with the specified baud
+     *
+     *  @param tx Transmit pin
+     *  @param rx Receive pin
+     *  @param baud The baud rate of the serial port
+     *
+     *  @note
+     *    Either tx or rx may be specified as NC if unused
+     */
+    Serial(PinName tx, PinName rx, int baud);
 
 protected:
     virtual int _getc();

--- a/drivers/SerialBase.cpp
+++ b/drivers/SerialBase.cpp
@@ -23,12 +23,12 @@ namespace mbed {
 
 static void donothing() {};
 
-SerialBase::SerialBase(PinName tx, PinName rx) :
+SerialBase::SerialBase(PinName tx, PinName rx, int baud) :
 #if DEVICE_SERIAL_ASYNCH
                                                  _thunk_irq(this), _tx_usage(DMA_USAGE_NEVER),
                                                  _rx_usage(DMA_USAGE_NEVER),
 #endif
-                                                _serial(), _baud(9600) {
+                                                _serial(), _baud(baud) {
     // No lock needed in the constructor
 
     for (size_t i = 0; i < sizeof _irq / sizeof _irq[0]; i++) {
@@ -36,6 +36,7 @@ SerialBase::SerialBase(PinName tx, PinName rx) :
     }
 
     serial_init(&_serial, tx, rx);
+    serial_baud(&_serial, _baud);
     serial_irq_handler(&_serial, SerialBase::_irq_handler, (uint32_t)this);
 }
 

--- a/drivers/SerialBase.h
+++ b/drivers/SerialBase.h
@@ -230,7 +230,7 @@ protected:
 #endif
 
 protected:
-    SerialBase(PinName tx, PinName rx);
+    SerialBase(PinName tx, PinName rx, int baud);
     virtual ~SerialBase() {
     }
 

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -14,6 +14,11 @@
         "stdio-flush-at-exit": {
             "help": "Enable or disable the flush of standard I/O's at exit.",
             "value": true
+        },
+
+        "default-serial-baud-rate": {
+            "help": "Default baud rate for a Serial or RawSerial instance (if not specified in the constructor)",
+            "value": 9600
         }
     },
     "target_overrides": {


### PR DESCRIPTION
This commit adds a `baud` argument for Serial and RawSerial objects:

- there is a new `Serial` constructor with a mandatory baud rate
  argument. The old constructor also got a `baud` argument with a
  default value (to keep backward compatibility).
- the `RawSerial` constructor also got a `baud` argument with a default
  value.

There's also a new configuration parameter (`default-serial-baud-rate`)
that can be used to specify the default value of the above `baud`
arguments.