### PR TITLE
DISCO_L476VG: add SPI nicknames

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/PinNames.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/PinNames.h
@@ -182,6 +182,14 @@ typedef enum {
     USBTX = PD_5,
     USBRX = PD_6,
 
+    I2C_SCL     = PB_8,
+    I2C_SDA     = PB_9,
+    SPI_MOSI    = PA_7,
+    SPI_MISO    = PA_6,
+    SPI_SCK     = PA_5,
+    SPI_CS      = PA_4,
+    PWM_OUT     = PB_3,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;


### PR DESCRIPTION
## Description
Add usual definition as in other STM32 targets

## Status
READY