### PR TITLE
Change default uvision exporter to uvision5

### DIFF
--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -28,8 +28,8 @@ from tools.targets import TARGET_NAMES, EXPORT_MAP, TARGET_MAP
 from project_generator_definitions.definitions import ProGenDef
 
 EXPORTERS = {
-    'uvision': uvision4.Uvision4,
-    'uvision4': uvision4.Uvision4,
+    'uvision': uvision5.Uvision5,
+    'uvision4': uvision4.Uvision4, # deprecated - to be removed in future version
     'uvision5': uvision5.Uvision5,
     'lpcxpresso': codered.CodeRed,
     'gcc_arm': gccarm.GccArm,

--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -55,6 +55,9 @@ class Uvision4(Exporter):
 
     def generate(self):
         """ Generates the project files """
+
+        print "WARNING: exporting to uVision4 is deprecated and will be removed in a future version"
+
         project_data = self.progen_get_project_data()
         tool_specific = {}
         # Expand tool specific settings by uvision specific settings which are required

--- a/tools/test/export/build_test.py
+++ b/tools/test/export/build_test.py
@@ -70,7 +70,7 @@ class ProgenBuildTest(object):
         """
         log = ''
         if tool == 'uvision' or tool == 'uvision4':
-            log = path.join(project_dir,"build","build_log.txt")
+            log = path.join(project_dir, "build", "build_log.txt")
         elif tool == 'iar':
             log = path.join(project_dir, 'build_log.txt')
         try:

--- a/tools/test/export/build_test.py
+++ b/tools/test/export/build_test.py
@@ -69,8 +69,8 @@ class ProgenBuildTest(object):
                    created project files
         """
         log = ''
-        if tool == 'uvision' or tool == 'uvision5':
-            log = path.join(project_dir, "build", "build_log.txt")
+        if tool == 'uvision' or tool == 'uvision4':
+            log = os.path.join(project_dir,"build","build_log.txt")
         elif tool == 'iar':
             log = path.join(project_dir, 'build_log.txt')
         try:
@@ -129,7 +129,7 @@ class ProgenBuildTest(object):
 
 def main():
     """Entry point"""
-    toolchainlist = ["iar", "uvision", "uvision5"]
+    toolchainlist = ["iar", "uvision", "uvision4"]
     default_tests = [test_name_known("MBED_BLINKY")]
     targetnames = TARGET_NAMES
     targetnames.sort()

--- a/tools/test/export/build_test.py
+++ b/tools/test/export/build_test.py
@@ -70,7 +70,7 @@ class ProgenBuildTest(object):
         """
         log = ''
         if tool == 'uvision' or tool == 'uvision4':
-            log = os.path.join(project_dir,"build","build_log.txt")
+            log = path.join(project_dir,"build","build_log.txt")
         elif tool == 'iar':
             log = path.join(project_dir, 'build_log.txt')
         try:


### PR DESCRIPTION
uVision4 is no longer maintained by the Keil team (support was stopped
long time ago).

This is why we need to make the uvision exporter able to generate uVision5
projects by default (which is based on software packs).

Also, adding note that the uvision4 exporter is now deprecated and will be
removed in the future.

@0xc0170 @sg- 