### PR TITLE
STM32L0xx - Add support of ADC internal channels

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/PeripheralPins.c
@@ -49,6 +49,9 @@ const PinMap PinMap_ADC[] = {
     {PA_7, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 7, 0)}, // ADC1_IN7
     {PB_0, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 8, 0)}, // ADC1_IN8
     {PB_1, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 9, 0)}, // ADC1_IN9
+    {ADC_TEMP, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VREF, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VLCD, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 16, 0)}, // See in analogin_api.c the correct ADC channel used
     {NC,   NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/PinNames.h
@@ -43,14 +43,14 @@ extern "C" {
 #define STM_PIN_DATA_EXT(MODE, PUPD, AFNUM, CHANNEL, INVERTED)  ((int)(((MODE     & 0x0F) <<  0) |\
                                                                        ((PUPD     & 0x07) <<  4) |\
                                                                        ((AFNUM    & 0x0F) <<  7) |\
-                                                                       ((CHANNEL  & 0x0F) << 11) |\
-                                                                       ((INVERTED & 0x01) << 15)))
+                                                                       ((CHANNEL  & 0x1F) << 11) |\
+                                                                       ((INVERTED & 0x01) << 16)))
 
 #define STM_PIN_MODE(X)     (((X) >>  0) & 0x0F)
 #define STM_PIN_PUPD(X)     (((X) >>  4) & 0x07)
 #define STM_PIN_AFNUM(X)    (((X) >>  7) & 0x0F)
-#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x0F)
-#define STM_PIN_INVERTED(X) (((X) >> 15) & 0x01)
+#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x1F)
+#define STM_PIN_INVERTED(X) (((X) >> 16) & 0x01)
 
 #define STM_MODE_INPUT              (0)
 #define STM_MODE_OUTPUT_PP          (1)
@@ -117,6 +117,11 @@ typedef enum {
 
     PH_0  = 0x70,
     PH_1  = 0x71,
+
+    // ADC internal channels
+    ADC_TEMP = 0xF0,
+    ADC_VREF = 0xF1,
+    ADC_VLCD = 0xF2,
 
     // Arduino connector namings
     // Note: The Arduino connector is not present on this board.

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/PeripheralPins.c
@@ -51,7 +51,6 @@ const PinMap PinMap_ADC[] = {
     {PB_1,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 9, 0)}, // ADC_IN9
     {ADC_TEMP, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)}, // See in analogin_api.c the correct ADC channel used
     {ADC_VREF, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)}, // See in analogin_api.c the correct ADC channel used
-    {ADC_VLCD, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 16, 0)}, // See in analogin_api.c the correct ADC channel used
     {NC,   NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/PeripheralPins.c
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- '*******************************************************************************
+ *******************************************************************************
  * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
@@ -49,6 +49,9 @@ const PinMap PinMap_ADC[] = {
     {PA_7,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 7, 0)}, // ADC_IN7
     {PB_0,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 8, 0)}, // ADC_IN8
     {PB_1,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 9, 0)}, // ADC_IN9
+    {ADC_TEMP, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VREF, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VLCD, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 16, 0)}, // See in analogin_api.c the correct ADC channel used
     {NC,   NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/PinNames.h
@@ -109,7 +109,6 @@ typedef enum {
     // ADC internal channels
     ADC_TEMP = 0xF0,
     ADC_VREF = 0xF1,
-    ADC_VLCD = 0xF2,
 
     // Arduino connector namings
     A0          = PA_0,

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/PinNames.h
@@ -43,14 +43,14 @@ extern "C" {
 #define STM_PIN_DATA_EXT(MODE, PUPD, AFNUM, CHANNEL, INVERTED)  ((int)(((MODE     & 0x0F) <<  0) |\
                                                                        ((PUPD     & 0x07) <<  4) |\
                                                                        ((AFNUM    & 0x0F) <<  7) |\
-                                                                       ((CHANNEL  & 0x0F) << 11) |\
-                                                                       ((INVERTED & 0x01) << 15)))
+                                                                       ((CHANNEL  & 0x1F) << 11) |\
+                                                                       ((INVERTED & 0x01) << 16)))
 
 #define STM_PIN_MODE(X)     (((X) >>  0) & 0x0F)
 #define STM_PIN_PUPD(X)     (((X) >>  4) & 0x07)
 #define STM_PIN_AFNUM(X)    (((X) >>  7) & 0x0F)
-#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x0F)
-#define STM_PIN_INVERTED(X) (((X) >> 15) & 0x01)
+#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x1F)
+#define STM_PIN_INVERTED(X) (((X) >> 16) & 0x01)
 
 #define STM_MODE_INPUT              (0)
 #define STM_MODE_OUTPUT_PP          (1)
