### PR TITLE
Fix pull overwrite

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/gpio_irq_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/gpio_irq_api.c
@@ -163,6 +163,7 @@ static void gpio_irq6(void)
 }
 
 extern uint32_t Set_GPIO_Clock(uint32_t port_idx);
+extern void pin_function_gpiomode(PinName pin, uint32_t gpiomode);
 
 int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
 {
@@ -267,15 +268,14 @@ void gpio_irq_free(gpio_irq_t *obj)
     gpio_channel->channel_gpio[gpio_idx] = 0;
     gpio_channel->channel_pin[gpio_idx] = 0;
 
-    // Disable EXTI line
-    pin_function(obj->pin, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    // Disable EXTI line, but don't change pull-up config
+    pin_function_gpiomode(obj->pin, STM_MODE_INPUT);
     obj->event = EDGE_NONE;
 }
 
 void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
 {
     uint32_t mode = STM_MODE_IT_EVT_RESET;
-    uint32_t pull = GPIO_NOPULL;
 
     if (enable) {
         if (event == IRQ_RISE) {
@@ -317,7 +317,7 @@ void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
         }
     }
 
-    pin_function(obj->pin, STM_PIN_DATA(mode, pull, 0));
+    pin_function_gpiomode(obj->pin, mode);
 }
 
 void gpio_irq_enable(gpio_irq_t *obj)

--- a/targets/TARGET_STM/TARGET_STM32F4/pinmap.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/pinmap.c
@@ -178,5 +178,20 @@ void pin_mode(PinName pin, PinMode mode)
     }
     gpio->PUPDR &= (uint32_t)(~(GPIO_PUPDR_PUPDR0 << (pin_index * 2)));
     gpio->PUPDR |= (uint32_t)(pupd << (pin_index * 2));
+}
 
+/*  Internal function for setting the gpiomode/function
+ *  without changing Pull mode
+ */
+void pin_function_gpiomode(PinName pin, uint32_t gpiomode) {
+
+    /* Read current pull state from HW to avoid over-write*/
+    uint32_t port_index = STM_PORT(pin);
+    uint32_t pin_index  = STM_PIN(pin);
+    GPIO_TypeDef *gpio = (GPIO_TypeDef *) Set_GPIO_Clock(port_index);
+    uint32_t temp = gpio->PUPDR;
+    uint32_t pull = (temp  >> (pin_index * 2U)) & GPIO_PUPDR_PUPDR0;
+
+    /* Then re-use global function for updating the mode part*/
+    pin_function(pin, STM_PIN_DATA(gpiomode, pull, 0));
 }


### PR DESCRIPTION
## Description
This is a fix to issue #2638
The pull-up / pull-down mode was overwritten

## Status
**READY**

- [ ] Tests
non regression on F4 family is ok 

