### PR TITLE
Fix STM32F407VG target name and LPC11U6X linker errors

### DIFF
--- a/hal/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TOOLCHAIN_GCC_ARM/TARGET_LPC11U68/startup_LPC11U68.cpp
+++ b/hal/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TOOLCHAIN_GCC_ARM/TARGET_LPC11U68/startup_LPC11U68.cpp
@@ -171,11 +171,3 @@ AFTER_VECTORS void IntDefaultHandler (void) {}
 
 int __aeabi_atexit(void *object, void (*destructor)(void *), void *dso_handle) {return 0;}
 }
-
-#include <stdlib.h>
-
-void *operator new(size_t size)  {return malloc(size);}
-void *operator new[](size_t size){return malloc(size);}
-
-void operator delete(void *p)   {free(p);}
-void operator delete[](void *p) {free(p);}

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -460,7 +460,7 @@ osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1U, 
 #elif defined(TARGET_DISCO_F303VC)
 #define INITIAL_SP            (0x2000A000UL)
 
-#elif defined(TARGET_STM32F407) || defined(TARGET_F407VG)
+#elif defined(TARGET_STM32F407) || defined(TARGET_STM32F407VG)
 #define INITIAL_SP            (0x20020000UL)
 
 #elif defined(TARGET_STM32F401RE)

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
@@ -49,7 +49,7 @@
 //   <i> Default: 6
 #ifndef OS_TASKCNT
 #  if   defined(TARGET_LPC1768) || defined(TARGET_LPC2368)   || defined(TARGET_LPC4088) || defined(TARGET_LPC4088_DM) || defined(TARGET_LPC4330) || defined(TARGET_LPC4337) || defined(TARGET_LPC1347) || defined(TARGET_K64F) || defined(TARGET_K66F)|| defined(TARGET_STM32F401RE)\
-   || defined(TARGET_STM32F410RB) || defined(TARGET_KL46Z) || defined(TARGET_KL43Z)  || defined(TARGET_STM32F407) || defined(TARGET_F407VG)  || defined(TARGET_STM32F303VC) || defined(TARGET_LPC1549) || defined(TARGET_LPC11U68) \
+   || defined(TARGET_STM32F410RB) || defined(TARGET_KL46Z) || defined(TARGET_KL43Z)  || defined(TARGET_STM32F407) || defined(TARGET_STM32F407VG)  || defined(TARGET_STM32F303VC) || defined(TARGET_LPC1549) || defined(TARGET_LPC11U68) \
    || defined(TARGET_STM32F411RE) || defined(TARGET_STM32F207ZG) || defined(TARGET_STM32F405RG) || defined(TARGET_K22F) || defined(TARGET_STM32F429ZI) || defined(TARGET_STM32F401VC) || defined(TARGET_MAX32610) || defined(TARGET_MAX32600) || defined(TARGET_MAX32620) || defined(TARGET_TEENSY3_1) \
    || defined(TARGET_STM32L152RE) || defined(TARGET_STM32F446RE) || defined(TARGET_STM32F446VE) || defined(TARGET_STM32F446ZE) || defined(TARGET_STM32L432KC) || defined(TARGET_STM32L476VG) || defined(TARGET_STM32L476RG) || defined(TARGET_STM32F469NI) || defined(TARGET_STM32F746NG) || defined(TARGET_STM32F746ZG) || defined(TARGET_STM32L152RC) \
    || defined(TARGET_EFM32GG_STK3700) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32PG_STK3401) || defined(TARGET_STM32F767ZI) \
@@ -85,7 +85,7 @@
 //   <o>Main Thread stack size [bytes] <64-32768:8><#/4>
 #ifndef OS_MAINSTKSIZE
 #  if   defined(TARGET_LPC1768) || defined(TARGET_LPC2368)   || defined(TARGET_LPC4088) || defined(TARGET_LPC4088_DM) || defined(TARGET_LPC4330) || defined(TARGET_LPC4337) || defined(TARGET_LPC1347)  || defined(TARGET_K64F) || defined(TARGET_K66F) ||defined(TARGET_STM32F401RE)\
