### PR TITLE
Fix bugs of PWM driver.

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1H/pwmout_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1H/pwmout_api.c
@@ -409,8 +409,6 @@ void pwmout_period_us(pwmout_t* obj, int us) {
     if (pwm_mode == MODE_MTU2) {
         /* PWM by MTU2 */
         int tmp_pwm;
-        uint16_t tmp_tgra;
-        uint16_t tmp_tgrc;
         uint8_t tmp_tcr_up;
         uint8_t tmp_tstr_sp;
         uint8_t tmp_tstr_st;
@@ -467,12 +465,10 @@ void pwmout_period_us(pwmout_t* obj, int us) {
         *MTU2_PWM_MATCH[tmp_pwm][MTU2_PERIOD] = (uint16_t)wk_cycle;     // Set period
 
         // Set duty again(TGRA)
-        tmp_tgra = *TGRA_MATCH[obj->ch];
-        set_mtu2_duty_again(&tmp_tgra, wk_last_cycle, wk_cycle);
+        set_mtu2_duty_again(TGRA_MATCH[obj->ch], wk_last_cycle, wk_cycle);
         if ((obj->ch == 0) || (obj->ch == 3) || (obj->ch == 4)) {
             // Set duty again(TGRC)
-            tmp_tgrc = *TGRC_MATCH[obj->ch];
-            set_mtu2_duty_again(&tmp_tgrc, wk_last_cycle, wk_cycle);
+            set_mtu2_duty_again(TGRC_MATCH[obj->ch], wk_last_cycle, wk_cycle);
         }
         *TMDR_MATCH[obj->ch] = 0x02;                                    // PWM mode 1
 
@@ -566,7 +562,6 @@ void pwmout_pulsewidth_us(pwmout_t* obj, int us) {
                 value = (float)us / (float)period_ch1;
             }
         }
-
-        pwmout_write(obj, value);
     }
+    pwmout_write(obj, value);
 }

--- a/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/pwmout_api.c
+++ b/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/pwmout_api.c
@@ -542,8 +542,6 @@ void pwmout_period_us(pwmout_t* obj, int us) {
     if (pwm_mode == MODE_MTU2) {
         /* PWM by MTU2 */
         int tmp_pwm;
-        uint16_t tmp_tgra;
-        uint16_t tmp_tgrc;
         uint8_t tmp_tcr_up;
         uint8_t tmp_tstr_sp;
         uint8_t tmp_tstr_st;
@@ -600,12 +598,10 @@ void pwmout_period_us(pwmout_t* obj, int us) {
         *MTU2_PWM_MATCH[tmp_pwm][MTU2_PERIOD] = (uint16_t)wk_cycle;     // Set period
 
         // Set duty again(TGRA)
-        tmp_tgra = *TGRA_MATCH[obj->ch];
-        set_mtu2_duty_again(&tmp_tgra, wk_last_cycle, wk_cycle);
+        set_mtu2_duty_again(TGRA_MATCH[obj->ch], wk_last_cycle, wk_cycle);
         if ((obj->ch == 0) || (obj->ch == 3) || (obj->ch == 4)) {
             // Set duty again(TGRC)
-            tmp_tgrc = *TGRC_MATCH[obj->ch];
-            set_mtu2_duty_again(&tmp_tgrc, wk_last_cycle, wk_cycle);
+            set_mtu2_duty_again(TGRC_MATCH[obj->ch], wk_last_cycle, wk_cycle);
         }
         *TMDR_MATCH[obj->ch] = 0x02;                                    // PWM mode 1
 
@@ -699,7 +695,6 @@ void pwmout_pulsewidth_us(pwmout_t* obj, int us) {
                 value = (float)us / (float)period_ch1;
             }
         }
-
-        pwmout_write(obj, value);
     }
+    pwmout_write(obj, value);
 }


### PR DESCRIPTION
I fixed bugs of PWM driver.

Bugs are as below.
- In the case of MTU2 mode, modify a problem that does not excute "pwmout_write ()" at the end of "pwmout_pulsewidth_us ()" function.
- In the case of MTU2 mode in "pwmout_period_us ()" function, modify a problem that the executing result of "set_mtu2_duty_again ()" function does not reflect in the register of TGRA_MATCH [] and TGRC_MATCH [].