### PR TITLE
Fix exported project file group naming

### DIFF
--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -121,8 +121,8 @@ class Exporter(object):
         def make_key(src):
             """turn a source file into it's group name"""
             key = os.path.basename(os.path.dirname(src))
-            if not key:
-                key = os.path.basename(os.path.normpath(self.export_dir))
+            if not key or relpath(key, self.export_dir) == '.':
+                key = self.project_name
             return key
 
         def grouped(sources):


### PR DESCRIPTION
The previous way of finding group names found the encompassing directory of each file. If the project is exported from the online compiler, this resulted in temporary folder names like tmpyKKWv_ showing up as group names in offline IDEs.

I propose defaulting to the project name if the file is in the project root.

@theotherjimmy @screamerbg 

Thanks to @bridadan for finding and reporting this issue.