### PR TITLE
MBED_A28: fix test string

### DIFF
--- a/libraries/tests/mbed/can_loopback/main.cpp
+++ b/libraries/tests/mbed/can_loopback/main.cpp
@@ -34,7 +34,7 @@ int main() {
     MBED_HOSTTEST_TIMEOUT(20);
     MBED_HOSTTEST_SELECT(dev_null);
     MBED_HOSTTEST_DESCRIPTION(CAN Loopback);
-    MBED_HOSTTEST_START("MBED_A27");
+    MBED_HOSTTEST_START("MBED_A28");
 
 #if !defined(TARGET_VK_RZ_A1H)
     can1.mode(CAN::Reset);


### PR DESCRIPTION
THe test string was wrongly set to MBED_A27. 