### PR TITLE
nRF5x uart hardware flow control configuration using mbed configuration systsem

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1891,6 +1891,11 @@
             "lf_clock_src": {
                 "value": "NRF_LF_SRC_XTAL",
                 "macro_name": "MBED_CONF_NORDIC_NRF_LF_CLOCK_SRC"
+            },
+            "uart_hwfc": {
+                "help": "Value: 1 for enable, 0 for disable",
+                "value": 1,
+                "macro_name": "MBED_CONF_NORDIC_UART_HWFC"
             }
         }
     },
@@ -1936,6 +1941,11 @@
             "lf_clock_src": {
                 "value": "NRF_LF_SRC_XTAL",
                 "macro_name": "MBED_CONF_NORDIC_NRF_LF_CLOCK_SRC"
+            },
+            "uart_hwfc": {
+                "help": "Value: 1 for enable, 0 for disable",
+                "value": 1,
+                "macro_name": "MBED_CONF_NORDIC_UART_HWFC"
             }
         }
     },

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/serial_api.c
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/serial_api.c
@@ -58,7 +58,19 @@
 
 #define UART_DEFAULT_BAUDRATE   UART0_CONFIG_BAUDRATE
 #define UART_DEFAULT_PARITY     UART0_CONFIG_PARITY
-#define UART_DEFAULT_HWFC       UART0_CONFIG_HWFC
+
+// expected the macro from mbed configuration system
+#ifndef MBED_CONF_NORDIC_UART_HWFC
+    #define MBED_CONF_NORDIC_UART_HWFC 1
+    #warning None of UART flow control configuration (expected macro MBED_CONF_NORDIC_UART_HWFC). The RTSCTS flow control is used by default .
+#endif
+
+#if MBED_CONF_NORDIC_UART_HWFC == 1
+    #define UART_DEFAULT_HWFC       UART0_CONFIG_HWFC
+#else
+    #define UART_DEFAULT_HWFC  NRF_UART_HWFC_DISABLED
+#endif
+
 #define UART_DEFAULT_CTS        UART0_CONFIG_PSEL_CTS
 #define UART_DEFAULT_RTS        UART0_CONFIG_PSEL_RTS
 


### PR DESCRIPTION
Introduce uart hardware flow control configuration using mbed configuration system for MCU_NRF51_UNIFIED and MCU_NRF52 targets.

The target.uart_hwfc key is used to configure flow control for nRF5x SoC.

Related to issues:
https://github.com/ARMmbed/mbed-os/issues/2474
https://github.com/ARMmbed/mbed-os/issues/2489
https://github.com/ARMmbed/mbed-os-example-ble/issues/25