### PR TITLE
OS_TCB struct size is increased to 64 bytes (from 60 bytes).  With th…

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_A/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_A/RTX_CM_lib.h
@@ -51,7 +51,7 @@
 #define _declare_box(pool,size,cnt)  uint32_t pool[(((size)+3)/4)*(cnt) + 3]
 #define _declare_box8(pool,size,cnt) uint64_t pool[(((size)+7)/8)*(cnt) + 2]
 
-#define OS_TCB_SIZE     60
+#define OS_TCB_SIZE     64
 #define OS_TMR_SIZE     8
 
 #if defined (__CC_ARM) && !defined (__MICROLIB)

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -52,7 +52,7 @@
 #define _declare_box(pool,size,cnt)  uint32_t pool[(((size)+3)/4)*(cnt) + 3]
 #define _declare_box8(pool,size,cnt) uint64_t pool[(((size)+7)/8)*(cnt) + 2]
 
-#define OS_TCB_SIZE     60
+#define OS_TCB_SIZE     64
 #define OS_TMR_SIZE     8
 
 typedef void    *OS_ID;


### PR DESCRIPTION
## Description
With submit #2642 (stack stats) a `void *argv` pointer has been added to the `OS_TCB` struct, hence it is now 64 bytes in size and not 60.

## Status
**READY**

## Related PRs
#2786

## Steps to test or reproduce
Build mbed-os for a target that uses `MBED_RTOS_SINGLE_THREAD` (i.e. small libraries).  Since, for such a build, there is a single task, and there's no longer enough room for even one `OS_TCB`, `rt_task_create()` returns 0 during RTOS init and the system fails to get to mbed startup.  With this change `rt_task_create()` returns 1 and the system boots correctly.