### PR TITLE
Modify the flash size for Nucleo L073RZ.

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/device/TOOLCHAIN_ARM_MICRO/stm32l073xz.sct
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/device/TOOLCHAIN_ARM_MICRO/stm32l073xz.sct
@@ -28,7 +28,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; STM32L073RZ: 192KB FLASH (0x30000) + 20KB RAM (0x5000)
-LR_IROM1 0x08000000 0x10000  {    ; load region size_region
+LR_IROM1 0x08000000 0x30000  {    ; load region size_region
 
   ER_IROM1 0x08000000 0x30000  {  ; load address = execution address
    *.o (RESET, +First)

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/device/TOOLCHAIN_ARM_STD/stm32l073xz.sct
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/device/TOOLCHAIN_ARM_STD/stm32l073xz.sct
@@ -28,7 +28,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; STM32L073RZ: 192KB FLASH (0x30000) + 20KB RAM (0x5000)
-LR_IROM1 0x08000000 0x10000  {    ; load region size_region
+LR_IROM1 0x08000000 0x30000  {    ; load region size_region
 
   ER_IROM1 0x08000000 0x30000  {  ; load address = execution address
    *.o (RESET, +First)


### PR DESCRIPTION
## Description
The changes modify the flash size for Nucleo L073RZ and fix a bug when trying to compile a program with a size greater than 64K.

## Steps to test or reproduce
Try to compile a program greater than 64K in the online IDE. I get this error:

Error number: L6220E
Load region LR_IROM1 size (69108 bytes) exceeds limit (65536 bytes). Region contains 105 bytes of padding and 0 bytes of veneers (total 105 bytes of linker generated content).
