### PR TITLE
Improve SingletonPtr const correctness

### DIFF
--- a/hal/api/SingletonPtr.h
+++ b/hal/api/SingletonPtr.h
@@ -73,7 +73,7 @@ struct SingletonPtr {
      * @returns
      *   A pointer to the singleton
      */
-    T* get() {
+    T* get() const {
         if (NULL == _ptr) {
             singleton_lock();
             if (NULL == _ptr) {
@@ -92,14 +92,14 @@ struct SingletonPtr {
      * @returns
      *   A pointer to the singleton
      */
-    T* operator->() {
+    T* operator->() const {
         return get();
     }
 
     // This is zero initialized when in global scope
-    T *_ptr;
+    mutable T * _ptr;
     // Force data to be 4 byte aligned
-    uint32_t _data[(sizeof(T) + sizeof(uint32_t) - 1) / sizeof(uint32_t)];
+    mutable uint32_t _data[(sizeof(T) + sizeof(uint32_t) - 1) / sizeof(uint32_t)];
 };
 
 #endif


### PR DESCRIPTION
Make all the functions of SingletonPtr const for improved const
correctness.