### PR TITLE
Disable global objects destruction

### DIFF
--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -629,6 +629,31 @@ extern "C" void exit(int return_code) {
 } //namespace std
 #endif
 
+#if defined(TOOLCHAIN_ARM)
+
+// This series of function disable the registration of global destructors
+// in a dynamic table which will be called when the application exit.
+// In mbed, program never exit properly, it dies.
+// More informations about this topic for ARMCC here:
+// http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/6449.html
+extern "C" {
+int __aeabi_atexit(void *object, void (*dtor)(void* /*this*/), void *handle) {
+    return 1;
+}
+
+int __cxa_atexit(void (*dtor)(void* /*this*/), void *object, void *handle) {
+    return 1;
+}
+
+void __cxa_finalize(void *handle) {
+}
+
+} // end of extern "C"
+
+
+#endif
+
+
 
 namespace mbed {
 

--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -629,7 +629,7 @@ extern "C" void exit(int return_code) {
 } //namespace std
 #endif
 
-#if defined(TOOLCHAIN_ARM)
+#if defined(TOOLCHAIN_ARM) || defined(TOOLCHAIN_GCC)
 
 // This series of function disable the registration of global destructors
 // in a dynamic table which will be called when the application exit.
@@ -650,6 +650,39 @@ void __cxa_finalize(void *handle) {
 
 } // end of extern "C"
 
+#endif
+
+
+#if defined(TOOLCHAIN_GCC)
+
+/*
+ * Depending on how newlib is  configured, it is often not enough to define
+ * __aeabi_atexit, __cxa_atexit and __cxa_finalize in order to override the
+ * behavior regarding the registration of handlers with atexit.
+ *
+ * To overcome this limitation, exit and atexit are overriden here.
+ */
+extern "C"{
+
+/**
+ * @brief Retarget of exit for GCC.
+ * @details Unlike the standard version, this function doesn't call any function
+ * registered with atexit before calling _exit.
+ */
+void __wrap_exit(int return_code) {
+    _exit(return_code);
+}
+
+/**
+ * @brief Retarget atexit from GCC.
+ * @details This function will always fail and never register any handler to be
+ * called at exit.
+ */
+int __wrap_atexit(void (*func)()) {
+    return 1;
+}
+
+}
 
 #endif
 

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -798,7 +798,6 @@ void pre_main(void) {
     singleton_mutex_id = osMutexCreate(osMutex(singleton_mutex));
     malloc_mutex_id = osMutexCreate(osMutex(malloc_mutex));
     env_mutex_id = osMutexCreate(osMutex(env_mutex));
-    atexit(__libc_fini_array);
     __libc_init_array();
     main(0, NULL);
 }

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -40,7 +40,8 @@ class GCC(mbedToolchain):
         'c': ["-std=gnu99"],
         'cxx': ["-std=gnu++98", "-fno-rtti", "-Wvla"],
         'ld': ["-Wl,--gc-sections", "-Wl,--wrap,main",
-            "-Wl,--wrap,_malloc_r", "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_calloc_r"],
+            "-Wl,--wrap,_malloc_r", "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_calloc_r",
+            "-Wl,--wrap,exit", "-Wl,--wrap,atexit"],
     }
 
     def __init__(self, target, options=None, notify=None, macros=None, silent=False, tool_path="", extra_verbose=False):

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -41,7 +41,7 @@ class IAR(mbedToolchain):
             "--diag_suppress=Pa050,Pa084,Pa093,Pa082"],
         'asm': [],
         'c': ["--vla"],
-        'cxx': ["--guard_calls"],
+        'cxx': ["--guard_calls", "--no_static_destruction"],
         'ld': ["--skip_dynamic_initialization", "--threaded_lib"],
     }
 


### PR DESCRIPTION
## Description

This pull request disable the destruction of global objects when exit is called. 
A different method is applied for each compiler: 
- IAR: use the compilation flag `--no_static_destruction`.
- ARMCC: override `__aeabi_atexit`, `__cxa_atexit` and `__cxa_finalize`. The methodology is explained [here](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/6449.html).
- GCC: For GCC it is a bit more complicated, depending on how it is compiled, it is possible or not to override the itanium abi calls. To ensure that the correct behavior is used, `exit` has been overridden to directly call `_exit` instead of calling in reverse order every function registered by `atexit`. In the meantime, `atexit` has been overridden to be a stub which does nothing. 
## Related PRs

This PR is a follow up of #2715 #2741 
## Gain:

The test have been conducted upon [mbed-os-example-blinky](https://github.com/ARMmbed/mbed-os-example-blinky) compiled with NDEBUG enabled.
- Without the patch: 

|  | GCC | ARMCC | IAR |
| --- | --- | --- | --- |
| RAM | 11832 | 10152 | 7970 |
| ROM | 37008 | 26868 | 21266 |
- With this patch #2715 and #2741 applied:

|  | GCC | ARMCC | IAR |
| --- | --- | --- | --- |
| RAM | 9236 bytes | 8020 bytes | 7350 bytes |
| ROM | 11480 bytes | 12686 bytes | 12398 bytes |
- Difference: 

|  | GCC | ARMCC | IAR |
| --- | --- | --- | --- |
| RAM | -2596 bytes (-21.94%) | -2132 bytes (-21%) | -620 bytes (7.8%) |
| ROM | -25528 bytes (-68.97%) | -14686 bytes (-52.8%) | -8868 bytes (-41.7%) |
