### PR TITLE
FEATURE_IPV4/TESTS: result status could be wrong

### DIFF
--- a/features/net/FEATURE_IPV4/TESTS/mbedmicro-net/tcp_client_hello_world/main.cpp
+++ b/features/net/FEATURE_IPV4/TESTS/mbedmicro-net/tcp_client_hello_world/main.cpp
@@ -75,8 +75,7 @@ int main() {
         printf("HTTP: Received message:\r\n");
         printf("%s", buffer);
         sock.close();
-    }
-    else {
+    } else {
         printf("HTTP: ERROR\r\n");
     }
 

--- a/features/net/FEATURE_IPV4/TESTS/mbedmicro-net/tcp_client_hello_world/main.cpp
+++ b/features/net/FEATURE_IPV4/TESTS/mbedmicro-net/tcp_client_hello_world/main.cpp
@@ -35,15 +35,16 @@ bool find_substring(const char *first, const char *last, const char *s_first, co
 int main() {
     GREENTEA_SETUP(20, "default_auto");
 
-    bool result = true;
+    bool result = false;
     EthernetInterface eth;
     //eth.init(); //Use DHCP
     eth.connect();
     printf("TCP client IP Address is %s\r\n", eth.get_ip_address());
 
     TCPSocket sock(&eth);
+    printf("HTTP: Connection to %s:%d\r\n", HTTP_SERVER_NAME, HTTP_SERVER_PORT);
     if (sock.connect(HTTP_SERVER_NAME, HTTP_SERVER_PORT) == 0) {
-        printf("HTTP: Connected to %s:%d\r\n", HTTP_SERVER_NAME, HTTP_SERVER_PORT);
+        printf("HTTP: OK\r\n");
 
         // We are constructing GET command like this:
         // GET http://developer.mbed.org/media/uploads/mbed_official/hello.txt HTTP/1.0\n\n
@@ -66,17 +67,21 @@ int main() {
         TEST_ASSERT_TRUE(found_200_ok);
         TEST_ASSERT_TRUE(found_hello);
 
+        result = true;
         if (!found_200_ok) result = false;
         if (!found_hello) result = false;
 
         printf("HTTP: Received %d chars from server\r\n", ret);
         printf("HTTP: Received 200 OK status ... %s\r\n", found_200_ok ? "[OK]" : "[FAIL]");
         printf("HTTP: Received '%s' status ... %s\r\n", HTTP_HELLO_STR, found_hello ? "[OK]" : "[FAIL]");
-        printf("HTTP: Received massage:\r\n\r\n");
+        printf("HTTP: Received message:\r\n");
         printf("%s", buffer);
+		    sock.close();
+    }
+    else {
+        printf("HTTP: ERROR\r\n");
     }
 
-    sock.close();
     eth.disconnect();
     GREENTEA_TESTSUITE_RESULT(result);
 }

--- a/features/net/FEATURE_IPV4/TESTS/mbedmicro-net/tcp_client_hello_world/main.cpp
+++ b/features/net/FEATURE_IPV4/TESTS/mbedmicro-net/tcp_client_hello_world/main.cpp
@@ -67,16 +67,14 @@ int main() {
         TEST_ASSERT_TRUE(found_200_ok);
         TEST_ASSERT_TRUE(found_hello);
 
-        result = true;
-        if (!found_200_ok) result = false;
-        if (!found_hello) result = false;
+        if (found_200_ok && found_hello) result = true;
 
         printf("HTTP: Received %d chars from server\r\n", ret);
         printf("HTTP: Received 200 OK status ... %s\r\n", found_200_ok ? "[OK]" : "[FAIL]");
         printf("HTTP: Received '%s' status ... %s\r\n", HTTP_HELLO_STR, found_hello ? "[OK]" : "[FAIL]");
         printf("HTTP: Received message:\r\n");
         printf("%s", buffer);
-		    sock.close();
+        sock.close();
     }
     else {
         printf("HTTP: ERROR\r\n");

--- a/features/net/FEATURE_IPV4/TESTS/mbedmicro-net/udp_echo_client/main.cpp
+++ b/features/net/FEATURE_IPV4/TESTS/mbedmicro-net/udp_echo_client/main.cpp
@@ -33,7 +33,7 @@ int main() {
 
     greentea_send_kv("target_ip", eth.get_ip_address());
 
-    bool result = true;
+    bool result = false;
 
     char recv_key[] = "host_port";
     char ipbuf[60] = {0};
@@ -66,6 +66,8 @@ int main() {
             result = false;
             break;
         }
+
+        result = true;
     }
 
     sock.close();


### PR DESCRIPTION
## Description
result status should be set to false by default before starting test execution.

For ex, tcp_client_hello_world test case was always OK event if there is no HTTP connection server.

## Status
READY

