### PR TITLE
Removed --no_static_destruction from IAR IDE flags

### DIFF
--- a/tools/export/iar.py
+++ b/tools/export/iar.py
@@ -63,7 +63,11 @@ class IAREmbeddedWorkbench(Exporter):
 
         project_data['misc'] = self.flags
         # VLA is enabled via template IccAllowVLA
-        project_data['misc']['c_flags'].remove("--vla")
+        if "--vla" in  project_data['misc']['c_flags']:
+            project_data['misc']['c_flags'].remove("--vla")
+        # Static destruction enabled via template
+        if "--no_static_destruction" in project_data['misc']['cxx_flags']:
+            project_data['misc']['cxx_flags'].remove("--no_static_destruction")
         project_data['misc']['asm_flags'] = list(set(project_data['misc']['asm_flags']))
         project_data['build_dir'] = os.path.join(project_data['build_dir'], 'iar_arm')
         self.progen_gen_file(project_data)


### PR DESCRIPTION
## Description
Removes #2745 IAR from the IAR IDE. The DEFAULT_FLAGS also go to the IAR IDE when exporting. This is a problem, as IAR only allows the c and c++ flags to be distinct through configuration window checkboxes. In other words (and pictures), they share a common list of flags except the following options:
![iar_flags](https://cloud.githubusercontent.com/assets/12565767/18762473/7e3fd346-80ce-11e6-8be7-2a2b6f994bd8.png)

Frustratingly, these can only be set here, and are disallowed from the common list (which looks just as command line flag strings would look). I assume they just append those flags given the selections seen here, as setting them in that list produces duplicated flag errors (even if the boxes are unchecked!).

For now, this optimization will be left off of the IAR IDE options, as it requires some XML shenanigans. I'd like to add that functionality to #2708. As it is, it would require a progen PR. 



## Status
**READY**


## Migrations
NO


## Steps to test or reproduce
Try to export and build IAR on master and with this branch.

@bridadan @sg- 