### PR TITLE
[GCC_CR] fix runtime hang for baremetal build

### DIFF
--- a/hal/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TOOLCHAIN_GCC_CR/TARGET_LPC11U68/startup_LPC11U68.cpp
+++ b/hal/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TOOLCHAIN_GCC_CR/TARGET_LPC11U68/startup_LPC11U68.cpp
@@ -137,7 +137,8 @@ AFTER_VECTORS void bss_init(unsigned int start, unsigned int len) {
 
 
 /* Reset entry point*/
-extern "C" void software_init_hook(void) __attribute__((weak));
+extern "C" void software_init_hook(void);
+extern "C" void pre_main(void) __attribute__((weak));
 
 AFTER_VECTORS void ResetISR(void) {
     unsigned int LoadAddr, ExeAddr, SectionLen;
@@ -169,9 +170,10 @@ AFTER_VECTORS void ResetISR(void) {
 
     
     SystemInit();
-    if (software_init_hook) 
-        software_init_hook(); 
-    else {
+    if (pre_main)  { // give control to the RTOS
+        software_init_hook();  // this will also call __libc_init_array
+    }
+    else {           // for BareMetal (non-RTOS) build
         __libc_init_array();
         main();
     }

--- a/hal/targets/cmsis/TARGET_NXP/TARGET_LPC11UXX/TOOLCHAIN_GCC_CR/startup_LPC11xx.cpp
+++ b/hal/targets/cmsis/TARGET_NXP/TARGET_LPC11UXX/TOOLCHAIN_GCC_CR/startup_LPC11xx.cpp
@@ -113,7 +113,8 @@ extern unsigned int __data_section_table;
 extern unsigned int __data_section_table_end;
 extern unsigned int __bss_section_table_end;
 
-extern "C" void software_init_hook(void) __attribute__((weak));
+extern "C" void software_init_hook(void);
+extern "C" void pre_main(void) __attribute__((weak));
 
 AFTER_VECTORS void ResetISR(void) {
     unsigned int LoadAddr, ExeAddr, SectionLen;
@@ -136,9 +137,10 @@ AFTER_VECTORS void ResetISR(void) {
     }
     
     SystemInit();
-    if (software_init_hook) // give control to the RTOS
+    if (pre_main) { // give control to the RTOS
         software_init_hook(); // this will also call __libc_init_array
-    else {
+    }
+    else {          // for BareMetal (non-RTOS) build
         __libc_init_array();
         main();
     }

--- a/hal/targets/cmsis/TARGET_NXP/TARGET_LPC11XX_11CXX/TOOLCHAIN_GCC_CR/TARGET_LPC11XX/startup_LPC11xx.cpp
+++ b/hal/targets/cmsis/TARGET_NXP/TARGET_LPC11XX_11CXX/TOOLCHAIN_GCC_CR/TARGET_LPC11XX/startup_LPC11xx.cpp
@@ -113,7 +113,8 @@ extern unsigned int __data_section_table;
 extern unsigned int __data_section_table_end;
 extern unsigned int __bss_section_table_end;
 
-extern "C" void software_init_hook(void) __attribute__((weak));
+extern "C" void software_init_hook(void);
+extern "C" void pre_main(void) __attribute__((weak));
 
 AFTER_VECTORS void ResetISR(void) {
     unsigned int LoadAddr, ExeAddr, SectionLen;
@@ -136,9 +137,10 @@ AFTER_VECTORS void ResetISR(void) {
     }
     
     SystemInit();
-    if (software_init_hook) // give control to the RTOS
+    if (pre_main) { // give control to the RTOS
         software_init_hook(); // this will also call __libc_init_array
-    else {
+    }
+    else {          // for BareMetal (non-RTOS) build
         __libc_init_array();
         main();
     }
@@ -147,7 +149,7 @@ AFTER_VECTORS void ResetISR(void) {
 
 AFTER_VECTORS void NMI_Handler      (void) {while(1){}}
 AFTER_VECTORS void HardFault_Handler(void) {while(1){}}
-AFTER_VECTORS void SVC_Handler   (void) {while(1){}}
+AFTER_VECTORS void SVC_Handler      (void) {while(1){}}
 AFTER_VECTORS void PendSV_Handler   (void) {while(1){}}
 AFTER_VECTORS void SysTick_Handler  (void) {while(1){}}
 AFTER_VECTORS void IntDefaultHandler(void) {while(1){}}

--- a/hal/targets/cmsis/TARGET_NXP/TARGET_LPC15XX/TOOLCHAIN_GCC_CR/startup_LPC15xx.cpp
+++ b/hal/targets/cmsis/TARGET_NXP/TARGET_LPC15XX/TOOLCHAIN_GCC_CR/startup_LPC15xx.cpp
@@ -166,7 +166,8 @@ AFTER_VECTORS void bss_init(unsigned int start, unsigned int len) {
 
 
 /* Reset entry point*/
-extern "C" void software_init_hook(void) __attribute__((weak));
+extern "C" void software_init_hook(void);
+extern "C" void pre_main(void) __attribute__((weak));
 
 AFTER_VECTORS void ResetISR(void) {
     unsigned int LoadAddr, ExeAddr, SectionLen;
@@ -187,9 +188,10 @@ AFTER_VECTORS void ResetISR(void) {
     }
     
     SystemInit();
-    if (software_init_hook) 
-        software_init_hook(); 
-    else {
+    if (pre_main) { // give control to the RTOS
+        software_init_hook();  // this will also call __libc_init_array
+    }
+    else {          // for BareMetal (non-RTOS) build
         __libc_init_array();
         main();
     }

--- a/hal/targets/cmsis/TARGET_NXP/TARGET_LPC176X/TOOLCHAIN_GCC_CR/startup_LPC17xx.cpp
+++ b/hal/targets/cmsis/TARGET_NXP/TARGET_LPC176X/TOOLCHAIN_GCC_CR/startup_LPC17xx.cpp
@@ -130,7 +130,8 @@ AFTER_VECTORS void bss_init(unsigned int start, unsigned int len) {
     for (loop = 0; loop < len; loop = loop + 4) *pulDest++ = 0;
 }
 
-extern "C" void software_init_hook(void) __attribute__((weak));
+extern "C" void software_init_hook(void);
+extern "C" void pre_main(void) __attribute__((weak));
 
 AFTER_VECTORS void ResetISR(void) {
     unsigned int LoadAddr, ExeAddr, SectionLen;
@@ -151,9 +152,10 @@ AFTER_VECTORS void ResetISR(void) {
     }
     
     SystemInit();
-    if (software_init_hook) // give control to the RTOS
+    if (pre_main) { // give control to the RTOS
         software_init_hook(); // this will also call __libc_init_array
-    else {
+    }
+    else {          // for BareMetal (non-RTOS) build
         __libc_init_array();
         main();
     }


### PR DESCRIPTION
See detail here: https://github.com/ARMmbed/mbed-os/issues/2581
Automated test result is below:

```

Test summary:
+--------+---------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| Result | Target  | Toolchain | Test ID     | Test Description                      | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------+---------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| OK     | LPC1768 | GCC_CR    | DTCT_1      | Simple detect test                    |        6.49        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | EXAMPLE_1   | /dev/null                             |        6.41        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_10     | Hello World                           |        6.47        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_11     | Ticker Int                            |        6.44        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_12     | C++                                   |        6.46        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_16     | RTC                                   |        6.41        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_2      | stdio                                 |        6.46        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_22     | Semihost                              |        6.47        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_23     | Ticker Int us                         |        6.44        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_24     | Timeout Int us                        |        6.47        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_25     | Time us                               |        6.36        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_26     | Integer constant division             |        6.47        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_34     | Ticker Two callbacks                  |        6.44        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_37     | Serial NC RX                          |        6.4         |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_38     | Serial NC TX                          |        6.47        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_A1     | Basic                                 |        6.46        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_A18    | Interrupt vector relocation           |        6.47        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_A2     | Semihost file system                  |        6.54        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_A21    | Call function before main (mbed_main) |        6.43        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_A9     | Serial Echo at 115200                 |        5.43        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | MBED_BUSOUT | BusOut                                |        5.38        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | RTOS_1      | Basic thread                          |        6.4         |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | RTOS_2      | Mutex resource lock                   |        5.43        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | RTOS_3      | Semaphore resource lock               |        6.49        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | RTOS_4      | Signals messaging                     |        6.44        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | RTOS_5      | Queue messaging                       |        6.49        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | RTOS_6      | Mail messaging                        |        6.49        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | RTOS_7      | Timer                                 |        6.51        |       20      |  1/1  |
| OK     | LPC1768 | GCC_CR    | RTOS_8      | ISR (Queue)                           |        5.48        |       20      |  1/1  |
+--------+---------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
Result: 29 OK

Completed in 292.32 sec

```
