### PR TITLE
Remove "lib" and "lib64" from the mbed-OS .gitignore file: they do no…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@ var
 sdist
 develop-eggs
 .installed.cfg
-lib
-lib64
 
 # Installer logs
 pip-log.txt


### PR DESCRIPTION
## Description
The `.gitignore` file that arrives with mbed has `lib` in its list. The u-blox mbed platform we have just submitted a pull request for (#2705) has a set of files, in a tree that is provided to us, with a sub-directory named `lib` ('cos those files are considered part of a library). So this is a real pain for us: git entirely ignores changes in somewhat important files.

After discussion with @bridadan  and @screamerbg in issue #2706, this pull request is submitted to remove both `lib` and `lib64` from the git ignore list.