### PR TITLE
[NUCLEO_F303ZE] MBED-OS5 capability

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -750,15 +750,14 @@
     "NUCLEO_F303ZE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
         "core": "Cortex-M4F",
-        "fpu": "single",
-        "default_toolchain": "uARM",
+        "default_toolchain": "ARM",
         "extra_labels": ["STM", "STM32F3", "STM32F303ZE"],
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
         "inherits": ["Target"],
         "progen": {"target": "nucleo-f303ze"},
-        "detect_code": ["0745"],
+        "detect_code": ["0747"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release_versions": ["2"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_F334R8": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303ZE/TOOLCHAIN_ARM_STD/startup_stm32f303xe.S
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303ZE/TOOLCHAIN_ARM_STD/startup_stm32f303xe.S
@@ -39,7 +39,7 @@
 ;
 ;*******************************************************************************
 
-__initial_sp    EQU     0x20004000 ; Top of RAM
+__initial_sp    EQU     0x20010000 ; Top of RAM
 
                 PRESERVE8
                 THUMB


### PR DESCRIPTION
## Description
All MBED OS2 (uARM, GCC, IAR, ARM) and OS5 (GCC, IAR, ARM) tests are OK with that patch and NUCLEO_F303ZE

## Status
READY
