### PR TITLE
Fix missing wrapping of calloc_r with uVisor enabled.

### DIFF
--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -500,8 +500,10 @@ void mbed_stats_heap_get(mbed_stats_heap_t *stats)
 #include "uvisor-lib/uvisor-lib.h"
 #endif/* FEATURE_UVISOR */
 
-#ifndef  FEATURE_UVISOR
 extern "C" {
+
+/* uVisor wraps malloc_r, realloc_r and free_r, but not calloc_r! */
+#ifndef  FEATURE_UVISOR
 
 extern "C" void __malloc_lock( struct _reent *_r );
 extern "C" void __malloc_unlock( struct _reent *_r );
@@ -586,6 +588,9 @@ void __wrap__free_r(struct _reent * r, void * ptr) {
     malloc_stats_mutex->unlock();
 #endif
 }
+
+#endif/* FEATURE_UVISOR */
+
 void* __wrap__calloc_r(struct _reent * r, size_t num, size_t size) {
 #if !defined(MBED_HEAP_STATS_ENABLED ) || !MBED_HEAP_STATS_ENABLED
     extern void* __real__calloc_r(struct _reent * r, size_t num, size_t size);
@@ -603,7 +608,6 @@ void* __wrap__calloc_r(struct _reent * r, size_t num, size_t size) {
 #endif
 }
 }
-#endif/* FEATURE_UVISOR */
 
 extern "C" WEAK void software_init_hook_rtos(void)
 {


### PR DESCRIPTION
uVisor only wraps malloc_r, realloc_r and free_r, not calloc_r!

Fixes what was added in https://github.com/ARMmbed/mbed-os/commit/6a31ffbf3e7e8411e3bfbb81961a792a040fcb28.

cc @c1728p9 @bogdanm @0xc0170 @AlessandroA @meriac @Patater 