### PR TITLE
Fix uvisor memory tracing

### DIFF
--- a/hal/common/mbed_alloc_wrappers.cpp
+++ b/hal/common/mbed_alloc_wrappers.cpp
@@ -67,15 +67,15 @@ void mbed_stats_heap_get(mbed_stats_heap_t *stats)
 #include "uvisor-lib/uvisor-lib.h"
 #endif/* FEATURE_UVISOR */
 
-// TODO: memory tracing doesn't work with uVisor enabled.
-#if !defined(FEATURE_UVISOR)
-
 extern "C" {
     void * __real__malloc_r(struct _reent * r, size_t size);
     void * __real__realloc_r(struct _reent * r, void * ptr, size_t size);
     void __real__free_r(struct _reent * r, void * ptr);
     void* __real__calloc_r(struct _reent * r, size_t nmemb, size_t size);
 }
+
+// TODO: memory tracing doesn't work with uVisor enabled.
+#if !defined(FEATURE_UVISOR)
 
 extern "C" void * __wrap__malloc_r(struct _reent * r, size_t size) {
     void *ptr = NULL;
@@ -167,6 +167,8 @@ extern "C" void __wrap__free_r(struct _reent * r, void * ptr) {
 #endif // #ifdef MBED_MEM_TRACING_ENABLED
 }
 
+#endif // if !defined(FEATURE_UVISOR)
+
 extern "C" void * __wrap__calloc_r(struct _reent * r, size_t nmemb, size_t size) {
     void *ptr = NULL;
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -187,7 +189,6 @@ extern "C" void * __wrap__calloc_r(struct _reent * r, size_t nmemb, size_t size)
     return ptr;
 }
 
-#endif // if !defined(FEATURE_UVISOR)
 
 /******************************************************************************/
 /* ARMCC memory allocation wrappers                                           */

--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -480,10 +480,9 @@ extern "C" WEAK void __cxa_pure_virtual(void) {
 #endif
 
 #if defined(TOOLCHAIN_GCC)
-/* uVisor wraps malloc_r, realloc_r and free_r, but not calloc_r! */
-#ifndef  FEATURE_UVISOR
 
-
+#ifdef  FEATURE_UVISOR
+#include "uvisor-lib/uvisor-lib.h"
 #endif/* FEATURE_UVISOR */
 
 


### PR DESCRIPTION
Tested with uvisor example:

```
+-------------------------+-------+-------+-------+
| Module                  | .text | .data |  .bss |
+-------------------------+-------+-------+-------+
| Fill                    |   141 |   512 |  2389 |
| Misc                    | 42795 |  1688 |  3838 |
| features/FEATURE_UVISOR |   650 |     0 |     1 |
| features/frameworks     |  4236 |    52 |   744 |
| hal/common              |  2619 |     0 |   325 |
| hal/targets             | 12851 |    12 |   200 |
| rtos/rtos               |   559 |     4 |     0 |
| rtos/rtx                |  6427 |    20 |  6787 |
| Subtotals               | 70278 |  2288 | 14284 |
+-------------------------+-------+-------+-------+
Allocated Heap: 65540 bytes
Allocated Stack: unknown
Total Static RAM memory (data + bss): 16572 bytes
Total RAM memory (data + bss + heap + stack): 82112 bytes
Total Flash memory (text + data + misc): 73606 bytes
Image: .\.build\K64F\GCC_ARM\mbed-os-example-uvisor.bin
```

+ example blinky, build without errors

Please review, I compared the changes before the memory tracing patch and after, this should match it.

@AlessandroA @niklas-arm @meriac @sg-