### PR TITLE
[tools] Making memap output consistent across output formats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ script:
   - PYTHONPATH=. python tools/test/config_test/config_test.py
   - python tools/test/pylint.py
   - py.test tools/test/toolchains/api.py
+  - python tools/test/memap/memap_test.py
   - python tools/build_travis.py
 before_install:
   - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -51,8 +51,13 @@ class MemapParser(object):
         # list of all object files and mappting to module names
         self.object_to_module = dict()
 
-        # Memory usage summary structure
+        # Memory report (sections + summary)
+        self.mem_report = []
+
+        # Just the memory summary section
         self.mem_summary = dict()
+
+        self.subtotal = dict()
 
     def module_add(self, module_name, size, section):
         """ Adds a module / section to the list
@@ -399,68 +404,27 @@ class MemapParser(object):
             print "I/O error({0}): {1}".format(error.errno, error.strerror)
             return False
 
-        subtotal = dict()
-        for k in self.sections:
-            subtotal[k] = 0
-
-        # Calculate misc flash sections
-        misc_flash_mem = 0
-        for i in self.modules:
-            for k in self.misc_flash_sections:
-                if self.modules[i][k]:
-                    misc_flash_mem += self.modules[i][k]
-
-        json_obj = []
-        for i in sorted(self.modules):
-
-            row = []
-
-            json_obj.append({
-                "module":i,
-                "size":{
-                    k:self.modules[i][k] for k in self.print_sections
-                }
-            })
-
-        summary = {
-            'summary':{
-                'static_ram': (subtotal['.data'] + subtotal['.bss']),
-                'heap': (subtotal['.heap']),
-                'stack': (subtotal['.stack']),
-                'total_ram': (subtotal['.data'] + subtotal['.bss'] +
-                              subtotal['.heap']+subtotal['.stack']),
-                'total_flash': (subtotal['.text'] + subtotal['.data'] +
-                                misc_flash_mem),
-            }
-        }
-
-        self.mem_summary = json_obj + [summary]
-
         to_call = {'json': self.generate_json,
                    'csv-ci': self.generate_csv,
                    'table': self.generate_table}[export_format]
-        to_call(subtotal, misc_flash_mem, file_desc)
+        to_call(file_desc)
 
         if file_desc is not sys.stdout:
             file_desc.close()
 
-    def generate_json(self, _, dummy, file_desc):
+    def generate_json(self, file_desc):
         """Generate a json file from a memory map
 
         Positional arguments:
-        subtotal - total sizes for each module
-        misc_flash_mem - size of misc flash sections
         file_desc - the file to write out the final report to
         """
-        file_desc.write(json.dumps(self.mem_summary, indent=4))
+        file_desc.write(json.dumps(self.mem_report, indent=4))
         file_desc.write('\n')
 
-    def generate_csv(self, subtotal, misc_flash_mem, file_desc):
+    def generate_csv(self, file_desc):
         """Generate a CSV file from a memoy map
 
         Positional arguments:
-        subtotal - total sizes for each module
-        misc_flash_mem - size of misc flash sections
         file_desc - the file to write out the final report to
         """
         csv_writer = csv.writer(file_desc, delimiter=',',
@@ -474,36 +438,33 @@ class MemapParser(object):
                 csv_sizes += [self.modules[i][k]]
 
         csv_module_section += ['static_ram']
-        csv_sizes += [subtotal['.data']+subtotal['.bss']]
+        csv_sizes += [self.mem_summary['static_ram']]
 
         csv_module_section += ['heap']
-        if subtotal['.heap'] == 0:
+        if self.mem_summary['heap'] == 0:
             csv_sizes += ['unknown']
         else:
-            csv_sizes += [subtotal['.heap']]
+            csv_sizes += [self.mem_summary['heap']]
 
         csv_module_section += ['stack']
-        if subtotal['.stack'] == 0:
+        if self.mem_summary['stack'] == 0:
             csv_sizes += ['unknown']
         else:
-            csv_sizes += [subtotal['.stack']]
+            csv_sizes += [self.mem_summary['stack']]
 
         csv_module_section += ['total_ram']
-        csv_sizes += [subtotal['.data'] + subtotal['.bss'] +
-                      subtotal['.heap'] + subtotal['.stack']]
+        csv_sizes += [self.mem_summary['total_ram']]
 
         csv_module_section += ['total_flash']
-        csv_sizes += [subtotal['.text']+subtotal['.data']+misc_flash_mem]
+        csv_sizes += [self.mem_summary['total_flash']]
 
         csv_writer.writerow(csv_module_section)
         csv_writer.writerow(csv_sizes)
 
-    def generate_table(self, subtotal, misc_flash_mem, file_desc):
+    def generate_table(self, file_desc):
         """Generate a table from a memoy map
 
         Positional arguments:
