### PR TITLE
nsapi - Add optional API for static configuration of network interfaces

### DIFF
--- a/features/net/FEATURE_IPV4/lwip-interface/EthernetInterface.cpp
+++ b/features/net/FEATURE_IPV4/lwip-interface/EthernetInterface.cpp
@@ -19,9 +19,32 @@
 
 
 /* Interface implementation */
+EthernetInterface::EthernetInterface()
+    : _dhcp(false), _ip_address(), _netmask(), _gateway()
+{
+}
+
+int EthernetInterface::set_network(const char *ip_address, const char *netmask, const char *gateway)
+{
+    _dhcp = false;
+    strncpy(_ip_address, ip_address ? ip_address : "", sizeof(_ip_address));
+    strncpy(_netmask, netmask ? netmask : "", sizeof(_netmask));
+    strncpy(_gateway, gateway ? gateway : "", sizeof(_gateway));
+    return 0;
+}
+
+int EthernetInterface::set_dhcp(bool dhcp)
+{
+    _dhcp = dhcp;
+    return 0;
+}
+
 int EthernetInterface::connect()
 {
-    return lwip_bringup();
+    return lwip_bringup(_dhcp,
+            _ip_address[0] ? _ip_address : 0,
+            _netmask[0] ? _netmask : 0,
+            _gateway[0] ? _gateway : 0);
 }
 
 int EthernetInterface::disconnect()
@@ -29,14 +52,24 @@ int EthernetInterface::disconnect()
     return lwip_bringdown();
 }
 
+const char *EthernetInterface::get_mac_address()
+{
+    return lwip_get_mac_address();
+}
+
 const char *EthernetInterface::get_ip_address()
 {
     return lwip_get_ip_address();
 }
 
-const char *EthernetInterface::get_mac_address()
+const char *EthernetInterface::get_netmask()
 {
-    return lwip_get_mac_address();
+    return lwip_get_netmask();
+}
+
+const char *EthernetInterface::get_gateway()
+{
+    return lwip_get_gateway();
 }
 
 NetworkStack *EthernetInterface::get_stack()

--- a/features/net/FEATURE_IPV4/lwip-interface/EthernetInterface.h
+++ b/features/net/FEATURE_IPV4/lwip-interface/EthernetInterface.h
@@ -31,6 +31,32 @@ class NetworkStack;
 class EthernetInterface : public EthInterface
 {
 public:
+    /** EthernetInterface lifetime
+     */
+    EthernetInterface();
+
+    /** Set a static IP address
+     *
+     *  Configures this network interface to use a static IP address.
+     *  Implicitly disables DHCP, which can be enabled in set_dhcp.
+     *  Requires that the network is disconnected.
+     *
+     *  @param address  Null-terminated representation of the local IP address
+     *  @param netmask  Null-terminated representation of the local network mask
+     *  @param gateway  Null-terminated representation of the local gateway
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int set_network(const char *ip_address, const char *netmask, const char *gateway);
+
+    /** Enable or disable DHCP on the network
+     *
+     *  Requires that the network is disconnected
+     *
+     *  @param dhcp     False to disable dhcp (defaults to enabled)
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int set_dhcp(bool dhcp);
+
     /** Start the interface
      *  @return             0 on success, negative on failure
      */
@@ -41,15 +67,37 @@ public:
      */
     virtual int disconnect();
 
-    /** Get the internally stored IP address
-     *  @return             IP address of the interface or null if not yet connected
+    /** Get the local MAC address
+     *
+     *  Provided MAC address is intended for info or debug purposes and
+     *  may not be provided if the underlying network interface does not
+     *  provide a MAC address
+     *  
+     *  @return         Null-terminated representation of the local MAC address
+     *                  or null if no MAC address is available
+     */
+    virtual const char *get_mac_address();
+
+    /** Get the local IP address
+     *
+     *  @return         Null-terminated representation of the local IP address
+     *                  or null if no IP address has been recieved
      */
     virtual const char *get_ip_address();
 
-    /** Get the internally stored MAC address
-     *  @return             MAC address of the interface
+    /** Get the local network mask
+     *
+     *  @return         Null-terminated representation of the local network mask 
+     *                  or null if no network mask has been recieved
      */
-    virtual const char *get_mac_address();
+    virtual const char *get_netmask();
+
+    /** Get the local gateway
+     *
+     *  @return         Null-terminated representation of the local gateway
+     *                  or null if no network mask has been recieved
+     */
+    virtual const char *get_gateway();
 
 protected:
     /** Provide access to the underlying stack
@@ -57,6 +105,11 @@ protected:
      *  @return The underlying network stack 
      */
     virtual NetworkStack *get_stack();
+
+    bool _dhcp;
+    char _ip_address[NSAPI_IPv4_SIZE];
+    char _netmask[NSAPI_IPv4_SIZE];
+    char _gateway[NSAPI_IPv4_SIZE];
 };
 
 

