### PR TITLE
[FIX] re-introduce release_version field erronously erased

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -862,7 +862,8 @@
         "progen": {"target": "nucleo-f446ze"},
         "detect_code": ["0778"],
         "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"]
+        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+         "release_versions": ["2", "5"]
     },
 
     "B96B_F446VE": {


### PR DESCRIPTION

## Description
As reported by @sg one line was erroneously erased

## Status
**READY**

The field was lost during rebase of SPI_ASYNCH introduction,
which is fixed in this commit.