### PR TITLE
Fix mbed-client behaviour in irq contexts

### DIFF
--- a/features/FEATURE_CLIENT/mbed-client-classic/source/m2mconnectionhandlerpimpl.cpp
+++ b/features/FEATURE_CLIENT/mbed-client-classic/source/m2mconnectionhandlerpimpl.cpp
@@ -33,6 +33,8 @@
 
 int8_t M2MConnectionHandlerPimpl::_tasklet_id = -1;
 
+static MemoryPool<M2MConnectionHandlerPimpl::TaskIdentifier, 16> memory_pool;
+
 extern "C" void connection_tasklet_event_handler(arm_event_s *event)
 {
     tr_debug("M2MConnectionHandlerPimpl::connection_tasklet_event_handler");
@@ -74,7 +76,7 @@ extern "C" void connection_tasklet_event_handler(arm_event_s *event)
             break;
     }
     if (task_id) {
-        free(task_id);
+        memory_pool.free(task_id);
     }
 }
 
@@ -145,7 +147,7 @@ bool M2MConnectionHandlerPimpl::resolve_server_address(const String& server_addr
     _server_port = server_port;
     _server_type = server_type;
     _server_address = server_address;
-    TaskIdentifier* task = (TaskIdentifier*)malloc(sizeof(TaskIdentifier));
+    TaskIdentifier* task = memory_pool.alloc();
     if (!task) {
         return false;
     }
@@ -248,7 +250,7 @@ bool M2MConnectionHandlerPimpl::send_data(uint8_t *data,
         return false;
     }
 
-    TaskIdentifier* task = (TaskIdentifier*)malloc(sizeof(TaskIdentifier));
+    TaskIdentifier* task = memory_pool.alloc();
     if (!task) {
         free(buffer);
         return false;
@@ -310,7 +312,7 @@ int8_t M2MConnectionHandlerPimpl::connection_tasklet_handler()
 
 void M2MConnectionHandlerPimpl::socket_event()
 {
-    TaskIdentifier* task = (TaskIdentifier*)malloc(sizeof(TaskIdentifier));
+    TaskIdentifier* task = memory_pool.alloc();
     if (!task) {
     	_observer.socket_error(M2MConnectionHandler::SOCKET_READ_ERROR, true);
         return;

--- a/features/FEATURE_CLIENT/mbed-client-classic/source/m2mconnectionhandlerpimpl.cpp
+++ b/features/FEATURE_CLIENT/mbed-client-classic/source/m2mconnectionhandlerpimpl.cpp
@@ -310,8 +310,6 @@ int8_t M2MConnectionHandlerPimpl::connection_tasklet_handler()
 
 void M2MConnectionHandlerPimpl::socket_event()
 {
-    tr_debug("M2MConnectionHandlerPimpl::socket_event()");
-
     TaskIdentifier* task = (TaskIdentifier*)malloc(sizeof(TaskIdentifier));
     if (!task) {
     	_observer.socket_error(M2MConnectionHandler::SOCKET_READ_ERROR, true);


### PR DESCRIPTION
Should resolve https://github.com/ARMmbed/mbed-os-example-client/issues/75

mbed-client defines `M2MConnectionHandlerPimpl::socket_event` for handling the event passed through the `UDPSocket::attach` function. Unfortunately, the previous implementation contained both a `tr_debug` call and `malloc` call that were unacceptably long-running and caused UART bytes to be dropped.

This issue was not unnoticable in lwip's implementation. We could update lwip to dispatch events in a critical section, insuring correct behaviour, although this would introduce unnecessary jitter in existing code.

cc @yogpan01, Should I be making this pr to https://github.com/armmbed/mbed-client-classic as well? Let me know how to best submit patches for this code.