### PR TITLE
nsapi - Standardize support of NSAPI_UNSPEC

### DIFF
--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -55,11 +55,6 @@ int NetworkInterface::set_dhcp(bool dhcp)
 }
 
 // DNS operations go through the underlying stack by default
-int NetworkInterface::gethostbyname(const char *name, SocketAddress *address)
-{
-    return get_stack()->gethostbyname(name, address);
-}
-
 int NetworkInterface::gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version)
 {
     return get_stack()->gethostbyname(name, address, version);

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -100,20 +100,6 @@ public:
      */
     virtual int disconnect() = 0;
 
-    /** Translates a hostname to an IP address
-     *
-     *  The hostname may be either a domain name or an IP address. If the
-     *  hostname is an IP address, no network transactions will be performed.
-     *
-     *  If no stack-specific DNS resolution is provided, the hostname
-     *  will be resolve using a UDP socket on the stack.
-     *
-     *  @param address  Destination for the host SocketAddress
-     *  @param host     Hostname to resolve
-     *  @return         0 on success, negative error code on failure
-     */
-    virtual int gethostbyname(const char *host, SocketAddress *address);
-
     /** Translates a hostname to an IP address with specific version
      *
      *  The hostname may be either a domain name or an IP address. If the
@@ -124,10 +110,11 @@ public:
      *
      *  @param address  Destination for the host SocketAddress
      *  @param host     Hostname to resolve
-     *  @param version  IP version of address to resolve
+     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
      *  @return         0 on success, negative error code on failure
      */
-    virtual int gethostbyname(const char *host, SocketAddress *address, nsapi_version_t version);
+    virtual int gethostbyname(const char *host, SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC);
 
     /** Add a domain name server to list of servers to query
      *

--- a/features/netsocket/NetworkStack.cpp
+++ b/features/netsocket/NetworkStack.cpp
@@ -22,16 +22,6 @@
 
 
 // Default NetworkStack operations
-int NetworkStack::gethostbyname(const char *name, SocketAddress *address)
-{
-    // check for simple ip addresses
-    if (address->set_ip_address(name)) {
-        return 0;
-    }
-
-    return nsapi_dns_query(this, name, address);
-}
-
 int NetworkStack::gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version)
 {
     // check for simple ip addresses
@@ -100,25 +90,13 @@ public:
         return address->get_ip_address();
     }
 
-    virtual int gethostbyname(const char *name, SocketAddress *address)
-    {
-        if (!_stack_api()->gethostbyname) {
-            return NetworkStack::gethostbyname(name, address);
-        }
-
-        nsapi_addr_t addr = {NSAPI_IPv4, 0};
-        int err = _stack_api()->gethostbyname(_stack(), name, &addr, NSAPI_UNSPEC);
-        address->set_addr(addr);
-        return err;
-    }
-
     virtual int gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version)
     {
         if (!_stack_api()->gethostbyname) {
             return NetworkStack::gethostbyname(name, address, version);
         }
 
-        nsapi_addr_t addr = {NSAPI_IPv4, 0};
+        nsapi_addr_t addr = {NSAPI_UNSPEC, 0};
         int err = _stack_api()->gethostbyname(_stack(), name, &addr, version);
         address->set_addr(addr);
         return err;

--- a/features/netsocket/NetworkStack.h
+++ b/features/netsocket/NetworkStack.h
@@ -41,20 +41,6 @@ public:
      */
     virtual const char *get_ip_address() = 0;
 
-    /** Translates a hostname to an IP address
-     *
-     *  The hostname may be either a domain name or an IP address. If the
-     *  hostname is an IP address, no network transactions will be performed.
-     *
-     *  If no stack-specific DNS resolution is provided, the hostname
-     *  will be resolve using a UDP socket on the stack.
-     *
-     *  @param host     Hostname to resolve
-     *  @param address  Destination for the host SocketAddress
-     *  @return         0 on success, negative error code on failure
-     */
-    virtual int gethostbyname(const char *host, SocketAddress *address);
-
     /** Translates a hostname to an IP address with specific version
      *
      *  The hostname may be either a domain name or an IP address. If the
@@ -65,10 +51,11 @@ public:
      *
      *  @param host     Hostname to resolve
      *  @param address  Destination for the host SocketAddress
-     *  @param version  IP version of address to resolve
+     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
      *  @return         0 on success, negative error code on failure
      */
-    virtual int gethostbyname(const char *host, SocketAddress *address, nsapi_version_t version);
+    virtual int gethostbyname(const char *host, SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC);
 
     /** Add a domain name server to list of servers to query
      *

--- a/features/netsocket/SocketAddress.h
+++ b/features/netsocket/SocketAddress.h
@@ -160,7 +160,7 @@ public:
 private:
     void _SocketAddress(NetworkStack *iface, const char *host, uint16_t port);
 
-    char _ip_address[NSAPI_IP_SIZE];
+    mutable char _ip_address[NSAPI_IP_SIZE];
     nsapi_addr_t _addr;
     uint16_t _port;
 };

--- a/features/netsocket/nsapi_dns.cpp
+++ b/features/netsocket/nsapi_dns.cpp
@@ -102,7 +102,7 @@ static void dns_append_question(uint8_t **p, const char *host, nsapi_version_t v
     dns_append_byte(p, 0);
 
     // fill out question footer
-    if (version == NSAPI_IPv4) {
+    if (version != NSAPI_IPv6) {
         dns_append_word(p, RR_A);       // qtype  = ipv4
     } else {
         dns_append_word(p, RR_AAAA);    // qtype  = ipv6

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -85,16 +85,18 @@ typedef enum nsapi_error {
  *  @enum nsapi_version_t
  */
 typedef enum nsapi_version {
-    NSAPI_IPv4,   /*!< Address is IPv4 */
-    NSAPI_IPv6,   /*!< Address is IPv6 */
-    NSAPI_UNSPEC  /*!< Address is unspecified */
+    NSAPI_UNSPEC,   /*!< Address is unspecified */
+    NSAPI_IPv4,     /*!< Address is IPv4 */
+    NSAPI_IPv6,     /*!< Address is IPv6 */
 } nsapi_version_t;
 
 /** IP address structure for passing IP addresses by value
  */
 typedef struct nsapi_addr {
     /** IP version
-     *  NSAPI_IPv4 or NSAPI_IPv6 (NSAPI_UNSPEC not currently supported)
+     *  - NSAPI_IPv4
+     *  - NSAPI_IPv6
+     *  - NSAPI_UNSPEC
      */
     nsapi_version_t version;
 


### PR DESCRIPTION
Standardize support of NSAPI_UNSPEC (renamed to NSAPI_IP_NONE)

Introduced in https://github.com/ARMmbed/mbed-os/pull/2767

- Renamed to NSAPI_IP_NONE for consistency with other enums
- Reordered nsapi_version_t to make defaule nsapi_addr_t NSAPI_IP_NONE
- Added support to NSAPI_IP_NONE in SocketAddress

cc @sg-, @c1728p9, @kjbracey-arm, @mikaleppanen