### PR TITLE
callback - Remove problematic callback overloads

### DIFF
--- a/TESTS/mbed_functional/callback/main.cpp
+++ b/TESTS/mbed_functional/callback/main.cpp
@@ -320,23 +320,23 @@ void test_dispatch0() {
     Verifier<T>::verify0((const Thing<T>*)&thing, &Thing<T>::const_member_func0);
     Verifier<T>::verify0((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func0);
     Verifier<T>::verify0((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func0);
-    Verifier<T>::verify0(&thing, &bound_func0<T>);
-    Verifier<T>::verify0((const Thing<T>*)&thing, &const_bound_func0<T>);
-    Verifier<T>::verify0((volatile Thing<T>*)&thing, &volatile_bound_func0<T>);
-    Verifier<T>::verify0((const volatile Thing<T>*)&thing, &const_volatile_bound_func0<T>);
-    Verifier<T>::verify0(&thing, &void_func0<T>);
-    Verifier<T>::verify0((const Thing<T>*)&thing, &const_void_func0<T>);
-    Verifier<T>::verify0((volatile Thing<T>*)&thing, &volatile_void_func0<T>);
-    Verifier<T>::verify0((const volatile Thing<T>*)&thing, &const_volatile_void_func0<T>);
+    Verifier<T>::verify0(&bound_func0<T>, &thing);
+    Verifier<T>::verify0(&const_bound_func0<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify0(&volatile_bound_func0<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify0(&const_volatile_bound_func0<T>, (const volatile Thing<T>*)&thing);
+    Verifier<T>::verify0(&void_func0<T>, &thing);
+    Verifier<T>::verify0(&const_void_func0<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify0(&volatile_void_func0<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify0(&const_volatile_void_func0<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify0(callback(static_func0<T>));
 
     Callback<T()> cb(static_func0);
     Verifier<T>::verify0(cb);
     cb = static_func0;
     Verifier<T>::verify0(cb);
-    cb.attach(&thing, &bound_func0<T>);
+    cb.attach(&bound_func0<T>, &thing);
     Verifier<T>::verify0(&cb, &Callback<T()>::call);
-    Verifier<T>::verify0((void*)&cb, &Callback<T()>::thunk);
+    Verifier<T>::verify0(&Callback<T()>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -347,23 +347,23 @@ void test_dispatch1() {
     Verifier<T>::verify1((const Thing<T>*)&thing, &Thing<T>::const_member_func1);
     Verifier<T>::verify1((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func1);
     Verifier<T>::verify1((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func1);
-    Verifier<T>::verify1(&thing, &bound_func1<T>);
-    Verifier<T>::verify1((const Thing<T>*)&thing, &const_bound_func1<T>);
-    Verifier<T>::verify1((volatile Thing<T>*)&thing, &volatile_bound_func1<T>);
-    Verifier<T>::verify1((const volatile Thing<T>*)&thing, &const_volatile_bound_func1<T>);
-    Verifier<T>::verify1(&thing, &void_func1<T>);
-    Verifier<T>::verify1((const Thing<T>*)&thing, &const_void_func1<T>);
-    Verifier<T>::verify1((volatile Thing<T>*)&thing, &volatile_void_func1<T>);
-    Verifier<T>::verify1((const volatile Thing<T>*)&thing, &const_volatile_void_func1<T>);
+    Verifier<T>::verify1(&bound_func1<T>, &thing);
+    Verifier<T>::verify1(&const_bound_func1<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify1(&volatile_bound_func1<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify1(&const_volatile_bound_func1<T>, (const volatile Thing<T>*)&thing);
+    Verifier<T>::verify1(&void_func1<T>, &thing);
+    Verifier<T>::verify1(&const_void_func1<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify1(&volatile_void_func1<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify1(&const_volatile_void_func1<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify1(callback(static_func1<T>));
 
     Callback<T(T)> cb(static_func1);
     Verifier<T>::verify1(cb);
     cb = static_func1;
     Verifier<T>::verify1(cb);
-    cb.attach(&thing, &bound_func1<T>);
+    cb.attach(&bound_func1<T>, &thing);
     Verifier<T>::verify1(&cb, &Callback<T(T)>::call);
-    Verifier<T>::verify1((void*)&cb, &Callback<T(T)>::thunk);
+    Verifier<T>::verify1(&Callback<T(T)>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -374,23 +374,23 @@ void test_dispatch2() {
     Verifier<T>::verify2((const Thing<T>*)&thing, &Thing<T>::const_member_func2);
     Verifier<T>::verify2((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func2);
     Verifier<T>::verify2((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func2);
-    Verifier<T>::verify2(&thing, &bound_func2<T>);
-    Verifier<T>::verify2((const Thing<T>*)&thing, &const_bound_func2<T>);
-    Verifier<T>::verify2((volatile Thing<T>*)&thing, &volatile_bound_func2<T>);
-    Verifier<T>::verify2((const volatile Thing<T>*)&thing, &const_volatile_bound_func2<T>);
-    Verifier<T>::verify2(&thing, &void_func2<T>);
-    Verifier<T>::verify2((const Thing<T>*)&thing, &const_void_func2<T>);
-    Verifier<T>::verify2((volatile Thing<T>*)&thing, &volatile_void_func2<T>);
-    Verifier<T>::verify2((const volatile Thing<T>*)&thing, &const_volatile_void_func2<T>);
+    Verifier<T>::verify2(&bound_func2<T>, &thing);
+    Verifier<T>::verify2(&const_bound_func2<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify2(&volatile_bound_func2<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify2(&const_volatile_bound_func2<T>, (const volatile Thing<T>*)&thing);
+    Verifier<T>::verify2(&void_func2<T>, &thing);
+    Verifier<T>::verify2(&const_void_func2<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify2(&volatile_void_func2<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify2(&const_volatile_void_func2<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify2(callback(static_func2<T>));
 
     Callback<T(T, T)> cb(static_func2);
     Verifier<T>::verify2(cb);
     cb = static_func2;
     Verifier<T>::verify2(cb);
-    cb.attach(&thing, &bound_func2<T>);
+    cb.attach(&bound_func2<T>, &thing);
     Verifier<T>::verify2(&cb, &Callback<T(T, T)>::call);
-    Verifier<T>::verify2((void*)&cb, &Callback<T(T, T)>::thunk);
+    Verifier<T>::verify2(&Callback<T(T, T)>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -401,23 +401,23 @@ void test_dispatch3() {
     Verifier<T>::verify3((const Thing<T>*)&thing, &Thing<T>::const_member_func3);
     Verifier<T>::verify3((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func3);
     Verifier<T>::verify3((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func3);
-    Verifier<T>::verify3(&thing, &bound_func3<T>);
-    Verifier<T>::verify3((const Thing<T>*)&thing, &const_bound_func3<T>);
-    Verifier<T>::verify3((volatile Thing<T>*)&thing, &volatile_bound_func3<T>);
-    Verifier<T>::verify3((const volatile Thing<T>*)&thing, &const_volatile_bound_func3<T>);
-    Verifier<T>::verify3(&thing, &void_func3<T>);
-    Verifier<T>::verify3((const Thing<T>*)&thing, &const_void_func3<T>);
-    Verifier<T>::verify3((volatile Thing<T>*)&thing, &volatile_void_func3<T>);
-    Verifier<T>::verify3((const volatile Thing<T>*)&thing, &const_volatile_void_func3<T>);
+    Verifier<T>::verify3(&bound_func3<T>, &thing);
+    Verifier<T>::verify3(&const_bound_func3<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify3(&volatile_bound_func3<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify3(&const_volatile_bound_func3<T>, (const volatile Thing<T>*)&thing);
+    Verifier<T>::verify3(&void_func3<T>, &thing);
+    Verifier<T>::verify3(&const_void_func3<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify3(&volatile_void_func3<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify3(&const_volatile_void_func3<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify3(callback(static_func3<T>));
 
     Callback<T(T, T, T)> cb(static_func3);
     Verifier<T>::verify3(cb);
     cb = static_func3;
     Verifier<T>::verify3(cb);
-    cb.attach(&thing, &bound_func3<T>);
+    cb.attach(&bound_func3<T>, &thing);
     Verifier<T>::verify3(&cb, &Callback<T(T, T, T)>::call);
-    Verifier<T>::verify3((void*)&cb, &Callback<T(T, T, T)>::thunk);
+    Verifier<T>::verify3(&Callback<T(T, T, T)>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -428,23 +428,23 @@ void test_dispatch4() {
     Verifier<T>::verify4((const Thing<T>*)&thing, &Thing<T>::const_member_func4);
     Verifier<T>::verify4((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func4);
     Verifier<T>::verify4((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func4);
-    Verifier<T>::verify4(&thing, &bound_func4<T>);
-    Verifier<T>::verify4((const Thing<T>*)&thing, &const_bound_func4<T>);
-    Verifier<T>::verify4((volatile Thing<T>*)&thing, &volatile_bound_func4<T>);
-    Verifier<T>::verify4((const volatile Thing<T>*)&thing, &const_volatile_bound_func4<T>);
-    Verifier<T>::verify4(&thing, &void_func4<T>);
-    Verifier<T>::verify4((const Thing<T>*)&thing, &const_void_func4<T>);
-    Verifier<T>::verify4((volatile Thing<T>*)&thing, &volatile_void_func4<T>);
-    Verifier<T>::verify4((const volatile Thing<T>*)&thing, &const_volatile_void_func4<T>);
+    Verifier<T>::verify4(&bound_func4<T>, &thing);
+    Verifier<T>::verify4(&const_bound_func4<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify4(&volatile_bound_func4<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify4(&const_volatile_bound_func4<T>, (const volatile Thing<T>*)&thing);
+    Verifier<T>::verify4(&void_func4<T>, &thing);
+    Verifier<T>::verify4(&const_void_func4<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify4(&volatile_void_func4<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify4(&const_volatile_void_func4<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify4(callback(static_func4<T>));
 
     Callback<T(T, T, T, T)> cb(static_func4);
     Verifier<T>::verify4(cb);
     cb = static_func4;
     Verifier<T>::verify4(cb);
-    cb.attach(&thing, &bound_func4<T>);
+    cb.attach(&bound_func4<T>, &thing);
     Verifier<T>::verify4(&cb, &Callback<T(T, T, T, T)>::call);
-    Verifier<T>::verify4((void*)&cb, &Callback<T(T, T, T, T)>::thunk);
+    Verifier<T>::verify4(&Callback<T(T, T, T, T)>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -455,23 +455,23 @@ void test_dispatch5() {
     Verifier<T>::verify5((const Thing<T>*)&thing, &Thing<T>::const_member_func5);
     Verifier<T>::verify5((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func5);
     Verifier<T>::verify5((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func5);
-    Verifier<T>::verify5(&thing, &bound_func5<T>);
-    Verifier<T>::verify5((const Thing<T>*)&thing, &const_bound_func5<T>);
-    Verifier<T>::verify5((volatile Thing<T>*)&thing, &volatile_bound_func5<T>);
-    Verifier<T>::verify5((const volatile Thing<T>*)&thing, &const_volatile_bound_func5<T>);
-    Verifier<T>::verify5(&thing, &void_func5<T>);
-    Verifier<T>::verify5((const Thing<T>*)&thing, &const_void_func5<T>);
-    Verifier<T>::verify5((volatile Thing<T>*)&thing, &volatile_void_func5<T>);
-    Verifier<T>::verify5((const volatile Thing<T>*)&thing, &const_volatile_void_func5<T>);
+    Verifier<T>::verify5(&bound_func5<T>, &thing);
+    Verifier<T>::verify5(&const_bound_func5<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify5(&volatile_bound_func5<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify5(&const_volatile_bound_func5<T>, (const volatile Thing<T>*)&thing);
+    Verifier<T>::verify5(&void_func5<T>, &thing);
+    Verifier<T>::verify5(&const_void_func5<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify5(&volatile_void_func5<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify5(&const_volatile_void_func5<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify5(callback(static_func5<T>));
 
     Callback<T(T, T, T, T, T)> cb(static_func5);
     Verifier<T>::verify5(cb);
     cb = static_func5;
     Verifier<T>::verify5(cb);
-    cb.attach(&thing, &bound_func5<T>);
+    cb.attach(&bound_func5<T>, &thing);
     Verifier<T>::verify5(&cb, &Callback<T(T, T, T, T, T)>::call);
-    Verifier<T>::verify5((void*)&cb, &Callback<T(T, T, T, T, T)>::thunk);
+    Verifier<T>::verify5(&Callback<T(T, T, T, T, T)>::thunk, (void*)&cb);
 }
 
 

--- a/TESTS/mbed_functional/callback_big/main.cpp
+++ b/TESTS/mbed_functional/callback_big/main.cpp
@@ -198,19 +198,19 @@ void test_dispatch0() {
     Verifier<T>::verify0((const Thing<T>*)&thing, &Thing<T>::const_member_func0);
     Verifier<T>::verify0((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func0);
     Verifier<T>::verify0((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func0);
-    Verifier<T>::verify0(&thing, &bound_func0<T>);
-    Verifier<T>::verify0((const Thing<T>*)&thing, &const_func0<T>);
-    Verifier<T>::verify0((volatile Thing<T>*)&thing, &volatile_func0<T>);
-    Verifier<T>::verify0((const volatile Thing<T>*)&thing, &const_volatile_func0<T>);
+    Verifier<T>::verify0(&bound_func0<T>, &thing);
+    Verifier<T>::verify0(&const_func0<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify0(&volatile_func0<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify0(&const_volatile_func0<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify0(callback(static_func0<T>));
 
     Callback<T()> cb(static_func0);
     Verifier<T>::verify0(cb);
     cb = static_func0;
     Verifier<T>::verify0(cb);
-    cb.attach(&thing, &bound_func0<T>);
+    cb.attach(&bound_func0<T>, &thing);
     Verifier<T>::verify0(&cb, &Callback<T()>::call);
-    Verifier<T>::verify0((void*)&cb, &Callback<T()>::thunk);
+    Verifier<T>::verify0(&Callback<T()>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -221,19 +221,19 @@ void test_dispatch1() {
     Verifier<T>::verify1((const Thing<T>*)&thing, &Thing<T>::const_member_func1);
     Verifier<T>::verify1((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func1);
     Verifier<T>::verify1((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func1);
-    Verifier<T>::verify1(&thing, &bound_func1<T>);
-    Verifier<T>::verify1((const Thing<T>*)&thing, &const_func1<T>);
-    Verifier<T>::verify1((volatile Thing<T>*)&thing, &volatile_func1<T>);
-    Verifier<T>::verify1((const volatile Thing<T>*)&thing, &const_volatile_func1<T>);
+    Verifier<T>::verify1(&bound_func1<T>, &thing);
+    Verifier<T>::verify1(&const_func1<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify1(&volatile_func1<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify1(&const_volatile_func1<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify1(callback(static_func1<T>));
 
     Callback<T(T)> cb(static_func1);
     Verifier<T>::verify1(cb);
     cb = static_func1;
     Verifier<T>::verify1(cb);
-    cb.attach(&thing, &bound_func1<T>);
+    cb.attach(&bound_func1<T>, &thing);
     Verifier<T>::verify1(&cb, &Callback<T(T)>::call);
-    Verifier<T>::verify1((void*)&cb, &Callback<T(T)>::thunk);
+    Verifier<T>::verify1(&Callback<T(T)>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -244,19 +244,19 @@ void test_dispatch2() {
     Verifier<T>::verify2((const Thing<T>*)&thing, &Thing<T>::const_member_func2);
     Verifier<T>::verify2((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func2);
     Verifier<T>::verify2((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func2);
-    Verifier<T>::verify2(&thing, &bound_func2<T>);
-    Verifier<T>::verify2((const Thing<T>*)&thing, &const_func2<T>);
-    Verifier<T>::verify2((volatile Thing<T>*)&thing, &volatile_func2<T>);
-    Verifier<T>::verify2((const volatile Thing<T>*)&thing, &const_volatile_func2<T>);
+    Verifier<T>::verify2(&bound_func2<T>, &thing);
+    Verifier<T>::verify2(&const_func2<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify2(&volatile_func2<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify2(&const_volatile_func2<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify2(callback(static_func2<T>));
 
     Callback<T(T, T)> cb(static_func2);
     Verifier<T>::verify2(cb);
     cb = static_func2;
     Verifier<T>::verify2(cb);
-    cb.attach(&thing, &bound_func2<T>);
+    cb.attach(&bound_func2<T>, &thing);
     Verifier<T>::verify2(&cb, &Callback<T(T, T)>::call);
-    Verifier<T>::verify2((void*)&cb, &Callback<T(T, T)>::thunk);
+    Verifier<T>::verify2(&Callback<T(T, T)>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -267,19 +267,19 @@ void test_dispatch3() {
     Verifier<T>::verify3((const Thing<T>*)&thing, &Thing<T>::const_member_func3);
     Verifier<T>::verify3((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func3);
     Verifier<T>::verify3((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func3);
-    Verifier<T>::verify3(&thing, &bound_func3<T>);
-    Verifier<T>::verify3((const Thing<T>*)&thing, &const_func3<T>);
-    Verifier<T>::verify3((volatile Thing<T>*)&thing, &volatile_func3<T>);
-    Verifier<T>::verify3((const volatile Thing<T>*)&thing, &const_volatile_func3<T>);
+    Verifier<T>::verify3(&bound_func3<T>, &thing);
+    Verifier<T>::verify3(&const_func3<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify3(&volatile_func3<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify3(&const_volatile_func3<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify3(callback(static_func3<T>));
 
     Callback<T(T, T, T)> cb(static_func3);
     Verifier<T>::verify3(cb);
     cb = static_func3;
     Verifier<T>::verify3(cb);
-    cb.attach(&thing, &bound_func3<T>);
+    cb.attach(&bound_func3<T>, &thing);
     Verifier<T>::verify3(&cb, &Callback<T(T, T, T)>::call);
-    Verifier<T>::verify3((void*)&cb, &Callback<T(T, T, T)>::thunk);
+    Verifier<T>::verify3(&Callback<T(T, T, T)>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -290,19 +290,19 @@ void test_dispatch4() {
     Verifier<T>::verify4((const Thing<T>*)&thing, &Thing<T>::const_member_func4);
     Verifier<T>::verify4((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func4);
     Verifier<T>::verify4((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func4);
-    Verifier<T>::verify4(&thing, &bound_func4<T>);
-    Verifier<T>::verify4((const Thing<T>*)&thing, &const_func4<T>);
-    Verifier<T>::verify4((volatile Thing<T>*)&thing, &volatile_func4<T>);
-    Verifier<T>::verify4((const volatile Thing<T>*)&thing, &const_volatile_func4<T>);
+    Verifier<T>::verify4(&bound_func4<T>, &thing);
+    Verifier<T>::verify4(&const_func4<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify4(&volatile_func4<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify4(&const_volatile_func4<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify4(callback(static_func4<T>));
 
     Callback<T(T, T, T, T)> cb(static_func4);
     Verifier<T>::verify4(cb);
     cb = static_func4;
     Verifier<T>::verify4(cb);
-    cb.attach(&thing, &bound_func4<T>);
+    cb.attach(&bound_func4<T>, &thing);
     Verifier<T>::verify4(&cb, &Callback<T(T, T, T, T)>::call);
-    Verifier<T>::verify4((void*)&cb, &Callback<T(T, T, T, T)>::thunk);
+    Verifier<T>::verify4(&Callback<T(T, T, T, T)>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -313,19 +313,19 @@ void test_dispatch5() {
     Verifier<T>::verify5((const Thing<T>*)&thing, &Thing<T>::const_member_func5);
     Verifier<T>::verify5((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func5);
     Verifier<T>::verify5((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func5);
-    Verifier<T>::verify5(&thing, &bound_func5<T>);
-    Verifier<T>::verify5((const Thing<T>*)&thing, &const_func5<T>);
-    Verifier<T>::verify5((volatile Thing<T>*)&thing, &volatile_func5<T>);
-    Verifier<T>::verify5((const volatile Thing<T>*)&thing, &const_volatile_func5<T>);
+    Verifier<T>::verify5(&bound_func5<T>, &thing);
+    Verifier<T>::verify5(&const_func5<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify5(&volatile_func5<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify5(&const_volatile_func5<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify5(callback(static_func5<T>));
 
     Callback<T(T, T, T, T, T)> cb(static_func5);
     Verifier<T>::verify5(cb);
     cb = static_func5;
     Verifier<T>::verify5(cb);
-    cb.attach(&thing, &bound_func5<T>);
+    cb.attach(&bound_func5<T>, &thing);
     Verifier<T>::verify5(&cb, &Callback<T(T, T, T, T, T)>::call);
-    Verifier<T>::verify5((void*)&cb, &Callback<T(T, T, T, T, T)>::thunk);
+    Verifier<T>::verify5(&Callback<T(T, T, T, T, T)>::thunk, (void*)&cb);
 }
 
 

--- a/TESTS/mbed_functional/callback_small/main.cpp
+++ b/TESTS/mbed_functional/callback_small/main.cpp
@@ -198,19 +198,19 @@ void test_dispatch0() {
     Verifier<T>::verify0((const Thing<T>*)&thing, &Thing<T>::const_member_func0);
     Verifier<T>::verify0((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func0);
     Verifier<T>::verify0((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func0);
-    Verifier<T>::verify0(&thing, &bound_func0<T>);
-    Verifier<T>::verify0((const Thing<T>*)&thing, &const_func0<T>);
-    Verifier<T>::verify0((volatile Thing<T>*)&thing, &volatile_func0<T>);
-    Verifier<T>::verify0((const volatile Thing<T>*)&thing, &const_volatile_func0<T>);
+    Verifier<T>::verify0(&bound_func0<T>, &thing);
+    Verifier<T>::verify0(&const_func0<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify0(&volatile_func0<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify0(&const_volatile_func0<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify0(callback(static_func0<T>));
 
     Callback<T()> cb(static_func0);
     Verifier<T>::verify0(cb);
     cb = static_func0;
     Verifier<T>::verify0(cb);
-    cb.attach(&thing, &bound_func0<T>);
+    cb.attach(&bound_func0<T>, &thing);
     Verifier<T>::verify0(&cb, &Callback<T()>::call);
-    Verifier<T>::verify0((void*)&cb, &Callback<T()>::thunk);
+    Verifier<T>::verify0(&Callback<T()>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -221,19 +221,19 @@ void test_dispatch1() {
     Verifier<T>::verify1((const Thing<T>*)&thing, &Thing<T>::const_member_func1);
     Verifier<T>::verify1((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func1);
     Verifier<T>::verify1((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func1);
-    Verifier<T>::verify1(&thing, &bound_func1<T>);
-    Verifier<T>::verify1((const Thing<T>*)&thing, &const_func1<T>);
-    Verifier<T>::verify1((volatile Thing<T>*)&thing, &volatile_func1<T>);
-    Verifier<T>::verify1((const volatile Thing<T>*)&thing, &const_volatile_func1<T>);
+    Verifier<T>::verify1(&bound_func1<T>, &thing);
+    Verifier<T>::verify1(&const_func1<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify1(&volatile_func1<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify1(&const_volatile_func1<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify1(callback(static_func1<T>));
 
     Callback<T(T)> cb(static_func1);
     Verifier<T>::verify1(cb);
     cb = static_func1;
     Verifier<T>::verify1(cb);
-    cb.attach(&thing, &bound_func1<T>);
+    cb.attach(&bound_func1<T>, &thing);
     Verifier<T>::verify1(&cb, &Callback<T(T)>::call);
-    Verifier<T>::verify1((void*)&cb, &Callback<T(T)>::thunk);
+    Verifier<T>::verify1(&Callback<T(T)>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -244,19 +244,19 @@ void test_dispatch2() {
     Verifier<T>::verify2((const Thing<T>*)&thing, &Thing<T>::const_member_func2);
     Verifier<T>::verify2((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func2);
     Verifier<T>::verify2((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func2);
-    Verifier<T>::verify2(&thing, &bound_func2<T>);
-    Verifier<T>::verify2((const Thing<T>*)&thing, &const_func2<T>);
-    Verifier<T>::verify2((volatile Thing<T>*)&thing, &volatile_func2<T>);
-    Verifier<T>::verify2((const volatile Thing<T>*)&thing, &const_volatile_func2<T>);
+    Verifier<T>::verify2(&bound_func2<T>, &thing);
+    Verifier<T>::verify2(&const_func2<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify2(&volatile_func2<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify2(&const_volatile_func2<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify2(callback(static_func2<T>));
 
     Callback<T(T, T)> cb(static_func2);
     Verifier<T>::verify2(cb);
     cb = static_func2;
     Verifier<T>::verify2(cb);
-    cb.attach(&thing, &bound_func2<T>);
+    cb.attach(&bound_func2<T>, &thing);
     Verifier<T>::verify2(&cb, &Callback<T(T, T)>::call);
-    Verifier<T>::verify2((void*)&cb, &Callback<T(T, T)>::thunk);
+    Verifier<T>::verify2(&Callback<T(T, T)>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -267,19 +267,19 @@ void test_dispatch3() {
     Verifier<T>::verify3((const Thing<T>*)&thing, &Thing<T>::const_member_func3);
     Verifier<T>::verify3((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func3);
     Verifier<T>::verify3((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func3);
-    Verifier<T>::verify3(&thing, &bound_func3<T>);
-    Verifier<T>::verify3((const Thing<T>*)&thing, &const_func3<T>);
-    Verifier<T>::verify3((volatile Thing<T>*)&thing, &volatile_func3<T>);
-    Verifier<T>::verify3((const volatile Thing<T>*)&thing, &const_volatile_func3<T>);
+    Verifier<T>::verify3(&bound_func3<T>, &thing);
+    Verifier<T>::verify3(&const_func3<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify3(&volatile_func3<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify3(&const_volatile_func3<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify3(callback(static_func3<T>));
 
     Callback<T(T, T, T)> cb(static_func3);
     Verifier<T>::verify3(cb);
     cb = static_func3;
     Verifier<T>::verify3(cb);
-    cb.attach(&thing, &bound_func3<T>);
+    cb.attach(&bound_func3<T>, &thing);
     Verifier<T>::verify3(&cb, &Callback<T(T, T, T)>::call);
-    Verifier<T>::verify3((void*)&cb, &Callback<T(T, T, T)>::thunk);
+    Verifier<T>::verify3(&Callback<T(T, T, T)>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -290,19 +290,19 @@ void test_dispatch4() {
     Verifier<T>::verify4((const Thing<T>*)&thing, &Thing<T>::const_member_func4);
     Verifier<T>::verify4((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func4);
     Verifier<T>::verify4((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func4);
-    Verifier<T>::verify4(&thing, &bound_func4<T>);
-    Verifier<T>::verify4((const Thing<T>*)&thing, &const_func4<T>);
-    Verifier<T>::verify4((volatile Thing<T>*)&thing, &volatile_func4<T>);
-    Verifier<T>::verify4((const volatile Thing<T>*)&thing, &const_volatile_func4<T>);
+    Verifier<T>::verify4(&bound_func4<T>, &thing);
+    Verifier<T>::verify4(&const_func4<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify4(&volatile_func4<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify4(&const_volatile_func4<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify4(callback(static_func4<T>));
 
     Callback<T(T, T, T, T)> cb(static_func4);
     Verifier<T>::verify4(cb);
     cb = static_func4;
     Verifier<T>::verify4(cb);
-    cb.attach(&thing, &bound_func4<T>);
+    cb.attach(&bound_func4<T>, &thing);
     Verifier<T>::verify4(&cb, &Callback<T(T, T, T, T)>::call);
-    Verifier<T>::verify4((void*)&cb, &Callback<T(T, T, T, T)>::thunk);
+    Verifier<T>::verify4(&Callback<T(T, T, T, T)>::thunk, (void*)&cb);
 }
 
 template <typename T>
@@ -313,19 +313,19 @@ void test_dispatch5() {
     Verifier<T>::verify5((const Thing<T>*)&thing, &Thing<T>::const_member_func5);
     Verifier<T>::verify5((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func5);
     Verifier<T>::verify5((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func5);
-    Verifier<T>::verify5(&thing, &bound_func5<T>);
-    Verifier<T>::verify5((const Thing<T>*)&thing, &const_func5<T>);
-    Verifier<T>::verify5((volatile Thing<T>*)&thing, &volatile_func5<T>);
-    Verifier<T>::verify5((const volatile Thing<T>*)&thing, &const_volatile_func5<T>);
+    Verifier<T>::verify5(&bound_func5<T>, &thing);
+    Verifier<T>::verify5(&const_func5<T>, (const Thing<T>*)&thing);
+    Verifier<T>::verify5(&volatile_func5<T>, (volatile Thing<T>*)&thing);
+    Verifier<T>::verify5(&const_volatile_func5<T>, (const volatile Thing<T>*)&thing);
     Verifier<T>::verify5(callback(static_func5<T>));
 
     Callback<T(T, T, T, T, T)> cb(static_func5);
     Verifier<T>::verify5(cb);
     cb = static_func5;
     Verifier<T>::verify5(cb);
-    cb.attach(&thing, &bound_func5<T>);
+    cb.attach(&bound_func5<T>, &thing);
     Verifier<T>::verify5(&cb, &Callback<T(T, T, T, T, T)>::call);
-    Verifier<T>::verify5((void*)&cb, &Callback<T(T, T, T, T, T)>::thunk);
+    Verifier<T>::verify5(&Callback<T(T, T, T, T, T)>::thunk, (void*)&cb);
 }
 
 

--- a/hal/api/Callback.h
+++ b/hal/api/Callback.h
@@ -4437,54 +4437,6 @@ Callback<R()> callback(R (*func)(const volatile T*), const volatile T *arg) {
 }
 
 /** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R>
-Callback<R()> callback(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R()>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R>
-Callback<R()> callback(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)() const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R()>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R>
-Callback<R()> callback(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)() volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R()>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R>
-Callback<R()> callback(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)() const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R()>(f);
-}
-
-/** Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4755,54 +4707,6 @@ Callback<R(A0)> callback(R (*func)(volatile T*, A0), volatile T *arg) {
 template <typename T, typename R, typename A0>
 Callback<R(A0)> callback(R (*func)(const volatile T*, A0), const volatile T *arg) {
     return Callback<R(A0)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0>
-Callback<R(A0)> callback(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0>
-Callback<R(A0)> callback(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0>
-Callback<R(A0)> callback(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0>
-Callback<R(A0)> callback(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0)>(f);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -5079,54 +4983,6 @@ Callback<R(A0, A1)> callback(R (*func)(const volatile T*, A0, A1), const volatil
 }
 
 /** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -5397,54 +5253,6 @@ Callback<R(A0, A1, A2)> callback(R (*func)(volatile T*, A0, A1, A2), volatile T 
 template <typename T, typename R, typename A0, typename A1, typename A2>
 Callback<R(A0, A1, A2)> callback(R (*func)(const volatile T*, A0, A1, A2), const volatile T *arg) {
     return Callback<R(A0, A1, A2)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1, A2)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1, A2)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1, A2)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1, A2)>(f);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -5721,54 +5529,6 @@ Callback<R(A0, A1, A2, A3)> callback(R (*func)(const volatile T*, A0, A1, A2, A3
 }
 
 /** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1, A2, A3)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1, A2, A3)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1, A2, A3)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1, A2, A3)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -6039,54 +5799,6 @@ Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(volatile T*, A0, A1, A2, A3, 
 template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
 Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(const volatile T*, A0, A1, A2, A3, A4), const volatile T *arg) {
     return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1, A2, A3, A4)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1, A2, A3, A4)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1, A2, A3, A4)>(f);
-}
-
-/** Create a callback class with type infered from the arguments
- *  @param func     Function object to attach
- *  @note The function object is limited to a single word of storage
- */
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
-    return Callback<R(A0, A1, A2, A3, A4)>(f);
 }
 
 /** Create a callback class with type infered from the arguments


### PR DESCRIPTION
Note: This has no api changes, just removes an erronous set of overloads:
``` cpp
class Func {
public:
    operator()() {};
}

ticker.attach(Func());            // perfectly fine
ticker.attach(callback(Func());   // compile error
```

Unfortunately, it is very difficult to infer the parameters of function-objects generically in C++03 without any additional type information. The current implementation fails to do so, and the compiler simply bails with "unable to deduce template parameter".

Rather than leaving the user with a small novel of error messages, this patch removes the problematic callback overloads, leaving only callback overloads for the original pointer types.

Also updated the tests based on argument order.

related issue in mbed-events: https://github.com/ARMmbed/mbed-events/pull/24
cc @pan-, @bogdanm, @bridadan 