--- a/features/net/FEATURE_IPV4/lwip-interface/lwip_stack.h
+++ b/features/net/FEATURE_IPV4/lwip-interface/lwip_stack.h
@@ -25,13 +25,15 @@ extern "C" {
 
 
 // Access to lwip through the nsapi
-int lwip_bringup(void);
+int lwip_bringup(bool dhcp, const char *ip, const char *netmask, const char *gw);
 int lwip_bringdown(void);
-
-extern nsapi_stack_t lwip_stack;
 
 const char *lwip_get_mac_address(void);
 const char *lwip_get_ip_address(void);
+const char *lwip_get_netmask(void);
+const char *lwip_get_gateway(void);
+
+extern nsapi_stack_t lwip_stack;
 
 
 #ifdef __cplusplus

--- a/features/net/network-socket/CellularInterface.cpp
+++ b/features/net/network-socket/CellularInterface.cpp
@@ -1,0 +1,77 @@
+/* Socket
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "network-socket/CellularInterface.h"
+#include <stdlib.h>
+#include <string.h>
+
+
+CellularInterface::CellularInterface()
+    : _apn(0), _user(0), _pass(0)
+{
+}
+
+CellularInterface::~CellularInterface()
+{
+    free(_apn);
+    free(_user);
+    free(_pass);
+}
+
+int CellularInterface::set_credentials(const char *apn, const char *user, const char *pass)
+{
+    free(_apn);
+    _apn = 0;
+    free(_user);
+    _user = 0;
+    free(_pass);
+    _pass = 0;
+
+    if (apn) {
+        _apn = (char*)malloc(strlen(apn)+1);
+        if (!_apn) {
+            return NSAPI_ERROR_NO_MEMORY;
+        }
+
+        strcpy(_apn, apn);
+    }
+
+    if (user) {
+        _user = (char*)malloc(strlen(user)+1);
+        if (!_user) {
+            return NSAPI_ERROR_NO_MEMORY;
+        }
+
+        strcpy(_user, user);
+    }
+
+    if (pass) {
+        _pass = (char*)malloc(strlen(pass)+1);
+        if (!_pass) {
+            return NSAPI_ERROR_NO_MEMORY;
+        }
+
+        strcpy(_pass, pass);
+    }
+
+    return 0;
+}
+
+int CellularInterface::connect()
+{
+    return connect(_apn, _user, _pass);
+}
+

--- a/features/net/network-socket/CellularInterface.h
+++ b/features/net/network-socket/CellularInterface.h
@@ -27,6 +27,19 @@
 class CellularInterface : public NetworkInterface
 {
 public:
+    /** CellularInterface lifetime
+     */
+    CellularInterface();
+    virtual ~CellularInterface();
+
+    /** Set the cellular network APN and credentials
+     *
+     *  @param apn      Optional name of the network to connect to
+     *  @param user     Optional username for the APN
+     *  @param pass     Optional password fot the APN
+     */
+    virtual int set_credentials(const char *apn, const char *user = 0, const char *pass = 0);
+
     /** Start the interface
      *
      *  @param apn      Optional name of the network to connect to
@@ -34,7 +47,15 @@ public:
      *  @param password Optional password for your APN 
      *  @return         0 on success, negative error code on failure
      */
-    virtual int connect(const char *apn = 0, const char *username = 0, const char *password = 0) = 0;
+    virtual int connect(const char *apn, const char *username = 0, const char *password = 0) = 0;
+
+    /** Start the interface
+     *
+     *  Attempts to connect to a cellular network based on supplied credentials
+     *
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int connect();
  
     /** Stop the interface
      *
@@ -42,11 +63,10 @@ public:
      */
     virtual int disconnect() = 0;
 
-    /** Get the local MAC address
-     *
-     *  @return         Null-terminated representation of the local MAC address
-     */
-    virtual const char *get_mac_address() = 0;
+private:
+    char *_apn;
+    char *_user;
+    char *_pass;
 };
 
  

