### PR TITLE
KSDK serial_api.c: Fix assertion error for ParityEven

### DIFF
--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K22F/serial_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K22F/serial_api.c
@@ -98,6 +98,8 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
         temp |= (UART_C1_PE_MASK | UART_C1_M_MASK);
         if (parity == ParityOdd) {
             temp |= UART_C1_PT_MASK;
+        } else if (parity == ParityEven) {
+            // PT=0 so nothing more to do
         } else {
             // Hardware does not support forced parity
             MBED_ASSERT(0);

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL27Z/serial_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL27Z/serial_api.c
@@ -103,6 +103,8 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
         temp |= (LPUART_CTRL_PE_MASK | LPUART_CTRL_M_MASK);
         if (parity == ParityOdd) {
             temp |= LPUART_CTRL_PT_MASK;
+        } else if (parity == ParityEven) {
+            // PT=0 so nothing more to do
         } else {
             // Hardware does not support forced parity
             MBED_ASSERT(0);

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL43Z/serial_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL43Z/serial_api.c
@@ -103,6 +103,8 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
         temp |= (LPUART_CTRL_PE_MASK | LPUART_CTRL_M_MASK);
         if (parity == ParityOdd) {
             temp |= LPUART_CTRL_PT_MASK;
+        } else if (parity == ParityEven) {
+            // PT=0 so nothing more to do
         } else {
             // Hardware does not support forced parity
             MBED_ASSERT(0);


### PR DESCRIPTION
## Description
Prevent assertion error for even parity on KL27, KL43 and K22 platforms. This fix was added to the K64 platform.

## Status
**READY

