### PR TITLE
EFM32GG: Add support for uVisor

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG_STK3700/device/TOOLCHAIN_GCC_ARM/efm32gg.ld
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG_STK3700/device/TOOLCHAIN_GCC_ARM/efm32gg.ld
@@ -9,6 +9,9 @@
 /* Version 4.2.0 */
 /*                                                                  */
 
+STACK_SIZE = 0x400;
+HEAP_SIZE = 0xC00;
+
 MEMORY
 {
   FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 1048576
@@ -53,6 +56,11 @@ __vector_size = 0xDC;
  */
 ENTRY(Reset_Handler)
 
+/* Note: The uVisor expects the text section at a fixed location, as specified
+             by the porting process configuration parameter: FLASH_OFFSET. */
+__UVISOR_TEXT_OFFSET = 0x100;
+__UVISOR_TEXT_START = ORIGIN(FLASH) + __UVISOR_TEXT_OFFSET;
+
 SECTIONS
 {
   .text :
@@ -61,6 +69,13 @@ SECTIONS
     __Vectors_End = .;
     __Vectors_Size = __Vectors_End - __Vectors;
     __end__ = .;
+
+    /* uVisor code and data */
+    . = __UVISOR_TEXT_OFFSET;
+    . = ALIGN(4);
+    __uvisor_main_start = .;
+    *(.uvisor.main)
+    __uvisor_main_end = .;
 
     *(.text*)
 
@@ -132,10 +147,51 @@ SECTIONS
   } > FLASH
   */
 
-  __etext = .;
-
-  .data : AT (__etext)
+  /* Ensure that the uVisor BSS section is put first in SRAM. */
+  /* Note: The uVisor expects this section at a fixed location, as specified
+           by the porting process configuration parameter: SRAM_OFFSET. */
+  __UVISOR_SRAM_OFFSET = 0x0;
+  __UVISOR_BSS_START = ORIGIN(RAM) + __UVISOR_SRAM_OFFSET;
+  .uvisor.bss __UVISOR_BSS_START (NOLOAD):
   {
+    . = ALIGN(32);
+    __uvisor_bss_start = .;
+
+    /* uVisor main BSS section */
+    . = ALIGN(32);
+    __uvisor_bss_main_start = .;
+    KEEP(*(.keep.uvisor.bss.main))
+    . = ALIGN(32);
+    __uvisor_bss_main_end = .;
+
+    /* Secure boxes BSS section */
+    . = ALIGN(32);
+    __uvisor_bss_boxes_start = .;
+    KEEP(*(.keep.uvisor.bss.boxes))
+    . = ALIGN(32);
+    __uvisor_bss_boxes_end = .;
+
+    . = ALIGN(32);
+    __uvisor_bss_end = .;
+  } > RAM
+
+  /* Heap space for the page allocator */
+  .page_heap (NOLOAD) :
+  {
+    . = ALIGN(32);
+    __uvisor_page_start = .;
+    KEEP(*(.keep.uvisor.page_heap))
+
+    . = ALIGN( (1 << LOG2CEIL(LENGTH(RAM))) / 8);
+
+    __uvisor_page_end = .;
+  } > RAM
+
+  .data :
+  {
+    PROVIDE(__etext = LOADADDR(.data));    /* Define a global symbol at end of code, */
+    PROVIDE(__DATA_ROM = LOADADDR(.data)); /* Symbol is used by startup for data initialization. */
+
     __data_start__ = .;
     *("dma")
     PROVIDE( __start_vector_table__ = .);
@@ -171,6 +227,51 @@ SECTIONS
     /* All data end */
     __data_end__ = .;
 
+  } > RAM AT > FLASH
+
+  /* uVisor configuration section
+   * This section must be located after all other flash regions. */
+  .uvisor.secure :
+  {
+    . = ALIGN(32);
+    __uvisor_secure_start = .;
+
+    /* uVisor secure boxes configuration tables */
+    . = ALIGN(32);
+    __uvisor_cfgtbl_start = .;
+    KEEP(*(.keep.uvisor.cfgtbl))
+    . = ALIGN(32);
+    __uvisor_cfgtbl_end = .;
+
+    /* Pointers to the uVisor secure boxes configuration tables */
+    /* Note: Do not add any further alignment here, as uVisor will need to
+             have access to the exact list of pointers. */
+    __uvisor_cfgtbl_ptr_start = .;
+    KEEP(*(.keep.uvisor.cfgtbl_ptr_first))
+    KEEP(*(.keep.uvisor.cfgtbl_ptr))
+    __uvisor_cfgtbl_ptr_end = .;
+
+    /* Pointers to all boxes register gateways. These are grouped here to
+       allow discoverability and firmware verification. */
+    __uvisor_register_gateway_ptr_start = .;
+    KEEP(*(.keep.uvisor.register_gateway_ptr))
+    __uvisor_register_gateway_ptr_end = .;
+
+    . = ALIGN(32);
+    __uvisor_secure_end = .;
+  } > FLASH
+
+  /* Uninitialized data section
+   * This region is not initialized by the C/C++ library and can be used to
+   * store state across soft reboots. */
+  .uninitialized (NOLOAD):
+  {
+    . = ALIGN(32);
+    __uninitialized_start = .;
+    *(.uninitialized)
+    KEEP(*(.keep.uninitialized))
+    . = ALIGN(32);
+    __uninitialized_end = .;
   } > RAM
 
   .bss :
@@ -183,33 +284,29 @@ SECTIONS
     __bss_end__ = .;
   } > RAM
 
