### PR TITLE
[Tools] Find and report duplicates

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -12,6 +12,16 @@
         "public": false,
         "default_lib": "std"
     },
+    ".Super-Target": {
+        "device_has": ["AACI", "ANALOGIN", "STDIO_MESSAGES", "STORAGE", "TSC", "PORTIN", "I2C_ASYNCH", "DEBUG_AWARENESS", "I2CSLAVE", "CAN", "RTC_LSI", "LOCALFILESYSTEM", "CLCD", "LOWPOWERTIMER", "RTC", "ERROR_PATTERN", "SPI", "SERIAL_ASYNCH", "SERIAL_FC", "SEMIHOST", "INTERRUPTIN", "SPI_ASYNCH", "PORTOUT", "SERIAL", "ANALOGOUT", "SPISLAVE", "PORTINOUT", "PWMOUT", "SLEEP", "ERROR_RED", "ETHERNET", "I2C", "SERIAL_ASYNCH_DMA"],
+        "features": ["BLE", "IPV4", "IPV6", "CLIENT", "UVISOR"],
+        "extra_labels": [],
+        "core": "Cortex-M4",
+        "fpu": "double",
+        "public": true,
+        "default_build": "standard",
+        "release": true
+    },
     "CM4_UARM": {
         "inherits": ["Target"],
         "core": "Cortex-M4",

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -20,7 +20,8 @@
         "fpu": "double",
         "public": true,
         "default_build": "standard",
-        "release": true
+        "release": true,
+        "supported_toolchains": ["ARM"]
     },
     "CM4_UARM": {
         "inherits": ["Target"],

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -12,17 +12,6 @@
         "public": false,
         "default_lib": "std"
     },
