### PR TITLE
Rename callback -> mbed_callback

### DIFF
--- a/TESTS/mbed_functional/callback/main.cpp
+++ b/TESTS/mbed_functional/callback/main.cpp
@@ -328,7 +328,7 @@ void test_dispatch0() {
     Verifier<T>::verify0((const Thing<T>*)&thing, &const_void_func0<T>);
     Verifier<T>::verify0((volatile Thing<T>*)&thing, &volatile_void_func0<T>);
     Verifier<T>::verify0((const volatile Thing<T>*)&thing, &const_volatile_void_func0<T>);
-    Verifier<T>::verify0(callback(static_func0<T>));
+    Verifier<T>::verify0(mbed_callback(static_func0<T>));
 
     Callback<T()> cb(static_func0);
     Verifier<T>::verify0(cb);
@@ -355,7 +355,7 @@ void test_dispatch1() {
     Verifier<T>::verify1((const Thing<T>*)&thing, &const_void_func1<T>);
     Verifier<T>::verify1((volatile Thing<T>*)&thing, &volatile_void_func1<T>);
     Verifier<T>::verify1((const volatile Thing<T>*)&thing, &const_volatile_void_func1<T>);
-    Verifier<T>::verify1(callback(static_func1<T>));
+    Verifier<T>::verify1(mbed_callback(static_func1<T>));
 
     Callback<T(T)> cb(static_func1);
     Verifier<T>::verify1(cb);
@@ -382,7 +382,7 @@ void test_dispatch2() {
     Verifier<T>::verify2((const Thing<T>*)&thing, &const_void_func2<T>);
     Verifier<T>::verify2((volatile Thing<T>*)&thing, &volatile_void_func2<T>);
     Verifier<T>::verify2((const volatile Thing<T>*)&thing, &const_volatile_void_func2<T>);
-    Verifier<T>::verify2(callback(static_func2<T>));
+    Verifier<T>::verify2(mbed_callback(static_func2<T>));
 
     Callback<T(T, T)> cb(static_func2);
     Verifier<T>::verify2(cb);
@@ -409,7 +409,7 @@ void test_dispatch3() {
     Verifier<T>::verify3((const Thing<T>*)&thing, &const_void_func3<T>);
     Verifier<T>::verify3((volatile Thing<T>*)&thing, &volatile_void_func3<T>);
     Verifier<T>::verify3((const volatile Thing<T>*)&thing, &const_volatile_void_func3<T>);
-    Verifier<T>::verify3(callback(static_func3<T>));
+    Verifier<T>::verify3(mbed_callback(static_func3<T>));
 
     Callback<T(T, T, T)> cb(static_func3);
     Verifier<T>::verify3(cb);
@@ -436,7 +436,7 @@ void test_dispatch4() {
     Verifier<T>::verify4((const Thing<T>*)&thing, &const_void_func4<T>);
     Verifier<T>::verify4((volatile Thing<T>*)&thing, &volatile_void_func4<T>);
     Verifier<T>::verify4((const volatile Thing<T>*)&thing, &const_volatile_void_func4<T>);
-    Verifier<T>::verify4(callback(static_func4<T>));
+    Verifier<T>::verify4(mbed_callback(static_func4<T>));
 
     Callback<T(T, T, T, T)> cb(static_func4);
     Verifier<T>::verify4(cb);
@@ -463,7 +463,7 @@ void test_dispatch5() {
     Verifier<T>::verify5((const Thing<T>*)&thing, &const_void_func5<T>);
     Verifier<T>::verify5((volatile Thing<T>*)&thing, &volatile_void_func5<T>);
     Verifier<T>::verify5((const volatile Thing<T>*)&thing, &const_volatile_void_func5<T>);
-    Verifier<T>::verify5(callback(static_func5<T>));
+    Verifier<T>::verify5(mbed_callback(static_func5<T>));
 
     Callback<T(T, T, T, T, T)> cb(static_func5);
     Verifier<T>::verify5(cb);

--- a/TESTS/mbed_functional/callback_big/main.cpp
+++ b/TESTS/mbed_functional/callback_big/main.cpp
@@ -202,7 +202,7 @@ void test_dispatch0() {
     Verifier<T>::verify0((const Thing<T>*)&thing, &const_func0<T>);
     Verifier<T>::verify0((volatile Thing<T>*)&thing, &volatile_func0<T>);
     Verifier<T>::verify0((const volatile Thing<T>*)&thing, &const_volatile_func0<T>);
-    Verifier<T>::verify0(callback(static_func0<T>));
+    Verifier<T>::verify0(mbed_callback(static_func0<T>));
 
     Callback<T()> cb(static_func0);
     Verifier<T>::verify0(cb);
@@ -225,7 +225,7 @@ void test_dispatch1() {
     Verifier<T>::verify1((const Thing<T>*)&thing, &const_func1<T>);
     Verifier<T>::verify1((volatile Thing<T>*)&thing, &volatile_func1<T>);
     Verifier<T>::verify1((const volatile Thing<T>*)&thing, &const_volatile_func1<T>);
-    Verifier<T>::verify1(callback(static_func1<T>));
+    Verifier<T>::verify1(mbed_callback(static_func1<T>));
 
     Callback<T(T)> cb(static_func1);
     Verifier<T>::verify1(cb);
@@ -248,7 +248,7 @@ void test_dispatch2() {
     Verifier<T>::verify2((const Thing<T>*)&thing, &const_func2<T>);
     Verifier<T>::verify2((volatile Thing<T>*)&thing, &volatile_func2<T>);
     Verifier<T>::verify2((const volatile Thing<T>*)&thing, &const_volatile_func2<T>);
-    Verifier<T>::verify2(callback(static_func2<T>));
+    Verifier<T>::verify2(mbed_callback(static_func2<T>));
 
     Callback<T(T, T)> cb(static_func2);
     Verifier<T>::verify2(cb);
@@ -271,7 +271,7 @@ void test_dispatch3() {
     Verifier<T>::verify3((const Thing<T>*)&thing, &const_func3<T>);
     Verifier<T>::verify3((volatile Thing<T>*)&thing, &volatile_func3<T>);
     Verifier<T>::verify3((const volatile Thing<T>*)&thing, &const_volatile_func3<T>);
-    Verifier<T>::verify3(callback(static_func3<T>));
+    Verifier<T>::verify3(mbed_callback(static_func3<T>));
 
     Callback<T(T, T, T)> cb(static_func3);
     Verifier<T>::verify3(cb);
@@ -294,7 +294,7 @@ void test_dispatch4() {
     Verifier<T>::verify4((const Thing<T>*)&thing, &const_func4<T>);
     Verifier<T>::verify4((volatile Thing<T>*)&thing, &volatile_func4<T>);
     Verifier<T>::verify4((const volatile Thing<T>*)&thing, &const_volatile_func4<T>);
-    Verifier<T>::verify4(callback(static_func4<T>));
+    Verifier<T>::verify4(mbed_callback(static_func4<T>));
 
     Callback<T(T, T, T, T)> cb(static_func4);
     Verifier<T>::verify4(cb);
@@ -317,7 +317,7 @@ void test_dispatch5() {
     Verifier<T>::verify5((const Thing<T>*)&thing, &const_func5<T>);
     Verifier<T>::verify5((volatile Thing<T>*)&thing, &volatile_func5<T>);
     Verifier<T>::verify5((const volatile Thing<T>*)&thing, &const_volatile_func5<T>);
-    Verifier<T>::verify5(callback(static_func5<T>));
+    Verifier<T>::verify5(mbed_callback(static_func5<T>));
 
     Callback<T(T, T, T, T, T)> cb(static_func5);
     Verifier<T>::verify5(cb);

--- a/TESTS/mbed_functional/callback_small/main.cpp
+++ b/TESTS/mbed_functional/callback_small/main.cpp
@@ -202,7 +202,7 @@ void test_dispatch0() {
     Verifier<T>::verify0((const Thing<T>*)&thing, &const_func0<T>);
     Verifier<T>::verify0((volatile Thing<T>*)&thing, &volatile_func0<T>);
     Verifier<T>::verify0((const volatile Thing<T>*)&thing, &const_volatile_func0<T>);
-    Verifier<T>::verify0(callback(static_func0<T>));
+    Verifier<T>::verify0(mbed_callback(static_func0<T>));
 
     Callback<T()> cb(static_func0);
     Verifier<T>::verify0(cb);
@@ -225,7 +225,7 @@ void test_dispatch1() {
     Verifier<T>::verify1((const Thing<T>*)&thing, &const_func1<T>);
     Verifier<T>::verify1((volatile Thing<T>*)&thing, &volatile_func1<T>);
     Verifier<T>::verify1((const volatile Thing<T>*)&thing, &const_volatile_func1<T>);
-    Verifier<T>::verify1(callback(static_func1<T>));
+    Verifier<T>::verify1(mbed_callback(static_func1<T>));
 
     Callback<T(T)> cb(static_func1);
     Verifier<T>::verify1(cb);
@@ -248,7 +248,7 @@ void test_dispatch2() {
     Verifier<T>::verify2((const Thing<T>*)&thing, &const_func2<T>);
     Verifier<T>::verify2((volatile Thing<T>*)&thing, &volatile_func2<T>);
     Verifier<T>::verify2((const volatile Thing<T>*)&thing, &const_volatile_func2<T>);
-    Verifier<T>::verify2(callback(static_func2<T>));
+    Verifier<T>::verify2(mbed_callback(static_func2<T>));
 
     Callback<T(T, T)> cb(static_func2);
     Verifier<T>::verify2(cb);
@@ -271,7 +271,7 @@ void test_dispatch3() {
     Verifier<T>::verify3((const Thing<T>*)&thing, &const_func3<T>);
     Verifier<T>::verify3((volatile Thing<T>*)&thing, &volatile_func3<T>);
     Verifier<T>::verify3((const volatile Thing<T>*)&thing, &const_volatile_func3<T>);
-    Verifier<T>::verify3(callback(static_func3<T>));
+    Verifier<T>::verify3(mbed_callback(static_func3<T>));
 
     Callback<T(T, T, T)> cb(static_func3);
     Verifier<T>::verify3(cb);
@@ -294,7 +294,7 @@ void test_dispatch4() {
     Verifier<T>::verify4((const Thing<T>*)&thing, &const_func4<T>);
     Verifier<T>::verify4((volatile Thing<T>*)&thing, &volatile_func4<T>);
     Verifier<T>::verify4((const volatile Thing<T>*)&thing, &const_volatile_func4<T>);
-    Verifier<T>::verify4(callback(static_func4<T>));
+    Verifier<T>::verify4(mbed_callback(static_func4<T>));
 
     Callback<T(T, T, T, T)> cb(static_func4);
     Verifier<T>::verify4(cb);
@@ -317,7 +317,7 @@ void test_dispatch5() {
     Verifier<T>::verify5((const Thing<T>*)&thing, &const_func5<T>);
     Verifier<T>::verify5((volatile Thing<T>*)&thing, &volatile_func5<T>);
     Verifier<T>::verify5((const volatile Thing<T>*)&thing, &const_volatile_func5<T>);
-    Verifier<T>::verify5(callback(static_func5<T>));
+    Verifier<T>::verify5(mbed_callback(static_func5<T>));
 
     Callback<T(T, T, T, T, T)> cb(static_func5);
     Verifier<T>::verify5(cb);

--- a/features/net/network-socket/Socket.h
+++ b/features/net/network-socket/Socket.h
@@ -177,9 +177,9 @@ public:
     template <typename T, typename M>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The attach function does not support cv-qualifiers. Replaced by "
-        "attach(callback(obj, method)).")
+        "attach(mbed_callback(obj, method)).")
     void attach(T *obj, M method) {
-        attach(mbed::callback(obj, method));
+        attach(mbed::mbed_callback(obj, method));
     }
 
 protected:

--- a/hal/api/Callback.h
+++ b/hal/api/Callback.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifndef MBED_CALLBACK_H
 #define MBED_CALLBACK_H
 
@@ -2614,7 +2615,7 @@ typedef Callback<void(int)> event_callback_t;
  *  @return     Callback with infered type
  */
 template <typename R>
-Callback<R()> callback(R (*func)() = 0) {
+Callback<R()> mbed_callback(R (*func)() = 0) {
     return Callback<R()>(func);
 }
 
@@ -2624,7 +2625,7 @@ Callback<R()> callback(R (*func)() = 0) {
  *  @return     Callback with infered type
  */
 template <typename R>
-Callback<R()> callback(const Callback<R()> &func) {
+Callback<R()> mbed_callback(const Callback<R()> &func) {
     return Callback<R()>(func);
 }
 
@@ -2635,7 +2636,7 @@ Callback<R()> callback(const Callback<R()> &func) {
  *  @return     Callback with infered type
  */
 template <typename R>
-Callback<R()> callback(void *obj, R (*func)(void*)) {
+Callback<R()> mbed_callback(void *obj, R (*func)(void*)) {
     return Callback<R()>(obj, func);
 }
 
@@ -2646,7 +2647,7 @@ Callback<R()> callback(void *obj, R (*func)(void*)) {
  *  @return     Callback with infered type
  */
 template <typename R>
-Callback<R()> callback(const void *obj, R (*func)(const void*)) {
+Callback<R()> mbed_callback(const void *obj, R (*func)(const void*)) {
     return Callback<R()>(obj, func);
 }
 
@@ -2657,7 +2658,7 @@ Callback<R()> callback(const void *obj, R (*func)(const void*)) {
  *  @return     Callback with infered type
  */
 template <typename R>
-Callback<R()> callback(volatile void *obj, R (*func)(volatile void*)) {
+Callback<R()> mbed_callback(volatile void *obj, R (*func)(volatile void*)) {
     return Callback<R()>(obj, func);
 }
 
@@ -2668,7 +2669,7 @@ Callback<R()> callback(volatile void *obj, R (*func)(volatile void*)) {
  *  @return     Callback with infered type
  */
 template <typename R>
-Callback<R()> callback(const volatile void *obj, R (*func)(const volatile void*)) {
+Callback<R()> mbed_callback(const volatile void *obj, R (*func)(const volatile void*)) {
     return Callback<R()>(obj, func);
 }
 
@@ -2679,7 +2680,7 @@ Callback<R()> callback(const volatile void *obj, R (*func)(const volatile void*)
  *  @return     Callback with infered type
  */
 template <typename T, typename R>
-Callback<R()> callback(T *obj, R (*func)(T*)) {
+Callback<R()> mbed_callback(T *obj, R (*func)(T*)) {
     return Callback<R()>(obj, func);
 }
 
@@ -2690,7 +2691,7 @@ Callback<R()> callback(T *obj, R (*func)(T*)) {
  *  @return     Callback with infered type
  */
 template <typename T, typename R>
-Callback<R()> callback(const T *obj, R (*func)(const T*)) {
+Callback<R()> mbed_callback(const T *obj, R (*func)(const T*)) {
     return Callback<R()>(obj, func);
 }
 
@@ -2701,7 +2702,7 @@ Callback<R()> callback(const T *obj, R (*func)(const T*)) {
  *  @return     Callback with infered type
  */
 template <typename T, typename R>
-Callback<R()> callback(volatile T *obj, R (*func)(volatile T*)) {
+Callback<R()> mbed_callback(volatile T *obj, R (*func)(volatile T*)) {
     return Callback<R()>(obj, func);
 }
 
@@ -2712,7 +2713,7 @@ Callback<R()> callback(volatile T *obj, R (*func)(volatile T*)) {
  *  @return     Callback with infered type
  */
 template <typename T, typename R>
-Callback<R()> callback(const volatile T *obj, R (*func)(const volatile T*)) {
+Callback<R()> mbed_callback(const volatile T *obj, R (*func)(const volatile T*)) {
     return Callback<R()>(obj, func);
 }
 
@@ -2723,7 +2724,7 @@ Callback<R()> callback(const volatile T *obj, R (*func)(const volatile T*)) {
  *  @return     Callback with infered type
  */
 template<typename T, typename R>
-Callback<R()> callback(T *obj, R (T::*func)()) {
+Callback<R()> mbed_callback(T *obj, R (T::*func)()) {
     return Callback<R()>(obj, func);
 }
 
@@ -2734,7 +2735,7 @@ Callback<R()> callback(T *obj, R (T::*func)()) {
  *  @return     Callback with infered type
  */
 template<typename T, typename R>
-Callback<R()> callback(const T *obj, R (T::*func)() const) {
+Callback<R()> mbed_callback(const T *obj, R (T::*func)() const) {
     return Callback<R()>(obj, func);
 }
 
@@ -2745,7 +2746,7 @@ Callback<R()> callback(const T *obj, R (T::*func)() const) {
  *  @return     Callback with infered type
  */
 template<typename T, typename R>
-Callback<R()> callback(volatile T *obj, R (T::*func)() volatile) {
+Callback<R()> mbed_callback(volatile T *obj, R (T::*func)() volatile) {
     return Callback<R()>(obj, func);
 }
 
@@ -2756,7 +2757,7 @@ Callback<R()> callback(volatile T *obj, R (T::*func)() volatile) {
  *  @return     Callback with infered type
  */
 template<typename T, typename R>
-Callback<R()> callback(const volatile T *obj, R (T::*func)() const volatile) {
+Callback<R()> mbed_callback(const volatile T *obj, R (T::*func)() const volatile) {
     return Callback<R()>(obj, func);
 }
 
@@ -2767,7 +2768,7 @@ Callback<R()> callback(const volatile T *obj, R (T::*func)() const volatile) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0>
-Callback<R(A0)> callback(R (*func)(A0) = 0) {
+Callback<R(A0)> mbed_callback(R (*func)(A0) = 0) {
     return Callback<R(A0)>(func);
 }
 
@@ -2777,7 +2778,7 @@ Callback<R(A0)> callback(R (*func)(A0) = 0) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0>
-Callback<R(A0)> callback(const Callback<R(A0)> &func) {
+Callback<R(A0)> mbed_callback(const Callback<R(A0)> &func) {
     return Callback<R(A0)>(func);
 }
 
@@ -2788,7 +2789,7 @@ Callback<R(A0)> callback(const Callback<R(A0)> &func) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0>
-Callback<R(A0)> callback(void *obj, R (*func)(void*, A0)) {
+Callback<R(A0)> mbed_callback(void *obj, R (*func)(void*, A0)) {
     return Callback<R(A0)>(obj, func);
 }
 
@@ -2799,7 +2800,7 @@ Callback<R(A0)> callback(void *obj, R (*func)(void*, A0)) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0>
-Callback<R(A0)> callback(const void *obj, R (*func)(const void*, A0)) {
+Callback<R(A0)> mbed_callback(const void *obj, R (*func)(const void*, A0)) {
     return Callback<R(A0)>(obj, func);
 }
 
@@ -2810,7 +2811,7 @@ Callback<R(A0)> callback(const void *obj, R (*func)(const void*, A0)) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0>
-Callback<R(A0)> callback(volatile void *obj, R (*func)(volatile void*, A0)) {
+Callback<R(A0)> mbed_callback(volatile void *obj, R (*func)(volatile void*, A0)) {
     return Callback<R(A0)>(obj, func);
 }
 
@@ -2821,7 +2822,7 @@ Callback<R(A0)> callback(volatile void *obj, R (*func)(volatile void*, A0)) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0>
-Callback<R(A0)> callback(const volatile void *obj, R (*func)(const volatile void*, A0)) {
+Callback<R(A0)> mbed_callback(const volatile void *obj, R (*func)(const volatile void*, A0)) {
     return Callback<R(A0)>(obj, func);
 }
 
@@ -2832,7 +2833,7 @@ Callback<R(A0)> callback(const volatile void *obj, R (*func)(const volatile void
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0>
-Callback<R(A0)> callback(T *obj, R (*func)(T*, A0)) {
+Callback<R(A0)> mbed_callback(T *obj, R (*func)(T*, A0)) {
     return Callback<R(A0)>(obj, func);
 }
 
@@ -2843,7 +2844,7 @@ Callback<R(A0)> callback(T *obj, R (*func)(T*, A0)) {
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0>
-Callback<R(A0)> callback(const T *obj, R (*func)(const T*, A0)) {
+Callback<R(A0)> mbed_callback(const T *obj, R (*func)(const T*, A0)) {
     return Callback<R(A0)>(obj, func);
 }
 
@@ -2854,7 +2855,7 @@ Callback<R(A0)> callback(const T *obj, R (*func)(const T*, A0)) {
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0>
-Callback<R(A0)> callback(volatile T *obj, R (*func)(volatile T*, A0)) {
+Callback<R(A0)> mbed_callback(volatile T *obj, R (*func)(volatile T*, A0)) {
     return Callback<R(A0)>(obj, func);
 }
 
@@ -2865,7 +2866,7 @@ Callback<R(A0)> callback(volatile T *obj, R (*func)(volatile T*, A0)) {
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0>
-Callback<R(A0)> callback(const volatile T *obj, R (*func)(const volatile T*, A0)) {
+Callback<R(A0)> mbed_callback(const volatile T *obj, R (*func)(const volatile T*, A0)) {
     return Callback<R(A0)>(obj, func);
 }
 
@@ -2876,7 +2877,7 @@ Callback<R(A0)> callback(const volatile T *obj, R (*func)(const volatile T*, A0)
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0>
-Callback<R(A0)> callback(T *obj, R (T::*func)(A0)) {
+Callback<R(A0)> mbed_callback(T *obj, R (T::*func)(A0)) {
     return Callback<R(A0)>(obj, func);
 }
 
@@ -2887,7 +2888,7 @@ Callback<R(A0)> callback(T *obj, R (T::*func)(A0)) {
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0>
-Callback<R(A0)> callback(const T *obj, R (T::*func)(A0) const) {
+Callback<R(A0)> mbed_callback(const T *obj, R (T::*func)(A0) const) {
     return Callback<R(A0)>(obj, func);
 }
 
@@ -2898,7 +2899,7 @@ Callback<R(A0)> callback(const T *obj, R (T::*func)(A0) const) {
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0>
-Callback<R(A0)> callback(volatile T *obj, R (T::*func)(A0) volatile) {
+Callback<R(A0)> mbed_callback(volatile T *obj, R (T::*func)(A0) volatile) {
     return Callback<R(A0)>(obj, func);
 }
 
@@ -2909,7 +2910,7 @@ Callback<R(A0)> callback(volatile T *obj, R (T::*func)(A0) volatile) {
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0>
-Callback<R(A0)> callback(const volatile T *obj, R (T::*func)(A0) const volatile) {
+Callback<R(A0)> mbed_callback(const volatile T *obj, R (T::*func)(A0) const volatile) {
     return Callback<R(A0)>(obj, func);
 }
 
@@ -2920,7 +2921,7 @@ Callback<R(A0)> callback(const volatile T *obj, R (T::*func)(A0) const volatile)
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(R (*func)(A0, A1) = 0) {
+Callback<R(A0, A1)> mbed_callback(R (*func)(A0, A1) = 0) {
     return Callback<R(A0, A1)>(func);
 }
 
@@ -2930,7 +2931,7 @@ Callback<R(A0, A1)> callback(R (*func)(A0, A1) = 0) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(const Callback<R(A0, A1)> &func) {
+Callback<R(A0, A1)> mbed_callback(const Callback<R(A0, A1)> &func) {
     return Callback<R(A0, A1)>(func);
 }
 
@@ -2941,7 +2942,7 @@ Callback<R(A0, A1)> callback(const Callback<R(A0, A1)> &func) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(void *obj, R (*func)(void*, A0, A1)) {
+Callback<R(A0, A1)> mbed_callback(void *obj, R (*func)(void*, A0, A1)) {
     return Callback<R(A0, A1)>(obj, func);
 }
 
@@ -2952,7 +2953,7 @@ Callback<R(A0, A1)> callback(void *obj, R (*func)(void*, A0, A1)) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(const void *obj, R (*func)(const void*, A0, A1)) {
+Callback<R(A0, A1)> mbed_callback(const void *obj, R (*func)(const void*, A0, A1)) {
     return Callback<R(A0, A1)>(obj, func);
 }
 
@@ -2963,7 +2964,7 @@ Callback<R(A0, A1)> callback(const void *obj, R (*func)(const void*, A0, A1)) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(volatile void *obj, R (*func)(volatile void*, A0, A1)) {
+Callback<R(A0, A1)> mbed_callback(volatile void *obj, R (*func)(volatile void*, A0, A1)) {
     return Callback<R(A0, A1)>(obj, func);
 }
 
@@ -2974,7 +2975,7 @@ Callback<R(A0, A1)> callback(volatile void *obj, R (*func)(volatile void*, A0, A
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1)) {
+Callback<R(A0, A1)> mbed_callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1)) {
     return Callback<R(A0, A1)>(obj, func);
 }
 
@@ -2985,7 +2986,7 @@ Callback<R(A0, A1)> callback(const volatile void *obj, R (*func)(const volatile 
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(T *obj, R (*func)(T*, A0, A1)) {
+Callback<R(A0, A1)> mbed_callback(T *obj, R (*func)(T*, A0, A1)) {
     return Callback<R(A0, A1)>(obj, func);
 }
 
@@ -2996,7 +2997,7 @@ Callback<R(A0, A1)> callback(T *obj, R (*func)(T*, A0, A1)) {
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(const T *obj, R (*func)(const T*, A0, A1)) {
+Callback<R(A0, A1)> mbed_callback(const T *obj, R (*func)(const T*, A0, A1)) {
     return Callback<R(A0, A1)>(obj, func);
 }
 
@@ -3007,7 +3008,7 @@ Callback<R(A0, A1)> callback(const T *obj, R (*func)(const T*, A0, A1)) {
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(volatile T *obj, R (*func)(volatile T*, A0, A1)) {
+Callback<R(A0, A1)> mbed_callback(volatile T *obj, R (*func)(volatile T*, A0, A1)) {
     return Callback<R(A0, A1)>(obj, func);
 }
 
@@ -3018,7 +3019,7 @@ Callback<R(A0, A1)> callback(volatile T *obj, R (*func)(volatile T*, A0, A1)) {
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1)) {
+Callback<R(A0, A1)> mbed_callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1)) {
     return Callback<R(A0, A1)>(obj, func);
 }
 
@@ -3029,7 +3030,7 @@ Callback<R(A0, A1)> callback(const volatile T *obj, R (*func)(const volatile T*,
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(T *obj, R (T::*func)(A0, A1)) {
+Callback<R(A0, A1)> mbed_callback(T *obj, R (T::*func)(A0, A1)) {
     return Callback<R(A0, A1)>(obj, func);
 }
 
@@ -3040,7 +3041,7 @@ Callback<R(A0, A1)> callback(T *obj, R (T::*func)(A0, A1)) {
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(const T *obj, R (T::*func)(A0, A1) const) {
+Callback<R(A0, A1)> mbed_callback(const T *obj, R (T::*func)(A0, A1) const) {
     return Callback<R(A0, A1)>(obj, func);
 }
 
@@ -3051,7 +3052,7 @@ Callback<R(A0, A1)> callback(const T *obj, R (T::*func)(A0, A1) const) {
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(volatile T *obj, R (T::*func)(A0, A1) volatile) {
+Callback<R(A0, A1)> mbed_callback(volatile T *obj, R (T::*func)(A0, A1) volatile) {
     return Callback<R(A0, A1)>(obj, func);
 }
 
@@ -3062,7 +3063,7 @@ Callback<R(A0, A1)> callback(volatile T *obj, R (T::*func)(A0, A1) volatile) {
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(const volatile T *obj, R (T::*func)(A0, A1) const volatile) {
+Callback<R(A0, A1)> mbed_callback(const volatile T *obj, R (T::*func)(A0, A1) const volatile) {
     return Callback<R(A0, A1)>(obj, func);
 }
 
@@ -3073,7 +3074,7 @@ Callback<R(A0, A1)> callback(const volatile T *obj, R (T::*func)(A0, A1) const v
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(R (*func)(A0, A1, A2) = 0) {
+Callback<R(A0, A1, A2)> mbed_callback(R (*func)(A0, A1, A2) = 0) {
     return Callback<R(A0, A1, A2)>(func);
 }
 
@@ -3083,7 +3084,7 @@ Callback<R(A0, A1, A2)> callback(R (*func)(A0, A1, A2) = 0) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(const Callback<R(A0, A1, A2)> &func) {
+Callback<R(A0, A1, A2)> mbed_callback(const Callback<R(A0, A1, A2)> &func) {
     return Callback<R(A0, A1, A2)>(func);
 }
 
@@ -3094,7 +3095,7 @@ Callback<R(A0, A1, A2)> callback(const Callback<R(A0, A1, A2)> &func) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(void *obj, R (*func)(void*, A0, A1, A2)) {
+Callback<R(A0, A1, A2)> mbed_callback(void *obj, R (*func)(void*, A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(obj, func);
 }
 
@@ -3105,7 +3106,7 @@ Callback<R(A0, A1, A2)> callback(void *obj, R (*func)(void*, A0, A1, A2)) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(const void *obj, R (*func)(const void*, A0, A1, A2)) {
+Callback<R(A0, A1, A2)> mbed_callback(const void *obj, R (*func)(const void*, A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(obj, func);
 }
 
@@ -3116,7 +3117,7 @@ Callback<R(A0, A1, A2)> callback(const void *obj, R (*func)(const void*, A0, A1,
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(volatile void *obj, R (*func)(volatile void*, A0, A1, A2)) {
+Callback<R(A0, A1, A2)> mbed_callback(volatile void *obj, R (*func)(volatile void*, A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(obj, func);
 }
 
@@ -3127,7 +3128,7 @@ Callback<R(A0, A1, A2)> callback(volatile void *obj, R (*func)(volatile void*, A
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2)) {
+Callback<R(A0, A1, A2)> mbed_callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(obj, func);
 }
 
@@ -3138,7 +3139,7 @@ Callback<R(A0, A1, A2)> callback(const volatile void *obj, R (*func)(const volat
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(T *obj, R (*func)(T*, A0, A1, A2)) {
+Callback<R(A0, A1, A2)> mbed_callback(T *obj, R (*func)(T*, A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(obj, func);
 }
 
@@ -3149,7 +3150,7 @@ Callback<R(A0, A1, A2)> callback(T *obj, R (*func)(T*, A0, A1, A2)) {
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(const T *obj, R (*func)(const T*, A0, A1, A2)) {
+Callback<R(A0, A1, A2)> mbed_callback(const T *obj, R (*func)(const T*, A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(obj, func);
 }
 
@@ -3160,7 +3161,7 @@ Callback<R(A0, A1, A2)> callback(const T *obj, R (*func)(const T*, A0, A1, A2)) 
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2)) {
+Callback<R(A0, A1, A2)> mbed_callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(obj, func);
 }
 
@@ -3171,7 +3172,7 @@ Callback<R(A0, A1, A2)> callback(volatile T *obj, R (*func)(volatile T*, A0, A1,
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2)) {
+Callback<R(A0, A1, A2)> mbed_callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(obj, func);
 }
 
@@ -3182,7 +3183,7 @@ Callback<R(A0, A1, A2)> callback(const volatile T *obj, R (*func)(const volatile
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(T *obj, R (T::*func)(A0, A1, A2)) {
+Callback<R(A0, A1, A2)> mbed_callback(T *obj, R (T::*func)(A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(obj, func);
 }
 
@@ -3193,7 +3194,7 @@ Callback<R(A0, A1, A2)> callback(T *obj, R (T::*func)(A0, A1, A2)) {
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(const T *obj, R (T::*func)(A0, A1, A2) const) {
+Callback<R(A0, A1, A2)> mbed_callback(const T *obj, R (T::*func)(A0, A1, A2) const) {
     return Callback<R(A0, A1, A2)>(obj, func);
 }
 
@@ -3204,7 +3205,7 @@ Callback<R(A0, A1, A2)> callback(const T *obj, R (T::*func)(A0, A1, A2) const) {
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(volatile T *obj, R (T::*func)(A0, A1, A2) volatile) {
+Callback<R(A0, A1, A2)> mbed_callback(volatile T *obj, R (T::*func)(A0, A1, A2) volatile) {
     return Callback<R(A0, A1, A2)>(obj, func);
 }
 
@@ -3215,7 +3216,7 @@ Callback<R(A0, A1, A2)> callback(volatile T *obj, R (T::*func)(A0, A1, A2) volat
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(const volatile T *obj, R (T::*func)(A0, A1, A2) const volatile) {
+Callback<R(A0, A1, A2)> mbed_callback(const volatile T *obj, R (T::*func)(A0, A1, A2) const volatile) {
     return Callback<R(A0, A1, A2)>(obj, func);
 }
 
@@ -3226,7 +3227,7 @@ Callback<R(A0, A1, A2)> callback(const volatile T *obj, R (T::*func)(A0, A1, A2)
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(R (*func)(A0, A1, A2, A3) = 0) {
+Callback<R(A0, A1, A2, A3)> mbed_callback(R (*func)(A0, A1, A2, A3) = 0) {
     return Callback<R(A0, A1, A2, A3)>(func);
 }
 
@@ -3236,7 +3237,7 @@ Callback<R(A0, A1, A2, A3)> callback(R (*func)(A0, A1, A2, A3) = 0) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(const Callback<R(A0, A1, A2, A3)> &func) {
+Callback<R(A0, A1, A2, A3)> mbed_callback(const Callback<R(A0, A1, A2, A3)> &func) {
     return Callback<R(A0, A1, A2, A3)>(func);
 }
 
@@ -3247,7 +3248,7 @@ Callback<R(A0, A1, A2, A3)> callback(const Callback<R(A0, A1, A2, A3)> &func) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(void *obj, R (*func)(void*, A0, A1, A2, A3)) {
+Callback<R(A0, A1, A2, A3)> mbed_callback(void *obj, R (*func)(void*, A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(obj, func);
 }
 
@@ -3258,7 +3259,7 @@ Callback<R(A0, A1, A2, A3)> callback(void *obj, R (*func)(void*, A0, A1, A2, A3)
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(const void *obj, R (*func)(const void*, A0, A1, A2, A3)) {
+Callback<R(A0, A1, A2, A3)> mbed_callback(const void *obj, R (*func)(const void*, A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(obj, func);
 }
 
@@ -3269,7 +3270,7 @@ Callback<R(A0, A1, A2, A3)> callback(const void *obj, R (*func)(const void*, A0,
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(volatile void *obj, R (*func)(volatile void*, A0, A1, A2, A3)) {
+Callback<R(A0, A1, A2, A3)> mbed_callback(volatile void *obj, R (*func)(volatile void*, A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(obj, func);
 }
 
@@ -3280,7 +3281,7 @@ Callback<R(A0, A1, A2, A3)> callback(volatile void *obj, R (*func)(volatile void
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2, A3)) {
+Callback<R(A0, A1, A2, A3)> mbed_callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(obj, func);
 }
 
@@ -3291,7 +3292,7 @@ Callback<R(A0, A1, A2, A3)> callback(const volatile void *obj, R (*func)(const v
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(T *obj, R (*func)(T*, A0, A1, A2, A3)) {
+Callback<R(A0, A1, A2, A3)> mbed_callback(T *obj, R (*func)(T*, A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(obj, func);
 }
 
@@ -3302,7 +3303,7 @@ Callback<R(A0, A1, A2, A3)> callback(T *obj, R (*func)(T*, A0, A1, A2, A3)) {
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(const T *obj, R (*func)(const T*, A0, A1, A2, A3)) {
+Callback<R(A0, A1, A2, A3)> mbed_callback(const T *obj, R (*func)(const T*, A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(obj, func);
 }
 
@@ -3313,7 +3314,7 @@ Callback<R(A0, A1, A2, A3)> callback(const T *obj, R (*func)(const T*, A0, A1, A
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3)) {
+Callback<R(A0, A1, A2, A3)> mbed_callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(obj, func);
 }
 
@@ -3324,7 +3325,7 @@ Callback<R(A0, A1, A2, A3)> callback(volatile T *obj, R (*func)(volatile T*, A0,
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3)) {
+Callback<R(A0, A1, A2, A3)> mbed_callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(obj, func);
 }
 
@@ -3335,7 +3336,7 @@ Callback<R(A0, A1, A2, A3)> callback(const volatile T *obj, R (*func)(const vola
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(T *obj, R (T::*func)(A0, A1, A2, A3)) {
+Callback<R(A0, A1, A2, A3)> mbed_callback(T *obj, R (T::*func)(A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(obj, func);
 }
 
@@ -3346,7 +3347,7 @@ Callback<R(A0, A1, A2, A3)> callback(T *obj, R (T::*func)(A0, A1, A2, A3)) {
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(const T *obj, R (T::*func)(A0, A1, A2, A3) const) {
+Callback<R(A0, A1, A2, A3)> mbed_callback(const T *obj, R (T::*func)(A0, A1, A2, A3) const) {
     return Callback<R(A0, A1, A2, A3)>(obj, func);
 }
 
@@ -3357,7 +3358,7 @@ Callback<R(A0, A1, A2, A3)> callback(const T *obj, R (T::*func)(A0, A1, A2, A3) 
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(volatile T *obj, R (T::*func)(A0, A1, A2, A3) volatile) {
+Callback<R(A0, A1, A2, A3)> mbed_callback(volatile T *obj, R (T::*func)(A0, A1, A2, A3) volatile) {
     return Callback<R(A0, A1, A2, A3)>(obj, func);
 }
 
@@ -3368,7 +3369,7 @@ Callback<R(A0, A1, A2, A3)> callback(volatile T *obj, R (T::*func)(A0, A1, A2, A
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(const volatile T *obj, R (T::*func)(A0, A1, A2, A3) const volatile) {
+Callback<R(A0, A1, A2, A3)> mbed_callback(const volatile T *obj, R (T::*func)(A0, A1, A2, A3) const volatile) {
     return Callback<R(A0, A1, A2, A3)>(obj, func);
 }
 
@@ -3379,7 +3380,7 @@ Callback<R(A0, A1, A2, A3)> callback(const volatile T *obj, R (T::*func)(A0, A1,
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(A0, A1, A2, A3, A4) = 0) {
+Callback<R(A0, A1, A2, A3, A4)> mbed_callback(R (*func)(A0, A1, A2, A3, A4) = 0) {
     return Callback<R(A0, A1, A2, A3, A4)>(func);
 }
 
@@ -3389,7 +3390,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(A0, A1, A2, A3, A4) = 0) {
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(const Callback<R(A0, A1, A2, A3, A4)> &func) {
+Callback<R(A0, A1, A2, A3, A4)> mbed_callback(const Callback<R(A0, A1, A2, A3, A4)> &func) {
     return Callback<R(A0, A1, A2, A3, A4)>(func);
 }
 
@@ -3400,7 +3401,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(const Callback<R(A0, A1, A2, A3, A4)> &
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(void *obj, R (*func)(void*, A0, A1, A2, A3, A4)) {
+Callback<R(A0, A1, A2, A3, A4)> mbed_callback(void *obj, R (*func)(void*, A0, A1, A2, A3, A4)) {
     return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
 }
 
@@ -3411,7 +3412,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(void *obj, R (*func)(void*, A0, A1, A2,
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(const void *obj, R (*func)(const void*, A0, A1, A2, A3, A4)) {
+Callback<R(A0, A1, A2, A3, A4)> mbed_callback(const void *obj, R (*func)(const void*, A0, A1, A2, A3, A4)) {
     return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
 }
 
@@ -3422,7 +3423,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(const void *obj, R (*func)(const void*,
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(volatile void *obj, R (*func)(volatile void*, A0, A1, A2, A3, A4)) {
+Callback<R(A0, A1, A2, A3, A4)> mbed_callback(volatile void *obj, R (*func)(volatile void*, A0, A1, A2, A3, A4)) {
     return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
 }
 
@@ -3433,7 +3434,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(volatile void *obj, R (*func)(volatile 
  *  @return     Callback with infered type
  */
 template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2, A3, A4)) {
+Callback<R(A0, A1, A2, A3, A4)> mbed_callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2, A3, A4)) {
     return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
 }
 
@@ -3444,7 +3445,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(const volatile void *obj, R (*func)(con
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(T *obj, R (*func)(T*, A0, A1, A2, A3, A4)) {
+Callback<R(A0, A1, A2, A3, A4)> mbed_callback(T *obj, R (*func)(T*, A0, A1, A2, A3, A4)) {
     return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
 }
 
@@ -3455,7 +3456,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(T *obj, R (*func)(T*, A0, A1, A2, A3, A
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(const T *obj, R (*func)(const T*, A0, A1, A2, A3, A4)) {
+Callback<R(A0, A1, A2, A3, A4)> mbed_callback(const T *obj, R (*func)(const T*, A0, A1, A2, A3, A4)) {
     return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
 }
 
@@ -3466,7 +3467,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(const T *obj, R (*func)(const T*, A0, A
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3, A4)) {
+Callback<R(A0, A1, A2, A3, A4)> mbed_callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3, A4)) {
     return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
 }
 
@@ -3477,7 +3478,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(volatile T *obj, R (*func)(volatile T*,
  *  @return     Callback with infered type
  */
 template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3, A4)) {
+Callback<R(A0, A1, A2, A3, A4)> mbed_callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3, A4)) {
     return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
 }
 
@@ -3488,7 +3489,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(const volatile T *obj, R (*func)(const 
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(T *obj, R (T::*func)(A0, A1, A2, A3, A4)) {
+Callback<R(A0, A1, A2, A3, A4)> mbed_callback(T *obj, R (T::*func)(A0, A1, A2, A3, A4)) {
     return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
 }
 
@@ -3499,7 +3500,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(T *obj, R (T::*func)(A0, A1, A2, A3, A4
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(const T *obj, R (T::*func)(A0, A1, A2, A3, A4) const) {
+Callback<R(A0, A1, A2, A3, A4)> mbed_callback(const T *obj, R (T::*func)(A0, A1, A2, A3, A4) const) {
     return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
 }
 
@@ -3510,7 +3511,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(const T *obj, R (T::*func)(A0, A1, A2, 
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(volatile T *obj, R (T::*func)(A0, A1, A2, A3, A4) volatile) {
+Callback<R(A0, A1, A2, A3, A4)> mbed_callback(volatile T *obj, R (T::*func)(A0, A1, A2, A3, A4) volatile) {
     return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
 }
 
@@ -3521,7 +3522,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(volatile T *obj, R (T::*func)(A0, A1, A
  *  @return     Callback with infered type
  */
 template<typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(const volatile T *obj, R (T::*func)(A0, A1, A2, A3, A4) const volatile) {
+Callback<R(A0, A1, A2, A3, A4)> mbed_callback(const volatile T *obj, R (T::*func)(A0, A1, A2, A3, A4) const volatile) {
     return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
 }
 

--- a/hal/api/SerialBase.h
+++ b/hal/api/SerialBase.h
@@ -106,14 +106,14 @@ public:
      *  @param type Which serial interrupt to attach the member function to (Seriall::RxIrq for receive, TxIrq for transmit buffer empty)
      *  @deprecated
      *      The attach function does not support cv-qualifiers. Replaced by
-     *      attach(callback(obj, method), type).
+     *      attach(mbed_callback(obj, method), type).
      */
     template<typename T>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The attach function does not support cv-qualifiers. Replaced by "
-        "attach(callback(obj, method), type).")
+        "attach(mbed_callback(obj, method), type).")
     void attach(T *obj, void (T::*method)(), IrqType type=RxIrq) {
-        attach(callback(obj, method), type);
+        attach(mbed_callback(obj, method), type);
     }
 
     /** Attach a member function to call whenever a serial interrupt is generated
@@ -123,14 +123,14 @@ public:
      *  @param type Which serial interrupt to attach the member function to (Seriall::RxIrq for receive, TxIrq for transmit buffer empty)
      *  @deprecated
      *      The attach function does not support cv-qualifiers. Replaced by
-     *      attach(callback(obj, method), type).
+     *      attach(mbed_callback(obj, method), type).
      */
     template<typename T>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The attach function does not support cv-qualifiers. Replaced by "
-        "attach(callback(obj, method), type).")
+        "attach(mbed_callback(obj, method), type).")
     void attach(T *obj, void (*method)(T*), IrqType type=RxIrq) {
-        attach(callback(obj, method), type);
+        attach(mbed_callback(obj, method), type);
     }
 
     /** Generate a break condition on the serial line

--- a/hal/api/Ticker.h
+++ b/hal/api/Ticker.h
@@ -83,14 +83,14 @@ public:
      *  @param t the time between calls in seconds
      *  @deprecated
      *      The attach function does not support cv-qualifiers. Replaced by
-     *      attach(callback(obj, method), t).
+     *      attach(mbed_callback(obj, method), t).
      */
     template<typename T, typename M>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The attach function does not support cv-qualifiers. Replaced by "
-        "attach(callback(obj, method), t).")
+        "attach(mbed_callback(obj, method), t).")
     void attach(T *obj, M method, float t) {
-        attach(callback(obj, method), t);
+        attach(mbed_callback(obj, method), t);
     }
 
     /** Attach a function to be called by the Ticker, specifiying the interval in micro-seconds
@@ -110,12 +110,12 @@ public:
      *  @param t the time between calls in micro-seconds
      *  @deprecated
      *      The attach_us function does not support cv-qualifiers. Replaced by
-     *      attach_us(callback(obj, method), t).
+     *      attach_us(mbed_callback(obj, method), t).
      */
     template<typename T, typename M>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The attach_us function does not support cv-qualifiers. Replaced by "
-        "attach_us(callback(obj, method), t).")
+        "attach_us(mbed_callback(obj, method), t).")
     void attach_us(T *obj, M method, timestamp_t t) {
         attach_us(Callback<void()>(obj, method), t);
     }

--- a/rtos/rtos/RtosTimer.h
+++ b/rtos/rtos/RtosTimer.h
@@ -47,7 +47,7 @@ public:
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Replaced with RtosTimer(Callback<void()>, os_timer_type)")
     RtosTimer(void (*func)(void const *argument), os_timer_type type=osTimerPeriodic, void *argument=NULL) {
-        constructor(mbed::callback(argument, (void (*)(void *))func), type);
+        constructor(mbed::mbed_callback(argument, (void (*)(void *))func), type);
     }
     
     /** Create timer.
@@ -64,14 +64,14 @@ public:
       @param   type      osTimerOnce for one-shot or osTimerPeriodic for periodic behaviour. (default: osTimerPeriodic)
       @deprecated
           The RtosTimer constructor does not support cv-qualifiers. Replaced by
-          RtosTimer(callback(obj, method), os_timer_type).
+          RtosTimer(mbed::mbed_callback(obj, method), os_timer_type).
     */
     template <typename T, typename M>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The RtosTimer constructor does not support cv-qualifiers. Replaced by "
-        "RtosTimer(callback(obj, method), os_timer_type).")
+        "RtosTimer(mbed_callback(obj, method), os_timer_type).")
     RtosTimer(T *obj, M method, os_timer_type type=osTimerPeriodic) {
-        constructor(mbed::callback(obj, method), type);
+        constructor(mbed::mbed_callback(obj, method), type);
     }
 
     /** Stop the timer.

--- a/rtos/rtos/Thread.h
+++ b/rtos/rtos/Thread.h
@@ -108,12 +108,12 @@ public:
       @param   stack_size      stack size (in bytes) requirements for the thread function. (default: DEFAULT_STACK_SIZE).
       @param   stack_pointer  pointer to the stack area to be used by this thread (default: NULL).
       @deprecated
-        Thread-spawning constructors hide errors. Replaced by thread.start(callback(argument, task)).
+        Thread-spawning constructors hide errors. Replaced by thread.start(mbed_callback(argument, task)).
 
         @code
         Thread thread(priority, stack_size, stack_pointer);
 
-        osStatus status = thread.start(callback(argument, task));
+        osStatus status = thread.start(mbed_callback(argument, task));
         if (status != osOK) {
             error("oh no!");
         }
@@ -122,12 +122,12 @@ public:
     template <typename T>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Thread-spawning constructors hide errors. "
-        "Replaced by thread.start(callback(argument, task)).")
+        "Replaced by thread.start(mbed_callback(argument, task)).")
     Thread(T *argument, void (T::*task)(),
            osPriority priority=osPriorityNormal,
            uint32_t stack_size=DEFAULT_STACK_SIZE,
            unsigned char *stack_pointer=NULL) {
-        constructor(mbed::callback(argument, task),
+        constructor(mbed::mbed_callback(argument, task),
                     priority, stack_size, stack_pointer);
     }
 
@@ -139,12 +139,12 @@ public:
       @param   stack_size      stack size (in bytes) requirements for the thread function. (default: DEFAULT_STACK_SIZE).
       @param   stack_pointer  pointer to the stack area to be used by this thread (default: NULL).
       @deprecated
-        Thread-spawning constructors hide errors. Replaced by thread.start(callback(argument, task)).
+        Thread-spawning constructors hide errors. Replaced by thread.start(mbed_callback(argument, task)).
 
         @code
         Thread thread(priority, stack_size, stack_pointer);
 
-        osStatus status = thread.start(callback(argument, task));
+        osStatus status = thread.start(mbed_callback(argument, task));
         if (status != osOK) {
             error("oh no!");
         }
@@ -153,12 +153,12 @@ public:
     template <typename T>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Thread-spawning constructors hide errors. "
-        "Replaced by thread.start(callback(argument, task)).")
+        "Replaced by thread.start(mbed_callback(argument, task)).")
     Thread(T *argument, void (*task)(T *),
            osPriority priority=osPriorityNormal,
            uint32_t stack_size=DEFAULT_STACK_SIZE,
            unsigned char *stack_pointer=NULL) {
-        constructor(mbed::callback(argument, task),
+        constructor(mbed::mbed_callback(argument, task),
                     priority, stack_size, stack_pointer);
     }
 
@@ -170,12 +170,12 @@ public:
       @param   stack_size      stack size (in bytes) requirements for the thread function. (default: DEFAULT_STACK_SIZE).
       @param   stack_pointer  pointer to the stack area to be used by this thread (default: NULL).
       @deprecated
-        Thread-spawning constructors hide errors. Replaced by thread.start(callback(argument, task)).
+        Thread-spawning constructors hide errors. Replaced by thread.start(mbed_callback(argument, task)).
 
         @code
         Thread thread(priority, stack_size, stack_pointer);
 
-        osStatus status = thread.start(callback(argument, task));
+        osStatus status = thread.start(mbed_callback(argument, task));
         if (status != osOK) {
             error("oh no!");
         }
@@ -183,12 +183,12 @@ public:
     */
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Thread-spawning constructors hide errors. "
-        "Replaced by thread.start(callback(argument, task)).")
+        "Replaced by thread.start(mbed_callback(argument, task)).")
     Thread(void (*task)(void const *argument), void *argument=NULL,
            osPriority priority=osPriorityNormal,
            uint32_t stack_size=DEFAULT_STACK_SIZE,
            unsigned char *stack_pointer=NULL) {
-        constructor(mbed::callback(argument, (void (*)(void *))task),
+        constructor(mbed::mbed_callback(argument, (void (*)(void *))task),
                     priority, stack_size, stack_pointer);
     }
 
@@ -203,14 +203,14 @@ public:
       @param   method         function to be executed by this thread.
       @return  status code that indicates the execution status of the function.
       @deprecated
-          The start function does not support cv-qualifiers. Replaced by start(callback(obj, method)).
+          The start function does not support cv-qualifiers. Replaced by start(mbed_callback(obj, method)).
     */
     template <typename T, typename M>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The start function does not support cv-qualifiers. "
-        "Replaced by thread.start(callback(obj, method)).")
+        "Replaced by thread.start(mbed_callback(obj, method)).")
     osStatus start(T *obj, M method) {
-        return start(mbed::callback(obj, method));
+        return start(mbed::mbed_callback(obj, method));
     }
 
     /** Wait for thread to terminate


### PR DESCRIPTION
Rename the `callback` function to the more unique name `mbed_callback` to avoid naming conflicts with user code.

should fix https://github.com/ARMmbed/mbed-os/issues/2653
alternative to https://github.com/ARMmbed/mbed-os/pull/2661
cc @sg-, @bridadan, @tommikas