### PR TITLE
Legacy rtos

### DIFF
--- a/platform/retarget.cpp
+++ b/platform/retarget.cpp
@@ -72,10 +72,6 @@ extern const char __stdout_name[] = "/stdout";
 extern const char __stderr_name[] = "/stderr";
 #endif
 
-// Heap limits - only used if set
-unsigned char *mbed_heap_start = 0;
-uint32_t mbed_heap_size = 0;
-
 /* newlib has the filehandle field in the FILE struct as a short, so
  * we can't just return a Filehandle* from _open and instead have to
  * put it in a filehandles array and return the index into that array
@@ -592,12 +588,6 @@ extern "C" caddr_t _sbrk(int incr) {
 #else
     if (new_heap >= (unsigned char*)__get_MSP()) {
 #endif
-        errno = ENOMEM;
-        return (caddr_t)-1;
-    }
-
-    // Additional heap checking if set
-    if (mbed_heap_size && (new_heap >= mbed_heap_start + mbed_heap_size)) {
         errno = ENOMEM;
         return (caddr_t)-1;
     }

--- a/rtos/rtx/TARGET_CORTEX_A/RTX_Conf_CA.c
+++ b/rtos/rtx/TARGET_CORTEX_A/RTX_Conf_CA.c
@@ -38,11 +38,6 @@
  *      RTX User configuration part BEGIN
  *---------------------------------------------------------------------------*/
 
-#if defined(MBED_RTOS_SINGLE_THREAD)
-#define OS_TASKCNT  1
-#define OS_TIMERS   0
-#endif
-
 // Include per-target RTX config file
 #include "mbed_rtx.h"
 

