### PR TITLE
lwip-interface: fix issue #2993

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/emac_lwip.c
+++ b/features/FEATURE_LWIP/lwip-interface/emac_lwip.c
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "platform.h"
-
 #if DEVICE_EMAC
 
 #include "emac_api.h"

--- a/features/FEATURE_LWIP/lwip-interface/emac_stack_lwip.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/emac_stack_lwip.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "platform.h"
-
 #if DEVICE_EMAC
 
 #include "emac_stack_mem.h"

--- a/features/netsocket/emac_stack_mem.h
+++ b/features/netsocket/emac_stack_mem.h
@@ -16,8 +16,6 @@
 #ifndef MBED_EMAC_STACK_MEM_H
 #define MBED_EMAC_STACK_MEM_H
 
-#include "platform.h"
-
 #if DEVICE_EMAC
 
 #include <stdint.h>

--- a/hal/hal/emac_api.h
+++ b/hal/hal/emac_api.h
@@ -17,9 +17,6 @@
 #ifndef MBED_EMAC_API_H
 #define MBED_EMAC_API_H
 
-#include "platform.h"
-
-
 #if DEVICE_EMAC
 
 #include <stdbool.h>


### PR DESCRIPTION
## Description

Fix for the issue #2993, do not use ``platform.h`` in the C files.

## Status
**READY**

Tested defining EMAC for one platform and  see if DEVICE_ it's properly defined and the code is compiled.

@pan- 