### PR TITLE
Fix ncs36510 by updating header guard

### DIFF
--- a/features/nanostack/FEATURE_NANOSTACK/targets/TARGET_NCS36510/NanostackRfPhyNcs36510.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/targets/TARGET_NCS36510/NanostackRfPhyNcs36510.cpp
@@ -1,6 +1,18 @@
 /*
- * Copyright (c) 2016, ARM Limited, All Rights Reserved
- */
+* Copyright (c) 2016-2016 ARM Limited. All rights reserved.
+* SPDX-License-Identifier: Apache-2.0
+* Licensed under the Apache License, Version 2.0 (the License); you may
+* not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an AS IS BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 #include "ns_types.h"
 #include <string.h>

--- a/features/nanostack/FEATURE_NANOSTACK/targets/TARGET_NCS36510/NanostackRfPhyNcs36510.h
+++ b/features/nanostack/FEATURE_NANOSTACK/targets/TARGET_NCS36510/NanostackRfPhyNcs36510.h
@@ -15,7 +15,7 @@
  */
 
 #ifndef NANOSTACK_PHY_NCS36510_H_
-#define NANOSTACK_PHY_MCR20A_H_
+#define NANOSTACK_PHY_NCS36510_H_
 
 #include "mbed.h"
 #include "NanostackRfPhy.h"
@@ -30,4 +30,4 @@ public:
     void set_mac_address(uint8_t *mac);
 };
 
-#endif /* NANOSTACK_PHY_MCR20A_H_ */
+#endif /* NANOSTACK_PHY_NCS36510_H_ */


### PR DESCRIPTION
Fix the header guard in the ncs36510 RF driver. Also update the license in NanostackRfPhyNcs36510.h.