@@ -105,6 +105,11 @@ typedef enum {
 
     PC_14 = 0x2E,
     PC_15 = 0x2F,
+
+    // ADC internal channels
+    ADC_TEMP = 0xF0,
+    ADC_VREF = 0xF1,
+    ADC_VLCD = 0xF2,
 
     // Arduino connector namings
     A0          = PA_0,

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/PeripheralPins.c
@@ -49,6 +49,9 @@ const PinMap PinMap_ADC[] = {
     {PA_7, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 7, 0)}, // ADC1_IN7
     {PB_0, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 8, 0)}, // ADC1_IN8
     {PB_1, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 9, 0)}, // ADC1_IN9
+    {ADC_TEMP, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VREF, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VLCD, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 16, 0)}, // See in analogin_api.c the correct ADC channel used
     {NC,   NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/PeripheralPins.c
@@ -51,7 +51,6 @@ const PinMap PinMap_ADC[] = {
     {PB_1, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 9, 0)}, // ADC1_IN9
     {ADC_TEMP, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)}, // See in analogin_api.c the correct ADC channel used
     {ADC_VREF, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)}, // See in analogin_api.c the correct ADC channel used
-    {ADC_VLCD, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 16, 0)}, // See in analogin_api.c the correct ADC channel used
     {NC,   NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/PinNames.h
@@ -109,7 +109,6 @@ typedef enum {
     // ADC internal channels
     ADC_TEMP = 0xF0,
     ADC_VREF = 0xF1,
-    ADC_VLCD = 0xF2,
 
     // Arduino connector namings
     A0          = PA_0,

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/PinNames.h
@@ -43,14 +43,14 @@ extern "C" {
 #define STM_PIN_DATA_EXT(MODE, PUPD, AFNUM, CHANNEL, INVERTED)  ((int)(((MODE     & 0x0F) <<  0) |\
                                                                        ((PUPD     & 0x07) <<  4) |\
                                                                        ((AFNUM    & 0x0F) <<  7) |\
-                                                                       ((CHANNEL  & 0x0F) << 11) |\
-                                                                       ((INVERTED & 0x01) << 15)))
+                                                                       ((CHANNEL  & 0x1F) << 11) |\
+                                                                       ((INVERTED & 0x01) << 16)))
 
 #define STM_PIN_MODE(X)     (((X) >>  0) & 0x0F)
 #define STM_PIN_PUPD(X)     (((X) >>  4) & 0x07)
 #define STM_PIN_AFNUM(X)    (((X) >>  7) & 0x0F)
-#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x0F)
-#define STM_PIN_INVERTED(X) (((X) >> 15) & 0x01)
+#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x1F)
+#define STM_PIN_INVERTED(X) (((X) >> 16) & 0x01)
 
 #define STM_MODE_INPUT              (0)
 #define STM_MODE_OUTPUT_PP          (1)
@@ -105,6 +105,11 @@ typedef enum {
 
     PC_14 = 0x2E,
     PC_15 = 0x2F,
+
+    // ADC internal channels
+    ADC_TEMP = 0xF0,
+    ADC_VREF = 0xF1,
+    ADC_VLCD = 0xF2,
 
     // Arduino connector namings
     A0          = PA_0,

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/PeripheralPins.c
@@ -55,6 +55,9 @@ const PinMap PinMap_ADC[] = {
     {PC_3, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 13, 0)}, // ADC1_IN13
     {PC_4, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 14, 0)}, // ADC1_IN14
     {PC_5, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 15, 0)}, // ADC1_IN15
+    {ADC_TEMP, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VREF, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VLCD, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 16, 0)}, // See in analogin_api.c the correct ADC channel used
     {NC,   NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/PinNames.h
@@ -43,14 +43,14 @@ extern "C" {
 #define STM_PIN_DATA_EXT(MODE, PUPD, AFNUM, CHANNEL, INVERTED)  ((int)(((MODE     & 0x0F) <<  0) |\
                                                                        ((PUPD     & 0x07) <<  4) |\
                                                                        ((AFNUM    & 0x0F) <<  7) |\
-                                                                       ((CHANNEL  & 0x0F) << 11) |\
-                                                                       ((INVERTED & 0x01) << 15)))
+                                                                       ((CHANNEL  & 0x1F) << 11) |\
+                                                                       ((INVERTED & 0x01) << 16)))
 
 #define STM_PIN_MODE(X)     (((X) >>  0) & 0x0F)
 #define STM_PIN_PUPD(X)     (((X) >>  4) & 0x07)
 #define STM_PIN_AFNUM(X)    (((X) >>  7) & 0x0F)
