### PR TITLE
Fixed link to release page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ mbed OS accelerates the process of creating a connected product by providing a p
  
 Our current release series is mbed OS 5.1:
 
-- [Release Note](https://docs.mbed.com/docs/mbed-os-release-notes/en/latest/5_1/release)
+- [Release Note](https://docs.mbed.com/docs/mbed-os-release-notes/en/latest/5_1/release/)
 
 ## Getting Started for Developers
  


### PR DESCRIPTION
It looks like https://docs.mbed.com/docs/mbed-os-release-notes/en/latest/5_1/release results in a 404 page, but https://docs.mbed.com/docs/mbed-os-release-notes/en/latest/5_1/release/ works.