### PR TITLE
BLE - Nordic implementation: Move singleton into a function.

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/nRF5xn.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/nRF5xn.cpp
@@ -33,7 +33,11 @@ extern "C" {
 /**
  * The singleton which represents the nRF51822 transport for the BLE.
  */
-static nRF5xn deviceInstance;
+static nRF5xn& getDeviceInstance() {
+    static nRF5xn deviceInstance;
+    return deviceInstance;
+}
+
 
 /**
  * BLE-API requires an implementation of the following function in order to
@@ -47,7 +51,7 @@ createBLEInstance(void)
 
 nRF5xn& nRF5xn::Instance(BLE::InstanceID_t instanceId)
 {
-    return deviceInstance;
+    return getDeviceInstance();
 }
 
 nRF5xn::nRF5xn(void) :

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/nRF5xn.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/nRF5xn.cpp
@@ -34,7 +34,11 @@ extern "C" {
 /**
  * The singleton which represents the nRF51822 transport for the BLE.
  */
-static nRF5xn deviceInstance;
+static nRF5xn& getDeviceInstance() {
+    static nRF5xn deviceInstance;
+    return deviceInstance;
+}
+
 
 /**
  * BLE-API requires an implementation of the following function in order to
@@ -48,7 +52,7 @@ createBLEInstance(void)
 
 nRF5xn& nRF5xn::Instance(BLE::InstanceID_t instanceId)
 {
-    return deviceInstance;
+    return getDeviceInstance();
 }
 
 nRF5xn::nRF5xn(void) :


### PR DESCRIPTION
This change remove BLE code from the binary generated if the user code doesn't
use BLE.

It fixes #2537.

Note: it was chosen to not use the SingletonPtr class in order to keep the code compatible with mbed OS 3. The BLE API is not thread safe, this is not an issue in this code.
