### PR TITLE
STM32F7xx - Add support of ADC internal channels

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F746NG/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F746NG/PeripheralPins.c
@@ -47,6 +47,9 @@ const PinMap PinMap_ADC[] = {
     {PF_8,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 6, 0)}, // ADC3_IN6 - ARDUINO A3
     {PF_9,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 7, 0)}, // ADC3_IN7 - ARDUINO A2
     {PF_10, ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 8, 0)}, // ADC3_IN8 - ARDUINO A1
+    {ADC_TEMP, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 16, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VREF, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VBAT, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)}, // See in analogin_api.c the correct ADC channel used
     {NC,    NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F746NG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F746NG/PinNames.h
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,14 +43,14 @@ extern "C" {
 #define STM_PIN_DATA_EXT(MODE, PUPD, AFNUM, CHANNEL, INVERTED)  ((int)(((MODE     & 0x0F) <<  0) |\
                                                                        ((PUPD     & 0x07) <<  4) |\
                                                                        ((AFNUM    & 0x0F) <<  7) |\
-                                                                       ((CHANNEL  & 0x0F) << 11) |\
-                                                                       ((INVERTED & 0x01) << 15)))
+                                                                       ((CHANNEL  & 0x1F) << 11) |\
+                                                                       ((INVERTED & 0x01) << 16)))
 
 #define STM_PIN_MODE(X)     (((X) >>  0) & 0x0F)
 #define STM_PIN_PUPD(X)     (((X) >>  4) & 0x07)
 #define STM_PIN_AFNUM(X)    (((X) >>  7) & 0x0F)
-#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x0F)
-#define STM_PIN_INVERTED(X) (((X) >> 15) & 0x01)
+#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x1F)
+#define STM_PIN_INVERTED(X) (((X) >> 16) & 0x01)
 
 #define STM_MODE_INPUT              (0)
 #define STM_MODE_OUTPUT_PP          (1)
@@ -255,6 +255,11 @@ typedef enum {
     PK_5  = 0xA5,
     PK_6  = 0xA6,
     PK_7  = 0xA7,
+
+    // ADC internal channels
+    ADC_TEMP = 0xF0,
+    ADC_VREF = 0xF1,
+    ADC_VBAT = 0xF2,
 
     // Arduino connector namings
     A0          = PA_0,

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F769NI/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F769NI/PeripheralPins.c
@@ -52,7 +52,9 @@ const PinMap PinMap_ADC[] = {
     {PF_8,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 6, 0)}, // ADC3_IN6 - ARDUINO A4
     {PF_9,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 7, 0)}, // ADC3_IN7 - ARDUINO A5
     {PF_10, ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 8, 0)}, // ADC3_IN8 - ARDUINO A3
-
+    {ADC_TEMP, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 16, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VREF, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VBAT, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)}, // See in analogin_api.c the correct ADC channel used
     {NC,    NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F769NI/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F769NI/PinNames.h
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,14 +43,14 @@ extern "C" {
 #define STM_PIN_DATA_EXT(MODE, PUPD, AFNUM, CHANNEL, INVERTED)  ((int)(((MODE     & 0x0F) <<  0) |\
                                                                        ((PUPD     & 0x07) <<  4) |\
                                                                        ((AFNUM    & 0x0F) <<  7) |\
-                                                                       ((CHANNEL  & 0x0F) << 11) |\
-                                                                       ((INVERTED & 0x01) << 15)))
+                                                                       ((CHANNEL  & 0x1F) << 11) |\
+                                                                       ((INVERTED & 0x01) << 16)))
 
 #define STM_PIN_MODE(X)     (((X) >>  0) & 0x0F)
 #define STM_PIN_PUPD(X)     (((X) >>  4) & 0x07)
 #define STM_PIN_AFNUM(X)    (((X) >>  7) & 0x0F)
