### PR TITLE
[STM32F410RB] update OS5 RTOS thread test

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
@@ -19,6 +19,8 @@
     #define STACK_SIZE 512
 #elif (defined(TARGET_STM32F070RB) || defined(TARGET_STM32F072RB) || defined(TARGET_STM32F103RB))
     #define STACK_SIZE 512
+#elif defined(TARGET_STM32F410RB)
+    #define STACK_SIZE 512
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif


### PR DESCRIPTION
## Description
Current status:
| NUCLEO_F410RB-IAR | NUCLEO_F410RB | tests-mbedmicro-rtos-mbed-threads                                            | TIMEOUT | 86.19              | shell       |

Test has been updated and is OK now for all tool chains.


## Status
READY
