### PR TITLE
LWIP - fix recv blocking send on accepted sockets

### DIFF
--- a/features/net/FEATURE_IPV4/lwip-interface/lwip_stack.c
+++ b/features/net/FEATURE_IPV4/lwip-interface/lwip_stack.c
@@ -304,6 +304,7 @@ static int lwip_socket_accept(nsapi_stack_t *stack, nsapi_socket_t server, nsapi
         return lwip_err_remap(err);
     }
 
+    netconn_set_recvtimeout(ns->conn, 1);
     *(struct lwip_socket **)handle = ns;
 
     (void) netconn_peer(ns->conn, (ip_addr_t *)addr->bytes, port);


### PR DESCRIPTION
When a socket is created via accept set the mode to nonblocking -
a timeout of 1ms. This allows send and recv to occur at the same time.