### PR TITLE
Refactor Target and Config away from global variables

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -303,14 +303,8 @@ def prepare_toolchain(src_paths, target, toolchain_name,
     src_paths = [src_paths[0]] + list(set(src_paths[1:]))
 
     # If the configuration object was not yet created, create it now
-    config = config or Config(target, src_paths, app_config=app_config)
-
-    # If the 'target' argument is a string, convert it to a target instance
-    if isinstance(target, basestring):
-        try:
-            target = TARGET_MAP[target]
-        except KeyError:
-            raise KeyError("Target '%s' not found" % target)
+    config = config or Config(target, src_paths)
+    target = config.target
 
     # Toolchain instance
     try:

--- a/tools/config.py
+++ b/tools/config.py
@@ -15,12 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from copy import deepcopy
 import os
-import sys
-
 # Implementation of mbed configuration mechanism
 from tools.utils import json_file_to_dict
-from tools.targets import Target
+from tools.targets import CUMULATIVE_ATTRIBUTES, TARGET_MAP, \
+    generate_py_target, get_resolution_order
 
 # Base class for all configuration exceptions
 class ConfigException(Exception):
@@ -350,7 +350,7 @@ class Config(object):
         "UVISOR", "BLE", "CLIENT", "IPV4", "IPV6", "COMMON_PAL", "STORAGE"
     ]
 
-    def __init__(self, target, top_level_dirs=None, app_config=None):
+    def __init__(self, tgt, top_level_dirs=None, app_config=None):
         """Construct a mbed configuration
 
         Positional arguments:
@@ -397,16 +397,23 @@ class Config(object):
         self.lib_config_data = {}
         # Make sure that each config is processed only once
         self.processed_configs = {}
-        self.target = target if isinstance(target, basestring) else target.name
-        self.target_labels = Target.get_target(self.target).get_labels()
+        if isinstance(tgt, basestring):
+            if tgt in TARGET_MAP:
+                self.target = TARGET_MAP[tgt]
+            else:
+                self.target = generate_py_target(
+                    self.app_config_data.get("custom_targets", {}), tgt)
+
+        else:
+            self.target = tgt
+        self.target = deepcopy(self.target)
+        self.target_labels = self.target.labels
 
         self.cumulative_overrides = {key: ConfigCumulativeOverride(key)
-                                     for key in
-                                     Target.cumulative_attributes}
+                                     for key in CUMULATIVE_ATTRIBUTES}
 
         self._process_config_and_overrides(self.app_config_data, {}, "app",
                                            "application")
-        self.target_labels = Target.get_target(self.target).get_labels()
         self.config_errors = None
 
     def add_config_files(self, flist):
@@ -509,7 +516,7 @@ class Config(object):
                                                                      label)))))
 
         for cumulatives in self.cumulative_overrides.itervalues():
-            cumulatives.update_target(Target.get_target(self.target))
+            cumulatives.update_target(self.target)
 
         return params
 
@@ -528,10 +535,10 @@ class Config(object):
 
         Arguments: None
         """
-        params, json_data = {}, Target.get_json_target_data()
+        params, json_data = {}, self.target.json_data
         resolution_order = [e[0] for e
                             in sorted(
-                                Target.get_target(self.target).resolution_order,
+                                self.target.resolution_order,
                                 key=lambda e: e[1], reverse=True)]
         for tname in resolution_order:
             # Read the target data directly from its description
@@ -547,9 +554,11 @@ class Config(object):
                 # in the target inheritance tree, raise an error We need to use
                 # 'defined_by[7:]' to remove the "target:" prefix from
                 # defined_by
+                rel_names = [tgt for tgt, _ in
+                             get_resolution_order(self.target.json_data, tname,
+                                                  [])]
                 if (full_name not in params) or \
-                   (params[full_name].defined_by[7:] not in
-                    Target.get_target(tname).resolution_order_names):
+                   (params[full_name].defined_by[7:] not in rel_names):
                     raise ConfigException(
                         "Attempt to override undefined parameter '%s' in '%s'"
                         % (name,
@@ -680,15 +689,14 @@ class Config(object):
         params, _ = self.get_config_data()
         self._check_required_parameters(params)
         self.cumulative_overrides['features']\
-            .update_target(Target.get_target(self.target))
-        features = Target.get_target(self.target).features
+            .update_target(self.target)
 
-        for feature in features:
+        for feature in self.target.features:
             if feature not in self.__allowed_features:
                 raise ConfigException(
                     "Feature '%s' is not a supported features" % feature)
 
-        return features
+        return self.target.features
 
     def validate_config(self):
         """ Validate configuration settings. This either returns True or

--- a/tools/test/config_test/config_test.py
+++ b/tools/test/config_test/config_test.py
@@ -27,6 +27,7 @@ def compare_config(cfg, expected):
             if cfg[k].value != expected[k]:
                 return "'%s': expected '%s', got '%s'" % (k, expected[k], cfg[k].value)
     except KeyError:
+        raise
         return "Unexpected key '%s' in configuration data" % k
     for k in expected:
         if k not in ["desc", "expected_macros", "expected_features"] + cfg.keys():

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -428,7 +428,7 @@ class mbedToolchain:
             toolchain_labels = [c.__name__ for c in getmro(self.__class__)]
             toolchain_labels.remove('mbedToolchain')
             self.labels = {
-                'TARGET': self.target.get_labels() + ["DEBUG" if "debug-info" in self.options else "RELEASE"],
+                'TARGET': self.target.labels + ["DEBUG" if "debug-info" in self.options else "RELEASE"],
                 'FEATURE': self.target.features,
                 'TOOLCHAIN': toolchain_labels
             }


### PR DESCRIPTION
avoids a multi-threading bug in the online export system