### PR TITLE
Updated deprecation notices to match branch names

### DIFF
--- a/TESTS/mbedmicro-mbed/attributes/attributes.c
+++ b/TESTS/mbedmicro-mbed/attributes/attributes.c
@@ -137,11 +137,11 @@ int testDeprecatedUsed() {
     return 0;
 }
 
-MBED_DEPRECATED_SINCE("v3.14", "this message should not be displayed")
+MBED_DEPRECATED_SINCE("mbed-os-3.14", "this message should not be displayed")
 void testDeprecatedSinceUnused();
 void testDeprecatedSinceUnused() { }
 
-MBED_DEPRECATED_SINCE("v3.14", "this message should be displayed")
+MBED_DEPRECATED_SINCE("mbed-os-3.14", "this message should be displayed")
 int testDeprecatedSinceUsed();
 int testDeprecatedSinceUsed() {
     return 0;

--- a/hal/api/FunctionPointer.h
+++ b/hal/api/FunctionPointer.h
@@ -29,13 +29,13 @@ namespace mbed {
 template <typename R, typename A1>
 class FunctionPointerArg1 : public Callback<R(A1)> {
 public:
-    MBED_DEPRECATED_SINCE("v5.1",
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "FunctionPointerArg1<R, A> has been replaced by Callback<R(A)>")
     FunctionPointerArg1(R (*function)(A1) = 0)
         : Callback<R(A1)>(function) {}
 
     template<typename T>
-    MBED_DEPRECATED_SINCE("v5.1",
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "FunctionPointerArg1<R, A> has been replaced by Callback<R(A)>")
     FunctionPointerArg1(T *object, R (T::*member)(A1))
         : Callback<R(A1)>(object, member) {}
@@ -48,13 +48,13 @@ public:
 template <typename R>
 class FunctionPointerArg1<R, void> : public Callback<R()> {
 public:
-    MBED_DEPRECATED_SINCE("v5.1",
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "FunctionPointer has been replaced by Callback<void()>")
     FunctionPointerArg1(R (*function)() = 0)
         : Callback<R()>(function) {}
 
     template<typename T>
-    MBED_DEPRECATED_SINCE("v5.1",
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "FunctionPointer has been replaced by Callback<void()>")
     FunctionPointerArg1(T *object, R (T::*member)())
         : Callback<R()>(object, member) {}

--- a/hal/api/toolchain.h
+++ b/hal/api/toolchain.h
@@ -234,7 +234,7 @@
  *  @code
  *  #include "toolchain.h"
  *
- *  MBED_DEPRECATED_SINCE("v5.1", "don't foo any more, bar instead")
+ *  MBED_DEPRECATED_SINCE("mbed-os-5.1", "don't foo any more, bar instead")
  *  void foo(int arg);
  *  @endcode
  */

--- a/rtos/rtos/RtosTimer.h
+++ b/rtos/rtos/RtosTimer.h
@@ -44,7 +44,7 @@ public:
       @param   argument  argument to the timer call back function. (default: NULL)
       @deprecated Replaced with RtosTimer(Callback<void()>, os_timer_type)
      */
-    MBED_DEPRECATED_SINCE("v5.1",
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Replaced with RtosTimer(Callback<void()>, os_timer_type)")
     RtosTimer(void (*func)(void const *argument), os_timer_type type=osTimerPeriodic, void *argument=NULL) {
         constructor(mbed::Callback<void()>(argument, (void (*)(void *))func), type);

--- a/rtos/rtos/Thread.h
+++ b/rtos/rtos/Thread.h
@@ -58,7 +58,7 @@ public:
         The explicit Thread::start member function should be used to spawn
         a thread.
     */
-    MBED_DEPRECATED_SINCE("v5.1",
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Thread-spawning constructors hide errors and may lead to complex "
         "program state when a thread is declared")
     Thread(mbed::Callback<void()> task,
@@ -83,7 +83,7 @@ public:
         a thread.
     */
     template <typename T>
-    MBED_DEPRECATED_SINCE("v5.1",
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Thread-spawning constructors hide errors and may lead to complex "
         "program state when a thread is declared")
     Thread(T *obj, void (T::*method)(),
@@ -109,7 +109,7 @@ public:
         a thread.
     */
     template <typename T>
-    MBED_DEPRECATED_SINCE("v5.1",
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Thread-spawning constructors hide errors and may lead to complex "
         "program state when a thread is declared")
     Thread(T *obj, void (*method)(T *),
@@ -134,7 +134,7 @@ public:
         The explicit Thread::start member function should be used to spawn
         a thread.
     */
-    MBED_DEPRECATED_SINCE("v5.1",
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Thread-spawning constructors hide errors and may lead to complex "
         "program state when a thread is declared")
     Thread(void (*task)(void const *argument), void *argument=NULL,


### PR DESCRIPTION
From an offline discussion, the `v5.1` notation is not used elsewhere in the code base. The branch name provides a reasonable precedence.

Example:
``` cpp
    MBED_DEPRECATED_SINCE("mbed-os-5.1", "don't foo any more, bar instead")
    void foo(int arg);
```

cc @sg-, @0xc0170 