### PR TITLE
[TY51822r3] Add support for mbed OS 5

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1517,11 +1517,13 @@
         "extra_labels_add": ["NRF51_MICROBIT"],
         "macros_add": ["TARGET_NRF51_MICROBIT", "TARGET_NRF_LFCLK_RC"]
     },
+
     "TY51822R3": {
-        "inherits": ["MCU_NRF51_32K"],
+        "inherits": ["MCU_NRF51_32K_UNIFIED"],
         "macros_add": ["TARGET_NRF_32MHZ_XTAL"],
-        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release_versions": ["2"]
+        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
+        "detect_code": ["1019"],
+        "release_versions": ["2", "5"]
     },
     "TY51822R3_BOOT": {
         "inherits": ["MCU_NRF51_32K_BOOT"],

--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/system_nrf51.c
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/system_nrf51.c
@@ -71,6 +71,27 @@ void SystemCoreClockUpdate(void)
 
 void SystemInit(void)
 {
+#if defined(TARGET_NRF_32MHZ_XTAL)
+    /* For 32MHz HFCLK XTAL such as Taiyo Yuden
+       Physically, tiny footprint XTAL oscillate higher freq. To make BLE modules smaller, some modules
+       are using 32MHz XTAL.
+       This code wriging the value 0xFFFFFF00 to the UICR (User Information Configuration Register)
+       at address 0x10001008, to make nRF51 works with 32MHz system clock. This register will be overwritten
+       by SoftDevice to 0xFFFFFFFF, the default value. Each hex files built with mbed classic online compiler
+       contain SoftDevice, so that, this code run once just after the hex file will be flashed onto nRF51.
+       After changing the value, nRF51 need to reboot. */
+    if (*(uint32_t *)0x10001008 == 0xFFFFFFFF)
+    {
+        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+        while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+        *(uint32_t *)0x10001008 = 0xFFFFFF00;
+        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+        while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+        NVIC_SystemReset();
+        while (true){}
+    }
+#endif
+
     /* If desired, switch off the unused RAM to lower consumption by the use of RAMON register.
        It can also be done in the application main() function. */
 

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TARGET_TY51822R3/PinNames.h
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TARGET_TY51822R3/PinNames.h
@@ -1,0 +1,178 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2015 Nordic Semiconductor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+#define PORT_SHIFT  3
+
+typedef enum {
+    p0  = 0,
+    p1  = 1,
+    p2  = 2,
+    p3  = 3,
+    p4  = 4,
+    p5  = 5,
+    p6  = 6,
+    p7  = 7,
+    p8  = 8,
+    p9  = 9,
+    p10 = 10,
+    p11 = 11,
+    p12 = 12,
+    p13 = 13,
+    p14 = 14,
+    p15 = 15,
+    p16 = 16,
+    p17 = 17,
+    p18 = 18,
+    p19 = 19,
+    p20 = 20,
+    p21 = 21,
+    p22 = 22,
+    p23 = 23,
+    p24 = 24,
+    p25 = 25,
+    p26 = 26,
+    p27 = 27,
+    p28 = 28,
+    p29 = 29,
+    p30 = 30,
+
+    P0_0  = p0,
+    P0_1  = p1,
+    P0_2  = p2,
+    P0_3  = p3,
+    P0_4  = p4,
+    P0_5  = p5,
+    P0_6  = p6,
+    P0_7  = p7,
+
+    P0_8  = p8,
+    P0_9  = p9,
+    P0_10 = p10,
+    P0_11 = p11,
+    P0_12 = p12,
+    P0_13 = p13,
+    P0_14 = p14,
+    P0_15 = p15,
+
+    P0_16 = p16,
+    P0_17 = p17,
+    P0_18 = p18,
+    P0_19 = p19,
+    P0_20 = p20,
+    P0_21 = p21,
+    P0_22 = p22,
+    P0_23 = p23,
+
+    P0_24 = p24,
+    P0_25 = p25,
+    P0_26 = p26,
+    P0_27 = p27,
+    P0_28 = p28,
+    P0_29 = p29,
+    P0_30 = p30,
+
+    LED1    = p21,
+    LED2    = p22,
+    LED3    = p23,
+    LED4    = p24,
+
+    BUTTON1 = p17,
+    BUTTON2 = p18,
+    BUTTON3 = p19,
+    BUTTON4 = p20,
+
+    RX_PIN_NUMBER  = p11,
+    TX_PIN_NUMBER  = p9,
+    CTS_PIN_NUMBER = p10,
+    RTS_PIN_NUMBER = p8,
+
+    // mBed interface Pins
+    USBTX = TX_PIN_NUMBER,
+    USBRX = RX_PIN_NUMBER,
+
+    SPI_PSELMOSI0 = p25,
+    SPI_PSELMISO0 = p28,
+    SPI_PSELSS0   = p24,
+    SPI_PSELSCK0  = p29,
+
+    SPI_PSELMOSI1 = p13,
+    SPI_PSELMISO1 = p14,
+    SPI_PSELSS1   = p12,
+    SPI_PSELSCK1  = p15,
+
+    SPIS_PSELMOSI = p13,
+    SPIS_PSELMISO = p14,
+    SPIS_PSELSS   = p12,
+    SPIS_PSELSCK  = p15,
+
+    I2C_SDA0 = p30,
+    I2C_SCL0 = p7,
+
+    D0  = p12,
+    D1  = p13,
+    D2  = p14,
+    D3  = p15,
+    D4  = p16,
+    D5  = p17,
+    D6  = p18,
+    D7  = p19,
+
+    D8  = p20,
+    D9  = p23,
+    D10 = p24,
+    D11 = p25,
+    D12 = p28,
+    D13 = p29,
+
+    D14 = p30,
+    D15 = p7,
+
+    A0  = p1,
+    A1  = p2,
+    A2  = p3,
+    A3  = p4,
+    A4  = p5,
+    A5  = p6,
+
+    // Not connected
+    NC = (int)0xFFFFFFFF
+} PinName;
+
+typedef enum {
+    PullNone = 0,
+    PullDown = 1,
+    PullUp = 3,
+    PullDefault = PullUp
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TARGET_TY51822R3/device.h
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TARGET_TY51822R3/device.h
@@ -1,0 +1,38 @@
+// The 'features' section in 'target.json' is now used to create the device's hardware preprocessor switches.
+// Check the 'features' section of the target description in 'targets.json' for more details.
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include "objects.h"
+
+#endif


### PR DESCRIPTION
- Changed inherit to "MCU_NRF51_32K_UNIFIED".
- Added 32MHz XTAL support to "system_nrf.c".
- Added TY51822r3 support to "MCU_NRF51_32K_UNIFIED".