--- a/features/net/network-socket/MeshInterface.h
+++ b/features/net/network-socket/MeshInterface.h
@@ -26,24 +26,6 @@
  */
 class MeshInterface : public NetworkInterface
 {
-public:
-    /** Start the interface
-     *
-     *  @return     0 on success, negative on failure
-     */
-    virtual int connect() = 0;
-
-    /** Stop the interface
-     *
-     *  @return     0 on success, negative on failure
-     */
-    virtual int disconnect() = 0;
-
-    /** Get the local MAC address
-     *
-     *  @return         Null-terminated representation of the local MAC address
-     */
-    virtual const char *get_mac_address() = 0;
 };
 
 

--- a/features/net/network-socket/NetworkInterface.cpp
+++ b/features/net/network-socket/NetworkInterface.cpp
@@ -1,4 +1,4 @@
-/* EthInterface
+/* Socket
  * Copyright (c) 2015 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,19 +14,41 @@
  * limitations under the License.
  */
 
-#ifndef ETH_INTERFACE_H
-#define ETH_INTERFACE_H
-
 #include "network-socket/NetworkInterface.h"
+#include <string.h>
 
 
-/** EthInterface class
- *
- *  Common interface that is shared between ethernet hardware.
- */
-class EthInterface : public NetworkInterface
+const char *NetworkInterface::get_mac_address()
 {
-};
+    return 0;
+}
 
+const char *NetworkInterface::get_ip_address()
+{
+    return 0;
+}
 
-#endif
+const char *NetworkInterface::get_netmask()
+{
+    return 0;
+}
+
+const char *NetworkInterface::get_gateway()
+{
+    return 0;
+}
+
+int NetworkInterface::set_network(const char *ip_address, const char *netmask, const char *gateway)
+{
+    return NSAPI_ERROR_UNSUPPORTED;
+}
+
+int NetworkInterface::set_dhcp(bool dhcp)
+{
+    if (!dhcp) {
+        return NSAPI_ERROR_UNSUPPORTED;
+    } else {
+        return 0;
+    }
+}
+

--- a/features/net/network-socket/NetworkInterface.h
+++ b/features/net/network-socket/NetworkInterface.h
@@ -17,6 +17,8 @@
 #ifndef NETWORK_INTERFACE_H
 #define NETWORK_INTERFACE_H
 
+#include "network-socket/nsapi_types.h"
+
 // Predeclared class
 class NetworkStack;
 
