### PR TITLE
Add jinja template for Callback class

### DIFF
--- a/hal/api/Callback.j2
+++ b/hal/api/Callback.j2
@@ -1,0 +1,195 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_CALLBACK_H
+#define MBED_CALLBACK_H
+
+#include <string.h>
+#include <stdint.h>
+
+namespace mbed {
+
+{%- set MBED_MAX_ARGS = 5 -%}
+
+{%- macro comma(n) -%}
+  {%- if n > 0 %}, {% endif -%}
+{%- endmacro -%}
+
+{%- macro va(format, n) -%}
+  {%- for i in range(n) -%}
+    {{ format.format(i) }}
+    {%- if not loop.last %}, {% endif -%}
+  {%- endfor -%}
+{%- endmacro %}
+
+
+/** Callback class based on template specialization
+ *
+ * @Note Synchronization level: Not protected
+ */
+template <typename F>
+class Callback;
+
+{% for n in range(MBED_MAX_ARGS+1) -%}
+
+/** Templated function class
+ */
+template <typename R{{comma(n) ~ va("typename A{0}", n)}}>
+class Callback<R({{va("A{0}", n)}})> {
+public:
+    /** Create a Callback with a static function
+     *  @param func Static function to attach
+     */
+    Callback(R (*func)({{va("A{0}", n)}}) = 0) {
+        attach(func);
+    }
+
+    /** Create a Callback with a static function and bound pointer
+     *  @param obj  Pointer to object to bind to function
+     *  @param func Static function to attach
+     */
+    template<typename T>
+    Callback(T *obj, R (*func)(T*{{comma(n) ~ va("A{0}", n)}})) {
+        attach(obj, func);
+    }
+
+    /** Create a Callback with a member function
+     *  @param obj  Pointer to object to invoke member function on
+     *  @param func Member function to attach
+     */
+    template<typename T>
+    Callback(T *obj, R (T::*func)({{va("A{0}", n)}})) {
+        attach(obj, func);
+    }
+
+    /** Create a Callback with another Callback
+     *  @param func Callback to attach
+     */
+    Callback(const Callback<R({{va("A{0}", n)}})> &func) {
+        attach(func);
+    }
+
+    /** Attach a static function
+     *  @param func Static function to attach
+     */
+    void attach(R (*func)({{va("A{0}", n)}})) {
+        memcpy(&_func, &func, sizeof func);
+        _thunk = func ? &Callback::_staticthunk : 0;
+    }
+
+    /** Attach a static function with a bound pointer
+     *  @param obj  Pointer to object to bind to function
+     *  @param func Static function to attach
+     */
+    template <typename T>
+    void attach(T *obj, R (*func)(T*{{comma(n) ~ va("A{0}", n)}})) {
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &Callback::_boundthunk<T>;
+    }
+
+    /** Attach a member function
+     *  @param obj  Pointer to object to invoke member function on
+     *  @param func Member function to attach
+     */
+    template<typename T>
+    void attach(T *obj, R (T::*func)({{va("A{0}", n)}})) {
+        _obj = static_cast<void*>(obj);
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &Callback::_methodthunk<T>;
+    }
+
+    /** Attach a Callback
+     *  @param func The Callback to attach
+     */
+    void attach(const Callback<R({{va("A{0}", n)}})> &func) {
+        _obj = func._obj;
+        memcpy(&_func, &func._func, sizeof _func);
+        _thunk = func._thunk;
+    }
+
+    /** Call the attached function
+     */
+    R call({{va("A{0} a{0}", n)}}) {
+        if (!_thunk) {
+            return (R)0;
+        }
+        return _thunk(_obj, &_func{{comma(n) ~ va("a{0}", n)}});
+    }
+
+    /** Call the attached function
+     */
+    R operator()({{va("A{0} a{0}", n)}}) {
+        return call({{va("a{0}", n)}});
+    }
+
+    /** Test if function has been attached
+     */
+    operator bool() const {
+        return _thunk;
+    }
+
+    /** Static thunk for passing as C-style function
+     *  @param func Callback to call passed as void pointer
+     */
+    static R thunk(void *func{{comma(n) ~ va("A{0} a{0}", n)}}) {
+        return static_cast<Callback<R({{va("A{0}", n)}})>*>(func)
+                ->call({{va("a{0}", n)}});
+    }
+
+private:
+    // Internal thunks for various function types
+    static R _staticthunk(void*, void *func{{comma(n) ~ va("A{0} a{0}", n)}}) {
+        return (*reinterpret_cast<R (**)({{va("A{0}", n)}})>(func))
+                ({{va("a{0}", n)}});
+    }
+
+    template<typename T>
+    static R _boundthunk(void *obj, void *func{{comma(n) ~ va("A{0} a{0}", n)}}) {
+        return (*reinterpret_cast<R (**)(T*{{comma(n) ~ va("A{0}", n)}})>(func))
+                (static_cast<T*>(obj){{comma(n) ~ va("a{0}", n)}});
+    }
+
+    template<typename T>
+    static R _methodthunk(void *obj, void *func{{comma(n) ~ va("A{0} a{0}", n)}}) {
+        return (static_cast<T*>(obj)->*
+                (*reinterpret_cast<R (T::**)({{va("A{0}", n)}})>(func)))
+                ({{va("a{0}", n)}});
+    }
+
+    // Stored as pointer to function and pointer to optional object
+    // Function pointer is stored as union of possible function types
+    // to garuntee proper size and alignment
+    struct _class;
+    union {
+        void (*_staticfunc)();
+        void (*_boundfunc)(_class *);
+        void (_class::*_methodfunc)();
+    } _func;
+
+    void *_obj;
+
+    // Thunk registered on attach to dispatch calls
+    R (*_thunk)(void*, void*{{comma(n) ~ va("A{0}", n)}});
+};
+
+{% endfor -%}
+
+typedef Callback<void(int)> event_callback_t;
+
+
+} // namespace mbed
+
+#endif


### PR DESCRIPTION
To workaround the lack of variadic arguments, multiple template specializations are declared for the Callback class based on the number of arguments. This is not required in C++11.

To avoid the tedious of updating the multiple declarations, the Callback class was ported to a jinja template, which is expanded on changes to the Callback class.

**Note:** The generated Callback.h file is also committed, and jinja is not necessary to compile the Callback class.

Using j2cli ([link](https://pypi.python.org/pypi/j2cli/)):
``` bash
j2 Callback.j2 > Callback.h
```

Let me know what your thoughts are about including these files, if there is a better place for them, or if there is a different templating engine we should use.

cc @pan-, @0xc0170, @bogdanm 