### PR TITLE
NUCLEO_F446ZE - Enable mbed5 release version

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -842,7 +842,7 @@
         "progen": {"target": "nucleo-f446ze"},
         "detect_code": ["0778"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release_versions": ["2"]
+        "release_versions": ["2", "5"]
     },
 
     "B96B_F446VE": {


### PR DESCRIPTION
Tests are OK

[nucleo-f446ze_mbed5_tests.zip](https://github.com/ARMmbed/mbed-os/files/461172/nucleo-f446ze_mbed5_tests.zip)
