### PR TITLE
rtos support for TARGET_BLUEPILL_F103C8

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -481,7 +481,7 @@ extern uint32_t __StackTop[];
 #elif defined(TARGET_STM32F410RB)
 #define INITIAL_SP            (0x20008000UL)
 
-#elif defined(TARGET_STM32F103RB) || defined(TARGET_STM32L073RZ)
+#elif defined(TARGET_STM32F103RB) || defined(TARGET_STM32F103C8) || defined(TARGET_STM32L073RZ)
 #define INITIAL_SP            (0x20005000UL)
 
 #elif defined(TARGET_STM32F302R8)

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
@@ -57,7 +57,7 @@
 #    define OS_TASKCNT         14
 #  elif defined(TARGET_LPC11U24) || defined(TARGET_STM32F303RE) || defined(TARGET_STM32F303K8) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPCCAPPUCCINO) || defined(TARGET_LPC1114) \
    || defined(TARGET_LPC812)   || defined(TARGET_KL25Z)         || defined(TARGET_KL26Z)       || defined(TARGET_KL27Z)         || defined(TARGET_KL05Z)        || defined(TARGET_STM32F100RB)  || defined(TARGET_STM32F051R8) \
-   || defined(TARGET_STM32F103RB) || defined(TARGET_LPC824) || defined(TARGET_STM32F302R8) || defined(TARGET_STM32F334R8) || defined(TARGET_STM32F334C8) \
+   || defined(TARGET_STM32F103RB) || defined(TARGET_STM32F103C8) || defined(TARGET_LPC824) || defined(TARGET_STM32F302R8) || defined(TARGET_STM32F334R8) || defined(TARGET_STM32F334C8) \
    || defined(TARGET_STM32L031K6) || defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8) || defined(TARGET_STM32L073RZ) || defined(TARGET_STM32F072RB) || defined(TARGET_STM32F091RC) || defined(TARGET_NZ32_SC151) \
    || defined(TARGET_SSCI824)  || defined(TARGET_STM32F030R8) || defined(TARGET_STM32F070RB) \
    || defined(TARGET_EFM32HG_STK3400) || defined(TARGET_MCU_NRF51822) || defined(TARGET_BEETLE) || defined(TARGET_MCU_NRF52832)
@@ -97,7 +97,7 @@
    || defined(TARGET_SSCI824) || defined(TARGET_STM32F030R8) || defined(TARGET_STM32F070RB) \
    || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32PG_STK3401)
 #      define OS_MAINSTKSIZE    128
-#  elif defined(TARGET_STM32F334R8) || defined(TARGET_STM32F303RE) ||  defined(TARGET_STM32F303K8) ||  defined(TARGET_STM32F334C8) \
+#  elif defined(TARGET_STM32F334R8) || defined(TARGET_STM32F303RE) ||  defined(TARGET_STM32F303K8) ||  defined(TARGET_STM32F334C8) || defined(TARGET_STM32F103C8) \
    || defined(TARGET_STM32L031K6) || defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8) || defined(TARGET_STM32L073RZ) \
    || defined(TARGET_EFM32HG_STK3400) || defined(TARGET_BEETLE)
 #      define OS_MAINSTKSIZE    112
@@ -212,7 +212,7 @@
 #  elif defined(TARGET_STM32F410RB)
 #     define OS_CLOCK      100000000
 
-#elif defined(TARGET_STM32F103RB)
+#elif defined(TARGET_STM32F103RB) || defined(TARGET_STM32F103C8)
 #    define OS_CLOCK       72000000
 
 #elif defined(TARGET_STM32F429ZI)


### PR DESCRIPTION
Add rtos support for TARGET_BLUEPILL_F103C8 (Actually for STM32F103C8 MCU)