### PR TITLE
Utest: default copy constructor for failure_t doesn't behave as expected

### DIFF
--- a/features/frameworks/utest/utest/utest_types.h
+++ b/features/frameworks/utest/utest/utest_types.h
@@ -88,6 +88,12 @@ namespace v1 {
         failure_t(location_t location) : reason(REASON_NONE), location(location) {}
         failure_t(failure_reason_t reason, location_t location) : reason(reason), location(location) {}
 
+        /// Copy constructor
+        failure_t(const failure_t &obj){
+            reason = obj.reason;
+            location = obj.location;
+        }
+
         /// @returns a copy of the failure with the reason ignored.
         failure_t ignored() const {
             return failure_t(failure_reason_t(reason | REASON_IGNORE), location);


### PR DESCRIPTION
Description

Fixes issue #2508.

The default compiler(ARMCC) copy constructor for failure_t doesn't behave as
expected and has unexpected side effects. This fix adds a custom copy constructor
to fix this.