### PR TITLE
Fixing issue where GCC fails to report compile errors when non-verbose

### DIFF
--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -138,7 +138,7 @@ class GCC(mbedToolchain):
         # The warning/error notification is multiline
         msg = None
         for line in output.splitlines():
-            match = GCC.DIAGNOSTIC_PATTERN.match(line)
+            match = GCC.DIAGNOSTIC_PATTERN.search(line)
             if match is not None:
                 if msg is not None:
                     self.cc_info(msg)


### PR DESCRIPTION
The output of the GCC compiler is such that the toolchain regex sometimes
got hung up on the `:` charcter being printed in front of the drive letter when
running on Windows. This PR changes the matching logic to be more flexible
by using `search` to check the entire string for a match, not just the
beginning of the string.

An example of where the current implementation fails is on this PR: https://github.com/ARMmbed/mbed-os/pull/2422

The CI failure is visible here (scroll to the bottom): http://10.118.12.43:8081/job/build_matrix/270/target=KL25Z,toolchain=GCC_ARM/console

You can see the tools didn't print the error here. This PR should fix this issue.