### PR TITLE
fix RTOS unit tests for MultiTech xDot platform

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
@@ -21,6 +21,8 @@
 #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
 #define STACK_SIZE 768
+#elif defined(TARGET_XDOT_L151CC)
+#define STACK_SIZE 1024
 #else
 #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/isr/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/isr/main.cpp
@@ -24,6 +24,8 @@
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
     #define STACK_SIZE 768
+#elif defined(TARGET_XDOT_L151CC)
+    #define STACK_SIZE 1024
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
@@ -30,6 +30,8 @@ typedef struct {
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
     #define STACK_SIZE 768
+#elif defined(TARGET_XDOT_L151CC)
+    #define STACK_SIZE 1024
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
@@ -34,6 +34,8 @@
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
     #define STACK_SIZE 1024
+#elif defined(TARGET_XDOT_L151CC)
+    #define STACK_SIZE 1024
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
@@ -30,6 +30,8 @@ typedef struct {
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
     #define STACK_SIZE 768
+#elif defined(TARGET_XDOT_L151CC)
+    #define STACK_SIZE 1024
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
@@ -37,6 +37,8 @@
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
     #define STACK_SIZE 768
+#elif defined(TARGET_XDOT_L151CC)
+    #define STACK_SIZE 1024
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
@@ -23,6 +23,8 @@ const int SIGNAL_HANDLE_DELEY = 25;
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
     #define STACK_SIZE 768
+#elif defined(TARGET_XDOT_L151CC)
+    #define STACK_SIZE 1024
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
@@ -23,6 +23,8 @@
     #define STACK_SIZE 512
 #elif defined(TARGET_STM32L073RZ)
     #define STACK_SIZE 512
+#elif defined(TARGET_XDOT_L151CC)
+    #define STACK_SIZE 1024
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif


### PR DESCRIPTION
## Description
Fix RTOS unit test failures for xDot platform. Due to memory constraints, the default stack size for xDot is 256 bytes. This appears to be too small for some unit tests, so we increase it to 1024 for the tests.


## Status
**READY**