### PR TITLE
Add .hpp to list of Uvision Exporter extensions

### DIFF
--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -122,7 +122,7 @@ class Uvision(Exporter):
     #File associations within .uvprojx file
     file_types = {'.cpp': 8, '.c': 1, '.s': 2,
                   '.obj': 3, '.o': 3, '.lib': 4,
-                  '.ar': 4, '.h': 5, '.sct': 4}
+                  '.ar': 4, '.h': 5, '.hpp': 5, '.sct': 4}
 
     def uv_file(self, loc):
         """Return a namedtuple of information about project file


### PR DESCRIPTION
Doing an export fails if .hpp files are included, this patch add it to the list of recognized extensions.
## Log

```
mbed export -i UVISION5 -m NRF52_DK
Traceback (most recent call last):
  File "c:\mbed-project\mbed-os\tools\project.py", line 234, in <module>
    main()
  File "c:\mbed-project\mbed-os\tools\project.py", line 230, in main
    zip_proj=zip_proj, build_profile=profile)
  File "c:\mbed-project\mbed-os\tools\project.py", line 93, in export
    build_profile=build_profile, silent=silent)
  File "c:\mbed-project\mbed-os\tools\project_api.py", line 229, in export_project
    macros=macros)
  File "c:\mbed-project\mbed-os\tools\project_api.py", line 90, in generate_project_files
    exporter.generate()
  File "c:\mbed-project\mbed-os\tools\export\uvision\__init__.py", line 189, in generate
    'project_files': self.format_src(srcs),
  File "c:\mbed-project\mbed-os\tools\export\uvision\__init__.py", line 175, in format_src
    grouped[group] = [self.uv_file(src) for src in files]
  File "c:\mbed-project\mbed-os\tools\export\uvision\__init__.py", line 141, in uv_file
    type = self.file_types[ext.lower()]
KeyError: '.hpp'
[mbed] ERROR: "python" returned error code 1.
[mbed] ERROR: Command "python -u c:\mbed-project\mbed-os\tools\project.py -i uvision5 -m NRF52_DK --source ." in "c:\mbed-project"
```
