### PR TITLE
Allow the trace output by mbed error to be conditional of NDEBUG.

### DIFF
--- a/hal/common/mbed_error.c
+++ b/hal/common/mbed_error.c
@@ -24,9 +24,11 @@
 #endif
 
 WEAK void error(const char* format, ...) {
+#ifndef NDEBUG
     va_list arg;
     va_start(arg, format);
     mbed_error_vfprintf(format, arg);
     va_end(arg);
+#endif
     exit(1);
 }


### PR DESCRIPTION
This change disable any trace output by `error` when the application is compiled with `NDEBUG`.

Unlike `assert`, `error` will still crash/halt the execution of the application even if `NDEBUG` is enabled.
In that regard, its core behavior is preserved. 

This change avoid the inclusion of `printf` and friends code in a binary when it is compiled with the macro `NDEBUG` enabled because a lot of driver code use `error` rather than `assert`.

The memory gain is non negligible: This is the differences with and without this change  when [mbed-os-example-blinky](https://github.com/ARMmbed/mbed-os-example-blinky) is compilef with NDEBUG enabled.
- Without the patch:

|  | GCC | ARMCC | IAR |
| --- | --- | --- | --- |
| RAM | 11832 | 10152 | 7970 |
| ROM | 37008 | 26868 | 21266 |
- With the patch:

|  | GCC | ARMCC | IAR |
| --- | --- | --- | --- |
| RAM | 11808 | 10152 | 7834 |
| ROM | 19852 | 20239 | 14600 |
- Difference

|  | GCC | ARMCC | IAR |
| --- | --- | --- | --- |
| RAM | -24 bytes (-0.2%) | 0 bytes (0%) | -136 bytes (-1.70%) |
| ROM | -17156 bytes (-46.3%) | -6629 bytes (-24.7%) | ROM: -6666 bytes (-31.3%) |
