### PR TITLE
STM32L4 - Update deepsleep implementation

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L4/sleep.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L4/sleep.c
@@ -47,8 +47,18 @@ void deepsleep(void)
     // Stop HAL systick
     HAL_SuspendTick();
 
-    // Request to enter STOP mode with regulator in low power mode
-    HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
+    // Request to enter STOP mode 1 with regulator in low power mode
+    if (__HAL_RCC_PWR_IS_CLK_ENABLED()) {
+        HAL_PWREx_EnableLowPowerRunMode();
+        HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
+        HAL_PWREx_DisableLowPowerRunMode();
+    } else {
+        __HAL_RCC_PWR_CLK_ENABLE();
+        HAL_PWREx_EnableLowPowerRunMode();
+        HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
+        HAL_PWREx_DisableLowPowerRunMode();
+        __HAL_RCC_PWR_CLK_DISABLE();
+    }
 
     // After wake-up from STOP reconfigure the PLL
     SetSysClock();


### PR DESCRIPTION
## Description
During deepsleep enter, the STM32L4 devices were entering in `stop mode 0` instead of `stop mode 1` due to a `PWR` clock not initialized.


## Status

**READY**


## Migrations

NO


## Steps to test or reproduce

```c++
#include "mbed.h"

int main() {
    printf("before deepsleep\n");
    deepsleep();
    printf("after deepsleep\n");
}
```
Flash this code on a STM32L4 and check the power consumption on IDD jumper. It should decrease from 110 uA to 9 uA with this PR

