### PR TITLE
[Tools] Copying main config json file for mbed lib builds

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -907,7 +907,8 @@ def build_mbed_libs(target, toolchain_name, options=None, verbose=False,
         hal_implementation = toolchain.scan_resources(hal_src)
         toolchain.copy_files(hal_implementation.headers +
                              hal_implementation.hex_files +
-                             hal_implementation.libraries,
+                             hal_implementation.libraries +
+                             [MBED_CONFIG_FILE],
                              build_target, resources=hal_implementation)
         incdirs = toolchain.scan_resources(build_target).inc_dirs
         objects = toolchain.compile_sources(hal_implementation, tmp_path,


### PR DESCRIPTION
## Description
This PR copies the main mbed config file (`mbed_lib.json` in the root of `mbed-os`) into the `<build_directory>/mbed/TARGET_<target_name>` folder. This can then be used when building tests using the mbed 2 flows.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Related PRs
This should unblock PR https://github.com/ARMmbed/mbed-os/pull/2422


## Todos
- [x] Tests
- [x] Review by @theotherjimmy 
- [x] Review by @screamerbg 


## Deploy notes
I'm a bit concerned that I'm copying json file either at the wrong point in the mbed lib build process OR that I'm copying it to the wrong directory. If you have any feedback on this @screamerbg that'd be great!


