### PR TITLE
Fix signed/unsigned comparison warning in SerialBase.cpp

### DIFF
--- a/hal/common/SerialBase.cpp
+++ b/hal/common/SerialBase.cpp
@@ -31,7 +31,7 @@ SerialBase::SerialBase(PinName tx, PinName rx) :
                                                 _serial(), _baud(9600) {
     // No lock needed in the constructor
 
-    for (int i = 0; i < sizeof _irq / sizeof _irq[0]; i++) {
+    for (size_t i = 0; i < sizeof _irq / sizeof _irq[0]; i++) {
         _irq[i].attach(donothing);
     }
 


### PR DESCRIPTION
Notes:
* Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
* This is just a template, so feel free to use/remove the unnecessary things

## Description
Fix signed/unsigned comparison warning in SerialBase.cpp

Silence the following compiler warning:

Compile: SerialBase.cpp
[Warning] SerialBase.cpp@34,23: comparison between signed and unsigned integer expressions [-Wsign-compare]

## Status
READY

## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO

## Related PRs
List related PRs against other branches:

## Todos

## Deploy notes

## Steps to test or reproduce
mbed compile -m K64F -t GCC_ARM
