### PR TITLE
Change K64F D8 pin from PTA0->PTC12

### DIFF
--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h
@@ -218,7 +218,7 @@ typedef enum {
     D5 = PTA2,
     D6 = PTC2,
     D7 = PTC3,
-    D8 = PTA0,
+    D8 = PTC12,
     D9 = PTC4,
     D10 = PTD0,
     D11 = PTD2,


### PR DESCRIPTION
## Description
Modifying D8 to reflect latest hardare changes in RevD hardware
https://github.com/ARMmbed/mbed-os/issues/2933