### PR TITLE
Print module information in 'table' output format

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -419,13 +419,6 @@ class MemapParser(object):
         for i in sorted(self.modules):
 
             row = []
-            row.append(i)
-
-            for k in self.sections:
-                subtotal[k] += self.modules[i][k]
-
-            for k in self.print_sections:
-                row.append(self.modules[i][k])
 
             json_obj.append({
                 "module":i,
@@ -530,6 +523,16 @@ class MemapParser(object):
         for i in list(self.print_sections):
             table.align[i] = 'r'
 
+        for i in sorted(self.modules):
+            row = [i]
+
+            for k in self.sections:
+                subtotal[k] += self.modules[i][k]
+
+            for k in self.print_sections:
+                row.append(self.modules[i][k])
+
+            table.add_row(row)
 
         subtotal_row = ['Subtotals']
         for k in self.print_sections:


### PR DESCRIPTION
It was simply in the wrong spot

before:
```
+-----------+--------+-------+-------+
| Module    |  .text | .data |  .bss |
+-----------+--------+-------+-------+
| Subtotals | 381094 |  2704 | 84676 |
+-----------+--------+-------+-------+
Allocated Heap: 65540 bytes
Allocated Stack: 32768 bytes
Total Static RAM memory (data + bss): 87380 bytes
Total RAM memory (data + bss + heap + stack): 185688 bytes
Total Flash memory (text + data + misc): 384838 bytes
```
after
```
+-----------------------------+--------+-------+-------+
| Module                      |  .text | .data |  .bss |
+-----------------------------+--------+-------+-------+
| Fill                        |    484 |    18 |  2161 |
| Misc                        | 110012 |  2341 |  5852 |
| features/FEATURE_CLIENT     |  66624 |     3 |    53 |
| features/FEATURE_COMMON_PAL |  18982 |    89 |  8404 |
| features/frameworks         |   3809 |    52 |   784 |
| features/mbedtls            | 118982 |    51 |  8867 |
| features/net                |  35378 |   102 | 51263 |
| hal/common                  |   3317 |    20 |   305 |
| hal/targets                 |  15292 |    12 |   200 |
| rtos/rtos                   |    773 |     4 |     0 |
| rtos/rtx                    |   7441 |    20 |  6787 |
| Subtotals                   | 381094 |  2712 | 84676 |
+-----------------------------+--------+-------+-------+
Allocated Heap: 65540 bytes
Allocated Stack: 32768 bytes
Total Static RAM memory (data + bss): 87388 bytes
Total RAM memory (data + bss + heap + stack): 185696 bytes
Total Flash memory (text + data + misc): 384846 bytes
```