-#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x0F)
-#define STM_PIN_INVERTED(X) (((X) >> 15) & 0x01)
+#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x1F)
+#define STM_PIN_INVERTED(X) (((X) >> 16) & 0x01)
 
 #define STM_MODE_INPUT              (0)
 #define STM_MODE_OUTPUT_PP          (1)
@@ -132,6 +132,11 @@ typedef enum {
 
     PH_0  = 0x70,
     PH_1  = 0x71,
+
+    // ADC internal channels
+    ADC_TEMP = 0xF0,
+    ADC_VREF = 0xF1,
+    ADC_VLCD = 0xF2,
 
     // Arduino connector namings
     A0          = PA_0,

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/PeripheralPins.c
@@ -55,6 +55,9 @@ const PinMap PinMap_ADC[] = {
     {PC_3, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 13, 0)}, // ADC1_IN13
     {PC_4, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 14, 0)}, // ADC1_IN14
     {PC_5, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 15, 0)}, // ADC1_IN15
+    {ADC_TEMP, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VREF, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)}, // See in analogin_api.c the correct ADC channel used
+    {ADC_VLCD, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 16, 0)}, // See in analogin_api.c the correct ADC channel used
     {NC,   NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/PinNames.h
@@ -43,14 +43,14 @@ extern "C" {
 #define STM_PIN_DATA_EXT(MODE, PUPD, AFNUM, CHANNEL, INVERTED)  ((int)(((MODE     & 0x0F) <<  0) |\
                                                                        ((PUPD     & 0x07) <<  4) |\
                                                                        ((AFNUM    & 0x0F) <<  7) |\
-                                                                       ((CHANNEL  & 0x0F) << 11) |\
-                                                                       ((INVERTED & 0x01) << 15)))
+                                                                       ((CHANNEL  & 0x1F) << 11) |\
+                                                                       ((INVERTED & 0x01) << 16)))
 
 #define STM_PIN_MODE(X)     (((X) >>  0) & 0x0F)
 #define STM_PIN_PUPD(X)     (((X) >>  4) & 0x07)
 #define STM_PIN_AFNUM(X)    (((X) >>  7) & 0x0F)
-#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x0F)
-#define STM_PIN_INVERTED(X) (((X) >> 15) & 0x01)
+#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x1F)
+#define STM_PIN_INVERTED(X) (((X) >> 16) & 0x01)
 
 #define STM_MODE_INPUT              (0)
 #define STM_MODE_OUTPUT_PP          (1)
@@ -132,6 +132,11 @@ typedef enum {
 
     PH_0  = 0x70,
     PH_1  = 0x71,
+
+    // ADC internal channels
+    ADC_TEMP = 0xF0,
+    ADC_VREF = 0xF1,
+    ADC_VLCD = 0xF2,
 
     // Arduino connector namings
     A0          = PA_0,

--- a/targets/TARGET_STM/TARGET_STM32L0/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/analogin_api.c
@@ -51,8 +51,10 @@ void analogin_init(analogin_t *obj, PinName pin)
     MBED_ASSERT(function != (uint32_t)NC);
     obj->channel = STM_PIN_CHANNEL(function);
 
-    // Configure GPIO
-    pinmap_pinout(pin, PinMap_ADC);
+    // Configure GPIO excepted for internal channels (Temperature, Vref, Vlcd)
+    if ((obj->channel != 16) && (obj->channel != 17) && (obj->channel != 18)) {
+        pinmap_pinout(pin, PinMap_ADC);
+    }
 
     // Save pin number for the read function
     obj->pin = pin;
@@ -150,6 +152,17 @@ static inline uint16_t adc_read(analogin_t *obj)
             break;
         case 15:
             sConfig.Channel = ADC_CHANNEL_15;
+            break;
+#ifdef ADC_CHANNEL_VLCD
+        case 16:
+            sConfig.Channel = ADC_CHANNEL_VLCD;
+            break;
+#endif
+        case 17:
+            sConfig.Channel = ADC_CHANNEL_VREFINT;
+            break;
+        case 18:
+            sConfig.Channel = ADC_CHANNEL_TEMPSENSOR;
             break;
         default:
             return 0;


### PR DESCRIPTION
## Description
Add the support of ADC internal channels (Temperature, VREF, VLCD) on STM32L0xx devices.

## Status
READY

## Migrations
No changes in API or behaviors.

## Related PRs
#2928 #2924 #2923 #2814 #2681 #2538