### PR TITLE
Updated ARM linker scripts for Kinetis platforms that use SDK 2.0

### DIFF
--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K22F/TOOLCHAIN_ARM_STD/MK22FN512xxx12.sct
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K22F/TOOLCHAIN_ARM_STD/MK22FN512xxx12.sct
@@ -3,19 +3,20 @@
 ** ###################################################################
 **     Processors:          MK22FN512CAP12
 **                          MK22FN512VDC12
+**                          MK22FN512VFX12
 **                          MK22FN512VLH12
 **                          MK22FN512VLL12
 **                          MK22FN512VMP12
 **
 **     Compiler:            Keil ARM C/C++ Compiler
 **     Reference manual:    K22P121M120SF7RM, Rev. 1, March 24, 2014
-**     Version:             rev. 2.8, 2015-02-19
-**     Build:               b151009
+**     Version:             rev. 2.9, 2016-03-21
+**     Build:               b160406
 **
 **     Abstract:
 **         Linker file for the Keil ARM C/C++ Compiler
 **
-**     Copyright (c) 2015 Freescale Semiconductor, Inc.
+**     Copyright (c) 2016 Freescale Semiconductor, Inc.
 **     All rights reserved.
 **
 **     Redistribution and use in source and binary forms, with or without modification,
@@ -50,6 +51,10 @@
 */
 #define __ram_vector_table__            1
 
+/* Heap 1/4 of ram and stack 1/8 */
+#define __stack_size__       0x4000
+#define __heap_size__        0x8000
+
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x00000400
 #else
@@ -74,25 +79,45 @@
 #define m_data_2_start                 0x20000000
 #define m_data_2_size                  0x00010000
 
+/* Sizes */
+#if (defined(__stack_size__))
+  #define Stack_Size                   __stack_size__
+#else
+  #define Stack_Size                   0x0400
+#endif
 
