### PR TITLE
Adding build profiles to build_release.py and singletest.py

### DIFF
--- a/tools/build_release.py
+++ b/tools/build_release.py
@@ -29,6 +29,7 @@ sys.path.insert(0, ROOT)
 from tools.build_api import build_mbed_libs
 from tools.build_api import write_build_report
 from tools.build_api import get_mbed_official_release
+from tools.options import extract_profile
 from tools.targets import TARGET_MAP, TARGET_NAMES
 from tools.test_exporters import ReportExporter, ResultExporterType
 from tools.test_api import SingleTestRunner
@@ -47,6 +48,8 @@ if __name__ == '__main__':
     parser.add_option("-v", "--verbose", action="store_true", dest="verbose",
                       default=False, help="Verbose diagnostic output")
     parser.add_option("-t", "--toolchains", dest="toolchains", help="Use toolchains names separated by comma")
+
+    parser.add_option("--profile", dest="profile", action="append", default=[])
 
     parser.add_option("-p", "--platforms", dest="platforms", default="", help="Build only for the platform namesseparated by comma")
 
@@ -127,6 +130,8 @@ if __name__ == '__main__':
             test_spec["targets"][target_name] = toolchains
 
         single_test = SingleTestRunner(_muts=mut,
+                                       _parser=parser,
+                                       _opts=options,
                                        _opts_report_build_file_name=options.report_build_file_name,
                                        _test_spec=test_spec,
                                        _opts_test_by_names=",".join(test_names),
@@ -162,8 +167,16 @@ if __name__ == '__main__':
             for toolchain in toolchains:
                 id = "%s::%s" % (target_name, toolchain)
 
+                profile = extract_profile(parser, options, toolchain)
+
                 try:
-                    built_mbed_lib = build_mbed_libs(TARGET_MAP[target_name], toolchain, verbose=options.verbose, jobs=options.jobs, report=build_report, properties=build_properties)
+                    built_mbed_lib = build_mbed_libs(TARGET_MAP[target_name],
+                                                     toolchain,
+                                                     verbose=options.verbose,
+                                                     jobs=options.jobs,
+                                                     report=build_report,
+                                                     properties=build_properties,
+                                                     build_profile=profile)
 
                 except Exception, e:
                     print str(e)

--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -22,6 +22,16 @@
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
         "ld": []
     },
+    "uARM": {
+        "common": ["-c", "--gnu", "-Otime", "--split_sections",
+                   "--apcs=interwork", "--brief_diagnostics", "--restrict",
+                   "--multibyte_chars", "-O0", "-D__MICROLIB", "-g"
+                   "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD"],
+        "asm": [],
+        "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
+        "cxx": ["--cpp", "--no_rtti", "--no_vla"],
+        "ld": ["--library_type=microlib"]
+    },
     "IAR": {
         "common": [
             "--no_wrap_diagnostics", "non-native end of line sequence", "-e",

--- a/tools/profiles/default.json
+++ b/tools/profiles/default.json
@@ -22,6 +22,16 @@
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
         "ld": []
     },
+    "uARM": {
+        "common": ["-c", "--gnu", "-Otime", "--split_sections",
+                   "--apcs=interwork", "--brief_diagnostics", "--restrict",
+                   "--multibyte_chars", "-O3", "-D__MICROLIB",
+                   "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD"],
+        "asm": [],
+        "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
+        "cxx": ["--cpp", "--no_rtti", "--no_vla"],
+        "ld": ["--library_type=microlib"]
+    },
     "IAR": {
         "common": [
             "--no_wrap_diagnostics", "-e",

--- a/tools/profiles/save-asm.json
+++ b/tools/profiles/save-asm.json
@@ -12,5 +12,12 @@
         "c": [],
         "cxx": [],
         "ld": []
+    },
+    "uARM": {
+        "common": ["--asm", "--interleave"],
+        "asm": [],
+        "c": [],
+        "cxx": [],
+        "ld": []
     }
 }

--- a/tools/singletest.py
+++ b/tools/singletest.py
@@ -225,6 +225,8 @@ if __name__ == '__main__':
                                    _test_loops_list=opts.test_loops_list,
                                    _muts=MUTs,
                                    _clean=opts.clean,
+                                   _parser=parser,
+                                   _opts=opts,
                                    _opts_db_url=opts.db_url,
                                    _opts_log_file_name=opts.log_file_name,
                                    _opts_report_html_file_name=opts.report_html_file_name,

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -240,37 +240,5 @@ class ARM_MICRO(ARM):
         ARM.__init__(self, target, notify, macros, silent,
                      extra_verbose=extra_verbose, build_profile=build_profile)
 
-        # Extend flags
-        self.flags['common'].extend(["-D__MICROLIB"])
-        self.flags['c'].extend(["--library_type=microlib"])
-        self.flags['ld'].extend(["--library_type=microlib"])
-
         # Run-time values
-        self.asm  += ["-D__MICROLIB"]
-        self.cc   += ["-D__MICROLIB", "--library_type=microlib"]
-        self.cppc += ["-D__MICROLIB", "--library_type=microlib"]
-        self.ld   += ["--library_type=microlib"]
-
-        # Only allow a single thread
-        self.cc += ["-DMBED_RTOS_SINGLE_THREAD"]
-        self.cppc += ["-DMBED_RTOS_SINGLE_THREAD"]
-
-        # We had to patch microlib to add C++ support
-        # In later releases this patch should have entered mainline
-        if ARM_MICRO.PATCHED_LIBRARY:
-            # Run-time values
-            self.flags['ld'].extend(["--noscanlib"])
-            # Run-time values
-            self.ld   += ["--noscanlib"]
-
-            # System Libraries
-            self.sys_libs.extend([join(TOOLCHAIN_PATHS['ARM'], "lib", "microlib", lib+".l") for lib in ["mc_p", "mf_p", "m_ps"]])
-
-            if target.core == "Cortex-M3":
-                self.sys_libs.extend([join(TOOLCHAIN_PATHS['ARM'], "lib", "cpplib", lib+".l") for lib in ["cpp_ws", "cpprt_w"]])
-
-            elif target.core in ["Cortex-M0", "Cortex-M0+"]:
-                self.sys_libs.extend([join(TOOLCHAIN_PATHS['ARM'], "lib", "cpplib", lib+".l") for lib in ["cpp_ps", "cpprt_p"]])
-        else:
-            # Run-time values
-            self.ld.extend(["--libpath", join(TOOLCHAIN_PATHS['ARM'], "lib")])
+        self.ld.extend(["--libpath", join(TOOLCHAIN_PATHS['ARM'], "lib")])


### PR DESCRIPTION
## Description

The build profiles configuration was missed in the`singletest.py` and `build_release.py` scripts (both of which are used in mbed 2 CI). This PR adds the missing configuration.
## Status

**READY**
## Migrations

If this PR changes any APIs or behaviors, give a short description of what _API users_ should do when this PR is merged.

NO
## Related PRs

Extending work done in https://github.com/ARMmbed/mbed-os/pull/2802
## Todos
- [x] mbed 2 tests
- [x] Review by @theotherjimmy 
