### PR TITLE
Updated USBHost for library changes

### DIFF
--- a/libraries/USBHost/USBHost/USBDeviceConnected.h
+++ b/libraries/USBHost/USBHost/USBDeviceConnected.h
@@ -21,6 +21,7 @@
 #include "USBEndpoint.h"
 #include "USBHostConf.h"
 #include "rtos.h"
+#include "Callback.h"
 
 class USBHostHub;
 
@@ -31,7 +32,7 @@ typedef struct {
     uint8_t intf_subclass;
     uint8_t intf_protocol;
     USBEndpoint * ep[MAX_ENDPOINT_PER_INTERFACE];
-    FunctionPointer detach;
+    Callback<void()> detach;
     char name[10];
 } INTERFACE;
 

--- a/libraries/USBHost/USBHost/USBEndpoint.h
+++ b/libraries/USBHost/USBHost/USBEndpoint.h
@@ -17,7 +17,7 @@
 #ifndef USBENDPOINT_H
 #define USBENDPOINT_H
 
-#include "FunctionPointer.h"
+#include "Callback.h"
 #include "USBHostTypes.h"
 #include "rtos.h"
 
@@ -153,7 +153,7 @@ private:
     int transferred;
     uint8_t * buf_start;
 
-    FunctionPointer rx;
+    Callback<void()> rx;
 
     USBEndpoint* nextEp;
 

--- a/libraries/USBHost/USBHost/USBHost.cpp
+++ b/libraries/USBHost/USBHost/USBHost.cpp
@@ -247,11 +247,7 @@ void USBHost::usb_process() {
     }
 }
 
-/* static */void USBHost::usb_process_static(void const * arg) {
-    ((USBHost *)arg)->usb_process();
-}
-
-USBHost::USBHost() : usbThread(USBHost::usb_process_static, (void *)this, osPriorityNormal, USB_THREAD_STACK)
+USBHost::USBHost() : usbThread(osPriorityNormal, USB_THREAD_STACK)
 {
     headControlEndpoint = NULL;
     headBulkEndpoint = NULL;
@@ -279,6 +275,8 @@ USBHost::USBHost() : usbThread(USBHost::usb_process_static, (void *)this, osPrio
         hub_in_use[i] = false;
     }
 #endif
+
+    usbThread.start(this, &USBHost::usb_process);
 }
 
 USBHost::Lock::Lock(USBHost* pHost) : m_pHost(pHost)

--- a/libraries/USBHost/USBHost/USBHost.h
+++ b/libraries/USBHost/USBHost/USBHost.h
@@ -278,7 +278,6 @@ private:
 
     Thread usbThread;
     void usb_process();
-    static void usb_process_static(void const * arg);
     Mail<message_t, 10> mail_usb_event;
     Mutex usb_mutex;
     Mutex td_mutex;

--- a/libraries/USBHost/USBHostMSD/USBHostMSD.cpp
+++ b/libraries/USBHost/USBHostMSD/USBHostMSD.cpp
@@ -136,7 +136,7 @@ int USBHostMSD::readCapacity() {
     if (status == 0) {
         blockCount = (result[0] << 24) | (result[1] << 16) | (result[2] << 8) | result[3];
         blockSize = (result[4] << 24) | (result[5] << 16) | (result[6] << 8) | result[7];
-        USB_INFO("MSD [dev: %p] - blockCount: %lld, blockSize: %d, Capacity: %lld\r\n", dev, blockCount, blockSize, blockCount*blockSize);
+        USB_INFO("MSD [dev: %p] - blockCount: %u, blockSize: %d, Capacity: %d\r\n", dev, blockCount, blockSize, blockCount*blockSize);
     }
     return status;
 }

--- a/libraries/USBHost/USBHostSerial/USBHostSerial.h
+++ b/libraries/USBHost/USBHostSerial/USBHostSerial.h
@@ -24,6 +24,7 @@
 #include "USBHost.h"
 #include "Stream.h"
 #include "MtxCircBuffer.h"
+#include "Callback.h"
 
 /**
  * A class to communicate a USB virtual serial port
@@ -137,8 +138,8 @@ private:
 
     void rxHandler();
     void txHandler();
-    FunctionPointer rx;
-    FunctionPointer tx;
+    Callback<void()> rx;
+    Callback<void()> tx;
 
     uint8_t serial_intf;
 };


### PR DESCRIPTION
Updated USBHost classes to use Callback<void()> and new Thread API to fix compiler warnings.