### PR TITLE
Remove main stack customizations

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -353,17 +353,7 @@ __attribute__((used)) void _mutex_release (OS_ID *mutex) {
 
 /* Main Thread definition */
 extern void pre_main (void);
-
-#if defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832) || defined (TARGET_STM32F334R8) ||\
-    defined(TARGET_STM32F070RB) || defined(TARGET_STM32F072RB) || \
-    defined(TARGET_STM32F302R8) || defined(TARGET_STM32F303K8) || defined (TARGET_STM32F334C8) ||\
-    defined(TARGET_STM32F103RB)
-static uint32_t thread_stack_main[DEFAULT_STACK_SIZE / sizeof(uint32_t)];
-#elif defined(TARGET_XDOT_L151CC)
-static uint32_t thread_stack_main[DEFAULT_STACK_SIZE * 6 / sizeof(uint32_t)];
-#else
 static uint32_t thread_stack_main[DEFAULT_STACK_SIZE * 2 / sizeof(uint32_t)];
-#endif
 osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1U, sizeof(thread_stack_main), thread_stack_main};
 
 /*

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_IAR/stm32f070xb.icf
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_IAR/stm32f070xb.icf
@@ -9,7 +9,7 @@ define symbol __ICFEDIT_region_ROM_end__   = 0x0801FFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x200000C0;
 define symbol __ICFEDIT_region_RAM_end__   = 0x20003FFF;
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x800;
+define symbol __ICFEDIT_size_cstack__ = 0x400;
 define symbol __ICFEDIT_size_heap__   = 0x1000;
 /**** End of ICF editor section. ###ICF###*/
 

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/TOOLCHAIN_IAR/stm32f072xb.icf
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/TOOLCHAIN_IAR/stm32f072xb.icf
@@ -9,7 +9,7 @@ define symbol __ICFEDIT_region_ROM_end__   = 0x0801FFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x200000C0;
 define symbol __ICFEDIT_region_RAM_end__   = 0x20003FFF;
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x800;
+define symbol __ICFEDIT_size_cstack__ = 0x400;
 define symbol __ICFEDIT_size_heap__   = 0x1000;
 /**** End of ICF editor section. ###ICF###*/
 


### PR DESCRIPTION
Set all platforms to have a main stack twice as big as the default.
