### PR TITLE
Added support for ADC only pins in LPC43xx

### DIFF
--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PeripheralNames.h
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PeripheralNames.h
@@ -45,7 +45,23 @@ typedef enum {
     ADC1_4,
     ADC1_5,
     ADC1_6,
-    ADC1_7
+    ADC1_7,
+    ADC_pin0_0,        // inlcude adc only pin channels
+    ADC_pin0_1,
+    ADC_pin0_2,
+    ADC_pin0_3,
+    ADC_pin0_4,
+    ADC_pin0_5,
+    ADC_pin0_6,
+    ADC_pin0_7,
+    ADC_pin1_0,
+    ADC_pin1_1,
+    ADC_pin1_2,
+    ADC_pin1_3,
+    ADC_pin1_4,
+    ADC_pin1_5,
+    ADC_pin1_6,
+    ADC_pin1_7
 } ADCName;
 
 typedef enum {

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PeripheralNames.h
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PeripheralNames.h
@@ -46,7 +46,7 @@ typedef enum {
     ADC1_5,
     ADC1_6,
     ADC1_7,
-    ADC_pin0_0,        // inlcude adc only pin channels
+    ADC_pin0_0,
     ADC_pin0_1,
     ADC_pin0_2,
     ADC_pin0_3,

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PinNames.h
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PinNames.h
@@ -29,6 +29,8 @@ typedef enum {
 
 #define PORT_SHIFT  5
 #define NO_GPIO     15
+#define NO_PORT     0xFF
+
 
 // On the LPC43xx the MCU pin name and the GPIO pin name are not the same.
 // Encode SCU and GPIO offsets as a pin identifier
@@ -663,6 +665,23 @@ typedef enum {
     DAC0 = P4_4,      // J8-6*    J8-6*   S3-5    S3-5
                       // (*)  if DAC0 is configured, ADC4 is not available
                       // (**) ADC5 requires JP2 mod
+
+    adc0_0 = MBED_PIN(NO_PORT, 0, NO_GPIO, 0),
+    adc0_1 = MBED_PIN(NO_PORT, 1, NO_GPIO, 0),
+    adc0_2 = MBED_PIN(NO_PORT, 2, NO_GPIO, 0),
+    adc0_3 = MBED_PIN(NO_PORT, 3, NO_GPIO, 0),
+    adc0_4 = MBED_PIN(NO_PORT, 4, NO_GPIO, 0),
+    adc0_5 = MBED_PIN(NO_PORT, 5, NO_GPIO, 0),
+    adc0_6 = MBED_PIN(NO_PORT, 6, NO_GPIO, 0),
+    adc0_7 = MBED_PIN(NO_PORT, 7, NO_GPIO, 0),
+    adc1_0 = MBED_PIN(NO_PORT, 8, NO_GPIO, 0),
+    adc1_1 = MBED_PIN(NO_PORT, 9, NO_GPIO, 0),
+    adc1_2 = MBED_PIN(NO_PORT, 10, NO_GPIO, 0),
+    adc1_3 = MBED_PIN(NO_PORT, 11, NO_GPIO, 0),
+    adc1_4 = MBED_PIN(NO_PORT, 12, NO_GPIO, 0),
+    adc1_5 = MBED_PIN(NO_PORT, 13, NO_GPIO, 0),
+    adc1_6 = MBED_PIN(NO_PORT, 14, NO_GPIO, 0),
+    adc1_7 = MBED_PIN(NO_PORT, 15, NO_GPIO, 0),
 
     // USB pins
     //                   210E    210     200E    200

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PinNames.h
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4330/PinNames.h
@@ -666,6 +666,7 @@ typedef enum {
                       // (*)  if DAC0 is configured, ADC4 is not available
                       // (**) ADC5 requires JP2 mod
 
+    // Analog Only Pins
     adc0_0 = MBED_PIN(NO_PORT, 0, NO_GPIO, 0),
     adc0_1 = MBED_PIN(NO_PORT, 1, NO_GPIO, 0),
     adc0_2 = MBED_PIN(NO_PORT, 2, NO_GPIO, 0),

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PeripheralNames.h
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PeripheralNames.h
@@ -45,7 +45,23 @@ typedef enum {
     ADC1_4,
     ADC1_5,
     ADC1_6,
-    ADC1_7
+    ADC1_7,
+    ADC_pin0_0,
+    ADC_pin0_1,
+    ADC_pin0_2,
+    ADC_pin0_3,
+    ADC_pin0_4,
+    ADC_pin0_5,
+    ADC_pin0_6,
+    ADC_pin0_7,
+    ADC_pin1_0,
+    ADC_pin1_1,
+    ADC_pin1_2,
+    ADC_pin1_3,
+    ADC_pin1_4,
+    ADC_pin1_5,
+    ADC_pin1_6,
+    ADC_pin1_7
 } ADCName;
 
 typedef enum {

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PinNames.h
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PinNames.h
@@ -30,6 +30,7 @@ typedef enum {
 
 #define PORT_SHIFT  5
 #define NO_GPIO     15
+#define NO_PORT     0xFF
 
 // On the LPC43xx the MCU pin name and the GPIO pin name are not the same.
 // Encode SCU and GPIO offsets as a pin identifier
@@ -503,6 +504,25 @@ typedef enum {
     LED2 = LED_BLUE,
     LED3 = LED_GREEN,
     LED4 = LED_RED,
+
+    // Analog Only pins
+
+    adc0_0 = MBED_PIN(NO_PORT, 0, NO_GPIO, 0),
+    adc0_1 = MBED_PIN(NO_PORT, 1, NO_GPIO, 0),
+    adc0_2 = MBED_PIN(NO_PORT, 2, NO_GPIO, 0),
+    adc0_3 = MBED_PIN(NO_PORT, 3, NO_GPIO, 0),
+    adc0_4 = MBED_PIN(NO_PORT, 4, NO_GPIO, 0),
+    adc0_5 = MBED_PIN(NO_PORT, 5, NO_GPIO, 0),
+    adc0_6 = MBED_PIN(NO_PORT, 6, NO_GPIO, 0),
+    adc0_7 = MBED_PIN(NO_PORT, 7, NO_GPIO, 0),
+    adc1_0 = MBED_PIN(NO_PORT, 8, NO_GPIO, 0),
+    adc1_1 = MBED_PIN(NO_PORT, 9, NO_GPIO, 0),
+    adc1_2 = MBED_PIN(NO_PORT, 10, NO_GPIO, 0),
+    adc1_3 = MBED_PIN(NO_PORT, 11, NO_GPIO, 0),
+    adc1_4 = MBED_PIN(NO_PORT, 12, NO_GPIO, 0),
+    adc1_5 = MBED_PIN(NO_PORT, 13, NO_GPIO, 0),
+    adc1_6 = MBED_PIN(NO_PORT, 14, NO_GPIO, 0),
+    adc1_7 = MBED_PIN(NO_PORT, 15, NO_GPIO, 0),
 
     // ---------- End of LPCXpresso 4337 pins ----------
 } PinName;

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PinNames.h
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PinNames.h
@@ -506,7 +506,6 @@ typedef enum {
     LED4 = LED_RED,
 
     // Analog Only pins
-
     adc0_0 = MBED_PIN(NO_PORT, 0, NO_GPIO, 0),
     adc0_1 = MBED_PIN(NO_PORT, 1, NO_GPIO, 0),
     adc0_2 = MBED_PIN(NO_PORT, 2, NO_GPIO, 0),

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/analogin_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/analogin_api.c
@@ -70,32 +70,27 @@ void analogin_init(analogin_t *obj, PinName pin) {
     MBED_ASSERT(obj->adc != (LPC_ADC_T *)NC);
     
     // Set ADC number
-    if(name < ADC1_0)
-    {
+    if(name < ADC1_0) {
         obj->num = 0;
-    } else if(name < ADC_pin0_0 && name > ADC0_6)
-    {
+    } else if(name < ADC_pin0_0 && name > ADC0_6) {
         obj->num = 1;
-    } else if(name < ADC_pin1_1 && name > ADC1_7)
-    {
+    } else if(name < ADC_pin1_1 && name > ADC1_7) {
         obj->num = 0;
-    } else if(name > ADC_pin0_7)
-    {
+    } else if(name > ADC_pin0_7) {
         obj->num = 1;
     }
 
-    // Set ADC register, number and channel
+    //ADC register and channel
     obj->ch = name % (ADC0_7 + 1);
     obj->adc = (LPC_ADC_T *) (obj->num > 0) ? LPC_ADC1 : LPC_ADC0;
 
     // Reset pin function to GPIO if it is a GPIO pin. for adc only pins it is not necessary
-    if(name < ADC_pin0_0)
-    {
-        gpio_set(pin);
-        // Select ADC on analog function select register in SCU
-        LPC_SCU->ENAIO[obj->num] |= (1 << obj->ch);
+    if(name < ADC_pin0_0) {
+    	gpio_set(pin);
+    	// Select ADC on analog function select register in SCU
+    	LPC_SCU->ENAIO[obj->num] |= (1 << obj->ch);
     } else {
-        LPC_SCU->ENAIO[obj->num] &= ~(1 << obj->ch);
+    	LPC_SCU->ENAIO[obj->num] &= ~(1 << obj->ch);
     }
     
     // Calculate minimum clock divider

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/analogin_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/analogin_api.c
@@ -44,6 +44,22 @@ static const PinMap PinMap_ADC[] = {
     {PF_11, ADC1_5, 0},
     {P7_7,  ADC1_6, 0},
     {PF_7,  ADC1_7, 0},
+    {adc0_0,  ADC_pin0_0, 0},
+    {adc0_1,  ADC_pin0_1, 0},
+    {adc0_2,  ADC_pin0_2, 0},
+    {adc0_3,  ADC_pin0_3, 0},
+    {adc0_4,  ADC_pin0_4, 0},
+    {adc0_5,  ADC_pin0_5, 0},
+    {adc0_6,  ADC_pin0_6, 0},
+    {adc0_7,  ADC_pin0_7, 0},
+    {adc1_0,  ADC_pin1_0, 0},
+    {adc1_1,  ADC_pin1_1, 0},
+    {adc1_2,  ADC_pin1_2, 0},
+    {adc1_3,  ADC_pin1_3, 0},
+    {adc1_4,  ADC_pin1_4, 0},
+    {adc1_5,  ADC_pin1_5, 0},
+    {adc1_6,  ADC_pin1_6, 0},
+    {adc1_7,  ADC_pin1_7, 0},
     {NC,    NC,     0   }
 };
 
@@ -52,16 +68,35 @@ void analogin_init(analogin_t *obj, PinName pin) {
 
     name = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
     MBED_ASSERT(obj->adc != (LPC_ADC_T *)NC);
+    
+    // Set ADC number
+    if(name < ADC1_0)
+    {
+        obj->num = 0;
+    } else if(name < ADC_pin0_0 && name > ADC0_6)
+    {
+        obj->num = 1;
+    } else if(name < ADC_pin1_1 && name > ADC1_7)
+    {
+        obj->num = 0;
+    } else if(name > ADC_pin0_7)
+    {
+        obj->num = 1;
+    }
 
     // Set ADC register, number and channel
-    obj->num = (name >> ADC0_7) ? 1 : 0;
     obj->ch = name % (ADC0_7 + 1);
     obj->adc = (LPC_ADC_T *) (obj->num > 0) ? LPC_ADC1 : LPC_ADC0;
 
-    // Reset pin function to GPIO
-    gpio_set(pin);
-    // Select ADC on analog function select register in SCU
-    LPC_SCU->ENAIO[obj->num] |= (1 << obj->ch);
+    // Reset pin function to GPIO if it is a GPIO pin. for adc only pins it is not necessary
+    if(name < ADC_pin0_0)
+    {
+        gpio_set(pin);
+        // Select ADC on analog function select register in SCU
+        LPC_SCU->ENAIO[obj->num] |= (1 << obj->ch);
+    } else {
+        LPC_SCU->ENAIO[obj->num] &= ~(1 << obj->ch);
+    }
     
     // Calculate minimum clock divider
     //  clkdiv = divider - 1


### PR DESCRIPTION
These changes make it possible to configure adc only pins available in LPC43xx devices.