### PR TITLE
NRF52_DK support for IAR exporter

### DIFF
--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -146,5 +146,8 @@
     },
     "STM32F407VG": {
         "OGChipSelectEditMenu": "STM32F407VG\tST STM32F407VG"
+    },
+    "nRF52832_xxAA":{
+        "OGChipSelectEditMenu": "nRF52832-xxAA\tNordicSemi nRF52832-xxAA"
     }
 }


### PR DESCRIPTION
Adds support for nrf52_dk in IAR. Solves https://github.com/ARMmbed/oob-mbed-os-example-blinky/issues/4#issuecomment-252595498

@0xc0170 