### PR TITLE
NCS36510 - decrease reserved heap space

### DIFF
--- a/targets/cmsis/TARGET_ONSEMI/TARGET_NCS36510/TOOLCHAIN_GCC_ARM/NCS36510.ld
+++ b/targets/cmsis/TARGET_ONSEMI/TARGET_NCS36510/TOOLCHAIN_GCC_ARM/NCS36510.ld
@@ -205,7 +205,7 @@ SECTIONS
         __end__ = .;
         end = __end__;
         *(.heap*);
-        . += 0x4000;
+        . += 0x800;
         __HeapLimit = .;
     } > RAM
     PROVIDE(__heap_size = SIZEOF(.heap));


### PR DESCRIPTION
Decrease the minimum space reserved for the heap from 16K down to
2K for GCC. This does not have an effect on the actual heap size since
the heap takes up all free RAM. This just allows code to compile in
configurations where the heap is smaller than 16K.