### PR TITLE
Correctly providing directories to build_apis

### DIFF
--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2001,10 +2001,10 @@ def find_tests(base_dir, target_name, toolchain_name, options=None):
     tests = {}
 
     # Prepare the toolchain
-    toolchain = prepare_toolchain(base_dir, target_name, toolchain_name, options=options, silent=True)
+    toolchain = prepare_toolchain([base_dir], target_name, toolchain_name, options=options, silent=True)
 
     # Scan the directory for paths to probe for 'TESTS' folders
-    base_resources = scan_resources(base_dir, toolchain)
+    base_resources = scan_resources([base_dir], toolchain)
 
     dirs = base_resources.inc_dirs
     for directory in dirs:


### PR DESCRIPTION
The shared `prepare_toolchain` and `scan_resources` functions in build_api
expect a list, not a string. This is different from the
toolchain.scan_resources function. Now the functions are being used
correctly within the `find_tests` function in test_api

Thanks @sarahmarshy for finding this!