### PR TITLE
mbed.h - Move to explicit using statements per class

### DIFF
--- a/features/net/network-socket/Socket.h
+++ b/features/net/network-socket/Socket.h
@@ -177,7 +177,7 @@ public:
     template <typename T, typename M>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The attach function does not support cv-qualifiers. Replaced by "
-        "attach(callback(obj, method)).")
+        "attach(mbed::callback(obj, method)).")
     void attach(T *obj, M method) {
         attach(mbed::callback(obj, method));
     }

--- a/hal/api/CallChain.h
+++ b/hal/api/CallChain.h
@@ -91,14 +91,14 @@ public:
      *
      *  @deprecated
      *  The add function does not support cv-qualifiers. Replaced by
-     *  add(callback(obj, method)).
+     *  add(mbed::callback(obj, method)).
      */
     template<typename T, typename M>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The add function does not support cv-qualifiers. Replaced by "
-        "add(callback(obj, method)).")
+        "add(mbed::callback(obj, method)).")
     pFunctionPointer_t add(T *obj, M method) {
-        return add(callback(obj, method));
+        return add(mbed::callback(obj, method));
     }
 
     /** Add a function at the beginning of the chain
@@ -120,14 +120,14 @@ public:
      *
      *  @deprecated
      *  The add_front function does not support cv-qualifiers. Replaced by
-     *  add_front(callback(obj, method)).
+     *  add_front(mbed::callback(obj, method)).
      */
     template<typename T, typename M>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The add_front function does not support cv-qualifiers. Replaced by "
-        "add_front(callback(obj, method)).")
+        "add_front(mbed::callback(obj, method)).")
     pFunctionPointer_t add_front(T *obj, M method) {
-        return add_front(callback(obj, method));
+        return add_front(mbed::callback(obj, method));
     }
 
     /** Get the number of functions in the chain

--- a/hal/api/InterruptIn.h
+++ b/hal/api/InterruptIn.h
@@ -91,15 +91,15 @@ public:
      *  @param method pointer to the member function to be called
      *  @deprecated
      *      The rise function does not support cv-qualifiers. Replaced by
-     *      rise(callback(obj, method)).
+     *      rise(mbed::callback(obj, method)).
      */
     template<typename T, typename M>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The rise function does not support cv-qualifiers. Replaced by "
-        "rise(callback(obj, method)).")
+        "rise(mbed::callback(obj, method)).")
     void rise(T *obj, M method) {
         core_util_critical_section_enter();
-        rise(callback(obj, method));
+        rise(mbed::callback(obj, method));
         core_util_critical_section_exit();
     }
 
@@ -115,15 +115,15 @@ public:
      *  @param method pointer to the member function to be called
      *  @deprecated
      *      The rise function does not support cv-qualifiers. Replaced by
-     *      rise(callback(obj, method)).
+     *      rise(mbed::callback(obj, method)).
      */
     template<typename T, typename M>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The fall function does not support cv-qualifiers. Replaced by "
-        "fall(callback(obj, method)).")
+        "fall(mbed::callback(obj, method)).")
     void fall(T *obj, M method) {
         core_util_critical_section_enter();
-        fall(callback(obj, method));
+        fall(mbed::callback(obj, method));
         core_util_critical_section_exit();
     }
 

--- a/hal/api/SerialBase.h
+++ b/hal/api/SerialBase.h
@@ -106,14 +106,14 @@ public:
      *  @param type Which serial interrupt to attach the member function to (Seriall::RxIrq for receive, TxIrq for transmit buffer empty)
      *  @deprecated
      *      The attach function does not support cv-qualifiers. Replaced by
-     *      attach(callback(obj, method), type).
+     *      attach(mbed::callback(obj, method), type).
      */
     template<typename T>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The attach function does not support cv-qualifiers. Replaced by "
-        "attach(callback(obj, method), type).")
+        "attach(mbed::callback(obj, method), type).")
     void attach(T *obj, void (T::*method)(), IrqType type=RxIrq) {
-        attach(callback(obj, method), type);
+        attach(mbed::callback(obj, method), type);
     }
 
     /** Attach a member function to call whenever a serial interrupt is generated
@@ -123,14 +123,14 @@ public:
      *  @param type Which serial interrupt to attach the member function to (Seriall::RxIrq for receive, TxIrq for transmit buffer empty)
      *  @deprecated
      *      The attach function does not support cv-qualifiers. Replaced by
-     *      attach(callback(obj, method), type).
+     *      attach(mbed::callback(obj, method), type).
      */
     template<typename T>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The attach function does not support cv-qualifiers. Replaced by "
