### PR TITLE
nsapi - Add equality operators to SocketAddress class

### DIFF
--- a/features/net/network-socket/SocketAddress.cpp
+++ b/features/net/network-socket/SocketAddress.cpp
@@ -258,6 +258,25 @@ SocketAddress::operator bool() const
     return false;
 }
 
+bool operator==(const SocketAddress &a, const SocketAddress &b)
+{
+    int count = 0;
+    if (a._addr.version == NSAPI_IPv4 && b._addr.version == NSAPI_IPv4) {
+        count = NSAPI_IPv4_BYTES;
+    } else if (a._addr.version == NSAPI_IPv6 && b._addr.version == NSAPI_IPv6) {
+        count = NSAPI_IPv6_BYTES;
+    } else {
+        return false;
+    }
+
+    return (memcmp(a._addr.bytes, b._addr.bytes, count) == 0);
+}
+
+bool operator!=(const SocketAddress &a, const SocketAddress &b)
+{
+    return !(a == b);
+}
+
 void SocketAddress::_SocketAddress(NetworkStack *iface, const char *host, uint16_t port)
 {
     _ip_address[0] = '\0';

--- a/features/net/network-socket/SocketAddress.h
+++ b/features/net/network-socket/SocketAddress.h
@@ -137,6 +137,18 @@ public:
      */
     operator bool() const;
 
+    /** Compare two addresses for equality
+     *
+     *  @return         True if both addresses are equal
+     */
+    friend bool operator==(const SocketAddress &a, const SocketAddress &b);
+
+    /** Compare two addresses for equality
+     *
+     *  @return         True if both addresses are not equal
+     */
+    friend bool operator!=(const SocketAddress &a, const SocketAddress &b);
+
 private:
     void _SocketAddress(NetworkStack *iface, const char *host, uint16_t port);
 


### PR DESCRIPTION
Add equality operators to the network-socket API Socket Address class:
``` cpp
bool operator==(const SocketAddress &a, const SocketAddress &b);
bool operator!=(const SocketAddress &a, const SocketAddress &b);
```

This is especially useful for checking udp packets to be from the correct sender:
``` cpp
UDPSocket server(&iface);
SocketAddress client_address;

int err = server->recvfrom(&client_address, packet, sizeof packet);
if (err || client_address !=expected_client_address) {
    error("oh no!");
}
```

cc @c1728p9 