### PR TITLE
Fixed bug on memap (non-default output path)

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -342,28 +342,23 @@ class MemapParser(object):
                 else:
                     self.module_add(name, size, section)
 
-    def search_objects(self, path, toolchain):
-        """ Check whether the specified map file matches with the toolchain.
-        Searches for object files and creates mapping: object --> module
+    def search_objects(self, path):
+        """ Searches for object files and creates mapping: object --> module
 
         Positional arguments:
         path - the path to an object file
-        toolchain - the toolchain used to build the object file
         """
 
         path = path.replace('\\', '/')
 
         # check location of map file
-        rex = r'^(.+\/)' + re.escape(toolchain) + r'\/(.+\.map)$'
+        rex = r'^(.+)' + r'\/(.+\.map)$'
         test_rex = re.match(rex, path)
 
         if test_rex:
-            search_path = test_rex.group(1) + toolchain + '/mbed-os/'
+            search_path = test_rex.group(1) + '/mbed-os/'
         else:
-            # It looks this is not an mbed project
-            # object-to-module mapping cannot be generated
-            print "Warning: specified toolchain doesn't match with"\
-                " path to the memory map file."
+            print "Warning: this doesn't look like an mbed project"
             return
 
         for root, _, obj_files in os.walk(search_path):
@@ -580,12 +575,12 @@ class MemapParser(object):
             with open(mapfile, 'r') as file_input:
                 if toolchain == "ARM" or toolchain == "ARM_STD" or\
                    toolchain == "ARM_MICRO":
-                    self.search_objects(os.path.abspath(mapfile), "ARM")
+                    self.search_objects(os.path.abspath(mapfile))
                     self.parse_map_file_armcc(file_input)
                 elif toolchain == "GCC_ARM":
                     self.parse_map_file_gcc(file_input)
                 elif toolchain == "IAR":
-                    self.search_objects(os.path.abspath(mapfile), toolchain)
+                    self.search_objects(os.path.abspath(mapfile))
                     self.parse_map_file_iar(file_input)
                 else:
                     result = False
@@ -597,7 +592,7 @@ class MemapParser(object):
 def main():
     """Entry Point"""
 
-    version = '0.3.11'
+    version = '0.3.12'
 
     # Parser handling
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
Removed code that checks if the path to the map file matches with the selected toolchain.

Fixes this: https://github.com/ARMmbed/mbed-os/issues/2608

Example:
```
C:\mbed\memap>mbed compile -t ARM -m K64F -c --build .build/XXX/
```

Output with patch:

```
+---------------------+-------+-------+-------+
| Module              | .text | .data |  .bss |
+---------------------+-------+-------+-------+
| Misc                | 13641 |    20 |  1372 |
| features/frameworks |  4315 |   572 |   296 |
| features/net        |    84 |     0 |    92 |
| hal/common          |  4790 |    28 |   168 |
| hal/targets         | 13904 |    76 |   136 |
| rtos/rtos           |   128 |     4 |     0 |
| rtos/rtx            |  6614 |    92 |  8316 |
| Subtotals           | 43476 |   792 | 10380 |
+---------------------+-------+-------+-------+
Allocated Heap: unknown
Allocated Stack: unknown
Total Static RAM memory (data + bss): 11172 bytes
Total RAM memory (data + bss + heap + stack): 11172 bytes
Total Flash memory (text + data + misc): 44268 bytes
Image: .build/XXX/memap.bin
```