-        "attach(callback(obj, method), type).")
+        "attach(mbed::callback(obj, method), type).")
     void attach(T *obj, void (*method)(T*), IrqType type=RxIrq) {
-        attach(callback(obj, method), type);
+        attach(mbed::callback(obj, method), type);
     }
 
     /** Generate a break condition on the serial line

--- a/hal/api/Ticker.h
+++ b/hal/api/Ticker.h
@@ -83,14 +83,14 @@ public:
      *  @param t the time between calls in seconds
      *  @deprecated
      *      The attach function does not support cv-qualifiers. Replaced by
-     *      attach(callback(obj, method), t).
+     *      attach(mbed::callback(obj, method), t).
      */
     template<typename T, typename M>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The attach function does not support cv-qualifiers. Replaced by "
-        "attach(callback(obj, method), t).")
+        "attach(mbed::callback(obj, method), t).")
     void attach(T *obj, M method, float t) {
-        attach(callback(obj, method), t);
+        attach(mbed::callback(obj, method), t);
     }
 
     /** Attach a function to be called by the Ticker, specifiying the interval in micro-seconds
@@ -110,12 +110,12 @@ public:
      *  @param t the time between calls in micro-seconds
      *  @deprecated
      *      The attach_us function does not support cv-qualifiers. Replaced by
-     *      attach_us(callback(obj, method), t).
+     *      attach_us(mbed::callback(obj, method), t).
      */
     template<typename T, typename M>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The attach_us function does not support cv-qualifiers. Replaced by "
-        "attach_us(callback(obj, method), t).")
+        "attach_us(mbed::callback(obj, method), t).")
     void attach_us(T *obj, M method, timestamp_t t) {
         attach_us(Callback<void()>(obj, method), t);
     }

--- a/hal/api/mbed.h
+++ b/hal/api/mbed.h
@@ -77,7 +77,74 @@
 #include "Callback.h"
 #include "FunctionPointer.h"
 
-using namespace mbed;
+// expansion of the std namespace
 using namespace std;
+
+// explicit expansion of mbed classes
+using mbed::DigitalIn;
+using mbed::DigitalOut;
+using mbed::DigitalInOut;
+using mbed::BusIn;
+using mbed::BusOut;
+using mbed::BusInOut;
+#if DEVICE_PORTIN
+using mbed::PortIn;
+#endif
+#if DEVICE_PORTINOUT
+using mbed::PortInOut;
+#endif
+#if DEVICE_PORTOUT
+using mbed::PortOut;
+#endif
+#if DEVICE_ANALOGIN
+using mbed::AnalogIn;
+#endif
+#if DEVICE_ANALOGOUT
+using mbed::AnalogOut;
+#endif
+#if DEVICE_PWMOUT
+using mbed::PwmOut;
+#endif
+#if DEVICE_SERIAL
+using mbed::SerialBase;
+using mbed::Serial;
+using mbed::RawSerial;
+#endif
+#if DEVICE_SPI
+using mbed::SPI;
+#endif
+#if DEVICE_SPISLAVE
+using mbed::SPISlave;
+#endif
+#if DEVICE_I2C
+using mbed::I2C;
+#endif
+#if DEVICE_I2CSLAVE
+using mbed::I2CSlave;
+#endif
+#if DEVICE_ETHERNET
+using mbed::Ethernet;
+#endif
+#if DEVICE_CAN
+using mbed::CAN;
+#endif
+using mbed::Timer;
+using mbed::Ticker;
+using mbed::Timeout;
+#if DEVICE_LOWPOWERTIMER
+using mbed::LowPowerTimeout;
+using mbed::LowPowerTicker;
+using mbed::LowPowerTimer;
+#endif
+#if DEVICE_LOCALFILESYSTEM
+using mbed::LocalFileSystem;
+#endif
+#if DEVICE_INTERRUPTIN
+using mbed::InterruptIn;
+#endif
+using mbed::Stream;
+using mbed::Callback;
+using mbed::FunctionPointer;
+
 
 #endif

--- a/rtos/rtos/RtosTimer.h
+++ b/rtos/rtos/RtosTimer.h
@@ -64,12 +64,12 @@ public:
       @param   type      osTimerOnce for one-shot or osTimerPeriodic for periodic behaviour. (default: osTimerPeriodic)
       @deprecated
           The RtosTimer constructor does not support cv-qualifiers. Replaced by
-          RtosTimer(callback(obj, method), os_timer_type).
+          RtosTimer(mbed::callback(obj, method), os_timer_type).
     */
     template <typename T, typename M>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The RtosTimer constructor does not support cv-qualifiers. Replaced by "
