### PR TITLE
[LPC11U68] Fix pin interrupt select offset

### DIFF
--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC11U6X/gpio_irq_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC11U6X/gpio_irq_api.c
@@ -82,9 +82,12 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     /* Gets offset value for each port */
     uint32_t offset;
     switch ((pin >> PORT_SHIFT) & 0x3) {
-        case 0: offset = 0;  break; // PIO0[23:0]
-        case 1: offset = 24; break; // PIO1[31:0]
-        case 2: offset = 56; break; // PIO2[7:0]
+        case 0: offset = 0; // PIO0[23:0]
+                break;
+        case 1: offset = 24; // PIO1[31:0]
+                break;
+        case 2: offset = 56; // PIO2[7:0]
+                break;
     }
     /* Set the INTPIN number : offset + pin_number */
     LPC_SYSCON->PINTSEL[obj->ch] = (offset + ((pin >> PIN_SHIFT) & 0x1F));
@@ -96,14 +99,22 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     
     void (*channels_irq)(void) = NULL;
     switch (obj->ch) {
-        case 0: channels_irq = &gpio_irq0; break;
-        case 1: channels_irq = &gpio_irq1; break;
-        case 2: channels_irq = &gpio_irq2; break;
-        case 3: channels_irq = &gpio_irq3; break;
-        case 4: channels_irq = &gpio_irq4; break;
-        case 5: channels_irq = &gpio_irq5; break;
-        case 6: channels_irq = &gpio_irq6; break;
-        case 7: channels_irq = &gpio_irq7; break;
+        case 0: channels_irq = &gpio_irq0;
+                break;
+        case 1: channels_irq = &gpio_irq1;
+                break;
+        case 2: channels_irq = &gpio_irq2;
+                break;
+        case 3: channels_irq = &gpio_irq3;
+                break;
+        case 4: channels_irq = &gpio_irq4;
+                break;
+        case 5: channels_irq = &gpio_irq5;
+                break;
+        case 6: channels_irq = &gpio_irq6;
+                break;
+        case 7: channels_irq = &gpio_irq7;
+                break;
     }
     NVIC_SetVector((IRQn_Type)(PININT_IRQ + obj->ch), (uint32_t)channels_irq);
     NVIC_EnableIRQ((IRQn_Type)(PININT_IRQ + obj->ch));


### PR DESCRIPTION
## Description

This pull request fix an issue of InterruptIn failure in particular port (PIO2[7:0]) of the LPC11U68 platform.
A test code below didn't work properly (no interrupt occurred), because of wrong offset for PINTSEL register setting.

```
#include "mbed.h"

Serial pc(USBTX, USBRX);
DigitalOut myled(LED1);
DigitalOut green(LED2, 1);

InterruptIn in(D9); // PIO2_3

void func()
{
    green = !green;
}
    
int main()
{
    in.mode(PullUp);
    in.fall(&func);
    pc.printf("hello, mbed\n");
    while(1) {
        myled = 1;
        wait(0.7);
        myled = 0;
        wait(1.2);
    }
}
```

This PR made fix for offset calculation for PINTSEL register which is described as users manual as follows.

