### PR TITLE
Revert "Allow 'small-build' and 'big-build' to be used as options."

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -10,7 +10,7 @@
         "features": [],
         "detect_code": [],
         "public": false,
-        "default_lib": "std"
+        "default_build": "standard"
     },
     "CM4_UARM": {
         "inherits": ["Target"],
@@ -18,7 +18,7 @@
         "default_toolchain": "uARM",
         "public": false,
         "supported_toolchains": ["uARM"],
-        "default_lib": "small"
+        "default_build": "small"
     },
     "CM4_ARM": {
         "inherits": ["Target"],
@@ -32,7 +32,7 @@
         "default_toolchain": "uARM",
         "public": false,
         "supported_toolchains": ["uARM"],
-        "default_lib": "small"
+        "default_build": "small"
     },
     "CM4F_ARM": {
         "inherits": ["Target"],
@@ -63,7 +63,7 @@
             "target": "lpc1114_102"
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "LPC11U24": {
@@ -77,7 +77,7 @@
         },
         "detect_code": ["1040"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOCALFILESYSTEM", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "OC_MBUINO": {
@@ -104,7 +104,7 @@
         "extra_labels": ["NXP", "LPC11UXX"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "default_lib": "small"
+        "default_build": "small"
     },
     "MICRONFCBOARD": {
         "inherits": ["LPC11U34_421"],
@@ -122,7 +122,7 @@
             "target": "lpc11u35_401"
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "LPC11U35_501": {
@@ -135,7 +135,7 @@
             "target": "lpc11u35_501"
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "LPC11U35_501_IBDAP": {
@@ -148,7 +148,7 @@
             "target": "lpc11u35_501"
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "default_lib": "small"
+        "default_build": "small"
     },
     "XADOW_M0": {
         "inherits": ["LPCTarget"],
@@ -160,7 +160,7 @@
             "target": "lpc11u35_501"
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "LPC11U35_Y5_MBUG": {
@@ -173,7 +173,7 @@
             "target": "lpc11u35_501"
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "default_lib": "small"
+        "default_build": "small"
     },
     "LPC11U37_501": {
         "inherits": ["LPCTarget"],
@@ -184,7 +184,7 @@
         "progen": {
             "target": "lpc11u37_501"
         },
-        "default_lib": "small"
+        "default_build": "small"
     },
     "LPCCAPPUCCINO": {
         "inherits": ["LPC11U37_501"],
@@ -204,7 +204,7 @@
             "target": "lpc11u37_501"
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "LPC11U68": {
@@ -219,7 +219,7 @@
         },
         "detect_code": ["1168"],
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "LPC1347": {
@@ -243,7 +243,7 @@
         },
         "detect_code": ["1549"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "INTERRUPTIN", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "LPC1768": {
@@ -315,7 +315,7 @@
             "target": "lpc810"
         },
         "device_has": ["ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE"],
-        "default_lib": "small"
+        "default_build": "small"
     },
     "LPC812": {
         "supported_form_factors": ["ARDUINO"],
@@ -330,7 +330,7 @@
         },
         "detect_code": ["1050"],
         "device_has": ["ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "LPC824": {
@@ -345,7 +345,7 @@
             "target": "lpc824m201"
         },
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "SSCI824": {
@@ -359,7 +359,7 @@
             "target": "ssci824"
         },
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "LPC4088": {
@@ -422,7 +422,7 @@
             "target": "lpc11u37_401"
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "ELEKTOR_COCORICO": {
@@ -436,7 +436,7 @@
         "progen": {
             "target": "cocorico"
         },
-        "default_lib": "small"
+        "default_build": "small"
     },
     "KL05Z": {
         "supported_form_factors": ["ARDUINO"],
@@ -450,7 +450,7 @@
             "target": "frdm-kl05z"
         },
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "KL25Z": {
@@ -539,7 +539,7 @@
         "detect_code": ["0261"],
         "progen_target": {"target": "frdm-kl27z"},
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_lib": "std",
+        "default_build": "standard",
         "release_versions": ["2"]
     },
     "KL43Z": {
@@ -590,7 +590,7 @@
         "detect_code": ["0214"],
         "progen": {"target": "hexiwear-k64f"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_lib": "std",
+        "default_build": "standard",
         "release_versions": ["2", "5"]
     },
     "K66F": {
@@ -629,7 +629,7 @@
         "progen": {"target": "nucleo-f031k6"},
         "detect_code": ["0791"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "NUCLEO_F042K6": {
@@ -642,7 +642,7 @@
         "progen": {"target": "nucleo-f042k6"},
         "detect_code": ["0785"],
         "device_has": ["ANALOGIN", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "NUCLEO_F070RB": {
@@ -803,7 +803,7 @@
         "inherits": ["Target"],
         "detect_code": ["----"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "NUCLEO_F429ZI": {
@@ -898,7 +898,7 @@
         "detect_code": ["0780"],
         "progen": {"target":"nucleo-l011k4"},
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
 
@@ -912,7 +912,7 @@
         "detect_code": ["0790"],
         "progen": {"target": "nucleo-l031k6"},
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "NUCLEO_L053R8": {
@@ -1152,7 +1152,7 @@
         "progen": {"target": "stm32l151rc"},
         "detect_code": ["4100"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_lib": "small",
+        "default_build": "small",
         "release_versions": ["2"]
     },
     "DISCO_F401VC": {
@@ -1172,7 +1172,7 @@
         "macros": ["HSE_VALUE=24000000", "HSE_STARTUP_TIMEOUT=5000"],
         "inherits": ["Target"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_lib": "small"
+        "default_build": "small"
     },
     "NZ32_SC151": {
         "inherits": ["Target"],
@@ -1183,7 +1183,7 @@
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
         "progen": {"target": "stm32l151rc"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_lib": "small"
+        "default_build": "small"
     },
     "MCU_NRF51": {
         "inherits": ["Target"],
@@ -1237,7 +1237,7 @@
         "extra_labels_add": ["MCU_NORDIC_16K", "MCU_NRF51_16K"],
         "macros_add": ["TARGET_MCU_NORDIC_16K", "TARGET_MCU_NRF51_16K"],
         "public": false,
-        "default_lib": "small"
+        "default_build": "small"
     },
     "MCU_NRF51_16K_BOOT_BASE": {
         "inherits": ["MCU_NRF51_16K_BASE"],
@@ -1691,7 +1691,7 @@
         "program_cycle_s": 2,
         "device_has": ["ANALOGIN", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "features": ["IPV4"],
-        "default_lib": "std",
+        "default_build": "standard",
         "release_versions": ["2", "5"]
     },
     "MAXWSNENV": {
@@ -1767,7 +1767,7 @@
             "target": "efm32zg-stk"
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
-        "default_lib": "small",
+        "default_build": "small",
         "forced_reset_timeout": 2,
         "release_versions": ["2"]
     },
@@ -1782,7 +1782,7 @@
             "target": "efm32hg-stk"
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
-        "default_lib": "small",
+        "default_build": "small",
         "forced_reset_timeout": 2,
         "release_versions": ["2"]
     },
@@ -1876,7 +1876,7 @@
         "progen": {"target": "samg55j19"},
         "progen_target": "samg55j19",
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH"],
-        "default_lib": "std"
+        "default_build": "standard"
     },
     "MCU_NRF51_UNIFIED": {
         "inherits": ["Target"],

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -198,12 +198,12 @@ def is_official_target(target_name, version):
                     ("following toolchains: %s" %
                      ", ".join(supported_toolchains_sorted))
 
-            elif not target.default_lib == 'std':
+            elif not target.default_build == 'standard':
                 result = False
                 reason = ("Target '%s' must set the " % target.name) + \
-                    ("'default_lib' to 'std' to be included in the ") + \
+                    ("'default_build' to 'standard' to be included in the ") + \
                     ("mbed OS 5.0 official release." + linesep) + \
-                    ("Currently it is set to '%s'" % target.default_lib)
+                    ("Currently it is set to '%s'" % target.default_build)
 
         else:
             result = False

--- a/tools/options.py
+++ b/tools/options.py
@@ -75,9 +75,7 @@ def get_default_options_parser(add_clean=True, add_options=True):
                                   'run Goanna static code analyzer")'),
                             type=argparse_lowercase_hyphen_type(['save-asm',
                                                                  'debug-info',
-                                                                 'analyze',
-                                                                 'small-lib',
-                                                                 'std-lib'],
+                                                                 'analyze'],
                                                                 "build option"))
 
     return parser

--- a/tools/test/config_test/test12/mbed_app.json
+++ b/tools/test/config_test/test12/mbed_app.json
@@ -4,7 +4,7 @@
             "core": "Cortex-M0",
             "extra_labels": [],
             "features": [],
-            "default_lib": "std"
+            "default_build": "standard"
         }
     },
     "target_overrides": {

--- a/tools/test/config_test/test16/mbed_app.json
+++ b/tools/test/config_test/test16/mbed_app.json
@@ -4,7 +4,7 @@
             "core": "Cortex-M0",
             "extra_labels": [],
             "features": [],
-            "default_lib": "std"
+            "default_build": "standard"
         }
     },
     "macros": ["APP1=10", "APP2", "LIB2_1=5"]

--- a/tools/test/config_test/test21/mbed_app.json
+++ b/tools/test/config_test/test21/mbed_app.json
@@ -4,7 +4,7 @@
             "core": "Cortex-M0",
             "extra_labels": [],
             "features": [],
-            "default_lib": "std"
+            "default_build": "standard"
         }
     },
     "target_overrides": {

--- a/tools/test/config_test/test22/mbed_app.json
+++ b/tools/test/config_test/test22/mbed_app.json
@@ -4,7 +4,7 @@
             "core": "Cortex-M0",
             "extra_labels": [],
             "features": [],
-            "default_lib": "std"
+            "default_build": "standard"
         }
     },
     "target_overrides": {
@@ -13,3 +13,4 @@
         }
     }
 }
+

--- a/tools/test/config_test/test24/mbed_app.json
+++ b/tools/test/config_test/test24/mbed_app.json
@@ -4,7 +4,7 @@
             "core": "Cortex-M0",
             "extra_labels": [],
             "features": [],
-            "default_lib": "std"
+            "default_build": "standard"
         }
     },
     "target_overrides": {

--- a/tools/test/config_test/test26/mbed_app.json
+++ b/tools/test/config_test/test26/mbed_app.json
@@ -4,7 +4,7 @@
             "core": "Cortex-M0",
             "extra_labels": [],
             "features": [],
-            "default_lib": "std"
+            "default_build": "standard"
         }
     },
     "target_overrides": {

--- a/tools/test/config_test/test27/mbed_app.json
+++ b/tools/test/config_test/test27/mbed_app.json
@@ -4,7 +4,8 @@
             "core": "Cortex-M0",
             "extra_labels": [],
             "features": ["IPV4"],
-            "default_lib": "std"
+            "default_build": "standard"
         }
     }
 }
+

--- a/tools/test/config_test/test28/mbed_app.json
+++ b/tools/test/config_test/test28/mbed_app.json
@@ -4,7 +4,7 @@
             "core": "Cortex-M0",
             "extra_labels": [],
             "features": [],
-            "default_lib": "std"
+            "default_build": "standard"
         }
     },
     "target_overrides": {
@@ -14,3 +14,4 @@
         }
     }
 }
