### PR TITLE
Set size of callback irq array to IrqCnt

### DIFF
--- a/hal/api/CAN.h
+++ b/hal/api/CAN.h
@@ -203,7 +203,9 @@ public:
         EpIrq,
         AlIrq,
         BeIrq,
-        IdIrq
+        IdIrq,
+
+        IrqCnt
     };
 
     /** Attach a function to call whenever a CAN frame received interrupt is
@@ -246,7 +248,7 @@ protected:
     virtual void lock();
     virtual void unlock();
     can_t               _can;
-    Callback<void()>    _irq[9];
+    Callback<void()>    _irq[IrqCnt];
     PlatformMutex       _mutex;
 };
 

--- a/hal/api/SerialBase.h
+++ b/hal/api/SerialBase.h
@@ -55,7 +55,9 @@ public:
 
     enum IrqType {
         RxIrq = 0,
-        TxIrq
+        TxIrq,
+
+        IrqCnt
     };
 
     enum Flow {
@@ -231,7 +233,7 @@ protected:
 #endif
 
     serial_t         _serial;
-    Callback<void()> _irq[2];
+    Callback<void()> _irq[IrqCnt];
     int              _baud;
 
 };


### PR DESCRIPTION
Rather than hard coding the size of the callback array for irqs,
instead set the size to IrqCnt which is defined by the irq enumeration.