### PR TITLE
Extension of BLE SecurityManager API and BLE Gap API

### DIFF
--- a/features/FEATURE_BLE/ble/Gap.h
+++ b/features/FEATURE_BLE/ble/Gap.h
@@ -1914,6 +1914,37 @@ private:
     /* Disallow copy and assignment. */
     Gap(const Gap &);
     Gap& operator=(const Gap &);
+
+public:
+    /** BLE Temporary Key length */
+    static const unsigned TEMPORARY_KEY_LEN = 16;
+
+    /** BLE Temporary Key type*/
+    typedef uint8_t Temporarykey_t[TEMPORARY_KEY_LEN];
+
+protected:
+    /** Temporary key value
+     *
+     *
+     * Requesting action from porters: use this value for servicing the OOB.
+     * */
+    Temporarykey_t OobTK;
+
+public:
+    /**
+    * Function for register Temporary Key.
+    *
+    * This function store in the object memory a temporary key for further using for OOB pairing.
+    *
+    * @param[in] A Temporary Key value to register.
+    *
+    * @retval BLE_ERROR_NONE             On success, always.
+    */
+    ble_error_t setOobTK(Temporarykey_t &tk) {
+        memcpy(&OobTK, &tk, sizeof(Temporarykey_t));
+        return BLE_ERROR_NONE;
+    }
+
 };
 
 #endif // ifndef __GAP_H__

--- a/features/FEATURE_BLE/ble/SecurityManager.h
+++ b/features/FEATURE_BLE/ble/SecurityManager.h
@@ -148,6 +148,7 @@ public:
      *                             set using BLE::Gap.setAddress() API.
      *                             
      * @param[in]  acceptReBonding Allow for bonding even if a bond for connection already exist.
+     * @param[in]  oob           Out Of Band pairing enable.
      *
      * @return BLE_ERROR_NONE on success.
      */
@@ -156,8 +157,9 @@ public:
                              SecurityIOCapabilities_t iocaps          = IO_CAPS_NONE,
                              const Passkey_t          passkey         = NULL,
                              const idResolvingkey_t   idResolvingkey  = NULL,
-                             uint16_t                 addressInterval = 0
-                             bool                     acceptReBonding = false) {
+                             uint16_t                 addressInterval = 0,
+                             bool                     acceptReBonding = false,
+                             bool                     oob             = false) {
         /* Avoid compiler warnings about unused variables. */
         (void)enableBonding;
         (void)requireMITM;
@@ -166,6 +168,7 @@ public:
         (void)idResolvingkey;
         (void)addressInterval;
         (void)acceptReBonding;
+        (void)oob;
 
         return BLE_ERROR_NOT_IMPLEMENTED; /* Requesting action from porters: override this API if security is supported. */
     }
@@ -392,6 +395,21 @@ protected:
 
 private:
     SecurityManagerShutdownCallbackChain_t shutdownCallChain;
+
+public:
+    /**
+     * Function for generate Temporary Key value.
+     *
+     * @param[out] tk   Generated Temporary Key.
+     *
+     * @retval BLE_ERROR_NONE             On success, else an error code indicating reason for failure.
+     * @retval BLE_ERROR_INVALID_STATE    If the API is called without module initialization or
+     *                                    application registration.
+     */
+     virtual ble_error_t generateTk(Gap::Temporarykey_t &tk) {
+        (void)tk;
+        return BLE_ERROR_NOT_IMPLEMENTED; /* Requesting action from porters: override this API if OOB pairing is supported. */
+     }
 };
 
 #endif /*__SECURITY_MANAGER_H__*/


### PR DESCRIPTION
## Description
- added extended version of init() method in order to support configuration of IRK, random address resolvable mode and repeated bonding.
- added callback for signalling repeated bonding event.
- added API for registering TK in Gap.
- extended init() API of the SecureManager by oob pairing enable flag
- added API for generation TK to the SecureManager
## Target of changes
- Add oob pairing support
- improvement for repeated bonding maintenance
- improvement of BLE private addressing setup
## Next steep

After acceptance of this API extension the nRF5 BLE implementation will be extended in order to fit this API changes.
