### PR TITLE
Clean RTOS tests after PR #2648

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
@@ -11,11 +11,7 @@
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
  * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
  */
-#if (defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8)) && defined(TOOLCHAIN_GCC)
-#define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif (defined(TARGET_STM32F030R8) || defined(TARGET_STM32F070RB)) && defined(TOOLCHAIN_GCC)
-#define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_IAR)
+#if defined(TARGET_STM32F070RB) && defined(TOOLCHAIN_GCC)
 #define STACK_SIZE DEFAULT_STACK_SIZE/2
 #elif (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
 #define STACK_SIZE 512

--- a/TESTS/mbedmicro-rtos-mbed/isr/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/isr/main.cpp
@@ -16,11 +16,7 @@
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
  * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
  */
-#if defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
+#if (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 512
 #elif (defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32PG_STK3401)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 768

--- a/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
@@ -22,13 +22,7 @@ typedef struct {
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
  * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
  */
-#if (defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8)) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
+#if (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 512
 #elif (defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32PG_STK3401)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 768

--- a/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
@@ -14,14 +14,8 @@
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
  * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
  */
-#if (defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8)) && defined(TOOLCHAIN_GCC)
+#if defined(TARGET_STM32F334R8) && defined(TOOLCHAIN_IAR)
     #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif defined(TARGET_STM32F030R8) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif defined(TARGET_STM32F334R8) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif defined(TARGET_STM32F030R8) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4	
 #elif defined(TARGET_STM32F070RB)
     #define STACK_SIZE DEFAULT_STACK_SIZE/2	
 #elif defined(TARGET_STM32F072RB)

--- a/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
@@ -22,13 +22,7 @@ typedef struct {
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
  * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
  */
-#if (defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8)) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
+#if (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 512
 #elif (defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32PG_STK3401)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 768

--- a/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
@@ -15,16 +15,10 @@
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
  * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
  */
-#if (defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8)) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/16
-#elif defined(TARGET_STM32F030R8) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/8
-#elif defined(TARGET_STM32F334R8) && (defined(TOOLCHAIN_GCC) || defined(TOOLCHAIN_IAR))
+#if defined(TARGET_STM32F334R8) && (defined(TOOLCHAIN_GCC) || defined(TOOLCHAIN_IAR))
     #define STACK_SIZE DEFAULT_STACK_SIZE/4
 #elif defined(TARGET_STM32F103RB)
     #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif defined(TARGET_STM32F030R8) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4	
 #elif defined(TARGET_STM32F070RB)
     #define STACK_SIZE DEFAULT_STACK_SIZE/2	
 #elif defined(TARGET_STM32F072RB)

--- a/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
@@ -15,11 +15,7 @@ const int SIGNAL_HANDLE_DELEY = 25;
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
  * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
  */
-#if defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
+#if (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 512
 #elif (defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32PG_STK3401)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 768

--- a/libraries/tests/rtos/mbed/basic/main.cpp
+++ b/libraries/tests/rtos/mbed/basic/main.cpp
@@ -11,13 +11,7 @@
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
  * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
  */
-#if (defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8)) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif defined(TARGET_STM32F030R8) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif defined(TARGET_STM32F070RB) || defined(TARGET_STM32F072RB)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_IAR)
+#if defined(TARGET_STM32F070RB) || defined(TARGET_STM32F072RB)
     #define STACK_SIZE DEFAULT_STACK_SIZE/2
 #elif (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 512

--- a/libraries/tests/rtos/mbed/isr/main.cpp
+++ b/libraries/tests/rtos/mbed/isr/main.cpp
@@ -16,11 +16,7 @@
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
  * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
  */
-#if defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
+#if (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 512
 #elif (defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32PG_STK3401)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 768

--- a/libraries/tests/rtos/mbed/mail/main.cpp
+++ b/libraries/tests/rtos/mbed/mail/main.cpp
@@ -22,13 +22,7 @@ typedef struct {
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
  * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
  */
-#if (defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8)) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
+#if (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 512
 #elif (defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32PG_STK3401)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 768

--- a/libraries/tests/rtos/mbed/mutex/main.cpp
+++ b/libraries/tests/rtos/mbed/mutex/main.cpp
@@ -14,13 +14,7 @@
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
  * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
  */
-#if (defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8)) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif defined(TARGET_STM32F334R8) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif defined(TARGET_STM32F030R8) && defined(TOOLCHAIN_IAR)
+#if defined(TARGET_STM32F334R8) && defined(TOOLCHAIN_IAR)
     #define STACK_SIZE DEFAULT_STACK_SIZE/4
 #elif (defined(TARGET_STM32F070RB) || defined(TARGET_STM32F072RB))
     #define STACK_SIZE DEFAULT_STACK_SIZE/2

--- a/libraries/tests/rtos/mbed/queue/main.cpp
+++ b/libraries/tests/rtos/mbed/queue/main.cpp
@@ -22,13 +22,7 @@ typedef struct {
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
  * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
  */
-#if (defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8)) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
+#if (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 512
 #elif (defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32PG_STK3401)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 768

--- a/libraries/tests/rtos/mbed/semaphore/main.cpp
+++ b/libraries/tests/rtos/mbed/semaphore/main.cpp
@@ -15,17 +15,11 @@
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
  * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
  */
-#if (defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8)) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/16
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_GCC)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/8
-#elif (defined(TARGET_STM32F072RB) || defined(TARGET_STM32F070RB))
+#if (defined(TARGET_STM32F072RB) || defined(TARGET_STM32F070RB))
     #define STACK_SIZE DEFAULT_STACK_SIZE/2
 #elif defined(TARGET_STM32F334R8) && (defined(TOOLCHAIN_GCC) || defined(TOOLCHAIN_IAR))
     #define STACK_SIZE DEFAULT_STACK_SIZE/4
 #elif defined(TARGET_STM32F103RB) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif defined(TARGET_STM32F030R8) && defined(TOOLCHAIN_IAR)
     #define STACK_SIZE DEFAULT_STACK_SIZE/4
 #elif defined(TARGET_STM32F302R8) && defined(TOOLCHAIN_IAR)
     #define STACK_SIZE DEFAULT_STACK_SIZE/2

--- a/libraries/tests/rtos/mbed/signals/main.cpp
+++ b/libraries/tests/rtos/mbed/signals/main.cpp
@@ -15,11 +15,7 @@
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
  * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
  */
-#if defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif (defined(TARGET_STM32F030R8)) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
+#if (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 512
 #elif (defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32PG_STK3401)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 768


### PR DESCRIPTION
## Description
Just a patch to clean RTOS tests as we doesn't support any more RTOS for some targets since #2648

## Status
READY

