### PR TITLE
Fix nordic critical section entry and exit 

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/hal_patch/nordic_critical.c
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/hal_patch/nordic_critical.c
@@ -21,12 +21,12 @@
 #include "nrf_soc.h"
 #include "nrf_sdm.h"
 
-static volatile union {
+static union {
     uint32_t _PRIMASK_state;
     uint8_t  _sd_state;
 } _state = { 0 } ;
 static volatile uint32_t _entry_count = 0;
-static volatile bool _use_softdevice_routine = false;
+static bool _use_softdevice_routine = false;
 
 void core_util_critical_section_enter()
 {

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/hal_patch/nordic_critical.c
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/hal_patch/nordic_critical.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>                  // uint32_t, UINT32_MAX
+#include <assert.h>                  // uint32_t, UINT32_MAX
+#include "cmsis.h"
+#include "nrf_soc.h"
+#include "nrf_sdm.h"
+
+static volatile union {
+    uint32_t _PRIMASK_state;
+    uint8_t  _sd_state;
+} _state = { 0 } ;
+static volatile uint32_t _entry_count = 0;
+static volatile bool _use_softdevice_routine = false;
+
+void core_util_critical_section_enter()
+{
+    // if a critical section has already been entered, just update the counter
+    if (_entry_count) {
+        ++_entry_count;
+        return;
+    }
+
+    // in this path, a critical section has never been entered
+    uint32_t primask = __get_PRIMASK();
+
+    // if interrupts are enabled, try to use the soft device
+    uint8_t sd_enabled;
+    if ((primask == 0) && (sd_softdevice_is_enabled(&sd_enabled) == NRF_SUCCESS) && sd_enabled == 1) {
+        // if the soft device can be use, use it
+        sd_nvic_critical_region_enter(&_state._sd_state);
+        _use_softdevice_routine = true;
+    } else {
+        // if interrupts where enabled, disable them
+        if(primask == 0) {
+            __disable_irq();
+        }
+
+        // store the PRIMASK state, it will be restored at the end of the critical section
+        _state._PRIMASK_state = primask;
+        _use_softdevice_routine = false;
+    }
+
+    assert(_entry_count == 0); // entry count should always be equal to 0 at this point
+    ++_entry_count;
+}
+
+void core_util_critical_section_exit()
+{
+    assert(_entry_count > 0);
+    --_entry_count;
+
+    // If their is other segments which have entered the critical section, just leave
+    if (_entry_count) {
+        return;
+    }
+
+    // This is the last segment of the critical section, state should be restored as before entering
+    // the critical section
+    if (_use_softdevice_routine) {
+        sd_nvic_critical_region_exit(_state._sd_state);
+    } else {
+        __set_PRIMASK(_state._PRIMASK_state);
+    }
+}

--- a/hal/common/mbed_critical.c
+++ b/hal/common/mbed_critical.c
@@ -19,6 +19,7 @@
 
 #include "cmsis.h"
 #include "mbed_assert.h"
+#include "toolchain.h"
 
 #define EXCLUSIVE_ACCESS (!defined (__CORTEX_M0) && !defined (__CORTEX_M0PLUS))
 
@@ -34,7 +35,7 @@ bool core_util_are_interrupts_enabled(void)
 #endif
 }
 
-void core_util_critical_section_enter(void)
+MBED_WEAK void core_util_critical_section_enter(void)
 {
     bool interrupts_disabled = !core_util_are_interrupts_enabled();
     __disable_irq();
@@ -59,7 +60,7 @@ void core_util_critical_section_enter(void)
     interrupt_enable_counter++;
 }
 
-void core_util_critical_section_exit(void)
+MBED_WEAK void core_util_critical_section_exit(void)
 {
     /* If critical_section_enter has not previously been called, do nothing */
     if (interrupt_enable_counter) {

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/nordic_critical.c
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/nordic_critical.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2015-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>                  // uint32_t, UINT32_MAX
+#include <assert.h>                  // uint32_t, UINT32_MAX
+#include "cmsis.h"
+#include "nrf_soc.h"
+#include "nrf_sdm.h"
+#include "nrf_nvic.h"
+
+static volatile uint8_t  _sd_state = 0;
+static volatile uint32_t _entry_count = 0;
+
+void core_util_critical_section_enter()
+{
+    // if a critical section has already been entered, just update the counter
+    if (_entry_count) {
+        ++_entry_count;
+        return;
+    }
+
+    // in this path, a critical section has never been entered
+    // routine of SD V11 work even if the softdevice is not active
+    sd_nvic_critical_region_enter(&_sd_state);
+
+    assert(_entry_count == 0); // entry count should always be equal to 0 at this point
+    ++_entry_count;
+}
+
+void core_util_critical_section_exit()
+{
+    assert(_entry_count > 0);
+    --_entry_count;
+
+    // If their is other segments which have entered the critical section, just leave
+    if (_entry_count) {
+        return;
+    }
+
+    // This is the last segment of the critical section, state should be restored as before entering
+    // the critical section
+    sd_nvic_critical_region_exit(_sd_state);
+}

--- a/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/nordic_critical.c
+++ b/hal/targets/hal/TARGET_NORDIC/TARGET_NRF5/nordic_critical.c
@@ -22,7 +22,7 @@
 #include "nrf_sdm.h"
 #include "nrf_nvic.h"
 
-static volatile uint8_t  _sd_state = 0;
+static uint8_t  _sd_state = 0;
 static volatile uint32_t _entry_count = 0;
 
 void core_util_critical_section_enter()


### PR DESCRIPTION
## Description

The default implementation of critical sections provided by mbed doesn't fit with the Nordic softdevice because it might blocks critical interrupts related to the radio management. 

The Nordic softdevice provides primitives to enter or exit a critical sections without disrupting IRQs used for radio management. 

This PR does three things: 
- Tag the default implementation of `core_util_critical_section_enter` and `core_util_critical_section_exit` as weak symbols so it can be overridden from somewhere else.
- Provides an implementation of `core_util_critical_section_enter` and `core_util_critical_section_exit` for the Nordic SDK v10 (used by legacy or not up to date targets).
- Provides another  implementation of `core_util_critical_section_enter` and `core_util_critical_section_exit` for the V11 of the Nordic SDK.
## Status

**READY**
