### PR TITLE
[nsapi] Add support for NSAPI_REUSEADDR to the lwip interface

### DIFF
--- a/features/net/FEATURE_IPV4/lwip-interface/lwip_stack.c
+++ b/features/net/FEATURE_IPV4/lwip-interface/lwip_stack.c
@@ -28,6 +28,7 @@
 #include "lwip/dhcp.h"
 #include "lwip/tcpip.h"
 #include "lwip/tcp.h"
+#include "lwip/ip.h"
 
 
 /* Static arena of sockets */
@@ -413,6 +414,18 @@ static int lwip_setsockopt(nsapi_stack_t *stack, nsapi_socket_t handle, int leve
             }
 
             s->conn->pcb.tcp->keep_intvl = *(int*)optval;
+            return 0;
+
+        case NSAPI_REUSEADDR:
+            if (optlen != sizeof(int)) {
+                return NSAPI_ERROR_UNSUPPORTED;
+            }
+
+            if (*(int *)optval) {
+                s->conn->pcb.tcp->so_options |= SOF_REUSEADDR;
+            } else {
+                s->conn->pcb.tcp->so_options &= ~SOF_REUSEADDR;
+            }
             return 0;
 
         default:

--- a/features/net/FEATURE_IPV4/lwip-interface/lwipopts.h
+++ b/features/net/FEATURE_IPV4/lwip-interface/lwipopts.h
@@ -67,6 +67,8 @@
 #define LWIP_DHCP                   1
 #define LWIP_DNS                    1
 
+#define SO_REUSE                    1
+
 // Support Multicast
 #include "stdlib.h"
 #define LWIP_IGMP                   1


### PR DESCRIPTION
From the [posix documentation](http://pubs.opengroup.org/onlinepubs/009695399/functions/setsockopt.html):
> SO_REUSEADDR - Specifies that the rules used in validating addresses supplied to bind() should allow reuse of local addresses, if this is supported by the protocol. This option takes an int value. This is a Boolean option.

This patch adds this behaviour for the non-conflicting NSAPI_REUSEADDR socket option.

Provides the standard solution for https://github.com/ARMmbed/mbed-os/issues/2438 and https://github.com/ARMmbed/mbed-os/issues/2408.