### PR TITLE
STM32L4xx - Add support of ADC internal channels

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/PeripheralPins.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,6 +55,9 @@ const PinMap PinMap_ADC[] = {
     {PC_3,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0,  4, 0)}, // IN4
     {PC_4,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 13, 0)}, // IN13
     {PC_5,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 14, 0)}, // IN14
+    {ADC_TEMP, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)},
+    {ADC_VREF, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0,  0, 0)},
+    {ADC_VBAT, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)},
     {NC,    NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/PinNames.h
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,14 +43,14 @@ extern "C" {
 #define STM_PIN_DATA_EXT(MODE, PUPD, AFNUM, CHANNEL, INVERTED)  ((int)(((MODE     & 0x0F) <<  0) |\
                                                                        ((PUPD     & 0x07) <<  4) |\
                                                                        ((AFNUM    & 0x0F) <<  7) |\
-                                                                       ((CHANNEL  & 0x0F) << 11) |\
-                                                                       ((INVERTED & 0x01) << 15)))
+                                                                       ((CHANNEL  & 0x1F) << 11) |\
+                                                                       ((INVERTED & 0x01) << 16)))
 
 #define STM_PIN_MODE(X)     (((X) >>  0) & 0x0F)
 #define STM_PIN_PUPD(X)     (((X) >>  4) & 0x07)
 #define STM_PIN_AFNUM(X)    (((X) >>  7) & 0x0F)
-#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x0F)
-#define STM_PIN_INVERTED(X) (((X) >> 15) & 0x01)
+#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x1F)
+#define STM_PIN_INVERTED(X) (((X) >> 16) & 0x01)
 
 #define STM_MODE_INPUT              (0)
 #define STM_MODE_OUTPUT_PP          (1)
@@ -165,6 +165,11 @@ typedef enum {
 
     PH_0  = 0x70, // On P1/P2 connectors
     PH_1  = 0x71, // On P1/P2 connectors
+
+    // ADC internal channels
+    ADC_TEMP = 0xF0,
+    ADC_VREF = 0xF1,
+    ADC_VBAT = 0xF2,
 
     // Generic signals namings
     LED1 = PE_8, // LD5 Green

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L432KC/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L432KC/PeripheralPins.c
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- '*******************************************************************************
+ *******************************************************************************
  * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
@@ -49,6 +49,9 @@ const PinMap PinMap_ADC[] = {
     {PA_7,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 12, 0)}, // ADC1_IN12
     {PB_0,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 15, 0)}, // ADC1_IN15
 //  {PB_1,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 16, 0)}, // ADC1_IN16 - does not support channel >= 16
+    {ADC_TEMP, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)},
+    {ADC_VREF, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0,  0, 0)},
+    {ADC_VBAT, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)},
     {NC,   NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L432KC/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L432KC/PinNames.h
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,14 +43,14 @@ extern "C" {
 #define STM_PIN_DATA_EXT(MODE, PUPD, AFNUM, CHANNEL, INVERTED)  ((int)(((MODE     & 0x0F) <<  0) |\
                                                                        ((PUPD     & 0x07) <<  4) |\
                                                                        ((AFNUM    & 0x0F) <<  7) |\
-                                                                       ((CHANNEL  & 0x0F) << 11) |\
-                                                                       ((INVERTED & 0x01) << 15)))
+                                                                       ((CHANNEL  & 0x1F) << 11) |\
+                                                                       ((INVERTED & 0x01) << 16)))
 
 #define STM_PIN_MODE(X)     (((X) >>  0) & 0x0F)
 #define STM_PIN_PUPD(X)     (((X) >>  4) & 0x07)
 #define STM_PIN_AFNUM(X)    (((X) >>  7) & 0x0F)
-#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x0F)
-#define STM_PIN_INVERTED(X) (((X) >> 15) & 0x01)
+#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x1F)
+#define STM_PIN_INVERTED(X) (((X) >> 16) & 0x01)
 
 #define STM_MODE_INPUT              (0)
 #define STM_MODE_OUTPUT_PP          (1)
