### PR TITLE
Updated USBDevice to use Callback

### DIFF
--- a/libraries/USBDevice/USBAudio/USBAudio.h
+++ b/libraries/USBDevice/USBAudio/USBAudio.h
@@ -25,7 +25,7 @@
 #include "USBDevice_Types.h"
 
 #include "USBDevice.h"
-
+#include "Callback.h"
 
 /**
 * USBAudio example
@@ -275,7 +275,7 @@ private:
     volatile uint8_t * buf_stream_out;
 
     // callback to update volume
-    FunctionPointer updateVol;
+    Callback<void()> updateVol;
 
     // boolean showing that the SOF handler has been called. Useful for readNB.
     volatile bool SOF_handler;

--- a/libraries/USBDevice/USBSerial/USBSerial.h
+++ b/libraries/USBDevice/USBSerial/USBSerial.h
@@ -22,7 +22,7 @@
 #include "USBCDC.h"
 #include "Stream.h"
 #include "CircBuffer.h"
-
+#include "Callback.h"
 
 /**
 * USBSerial example
@@ -153,7 +153,7 @@ protected:
     }
 
 private:
-    FunctionPointer rx;
+    Callback<void()> rx;
     CircBuffer<uint8_t,128> buf;
     void (*settingsChangedCallback)(int baud, int bits, int parity, int stop);
 };


### PR DESCRIPTION
Updated USBAudio and USBSerial to use Callback<void()> instead of FunctionPointer to fix compiler warnings.