### PR TITLE
Remove shared spi_s struct from XDOT_L151CC

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/objects.h
@@ -65,20 +65,6 @@ struct dac_s {
     PinName pin;
 };
 
-struct spi_s {
-    SPIName spi;
-    uint32_t bits;
-    uint32_t cpol;
-    uint32_t cpha;
-    uint32_t mode;
-    uint32_t nss;
-    uint32_t br_presc;
-    PinName  pin_miso;
-    PinName  pin_mosi;
-    PinName  pin_sclk;
-    PinName  pin_ssel;
-};
-
 struct i2c_s {
     I2CName  i2c;
     uint32_t slave;


### PR DESCRIPTION
## Description
PR #2888 broke the build for the XDOT_L151CC. It looks like it was missed in the PR. This should fix the build and allow CI to complete for other PRs

Since you submitted #2888, would you be able to review this please @LMESTM?


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [ ] Tests
- [ ] Review by @LMESTM 

