### PR TITLE
Add cv-qualifiers to Callback and deprecate combinatorial explody functions

### DIFF
--- a/TESTS/mbed_drivers/callback/main.cpp
+++ b/TESTS/mbed_drivers/callback/main.cpp
@@ -203,20 +203,14 @@ void test_dispatch0() {
     Verifier<T>::verify0((volatile Thing<T>*)&thing, &volatile_func0<T>);
     Verifier<T>::verify0((const volatile Thing<T>*)&thing, &const_volatile_func0<T>);
     Verifier<T>::verify0(callback(static_func0<T>));
-    Verifier<T>::verify0(callback(&thing, &Thing<T>::member_func0));
-    Verifier<T>::verify0(callback((const Thing<T>*)&thing, &Thing<T>::const_member_func0));
-    Verifier<T>::verify0(callback((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func0));
-    Verifier<T>::verify0(callback((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func0));
-    Verifier<T>::verify0(callback(&thing, &bound_func0<T>));
-    Verifier<T>::verify0(callback((const Thing<T>*)&thing, &const_func0<T>));
-    Verifier<T>::verify0(callback((volatile Thing<T>*)&thing, &volatile_func0<T>));
-    Verifier<T>::verify0(callback((const volatile Thing<T>*)&thing, &const_volatile_func0<T>));
 
-    Callback<T()> callback(static_func0);
-    Verifier<T>::verify0(callback);
-    callback.attach(&thing, &bound_func0<T>);
-    Verifier<T>::verify0(&callback, &Callback<T()>::call);
-    Verifier<T>::verify0((void*)&callback, &Callback<T()>::thunk);
+    Callback<T()> cb(static_func0);
+    Verifier<T>::verify0(cb);
+    cb = static_func0;
+    Verifier<T>::verify0(cb);
+    cb.attach(&thing, &bound_func0<T>);
+    Verifier<T>::verify0(&cb, &Callback<T()>::call);
+    Verifier<T>::verify0((void*)&cb, &Callback<T()>::thunk);
 }
 
 template <typename T>
@@ -232,20 +226,14 @@ void test_dispatch1() {
     Verifier<T>::verify1((volatile Thing<T>*)&thing, &volatile_func1<T>);
     Verifier<T>::verify1((const volatile Thing<T>*)&thing, &const_volatile_func1<T>);
     Verifier<T>::verify1(callback(static_func1<T>));
-    Verifier<T>::verify1(callback(&thing, &Thing<T>::member_func1));
-    Verifier<T>::verify1(callback((const Thing<T>*)&thing, &Thing<T>::const_member_func1));
-    Verifier<T>::verify1(callback((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func1));
-    Verifier<T>::verify1(callback((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func1));
-    Verifier<T>::verify1(callback(&thing, &bound_func1<T>));
-    Verifier<T>::verify1(callback((const Thing<T>*)&thing, &const_func1<T>));
-    Verifier<T>::verify1(callback((volatile Thing<T>*)&thing, &volatile_func1<T>));
-    Verifier<T>::verify1(callback((const volatile Thing<T>*)&thing, &const_volatile_func1<T>));
 
-    Callback<T(T)> callback(static_func1);
-    Verifier<T>::verify1(callback);
-    callback.attach(&thing, &bound_func1<T>);
-    Verifier<T>::verify1(&callback, &Callback<T(T)>::call);
-    Verifier<T>::verify1((void*)&callback, &Callback<T(T)>::thunk);
+    Callback<T(T)> cb(static_func1);
+    Verifier<T>::verify1(cb);
+    cb = static_func1;
+    Verifier<T>::verify1(cb);
+    cb.attach(&thing, &bound_func1<T>);
+    Verifier<T>::verify1(&cb, &Callback<T(T)>::call);
+    Verifier<T>::verify1((void*)&cb, &Callback<T(T)>::thunk);
 }
 
 template <typename T>
@@ -261,20 +249,14 @@ void test_dispatch2() {
     Verifier<T>::verify2((volatile Thing<T>*)&thing, &volatile_func2<T>);
     Verifier<T>::verify2((const volatile Thing<T>*)&thing, &const_volatile_func2<T>);
     Verifier<T>::verify2(callback(static_func2<T>));
-    Verifier<T>::verify2(callback(&thing, &Thing<T>::member_func2));
-    Verifier<T>::verify2(callback((const Thing<T>*)&thing, &Thing<T>::const_member_func2));
-    Verifier<T>::verify2(callback((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func2));
-    Verifier<T>::verify2(callback((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func2));
-    Verifier<T>::verify2(callback(&thing, &bound_func2<T>));
-    Verifier<T>::verify2(callback((const Thing<T>*)&thing, &const_func2<T>));
-    Verifier<T>::verify2(callback((volatile Thing<T>*)&thing, &volatile_func2<T>));
-    Verifier<T>::verify2(callback((const volatile Thing<T>*)&thing, &const_volatile_func2<T>));
 
-    Callback<T(T, T)> callback(static_func2);
-    Verifier<T>::verify2(callback);
-    callback.attach(&thing, &bound_func2<T>);
-    Verifier<T>::verify2(&callback, &Callback<T(T, T)>::call);
-    Verifier<T>::verify2((void*)&callback, &Callback<T(T, T)>::thunk);
+    Callback<T(T, T)> cb(static_func2);
+    Verifier<T>::verify2(cb);
+    cb = static_func2;
+    Verifier<T>::verify2(cb);
+    cb.attach(&thing, &bound_func2<T>);
+    Verifier<T>::verify2(&cb, &Callback<T(T, T)>::call);
+    Verifier<T>::verify2((void*)&cb, &Callback<T(T, T)>::thunk);
 }
 
 template <typename T>
@@ -290,20 +272,14 @@ void test_dispatch3() {
     Verifier<T>::verify3((volatile Thing<T>*)&thing, &volatile_func3<T>);
     Verifier<T>::verify3((const volatile Thing<T>*)&thing, &const_volatile_func3<T>);
     Verifier<T>::verify3(callback(static_func3<T>));
-    Verifier<T>::verify3(callback(&thing, &Thing<T>::member_func3));
-    Verifier<T>::verify3(callback((const Thing<T>*)&thing, &Thing<T>::const_member_func3));
-    Verifier<T>::verify3(callback((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func3));
-    Verifier<T>::verify3(callback((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func3));
-    Verifier<T>::verify3(callback(&thing, &bound_func3<T>));
-    Verifier<T>::verify3(callback((const Thing<T>*)&thing, &const_func3<T>));
-    Verifier<T>::verify3(callback((volatile Thing<T>*)&thing, &volatile_func3<T>));
-    Verifier<T>::verify3(callback((const volatile Thing<T>*)&thing, &const_volatile_func3<T>));
 
-    Callback<T(T, T, T)> callback(static_func3);
-    Verifier<T>::verify3(callback);
-    callback.attach(&thing, &bound_func3<T>);
-    Verifier<T>::verify3(&callback, &Callback<T(T, T, T)>::call);
-    Verifier<T>::verify3((void*)&callback, &Callback<T(T, T, T)>::thunk);
+    Callback<T(T, T, T)> cb(static_func3);
+    Verifier<T>::verify3(cb);
+    cb = static_func3;
+    Verifier<T>::verify3(cb);
+    cb.attach(&thing, &bound_func3<T>);
+    Verifier<T>::verify3(&cb, &Callback<T(T, T, T)>::call);
+    Verifier<T>::verify3((void*)&cb, &Callback<T(T, T, T)>::thunk);
 }
 
 template <typename T>
@@ -319,20 +295,14 @@ void test_dispatch4() {
     Verifier<T>::verify4((volatile Thing<T>*)&thing, &volatile_func4<T>);
     Verifier<T>::verify4((const volatile Thing<T>*)&thing, &const_volatile_func4<T>);
     Verifier<T>::verify4(callback(static_func4<T>));
-    Verifier<T>::verify4(callback(&thing, &Thing<T>::member_func4));
-    Verifier<T>::verify4(callback((const Thing<T>*)&thing, &Thing<T>::const_member_func4));
-    Verifier<T>::verify4(callback((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func4));
-    Verifier<T>::verify4(callback((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func4));
-    Verifier<T>::verify4(callback(&thing, &bound_func4<T>));
-    Verifier<T>::verify4(callback((const Thing<T>*)&thing, &const_func4<T>));
-    Verifier<T>::verify4(callback((volatile Thing<T>*)&thing, &volatile_func4<T>));
-    Verifier<T>::verify4(callback((const volatile Thing<T>*)&thing, &const_volatile_func4<T>));
 
-    Callback<T(T, T, T, T)> callback(static_func4);
-    Verifier<T>::verify4(callback);
-    callback.attach(&thing, &bound_func4<T>);
-    Verifier<T>::verify4(&callback, &Callback<T(T, T, T, T)>::call);
-    Verifier<T>::verify4((void*)&callback, &Callback<T(T, T, T, T)>::thunk);
+    Callback<T(T, T, T, T)> cb(static_func4);
+    Verifier<T>::verify4(cb);
+    cb = static_func4;
+    Verifier<T>::verify4(cb);
+    cb.attach(&thing, &bound_func4<T>);
+    Verifier<T>::verify4(&cb, &Callback<T(T, T, T, T)>::call);
+    Verifier<T>::verify4((void*)&cb, &Callback<T(T, T, T, T)>::thunk);
 }
 
 template <typename T>
@@ -348,20 +318,14 @@ void test_dispatch5() {
     Verifier<T>::verify5((volatile Thing<T>*)&thing, &volatile_func5<T>);
     Verifier<T>::verify5((const volatile Thing<T>*)&thing, &const_volatile_func5<T>);
     Verifier<T>::verify5(callback(static_func5<T>));
-    Verifier<T>::verify5(callback(&thing, &Thing<T>::member_func5));
-    Verifier<T>::verify5(callback((const Thing<T>*)&thing, &Thing<T>::const_member_func5));
-    Verifier<T>::verify5(callback((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func5));
-    Verifier<T>::verify5(callback((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func5));
-    Verifier<T>::verify5(callback(&thing, &bound_func5<T>));
-    Verifier<T>::verify5(callback((const Thing<T>*)&thing, &const_func5<T>));
-    Verifier<T>::verify5(callback((volatile Thing<T>*)&thing, &volatile_func5<T>));
-    Verifier<T>::verify5(callback((const volatile Thing<T>*)&thing, &const_volatile_func5<T>));
 
-    Callback<T(T, T, T, T, T)> callback(static_func5);
-    Verifier<T>::verify5(callback);
-    callback.attach(&thing, &bound_func5<T>);
-    Verifier<T>::verify5(&callback, &Callback<T(T, T, T, T, T)>::call);
-    Verifier<T>::verify5((void*)&callback, &Callback<T(T, T, T, T, T)>::thunk);
+    Callback<T(T, T, T, T, T)> cb(static_func5);
+    Verifier<T>::verify5(cb);
+    cb = static_func5;
+    Verifier<T>::verify5(cb);
+    cb.attach(&thing, &bound_func5<T>);
+    Verifier<T>::verify5(&cb, &Callback<T(T, T, T, T, T)>::call);
+    Verifier<T>::verify5((void*)&cb, &Callback<T(T, T, T, T, T)>::thunk);
 }
 
 template <typename T>

--- a/TESTS/mbed_drivers/callback/main.cpp
+++ b/TESTS/mbed_drivers/callback/main.cpp
@@ -8,17 +8,17 @@ using namespace utest::v1;
 
 // static functions
 template <typename T>
-T static_func5(T a0, T a1, T a2, T a3, T a4) { return a0 | a1 | a2 | a3 | a4; }
-template <typename T>
-T static_func4(T a0, T a1, T a2, T a3) { return a0 | a1 | a2 | a3; }
-template <typename T>
-T static_func3(T a0, T a1, T a2) { return a0 | a1 | a2; }
-template <typename T>
-T static_func2(T a0, T a1) { return a0 | a1; }
-template <typename T>
-T static_func1(T a0) { return a0; }
-template <typename T>
 T static_func0() { return 0; }
+template <typename T>
+T static_func1(T a0) { return 0 | a0; }
+template <typename T>
+T static_func2(T a0, T a1) { return 0 | a0 | a1; }
+template <typename T>
+T static_func3(T a0, T a1, T a2) { return 0 | a0 | a1 | a2; }
+template <typename T>
+T static_func4(T a0, T a1, T a2, T a3) { return 0 | a0 | a1 | a2 | a3; }
+template <typename T>
+T static_func5(T a0, T a1, T a2, T a3, T a4) { return 0 | a0 | a1 | a2 | a3 | a4; }
 
 // class functions
 template <typename T>
@@ -26,134 +26,95 @@ struct Thing {
     T t;
     Thing() : t(0x80) {}
 
-    T member_func5(T a0, T a1, T a2, T a3, T a4) { return t | a0 | a1 | a2 | a3 | a4; }
-    T member_func4(T a0, T a1, T a2, T a3) { return t | a0 | a1 | a2 | a3; }
-    T member_func3(T a0, T a1, T a2) { return t | a0 | a1 | a2; }
-    T member_func2(T a0, T a1) { return t | a0 | a1; }
-    T member_func1(T a0) { return t | a0; }
     T member_func0() { return t; }
+    T member_func1(T a0) { return t | a0; }
+    T member_func2(T a0, T a1) { return t | a0 | a1; }
+    T member_func3(T a0, T a1, T a2) { return t | a0 | a1 | a2; }
+    T member_func4(T a0, T a1, T a2, T a3) { return t | a0 | a1 | a2 | a3; }
+    T member_func5(T a0, T a1, T a2, T a3, T a4) { return t | a0 | a1 | a2 | a3 | a4; }
+
+    T const_member_func0() const { return t; }
+    T const_member_func1(T a0) const { return t | a0; }
+    T const_member_func2(T a0, T a1) const { return t | a0 | a1; }
+    T const_member_func3(T a0, T a1, T a2) const { return t | a0 | a1 | a2; }
+    T const_member_func4(T a0, T a1, T a2, T a3) const { return t | a0 | a1 | a2 | a3; }
+    T const_member_func5(T a0, T a1, T a2, T a3, T a4) const { return t | a0 | a1 | a2 | a3 | a4; }
+
+    T volatile_member_func0() volatile { return t; }
+    T volatile_member_func1(T a0) volatile { return t | a0; }
+    T volatile_member_func2(T a0, T a1) volatile { return t | a0 | a1; }
+    T volatile_member_func3(T a0, T a1, T a2) volatile { return t | a0 | a1 | a2; }
+    T volatile_member_func4(T a0, T a1, T a2, T a3) volatile { return t | a0 | a1 | a2 | a3; }
+    T volatile_member_func5(T a0, T a1, T a2, T a3, T a4) volatile { return t | a0 | a1 | a2 | a3 | a4; }
+
+    T const_volatile_member_func0() const volatile { return t; }
+    T const_volatile_member_func1(T a0) const volatile { return t | a0; }
+    T const_volatile_member_func2(T a0, T a1) const volatile { return t | a0 | a1; }
+    T const_volatile_member_func3(T a0, T a1, T a2) const volatile { return t | a0 | a1 | a2; }
+    T const_volatile_member_func4(T a0, T a1, T a2, T a3) const volatile { return t | a0 | a1 | a2 | a3; }
+    T const_volatile_member_func5(T a0, T a1, T a2, T a3, T a4) const volatile { return t | a0 | a1 | a2 | a3 | a4; }
 };
 
 // bound functions
 template <typename T>
-T bound_func5(Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
-template <typename T>
-T bound_func4(Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
-template <typename T>
-T bound_func3(Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
-template <typename T>
-T bound_func2(Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+T bound_func0(Thing<T> *t) { return t->t; }
 template <typename T>
 T bound_func1(Thing<T> *t, T a0) { return t->t | a0; }
 template <typename T>
-T bound_func0(Thing<T> *t) { return t->t; }
+T bound_func2(Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T bound_func3(Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T bound_func4(Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T bound_func5(Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
 
 // const bound functions
 template <typename T>
-T const_func5(const Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
-template <typename T>
-T const_func4(const Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
-template <typename T>
-T const_func3(const Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
-template <typename T>
-T const_func2(const Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+T const_func0(const Thing<T> *t) { return t->t; }
 template <typename T>
 T const_func1(const Thing<T> *t, T a0) { return t->t | a0; }
 template <typename T>
-T const_func0(const Thing<T> *t) { return t->t; }
+T const_func2(const Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T const_func3(const Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T const_func4(const Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T const_func5(const Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
 
 // volatile bound functions
 template <typename T>
-T volatile_func5(volatile Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
-template <typename T>
-T volatile_func4(volatile Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
-template <typename T>
-T volatile_func3(volatile Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
-template <typename T>
-T volatile_func2(volatile Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+T volatile_func0(volatile Thing<T> *t) { return t->t; }
 template <typename T>
 T volatile_func1(volatile Thing<T> *t, T a0) { return t->t | a0; }
 template <typename T>
-T volatile_func0(volatile Thing<T> *t) { return t->t; }
+T volatile_func2(volatile Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T volatile_func3(volatile Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T volatile_func4(volatile Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T volatile_func5(volatile Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
 
-// const volatil bound functions
+// const volatile bound functions
 template <typename T>
-T const_volatile_func5(const volatile Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
-template <typename T>
-T const_volatile_func4(const volatile Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
-template <typename T>
-T const_volatile_func3(const volatile Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
-template <typename T>
-T const_volatile_func2(const volatile Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+T const_volatile_func0(const volatile Thing<T> *t) { return t->t; }
 template <typename T>
 T const_volatile_func1(const volatile Thing<T> *t, T a0) { return t->t | a0; }
 template <typename T>
-T const_volatile_func0(const volatile Thing<T> *t) { return t->t; }
+T const_volatile_func2(const volatile Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T const_volatile_func3(const volatile Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T const_volatile_func4(const volatile Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T const_volatile_func5(const volatile Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
 
 
 // function call and result verification
 template <typename T>
 struct Verifier {
-    static void verify5(Callback<T(T,T,T,T,T)> func) {
-        T result = func(0x01, 0x02, 0x04, 0x08, 0x10);
-        TEST_ASSERT_EQUAL(result, 0x1f);
-    }
-
-    template <typename O, typename M>
-    static void verify5(O *obj, M method) {
-        Callback<T(T,T,T,T,T)> func(obj, method);
-        T result = func(0x01, 0x02, 0x04, 0x08, 0x10);
-        TEST_ASSERT_EQUAL(result, 0x9f);
-    }
-
-    static void verify4(Callback<T(T,T,T,T)> func) {
-        T result = func(0x01, 0x02, 0x04, 0x08);
-        TEST_ASSERT_EQUAL(result, 0x0f);
-    }
-
-    template <typename O, typename M>
-    static void verify4(O *obj, M method) {
-        Callback<T(T,T,T,T)> func(obj, method);
-        T result = func(0x01, 0x02, 0x04, 0x08);
-        TEST_ASSERT_EQUAL(result, 0x8f);
-    }
-
-    static void verify3(Callback<T(T,T,T)> func) {
-        T result = func(0x01, 0x02, 0x04);
-        TEST_ASSERT_EQUAL(result, 0x07);
-    }
-
-    template <typename O, typename M>
-    static void verify3(O *obj, M method) {
-        Callback<T(T,T,T)> func(obj, method);
-        T result = func(0x01, 0x02, 0x04);
-        TEST_ASSERT_EQUAL(result, 0x87);
-    }
-
-    static void verify2(Callback<T(T,T)> func) {
-        T result = func(0x01, 0x02);
-        TEST_ASSERT_EQUAL(result, 0x03);
-    }
-
-    template <typename O, typename M>
-    static void verify2(O *obj, M method) {
-        Callback<T(T,T)> func(obj, method);
-        T result = func(0x01, 0x02);
-        TEST_ASSERT_EQUAL(result, 0x83);
-    }
-
-    static void verify1(Callback<T(T)> func) {
-        T result = func(0x01);
-        TEST_ASSERT_EQUAL(result, 0x01);
-    }
-
-    template <typename O, typename M>
-    static void verify1(O *obj, M method) {
-        Callback<T(T)> func(obj, method);
-        T result = func(0x01);
-        TEST_ASSERT_EQUAL(result, 0x81);
-    }
-
     static void verify0(Callback<T()> func) {
         T result = func();
         TEST_ASSERT_EQUAL(result, 0x00);
@@ -165,76 +126,97 @@ struct Verifier {
         T result = func();
         TEST_ASSERT_EQUAL(result, 0x80);
     }
+
+    static void verify1(Callback<T(T)> func) {
+        T result = func((1 << 0));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0));
+    }
+
+    template <typename O, typename M>
+    static void verify1(O *obj, M method) {
+        Callback<T(T)> func(obj, method);
+        T result = func((1 << 0));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0));
+    }
+
+    static void verify2(Callback<T(T, T)> func) {
+        T result = func((1 << 0), (1 << 1));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1));
+    }
+
+    template <typename O, typename M>
+    static void verify2(O *obj, M method) {
+        Callback<T(T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1));
+    }
+
+    static void verify3(Callback<T(T, T, T)> func) {
+        T result = func((1 << 0), (1 << 1), (1 << 2));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1) | (1 << 2));
+    }
+
+    template <typename O, typename M>
+    static void verify3(O *obj, M method) {
+        Callback<T(T, T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1), (1 << 2));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1) | (1 << 2));
+    }
+
+    static void verify4(Callback<T(T, T, T, T)> func) {
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3));
+    }
+
+    template <typename O, typename M>
+    static void verify4(O *obj, M method) {
+        Callback<T(T, T, T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3));
+    }
+
+    static void verify5(Callback<T(T, T, T, T, T)> func) {
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3), (1 << 4));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4));
+    }
+
+    template <typename O, typename M>
+    static void verify5(O *obj, M method) {
+        Callback<T(T, T, T, T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3), (1 << 4));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4));
+    }
 };
 
 
 // test dispatch
 template <typename T>
-void test_dispatch5() {
+void test_dispatch0() {
     Thing<T> thing;
-    Verifier<T>::verify5(static_func5<T>);
-    Verifier<T>::verify5(&thing, &Thing<T>::member_func5);
-    Verifier<T>::verify5(&thing, &bound_func5<T>);
-    Verifier<T>::verify5((const Thing<T>*)&thing, &const_func5<T>);
-    Verifier<T>::verify5((volatile Thing<T>*)&thing, &volatile_func5<T>);
-    Verifier<T>::verify5((const volatile Thing<T>*)&thing, &const_volatile_func5<T>);
+    Verifier<T>::verify0(static_func0<T>);
+    Verifier<T>::verify0(&thing, &Thing<T>::member_func0);
+    Verifier<T>::verify0((const Thing<T>*)&thing, &Thing<T>::const_member_func0);
+    Verifier<T>::verify0((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func0);
+    Verifier<T>::verify0((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func0);
+    Verifier<T>::verify0(&thing, &bound_func0<T>);
+    Verifier<T>::verify0((const Thing<T>*)&thing, &const_func0<T>);
+    Verifier<T>::verify0((volatile Thing<T>*)&thing, &volatile_func0<T>);
+    Verifier<T>::verify0((const volatile Thing<T>*)&thing, &const_volatile_func0<T>);
+    Verifier<T>::verify0(callback(static_func0<T>));
+    Verifier<T>::verify0(callback(&thing, &Thing<T>::member_func0));
+    Verifier<T>::verify0(callback((const Thing<T>*)&thing, &Thing<T>::const_member_func0));
+    Verifier<T>::verify0(callback((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func0));
+    Verifier<T>::verify0(callback((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func0));
+    Verifier<T>::verify0(callback(&thing, &bound_func0<T>));
+    Verifier<T>::verify0(callback((const Thing<T>*)&thing, &const_func0<T>));
+    Verifier<T>::verify0(callback((volatile Thing<T>*)&thing, &volatile_func0<T>));
+    Verifier<T>::verify0(callback((const volatile Thing<T>*)&thing, &const_volatile_func0<T>));
 
-    Callback<T(T,T,T,T,T)> callback(static_func5);
-    Verifier<T>::verify5(callback);
-    callback.attach(&thing, &bound_func5<T>);
-    Verifier<T>::verify5(&callback, &Callback<T(T,T,T,T,T)>::call);
-    Verifier<T>::verify5((void*)&callback, &Callback<T(T,T,T,T,T)>::thunk);
-}
-
-template <typename T>
-void test_dispatch4() {
-    Thing<T> thing;
-    Verifier<T>::verify4(static_func4<T>);
-    Verifier<T>::verify4(&thing, &Thing<T>::member_func4);
-    Verifier<T>::verify4(&thing, &bound_func4<T>);
-    Verifier<T>::verify4((const Thing<T>*)&thing, &const_func4<T>);
-    Verifier<T>::verify4((volatile Thing<T>*)&thing, &volatile_func4<T>);
-    Verifier<T>::verify4((const volatile Thing<T>*)&thing, &const_volatile_func4<T>);
-
-    Callback<T(T,T,T,T)> callback(static_func4);
-    Verifier<T>::verify4(callback);
-    callback.attach(&thing, &bound_func4<T>);
-    Verifier<T>::verify4(&callback, &Callback<T(T,T,T,T)>::call);
-    Verifier<T>::verify4((void*)&callback, &Callback<T(T,T,T,T)>::thunk);
-}
-
-template <typename T>
-void test_dispatch3() {
-    Thing<T> thing;
-    Verifier<T>::verify3(static_func3<T>);
-    Verifier<T>::verify3(&thing, &Thing<T>::member_func3);
-    Verifier<T>::verify3(&thing, &bound_func3<T>);
-    Verifier<T>::verify3((const Thing<T>*)&thing, &const_func3<T>);
-    Verifier<T>::verify3((volatile Thing<T>*)&thing, &volatile_func3<T>);
-    Verifier<T>::verify3((const volatile Thing<T>*)&thing, &const_volatile_func3<T>);
-
-    Callback<T(T,T,T)> callback(static_func3);
-    Verifier<T>::verify3(callback);
-    callback.attach(&thing, &bound_func3<T>);
-    Verifier<T>::verify3(&callback, &Callback<T(T,T,T)>::call);
-    Verifier<T>::verify3((void*)&callback, &Callback<T(T,T,T)>::thunk);
-}
-
-template <typename T>
-void test_dispatch2() {
-    Thing<T> thing;
-    Verifier<T>::verify2(static_func2<T>);
-    Verifier<T>::verify2(&thing, &Thing<T>::member_func2);
-    Verifier<T>::verify2(&thing, &bound_func2<T>);
-    Verifier<T>::verify2((const Thing<T>*)&thing, &const_func2<T>);
-    Verifier<T>::verify2((volatile Thing<T>*)&thing, &volatile_func2<T>);
-    Verifier<T>::verify2((const volatile Thing<T>*)&thing, &const_volatile_func2<T>);
-
-    Callback<T(T,T)> callback(static_func2);
-    Verifier<T>::verify2(callback);
-    callback.attach(&thing, &bound_func2<T>);
-    Verifier<T>::verify2(&callback, &Callback<T(T,T)>::call);
-    Verifier<T>::verify2((void*)&callback, &Callback<T(T,T)>::thunk);
+    Callback<T()> callback(static_func0);
+    Verifier<T>::verify0(callback);
+    callback.attach(&thing, &bound_func0<T>);
+    Verifier<T>::verify0(&callback, &Callback<T()>::call);
+    Verifier<T>::verify0((void*)&callback, &Callback<T()>::thunk);
 }
 
 template <typename T>
@@ -242,10 +224,22 @@ void test_dispatch1() {
     Thing<T> thing;
     Verifier<T>::verify1(static_func1<T>);
     Verifier<T>::verify1(&thing, &Thing<T>::member_func1);
+    Verifier<T>::verify1((const Thing<T>*)&thing, &Thing<T>::const_member_func1);
+    Verifier<T>::verify1((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func1);
+    Verifier<T>::verify1((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func1);
     Verifier<T>::verify1(&thing, &bound_func1<T>);
     Verifier<T>::verify1((const Thing<T>*)&thing, &const_func1<T>);
     Verifier<T>::verify1((volatile Thing<T>*)&thing, &volatile_func1<T>);
     Verifier<T>::verify1((const volatile Thing<T>*)&thing, &const_volatile_func1<T>);
+    Verifier<T>::verify1(callback(static_func1<T>));
+    Verifier<T>::verify1(callback(&thing, &Thing<T>::member_func1));
+    Verifier<T>::verify1(callback((const Thing<T>*)&thing, &Thing<T>::const_member_func1));
+    Verifier<T>::verify1(callback((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func1));
+    Verifier<T>::verify1(callback((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func1));
+    Verifier<T>::verify1(callback(&thing, &bound_func1<T>));
+    Verifier<T>::verify1(callback((const Thing<T>*)&thing, &const_func1<T>));
+    Verifier<T>::verify1(callback((volatile Thing<T>*)&thing, &volatile_func1<T>));
+    Verifier<T>::verify1(callback((const volatile Thing<T>*)&thing, &const_volatile_func1<T>));
 
     Callback<T(T)> callback(static_func1);
     Verifier<T>::verify1(callback);
@@ -255,20 +249,119 @@ void test_dispatch1() {
 }
 
 template <typename T>
-void test_dispatch0() {
+void test_dispatch2() {
     Thing<T> thing;
-    Verifier<T>::verify0(static_func0<T>);
-    Verifier<T>::verify0(&thing, &Thing<T>::member_func0);
-    Verifier<T>::verify0(&thing, &bound_func0<T>);
-    Verifier<T>::verify0((const Thing<T>*)&thing, &const_func0<T>);
-    Verifier<T>::verify0((volatile Thing<T>*)&thing, &volatile_func0<T>);
-    Verifier<T>::verify0((const volatile Thing<T>*)&thing, &const_volatile_func0<T>);
+    Verifier<T>::verify2(static_func2<T>);
+    Verifier<T>::verify2(&thing, &Thing<T>::member_func2);
+    Verifier<T>::verify2((const Thing<T>*)&thing, &Thing<T>::const_member_func2);
+    Verifier<T>::verify2((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func2);
+    Verifier<T>::verify2((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func2);
+    Verifier<T>::verify2(&thing, &bound_func2<T>);
+    Verifier<T>::verify2((const Thing<T>*)&thing, &const_func2<T>);
+    Verifier<T>::verify2((volatile Thing<T>*)&thing, &volatile_func2<T>);
+    Verifier<T>::verify2((const volatile Thing<T>*)&thing, &const_volatile_func2<T>);
+    Verifier<T>::verify2(callback(static_func2<T>));
+    Verifier<T>::verify2(callback(&thing, &Thing<T>::member_func2));
+    Verifier<T>::verify2(callback((const Thing<T>*)&thing, &Thing<T>::const_member_func2));
+    Verifier<T>::verify2(callback((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func2));
+    Verifier<T>::verify2(callback((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func2));
+    Verifier<T>::verify2(callback(&thing, &bound_func2<T>));
+    Verifier<T>::verify2(callback((const Thing<T>*)&thing, &const_func2<T>));
+    Verifier<T>::verify2(callback((volatile Thing<T>*)&thing, &volatile_func2<T>));
+    Verifier<T>::verify2(callback((const volatile Thing<T>*)&thing, &const_volatile_func2<T>));
 
-    Callback<T()> callback(static_func0);
-    Verifier<T>::verify0(callback);
-    callback.attach(&thing, &bound_func0<T>);
-    Verifier<T>::verify0(&callback, &Callback<T()>::call);
-    Verifier<T>::verify0((void*)&callback, &Callback<T()>::thunk);
+    Callback<T(T, T)> callback(static_func2);
+    Verifier<T>::verify2(callback);
+    callback.attach(&thing, &bound_func2<T>);
+    Verifier<T>::verify2(&callback, &Callback<T(T, T)>::call);
+    Verifier<T>::verify2((void*)&callback, &Callback<T(T, T)>::thunk);
+}
+
+template <typename T>
+void test_dispatch3() {
+    Thing<T> thing;
+    Verifier<T>::verify3(static_func3<T>);
+    Verifier<T>::verify3(&thing, &Thing<T>::member_func3);
+    Verifier<T>::verify3((const Thing<T>*)&thing, &Thing<T>::const_member_func3);
+    Verifier<T>::verify3((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func3);
+    Verifier<T>::verify3((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func3);
+    Verifier<T>::verify3(&thing, &bound_func3<T>);
+    Verifier<T>::verify3((const Thing<T>*)&thing, &const_func3<T>);
+    Verifier<T>::verify3((volatile Thing<T>*)&thing, &volatile_func3<T>);
+    Verifier<T>::verify3((const volatile Thing<T>*)&thing, &const_volatile_func3<T>);
+    Verifier<T>::verify3(callback(static_func3<T>));
+    Verifier<T>::verify3(callback(&thing, &Thing<T>::member_func3));
+    Verifier<T>::verify3(callback((const Thing<T>*)&thing, &Thing<T>::const_member_func3));
+    Verifier<T>::verify3(callback((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func3));
+    Verifier<T>::verify3(callback((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func3));
+    Verifier<T>::verify3(callback(&thing, &bound_func3<T>));
+    Verifier<T>::verify3(callback((const Thing<T>*)&thing, &const_func3<T>));
+    Verifier<T>::verify3(callback((volatile Thing<T>*)&thing, &volatile_func3<T>));
+    Verifier<T>::verify3(callback((const volatile Thing<T>*)&thing, &const_volatile_func3<T>));
+
+    Callback<T(T, T, T)> callback(static_func3);
+    Verifier<T>::verify3(callback);
+    callback.attach(&thing, &bound_func3<T>);
+    Verifier<T>::verify3(&callback, &Callback<T(T, T, T)>::call);
+    Verifier<T>::verify3((void*)&callback, &Callback<T(T, T, T)>::thunk);
+}
+
+template <typename T>
+void test_dispatch4() {
+    Thing<T> thing;
+    Verifier<T>::verify4(static_func4<T>);
+    Verifier<T>::verify4(&thing, &Thing<T>::member_func4);
+    Verifier<T>::verify4((const Thing<T>*)&thing, &Thing<T>::const_member_func4);
+    Verifier<T>::verify4((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func4);
+    Verifier<T>::verify4((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func4);
+    Verifier<T>::verify4(&thing, &bound_func4<T>);
+    Verifier<T>::verify4((const Thing<T>*)&thing, &const_func4<T>);
+    Verifier<T>::verify4((volatile Thing<T>*)&thing, &volatile_func4<T>);
+    Verifier<T>::verify4((const volatile Thing<T>*)&thing, &const_volatile_func4<T>);
+    Verifier<T>::verify4(callback(static_func4<T>));
+    Verifier<T>::verify4(callback(&thing, &Thing<T>::member_func4));
+    Verifier<T>::verify4(callback((const Thing<T>*)&thing, &Thing<T>::const_member_func4));
+    Verifier<T>::verify4(callback((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func4));
+    Verifier<T>::verify4(callback((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func4));
+    Verifier<T>::verify4(callback(&thing, &bound_func4<T>));
+    Verifier<T>::verify4(callback((const Thing<T>*)&thing, &const_func4<T>));
+    Verifier<T>::verify4(callback((volatile Thing<T>*)&thing, &volatile_func4<T>));
+    Verifier<T>::verify4(callback((const volatile Thing<T>*)&thing, &const_volatile_func4<T>));
+
+    Callback<T(T, T, T, T)> callback(static_func4);
+    Verifier<T>::verify4(callback);
+    callback.attach(&thing, &bound_func4<T>);
+    Verifier<T>::verify4(&callback, &Callback<T(T, T, T, T)>::call);
+    Verifier<T>::verify4((void*)&callback, &Callback<T(T, T, T, T)>::thunk);
+}
+
+template <typename T>
+void test_dispatch5() {
+    Thing<T> thing;
+    Verifier<T>::verify5(static_func5<T>);
+    Verifier<T>::verify5(&thing, &Thing<T>::member_func5);
+    Verifier<T>::verify5((const Thing<T>*)&thing, &Thing<T>::const_member_func5);
+    Verifier<T>::verify5((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func5);
+    Verifier<T>::verify5((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func5);
+    Verifier<T>::verify5(&thing, &bound_func5<T>);
+    Verifier<T>::verify5((const Thing<T>*)&thing, &const_func5<T>);
+    Verifier<T>::verify5((volatile Thing<T>*)&thing, &volatile_func5<T>);
+    Verifier<T>::verify5((const volatile Thing<T>*)&thing, &const_volatile_func5<T>);
+    Verifier<T>::verify5(callback(static_func5<T>));
+    Verifier<T>::verify5(callback(&thing, &Thing<T>::member_func5));
+    Verifier<T>::verify5(callback((const Thing<T>*)&thing, &Thing<T>::const_member_func5));
+    Verifier<T>::verify5(callback((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func5));
+    Verifier<T>::verify5(callback((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func5));
+    Verifier<T>::verify5(callback(&thing, &bound_func5<T>));
+    Verifier<T>::verify5(callback((const Thing<T>*)&thing, &const_func5<T>));
+    Verifier<T>::verify5(callback((volatile Thing<T>*)&thing, &volatile_func5<T>));
+    Verifier<T>::verify5(callback((const volatile Thing<T>*)&thing, &const_volatile_func5<T>));
+
+    Callback<T(T, T, T, T, T)> callback(static_func5);
+    Verifier<T>::verify5(callback);
+    callback.attach(&thing, &bound_func5<T>);
+    Verifier<T>::verify5(&callback, &Callback<T(T, T, T, T, T)>::call);
+    Verifier<T>::verify5((void*)&callback, &Callback<T(T, T, T, T, T)>::thunk);
 }
 
 template <typename T>
@@ -295,26 +388,26 @@ utest::v1::status_t test_setup(const size_t number_of_cases) {
 }
 
 Case cases[] = {
-    Case("Testing callbacks with 5 ints", test_dispatch5<int>),
-    Case("Testing callbacks with 4 ints", test_dispatch4<int>),
-    Case("Testing callbacks with 3 ints", test_dispatch3<int>),
-    Case("Testing callbacks with 2 ints", test_dispatch2<int>),
-    Case("Testing callbacks with 1 ints", test_dispatch1<int>),
     Case("Testing callbacks with 0 ints", test_dispatch0<int>),
+    Case("Testing callbacks with 1 ints", test_dispatch1<int>),
+    Case("Testing callbacks with 2 ints", test_dispatch2<int>),
+    Case("Testing callbacks with 3 ints", test_dispatch3<int>),
+    Case("Testing callbacks with 4 ints", test_dispatch4<int>),
+    Case("Testing callbacks with 5 ints", test_dispatch5<int>),
 
-    Case("Testing callbacks with 5 uchars", test_dispatch5<unsigned char>),
-    Case("Testing callbacks with 4 uchars", test_dispatch4<unsigned char>),
-    Case("Testing callbacks with 3 uchars", test_dispatch3<unsigned char>),
-    Case("Testing callbacks with 2 uchars", test_dispatch2<unsigned char>),
-    Case("Testing callbacks with 1 uchars", test_dispatch1<unsigned char>),
     Case("Testing callbacks with 0 uchars", test_dispatch0<unsigned char>),
+    Case("Testing callbacks with 1 uchars", test_dispatch1<unsigned char>),
+    Case("Testing callbacks with 2 uchars", test_dispatch2<unsigned char>),
+    Case("Testing callbacks with 3 uchars", test_dispatch3<unsigned char>),
+    Case("Testing callbacks with 4 uchars", test_dispatch4<unsigned char>),
+    Case("Testing callbacks with 5 uchars", test_dispatch5<unsigned char>),
 
-    Case("Testing callbacks with 5 uint64s", test_dispatch5<uint64_t>),
-    Case("Testing callbacks with 4 uint64s", test_dispatch4<uint64_t>),
-    Case("Testing callbacks with 3 uint64s", test_dispatch3<uint64_t>),
-    Case("Testing callbacks with 2 uint64s", test_dispatch2<uint64_t>),
-    Case("Testing callbacks with 1 uint64s", test_dispatch1<uint64_t>),
     Case("Testing callbacks with 0 uint64s", test_dispatch0<uint64_t>),
+    Case("Testing callbacks with 1 uint64s", test_dispatch1<uint64_t>),
+    Case("Testing callbacks with 2 uint64s", test_dispatch2<uint64_t>),
+    Case("Testing callbacks with 3 uint64s", test_dispatch3<uint64_t>),
+    Case("Testing callbacks with 4 uint64s", test_dispatch4<uint64_t>),
+    Case("Testing callbacks with 5 uint64s", test_dispatch5<uint64_t>),
 
     Case("Testing FunctionPointerArg1 compatibility", test_fparg1<int>),
     Case("Testing FunctionPointer compatibility", test_fparg0<int>),

--- a/TESTS/mbed_functional/callback/main.cpp
+++ b/TESTS/mbed_functional/callback/main.cpp
@@ -1,0 +1,351 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+
+using namespace utest::v1;
+
+
+// static functions
+template <typename T>
+T static_func0() { return 0; }
+template <typename T>
+T static_func1(T a0) { return 0 | a0; }
+template <typename T>
+T static_func2(T a0, T a1) { return 0 | a0 | a1; }
+template <typename T>
+T static_func3(T a0, T a1, T a2) { return 0 | a0 | a1 | a2; }
+template <typename T>
+T static_func4(T a0, T a1, T a2, T a3) { return 0 | a0 | a1 | a2 | a3; }
+template <typename T>
+T static_func5(T a0, T a1, T a2, T a3, T a4) { return 0 | a0 | a1 | a2 | a3 | a4; }
+
+// class functions
+template <typename T>
+struct Thing {
+    T t;
+    Thing() : t(0x80) {}
+
+    T member_func0() { return t; }
+    T member_func1(T a0) { return t | a0; }
+    T member_func2(T a0, T a1) { return t | a0 | a1; }
+    T member_func3(T a0, T a1, T a2) { return t | a0 | a1 | a2; }
+    T member_func4(T a0, T a1, T a2, T a3) { return t | a0 | a1 | a2 | a3; }
+    T member_func5(T a0, T a1, T a2, T a3, T a4) { return t | a0 | a1 | a2 | a3 | a4; }
+
+    T const_member_func0() const { return t; }
+    T const_member_func1(T a0) const { return t | a0; }
+    T const_member_func2(T a0, T a1) const { return t | a0 | a1; }
+    T const_member_func3(T a0, T a1, T a2) const { return t | a0 | a1 | a2; }
+    T const_member_func4(T a0, T a1, T a2, T a3) const { return t | a0 | a1 | a2 | a3; }
+    T const_member_func5(T a0, T a1, T a2, T a3, T a4) const { return t | a0 | a1 | a2 | a3 | a4; }
+
+    T volatile_member_func0() volatile { return t; }
+    T volatile_member_func1(T a0) volatile { return t | a0; }
+    T volatile_member_func2(T a0, T a1) volatile { return t | a0 | a1; }
+    T volatile_member_func3(T a0, T a1, T a2) volatile { return t | a0 | a1 | a2; }
+    T volatile_member_func4(T a0, T a1, T a2, T a3) volatile { return t | a0 | a1 | a2 | a3; }
+    T volatile_member_func5(T a0, T a1, T a2, T a3, T a4) volatile { return t | a0 | a1 | a2 | a3 | a4; }
+
+    T const_volatile_member_func0() const volatile { return t; }
+    T const_volatile_member_func1(T a0) const volatile { return t | a0; }
+    T const_volatile_member_func2(T a0, T a1) const volatile { return t | a0 | a1; }
+    T const_volatile_member_func3(T a0, T a1, T a2) const volatile { return t | a0 | a1 | a2; }
+    T const_volatile_member_func4(T a0, T a1, T a2, T a3) const volatile { return t | a0 | a1 | a2 | a3; }
+    T const_volatile_member_func5(T a0, T a1, T a2, T a3, T a4) const volatile { return t | a0 | a1 | a2 | a3 | a4; }
+};
+
+// bound functions
+template <typename T>
+T bound_func0(Thing<T> *t) { return t->t; }
+template <typename T>
+T bound_func1(Thing<T> *t, T a0) { return t->t | a0; }
+template <typename T>
+T bound_func2(Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T bound_func3(Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T bound_func4(Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T bound_func5(Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
+
+// const bound functions
+template <typename T>
+T const_func0(const Thing<T> *t) { return t->t; }
+template <typename T>
+T const_func1(const Thing<T> *t, T a0) { return t->t | a0; }
+template <typename T>
+T const_func2(const Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T const_func3(const Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T const_func4(const Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T const_func5(const Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
+
+// volatile bound functions
+template <typename T>
+T volatile_func0(volatile Thing<T> *t) { return t->t; }
+template <typename T>
+T volatile_func1(volatile Thing<T> *t, T a0) { return t->t | a0; }
+template <typename T>
+T volatile_func2(volatile Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T volatile_func3(volatile Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T volatile_func4(volatile Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T volatile_func5(volatile Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
+
+// const volatile bound functions
+template <typename T>
+T const_volatile_func0(const volatile Thing<T> *t) { return t->t; }
+template <typename T>
+T const_volatile_func1(const volatile Thing<T> *t, T a0) { return t->t | a0; }
+template <typename T>
+T const_volatile_func2(const volatile Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T const_volatile_func3(const volatile Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T const_volatile_func4(const volatile Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T const_volatile_func5(const volatile Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
+
+
+// function call and result verification
+template <typename T>
+struct Verifier {
+    static void verify0(Callback<T()> func) {
+        T result = func();
+        TEST_ASSERT_EQUAL(result, 0x00);
+    }
+
+    template <typename O, typename M>
+    static void verify0(O *obj, M method) {
+        Callback<T()> func(obj, method);
+        T result = func();
+        TEST_ASSERT_EQUAL(result, 0x80);
+    }
+
+    static void verify1(Callback<T(T)> func) {
+        T result = func((1 << 0));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0));
+    }
+
+    template <typename O, typename M>
+    static void verify1(O *obj, M method) {
+        Callback<T(T)> func(obj, method);
+        T result = func((1 << 0));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0));
+    }
+
+    static void verify2(Callback<T(T, T)> func) {
+        T result = func((1 << 0), (1 << 1));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1));
+    }
+
+    template <typename O, typename M>
+    static void verify2(O *obj, M method) {
+        Callback<T(T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1));
+    }
+
+    static void verify3(Callback<T(T, T, T)> func) {
+        T result = func((1 << 0), (1 << 1), (1 << 2));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1) | (1 << 2));
+    }
+
+    template <typename O, typename M>
+    static void verify3(O *obj, M method) {
+        Callback<T(T, T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1), (1 << 2));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1) | (1 << 2));
+    }
+
+    static void verify4(Callback<T(T, T, T, T)> func) {
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3));
+    }
+
+    template <typename O, typename M>
+    static void verify4(O *obj, M method) {
+        Callback<T(T, T, T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3));
+    }
+
+    static void verify5(Callback<T(T, T, T, T, T)> func) {
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3), (1 << 4));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4));
+    }
+
+    template <typename O, typename M>
+    static void verify5(O *obj, M method) {
+        Callback<T(T, T, T, T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3), (1 << 4));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4));
+    }
+};
+
+
+// test dispatch
+template <typename T>
+void test_dispatch0() {
+    Thing<T> thing;
+    Verifier<T>::verify0(static_func0<T>);
+    Verifier<T>::verify0(&thing, &Thing<T>::member_func0);
+    Verifier<T>::verify0((const Thing<T>*)&thing, &Thing<T>::const_member_func0);
+    Verifier<T>::verify0((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func0);
+    Verifier<T>::verify0((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func0);
+    Verifier<T>::verify0(&thing, &bound_func0<T>);
+    Verifier<T>::verify0((const Thing<T>*)&thing, &const_func0<T>);
+    Verifier<T>::verify0((volatile Thing<T>*)&thing, &volatile_func0<T>);
+    Verifier<T>::verify0((const volatile Thing<T>*)&thing, &const_volatile_func0<T>);
+    Verifier<T>::verify0(callback(static_func0<T>));
+
+    Callback<T()> cb(static_func0);
+    Verifier<T>::verify0(cb);
+    cb = static_func0;
+    Verifier<T>::verify0(cb);
+    cb.attach(&thing, &bound_func0<T>);
+    Verifier<T>::verify0(&cb, &Callback<T()>::call);
+    Verifier<T>::verify0((void*)&cb, &Callback<T()>::thunk);
+}
+
+template <typename T>
+void test_dispatch1() {
+    Thing<T> thing;
+    Verifier<T>::verify1(static_func1<T>);
+    Verifier<T>::verify1(&thing, &Thing<T>::member_func1);
+    Verifier<T>::verify1((const Thing<T>*)&thing, &Thing<T>::const_member_func1);
+    Verifier<T>::verify1((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func1);
+    Verifier<T>::verify1((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func1);
+    Verifier<T>::verify1(&thing, &bound_func1<T>);
+    Verifier<T>::verify1((const Thing<T>*)&thing, &const_func1<T>);
+    Verifier<T>::verify1((volatile Thing<T>*)&thing, &volatile_func1<T>);
+    Verifier<T>::verify1((const volatile Thing<T>*)&thing, &const_volatile_func1<T>);
+    Verifier<T>::verify1(callback(static_func1<T>));
+
+    Callback<T(T)> cb(static_func1);
+    Verifier<T>::verify1(cb);
+    cb = static_func1;
+    Verifier<T>::verify1(cb);
+    cb.attach(&thing, &bound_func1<T>);
+    Verifier<T>::verify1(&cb, &Callback<T(T)>::call);
+    Verifier<T>::verify1((void*)&cb, &Callback<T(T)>::thunk);
+}
+
+template <typename T>
+void test_dispatch2() {
+    Thing<T> thing;
+    Verifier<T>::verify2(static_func2<T>);
+    Verifier<T>::verify2(&thing, &Thing<T>::member_func2);
+    Verifier<T>::verify2((const Thing<T>*)&thing, &Thing<T>::const_member_func2);
+    Verifier<T>::verify2((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func2);
+    Verifier<T>::verify2((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func2);
+    Verifier<T>::verify2(&thing, &bound_func2<T>);
+    Verifier<T>::verify2((const Thing<T>*)&thing, &const_func2<T>);
+    Verifier<T>::verify2((volatile Thing<T>*)&thing, &volatile_func2<T>);
+    Verifier<T>::verify2((const volatile Thing<T>*)&thing, &const_volatile_func2<T>);
+    Verifier<T>::verify2(callback(static_func2<T>));
+
+    Callback<T(T, T)> cb(static_func2);
+    Verifier<T>::verify2(cb);
+    cb = static_func2;
+    Verifier<T>::verify2(cb);
+    cb.attach(&thing, &bound_func2<T>);
+    Verifier<T>::verify2(&cb, &Callback<T(T, T)>::call);
+    Verifier<T>::verify2((void*)&cb, &Callback<T(T, T)>::thunk);
+}
+
+template <typename T>
+void test_dispatch3() {
+    Thing<T> thing;
+    Verifier<T>::verify3(static_func3<T>);
+    Verifier<T>::verify3(&thing, &Thing<T>::member_func3);
+    Verifier<T>::verify3((const Thing<T>*)&thing, &Thing<T>::const_member_func3);
+    Verifier<T>::verify3((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func3);
+    Verifier<T>::verify3((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func3);
+    Verifier<T>::verify3(&thing, &bound_func3<T>);
+    Verifier<T>::verify3((const Thing<T>*)&thing, &const_func3<T>);
+    Verifier<T>::verify3((volatile Thing<T>*)&thing, &volatile_func3<T>);
+    Verifier<T>::verify3((const volatile Thing<T>*)&thing, &const_volatile_func3<T>);
+    Verifier<T>::verify3(callback(static_func3<T>));
+
+    Callback<T(T, T, T)> cb(static_func3);
+    Verifier<T>::verify3(cb);
+    cb = static_func3;
+    Verifier<T>::verify3(cb);
+    cb.attach(&thing, &bound_func3<T>);
+    Verifier<T>::verify3(&cb, &Callback<T(T, T, T)>::call);
+    Verifier<T>::verify3((void*)&cb, &Callback<T(T, T, T)>::thunk);
+}
+
+template <typename T>
+void test_dispatch4() {
+    Thing<T> thing;
+    Verifier<T>::verify4(static_func4<T>);
+    Verifier<T>::verify4(&thing, &Thing<T>::member_func4);
+    Verifier<T>::verify4((const Thing<T>*)&thing, &Thing<T>::const_member_func4);
+    Verifier<T>::verify4((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func4);
+    Verifier<T>::verify4((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func4);
+    Verifier<T>::verify4(&thing, &bound_func4<T>);
+    Verifier<T>::verify4((const Thing<T>*)&thing, &const_func4<T>);
+    Verifier<T>::verify4((volatile Thing<T>*)&thing, &volatile_func4<T>);
+    Verifier<T>::verify4((const volatile Thing<T>*)&thing, &const_volatile_func4<T>);
+    Verifier<T>::verify4(callback(static_func4<T>));
+
+    Callback<T(T, T, T, T)> cb(static_func4);
+    Verifier<T>::verify4(cb);
+    cb = static_func4;
+    Verifier<T>::verify4(cb);
+    cb.attach(&thing, &bound_func4<T>);
+    Verifier<T>::verify4(&cb, &Callback<T(T, T, T, T)>::call);
+    Verifier<T>::verify4((void*)&cb, &Callback<T(T, T, T, T)>::thunk);
+}
+
+template <typename T>
+void test_dispatch5() {
+    Thing<T> thing;
+    Verifier<T>::verify5(static_func5<T>);
+    Verifier<T>::verify5(&thing, &Thing<T>::member_func5);
+    Verifier<T>::verify5((const Thing<T>*)&thing, &Thing<T>::const_member_func5);
+    Verifier<T>::verify5((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func5);
+    Verifier<T>::verify5((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func5);
+    Verifier<T>::verify5(&thing, &bound_func5<T>);
+    Verifier<T>::verify5((const Thing<T>*)&thing, &const_func5<T>);
+    Verifier<T>::verify5((volatile Thing<T>*)&thing, &volatile_func5<T>);
+    Verifier<T>::verify5((const volatile Thing<T>*)&thing, &const_volatile_func5<T>);
+    Verifier<T>::verify5(callback(static_func5<T>));
+
+    Callback<T(T, T, T, T, T)> cb(static_func5);
+    Verifier<T>::verify5(cb);
+    cb = static_func5;
+    Verifier<T>::verify5(cb);
+    cb.attach(&thing, &bound_func5<T>);
+    Verifier<T>::verify5(&cb, &Callback<T(T, T, T, T, T)>::call);
+    Verifier<T>::verify5((void*)&cb, &Callback<T(T, T, T, T, T)>::thunk);
+}
+
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(10, "default_auto");
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("Testing callbacks with 0 ints", test_dispatch0<int>),
+    Case("Testing callbacks with 1 ints", test_dispatch1<int>),
+    Case("Testing callbacks with 2 ints", test_dispatch2<int>),
+    Case("Testing callbacks with 3 ints", test_dispatch3<int>),
+    Case("Testing callbacks with 4 ints", test_dispatch4<int>),
+    Case("Testing callbacks with 5 ints", test_dispatch5<int>),
+};
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}

--- a/TESTS/mbed_functional/callback_big/main.cpp
+++ b/TESTS/mbed_functional/callback_big/main.cpp
@@ -328,22 +328,6 @@ void test_dispatch5() {
     Verifier<T>::verify5((void*)&cb, &Callback<T(T, T, T, T, T)>::thunk);
 }
 
-template <typename T>
-void test_fparg1() {
-    Thing<T> thing;
-    FunctionPointerArg1<T,T> fp(static_func1<T>);
-    Verifier<T>::verify1(fp);
-    Verifier<T>::verify1(fp.get_function());
-}
-
-template <typename T>
-void test_fparg0() {
-    Thing<T> thing;
-    FunctionPointerArg1<T,void> fp(static_func0<T>);
-    Verifier<T>::verify0(fp);
-    Verifier<T>::verify0(fp.get_function());
-}
-
 
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases) {
@@ -352,29 +336,12 @@ utest::v1::status_t test_setup(const size_t number_of_cases) {
 }
 
 Case cases[] = {
-    Case("Testing callbacks with 0 ints", test_dispatch0<int>),
-    Case("Testing callbacks with 1 ints", test_dispatch1<int>),
-    Case("Testing callbacks with 2 ints", test_dispatch2<int>),
-    Case("Testing callbacks with 3 ints", test_dispatch3<int>),
-    Case("Testing callbacks with 4 ints", test_dispatch4<int>),
-    Case("Testing callbacks with 5 ints", test_dispatch5<int>),
-
-    Case("Testing callbacks with 0 uchars", test_dispatch0<unsigned char>),
-    Case("Testing callbacks with 1 uchars", test_dispatch1<unsigned char>),
-    Case("Testing callbacks with 2 uchars", test_dispatch2<unsigned char>),
-    Case("Testing callbacks with 3 uchars", test_dispatch3<unsigned char>),
-    Case("Testing callbacks with 4 uchars", test_dispatch4<unsigned char>),
-    Case("Testing callbacks with 5 uchars", test_dispatch5<unsigned char>),
-
     Case("Testing callbacks with 0 uint64s", test_dispatch0<uint64_t>),
     Case("Testing callbacks with 1 uint64s", test_dispatch1<uint64_t>),
     Case("Testing callbacks with 2 uint64s", test_dispatch2<uint64_t>),
     Case("Testing callbacks with 3 uint64s", test_dispatch3<uint64_t>),
     Case("Testing callbacks with 4 uint64s", test_dispatch4<uint64_t>),
     Case("Testing callbacks with 5 uint64s", test_dispatch5<uint64_t>),
-
-    Case("Testing FunctionPointerArg1 compatibility", test_fparg1<int>),
-    Case("Testing FunctionPointer compatibility", test_fparg0<int>),
 };
 
 Specification specification(test_setup, cases);

--- a/TESTS/mbed_functional/callback_small/main.cpp
+++ b/TESTS/mbed_functional/callback_small/main.cpp
@@ -1,0 +1,351 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+
+using namespace utest::v1;
+
+
+// static functions
+template <typename T>
+T static_func0() { return 0; }
+template <typename T>
+T static_func1(T a0) { return 0 | a0; }
+template <typename T>
+T static_func2(T a0, T a1) { return 0 | a0 | a1; }
+template <typename T>
+T static_func3(T a0, T a1, T a2) { return 0 | a0 | a1 | a2; }
+template <typename T>
+T static_func4(T a0, T a1, T a2, T a3) { return 0 | a0 | a1 | a2 | a3; }
+template <typename T>
+T static_func5(T a0, T a1, T a2, T a3, T a4) { return 0 | a0 | a1 | a2 | a3 | a4; }
+
+// class functions
+template <typename T>
+struct Thing {
+    T t;
+    Thing() : t(0x80) {}
+
+    T member_func0() { return t; }
+    T member_func1(T a0) { return t | a0; }
+    T member_func2(T a0, T a1) { return t | a0 | a1; }
+    T member_func3(T a0, T a1, T a2) { return t | a0 | a1 | a2; }
+    T member_func4(T a0, T a1, T a2, T a3) { return t | a0 | a1 | a2 | a3; }
+    T member_func5(T a0, T a1, T a2, T a3, T a4) { return t | a0 | a1 | a2 | a3 | a4; }
+
+    T const_member_func0() const { return t; }
+    T const_member_func1(T a0) const { return t | a0; }
+    T const_member_func2(T a0, T a1) const { return t | a0 | a1; }
+    T const_member_func3(T a0, T a1, T a2) const { return t | a0 | a1 | a2; }
+    T const_member_func4(T a0, T a1, T a2, T a3) const { return t | a0 | a1 | a2 | a3; }
+    T const_member_func5(T a0, T a1, T a2, T a3, T a4) const { return t | a0 | a1 | a2 | a3 | a4; }
+
+    T volatile_member_func0() volatile { return t; }
+    T volatile_member_func1(T a0) volatile { return t | a0; }
+    T volatile_member_func2(T a0, T a1) volatile { return t | a0 | a1; }
+    T volatile_member_func3(T a0, T a1, T a2) volatile { return t | a0 | a1 | a2; }
+    T volatile_member_func4(T a0, T a1, T a2, T a3) volatile { return t | a0 | a1 | a2 | a3; }
+    T volatile_member_func5(T a0, T a1, T a2, T a3, T a4) volatile { return t | a0 | a1 | a2 | a3 | a4; }
+
+    T const_volatile_member_func0() const volatile { return t; }
+    T const_volatile_member_func1(T a0) const volatile { return t | a0; }
+    T const_volatile_member_func2(T a0, T a1) const volatile { return t | a0 | a1; }
+    T const_volatile_member_func3(T a0, T a1, T a2) const volatile { return t | a0 | a1 | a2; }
+    T const_volatile_member_func4(T a0, T a1, T a2, T a3) const volatile { return t | a0 | a1 | a2 | a3; }
+    T const_volatile_member_func5(T a0, T a1, T a2, T a3, T a4) const volatile { return t | a0 | a1 | a2 | a3 | a4; }
+};
+
+// bound functions
+template <typename T>
+T bound_func0(Thing<T> *t) { return t->t; }
+template <typename T>
+T bound_func1(Thing<T> *t, T a0) { return t->t | a0; }
+template <typename T>
+T bound_func2(Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T bound_func3(Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T bound_func4(Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T bound_func5(Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
+
+// const bound functions
+template <typename T>
+T const_func0(const Thing<T> *t) { return t->t; }
+template <typename T>
+T const_func1(const Thing<T> *t, T a0) { return t->t | a0; }
+template <typename T>
+T const_func2(const Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T const_func3(const Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T const_func4(const Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T const_func5(const Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
+
+// volatile bound functions
+template <typename T>
+T volatile_func0(volatile Thing<T> *t) { return t->t; }
+template <typename T>
+T volatile_func1(volatile Thing<T> *t, T a0) { return t->t | a0; }
+template <typename T>
+T volatile_func2(volatile Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T volatile_func3(volatile Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T volatile_func4(volatile Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T volatile_func5(volatile Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
+
+// const volatile bound functions
+template <typename T>
+T const_volatile_func0(const volatile Thing<T> *t) { return t->t; }
+template <typename T>
+T const_volatile_func1(const volatile Thing<T> *t, T a0) { return t->t | a0; }
+template <typename T>
+T const_volatile_func2(const volatile Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T const_volatile_func3(const volatile Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T const_volatile_func4(const volatile Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T const_volatile_func5(const volatile Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
+
+
+// function call and result verification
+template <typename T>
+struct Verifier {
+    static void verify0(Callback<T()> func) {
+        T result = func();
+        TEST_ASSERT_EQUAL(result, 0x00);
+    }
+
+    template <typename O, typename M>
+    static void verify0(O *obj, M method) {
+        Callback<T()> func(obj, method);
+        T result = func();
+        TEST_ASSERT_EQUAL(result, 0x80);
+    }
+
+    static void verify1(Callback<T(T)> func) {
+        T result = func((1 << 0));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0));
+    }
+
+    template <typename O, typename M>
+    static void verify1(O *obj, M method) {
+        Callback<T(T)> func(obj, method);
+        T result = func((1 << 0));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0));
+    }
+
+    static void verify2(Callback<T(T, T)> func) {
+        T result = func((1 << 0), (1 << 1));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1));
+    }
+
+    template <typename O, typename M>
+    static void verify2(O *obj, M method) {
+        Callback<T(T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1));
+    }
+
+    static void verify3(Callback<T(T, T, T)> func) {
+        T result = func((1 << 0), (1 << 1), (1 << 2));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1) | (1 << 2));
+    }
+
+    template <typename O, typename M>
+    static void verify3(O *obj, M method) {
+        Callback<T(T, T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1), (1 << 2));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1) | (1 << 2));
+    }
+
+    static void verify4(Callback<T(T, T, T, T)> func) {
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3));
+    }
+
+    template <typename O, typename M>
+    static void verify4(O *obj, M method) {
+        Callback<T(T, T, T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3));
+    }
+
+    static void verify5(Callback<T(T, T, T, T, T)> func) {
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3), (1 << 4));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4));
+    }
+
+    template <typename O, typename M>
+    static void verify5(O *obj, M method) {
+        Callback<T(T, T, T, T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3), (1 << 4));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4));
+    }
+};
+
+
+// test dispatch
+template <typename T>
+void test_dispatch0() {
+    Thing<T> thing;
+    Verifier<T>::verify0(static_func0<T>);
+    Verifier<T>::verify0(&thing, &Thing<T>::member_func0);
+    Verifier<T>::verify0((const Thing<T>*)&thing, &Thing<T>::const_member_func0);
+    Verifier<T>::verify0((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func0);
+    Verifier<T>::verify0((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func0);
+    Verifier<T>::verify0(&thing, &bound_func0<T>);
+    Verifier<T>::verify0((const Thing<T>*)&thing, &const_func0<T>);
+    Verifier<T>::verify0((volatile Thing<T>*)&thing, &volatile_func0<T>);
+    Verifier<T>::verify0((const volatile Thing<T>*)&thing, &const_volatile_func0<T>);
+    Verifier<T>::verify0(callback(static_func0<T>));
+
+    Callback<T()> cb(static_func0);
+    Verifier<T>::verify0(cb);
+    cb = static_func0;
+    Verifier<T>::verify0(cb);
+    cb.attach(&thing, &bound_func0<T>);
+    Verifier<T>::verify0(&cb, &Callback<T()>::call);
+    Verifier<T>::verify0((void*)&cb, &Callback<T()>::thunk);
+}
+
+template <typename T>
+void test_dispatch1() {
+    Thing<T> thing;
+    Verifier<T>::verify1(static_func1<T>);
+    Verifier<T>::verify1(&thing, &Thing<T>::member_func1);
+    Verifier<T>::verify1((const Thing<T>*)&thing, &Thing<T>::const_member_func1);
+    Verifier<T>::verify1((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func1);
+    Verifier<T>::verify1((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func1);
+    Verifier<T>::verify1(&thing, &bound_func1<T>);
+    Verifier<T>::verify1((const Thing<T>*)&thing, &const_func1<T>);
+    Verifier<T>::verify1((volatile Thing<T>*)&thing, &volatile_func1<T>);
+    Verifier<T>::verify1((const volatile Thing<T>*)&thing, &const_volatile_func1<T>);
+    Verifier<T>::verify1(callback(static_func1<T>));
+
+    Callback<T(T)> cb(static_func1);
+    Verifier<T>::verify1(cb);
+    cb = static_func1;
+    Verifier<T>::verify1(cb);
+    cb.attach(&thing, &bound_func1<T>);
+    Verifier<T>::verify1(&cb, &Callback<T(T)>::call);
+    Verifier<T>::verify1((void*)&cb, &Callback<T(T)>::thunk);
+}
+
+template <typename T>
+void test_dispatch2() {
+    Thing<T> thing;
+    Verifier<T>::verify2(static_func2<T>);
+    Verifier<T>::verify2(&thing, &Thing<T>::member_func2);
+    Verifier<T>::verify2((const Thing<T>*)&thing, &Thing<T>::const_member_func2);
+    Verifier<T>::verify2((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func2);
+    Verifier<T>::verify2((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func2);
+    Verifier<T>::verify2(&thing, &bound_func2<T>);
+    Verifier<T>::verify2((const Thing<T>*)&thing, &const_func2<T>);
+    Verifier<T>::verify2((volatile Thing<T>*)&thing, &volatile_func2<T>);
+    Verifier<T>::verify2((const volatile Thing<T>*)&thing, &const_volatile_func2<T>);
+    Verifier<T>::verify2(callback(static_func2<T>));
+
+    Callback<T(T, T)> cb(static_func2);
+    Verifier<T>::verify2(cb);
+    cb = static_func2;
+    Verifier<T>::verify2(cb);
+    cb.attach(&thing, &bound_func2<T>);
+    Verifier<T>::verify2(&cb, &Callback<T(T, T)>::call);
+    Verifier<T>::verify2((void*)&cb, &Callback<T(T, T)>::thunk);
+}
+
+template <typename T>
+void test_dispatch3() {
+    Thing<T> thing;
+    Verifier<T>::verify3(static_func3<T>);
+    Verifier<T>::verify3(&thing, &Thing<T>::member_func3);
+    Verifier<T>::verify3((const Thing<T>*)&thing, &Thing<T>::const_member_func3);
+    Verifier<T>::verify3((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func3);
+    Verifier<T>::verify3((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func3);
+    Verifier<T>::verify3(&thing, &bound_func3<T>);
+    Verifier<T>::verify3((const Thing<T>*)&thing, &const_func3<T>);
+    Verifier<T>::verify3((volatile Thing<T>*)&thing, &volatile_func3<T>);
+    Verifier<T>::verify3((const volatile Thing<T>*)&thing, &const_volatile_func3<T>);
+    Verifier<T>::verify3(callback(static_func3<T>));
+
+    Callback<T(T, T, T)> cb(static_func3);
+    Verifier<T>::verify3(cb);
+    cb = static_func3;
+    Verifier<T>::verify3(cb);
+    cb.attach(&thing, &bound_func3<T>);
+    Verifier<T>::verify3(&cb, &Callback<T(T, T, T)>::call);
+    Verifier<T>::verify3((void*)&cb, &Callback<T(T, T, T)>::thunk);
+}
+
+template <typename T>
+void test_dispatch4() {
+    Thing<T> thing;
+    Verifier<T>::verify4(static_func4<T>);
+    Verifier<T>::verify4(&thing, &Thing<T>::member_func4);
+    Verifier<T>::verify4((const Thing<T>*)&thing, &Thing<T>::const_member_func4);
+    Verifier<T>::verify4((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func4);
+    Verifier<T>::verify4((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func4);
+    Verifier<T>::verify4(&thing, &bound_func4<T>);
+    Verifier<T>::verify4((const Thing<T>*)&thing, &const_func4<T>);
+    Verifier<T>::verify4((volatile Thing<T>*)&thing, &volatile_func4<T>);
+    Verifier<T>::verify4((const volatile Thing<T>*)&thing, &const_volatile_func4<T>);
+    Verifier<T>::verify4(callback(static_func4<T>));
+
+    Callback<T(T, T, T, T)> cb(static_func4);
+    Verifier<T>::verify4(cb);
+    cb = static_func4;
+    Verifier<T>::verify4(cb);
+    cb.attach(&thing, &bound_func4<T>);
+    Verifier<T>::verify4(&cb, &Callback<T(T, T, T, T)>::call);
+    Verifier<T>::verify4((void*)&cb, &Callback<T(T, T, T, T)>::thunk);
+}
+
+template <typename T>
+void test_dispatch5() {
+    Thing<T> thing;
+    Verifier<T>::verify5(static_func5<T>);
+    Verifier<T>::verify5(&thing, &Thing<T>::member_func5);
+    Verifier<T>::verify5((const Thing<T>*)&thing, &Thing<T>::const_member_func5);
+    Verifier<T>::verify5((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func5);
+    Verifier<T>::verify5((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func5);
+    Verifier<T>::verify5(&thing, &bound_func5<T>);
+    Verifier<T>::verify5((const Thing<T>*)&thing, &const_func5<T>);
+    Verifier<T>::verify5((volatile Thing<T>*)&thing, &volatile_func5<T>);
+    Verifier<T>::verify5((const volatile Thing<T>*)&thing, &const_volatile_func5<T>);
+    Verifier<T>::verify5(callback(static_func5<T>));
+
+    Callback<T(T, T, T, T, T)> cb(static_func5);
+    Verifier<T>::verify5(cb);
+    cb = static_func5;
+    Verifier<T>::verify5(cb);
+    cb.attach(&thing, &bound_func5<T>);
+    Verifier<T>::verify5(&cb, &Callback<T(T, T, T, T, T)>::call);
+    Verifier<T>::verify5((void*)&cb, &Callback<T(T, T, T, T, T)>::thunk);
+}
+
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(10, "default_auto");
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("Testing callbacks with 0 uchars", test_dispatch0<unsigned char>),
+    Case("Testing callbacks with 1 uchars", test_dispatch1<unsigned char>),
+    Case("Testing callbacks with 2 uchars", test_dispatch2<unsigned char>),
+    Case("Testing callbacks with 3 uchars", test_dispatch3<unsigned char>),
+    Case("Testing callbacks with 4 uchars", test_dispatch4<unsigned char>),
+    Case("Testing callbacks with 5 uchars", test_dispatch5<unsigned char>),
+};
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}

--- a/TESTS/mbed_functional/functionpointer/main.cpp
+++ b/TESTS/mbed_functional/functionpointer/main.cpp
@@ -1,0 +1,225 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+
+using namespace utest::v1;
+
+
+// static functions
+template <typename T>
+T static_func0() { return 0; }
+template <typename T>
+T static_func1(T a0) { return 0 | a0; }
+template <typename T>
+T static_func2(T a0, T a1) { return 0 | a0 | a1; }
+template <typename T>
+T static_func3(T a0, T a1, T a2) { return 0 | a0 | a1 | a2; }
+template <typename T>
+T static_func4(T a0, T a1, T a2, T a3) { return 0 | a0 | a1 | a2 | a3; }
+template <typename T>
+T static_func5(T a0, T a1, T a2, T a3, T a4) { return 0 | a0 | a1 | a2 | a3 | a4; }
+
+// class functions
+template <typename T>
+struct Thing {
+    T t;
+    Thing() : t(0x80) {}
+
+    T member_func0() { return t; }
+    T member_func1(T a0) { return t | a0; }
+    T member_func2(T a0, T a1) { return t | a0 | a1; }
+    T member_func3(T a0, T a1, T a2) { return t | a0 | a1 | a2; }
+    T member_func4(T a0, T a1, T a2, T a3) { return t | a0 | a1 | a2 | a3; }
+    T member_func5(T a0, T a1, T a2, T a3, T a4) { return t | a0 | a1 | a2 | a3 | a4; }
+
+    T const_member_func0() const { return t; }
+    T const_member_func1(T a0) const { return t | a0; }
+    T const_member_func2(T a0, T a1) const { return t | a0 | a1; }
+    T const_member_func3(T a0, T a1, T a2) const { return t | a0 | a1 | a2; }
+    T const_member_func4(T a0, T a1, T a2, T a3) const { return t | a0 | a1 | a2 | a3; }
+    T const_member_func5(T a0, T a1, T a2, T a3, T a4) const { return t | a0 | a1 | a2 | a3 | a4; }
+
+    T volatile_member_func0() volatile { return t; }
+    T volatile_member_func1(T a0) volatile { return t | a0; }
+    T volatile_member_func2(T a0, T a1) volatile { return t | a0 | a1; }
+    T volatile_member_func3(T a0, T a1, T a2) volatile { return t | a0 | a1 | a2; }
+    T volatile_member_func4(T a0, T a1, T a2, T a3) volatile { return t | a0 | a1 | a2 | a3; }
+    T volatile_member_func5(T a0, T a1, T a2, T a3, T a4) volatile { return t | a0 | a1 | a2 | a3 | a4; }
+
+    T const_volatile_member_func0() const volatile { return t; }
+    T const_volatile_member_func1(T a0) const volatile { return t | a0; }
+    T const_volatile_member_func2(T a0, T a1) const volatile { return t | a0 | a1; }
+    T const_volatile_member_func3(T a0, T a1, T a2) const volatile { return t | a0 | a1 | a2; }
+    T const_volatile_member_func4(T a0, T a1, T a2, T a3) const volatile { return t | a0 | a1 | a2 | a3; }
+    T const_volatile_member_func5(T a0, T a1, T a2, T a3, T a4) const volatile { return t | a0 | a1 | a2 | a3 | a4; }
+};
+
+// bound functions
+template <typename T>
+T bound_func0(Thing<T> *t) { return t->t; }
+template <typename T>
+T bound_func1(Thing<T> *t, T a0) { return t->t | a0; }
+template <typename T>
+T bound_func2(Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T bound_func3(Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T bound_func4(Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T bound_func5(Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
+
+// const bound functions
+template <typename T>
+T const_func0(const Thing<T> *t) { return t->t; }
+template <typename T>
+T const_func1(const Thing<T> *t, T a0) { return t->t | a0; }
+template <typename T>
+T const_func2(const Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T const_func3(const Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T const_func4(const Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T const_func5(const Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
+
+// volatile bound functions
+template <typename T>
+T volatile_func0(volatile Thing<T> *t) { return t->t; }
+template <typename T>
+T volatile_func1(volatile Thing<T> *t, T a0) { return t->t | a0; }
+template <typename T>
+T volatile_func2(volatile Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T volatile_func3(volatile Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T volatile_func4(volatile Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T volatile_func5(volatile Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
+
+// const volatile bound functions
+template <typename T>
+T const_volatile_func0(const volatile Thing<T> *t) { return t->t; }
+template <typename T>
+T const_volatile_func1(const volatile Thing<T> *t, T a0) { return t->t | a0; }
+template <typename T>
+T const_volatile_func2(const volatile Thing<T> *t, T a0, T a1) { return t->t | a0 | a1; }
+template <typename T>
+T const_volatile_func3(const volatile Thing<T> *t, T a0, T a1, T a2) { return t->t | a0 | a1 | a2; }
+template <typename T>
+T const_volatile_func4(const volatile Thing<T> *t, T a0, T a1, T a2, T a3) { return t->t | a0 | a1 | a2 | a3; }
+template <typename T>
+T const_volatile_func5(const volatile Thing<T> *t, T a0, T a1, T a2, T a3, T a4) { return t->t | a0 | a1 | a2 | a3 | a4; }
+
+
+// function call and result verification
+template <typename T>
+struct Verifier {
+    static void verify0(Callback<T()> func) {
+        T result = func();
+        TEST_ASSERT_EQUAL(result, 0x00);
+    }
+
+    template <typename O, typename M>
+    static void verify0(O *obj, M method) {
+        Callback<T()> func(obj, method);
+        T result = func();
+        TEST_ASSERT_EQUAL(result, 0x80);
+    }
+
+    static void verify1(Callback<T(T)> func) {
+        T result = func((1 << 0));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0));
+    }
+
+    template <typename O, typename M>
+    static void verify1(O *obj, M method) {
+        Callback<T(T)> func(obj, method);
+        T result = func((1 << 0));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0));
+    }
+
+    static void verify2(Callback<T(T, T)> func) {
+        T result = func((1 << 0), (1 << 1));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1));
+    }
+
+    template <typename O, typename M>
+    static void verify2(O *obj, M method) {
+        Callback<T(T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1));
+    }
+
+    static void verify3(Callback<T(T, T, T)> func) {
+        T result = func((1 << 0), (1 << 1), (1 << 2));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1) | (1 << 2));
+    }
+
+    template <typename O, typename M>
+    static void verify3(O *obj, M method) {
+        Callback<T(T, T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1), (1 << 2));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1) | (1 << 2));
+    }
+
+    static void verify4(Callback<T(T, T, T, T)> func) {
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3));
+    }
+
+    template <typename O, typename M>
+    static void verify4(O *obj, M method) {
+        Callback<T(T, T, T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3));
+    }
+
+    static void verify5(Callback<T(T, T, T, T, T)> func) {
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3), (1 << 4));
+        TEST_ASSERT_EQUAL(result, 0x00 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4));
+    }
+
+    template <typename O, typename M>
+    static void verify5(O *obj, M method) {
+        Callback<T(T, T, T, T, T)> func(obj, method);
+        T result = func((1 << 0), (1 << 1), (1 << 2), (1 << 3), (1 << 4));
+        TEST_ASSERT_EQUAL(result, 0x80 | (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4));
+    }
+};
+
+
+// test dispatch
+template <typename T>
+void test_fparg1() {
+    Thing<T> thing;
+    FunctionPointerArg1<T,T> fp(static_func1<T>);
+    Verifier<T>::verify1(fp);
+    Verifier<T>::verify1(fp.get_function());
+}
+
+template <typename T>
+void test_fparg0() {
+    Thing<T> thing;
+    FunctionPointerArg1<T,void> fp(static_func0<T>);
+    Verifier<T>::verify0(fp);
+    Verifier<T>::verify0(fp.get_function());
+}
+
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(10, "default_auto");
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("Testing FunctionPointerArg1 compatibility", test_fparg1<int>),
+    Case("Testing FunctionPointer compatibility", test_fparg0<int>),
+};
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}

--- a/features/net/network-socket/Socket.h
+++ b/features/net/network-socket/Socket.h
@@ -21,6 +21,7 @@
 #include "network-socket/NetworkStack.h"
 #include "rtos/Mutex.h"
 #include "Callback.h"
+#include "toolchain.h"
 
 
 /** Abstract socket class
@@ -168,10 +169,17 @@ public:
      *
      *  @param obj      Pointer to object to call method on
      *  @param method   Method to call on state change
+     *
+     *  @deprecated
+     *      The attach function does not support cv-qualifiers. Replaced by
+     *      attach(callback(obj, method)).
      */
     template <typename T, typename M>
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
+        "The attach function does not support cv-qualifiers. Replaced by "
+        "attach(callback(obj, method)).")
     void attach(T *obj, M method) {
-        attach(mbed::Callback<void()>(obj, method));
+        attach(mbed::callback(obj, method));
     }
 
 protected:

--- a/hal/api/CallChain.h
+++ b/hal/api/CallChain.h
@@ -17,6 +17,7 @@
 #define MBED_CALLCHAIN_H
 
 #include "Callback.h"
+#include "toolchain.h"
 #include <string.h>
 
 namespace mbed {
@@ -87,10 +88,17 @@ public:
      *
      *  @returns
      *  The function object created for 'obj' and 'method'
+     *
+     *  @deprecated
+     *  The add function does not support cv-qualifiers. Replaced by
+     *  add(callback(obj, method)).
      */
     template<typename T, typename M>
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
+        "The add function does not support cv-qualifiers. Replaced by "
+        "add(callback(obj, method)).")
     pFunctionPointer_t add(T *obj, M method) {
-        return add(Callback<void()>(obj, method));
+        return add(callback(obj, method));
     }
 
     /** Add a function at the beginning of the chain
@@ -109,10 +117,17 @@ public:
      *
      *  @returns
      *  The function object created for 'tptr' and 'mptr'
+     *
+     *  @deprecated
+     *  The add_front function does not support cv-qualifiers. Replaced by
+     *  add_front(callback(obj, method)).
      */
     template<typename T, typename M>
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
+        "The add_front function does not support cv-qualifiers. Replaced by "
+        "add_front(callback(obj, method)).")
     pFunctionPointer_t add_front(T *obj, M method) {
-        return add_front(Callback<void()>(obj, method));
+        return add_front(callback(obj, method));
     }
 
     /** Get the number of functions in the chain

--- a/hal/api/Callback.h
+++ b/hal/api/Callback.h
@@ -31,711 +31,6 @@ class Callback;
 
 /** Templated function class
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-class Callback<R(A0, A1, A2, A3, A4)> {
-public:
-    /** Create a Callback with a static function
-     *  @param func Static function to attach
-     */
-    Callback(R (*func)(A0, A1, A2, A3, A4) = 0) {
-        attach(func);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     */
-    template<typename T>
-    Callback(T *obj, R (*func)(T*, A0, A1, A2, A3, A4)) {
-        attach(obj, func);
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj  Pointer to object to invoke member function on
-     *  @param func Member function to attach
-     */
-    template<typename T>
-    Callback(T *obj, R (T::*func)(A0, A1, A2, A3, A4)) {
-        attach(obj, func);
-    }
-
-    /** Create a Callback with another Callback
-     *  @param func Callback to attach
-     */
-    Callback(const Callback<R(A0, A1, A2, A3, A4)> &func) {
-        attach(func);
-    }
-
-    /** Attach a static function
-     *  @param func Static function to attach
-     */
-    void attach(R (*func)(A0, A1, A2, A3, A4)) {
-        memcpy(&_func, &func, sizeof func);
-        _thunk = func ? &Callback::_staticthunk : 0;
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     */
-    template <typename T>
-    void attach(T *obj, R (*func)(T*, A0, A1, A2, A3, A4)) {
-        _obj = (void*)obj;
-        memcpy(&_func, &func, sizeof func);
-        _thunk = &Callback::_boundthunk<T>;
-    }
-
-    /** Attach a member function
-     *  @param obj  Pointer to object to invoke member function on
-     *  @param func Member function to attach
-     */
-    template<typename T>
-    void attach(T *obj, R (T::*func)(A0, A1, A2, A3, A4)) {
-        _obj = static_cast<void*>(obj);
-        memcpy(&_func, &func, sizeof func);
-        _thunk = &Callback::_methodthunk<T>;
-    }
-
-    /** Attach a Callback
-     *  @param func The Callback to attach
-     */
-    void attach(const Callback<R(A0, A1, A2, A3, A4)> &func) {
-        _obj = func._obj;
-        memcpy(&_func, &func._func, sizeof _func);
-        _thunk = func._thunk;
-    }
-
-    /** Call the attached function
-     */
-    R call(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        if (!_thunk) {
-            return (R)0;
-        }
-        return _thunk(_obj, &_func, a0, a1, a2, a3, a4);
-    }
-
-    /** Call the attached function
-     */
-    R operator()(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return call(a0, a1, a2, a3, a4);
-    }
-
-    /** Test if function has been attached
-     */
-    operator bool() const {
-        return _thunk;
-    }
-
-    /** Static thunk for passing as C-style function
-     *  @param func Callback to call passed as void pointer
-     */
-    static R thunk(void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return static_cast<Callback<R(A0, A1, A2, A3, A4)>*>(func)
-                ->call(a0, a1, a2, a3, a4);
-    }
-
-private:
-    // Internal thunks for various function types
-    static R _staticthunk(void*, void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return (*reinterpret_cast<R (**)(A0, A1, A2, A3, A4)>(func))
-                (a0, a1, a2, a3, a4);
-    }
-
-    template<typename T>
-    static R _boundthunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return (*reinterpret_cast<R (**)(T*, A0, A1, A2, A3, A4)>(func))
-                (static_cast<T*>(obj), a0, a1, a2, a3, a4);
-    }
-
-    template<typename T>
-    static R _methodthunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return (static_cast<T*>(obj)->*
-                (*reinterpret_cast<R (T::**)(A0, A1, A2, A3, A4)>(func)))
-                (a0, a1, a2, a3, a4);
-    }
-
-    // Stored as pointer to function and pointer to optional object
-    // Function pointer is stored as union of possible function types
-    // to garuntee proper size and alignment
-    struct _class;
-    union {
-        void (*_staticfunc)();
-        void (*_boundfunc)(_class *);
-        void (_class::*_methodfunc)();
-    } _func;
-
-    void *_obj;
-
-    // Thunk registered on attach to dispatch calls
-    R (*_thunk)(void*, void*, A0, A1, A2, A3, A4); 
-};
-
-/** Templated function class
- */
-template <typename R, typename A0, typename A1, typename A2, typename A3>
-class Callback<R(A0, A1, A2, A3)> {
-public:
-    /** Create a Callback with a static function
-     *  @param func Static function to attach
-     */
-    Callback(R (*func)(A0, A1, A2, A3) = 0) {
-        attach(func);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     */
-    template<typename T>
-    Callback(T *obj, R (*func)(T*, A0, A1, A2, A3)) {
-        attach(obj, func);
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj  Pointer to object to invoke member function on
-     *  @param func Member function to attach
-     */
-    template<typename T>
-    Callback(T *obj, R (T::*func)(A0, A1, A2, A3)) {
-        attach(obj, func);
-    }
-
-    /** Create a Callback with another Callback
-     *  @param func Callback to attach
-     */
-    Callback(const Callback<R(A0, A1, A2, A3)> &func) {
-        attach(func);
-    }
-
-    /** Attach a static function
-     *  @param func Static function to attach
-     */
-    void attach(R (*func)(A0, A1, A2, A3)) {
-        memcpy(&_func, &func, sizeof func);
-        _thunk = func ? &Callback::_staticthunk : 0;
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     */
-    template <typename T>
-    void attach(T *obj, R (*func)(T*, A0, A1, A2, A3)) {
-        _obj = (void*)obj;
-        memcpy(&_func, &func, sizeof func);
-        _thunk = &Callback::_boundthunk<T>;
-    }
-
-    /** Attach a member function
-     *  @param obj  Pointer to object to invoke member function on
-     *  @param func Member function to attach
-     */
-    template<typename T>
-    void attach(T *obj, R (T::*func)(A0, A1, A2, A3)) {
-        _obj = static_cast<void*>(obj);
-        memcpy(&_func, &func, sizeof func);
-        _thunk = &Callback::_methodthunk<T>;
-    }
-
-    /** Attach a Callback
-     *  @param func The Callback to attach
-     */
-    void attach(const Callback<R(A0, A1, A2, A3)> &func) {
-        _obj = func._obj;
-        memcpy(&_func, &func._func, sizeof _func);
-        _thunk = func._thunk;
-    }
-
-    /** Call the attached function
-     */
-    R call(A0 a0, A1 a1, A2 a2, A3 a3) {
-        if (!_thunk) {
-            return (R)0;
-        }
-        return _thunk(_obj, &_func, a0, a1, a2, a3);
-    }
-
-    /** Call the attached function
-     */
-    R operator()(A0 a0, A1 a1, A2 a2, A3 a3) {
-        return call(a0, a1, a2, a3);
-    }
-
-    /** Test if function has been attached
-     */
-    operator bool() const {
-        return _thunk;
-    }
-
-    /** Static thunk for passing as C-style function
-     *  @param func Callback to call passed as void pointer
-     */
-    static R thunk(void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return static_cast<Callback<R(A0, A1, A2, A3)>*>(func)
-                ->call(a0, a1, a2, a3);
-    }
-
-private:
-    // Internal thunks for various function types
-    static R _staticthunk(void*, void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return (*reinterpret_cast<R (**)(A0, A1, A2, A3)>(func))
-                (a0, a1, a2, a3);
-    }
-
-    template<typename T>
-    static R _boundthunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return (*reinterpret_cast<R (**)(T*, A0, A1, A2, A3)>(func))
-                (static_cast<T*>(obj), a0, a1, a2, a3);
-    }
-
-    template<typename T>
-    static R _methodthunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return (static_cast<T*>(obj)->*
-                (*reinterpret_cast<R (T::**)(A0, A1, A2, A3)>(func)))
-                (a0, a1, a2, a3);
-    }
-
-    // Stored as pointer to function and pointer to optional object
-    // Function pointer is stored as union of possible function types
-    // to garuntee proper size and alignment
-    struct _class;
-    union {
-        void (*_staticfunc)();
-        void (*_boundfunc)(_class *);
-        void (_class::*_methodfunc)();
-    } _func;
-
-    void *_obj;
-
-    // Thunk registered on attach to dispatch calls
-    R (*_thunk)(void*, void*, A0, A1, A2, A3); 
-};
-
-/** Templated function class
- */
-template <typename R, typename A0, typename A1, typename A2>
-class Callback<R(A0, A1, A2)> {
-public:
-    /** Create a Callback with a static function
-     *  @param func Static function to attach
-     */
-    Callback(R (*func)(A0, A1, A2) = 0) {
-        attach(func);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     */
-    template<typename T>
-    Callback(T *obj, R (*func)(T*, A0, A1, A2)) {
-        attach(obj, func);
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj  Pointer to object to invoke member function on
-     *  @param func Member function to attach
-     */
-    template<typename T>
-    Callback(T *obj, R (T::*func)(A0, A1, A2)) {
-        attach(obj, func);
-    }
-
-    /** Create a Callback with another Callback
-     *  @param func Callback to attach
-     */
-    Callback(const Callback<R(A0, A1, A2)> &func) {
-        attach(func);
-    }
-
-    /** Attach a static function
-     *  @param func Static function to attach
-     */
-    void attach(R (*func)(A0, A1, A2)) {
-        memcpy(&_func, &func, sizeof func);
-        _thunk = func ? &Callback::_staticthunk : 0;
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     */
-    template <typename T>
-    void attach(T *obj, R (*func)(T*, A0, A1, A2)) {
-        _obj = (void*)obj;
-        memcpy(&_func, &func, sizeof func);
-        _thunk = &Callback::_boundthunk<T>;
-    }
-
-    /** Attach a member function
-     *  @param obj  Pointer to object to invoke member function on
-     *  @param func Member function to attach
-     */
-    template<typename T>
-    void attach(T *obj, R (T::*func)(A0, A1, A2)) {
-        _obj = static_cast<void*>(obj);
-        memcpy(&_func, &func, sizeof func);
-        _thunk = &Callback::_methodthunk<T>;
-    }
-
-    /** Attach a Callback
-     *  @param func The Callback to attach
-     */
-    void attach(const Callback<R(A0, A1, A2)> &func) {
-        _obj = func._obj;
-        memcpy(&_func, &func._func, sizeof _func);
-        _thunk = func._thunk;
-    }
-
-    /** Call the attached function
-     */
-    R call(A0 a0, A1 a1, A2 a2) {
-        if (!_thunk) {
-            return (R)0;
-        }
-        return _thunk(_obj, &_func, a0, a1, a2);
-    }
-
-    /** Call the attached function
-     */
-    R operator()(A0 a0, A1 a1, A2 a2) {
-        return call(a0, a1, a2);
-    }
-
-    /** Test if function has been attached
-     */
-    operator bool() const {
-        return _thunk;
-    }
-
-    /** Static thunk for passing as C-style function
-     *  @param func Callback to call passed as void pointer
-     */
-    static R thunk(void *func, A0 a0, A1 a1, A2 a2) {
-        return static_cast<Callback<R(A0, A1, A2)>*>(func)
-                ->call(a0, a1, a2);
-    }
-
-private:
-    // Internal thunks for various function types
-    static R _staticthunk(void*, void *func, A0 a0, A1 a1, A2 a2) {
-        return (*reinterpret_cast<R (**)(A0, A1, A2)>(func))
-                (a0, a1, a2);
-    }
-
-    template<typename T>
-    static R _boundthunk(void *obj, void *func, A0 a0, A1 a1, A2 a2) {
-        return (*reinterpret_cast<R (**)(T*, A0, A1, A2)>(func))
-                (static_cast<T*>(obj), a0, a1, a2);
-    }
-
-    template<typename T>
-    static R _methodthunk(void *obj, void *func, A0 a0, A1 a1, A2 a2) {
-        return (static_cast<T*>(obj)->*
-                (*reinterpret_cast<R (T::**)(A0, A1, A2)>(func)))
-                (a0, a1, a2);
-    }
-
-    // Stored as pointer to function and pointer to optional object
-    // Function pointer is stored as union of possible function types
-    // to garuntee proper size and alignment
-    struct _class;
-    union {
-        void (*_staticfunc)();
-        void (*_boundfunc)(_class *);
-        void (_class::*_methodfunc)();
-    } _func;
-
-    void *_obj;
-
-    // Thunk registered on attach to dispatch calls
-    R (*_thunk)(void*, void*, A0, A1, A2);
-};
-
-/** Templated function class
- */
-template <typename R, typename A0, typename A1>
-class Callback<R(A0, A1)> {
-public:
-    /** Create a Callback with a static function
-     *  @param func Static function to attach
-     */
-    Callback(R (*func)(A0, A1) = 0) {
-        attach(func);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     */
-    template<typename T>
-    Callback(T *obj, R (*func)(T*, A0, A1)) {
-        attach(obj, func);
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj  Pointer to object to invoke member function on
-     *  @param func Member function to attach
-     */
-    template<typename T>
-    Callback(T *obj, R (T::*func)(A0, A1)) {
-        attach(obj, func);
-    }
-
-    /** Create a Callback with another Callback
-     *  @param func Callback to attach
-     */
-    Callback(const Callback<R(A0, A1)> &func) {
-        attach(func);
-    }
-
-    /** Attach a static function
-     *  @param func Static function to attach
-     */
-    void attach(R (*func)(A0, A1)) {
-        memcpy(&_func, &func, sizeof func);
-        _thunk = func ? &Callback::_staticthunk : 0;
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     */
-    template <typename T>
-    void attach(T *obj, R (*func)(T*, A0, A1)) {
-        _obj = (void*)obj;
-        memcpy(&_func, &func, sizeof func);
-        _thunk = &Callback::_boundthunk<T>;
-    }
-
-    /** Attach a member function
-     *  @param obj  Pointer to object to invoke member function on
-     *  @param func Member function to attach
-     */
-    template<typename T>
-    void attach(T *obj, R (T::*func)(A0, A1)) {
-        _obj = static_cast<void*>(obj);
-        memcpy(&_func, &func, sizeof func);
-        _thunk = &Callback::_methodthunk<T>;
-    }
-
-    /** Attach a Callback
-     *  @param func The Callback to attach
-     */
-    void attach(const Callback<R(A0, A1)> &func) {
-        _obj = func._obj;
-        memcpy(&_func, &func._func, sizeof _func);
-        _thunk = func._thunk;
-    }
-
-    /** Call the attached function
-     */
-    R call(A0 a0, A1 a1) {
-        if (!_thunk) {
-            return (R)0;
-        }
-        return _thunk(_obj, &_func, a0, a1);
-    }
-
-    /** Call the attached function
-     */
-    R operator()(A0 a0, A1 a1) {
-        return call(a0, a1);
-    }
-
-    /** Test if function has been attached
-     */
-    operator bool() const {
-        return _thunk;
-    }
-
-    /** Static thunk for passing as C-style function
-     *  @param func Callback to call passed as void pointer
-     */
-    static R thunk(void *func, A0 a0, A1 a1) {
-        return static_cast<Callback<R(A0, A1)>*>(func)
-                ->call(a0, a1);
-    }
-
-private:
-    // Internal thunks for various function types
-    static R _staticthunk(void*, void *func, A0 a0, A1 a1) {
-        return (*reinterpret_cast<R (**)(A0, A1)>(func))
-                (a0, a1);
-    }
-
-    template<typename T>
-    static R _boundthunk(void *obj, void *func, A0 a0, A1 a1) {
-        return (*reinterpret_cast<R (**)(T*, A0, A1)>(func))
-                (static_cast<T*>(obj), a0, a1);
-    }
-
-    template<typename T>
-    static R _methodthunk(void *obj, void *func, A0 a0, A1 a1) {
-        return (static_cast<T*>(obj)->*
-                (*reinterpret_cast<R (T::**)(A0, A1)>(func)))
-                (a0, a1);
-    }
-
-    // Stored as pointer to function and pointer to optional object
-    // Function pointer is stored as union of possible function types
-    // to garuntee proper size and alignment
-    struct _class;
-    union {
-        void (*_staticfunc)();
-        void (*_boundfunc)(_class *);
-        void (_class::*_methodfunc)();
-    } _func;
-
-    void *_obj;
-
-    // Thunk registered on attach to dispatch calls
-    R (*_thunk)(void*, void*, A0, A1); 
-};
-
-/** Templated function class
- */
-template <typename R, typename A0>
-class Callback<R(A0)> {
-public:
-    /** Create a Callback with a static function
-     *  @param func Static function to attach
-     */
-    Callback(R (*func)(A0) = 0) {
-        attach(func);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     */
-    template<typename T>
-    Callback(T *obj, R (*func)(T*, A0)) {
-        attach(obj, func);
-    }
-
-    /** Create a Callback with a member function
-     *  @param obj  Pointer to object to invoke member function on
-     *  @param func Member function to attach
-     */
-    template<typename T>
-    Callback(T *obj, R (T::*func)(A0)) {
-        attach(obj, func);
-    }
-
-    /** Create a Callback with another Callback
-     *  @param func Callback to attach
-     */
-    Callback(const Callback<R(A0)> &func) {
-        attach(func);
-    }
-
-    /** Attach a static function
-     *  @param func Static function to attach
-     */
-    void attach(R (*func)(A0)) {
-        memcpy(&_func, &func, sizeof func);
-        _thunk = func ? &Callback::_staticthunk : 0;
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     */
-    template <typename T>
-    void attach(T *obj, R (*func)(T*, A0)) {
-        _obj = (void*)obj;
-        memcpy(&_func, &func, sizeof func);
-        _thunk = &Callback::_boundthunk<T>;
-    }
-
-    /** Attach a member function
-     *  @param obj  Pointer to object to invoke member function on
-     *  @param func Member function to attach
-     */
-    template<typename T>
-    void attach(T *obj, R (T::*func)(A0)) {
-        _obj = static_cast<void*>(obj);
-        memcpy(&_func, &func, sizeof func);
-        _thunk = &Callback::_methodthunk<T>;
-    }
-
-    /** Attach a Callback
-     *  @param func The Callback to attach
-     */
-    void attach(const Callback<R(A0)> &func) {
-        _obj = func._obj;
-        memcpy(&_func, &func._func, sizeof _func);
-        _thunk = func._thunk;
-    }
-
-    /** Call the attached function
-     */
-    R call(A0 a0) {
-        if (!_thunk) {
-            return (R)0;
-        }
-        return _thunk(_obj, &_func, a0);
-    }
-
-    /** Call the attached function
-     */
-    R operator()(A0 a0) {
-        return call(a0);
-    }
-
-    /** Test if function has been attached
-     */
-    operator bool() const {
-        return _thunk;
-    }
-
-    /** Static thunk for passing as C-style function
-     *  @param func Callback to call passed as void pointer
-     */
-    static R thunk(void *func, A0 a0) {
-        return static_cast<Callback<R(A0)>*>(func)
-                ->call(a0);
-    }
-
-private:
-    // Internal thunks for various function types
-    static R _staticthunk(void*, void *func, A0 a0) {
-        return (*reinterpret_cast<R (**)(A0)>(func))
-                (a0);
-    }
-
-    template<typename T>
-    static R _boundthunk(void *obj, void *func, A0 a0) {
-        return (*reinterpret_cast<R (**)(T*, A0)>(func))
-                (static_cast<T*>(obj), a0);
-    }
-
-    template<typename T>
-    static R _methodthunk(void *obj, void *func, A0 a0) {
-        return (static_cast<T*>(obj)->*
-                (*reinterpret_cast<R (T::**)(A0)>(func)))
-                (a0);
-    }
-
-    // Stored as pointer to function and pointer to optional object
-    // Function pointer is stored as union of possible function types
-    // to garuntee proper size and alignment
-    struct _class;
-    union {
-        void (*_staticfunc)();
-        void (*_boundfunc)(_class *);
-        void (_class::*_methodfunc)();
-    } _func;
-
-    void *_obj;
-
-    // Thunk registered on attach to dispatch calls
-    R (*_thunk)(void*, void*, A0); 
-};
-
-/** Templated function class
- */
 template <typename R>
 class Callback<R()> {
 public:
@@ -743,6 +38,13 @@ public:
      *  @param func Static function to attach
      */
     Callback(R (*func)() = 0) {
+        attach(func);
+    }
+
+    /** Create a Callback with another Callback
+     *  @param func Callback to attach
+     */
+    Callback(const Callback<R()> &func) {
         attach(func);
     }
 
@@ -755,6 +57,21 @@ public:
         attach(obj, func);
     }
 
+    template<typename T>
+    Callback(const T *obj, R (*func)(const T*)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(volatile T *obj, R (*func)(volatile T*)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const volatile T *obj, R (*func)(const volatile T*)) {
+        attach(obj, func);
+    }
+
     /** Create a Callback with a member function
      *  @param obj  Pointer to object to invoke member function on
      *  @param func Member function to attach
@@ -764,41 +81,34 @@ public:
         attach(obj, func);
     }
 
-    /** Create a Callback with another Callback
-     *  @param func Callback to attach
-     */
-    Callback(const Callback<R()> &func) {
-        attach(func);
+    template<typename T>
+    Callback(const T *obj, R (T::*func)() const) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(volatile T *obj, R (T::*func)() volatile) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const volatile T *obj, R (T::*func)() const volatile) {
+        attach(obj, func);
     }
 
     /** Attach a static function
      *  @param func Static function to attach
      */
     void attach(R (*func)()) {
-        memcpy(&_func, &func, sizeof func);
-        _thunk = func ? &Callback::_staticthunk : 0;
-    }
+        struct local {
+            static R _thunk(void*, void *func) {
+                return (*(R (**)())func)(
+                        );
+            }
+        };
 
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     */
-    template <typename T>
-    void attach(T *obj, R (*func)(T*)) {
-        _obj = (void*)obj;
         memcpy(&_func, &func, sizeof func);
-        _thunk = &Callback::_boundthunk<T>;
-    }
-
-    /** Attach a member function
-     *  @param obj  Pointer to object to invoke member function on
-     *  @param func Member function to attach
-     */
-    template<typename T>
-    void attach(T *obj, R (T::*func)()) {
-        _obj = static_cast<void*>(obj);
-        memcpy(&_func, &func, sizeof func);
-        _thunk = &Callback::_methodthunk<T>;
+        _thunk = func ? &local::_thunk : 0;
     }
 
     /** Attach a Callback
@@ -808,6 +118,126 @@ public:
         _obj = func._obj;
         memcpy(&_func, &func._func, sizeof _func);
         _thunk = func._thunk;
+    }
+
+    /** Attach a static function with a bound pointer
+     *  @param obj  Pointer to object to bind to function
+     *  @param func Static function to attach
+     */
+    template <typename T>
+    void attach(T *obj, R (*func)(T*)) {
+        struct local {
+            static R _thunk(void *obj, void *func) {
+                return (*(R (**)(T*))func)(
+                        (T*)obj);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(const T *obj, R (*func)(const T*)) {
+        struct local {
+            static R _thunk(void *obj, void *func) {
+                return (*(R (**)(const T*))func)(
+                        (const T*)obj);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(volatile T *obj, R (*func)(volatile T*)) {
+        struct local {
+            static R _thunk(void *obj, void *func) {
+                return (*(R (**)(volatile T*))func)(
+                        (volatile T*)obj);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(const volatile T *obj, R (*func)(const volatile T*)) {
+        struct local {
+            static R _thunk(void *obj, void *func) {
+                return (*(R (**)(const volatile T*))func)(
+                        (const volatile T*)obj);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    /** Attach a member function
+     *  @param obj  Pointer to object to invoke member function on
+     *  @param func Member function to attach
+     */
+    template<typename T>
+    void attach(T *obj, R (T::*func)()) {
+        struct local {
+            static R _thunk(void *obj, void *func) {
+                return (((T*)obj)->*(*(R (T::**)())func))(
+                        );
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(const T *obj, R (T::*func)() const) {
+        struct local {
+            static R _thunk(void *obj, void *func) {
+                return (((const T*)obj)->*(*(R (T::**)() const)func))(
+                        );
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(volatile T *obj, R (T::*func)() volatile) {
+        struct local {
+            static R _thunk(void *obj, void *func) {
+                return (((volatile T*)obj)->*(*(R (T::**)() volatile)func))(
+                        );
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(const volatile T *obj, R (T::*func)() const volatile) {
+        struct local {
+            static R _thunk(void *obj, void *func) {
+                return (((const volatile T*)obj)->*(*(R (T::**)() const volatile)func))(
+                        );
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
     }
 
     /** Call the attached function
@@ -835,30 +265,11 @@ public:
      *  @param func Callback to call passed as void pointer
      */
     static R thunk(void *func) {
-        return static_cast<Callback<R()>*>(func)
-                ->call();
+        return static_cast<Callback<R()>*>(func)->call(
+                );
     }
 
 private:
-    // Internal thunks for various function types
-    static R _staticthunk(void*, void *func) {
-        return (*reinterpret_cast<R (**)()>(func))
-                ();
-    }
-
-    template<typename T>
-    static R _boundthunk(void *obj, void *func) {
-        return (*reinterpret_cast<R (**)(T*)>(func))
-                (static_cast<T*>(obj));
-    }
-
-    template<typename T>
-    static R _methodthunk(void *obj, void *func) {
-        return (static_cast<T*>(obj)->*
-                (*reinterpret_cast<R (T::**)()>(func)))
-                ();
-    }
-
     // Stored as pointer to function and pointer to optional object
     // Function pointer is stored as union of possible function types
     // to garuntee proper size and alignment
@@ -872,10 +283,1596 @@ private:
     void *_obj;
 
     // Thunk registered on attach to dispatch calls
-    R (*_thunk)(void*, void*); 
+    R (*_thunk)(void*, void*);
 };
 
- typedef Callback<void(int)> event_callback_t;
+/** Templated function class
+ */
+template <typename R, typename A0>
+class Callback<R(A0)> {
+public:
+    /** Create a Callback with a static function
+     *  @param func Static function to attach
+     */
+    Callback(R (*func)(A0) = 0) {
+        attach(func);
+    }
+
+    /** Create a Callback with another Callback
+     *  @param func Callback to attach
+     */
+    Callback(const Callback<R(A0)> &func) {
+        attach(func);
+    }
+
+    /** Create a Callback with a static function and bound pointer
+     *  @param obj  Pointer to object to bind to function
+     *  @param func Static function to attach
+     */
+    template<typename T>
+    Callback(T *obj, R (*func)(T*, A0)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const T *obj, R (*func)(const T*, A0)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(volatile T *obj, R (*func)(volatile T*, A0)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const volatile T *obj, R (*func)(const volatile T*, A0)) {
+        attach(obj, func);
+    }
+
+    /** Create a Callback with a member function
+     *  @param obj  Pointer to object to invoke member function on
+     *  @param func Member function to attach
+     */
+    template<typename T>
+    Callback(T *obj, R (T::*func)(A0)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const T *obj, R (T::*func)(A0) const) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(volatile T *obj, R (T::*func)(A0) volatile) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const volatile T *obj, R (T::*func)(A0) const volatile) {
+        attach(obj, func);
+    }
+
+    /** Attach a static function
+     *  @param func Static function to attach
+     */
+    void attach(R (*func)(A0)) {
+        struct local {
+            static R _thunk(void*, void *func, A0 a0) {
+                return (*(R (**)(A0))func)(
+                        a0);
+            }
+        };
+
+        memcpy(&_func, &func, sizeof func);
+        _thunk = func ? &local::_thunk : 0;
+    }
+
+    /** Attach a Callback
+     *  @param func The Callback to attach
+     */
+    void attach(const Callback<R(A0)> &func) {
+        _obj = func._obj;
+        memcpy(&_func, &func._func, sizeof _func);
+        _thunk = func._thunk;
+    }
+
+    /** Attach a static function with a bound pointer
+     *  @param obj  Pointer to object to bind to function
+     *  @param func Static function to attach
+     */
+    template <typename T>
+    void attach(T *obj, R (*func)(T*, A0)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0) {
+                return (*(R (**)(T*, A0))func)(
+                        (T*)obj, a0);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(const T *obj, R (*func)(const T*, A0)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0) {
+                return (*(R (**)(const T*, A0))func)(
+                        (const T*)obj, a0);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(volatile T *obj, R (*func)(volatile T*, A0)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0) {
+                return (*(R (**)(volatile T*, A0))func)(
+                        (volatile T*)obj, a0);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(const volatile T *obj, R (*func)(const volatile T*, A0)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0) {
+                return (*(R (**)(const volatile T*, A0))func)(
+                        (const volatile T*)obj, a0);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    /** Attach a member function
+     *  @param obj  Pointer to object to invoke member function on
+     *  @param func Member function to attach
+     */
+    template<typename T>
+    void attach(T *obj, R (T::*func)(A0)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0) {
+                return (((T*)obj)->*(*(R (T::**)(A0))func))(
+                        a0);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(const T *obj, R (T::*func)(A0) const) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0) {
+                return (((const T*)obj)->*(*(R (T::**)(A0) const)func))(
+                        a0);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(volatile T *obj, R (T::*func)(A0) volatile) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0) {
+                return (((volatile T*)obj)->*(*(R (T::**)(A0) volatile)func))(
+                        a0);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(const volatile T *obj, R (T::*func)(A0) const volatile) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0) {
+                return (((const volatile T*)obj)->*(*(R (T::**)(A0) const volatile)func))(
+                        a0);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    /** Call the attached function
+     */
+    R call(A0 a0) {
+        if (!_thunk) {
+            return (R)0;
+        }
+        return _thunk(_obj, &_func, a0);
+    }
+
+    /** Call the attached function
+     */
+    R operator()(A0 a0) {
+        return call(a0);
+    }
+
+    /** Test if function has been attached
+     */
+    operator bool() const {
+        return _thunk;
+    }
+
+    /** Static thunk for passing as C-style function
+     *  @param func Callback to call passed as void pointer
+     */
+    static R thunk(void *func, A0 a0) {
+        return static_cast<Callback<R(A0)>*>(func)->call(
+                a0);
+    }
+
+private:
+    // Stored as pointer to function and pointer to optional object
+    // Function pointer is stored as union of possible function types
+    // to garuntee proper size and alignment
+    struct _class;
+    union {
+        void (*_staticfunc)();
+        void (*_boundfunc)(_class *);
+        void (_class::*_methodfunc)();
+    } _func;
+
+    void *_obj;
+
+    // Thunk registered on attach to dispatch calls
+    R (*_thunk)(void*, void*, A0);
+};
+
+/** Templated function class
+ */
+template <typename R, typename A0, typename A1>
+class Callback<R(A0, A1)> {
+public:
+    /** Create a Callback with a static function
+     *  @param func Static function to attach
+     */
+    Callback(R (*func)(A0, A1) = 0) {
+        attach(func);
+    }
+
+    /** Create a Callback with another Callback
+     *  @param func Callback to attach
+     */
+    Callback(const Callback<R(A0, A1)> &func) {
+        attach(func);
+    }
+
+    /** Create a Callback with a static function and bound pointer
+     *  @param obj  Pointer to object to bind to function
+     *  @param func Static function to attach
+     */
+    template<typename T>
+    Callback(T *obj, R (*func)(T*, A0, A1)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const T *obj, R (*func)(const T*, A0, A1)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(volatile T *obj, R (*func)(volatile T*, A0, A1)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1)) {
+        attach(obj, func);
+    }
+
+    /** Create a Callback with a member function
+     *  @param obj  Pointer to object to invoke member function on
+     *  @param func Member function to attach
+     */
+    template<typename T>
+    Callback(T *obj, R (T::*func)(A0, A1)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const T *obj, R (T::*func)(A0, A1) const) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(volatile T *obj, R (T::*func)(A0, A1) volatile) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const volatile T *obj, R (T::*func)(A0, A1) const volatile) {
+        attach(obj, func);
+    }
+
+    /** Attach a static function
+     *  @param func Static function to attach
+     */
+    void attach(R (*func)(A0, A1)) {
+        struct local {
+            static R _thunk(void*, void *func, A0 a0, A1 a1) {
+                return (*(R (**)(A0, A1))func)(
+                        a0, a1);
+            }
+        };
+
+        memcpy(&_func, &func, sizeof func);
+        _thunk = func ? &local::_thunk : 0;
+    }
+
+    /** Attach a Callback
+     *  @param func The Callback to attach
+     */
+    void attach(const Callback<R(A0, A1)> &func) {
+        _obj = func._obj;
+        memcpy(&_func, &func._func, sizeof _func);
+        _thunk = func._thunk;
+    }
+
+    /** Attach a static function with a bound pointer
+     *  @param obj  Pointer to object to bind to function
+     *  @param func Static function to attach
+     */
+    template <typename T>
+    void attach(T *obj, R (*func)(T*, A0, A1)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1) {
+                return (*(R (**)(T*, A0, A1))func)(
+                        (T*)obj, a0, a1);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(const T *obj, R (*func)(const T*, A0, A1)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1) {
+                return (*(R (**)(const T*, A0, A1))func)(
+                        (const T*)obj, a0, a1);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(volatile T *obj, R (*func)(volatile T*, A0, A1)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1) {
+                return (*(R (**)(volatile T*, A0, A1))func)(
+                        (volatile T*)obj, a0, a1);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(const volatile T *obj, R (*func)(const volatile T*, A0, A1)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1) {
+                return (*(R (**)(const volatile T*, A0, A1))func)(
+                        (const volatile T*)obj, a0, a1);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    /** Attach a member function
+     *  @param obj  Pointer to object to invoke member function on
+     *  @param func Member function to attach
+     */
+    template<typename T>
+    void attach(T *obj, R (T::*func)(A0, A1)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1) {
+                return (((T*)obj)->*(*(R (T::**)(A0, A1))func))(
+                        a0, a1);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(const T *obj, R (T::*func)(A0, A1) const) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1) {
+                return (((const T*)obj)->*(*(R (T::**)(A0, A1) const)func))(
+                        a0, a1);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(volatile T *obj, R (T::*func)(A0, A1) volatile) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1) {
+                return (((volatile T*)obj)->*(*(R (T::**)(A0, A1) volatile)func))(
+                        a0, a1);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(const volatile T *obj, R (T::*func)(A0, A1) const volatile) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1) {
+                return (((const volatile T*)obj)->*(*(R (T::**)(A0, A1) const volatile)func))(
+                        a0, a1);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    /** Call the attached function
+     */
+    R call(A0 a0, A1 a1) {
+        if (!_thunk) {
+            return (R)0;
+        }
+        return _thunk(_obj, &_func, a0, a1);
+    }
+
+    /** Call the attached function
+     */
+    R operator()(A0 a0, A1 a1) {
+        return call(a0, a1);
+    }
+
+    /** Test if function has been attached
+     */
+    operator bool() const {
+        return _thunk;
+    }
+
+    /** Static thunk for passing as C-style function
+     *  @param func Callback to call passed as void pointer
+     */
+    static R thunk(void *func, A0 a0, A1 a1) {
+        return static_cast<Callback<R(A0, A1)>*>(func)->call(
+                a0, a1);
+    }
+
+private:
+    // Stored as pointer to function and pointer to optional object
+    // Function pointer is stored as union of possible function types
+    // to garuntee proper size and alignment
+    struct _class;
+    union {
+        void (*_staticfunc)();
+        void (*_boundfunc)(_class *);
+        void (_class::*_methodfunc)();
+    } _func;
+
+    void *_obj;
+
+    // Thunk registered on attach to dispatch calls
+    R (*_thunk)(void*, void*, A0, A1);
+};
+
+/** Templated function class
+ */
+template <typename R, typename A0, typename A1, typename A2>
+class Callback<R(A0, A1, A2)> {
+public:
+    /** Create a Callback with a static function
+     *  @param func Static function to attach
+     */
+    Callback(R (*func)(A0, A1, A2) = 0) {
+        attach(func);
+    }
+
+    /** Create a Callback with another Callback
+     *  @param func Callback to attach
+     */
+    Callback(const Callback<R(A0, A1, A2)> &func) {
+        attach(func);
+    }
+
+    /** Create a Callback with a static function and bound pointer
+     *  @param obj  Pointer to object to bind to function
+     *  @param func Static function to attach
+     */
+    template<typename T>
+    Callback(T *obj, R (*func)(T*, A0, A1, A2)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const T *obj, R (*func)(const T*, A0, A1, A2)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2)) {
+        attach(obj, func);
+    }
+
+    /** Create a Callback with a member function
+     *  @param obj  Pointer to object to invoke member function on
+     *  @param func Member function to attach
+     */
+    template<typename T>
+    Callback(T *obj, R (T::*func)(A0, A1, A2)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const T *obj, R (T::*func)(A0, A1, A2) const) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(volatile T *obj, R (T::*func)(A0, A1, A2) volatile) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const volatile T *obj, R (T::*func)(A0, A1, A2) const volatile) {
+        attach(obj, func);
+    }
+
+    /** Attach a static function
+     *  @param func Static function to attach
+     */
+    void attach(R (*func)(A0, A1, A2)) {
+        struct local {
+            static R _thunk(void*, void *func, A0 a0, A1 a1, A2 a2) {
+                return (*(R (**)(A0, A1, A2))func)(
+                        a0, a1, a2);
+            }
+        };
+
+        memcpy(&_func, &func, sizeof func);
+        _thunk = func ? &local::_thunk : 0;
+    }
+
+    /** Attach a Callback
+     *  @param func The Callback to attach
+     */
+    void attach(const Callback<R(A0, A1, A2)> &func) {
+        _obj = func._obj;
+        memcpy(&_func, &func._func, sizeof _func);
+        _thunk = func._thunk;
+    }
+
+    /** Attach a static function with a bound pointer
+     *  @param obj  Pointer to object to bind to function
+     *  @param func Static function to attach
+     */
+    template <typename T>
+    void attach(T *obj, R (*func)(T*, A0, A1, A2)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2) {
+                return (*(R (**)(T*, A0, A1, A2))func)(
+                        (T*)obj, a0, a1, a2);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(const T *obj, R (*func)(const T*, A0, A1, A2)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2) {
+                return (*(R (**)(const T*, A0, A1, A2))func)(
+                        (const T*)obj, a0, a1, a2);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(volatile T *obj, R (*func)(volatile T*, A0, A1, A2)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2) {
+                return (*(R (**)(volatile T*, A0, A1, A2))func)(
+                        (volatile T*)obj, a0, a1, a2);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2) {
+                return (*(R (**)(const volatile T*, A0, A1, A2))func)(
+                        (const volatile T*)obj, a0, a1, a2);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    /** Attach a member function
+     *  @param obj  Pointer to object to invoke member function on
+     *  @param func Member function to attach
+     */
+    template<typename T>
+    void attach(T *obj, R (T::*func)(A0, A1, A2)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2) {
+                return (((T*)obj)->*(*(R (T::**)(A0, A1, A2))func))(
+                        a0, a1, a2);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(const T *obj, R (T::*func)(A0, A1, A2) const) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2) {
+                return (((const T*)obj)->*(*(R (T::**)(A0, A1, A2) const)func))(
+                        a0, a1, a2);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(volatile T *obj, R (T::*func)(A0, A1, A2) volatile) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2) {
+                return (((volatile T*)obj)->*(*(R (T::**)(A0, A1, A2) volatile)func))(
+                        a0, a1, a2);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(const volatile T *obj, R (T::*func)(A0, A1, A2) const volatile) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2) {
+                return (((const volatile T*)obj)->*(*(R (T::**)(A0, A1, A2) const volatile)func))(
+                        a0, a1, a2);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    /** Call the attached function
+     */
+    R call(A0 a0, A1 a1, A2 a2) {
+        if (!_thunk) {
+            return (R)0;
+        }
+        return _thunk(_obj, &_func, a0, a1, a2);
+    }
+
+    /** Call the attached function
+     */
+    R operator()(A0 a0, A1 a1, A2 a2) {
+        return call(a0, a1, a2);
+    }
+
+    /** Test if function has been attached
+     */
+    operator bool() const {
+        return _thunk;
+    }
+
+    /** Static thunk for passing as C-style function
+     *  @param func Callback to call passed as void pointer
+     */
+    static R thunk(void *func, A0 a0, A1 a1, A2 a2) {
+        return static_cast<Callback<R(A0, A1, A2)>*>(func)->call(
+                a0, a1, a2);
+    }
+
+private:
+    // Stored as pointer to function and pointer to optional object
+    // Function pointer is stored as union of possible function types
+    // to garuntee proper size and alignment
+    struct _class;
+    union {
+        void (*_staticfunc)();
+        void (*_boundfunc)(_class *);
+        void (_class::*_methodfunc)();
+    } _func;
+
+    void *_obj;
+
+    // Thunk registered on attach to dispatch calls
+    R (*_thunk)(void*, void*, A0, A1, A2);
+};
+
+/** Templated function class
+ */
+template <typename R, typename A0, typename A1, typename A2, typename A3>
+class Callback<R(A0, A1, A2, A3)> {
+public:
+    /** Create a Callback with a static function
+     *  @param func Static function to attach
+     */
+    Callback(R (*func)(A0, A1, A2, A3) = 0) {
+        attach(func);
+    }
+
+    /** Create a Callback with another Callback
+     *  @param func Callback to attach
+     */
+    Callback(const Callback<R(A0, A1, A2, A3)> &func) {
+        attach(func);
+    }
+
+    /** Create a Callback with a static function and bound pointer
+     *  @param obj  Pointer to object to bind to function
+     *  @param func Static function to attach
+     */
+    template<typename T>
+    Callback(T *obj, R (*func)(T*, A0, A1, A2, A3)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const T *obj, R (*func)(const T*, A0, A1, A2, A3)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3)) {
+        attach(obj, func);
+    }
+
+    /** Create a Callback with a member function
+     *  @param obj  Pointer to object to invoke member function on
+     *  @param func Member function to attach
+     */
+    template<typename T>
+    Callback(T *obj, R (T::*func)(A0, A1, A2, A3)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const T *obj, R (T::*func)(A0, A1, A2, A3) const) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(volatile T *obj, R (T::*func)(A0, A1, A2, A3) volatile) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const volatile T *obj, R (T::*func)(A0, A1, A2, A3) const volatile) {
+        attach(obj, func);
+    }
+
+    /** Attach a static function
+     *  @param func Static function to attach
+     */
+    void attach(R (*func)(A0, A1, A2, A3)) {
+        struct local {
+            static R _thunk(void*, void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
+                return (*(R (**)(A0, A1, A2, A3))func)(
+                        a0, a1, a2, a3);
+            }
+        };
+
+        memcpy(&_func, &func, sizeof func);
+        _thunk = func ? &local::_thunk : 0;
+    }
+
+    /** Attach a Callback
+     *  @param func The Callback to attach
+     */
+    void attach(const Callback<R(A0, A1, A2, A3)> &func) {
+        _obj = func._obj;
+        memcpy(&_func, &func._func, sizeof _func);
+        _thunk = func._thunk;
+    }
+
+    /** Attach a static function with a bound pointer
+     *  @param obj  Pointer to object to bind to function
+     *  @param func Static function to attach
+     */
+    template <typename T>
+    void attach(T *obj, R (*func)(T*, A0, A1, A2, A3)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
+                return (*(R (**)(T*, A0, A1, A2, A3))func)(
+                        (T*)obj, a0, a1, a2, a3);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(const T *obj, R (*func)(const T*, A0, A1, A2, A3)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
+                return (*(R (**)(const T*, A0, A1, A2, A3))func)(
+                        (const T*)obj, a0, a1, a2, a3);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
+                return (*(R (**)(volatile T*, A0, A1, A2, A3))func)(
+                        (volatile T*)obj, a0, a1, a2, a3);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
+                return (*(R (**)(const volatile T*, A0, A1, A2, A3))func)(
+                        (const volatile T*)obj, a0, a1, a2, a3);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    /** Attach a member function
+     *  @param obj  Pointer to object to invoke member function on
+     *  @param func Member function to attach
+     */
+    template<typename T>
+    void attach(T *obj, R (T::*func)(A0, A1, A2, A3)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
+                return (((T*)obj)->*(*(R (T::**)(A0, A1, A2, A3))func))(
+                        a0, a1, a2, a3);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(const T *obj, R (T::*func)(A0, A1, A2, A3) const) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
+                return (((const T*)obj)->*(*(R (T::**)(A0, A1, A2, A3) const)func))(
+                        a0, a1, a2, a3);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(volatile T *obj, R (T::*func)(A0, A1, A2, A3) volatile) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
+                return (((volatile T*)obj)->*(*(R (T::**)(A0, A1, A2, A3) volatile)func))(
+                        a0, a1, a2, a3);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(const volatile T *obj, R (T::*func)(A0, A1, A2, A3) const volatile) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
+                return (((const volatile T*)obj)->*(*(R (T::**)(A0, A1, A2, A3) const volatile)func))(
+                        a0, a1, a2, a3);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    /** Call the attached function
+     */
+    R call(A0 a0, A1 a1, A2 a2, A3 a3) {
+        if (!_thunk) {
+            return (R)0;
+        }
+        return _thunk(_obj, &_func, a0, a1, a2, a3);
+    }
+
+    /** Call the attached function
+     */
+    R operator()(A0 a0, A1 a1, A2 a2, A3 a3) {
+        return call(a0, a1, a2, a3);
+    }
+
+    /** Test if function has been attached
+     */
+    operator bool() const {
+        return _thunk;
+    }
+
+    /** Static thunk for passing as C-style function
+     *  @param func Callback to call passed as void pointer
+     */
+    static R thunk(void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
+        return static_cast<Callback<R(A0, A1, A2, A3)>*>(func)->call(
+                a0, a1, a2, a3);
+    }
+
+private:
+    // Stored as pointer to function and pointer to optional object
+    // Function pointer is stored as union of possible function types
+    // to garuntee proper size and alignment
+    struct _class;
+    union {
+        void (*_staticfunc)();
+        void (*_boundfunc)(_class *);
+        void (_class::*_methodfunc)();
+    } _func;
+
+    void *_obj;
+
+    // Thunk registered on attach to dispatch calls
+    R (*_thunk)(void*, void*, A0, A1, A2, A3);
+};
+
+/** Templated function class
+ */
+template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+class Callback<R(A0, A1, A2, A3, A4)> {
+public:
+    /** Create a Callback with a static function
+     *  @param func Static function to attach
+     */
+    Callback(R (*func)(A0, A1, A2, A3, A4) = 0) {
+        attach(func);
+    }
+
+    /** Create a Callback with another Callback
+     *  @param func Callback to attach
+     */
+    Callback(const Callback<R(A0, A1, A2, A3, A4)> &func) {
+        attach(func);
+    }
+
+    /** Create a Callback with a static function and bound pointer
+     *  @param obj  Pointer to object to bind to function
+     *  @param func Static function to attach
+     */
+    template<typename T>
+    Callback(T *obj, R (*func)(T*, A0, A1, A2, A3, A4)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const T *obj, R (*func)(const T*, A0, A1, A2, A3, A4)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3, A4)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3, A4)) {
+        attach(obj, func);
+    }
+
+    /** Create a Callback with a member function
+     *  @param obj  Pointer to object to invoke member function on
+     *  @param func Member function to attach
+     */
+    template<typename T>
+    Callback(T *obj, R (T::*func)(A0, A1, A2, A3, A4)) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const T *obj, R (T::*func)(A0, A1, A2, A3, A4) const) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(volatile T *obj, R (T::*func)(A0, A1, A2, A3, A4) volatile) {
+        attach(obj, func);
+    }
+
+    template<typename T>
+    Callback(const volatile T *obj, R (T::*func)(A0, A1, A2, A3, A4) const volatile) {
+        attach(obj, func);
+    }
+
+    /** Attach a static function
+     *  @param func Static function to attach
+     */
+    void attach(R (*func)(A0, A1, A2, A3, A4)) {
+        struct local {
+            static R _thunk(void*, void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+                return (*(R (**)(A0, A1, A2, A3, A4))func)(
+                        a0, a1, a2, a3, a4);
+            }
+        };
+
+        memcpy(&_func, &func, sizeof func);
+        _thunk = func ? &local::_thunk : 0;
+    }
+
+    /** Attach a Callback
+     *  @param func The Callback to attach
+     */
+    void attach(const Callback<R(A0, A1, A2, A3, A4)> &func) {
+        _obj = func._obj;
+        memcpy(&_func, &func._func, sizeof _func);
+        _thunk = func._thunk;
+    }
+
+    /** Attach a static function with a bound pointer
+     *  @param obj  Pointer to object to bind to function
+     *  @param func Static function to attach
+     */
+    template <typename T>
+    void attach(T *obj, R (*func)(T*, A0, A1, A2, A3, A4)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+                return (*(R (**)(T*, A0, A1, A2, A3, A4))func)(
+                        (T*)obj, a0, a1, a2, a3, a4);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(const T *obj, R (*func)(const T*, A0, A1, A2, A3, A4)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+                return (*(R (**)(const T*, A0, A1, A2, A3, A4))func)(
+                        (const T*)obj, a0, a1, a2, a3, a4);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3, A4)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+                return (*(R (**)(volatile T*, A0, A1, A2, A3, A4))func)(
+                        (volatile T*)obj, a0, a1, a2, a3, a4);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template <typename T>
+    void attach(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3, A4)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+                return (*(R (**)(const volatile T*, A0, A1, A2, A3, A4))func)(
+                        (const volatile T*)obj, a0, a1, a2, a3, a4);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    /** Attach a member function
+     *  @param obj  Pointer to object to invoke member function on
+     *  @param func Member function to attach
+     */
+    template<typename T>
+    void attach(T *obj, R (T::*func)(A0, A1, A2, A3, A4)) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+                return (((T*)obj)->*(*(R (T::**)(A0, A1, A2, A3, A4))func))(
+                        a0, a1, a2, a3, a4);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(const T *obj, R (T::*func)(A0, A1, A2, A3, A4) const) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+                return (((const T*)obj)->*(*(R (T::**)(A0, A1, A2, A3, A4) const)func))(
+                        a0, a1, a2, a3, a4);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(volatile T *obj, R (T::*func)(A0, A1, A2, A3, A4) volatile) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+                return (((volatile T*)obj)->*(*(R (T::**)(A0, A1, A2, A3, A4) volatile)func))(
+                        a0, a1, a2, a3, a4);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    template<typename T>
+    void attach(const volatile T *obj, R (T::*func)(A0, A1, A2, A3, A4) const volatile) {
+        struct local {
+            static R _thunk(void *obj, void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+                return (((const volatile T*)obj)->*(*(R (T::**)(A0, A1, A2, A3, A4) const volatile)func))(
+                        a0, a1, a2, a3, a4);
+            }
+        };
+
+        _obj = (void*)obj;
+        memcpy(&_func, &func, sizeof func);
+        _thunk = &local::_thunk;
+    }
+
+    /** Call the attached function
+     */
+    R call(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+        if (!_thunk) {
+            return (R)0;
+        }
+        return _thunk(_obj, &_func, a0, a1, a2, a3, a4);
+    }
+
+    /** Call the attached function
+     */
+    R operator()(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+        return call(a0, a1, a2, a3, a4);
+    }
+
+    /** Test if function has been attached
+     */
+    operator bool() const {
+        return _thunk;
+    }
+
+    /** Static thunk for passing as C-style function
+     *  @param func Callback to call passed as void pointer
+     */
+    static R thunk(void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+        return static_cast<Callback<R(A0, A1, A2, A3, A4)>*>(func)->call(
+                a0, a1, a2, a3, a4);
+    }
+
+private:
+    // Stored as pointer to function and pointer to optional object
+    // Function pointer is stored as union of possible function types
+    // to garuntee proper size and alignment
+    struct _class;
+    union {
+        void (*_staticfunc)();
+        void (*_boundfunc)(_class *);
+        void (_class::*_methodfunc)();
+    } _func;
+
+    void *_obj;
+
+    // Thunk registered on attach to dispatch calls
+    R (*_thunk)(void*, void*, A0, A1, A2, A3, A4);
+};
+
+typedef Callback<void(int)> event_callback_t;
+
+
+/** Create a callback class with type infered from the arguments
+ *
+ *  @param obj  Optional pointer to object to bind to function
+ *  @param func Static function to attach
+ *  @return     Callback with type infered from arguments
+ */
+template <typename R>
+Callback<R()> callback(R (*func)() = 0) {
+    return Callback<R()>(func);
+}
+
+template <typename R>
+Callback<R()> callback(const Callback<R()> &func) {
+    return Callback<R()>(func);
+}
+template <typename T, typename R>
+Callback<R()> callback(T *obj, R (*func)(T*)) {
+    return Callback<R()>(obj, func);
+}
+
+template <typename T, typename R>
+Callback<R()> callback(const T *obj, R (*func)(const T*)) {
+    return Callback<R()>(obj, func);
+}
+
+template <typename T, typename R>
+Callback<R()> callback(volatile T *obj, R (*func)(volatile T*)) {
+    return Callback<R()>(obj, func);
+}
+
+template <typename T, typename R>
+Callback<R()> callback(const volatile T *obj, R (*func)(const volatile T*)) {
+    return Callback<R()>(obj, func);
+}
+
+template<typename T, typename R>
+Callback<R()> callback(T *obj, R (T::*func)()) {
+    return Callback<R()>(obj, func);
+}
+
+template<typename T, typename R>
+Callback<R()> callback(const T *obj, R (T::*func)() const) {
+    return Callback<R()>(obj, func);
+}
+
+template<typename T, typename R>
+Callback<R()> callback(volatile T *obj, R (T::*func)() volatile) {
+    return Callback<R()>(obj, func);
+}
+
+template<typename T, typename R>
+Callback<R()> callback(const volatile T *obj, R (T::*func)() const volatile) {
+    return Callback<R()>(obj, func);
+}
+
+template <typename R, typename A0>
+Callback<R(A0)> callback(R (*func)(A0) = 0) {
+    return Callback<R(A0)>(func);
+}
+
+template <typename R, typename A0>
+Callback<R(A0)> callback(const Callback<R(A0)> &func) {
+    return Callback<R(A0)>(func);
+}
+template <typename T, typename R, typename A0>
+Callback<R(A0)> callback(T *obj, R (*func)(T*, A0)) {
+    return Callback<R(A0)>(obj, func);
+}
+
+template <typename T, typename R, typename A0>
+Callback<R(A0)> callback(const T *obj, R (*func)(const T*, A0)) {
+    return Callback<R(A0)>(obj, func);
+}
+
+template <typename T, typename R, typename A0>
+Callback<R(A0)> callback(volatile T *obj, R (*func)(volatile T*, A0)) {
+    return Callback<R(A0)>(obj, func);
+}
+
+template <typename T, typename R, typename A0>
+Callback<R(A0)> callback(const volatile T *obj, R (*func)(const volatile T*, A0)) {
+    return Callback<R(A0)>(obj, func);
+}
+
+template<typename T, typename R, typename A0>
+Callback<R(A0)> callback(T *obj, R (T::*func)(A0)) {
+    return Callback<R(A0)>(obj, func);
+}
+
+template<typename T, typename R, typename A0>
+Callback<R(A0)> callback(const T *obj, R (T::*func)(A0) const) {
+    return Callback<R(A0)>(obj, func);
+}
+
+template<typename T, typename R, typename A0>
+Callback<R(A0)> callback(volatile T *obj, R (T::*func)(A0) volatile) {
+    return Callback<R(A0)>(obj, func);
+}
+
+template<typename T, typename R, typename A0>
+Callback<R(A0)> callback(const volatile T *obj, R (T::*func)(A0) const volatile) {
+    return Callback<R(A0)>(obj, func);
+}
+
+template <typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(R (*func)(A0, A1) = 0) {
+    return Callback<R(A0, A1)>(func);
+}
+
+template <typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(const Callback<R(A0, A1)> &func) {
+    return Callback<R(A0, A1)>(func);
+}
+template <typename T, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(T *obj, R (*func)(T*, A0, A1)) {
+    return Callback<R(A0, A1)>(obj, func);
+}
+
+template <typename T, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(const T *obj, R (*func)(const T*, A0, A1)) {
+    return Callback<R(A0, A1)>(obj, func);
+}
+
+template <typename T, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(volatile T *obj, R (*func)(volatile T*, A0, A1)) {
+    return Callback<R(A0, A1)>(obj, func);
+}
+
+template <typename T, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1)) {
+    return Callback<R(A0, A1)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(T *obj, R (T::*func)(A0, A1)) {
+    return Callback<R(A0, A1)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(const T *obj, R (T::*func)(A0, A1) const) {
+    return Callback<R(A0, A1)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(volatile T *obj, R (T::*func)(A0, A1) volatile) {
+    return Callback<R(A0, A1)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(const volatile T *obj, R (T::*func)(A0, A1) const volatile) {
+    return Callback<R(A0, A1)>(obj, func);
+}
+
+template <typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(R (*func)(A0, A1, A2) = 0) {
+    return Callback<R(A0, A1, A2)>(func);
+}
+
+template <typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(const Callback<R(A0, A1, A2)> &func) {
+    return Callback<R(A0, A1, A2)>(func);
+}
+template <typename T, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(T *obj, R (*func)(T*, A0, A1, A2)) {
+    return Callback<R(A0, A1, A2)>(obj, func);
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(const T *obj, R (*func)(const T*, A0, A1, A2)) {
+    return Callback<R(A0, A1, A2)>(obj, func);
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2)) {
+    return Callback<R(A0, A1, A2)>(obj, func);
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2)) {
+    return Callback<R(A0, A1, A2)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(T *obj, R (T::*func)(A0, A1, A2)) {
+    return Callback<R(A0, A1, A2)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(const T *obj, R (T::*func)(A0, A1, A2) const) {
+    return Callback<R(A0, A1, A2)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(volatile T *obj, R (T::*func)(A0, A1, A2) volatile) {
+    return Callback<R(A0, A1, A2)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(const volatile T *obj, R (T::*func)(A0, A1, A2) const volatile) {
+    return Callback<R(A0, A1, A2)>(obj, func);
+}
+
+template <typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(R (*func)(A0, A1, A2, A3) = 0) {
+    return Callback<R(A0, A1, A2, A3)>(func);
+}
+
+template <typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(const Callback<R(A0, A1, A2, A3)> &func) {
+    return Callback<R(A0, A1, A2, A3)>(func);
+}
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(T *obj, R (*func)(T*, A0, A1, A2, A3)) {
+    return Callback<R(A0, A1, A2, A3)>(obj, func);
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(const T *obj, R (*func)(const T*, A0, A1, A2, A3)) {
+    return Callback<R(A0, A1, A2, A3)>(obj, func);
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3)) {
+    return Callback<R(A0, A1, A2, A3)>(obj, func);
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3)) {
+    return Callback<R(A0, A1, A2, A3)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(T *obj, R (T::*func)(A0, A1, A2, A3)) {
+    return Callback<R(A0, A1, A2, A3)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(const T *obj, R (T::*func)(A0, A1, A2, A3) const) {
+    return Callback<R(A0, A1, A2, A3)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(volatile T *obj, R (T::*func)(A0, A1, A2, A3) volatile) {
+    return Callback<R(A0, A1, A2, A3)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(const volatile T *obj, R (T::*func)(A0, A1, A2, A3) const volatile) {
+    return Callback<R(A0, A1, A2, A3)>(obj, func);
+}
+
+template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(A0, A1, A2, A3, A4) = 0) {
+    return Callback<R(A0, A1, A2, A3, A4)>(func);
+}
+
+template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(const Callback<R(A0, A1, A2, A3, A4)> &func) {
+    return Callback<R(A0, A1, A2, A3, A4)>(func);
+}
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(T *obj, R (*func)(T*, A0, A1, A2, A3, A4)) {
+    return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(const T *obj, R (*func)(const T*, A0, A1, A2, A3, A4)) {
+    return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3, A4)) {
+    return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3, A4)) {
+    return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(T *obj, R (T::*func)(A0, A1, A2, A3, A4)) {
+    return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(const T *obj, R (T::*func)(A0, A1, A2, A3, A4) const) {
+    return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(volatile T *obj, R (T::*func)(A0, A1, A2, A3, A4) volatile) {
+    return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
+}
+
+template<typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(const volatile T *obj, R (T::*func)(A0, A1, A2, A3, A4) const volatile) {
+    return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
+}
 
 
 } // namespace mbed

--- a/hal/api/FunctionPointer.h
+++ b/hal/api/FunctionPointer.h
@@ -43,6 +43,18 @@ public:
     R (*get_function())(A1) {
         return *reinterpret_cast<R (**)(A1)>(this);
     }
+
+    R call(A1 a1) const {
+        if (!Callback<R(A1)>::operator bool()) {
+            return (R)0;
+        }
+
+        return Callback<R(A1)>::call(a1);
+    }
+
+    R operator()(A1 a1) const {
+        return Callback<R(A1)>::call(a1);
+    }
 };
 
 template <typename R>
@@ -61,6 +73,18 @@ public:
 
     R (*get_function())() {
         return *reinterpret_cast<R (**)()>(this);
+    }
+
+    R call() const {
+        if (!Callback<R()>::operator bool()) {
+            return (R)0;
+        }
+
+        return Callback<R()>::call();
+    }
+
+    R operator()() const {
+        return Callback<R()>::call();
     }
 };
 

--- a/hal/api/InterruptIn.h
+++ b/hal/api/InterruptIn.h
@@ -24,6 +24,7 @@
 #include "gpio_irq_api.h"
 #include "Callback.h"
 #include "critical.h"
+#include "toolchain.h"
 
 namespace mbed {
 
@@ -88,11 +89,17 @@ public:
      *
      *  @param obj pointer to the object to call the member function on
      *  @param method pointer to the member function to be called
+     *  @deprecated
+     *      The rise function does not support cv-qualifiers. Replaced by
+     *      rise(callback(obj, method)).
      */
     template<typename T, typename M>
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
+        "The rise function does not support cv-qualifiers. Replaced by "
+        "rise(callback(obj, method)).")
     void rise(T *obj, M method) {
         core_util_critical_section_enter();
-        rise(Callback<void()>(obj, method));
+        rise(callback(obj, method));
         core_util_critical_section_exit();
     }
 
@@ -106,11 +113,17 @@ public:
      *
      *  @param obj pointer to the object to call the member function on
      *  @param method pointer to the member function to be called
+     *  @deprecated
+     *      The rise function does not support cv-qualifiers. Replaced by
+     *      rise(callback(obj, method)).
      */
     template<typename T, typename M>
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
+        "The fall function does not support cv-qualifiers. Replaced by "
+        "fall(callback(obj, method)).")
     void fall(T *obj, M method) {
         core_util_critical_section_enter();
-        fall(Callback<void()>(obj, method));
+        fall(callback(obj, method));
         core_util_critical_section_exit();
     }
 

--- a/hal/api/SerialBase.h
+++ b/hal/api/SerialBase.h
@@ -23,6 +23,7 @@
 #include "Stream.h"
 #include "Callback.h"
 #include "serial_api.h"
+#include "toolchain.h"
 
 #if DEVICE_SERIAL_ASYNCH
 #include "CThunk.h"
@@ -101,10 +102,16 @@ public:
      *  @param obj pointer to the object to call the member function on
      *  @param method pointer to the member function to be called
      *  @param type Which serial interrupt to attach the member function to (Seriall::RxIrq for receive, TxIrq for transmit buffer empty)
+     *  @deprecated
+     *      The attach function does not support cv-qualifiers. Replaced by
+     *      attach(callback(obj, method), type).
      */
     template<typename T>
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
+        "The attach function does not support cv-qualifiers. Replaced by "
+        "attach(callback(obj, method), type).")
     void attach(T *obj, void (T::*method)(), IrqType type=RxIrq) {
-        attach(Callback<void()>(obj, method), type);
+        attach(callback(obj, method), type);
     }
 
     /** Attach a member function to call whenever a serial interrupt is generated
@@ -112,10 +119,16 @@ public:
      *  @param obj pointer to the object to call the member function on
      *  @param method pointer to the member function to be called
      *  @param type Which serial interrupt to attach the member function to (Seriall::RxIrq for receive, TxIrq for transmit buffer empty)
+     *  @deprecated
+     *      The attach function does not support cv-qualifiers. Replaced by
+     *      attach(callback(obj, method), type).
      */
     template<typename T>
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
+        "The attach function does not support cv-qualifiers. Replaced by "
+        "attach(callback(obj, method), type).")
     void attach(T *obj, void (*method)(T*), IrqType type=RxIrq) {
-        attach(Callback<void()>(obj, method), type);
+        attach(callback(obj, method), type);
     }
 
     /** Generate a break condition on the serial line

--- a/hal/api/Ticker.h
+++ b/hal/api/Ticker.h
@@ -18,6 +18,7 @@
 
 #include "TimerEvent.h"
 #include "Callback.h"
+#include "toolchain.h"
 
 namespace mbed {
 
@@ -80,10 +81,16 @@ public:
      *  @param obj pointer to the object to call the member function on
      *  @param method pointer to the member function to be called
      *  @param t the time between calls in seconds
+     *  @deprecated
+     *      The attach function does not support cv-qualifiers. Replaced by
+     *      attach(callback(obj, method), t).
      */
     template<typename T, typename M>
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
+        "The attach function does not support cv-qualifiers. Replaced by "
+        "attach(callback(obj, method), t).")
     void attach(T *obj, M method, float t) {
-        attach(Callback<void()>(obj, method), t);
+        attach(callback(obj, method), t);
     }
 
     /** Attach a function to be called by the Ticker, specifiying the interval in micro-seconds
@@ -101,8 +108,14 @@ public:
      *  @param tptr pointer to the object to call the member function on
      *  @param mptr pointer to the member function to be called
      *  @param t the time between calls in micro-seconds
+     *  @deprecated
+     *      The attach_us function does not support cv-qualifiers. Replaced by
+     *      attach_us(callback(obj, method), t).
      */
     template<typename T, typename M>
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
+        "The attach_us function does not support cv-qualifiers. Replaced by "
+        "attach_us(callback(obj, method), t).")
     void attach_us(T *obj, M method, timestamp_t t) {
         attach_us(Callback<void()>(obj, method), t);
     }

--- a/hal/common/CAN.cpp
+++ b/hal/common/CAN.cpp
@@ -21,8 +21,15 @@
 
 namespace mbed {
 
+static void donothing() {}
+
 CAN::CAN(PinName rd, PinName td) : _can(), _irq() {
     // No lock needed in constructor
+
+    for (int i = 0; i < sizeof _irq / sizeof _irq[0]; i++) {
+        _irq[i].attach(donothing);
+    }
+
     can_init(&_can, rd, td);
     can_irq_init(&_can, (&CAN::_irq_handler), (uint32_t)this);
 }
@@ -100,6 +107,7 @@ void CAN::attach(Callback<void()> func, IrqType type) {
         _irq[(CanIrqType)type].attach(func);
         can_irq_set(&_can, (CanIrqType)type, 1);
     } else {
+        _irq[(CanIrqType)type].attach(donothing);
         can_irq_set(&_can, (CanIrqType)type, 0);
     }
     unlock();

--- a/hal/common/InterruptIn.cpp
+++ b/hal/common/InterruptIn.cpp
@@ -19,11 +19,17 @@
 
 namespace mbed {
 
+static void donothing() {}
+
 InterruptIn::InterruptIn(PinName pin) : gpio(),
                                         gpio_irq(),
                                         _rise(),
                                         _fall() {
     // No lock needed in the constructor
+
+    _rise.attach(donothing);
+    _fall.attach(donothing);
+
     gpio_irq_init(&gpio_irq, pin, (&InterruptIn::_irq_handler), (uint32_t)this);
     gpio_init_in(&gpio, pin);
 }
@@ -50,7 +56,7 @@ void InterruptIn::rise(Callback<void()> func) {
         _rise.attach(func);
         gpio_irq_set(&gpio_irq, IRQ_RISE, 1);
     } else {
-        _rise.attach(NULL);
+        _rise.attach(donothing);
         gpio_irq_set(&gpio_irq, IRQ_RISE, 0);
     }
     core_util_critical_section_exit();
@@ -62,7 +68,7 @@ void InterruptIn::fall(Callback<void()> func) {
         _fall.attach(func);
         gpio_irq_set(&gpio_irq, IRQ_FALL, 1);
     } else {
-        _fall.attach(NULL);
+        _fall.attach(donothing);
         gpio_irq_set(&gpio_irq, IRQ_FALL, 0);
     }
     core_util_critical_section_exit();

--- a/rtos/rtos/RtosTimer.h
+++ b/rtos/rtos/RtosTimer.h
@@ -47,7 +47,7 @@ public:
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Replaced with RtosTimer(Callback<void()>, os_timer_type)")
     RtosTimer(void (*func)(void const *argument), os_timer_type type=osTimerPeriodic, void *argument=NULL) {
-        constructor(mbed::Callback<void()>(argument, (void (*)(void *))func), type);
+        constructor(mbed::callback(argument, (void (*)(void *))func), type);
     }
     
     /** Create timer.
@@ -62,10 +62,16 @@ public:
       @param   obj       pointer to the object to call the member function on.
       @param   method    member function to be executed by this timer.
       @param   type      osTimerOnce for one-shot or osTimerPeriodic for periodic behaviour. (default: osTimerPeriodic)
+      @deprecated
+          The RtosTimer constructor does not support cv-qualifiers. Replaced by
+          RtosTimer(callback(obj, method), os_timer_type).
     */
     template <typename T, typename M>
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
+        "The RtosTimer constructor does not support cv-qualifiers. Replaced by "
+        "RtosTimer(callback(obj, method), os_timer_type).")
     RtosTimer(T *obj, M method, os_timer_type type=osTimerPeriodic) {
-        constructor(mbed::Callback<void()>(obj, method), type);
+        constructor(mbed::callback(obj, method), type);
     }
 
     /** Stop the timer.

--- a/rtos/rtos/Thread.h
+++ b/rtos/rtos/Thread.h
@@ -90,7 +90,7 @@ public:
            osPriority priority=osPriorityNormal,
            uint32_t stack_size=DEFAULT_STACK_SIZE,
            unsigned char *stack_pointer=NULL) {
-        constructor(mbed::Callback<void()>(obj, method),
+        constructor(mbed::callback(obj, method),
                     priority, stack_size, stack_pointer);
     }
 
@@ -116,7 +116,7 @@ public:
            osPriority priority=osPriorityNormal,
            uint32_t stack_size=DEFAULT_STACK_SIZE,
            unsigned char *stack_pointer=NULL) {
-        constructor(mbed::Callback<void()>(obj, method),
+        constructor(mbed::callback(obj, method),
                     priority, stack_size, stack_pointer);
     }
 
@@ -141,7 +141,7 @@ public:
            osPriority priority=osPriorityNormal,
            uint32_t stack_size=DEFAULT_STACK_SIZE,
            unsigned char *stack_pointer=NULL) {
-        constructor(mbed::Callback<void()>(argument, (void (*)(void *))task),
+        constructor(mbed::callback(argument, (void (*)(void *))task),
                     priority, stack_size, stack_pointer);
     }
 
@@ -155,10 +155,16 @@ public:
       @param   obj            argument to task
       @param   method         function to be executed by this thread.
       @return  status code that indicates the execution status of the function.
+      @deprecated
+          The start function does not support cv-qualifiers. Replaced by
+          start(callback(obj, method)).
     */
     template <typename T, typename M>
+    MBED_DEPRECATED_SINCE("mbed-os-5.1",
+        "The start function does not support cv-qualifiers. Replaced by "
+        "start(callback(obj, method)).")
     osStatus start(T *obj, M method) {
-        return start(mbed::Callback<void()>(obj, method));
+        return start(mbed::callback(obj, method));
     }
 
     /** Wait for thread to terminate


### PR DESCRIPTION
From this discussion https://github.com/ARMmbed/mbed-os/pull/2395 and the related issue https://github.com/ARMmbed/mbed-os/issues/2490

The combination of cv-qualifiers with callback overloads results in a large number of overloads to match all possible types that could be passed to the Callback class.

This isn't a big problem for `void (*)(cv T *)` function types, but for `void (T::*)() cv` types, the method in which cv-qualifiers are associated prevents encoding the cv-qualifiers in the `T` type, and requiring a large combination of overloads for all cv-qualifiers.

This pr involves several changes:
- Adds full support for cv-qualifiers in Callback constructor
- Provides convenience `mbed::callback` function to pass different arguments to Callback with infered type.
- Deprecates existing convenience functions to avoid confusion if the user attempts to use a `const` or `volatile` object with the existing convenience functions.
- Updates tests appropriately

Supported overloads:
``` cpp
callback(void (*f)(A...));
callback(const Callback<R(A...)> &);
callback(T *t,                void (*f)(T*, A...));
callback(const T *t,          void (*f)(const T*, A...));
callback(volatile T *t,       void (*f)(volatile T*, A...));
callback(const volatile T *t, void (*f)(const volatile T*, A...));
callback(T *t,                void (T::*f)(A...));
callback(const T *t,          void (T::*f)(A...) const);
callback(volatile T *t,       void (T::*f)(A...) volatile);
callback(const volatile T *t, void (T::*f)(A...) const volatile);
```

Should fix: https://github.com/ARMmbed/mbed-os/issues/2490
Replaces:  https://github.com/ARMmbed/mbed-os/pull/2395 and https://github.com/ARMmbed/mbed-os/pull/2495
cc @pan-, @0xc0170

Let me know any thoughts/suggestions on this solution you guys have.