### PR TITLE
STM32F0xx - Use ADC internal channels specific definitions

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/analogin_api.c
@@ -153,14 +153,14 @@ static inline uint16_t adc_read(analogin_t *obj) {
             sConfig.Channel = ADC_CHANNEL_15;
             break;
         case 16:
-            sConfig.Channel = ADC_CHANNEL_16;
+            sConfig.Channel = ADC_CHANNEL_TEMPSENSOR;
             break;
         case 17:
-            sConfig.Channel = ADC_CHANNEL_17;
+            sConfig.Channel = ADC_CHANNEL_VREFINT;
             break;
-#ifdef ADC_CHANNEL_18
+#ifdef ADC_CHANNEL_VBAT
         case 18:
-            sConfig.Channel = ADC_CHANNEL_18;
+            sConfig.Channel = ADC_CHANNEL_VBAT;
             break;
 #endif
         default:


### PR DESCRIPTION
## Description
Use the ADC internal channels specific definitions instead of using the channel number.

## Status
READY

## Migrations
No API or behavior change.
