### PR TITLE
Remove IPv6 link time dependency on an RF phy

### DIFF
--- a/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_random.c
+++ b/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_random.c
@@ -16,9 +16,6 @@
 #include "ns_types.h"
 #include "arm_hal_random.h"
 
-#ifdef MBED_CONF_NANOSTACK_CONFIGURATION
-#include "driverRFPhy.h"
-#endif
 #include "mbedtls/entropy_poll.h"
 
 void arm_random_module_init(void)
@@ -32,14 +29,6 @@ uint32_t arm_random_seed_get(void)
     /* Grab a seed from a function we provide for mbedtls */
     size_t len;
     mbedtls_hardware_poll(NULL, (uint8_t *) &result, sizeof result, &len);
-#endif
-#ifdef MBED_CONF_NANOSTACK_CONFIGURATION
-    uint8_t mac[8];
-    rf_read_mac_address(mac);
-    for (int i = 0; i <= 7; i++) {
-        result ^= (uint32_t) mac[i] << ((i % 4) * 8);
-    }
-    result ^= rf_read_random();
 #endif
     return result;
 }

--- a/features/net/FEATURE_IPV6/nanostack-interface/NanostackInterface.cpp
+++ b/features/net/FEATURE_IPV6/nanostack-interface/NanostackInterface.cpp
@@ -27,7 +27,6 @@
 
 #include "mesh_system.h" // from inside mbed-mesh-api
 #include "socket_api.h"
-#include "driverRFPhy.h"
 #include "net_interface.h"
 #include "ip6string.h"
 // Uncomment to enable trace
@@ -452,6 +451,28 @@ void NanostackSocket::event_connnect_closed(socket_callback_t *sock_cb)
     close();
 }
 
+MeshInterfaceNanostack::MeshInterfaceNanostack()
+    : phy(NULL), mesh_api(NULL), rf_device_id(-1), eui64(),
+      ip_addr_str(), mac_addr_str(), connect_semaphore(0)
+{
+    // Nothing to do
+}
+
+MeshInterfaceNanostack::MeshInterfaceNanostack(NanostackRfPhy *phy)
+    : phy(phy), mesh_api(NULL), rf_device_id(-1), connect_semaphore(0)
+{
+    // Nothing to do
+}
+
+int MeshInterfaceNanostack::initialize(NanostackRfPhy *phy)
+{
+    if (this->phy != NULL) {
+        error("Phy already set");
+    }
+    this->phy = phy;
+    return 0;
+}
+
 void MeshInterfaceNanostack::mesh_network_handler(mesh_connection_status_t status)
 {
     nanostack_lock();
@@ -467,13 +488,13 @@ int MeshInterfaceNanostack::register_rf()
 {
     nanostack_lock();
 
-    rf_device_id = rf_device_register();
+    rf_device_id = phy->rf_register();
     if (rf_device_id < 0) {
         nanostack_unlock();
         return -1;
     }
     // Read mac address after registering the device.
-    rf_read_mac_address(eui64);
+    phy->get_mac_address(eui64);
     sprintf(mac_addr_str, "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", eui64[0], eui64[1], eui64[2], eui64[3], eui64[4], eui64[5], eui64[6], eui64[7]);
 
     nanostack_unlock();

--- a/features/net/FEATURE_IPV6/nanostack-interface/NanostackInterface.h
+++ b/features/net/FEATURE_IPV6/nanostack-interface/NanostackInterface.h
@@ -7,6 +7,7 @@
 
 #include "NetworkStack.h"
 #include "MeshInterface.h"
+#include "NanostackRfPhy.h"
 
 #include "mbed-mesh-api/Mesh6LoWPAN_ND.h"
 #include "mbed-mesh-api/MeshThread.h"
@@ -220,6 +221,15 @@ private:
 class MeshInterfaceNanostack : public MeshInterface {
 public:
 
+    /** Attach phy and initialize the mesh
+     *
+     *  Initializes a mesh interface on the given phy. Not needed if
+     *  the phy is passed to the mesh's constructor.
+     *
+     *  @return     0 on success, negative on failure
+     */
+    virtual int initialize(NanostackRfPhy *phy);
+
     /** Start the interface
      *
      *  @return     0 on success, negative on failure
@@ -243,12 +253,14 @@ public:
     virtual const char *get_mac_address();
 
 protected:
-    MeshInterfaceNanostack() : connect_semaphore(0) { }
+    MeshInterfaceNanostack();
+    MeshInterfaceNanostack(NanostackRfPhy *phy);
     int register_rf();
     int actual_connect();
     virtual NetworkStack * get_stack(void);
 
     void mesh_network_handler(mesh_connection_status_t status);
+    NanostackRfPhy *phy;
     AbstractMesh *mesh_api;
     int8_t rf_device_id;
     uint8_t eui64[8];
@@ -259,6 +271,22 @@ protected:
 
 class LoWPANNDInterface : public MeshInterfaceNanostack {
 public:
+
+    /** Create an uninitialized LoWPANNDInterface
+     *
+     *  Must initialize to initialize the mesh on a phy.
+     */
+    LoWPANNDInterface() : MeshInterfaceNanostack() {
+
+    }
+
+    /** Create an initialized MeshInterface
+     *
+     */
+    LoWPANNDInterface(NanostackRfPhy *phy) : MeshInterfaceNanostack(phy) {
+
+    }
+
     int connect();
 protected:
     Mesh6LoWPAN_ND *get_mesh_api() const { return static_cast<Mesh6LoWPAN_ND *>(mesh_api); }
@@ -268,6 +296,22 @@ private:
 
 class ThreadInterface : public MeshInterfaceNanostack {
 public:
+
+    /** Create an uninitialized LoWPANNDInterface
+     *
+     *  Must initialize to initialize the mesh on a phy.
+     */
+    ThreadInterface() : MeshInterfaceNanostack() {
+
+    }
+
+    /** Create an initialized MeshInterface
+     *
+     */
+    ThreadInterface(NanostackRfPhy *phy) : MeshInterfaceNanostack(phy) {
+
+    }
+
     int connect();
 protected:
     MeshThread *get_mesh_api() const { return static_cast<MeshThread *>(mesh_api); }

--- a/features/net/FEATURE_IPV6/nanostack-interface/NanostackRfPhy.h
+++ b/features/net/FEATURE_IPV6/nanostack-interface/NanostackRfPhy.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016 ARM Limited. All rights reserved.
+ */
+
+#ifndef NANOSTACK_RF_PHY_H_
+#define NANOSTACK_RF_PHY_H_
+
+class NanostackRfPhy {
+public:
+
+    /** Register this physical interface with Nanostack
+     *
+     *  @return         Device driver ID or a negative error
+     *                  code on failure
+     */
+    virtual int8_t rf_register() = 0;
+
+    /** Unregister this physical interface
+     *
+     */
+    virtual void rf_unregister() = 0;
+
+    /** Read the mac address of this physical interface
+     *
+     * Note - some devices do not have a mac address
+     *        in hardware.
+     */
+    virtual void get_mac_address(uint8_t *mac) = 0;
+
+    /** Set the mac address of this physical interface
+     *
+     */
+    virtual void set_mac_address(uint8_t *mac) = 0;
+
+protected:
+    NanostackRfPhy() {}
+    virtual ~NanostackRfPhy() {}
+};
+
+#endif /* NANOSTACK_INTERFACE_H_ */


### PR DESCRIPTION
Create a Nanostack rf phy class to wrap various rf physical interfaces.
Allow this phy to be set at runtime rather than compile time.