### PR TITLE
add PTEx pins as option for SPI on Hexiwear - for SD Card Interface

### DIFF
--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/TARGET_HEXIWEAR/PeripheralPins.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/TARGET_HEXIWEAR/PeripheralPins.c
@@ -99,6 +99,7 @@ const PinMap PinMap_UART_RTS[] = {
 
 /************SPI***************/
 const PinMap PinMap_SPI_SCLK[] = {
+    {PTE2 , SPI_1, 2},
     {PTB21, SPI_2, 2},
     {PTC5 , SPI_0, 2},
     {PTD5 , SPI_1, 7},
@@ -106,6 +107,8 @@ const PinMap PinMap_SPI_SCLK[] = {
 };
 
 const PinMap PinMap_SPI_MOSI[] = {
+    {PTE1 , SPI_1, 2},
+    {PTE3 , SPI_1, 7},
     {PTB22, SPI_2, 2},
     {PTC6 , SPI_0, 2},
     {PTD6 , SPI_1, 7},
@@ -113,6 +116,8 @@ const PinMap PinMap_SPI_MOSI[] = {
 };
 
 const PinMap PinMap_SPI_MISO[] = {
+    {PTE1 , SPI_1, 7},
+    {PTE3 , SPI_1, 2},
     {PTB23, SPI_2, 2},
     {PTC7 , SPI_0, 2},
     {PTD7 , SPI_1, 7},
@@ -120,6 +125,7 @@ const PinMap PinMap_SPI_MISO[] = {
 };
 
 const PinMap PinMap_SPI_SSEL[] = {
+    {PTE4 , SPI_1, 2},
     {PTB20, SPI_2, 2},
     {PTC4 , SPI_0, 2},
     {PTD4 , SPI_1, 7},


### PR DESCRIPTION
Although the signals connected to the SD Card on Hexiwear are marked as SDHC, the  [SDFileSystem](https://developer.mbed.org/teams/mbed/code/SDFileSystem/) library on mbed uses legacy SPI mode and thus the pins need to be able to be configured for SPI, which they can be with this patch.  

