### PR TITLE
change NVIC_SystemReset to __NVIC_SystemReset

### DIFF
--- a/hal/targets/cmsis/core_cm3.h
+++ b/hal/targets/cmsis/core_cm3.h
@@ -1581,7 +1581,7 @@ __STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGr
 
     The function initiates a system reset request to reset the MCU.
  */
-__STATIC_INLINE void NVIC_SystemReset(void)
+__STATIC_INLINE void __NVIC_SystemReset(void)
 {
   __DSB();                                                          /* Ensure all outstanding memory accesses included
                                                                        buffered write are completed before reset */

--- a/hal/targets/cmsis/core_cm3.h
+++ b/hal/targets/cmsis/core_cm3.h
@@ -1353,6 +1353,7 @@ typedef struct
   #define NVIC_GetActive              __NVIC_GetActive
   #define NVIC_SetPriority            __NVIC_SetPriority
   #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset           __NVIC_SystemReset
 #endif /* CMSIS_NVIC_VIRTUAL */
 
 #ifdef CMSIS_VECTAB_VIRTUAL


### PR DESCRIPTION
Change __STATIC_INLINE void NVIC_SystemReset(void) to __STATIC_INLINE void __NVIC_SystemReset(void) in core_cm3.h because of this [PR](https://github.com/ARMmbed/uvisor/pull/334)