### PR TITLE
Add RTOS configuration for default stack size

### DIFF
--- a/rtos/mbed_lib.json
+++ b/rtos/mbed_lib.json
@@ -1,6 +1,7 @@
 {
     "name": "rtos",
     "config": {
-        "present": 1
+        "present": 1,
+        "default_stack_size": "(WORDS_STACK_SIZE*4)"
     }
 }

--- a/rtos/rtx/TARGET_CORTEX_A/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_A/cmsis_os.h
@@ -149,7 +149,11 @@ used throughout the whole project.
 #    define WORDS_STACK_SIZE   128
 #endif
 
-#define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE*4)
+#ifndef MBED_CONF_RTOS_DEFAULT_STACK_SIZE
+#define MBED_CONF_RTOS_DEFAULT_STACK_SIZE (WORDS_STACK_SIZE*4)
+#endif
+
+#define DEFAULT_STACK_SIZE         MBED_CONF_RTOS_DEFAULT_STACK_SIZE
 
 /// \note MUST REMAIN UNCHANGED: \b osFeature_xxx shall be consistent in every CMSIS-RTOS.
 #define osFeature_MainThread   1       ///< main thread      1=main can be thread, 0=not available

--- a/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
@@ -82,7 +82,11 @@
 
 #endif
 
-#define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE*4)
+#ifndef MBED_CONF_RTOS_DEFAULT_STACK_SIZE
+#define MBED_CONF_RTOS_DEFAULT_STACK_SIZE (WORDS_STACK_SIZE*4)
+#endif
+ 
+#define DEFAULT_STACK_SIZE         MBED_CONF_RTOS_DEFAULT_STACK_SIZE
 
 #define osCMSIS           0x10002U     ///< CMSIS-RTOS API version (main [31:16] .sub [15:0])
 


### PR DESCRIPTION
This pull request adds default stack size as a configuration option for the RTOS library. Since this exactly replicates the previous functionality, this pull request does not result in any functional changes.

This is mainly helpful for single-threaded projects, where creating a new thread just to set the stack size is unnecessary.

From what I can tell this is relevant to #2631 and #2635, and is needed in Samsung/jerryscript#1318 to support parsing non-trivial javascript files.

cc: @janjongboom