### PR TITLE
[STM32F429ZI] INITIAL_SP correction

### DIFF
--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/TOOLCHAIN_ARM_STD/startup_stm32f429xx.s
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/TOOLCHAIN_ARM_STD/startup_stm32f429xx.s
@@ -39,7 +39,7 @@
 ; 
 ;*******************************************************************************
 
-__initial_sp    EQU     0x20020000 ; Top of RAM
+__initial_sp    EQU     0x20030000 ; Top of RAM
 
                 PRESERVE8
                 THUMB

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/TOOLCHAIN_ARM_STD/stm32f429xx.sct
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/TOOLCHAIN_ARM_STD/stm32f429xx.sct
@@ -27,7 +27,7 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; 2 MB FLASH (0x200000) + 256 KB SRAM (0x40000)
+; 2 MB FLASH (0x200000) + 192 KB SRAM (0x30000)
 LR_IROM1 0x08000000 0x200000  {    ; load region size_region
 
   ER_IROM1 0x08000000 0x200000  {  ; load address = execution address
@@ -37,7 +37,7 @@ LR_IROM1 0x08000000 0x200000  {    ; load region size_region
   }
 
   ; Total: 107 vectors = 428 bytes (0x1AC) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1AC) (0x20000-0x1AC)  {  ; RW data
+  RW_IRAM1 (0x20000000+0x1AC) (0x30000-0x1AC)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F429ZI/TOOLCHAIN_ARM_STD/startup_stm32f429xx.s
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F429ZI/TOOLCHAIN_ARM_STD/startup_stm32f429xx.s
@@ -39,7 +39,7 @@
 ; 
 ;*******************************************************************************
 
-__initial_sp    EQU     0x20020000 ; Top of RAM
+__initial_sp    EQU     0x20030000 ; Top of RAM
 
                 PRESERVE8
                 THUMB

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F429ZI/TOOLCHAIN_ARM_STD/stm32f429xx.sct
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F429ZI/TOOLCHAIN_ARM_STD/stm32f429xx.sct
@@ -27,7 +27,7 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; 2 MB FLASH (0x200000) + 256 KB SRAM (0x40000)
+; 2 MB FLASH (0x200000) + 192 KB SRAM (0x30000)
 LR_IROM1 0x08000000 0x200000  {    ; load region size_region
 
   ER_IROM1 0x08000000 0x200000  {  ; load address = execution address
@@ -37,7 +37,7 @@ LR_IROM1 0x08000000 0x200000  {    ; load region size_region
   }
 
   ; Total: 107 vectors = 428 bytes (0x1AC) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1AC) (0x20000-0x1AC)  {  ; RW data
+  RW_IRAM1 (0x20000000+0x1AC) (0x30000-0x1AC)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/hal/targets/cmsis/TARGET_STM/mbed_rtx.h
+++ b/hal/targets/cmsis/TARGET_STM/mbed_rtx.h
@@ -422,21 +422,6 @@
 #define OS_CLOCK                100000000
 #endif
 
-#elif defined(TARGET_STM32F429ZI)
-
-#ifndef INITIAL_SP
-#define INITIAL_SP              (0x20030000UL)
-#endif
-#ifndef OS_TASKCNT
-#define OS_TASKCNT              14
-#endif
-#ifndef OS_MAINSTKSIZE
-#define OS_MAINSTKSIZE          256
-#endif
-#ifndef OS_CLOCK
-#define OS_CLOCK                168000000
-#endif
-
 #elif defined(TARGET_STM32F446RE)
 
 #ifndef INITIAL_SP


### PR DESCRIPTION
## Description
rtos-rtx-target_cortex_m-tests-memory-heap_and_stack was failed with DISCO_F429ZI and NUCLEO_F429ZI

New tests status for both targets:
- MBED OS2 tests OK with GCC/ARM/IAR
- MBED OS5 tests OK with GCC/ARM/IAR

## Status
READY

