### PR TITLE
[STM32F3xx] LowPowerTicker implementation

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/lp_ticker.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/lp_ticker.c
@@ -1,0 +1,94 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2016, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include "device.h"
+
+#if DEVICE_LOWPOWERTIMER
+
+#include "ticker_api.h"
+#include "lp_ticker_api.h"
+#include "rtc_api.h"
+#include "rtc_api_hal.h"
+
+static uint8_t lp_ticker_inited = 0;
+static uint8_t lp_ticker_reconf_presc = 0;
+
+void lp_ticker_init() {
+    if (lp_ticker_inited) return;
+    lp_ticker_inited = 1;
+
+    rtc_init();
+    rtc_set_irq_handler((uint32_t) lp_ticker_irq_handler);
+}
+
+uint32_t lp_ticker_read() {
+    uint32_t sub_secs, milis;
+    time_t time;
+
+    lp_ticker_init();
+
+    time = rtc_read();
+    sub_secs = rtc_read_subseconds();
+    milis = 1000 - (sub_secs * 1000 / rtc_ticker_get_synch_presc());
+
+    return (time * 1000000) + (milis * 1000);
+}
+
+void lp_ticker_set_interrupt(timestamp_t timestamp) {
+    uint32_t sub_secs, delta, milis;
+    time_t secs;
+    struct tm *timeinfo;
+
+    // Reconfigure RTC prescalers whenever the timestamp is below 30ms
+    if (!lp_ticker_reconf_presc && timestamp < 30000) {
+        rtc_reconfigure_prescalers();
+        lp_ticker_reconf_presc = 1;
+    }
+
+    milis = (timestamp % 1000000) / 1000;
+
+    secs = rtc_read();
+    delta = ((timestamp / 1000000) - secs);
+
+    secs += delta;
+    sub_secs = (rtc_ticker_get_synch_presc() * (1000 - milis)) / 1000;
+    timeinfo = localtime(&secs);
+
+    rtc_set_alarm(timeinfo, sub_secs);
+}
+
+void lp_ticker_disable_interrupt() {
+    lp_ticker_reconf_presc = 0;
+    rtc_ticker_disable_irq();
+}
+
+void lp_ticker_clear_interrupt() {
+}
+
+#endif

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/rtc_api.c
@@ -99,6 +99,7 @@ void rtc_init(void)
 #endif
 
 #if DEVICE_RTC_LSI
+    if (rtc_inited) return;
     rtc_inited = 1;
 #endif
 

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/rtc_api.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2014, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
  *******************************************************************************
  */
 #include "rtc_api.h"
+#include "rtc_api_hal.h"
 
 #if DEVICE_RTC
 
@@ -39,10 +40,63 @@ static int rtc_inited = 0;
 
 static RTC_HandleTypeDef RtcHandle;
 
+#if DEVICE_LOWPOWERTIMER
+static uint32_t m_synch_prediv = RTC_SYNCH_PREDIV;
+static uint32_t m_asynch_prediv = RTC_ASYNCH_PREDIV;
+
+static void (*irq_handler)(void);
+
+static void rtc_configure_time_and_date()
+{
+    RTC_TimeTypeDef mTime;
+    RTC_DateTypeDef mDate;
+
+    mDate.WeekDay = 1;
+    mDate.Month = 1;
+    mDate.Date = 1;
+    mDate.Year = 2;
+    if (HAL_RTC_SetDate(&RtcHandle, &mDate, RTC_FORMAT_BIN) != HAL_OK) {
+        error("Date set failed\n");
+    }
+
+    mTime.Hours = 0;
+    mTime.Minutes = 0;
+    mTime.Seconds = 0;
+    mTime.TimeFormat = RTC_HOURFORMAT_24;
+    mTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
+    mTime.StoreOperation = RTC_STOREOPERATION_RESET;
+    if (HAL_RTC_SetTime(&RtcHandle, &mTime, RTC_FORMAT_BIN) != HAL_OK) {
+        error("Time set failed\n");
+    }
+}
+
+void RTC_IRQHandler()
+{
+    HAL_RTC_AlarmIRQHandler(&RtcHandle);
+}
+
+void HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc)
+{
+    if (irq_handler)
+    {
+        // Fire the user callback
+        irq_handler();
+    }
+}
+
+void rtc_set_irq_handler(uint32_t handler)
+{
+    irq_handler = (void (*)(void)) handler;
+}
+
+#endif
+
 void rtc_init(void)
 {
     RCC_OscInitTypeDef RCC_OscInitStruct;
+#if !DEVICE_LOWPOWERTIMER
     uint32_t rtc_freq = 0;
+#endif
 
 #if DEVICE_RTC_LSI
     rtc_inited = 1;
@@ -58,7 +112,9 @@ void rtc_init(void)
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK) {
         // Connect LSE to RTC
         __HAL_RCC_RTC_CONFIG(RCC_RTCCLKSOURCE_LSE);
+#if !DEVICE_LOWPOWERTIMER
         rtc_freq = LSE_VALUE;
+#endif
     }
     else {
       error("RTC error: LSE clock initialization failed.");
@@ -85,7 +141,9 @@ void rtc_init(void)
 	// Connect LSI to RTC
 	__HAL_RCC_RTC_CONFIG(RCC_RTCCLKSOURCE_LSI);
 	// Note: The LSI clock can be measured precisely using a timer input capture.
+#if !DEVICE_LOWPOWERTIMER
 	rtc_freq = LSI_VALUE;
+#endif
 #endif    
 
 
@@ -93,8 +151,13 @@ void rtc_init(void)
     __HAL_RCC_RTC_ENABLE();
 
     RtcHandle.Init.HourFormat     = RTC_HOURFORMAT_24;
+#if !DEVICE_LOWPOWERTIMER
     RtcHandle.Init.AsynchPrediv   = 127;
     RtcHandle.Init.SynchPrediv    = (rtc_freq / 128) - 1;
+#else
+    RtcHandle.Init.AsynchPrediv   = m_asynch_prediv;
+    RtcHandle.Init.SynchPrediv    = m_synch_prediv;
+#endif
     RtcHandle.Init.OutPut         = RTC_OUTPUT_DISABLE;
     RtcHandle.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
     RtcHandle.Init.OutPutType     = RTC_OUTPUT_TYPE_OPENDRAIN;
@@ -102,6 +165,12 @@ void rtc_init(void)
     if (HAL_RTC_Init(&RtcHandle) != HAL_OK) {
         error("RTC error: RTC initialization failed.");
     }
+
+#if DEVICE_LOWPOWERTIMER
+    rtc_configure_time_and_date();
+    NVIC_SetVector(RTC_WKUP_IRQn, (uint32_t)&RTC_IRQHandler);
+    HAL_NVIC_EnableIRQ(RTC_WKUP_IRQn);
+#endif
 }
 
 void rtc_free(void)
