### PR TITLE
STM32F0 - Add low power timer

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -615,7 +615,7 @@
         "inherits": ["Target"],
         "progen": {"target": "nucleo-f030r8"},
         "detect_code": ["0725"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_lib": "small",
         "release_versions": ["2"]
     },

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F0/rtc_api_hal.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F0/rtc_api_hal.h
@@ -41,18 +41,36 @@ extern "C" {
  * Extend rtc_api.h
  */
 
-// Prescaler values for LSE clock
-#define RTC_ASYNCH_PREDIV   0x7F
-#define RTC_SYNCH_PREDIV    0x00FF
-
+/** Set the given function as handler of wakeup timer event.
+ *
+ * @param handler    The function to set as handler
+ */
 void rtc_set_irq_handler(uint32_t handler);
 
-void rtc_ticker_disable_irq();
-uint32_t rtc_ticker_get_synch_presc();
+/** Read the subsecond register.
+ *
+ * @return The remaining time as microseconds (0-999999)
+ */
+uint32_t rtc_read_subseconds(void);
 
-void rtc_set_alarm(struct tm *ti, uint32_t subsecs);
-uint32_t rtc_read_subseconds();
-void rtc_reconfigure_prescalers();
+/** Program a wake up timer event in delta microseconds.
+ *
+ * @param delta    The time to wait
+ */
+void rtc_set_wake_up_timer(uint32_t delta);
+
+/** Disable the wake up timer event.
+ *
+ * The wake up timer use auto reload, you have to deactivate it manually.
+ */
+void rtc_deactivate_wake_up_timer(void);
+
+/** Synchronise the RTC shadow registers.
+ *
+ * Must be called after a deepsleep.
+ */
+void rtc_synchronize(void);
+
 
 #ifdef __cplusplus
 }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F0/sleep.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F0/sleep.c
@@ -28,7 +28,7 @@
  *******************************************************************************
  */
 #include "sleep_api.h"
-
+#include "rtc_api_hal.h"
 
 #if DEVICE_SLEEP
 
@@ -44,28 +44,16 @@ void sleep(void) {
     HAL_ResumeTick();
 }
 
-
-#if defined(TARGET_STM32F030R8) || defined (TARGET_STM32F051R8)
-void deepsleep(void) {
-    // Request to enter STOP mode with regulator in low power mode
-    HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
-
-    HAL_InitTick(TICK_INT_PRIORITY);
-
-    // After wake-up from STOP reconfigure the PLL
-    SetSysClock();
-
-    HAL_InitTick(TICK_INT_PRIORITY);
-}
-
-#else
 void deepsleep(void) {
     // Request to enter STOP mode with regulator in low power mode
     HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
 
     // After wake-up from STOP reconfigure the PLL
     SetSysClock();
-}
+
+#if DEVICE_LOWPOWERTIMER
+    rtc_synchronize();
 #endif
+}
 
 #endif


### PR DESCRIPTION
This PR add a low power timer implementation for STM32F0 targets.

need this PR #2640 to pass the tests.

### Concern:
 - NUCLEO_F070RB
 - NUCLEO_F072RB
 - NUCLEO_F091RC

The following ones are not enabled because they don't have a wake up timer, (or it is not supported by STM32CUBE library):
 - NUCLEO_F030R8
 - NUCLEO_F031K6
 - NUCLEO_F042K6

## Results

 - This is failing on GCC due to this issue #2647

---
 
# Tests
   * **ARM**
