### PR TITLE
Update USB driver for devices with Kinetis SDK support

### DIFF
--- a/features/unsupported/tests/mbed/sd/main.cpp
+++ b/features/unsupported/tests/mbed/sd/main.cpp
@@ -5,7 +5,7 @@
 #if defined(TARGET_KL25Z)
 SDFileSystem sd(PTD2, PTD3, PTD1, PTD0, "sd");
 
-#elif defined(TARGET_KL46Z)
+#elif defined(TARGET_KL46Z) || defined(TARGET_KL43Z)
 SDFileSystem sd(PTD6, PTD7, PTD5, PTD4, "sd");
 
 #elif defined(TARGET_K64F) || defined(TARGET_K66F)

--- a/features/unsupported/tests/mbed/sd_perf_fatfs/main.cpp
+++ b/features/unsupported/tests/mbed/sd_perf_fatfs/main.cpp
@@ -7,7 +7,7 @@
 #if defined(TARGET_KL25Z)
 SDFileSystem sd(PTD2, PTD3, PTD1, PTD0, "sd");
 
-#elif defined(TARGET_KL46Z)
+#elif defined(TARGET_KL46Z) || defined(TARGET_KL43Z)
 SDFileSystem sd(PTD6, PTD7, PTD5, PTD4, "sd");
 
 #elif defined(TARGET_K64F) || defined(TARGET_K66F)

--- a/features/unsupported/tests/mbed/sd_perf_fhandle/main.cpp
+++ b/features/unsupported/tests/mbed/sd_perf_fhandle/main.cpp
@@ -7,7 +7,7 @@
 #if defined(TARGET_KL25Z)
 SDFileSystem sd(PTD2, PTD3, PTD1, PTD0, "sd");
 
-#elif defined(TARGET_KL46Z)
+#elif defined(TARGET_KL46Z) || defined(TARGET_KL43Z)
 SDFileSystem sd(PTD6, PTD7, PTD5, PTD4, "sd");
 
 #elif defined(TARGET_K64F) || defined(TARGET_K66F)

--- a/features/unsupported/tests/mbed/sd_perf_stdio/main.cpp
+++ b/features/unsupported/tests/mbed/sd_perf_stdio/main.cpp
@@ -7,7 +7,7 @@
 #if defined(TARGET_KL25Z)
 SDFileSystem sd(PTD2, PTD3, PTD1, PTD0, "sd");
 
-#elif defined(TARGET_KL46Z)
+#elif defined(TARGET_KL46Z) || defined(TARGET_KL43Z)
 SDFileSystem sd(PTD6, PTD7, PTD5, PTD4, "sd");
 
 #elif defined(TARGET_K64F) || defined(TARGET_K66F)

--- a/tools/build_travis.py
+++ b/tools/build_travis.py
@@ -137,6 +137,30 @@ linking_list = [
                "rtos" : ["RTOS_1", "RTOS_2", "RTOS_3"],
                "usb"  : ["USB_1", "USB_2" ,"USB_3"],
                }
+     },
+    {"target": "K64F",
+     "toolchains": "GCC_ARM",
+     "tests": {""     : ["MBED_2", "MBED_10", "MBED_11", "MBED_15", "MBED_16", "MBED_17"],
+               "fat"  : ["MBED_A12", "PERF_1", "PERF_2", "PERF_3"],
+               "rtos" : ["RTOS_1", "RTOS_2", "RTOS_3"],
+               "usb"  : ["USB_1", "USB_2" ,"USB_3"],
+               }
+     },
+    {"target": "K22F",
+     "toolchains": "GCC_ARM",
+     "tests": {""     : ["MBED_2", "MBED_10", "MBED_11", "MBED_15", "MBED_16", "MBED_17"],
+               "fat"  : ["MBED_A12", "PERF_1", "PERF_2", "PERF_3"],
+               "rtos" : ["RTOS_1", "RTOS_2", "RTOS_3"],
+               "usb"  : ["USB_1", "USB_2" ,"USB_3"],
+               }
+     },
+    {"target": "KL43Z",
+     "toolchains": "GCC_ARM",
+     "tests": {""     : ["MBED_2", "MBED_10", "MBED_11", "MBED_15", "MBED_16", "MBED_17"],
+               "fat"  : ["MBED_A12", "PERF_1", "PERF_2", "PERF_3"],
+               "rtos" : ["RTOS_1", "RTOS_2", "RTOS_3"],
+               "usb"  : ["USB_1", "USB_2" ,"USB_3"],
+               }
      }
      ]
 


### PR DESCRIPTION
## Description

Update USB driver for devices with Kinetis SDK support
1. Fix build issues with IAR and GCC toolchain
2. Update clock initialization code
## Status

USB unit tests with ARMCC failed, I feel this is something outside the USB driver. The same tests with IAR and GCC_ARM work fine. Also USB unit test with ARMCC without the RTOS work, 
