### PR TITLE
Add configuration for IO flushing during exit.

### DIFF
--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -609,8 +609,10 @@ extern "C" void exit(int return_code) {
 #endif
 
 #if DEVICE_STDIO_MESSAGES
+#if MBED_CONF_CORE_STDIO_FLUSH_AT_EXIT
     fflush(stdout);
     fflush(stderr);
+#endif
 #endif
 
 #if DEVICE_SEMIHOST

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -9,6 +9,11 @@
         "stdio-baud-rate": {
             "help": "Baud rate for stdio",
             "value": 9600
+        },
+
+        "stdio-flush-at-exit": {
+            "help": "Enable or disable the flush of standard I/O's at exit.",
+            "value": true
         }
     }
 }


### PR DESCRIPTION
## Description

This PR allows application to enable or disable the flush of standard I/O's when `exit` is called. 
This change can save a lot of space for applications which don't use standard stream because even if `NDEBUG` is enabled, a lot of the I/O subsystem is stilled pulled when the exit function invoke `fflush` over standard streams.

By default, the streams are still flushed but the user can override this behavior in the configuration file: 

``` json
{
        "target_overrides": {
                "*": {
                        "core.stdio-flush-at-exit": false
                }
        }
}
```
## Related PRs

With #2715, this PR allows user to completely remove the IO subsystem from their application.
## Gain:

The test have been conducted upon [mbed-os-example-blinky](https://github.com/ARMmbed/mbed-os-example-blinky) compiled with NDEBUG enabled.
- Without the patch: 

|  | GCC | ARMCC | IAR |
| --- | --- | --- | --- |
| RAM | 11832 | 10152 | 7970 |
| ROM | 37008 | 26868 | 21266 |
- With this patch and #2715:

|  | GCC | ARMCC | IAR |
| --- | --- | --- | --- |
| RAM | 11288 bytes | 8020 bytes | 7350 bytes |
| ROM | 16640 bytes | 12686 bytes | 12398 bytes |
- Difference: 

|  | GCC | ARMCC | IAR |
| --- | --- | --- | --- |
| RAM | -544 bytes (4.6%) | -2132 bytes (-21%) | -620 bytes (7.8%) |
| ROM | -20368 bytes (-55%) | -14686 bytes (-52.8%) | -8868 bytes (-41.7%) |
