### PR TITLE
[EFM32] Fix exporter to pull root path

### DIFF
--- a/tools/export/simplicityv3.py
+++ b/tools/export/simplicityv3.py
@@ -175,6 +175,7 @@ class SimplicityV3(Exporter):
         ## Strip main folder from include paths because ssproj is not capable of handling it
         if '.' in ctx['include_paths']:
             ctx['include_paths'].remove('.')
+            ctx['include_root'] = True
 
         '''
         Suppress print statements

--- a/tools/export/simplicityv3_slsproj.tmpl
+++ b/tools/export/simplicityv3_slsproj.tmpl
@@ -18,6 +18,9 @@
   {%- for file in main_files -%}
   <file name = "{{ file }}" uri = "file:./{{ file }}" partCompatibility = ""/>
   {%- endfor %}
+  {%- if include_root %}
+  <file name = "mbed_config.h" uri = "file:./mbed_config.h" partCompatibility = ""/>
+  {%- endif %}
 
   <sourceFolder></sourceFolder>
   <model:property key="cppProjectCommon.languageId" value="org.eclipse.cdt.core.g++"/>
@@ -25,6 +28,9 @@
   <configuration name="com.silabs.ide.si32.gcc.debug#com.silabs.ide.si32.gcc:4.8.3.20131129" label="GNU ARM v4.8.3 - Debug" stockConfigCompatibility="com.silabs.ide.toolchain.core.debug">
     <model:description></model:description>
 {# Add all include paths to the managed build compiler, paths relative to project #}
+    {%- if include_root %}
+    <includePath languageCompatibility="c cpp" uri="."/>
+    {%- endif %}
     {%- for path in include_paths %}
     <includePath languageCompatibility="c cpp" uri="studio:/project/{{ path }}/"/>
     {%- endfor %}
@@ -83,6 +89,9 @@
   <configuration name="com.silabs.ide.si32.gcc.release#com.silabs.ide.si32.gcc:4.8.3.20131129" label="GNU ARM v4.8.3 - Release" stockConfigCompatibility="com.silabs.ide.toolchain.core.release">
     <model:description></model:description>
 {# Add all include paths to the managed build compiler, paths relative to project #}
+    {%- if include_root %}
+    <includePath languageCompatibility="c cpp" uri="."/>
+    {%- endif %}
     {%- for path in include_paths %}
     <includePath languageCompatibility="c cpp" uri="studio:/project/{{ path }}/"/>
     {%- endfor %}


### PR DESCRIPTION
Simplicity Studio exporter doesnt really support header files in the root directory (looking at you, mbed_config.h), so this is a workaround for that issue.

Fix for #2655 