-   || defined(TARGET_STM32F410RB) || defined(TARGET_KL46Z) || defined(TARGET_KL43Z) || defined(TARGET_STM32F407) || defined(TARGET_F407VG)  || defined(TARGET_STM32F303VC) || defined(TARGET_LPC1549) || defined(TARGET_LPC11U68) \
+   || defined(TARGET_STM32F410RB) || defined(TARGET_KL46Z) || defined(TARGET_KL43Z) || defined(TARGET_STM32F407) || defined(TARGET_STM32F407VG)  || defined(TARGET_STM32F303VC) || defined(TARGET_LPC1549) || defined(TARGET_LPC11U68) \
    || defined(TARGET_STM32F411RE) || defined(TARGET_STM32F405RG) || defined(TARGET_K22F) || defined(TARGET_STM32F429ZI) || defined(TARGET_STM32F401VC) || defined(TARGET_MAX32610) || defined(TARGET_MAX32600) || defined(TARGET_MAX32620) || defined(TARGET_TEENSY3_1) \
    || defined(TARGET_STM32L152RE) || defined(TARGET_STM32F446RE) || defined(TARGET_STM32F446VE) || defined(TARGET_STM32F446ZE) || defined(TARGET_STM32L432KC) || defined(TARGET_STM32L476VG) || defined(TARGET_STM32L476RG) || defined(TARGET_STM32F469NI) || defined(TARGET_STM32F746NG) || defined(TARGET_STM32F746ZG) || defined(TARGET_STM32L152RC) \
    ||defined(TARGET_EFM32GG_STK3700) || defined(TARGET_STM32F767ZI) || defined(TARGET_STM32F207ZG) \
@@ -197,7 +197,7 @@
 #  elif defined(TARGET_LPC4337)
 #    define OS_CLOCK       204000000
 
-#  elif defined(TARGET_STM32F407) || defined(TARGET_F407VG)
+#  elif defined(TARGET_STM32F407) || defined(TARGET_STM32F407VG)
 #    define OS_CLOCK       168000000
 
 #  elif defined(TARGET_STM32F401RE)


### PR DESCRIPTION
1. STM32F4 - Fix STM32F407VG target name

The target name of STM32F407VG should be TARGET_STM32F407VG,
rather than TARGET_F407VG.

Signed-off-by: Tony Wu <tung7970@gmail.com>

2.  LPC11U6X - Fix multiple definition of operator new/delete
    
    Fix the following linker errors:
    
    ToolException: ./.build/LPC11U68/GCC_ARM/mbed-os/hal/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TO
    startup_LPC11U68.cpp:(.text._Znwj+0x0): multiple definition of `operator new(unsigned int)'
    ./.build/LPC11U68/GCC_ARM/mbed-os/hal/common/retarget.o:retarget.cpp:(.text._Znwj+0x0): first de
    ./.build/LPC11U68/GCC_ARM/mbed-os/hal/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TOOLCHAIN_GCC_ARM
    startup_LPC11U68.cpp:(.text._Znaj+0x0): multiple definition of `operator new[](unsigned int)'
    ./.build/LPC11U68/GCC_ARM/mbed-os/hal/common/retarget.o:retarget.cpp:(.text._Znaj+0x0): first de
    ./.build/LPC11U68/GCC_ARM/mbed-os/hal/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TOOLCHAIN_GCC_ARM
    startup_LPC11U68.cpp:(.text._ZdlPv+0x0): multiple definition of `operator delete(void*)'
    ./.build/LPC11U68/GCC_ARM/mbed-os/hal/common/retarget.o:retarget.cpp:(.text._ZdlPv+0x0): first d
    ./.build/LPC11U68/GCC_ARM/mbed-os/hal/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TOOLCHAIN_GCC_ARM
    startup_LPC11U68.cpp:(.text._ZdaPv+0x0): multiple definition of `operator delete[](void*)'
    ./.build/LPC11U68/GCC_ARM/mbed-os/hal/common/retarget.o:retarget.cpp:(.text._ZdaPv+0x0): first d
    collect2: error: ld returned 1 exit status
    
    Signed-off-by: Tony Wu <tung7970@gmail.com>