-LR_m_text m_interrupts_start m_text_size+m_interrupts_size+m_flash_config_size {   ; load region size_region
+#if (defined(__heap_size__))
+  #define Heap_Size                    __heap_size__
+#else
+  #define Heap_Size                    0x0400
+#endif
+
+LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
-  ER_m_flash_config m_flash_config_start m_flash_config_size { ; load address = execution address
+  ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
   ER_m_text m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }
+
+#if (defined(__ram_vector_table__))
+  VECTOR_RAM m_interrupts_ram_start EMPTY m_interrupts_ram_size {
+  }
+#else
+  VECTOR_RAM m_interrupts_start EMPTY 0 {
+  }
+#endif
   RW_m_data m_data_start m_data_size { ; RW data
     .ANY (+RW +ZI)
   }
-  RW_IRAM1 m_data_2_start m_data_2_size { ; RW data
+  RW_m_data_2 m_data_2_start m_data_2_size-Stack_Size-Heap_Size { ; RW data
     .ANY (+RW +ZI)
   }
-  VECTOR_RAM m_interrupts_ram_start EMPTY m_interrupts_ram_size {
+  RW_IRAM1 ImageLimit(RW_m_data_2) { ; Heap region growing up
   }
 }
 

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K66F/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K66F/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
@@ -7,12 +7,12 @@
 **     Compiler:            Keil ARM C/C++ Compiler
 **     Reference manual:    K66P144M180SF5RMV2, Rev. 1, Mar 2015
 **     Version:             rev. 3.0, 2015-03-25
-**     Build:               b151009
+**     Build:               b160406
 **
 **     Abstract:
 **         Linker file for the Keil ARM C/C++ Compiler
 **
-**     Copyright (c) 2015 Freescale Semiconductor, Inc.
+**     Copyright (c) 2016 Freescale Semiconductor, Inc.
 **     All rights reserved.
 **
 **     Redistribution and use in source and binary forms, with or without modification,
@@ -47,6 +47,10 @@
 */
 #define __ram_vector_table__            1
 
+/* Heap 1/4 of ram and stack 1/8 */
+#define __stack_size__       0x8000
+#define __heap_size__        0x10000
+
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x00000400
 #else
@@ -71,24 +75,44 @@
 #define m_data_2_start                 0x20000000
 #define m_data_2_size                  0x00030000
 
+/* Sizes */
+#if (defined(__stack_size__))
+  #define Stack_Size                   __stack_size__
+#else
+  #define Stack_Size                   0x0400
+#endif
 
-LR_m_text m_interrupts_start m_text_size+m_interrupts_size+m_flash_config_size {   ; load region size_region
+#if (defined(__heap_size__))
+  #define Heap_Size                    __heap_size__
+#else
+  #define Heap_Size                    0x0400
+#endif
+
+LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
-  ER_m_flash_config m_flash_config_start m_flash_config_size { ; load address = execution address
+  ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
   ER_m_text m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }
+
+#if (defined(__ram_vector_table__))
+  VECTOR_RAM m_interrupts_ram_start EMPTY m_interrupts_ram_size {
+  }
+#else
+  VECTOR_RAM m_interrupts_start EMPTY 0 {
+  }
+#endif
   RW_m_data m_data_start m_data_size { ; RW data
     .ANY (+RW +ZI)
   }
-  RW_IRAM1 m_data_2_start m_data_2_size { ; RW data
+  RW_m_data_2 m_data_2_start m_data_2_size-Stack_Size-Heap_Size { ; RW data
     .ANY (+RW +ZI)
   }
-  VECTOR_RAM m_interrupts_ram_start EMPTY m_interrupts_ram_size {  
+  RW_IRAM1 ImageLimit(RW_m_data_2) { ; Heap region growing up
   }
 }

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_KL27Z/TOOLCHAIN_ARM_STD/MKL27Z64xxx4.sct
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_KL27Z/TOOLCHAIN_ARM_STD/MKL27Z64xxx4.sct
@@ -110,7 +110,7 @@ LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; l
   RW_m_data m_data_start m_data_size-Stack_Size-Heap_Size { ; RW data
     .ANY (+RW +ZI)
   }
-  RW_IRAM1 +0 EMPTY Heap_Size { ; RW data
+  RW_IRAM1 +0 { ; Heap region growing up
   }
 }
 

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_KL43Z/TOOLCHAIN_ARM_STD/MKL43Z256xxx4.sct
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_KL43Z/TOOLCHAIN_ARM_STD/MKL43Z256xxx4.sct
@@ -107,7 +107,7 @@ LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; loa
   RW_m_data m_data_start m_data_size-Stack_Size-Heap_Size { ; RW data
     .ANY (+RW +ZI)
   }
-  RW_IRAM1 +0 EMPTY Heap_Size {    ; Heap region growing up
+  RW_IRAM1 +0 {    ; Heap region growing up
   }
 }
 

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_MCU_K64F/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_MCU_K64F/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
@@ -1,20 +1,21 @@
 #! armcc -E
 /*
 ** ###################################################################
-**     Processors:          MK64FN1M0VDC12
+**     Processors:          MK64FN1M0CAJ12
+**                          MK64FN1M0VDC12
 **                          MK64FN1M0VLL12
 **                          MK64FN1M0VLQ12
 **                          MK64FN1M0VMD12
 **
 **     Compiler:            Keil ARM C/C++ Compiler
 **     Reference manual:    K64P144M120SF5RM, Rev.2, January 2014
-**     Version:             rev. 2.8, 2015-02-19
-**     Build:               b151009
+**     Version:             rev. 2.9, 2016-03-21
+**     Build:               b160406
 **
 **     Abstract:
 **         Linker file for the Keil ARM C/C++ Compiler
 **
-**     Copyright (c) 2015 Freescale Semiconductor, Inc.
+**     Copyright (c) 2016 Freescale Semiconductor, Inc.
 **     All rights reserved.
 **
 **     Redistribution and use in source and binary forms, with or without modification,
@@ -49,6 +50,10 @@
 */
 #define __ram_vector_table__            1
 
+/* Heap 1/4 of ram and stack 1/8 */
+#define __stack_size__       0x8000
+#define __heap_size__        0x10000
+
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x00000400
 #else
@@ -73,24 +78,44 @@
 #define m_data_2_start                 0x20000000
 #define m_data_2_size                  0x00030000
 
+/* Sizes */
+#if (defined(__stack_size__))
+  #define Stack_Size                   __stack_size__
+#else
+  #define Stack_Size                   0x0400
+#endif
 
-LR_m_text m_interrupts_start m_text_size+m_interrupts_size+m_flash_config_size {   ; load region size_region
+#if (defined(__heap_size__))
+  #define Heap_Size                    __heap_size__
+#else
+  #define Heap_Size                    0x0400
+#endif
+
+LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
-  ER_m_flash_config m_flash_config_start m_flash_config_size { ; load address = execution address
+  ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
   ER_m_text m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }
+
+#if (defined(__ram_vector_table__))
+  VECTOR_RAM m_interrupts_ram_start EMPTY m_interrupts_ram_size {
+  }
+#else
+  VECTOR_RAM m_interrupts_start EMPTY 0 {
+  }
+#endif
   RW_m_data m_data_start m_data_size { ; RW data
     .ANY (+RW +ZI)
   }
-  RW_IRAM1 m_data_2_start m_data_2_size { ; RW data
+  RW_m_data_2 m_data_2_start m_data_2_size-Stack_Size-Heap_Size { ; RW data
     .ANY (+RW +ZI)
   }
-  VECTOR_RAM m_interrupts_ram_start EMPTY m_interrupts_ram_size {
+  RW_IRAM1 ImageLimit(RW_m_data_2) { ; Heap region growing up
   }
 }


### PR DESCRIPTION
## Description
1. This fixes a gap introduced in the memory map of ARMCC toolchain saved of the HEAP. Heap space is allocated at run time inside sys.cpp.
2. Updated to the latest scripts

## Status
**READY

## Todos
- [x] Tests : Ran all mbed tests.

1. Fix Heap start address
2. Update to the latest script provided by the Kinetis SDK team

Signed-off-by: Mahadevan Mahesh <Mahesh.Mahadevan@nxp.com>