### PR TITLE
Fix serial stdio - add new get_stdio_serial()

### DIFF
--- a/hal/api/Serial.h
+++ b/hal/api/Serial.h
@@ -74,6 +74,13 @@ protected:
     PlatformMutex _mutex;
 };
 
+/** Get the stdio Serial object, which is lazy instantiated. There's only 
+ *  one stdio object that should be used within an application.
+ *
+ *  @returns stdio object 
+ */
+Serial& get_stdio_serial();
+
 } // namespace mbed
 
 #endif

--- a/hal/common/mbed_board.c
+++ b/hal/common/mbed_board.c
@@ -21,11 +21,6 @@
 #include "critical.h"
 #include "serial_api.h"
 
-#if DEVICE_SERIAL
-extern int stdio_uart_inited;
-extern serial_t stdio_uart;
-#endif
-
 WEAK void mbed_die(void) {
 #if !defined (NRF51_H) && !defined(TARGET_EFM32)
     core_util_critical_section_enter();
@@ -79,11 +74,8 @@ void mbed_error_vfprintf(const char * format, va_list arg) {
     char buffer[128];
     int size = vsprintf(buffer, format, arg);
     if (size > 0) {
-        if (!stdio_uart_inited) {
-        serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
-        }
         for (int i = 0; i < size; i++) {
-            serial_putc(&stdio_uart, buffer[i]);
+            putc(buffer[i], stdout);
         }
     }
     core_util_critical_section_exit();

--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -24,6 +24,7 @@
 #include "SingletonPtr.h"
 #include "PlatformMutex.h"
 #include "mbed_error.h"
+#include "Serial.h"
 #include <stdlib.h>
 #if DEVICE_STDIO_MESSAGES
 #include <stdio.h>
@@ -94,23 +95,29 @@ FileHandle::~FileHandle() {
 }
 
 #if DEVICE_SERIAL
-extern int stdio_uart_inited;
-extern serial_t stdio_uart;
 #if MBED_CONF_CORE_STDIO_CONVERT_NEWLINES
 static char stdio_in_prev;
 static char stdio_out_prev;
 #endif
-#endif
 
-static void init_serial() {
-#if DEVICE_SERIAL
-    if (stdio_uart_inited) return;
-    serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
+namespace mbed {
+
+Serial& get_stdio_serial()
+{
+    static bool stdio_uart_inited = false;
+    static Serial stdio_serial(STDIO_UART_TX, STDIO_UART_RX);
+    if (!stdio_uart_inited) {
 #if MBED_CONF_CORE_STDIO_BAUD_RATE
-    serial_baud(&stdio_uart, MBED_CONF_CORE_STDIO_BAUD_RATE);
+        stdio_serial.baud(MBED_CONF_CORE_STDIO_BAUD_RATE);
 #endif
-#endif
+        stdio_uart_inited = true;
+    }
+    return stdio_serial;
 }
+
+} // namespace mbed
+
+#endif
 
 static inline int openmode_to_posix(int openmode) {
     int posix = openmode;
@@ -158,13 +165,13 @@ extern "C" FILEHANDLE PREFIX(_open)(const char* name, int openmode) {
     /* Use the posix convention that stdin,out,err are filehandles 0,1,2.
      */
     if (std::strcmp(name, __stdin_name) == 0) {
-        init_serial();
+        get_stdio_serial();
         return 0;
     } else if (std::strcmp(name, __stdout_name) == 0) {
-        init_serial();
+        get_stdio_serial();
         return 1;
     } else if (std::strcmp(name, __stderr_name) == 0) {
-        init_serial();
+        get_stdio_serial();
         return 2;
     }
     #endif
@@ -240,18 +247,17 @@ extern "C" int PREFIX(_write)(FILEHANDLE fh, const unsigned char *buffer, unsign
     int n; // n is the number of bytes written
     if (fh < 3) {
 #if DEVICE_SERIAL
-        if (!stdio_uart_inited) init_serial();
 #if MBED_CONF_CORE_STDIO_CONVERT_NEWLINES
         for (unsigned int i = 0; i < length; i++) {
             if (buffer[i] == '\n' && stdio_out_prev != '\r') {
-                 serial_putc(&stdio_uart, '\r');
+                 get_stdio_serial().putc('\r');
             }
-            serial_putc(&stdio_uart, buffer[i]);
+            get_stdio_serial().putc(buffer[i]);
             stdio_out_prev = buffer[i];
         }
 #else
         for (unsigned int i = 0; i < length; i++) {
-            serial_putc(&stdio_uart, buffer[i]);
+            get_stdio_serial().putc(buffer[i]);
         }
 #endif
 #endif
@@ -278,10 +284,9 @@ extern "C" int PREFIX(_read)(FILEHANDLE fh, unsigned char *buffer, unsigned int 
     if (fh < 3) {
         // only read a character at a time from stdin
 #if DEVICE_SERIAL
-        if (!stdio_uart_inited) init_serial();
 #if MBED_CONF_CORE_STDIO_CONVERT_NEWLINES
         while (true) {
-            char c = serial_getc(&stdio_uart);
+            char c = get_stdio_serial().getc();
             if ((c == '\r' && stdio_in_prev != '\n') ||
                 (c == '\n' && stdio_in_prev != '\r')) {
                 stdio_in_prev = c;
@@ -299,7 +304,7 @@ extern "C" int PREFIX(_read)(FILEHANDLE fh, unsigned char *buffer, unsigned int 
             }
         }
 #else
-        *buffer = serial_getc(&stdio_uart);
+        *buffer = get_stdio_serial().getc();
 #endif
 #endif
         n = 1;

--- a/hal/targets/hal/TARGET_ARM_SSG/TARGET_BEETLE/serial_api.c
+++ b/hal/targets/hal/TARGET_ARM_SSG/TARGET_BEETLE/serial_api.c
@@ -46,9 +46,6 @@ static const PinMap PinMap_UART_RX[] = {
 
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 struct serial_global_data_s {
     uint32_t serial_irq_id;
     gpio_t sw_rts, sw_cts;
@@ -113,13 +110,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     uart_data[obj->index].sw_rts.pin = NC;
     uart_data[obj->index].sw_cts.pin = NC;
     serial_set_flow_control(obj, FlowControlNone, NC, NC);
-
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj) {

--- a/hal/targets/hal/TARGET_ARM_SSG/TARGET_IOTSS/serial_api.c
+++ b/hal/targets/hal/TARGET_ARM_SSG/TARGET_IOTSS/serial_api.c
@@ -49,9 +49,6 @@ static const PinMap PinMap_UART_RX[] = {
 
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 struct serial_global_data_s {
     uint32_t serial_irq_id;
     gpio_t sw_rts, sw_cts;
@@ -156,13 +153,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     uart_data[obj->index].sw_rts.pin = NC;
     uart_data[obj->index].sw_cts.pin = NC;
     serial_set_flow_control(obj, FlowControlNone, NC, NC);
-    
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-    
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj) {

--- a/hal/targets/hal/TARGET_ARM_SSG/TARGET_MPS2/serial_api.c
+++ b/hal/targets/hal/TARGET_ARM_SSG/TARGET_MPS2/serial_api.c
@@ -49,9 +49,6 @@ static const PinMap PinMap_UART_RX[] = {
 
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 struct serial_global_data_s {
     uint32_t serial_irq_id;
     gpio_t sw_rts, sw_cts;
@@ -158,13 +155,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     uart_data[obj->index].sw_rts.pin = NC;
     uart_data[obj->index].sw_cts.pin = NC;
     serial_set_flow_control(obj, FlowControlNone, NC, NC);
-    
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-    
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj) {

--- a/hal/targets/hal/TARGET_Atmel/TARGET_SAM_CortexM0P/serial_api.c
+++ b/hal/targets/hal/TARGET_Atmel/TARGET_SAM_CortexM0P/serial_api.c
@@ -52,9 +52,6 @@ void uart5_irq(void);
 static uint32_t serial_irq_ids[USART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 extern uint8_t g_sys_init;
 
 static inline void usart_syncing(serial_t *obj)
@@ -329,10 +326,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         }
     }
 
-    if (uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
     /* Wait until synchronization is complete */
     usart_syncing(obj);
 

--- a/hal/targets/hal/TARGET_Atmel/TARGET_SAM_CortexM4/serial_api.c
+++ b/hal/targets/hal/TARGET_Atmel/TARGET_SAM_CortexM4/serial_api.c
@@ -48,10 +48,6 @@ static void uart5_irq(void);
 static void uart6_irq(void);
 static void uart7_irq(void);
 
-
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 extern uint8_t g_sys_init;
 
 static int get_usart_clock_id(UARTName peripheral)
@@ -191,11 +187,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     }
     if(rx != NC) {
     usart_enable_rx((Usart*)uart);
-    }
-
-    if(uart == STDIO_UART) {
-    stdio_uart_inited = 1;
-    memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/serial_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/serial_api.c
@@ -53,9 +53,6 @@
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // determine the UART to use
     UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
@@ -104,11 +101,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     }
 
     obj->uart->C2 |= (UARTLP_C2_RE_MASK | UARTLP_C2_TE_MASK);
-
-    if (uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj) {

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/serial_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/serial_api.c
@@ -54,9 +54,6 @@
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // determine the UART to use
     UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
@@ -114,11 +111,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     if (rx != NC) {
         obj->uart->C2 |= UARTLP_C2_RE_MASK;
         pin_mode(rx, PullUp);
-    }
-
-    if (uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/serial_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/serial_api.c
@@ -54,9 +54,6 @@
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // determine the UART to use
     UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
@@ -114,11 +111,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     if (rx != NC) {
         obj->uart->C2 |= UARTLP_C2_RE_MASK;
         pin_mode(rx, PullUp);
-    }
-
-    if (uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL43Z/serial_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL43Z/serial_api.c
@@ -35,9 +35,6 @@
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 static inline uint32_t serial_get_src_clock(serial_t *obj) {
   uint32_t mux, srcclk;
 
@@ -108,11 +105,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     if (rx != NC) pin_mode(rx, PullUp);
 
     obj->uart->CTRL |= (LPUART_CTRL_RE_MASK | LPUART_CTRL_TE_MASK);
-
-    if (uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj) {

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/serial_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/serial_api.c
@@ -54,9 +54,6 @@
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     // determine the UART to use
     UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
@@ -114,11 +111,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     if (rx != NC) {
         obj->uart->C2 |= UARTLP_C2_RE_MASK;
         pin_mode(rx, PullUp);
-    }
-
-    if (uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K22F/serial_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K22F/serial_api.c
@@ -37,10 +37,6 @@ static UART_Type *const uart_addrs[] = UART_BASE_PTRS;
 /* Array of UART bus clock frequencies */
 static clock_name_t const uart_clocks[] = UART_CLOCK_FREQS;
 
-
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     uint32_t uart_tx = pinmap_peripheral(tx, PinMap_UART_TX);
     uint32_t uart_rx = pinmap_peripheral(rx, PinMap_UART_RX);
@@ -70,11 +66,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     if (rx != NC) {
         UART_EnableRx(uart_addrs[obj->index], true);
         pin_mode(rx, PullUp);
-    }
-
-    if (obj->index == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL27Z/serial_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL27Z/serial_api.c
@@ -37,9 +37,6 @@ static LPUART_Type *const uart_addrs[] = LPUART_BASE_PTRS;
 /* Array of LPUART bus clock frequencies */
 static clock_name_t const uart_clocks[] = LPUART_CLOCK_FREQS;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     uint32_t uart_tx = pinmap_peripheral(tx, PinMap_UART_TX);
     uint32_t uart_rx = pinmap_peripheral(rx, PinMap_UART_RX);
@@ -75,11 +72,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     if (rx != NC) {
         LPUART_EnableRx(uart_addrs[obj->index], true);
         pin_mode(rx, PullUp);
-    }
-
-    if (obj->index == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/serial_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/serial_api.c
@@ -37,10 +37,6 @@ static UART_Type *const uart_addrs[] = UART_BASE_PTRS;
 /* Array of UART bus clock frequencies */
 static clock_name_t const uart_clocks[] = UART_CLOCK_FREQS;
 
-
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     uint32_t uart_tx = pinmap_peripheral(tx, PinMap_UART_TX);
     uint32_t uart_rx = pinmap_peripheral(rx, PinMap_UART_RX);
@@ -70,11 +66,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     if (rx != NC) {
         UART_EnableRx(uart_addrs[obj->index], true);
         pin_mode(rx, PullUp);
-    }
-
-    if (obj->index == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_Maxim/TARGET_MAX32600/serial_api.c
+++ b/hal/targets/hal/TARGET_Maxim/TARGET_MAX32600/serial_api.c
@@ -49,10 +49,6 @@
                      MXC_F_UART_INTFL_RX_PARITY_ERROR | \
                      MXC_F_UART_INTFL_RX_OVERRUN)
 
-// Variables for managing the stdio UART
-int stdio_uart_inited;
-serial_t stdio_uart;
-
 // Variables for interrupt driven
 static uart_irq_handler irq_handler;
 static uint32_t serial_irq_ids[UART_NUM];
@@ -88,12 +84,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     // Configure to default settings
     serial_baud(obj, DEFAULT_BAUD);
     serial_format(obj, 8, ParityNone, 1);
-
-    // Manage stdio UART
-    if(uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 //******************************************************************************

--- a/hal/targets/hal/TARGET_Maxim/TARGET_MAX32610/serial_api.c
+++ b/hal/targets/hal/TARGET_Maxim/TARGET_MAX32610/serial_api.c
@@ -49,10 +49,6 @@
                      MXC_F_UART_INTFL_RX_PARITY_ERROR | \
                      MXC_F_UART_INTFL_RX_OVERRUN)
 
-// Variables for managing the stdio UART
-int stdio_uart_inited;
-serial_t stdio_uart;
-
 // Variables for interrupt driven
 static uart_irq_handler irq_handler;
 static uint32_t serial_irq_ids[UART_NUM];
@@ -88,12 +84,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     // Configure to default settings
     serial_baud(obj, DEFAULT_BAUD);
     serial_format(obj, 8, ParityNone, 1);
-
-    // Manage stdio UART
-    if(uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 //******************************************************************************

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
@@ -50,10 +50,6 @@ static const int acceptedSpeeds[18][2] = {
     {1000000, UART_BAUDRATE_BAUDRATE_Baud1M}
 };
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     UARTName uart = UART_0;
     obj->uart = (NRF_UART_Type *)uart;
@@ -96,11 +92,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     }
     if (rx != NC) {
         pin_mode(rx, PullUp);
-    }
-
-    if (uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/serial_api.c
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/serial_api.c
@@ -62,10 +62,6 @@
 #define UART_DEFAULT_CTS        UART0_CONFIG_PSEL_CTS
 #define UART_DEFAULT_RTS        UART0_CONFIG_PSEL_RTS
 
-// Required by "retarget.cpp".
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 typedef struct {
     bool                initialized;
     uint32_t            irq_context;
@@ -304,14 +300,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
 
         UART_CB.initialized = true;
     }
-
-    if (tx == STDIO_UART_TX && rx == STDIO_UART_RX) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
-    else {
-        stdio_uart_inited = 0;
-    }
 }
 
 void serial_free(serial_t *obj)
@@ -325,10 +313,6 @@ void serial_free(serial_t *obj)
                                             NRF_UART_INT_MASK_ERROR);
         nrf_drv_common_irq_disable(UART_IRQn);
         UART_CB.initialized = false;
-
-        // There is only one UART instance, thus at this point the stdio UART
-        // can no longer be initialized.
-        stdio_uart_inited = 0;
     }
 }
 

--- a/hal/targets/hal/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
+++ b/hal/targets/hal/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
@@ -151,8 +151,6 @@ static struct nu_uart_var uart5_var = {
 };
 
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
 static uint32_t uart_modinit_mask = 0;
 
 static const struct nu_modinit_s uart_modinit_tab[] = {
@@ -219,13 +217,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     obj->serial.dma_chn_id_rx = DMA_ERROR_OUT_OF_CHANNELS;
 #endif
 
-    // For stdio management
-    if (obj == &stdio_uart) {
-        stdio_uart_inited = 1;
-        /* NOTE: Not required anymore because stdio_uart will be manually initialized in mbed-drivers/source/retarget.cpp from mbed beta */
-        //memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
-    
     // Mark this module to be inited.
     int i = modinit - uart_modinit_tab;
     uart_modinit_mask |= 1 << i;

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC11U6X/serial_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC11U6X/serial_api.c
@@ -74,9 +74,6 @@ static const PinMap PinMap_UART_RX[] = {
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     int is_stdio_uart = 0;
     
@@ -149,13 +146,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     }
     if (rx != NC) {
         pin_mode(rx, PullUp);
-    }
-    
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-    
-    if (is_stdio_uart && (obj->index == 0)) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC11UXX/serial_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC11UXX/serial_api.c
@@ -31,9 +31,6 @@
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     int is_stdio_uart = 0;
     
@@ -82,13 +79,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     
     switch (uart) {
         case UART_0: obj->index = 0; break;
-    }
-    
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-    
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/serial_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/serial_api.c
@@ -47,9 +47,6 @@ static const PinMap PinMap_UART_RX[] = {
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     int is_stdio_uart = 0;
     
@@ -91,13 +88,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     
     switch (uart) {
         case UART_0: obj->index = 0; break;
-    }
-    
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-    
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC13XX/serial_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC13XX/serial_api.c
@@ -45,9 +45,6 @@ static const PinMap PinMap_UART_RX[] = {
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     int is_stdio_uart = 0;
     
@@ -94,13 +91,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     
     switch (uart) {
         case UART_0: obj->index = 0; break;
-    }
-    
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-    
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC15XX/serial_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC15XX/serial_api.c
@@ -80,9 +80,6 @@ static uint32_t UARTSysClk;
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 static void switch_pin(const SWM_Map *swm, PinName pn)
 {
     uint32_t regVal;
@@ -148,13 +145,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     
     /* Enable UART */
     obj->uart->CFG |= UART_EN;
-    
-    is_stdio_uart = ((tx == USBTX) && (rx == USBRX));
-    
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj) {

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC176X/serial_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC176X/serial_api.c
@@ -71,9 +71,6 @@ static const PinMap PinMap_UART_CTS[] = {
 
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 struct serial_global_data_s {
     uint32_t serial_irq_id;
     gpio_t sw_rts, sw_cts;
@@ -136,13 +133,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     uart_data[obj->index].sw_rts.pin = NC;
     uart_data[obj->index].sw_cts.pin = NC;
     serial_set_flow_control(obj, FlowControlNone, NC, NC);
-
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj) {

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC23XX/serial_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC23XX/serial_api.c
@@ -55,9 +55,6 @@ static const PinMap PinMap_UART_RX[] = {
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     int is_stdio_uart = 0;
     
@@ -108,13 +105,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
         case UART_1: obj->index = 1; break;
         case UART_2: obj->index = 2; break;
         case UART_3: obj->index = 3; break;
-    }
-    
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-    
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC2460/serial_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC2460/serial_api.c
@@ -55,9 +55,6 @@ static const PinMap PinMap_UART_RX[] = {
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     int is_stdio_uart = 0;
     
@@ -108,13 +105,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
         case UART_1: obj->index = 1; break;
         case UART_2: obj->index = 2; break;
         case UART_3: obj->index = 3; break;
-    }
-    
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-    
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/serial_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/serial_api.c
@@ -62,9 +62,6 @@ static const PinMap PinMap_UART_RX[] = {
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     int is_stdio_uart = 0;
     
@@ -117,13 +114,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
         case UART_2: obj->index = 2; break;
         case UART_3: obj->index = 3; break;
         case UART_4: obj->index = 4; break;
-    }
-    
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-    
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/serial_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/serial_api.c
@@ -49,9 +49,6 @@ static const PinMap PinMap_UART_RX[] = {
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     int is_stdio_uart = 0;
 
@@ -104,13 +101,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
         case UART_2: obj->index = 2; break;
         case UART_3: obj->index = 3; break;
         case UART_4: obj->index = 4; break;
-    }
-
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 }
 

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/serial_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/serial_api.c
@@ -98,9 +98,6 @@ static const PinMap PinMap_UART_CTS[] = {
 
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 struct serial_global_data_s {
     uint32_t serial_irq_id;
     gpio_t sw_rts, sw_cts;
@@ -158,14 +155,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     uart_data[obj->index].sw_rts.pin = NC;
     uart_data[obj->index].sw_cts.pin = NC;
     serial_set_flow_control(obj, FlowControlNone, NC, NC);
-    
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        serial_baud (obj, STDIO_BAUD);
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj) {

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC81X/serial_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC81X/serial_api.c
@@ -80,9 +80,6 @@ static uint32_t UARTSysClk;
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 void serial_init(serial_t *obj, PinName tx, PinName rx) {
     int is_stdio_uart = 0;
     
@@ -136,13 +133,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     
     /* Enable UART */
     obj->uart->CFG |= UART_EN;
-    
-    is_stdio_uart = ((tx == USBTX) && (rx == USBRX));
-    
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj) {

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC82X/serial_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC82X/serial_api.c
@@ -87,9 +87,6 @@ static uint32_t UARTSysClk;
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 static int check_duplication(serial_t *obj, PinName tx, PinName rx)
 {
     if (uart_used == 0)
@@ -171,11 +168,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     obj->uart->CFG |= UART_EN;
 
     is_stdio_uart = ((tx == USBTX) && (rx == USBRX));
-
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj)

--- a/hal/targets/hal/TARGET_RENESAS/TARGET_RZ_A1H/serial_api.c
+++ b/hal/targets/hal/TARGET_RENESAS/TARGET_RZ_A1H/serial_api.c
@@ -120,9 +120,6 @@ static const PinMap PinMap_UART_RTS[] = {
 static const struct st_scif *SCIF[] = SCIF_ADDRESS_LIST;
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 struct serial_global_data_s {
     uint32_t serial_irq_id;
     gpio_t sw_rts, sw_cts;
@@ -296,13 +293,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     /* ---- Serial control register (SCSCR) setting ---- */
     /* Setting the TE and RE bits enables the TxD and RxD pins to be used. */
     obj->serial.uart->SCSCR = 0x0070;
-
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj) {

--- a/hal/targets/hal/TARGET_RENESAS/TARGET_VK_RZ_A1H/serial_api.c
+++ b/hal/targets/hal/TARGET_RENESAS/TARGET_VK_RZ_A1H/serial_api.c
@@ -165,9 +165,6 @@ static const PinMap PinMap_UART_RTS[] = {
 static const struct st_scif *SCIF[] = SCIF_ADDRESS_LIST;
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 struct serial_global_data_s {
     uint32_t serial_irq_id;
     gpio_t sw_rts, sw_cts;
@@ -342,13 +339,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     /* ---- Serial control register (SCSCR) setting ---- */
     /* Setting the TE and RE bits enables the TxD and RxD pins to be used. */
     obj->uart->SCSCR = (((uart_tx != (uint32_t)NC)? 0xA0 : 0) | ((uart_rx != (uint32_t)NC)? 0x50 : 0 )); //0x00F0;
-
-    is_stdio_uart = (uart == STDIO_UART) ? (1) : (0);
-
-    if (is_stdio_uart) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj) {

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F0/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F0/serial_api.c
@@ -63,9 +63,6 @@ static uart_irq_handler irq_handler;
 
 UART_HandleTypeDef UartHandle;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 static void init_uart(serial_t *obj) {
     UartHandle.Instance = (USART_TypeDef *)(obj->uart);
 
@@ -191,11 +188,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
 
     init_uart(obj);
 
-    // For stdio management
-    if (obj->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj) {

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F1/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F1/serial_api.c
@@ -46,9 +46,6 @@ static uart_irq_handler irq_handler;
 
 UART_HandleTypeDef UartHandle;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 static void init_uart(serial_t *obj)
 {
 
@@ -127,12 +124,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     obj->pin_rx = rx;
 
     init_uart(obj);
-
-    // For stdio management
-    if (obj->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj)

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F2/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F2/serial_api.c
@@ -92,9 +92,6 @@ static DMA_HandleTypeDef DmaTxHandle[UART_NUM];
 static DMA_HandleTypeDef DmaRxHandle[UART_NUM];
 static UART_HandleTypeDef UartHandle[UART_NUM];
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 #if DEVICE_SERIAL_ASYNCH
 #define SERIAL_OBJ(X) (obj->serial.X)
 #else
@@ -314,14 +311,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     SERIAL_OBJ(pin_rx) = rx;
 
     init_uart(obj, instance);
-
-#ifndef YOTTA_CFG_MBED_OS
-    // For stdio management
-    if ((int)(UartHandle[SERIAL_OBJ(index)].Instance) == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
-#endif
 
     DEBUG_PRINTF("UART%u: Init\n", obj->serial.module + 1);
 }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/serial_api.c
@@ -46,9 +46,6 @@ static uart_irq_handler irq_handler;
 
 UART_HandleTypeDef UartHandle;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 static void init_uart(serial_t *obj)
 {
     UartHandle.Instance = (USART_TypeDef *)(obj->uart);
@@ -164,11 +161,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
     init_uart(obj);
 
-    // For stdio management
-    if (obj->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj)

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
@@ -45,9 +45,6 @@ static UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 #if DEVICE_SERIAL_ASYNCH
     #define SERIAL_S(obj) (&((obj)->serial))
 #else
@@ -195,12 +192,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     obj_s->pin_rx = rx;
 
     init_uart(obj);
-
-    // For stdio management
-    if (obj_s->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj)

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F7/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F7/serial_api.c
@@ -46,9 +46,6 @@ static uart_irq_handler irq_handler;
 
 UART_HandleTypeDef UartHandle;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 static void init_uart(serial_t *obj)
 {
     UartHandle.Instance = (USART_TypeDef *)(obj->uart);
@@ -168,11 +165,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
     init_uart(obj);
 
-    // For stdio management
-    if (obj->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj)

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L0/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L0/serial_api.c
@@ -46,9 +46,6 @@ static uart_irq_handler irq_handler;
 
 UART_HandleTypeDef UartHandle;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 static void init_uart(serial_t *obj)
 {
     UartHandle.Instance = (USART_TypeDef *)(obj->uart);
@@ -150,11 +147,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
     init_uart(obj);
 
-    // For stdio management
-    if (obj->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj)

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L1/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L1/serial_api.c
@@ -45,9 +45,6 @@ static uart_irq_handler irq_handler;
 
 UART_HandleTypeDef UartHandle;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 static void init_uart(serial_t *obj)
 {
     UartHandle.Instance = (USART_TypeDef *)(obj->uart);
@@ -141,11 +138,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
     init_uart(obj);
 
-    // For stdio management
-    if (obj->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj)

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L4/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L4/serial_api.c
@@ -46,9 +46,6 @@ static uart_irq_handler irq_handler;
 
 UART_HandleTypeDef UartHandle;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 #if DEVICE_SERIAL_ASYNCH
 #define SERIAL_OBJ(X) (obj->serial.X)
 #else
@@ -170,11 +167,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
     init_uart(obj);
 
-    // For stdio management
-    if (obj->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj)

--- a/hal/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/serial_api.c
+++ b/hal/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/serial_api.c
@@ -68,10 +68,6 @@ static uart_irq_handler irq_handler;
 /* Keep track of incoming DMA IRQ's */
 static bool serial_dma_irq_fired[DMACTRL_CH_CNT] = { false };
 
-/* Serial interface on USBTX/USBRX retargets stdio */
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 static void uart_irq(UARTName, SerialIrq);
 static uint8_t serial_get_index(serial_t *obj);
 static void serial_enable(serial_t *obj, uint8_t enable);
@@ -600,12 +596,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         obj->serial.periph.leuart->CTRL |= LEUART_CTRL_RXDMAWU | LEUART_CTRL_TXDMAWU;
     } else {
         obj->serial.periph.uart->IFC = USART_IFC_TXC;
-    }
-
-    /* If this is the UART to be used for stdio, copy it to the stdio_uart struct */
-    if(uart_for_stdio) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
 
     serial_enable_pins(obj, true);

--- a/hal/targets/hal/TARGET_WIZNET/TARGET_W7500x/serial_api.c
+++ b/hal/targets/hal/TARGET_WIZNET/TARGET_W7500x/serial_api.c
@@ -50,9 +50,6 @@ static UART_TypeDef *UART;
 
 UART_InitTypeDef UART_InitStructure;
 
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
 static void init_uart(serial_t *obj)
 {
     if(obj->index == 2)        // For UART2, It is simple UART.
@@ -143,11 +140,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
     init_uart(obj);
 
-    // For stdio management
-    if (obj->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 }
 
 void serial_free(serial_t *obj)


### PR DESCRIPTION
This is similar to what we already did in mbed-drivers (PR for the addition there https://github.com/ARMmbed/mbed-drivers/pull/145).

I considered ``SingletonPtr`` object for this serial stdio but did not find any benefit, just more sugar around to get the same result, or? Additionally, the first commit cleans HAL targets, the memcpy of stdio objects.

Replaces #2455 , an application should use this new method for stdio configuration.

Questions:
- what to do with patterns like ``Serial pc(USBTX,USBRX)`` ? We could potentially deprecate it (somehow check that serial was already initialized, and a user is doing it for the same pins (might not work for each use case as sometimes stdio gets initalized later once used..), thus printf a warning that use a new method since v5.1.2 mbed-os version). ideas?

@bridadan @bogdanm @sg- @geky @c1728p9 