### PR TITLE
[Tests] Prevent garbage generation from toolchain api test

### DIFF
--- a/tools/test/toolchains/api.py
+++ b/tools/test/toolchains/api.py
@@ -3,7 +3,7 @@ import sys
 import os
 from string import printable
 from copy import deepcopy
-from mock import MagicMock
+from mock import MagicMock, patch
 from hypothesis import given
 from hypothesis.strategies import text, lists, fixed_dictionaries
 
@@ -37,16 +37,17 @@ def test_toolchain_profile_c(profile, source_file):
     filename = deepcopy(source_file)
     filename[-1] += ".c"
     to_compile = os.path.join(*filename)
-    for _, tc_class in TOOLCHAIN_CLASSES.items():
-        toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile)
-        toolchain.inc_md5 = ""
-        toolchain.build_dir = ""
-        compile_command = toolchain.compile_command(to_compile,
-                                                    to_compile + ".o", [])
-        for parameter in profile['c'] + profile['common']:
-            assert any(parameter in cmd for cmd in compile_command), \
-                "Toolchain %s did not propigate arg %s" % (toolchain.name,
-                                                           parameter)
+    with patch('os.mkdir') as _mkdir:
+        for _, tc_class in TOOLCHAIN_CLASSES.items():
+            toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile)
+            toolchain.inc_md5 = ""
+            toolchain.build_dir = ""
+            compile_command = toolchain.compile_command(to_compile,
+                                                        to_compile + ".o", [])
+            for parameter in profile['c'] + profile['common']:
+                assert any(parameter in cmd for cmd in compile_command), \
+                    "Toolchain %s did not propigate arg %s" % (toolchain.name,
+                                                            parameter)
 
 @given(fixed_dictionaries({
     'common': lists(text()),
@@ -61,16 +62,17 @@ def test_toolchain_profile_cpp(profile, source_file):
     filename = deepcopy(source_file)
     filename[-1] += ".cpp"
     to_compile = os.path.join(*filename)
-    for _, tc_class in TOOLCHAIN_CLASSES.items():
-        toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile)
-        toolchain.inc_md5 = ""
-        toolchain.build_dir = ""
-        compile_command = toolchain.compile_command(to_compile,
-                                                    to_compile + ".o", [])
-        for parameter in profile['cxx'] + profile['common']:
-            assert any(parameter in cmd for cmd in compile_command), \
-                "Toolchain %s did not propigate arg %s" % (toolchain.name,
-                                                           parameter)
+    with patch('os.mkdir') as _mkdir:
+        for _, tc_class in TOOLCHAIN_CLASSES.items():
+            toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile)
+            toolchain.inc_md5 = ""
+            toolchain.build_dir = ""
+            compile_command = toolchain.compile_command(to_compile,
+                                                        to_compile + ".o", [])
+            for parameter in profile['cxx'] + profile['common']:
+                assert any(parameter in cmd for cmd in compile_command), \
+                    "Toolchain %s did not propigate arg %s" % (toolchain.name,
+                                                            parameter)
 
 @given(fixed_dictionaries({
     'common': lists(text()),
@@ -85,18 +87,19 @@ def test_toolchain_profile_asm(profile, source_file):
     filename = deepcopy(source_file)
     filename[-1] += ".s"
     to_compile = os.path.join(*filename)
-    for _, tc_class in TOOLCHAIN_CLASSES.items():
-        toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile)
-        toolchain.inc_md5 = ""
-        toolchain.build_dir = ""
-        compile_command = toolchain.compile_command(to_compile,
-                                                    to_compile + ".o", [])
-        if not compile_command:
-            assert compile_command, to_compile
-        for parameter in profile['asm']:
-            assert any(parameter in cmd for cmd in compile_command), \
-                "Toolchain %s did not propigate arg %s" % (toolchain.name,
-                                                           parameter)
+    with patch('os.mkdir') as _mkdir:
+        for _, tc_class in TOOLCHAIN_CLASSES.items():
+            toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile)
+            toolchain.inc_md5 = ""
+            toolchain.build_dir = ""
+            compile_command = toolchain.compile_command(to_compile,
+                                                        to_compile + ".o", [])
+            if not compile_command:
+                assert compile_command, to_compile
+            for parameter in profile['asm']:
+                assert any(parameter in cmd for cmd in compile_command), \
+                    "Toolchain %s did not propigate arg %s" % (toolchain.name,
+                                                            parameter)
 
     for name, Class in  TOOLCHAIN_CLASSES.items():
         CLS = Class(TARGET_MAP["K64F"])


### PR DESCRIPTION
## Description
Prevent the garbage folders from showing up after running tests. They were caused by some compile command function generating directories.


## Status
**READY**


## Migrations
Nope!

## Todos
- [x] Tests
- [x] Review by @bridadan 
- [x] Review by @geky 

## Steps to test or reproduce
Run `py.test tools/test/toolchain/api.py`

```
$ py.test tools/test/toolchains/api.py
========================================== test session starts ==========================================
platform linux2 -- Python 2.7.12, pytest-3.0.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/jimbri01/src/mbedmicro/mbed, inifile: 
plugins: hypothesis-3.5.2, quickcheck-0.8.2
collected 5 items 

tools/test/toolchains/api.py .....

======================================= 5 passed in 2.24 seconds ========================================
$ ls
`                     [A?                   Jenkinsfile         #%\`RiS
~<                    aVqu                  K                   rtos
 ?                    CONTRIBUTING.md       k8 )STNnqN(bq0d     s1Ad
_=                    CP'@Ne                ?k?Tm}OJ            S9]j"MbYvY]hrnH1^?!0_rXy?^`=Z
!                     docs                  l                   SP\,
'                     DOXYGEN_FRONTPAGE.md  LICENSE             targets
(                     drivers               ;lJ^GDcS6qJV        ;*TBTz?KXoa9+
)]                    dRnW:?%               )l;?KWm?>D\ t*Jp"k  TESTS
[)                    E                     m$6S8l-t            tools
]                     E2ZJ#cI7`ME           mbed.h              u
{;                    }?e41                 mbed_settings.py    >}Ue
}                     events                mbed_settings.pyc   U%]}G$r
\                     #eW}o|n                n                  v
0                     features              N?                  (v
00                    fRw                   O                   %v
0\+1*18q0501          g                     \oa<:%?CNt          v{B:
0T                    G?I?5v                #@*oH{](2;>Y*       w
1                     +GoFLVp1d{U"yP        #o(j                w0
?\1Gfe88S?8A-:Zi0'r?  ^G>P\                 platform            x
2                     gp5o                  %pq                 XU#
2[sy                  h                     ;P?$uT"             xw
30                    H00                   Q                   XZww
5#5^m`S3p `E~$F&$z    hal                   ~qKN<               - \YIVJX?
6                     ia]?!-@&}D7EV~%1<J?e  RAkg                zDX
@?))7*>z              iqY#                  README.md
9                     j?                    re=qj[3_%*A
a                     jDzw%                 requirements.txt
