### PR TITLE
events - Add workaround for armc assumptions on integer overflow

### DIFF
--- a/events/equeue/equeue.c
+++ b/events/equeue/equeue.c
@@ -24,7 +24,7 @@
 // calculate the relative-difference between absolute times while
 // correctly handling overflow conditions
 static inline int equeue_tickdiff(unsigned a, unsigned b) {
-    return (int)(a - b);
+    return (int)(unsigned)(a - b);
 }
 
 // calculate the relative-difference between absolute times, but


### PR DESCRIPTION
Added workaround for armc assumptions on integer underflow

With ARM Compiler 5.06u3, when the equeue_tickdiff function is inlined, the compiler treats the unsigned integer subtraction as undefined behaviour and assumes falsely the comparisons could never be true.

The workaround is to an explicit cast, which politely reminds the compiler to emit the correct comparison.