### PR TITLE
Added ethernet and enabled IPV4 feature for the EVK-ODIN-W2/C029 target

### DIFF
--- a/features/net/FEATURE_IPV4/lwip-interface/lwip-eth/arch/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C029/stm32f4_eth_init.c
+++ b/features/net/FEATURE_IPV4/lwip-interface/lwip-eth/arch/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C029/stm32f4_eth_init.c
@@ -1,0 +1,86 @@
+#include "stm32f4xx_hal.h"
+
+/**
+ * Override HAL Eth Init function
+ */
+void HAL_ETH_MspInit(ETH_HandleTypeDef* heth)
+{
+    GPIO_InitTypeDef GPIO_InitStructure;
+    if (heth->Instance == ETH) {
+
+        /* Enable GPIOs clocks */
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+
+        /** ETH GPIO Configuration
+          RMII_REF_CLK ----------------------> PA1
+          RMII_MDIO -------------------------> PA2
+          RMII_MDC --------------------------> PC1
+          RMII_MII_CRS_DV -------------------> PA7
+          RMII_MII_RXD0 ---------------------> PC4
+          RMII_MII_RXD1 ---------------------> PC5
+          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_TX_EN --------------------> PB11
+          RMII_MII_TXD0 ---------------------> PB12
+          RMII_MII_TXD1 ---------------------> PB13
+         */
+        /* Configure PA1, PA2 and PA7 */       
+        GPIO_InitStructure.Speed = GPIO_SPEED_HIGH;
+        GPIO_InitStructure.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStructure.Pull = GPIO_PULLUP;
+        GPIO_InitStructure.Pin = GPIO_PIN_2 | GPIO_PIN_7;
+        GPIO_InitStructure.Alternate = GPIO_AF11_ETH;
+        HAL_GPIO_Init(GPIOA, &GPIO_InitStructure);
+        
+        GPIO_InitStructure.Pull = GPIO_NOPULL;
+        GPIO_InitStructure.Pin = GPIO_PIN_1;
+        HAL_GPIO_Init(GPIOA, &GPIO_InitStructure);
+
+        /* Configure PB13 */
+	    GPIO_InitStructure.Pin = GPIO_PIN_13 | GPIO_PIN_11 | GPIO_PIN_12;
+        HAL_GPIO_Init(GPIOB, &GPIO_InitStructure);
+
+        /* Configure PC1, PC4 and PC5 */
+        GPIO_InitStructure.Pin = GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5;
+	    HAL_GPIO_Init(GPIOC, &GPIO_InitStructure);
+
+
+        /* Enable the Ethernet global Interrupt */
+        HAL_NVIC_SetPriority(ETH_IRQn, 0x7, 0);
+        HAL_NVIC_EnableIRQ(ETH_IRQn);
+        
+        /* Enable ETHERNET clock  */
+        __HAL_RCC_ETH_CLK_ENABLE();
+    }
+}
+
+/**
+ * Override HAL Eth DeInit function
+ */
+void HAL_ETH_MspDeInit(ETH_HandleTypeDef* heth)
+{
+    if (heth->Instance == ETH) {
+        /* Peripheral clock disable */
+        __HAL_RCC_ETH_CLK_DISABLE();
+
+        /** ETH GPIO Configuration
+          RMII_REF_CLK ----------------------> PA1
+          RMII_MDIO -------------------------> PA2
+          RMII_MDC --------------------------> PC1
+          RMII_MII_CRS_DV -------------------> PA7
+          RMII_MII_RXD0 ---------------------> PC4
+          RMII_MII_RXD1 ---------------------> PC5
+          RMII_MII_RXER ---------------------> PG2
+          RMII_MII_TX_EN --------------------> PB11
+          RMII_MII_TXD0 ---------------------> PB12
+          RMII_MII_TXD1 ---------------------> PB13
+         */
+        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_1 | GPIO_PIN_2 | GPIO_PIN_7);
+        HAL_GPIO_DeInit(GPIOB, GPIO_PIN_13 | GPIO_PIN_11 | GPIO_PIN_12);
+        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5);
+
+        /* Disable the Ethernet global Interrupt */
+        NVIC_DisableIRQ(ETH_IRQn);
+    }
+}

--- a/features/net/FEATURE_IPV4/lwip-interface/lwip-eth/arch/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C029/stm32f4_eth_init.c
+++ b/features/net/FEATURE_IPV4/lwip-interface/lwip-eth/arch/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C029/stm32f4_eth_init.c
@@ -1,15 +1,16 @@
 #include <string.h>
 #include "stm32f4xx_hal.h"
+#include "toolchain.h"
 
 #define C029_OTP_START_ADDRESS           (0x1FFF7800U)
 #define C029_OTP_END_ADDRESS             (C029_OTP_START_ADDRESS + (16*32))
 #define C029_MAC_ETHERNET_ID             (3)
 