-#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x0F)
-#define STM_PIN_INVERTED(X) (((X) >> 15) & 0x01)
+#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x1F)
+#define STM_PIN_INVERTED(X) (((X) >> 16) & 0x01)
 
 #define STM_MODE_INPUT              (0)
 #define STM_MODE_OUTPUT_PP          (1)
@@ -255,6 +255,11 @@ typedef enum {
     PK_5  = 0xA5,
     PK_6  = 0xA6,
     PK_7  = 0xA7,
+
+    // ADC internal channels
+    ADC_TEMP = 0xF0,
+    ADC_VREF = 0xF1,
+    ADC_VBAT = 0xF2,
 
     // Arduino connector namings
     A0          = PA_6,

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F746ZG/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F746ZG/PeripheralPins.c
@@ -57,7 +57,6 @@ const PinMap PinMap_ADC[] = {
     {PC_3,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0,13, 0)}, // ADC1_IN13 - ARDUINO A2
  // {PC_4,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0,14, 0)}, // ADC1_IN14 (used by ethernet)
  // {PC_5,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0,15, 0)}, // ADC1_IN15 (used by ethernet)
-
     {PF_3,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 9, 0)}, // ADC3_IN9  - ARDUINO A3
     {PF_4,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0,14, 0)}, // ADC3_IN14
     {PF_5,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0,15, 0)}, // ADC3_IN15 - ARDUINO A4
@@ -66,7 +65,9 @@ const PinMap PinMap_ADC[] = {
     {PF_8,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 6, 0)}, // ADC3_IN6
     {PF_9,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 7, 0)}, // ADC3_IN7
     {PF_10, ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 8, 0)}, // ADC3_IN8 - ARDUINO A5
-
+    {ADC_TEMP, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 16, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VREF, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VBAT, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)}, // See in analogin_api.c the correct ADC channel used
     {NC,    NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F746ZG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F746ZG/PinNames.h
@@ -43,14 +43,14 @@ extern "C" {
 #define STM_PIN_DATA_EXT(MODE, PUPD, AFNUM, CHANNEL, INVERTED)  ((int)(((MODE     & 0x0F) <<  0) |\
                                                                        ((PUPD     & 0x07) <<  4) |\
                                                                        ((AFNUM    & 0x0F) <<  7) |\
-                                                                       ((CHANNEL  & 0x0F) << 11) |\
-                                                                       ((INVERTED & 0x01) << 15)))
+                                                                       ((CHANNEL  & 0x1F) << 11) |\
+                                                                       ((INVERTED & 0x01) << 16)))
 
 #define STM_PIN_MODE(X)     (((X) >>  0) & 0x0F)
 #define STM_PIN_PUPD(X)     (((X) >>  4) & 0x07)
 #define STM_PIN_AFNUM(X)    (((X) >>  7) & 0x0F)
-#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x0F)
-#define STM_PIN_INVERTED(X) (((X) >> 15) & 0x01)
+#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x1F)
+#define STM_PIN_INVERTED(X) (((X) >> 16) & 0x01)
 
 #define STM_MODE_INPUT              (0)
 #define STM_MODE_OUTPUT_PP          (1)
@@ -198,6 +198,11 @@ typedef enum {
 
     PH_0  = 0x70,
     PH_1  = 0x71,
+
+    // ADC internal channels
+    ADC_TEMP = 0xF0,
+    ADC_VREF = 0xF1,
+    ADC_VBAT = 0xF2,
 
     // Arduino connector namings
     A0          = PA_3,

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F767ZI/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F767ZI/PeripheralPins.c
@@ -57,7 +57,6 @@ const PinMap PinMap_ADC[] = {
     {PC_3,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0,13, 0)}, // ADC1_IN13 - ARDUINO A2
  // {PC_4,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0,14, 0)}, // ADC1_IN14 (used by ethernet)
  // {PC_5,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0,15, 0)}, // ADC1_IN15 (used by ethernet)
-
     {PF_3,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 9, 0)}, // ADC3_IN9  - ARDUINO A3
     {PF_4,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0,14, 0)}, // ADC3_IN14
     {PF_5,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0,15, 0)}, // ADC3_IN15 - ARDUINO A4