Test summary:
+--------------+---------------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| Result       | Target              | Toolchain | Test ID     | Test Description                      | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------------+---------------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| OK           | DISCO_F429ZI[F0A3]  | ARM       | DTCT_1      | Simple detect test                    |        0.45        |       10      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | EXAMPLE_1   | /dev/null                             |        3.43        |       20      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_10     | Hello World                           |        0.33        |       5       |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_11     | Ticker Int                            |        11.4        |       15      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_12     | C++                                   |        1.39        |       10      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_16     | RTC                                   |        4.59        |       20      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_2      | stdio                                 |        0.76        |       20      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_23     | Ticker Int us                         |       11.37        |       15      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_24     | Timeout Int us                        |       11.47        |       15      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_25     | Time us                               |        11.4        |       15      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_26     | Integer constant division             |        1.4         |       20      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_34     | Ticker Two callbacks                  |        11.4        |       15      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_37     | Serial NC RX                          |       12.08        |       20      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_38     | Serial NC TX                          |       11.05        |       20      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_A1     | Basic                                 |        1.33        |       20      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.42        |       20      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_A28    | CAN loopback test                     |       10.52        |       20      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_A9     | Serial Echo at 115200                 |       27.57        |       20      |  1/1  |
| OK           | DISCO_F429ZI[F0A3]  | ARM       | MBED_BUSOUT | BusOut                                |        1.28        |       15      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | DTCT_1      | Simple detect test                    |        0.48        |       10      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | EXAMPLE_1   | /dev/null                             |        3.43        |       20      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_10     | Hello World                           |        0.38        |       5       |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_11     | Ticker Int                            |       11.36        |       15      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_12     | C++                                   |        1.4         |       10      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_16     | RTC                                   |        4.54        |       20      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_2      | stdio                                 |        0.76        |       20      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_23     | Ticker Int us                         |       11.42        |       15      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_24     | Timeout Int us                        |       11.43        |       15      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_25     | Time us                               |       11.42        |       15      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_26     | Integer constant division             |        1.36        |       20      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_34     | Ticker Two callbacks                  |       11.39        |       15      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_37     | Serial NC RX                          |       12.11        |       20      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_38     | Serial NC TX                          |       11.03        |       20      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_A1     | Basic                                 |        1.36        |       20      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.43        |       20      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_A9     | Serial Echo at 115200                 |       27.72        |       20      |  1/1  |
| OK           | NUCLEO_F429ZI[F1CD] | ARM       | MBED_BUSOUT | BusOut                                |        2.32        |       15      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | DTCT_1      | Simple detect test                    |        0.45        |       10      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | EXAMPLE_1   | /dev/null                             |        3.45        |       20      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_10     | Hello World                           |        0.37        |       5       |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_11     | Ticker Int                            |       11.37        |       15      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_12     | C++                                   |        1.4         |       10      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_16     | RTC                                   |        4.57        |       20      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_2      | stdio                                 |        0.73        |       20      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_23     | Ticker Int us                         |       11.37        |       15      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_24     | Timeout Int us                        |       11.43        |       15      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_25     | Time us                               |       11.33        |       15      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_26     | Integer constant division             |        1.42        |       20      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_34     | Ticker Two callbacks                  |       11.42        |       15      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_37     | Serial NC RX                          |       12.12        |       20      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_38     | Serial NC TX                          |       11.08        |       20      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_A1     | Basic                                 |        1.37        |       20      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.47        |       20      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_A28    | CAN loopback test                     |       10.56        |       20      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_A9     | Serial Echo at 115200                 |       28.14        |       20      |  1/1  |
| OK           | NUCLEO_F446ZE[F130] | ARM       | MBED_BUSOUT | BusOut                                |        2.28        |       15      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | DTCT_1      | Simple detect test                    |        0.5         |       10      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | EXAMPLE_1   | /dev/null                             |        3.45        |       20      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_10     | Hello World                           |        0.36        |       5       |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_11     | Ticker Int                            |       11.37        |       15      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_12     | C++                                   |        1.4         |       10      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_16     | RTC                                   |        4.56        |       20      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_2      | stdio                                 |        0.72        |       20      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_23     | Ticker Int us                         |       11.37        |       15      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_24     | Timeout Int us                        |       11.48        |       15      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_25     | Time us                               |       11.39        |       15      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_26     | Integer constant division             |        1.37        |       20      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_34     | Ticker Two callbacks                  |       11.39        |       15      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_37     | Serial NC RX                          |       12.03        |       20      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_38     | Serial NC TX                          |        11.0        |       20      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_A1     | Basic                                 |        1.39        |       20      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.44        |       20      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_A9     | Serial Echo at 115200                 |       28.41        |       20      |  1/1  |
| OK           | NUCLEO_F411RE[F26A] | ARM       | MBED_BUSOUT | BusOut                                |        2.34        |       15      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | DTCT_1      | Simple detect test                    |        0.47        |       10      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | EXAMPLE_1   | /dev/null                             |        3.46        |       20      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_10     | Hello World                           |        0.39        |       5       |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_11     | Ticker Int                            |       11.34        |       15      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_12     | C++                                   |        1.4         |       10      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_16     | RTC                                   |        4.54        |       20      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_2      | stdio                                 |        0.73        |       20      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_23     | Ticker Int us                         |       11.39        |       15      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_24     | Timeout Int us                        |       11.42        |       15      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_25     | Time us                               |        11.4        |       15      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_26     | Integer constant division             |        1.4         |       20      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_34     | Ticker Two callbacks                  |       11.39        |       15      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_37     | Serial NC RX                          |       12.08        |       20      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_38     | Serial NC TX                          |       11.08        |       20      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_A1     | Basic                                 |        1.36        |       20      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.47        |       20      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_A28    | CAN loopback test                     |       10.55        |       20      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_A9     | Serial Echo at 115200                 |        28.0        |       20      |  1/1  |
| OK           | NUCLEO_F446RE[F048] | ARM       | MBED_BUSOUT | BusOut                                |        2.28        |       15      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | DTCT_1      | Simple detect test                    |        0.48        |       10      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | EXAMPLE_1   | /dev/null                             |        3.43        |       20      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_10     | Hello World                           |        0.37        |       5       |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_11     | Ticker Int                            |       11.39        |       15      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_12     | C++                                   |        1.36        |       10      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_16     | RTC                                   |        4.56        |       20      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_2      | stdio                                 |        0.73        |       20      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_23     | Ticker Int us                         |        11.4        |       15      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_24     | Timeout Int us                        |       11.51        |       15      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_25     | Time us                               |        11.4        |       15      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_26     | Integer constant division             |        1.39        |       20      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_34     | Ticker Two callbacks                  |       11.37        |       15      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_37     | Serial NC RX                          |       12.11        |       20      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_38     | Serial NC TX                          |       11.08        |       20      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_A1     | Basic                                 |        1.36        |       20      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.45        |       20      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_A9     | Serial Echo at 115200                 |       28.18        |       20      |  1/1  |
| OK           | NUCLEO_F401RE[F17C] | ARM       | MBED_BUSOUT | BusOut                                |        2.34        |       15      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | DTCT_1      | Simple detect test                    |        0.45        |       10      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | EXAMPLE_1   | /dev/null                             |        3.46        |       20      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_10     | Hello World                           |        0.36        |       5       |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_11     | Ticker Int                            |       11.37        |       15      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_12     | C++                                   |        1.37        |       10      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_16     | RTC                                   |        4.82        |       20      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_2      | stdio                                 |        0.77        |       20      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_23     | Ticker Int us                         |       11.91        |       15      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_24     | Timeout Int us                        |       12.01        |       15      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_25     | Time us                               |       11.96        |       15      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_26     | Integer constant division             |        1.38        |       20      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_34     | Ticker Two callbacks                  |       11.58        |       15      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_37     | Serial NC RX                          |       12.33        |       20      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_38     | Serial NC TX                          |       11.23        |       20      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_A1     | Basic                                 |        1.4         |       20      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.4         |       20      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_A9     | Serial Echo at 115200                 |       28.08        |       20      |  1/1  |
| OK           | NUCLEO_F410RB[F619] | ARM       | MBED_BUSOUT | BusOut                                |        2.29        |       15      |  1/1  ||
| OK           | DISCO_F469NI[F7B1]  | ARM       | DTCT_1      | Simple detect test                    |        0.47        |       10      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | EXAMPLE_1   | /dev/null                             |        3.47        |       20      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_10     | Hello World                           |        0.38        |       5       |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_11     | Ticker Int                            |       11.38        |       15      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_12     | C++                                   |        1.34        |       10      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_16     | RTC                                   |        4.59        |       20      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_2      | stdio                                 |        0.75        |       20      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_23     | Ticker Int us                         |       11.39        |       15      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_24     | Timeout Int us                        |       11.41        |       15      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_25     | Time us                               |       11.36        |       15      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_26     | Integer constant division             |        1.36        |       20      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_34     | Ticker Two callbacks                  |       11.36        |       15      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_37     | Serial NC RX                          |        12.1        |       20      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_38     | Serial NC TX                          |       11.05        |       20      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_A1     | Basic                                 |        1.39        |       20      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.4         |       20      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_A28    | CAN loopback test                     |       10.52        |       20      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_A9     | Serial Echo at 115200                 |       27.57        |       20      |  1/1  |
| OK           | DISCO_F469NI[F7B1]  | ARM       | MBED_BUSOUT | BusOut                                |        2.26        |       15      |  1/1  |
+--------------+---------------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+

## Steps to test or reproduce
See Issue #2638.
