### PR TITLE
Use lp_timer to count time in the deepsleep tests

### DIFF
--- a/TESTS/mbed_drivers/lp_timeout/main.cpp
+++ b/TESTS/mbed_drivers/lp_timeout/main.cpp
@@ -43,11 +43,15 @@ void lp_timeout_1s_deepsleep(void)
 {
     complete = false;
 
-    timestamp_t start = us_ticker_read();
+    /* 
+     * We use here lp_ticker_read() instead of us_ticker_read() for start and 
+     * end because the microseconds timer might be disable during deepsleep.
+     */
+    timestamp_t start = lp_ticker_read();
     lpt.attach(&cb_done, 1);
     deepsleep();
     while (!complete);
-    timestamp_t end = us_ticker_read();
+    timestamp_t end = lp_ticker_read();
 
     /* It takes longer to wake up from deep sleep */
     TEST_ASSERT_UINT32_WITHIN(LONG_TIMEOUT, 1000000, end - start);

--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -69,11 +69,15 @@ void lp_ticker_1s_deepsleep()
     ticker_remove_event(lp_ticker_data, &delay_event);
     delay_ts = lp_ticker_read() + 1000000;
 
-    timestamp_t start = us_ticker_read();
+    /* 
+     * We use here lp_ticker_read() instead of us_ticker_read() for start and 
+     * end because the microseconds timer might be disable during deepsleep.
+     */
+    timestamp_t start = lp_ticker_read();
     ticker_insert_event(lp_ticker_data, &delay_event, delay_ts, (uint32_t)&delay_event);
     deepsleep();
     while (!complete);
-    timestamp_t end = us_ticker_read();
+    timestamp_t end = lp_ticker_read();
 
     TEST_ASSERT_UINT32_WITHIN(LONG_TIMEOUT, 1000000, end - start);
     TEST_ASSERT_TRUE(complete);


### PR DESCRIPTION
Because microseconds timer can be disable during deepsleep.