### PR TITLE
[EFM32] Set default baud rate to 115200.

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -10,5 +10,10 @@
             "help": "Baud rate for stdio",
             "value": 9600
         }
+    },
+    "target_overrides": {
+        "EFM32": {
+            "stdio-baud-rate": 115200
+        }
     }
 }


### PR DESCRIPTION
Set correct default stdio baud rate on EFM32 STKs.

Should fix #2791.

@0xc0170 
