### PR TITLE
[Tests] Example build toolchain filtering

### DIFF
--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -8,5 +8,5 @@
     {"features": ["IPV6"]},
     "https://github.com/ARMmbed/mbed-os-example-client" : {"features": ["IPV6"]},
     "https://github.com/ARMmbed/mbed-os-example-sockets" : {"features": ["IPV6"]},
-    "https://github.com/ARMmbed/mbed-os-example-uvisor" : {"targets": ["K64F"]}
+    "https://github.com/ARMmbed/mbed-os-example-uvisor" : {"targets": ["K64F"], "toolchains":["GCC_ARM"]}
 }

--- a/tools/test/examples/examples.py
+++ b/tools/test/examples/examples.py
@@ -32,7 +32,8 @@ SUPPORTED_TOOLCHAINS = ["ARM", "IAR", "GCC_ARM"]
 
 
 def target_cross_toolchain(allowed_toolchains,
-                           features=[], targets=TARGET_MAP.keys()):
+                           features=[], targets=TARGET_MAP.keys(),
+                           toolchains=SUPPORTED_TOOLCHAINS):
     """Generate pairs of target and toolchains
 
     Args:
@@ -42,14 +43,16 @@ def target_cross_toolchain(allowed_toolchains,
     features - the features that must be in the features array of a
                target
     targets - a list of available targets
+    toolchains - a list of available toolchains
     """
-    for target, toolchains in get_mbed_official_release("5"):
-        for toolchain in toolchains:
+    for release_target, release_toolchains in get_mbed_official_release("5"):
+        for toolchain in release_toolchains:
             if (toolchain in allowed_toolchains and
-                target in targets and
-                all(feature in TARGET_MAP[target].features
+                toolchain in toolchains and
+                release_target in targets and
+                all(feature in TARGET_MAP[release_target].features
                     for feature in features)):
-                yield target, toolchain
+                yield release_target, toolchain
 
 
 def main():


### PR DESCRIPTION
## Description
This PR was driven by the fact that the uVisor example only supports being compiled for K64F with GCC_ARM.

In order to support this, this adds the ability to filter examples by toolchains.

It then uses these changes to limit the uvisor example to just the GCC_ARM toolchain


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO

## Todos
- [x] Tests
- [x] Review by @theotherjimmy 
