### PR TITLE
Accept profile name as well as file path for tools/make.py --profile

### DIFF
--- a/tools/options.py
+++ b/tools/options.py
@@ -16,12 +16,13 @@ limitations under the License.
 """
 from json import load
 from os.path import join, dirname
+from os import listdir
 from argparse import ArgumentParser
 from tools.toolchains import TOOLCHAINS
 from tools.targets import TARGET_NAMES
 from tools.utils import argparse_force_uppercase_type, \
     argparse_lowercase_hyphen_type, argparse_many, \
-    argparse_filestring_type, args_error
+    argparse_filestring_type, args_error, argparse_profile_filestring_type
 
 def get_default_options_parser(add_clean=True, add_options=True,
                                add_app_config=False):
@@ -73,7 +74,9 @@ def get_default_options_parser(add_clean=True, add_options=True,
 
     if add_options:
         parser.add_argument("--profile", dest="profile", action="append",
-                            type=argparse_filestring_type,
+                            type=argparse_profile_filestring_type,
+                            help="Build profile to use. Can be either path to json" \
+                            "file or one of the default one ({})".format(", ".join(list_profiles())),
                             default=[])
     if add_app_config:
         parser.add_argument("--app-config", default=None, dest="app_config",
@@ -82,6 +85,12 @@ def get_default_options_parser(add_clean=True, add_options=True,
 
     return parser
 
+def list_profiles():
+    """Lists available build profiles
+
+    Checks default profile directory (mbed-os/tools/profiles/) for all the json files and return list of names only
+    """
+    return [fn.replace(".json", "") for fn in listdir(join(dirname(__file__), "profiles")) if fn.endswith(".json")]
 
 def extract_profile(parser, options, toolchain):
     """Extract a Toolchain profile from parsed options

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -22,7 +22,7 @@ import math
 from os import listdir, remove, makedirs
 from shutil import copyfile
 from os.path import isdir, join, exists, split, relpath, splitext, abspath
-from os.path import commonprefix, normpath
+from os.path import commonprefix, normpath, dirname
 from subprocess import Popen, PIPE, STDOUT, call
 import json
 from collections import OrderedDict
@@ -434,6 +434,19 @@ def argparse_filestring_type(string):
     else:
         raise argparse.ArgumentTypeError(
             "{0}"" does not exist in the filesystem.".format(string))
+
+def argparse_profile_filestring_type(string):
+    """ An argument parser that verifies that a string passed in is either
+    absolute path or a file name (expanded to
+    mbed-os/tools/profiles/<fname>.json) of a existing file"""
+    fpath = join(dirname(__file__), "profiles/{}.json".format(string))
+    if exists(string):
+        return string
+    elif exists(fpath):
+        return fpath
+    else:
+        raise argparse.ArgumentTypeError(
+            "{0} does not exist in the filesystem.".format(string))
 
 def columnate(strings, separator=", ", chars=80):
     """ render a list of strings as a in a bunch of columns


### PR DESCRIPTION

## Description
--profile can be used with just a profile name eg. default, debug as
long as <name>.json file is in default profile directory.

## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO

CC: @0xc0170 @theotherjimmy @bridadan 