### PR TITLE
Fix SingletonPtr problems

### DIFF
--- a/hal/api/SingletonPtr.h
+++ b/hal/api/SingletonPtr.h
@@ -76,7 +76,9 @@ struct SingletonPtr {
     T* get() {
         if (NULL == _ptr) {
             singleton_lock();
-            _ptr = new (_data) T;
+            if (NULL == _ptr) {
+                _ptr = new (_data) T();
+            }
             singleton_unlock();
         }
         // _ptr was not zero initialized or was


### PR DESCRIPTION
Check to see if ptr is NULL after acquiring the singleton lock to
prevent initialization race conditions. Also explicitly call the
constructor for type T.