### PR TITLE
Allow TLS configuration when no TRGN or NV seed

### DIFF
--- a/features/mbedtls/inc/mbedtls/config.h
+++ b/features/mbedtls/inc/mbedtls/config.h
@@ -29,15 +29,6 @@
 
 #include "platform/inc/platform_mbed.h"
 
-/*
- * Only use features that do not require an entropy source when
- * DEVICE_ENTROPY_SOURCE is not defined in mbed OS.
- */
-#if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
-#include "mbedtls/config-no-entropy.h"
-#else
-#define MBEDTLS_CONFIG_H
-
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE 1
 #endif
@@ -2606,5 +2597,4 @@
 
 #include "check_config.h"
 
-#endif /* !MBEDTLS_ENTROPY_HARDWARE_ALT */
 #endif /* MBEDTLS_CONFIG_H */


### PR DESCRIPTION
## Description
Remove the code which forces the no entropy configuration when
MBEDTLS_ENTROPY_HARDWARE_ALT is not defined. This makes it possible for
users to turn on null entropy from the configuration system.

## Related PRs
https://github.com/ARMmbed/mbed-os/pull/2843

## Related issues
https://github.com/ARMmbed/mbed-os/issues/2914
https://github.com/ARMmbed/mbed-os-example-client/issues/83
https://github.com/ARMmbed/mbed-os-example-client/issues/84

## Todos
- [ ] Tests