--- a/rtos/rtx/TARGET_CORTEX_M/HAL_CM.c
+++ b/rtos/rtx/TARGET_CORTEX_M/HAL_CM.c
@@ -90,6 +90,32 @@ void rt_init_stack (P_TCB p_TCB, FUNCP task_body) {
   /* Task entry point. */
   p_TCB->ptask = task_body;
 
+
+#ifdef __MBED_CMSIS_RTOS_CM
+  /* Set a magic word for checking of stack overflow.
+   For the main thread (ID: MAIN_THREAD_ID) the stack is in a memory area shared with the
+   heap, therefore the last word of the stack is a moving target.
+   We want to do stack/heap collision detection instead.
+   Similar applies to stack filling for the magic pattern.
+  */
+  if (p_TCB->task_id != MAIN_THREAD_ID) {
+    p_TCB->stack[0] = MAGIC_WORD;
+
+    /* Initialize stack with magic pattern. */
+    if (os_stackinfo & 0x10000000U) {
+      if (size > (16U+1U)) {
+        for (i = ((size - 16U)/2U) - 1U; i; i--) {
+          stk -= 2U;
+          stk[1] = MAGIC_PATTERN;
+          stk[0] = MAGIC_PATTERN;
+        }
+        if (--stk > p_TCB->stack) {
+          *stk = MAGIC_PATTERN;
+        }
+      }
+    }
+  }
+#else
   /* Initialize stack with magic pattern. */
   if (os_stackinfo & 0x10000000U) {
     if (size > (16U+1U)) {
@@ -106,6 +132,7 @@ void rt_init_stack (P_TCB p_TCB, FUNCP task_body) {
 
   /* Set a magic word for checking of stack overflow. */
   p_TCB->stack[0] = MAGIC_WORD;
+#endif
 }
 
 

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -378,24 +378,17 @@ void set_main_stack(void) {
     os_thread_def_main.stack_pointer = (uint32_t *) FINAL_SP;
     os_thread_def_main.stacksize = (uint32_t) INITIAL_SP - (uint32_t) FINAL_SP - OS_MAINSTKSIZE * 4;
 #else
-    uint32_t interrupt_stack_size = ((uint32_t)OS_MAINSTKSIZE * 4);
 #if defined(__ICCARM__)
     /* For IAR heap is defined  .icf file */
     uint32_t main_stack_size = ((uint32_t)INITIAL_SP - (uint32_t)HEAP_END) - interrupt_stack_size;
 #else
     /* For ARM , uARM, or GCC_ARM , heap can grow and reach main stack */
-    uint32_t heap_plus_stack_size = ((uint32_t)INITIAL_SP - (uint32_t)HEAP_START) - interrupt_stack_size;
-    // Main thread's stack is 1/4 of the heap
-    uint32_t main_stack_size = heap_plus_stack_size/4;
 #endif
-    // The main thread must be 4 byte aligned
-    uint32_t main_stack_start = ((uint32_t)INITIAL_SP - interrupt_stack_size - main_stack_size) & ~0x7;
-
     // That is the bottom of the main stack block: no collision detection
-    os_thread_def_main.stack_pointer = (uint32_t*)main_stack_start;
+    os_thread_def_main.stack_pointer = HEAP_START;
 
     // Leave OS_MAINSTKSIZE words for the scheduler and interrupts
-    os_thread_def_main.stacksize = main_stack_size;
+    os_thread_def_main.stacksize = (INITIAL_SP - (unsigned int)HEAP_START) - (OS_MAINSTKSIZE * 4);
 #endif
 }
 

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -353,139 +353,50 @@ __attribute__((used)) void _mutex_release (OS_ID *mutex) {
 
 /* Main Thread definition */
 extern void pre_main (void);
+osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1U, 0U, NULL};
 
-#if defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832) || defined (TARGET_STM32F334R8) ||\
-    defined(TARGET_STM32F070RB) || defined(TARGET_STM32F072RB) || \
-    defined(TARGET_STM32F302R8) || defined(TARGET_STM32F303K8) || defined (TARGET_STM32F334C8) ||\
-    defined(TARGET_STM32F103RB)
-static uint32_t thread_stack_main[DEFAULT_STACK_SIZE / sizeof(uint32_t)];
-#elif defined(TARGET_XDOT_L151CC)
-static uint32_t thread_stack_main[DEFAULT_STACK_SIZE * 6 / sizeof(uint32_t)];
+#ifdef __CC_ARM
+#if defined(TARGET_NUMAKER_PFM_NUC472)
+extern uint32_t          Image$$ARM_LIB_HEAP$$Base[];
+#define HEAP_START      ((uint32_t) Image$$ARM_LIB_HEAP$$Base)
 #else
-static uint32_t thread_stack_main[DEFAULT_STACK_SIZE * 2 / sizeof(uint32_t)];
+extern uint32_t          Image$$RW_IRAM1$$ZI$$Limit[];
+#define HEAP_START      (Image$$RW_IRAM1$$ZI$$Limit)
 #endif
-osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1U, sizeof(thread_stack_main), thread_stack_main};
-
-/*
- * IAR Default Memory layout notes:
- * -Heap defined by "HEAP" region in .icf file
- * -Interrupt stack defined by "CSTACK" region in .icf file
- * -Value INITIAL_SP is ignored
- *
- * IAR Custom Memory layout notes:
- * -There is no custom layout available for IAR - everything must be defined in
- *      the .icf file and use the default layout
- *
- *
- * GCC Default Memory layout notes:
- * -Block of memory from symbol __end__ to define INITIAL_SP used to setup interrupt
- *      stack and heap in the function set_stack_heap()
- * -ISR_STACK_SIZE can be overridden to be larger or smaller
- *
- * GCC Custom Memory layout notes:
- * -Heap can be explicitly placed by defining both HEAP_START and HEAP_SIZE
- * -Interrupt stack can be explicitly placed by defining both ISR_STACK_START and ISR_STACK_SIZE
- *
- *
- * ARM Memory layout
- * -Block of memory from end of region "RW_IRAM1" to define INITIAL_SP used to setup interrupt
- *      stack and heap in the function set_stack_heap()
- * -ISR_STACK_SIZE can be overridden to be larger or smaller
- *
- * ARM Custom Memory layout notes:
- * -Heap can be explicitly placed by defining both HEAP_START and HEAP_SIZE
- * -Interrupt stack can be explicitly placed by defining both ISR_STACK_START and ISR_STACK_SIZE
- *
- */
-
-extern unsigned char *mbed_heap_start;
-extern uint32_t mbed_heap_size;
-
-unsigned char *mbed_stack_isr_start = 0;
-uint32_t mbed_stack_isr_size = 0;
-
-/*
- * Sanity check values
- */
-#if defined(__ICCARM__) &&                                  \
-    (defined(HEAP_START) || defined(HEAP_SIZE) ||           \
-     defined(ISR_STACK_START) && defined(ISR_STACK_SIZE))
-    #error "No custom layout allowed for IAR. Use .icf file instead"
-#endif
-#if defined(HEAP_START) && !defined(HEAP_SIZE)
-    #error "HEAP_SIZE must be defined if HEAP_START is defined"
-#endif
-#if defined(ISR_STACK_START) && !defined(ISR_STACK_SIZE)
-    #error "ISR_STACK_SIZE must be defined if ISR_STACK_START is defined"
-#endif
-#if defined(HEAP_SIZE) && !defined(HEAP_START)
-    #error "HEAP_START must be defined if HEAP_SIZE is defined"
+#elif defined(__GNUC__)
+extern uint32_t          __end__[];
+#define HEAP_START      (__end__)
+#elif defined(__ICCARM__)
+#pragma section="HEAP"
+#define HEAP_END  (void *)__section_end("HEAP")
 #endif
 
-/* Interrupt stack and heap always defined for IAR
- * Main thread defined here
- */
+void set_main_stack(void) {
+#if defined(TARGET_NUMAKER_PFM_NUC472)
+    // Scheduler stack: OS_MAINSTKSIZE words
+    // Main thread stack: Reserved stack size - OS_MAINSTKSIZE words
+    os_thread_def_main.stack_pointer = (uint32_t *) FINAL_SP;
+    os_thread_def_main.stacksize = (uint32_t) INITIAL_SP - (uint32_t) FINAL_SP - OS_MAINSTKSIZE * 4;
+#else
+    uint32_t interrupt_stack_size = ((uint32_t)OS_MAINSTKSIZE * 4);
 #if defined(__ICCARM__)
-    #pragma section="CSTACK"
-    #pragma section="HEAP"
-    #define HEAP_START          ((unsigned char*)__section_begin("HEAP"))
-    #define HEAP_SIZE           ((uint32_t)__section_size("HEAP"))
-    #define ISR_STACK_START     ((unsigned char*)__section_begin("CSTACK"))
-    #define ISR_STACK_SIZE      ((uint32_t)__section_size("CSTACK"))
-#endif
-
-#if !defined(INITIAL_SP) && !defined(HEAP_START)
-    #error "no target defined"
-#endif
-
-/* Define heap region if it has not been defined already */
-#if !defined(HEAP_START)
-    #if defined(__ICCARM__)
-        #error "Heap should already be defined for IAR"
-    #elif defined(__CC_ARM)
-        extern uint32_t          Image$$RW_IRAM1$$ZI$$Limit[];
-        #define HEAP_START      ((unsigned char*)Image$$RW_IRAM1$$ZI$$Limit)
-        #define HEAP_SIZE       ((uint32_t)((uint32_t)INITIAL_SP - (uint32_t)HEAP_START))
-    #elif defined(__GNUC__)
-        extern uint32_t         __end__[];
-        #define HEAP_START      ((unsigned char*)__end__)
-        #define HEAP_SIZE       ((uint32_t)((uint32_t)INITIAL_SP - (uint32_t)HEAP_START))
-    #endif
-#endif
-
-/* Define stack sizes if they haven't been set already */
-#if !defined(ISR_STACK_SIZE)
-    #define ISR_STACK_SIZE ((uint32_t)OS_MAINSTKSIZE * 4)
-#endif
-
-/*
- * set_stack_heap purpose is to set the following variables:
- * -mbed_heap_start
- * -mbed_heap_size
- * -mbed_stack_isr_start
- * -mbed_stack_isr_size
- *
- * Along with setting up os_thread_def_main
- */
-void set_stack_heap(void) {
-
-    unsigned char *free_start = HEAP_START;
-    uint32_t free_size = HEAP_SIZE;
-
-#ifdef ISR_STACK_START
-    /* Interrupt stack explicitly specified */
-    mbed_stack_isr_size = ISR_STACK_SIZE;
-    mbed_stack_isr_start = ISR_STACK_START;
+    /* For IAR heap is defined  .icf file */
+    uint32_t main_stack_size = ((uint32_t)INITIAL_SP - (uint32_t)HEAP_END) - interrupt_stack_size;
 #else
-    /* Interrupt stack -  reserve space at the end of the free block */
-    mbed_stack_isr_size = ISR_STACK_SIZE;
-    mbed_stack_isr_start = free_start + free_size - mbed_stack_isr_size;
-    free_size -= mbed_stack_isr_size;
+    /* For ARM , uARM, or GCC_ARM , heap can grow and reach main stack */
+    uint32_t heap_plus_stack_size = ((uint32_t)INITIAL_SP - (uint32_t)HEAP_START) - interrupt_stack_size;
+    // Main thread's stack is 1/4 of the heap
+    uint32_t main_stack_size = heap_plus_stack_size/4;
 #endif
+    // The main thread must be 4 byte aligned
+    uint32_t main_stack_start = ((uint32_t)INITIAL_SP - interrupt_stack_size - main_stack_size) & ~0x7;
 
-    /* Heap - everything else */
-    mbed_heap_size = free_size;
-    mbed_heap_start = free_start;
+    // That is the bottom of the main stack block: no collision detection
+    os_thread_def_main.stack_pointer = (uint32_t*)main_stack_start;
+
+    // Leave OS_MAINSTKSIZE words for the scheduler and interrupts
+    os_thread_def_main.stacksize = main_stack_size;
+#endif
 }
 
 #if defined (__CC_ARM)
@@ -499,7 +410,7 @@ void $Super$$__cpp_initialize__aeabi_(void);
 void _main_init (void) {
   osKernelInitialize();
 #ifdef __MBED_CMSIS_RTOS_CM
-  set_stack_heap();
+  set_main_stack();
 #endif
   osThreadCreate(&os_thread_def_main, NULL);
   osKernelStart();
@@ -521,12 +432,15 @@ void pre_main()
 
 #else
 
+void * armcc_heap_base;
+void * armcc_heap_top;
+
 int main(void);
 
 void pre_main (void)
 {
     singleton_mutex_id = osMutexCreate(osMutex(singleton_mutex));
-    __rt_lib_init((unsigned)mbed_heap_start, (unsigned)(mbed_heap_start + mbed_heap_size));
+    __rt_lib_init((unsigned)armcc_heap_base, (unsigned)armcc_heap_top);
     main();
 }
 
@@ -541,11 +455,13 @@ void pre_main (void)
 __asm void __rt_entry (void) {
 
   IMPORT  __user_setup_stackheap
+  IMPORT  armcc_heap_base
+  IMPORT  armcc_heap_top
   IMPORT  _platform_post_stackheap_init
   IMPORT  os_thread_def_main
   IMPORT  osKernelInitialize
 #ifdef __MBED_CMSIS_RTOS_CM
-  IMPORT  set_stack_heap
+  IMPORT  set_main_stack
 #endif
   IMPORT  osKernelStart
   IMPORT  osThreadCreate
@@ -559,13 +475,14 @@ __asm void __rt_entry (void) {
    * ARM Compiler ARM C and C++ Libraries and Floating-Point Support User Guide
    */
   BL      __user_setup_stackheap
-  /* Ignore return value of __user_setup_stackheap since
-   * this will be setup by set_stack_heap
-   */
+  LDR     R3,=armcc_heap_base
+  LDR     R4,=armcc_heap_top
+  STR     R0,[R3]
+  STR     R2,[R4]
   BL      _platform_post_stackheap_init
   BL      osKernelInitialize
 #ifdef __MBED_CMSIS_RTOS_CM
-  BL      set_stack_heap
+  BL      set_main_stack
 #endif
   LDR     R0,=os_thread_def_main
   MOVS    R1,#0
@@ -603,7 +520,7 @@ __attribute__((naked)) void software_init_hook_rtos (void) {
   __asm (
     "bl   osKernelInitialize\n"
 #ifdef __MBED_CMSIS_RTOS_CM
-    "bl   set_stack_heap\n"
+    "bl   set_main_stack\n"
 #endif
     "ldr  r0,=os_thread_def_main\n"
     "movs r1,#0\n"
@@ -680,7 +597,7 @@ void __iar_program_start( void )
 #endif
   osKernelInitialize();
 #ifdef __MBED_CMSIS_RTOS_CM
-  set_stack_heap();
+  set_main_stack();
 #endif
   osThreadCreate(&os_thread_def_main, NULL);
   osKernelStart();

--- a/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
@@ -77,12 +77,6 @@
 
 #ifdef __MBED_CMSIS_RTOS_CM
 
-/* Single thread - disable timers and set task count to one */
-#if defined(MBED_RTOS_SINGLE_THREAD)
-#define OS_TASKCNT  1
-#define OS_TIMERS   0
-#endif
-
 /* If os timers macro is set to 0, there's no timer thread created, therefore
  * main thread has tid 0x01  
  */

--- a/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
@@ -83,6 +83,14 @@
 #define OS_TIMERS   0
 #endif
 
+/* If os timers macro is set to 0, there's no timer thread created, therefore
+ * main thread has tid 0x01  
+ */
+#if defined(OS_TIMERS) && (OS_TIMERS == 0)
+#define MAIN_THREAD_ID 0x01
+#else
+#define MAIN_THREAD_ID 0x02
+#endif
 #endif
 
 #if defined(TARGET_XDOT_L151CC)

--- a/rtos/rtx/TARGET_CORTEX_M/rt_System.c
+++ b/rtos/rtx/TARGET_CORTEX_M/rt_System.c
@@ -313,10 +313,22 @@ void rt_systick (void) {
 /*--------------------------- rt_stk_check ----------------------------------*/
 
 __weak void rt_stk_check (void) {
+#ifdef __MBED_CMSIS_RTOS_CM
+    /* Check for stack overflow. */
+    if (os_tsk.run->task_id == MAIN_THREAD_ID) {
+        // TODO: For the main thread the check should be done against the main heap pointer
+    } else {
+        if ((os_tsk.run->tsk_stack < (U32)os_tsk.run->stack) ||
+            (os_tsk.run->stack[0] != MAGIC_WORD)) {
+            os_error (OS_ERR_STK_OVF);
+        }
+    }
+#else
     if ((os_tsk.run->tsk_stack < (U32)os_tsk.run->stack) ||
         (os_tsk.run->stack[0] != MAGIC_WORD)) {
         os_error (OS_ERR_STK_OVF);
     }
+#endif
 }
 
 /*----------------------------------------------------------------------------


### PR DESCRIPTION
Revert memory model changes that were made to the rtos so it is compatible with older versions of mbed. This consists of:
1. Allow RTOS threads to be created in all configurations, rather than just the ones which provide thread safety
2. Revert back to the memory model shown [here](https://developer.mbed.org/handbook/RTOS-Memory-Model) by disabling heap overflow checking and chaning the main thread so it overlaps with the heap.
