### PR TITLE
[IAR build] fix debug build

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -34,7 +34,7 @@
     },
     "IAR": {
         "common": [
-            "--no_wrap_diagnostics", "non-native end of line sequence", "-e",
+            "--no_wrap_diagnostics",  "-e",
             "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-On", "-r"],
         "asm": [],
         "c": ["--vla"],


### PR DESCRIPTION
## Description
with option  --profile ./tools/profiles/debug.json , the IAR built is failed

## Status
READY

## Migrations
No change needed

## Steps to test or reproduce
python ./tools/build.py -m DISCO_L476VG -t IAR --profile ./tools/profiles/debug.json
command return  
Fatal error[Su011]: More than one source file specified:
            non-native end of line sequence
## Reviews
- [x] @theotherjimmy
- [x] @0xc0170 
- [x] @screamerbg 