### PR TITLE
[Tools] Handling Exceptions better when building tests

### DIFF
--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2106,14 +2106,14 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
                                      verbose=verbose,
                                      app_config=app_config)
 
-        except Exception, e:
-            if not isinstance(e, NotSupportedException):
-                result = False
-
-                if continue_on_build_fail:
-                    continue
-                else:
-                    break
+        except NotSupportedException:
+            pass
+        except ToolException:
+            result = False
+            if continue_on_build_fail:
+                continue
+            else:
+                break
 
         # If a clean build was carried out last time, disable it for the next build.
         # Otherwise the previously built test will be deleted.


### PR DESCRIPTION
## Description
Previously, when building tests with `test.py`, if an exception occurred, the
error message would be masked by the function 'build_tests'. This commit
handles `NotSupportedException`s and `ToolException`s, but lets all other
Exceptions propigate up to the caller function. In most cases, this is the
CLI scripts, which will print a traceback. This will allow us to better
debug the python tools if errors occur.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [ ] Tests
- [x] Review by @theotherjimmy