### PR TITLE
allow rtos idle thread to call sleep();

### DIFF
--- a/rtos/rtos/rtos_idle.c
+++ b/rtos/rtos/rtos_idle.c
@@ -24,11 +24,11 @@
 
 static void default_idle_hook(void)
 {
-    /* Sleep: ideally, we should put the chip to sleep.
-     Unfortunately, this usually requires disconnecting the interface chip (debugger).
-     This can be done, but it would break the local file system.
+    /* Sleep: Please note - for the most power savings, disconnect the 
+       interface chip (debugger).
+       This can be done, but it would break the local file system.
     */
-    // sleep();
+     sleep();
 }
 static void (*idle_hook_fptr)(void) = &default_idle_hook;
 

--- a/rtos/rtos/rtos_idle.c
+++ b/rtos/rtos/rtos_idle.c
@@ -20,13 +20,13 @@
  * SOFTWARE.
  */
 
-#include "rtos_idle.h"
+#include "rtos/rtos_idle.h"
 
 static void default_idle_hook(void)
 {
-    /* Sleep: Please note - for the most power savings, disconnect the 
-       interface chip (debugger).
-       This can be done, but it would break the local file system.
+    /* Sleep: Please note - for the most power savings, disconnect the.
+     interface chip (debugger).
+     This can be done, but it would break the local file system.
     */
      sleep();
 }


### PR DESCRIPTION
To enable power efficiency, the rtos thread should call sleep().  To my knowledge, this can be done regardless if the debugger interface is connected (at least it can on the Kinetis MCUs).  If the debugger interface is connected, the device may not achieve as great of power savings, but it still can enter low power mode.  Something is better than nothing.