### PR TITLE
lwip - Add check for previously-bound socket

### DIFF
--- a/features/net/FEATURE_IPV4/lwip-interface/lwip_stack.c
+++ b/features/net/FEATURE_IPV4/lwip-interface/lwip_stack.c
@@ -278,6 +278,11 @@ static int lwip_socket_bind(nsapi_stack_t *stack, nsapi_socket_t handle, nsapi_a
         return NSAPI_ERROR_PARAMETER;
     }
 
+    if ((s->conn->type == NETCONN_TCP && s->conn->pcb.tcp->local_port != 0) ||
+        (s->conn->type == NETCONN_UDP && s->conn->pcb.udp->local_port != 0)) {
+        return NSAPI_ERROR_PARAMETER;
+    }
+
     err_t err = netconn_bind(s->conn, (ip_addr_t *)addr.bytes, port);
     return lwip_err_remap(err);
 }


### PR DESCRIPTION
Avoids issues like this https://github.com/ARMmbed/mbed-os/issues/2424, which turn into an infinite loop in lwip's internals.

In BSD sockets, `EINVALID` would be returned:
http://man7.org/linux/man-pages/man2/bind.2.html