### PR TITLE
[NRF5] Add fs_data symbol in data secton for gcc

### DIFF
--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TOOLCHAIN_GCC_ARM/TARGET_MCU_NORDIC_32K/NRF51822.ld
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TOOLCHAIN_GCC_ARM/TARGET_MCU_NORDIC_32K/NRF51822.ld
@@ -107,6 +107,11 @@ SECTIONS
 		KEEP(*(.fini_array))
 		PROVIDE_HIDDEN (__fini_array_end = .);
 
+		. = ALIGN(4);
+		PROVIDE(__start_fs_data = .);
+		KEEP(*(.fs_data))
+		PROVIDE(__stop_fs_data = .);
+        
 		*(.jcr)
 		. = ALIGN(4);
 		/* All data end */
@@ -115,13 +120,6 @@ SECTIONS
 	} > RAM
 
     __edata = .;
-
-    .fs_data :
-    {
-      PROVIDE(__start_fs_data = .);
-      KEEP(*(.fs_data))
-      PROVIDE(__stop_fs_data = .);
-    } > RAM
 
 	.bss :
 	{

--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TOOLCHAIN_GCC_ARM/TARGET_MCU_NRF51_16K_S130/NRF51822.ld
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TOOLCHAIN_GCC_ARM/TARGET_MCU_NRF51_16K_S130/NRF51822.ld
@@ -106,6 +106,11 @@ SECTIONS
 		KEEP(*(SORT(.fini_array.*)))
 		KEEP(*(.fini_array))
 		PROVIDE_HIDDEN (__fini_array_end = .);
+        
+		. = ALIGN(4);
+		PROVIDE(__start_fs_data = .);
+		KEEP(*(.fs_data))
+		PROVIDE(__stop_fs_data = .);
 
 		*(.jcr)
 		. = ALIGN(4);

--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TOOLCHAIN_GCC_ARM/NRF52832.ld
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TOOLCHAIN_GCC_ARM/NRF52832.ld
@@ -126,6 +126,11 @@ SECTIONS
         KEEP(*(.fini_array))
         PROVIDE_HIDDEN (__fini_array_end = .);
 
+        . = ALIGN(4);
+        PROVIDE(__start_fs_data = .);
+        KEEP(*(.fs_data))
+        PROVIDE(__stop_fs_data = .);
+        
         *(.jcr)
         . = ALIGN(4);
         /* All data end */
@@ -134,13 +139,6 @@ SECTIONS
     } > RAM
 
     __edata = .;
-
-    .fs_data :
-    {
-      PROVIDE(__start_fs_data = .);
-      KEEP(*(.fs_data))
-      PROVIDE(__stop_fs_data = .);
-    } > RAM
 
     .bss :
     {


### PR DESCRIPTION
fs_data symbol is needed for flowing nRF5 SDk components:
fstorage, fds, Peer manager.
This part of RAM must be initialized at the startup.