### PR TITLE
Tools - Fix fill section size variation

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -954,6 +954,7 @@ class mbedToolchain:
         bin = join(tmp_path, filename)
         map = join(tmp_path, name + '.map')
 
+        r.objects = sorted(set(r.objects))
         if self.need_update(elf, r.objects + r.libraries + [r.linker_script]):
             needed_update = True
             self.progress("link", name)


### PR DESCRIPTION
The linking order of object files affects the actual code placement,
which in turn affects the size of fill section due to the number of
zeros required to maintain appropriate data/code alignment may change.
This is observed when building on Mac and Linux host.

example: mbed compile -m K64F -t GCC_ARM (build 1)
```
+---------------------+-------+-------+-------+
| Module              | .text | .data |  .bss |
+---------------------+-------+-------+-------+
| Fill                |   120 |     4 |  2381 |
| Misc                | 28755 |  2216 |    84 |
| features/frameworks |  4236 |    52 |   744 |
| hal/common          |  2745 |     4 |   325 |
| hal/targets         | 12116 |    12 |   200 |
| rtos/rtos           |   119 |     4 |     0 |
| rtos/rtx            |  5721 |    20 |  6786 |
| Subtotals           | 53812 |  2312 | 10520 |
+---------------------+-------+-------+-------+
```
example: mbed compile -m K64F -t GCC_ARM (build 2)
```
+---------------------+-------+-------+-------+
| Module              | .text | .data |  .bss |
+---------------------+-------+-------+-------+
| Fill                |   128 |     4 |  2381 |
| Misc                | 28755 |  2216 |    84 |
| features/frameworks |  4236 |    52 |   744 |
| hal/common          |  2745 |     4 |   325 |
| hal/targets         | 12116 |    12 |   200 |
| rtos/rtos           |   119 |     4 |     0 |
| rtos/rtx            |  5721 |    20 |  6786 |
| Subtotals           | 53820 |  2312 | 10520 |
+---------------------+-------+-------+-------+
```
This patch fixes fill section size variation by sorting object
files before passing to linker.

Signed-off-by: Tony Wu <tung7970@gmail.com>