@@ -29,12 +31,73 @@ class NetworkInterface {
 public:
     virtual ~NetworkInterface() {};
 
+    /** Get the local MAC address
+     *
+     *  Provided MAC address is intended for info or debug purposes and
+     *  may not be provided if the underlying network interface does not
+     *  provide a MAC address
+     *  
+     *  @return         Null-terminated representation of the local MAC address
+     *                  or null if no MAC address is available
+     */
+    virtual const char *get_mac_address();
+
     /** Get the local IP address
      *
      *  @return         Null-terminated representation of the local IP address
-     *                  or null if not yet connected
+     *                  or null if no IP address has been recieved
      */
-    virtual const char *get_ip_address() = 0;
+    virtual const char *get_ip_address();
+
+    /** Get the local network mask
+     *
+     *  @return         Null-terminated representation of the local network mask 
+     *                  or null if no network mask has been recieved
+     */
+    virtual const char *get_netmask();
+
+    /** Get the local gateway
+     *
+     *  @return         Null-terminated representation of the local gateway
+     *                  or null if no network mask has been recieved
+     */
+    virtual const char *get_gateway();
+
+    /** Set a static IP address
+     *
+     *  Configures this network interface to use a static IP address.
+     *  Implicitly disables DHCP, which can be enabled in set_dhcp.
+     *  Requires that the network is disconnected.
+     *
+     *  @param address  Null-terminated representation of the local IP address
+     *  @param netmask  Null-terminated representation of the local network mask
+     *  @param gateway  Null-terminated representation of the local gateway
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int set_network(const char *ip_address, const char *netmask, const char *gateway);
+
+    /** Enable or disable DHCP on the network
+     *
+     *  Enables DHCP on connecting the network. Defaults to enabled unless
+     *  a static IP address has been assigned. Requires that the network is
+     *  disconnected.
+     *
+     *  @param dhcp     True to enable DHCP
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int set_dhcp(bool dhcp);
+
+    /** Start the interface
+     *
+     *  @return     0 on success, negative error code on failure
+     */
+    virtual int connect() = 0;
+
+    /** Stop the interface
+     *
+     *  @return     0 on success, negative error code on failure
+     */
+    virtual int disconnect() = 0;
 
 protected:
     friend class Socket;

--- a/features/net/network-socket/WiFiInterface.cpp
+++ b/features/net/network-socket/WiFiInterface.cpp
@@ -1,0 +1,71 @@
+/* Socket
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "network-socket/WiFiInterface.h"
+#include <stdlib.h>
+#include <string.h>
+
+
+WiFiInterface::WiFiInterface()
+    : _ssid(0), _pass(0), _security(NSAPI_SECURITY_NONE)
+{
+}
+
+WiFiInterface::~WiFiInterface()
+{
+    free(_ssid);
+    free(_pass);
+}
+
+int WiFiInterface::set_credentials(const char *ssid, const char *pass, nsapi_security_t security)
+{
+    free(_ssid);
+    _ssid = 0;
+    free(_pass);
+    _pass = 0;
+
+    if (ssid) {
+        _ssid = (char*)malloc(strlen(ssid)+1);
+        if (!_ssid) {
+            return NSAPI_ERROR_NO_MEMORY;
+        }
+
+        strcpy(_ssid, ssid);
+    }
+
+    if (pass) {
+        _pass = (char*)malloc(strlen(pass)+1);
+        if (!_pass) {
+            return NSAPI_ERROR_NO_MEMORY;
+        }
+
+        strcpy(_pass, pass);
+    }
+
+    _security = security;
+
+    return 0;
+}
+
+int WiFiInterface::connect()
+{
+    if (!_ssid || !_pass) {
+        return NSAPI_ERROR_PARAMETER;
+    }
+
+    return connect(_ssid, _pass, _security);
+}
+

--- a/features/net/network-socket/WiFiInterface.h
+++ b/features/net/network-socket/WiFiInterface.h
@@ -41,6 +41,20 @@ enum nsapi_security_t {
 class WiFiInterface: public NetworkInterface
 {
 public:
+    /** WiFiInterface lifetime
+     */
+    WiFiInterface();
+    virtual ~WiFiInterface();
+
+    /** Set the WiFi network credentials
+     *
+     *  @param ssid     Name of the network to connect to
+     *  @param pass     Security passphrase to connect to the network
+     *  @param security Type of encryption for connection
+     *                  (defaults to NSAPI_SECURITY_NONE)
+     */
+    virtual int set_credentials(const char *ssid, const char *pass, nsapi_security_t security = NSAPI_SECURITY_NONE);
+
     /** Start the interface
      *
      *  Attempts to connect to a WiFi network. If passphrase is invalid,
@@ -53,17 +67,25 @@ public:
      */
     virtual int connect(const char *ssid, const char *pass, nsapi_security_t security = NSAPI_SECURITY_NONE) = 0;
 
+    /** Start the interface
+     *
+     *  Attempts to connect to a WiFi network. Requires ssid and passphrase to be set.
+     *  If passphrase is invalid, NSAPI_ERROR_AUTH_ERROR is returned.
+     *
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int connect();
+
     /** Stop the interface
      *
      *  @return          0 on success, negative error code on failure
      */
     virtual int disconnect() = 0;
 
-    /** Get the local MAC address
-     *
-     *  @return         Null-terminated representation of the local MAC address
-     */
-    virtual const char *get_mac_address() = 0;
+private:
+    char *_ssid;
+    char *_pass;
+    nsapi_security_t _security;
 };
 
 


### PR DESCRIPTION
This is a proposal to add static configuration to network interfaces.

This accomplishes two things:
1. Provides a simple route for adding static IP address support to the base NetworkInterface
2. Provides a simple route for adding configurability to network interfaces and unifies the network interface to consistent connect call, allowing network interfaces to be passed around abstractly

Additional functions:
``` cpp
int NetworkInterface::set_network(const char *ip_address, const char *netmask, const char *gateway);
int NetworkInterface::set_dhcp(bool dhcp);
int WiFiInterface::set_credentials(const char *ssid, const char *pass);
int CellularInterface::set_credentials(const char *apn, const char *user, const char *pass);
```

Let me know any concerns

related discussion https://github.com/ARMmbed/mbed-os/pull/2627
should resolve https://github.com/ARMmbed/mbed-os/issues/2649
cc @bulislaw, @sg-, @c1728p9 