### PR TITLE
Add debug symbols to release builds

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -74,8 +74,8 @@ class ARM(mbedToolchain):
         if "save-asm" in self.options:
             self.flags['common'].extend(["--asm", "--interleave"])
 
+        self.flags['common'].extend(["--debug", "--dwarf3", "--no_debug_macros", "--remove_unneeded_entities"])
         if "debug-info" in self.options:
-            self.flags['common'].append("-g")
             self.flags['c'].append("-O0")
         else:
             self.flags['c'].append("-O3")

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -92,8 +92,8 @@ class GCC(mbedToolchain):
         if "save-asm" in self.options:
             self.flags["common"].append("-save-temps")
 
+        self.flags["common"].append("-g")
         if "debug-info" in self.options:
-            self.flags["common"].append("-g")
             self.flags["common"].append("-O0")
         else:
             self.flags["common"].append("-Os")

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -94,8 +94,8 @@ class IAR(mbedToolchain):
             asm_flags_cmd += ["--fpu", "VFPv5_sp"]
             c_flags_cmd.append("--fpu=VFPv5_sp")
 
+        c_flags_cmd.append("-r")
         if "debug-info" in self.options:
-            c_flags_cmd.append("-r")
             c_flags_cmd.append("-On")
         else:
             c_flags_cmd.append("-Oh")


### PR DESCRIPTION
Replaces #2139, adding more flags for ARMCC to make the output smaller, now it should be 2x bigger than usual (more info in the referenced pull request).

All toolchains now produces output folders with acceptable sizes. Please review

@bogdanm @sg- @meriac @bridadan @screamerbg 