### PR TITLE
lwip - Fix handling of max sockets in socket_accept

### DIFF
--- a/features/net/FEATURE_IPV4/lwip-interface/lwip_stack.c
+++ b/features/net/FEATURE_IPV4/lwip-interface/lwip_stack.c
@@ -308,6 +308,9 @@ static int lwip_socket_accept(nsapi_stack_t *stack, nsapi_socket_t server, nsapi
 {
     struct lwip_socket *s = (struct lwip_socket *)server;
     struct lwip_socket *ns = lwip_arena_alloc();
+    if (!ns) {
+        return NSAPI_ERROR_NO_SOCKET;
+    }
 
     err_t err = netconn_accept(s->conn, &ns->conn);
     if (err != ERR_OK) {

--- a/features/net/network-socket/TCPServer.cpp
+++ b/features/net/network-socket/TCPServer.cpp
@@ -76,16 +76,19 @@ int TCPServer::accept(TCPSocket *connection, SocketAddress *address)
 
             connection->_lock.unlock();
             break;
-        }
-
-        if (NSAPI_ERROR_WOULD_BLOCK == ret) {
+        } else if (NSAPI_ERROR_WOULD_BLOCK != ret) {
+            break;
+        } else {
             int32_t count;
 
+            // Release lock before blocking so other threads
+            // accessing this object aren't blocked
             _lock.unlock();
             count = _accept_sem.wait(_timeout);
             _lock.lock();
 
             if (count < 1) {
+                // Semaphore wait timed out so break out and return
                 ret = NSAPI_ERROR_WOULD_BLOCK;
                 break;
             }


### PR DESCRIPTION
This required two small modifications:
- Correct handling of max sockets in lwip socket_accept
- Correct handling of errors in TCPServer accept

Related issue https://github.com/ARMmbed/mbed-os/issues/2523