@@ -217,5 +286,49 @@ void rtc_write(time_t t)
     HAL_RTC_SetDate(&RtcHandle, &dateStruct, FORMAT_BIN);
     HAL_RTC_SetTime(&RtcHandle, &timeStruct, FORMAT_BIN);
 }
+
+#if DEVICE_LOWPOWERTIMER
+void rtc_set_alarm(struct tm *ti, uint32_t subsecs)
+{
+    RTC_AlarmTypeDef mAlarm;
+
+    mAlarm.AlarmTime.Hours = ti->tm_hour;
+    mAlarm.AlarmTime.Minutes = ti->tm_min;
+    mAlarm.AlarmTime.Seconds = ti->tm_sec;
+    mAlarm.AlarmTime.SubSeconds = subsecs;
+    mAlarm.AlarmTime.TimeFormat = RTC_HOURFORMAT_24;
+    mAlarm.AlarmMask = RTC_ALARMMASK_DATEWEEKDAY;
+    mAlarm.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_NONE;
+    mAlarm.AlarmDateWeekDaySel = RTC_ALARMDATEWEEKDAYSEL_DATE;
+    mAlarm.AlarmDateWeekDay = 1;
+    mAlarm.Alarm = RTC_ALARM_A;
+
+    if (HAL_RTC_SetAlarm_IT(&RtcHandle, &mAlarm, RTC_FORMAT_BIN) != HAL_OK) {
+        error("Set Alarm failed\n");
+    }
+}
+
+void rtc_reconfigure_prescalers(void)
+{
+    m_synch_prediv = 0x3FF;
+    m_asynch_prediv = 0x1F;
+    rtc_init();
+}
+
+uint32_t rtc_ticker_get_synch_presc(void)
+{
+    return m_synch_prediv;
+}
+
+uint32_t rtc_read_subseconds(void)
+{
+    return RTC->SSR;
+}
+
+void rtc_ticker_disable_irq(void)
+{
+    HAL_RTC_DeactivateAlarm(&RtcHandle, RTC_ALARM_A);
+}
+#endif // DEVICE_LOWPOWERTIMER
 
 #endif

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/rtc_api_hal.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/rtc_api_hal.h
@@ -1,0 +1,61 @@
+/* mbed Microcontroller Library
+*******************************************************************************
+* Copyright (c) 2016, STMicroelectronics
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+* 3. Neither the name of STMicroelectronics nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************
+*/
+
+#ifndef MBED_RTC_API_HAL_H
+#define MBED_RTC_API_HAL_H
+
+#include <stdint.h>
+#include "rtc_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Extend rtc_api.h
+ */
+
+// Prescaler values for LSE clock
+#define RTC_ASYNCH_PREDIV   0x7F
+#define RTC_SYNCH_PREDIV    0x00FF
+
+void rtc_set_irq_handler(uint32_t handler);
+
+void rtc_ticker_disable_irq(void);
+uint32_t rtc_ticker_get_synch_presc(void);
+
+void rtc_set_alarm(struct tm *ti, uint32_t subsecs);
+uint32_t rtc_read_subseconds(void);
+void rtc_reconfigure_prescalers(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This is the continuation of PR #1813. First LPtimer implementation has been done on STM32F0xx in PR #1796.

Timer and RTC tests are OK. Tested on 3 different F3 devices. No regression with these tests.
[Tests report here](https://github.com/ARMmbed/mbed-os/files/430507/report_mbed2__2016-08-22_17.09.48.91__F3__timer_rtc__ALL.html.zip)

Concerning the UT LowPower test, it fails. The status is the following:
2s test: OK, measured 2.002s with a scope and 2.000076s with sw
2ms test: Fail, measured 3.40ms with a scope and same with sw
1ms test: Fail, measured 2.42ms with a scope and same with sw
50us test: Fail, program is stucked
5s + deepsleep test: Fail, program is stucked
5s + sleep test: OK

I have rechecked the UT LowPower test on a F0 device and I found the same result. This is not in line with latest comment published in PR #1796 saying everything was fine.

