### PR TITLE
tools-exporters! - Globally add a gettingstarted.html

### DIFF
--- a/tools/export/GettingStarted.html
+++ b/tools/export/GettingStarted.html
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh"
+              content="1;url="https://developer.mbed.org/handbook/Getting-Started-mbed-Exporters>
+        <script type="text/javascript">
+            window.location.href = "https://developer.mbed.org/handbook/Getting-Started-mbed-Exporters"
+        </script>
+        <title>Page Redirection</title>
+    </head>
+    <body>
+        If you are not redirected automatically, please follow the
+        <a href='https://developer.mbed.org/handbook/Getting-Started-mbed-Exporters'>link to the online exporter documentation</a>
+    </body>
+</html>

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -71,7 +71,7 @@ class Exporter(object):
         jinja_loader = FileSystemLoader(os.path.dirname(os.path.abspath(__file__)))
         self.jinja_environment = Environment(loader=jinja_loader)
         self.resources = resources
-        self.generated_files = []
+        self.generated_files = [join(self.TEMPLATE_DIR,"GettingStarted.html")]
         self.builder_files_dict = {}
 
     def get_toolchain(self):


### PR DESCRIPTION
This was auto-generated within the old exporters, and I think it would be useful to have in the new exporters. The link may contain extra steps that must be taken to have an export work for the end user.