### PR TITLE
Copying JSON files to pick up config for built libraries

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -177,7 +177,8 @@ if __name__ == '__main__':
                                                 macros=options.macros,
                                                 verbose=options.verbose,
                                                 notify=notify,
-                                                archive=False)
+                                                archive=False,
+                                                remove_config_header_file=True)
 
                 library_build_success = True
             except ToolException, e:


### PR DESCRIPTION
This came up when building tests, but affects any library using config that's first built, then included as "source" with the mbed tools. JSON files are not copied by default when building a library, so when this is built it loses the config data associated with the library. This commit copies all JSON files into the build directory when building libraries.

There is a strange side effect now which is there are now multiple `mbed_config.h` files created during the build process: one when building the library and one when building the actual application. This isn't currently a problem since none of our code explicitly includes `mbed_config`, but it does look strange. Is anyone aware of potential issues with this? If so, having the ability to prevent an `mbed_config.h` from being created in the API may be a solution.

cc @bogdanm @AlessandroA @screamerbg 