### PR TITLE
Allowing mbed_app.json files to be discovered for tests.

### DIFF
--- a/docs/testing_mbed_OS_5.md
+++ b/docs/testing_mbed_OS_5.md
@@ -78,7 +78,9 @@ The full build process is:
 
 When building an mbed application, the presence of a `mbed_app.json` file allows you to set or override different config settings from libraries and targets. However, because the tests share a common build, this can cause issues when tests have different configurations that affect the OS.
 
-If you need to use app config, this must be set via the `--app-config` option when calling `mbed test`. **If this option is not specified, the build system will ignore all `mbed_app.json` files and use the default config values.**
+The build system will look for an `mbed_app.json` file in your shared project files (any directory not inside of a `TESTS` folder). If this is found, this configuration file will be used for both the non-test code as well as each test case inside your project's source tree. If there is more than one `mbed_app.json` files in the source tree, the config system will error.
+
+If you need to test with multiple configurations, then you can use the `--app-config` option. This will override the search for an `mbed_app.json` file and use the config file you specify for the build.
 
 ### Running tests
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -26,6 +26,7 @@ import fnmatch
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
+from tools.config import ConfigException
 from tools.test_api import test_path_to_name, find_tests, print_tests, build_tests, test_spec_from_test_builds
 from tools.options import get_default_options_parser, extract_profile
 from tools.build_api import build_project, build_library
@@ -120,15 +121,6 @@ if __name__ == '__main__':
             args_error(parser, "Could not find executable for %s.\n"
                                "Currently set search path: %s"
                        % (toolchain, search_path))
-
-        # App config
-        # Disable finding `mbed_app.json` files in the source tree if not
-        # explicitly defined on the command line. Config system searches for
-        # `mbed_app.json` files if `app_config` is None, but will set the
-        # app config data to an empty dictionary if the path value is another
-        # falsey value besides None.
-        if options.app_config is None:
-            options.app_config = ''
 
         # Find all tests in the relevant paths
         for path in all_paths:
@@ -261,6 +253,9 @@ if __name__ == '__main__':
 
     except KeyboardInterrupt, e:
         print "\n[CTRL+c] exit"
+    except ConfigException, e:
+        # Catching ConfigException here to prevent a traceback
+        print "[ERROR] %s" % str(e)
     except Exception,e:
         import traceback
         traceback.print_exc(file=sys.stdout)


### PR DESCRIPTION
## Description

Before, `mbed_app.json` files were explicitly ignored when building tests.
This was mostly because you could have multiple `mbed_app.json` files in the
tree (for instance, in test case folders) and the behavior would be
undefined. Now the tools explicitly ensure that there aren't multiple
`mbed_app.json` files in your source files. So auto discovery of
`mbed_app.json` for testing is being reintroduced.
## Status

**ON HOLD (pending review)**
## Migrations

If this PR changes any APIs or behaviors, give a short description of what _API users_ should do when this PR is merged.

YES

If you relied on the behavior of `mbed_app.json` being ignored when building tests, this is a breaking change.
## Todos
- [ ] Tests
- [x] Review by @mazimkhan (Does this affect uVisor CI testing?)
- [ ] Review by @AlessandroA (Does this affect uVisor local testing?)

FYI @BlackstoneEngineering and @screamerbg 
