### PR TITLE
Fix implicit declaration of function 'atexit'

### DIFF
--- a/rtos/rtx/TARGET_ARM7/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_ARM7/RTX_CM_lib.h
@@ -329,6 +329,7 @@ __asm void __rt_entry (void) {
 
 #elif defined (__GNUC__)
 
+extern int atexit(void (*func)(void));
 extern void __libc_fini_array(void);
 extern void __libc_init_array (void);
 extern int main(int argc, char **argv);

--- a/rtos/rtx/TARGET_CORTEX_A/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_A/RTX_CM_lib.h
@@ -485,6 +485,7 @@ __asm void __rt_entry (void) {
 #endif
 
 #elif defined (__GNUC__)
+extern int atexit(void (*func)(void));
 extern void __libc_fini_array(void);
 extern void __libc_init_array (void);
 extern int main(int argc, char **argv);

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -789,6 +789,7 @@ static osMutexId malloc_mutex_id;
 osMutexDef(env_mutex);
 static osMutexId env_mutex_id;
 
+extern int atexit(void (*func)(void));
 extern void __libc_fini_array(void);
 extern void __libc_init_array (void);
 extern int main(int argc, char **argv);


### PR DESCRIPTION
Silence the following compiler warning: 

[Warning] RTX_CM_lib.h@807,5: implicit declaration of function 'atexit' [-Wimplicit-function-declaration]