### PR TITLE
Ignore BUILD directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ mbed_settings.py
 
 # Default Build Directory
 .build/
+BUILD/
 .mbed
 venv/
 


### PR DESCRIPTION
The latest versions of mbed-cli generate their output in BUILD/ instead
of .build/. This commit adds BUILD/ to the list of git ignored
directories.

# Reviews:
- [x] @theotherjimmy
- [x] @bridadan 