@@ -66,7 +65,9 @@ const PinMap PinMap_ADC[] = {
     {PF_8,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 6, 0)}, // ADC3_IN6
     {PF_9,  ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 7, 0)}, // ADC3_IN7
     {PF_10, ADC_3, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 8, 0)}, // ADC3_IN8 - ARDUINO A5
-
+    {ADC_TEMP, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 16, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VREF, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VBAT, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)}, // See in analogin_api.c the correct ADC channel used
     {NC,    NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F767ZI/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F767ZI/PinNames.h
@@ -43,14 +43,14 @@ extern "C" {
 #define STM_PIN_DATA_EXT(MODE, PUPD, AFNUM, CHANNEL, INVERTED)  ((int)(((MODE     & 0x0F) <<  0) |\
                                                                        ((PUPD     & 0x07) <<  4) |\
                                                                        ((AFNUM    & 0x0F) <<  7) |\
-                                                                       ((CHANNEL  & 0x0F) << 11) |\
-                                                                       ((INVERTED & 0x01) << 15)))
+                                                                       ((CHANNEL  & 0x1F) << 11) |\
+                                                                       ((INVERTED & 0x01) << 16)))
 
 #define STM_PIN_MODE(X)     (((X) >>  0) & 0x0F)
 #define STM_PIN_PUPD(X)     (((X) >>  4) & 0x07)
 #define STM_PIN_AFNUM(X)    (((X) >>  7) & 0x0F)
-#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x0F)
-#define STM_PIN_INVERTED(X) (((X) >> 15) & 0x01)
+#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x1F)
+#define STM_PIN_INVERTED(X) (((X) >> 16) & 0x01)
 
 #define STM_MODE_INPUT              (0)
 #define STM_MODE_OUTPUT_PP          (1)
@@ -198,6 +198,11 @@ typedef enum {
 
     PH_0  = 0x70,
     PH_1  = 0x71,
+
+    // ADC internal channels
+    ADC_TEMP = 0xF0,
+    ADC_VREF = 0xF1,
+    ADC_VBAT = 0xF2,
 
     // Arduino connector namings
     A0          = PA_3,

--- a/targets/TARGET_STM/TARGET_STM32F7/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/analogin_api.c
@@ -59,8 +59,10 @@ void analogin_init(analogin_t *obj, PinName pin)
     MBED_ASSERT(function != (uint32_t)NC);
     obj->channel = STM_PIN_CHANNEL(function);
 
-    // Configure GPIO
-    pinmap_pinout(pin, PinMap_ADC);
+    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat)
+    if ((obj->channel != 16) && (obj->channel != 17) && (obj->channel != 18)) {
+        pinmap_pinout(pin, PinMap_ADC);
+    }
 
     // Save pin number for the read function
     obj->pin = pin;
@@ -170,13 +172,13 @@ static inline uint16_t adc_read(analogin_t *obj)
             sConfig.Channel = ADC_CHANNEL_15;
             break;
         case 16:
-            sConfig.Channel = ADC_CHANNEL_16;
+            sConfig.Channel = ADC_CHANNEL_TEMPSENSOR;
             break;
         case 17:
-            sConfig.Channel = ADC_CHANNEL_17;
+            sConfig.Channel = ADC_CHANNEL_VREFINT;
             break;
         case 18:
-            sConfig.Channel = ADC_CHANNEL_18;
+            sConfig.Channel = ADC_CHANNEL_VBAT;
             break;
         default:
             return 0;


### PR DESCRIPTION
## Description
Add the support of ADC internal channels.

## Status
READY

## Migrations
NO changes in API or behaviors.

## Related PRs
#2924 #2923 #2814 #2681 #2538