### PR TITLE
lwip - Fix default behaviour of DHCP

### DIFF
--- a/features/net/FEATURE_IPV4/lwip-interface/EthernetInterface.cpp
+++ b/features/net/FEATURE_IPV4/lwip-interface/EthernetInterface.cpp
@@ -20,7 +20,7 @@
 
 /* Interface implementation */
 EthernetInterface::EthernetInterface()
-    : _dhcp(false), _ip_address(), _netmask(), _gateway()
+    : _dhcp(true), _ip_address(), _netmask(), _gateway()
 {
 }
 


### PR DESCRIPTION
`EthernetInterface` should default to enabled DHCP to preserve backwards compatibility.

missed change to https://github.com/ARMmbed/mbed-os/pull/2664#issuecomment-248826695
cc @sg- 