### PR TITLE
[STM32F091RC] patch for tests-mbedmicro-rtos-mbed-threads

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
@@ -17,7 +17,7 @@
  */
 #if defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
     #define STACK_SIZE 512
-#elif (defined(TARGET_STM32F070RB) || defined(TARGET_STM32F072RB) || defined(TARGET_STM32F103RB))
+#elif defined(TARGET_STM32F070RB) || defined(TARGET_STM32F072RB) || defined(TARGET_STM32F103RB) || defined(TARGET_STM32F091RC)
     #define STACK_SIZE 512
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE


### PR DESCRIPTION
## Description
NUCLEO_F091RC patch for tests-mbedmicro-rtos-mbed-threads

Previous status:
- OK with GCC and ARM
- FAIL with IAR

## Status
READY
```
+-------------------+---------------+-----------------------------------+--------------------------------------+--------+--------+--------+--------------------+
| target            | platform_name | test suite                        | test case                            | passed | failed | result | elapsed_time (sec) |
+-------------------+---------------+-----------------------------------+--------------------------------------+--------+--------+--------+--------------------+
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing parallel threads             | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing parallel threads with child  | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing parallel threads with murder | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing parallel threads with wait   | 1      | 0      | OK     | 0.16               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing parallel threads with yield  | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing serial threads               | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing serial threads with child    | 1      | 0      | OK     | 0.07               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing serial threads with murder   | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing serial threads with wait     | 1      | 0      | OK     | 1.05               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing serial threads with yield    | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing single thread                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing single thread with child     | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing single thread with murder    | 1      | 0      | OK     | 0.05               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing single thread with wait      | 1      | 0      | OK     | 0.15               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing single thread with yield     | 1      | 0      | OK     | 0.06               |
| NUCLEO_F091RC-IAR | NUCLEO_F091RC | tests-mbedmicro-rtos-mbed-threads | Testing thread self terminate        | 1      | 0      | OK     | 0.06               |
+-------------------+---------------+-----------------------------------+--------------------------------------+--------+--------+--------+--------------------+
```