### PR TITLE
[BLE NRF5] introduce the SDK nRF5 Peer manager into BLE security features

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle_discovery.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle_discovery.cpp
@@ -23,7 +23,6 @@
 void bleGattcEventHandler(const ble_evt_t *p_ble_evt)
 {
     nRF5xn                &ble         = nRF5xn::Instance(BLE::DEFAULT_INSTANCE);
-    nRF5xGap              &gap         = (nRF5xGap &) ble.getGap();
     nRF5xGattClient       &gattClient  = (nRF5xGattClient &) ble.getGattClient();
     nRF5xServiceDiscovery &sdSingleton = gattClient.discovery();
     nRF5xCharacteristicDescriptorDiscoverer &characteristicDescriptorDiscoverer =

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/ble/peer_manager/pm_buffer.h
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/ble/peer_manager/pm_buffer.h
@@ -60,10 +60,13 @@
 #define PM_BUFFER_INIT(p_buffer, n_blocks, block_size, err_code)    \
 do                                                                  \
 {                                                                   \
-    static uint8_t buffer_memory[(n_blocks) * (block_size)];        \
+    static union {                                                  \
+        uint8_t  u8[(n_blocks) * (block_size)];                     \
+        uint32_t u32[1]; /*force allign to uint32_t*/               \
+    } buffer_memory;                                                \
     static uint8_t mutex_memory[MUTEX_STORAGE_SIZE(n_blocks)];      \
     err_code = pm_buffer_init((p_buffer),                           \
-                               buffer_memory,                       \
+                               buffer_memory.u8,                    \
                               (n_blocks) * (block_size),            \
                                mutex_memory,                        \
                                MUTEX_STORAGE_SIZE(n_blocks),        \

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/libraries/util/app_util_platform.h
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/libraries/util/app_util_platform.h
@@ -111,7 +111,9 @@ typedef enum
 #define EXTERNAL_INT_VECTOR_OFFSET 16
 /**@endcond */
 
-#define PACKED(TYPE) __packed TYPE
+#ifndef PACKED
+    #define PACKED(TYPE) __packed TYPE
+#endif
 
 void app_util_critical_region_enter (uint8_t *p_nested);
 void app_util_critical_region_exit (uint8_t nested);


### PR DESCRIPTION
Peer manager (PM) replace security features implemented so fare by Device Manager. Device manager is a legacy module, not recommended to feature use. Changes touch those targets that uses SoftDevices sd13x. S110 based target (doesn't exist any so fare) keeps Device manager in usage.

## prerequisited
merged https://github.com/ARMmbed/mbed-os/pull/2687

## fixes

- security key distribution settings - signing is not supported.
- PM internal bug (For gcc with -0s optimization an application fail to save a boonding data)

## minor changes
- fuse redeclaration of PACKED macro in nRF5 SDK sources
- deleted unused local reference to nRF5xGap class in bleGattcEventHandler.