### PR TITLE
HAL - Add a newline at the end of hal/api/Callback.h.

### DIFF
--- a/hal/api/Callback.h
+++ b/hal/api/Callback.h
@@ -5930,3 +5930,4 @@ Callback<R(A0, A1, A2, A3, A4)> callback(const volatile T *obj, R (*func)(const 
 } // namespace mbed
 
 #endif
+


### PR DESCRIPTION
This is a trivial change which remove a warning issued by ARMCC.
