### PR TITLE
[STM32F4] pwmout: remove printf

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/pwmout_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/pwmout_api.c
@@ -296,7 +296,6 @@ void pwmout_pulsewidth_ms(pwmout_t* obj, int ms)
 void pwmout_pulsewidth_us(pwmout_t* obj, int us)
 {
     float value = (float)us / (float)obj->period;
-    printf("pwmout_pulsewidth_us: period=%d, us=%d, dc=%d%%\r\n", obj->period, us, (int) (value*100));
     pwmout_write(obj, value);
 }
 


### PR DESCRIPTION
This remains from a debug session but is not needed and creates a warning,
so better remove it.