-        subtotal - total sizes for each module
-        misc_flash_mem - size of misc flash sections
         file_desc - the file to write out the final report to
         """
         # Create table
@@ -521,9 +482,6 @@ class MemapParser(object):
         for i in sorted(self.modules):
             row = [i]
 
-            for k in self.sections:
-                subtotal[k] += self.modules[i][k]
-
             for k in self.print_sections:
                 row.append(self.modules[i][k])
 
@@ -531,34 +489,32 @@ class MemapParser(object):
 
         subtotal_row = ['Subtotals']
         for k in self.print_sections:
-            subtotal_row.append(subtotal[k])
+            subtotal_row.append(self.subtotal[k])
 
         table.add_row(subtotal_row)
 
         file_desc.write(table.get_string())
         file_desc.write('\n')
 
-        if subtotal['.heap'] == 0:
+        if self.mem_summary['heap'] == 0:
             file_desc.write("Allocated Heap: unknown\n")
         else:
             file_desc.write("Allocated Heap: %s bytes\n" %
-                            str(subtotal['.heap']))
+                            str(self.mem_summary['heap']))
 
-        if subtotal['.stack'] == 0:
+        if self.mem_summary['stack'] == 0:
             file_desc.write("Allocated Stack: unknown\n")
         else:
             file_desc.write("Allocated Stack: %s bytes\n" %
-                            str(subtotal['.stack']))
+                            str(self.mem_summary['stack']))
 
         file_desc.write("Total Static RAM memory (data + bss): %s bytes\n" %
-                        (str(subtotal['.data'] + subtotal['.bss'])))
+                        (str(self.mem_summary['static_ram'])))
         file_desc.write(
             "Total RAM memory (data + bss + heap + stack): %s bytes\n"
-            % (str(subtotal['.data'] + subtotal['.bss'] + subtotal['.heap'] +
-                   subtotal['.stack'])))
+            % (str(self.mem_summary['total_ram'])))
         file_desc.write("Total Flash memory (text + data + misc): %s bytes\n" %
-                        (str(subtotal['.text'] + subtotal['.data'] +
-                             misc_flash_mem)))
+                        (str(self.mem_summary['total_flash'])))
 
     toolchains = ["ARM", "ARM_STD", "ARM_MICRO", "GCC_ARM", "IAR"]
 
@@ -584,6 +540,44 @@ class MemapParser(object):
                     self.parse_map_file_iar(file_input)
                 else:
                     result = False
+
+            for k in self.sections:
+                self.subtotal[k] = 0
+
+            for i in sorted(self.modules):
+                for k in self.sections:
+                    self.subtotal[k] += self.modules[i][k]
+
+            # Calculate misc flash sections
+            self.misc_flash_mem = 0
+            for i in self.modules:
+                for k in self.misc_flash_sections:
+                    if self.modules[i][k]:
+                        self.misc_flash_mem += self.modules[i][k]
+
+            self.mem_summary = {
+                'static_ram': (self.subtotal['.data'] + self.subtotal['.bss']),
+                'heap': (self.subtotal['.heap']),
+                'stack': (self.subtotal['.stack']),
+                'total_ram': (self.subtotal['.data'] + self.subtotal['.bss'] +
+                              self.subtotal['.heap']+self.subtotal['.stack']),
+                'total_flash': (self.subtotal['.text'] + self.subtotal['.data'] +
+                                self.misc_flash_mem),
+            }
+
+            self.mem_report = []
+            for i in sorted(self.modules):
+                self.mem_report.append({
+                    "module":i,
+                    "size":{
+                        k:self.modules[i][k] for k in self.print_sections
+                    }
+                })
+
+            self.mem_report.append({
+                'summary': self.mem_summary
+            })
+
         except IOError as error:
             print "I/O error({0}): {1}".format(error.errno, error.strerror)
             result = False

--- a/tools/test/memap/memap_test.py
+++ b/tools/test/memap/memap_test.py
@@ -1,0 +1,168 @@
+"""
+mbed SDK
+Copyright (c) 2016 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import sys
+import os
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.insert(0, ROOT)
+
+import unittest
+from tools.memap import MemapParser
+from copy import deepcopy
+
+"""
+Tests for test_api.py
+"""
+
+class MemapParserTests(unittest.TestCase):
+    """
+    Test cases for Test Api
+    """
+
+    def setUp(self):
+        """
+        Called before each test case
+
+        :return:
+        """
+        self.memap_parser = MemapParser()
+        
+        self.memap_parser.modules = {
+            "Misc": {
+                "unknown": 0,
+                ".ARM": 8,
+                ".ARM.extab": 0,
+                ".init": 12,
+                "OUTPUT": 0,
+                ".stack": 0,
+                ".eh_frame": 0,
+                ".fini_array": 4,
+                ".heap": 0,
+                ".stabstr": 0,
+                ".interrupts_ram": 0,
+                ".init_array": 0,
+                ".stab": 0,
+                ".ARM.attributes": 7347,
+                ".bss": 8517,
+                ".flash_config": 16,
+                ".interrupts": 1024,
+                ".data": 2325,
+                ".ARM.exidx": 0,
+                ".text": 59906,
+                ".jcr": 0
+            },
+            "Fill": {
+                "unknown": 12,
+                ".ARM": 0,
+                ".ARM.extab": 0,
+                ".init": 0,
+                "OUTPUT": 0,
+                ".stack": 0,
+                ".eh_frame": 0,
+                ".fini_array": 0,
+                ".heap": 65536,
+                ".stabstr": 0,
+                ".interrupts_ram": 1024,
+                ".init_array": 0,
+                ".stab": 0,
+                ".ARM.attributes": 0,
+                ".bss": 2235,
+                ".flash_config": 0,
+                ".interrupts": 0,
+                ".data": 3,
+                ".ARM.exidx": 0,
+                ".text": 136,
+                ".jcr": 0
+            }
+        }
+        
+        self.memap_parser.compute_report()
+
+    def tearDown(self):
+        """
+        Called after each test case
+
+        :return:
+        """
+        pass
+    
+    def generate_test_helper(self, output_type, file_output=None):
+        """
+        Helper that ensures that the member variables "modules", "mem_report",
+        and "mem_summary" are unchanged after calling "generate_output"
+        
+        :param output_type: type string that is passed to "generate_output"
+        :param file_output: path to output file that is passed to "generate_output"      
+        :return:
+        """
+        
+        old_modules = deepcopy(self.memap_parser.modules)
+        old_report = deepcopy(self.memap_parser.mem_report)
+        old_summary = deepcopy(self.memap_parser.mem_summary)
+        self.memap_parser.generate_output(output_type, file_output)
+        self.assertEqual(self.memap_parser.modules, old_modules,
+                         "generate_output modified the 'modules' property")
+        self.assertEqual(self.memap_parser.mem_report, old_report,
+                         "generate_output modified the 'mem_report' property")
+        self.assertEqual(self.memap_parser.mem_summary, old_summary,
+                         "generate_output modified the 'mem_summary' property")
+
+    def test_report_computed(self):
+        """
+        Test ensures the report and summary are computed
+        
+        :return:
+        """
+        self.assertTrue(self.memap_parser.mem_report)
+        self.assertTrue(self.memap_parser.mem_summary)
+        self.assertEqual(self.memap_parser.mem_report[-1]['summary'],
+                         self.memap_parser.mem_summary,
+                         "mem_report did not contain a correct copy of mem_summary")
+    
+    def test_generate_output_table(self):
+        """
+        Test ensures that an output of type "table" can be generated correctly
+        
+        :return:
+        """
+        self.generate_test_helper('table')
+    
+    def test_generate_output_json(self):
+        """
+        Test ensures that an output of type "json" can be generated correctly
+        
+        :return:
+        """
+        file_name = '.json_test_output.json'
+        self.generate_test_helper('json', file_output=file_name)
+        self.assertTrue(os.path.exists(file_name), "Failed to create json file")
+        os.remove(file_name)
+    
+    def test_generate_output_csv_ci(self):
+        """
+        Test ensures that an output of type "csv-ci" can be generated correctly
+        
+        :return:
+        """
+        file_name = '.csv_ci_test_output.csv'
+        self.generate_test_helper('csv-ci', file_output=file_name)
+        self.assertTrue(os.path.exists(file_name), "Failed to create csv-ci file")
+        os.remove(file_name)
+    
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -1047,7 +1047,7 @@ class mbedToolchain:
         # Here we return memory statistics structure (constructed after
         # call to generate_output) which contains raw data in bytes
         # about sections + summary
-        return memap.mem_summary
+        return memap.mem_report
 
     # Set the configuration data
     def set_config_data(self, config_data):


### PR DESCRIPTION
## Description
This fixes an issue where the output from memap.py was not
consistent across all output formats. This issue stemmed from the fact
that a few important calculations were being performed at output
generation time. This has been moved to the 'parse' function and saved for
future use by the 'generate' functions.

## Status
**IN DEVELOPMENT**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

YES

Because this commit saves more data to the MemapParser instance, there
were some name collisions. The public member 'mem_summary' has been
renamed to 'mem_report'. 'mem_report' contains the data structure used by
the json generator. This includes both the section data and the memory
summary. The 'mem_summary' member now just contains the summary. The
summary includes total allocated heap, total static RAM, etc.


## Related Issue
Fixes issue in https://github.com/ARMmbed/mbed-os/issues/2820

## Todos
- [x] Tests
- [x] Write Python tests for memap
- [x] Review by @theotherjimmy 
- [x] Review by @MarceloSalazar (if available)
