### PR TITLE
Fixing constant cleaning when compiling tests

### DIFF
--- a/docs/testing_mbed_OS_5.md
+++ b/docs/testing_mbed_OS_5.md
@@ -10,6 +10,7 @@ The way tests are run and compiled in mbed OS 5 is substantially different from 
     - [Test names](#test-names)
   - [Building tests](#building-tests)
     - [Building process](#building-process)
+    - [App config](#app-config)
   - [Running tests](#running-tests)
   - [Writing tests](#writing-tests)
 - [Debugging tests](#debugging-tests)
@@ -72,6 +73,12 @@ The full build process is:
 1. Find all tests that match the given target and toolchain.
 1. For each discovered test, build all of its source files and link it with the non-test code that was built in step 1.
 1. If specified, create a test specification file and place it in the given directory for use by testing tools. This is placed in the build directory by default when using mbed CLI.
+
+#### App config
+
+When building an mbed application, the presence of a `mbed_app.json` file allows you to set or override different config settings from libraries and targets. However, because the tests share a common build, this can cause issues when tests have different configurations that affect the OS.
+
+If you need to use app config, this must be set via the `--app-config` option when calling `mbed test`. **If this option is not specified, the build system will ignore all `mbed_app.json` files and use the default config values.**
 
 ### Running tests
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -121,6 +121,15 @@ if __name__ == '__main__':
                                "Currently set search path: %s"
                        % (toolchain, search_path))
 
+        # App config
+        # Disable finding `mbed_app.json` files in the source tree if not
+        # explicitly defined on the command line. Config system searches for
+        # `mbed_app.json` files if `app_config` is None, but will set the
+        # app config data to an empty dictionary if the path value is another
+        # falsey value besides None.
+        if options.app_config is None:
+            options.app_config = ''
+
         # Find all tests in the relevant paths
         for path in all_paths:
             all_tests.update(find_tests(path, mcu, toolchain, options.options,
@@ -184,7 +193,6 @@ if __name__ == '__main__':
                                                 verbose=options.verbose,
                                                 notify=notify,
                                                 archive=False,
-                                                remove_config_header_file=True,
                                                 app_config=options.app_config)
 
                 library_build_success = True


### PR DESCRIPTION
This PR was spurred in response to https://github.com/ARMmbed/mbed-cli/issues/344, however it has larger implications to make the implementation cleaner and to provide a more consistent experience when building tests.

## Description
This addresses the issue where building tests via test.py always triggered
a clean build. This is because the mbed_config.h file was being deleted from
the shared OS build to ensure that the correct config was always being
used. However, this constantly triggered a rebuild of the OS since the
config file was not present.

Due to the shared build, having multiple app configurations that could
override the OS settings is not possible. For this reason, we now ignore
app config files unless explicitly set via the command line option
'--app-config'. Though there will now be two mbed_config.h files in the
include path of the build, it shouldn't matter since the contents will be
the same.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

YES (potentially, pending feedback from @AlessandroA)

@AlessandroA from the conversation we had on https://github.com/ARMmbed/mbed-os/issues/2397, it seemed like you were going to be using `mbed_app.json` files in each test case folder to get configuration for tests. Would this PR break your tests? Or are you already using the `--app_config` option for `mbed test`? In that case, this PR shouldn't affect your workflow.


## Todos
- [x] Tests
- [x] Review by @AlessandroA
- [x] Review by @bogdanm 
- [x] Review by @theotherjimmy  

Also, @sg- we discussed this offline but if you have a moment, would confirm the strategy I implemented here is consistent with what you had in mind?

