### PR TITLE
STM32L0 - Add low power timer

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -918,7 +918,7 @@
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0780"],
         "progen": {"target":"nucleo-l011k4"},
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_lib": "small",
         "release_versions": ["2"]
     },
@@ -932,7 +932,7 @@
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0790"],
         "progen": {"target": "nucleo-l031k6"},
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_lib": "small",
         "release_versions": ["2"]
     },
@@ -945,7 +945,7 @@
         "inherits": ["Target"],
         "progen": {"target": "nucleo-l053r8"},
         "detect_code": ["0715"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_lib": "small",
         "release_versions": ["2"]
     },
@@ -958,7 +958,7 @@
         "inherits": ["Target"],
         "progen": {"target": "nucleo-l073rz"},
         "detect_code": ["0760"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "release_versions": ["2", "5"]
     },
     "NUCLEO_L152RE": {
@@ -1100,7 +1100,7 @@
         "extra_labels": ["STM", "STM32L0", "STM32L053C8"],
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
         "progen": {"target": "disco-l053c8"},
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_lib": "small",
         "release_versions": ["2"]
     },

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L0/lp_ticker.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L0/lp_ticker.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,34 +27,57 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************
  */
-#include "sleep_api.h"
+#include "device.h"
+
+#if DEVICE_LOWPOWERTIMER
+
+#include "ticker_api.h"
+#include "lp_ticker_api.h"
+#include "rtc_api.h"
 #include "rtc_api_hal.h"
 
-#if DEVICE_SLEEP
+static uint8_t lp_ticker_inited = 0;
 
