### PR TITLE
Fix double free in NanostackInterface

### DIFF
--- a/features/net/FEATURE_IPV6/nanostack-interface/NanostackInterface.cpp
+++ b/features/net/FEATURE_IPV6/nanostack-interface/NanostackInterface.cpp
@@ -368,6 +368,7 @@ void NanostackSocket::data_free_all(void)
     // No mode requirement
 
     NanostackBuffer *buffer = rxBufChain;
+    rxBufChain = NULL;
     while (buffer != NULL) {
         NanostackBuffer *next_buffer = buffer->next;
         FREE(buffer);


### PR DESCRIPTION
When freeing all memory in the rx buffer chain set the head pointer to
NULL. This prevents the head rx buffer from getting freed twice.