### PR TITLE
The HAL CM4 for ARM and IAR toolchains is valid only for FPU present.…

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/TARGET_RTOS_M4_M7/TOOLCHAIN_ARM/HAL_CM4.c
+++ b/rtos/rtx/TARGET_CORTEX_M/TARGET_RTOS_M4_M7/TOOLCHAIN_ARM/HAL_CM4.c
@@ -164,7 +164,9 @@ SVC_Handler_Veneer
 
 SVC_ContextSave
         TST     LR,#0x10                ; is it extended frame?
+#if (__FPU_PRESENT == 1)
         VSTMDBEQ R12!,{S16-S31}         ; yes, stack also VFP hi-regs
+#endif
         MOVEQ   R0,#0x01                ; os_tsk->stack_frame val
         MOVNE   R0,#0x00
         STRB    R0,[R1,#TCB_STACKF]     ; os_tsk.run->stack_frame = val
@@ -184,7 +186,9 @@ SVC_ContextRestore
         CMP     R0,#0                   ; Basic/Extended Stack Frame
         MVNEQ   LR,#:NOT:0xFFFFFFFD     ; set EXC_RETURN value
         MVNNE   LR,#:NOT:0xFFFFFFED
+#if (__FPU_PRESENT == 1)
         VLDMIANE R12!,{S16-S31}         ; restore VFP hi-registers
+#endif
         MSR     PSP,R12                 ; Write PSP
 
 SVC_Exit
@@ -247,7 +251,9 @@ Sys_Switch
 
         MRS     R12,PSP                 ; Read PSP
         TST     LR,#0x10                ; is it extended frame?
+#if (__FPU_PRESENT == 1)
         VSTMDBEQ R12!,{S16-S31}         ; yes, stack also VFP hi-regs
+#endif
         MOVEQ   R0,#0x01                ; os_tsk->stack_frame val
         MOVNE   R0,#0x00
         STRB    R0,[R1,#TCB_STACKF]     ; os_tsk.run->stack_frame = val
@@ -266,7 +272,9 @@ Sys_Switch
         CMP     R0,#0                   ; Basic/Extended Stack Frame
         MVNEQ   LR,#:NOT:0xFFFFFFFD     ; set EXC_RETURN value
         MVNNE   LR,#:NOT:0xFFFFFFED
+#if (__FPU_PRESENT == 1)
         VLDMIANE R12!,{S16-S31}         ; restore VFP hi-regs
+#endif
         MSR     PSP,R12                 ; Write PSP
 
 Sys_Exit

--- a/rtos/rtx/TARGET_CORTEX_M/TARGET_RTOS_M4_M7/TOOLCHAIN_IAR/HAL_CM4.S
+++ b/rtos/rtx/TARGET_CORTEX_M/TARGET_RTOS_M4_M7/TOOLCHAIN_IAR/HAL_CM4.S
@@ -188,8 +188,12 @@ SVC_Handler_Veneer:
 
 SVC_ContextSave:
         TST     LR,#0x10                /* is it extended frame? */
+#if (__FPU_PRESENT == 1)
         ITTE    EQ
         VSTMDBEQ R12!,{S16-S31}         /* yes, stack also VFP hi-regs */
+#else
+        ITE     EQ
+#endif
         MOVEQ   R0,#0x01                /* os_tsk->stack_frame val */
         MOVNE   R0,#0x00
         STRB    R0,[R1,#TCB_STACKF]     /* os_tsk.run->stack_frame = val */
@@ -207,10 +211,16 @@ SVC_ContextRestore:
         LDMIA   R12!,{R4-R11}           /* Restore New Context */
         LDRB    R0,[R2,#TCB_STACKF]     /* Stack Frame */
         CMP     R0,#0                   /* Basic/Extended Stack Frame */
+#if (__FPU_PRESENT == 1)
         ITEE    EQ
+#else
+        ITE     EQ
+#endif
         MVNEQ   LR,#~0xFFFFFFFD         /* set EXC_RETURN value */
         MVNNE   LR,#~0xFFFFFFED
+#if (__FPU_PRESENT == 1)
         VLDMIANE R12!,{S16-S31}         /* restore VFP hi-registers */
+#endif
         MSR     PSP,R12                 /* Write PSP */
 
 SVC_Exit:
@@ -274,8 +284,12 @@ Sys_Switch:
 
         MRS     R12,PSP                 /* Read PSP */
         TST     LR,#0x10                /* is it extended frame? */
+#if (__FPU_PRESENT == 1)
         ITTE    EQ
         VSTMDBEQ R12!,{S16-S31}         /* yes, stack also VFP hi-regs */
+#else
+        ITE     EQ
+#endif
         MOVEQ   R0,#0x01                /* os_tsk->stack_frame val */
         MOVNE   R0,#0x00
         STRB    R0,[R1,#TCB_STACKF]     /* os_tsk.run->stack_frame = val */
@@ -292,10 +306,16 @@ Sys_Switch:
         LDMIA   R12!,{R4-R11}           /* Restore New Context */
         LDRB    R0,[R2,#TCB_STACKF]     /* Stack Frame */
         CMP     R0,#0                   /* Basic/Extended Stack Frame */
+#if (__FPU_PRESENT == 1)
         ITEE    EQ
+#else
+        ITE     EQ
+#endif
         MVNEQ   LR,#~0xFFFFFFFD         /* set EXC_RETURN value */
         MVNNE   LR,#~0xFFFFFFED
+#if (__FPU_PRESENT == 1)
         VLDMIANE R12!,{S16-S31}         /* restore VFP hi-registers */
+#endif
         MSR     PSP,R12                 /* Write PSP */
 
 Sys_Exit:


### PR DESCRIPTION
## Description
The HAL CM4 for ARM and IAR toolchains is valid only for FPU present. These guards were added to mbed SDK as there are targets with Cortex-M4. This is similar to the implementation already done for GCC ARM

## Status
**READY

## Todos
- [ ] Tests
- [ ] Documentation

## Steps to test or reproduce
Compile with ARM or IAR toolchain any platform that has Cortex-M4 cpu.