@@ -106,6 +106,11 @@ typedef enum {
 
   PC_14 = 0x2E,
   PC_15 = 0x2F,
+
+  // ADC internal channels
+  ADC_TEMP = 0xF0,
+  ADC_VREF = 0xF1,
+  ADC_VBAT = 0xF2,
 
   // Arduino connector namings
   A0          = PA_0,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/PeripheralPins.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,6 +55,9 @@ const PinMap PinMap_ADC[] = {
     {PC_3,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0,  4, 0)}, // IN4
     {PC_4,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 13, 0)}, // IN13
     {PC_5,  ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG_ADC_CONTROL, GPIO_NOPULL, 0, 14, 0)}, // IN14
+    {ADC_TEMP, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 17, 0)},
+    {ADC_VREF, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0,  0, 0)},
+    {ADC_VBAT, ADC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 18, 0)},
     {NC,    NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/PinNames.h
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,14 +43,14 @@ extern "C" {
 #define STM_PIN_DATA_EXT(MODE, PUPD, AFNUM, CHANNEL, INVERTED)  ((int)(((MODE     & 0x0F) <<  0) |\
                                                                        ((PUPD     & 0x07) <<  4) |\
                                                                        ((AFNUM    & 0x0F) <<  7) |\
-                                                                       ((CHANNEL  & 0x0F) << 11) |\
-                                                                       ((INVERTED & 0x01) << 15)))
+                                                                       ((CHANNEL  & 0x1F) << 11) |\
+                                                                       ((INVERTED & 0x01) << 16)))
 
 #define STM_PIN_MODE(X)     (((X) >>  0) & 0x0F)
 #define STM_PIN_PUPD(X)     (((X) >>  4) & 0x07)
 #define STM_PIN_AFNUM(X)    (((X) >>  7) & 0x0F)
-#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x0F)
-#define STM_PIN_INVERTED(X) (((X) >> 15) & 0x01)
+#define STM_PIN_CHANNEL(X)  (((X) >> 11) & 0x1F)
+#define STM_PIN_INVERTED(X) (((X) >> 16) & 0x01)
 
 #define STM_MODE_INPUT              (0)
 #define STM_MODE_OUTPUT_PP          (1)
@@ -133,6 +133,11 @@ typedef enum {
 
     PH_0  = 0x70,
     PH_1  = 0x71,
+
+    // ADC internal channels
+    ADC_TEMP = 0xF0,
+    ADC_VREF = 0xF1,
+    ADC_VBAT = 0xF2,
 
     // Arduino connector namings
     A0          = PA_0,

--- a/targets/TARGET_STM/TARGET_STM32L4/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/analogin_api.c
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -51,8 +51,10 @@ void analogin_init(analogin_t *obj, PinName pin)
     MBED_ASSERT(function != (uint32_t)NC);
     obj->channel = STM_PIN_CHANNEL(function);
 
-    // Configure GPIO
-    pinmap_pinout(pin, PinMap_ADC);
+    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat)
+    if ((obj->channel != 0) && (obj->channel != 17) && (obj->channel != 18)) {
+        pinmap_pinout(pin, PinMap_ADC);
+    }
 
     // Save pin number for the read function
     obj->pin = pin;
@@ -99,7 +101,7 @@ static inline uint16_t adc_read(analogin_t *obj)
     // Configure ADC channel
     switch (obj->channel) {
         case 0:
-            sConfig.Channel = ADC_CHANNEL_0;
+            sConfig.Channel = ADC_CHANNEL_VREFINT;
             break;
         case 1:
             sConfig.Channel = ADC_CHANNEL_1;
@@ -150,10 +152,10 @@ static inline uint16_t adc_read(analogin_t *obj)
             sConfig.Channel = ADC_CHANNEL_16;
             break;
         case 17:
-            sConfig.Channel = ADC_CHANNEL_17;
+            sConfig.Channel = ADC_CHANNEL_TEMPSENSOR;
             break;
         case 18:
-            sConfig.Channel = ADC_CHANNEL_18;
+            sConfig.Channel = ADC_CHANNEL_VBAT;
             break;
         default:
             return 0;


### PR DESCRIPTION
## Description
Add the support of ADC internal channels (Temperature, VREF, VLCD) on STM32L4xx devices.

## Status
READY

## Migrations
No changes in API or behaviors.

## Related PRs
#2946 #2928 #2924 #2923 #2814 #2681 #2538