### PR TITLE
Print percent complete when building

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -341,7 +341,13 @@ class mbedToolchain:
 
         elif event['type'] == 'progress':
             if not silent:
-                msg = '%s: %s' % (event['action'].title(), basename(event['file']))
+                if 'percent' in event:
+                    msg = '{} [{:>5.1f}%]: {}'.format(event['action'].title(),
+                                                      event['percent'],
+                                                      basename(event['file']))
+                else:
+                    msg = '{}: {}'.format(event['action'].title(),
+                                          basename(event['file']))
 
         if msg:
             print msg


### PR DESCRIPTION
e.g.:
```
$ mbed compile -t gcc_arm -m k64f -c
[mbed] Auto-installing missing Python modules...
[mbed] WARNING: Unable to auto-install required Python modules.
---
[mbed] WARNING: -----------------------------------------------------------------
[mbed] WARNING: The mbed OS tools in this program require the following Python modules: colorama, requests
[mbed] WARNING: You can install all missing modules by running "pip install -r requirements.txt" in "/home/jimbri01/src/arm-mbed/mbed-os-example-blinky/mbed-os"
[mbed] WARNING: On Posix systems (Linux, Mac, etc) you might have to switch to superuser account or use "sudo"
---
Building project mbed-os-example-blinky (K64F, GCC_ARM)
Scan: .
Scan: FEATURE_COMMON_PAL
Scan: FEATURE_UVISOR
Scan: FEATURE_BLE
Scan: FEATURE_IPV6
Scan: FEATURE_IPV4
Scan: FEATURE_STORAGE
Scan: mbed
Scan: env
Compile [  0.3%]: greentea_serial.cpp
Compile [  0.7%]: main.cpp
Compile [  1.0%]: unity_handler.cpp
Compile [  1.4%]: greentea_metrics.cpp
Compile [  1.7%]: mbed-utest-shim.cpp
Compile [  2.1%]: utest_stack_trace.cpp
Compile [  2.4%]: utest_case.cpp
Compile [  2.8%]: test_env.cpp
Compile [  3.1%]: aesni.c
Compile [  3.5%]: unity.c
Compile [  3.8%]: arc4.c
Compile [  4.2%]: utest_default_handlers.cpp
Compile [  4.5%]: utest_shim.cpp
Compile [  4.8%]: utest_greentea_handlers.cpp
Compile [  5.2%]: asn1parse.c
Compile [  5.5%]: utest_types.cpp
Compile [  5.9%]: blowfish.c
Compile [  6.2%]: asn1write.c
Compile [  6.6%]: base64.c
Compile [  6.9%]: camellia.c
Compile [  7.3%]: certs.c
Compile [  7.6%]: utest_harness.cpp
Compile [  8.0%]: aes.c
Compile [  8.3%]: des.c
Compile [  8.7%]: dhm.c
Compile [  9.0%]: cipher_wrap.c
Compile [  9.3%]: ccm.c
Compile [  9.7%]: ecjpake.c
Compile [ 10.0%]: ctr_drbg.c
Compile [ 10.4%]: ecdh.c
Compile [ 10.7%]: debug.c
Compile [ 11.1%]: cipher.c
Compile [ 11.4%]: entropy_poll.c
Compile [ 11.8%]: havege.c
Compile [ 12.1%]: ecdsa.c
Compile [ 12.5%]: entropy.c
Compile [ 12.8%]: md2.c
Compile [ 13.1%]: md4.c
Compile [ 13.5%]: hmac_drbg.c
Compile [ 13.8%]: ecp_curves.c
Compile [ 14.2%]: md.c
Compile [ 14.5%]: gcm.c
Compile [ 14.9%]: md5.c
Compile [ 15.2%]: memory_buffer_alloc.c
Compile [ 15.6%]: net.c
Compile [ 15.9%]: padlock.c
Compile [ 16.3%]: md_wrap.c
Compile [ 16.6%]: error.c
Compile [ 17.0%]: pem.c
Compile [ 17.3%]: pkcs11.c
Compile [ 17.6%]: pkcs12.c
Compile [ 18.0%]: bignum.c
Compile [ 18.3%]: oid.c
Compile [ 18.7%]: pkcs5.c
Compile [ 19.0%]: pk.c
Compile [ 19.4%]: ripemd160.c
Compile [ 19.7%]: pk_wrap.c
Compile [ 20.1%]: platform.c
Compile [ 20.4%]: sha1.c
Compile [ 20.8%]: pkwrite.c
Compile [ 21.1%]: pkparse.c
Compile [ 21.5%]: ssl_cache.c
Compile [ 21.8%]: ssl_ciphersuites.c
Compile [ 22.1%]: ssl_cookie.c
Compile [ 22.5%]: ecp.c
Compile [ 22.8%]: sha256.c
Compile [ 23.2%]: sha512.c
Compile [ 23.5%]: ssl_ticket.c
Compile [ 23.9%]: threading.c
Compile [ 24.2%]: timing.c
Compile [ 24.6%]: version.c
Compile [ 24.9%]: x509_create.c
Compile [ 25.3%]: version_features.c
Compile [ 25.6%]: x509_csr.c
Compile [ 26.0%]: rsa.c
Compile [ 26.3%]: x509write_crt.c
Compile [ 26.6%]: x509write_csr.c
Compile [ 27.0%]: xtea.c
Compile [ 27.3%]: x509.c
Compile [ 27.7%]: x509_crl.c
Compile [ 28.0%]: lwip_checksum.c
Compile [ 28.4%]: hardware_init_MK64F12.c
Compile [ 28.7%]: lwip_memcpy.c
Compile [ 29.1%]: EthernetInterface.cpp
Compile [ 29.4%]: ssl_cli.c
Compile [ 29.8%]: k64f_emac.c
Compile [ 30.1%]: lwip_sys_arch.c
Compile [ 30.4%]: lwip_err.c
Compile [ 30.8%]: ssl_srv.c
Compile [ 31.1%]: lwip_api_lib.c
Compile [ 31.5%]: lwip_netdb.c
Compile [ 31.8%]: lwip_netbuf.c
Compile [ 32.2%]: lwip_netifapi.c
Compile [ 32.5%]: x509_crt.c
Compile [ 32.9%]: lwip_sockets.c
Compile [ 33.2%]: lwip_autoip.c
Compile [ 33.6%]: lwip_tcpip.c
Compile [ 33.9%]: lwip_icmp.c
Compile [ 34.3%]: lwip_inet.c
Compile [ 34.6%]: lwip_api_msg.c
Compile [ 34.9%]: lwip_inet_chksum.c
Compile [ 35.3%]: lwip_igmp.c
Compile [ 35.6%]: lwip_ip_addr.c
Compile [ 36.0%]: lwip_def.c
Compile [ 36.3%]: lwip_ip.c
Compile [ 36.7%]: lwip_ip_frag.c
Compile [ 37.0%]: lwip_init.c
Compile [ 37.4%]: lwip_memp.c
Compile [ 37.7%]: lwip_dns.c
Compile [ 38.1%]: lwip_mem.c
Compile [ 38.4%]: lwip_netif.c
Compile [ 38.8%]: lwip_raw.c
Compile [ 39.1%]: lwip_stats.c
Compile [ 39.4%]: lwip_dhcp.c
Compile [ 39.8%]: lwip_pbuf.c
Compile [ 40.1%]: lwip_timers.c
Compile [ 40.5%]: lwip_asn1_dec.c
Compile [ 40.8%]: lwip_asn1_enc.c
Compile [ 41.2%]: lwip_udp.c
Compile [ 41.5%]: lwip_tcp.c
Compile [ 41.9%]: lwip_mib2.c
Compile [ 42.2%]: lwip_tcp_out.c
Compile [ 42.6%]: lwip_mib_structs.c
Compile [ 42.9%]: lwip_tcp_in.c
Compile [ 43.3%]: lwip_msg_in.c
Compile [ 43.6%]: lwip_msg_out.c
Compile [ 43.9%]: lwip_ethernetif.c
Compile [ 44.3%]: ssl_tls.c
Compile [ 44.6%]: lwip_slipif.c
Compile [ 45.0%]: lwip_auth.c
Compile [ 45.3%]: lwip_chap.c
Compile [ 45.7%]: lwip_chpms.c
Compile [ 46.0%]: lwip_fsm.c
Compile [ 46.4%]: lwip_magic.c
Compile [ 46.7%]: lwip_md5.c
Compile [ 47.1%]: lwip_etharp.c
Compile [ 47.4%]: lwip_lcp.c
Compile [ 47.8%]: lwip_ppp.c
Compile [ 48.1%]: lwip_randm.c
Compile [ 48.4%]: lwip_ipcp.c
Compile [ 48.8%]: lwip_ppp_oe.c
Compile [ 49.1%]: lwip_pap.c
Compile [ 49.5%]: lwip_vj.c
Compile [ 49.8%]: TCPSocket.cpp
Compile [ 50.2%]: nsapi_dns.cpp
Compile [ 50.5%]: UDPSocket.cpp
Compile [ 50.9%]: lwip_stack.c
Compile [ 51.2%]: Socket.cpp
Compile [ 51.6%]: TCPServer.cpp
Compile [ 51.9%]: cfstore_svm.cpp
Compile [ 52.2%]: SocketAddress.cpp
Compile [ 52.6%]: cfstore_fnmatch.c
Compile [ 52.9%]: flash_journal_crc.c
Compile [ 53.3%]: NetworkStack.cpp
Compile [ 53.6%]: cfstore_test.c
Compile [ 54.0%]: storage_volume.cpp
Compile [ 54.3%]: strategy.c
Compile [ 54.7%]: support_funcs.c
Compile [ 55.0%]: AnalogIn.cpp
Compile [ 55.4%]: BusIn.cpp
Compile [ 55.7%]: storage_volume_manager.cpp
Compile [ 56.1%]: CAN.cpp
Compile [ 56.4%]: BusInOut.cpp
Compile [ 56.7%]: BusOut.cpp
Compile [ 57.1%]: Ethernet.cpp
Compile [ 57.4%]: CallChain.cpp
Compile [ 57.8%]: FileBase.cpp
Compile [ 58.1%]: FileLike.cpp
Compile [ 58.5%]: FilePath.cpp
Compile [ 58.8%]: I2CSlave.cpp
Compile [ 59.2%]: FileSystemLike.cpp
Compile [ 59.5%]: I2C.cpp
Compile [ 59.9%]: configuration_store.c
Compile [ 60.2%]: LocalFileSystem.cpp
Compile [ 60.6%]: InterruptIn.cpp
Compile [ 60.9%]: InterruptManager.cpp
Compile [ 61.2%]: SPISlave.cpp
Compile [ 61.6%]: SPI.cpp
Compile [ 61.9%]: RawSerial.cpp
Compile [ 62.3%]: Serial.cpp
Compile [ 62.6%]: TimerEvent.cpp
Compile [ 63.0%]: Timeout.cpp
Compile [ 63.3%]: mbed_alloc_wrappers.cpp
Compile [ 63.7%]: mbed_assert.c
Compile [ 64.0%]: SerialBase.cpp
[Warning] SerialBase.cpp@34,23: comparison between signed and unsigned integer expressions [-Wsign-compare]
Compile [ 64.4%]: Timer.cpp
Compile [ 64.7%]: Stream.cpp
Compile [ 65.1%]: Ticker.cpp
Compile [ 65.4%]: mbed_board.c
Compile [ 65.7%]: mbed_error.c
Compile [ 66.1%]: mbed_critical.c
Compile [ 66.4%]: mbed_interface.c
Compile [ 66.8%]: mbed_mem_trace.c
Compile [ 67.1%]: mbed_gpio.c
Compile [ 67.5%]: mbed_lp_ticker_api.c
Compile [ 67.8%]: mbed_wait_api_no_rtos.c
Compile [ 68.2%]: mbed_pinmap_common.c
Compile [ 68.5%]: mbed_semihost_api.c
Compile [ 68.9%]: mbed_us_ticker_api.c
Compile [ 69.2%]: startup_MK64F12.S
Compile [ 69.6%]: mbed_rtc_time.cpp
Compile [ 69.9%]: mbed_ticker_api.c
Compile [ 70.2%]: cmsis_nvic.c
Compile [ 70.6%]: crc.c
Compile [ 70.9%]: system_MK64F12.c
Compile [ 71.3%]: PeripheralPins.c
Compile [ 71.6%]: fsl_clock_config.c
Compile [ 72.0%]: mbed_overrides.c
Compile [ 72.3%]: mbed_wait_api_rtos.cpp
Compile [ 72.7%]: fsl_phy.c
Compile [ 73.0%]: fsl_adc16.c
Compile [ 73.4%]: fsl_common.c
Compile [ 73.7%]: fsl_cmp.c
Compile [ 74.0%]: retarget.cpp
Compile [ 74.4%]: fsl_cmt.c
Compile [ 74.7%]: fsl_crc.c
Compile [ 75.1%]: fsl_dac.c
Compile [ 75.4%]: fsl_dmamux.c
Compile [ 75.8%]: fsl_ewm.c
Compile [ 76.1%]: fsl_flexbus.c
Compile [ 76.5%]: fsl_clock.c
Compile [ 76.8%]: fsl_dspi_edma.c
Compile [ 77.2%]: fsl_gpio.c
Compile [ 77.5%]: fsl_edma.c
Compile [ 77.9%]: fsl_enet.c
[Warning] fsl_enet.c@493,29: comparison between pointer and integer
Compile [ 78.2%]: fsl_dspi.c
Compile [ 78.5%]: fsl_flash.c
Compile [ 78.9%]: fsl_ftm.c
Compile [ 79.2%]: fsl_llwu.c
Compile [ 79.6%]: fsl_lptmr.c
Compile [ 79.9%]: fsl_flexcan.c
Compile [ 80.3%]: fsl_pdb.c
Compile [ 80.6%]: fsl_i2c_edma.c
Compile [ 81.0%]: fsl_mpu.c
Compile [ 81.3%]: fsl_pit.c
Compile [ 81.7%]: fsl_rcm.c
Compile [ 82.0%]: fsl_pmc.c
Compile [ 82.4%]: fsl_rnga.c
Compile [ 82.7%]: fsl_sim.c
Compile [ 83.0%]: fsl_rtc.c
Compile [ 83.4%]: fsl_smc.c
Compile [ 83.7%]: fsl_sai_edma.c
Compile [ 84.1%]: fsl_i2c.c
Compile [ 84.4%]: fsl_uart_edma.c
Compile [ 84.8%]: fsl_vref.c
Compile [ 85.1%]: entropy_hardware_poll.c
Compile [ 85.5%]: fsl_wdog.c
Compile [ 85.8%]: fsl_sai.c
Compile [ 86.2%]: fsl_sdhc.c
Compile [ 86.5%]: pwmout_api.c
Compile [ 86.9%]: fsl_uart.c
Compile [ 87.2%]: us_ticker.c
Compile [ 87.5%]: spi_api.c
Compile [ 87.9%]: analogin_api.c
Compile [ 88.2%]: analogout_api.c
Compile [ 88.6%]: gpio_api.c
Compile [ 88.9%]: serial_api.c
Compile [ 89.3%]: gpio_irq_api.c
Compile [ 89.6%]: port_api.c
Compile [ 90.0%]: storage_driver.c
Compile [ 90.3%]: pinmap.c
Compile [ 90.7%]: lp_ticker.c
Compile [ 91.0%]: i2c_api.c
Compile [ 91.3%]: sleep.c
Compile [ 91.7%]: Semaphore.cpp
Compile [ 92.0%]: rtc_api.c
Compile [ 92.4%]: rtos_idle.c
Compile [ 92.7%]: HAL_CM4.S
Compile [ 93.1%]: Mutex.cpp
Compile [ 93.4%]: SVC_Table.S
Compile [ 93.8%]: HAL_CM.c
Compile [ 94.1%]: RTX_Conf_CM.c
Compile [ 94.5%]: rt_Event.c
Compile [ 94.8%]: rt_Mailbox.c
Compile [ 95.2%]: rt_Memory.c
Compile [ 95.5%]: rt_List.c
Compile [ 95.8%]: RtosTimer.cpp
Compile [ 96.2%]: rt_MemBox.c
Compile [ 96.5%]: rt_OsEventObserver.c
Compile [ 96.9%]: rt_Mutex.c
Compile [ 97.2%]: rt_Robin.c
Compile [ 97.6%]: rt_Semaphore.c
Compile [ 97.9%]: rt_Time.c
Compile [ 98.3%]: rt_System.c
Compile [ 98.6%]: rt_Timer.c
Compile [ 99.0%]: Thread.cpp
Compile [ 99.3%]: rt_Task.c
Compile [ 99.7%]: test_env.cpp
Compile [100.0%]: rt_CMSIS.c
Link: mbed-os-example-blinky
Elf2Bin: mbed-os-example-blinky
+------------------+-------+-------+-------+
| Module           | .text | .data |  .bss |
+------------------+-------+-------+-------+
| Fill             |    63 |     4 |  2533 |
| Misc             | 26603 |  2212 |    88 |
| features/storage |    42 |     0 |   184 |
| hal/common       |  1560 |     4 |   277 |
| hal/targets      | 10101 |    12 |   184 |
| rtos/rtos        |    38 |     4 |     4 |
| rtos/rtx         |  5785 |    20 |  6810 |
| Subtotals        | 44192 |  2256 | 10080 |
+------------------+-------+-------+-------+
Allocated Heap: 65536 bytes
Allocated Stack: unknown
Total Static RAM memory (data + bss): 12336 bytes
Total RAM memory (data + bss + heap + stack): 77872 bytes
Total Flash memory (text + data + misc): 47488 bytes
Image: ./.build/k64f/gcc_arm/mbed-os-example-blinky.bin
```