### PR TITLE
Fixing archived library builds for IAR

### DIFF
--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -16,7 +16,7 @@ limitations under the License.
 """
 import re
 from os import remove
-from os.path import join, splitext
+from os.path import join, splitext, exists
 
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool


### PR DESCRIPTION
## Description
There is a missing import statement for os.path.exists in the IAR toolchain script. This adds it back in.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO

## Todos
- [ ] Tests
- [ ] Documentation


## Deploy notes
Notes regarding the deployment of this PR. These should note any
required changes in the build environment, tools, compilers, etc.


## Steps to test or reproduce
If you currently run `python tools/build.py -m LPC1768 -t IAR`, it will fail with the error `global name 'exists' is not defined`.

