### PR TITLE
[Exporters] [Makefile] Single quotes for escaping commands

### DIFF
--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -59,15 +59,15 @@ class Makefile(Exporter):
                       if (basename(dirname(dirname(self.export_dir)))
                           == "projectfiles")
                       else [".."]),
-            'cc_cmd': " ".join(["\"" + part + "\"" for part
+            'cc_cmd': " ".join(["\'" + part + "\'" for part
                                 in self.toolchain.cc]),
-            'cppc_cmd': " ".join(["\"" + part + "\"" for part
+            'cppc_cmd': " ".join(["\'" + part + "\'" for part
                                   in self.toolchain.cppc]),
-            'asm_cmd': " ".join(["\"" + part + "\"" for part
+            'asm_cmd': " ".join(["\'" + part + "\'" for part
                                  in self.toolchain.asm]),
-            'ld_cmd': " ".join(["\"" + part + "\"" for part
+            'ld_cmd': " ".join(["\'" + part + "\'" for part
                                 in self.toolchain.ld]),
-            'elf2bin_cmd': self.toolchain.elf2bin,
+            'elf2bin_cmd': "\'" + self.toolchain.elf2bin + "\'",
             'link_script_ext': self.toolchain.LINKER_EXT,
             'link_script_option': self.LINK_SCRIPT_OPTION,
         }


### PR DESCRIPTION
## Description
Commands must be in quotes on Windows, in case the path contains spaces. Previously, they were escaped with ```"```, but it seems like ```'``` is more agreeable to Windows. 

## Status
**READY**


## Migrations
NO


## Related PRs
List related PRs against other branches:
#2577 

## Todos
- [ ] Tests
- [ ] Documentation


## Steps to test or reproduce
**Only reproducible on Windows** 
Run this from master:
```mbed export -m whatever -i make_iar```
Try to execute the makefile.
Repeat with this PR.

@sg- @theotherjimmy @screamerbg 
