### PR TITLE
ARMC6 support

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/sdk/source/ble/common/ble_conn_state.c
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/sdk/source/ble/common/ble_conn_state.c
@@ -44,7 +44,7 @@
   #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #endif
 
@@ -84,7 +84,7 @@ typedef struct
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #endif
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/sdk/source/device/nrf51.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/sdk/source/device/nrf51.h
@@ -114,7 +114,7 @@ typedef enum {
   #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
 /* anonymous unions are enabled by default */
@@ -1159,7 +1159,7 @@ typedef struct {                                    /*!< GPIO Structure         
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
   /* anonymous unions are enabled by default */

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/common/binary.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/common/binary.h
@@ -60,7 +60,7 @@
 /// test n-th bit of x
 #define BIT_TEST(x, n) ( (x) & BIT(n) )
 
-#if defined(__GNUC__) && !defined(__CC_ARM) // keil does not support binary format
+#if defined(__GNUC__) || defined(__clang__) && !defined(__CC_ARM) // keil does not support binary format
 
 #define BIN8(x)               ((uint8_t)  (0b##x))
 #define BIN16(b1, b2)         ((uint16_t) (0b##b1##b2))

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/common/binary.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/common/binary.h
@@ -60,7 +60,7 @@
 /// test n-th bit of x
 #define BIT_TEST(x, n) ( (x) & BIT(n) )
 
-#if defined(__GNUC__) && !defined(__CC_ARM) // keil does not support binary format
+#if defined(__GNUC__) || defined(__clang__) && !defined(__CC_ARM) // keil does not support binary format
 
 #define BIN8(x)               ((uint8_t)  (0b##x))
 #define BIN16(b1, b2)         ((uint16_t) (0b##b1##b2))

--- a/features/FEATURE_COMMON_PAL/mbed-trace/mbed-trace/mbed_trace.h
+++ b/features/FEATURE_COMMON_PAL/mbed-trace/mbed-trace/mbed_trace.h
@@ -263,7 +263,7 @@ const char* mbed_trace_include_filters_get(void);
  * @param fmt    trace format (like printf)
  * @param ...    variable arguments related to fmt
  */
-#if defined(__GNUC__) || defined(__CC_ARM)
+#if defined(__GNUC__) || defined(__clang__) || defined(__CC_ARM)
 void mbed_tracef(uint8_t dlevel, const char* grp, const char *fmt, ...) __attribute__ ((__format__(__printf__, 3, 4)));
 #else
 void mbed_tracef(uint8_t dlevel, const char* grp, const char *fmt, ...);
@@ -283,7 +283,7 @@ void mbed_tracef(uint8_t dlevel, const char* grp, const char *fmt, ...);
  * @param fmt    trace format (like vprintf)
  * @param ap     variable arguments list (like vprintf)
  */
-#if defined(__GNUC__) || defined(__CC_ARM)
+#if defined(__GNUC__) || defined(__clang__) || defined(__CC_ARM)
 void mbed_vtracef(uint8_t dlevel, const char* grp, const char *fmt, va_list ap) __attribute__ ((__format__(__printf__, 3, 0)));
 #else
 void mbed_vtracef(uint8_t dlevel, const char* grp, const char *fmt, va_list ap);

--- a/features/FEATURE_UVISOR/includes/uvisor/api/inc/svc_exports.h
+++ b/features/FEATURE_UVISOR/includes/uvisor/api/inc/svc_exports.h
@@ -132,7 +132,7 @@
 /* note: the macro is implicitly overloaded to allow 0 to 4 32bits arguments */
 #if defined(__CC_ARM)
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 
 #define UVISOR_SVC(id, metadata, ...) \
     ({ \
@@ -160,6 +160,6 @@
         res; \
     })
 
-#endif /* defined(__CC_ARM) || defined(__GNUC__) */
+#endif /* defined(__CC_ARM) || defined(__GNUC__) || defined(__clang__) */
 
 #endif /* __UVISOR_API_SVC_EXPORTS_H__ */

--- a/features/FEATURE_UVISOR/includes/uvisor/api/inc/uvisor_exports.h
+++ b/features/FEATURE_UVISOR/includes/uvisor/api/inc/uvisor_exports.h
@@ -164,7 +164,7 @@
 
 /* TODO/FIXME */
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 
 #define __UVISOR_ASM_MEMORY_ACCESS_R(opcode, type, ...) \
     ({ \
@@ -188,6 +188,6 @@
         : UVISOR_MACRO_GCC_ASM_INPUT(__VA_ARGS__) \
     );
 
-#endif /* defined(__CC_ARM) || defined(__GNUC__) */
+#endif /* defined(__CC_ARM) || defined(__GNUC__) || defined(__clang__) */
 
 #endif /* __UVISOR_API_UVISOR_EXPORTS_H__ */

--- a/features/mbedtls/inc/mbedtls/aesni.h
+++ b/features/mbedtls/inc/mbedtls/aesni.h
@@ -28,7 +28,7 @@
 #define MBEDTLS_AESNI_AES      0x02000000u
 #define MBEDTLS_AESNI_CLMUL    0x00000002u
 
-#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) &&  \
+#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) || defined(__clang__) &&  \
     ( defined(__amd64__) || defined(__x86_64__) )   &&  \
     ! defined(MBEDTLS_HAVE_X86_64)
 #define MBEDTLS_HAVE_X86_64

--- a/features/mbedtls/inc/mbedtls/bignum.h
+++ b/features/mbedtls/inc/mbedtls/bignum.h
@@ -113,7 +113,7 @@
   typedef uint64_t mbedtls_mpi_uint;
 #else
   #if ( ! defined(MBEDTLS_HAVE_INT32) &&               \
-        defined(__GNUC__) && (                          \
+        defined(__GNUC__) || defined(__clang__) && (                          \
         defined(__amd64__) || defined(__x86_64__)    || \
         defined(__ppc64__) || defined(__powerpc64__) || \
         defined(__ia64__)  || defined(__alpha__)     || \

--- a/features/mbedtls/inc/mbedtls/bn_mul.h
+++ b/features/mbedtls/inc/mbedtls/bn_mul.h
@@ -46,7 +46,7 @@
 #endif
 
 /* armcc5 --gnu defines __GNUC__ but doesn't support GNU's extended asm */
-#if defined(__GNUC__) && \
+#if defined(__GNUC__) || defined(__clang__) && \
     ( !defined(__ARMCC_VERSION) || __ARMCC_VERSION >= 6000000 )
 #if defined(__i386__)
 
@@ -568,7 +568,7 @@
  * So, only use the optimized assembly below for optimized build, which avoids
  * the build error and is pretty reasonable anyway.
  */
-#if defined(__GNUC__) && !defined(__OPTIMIZE__)
+#if defined(__GNUC__) || defined(__clang__) && !defined(__OPTIMIZE__)
 #define MULADDC_CANNOT_USE_R7
 #endif
 

--- a/features/mbedtls/inc/mbedtls/check_config.h
+++ b/features/mbedtls/inc/mbedtls/check_config.h
@@ -57,7 +57,7 @@
 #endif
 
 #if defined(MBEDTLS_DEPRECATED_WARNING) && \
-    !defined(__GNUC__) && !defined(__clang__)
+    !defined(__GNUC__) || defined(__clang__) && !defined(__clang__)
 #error "MBEDTLS_DEPRECATED_WARNING only works with GCC and Clang"
 #endif
 

--- a/features/mbedtls/inc/mbedtls/padlock.h
+++ b/features/mbedtls/inc/mbedtls/padlock.h
@@ -35,7 +35,7 @@
 #endif
 
 /* Some versions of ASan result in errors about not enough registers */
-#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) && defined(__i386__) && \
+#if defined(MBEDTLS_HAVE_ASM) && defined(__GNUC__) || defined(__clang__) && defined(__i386__) && \
     !defined(MBEDTLS_HAVE_ASAN)
 
 #ifndef MBEDTLS_HAVE_X86

--- a/features/mbedtls/src/timing.c
+++ b/features/mbedtls/src/timing.c
@@ -89,7 +89,7 @@ unsigned long mbedtls_timing_hardclock( void )
 
 /* some versions of mingw-64 have 32-bit longs even on x84_64 */
 #if !defined(HAVE_HARDCLOCK) && defined(MBEDTLS_HAVE_ASM) &&  \
-    defined(__GNUC__) && ( defined(__i386__) || (                       \
+    defined(__GNUC__) || defined(__clang__) && ( defined(__i386__) || (                       \
     ( defined(__amd64__) || defined( __x86_64__) ) && __SIZEOF_LONG__ == 4 ) )
 
 #define HAVE_HARDCLOCK
@@ -104,7 +104,7 @@ unsigned long mbedtls_timing_hardclock( void )
           __GNUC__ && __i386__ */
 
 #if !defined(HAVE_HARDCLOCK) && defined(MBEDTLS_HAVE_ASM) &&  \
-    defined(__GNUC__) && ( defined(__amd64__) || defined(__x86_64__) )
+    defined(__GNUC__) || defined(__clang__) && ( defined(__amd64__) || defined(__x86_64__) )
 
 #define HAVE_HARDCLOCK
 
@@ -118,7 +118,7 @@ unsigned long mbedtls_timing_hardclock( void )
           __GNUC__ && ( __amd64__ || __x86_64__ ) */
 
 #if !defined(HAVE_HARDCLOCK) && defined(MBEDTLS_HAVE_ASM) &&  \
-    defined(__GNUC__) && ( defined(__powerpc__) || defined(__ppc__) )
+    defined(__GNUC__) || defined(__clang__) && ( defined(__powerpc__) || defined(__ppc__) )
 
 #define HAVE_HARDCLOCK
 
@@ -140,7 +140,7 @@ unsigned long mbedtls_timing_hardclock( void )
           __GNUC__ && ( __powerpc__ || __ppc__ ) */
 
 #if !defined(HAVE_HARDCLOCK) && defined(MBEDTLS_HAVE_ASM) &&  \
-    defined(__GNUC__) && defined(__sparc64__)
+    defined(__GNUC__) || defined(__clang__) && defined(__sparc64__)
 
 #if defined(__OpenBSD__)
 #warning OpenBSD does not allow access to tick register using software version instead
@@ -158,7 +158,7 @@ unsigned long mbedtls_timing_hardclock( void )
           __GNUC__ && __sparc64__ */
 
 #if !defined(HAVE_HARDCLOCK) && defined(MBEDTLS_HAVE_ASM) &&  \
-    defined(__GNUC__) && defined(__sparc__) && !defined(__sparc64__)
+    defined(__GNUC__) || defined(__clang__) && defined(__sparc__) && !defined(__sparc64__)
 
 #define HAVE_HARDCLOCK
 
@@ -173,7 +173,7 @@ unsigned long mbedtls_timing_hardclock( void )
           __GNUC__ && __sparc__ && !__sparc64__ */
 
 #if !defined(HAVE_HARDCLOCK) && defined(MBEDTLS_HAVE_ASM) &&      \
-    defined(__GNUC__) && defined(__alpha__)
+    defined(__GNUC__) || defined(__clang__) && defined(__alpha__)
 
 #define HAVE_HARDCLOCK
 
@@ -187,7 +187,7 @@ unsigned long mbedtls_timing_hardclock( void )
           __GNUC__ && __alpha__ */
 
 #if !defined(HAVE_HARDCLOCK) && defined(MBEDTLS_HAVE_ASM) &&      \
-    defined(__GNUC__) && defined(__ia64__)
+    defined(__GNUC__) || defined(__clang__) && defined(__ia64__)
 
 #define HAVE_HARDCLOCK
 

--- a/features/net/FEATURE_IPV4/lwip-interface/lwip-sys/arch/cc.h
+++ b/features/net/FEATURE_IPV4/lwip-interface/lwip-sys/arch/cc.h
@@ -59,7 +59,7 @@ typedef uintptr_t          mem_ptr_t;
 /* Use LWIP error codes */
 #define LWIP_PROVIDE_ERRNO
 
-#if defined(__arm__) && defined(__ARMCC_VERSION) 
+#if defined(__CC_ARM)
     /* Keil uVision4 tools */
     #define PACK_STRUCT_BEGIN __packed
     #define PACK_STRUCT_STRUCT

--- a/features/net/FEATURE_IPV6/mbed-mesh-api/source/AbstractMesh.cpp
+++ b/features/net/FEATURE_IPV6/mbed-mesh-api/source/AbstractMesh.cpp
@@ -109,7 +109,7 @@ mesh_error_t AbstractMesh::connect()
 /*
  * Disable optimization as gcc compiler fails to return correct enum value.
  */
-#if defined(__GNUC__) && !defined(__ARMCC_VERSION)
+#if defined(__GNUC__) || defined(__clang__) && !defined(__ARMCC_VERSION)
 #define DISABLE_GCC_OPT __attribute__((optimize("O0")))
 #else
 #define DISABLE_GCC_OPT

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -558,7 +558,7 @@
     "K64F": {
         "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M4F",
-        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR", "ARMC6"],
         "extra_labels": ["Freescale", "KSDK2_MCUS", "FRDM", "KPSDK_MCUS", "KPSDK_CODE", "MCU_K64F"],
         "is_disk_virtual": true,
         "macros": ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED", "MBEDTLS_ENTROPY_HARDWARE_ALT"],

--- a/hal/targets/cmsis/TARGET_ARM_SSG/TARGET_BEETLE/CMSDK_BEETLE.h
+++ b/hal/targets/cmsis/TARGET_ARM_SSG/TARGET_BEETLE/CMSDK_BEETLE.h
@@ -117,7 +117,7 @@ typedef enum IRQn
 #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
 /* anonymous unions are enabled by default */
@@ -827,7 +827,7 @@ typedef struct
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
   /* anonymous unions are enabled by default */

--- a/hal/targets/cmsis/TARGET_ARM_SSG/TARGET_IOTSS_BEID/CMSDK_BEID.h
+++ b/hal/targets/cmsis/TARGET_ARM_SSG/TARGET_IOTSS_BEID/CMSDK_BEID.h
@@ -141,7 +141,7 @@ typedef enum IRQn
 #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
 /* anonymous unions are enabled by default */
@@ -714,7 +714,7 @@ typedef struct
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
   /* anonymous unions are enabled by default */

--- a/hal/targets/cmsis/TARGET_ARM_SSG/TARGET_MPS2_M0/CMSDK_CM0.h
+++ b/hal/targets/cmsis/TARGET_ARM_SSG/TARGET_MPS2_M0/CMSDK_CM0.h
@@ -117,7 +117,7 @@ typedef enum IRQn
 #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
 /* anonymous unions are enabled by default */
@@ -644,7 +644,7 @@ typedef struct
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
   /* anonymous unions are enabled by default */

--- a/hal/targets/cmsis/TARGET_ARM_SSG/TARGET_MPS2_M0P/CMSDK_CM0plus.h
+++ b/hal/targets/cmsis/TARGET_ARM_SSG/TARGET_MPS2_M0P/CMSDK_CM0plus.h
@@ -118,7 +118,7 @@ typedef enum IRQn
 #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
 /* anonymous unions are enabled by default */
@@ -645,7 +645,7 @@ typedef struct
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
   /* anonymous unions are enabled by default */

--- a/hal/targets/cmsis/TARGET_ARM_SSG/TARGET_MPS2_M3/CMSDK_CM3.h
+++ b/hal/targets/cmsis/TARGET_ARM_SSG/TARGET_MPS2_M3/CMSDK_CM3.h
@@ -119,7 +119,7 @@ typedef enum IRQn
 #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
 /* anonymous unions are enabled by default */
@@ -646,7 +646,7 @@ typedef struct
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
   /* anonymous unions are enabled by default */

--- a/hal/targets/cmsis/TARGET_Atmel/TARGET_SAM_CortexM0P/utils/compiler.h
+++ b/hal/targets/cmsis/TARGET_Atmel/TARGET_SAM_CortexM0P/utils/compiler.h
@@ -969,14 +969,14 @@ typedef double                  F64;  //!< 64-bit floating-point number.
 
 #if defined(__ICCARM__)
 #define SHORTENUM           __packed
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 #define SHORTENUM           __attribute__((packed))
 #endif
 
 /* No operation */
 #if defined(__ICCARM__)
 #define nop()               __no_operation()
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 #define nop()               (__NOP())
 #endif
 

--- a/hal/targets/cmsis/TARGET_Atmel/TARGET_SAM_CortexM4/utils/compiler.h
+++ b/hal/targets/cmsis/TARGET_Atmel/TARGET_SAM_CortexM4/utils/compiler.h
@@ -1034,14 +1034,14 @@ typedef U8                  Byte;       //!< 8-bit unsigned integer.
 
 #if defined(__ICCARM__)
 #define SHORTENUM           __packed
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 #define SHORTENUM           __attribute__((packed))
 #endif
 
 /* No operation */
 #if defined(__ICCARM__)
 #define nop()               __no_operation()
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 #define nop()               (__NOP())
 #endif
 

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K20XX/TARGET_K20D50M/MK20D5.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K20XX/TARGET_K20D50M/MK20D5.h
@@ -172,7 +172,7 @@ typedef enum IRQn {
 #elif defined(__CWCC__)
   #pragma push
   #pragma cpp_extensions on
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=extended
@@ -5802,7 +5802,7 @@ typedef struct {
   #pragma pop
 #elif defined(__CWCC__)
   #pragma pop
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* leave anonymous unions enabled */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=default

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/MK20DX256.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/MK20DX256.h
@@ -233,7 +233,7 @@ typedef enum IRQn {
 #elif defined(__CWCC__)
   #pragma push
   #pragma cpp_extensions on
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=extended
@@ -5999,7 +5999,7 @@ typedef struct {
   #pragma pop
 #elif defined(__CWCC__)
   #pragma pop
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* leave anonymous unions enabled */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=default

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K22F/MK22F51212.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K22F/MK22F51212.h
@@ -403,7 +403,7 @@ typedef enum _dma_request_source
 #elif defined(__CWCC__)
   #pragma push
   #pragma cpp_extensions on
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=extended
@@ -8692,7 +8692,7 @@ typedef struct {
   #pragma pop
 #elif defined(__CWCC__)
   #pragma pop
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* leave anonymous unions enabled */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=default

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K66F/MK66F18.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K66F/MK66F18.h
@@ -429,7 +429,7 @@ typedef enum _dma_request_source
 #elif defined(__CWCC__)
   #pragma push
   #pragma cpp_extensions on
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=extended
@@ -17236,7 +17236,7 @@ typedef struct {
   #pragma pop
 #elif defined(__CWCC__)
   #pragma pop
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* leave anonymous unions enabled */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=default

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_KL27Z/MKL27Z644.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_KL27Z/MKL27Z644.h
@@ -312,7 +312,7 @@ typedef enum _dma_request_source
 #elif defined(__CWCC__)
   #pragma push
   #pragma cpp_extensions on
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=extended
@@ -5776,7 +5776,7 @@ typedef struct {
   #pragma pop
 #elif defined(__CWCC__)
   #pragma pop
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* leave anonymous unions enabled */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=default

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_KL43Z/MKL43Z4.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_KL43Z/MKL43Z4.h
@@ -314,7 +314,7 @@ typedef enum _dma_request_source
 #elif defined(__CWCC__)
   #pragma push
   #pragma cpp_extensions on
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=extended
@@ -7978,7 +7978,7 @@ typedef struct {
   #pragma pop
 #elif defined(__CWCC__)
   #pragma pop
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* leave anonymous unions enabled */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=default

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/MKL05Z4.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/MKL05Z4.h
@@ -154,7 +154,7 @@ typedef enum IRQn {
 #elif defined(__CWCC__)
   #pragma push
   #pragma cpp_extensions on
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=extended
@@ -3399,7 +3399,7 @@ typedef struct {
   #pragma pop
 #elif defined(__CWCC__)
   #pragma pop
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* leave anonymous unions enabled */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=default

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/MKL25Z4.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/MKL25Z4.h
@@ -146,7 +146,7 @@ typedef enum IRQn {
 #elif defined(__CWCC__)
   #pragma push
   #pragma cpp_extensions on
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=extended
@@ -4121,7 +4121,7 @@ typedef struct {
   #pragma pop
 #elif defined(__CWCC__)
   #pragma pop
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* leave anonymous unions enabled */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=default

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/MKL26Z4.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/MKL26Z4.h
@@ -159,7 +159,7 @@ typedef enum IRQn {
 #elif defined(__CWCC__)
   #pragma push
   #pragma cpp_extensions on
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=extended
@@ -4420,7 +4420,7 @@ typedef struct {
   #pragma pop
 #elif defined(__CWCC__)
   #pragma pop
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* leave anonymous unions enabled */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=default

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/MKL46Z4.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/MKL46Z4.h
@@ -157,7 +157,7 @@ typedef enum IRQn {
 #elif defined(__CWCC__)
   #pragma push
   #pragma cpp_extensions on
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=extended
@@ -5767,7 +5767,7 @@ typedef struct {
   #pragma pop
 #elif defined(__CWCC__)
   #pragma pop
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* leave anonymous unions enabled */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=default

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_MCU_K64F/MK64F12.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_MCU_K64F/MK64F12.h
@@ -405,13 +405,13 @@ typedef enum _dma_request_source
 ** Start of section using anonymous unions
 */
 
-#if defined(__ARMCC_VERSION)
+#if defined(__CC_ARM)
   #pragma push
   #pragma anon_unions
 #elif defined(__CWCC__)
   #pragma push
   #pragma cpp_extensions on
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=extended
@@ -12613,11 +12613,11 @@ typedef struct {
 ** End of section using anonymous unions
 */
 
-#if defined(__ARMCC_VERSION)
+#if defined(__CC_ARM)
   #pragma pop
 #elif defined(__CWCC__)
   #pragma pop
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* leave anonymous unions enabled */
 #elif defined(__IAR_SYSTEMS_ICC__)
   #pragma language=default

--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf51.h
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf51.h
@@ -114,7 +114,7 @@ typedef enum {
   #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
 /* anonymous unions are enabled by default */
@@ -1159,7 +1159,7 @@ typedef struct {                                    /*!< GPIO Structure         
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
   /* anonymous unions are enabled by default */

--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/sdk/device/nrf51.h
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/sdk/device/nrf51.h
@@ -136,7 +136,7 @@ typedef enum {
   #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
 /* anonymous unions are enabled by default */
@@ -1181,7 +1181,7 @@ typedef struct {                                    /*!< GPIO Structure         
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
   /* anonymous unions are enabled by default */

--- a/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/sdk/device/nrf52.h
+++ b/hal/targets/cmsis/TARGET_NORDIC/TARGET_NRF5/sdk/device/nrf52.h
@@ -154,7 +154,7 @@ typedef enum {
   #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
 /* anonymous unions are enabled by default */
@@ -1955,7 +1955,7 @@ typedef struct {                                    /*!< GPIO Structure         
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
   /* anonymous unions are enabled by default */

--- a/hal/targets/cmsis/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/startup_NUC472_442.c
+++ b/hal/targets/cmsis/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/startup_NUC472_442.c
@@ -28,7 +28,7 @@ _Pragma(_STRINGIFY(_WEAK_ALIAS_FUNC(FUN, FUN_ALIAS)))
 #define _WEAK_ALIAS_FUNC(FUN, FUN_ALIAS) weak __WEAK_ALIAS_FUNC(FUN, FUN_ALIAS)
 #define __WEAK_ALIAS_FUNC(FUN, FUN_ALIAS) FUN##=##FUN_ALIAS
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 #define WEAK            __attribute__ ((weak))
 #define ALIAS(f)        __attribute__ ((weak, alias(#f)))
 
@@ -44,7 +44,7 @@ extern uint32_t Image$$ARM_LIB_STACK$$ZI$$Limit;
 extern void __main(void);
 #elif defined(__ICCARM__)
 void __iar_program_start(void);
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 extern uint32_t __StackTop;
 extern uint32_t __etext;
 extern uint32_t __data_start__;
@@ -231,7 +231,7 @@ const uint32_t __vector_handlers[] = {
 #elif defined(__ICCARM__)
 extern uint32_t CSTACK$$Limit;
 const uint32_t __vector_table[] @ ".intvec" = {
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 __attribute__ ((section(".vector_table")))
 const uint32_t __vector_handlers[] = {
 #endif
@@ -242,7 +242,7 @@ const uint32_t __vector_handlers[] = {
 #elif defined(__ICCARM__)
     //(uint32_t) __sfe("CSTACK"),
     (uint32_t) &CSTACK$$Limit,
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
     &__StackTop,
 #endif
 
@@ -437,7 +437,7 @@ void Reset_Handler(void)
 #elif defined(__ICCARM__)
     __iar_program_start();
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
     uint32_t *src_ind = (uint32_t *) &__etext;
     uint32_t *dst_ind = (uint32_t *) &__data_start__;
     uint32_t *dst_end = (uint32_t *) &__data_end__;

--- a/hal/targets/cmsis/TARGET_NUVOTON/TARGET_NUC472/cmsis.h
+++ b/hal/targets/cmsis/TARGET_NUVOTON/TARGET_NUC472/cmsis.h
@@ -26,7 +26,7 @@
 extern uint32_t Image$$ER_IRAMVEC$$ZI$$Base;
 #elif defined(__ICCARM__)
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 extern uint32_t __start_vector_table__;
 #endif
 

--- a/hal/targets/cmsis/TARGET_NUVOTON/TARGET_NUC472/cmsis_nvic.h
+++ b/hal/targets/cmsis/TARGET_NUVOTON/TARGET_NUC472/cmsis_nvic.h
@@ -28,7 +28,7 @@
 #elif defined(__ICCARM__)
 #   pragma section = "IRAMVEC"
 #   define NVIC_RAM_VECTOR_ADDRESS  ((uint32_t) __section_begin("IRAMVEC"))
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 #   define NVIC_RAM_VECTOR_ADDRESS  &__start_vector_table__
 #endif
 

--- a/hal/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/LPC11U6x.h
+++ b/hal/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/LPC11U6x.h
@@ -119,7 +119,7 @@ typedef enum {
   #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
 /* anonymous unions are enabled by default */
@@ -1149,7 +1149,7 @@ typedef struct {                                    /*!< PINT Structure         
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
   /* anonymous unions are enabled by default */

--- a/hal/targets/cmsis/TARGET_NXP/TARGET_LPC15XX/LPC15xx.h
+++ b/hal/targets/cmsis/TARGET_NXP/TARGET_LPC15XX/LPC15xx.h
@@ -136,7 +136,7 @@ typedef enum {
   #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
 /* anonymous unions are enabled by default */
@@ -1619,7 +1619,7 @@ typedef struct {                                    /*!< IOCON Structure        
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
   /* anonymous unions are enabled by default */

--- a/hal/targets/cmsis/TARGET_NXP/TARGET_LPC43XX/LPC43xx.h
+++ b/hal/targets/cmsis/TARGET_NXP/TARGET_LPC43XX/LPC43xx.h
@@ -68,7 +68,7 @@ extern "C" {
 #elif defined(__IAR_SYSTEMS_ICC__)
   //#pragma push // FIXME not usable for IAR
   #pragma language=extended
-#else /* defined(__GNUC__) and others */
+#else /* defined(__GNUC__) || defined(__clang__) and others */
   /* Assume anonymous unions are enabled by default */
 #endif
 
@@ -2039,7 +2039,7 @@ typedef struct {                        /* SGPIO Structure        */
   #pragma pop
 #elif defined(__IAR_SYSTEMS_ICC__)
   //#pragma pop // FIXME not usable for IAR
-#else /* defined(__GNUC__) and others */
+#else /* defined(__GNUC__) || defined(__clang__) and others */
   /* Leave anonymous unions enabled */
 #endif
 

--- a/hal/targets/cmsis/TARGET_NXP/TARGET_LPC43XX/system_LPC43xx.c
+++ b/hal/targets/cmsis/TARGET_NXP/TARGET_LPC43XX/system_LPC43xx.c
@@ -144,7 +144,7 @@ void SystemInit(void)
     extern void *__isr_vector;
 
     SCB->VTOR = (unsigned int) &__isr_vector;
-#else /* defined(__GNUC__) and others */
+#else /* defined(__GNUC__) || defined(__clang__) and others */
     extern void *g_pfnVectors;
 
     SCB->VTOR = (unsigned int) &g_pfnVectors;

--- a/hal/targets/cmsis/TARGET_NXP/TARGET_LPC82X/LPC82x.h
+++ b/hal/targets/cmsis/TARGET_NXP/TARGET_LPC82X/LPC82x.h
@@ -111,7 +111,7 @@ typedef enum {
   #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
 /* anonymous unions are enabled by default */
@@ -1218,7 +1218,7 @@ typedef struct {                                    /*!< (@ 0xA0004000) PIN_INT 
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #elif defined(__TMS470__)
   /* anonymous unions are enabled by default */

--- a/hal/targets/cmsis/TARGET_RENESAS/TARGET_RZ_A1H/system_MBRZA1H.c
+++ b/hal/targets/cmsis/TARGET_RENESAS/TARGET_RZ_A1H/system_MBRZA1H.c
@@ -106,7 +106,7 @@ void InitMemorySubsystem(void) {
 }
 #pragma pop
 
-#elif defined(__GNUC__) 
+#elif defined(__GNUC__) || defined(__clang__) 
 
 void InitMemorySubsystem(void) { 
  
@@ -449,7 +449,7 @@ __asm void FPUEnable(void) {
 }
 #pragma pop
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 void FPUEnable(void) {
     __asm__ (
         ".ARM;"

--- a/hal/targets/cmsis/TARGET_RENESAS/TARGET_VK_RZ_A1H/system_VKRZA1H.c
+++ b/hal/targets/cmsis/TARGET_RENESAS/TARGET_VK_RZ_A1H/system_VKRZA1H.c
@@ -106,7 +106,7 @@ void InitMemorySubsystem(void) {
 }
 #pragma pop
 
-#elif defined(__GNUC__) 
+#elif defined(__GNUC__) || defined(__clang__) 
 
 void InitMemorySubsystem(void) { 
  
@@ -449,7 +449,7 @@ __asm void FPUEnable(void) {
 }
 #pragma pop
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 void FPUEnable(void) {
     __asm__ (
         ".ARM;"

--- a/hal/targets/cmsis/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG_STK3400/arm_math.h
+++ b/hal/targets/cmsis/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG_STK3400/arm_math.h
@@ -7265,7 +7265,7 @@ void arm_rfft_fast_f32(
 //Exit low optimization region - place directly after end of function definition
   #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
  //SMMLA
   #define multAcc_32x32_keep32_R(a, x, y) \
   a += (q31_t) (((q63_t) x * y) >> 32)

--- a/hal/targets/cmsis/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG_STK3200/arm_math.h
+++ b/hal/targets/cmsis/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG_STK3200/arm_math.h
@@ -7265,7 +7265,7 @@ void arm_rfft_fast_f32(
 //Exit low optimization region - place directly after end of function definition
   #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
  //SMMLA
   #define multAcc_32x32_keep32_R(a, x, y) \
   a += (q31_t) (((q63_t) x * y) >> 32)

--- a/hal/targets/cmsis/arm_math.h
+++ b/hal/targets/cmsis/arm_math.h
@@ -7516,7 +7516,7 @@ void arm_rfft_fast_f32(
 //Exit low optimization region - place directly after end of function definition
   #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 
   #define LOW_OPTIMIZATION_ENTER __attribute__(( optimize("-O1") ))
 

--- a/hal/targets/cmsis/core_cm4.h
+++ b/hal/targets/cmsis/core_cm4.h
@@ -81,7 +81,7 @@
   #define __INLINE         __inline                                   /*!< inline keyword for ARM Compiler       */
   #define __STATIC_INLINE  static __inline
 
-#elif defined ( __GNUC__ )
+#elif defined ( __GNUC__ ) || defined ( __clang__ )
   #define __ASM            __asm                                      /*!< asm keyword for GNU Compiler          */
   #define __INLINE         inline                                     /*!< inline keyword for GNU Compiler       */
   #define __STATIC_INLINE  static inline
@@ -123,7 +123,7 @@
     #define __FPU_USED         0
   #endif
 
-#elif defined ( __GNUC__ )
+#elif defined ( __GNUC__ ) || defined ( __clang__ )
   #if defined (__VFP_FP__) && !defined(__SOFTFP__)
     #if (__FPU_PRESENT == 1)
       #define __FPU_USED       1

--- a/hal/targets/cmsis/core_cmFunc.h
+++ b/hal/targets/cmsis/core_cmFunc.h
@@ -320,7 +320,7 @@ __STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
 #endif /* (__CORTEX_M == 0x04) || (__CORTEX_M == 0x07) */
 
 
-#elif defined ( __GNUC__ ) /*------------------ GNU Compiler ---------------------*/
+#elif defined ( __GNUC__ ) || defined ( __clang__ ) /*------------------ GNU Compiler ---------------------*/
 /* GNU gcc specific functions */
 
 /** \brief  Enable IRQ Interrupts

--- a/hal/targets/cmsis/core_cmInstr.h
+++ b/hal/targets/cmsis/core_cmInstr.h
@@ -395,7 +395,7 @@ __attribute__((section(".rrx_text"))) __STATIC_INLINE __ASM uint32_t __RRX(uint3
 #endif /* (__CORTEX_M >= 0x03) || (__CORTEX_SC >= 300) */
 
 
-#elif defined ( __GNUC__ ) /*------------------ GNU Compiler ---------------------*/
+#elif defined ( __GNUC__ ) || defined ( __clang__ ) /*------------------ GNU Compiler ---------------------*/
 /* GNU gcc specific functions */
 
 /* Define macros for porting to both thumb1 and thumb2.

--- a/hal/targets/hal/TARGET_ARM_SSG/TARGET_BEETLE/cordio/include/util/utils.h
+++ b/hal/targets/hal/TARGET_ARM_SSG/TARGET_BEETLE/cordio/include/util/utils.h
@@ -32,7 +32,7 @@
 
 #include "wsf_types.h"
 
-#if defined(__GNUC__) || defined(__CC_ARM)
+#if defined(__GNUC__) || defined(__clang__) || defined(__CC_ARM)
 #define PRINTF_ATTRIBUTE(a, b) __attribute__((format(printf, a, b)))
 #else
 #define PRINTF_ATTRIBUTE(a, b)

--- a/hal/targets/hal/TARGET_Atmel/TARGET_SAM_CortexM0P/drivers/system/system.c
+++ b/hal/targets/hal/TARGET_Atmel/TARGET_SAM_CortexM0P/drivers/system/system.c
@@ -59,7 +59,7 @@ void _system_dummy_init(void)
 }
 
 #if !defined(__DOXYGEN__)
-#  if defined(__GNUC__)
+#  if defined(__GNUC__) || defined(__clang__)
 void system_clock_init(void) WEAK __attribute__((alias("_system_dummy_init")));
 void system_board_init(void) WEAK __attribute__((alias("_system_dummy_init")));
 void _system_events_init(void) WEAK __attribute__((alias("_system_dummy_init")));

--- a/hal/targets/hal/TARGET_Atmel/TARGET_SAM_CortexM4/TARGET_SAMG55J19/SAMG55_XPLAINED_PRO/board_init.c
+++ b/hal/targets/hal/TARGET_Atmel/TARGET_SAM_CortexM4/TARGET_SAMG55J19/SAMG55_XPLAINED_PRO/board_init.c
@@ -79,7 +79,7 @@
 		ioport_disable_pin(pin);\
 	} while (0)
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 void board_init(void) WEAK __attribute__((alias("system_board_init")));
 #elif defined(__ICCARM__)
 void board_init(void);

--- a/hal/targets/hal/TARGET_Atmel/TARGET_SAM_CortexM4/board.h
+++ b/hal/targets/hal/TARGET_Atmel/TARGET_SAM_CortexM4/board.h
@@ -383,7 +383,7 @@ extern "C" {
 #endif
 
 
-#if (defined(__GNUC__) && defined(__AVR32__)) || (defined(__ICCAVR32__) || defined(__AAVR32__))
+#if (defined(__GNUC__) || defined(__clang__) && defined(__AVR32__)) || (defined(__ICCAVR32__) || defined(__AAVR32__))
 #ifdef __AVR32_ABI_COMPILER__ // Automatically defined when compiling for AVR32, not when assembling.
 
 /*! \brief This function initializes the board target resources

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K22F/drivers/fsl_common.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K22F/drivers/fsl_common.c
@@ -43,7 +43,7 @@ void __aeabi_assert(const char *failedExpr, const char *file, int line)
         __asm("bkpt #0");
     }
 }
-#elif(defined(__GNUC__))
+#elif(defined(__GNUC__) || defined(__clang__))
 void __assert_func(const char *file, int line, const char *func, const char *failedExpr)
 {
     PRINTF("ASSERT ERROR \" %s \": file \"%s\" Line \"%d\" function name \"%s\" \n", failedExpr, file, line, func);
@@ -70,7 +70,7 @@ void InstallIRQHandler(IRQn_Type irq, uint32_t irqHandler)
     extern uint32_t __RAM_VECTOR_TABLE_SIZE[];
     extern uint32_t __VECTOR_TABLE[];
     extern uint32_t __VECTOR_RAM[];
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
     extern uint32_t __VECTOR_TABLE[];
     extern uint32_t __VECTOR_RAM[];
     extern uint32_t __RAM_VECTOR_TABLE_SIZE_BYTES[];

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K22F/drivers/fsl_flash.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K22F/drivers/fsl_flash.c
@@ -2095,7 +2095,7 @@ static void copy_flash_cache_clear_command(uint8_t *flashCacheClearCommand)
  *
  * This function is used to perform the cache clear to the flash.
  */
-#if (defined(__GNUC__))
+#if (defined(__GNUC__) || defined(__clang__))
 /* #pragma GCC push_options */
 /* #pragma GCC optimize("O0") */
 void __attribute__((optimize("O0"))) flash_cache_clear(flash_config_t *config)
@@ -2173,7 +2173,7 @@ void flash_cache_clear(flash_config_t *config)
 #if (defined(__CC_ARM))
 #pragma pop
 #endif
-#if (defined(__GNUC__))
+#if (defined(__GNUC__) || defined(__clang__))
 /* #pragma GCC pop_options */
 #endif
 

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K66F/drivers/fsl_common.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K66F/drivers/fsl_common.c
@@ -43,7 +43,7 @@ void __aeabi_assert(const char *failedExpr, const char *file, int line)
         __asm("bkpt #0");
     }
 }
-#elif(defined(__GNUC__))
+#elif(defined(__GNUC__) || defined(__clang__))
 void __assert_func(const char *file, int line, const char *func, const char *failedExpr)
 {
     PRINTF("ASSERT ERROR \" %s \": file \"%s\" Line \"%d\" function name \"%s\" \n", failedExpr, file, line, func);
@@ -70,7 +70,7 @@ void InstallIRQHandler(IRQn_Type irq, uint32_t irqHandler)
     extern uint32_t __RAM_VECTOR_TABLE_SIZE[];
     extern uint32_t __VECTOR_TABLE[];
     extern uint32_t __VECTOR_RAM[];
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
     extern uint32_t __VECTOR_TABLE[];
     extern uint32_t __VECTOR_RAM[];
     extern uint32_t __RAM_VECTOR_TABLE_SIZE_BYTES[];

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K66F/drivers/fsl_flash.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K66F/drivers/fsl_flash.c
@@ -2095,7 +2095,7 @@ static void copy_flash_cache_clear_command(uint8_t *flashCacheClearCommand)
  *
  * This function is used to perform the cache clear to the flash.
  */
-#if (defined(__GNUC__))
+#if (defined(__GNUC__) || defined(__clang__))
 /* #pragma GCC push_options */
 /* #pragma GCC optimize("O0") */
 void __attribute__((optimize("O0"))) flash_cache_clear(flash_config_t *config)
@@ -2173,7 +2173,7 @@ void flash_cache_clear(flash_config_t *config)
 #if (defined(__CC_ARM))
 #pragma pop
 #endif
-#if (defined(__GNUC__))
+#if (defined(__GNUC__) || defined(__clang__))
 /* #pragma GCC pop_options */
 #endif
 

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL27Z/drivers/fsl_common.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL27Z/drivers/fsl_common.c
@@ -43,7 +43,7 @@ void __aeabi_assert(const char *failedExpr, const char *file, int line)
         __asm("bkpt #0");
     }
 }
-#elif(defined(__GNUC__))
+#elif(defined(__GNUC__) || defined(__clang__))
 void __assert_func(const char *file, int line, const char *func, const char *failedExpr)
 {
     PRINTF("ASSERT ERROR \" %s \": file \"%s\" Line \"%d\" function name \"%s\" \n", failedExpr, file, line, func);
@@ -70,7 +70,7 @@ void InstallIRQHandler(IRQn_Type irq, uint32_t irqHandler)
     extern uint32_t __RAM_VECTOR_TABLE_SIZE[];
     extern uint32_t __VECTOR_TABLE[];
     extern uint32_t __VECTOR_RAM[];
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
     extern uint32_t __VECTOR_TABLE[];
     extern uint32_t __VECTOR_RAM[];
     extern uint32_t __RAM_VECTOR_TABLE_SIZE_BYTES[];

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL27Z/drivers/fsl_flash.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL27Z/drivers/fsl_flash.c
@@ -2095,7 +2095,7 @@ static void copy_flash_cache_clear_command(uint8_t *flashCacheClearCommand)
  *
  * This function is used to perform the cache clear to the flash.
  */
-#if (defined(__GNUC__))
+#if (defined(__GNUC__) || defined(__clang__))
 /* #pragma GCC push_options */
 /* #pragma GCC optimize("O0") */
 void __attribute__((optimize("O0"))) flash_cache_clear(flash_config_t *config)
@@ -2173,7 +2173,7 @@ void flash_cache_clear(flash_config_t *config)
 #if (defined(__CC_ARM))
 #pragma pop
 #endif
-#if (defined(__GNUC__))
+#if (defined(__GNUC__) || defined(__clang__))
 /* #pragma GCC pop_options */
 #endif
 

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL43Z/drivers/fsl_common.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL43Z/drivers/fsl_common.c
@@ -43,7 +43,7 @@ void __aeabi_assert(const char *failedExpr, const char *file, int line)
         __asm("bkpt #0");
     }
 }
-#elif(defined(__GNUC__))
+#elif(defined(__GNUC__) || defined(__clang__))
 void __assert_func(const char *file, int line, const char *func, const char *failedExpr)
 {
     PRINTF("ASSERT ERROR \" %s \": file \"%s\" Line \"%d\" function name \"%s\" \n", failedExpr, file, line, func);
@@ -70,7 +70,7 @@ void InstallIRQHandler(IRQn_Type irq, uint32_t irqHandler)
     extern uint32_t __RAM_VECTOR_TABLE_SIZE[];
     extern uint32_t __VECTOR_TABLE[];
     extern uint32_t __VECTOR_RAM[];
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
     extern uint32_t __VECTOR_TABLE[];
     extern uint32_t __VECTOR_RAM[];
     extern uint32_t __RAM_VECTOR_TABLE_SIZE_BYTES[];

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL43Z/drivers/fsl_flash.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL43Z/drivers/fsl_flash.c
@@ -2095,7 +2095,7 @@ static void copy_flash_cache_clear_command(uint8_t *flashCacheClearCommand)
  *
  * This function is used to perform the cache clear to the flash.
  */
-#if (defined(__GNUC__))
+#if (defined(__GNUC__) || defined(__clang__))
 /* #pragma GCC push_options */
 /* #pragma GCC optimize("O0") */
 void __attribute__((optimize("O0"))) flash_cache_clear(flash_config_t *config)
@@ -2173,7 +2173,7 @@ void flash_cache_clear(flash_config_t *config)
 #if (defined(__CC_ARM))
 #pragma pop
 #endif
-#if (defined(__GNUC__))
+#if (defined(__GNUC__) || defined(__clang__))
 /* #pragma GCC pop_options */
 #endif
 

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/drivers/fsl_common.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/drivers/fsl_common.c
@@ -43,7 +43,7 @@ void __aeabi_assert(const char *failedExpr, const char *file, int line)
         __asm("bkpt #0");
     }
 }
-#elif(defined(__GNUC__))
+#elif(defined(__GNUC__) || defined(__clang__))
 void __assert_func(const char *file, int line, const char *func, const char *failedExpr)
 {
     PRINTF("ASSERT ERROR \" %s \": file \"%s\" Line \"%d\" function name \"%s\" \n", failedExpr, file, line, func);
@@ -70,7 +70,7 @@ void InstallIRQHandler(IRQn_Type irq, uint32_t irqHandler)
     extern uint32_t __RAM_VECTOR_TABLE_SIZE[];
     extern uint32_t __VECTOR_TABLE[];
     extern uint32_t __VECTOR_RAM[];
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
     extern uint32_t __VECTOR_TABLE[];
     extern uint32_t __VECTOR_RAM[];
     extern uint32_t __RAM_VECTOR_TABLE_SIZE_BYTES[];

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/drivers/fsl_flash.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/drivers/fsl_flash.c
@@ -2095,7 +2095,7 @@ static void copy_flash_cache_clear_command(uint8_t *flashCacheClearCommand)
  *
  * This function is used to perform the cache clear to the flash.
  */
-#if (defined(__GNUC__))
+#if (defined(__GNUC__) || defined(__clang__))
 /* #pragma GCC push_options */
 /* #pragma GCC optimize("O0") */
 void __attribute__((optimize("O0"))) flash_cache_clear(flash_config_t *config)
@@ -2173,7 +2173,7 @@ void flash_cache_clear(flash_config_t *config)
 #if (defined(__CC_ARM))
 #pragma pop
 #endif
-#if (defined(__GNUC__))
+#if (defined(__GNUC__) || defined(__clang__))
 /* #pragma GCC pop_options */
 #endif
 

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/Lib/nordic_sdk/components/libraries/util/app_util.h
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/Lib/nordic_sdk/components/libraries/util/app_util.h
@@ -48,7 +48,7 @@ enum
  * @param[in]   EXPR   Constant expression to be verified.
  */
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #define STATIC_ASSERT(EXPR) typedef char __attribute__((unused)) static_assert_failed[(EXPR) ? 1 : -1]
 #elif defined(__ICCARM__)
 #define STATIC_ASSERT(EXPR) extern char static_assert_failed[(EXPR) ? 1 : -1] 

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/ble/common/ble_conn_state.c
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/ble/common/ble_conn_state.c
@@ -51,7 +51,7 @@
   #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #endif
 
@@ -91,7 +91,7 @@ typedef struct
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #endif
 

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/libraries/experimental_section_vars/section_vars.h
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/libraries/experimental_section_vars/section_vars.h
@@ -68,7 +68,7 @@
 // Not required by this compiler.
 #define NRF_SECTION_VARS_REGISTER_SECTION(section_name)
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 
 // Not required by this compiler.
 #define NRF_SECTION_VARS_REGISTER_SECTION(section_name)
@@ -92,7 +92,7 @@
 
 #define NRF_SECTION_VARS_START_SYMBOL(section_name)         section_name ## $$Base
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 
 #define NRF_SECTION_VARS_START_SYMBOL(section_name)         __start_ ## section_name
 
@@ -113,7 +113,7 @@
 
 #define NRF_SECTION_VARS_END_SYMBOL(section_name)           section_name ## $$Limit
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 
 #define NRF_SECTION_VARS_END_SYMBOL(section_name)           __stop_ ## section_name
 
@@ -135,7 +135,7 @@
 #define NRF_SECTION_VARS_LENGTH(section_name) \
     ((uint32_t)&NRF_SECTION_VARS_END_SYMBOL(section_name) - (uint32_t)&NRF_SECTION_VARS_START_SYMBOL(section_name))
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 
  #define NRF_SECTION_VARS_LENGTH(section_name) \
     ((uint32_t)&NRF_SECTION_VARS_END_SYMBOL(section_name) - (uint32_t)&NRF_SECTION_VARS_START_SYMBOL(section_name))
@@ -156,7 +156,7 @@
 
 #define NRF_SECTION_VARS_START_ADDR(section_name)       (uint32_t)&NRF_SECTION_VARS_START_SYMBOL(section_name)
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 
 #define NRF_SECTION_VARS_START_ADDR(section_name)       (uint32_t)&NRF_SECTION_VARS_START_SYMBOL(section_name)
 
@@ -175,7 +175,7 @@
 
 #define NRF_SECTION_VARS_END_ADDR(section_name)         (uint32_t)&NRF_SECTION_VARS_END_SYMBOL(section_name)
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 
 #define NRF_SECTION_VARS_END_ADDR(section_name)         (uint32_t)&NRF_SECTION_VARS_END_SYMBOL(section_name)
 
@@ -199,7 +199,7 @@
     extern type_name * NRF_SECTION_VARS_START_SYMBOL(section_name); \
     extern void      * NRF_SECTION_VARS_END_SYMBOL(section_name)
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 
 #define NRF_SECTION_VARS_REGISTER_SYMBOLS(type_name, section_name)  \
     extern type_name * NRF_SECTION_VARS_START_SYMBOL(section_name); \
@@ -234,7 +234,7 @@
 #define NRF_SECTION_VARS_ADD(section_name, type_def) \
     static type_def __attribute__ ((section(#section_name))) __attribute__((used))
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 
 #define NRF_SECTION_VARS_ADD(section_name, type_def) \
     static type_def __attribute__ ((section("."#section_name))) __attribute__((used))
@@ -264,7 +264,7 @@
 #define NRF_SECTION_VARS_GET(i, type_name, section_name) \
     (type_name*)(NRF_SECTION_VARS_START_ADDR(section_name) + i * sizeof(type_name))
       
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 
 #define NRF_SECTION_VARS_GET(i, type_name, section_name) \
     (type_name*)(NRF_SECTION_VARS_START_ADDR(section_name) + i * sizeof(type_name))

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/libraries/fds/fds.h
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/libraries/fds/fds.h
@@ -231,7 +231,7 @@ typedef enum
     #pragma anon_unions
 #elif defined(__ICCARM__)
     #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
     /* anonymous unions are enabled by default */
 #endif
 
@@ -275,7 +275,7 @@ typedef struct
     #pragma pop
 #elif defined(__ICCARM__)
     /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
     /* anonymous unions are enabled by default */
 #endif
 

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/libraries/fds/fds_internal_defs.h
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/libraries/fds/fds_internal_defs.h
@@ -187,7 +187,7 @@ typedef enum
     #pragma anon_unions
 #elif defined(__ICCARM__)
     #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
     // anonymous unions are enabled by default
 #endif
 
@@ -223,7 +223,7 @@ typedef struct
     #pragma pop
 #elif defined(__ICCARM__)
     // leave anonymous unions enabled
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
     // anonymous unions are enabled by default
 #endif
 

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/libraries/fstorage/fstorage.h
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/libraries/fstorage/fstorage.h
@@ -81,7 +81,7 @@ typedef enum
   #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #endif
 
@@ -108,7 +108,7 @@ typedef struct
   #pragma pop
 #elif defined(__ICCARM__)
   /* leave anonymous unions enabled */
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   /* anonymous unions are enabled by default */
 #endif
 

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/libraries/fstorage/fstorage_internal_defs.h
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/sdk/libraries/fstorage/fstorage_internal_defs.h
@@ -82,7 +82,7 @@ typedef enum
   #pragma anon_unions
 #elif defined(__ICCARM__)
   #pragma language=extended
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   // anonymous unions are enabled by default.
 #endif
 
@@ -114,7 +114,7 @@ typedef struct
   #pragma pop
 #elif defined(__ICCARM__)
   // leave anonymous unions enabled.
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   // anonymous unions are enabled by default.
 #endif
 

--- a/hal/targets/hal/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/mbed_overrides.c
+++ b/hal/targets/hal/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/mbed_overrides.c
@@ -18,7 +18,7 @@
 #include "analogin_api.h"
 
 // NOTE: Ensurce mbed_sdk_init() will get called before C++ global object constructor.
-#if defined(__CC_ARM) || defined(__GNUC__)
+#if defined(__CC_ARM) || defined(__GNUC__) || defined(__clang__)
 void mbed_sdk_init_forced(void) __attribute__((constructor(101)));
 #elif defined(__ICCARM__)
     // FIXME: How to achieve it in IAR?

--- a/hal/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/emlib/inc/em_common.h
+++ b/hal/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/emlib/inc/em_common.h
@@ -51,7 +51,7 @@ extern "C" {
  * @{
  ******************************************************************************/
 
-#if !defined(__GNUC__)
+#if !defined(__GNUC__) || defined(__clang__)
 
 /** Macro for getting minimum value. */
 #define EFM32_MIN(a, b)    ((a) < (b) ? (a) : (b))
@@ -73,7 +73,7 @@ extern "C" {
 #define EFM32_ALIGN(X) _Pragma( STRINGIZE( data_alignment=X ) )
 #endif
 
-#else // !defined(__GNUC__)
+#else // !defined(__GNUC__) || defined(__clang__)
 
 /** Macro for getting minimum value. No sideeffects, a and b are evaluated once only. */
 #define EFM32_MIN(a, b)    ({ __typeof__(a) _a = (a); __typeof__(b) _b = (b); _a < _b ? _a : _b; })
@@ -102,7 +102,7 @@ extern "C" {
  */
 #define EFM32_ALIGN(X)
 
-#endif // !defined(__GNUC__)
+#endif // !defined(__GNUC__) || defined(__clang__)
 
 /***************************************************************************//**
  * @brief

--- a/hal/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/emlib/inc/em_msc.h
+++ b/hal/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/emlib/inc/em_msc.h
@@ -425,10 +425,10 @@ __STATIC_INLINE void MSC_BusStrategy(mscBusStrategy_Typedef mode)
 #elif defined(__ICCARM__)
 #define MSC_FUNC_PREFIX   __ramfunc
 #define MSC_FUNC_POSTFIX
-#elif defined(__GNUC__) && defined(__CROSSWORKS_ARM)
+#elif defined(__GNUC__) || defined(__clang__) && defined(__CROSSWORKS_ARM)
 #define MSC_FUNC_PREFIX
 #define MSC_FUNC_POSTFIX  __attribute__ ((section(".fast")))
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 #define MSC_FUNC_PREFIX
 #define MSC_FUNC_POSTFIX  __attribute__ ((section(".ram")))
 #endif

--- a/libraries/USBDevice/USBDevice/TARGET_Silicon_Labs/inc/em_usb.h
+++ b/libraries/USBDevice/USBDevice/TARGET_Silicon_Labs/inc/em_usb.h
@@ -239,7 +239,7 @@ extern "C" {
 #define PORT_FULL_SPEED                   1     /**< Full speed return value for USBH_GetPortSpeed(). */
 #define PORT_LOW_SPEED                    2     /**< Low speed return value for USBH_GetPortSpeed().  */
 
-#if defined( __GNUC__  )                  /* GCC compilers */
+#if defined( __GNUC__  ) || defined( __clang__  ) || defined( __clang__  )                  /* GCC compilers */
 #if defined( __CHAR16_TYPE__ )
 typedef __CHAR16_TYPE__ char16_t;
 #else
@@ -306,7 +306,7 @@ EFM32_PACK_END()
  *  is a multiple of WORD size.
  *  @n Example: @n UBUF( rxBuffer, 37 );  =>  uint8_t rxBuffer[ 40 ];
  */
-#if !defined(__GNUC__)
+#if !defined(__GNUC__) || defined(__clang__)
 #define        UBUF( x, y ) EFM32_ALIGN( 4 )        uint8_t x[((y)+3)&~3]
 #define STATIC_UBUF( x, y ) EFM32_ALIGN( 4 ) static uint8_t x[((y)+3)&~3]
 #else

--- a/libraries/dsp/cmsis_dsp/arm_math.h
+++ b/libraries/dsp/cmsis_dsp/arm_math.h
@@ -5754,7 +5754,7 @@ void arm_rfft_fast_f32(
       *pOut = __sqrtf(in);
 #elif (__FPU_USED == 1) && (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
       *pOut = __builtin_sqrtf(in);
-#elif (__FPU_USED == 1) && defined(__GNUC__)
+#elif (__FPU_USED == 1) && defined(__GNUC__) || defined(__clang__)
       *pOut = __builtin_sqrtf(in);
 #elif (__FPU_USED == 1) && defined ( __ICCARM__ ) && (__VER__ >= 6040000)
       __ASM("VSQRT.F32 %0,%1" : "=t"(*pOut) : "t"(in));
@@ -7094,7 +7094,7 @@ void arm_rfft_fast_f32(
   #define IAR_ONLY_LOW_OPTIMIZATION_ENTER
   #define IAR_ONLY_LOW_OPTIMIZATION_EXIT
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
   #define LOW_OPTIMIZATION_ENTER __attribute__(( optimize("-O1") ))
   #define LOW_OPTIMIZATION_EXIT
   #define IAR_ONLY_LOW_OPTIMIZATION_ENTER

--- a/rtos/rtx/TARGET_ARM7/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_ARM7/RTX_CM_lib.h
@@ -212,7 +212,7 @@ extern unsigned char     __usr_stack_top__[];
 #ifdef __CC_ARM
 extern unsigned char     Image$$RW_IRAM1$$ZI$$Limit[];
 #define HEAP_START      (Image$$RW_IRAM1$$ZI$$Limit)
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(__clang__)
 extern unsigned char     __end__[];
 #define HEAP_START      (__end__)
 #elif defined(__ICCARM__)

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -37,7 +37,7 @@
 #include <rt_misc.h>
 #pragma O3
 #define __USED __attribute__((used))
-#elif defined (__GNUC__)
+#elif defined (__GNUC__) || defined (__clang__)
 #pragma GCC optimize ("O3")
 #define __USED __attribute__((used))
 #elif defined (__ICCARM__)
@@ -424,7 +424,7 @@ osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1U, 
 #elif defined(TARGET_K64F)
 #define INITIAL_SP            (0x20030000UL)
 
-#if defined(__CC_ARM) || defined(__GNUC__)
+#if defined(__CC_ARM) || defined(__GNUC__) || defined(__clang__)
 #define ISR_STACK_SIZE        (0x1000)
 #endif
 
@@ -582,7 +582,7 @@ extern uint32_t                 Image$$ARM_LIB_STACK$$ZI$$Length[];
 #define HEAP_SIZE               ((uint32_t) Image$$ARM_LIB_HEAP$$ZI$$Length)
 #define ISR_STACK_START         ((unsigned char*)Image$$ARM_LIB_STACK$$ZI$$Base)
 #define ISR_STACK_SIZE          ((uint32_t)Image$$ARM_LIB_STACK$$ZI$$Length)
-#   elif defined(__GNUC__)
+#   elif defined(__GNUC__) || defined(__clang__)
 extern uint32_t	                __StackTop[];
 extern uint32_t	                __StackLimit[];
 extern uint32_t                 __end__[];
@@ -649,7 +649,7 @@ uint32_t mbed_stack_isr_size = 0;
         extern uint32_t          Image$$RW_IRAM1$$ZI$$Limit[];
         #define HEAP_START      ((unsigned char*)Image$$RW_IRAM1$$ZI$$Limit)
         #define HEAP_SIZE       ((uint32_t)((uint32_t)INITIAL_SP - (uint32_t)HEAP_START))
-    #elif defined(__GNUC__)
+    #elif defined(__GNUC__) || defined(__clang__)
         extern uint32_t         __end__[];
         #define HEAP_START      ((unsigned char*)__end__)
         #define HEAP_SIZE       ((uint32_t)((uint32_t)INITIAL_SP - (uint32_t)HEAP_START))

--- a/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
@@ -66,7 +66,7 @@
 #endif
 
 // The stack space occupied is mainly dependent on the underling C standard library
-#if defined(TOOLCHAIN_GCC) || defined(TOOLCHAIN_ARM_STD) || defined(TOOLCHAIN_IAR)
+#if defined(TOOLCHAIN_ARMC6) || defined(TOOLCHAIN_GCC) || defined(TOOLCHAIN_ARM_STD) || defined(TOOLCHAIN_IAR)
 #    define WORDS_STACK_SIZE   512
 #elif defined(TOOLCHAIN_ARM_MICRO)
 #    define WORDS_STACK_SIZE   128

--- a/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
+++ b/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
@@ -149,7 +149,7 @@ static __inline   t __##f (t1 a1, t2 a2, t3 a3, t4 a4) {                       \
 #define SVC_1_3 SVC_1_1 
 #define SVC_2_3 SVC_2_1 
 
-#elif defined (__GNUC__)        /* GNU Compiler */
+#elif defined (__GNUC__) || defined (__clang__)        /* GNU Compiler */
 
 #define __NO_RETURN __attribute__((noreturn))
 

--- a/rtos/rtx/TARGET_CORTEX_M/rt_HAL_CM.h
+++ b/rtos/rtx/TARGET_CORTEX_M/rt_HAL_CM.h
@@ -60,7 +60,7 @@
                 } while (0)
 #endif
 
-#elif defined (__GNUC__)        /* GNU Compiler */
+#elif defined (__GNUC__) || defined (__clang__)        /* GNU Compiler */
 
 #undef  __USE_EXCLUSIVE_ACCESS
 

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -30,6 +30,9 @@ BUILD_DIR = abspath(join(ROOT, ".build"))
 # ARM Compiler 5
 ARM_PATH = "C:/Keil_v5/ARM/ARMCC"
 
+# ARM Compiler 6
+ARMC6_PATH = ""
+
 # GCC ARM
 GCC_ARM_PATH = ""
 

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -181,11 +181,13 @@ LEGACY_IGNORE_DIRS = set([
     'LPC11U24', 'LPC1768', 'LPC2368', 'LPC4088', 'LPC812', 'KL25Z',
     'ARM', 'uARM', 'IAR',
     'GCC_ARM', 'GCC_CS', 'GCC_CR', 'GCC_CW', 'GCC_CW_EWL', 'GCC_CW_NEWLIB',
+    'ARMC6'
 ])
 LEGACY_TOOLCHAIN_NAMES = {
     'ARM_STD':'ARM', 'ARM_MICRO': 'uARM',
     'GCC_ARM': 'GCC_ARM', 'GCC_CR': 'GCC_CR',
     'IAR': 'IAR',
+    'ARMC6': 'ARMC6',
 }
 
 
@@ -1290,9 +1292,11 @@ class mbedToolchain:
 from tools.settings import ARM_PATH
 from tools.settings import GCC_ARM_PATH, GCC_CR_PATH
 from tools.settings import IAR_PATH
+from tools.settings import ARMC6_PATH
 
 TOOLCHAIN_PATHS = {
     'ARM': ARM_PATH,
+    'ARMC6': ARMC6_PATH,
     'uARM': ARM_PATH,
     'GCC_ARM': GCC_ARM_PATH,
     'GCC_CR': GCC_CR_PATH,
@@ -1302,9 +1306,11 @@ TOOLCHAIN_PATHS = {
 from tools.toolchains.arm import ARM_STD, ARM_MICRO
 from tools.toolchains.gcc import GCC_ARM, GCC_CR
 from tools.toolchains.iar import IAR
+from tools.toolchains.armc6 import ARMC6
 
 TOOLCHAIN_CLASSES = {
     'ARM': ARM_STD,
+    'ARMC6': ARMC6,
     'uARM': ARM_MICRO,
     'GCC_ARM': GCC_ARM,
     'GCC_CR': GCC_CR,

--- a/tools/toolchains/armc6.py
+++ b/tools/toolchains/armc6.py
@@ -35,8 +35,8 @@ class ARMC6(mbedToolchain):
     DEFAULT_FLAGS = {
         'common': ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g"],
         'asm': [],
-        'c': ["-D__ASSERT_MSG"],
-        'cxx': [],
+        'c': ["-std=gnu99", "-D__ASSERT_MSG"],
+        'cxx': ["-std=gnu++98"],
         'ld': [],
     }
 

--- a/tools/toolchains/armc6.py
+++ b/tools/toolchains/armc6.py
@@ -1,0 +1,178 @@
+"""
+mbed SDK
+Copyright (c) 2011-2013 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import re
+from os.path import join, dirname, splitext, basename
+
+from tools.settings import ARMC6_PATH
+
+from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
+from tools.hooks import hook_tool
+from tools.utils import mkdir
+
+class ARMC6(mbedToolchain):
+    LINKER_EXT = '.sct'
+    LIBRARY_EXT = '.ar'
+
+    STD_LIB_NAME = "%s.ar"
+
+    # ANY changes to these default flags is backwards incompatible and require
+    # an update to the mbed-sdk-tools and website that introduces a profile
+    # for the previous version of these flags
+    DEFAULT_FLAGS = {
+        'common': ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g"],
+        'asm': [],
+        'c': ["-D__ASSERT_MSG"],
+        'cxx': [],
+        'ld': [],
+    }
+
+    @staticmethod
+    def check_executable():
+        """Returns True if the executable (armcc) location specified by the
+         user exists OR the executable can be found on the PATH.
+         Returns False otherwise."""
+        return True
+
+    def __init__(self, target, options=None, notify=None, macros=None, silent=False, extra_verbose=False):
+        mbedToolchain.__init__(self, target, options, notify, macros, silent, extra_verbose=extra_verbose)
+        if target.core.lower()[-1] == 'f':
+            self.flags['common'].append("-mcpu={}".format(target.core.lower()[:-1]))
+        else:
+            self.flags['common'].append("-mcpu={}".format(target.core.lower()))
+
+        if target.core == "Cortex-M4F":
+            self.flags['common'].append("-mfpu=fpv4-sp-d16")
+            self.flags['common'].append("-mfloat-abi=softfp")
+        elif target.core == "Cortex-M7F":
+            self.flags['common'].append("-mfpu=fpv5-sp-d16")
+            self.flags['common'].append("-mfloat-abi=softfp")
+        elif target.core == "Cortex-M7FD":
+            self.flags['common'].append("-mfpu=fpv5-d16")
+            self.flags['common'].append("-mfloat-abi=softfp")
+
+        self.cc = [join(ARMC6_PATH, "armclang")] + self.flags['common'] + self.flags['c']
+        self.cppc = [join(ARMC6_PATH, "armclang")] + self.flags['common'] + self.flags['cxx']
+        self.asm = [join(ARMC6_PATH, "armasm")] + self.flags['asm']
+        self.ld = [join(ARMC6_PATH, "armlink")] + self.flags['ld']
+        self.ar = [join(ARMC6_PATH, "armar")]
+        self.elf2bin = join(ARMC6_PATH, "fromelf")
+
+
+    def parse_dependencies(self, dep_path):
+        return []
+
+    def parse_output(self, output):
+        pass
+
+    def get_config_option(self, config_header):
+        return ["-include", config_header]
+
+    def get_compile_options(self, defines, includes, for_asm=False):
+        opts = ['-D%s' % d for d in defines]
+        opts += ["-I%s" % i for i in includes]
+        if not for_asm:
+            config_header = self.get_config_header()
+            if config_header is not None:
+                opts = opts + self.get_config_option(config_header)
+        return opts
+
+    @hook_tool
+    def assemble(self, source, object, includes):
+        # Preprocess first, then assemble
+        dir = join(dirname(object), '.temp')
+        mkdir(dir)
+        tempfile = join(dir, basename(object) + '.E.s')
+
+        # Build preprocess assemble command
+        cmd_pre = self.asm + self.get_compile_options(self.get_symbols(True), includes) + ["-E", "-o", tempfile, source]
+
+        # Build main assemble command
+        cmd = self.asm + ["-o", object, tempfile]
+
+        # Call cmdline hook
+        cmd_pre = self.hook.get_cmdline_assembler(cmd_pre)
+        cmd = self.hook.get_cmdline_assembler(cmd)
+
+        # Return command array, don't execute
+        return [cmd_pre, cmd]
+
+    @hook_tool
+    def compile(self, cc, source, object, includes):
+        # Build compile command
+        cmd = cc + self.get_compile_options(self.get_symbols(), includes)
+
+        cmd.extend(["-o", object, source])
+
+        # Call cmdline hook
+        cmd = self.hook.get_cmdline_compiler(cmd)
+
+        return [cmd]
+
+    def compile_c(self, source, object, includes):
+        return self.compile(self.cc, source, object, includes)
+
+    def compile_cpp(self, source, object, includes):
+        return self.compile(self.cppc, source, object, includes)
+
+    @hook_tool
+    def link(self, output, objects, libraries, lib_dirs, mem_map):
+        map_file = splitext(output)[0] + ".map"
+        if len(lib_dirs):
+            args = ["-o", output, "--userlibpath", ",".join(lib_dirs), "--info=totals", "--map", "--list=%s" % map_file]
+        else:
+            args = ["-o", output, "--info=totals", "--map", "--list=%s" % map_file]
+
+        if mem_map:
+            args.extend(["--scatter", mem_map])
+
+        # Build linker command
+        cmd = self.ld + args + objects + libraries
+
+        # Call cmdline hook
+        cmd = self.hook.get_cmdline_linker(cmd)
+
+        if self.RESPONSE_FILES:
+            # Split link command to linker executable + response file
+            cmd_linker = cmd[0]
+            link_files = self.get_link_file(cmd[1:])
+            cmd = [cmd_linker, '--via', link_files]
+
+        # Exec command
+        self.cc_verbose("Link: %s" % ' '.join(cmd))
+        self.default_cmd(cmd)
+
+    @hook_tool
+    def archive(self, objects, lib_path):
+        if self.RESPONSE_FILES:
+            param = ['--via', self.get_arch_file(objects)]
+        else:
+            param = objects
+
+        # Exec command
+        self.default_cmd([self.ar, '-r', lib_path] + param)
+
+    @hook_tool
+    def binary(self, resources, elf, bin):
+        # Build binary command
+        cmd = [self.elf2bin, '--bin', '-o', bin, elf]
+
+        # Call cmdline hook
+        cmd = self.hook.get_cmdline_binary(cmd)
+
+        # Exec command
+        self.cc_verbose("FromELF: %s" % ' '.join(cmd))
+        self.default_cmd(cmd)


### PR DESCRIPTION
## Description
Add ARMC6 support to mbed compile command.


## Status
**IN DEVELOPMENT**


## Migrations
NO, but it would allow for `mbed compile -t armc6`, which is new

## Todos
- [ ] Get something compiling
- [ ] Tests
- [ ] Documentation


## Steps to test or reproduce
Merge this PR with master, run `mbed compile -t armc6 -m k64f` within a project, watch the errors fly!