```
 +-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
| target            | platform_name | test suite                            | test case                           | passed | failed | result | elapsed_time (sec) |
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
| NUCLEO_F070RB-ARM | NUCLEO_F070RB | mbed-os-tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
| NUCLEO_F070RB-ARM | NUCLEO_F070RB | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
| NUCLEO_F070RB-ARM | NUCLEO_F070RB | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 0.0                |
| NUCLEO_F070RB-ARM | NUCLEO_F070RB | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| NUCLEO_F070RB-ARM | NUCLEO_F070RB | mbed-os-tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| NUCLEO_F070RB-ARM | NUCLEO_F070RB | mbed-os-tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.05               |
| NUCLEO_F070RB-ARM | NUCLEO_F070RB | mbed-os-tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.05               |
| NUCLEO_F070RB-ARM | NUCLEO_F070RB | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.04               |
| NUCLEO_F070RB-ARM | NUCLEO_F070RB | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 0.0                |
| NUCLEO_F070RB-ARM | NUCLEO_F070RB | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.05               |
| NUCLEO_F070RB-ARM | NUCLEO_F070RB | mbed-os-tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.04               |
| NUCLEO_F070RB-ARM | NUCLEO_F070RB | mbed-os-tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
| target            | platform_name | test suite                            | test case                           | passed | failed | result | elapsed_time (sec) |
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
| NUCLEO_F072RB-ARM | NUCLEO_F072RB | mbed-os-tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
| NUCLEO_F072RB-ARM | NUCLEO_F072RB | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.03               |
| NUCLEO_F072RB-ARM | NUCLEO_F072RB | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 0.0                |
| NUCLEO_F072RB-ARM | NUCLEO_F072RB | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.04               |
| NUCLEO_F072RB-ARM | NUCLEO_F072RB | mbed-os-tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| NUCLEO_F072RB-ARM | NUCLEO_F072RB | mbed-os-tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 4.96               |
| NUCLEO_F072RB-ARM | NUCLEO_F072RB | mbed-os-tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.04               |
| NUCLEO_F072RB-ARM | NUCLEO_F072RB | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.02               |
| NUCLEO_F072RB-ARM | NUCLEO_F072RB | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 0.0                |
| NUCLEO_F072RB-ARM | NUCLEO_F072RB | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.03               |
| NUCLEO_F072RB-ARM | NUCLEO_F072RB | mbed-os-tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.04               |
| NUCLEO_F072RB-ARM | NUCLEO_F072RB | mbed-os-tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 4.96               |
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
| target            | platform_name | test suite                            | test case                           | passed | failed | result | elapsed_time (sec) |
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | mbed-os-tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.04               |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 0.0                |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | mbed-os-tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | mbed-os-tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.04               |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | mbed-os-tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.04               |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.04               |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 0.0                |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.04               |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | mbed-os-tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.05               |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | mbed-os-tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
```
   * **GCC_ARM**
```
Fail
```
   * **IAR**
```
 +-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
 | target            | platform_name | test suite                            | test case                           | passed | failed | result | elapsed_time (sec) |
 +-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
 | NUCLEO_F070RB-IAR | NUCLEO_F070RB | mbed-os-tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
 | NUCLEO_F070RB-IAR | NUCLEO_F070RB | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
 | NUCLEO_F070RB-IAR | NUCLEO_F070RB | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 0.0                |
 | NUCLEO_F070RB-IAR | NUCLEO_F070RB | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
 | NUCLEO_F070RB-IAR | NUCLEO_F070RB | mbed-os-tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
 | NUCLEO_F070RB-IAR | NUCLEO_F070RB | mbed-os-tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.05               |
 | NUCLEO_F070RB-IAR | NUCLEO_F070RB | mbed-os-tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.04               |
 | NUCLEO_F070RB-IAR | NUCLEO_F070RB | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.04               |
 | NUCLEO_F070RB-IAR | NUCLEO_F070RB | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 0.0                |
 | NUCLEO_F070RB-IAR | NUCLEO_F070RB | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.04               |
 | NUCLEO_F070RB-IAR | NUCLEO_F070RB | mbed-os-tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.04               |
 | NUCLEO_F070RB-IAR | NUCLEO_F070RB | mbed-os-tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
 +-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
 +-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
| target            | platform_name | test suite                            | test case                           | passed | failed | result | elapsed_time (sec) |
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
| NUCLEO_F072RB-IAR | NUCLEO_F072RB | mbed-os-tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
| NUCLEO_F072RB-IAR | NUCLEO_F072RB | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.03               |
| NUCLEO_F072RB-IAR | NUCLEO_F072RB | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 0.0                |
| NUCLEO_F072RB-IAR | NUCLEO_F072RB | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.04               |
| NUCLEO_F072RB-IAR | NUCLEO_F072RB | mbed-os-tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| NUCLEO_F072RB-IAR | NUCLEO_F072RB | mbed-os-tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 4.97               |
| NUCLEO_F072RB-IAR | NUCLEO_F072RB | mbed-os-tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.05               |
| NUCLEO_F072RB-IAR | NUCLEO_F072RB | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.02               |
| NUCLEO_F072RB-IAR | NUCLEO_F072RB | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 0.0                |
| NUCLEO_F072RB-IAR | NUCLEO_F072RB | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.02               |
| NUCLEO_F072RB-IAR | NUCLEO_F072RB | mbed-os-tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.04               |
| NUCLEO_F072RB-IAR | NUCLEO_F072RB | mbed-os-tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 4.94               |
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
| target            | platform_name | test suite                            | test case                           | passed | failed | result | elapsed_time (sec) |
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | mbed-os-tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 0.0                |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | mbed-os-tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | mbed-os-tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.04               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | mbed-os-tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.04               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.04               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 0.0                |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.05               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | mbed-os-tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.04               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | mbed-os-tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
```