### PR TITLE
Avoid type collision by renaming callback variable

### DIFF
--- a/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_timer.cpp
+++ b/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_timer.cpp
@@ -16,7 +16,7 @@ static osThreadId timer_thread_id;
 static Timer timer;
 static Timeout timeout;
 static uint32_t due;
-static void (*callback)(void);
+static void (*arm_hal_callback)(void);
 
 static void timer_thread(const void *)
 {
@@ -25,7 +25,7 @@ static void timer_thread(const void *)
         // !!! We don't do our own enter/exit critical - we rely on callback
         // doing it (ns_timer_interrupt_handler does)
         //platform_enter_critical();
-        callback();
+        arm_hal_callback();
         //platform_exit_critical();
     }
 }
@@ -47,7 +47,7 @@ void platform_timer_disable(void)
 // Not called while running, fortunately
 void platform_timer_set_cb(void (*new_fp)(void))
 {
-    callback = new_fp;
+    arm_hal_callback = new_fp;
 }
 
 static void timer_callback(void)


### PR DESCRIPTION
## Description
Jenkins jobs are failing due build error: 
```
Compile: arm_hal_timer.cpp
[Error] arm_hal_timer.cpp@28,9: reference to 'callback' is ambiguous
[Error] arm_hal_timer.cpp@50,5: reference to 'callback' is ambiguous
[Warning] arm_hal_timer.cpp@19,15: 'callback' defined but not used [-Wunused-variable]
[ERROR] ./mbed-os/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_timer.cpp: In function 'void timer_thread(const void*)':
./mbed-os/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_timer.cpp:28:9: error: reference to 'callback' is ambiguous
         callback();
         ^
./mbed-os/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_timer.cpp:19:15: note: candidates are: void (* callback)()
 static void (*callback)(void);
               ^
In file included from ./mbed-os/rtos/rtos/Thread.h:27:0,
                 from ./mbed-os/rtos/rtos/rtos.h:25,
                 from ./mbed-os/hal/api/mbed.h:22,
                 from ./mbed-os/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_timer.cpp:9:
./mbed-os/hal/api/Callback.h:3524:33: note:                 template<class T, class R, class A0, class A1, class A2, class A3, class A4> mbed::Callback<R(A0, A1, A2, A3, A4)> mbed::callback(const volatile T*, R (T::*)(A0, A1, A2, A3, A4) const volatile)
 Callback<R(A0, A1, A2, A3, A4)> callback(const volatile T *obj, R (T::*func)(A0, A1, A2, A3, A4) const volatile) {
```

Fix the error by renaming callback as arm_hal_callback.