### PR TITLE
Enabled TRNG functionality for UBLOX_EVK_ODIN_W2 target.

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/device/TOOLCHAIN_ARM_STD/startup_stm32f439xx.S
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/device/TOOLCHAIN_ARM_STD/startup_stm32f439xx.S
@@ -39,7 +39,7 @@
 ; 
 ;*******************************************************************************
 
-__initial_sp    EQU     0x20020000 ; Top of RAM
+__initial_sp    EQU     0x20030000 ; Top of RAM
 
                 PRESERVE8
                 THUMB

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/objects.h
@@ -60,7 +60,9 @@ struct analogin_s {
     uint8_t channel;
 };
 
-
+struct trng_s {
+    RNG_HandleTypeDef handle;
+};
 
 #include "common_objects.h"
 struct can_s {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1183,10 +1183,10 @@
         "core": "Cortex-M4F",
         "default_toolchain": "ARM",
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
-        "extra_labels": ["STM", "STM32F4", "STM32F439", "STM32F439ZI"],
+        "extra_labels": ["STM", "STM32F4", "STM32F439", "STM32F439ZI","STM32F439xx"],
         "macros": ["HSE_VALUE=24000000", "HSE_STARTUP_TIMEOUT=5000", "CB_INTERFACE_SDIO","CB_CHIP_WL18XX","SUPPORT_80211D_ALWAYS","WLAN_ENABLED"],
         "inherits": ["Target"],
-        "device_has": ["ANALOGIN", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG"],
         "features": ["LWIP"],
         "release_versions": ["5"],
         "device_name": "STM32F439ZI"


### PR DESCRIPTION
## Description
Enabled TRNG functionality for UBLOX_EVK_ODIN_W2 target the same way as:
https://github.com/ARMmbed/mbed-os/pull/2611

## Steps to test or reproduce
Tested the same way as done for https://github.com/ARMmbed/mbed-os/pull/2611 for ARM and GCC_ARM.

@screamerbg
@0xc0170 