### PR TITLE
STM32xx - Change how the ADC internal pins are checked before pinmap_…

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/analogin_api.c
@@ -50,8 +50,9 @@ void analogin_init(analogin_t *obj, PinName pin) {
     MBED_ASSERT(function != (uint32_t)NC);
     obj->channel = STM_PIN_CHANNEL(function);
 
-    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat)
-    if ((obj->channel != 16) && (obj->channel != 17) && (obj->channel != 18)) {
+    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat, ...)
+    // ADC Internal Channels "pins" are described in PinNames.h and must have a value >= 0xF0
+    if (pin < 0xF0) {
         pinmap_pinout(pin, PinMap_ADC);
     }
 

--- a/targets/TARGET_STM/TARGET_STM32F1/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/analogin_api.c
@@ -52,8 +52,9 @@ void analogin_init(analogin_t *obj, PinName pin)
     MBED_ASSERT(function != (uint32_t)NC);
     obj->channel = STM_PIN_CHANNEL(function);
 
-    // Configure GPIO excepted for internal channels (Temperature, Vref)
-    if ((obj->channel != 16) && (obj->channel != 17)) {
+    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat, ...)
+    // ADC Internal Channels "pins" are described in PinNames.h and must have a value >= 0xF0
+    if (pin < 0xF0) {
         pinmap_pinout(pin, PinMap_ADC);
     }
 

--- a/targets/TARGET_STM/TARGET_STM32F2/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/analogin_api.c
@@ -58,8 +58,9 @@ void analogin_init(analogin_t *obj, PinName pin)
     MBED_ASSERT(function != (uint32_t)NC);
     obj->channel = STM_PIN_CHANNEL(function);
 
-    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat)
-    if ((obj->channel != 16) && (obj->channel != 17) && (obj->channel != 18)) {
+    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat, ...)
+    // ADC Internal Channels "pins" are described in PinNames.h and must have a value >= 0xF0
+    if (pin < 0xF0) {
         pinmap_pinout(pin, PinMap_ADC);
     }
 

--- a/targets/TARGET_STM/TARGET_STM32F3/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/analogin_api.c
@@ -62,8 +62,9 @@ void analogin_init(analogin_t *obj, PinName pin)
     MBED_ASSERT(function != (uint32_t)NC);
     obj->channel = STM_PIN_CHANNEL(function);
 
-    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat)
-    if ((obj->channel != 16) && (obj->channel != 17) && (obj->channel != 18)) {
+    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat, ...)
+    // ADC Internal Channels "pins" are described in PinNames.h and must have a value >= 0xF0
+    if (pin < 0xF0) {
         pinmap_pinout(pin, PinMap_ADC);
     }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
@@ -58,8 +58,9 @@ void analogin_init(analogin_t *obj, PinName pin)
     MBED_ASSERT(function != (uint32_t)NC);
     obj->channel = STM_PIN_CHANNEL(function);
 
-    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat)
-    if ((obj->channel != 16) && (obj->channel != 17) && (obj->channel != 18)) {
+    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat, ...)
+    // ADC Internal Channels "pins" are described in PinNames.h and must have a value >= 0xF0
+    if (pin < 0xF0) {
         pinmap_pinout(pin, PinMap_ADC);
     }
 

--- a/targets/TARGET_STM/TARGET_STM32F7/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/analogin_api.c
@@ -59,8 +59,9 @@ void analogin_init(analogin_t *obj, PinName pin)
     MBED_ASSERT(function != (uint32_t)NC);
     obj->channel = STM_PIN_CHANNEL(function);
 
-    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat)
-    if ((obj->channel != 16) && (obj->channel != 17) && (obj->channel != 18)) {
+    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat, ...)
+    // ADC Internal Channels "pins" are described in PinNames.h and must have a value >= 0xF0
+    if (pin < 0xF0) {
         pinmap_pinout(pin, PinMap_ADC);
     }
 

--- a/targets/TARGET_STM/TARGET_STM32L0/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/analogin_api.c
@@ -51,8 +51,9 @@ void analogin_init(analogin_t *obj, PinName pin)
     MBED_ASSERT(function != (uint32_t)NC);
     obj->channel = STM_PIN_CHANNEL(function);
 
-    // Configure GPIO excepted for internal channels (Temperature, Vref, Vlcd)
-    if ((obj->channel != 16) && (obj->channel != 17) && (obj->channel != 18)) {
+    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat, ...)
+    // ADC Internal Channels "pins" are described in PinNames.h and must have a value >= 0xF0
+    if (pin < 0xF0) {
         pinmap_pinout(pin, PinMap_ADC);
     }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/analogin_api.c
@@ -53,8 +53,9 @@ void analogin_init(analogin_t *obj, PinName pin)
     MBED_ASSERT(function != (uint32_t)NC);
     obj->channel = STM_PIN_CHANNEL(function);
 
-    // Configure GPIO excepted for internal channels (Temperature, Vref)
-    if ((obj->channel != 16) && (obj->channel != 17)) {
+    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat, ...)
+    // ADC Internal Channels "pins" are described in PinNames.h and must have a value >= 0xF0
+    if (pin < 0xF0) {
         pinmap_pinout(pin, PinMap_ADC);
     }
 

--- a/targets/TARGET_STM/TARGET_STM32L4/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/analogin_api.c
@@ -51,8 +51,9 @@ void analogin_init(analogin_t *obj, PinName pin)
     MBED_ASSERT(function != (uint32_t)NC);
     obj->channel = STM_PIN_CHANNEL(function);
 
-    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat)
-    if ((obj->channel != 0) && (obj->channel != 17) && (obj->channel != 18)) {
+    // Configure GPIO excepted for internal channels (Temperature, Vref, Vbat, ...)
+    // ADC Internal Channels "pins" are described in PinNames.h and must have a value >= 0xF0
+    if (pin < 0xF0) {
         pinmap_pinout(pin, PinMap_ADC);
     }
 


### PR DESCRIPTION
## Description
The pinmap_pinout must be called only for real pins and not ADC internal channel "pins". Before this patch we checked the ADC channel number, now we check the pin number.

## Status
READY

## Migrations
No API or behavior change.