### PR TITLE
Serial init timeout: increase default value

### DIFF
--- a/tools/tests.py
+++ b/tools/tests.py
@@ -1192,7 +1192,7 @@ class Test:
         #'mcu': None,
         'description': None,
         'dependencies': None,
-        'duration': 10,
+        'duration': 20,
         'host_test': 'host_test',
         'automated': False,
         'peripherals': None,


### PR DESCRIPTION
## Description
It seems that my test bench is very slow...
I need to increase the timeout value in order to get the port ready...

## Status
READY