-        "RtosTimer(callback(obj, method), os_timer_type).")
+        "RtosTimer(mbed::callback(obj, method), os_timer_type).")
     RtosTimer(T *obj, M method, os_timer_type type=osTimerPeriodic) {
         constructor(mbed::callback(obj, method), type);
     }

--- a/rtos/rtos/Thread.h
+++ b/rtos/rtos/Thread.h
@@ -108,12 +108,12 @@ public:
       @param   stack_size      stack size (in bytes) requirements for the thread function. (default: DEFAULT_STACK_SIZE).
       @param   stack_pointer  pointer to the stack area to be used by this thread (default: NULL).
       @deprecated
-        Thread-spawning constructors hide errors. Replaced by thread.start(callback(argument, task)).
+        Thread-spawning constructors hide errors. Replaced by thread.start(mbed::callback(argument, task)).
 
         @code
         Thread thread(priority, stack_size, stack_pointer);
 
-        osStatus status = thread.start(callback(argument, task));
+        osStatus status = thread.start(mbed::callback(argument, task));
         if (status != osOK) {
             error("oh no!");
         }
@@ -122,7 +122,7 @@ public:
     template <typename T>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Thread-spawning constructors hide errors. "
-        "Replaced by thread.start(callback(argument, task)).")
+        "Replaced by thread.start(mbed::callback(argument, task)).")
     Thread(T *argument, void (T::*task)(),
            osPriority priority=osPriorityNormal,
            uint32_t stack_size=DEFAULT_STACK_SIZE,
@@ -139,12 +139,12 @@ public:
       @param   stack_size      stack size (in bytes) requirements for the thread function. (default: DEFAULT_STACK_SIZE).
       @param   stack_pointer  pointer to the stack area to be used by this thread (default: NULL).
       @deprecated
-        Thread-spawning constructors hide errors. Replaced by thread.start(callback(argument, task)).
+        Thread-spawning constructors hide errors. Replaced by thread.start(mbed::callback(argument, task)).
 
         @code
         Thread thread(priority, stack_size, stack_pointer);
 
-        osStatus status = thread.start(callback(argument, task));
+        osStatus status = thread.start(mbed::callback(argument, task));
         if (status != osOK) {
             error("oh no!");
         }
@@ -153,7 +153,7 @@ public:
     template <typename T>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Thread-spawning constructors hide errors. "
-        "Replaced by thread.start(callback(argument, task)).")
+        "Replaced by thread.start(mbed::callback(argument, task)).")
     Thread(T *argument, void (*task)(T *),
            osPriority priority=osPriorityNormal,
            uint32_t stack_size=DEFAULT_STACK_SIZE,
@@ -170,12 +170,12 @@ public:
       @param   stack_size      stack size (in bytes) requirements for the thread function. (default: DEFAULT_STACK_SIZE).
       @param   stack_pointer  pointer to the stack area to be used by this thread (default: NULL).
       @deprecated
-        Thread-spawning constructors hide errors. Replaced by thread.start(callback(argument, task)).
+        Thread-spawning constructors hide errors. Replaced by thread.start(mbed::callback(argument, task)).
 
         @code
         Thread thread(priority, stack_size, stack_pointer);
 
-        osStatus status = thread.start(callback(argument, task));
+        osStatus status = thread.start(mbed::callback(argument, task));
         if (status != osOK) {
             error("oh no!");
         }
@@ -183,7 +183,7 @@ public:
     */
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Thread-spawning constructors hide errors. "
-        "Replaced by thread.start(callback(argument, task)).")
+        "Replaced by thread.start(mbed::callback(argument, task)).")
     Thread(void (*task)(void const *argument), void *argument=NULL,
            osPriority priority=osPriorityNormal,
            uint32_t stack_size=DEFAULT_STACK_SIZE,
@@ -203,12 +203,12 @@ public:
       @param   method         function to be executed by this thread.
       @return  status code that indicates the execution status of the function.
       @deprecated
-          The start function does not support cv-qualifiers. Replaced by start(callback(obj, method)).
+          The start function does not support cv-qualifiers. Replaced by start(mbed::callback(obj, method)).
     */
     template <typename T, typename M>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The start function does not support cv-qualifiers. "
-        "Replaced by thread.start(callback(obj, method)).")
+        "Replaced by thread.start(mbed::callback(obj, method)).")
     osStatus start(T *obj, M method) {
         return start(mbed::callback(obj, method));
     }


### PR DESCRIPTION
This avoids revealing the entire mbed namespace, allowing less-unique names to be used behind the mbed namespace. Additionally this adds an extra step to introducing new names into the global namespace which will hopefully avoid name polution in the future.

should fix https://github.com/ARMmbed/mbed-os/issues/2653
cc @sg-, @bridadan, @tommikas 