### PR TITLE
lwip - Fixed error code on disconnect TCP socket

### DIFF
--- a/features/net/FEATURE_IPV4/lwip-interface/lwip_stack.c
+++ b/features/net/FEATURE_IPV4/lwip-interface/lwip_stack.c
@@ -194,11 +194,12 @@ void lwip_bringdown(void)
 static int lwip_err_remap(err_t err) {
     switch (err) {
         case ERR_OK:
+        case ERR_CLSD:
+        case ERR_RST:
             return 0;
         case ERR_MEM:
             return NSAPI_ERROR_NO_MEMORY;
         case ERR_CONN:
-        case ERR_CLSD:
             return NSAPI_ERROR_NO_CONNECTION;
         case ERR_TIMEOUT:
         case ERR_RTE:
@@ -353,7 +354,7 @@ static int lwip_socket_recv(nsapi_stack_t *stack, nsapi_socket_t handle, void *d
         s->offset = 0;
 
         if (err != ERR_OK) {
-            return (err == ERR_CLSD) ? 0 : lwip_err_remap(err);
+            return lwip_err_remap(err);
         }
     }
 


### PR DESCRIPTION
Fixed to return 0 on successful shutdown

should resolve https://github.com/ARMmbed/mbed-os/issues/2554
cc @infinnovation