+

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -279,13 +279,13 @@ class GCC_ARM(GCC):
         GCC.__init__(self, target, options, notify, macros, silent, TOOLCHAIN_PATHS['GCC_ARM'], extra_verbose=extra_verbose)
 
         # Use latest gcc nanolib
-        if "std-lib" in self.options:
+        if "big-build" in self.options:
             use_nano = False
-        elif "small-lib" in self.options:
+        elif "small-build" in self.options:
             use_nano = True
-        elif target.default_lib == "std":
+        elif target.default_build == "standard":
             use_nano = False
-        elif target.default_lib == "small":
+        elif target.default_build == "small":
             use_nano = True
         else:
             use_nano = False


### PR DESCRIPTION
Reverts ARMmbed/mbed-os#2409 as this breaks backwards compatibility with mbed 2.0 build tools and online build system. Namely the problem is in the "default_build" field which is being renamed to "default_lib".
As "default_lib" is mandatory attribute for all targets, the build system cannot be used with older targets.json files, like the ones released in revision 122 and 123 the mbed library (mbed 2.0 SDK), which have the "default_build" instead, e.g. https://developer.mbed.org/users/mbed_official/code/mbed/file/2241e3a39974/targets.json

My recommendation is to revert the field name to "default_build" and rather change how field values are handled.

@sg- @theotherjimmy @pan- 