-  .heap (COPY):
+  __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+  __stack = __StackTop;
+  __StackLimit = __StackTop - STACK_SIZE;
+
+  .heap (NOLOAD):
   {
+    __uvisor_heap_start = .;
     __HeapBase = .;
     __end__ = .;
     end = __end__;
     _end = __end__;
-    KEEP(*(.heap*))
-    __HeapLimit = .;
+    . += HEAP_SIZE;
   } > RAM
 
-  /* .stack_dummy section doesn't contains any symbols. It is only
-   * used for linker to calculate size of stack sections, and assign
-   * values to stack symbols later */
-  .stack_dummy (COPY):
-  {
-    KEEP(*(.stack*))
-  } > RAM
+  __HeapLimit = __StackLimit;
+  __uvisor_heap_end = __StackLimit;
 
-  /* Set stack top to end of RAM, and stack limit move down by
-   * size of stack_dummy section */
-  __StackTop = ORIGIN(RAM) + LENGTH(RAM);
-  __StackLimit = __StackTop - SIZEOF(.stack_dummy);
-  PROVIDE(__stack = __StackTop);
+  /* Provide physical memory boundaries for uVisor. */
+  __uvisor_flash_start = ORIGIN(FLASH);
+  __uvisor_flash_end = ORIGIN(FLASH) + LENGTH(FLASH);
+  __uvisor_sram_start = ORIGIN(RAM);
+  __uvisor_sram_end = ORIGIN(RAM) + LENGTH(RAM);
 
-  /* Check if data + heap + stack exceeds RAM limit */
-  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
-
-  /* Check if FLASH usage exceeds FLASH size */
-  ASSERT( LENGTH(FLASH) >= (__etext + SIZEOF(.data)), "FLASH memory overflowed !")
+  /* Check if FLASH usage exceeds FLASH size. */
+  ASSERT(LENGTH(FLASH) >= __uvisor_secure_end, "FLASH memory overflowed!")
 }

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG_STK3700/device/TOOLCHAIN_GCC_ARM/startup_efm32gg.S
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG_STK3700/device/TOOLCHAIN_GCC_ARM/startup_efm32gg.S
@@ -49,23 +49,6 @@ __StackLimit:
 __StackTop:
     .size       __StackTop, . - __StackTop
 
-    .section    .heap
-    .align      3
-#ifdef __HEAP_SIZE
-    .equ        Heap_Size, __HEAP_SIZE
-#else
-    .equ        Heap_Size, 0x00000C00
-#endif
-    .globl      __HeapBase
-    .globl      __HeapLimit
-__HeapBase:
-    .if Heap_Size
-    .space      Heap_Size
-    .endif
-    .size       __HeapBase, . - __HeapBase
-__HeapLimit:
-    .size       __HeapLimit, . - __HeapLimit
-
     .section    .vectors
     .align      2
     .globl      __Vectors
@@ -143,6 +126,11 @@ Reset_Handler:
     ldr     r0, =SystemInit
     blx     r0
 #endif