-typedef struct C029_OTP_Header {
+typedef MBED_PACKED(struct) C029_OTP_Header {
     uint8_t id;
     uint8_t len;
     uint8_t data[];
-} __attribute__((__packed__)) C029_OTP_Header;
+} C029_OTP_Header;
 
 static int _macRetrieved = 0;
 static char _macAddr[6] = { 0x02, 0x02, 0xF7, 0xF0, 0x00, 0x00 };

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1203,6 +1203,7 @@
         "macros": ["HSE_VALUE=24000000", "HSE_STARTUP_TIMEOUT=5000", "CB_INTERFACE_SDIO","CB_CHIP_WL18XX","SUPPORT_80211D_ALWAYS","WLAN_ENABLED"],
         "inherits": ["Target"],
         "device_has": ["ANALOGIN", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "features": ["IPV4"],
         "release_versions": ["5"]
     },
     "NZ32_SC151": {


### PR DESCRIPTION
## Test results
Note that the test station could not be connected to the same network as the IUT which resulted in two IPV4 tests failing.

```
+--------------------+---------------+------------------------------------------------------------------------------+---------+--------------------+-------------+
| target             | platform_name | test suite                                                                   | result  | elapsed_time (sec) | copy_method |
+--------------------+---------------+------------------------------------------------------------------------------+---------+--------------------+-------------+
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-frameworks-utest-tests-unit_tests-basic_test                        | OK      | 9.05               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-frameworks-utest-tests-unit_tests-basic_test_default                | OK      | 9.02               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-frameworks-utest-tests-unit_tests-case_async_validate               | OK      | 10.76              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-frameworks-utest-tests-unit_tests-case_control_async                | OK      | 16.95              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-frameworks-utest-tests-unit_tests-case_control_repeat               | OK      | 11.04              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-frameworks-utest-tests-unit_tests-case_selection                    | OK      | 8.86               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-frameworks-utest-tests-unit_tests-case_setup_failure                | OK      | 9.59               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-frameworks-utest-tests-unit_tests-case_teardown_failure             | OK      | 9.67               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-frameworks-utest-tests-unit_tests-control_type                      | OK      | 9.68               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-frameworks-utest-tests-unit_tests-minimal_async_scheduler           | OK      | 9.8                | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-frameworks-utest-tests-unit_tests-minimal_scheduler                 | OK      | 10.51              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-frameworks-utest-tests-unit_tests-test_assertion_failure_test_setup | OK      | 8.74               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-frameworks-utest-tests-unit_tests-test_setup_case_selection_failure | OK      | 8.86               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-frameworks-utest-tests-unit_tests-test_setup_failure                | OK      | 8.87               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-net-feature_ipv4-tests-mbedmicro-net-nist_internet_time_service     | OK      | 12.8               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-net-feature_ipv4-tests-mbedmicro-net-tcp_client_echo                | TIMEOUT | 29.89              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-net-feature_ipv4-tests-mbedmicro-net-tcp_client_hello_world         | OK      | 13.99              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | features-net-feature_ipv4-tests-mbedmicro-net-udp_echo_client                | TIMEOUT | 29.71              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | rtos-rtx-target_cortex_m-tests-memory-heap_and_stack                         | OK      | 8.37               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-integration-basic                                                      | OK      | 8.16               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbed_drivers-c_strings                                                 | OK      | 10.92              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbed_drivers-dev_null                                                  | OK      | 11.01              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbed_drivers-echo                                                      | OK      | 19.84              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbed_drivers-generic_tests                                             | OK      | 9.58               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbed_drivers-race_test                                                 | OK      | 10.27              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbed_drivers-rtc                                                       | OK      | 19.16              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbed_drivers-stl_features                                              | OK      | 10.24              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbed_drivers-ticker                                                    | OK      | 42.17              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbed_drivers-timeout                                                   | OK      | 19.64              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbed_drivers-wait_us                                                   | OK      | 19.7               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbed_functional-callback                                               | OK      | 10.36              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbed_functional-callback_big                                           | OK      | 10.4               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbed_functional-callback_small                                         | OK      | 10.46              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbed_functional-functionpointer                                        | OK      | 9.04               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbedmicro-mbed-attributes                                              | OK      | 10.75              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbedmicro-mbed-call_before_main                                        | OK      | 8.27               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbedmicro-mbed-cpp                                                     | OK      | 8.53               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbedmicro-mbed-div                                                     | OK      | 8.39               | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbedmicro-rtos-mbed-basic                                              | OK      | 19.22              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbedmicro-rtos-mbed-isr                                                | OK      | 13.64              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbedmicro-rtos-mbed-mail                                               | OK      | 10.14              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbedmicro-rtos-mbed-malloc                                             | OK      | 23.23              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbedmicro-rtos-mbed-mutex                                              | OK      | 18.61              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbedmicro-rtos-mbed-queue                                              | OK      | 10.03              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbedmicro-rtos-mbed-semaphore                                          | OK      | 15.75              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbedmicro-rtos-mbed-signals                                            | OK      | 13.46              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbedmicro-rtos-mbed-threads                                            | OK      | 14.53              | shell       |
| UBLOX_C029-GCC_ARM | UBLOX_C029    | tests-mbedmicro-rtos-mbed-timer                                              | OK      | 19.21              | shell       |
+--------------------+---------------+------------------------------------------------------------------------------+---------+--------------------+-------------+
mbedgt: test suite results: 46 OK / 2 TIMEOUT

```