### PR TITLE
[Tools] Making all toolchains print final compiler message

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -106,6 +106,7 @@ class ARM(mbedToolchain):
             if match is not None:
                 if msg is not None:
                     self.cc_info(msg)
+                    msg = None
                 msg = {
                     'severity': match.group('severity').lower(),
                     'file': match.group('file'),

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -146,6 +146,7 @@ class GCC(mbedToolchain):
             if match is not None:
                 if msg is not None:
                     self.cc_info(msg)
+                    msg = None
                 msg = {
                     'severity': match.group('severity').lower(),
                     'file': match.group('file'),
@@ -165,6 +166,9 @@ class GCC(mbedToolchain):
                     msg = None
                 else:
                     msg['text'] += line+"\n"
+
+        if msg is not None:
+            self.cc_info(msg)
 
     def get_dep_option(self, object):
         base, _ = splitext(object)

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -123,6 +123,7 @@ class IAR(mbedToolchain):
             if match is not None:
                 if msg is not None:
                     self.cc_info(msg)
+                    msg = None
                 msg = {
                     'severity': match.group('severity').lower(),
                     'file': match.group('file'),
@@ -142,6 +143,9 @@ class IAR(mbedToolchain):
                     msg = None
                 else:
                     msg['text'] += line+"\n"
+
+        if msg is not None:
+            self.cc_info(msg)
 
     def get_dep_option(self, object):
         base, _ = splitext(object)


### PR DESCRIPTION
## Description
This functionality was already present in the ARM toolchain script, but
this commit adds this across all toolchain scripts. Solves an issue that
cropped up where a build error wasn't being printed unless the verbose
flag was used. This should now print any existing error messages that have
been printed when the compiler output is being parsed.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO, **however this does touch the toolchain scripts, so this definitely needs to be under review for a bit before it gets merged.**


## Related PRs
This issue cropped up on the IAR build of this PR in CI: https://github.com/ARMmbed/mbed-os/pull/2849

The build correctly failed, however the error message was not printed


## Todos
- [x] Tests
- [x] Review by @theotherjimmy 
- [x] Review by @screamerbg 


## Deploy notes
This may add more warnings that weren't being printed before, so the overall build log for existing projects may change (for the better!)


## Steps to test or reproduce
Build log before this change testing this PR: https://github.com/ARMmbed/mbed-os/pull/2849

```
11:25:02 + mbed test --compile -m TY51822R3 -t IAR -DMBED_HEAP_STATS_ENABLED=1 -DMBED_STACK_STATS_ENABLED=1 --build-report-junit=C:/Jenkins/workspace/bm_wrap/655/.axes/target/TY51822R3/toolchain/IAR/build_report_TY51822R3_IAR.xml
11:25:03 Building library mbed-build (TY51822R3, IAR)
11:25:03 Scan: 655
11:25:03 Scan: FEATURE_BLE
11:25:03 Scan: FEATURE_COMMON_PAL
11:25:03 Scan: FEATURE_UVISOR
11:25:03 Scan: FEATURE_IPV4
11:25:03 Scan: FEATURE_IPV6
11:25:03 Scan: FEATURE_STORAGE
11:25:03 Copy: greentea_metrics.h
11:25:03 Copy: greentea_serial.h
...
11:25:15 Compile [ 64.6%]: nordic_critical.c
11:25:16 Failed to build library
```

Failed to build but no error message! :-1: 

Build log after this change testing this PR: https://github.com/ARMmbed/mbed-os/pull/2849

```
C:\Users\bridan01\Documents\dev\m_mbed\mbed>mbed test --compile -m TY51822R3  -t IAR
Building library mbed-build (TY51822R3, IAR)
Scan: mbed
Scan: FEATURE_BLE
Scan: FEATURE_COMMON_PAL
Scan: FEATURE_UVISOR
Scan: FEATURE_IPV4
Scan: FEATURE_IPV6
Scan: FEATURE_STORAGE
Compile [  0.4%]: mbed_critical.c
Compile [  0.8%]: nordic_critical.c
[Error] nordic_critical.c@38,0: [Pe167]: argument of type "uint8_t volatile *" is incompatible with parameter of type "uint8_t *"
Failed to build library
```

Failed to build, but there's an error message! :+1: 