### PR TITLE
[LPC1347] Fix PwmOut prescaler for 16-bit timer 

### DIFF
--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC13XX/pwmout_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC13XX/pwmout_api.c
@@ -69,7 +69,7 @@ static LPC_CTxxBx_Type *Timers[4] = {
 void pwmout_init(pwmout_t* obj, PinName pin) {
     // determine the channel
     PWMName pwm = (PWMName)pinmap_peripheral(pin, PinMap_PWM);
-    MBED_ASSERT(pwm != (uint32_t)NC);
+    MBED_ASSERT(pwm != (PWMName)NC);
 
     obj->pwm = pwm;
     

--- a/libraries/tests/mbed/pwm/main.cpp
+++ b/libraries/tests/mbed/pwm/main.cpp
@@ -48,6 +48,16 @@ int main() {
     printf("Initialize PWM on pin 24 with duty cycle: %.2f\n", pwm_dp24.read());
     printf("Initialize PWM on pin 18 with duty cycle: %.2f\n", pwm_dp18.read());
 
+#elif defined(TARGET_LPC1347)
+    PwmOut pwm_1(P0_18);
+    PwmOut pwm_2(P0_9);
+
+    pwm_1.write(0.75);
+    pwm_2.write(0.50);
+
+    printf("Initialize PWM on P0_18 with duty cycle: %.2f\n", pwm_1.read());
+    printf("Initialize PWM on P0_9 with duty cycle: %.2f\n", pwm_2.read());
+
 #elif defined(TARGET_NRF51822)
     PwmOut pwm_p24(p24);
     PwmOut pwm_p25(p25);


### PR DESCRIPTION
## Description
Fix PwmOut prescaler for 16-bit timer on the LPC1347 platform.
See #2660 more detail.

## Status
**READY**

## Steps to test or reproduce
https://github.com/ARMmbed/mbed-os/issues/2660#issue-176174346

## Test result
### Automated test result
```
Test summary:
+---------------+---------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| Result        | Target  | Toolchain | Test ID     | Test Description                      | Elapsed Time (sec) | Timeout (sec) | Loops |
+---------------+---------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| OK            | LPC1347 | ARM       | DTCT_1      | Simple detect test                    |        0.51        |       10      |  1/1  |
| OK            | LPC1347 | ARM       | EXAMPLE_1   | /dev/null                             |        3.5         |       20      |  1/1  |
| OK            | LPC1347 | ARM       | MBED_10     | Hello World                           |        0.39        |       5       |  1/1  |
| OK            | LPC1347 | ARM       | MBED_11     | Ticker Int                            |       11.38        |       15      |  1/1  |
| OK            | LPC1347 | ARM       | MBED_12     | C++                                   |        1.4         |       10      |  1/1  |
| NOT_SUPPORTED | LPC1347 | ARM       | MBED_16     | RTC                                   |         0          |       0       |   -   |
| OK            | LPC1347 | ARM       | MBED_2      | stdio                                 |        0.74        |       20      |  1/1  |
| OK            | LPC1347 | ARM       | MBED_23     | Ticker Int us                         |       11.36        |       15      |  1/1  |
| OK            | LPC1347 | ARM       | MBED_24     | Timeout Int us                        |       11.54        |       15      |  1/1  |
| OK            | LPC1347 | ARM       | MBED_25     | Time us                               |       11.39        |       15      |  1/1  |
| OK            | LPC1347 | ARM       | MBED_26     | Integer constant division             |        1.4         |       20      |  1/1  |
| OK            | LPC1347 | ARM       | MBED_34     | Ticker Two callbacks                  |       11.38        |       15      |  1/1  |
| FAIL          | LPC1347 | ARM       | MBED_37     | Serial NC RX                          |        1.95        |       20      |  0/1  |
| FAIL          | LPC1347 | ARM       | MBED_38     | Serial NC TX                          |        0.93        |       20      |  0/1  |
| OK            | LPC1347 | ARM       | MBED_A1     | Basic                                 |        1.38        |       20      |  1/1  |
| OK            | LPC1347 | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.46        |       20      |  1/1  |
| OK            | LPC1347 | ARM       | MBED_A9     | Serial Echo at 115200                 |        6.36        |       20      |  1/1  |
| OK            | LPC1347 | ARM       | MBED_BUSOUT | BusOut                                |        2.32        |       15      |  1/1  |
+---------------+---------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
Result: 2 FAIL / 15 OK / 1 NOT_SUPPORTED

Completed in 150.98 sec
```

### Manual test MBED_5 result
```
Initialize PWM on P0_18 with duty cycle: 0.75
Initialize PWM on P0_9 with duty cycle: 0.50
{{success}}
{{end}}
```