### PR TITLE
nsapi - Fix leftover bytes from suffix during ipv6 parsing

### DIFF
--- a/TESTS/netsocket/ip_parsing/main.cpp
+++ b/TESTS/netsocket/ip_parsing/main.cpp
@@ -1,0 +1,94 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+
+using namespace utest::v1;
+
+
+// IP parsing verification
+void test_ip_accept(const char *string, nsapi_addr_t addr) {
+    SocketAddress address;
+    TEST_ASSERT(address.set_ip_address(string));
+    TEST_ASSERT(address == SocketAddress(addr));
+}
+
+template <const char *string>
+void test_ip_reject() {
+    SocketAddress address;
+    TEST_ASSERT(!address.set_ip_address(string));
+    TEST_ASSERT(!address);
+}
+
+#define TEST_IP_ACCEPT(name, string, ...)           \
+void name() {                                       \
+    nsapi_addr_t addr = __VA_ARGS__;                \
+    test_ip_accept(string, addr);                   \
+}
+
+#define TEST_IP_REJECT(name, string)                \
+void name() {                                       \
+    test_ip_reject(string);                         \
+}
+
+
+// Test cases
+TEST_IP_ACCEPT(test_simple_ipv4_address,
+    "12.34.56.78",
+    {NSAPI_IPv4,{12,34,56,78}})
+TEST_IP_ACCEPT(test_left_weighted_ipv4_address,
+    "255.0.0.0",
+    {NSAPI_IPv4,{255,0,0,0}})
+TEST_IP_ACCEPT(test_right_weighted_ipv4_address,
+    "0.0.0.255",
+    {NSAPI_IPv4,{0,0,0,255}})
+TEST_IP_ACCEPT(test_null_ipv4_address,
+    "0.0.0.0",
+    {NSAPI_IPv4,{0,0,0,0}})
+
+TEST_IP_ACCEPT(test_simple_ipv6_address,
+    "1234:5678:9abc:def0:1234:5678:9abc:def0",
+    {NSAPI_IPv6,{0x12,0x34,0x56,0x78,0x9a,0xbc,0xde,0xf0,
+                 0x12,0x34,0x56,0x78,0x9a,0xbc,0xde,0xf0}})
+TEST_IP_ACCEPT(test_left_weighted_ipv6_address,
+    "1234:5678::",
+    {NSAPI_IPv6,{0x12,0x34,0x56,0x78,0x00,0x00,0x00,0x00,
+                 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}})
+TEST_IP_ACCEPT(test_right_weighted_ipv6_address,
+    "::1234:5678",
+    {NSAPI_IPv6,{0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                 0x00,0x00,0x00,0x00,0x12,0x34,0x56,0x78}})
+TEST_IP_ACCEPT(test_hollowed_ipv6_address,
+    "1234:5678::9abc:def8",
+    {NSAPI_IPv6,{0x12,0x34,0x56,0x78,0x00,0x00,0x00,0x00,
+                 0x00,0x00,0x00,0x00,0x9a,0xbc,0xde,0xf8}})
+TEST_IP_ACCEPT(test_null_ipv6_address,
+    "::",
+    {NSAPI_IPv6,{0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}})
+
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(10, "default_auto");
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("Simple IPv4 address", test_simple_ipv4_address),
+    Case("Left-weighted IPv4 address", test_left_weighted_ipv4_address),
+    Case("Right-weighted IPv4 address", test_right_weighted_ipv4_address),
+    Case("Null IPv4 address", test_null_ipv4_address),
+
+    Case("Simple IPv6 address", test_simple_ipv6_address),
+    Case("Left-weighted IPv6 address", test_left_weighted_ipv6_address),
+    Case("Right-weighted IPv6 address", test_right_weighted_ipv6_address),
+    Case("Hollowed IPv6 address", test_hollowed_ipv6_address),
+    Case("Null IPv6 address", test_null_ipv6_address),
+};
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}

--- a/features/netsocket/SocketAddress.cpp
+++ b/features/netsocket/SocketAddress.cpp
@@ -107,8 +107,6 @@ static void ipv6_from_address(uint8_t *bytes, const char *addr)
 {
     // Start with zeroed address
     uint16_t shorts[NSAPI_IPv6_BYTES/2];
-    memset(shorts, 0, sizeof shorts);
-
     int suffix = 0;
 
     // Find double colons and scan suffix
@@ -122,6 +120,8 @@ static void ipv6_from_address(uint8_t *bytes, const char *addr)
     // Move suffix to end
     memmove(&shorts[NSAPI_IPv6_BYTES/2-suffix], &shorts[0],
             suffix*sizeof(uint16_t));
+    memset(&shorts[0], 0,
+            (NSAPI_IPv6_BYTES/2-suffix)*sizeof(uint16_t));
 
     // Scan prefix
     ipv6_scan_chunk(shorts, &addr[0]);

--- a/features/netsocket/SocketAddress.cpp
+++ b/features/netsocket/SocketAddress.cpp
@@ -66,10 +66,13 @@ static void ipv4_from_address(uint8_t *bytes, const char *addr)
     int i = 0;
 
     for (; count < NSAPI_IPv4_BYTES; count++) {
-        int scanned = sscanf(&addr[i], "%hhu", &bytes[count]);
+        unsigned char b;
+        int scanned = sscanf(&addr[i], "%hhu", &b);
         if (scanned < 1) {
             return;
         }
+
+        bytes[count] = b;
 
         for (; addr[i] != '.'; i++) {
             if (!addr[i]) {
@@ -86,10 +89,13 @@ static int ipv6_scan_chunk(uint16_t *shorts, const char *chunk) {
     int i = 0;
 
     for (; count < NSAPI_IPv6_BYTES/2; count++) {
-        int scanned = sscanf(&chunk[i], "%hx", &shorts[count]);
+        unsigned short s;
+        int scanned = sscanf(&chunk[i], "%hx", &s);
         if (scanned < 1) {
             return count;
         }
+
+        shorts[count] = s;
 
         for (; chunk[i] != ':'; i++) {
             if (!chunk[i]) {


### PR DESCRIPTION
Thanks to @EduardPon for hunting this down:

> In the function ipv6_from_address(), address values of IPv6 address after a :: is found are moved to the end of the short[] array. But the source memory of the moved part should also be cleared with zeros before the address values in front of the :: are copied. In the current implementation this may lead to an invalid address conversion. 

fixes #2931