+
+#if defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED)
+    ldr r0, =uvisor_init
+    blx r0
+#endif /* defined(FEATURE_UVISOR) && defined(UVISOR_SUPPORTED) */
 
 /*  Firstly it copies data from read only memory to RAM. There are two schemes
  *  to copy. One can copy more than one sections. Another can only copy

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG_STK3700/device/cmsis_nvic.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG_STK3700/device/cmsis_nvic.c
@@ -12,7 +12,7 @@ extern uint32_t __start_vector_table__;		  // Dynamic vector positioning in GCC
 #define NVIC_RAM_VECTOR_ADDRESS (0x20000000)  // Vectors positioned at start of RAM
 #define NVIC_FLASH_VECTOR_ADDRESS (0x0)       // Initial vector position in flash
 
-void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
+void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     uint32_t *vectors = (uint32_t*)SCB->VTOR;
     uint32_t i;
 
@@ -41,7 +41,7 @@ void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     vectors[IRQn + 16] = vector;
 }
 
-uint32_t NVIC_GetVector(IRQn_Type IRQn) {
+uint32_t __NVIC_GetVector(IRQn_Type IRQn) {
     uint32_t *vectors = (uint32_t*)SCB->VTOR;
     return vectors[IRQn + 16];
 }

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG_STK3700/device/cmsis_nvic.h
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG_STK3700/device/cmsis_nvic.h
@@ -16,8 +16,8 @@
 extern "C" {
 #endif
 
-void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
-uint32_t NVIC_GetVector(IRQn_Type IRQn);
+void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
+uint32_t __NVIC_GetVector(IRQn_Type IRQn);
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/emlib/src/em_system.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/emlib/src/em_system.c
@@ -32,6 +32,7 @@
 
 #include "em_system.h"
 #include "em_assert.h"
+#include "core_cmSecureAccess.h"
 
 /***************************************************************************//**
  * @addtogroup EM_Library
@@ -61,19 +62,24 @@ void SYSTEM_ChipRevisionGet(SYSTEM_ChipRevision_TypeDef *rev)
 
   EFM_ASSERT(rev);
 
+  uint32_t pid0 = SECURE_READ(&(ROMTABLE->PID0));
+  uint32_t pid1 = SECURE_READ(&(ROMTABLE->PID1));
+  uint32_t pid2 = SECURE_READ(&(ROMTABLE->PID2));
+  uint32_t pid3 = SECURE_READ(&(ROMTABLE->PID3));
+
   /* CHIP FAMILY bit [5:2] */
-  tmp  = (((ROMTABLE->PID1 & _ROMTABLE_PID1_FAMILYMSB_MASK) >> _ROMTABLE_PID1_FAMILYMSB_SHIFT) << 2);
+  tmp  = (((pid1 & _ROMTABLE_PID1_FAMILYMSB_MASK) >> _ROMTABLE_PID1_FAMILYMSB_SHIFT) << 2);
   /* CHIP FAMILY bit [1:0] */
-  tmp |=  ((ROMTABLE->PID0 & _ROMTABLE_PID0_FAMILYLSB_MASK) >> _ROMTABLE_PID0_FAMILYLSB_SHIFT);
+  tmp |=  ((pid0 & _ROMTABLE_PID0_FAMILYLSB_MASK) >> _ROMTABLE_PID0_FAMILYLSB_SHIFT);
   rev->family = tmp;
 
   /* CHIP MAJOR bit [3:0] */
-  rev->major = (ROMTABLE->PID0 & _ROMTABLE_PID0_REVMAJOR_MASK) >> _ROMTABLE_PID0_REVMAJOR_SHIFT;
+  rev->major = (pid0 & _ROMTABLE_PID0_REVMAJOR_MASK) >> _ROMTABLE_PID0_REVMAJOR_SHIFT;
 
   /* CHIP MINOR bit [7:4] */
-  tmp  = (((ROMTABLE->PID2 & _ROMTABLE_PID2_REVMINORMSB_MASK) >> _ROMTABLE_PID2_REVMINORMSB_SHIFT) << 4);
+  tmp  = (((pid2 & _ROMTABLE_PID2_REVMINORMSB_MASK) >> _ROMTABLE_PID2_REVMINORMSB_SHIFT) << 4);
   /* CHIP MINOR bit [3:0] */
-  tmp |=  ((ROMTABLE->PID3 & _ROMTABLE_PID3_REVMINORLSB_MASK) >> _ROMTABLE_PID3_REVMINORLSB_SHIFT);
+  tmp |=  ((pid3 & _ROMTABLE_PID3_REVMINORLSB_MASK) >> _ROMTABLE_PID3_REVMINORLSB_SHIFT);
   rev->minor = tmp;
 }
 


### PR DESCRIPTION
This PR adds support for uVisor to the EFM32GG target.

Changes:

* Linker script and startup file, as documented by [the uVisor porting guide](https://github.com/ARMmbed/uvisor/blob/master/docs/core/PORTING.md).
* Apply NVIC virtualization (backwards-compatible when uVisor is not present).
* Use `SECURE_ACCESS()` APIs to read/write from the device ROM table at startup time. Those APIs map to a regular memory access when uVisor is not present.

@sg- @0xc0170 @meriac @Patater 