### PR TITLE
[HAL] Fixed "intrinsic is deprecated" warnings

### DIFF
--- a/hal/common/mbed_critical.c
+++ b/hal/common/mbed_critical.c
@@ -87,7 +87,9 @@ void core_util_critical_section_exit(void)
 #if EXCLUSIVE_ACCESS
 
 /* Supress __ldrex and __strex deprecated warnings - "#3731-D: intrinsic is deprecated" */
+#if defined (__CC_ARM) 
 #pragma diag_suppress 3731
+#endif
 
 bool core_util_atomic_cas_u8(uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_t desiredValue)
 {

--- a/hal/common/mbed_critical.c
+++ b/hal/common/mbed_critical.c
@@ -86,6 +86,9 @@ void core_util_critical_section_exit(void)
 
 #if EXCLUSIVE_ACCESS
 
+/* Supress __ldrex and __strex deprecated warnings - "#3731-D: intrinsic is deprecated" */
+#pragma diag_suppress 3731
+
 bool core_util_atomic_cas_u8(uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_t desiredValue)
 {
     uint8_t currentValue = __LDREXB((volatile uint8_t*)ptr);


### PR DESCRIPTION
Suppressed "#3731-D: intrinsic is deprecated" compiler warnings in critical API.