### PR TITLE
added feature IPv4 to target.json and TARGET_NUCLEO_F767ZI to F7 emac…

### DIFF
--- a/features/net/FEATURE_IPV4/lwip-interface/lwip-eth/arch/TARGET_STM/stm32f7_emac.c
+++ b/features/net/FEATURE_IPV4/lwip-interface/lwip-eth/arch/TARGET_STM/stm32f7_emac.c
@@ -1,4 +1,4 @@
-#if defined(TARGET_NUCLEO_F746ZG)
+#if defined(TARGET_NUCLEO_F746ZG) || defined(TARGET_NUCLEO_F767ZI)
 #include "stm32f7xx_hal.h"
 #include "lwip/opt.h"
 

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -860,6 +860,7 @@
         "progen": {"target": "nucleo-f767zi"},
         "detect_code": ["0818"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "features": ["IPV4"],
         "release_versions": ["2", "5"]
     },
     "NUCLEO_L011K4": {


### PR DESCRIPTION
… file.  
Was able to get an ip address via DHCP and communicate with both UPD and TCP sockets with RTOS mbed 5.1 on a NUCLEO-F767ZI. 

