### PR TITLE
tools-exporters! - Clean exports with git

### DIFF
--- a/tools/project.py
+++ b/tools/project.py
@@ -63,7 +63,7 @@ def setup_project(ide, target, program=None, source_dir=None, build=None):
 
 
 def export(target, ide, build=None, src=None, macros=None, project_id=None,
-           clean=False, zip_proj=False, options=None):
+           zip_proj=False, options=None):
     """Do an export of a project.
 
     Positional arguments:
@@ -75,7 +75,6 @@ def export(target, ide, build=None, src=None, macros=None, project_id=None,
     src - directory or directories that contain the source to export
     macros - extra macros to add to the project
     project_id - the name of the project
-    clean - start from a clean state before exporting
     zip_proj - create a zip file or not
     """
     project_dir, name, src, lib = setup_project(ide, target, program=project_id,
@@ -83,8 +82,8 @@ def export(target, ide, build=None, src=None, macros=None, project_id=None,
 
     zip_name = name+".zip" if zip_proj else None
 
-    export_project(src, project_dir, target, ide, clean=clean, name=name,
-                   macros=macros, libraries_paths=lib, zip_proj=zip_name, options=options)
+    export_project(src, project_dir, target, ide, name=name, macros=macros,
+                   libraries_paths=lib, zip_proj=zip_name, options=options)
 
 
 def main():
@@ -219,8 +218,8 @@ def main():
         # Export to selected toolchain
     export(options.mcu, options.ide, build=options.build,
            src=options.source_dir, macros=options.macros,
-           project_id=options.program, clean=options.clean,
-           zip_proj=zip_proj, options=options.opts)
+           project_id=options.program, zip_proj=zip_proj,
+           options=options.opts)
 
 
 if __name__ == "__main__":

--- a/tools/project.py
+++ b/tools/project.py
@@ -6,7 +6,7 @@ from os.path import join, abspath, dirname, exists, basename
 ROOT = abspath(join(dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
-from subprocess import Popen
+from subprocess import check_call, CalledProcessError
 from shutil import move, rmtree
 from argparse import ArgumentParser
 from os.path import normpath, realpath
@@ -200,7 +200,12 @@ def main():
 
     # Clean Export Directory
     if options.clean:
-        Popen(["git", "clean", "-fe", "mbed-os"]).wait()
+        try:
+            check_call(["git", "clean", "-fe", "mbed-os"])
+        except CalledProcessError:
+            print "Warning: your directory was not cleaned because it was not"\
+                " recognized as a git repo or you do not have git installed in"\
+                " your path."
 
     for mcu in options.mcu:
         zip_proj = not bool(options.source_dir)

--- a/tools/project.py
+++ b/tools/project.py
@@ -6,6 +6,7 @@ from os.path import join, abspath, dirname, exists, basename
 ROOT = abspath(join(dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
+from subprocess import Popen
 from shutil import move, rmtree
 from argparse import ArgumentParser
 from os.path import normpath, realpath
@@ -199,8 +200,7 @@ def main():
 
     # Clean Export Directory
     if options.clean:
-        if exists(EXPORT_DIR):
-            rmtree(EXPORT_DIR)
+        Popen(["git", "clean", "-fe", "mbed-os"]).wait()
 
     for mcu in options.mcu:
         zip_proj = not bool(options.source_dir)

--- a/tools/project_api.py
+++ b/tools/project_api.py
@@ -130,9 +130,9 @@ def zip_export(file_name, prefix, resources, project_files):
 
 def export_project(src_paths, export_path, target, ide,
                    libraries_paths=None, options=None, linker_script=None,
-                   clean=False, notify=None, verbose=False, name=None,
-                   inc_dirs=None, jobs=1, silent=False, extra_verbose=False,
-                   config=None, macros=None, zip_proj=None):
+                   notify=None, verbose=False, name=None, inc_dirs=None,
+                   jobs=1, silent=False, extra_verbose=False, config=None,
+                   macros=None, zip_proj=None):
     """Generates a project file and creates a zip archive if specified
 
     Positional Arguments:
@@ -145,7 +145,6 @@ def export_project(src_paths, export_path, target, ide,
     libraries_paths - paths to additional libraries
     options - build options passed by -o flag
     linker_script - path to the linker script for the specified target
-    clean - removes the export_path if it exists
     notify - function is passed all events, and expected to handle notification
       of the user, emit the events to a log, etc.
     verbose - assigns the notify function to toolchains print_notify_verbose
@@ -177,8 +176,6 @@ def export_project(src_paths, export_path, target, ide,
         src_paths = {"": paths}
 
     # Export Directory
-    if exists(export_path) and clean:
-        rmtree(export_path)
     if not exists(export_path):
         makedirs(export_path)
 
@@ -186,10 +183,9 @@ def export_project(src_paths, export_path, target, ide,
 
     # Pass all params to the unified prepare_resources()
     toolchain = prepare_toolchain(paths, target, toolchain_name,
-                                  macros=macros, options=options, clean=clean,
-                                  jobs=jobs, notify=notify, silent=silent,
-                                  verbose=verbose, extra_verbose=extra_verbose,
-                                  config=config)
+                                  macros=macros, options=options, jobs=jobs,
+                                  notify=notify, silent=silent, verbose=verbose,
+                                  extra_verbose=extra_verbose, config=config)
     # The first path will give the name to the library
     if name is None:
         name = basename(normpath(abspath(src_paths[0])))


### PR DESCRIPTION
Note: This is a proposal with a bit of code.

So the idea is to clean the files that are generated by an export with
the git clean command. This has a benefit for the UX: it tells you when
it removes something. In this way, you know that the clean flag worked,
and you will know immediately if it did something wrong.

An example export with a clean from within mbed-os-example-blinky after
a previous export (or two):

```
$ mbed export -c -i gcc_arm -m K64F
Removing Makefile
Removing mbed-os-example-blinky.uvopt
Removing mbed-os-example-blinky.uvproj
Removing mbed_config.h
Build Options: debug-info
Scan: .
Scan: FEATURE_COMMON_PAL
Scan: FEATURE_UVISOR
Scan: FEATURE_BLE
Scan: FEATURE_CLIENT
Scan: FEATURE_IPV6
Scan: FEATURE_IPV4
Scan: FEATURE_STORAGE
```