### PR TITLE
Fix file path quoting while constructing CSV file in memmap.py

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -428,7 +428,7 @@ class MemapParser(object):
         file_desc - the file to write out the final report to
         """
         csv_writer = csv.writer(file_desc, delimiter=',',
-                                quoting=csv.QUOTE_NONE)
+                                quoting=csv.QUOTE_MINIMAL)
 
         csv_module_section = []
         csv_sizes = []


### PR DESCRIPTION

## Description
I'm getting:
```
Allocated Heap: 32768 bytes
Allocated Stack: 16384 bytes
Total Static RAM memory (data + bss): 11896 bytes
Total RAM memory (data + bss + heap + stack): 61048 bytes
Total Flash memory (text + data + misc): 44975 bytes
Traceback (most recent call last):
  File "/Users/barsza01/devel/mbed/bulislaw/mbed-os-example-blinky/mbed-os/tools/make.py", line 292, in <module>
    toolchain))
  File "/Users/barsza01/devel/mbed/bulislaw/mbed-os-example-blinky/mbed-os/tools/build_api.py", line 455, in build_project
    res, _ = toolchain.link_program(resources, build_path, name)
  File "/Users/barsza01/devel/mbed/bulislaw/mbed-os-example-blinky/mbed-os/tools/toolchains/__init__.py", line 999, in link_program
    self.map_outputs = self.mem_stats(map)
  File "/Users/barsza01/devel/mbed/bulislaw/mbed-os-example-blinky/mbed-os/tools/toolchains/__init__.py", line 1086, in mem_stats
    memap.generate_output('csv-ci', map_csv)
  File "/Users/barsza01/devel/mbed/bulislaw/mbed-os-example-blinky/mbed-os/tools/memap.py", line 410, in generate_output
    to_call(file_desc)
  File "/Users/barsza01/devel/mbed/bulislaw/mbed-os-example-blinky/mbed-os/tools/memap.py", line 461, in generate_csv
    csv_writer.writerow(csv_module_section)
Error: need to escape, but no escapechar set
```
I've tracked it down to using unquoted ',' to build CSV file. The default behavior is to rise error when the parser hits delimiter char. Comma is an legal character in file path in POSIX systems (including default Linaro ARM GCC package).

It stopped working for me today.

I'm actually not sure whether that's the right solution. @theotherjimmy can you have a look please?

## Steps to test or reproduce
Try ```mbed compile``` on POSIX system when one of the used files (eg compiler) has ```,``` in filepath.