### PR TITLE
NORDIC - Update NRF51_DONGLE target to takes advantage of latest implementation NRF5.

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1981,7 +1981,7 @@
     "NRF51_DONGLE": {
         "inherits": ["MCU_NRF51_32K_UNIFIED"],
         "progen": {"target": "nrf51-dongle"},
-        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],        
+        "device_has": ["ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],        
         "release_versions": ["2", "5"]
     },
     "MCU_NRF52": {

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1516,6 +1516,7 @@
     "NRF51_DK_LEGACY": {
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF51_32K"],
+        "extra_labels_add": ["NRF51_DK"],
         "progen": {"target": "nrf51-dk"}
     },
     "NRF51_DK_BOOT": {

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1534,6 +1534,7 @@
     "NRF51_DONGLE_LEGACY": {
         "inherits": ["MCU_NRF51_32K"],
         "progen": {"target": "nrf51-dongle"},
+        "extra_labels_add": ["NRF51_DONGLE"],
         "release_versions": ["2"]
     },
     "NRF51_DONGLE_BOOT": {

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1530,7 +1530,7 @@
         "extra_labels_add": ["NRF51_DK"],
         "macros_add": ["TARGET_NRF51_DK"]
     },
-    "NRF51_DONGLE": {
+    "NRF51_DONGLE_LEGACY": {
         "inherits": ["MCU_NRF51_32K"],
         "progen": {"target": "nrf51-dongle"},
         "release_versions": ["2"]
@@ -1976,6 +1976,12 @@
         "inherits": ["MCU_NRF51_32K_UNIFIED"],
         "progen": {"target": "nrf51-dk"},
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
+        "release_versions": ["2", "5"]
+    },
+    "NRF51_DONGLE": {
+        "inherits": ["MCU_NRF51_32K_UNIFIED"],
+        "progen": {"target": "nrf51-dongle"},
+        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],        
         "release_versions": ["2", "5"]
     },
     "MCU_NRF52": {

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TARGET_NRF51_DONGLE/PinNames.h
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TARGET_NRF51_DONGLE/PinNames.h
@@ -1,0 +1,145 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2013 Nordic Semiconductor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+#define PORT_SHIFT  3
+
+typedef enum {
+    p0  = 0,
+    p1  = 1,
+    p2  = 2,
+    p3  = 3,
+    p4  = 4,
+    p5  = 5,
+    p6  = 6,
+    p7  = 7,
+    p8  = 8,
+    p9  = 9,
+    p10 = 10,
+    p11 = 11,
+    p12 = 12,
+    p13 = 13,
+    p14 = 14,
+    p15 = 15,
+    p16 = 16,
+    p17 = 17,
+    p18 = 18,
+    p19 = 19,
+    p20 = 20,
+    p21 = 21,
+    p22 = 22,
+    p23 = 23,
+    p24 = 24,
+    p25 = 25,
+    p28 = 28,
+    p29 = 29,
+    p30 = 30,
+
+    P0_0  = p0,
+    P0_1  = p1,
+    P0_2  = p2,
+    P0_3  = p3,
+    P0_4  = p4,
+    P0_5  = p5,
+    P0_6  = p6,
+    P0_7  = p7,
+
+    P0_8  = p8,
+    P0_9  = p9,
+    P0_10 = p10,
+    P0_11 = p11,
+    P0_12 = p12,
+    P0_13 = p13,
+    P0_14 = p14,
+    P0_15 = p15,
+
+    P0_16 = p16,
+    P0_17 = p17,
+    P0_18 = p18,
+    P0_19 = p19,
+    P0_20 = p20,
+    P0_21 = p21,
+    P0_22 = p22,
+    P0_23 = p23,
+
+    P0_24 = p24,
+    P0_25 = p25,
+    P0_28 = p28,
+    P0_29 = p29,
+
+    LED1    = p21,
+    LED2    = p22,
+    LED3    = p23,
+    LED4    = p23,
+    LEDR    = LED1,
+    LEDG    = LED2,
+    LEDB    = LED3,
+
+    RX_PIN_NUMBER  = p11,
+    TX_PIN_NUMBER  = p9,
+    CTS_PIN_NUMBER = p10,
+    RTS_PIN_NUMBER = p8,
+
+    // mBed interface Pins
+    USBTX = TX_PIN_NUMBER,
+    USBRX = RX_PIN_NUMBER,
+
+    SPI_PSELMOSI0 = p15,
+    SPI_PSELMISO0 = p16,
+    SPI_PSELSS0   = p17,
+    SPI_PSELSCK0  = p18,
+
+    SPI_PSELMOSI1 = p15,
+    SPI_PSELMISO1 = p16,
+    SPI_PSELSS1   = p17,
+    SPI_PSELSCK1  = p18,
+    
+    SPIS_PSELMOSI = p15,
+    SPIS_PSELMISO = p16,
+    SPIS_PSELSS   = p17,
+    SPIS_PSELSCK  = p18,
+    
+    I2C_SDA0 = p19,
+    I2C_SCL0 = p20,
+
+    // Not connected
+    NC = (int)0xFFFFFFFF
+} PinName;
+
+typedef enum {
+    PullNone = 0,
+    PullDown = 1,
+    PullUp = 3,
+    PullDefault = PullUp
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TARGET_NRF51_DONGLE/device.h
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/TARGET_NRF51_DONGLE/device.h
@@ -1,0 +1,38 @@
+// The 'features' section in 'target.json' is now used to create the device's hardware preprocessor switches.
+// Check the 'features' section of the target description in 'targets.json' for more details.
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include "objects.h"
+
+#endif


### PR DESCRIPTION
This change allows the NRF51_DONGLE target to be used with mbed-os 5. 
It also brings the latest BLE and Nordic device drivers to this target.
