### PR TITLE
Fixed assert failure on reconections

### DIFF
--- a/features/net/FEATURE_IPV6/nanostack-interface/NanostackInterface.cpp
+++ b/features/net/FEATURE_IPV6/nanostack-interface/NanostackInterface.cpp
@@ -170,6 +170,7 @@ NanostackSocket::~NanostackSocket()
         int ret = socket_free(socket_id);
         MBED_ASSERT(0 == ret);
         MBED_ASSERT(socket_tbl[socket_id] == this);
+        socket_tbl[socket_id] = NULL;
         socket_id = -1;
         data_free_all();
     }


### PR DESCRIPTION
## Description
When the border router is switched off, the several retries will end up triggering the asserts in NanostackSocket::open. This is caused because socket_tbl elements, are never set to NULL. This fix prevents that.


## Status
**READY**


## Related
https://github.com/ARMmbed/mbed-os/issues/2840