### PR TITLE
Compiler profiles for size optimization

### DIFF
--- a/tools/profiles/debug-size.json
+++ b/tools/profiles/debug-size.json
@@ -1,0 +1,44 @@
+{
+    "GCC_ARM": {
+        "common": ["-c", "-Wall", "-Wextra",
+                   "-Wno-unused-parameter", "-Wno-missing-field-initializers",
+                   "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
+                   "-ffunction-sections", "-fdata-sections", "-funsigned-char",
+                   "-MMD", "-fno-delete-null-pointer-checks",
+                   "-fomit-frame-pointer", "-O1", "-g"],
+        "asm": ["-x", "assembler-with-cpp"],
+        "c": ["-std=gnu99"],
+        "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],
+        "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
+               "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r",
+               "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit"]
+    },
+    "ARM": {
+        "common": ["-c", "--gnu", "-Ospace", "--split_sections",
+                   "--apcs=interwork", "--brief_diagnostics", "--restrict",
+                   "--multibyte_chars", "-O1", "-g"],
+        "asm": [],
+        "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
+        "cxx": ["--cpp", "--no_rtti", "--no_vla"],
+        "ld": []
+    },
+    "uARM": {
+        "common": ["-c", "--gnu", "-Ospace", "--split_sections",
+                   "--apcs=interwork", "--brief_diagnostics", "--restrict",
+                   "--multibyte_chars", "-O1", "-D__MICROLIB", "-g",
+                   "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD"],
+        "asm": [],
+        "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
+        "cxx": ["--cpp", "--no_rtti", "--no_vla"],
+        "ld": ["--library_type=microlib"]
+    },
+    "IAR": {
+        "common": [
+            "--no_wrap_diagnostics",  "-e",
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Ol", "-r"],
+        "asm": [],
+        "c": ["--vla"],
+        "cxx": ["--guard_calls", "--no_static_destruction"],
+        "ld": ["--skip_dynamic_initialization", "--threaded_lib"]
+    }
+}

--- a/tools/profiles/size.json
+++ b/tools/profiles/size.json
@@ -1,0 +1,44 @@
+{
+    "GCC_ARM": {
+        "common": ["-c", "-Wall", "-Wextra",
+                   "-Wno-unused-parameter", "-Wno-missing-field-initializers",
+                   "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
+                   "-ffunction-sections", "-fdata-sections", "-funsigned-char",
+                   "-MMD", "-fno-delete-null-pointer-checks",
+                   "-fomit-frame-pointer", "-Os"],
+        "asm": ["-x", "assembler-with-cpp"],
+        "c": ["-std=gnu99"],
+        "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],
+        "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
+               "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r",
+               "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit"]
+    },
+    "ARM": {
+        "common": ["-c", "--gnu", "-Ospace", "--split_sections",
+                   "--apcs=interwork", "--brief_diagnostics", "--restrict",
+                   "--multibyte_chars", "-O3"],
+        "asm": [],
+        "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
+        "cxx": ["--cpp", "--no_rtti", "--no_vla"],
+        "ld": []
+    },
+    "uARM": {
+        "common": ["-c", "--gnu", "-Ospace", "--split_sections",
+                   "--apcs=interwork", "--brief_diagnostics", "--restrict",
+                   "--multibyte_chars", "-O3", "-D__MICROLIB",
+                   "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD"],
+        "asm": [],
+        "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
+        "cxx": ["--cpp", "--no_rtti", "--no_vla"],
+        "ld": ["--library_type=microlib"]
+    },
+    "IAR": {
+        "common": [
+            "--no_wrap_diagnostics", "-e",
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Ohz"],
+        "asm": [],
+        "c": ["--vla"],
+        "cxx": ["--guard_calls", "--no_static_destruction"],
+        "ld": ["--skip_dynamic_initialization", "--threaded_lib"]
+    }
+}


### PR DESCRIPTION
## Description

This pull request adds two new compiler profiles, one for size optimization for release builds and one for minimally optimized debug build.
## Status

**READY/IN DEVELOPMENT/HOLD**
## Migrations

If this PR changes any APIs or behaviors, give a short description of what _API users_ should do when this PR is merged.

NO
## Related PRs

List related PRs against other branches:

| branch | PR |
| --- | --- |
| other_pr_production | [link]() |
| other_pr_master | [link]() |
## Todos
- [ ] Tests
- [x] Documentation
- [x] Review by @theotherjimmy
- [x] Review by @screamerbg 
## Deploy notes
## Steps to test or reproduce

mbed compile -m K64F -t ARM --profile mbed-os/tools/profiles/size.json
mbed compile -m K64F -t GCC_ARM --profile mbed-os/tools/profiles/debug-size.json