-#include "cmsis.h"
-
-
-void sleep(void) {
-    // Stop HAL systick
-    HAL_SuspendTick();
-    // Request to enter SLEEP mode
-    HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
-    // Restart HAL systick
-    HAL_ResumeTick();
+void lp_ticker_init(void)
+{
+    if (lp_ticker_inited) return;
+    lp_ticker_inited = 1;
+    
+    rtc_init();
+    rtc_set_irq_handler((uint32_t) lp_ticker_irq_handler);
 }
 
-void deepsleep(void)
+uint32_t lp_ticker_read(void)
 {
-    // Request to enter STOP mode with regulator in low power mode
-    HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
+    uint32_t usecs;
+    time_t time;
 
-    // After wake-up from STOP reconfigure the PLL
-    SetSysClock();
+    lp_ticker_init();
     
-#if DEVICE_LOWPOWERTIMER
-    rtc_synchronize();
-#endif
+    do {
+      time = rtc_read();
+      usecs = rtc_read_subseconds();
+    } while (time != rtc_read());
+    
+    return (time * 1000000) + usecs;
+}
+
+void lp_ticker_set_interrupt(timestamp_t timestamp)
+{
+    uint32_t delta;
+
+    delta = timestamp - lp_ticker_read();
+    rtc_set_wake_up_timer(delta);
+}
+
+void lp_ticker_disable_interrupt(void)
+{
+    rtc_deactivate_wake_up_timer();
+}
+
+void lp_ticker_clear_interrupt(void)
+{
+    
 }
 
 #endif

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L0/rtc_api_hal.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L0/rtc_api_hal.h
@@ -1,0 +1,79 @@
+/* mbed Microcontroller Library
+*******************************************************************************
+* Copyright (c) 2016, STMicroelectronics
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+* 3. Neither the name of STMicroelectronics nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************
+*/
+
+#ifndef MBED_RTC_API_HAL_H
+#define MBED_RTC_API_HAL_H
+
+#include <stdint.h>
+#include "rtc_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Extend rtc_api.h
+ */
+
+/** Set the given function as handler of wakeup timer event.
+ *
+ * @param handler    The function to set as handler
+ */
+void rtc_set_irq_handler(uint32_t handler);
+
+/** Read the subsecond register.
+ *
+ * @return The remaining time as microseconds (0-999999)
+ */
+uint32_t rtc_read_subseconds(void);
+
+/** Program a wake up timer event in delta microseconds.
+ *
+ * @param delta    The time to wait
+ */
+void rtc_set_wake_up_timer(uint32_t delta);
+
+/** Disable the wake up timer event.
+ *
+ * The wake up timer use auto reload, you have to deactivate it manually.
+ */
+void rtc_deactivate_wake_up_timer(void);
+
+/** Synchronise the RTC shadow registers.
+ *
+ * Must be called after a deepsleep.
+ */
+void rtc_synchronize(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This PR add a low power timer implementation for STM32L0 targets.
### Concern:

 - NUCLEO_L053R8
 - NUCLEO_L073RZ
 - NUCLEO_L011K4
 - NUCLEO_L031K6
 - DISCO_L053C8

## Results

 - This is failing on GCC due to this issue #2647

---
 
# Tests
   * **ARM**
```
 +-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
 | target            | platform_name | test suite                            | test case                           | passed | failed | result | elapsed_time (sec) |
 +-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
 | NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
 | NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
 | NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 0.0                |
 | NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.05               |
 | NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
 | NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.04               |
 | NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.04               |
 | NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.04               |
 | NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 0.0                |
 | NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.05               |
 | NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.05               |
 | NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
 +-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
```
   * **GCC_ARM**
```
+-----------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+---------+--------------------+
| target                | platform_name | test suite                            | test case                           | passed | failed | result  | elapsed_time (sec) |
+-----------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+---------+--------------------+
| NUCLEO_L073RZ-GCC_ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 0      | 0      | SKIPPED | 0.0                |
| NUCLEO_L073RZ-GCC_ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 0      | 0      | SKIPPED | 0.0                |
| NUCLEO_L073RZ-GCC_ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 0      | 0      | SKIPPED | 0.0                |
| NUCLEO_L073RZ-GCC_ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 0      | 0      | SKIPPED | 0.0                |
| NUCLEO_L073RZ-GCC_ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 0      | 0      | ERROR   | 0.0                |
| NUCLEO_L073RZ-GCC_ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 0      | 0      | SKIPPED | 0.0                |
| NUCLEO_L073RZ-GCC_ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 0      | 0      | SKIPPED | 0.0                |
| NUCLEO_L073RZ-GCC_ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 0      | 0      | SKIPPED | 0.0                |
| NUCLEO_L073RZ-GCC_ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 0      | 0      | SKIPPED | 0.0                |
| NUCLEO_L073RZ-GCC_ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 0      | 0      | SKIPPED | 0.0                |
| NUCLEO_L073RZ-GCC_ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 0      | 0      | ERROR   | 0.0                |
| NUCLEO_L073RZ-GCC_ARM | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 0      | 0      | SKIPPED | 0.0                |
+-----------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+---------+--------------------+
```
   * **IAR**
```
 +-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
| target            | platform_name | test suite                            | test case                           | passed | failed | result | elapsed_time (sec) |
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
| NUCLEO_L073RZ-IAR | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
| NUCLEO_L073RZ-IAR | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
| NUCLEO_L073RZ-IAR | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 0.0                |
| NUCLEO_L073RZ-IAR | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| NUCLEO_L073RZ-IAR | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.06               |
| NUCLEO_L073RZ-IAR | NUCLEO_L073RZ | mbed-os-tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.06               |
| NUCLEO_L073RZ-IAR | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.04               |
| NUCLEO_L073RZ-IAR | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.04               |
| NUCLEO_L073RZ-IAR | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 0.0                |
| NUCLEO_L073RZ-IAR | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.05               |
| NUCLEO_L073RZ-IAR | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.04               |
| NUCLEO_L073RZ-IAR | NUCLEO_L073RZ | mbed-os-tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.05               |
+-------------------+---------------+---------------------------------------+-------------------------------------+--------+--------+--------+--------------------+
```