### PR TITLE
[MTM_MTCONNECT04S] Added support for MTM_MTCONNECT04S

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1550,6 +1550,22 @@
         "extra_labels_add": ["NRF51_MICROBIT"],
         "macros_add": ["TARGET_NRF51_MICROBIT", "TARGET_NRF_LFCLK_RC"]
     },
+    "MTM_MTCONNECT04S": {
+        "inherits": ["MCU_NRF51_32K"],
+        "progen": {"target": "mtm-mtconnect04s"},
+        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
+        "release_versions": ["2"]
+    },
+    "MTM_MTCONNECT04S_BOOT": {
+        "inherits": ["MCU_NRF51_32K_BOOT"],
+        "extra_labels_add": ["MTM_CONNECT04S"],
+        "macros_add": ["TARGET_MTM_CONNECT04S"]
+    },
+    "MTM_MTCONNECT04S_OTA": {
+        "inherits": ["MCU_NRF51_32K_OTA"],
+        "extra_labels_add": ["MTM_CONNECT04S"],
+        "macros_add": ["TARGET_MTM_CONNECT04S"]
+    },
 
     "TY51822R3": {
         "inherits": ["MCU_NRF51_32K_UNIFIED"],

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_MTM_MTCONNECT04S/PinNames.h
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_MTM_MTCONNECT04S/PinNames.h
@@ -1,0 +1,137 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2015 Nordic Semiconductor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+#define PORT_SHIFT  3
+
+typedef enum {
+    p0  = 0,
+    p1  = 1,
+    p2  = 2,
+    p3  = 3,
+    p4  = 4,
+    p5  = 5,
+    p6  = 6,
+    p7  = 7,
+    p8  = 8,
+    p9  = 9,
+    p10 = 10,
+    p11 = 11,
+    p12 = 12,
+    p13 = 13,
+    p14 = 14,
+    p15 = 15,
+    p16 = 16,
+    p17 = 17,
+    p18 = 18,
+    p19 = 19,
+    p20 = 20,
+    p21 = 21,
+    p22 = 22,
+    p23 = 23,
+    p24 = 24,
+    p25 = 25,
+    p26 = 26,
+    p27 = 27,
+    p28 = 28,
+    p29 = 29,
+    p30 = 30,      
+    p31 = 31,
+
+    P0_0  = p0,
+    P0_1  = p1,
+    P0_2  = p2,
+    P0_3  = p3,
+    P0_4  = p4,
+    P0_5  = p5,
+    P0_6  = p6,
+    P0_7  = p7,
+
+    P0_8  = p8,
+    P0_9  = p9,
+    P0_10 = p10,
+    P0_11 = p11,
+    P0_12 = p12,
+    P0_13 = p13,
+    P0_14 = p14,
+    P0_15 = p15,
+
+    P0_16 = p16,
+    P0_17 = p17,
+    P0_18 = p18,
+    P0_19 = p19,
+    P0_20 = p20,
+    P0_21 = p21,
+    P0_22 = p22,
+    P0_23 = p23,
+
+    P0_24 = p24,
+    P0_25 = p25,
+    P0_26 = p26,
+    P0_27 = p27,
+    P0_28 = p28,
+    P0_29 = p29,
+    P0_30 = p30,  
+    P0_31 = p31,
+                  
+    LEDR    = p16,
+    LEDG    = p15,
+    LEDB    = p6,
+    LED1    = LEDR,
+    LED2    = LEDG,
+    LED3    = LEDB,
+    LED4    = LEDB,
+
+    RX_PIN_NUMBER  = p4,
+    TX_PIN_NUMBER  = p5,
+    CTS_PIN_NUMBER = p2,
+    RTS_PIN_NUMBER = p3,
+
+    // mBed interface Pins
+    USBTX = TX_PIN_NUMBER,
+    USBRX = RX_PIN_NUMBER,
+
+    I2C_SDA0 = p14,
+    I2C_SCL0 = p13,
+
+    // Not connected
+    NC = (int)0xFFFFFFFF
+} PinName;
+
+typedef enum {
+    PullNone = 0,
+    PullDown = 1,
+    PullUp = 3,
+    PullDefault = PullUp
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_MTM_MTCONNECT04S/device.h
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_MTM_MTCONNECT04S/device.h
@@ -1,0 +1,38 @@
+// The 'features' section in 'target.json' is now used to create the device's hardware preprocessor switches.
+// Check the 'features' section of the target description in 'targets.json' for more details.
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include "objects.h"
+
+#endif

--- a/tools/export/gcc_arm_mtm_mtconnect04S.tmpl
+++ b/tools/export/gcc_arm_mtm_mtconnect04S.tmpl
@@ -1,0 +1,14 @@
+{% extends "gcc_arm_common.tmpl" %}
+
+{% block additional_variables %}
+SOFTDEVICE = mbed/TARGET_MTM_MTCONNECT04S/TARGET_NORDIC/TARGET_MCU_NRF51822/Lib/s130_nrf51822_1_0_0/s130_nrf51_1.0.0_softdevice.hex
+{% endblock %}
+
+{% block additional_executables %}
+SREC_CAT = srec_cat
+{% endblock %}
+
+{% block additional_targets %}
+merge:
+	$(SREC_CAT) $(SOFTDEVICE) -intel $(PROJECT).hex -intel -o combined.hex -intel --line-length=44
+{% endblock %}

--- a/tools/export/gccarm.py
+++ b/tools/export/gccarm.py
@@ -106,6 +106,7 @@ class GccArm(Exporter):
         'NRF51_DK',
         'NRF51_DONGLE',
         'NRF51_MICROBIT',
+        'MTM_MTCONNECT04S',
         'SEEED_TINY_BLE',
         'DISCO_F401VC',
         'DELTA_DFCM_NNN40',


### PR DESCRIPTION
Added support for the target MTM_MTCONNECT04S.

Automated test report:
![mtm_mtconnect04s](https://cloud.githubusercontent.com/assets/829399/18236949/405c5f9a-735e-11e6-8156-4c74dcb55d15.jpg)

For further information, please refer to the following websites:
https://developer.mbed.org/teams/MtM/
http://www.nordicsemi.com/eng/News/News-releases/Product-Related-News/Nordic-powered-Bluetooth-low-energy-development-kit-offers-complete-turnkey-solution-for-rapid-Internet-of-Things-product-development
https://blog.mtmtech.com.tw/mtconnect04s/

