### PR TITLE
[tools] Parallel building of tests

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -459,7 +459,10 @@ def build_project(src_paths, build_path, target, toolchain_name,
         memap_table = ''
         if memap_instance:
             # Write output to stdout in text (pretty table) format
-            memap_table = memap_instance.generate_output('table', silent=silent)
+            memap_table = memap_instance.generate_output('table')
+
+            if not silent:
+                print memap_table
 
             # Write output to file in JSON format
             map_out = join(build_path, name + "_map.json")

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -455,12 +455,26 @@ def build_project(src_paths, build_path, target, toolchain_name,
         # Link Program
         res, _ = toolchain.link_program(resources, build_path, name)
 
+        memap_instance = getattr(toolchain, 'memap_instance', None)
+        memap_table = ''
+        if memap_instance:
+            # Write output to stdout in text (pretty table) format
+            memap_table = memap_instance.generate_output('table', silent=silent)
+
+            # Write output to file in JSON format
+            map_out = join(build_path, name + "_map.json")
+            memap_instance.generate_output('json', map_out)
+
+            # Write output to file in CSV format for the CI
+            map_csv = join(build_path, name + "_map.csv")
+            memap_instance.generate_output('csv-ci', map_csv)
+
         resources.detect_duplicates(toolchain)
 
         if report != None:
             end = time()
             cur_result["elapsed_time"] = end - start
-            cur_result["output"] = toolchain.get_output()
+            cur_result["output"] = toolchain.get_output() + memap_table
             cur_result["result"] = "OK"
             cur_result["memory_usage"] = toolchain.map_outputs
 

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -1075,16 +1075,8 @@ class mbedToolchain:
             self.info("Unknown toolchain for memory statistics %s" % toolchain)
             return None
 
-        # Write output to stdout in text (pretty table) format
-        self.info(memap.generate_output('table', silent=True))
-
-        # Write output to file in JSON format
-        map_out = splitext(map)[0] + "_map.json"
-        memap.generate_output('json', map_out)
-
-        # Write output to file in CSV format for the CI
-        map_csv = splitext(map)[0] + "_map.csv"
-        memap.generate_output('csv-ci', map_csv)
+        # Store the memap instance for later use
+        self.memap_instance = memap
 
         # Here we return memory statistics structure (constructed after
         # call to generate_output) which contains raw data in bytes

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -370,24 +370,24 @@ class mbedToolchain:
             msg = '[%(severity)s] %(file)s@%(line)s,%(col)s: %(message)s' % event
 
         elif event['type'] == 'progress':
-            if not silent:
-                if 'percent' in event:
-                    msg = '{} [{:>5.1f}%]: {}'.format(event['action'].title(),
-                                                      event['percent'],
-                                                      basename(event['file']))
-                else:
-                    msg = '{}: {}'.format(event['action'].title(),
-                                          basename(event['file']))
+            if 'percent' in event:
+                msg = '{} [{:>5.1f}%]: {}'.format(event['action'].title(),
+                                                  event['percent'],
+                                                  basename(event['file']))
+            else:
+                msg = '{}: {}'.format(event['action'].title(),
+                                      basename(event['file']))
 
         if msg:
-            print msg
+            if not silent:
+                print msg
             self.output += msg + "\n"
 
     def print_notify_verbose(self, event, silent=False):
         """ Default command line notification with more verbose mode
         """
         if event['type'] in ['info', 'debug']:
-            self.print_notify(event) # standard handle
+            self.print_notify(event, silent=silent) # standard handle
 
         elif event['type'] == 'cc':
             event['severity'] = event['severity'].title()
@@ -396,7 +396,8 @@ class mbedToolchain:
             event['target_name'] = event['target_name'].upper() if event['target_name'] else "Unknown"
             event['toolchain_name'] = event['toolchain_name'].upper() if event['toolchain_name'] else "Unknown"
             msg = '[%(severity)s] %(target_name)s::%(toolchain_name)s::%(file)s@%(line)s: %(message)s' % event
-            print msg
+            if not silent:
+                print msg
             self.output += msg + "\n"
 
         elif event['type'] == 'progress':

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -1076,7 +1076,7 @@ class mbedToolchain:
             return None
 
         # Write output to stdout in text (pretty table) format
-        memap.generate_output('table')
+        self.info(memap.generate_output('table', silent=True))
 
         # Write output to file in JSON format
         map_out = splitext(map)[0] + "_map.json"


### PR DESCRIPTION
## Description
**tl;dr:** the linking step of building tests now respects the `-j` flag, so it can be parallelized to make building tests faster.

This uses similar code that is used withing the toolchains when compiling to parallelize the linking process of all the tests across the available CPUs.

To prevent interleaving of build output, I had to modify how the toolchains handle the `silent` parameter. @screamerbg or @theotherjimmy if this will cause issues, please let me know and I will add a different parameter to stop the printing from occurring.

## Statistics
Some brief numbers, cuz who doesn't like numbers :)

Before parallelization, building all tests for the K64F with GCC_ARM on our "Build beast" CI machine took **~45 seconds**, with almost 40 seconds of that taken up by the linking stage.

After parallelization, the same build now takes **~6 seconds**!


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO

## Todos
- [x] Tests
- [x] Review by @screamerbg 
- [x] Review by @theotherjimmy 
- [ ] Review by @MarceloSalazar (memap changes)


## Deploy notes
This will consume more resources on a host machine for a shorter amount of time. But this should be taken into consideration in CI.