![lpc11u68_pintsel](https://cloud.githubusercontent.com/assets/4926755/18659814/fa0cd5f6-7f47-11e6-8d54-7f2fa83e65ed.jpg)


## Status
**READY**

## Related PRs

None

## Todos
- [x] Review

## Deploy notes
Notes regarding the deployment of this PR. These should note any
required changes in the build environment, tools, compilers, etc.

None

## Test result

```
Test summary:
+--------+----------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| Result | Target   | Toolchain | Test ID     | Test Description                      | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------+----------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| OK     | LPC11U68 | uARM      | DTCT_1      | Simple detect test                    |        0.51        |       10      |  1/1  |
| OK     | LPC11U68 | uARM      | EXAMPLE_1   | /dev/null                             |        3.53        |       20      |  1/1  |
| OK     | LPC11U68 | uARM      | MBED_10     | Hello World                           |        0.39        |       5       |  1/1  |
| OK     | LPC11U68 | uARM      | MBED_11     | Ticker Int                            |       11.38        |       15      |  1/1  |
| OK     | LPC11U68 | uARM      | MBED_12     | C++                                   |        1.37        |       10      |  1/1  |
| OK     | LPC11U68 | uARM      | MBED_16     | RTC                                   |        4.63        |       20      |  1/1  |
| OK     | LPC11U68 | uARM      | MBED_2      | stdio                                 |        0.8         |       20      |  1/1  |
| OK     | LPC11U68 | uARM      | MBED_23     | Ticker Int us                         |       11.36        |       15      |  1/1  |
| OK     | LPC11U68 | uARM      | MBED_24     | Timeout Int us                        |       11.64        |       15      |  1/1  |
| OK     | LPC11U68 | uARM      | MBED_25     | Time us                               |        11.4        |       15      |  1/1  |
| OK     | LPC11U68 | uARM      | MBED_26     | Integer constant division             |        1.38        |       20      |  1/1  |
| OK     | LPC11U68 | uARM      | MBED_34     | Ticker Two callbacks                  |        11.4        |       15      |  1/1  |
| FAIL   | LPC11U68 | uARM      | MBED_37     | Serial NC RX                          |        2.01        |       20      |  0/1  |
| FAIL   | LPC11U68 | uARM      | MBED_38     | Serial NC TX                          |        0.94        |       20      |  0/1  |
| OK     | LPC11U68 | uARM      | MBED_A1     | Basic                                 |        1.38        |       20      |  1/1  |
| OK     | LPC11U68 | uARM      | MBED_A21    | Call function before main (mbed_main) |        1.45        |       20      |  1/1  |
| OK     | LPC11U68 | uARM      | MBED_A9     | Serial Echo at 115200                 |        1.26        |       20      |  1/1  |
| OK     | LPC11U68 | uARM      | MBED_BUSOUT | BusOut                                |        2.31        |       15      |  1/1  |
+--------+----------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
Result: 2 FAIL / 16 OK

Completed in 152.19 sec

Test summary:
+--------+----------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| Result | Target   | Toolchain | Test ID     | Test Description                      | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------+----------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| OK     | LPC11U68 | GCC_CR    | DTCT_1      | Simple detect test                    |        0.51        |       10      |  1/1  |
| OK     | LPC11U68 | GCC_CR    | EXAMPLE_1   | /dev/null                             |        3.5         |       20      |  1/1  |
| OK     | LPC11U68 | GCC_CR    | MBED_10     | Hello World                           |        0.4         |       5       |  1/1  |
| OK     | LPC11U68 | GCC_CR    | MBED_11     | Ticker Int                            |       11.38        |       15      |  1/1  |
| OK     | LPC11U68 | GCC_CR    | MBED_12     | C++                                   |        1.4         |       10      |  1/1  |
| OK     | LPC11U68 | GCC_CR    | MBED_16     | RTC                                   |        4.64        |       20      |  1/1  |
| OK     | LPC11U68 | GCC_CR    | MBED_2      | stdio                                 |        0.78        |       20      |  1/1  |
| OK     | LPC11U68 | GCC_CR    | MBED_23     | Ticker Int us                         |       11.39        |       15      |  1/1  |
| OK     | LPC11U68 | GCC_CR    | MBED_24     | Timeout Int us                        |       11.91        |       15      |  1/1  |
| OK     | LPC11U68 | GCC_CR    | MBED_25     | Time us                               |        11.4        |       15      |  1/1  |
| OK     | LPC11U68 | GCC_CR    | MBED_26     | Integer constant division             |        1.41        |       20      |  1/1  |
| OK     | LPC11U68 | GCC_CR    | MBED_34     | Ticker Two callbacks                  |       11.39        |       15      |  1/1  |
| FAIL   | LPC11U68 | GCC_CR    | MBED_37     | Serial NC RX                          |        2.01        |       20      |  0/1  |
| FAIL   | LPC11U68 | GCC_CR    | MBED_38     | Serial NC TX                          |        0.92        |       20      |  0/1  |
| OK     | LPC11U68 | GCC_CR    | MBED_A1     | Basic                                 |        1.37        |       20      |  1/1  |
| OK     | LPC11U68 | GCC_CR    | MBED_A21    | Call function before main (mbed_main) |        1.44        |       20      |  1/1  |
| OK     | LPC11U68 | GCC_CR    | MBED_A9     | Serial Echo at 115200                 |        1.27        |       20      |  1/1  |
| OK     | LPC11U68 | GCC_CR    | MBED_BUSOUT | BusOut                                |        2.32        |       15      |  1/1  |
+--------+----------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
Result: 2 FAIL / 16 OK

Completed in 154.39 sec

```