-    ".Super-Target": {
-        "device_has": ["AACI", "ANALOGIN", "STDIO_MESSAGES", "STORAGE", "TSC", "PORTIN", "I2C_ASYNCH", "DEBUG_AWARENESS", "I2CSLAVE", "CAN", "RTC_LSI", "LOCALFILESYSTEM", "CLCD", "LOWPOWERTIMER", "RTC", "ERROR_PATTERN", "SPI", "SERIAL_ASYNCH", "SERIAL_FC", "SEMIHOST", "INTERRUPTIN", "SPI_ASYNCH", "PORTOUT", "SERIAL", "ANALOGOUT", "SPISLAVE", "PORTINOUT", "PWMOUT", "SLEEP", "ERROR_RED", "ETHERNET", "I2C", "SERIAL_ASYNCH_DMA"],
-        "features": ["BLE", "IPV4", "IPV6", "CLIENT", "UVISOR"],
-        "extra_labels": [],
-        "core": "Cortex-M4",
-        "fpu": "double",
-        "public": true,
-        "default_build": "standard",
-        "release": true,
-        "supported_toolchains": ["ARM"]
-    },
     "CM4_UARM": {
         "inherits": ["Target"],
         "core": "Cortex-M4",

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -452,7 +452,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
         # Link Program
         res, _ = toolchain.link_program(resources, build_path, name)
 
-        resources.detect_duplicates()
+        resources.detect_duplicates(toolchain)
 
         if report != None:
             end = time()

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -452,6 +452,8 @@ def build_project(src_paths, build_path, target, toolchain_name,
         # Link Program
         res, _ = toolchain.link_program(resources, build_path, name)
 
+        resources.detect_duplicates()
+
         if report != None:
             end = time()
             cur_result["elapsed_time"] = end - start

--- a/tools/git_hooks/find_duplicates.py
+++ b/tools/git_hooks/find_duplicates.py
@@ -1,5 +1,12 @@
 from os import walk
-from os.path import join
+from os.path import join, abspath, dirname, basename
+import sys
+
+ROOT = abspath(join(dirname(__file__), "..", ".."))
+sys.path.insert(0, ROOT)
+
+from tools.toolchains.gcc import GCC_ARM
+from tools.targets import TARGET_MAP
 from argparse import ArgumentParser
 
 if __name__ == "__main__":
@@ -9,13 +16,16 @@ if __name__ == "__main__":
     parser.add_argument("--silent", help="Supress printing of filenames, just return number of duplicates", action="store_true")
     args = parser.parse_args()
 
+    toolchain = GCC_ARM(TARGET_MAP[".Super-Target"])
+
+    resources = sum([toolchain.scan_resources(d) for d in args.dirs], None)
+
     scanned_files = {}
 
-    for dir in args.dirs:
-        for root, dirs, files in walk(dir):
-            for file in files:
-                scanned_files.setdefault(file, [])
-                scanned_files[file].append(join(root, file))
+    for r in [resources] + resources.features.values():
+        for file in r.c_sources + r.s_sources + r.cpp_sources + r.objects + r.libraries + r.hex_files + r.bin_files:
+            scanned_files.setdefault(basename(file), [])
+            scanned_files[basename(file)].append(file)
 
     count_dupe = 0
     for key, value in scanned_files.iteritems():

--- a/tools/git_hooks/find_duplicates.py
+++ b/tools/git_hooks/find_duplicates.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     parser.add_argument("--silent", help="Supress printing of filenames, just return number of duplicates", action="store_true")
     args = parser.parse_args()
 
-    toolchain = GCC_ARM(TARGET_MAP[".Super-Target"])
+    toolchain = GCC_ARM(TARGET_MAP["K64F"])
 
     resources = sum([toolchain.scan_resources(d) for d in args.dirs], None)
 

--- a/tools/git_hooks/find_duplicates.py
+++ b/tools/git_hooks/find_duplicates.py
@@ -1,0 +1,30 @@
+from os import walk
+from os.path import join
+from argparse import ArgumentParser
+
+if __name__ == "__main__":
+    parser = ArgumentParser("Find duplicate file names within a directory structure")
+    parser.add_argument("dirs", help="Directories to search for duplicate file names"
+                        , nargs="*")
+    parser.add_argument("--silent", help="Supress printing of filenames, just return number of duplicates", action="store_true")
+    args = parser.parse_args()
+
+    scanned_files = {}
+
+    for dir in args.dirs:
+        for root, dirs, files in walk(dir):
+            for file in files:
+                scanned_files.setdefault(file, [])
+                scanned_files[file].append(join(root, file))
+
+    count_dupe = 0
+    for key, value in scanned_files.iteritems():
+        if len(value) > 1:
+            count_dupe += 1
+            if not args.silent:
+                print("Multiple files found with name {}".format(key))
+                for file in value:
+                    print("  {}".format(file))
+
+    exit(count_dupe)
+

--- a/tools/git_hooks/find_duplicates.py
+++ b/tools/git_hooks/find_duplicates.py
@@ -1,5 +1,5 @@
 from os import walk
-from os.path import join, abspath, dirname, basename
+from os.path import join, abspath, dirname, basename, splitext
 import sys
 
 ROOT = abspath(join(dirname(__file__), "..", ".."))
@@ -26,6 +26,12 @@ if __name__ == "__main__":
         for file in r.c_sources + r.s_sources + r.cpp_sources + r.objects + r.libraries + r.hex_files + r.bin_files:
             scanned_files.setdefault(basename(file), [])
             scanned_files[basename(file)].append(file)
+            filenameparts = splitext(file)
+            if filenameparts[-1] in ["c", "cpp", "s", "S"]:
+                filenameparts[-1] = "o"
+                file = ".".join(filenamparts)
+                scanned_files.setdefault(basename(file), [])
+                scanned_files[basename(file)].append(file)
 
     count_dupe = 0
     for key, value in scanned_files.iteritems():

--- a/tools/git_hooks/find_duplicates.py
+++ b/tools/git_hooks/find_duplicates.py
@@ -22,5 +22,5 @@ if __name__ == "__main__":
 
     scanned_files = {}
 
-    exit(resources.detect_duplicates())
+    exit(resources.detect_duplicates(toolchain))
 

--- a/tools/git_hooks/find_duplicates.py
+++ b/tools/git_hooks/find_duplicates.py
@@ -22,25 +22,5 @@ if __name__ == "__main__":
 
     scanned_files = {}
 
-    for r in [resources] + resources.features.values():
-        for file in r.c_sources + r.s_sources + r.cpp_sources + r.objects + r.libraries + r.hex_files + r.bin_files:
-            scanned_files.setdefault(basename(file), [])
-            scanned_files[basename(file)].append(file)
-            filenameparts = splitext(file)
-            if filenameparts[-1] in ["c", "cpp", "s", "S"]:
-                filenameparts[-1] = "o"
-                file = ".".join(filenamparts)
-                scanned_files.setdefault(basename(file), [])
-                scanned_files[basename(file)].append(file)
-
-    count_dupe = 0
-    for key, value in scanned_files.iteritems():
-        if len(value) > 1:
-            count_dupe += 1
-            if not args.silent:
-                print("Multiple files found with name {}".format(key))
-                for file in value:
-                    print("  {}".format(file))
-
-    exit(count_dupe)
+    exit(resources.detect_duplicates())
 

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -133,21 +133,21 @@ class Resources:
             res._collect_duplicates(dupe_dict, dupe_headers)
         return dupe_dict, dupe_headers
 
-    def detect_duplicates(self):
+    def detect_duplicates(self, toolchain):
         count = 0
         dupe_dict, dupe_headers = self._collect_duplicates(dict(), dict())
         for objname, filenames in dupe_dict.iteritems():
             if len(filenames) > 1:
                 count+=1
-                print "[ERROR] Object file %s.o is not unique!"\
-                    " It could be made from:" % objname
-                print columnate(filenames)
+                toolchain.tool_error(
+                    "Object file %s.o is not unique! It could be made from: %s"\
+                    % (objname, " ".join(filenames)))
         for headername, locations in dupe_headers.iteritems():
             if len(locations) > 1:
                 count+=1
-                print "[ERROR] Header file %s is not unique! It could be:" %\
-                    headername
-                print columnate(locations)
+                toolchain.tool_error(
+                    "Header file %s is not unique! It could be: %s" %\
+                    (headername, " ".join(locations)))
         return count
 
 

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -120,6 +120,29 @@ class Resources:
 
         return self
 
+    def detect_duplicates(self):
+        dupe_dict = dict()
+        for filename in self.s_sources + self.c_sources + self.cpp_sources:
+            objname, _ = splitext(basename(filename))
+            dupe_dict.setdefault(objname, [])
+            dupe_dict[objname].append(filename)
+        for objname, filenames in dupe_dict.iteritems():
+            if len(filenames) > 1:
+                print "[ERROR] Object file %s.o is not unique!"\
+                    " It could be made from:" % objname
+                print columnate(filenames)
+        dupe_headers = dict()
+        for filename in self.headers:
+            headername = basename(filename)
+            dupe_headers.setdefault(headername, [])
+            dupe_headers[headername].append(headername)
+        for headername, locations in dupe_headers.iteritems():
+            if len(filenames) > 1:
+                print "[ERROR] Header file %s is not unique! It could be:" %\
+                    headername
+                print columnate(locations)
+
+
     def relative_to(self, base, dot=False):
         for field in ['inc_dirs', 'headers', 's_sources', 'c_sources',
                       'cpp_sources', 'lib_dirs', 'objects', 'libraries',

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -134,6 +134,12 @@ class Resources:
         return dupe_dict, dupe_headers
 
     def detect_duplicates(self, toolchain):
+        """Detect all potential ambiguities in filenames and report them with
+        a toolchain notification
+
+        Positional Arguments:
+        toolchain - used for notifications
+        """
         count = 0
         dupe_dict, dupe_headers = self._collect_duplicates(dict(), dict())
         for objname, filenames in dupe_dict.iteritems():


### PR DESCRIPTION
## Description
Find duplicate object files and header files as part of the build process.
Also contains a git hook.


## Status
**READY**


## Migrations
Nope

## Todos
- [x] Tests
- [x] Documentation
- [x] Review by @screamerbg 

## Example output
```
$ mbed compile
[mbed] Auto-installing missing Python modules...
Building project mbed-os-example-blinky (K64F, GCC_ARM)
Scan: .
Scan: FEATURE_COMMON_PAL
Scan: FEATURE_UVISOR
Scan: FEATURE_BLE
Scan: FEATURE_IPV6
Scan: FEATURE_IPV4
Scan: FEATURE_STORAGE
Scan: mbed
Scan: env
+------------------+-------+-------+-------+
| Module           | .text | .data |  .bss |
+------------------+-------+-------+-------+
| Fill             |    70 |     4 |  2532 |
| Misc             | 26603 |  2212 |    88 |
| features/storage |    42 |     0 |   184 |
| hal/common       |  1560 |     4 |   277 |
| hal/targets      | 10004 |    12 |   188 |
| rtos/rtos        |    38 |     4 |     4 |
| rtos/rtx         |  5907 |    20 |  6871 |
| Subtotals        | 44224 |  2256 | 10144 |
+------------------+-------+-------+-------+
Allocated Heap: 65536 bytes
Allocated Stack: unknown
Total Static RAM memory (data + bss): 12400 bytes
Total RAM memory (data + bss + heap + stack): 77936 bytes
Total Flash memory (text + data + misc): 47520 bytes
Object file test_env.o is not unique! It could be made from: ./mbed-os/features/frameworks/greentea-client/source/test_env.cpp /home/jimbri01/src/arm-mbed/mbed-os-example-uvisor/mbed-os/libraries/tests/mbed/env/test_env.cpp

```
