### PR TITLE
Changes in greentea-client for uvisor-tests-standalone integration

### DIFF
--- a/features/frameworks/greentea-client/greentea-client/test_env.h
+++ b/features/frameworks/greentea-client/greentea-client/test_env.h
@@ -75,6 +75,8 @@ extern const char* GREENTEA_TEST_ENV_LCOV_START;
  */
 void GREENTEA_SETUP(const int, const char *);
 void GREENTEA_TESTSUITE_RESULT(const int);
+void GREENTEA_TESTCASE_START(const char *test_case_name);
+void GREENTEA_TESTCASE_FINISH(const char *test_case_name, const size_t passes, const size_t failed);
 
 /**
  *  Test suite result related notification API

--- a/features/frameworks/greentea-client/source/test_env.cpp
+++ b/features/frameworks/greentea-client/source/test_env.cpp
@@ -57,6 +57,7 @@ static void greentea_notify_timeout(const int);
 static void greentea_notify_hosttest(const char *);
 static void greentea_notify_completion(const int);
 static void greentea_notify_version();
+static void greentea_write_string(const char *str);
 
 /** \brief Handshake with host and send setup data (timeout and host test name)
  *  \details This function will send preamble to master.
@@ -72,6 +73,7 @@ void GREENTEA_SETUP(const int timeout, const char *host_test_name) {
 	char _value[48] = {0};
 	while (1) {
         greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+        greentea_write_string("mbedmbedmbedmbedmbedmbedmbedmbed\r\n");
         if (strcmp(_key, GREENTEA_TEST_ENV_SYNC) == 0) {
             // Found correct __sunc message
             greentea_send_kv(_key, _value);
@@ -207,6 +209,7 @@ inline void greentea_write_postamble()
 {
     greentea_serial->putc('}');
     greentea_serial->putc('}');
+    greentea_serial->putc('\r');
     greentea_serial->putc('\n');
 }
 


### PR DESCRIPTION
Notes:
* Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
* This is just a template, so feel free to use/remove the unnecessary things

## Description
Changes in greentea-client API to support uVisor standalone test framework. Enables PR https://github.com/ARMmbed/uvisor-tests-standalone/pull/2


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Related PRs
List related PRs against other branches:
https://github.com/ARMmbed/uvisor-tests-standalone/pull/2

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ ] Documentation


## Deploy notes
Notes regarding the deployment of this PR. These should note any
required changes in the build environment, tools, compilers, etc.


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.

