### PR TITLE
[tests] Waiting before call to deepsleep to allow buffers to flush

### DIFF
--- a/TESTS/mbed_drivers/lp_timeout/main.cpp
+++ b/TESTS/mbed_drivers/lp_timeout/main.cpp
@@ -43,8 +43,18 @@ void lp_timeout_1s_deepsleep(void)
 {
     complete = false;
 
-    /* 
-     * We use here lp_ticker_read() instead of us_ticker_read() for start and 
+    /*
+     * Since deepsleep() may shut down the UART peripheral, we wait for 10ms
+     * to allow for hardware serial buffers to completely flush.
+
+     * This should be replaced with a better function that checks if the
+     * hardware buffers are empty. However, such an API does not exist now,
+     * so we'll use the wait_ms() function for now.
+     */
+    wait_ms(10);
+
+    /*
+     * We use here lp_ticker_read() instead of us_ticker_read() for start and
      * end because the microseconds timer might be disable during deepsleep.
      */
     timestamp_t start = lp_ticker_read();

--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -65,12 +65,22 @@ void lp_ticker_1s_deepsleep()
     complete = false;
     uint32_t delay_ts;
 
+    /*
+     * Since deepsleep() may shut down the UART peripheral, we wait for 10ms
+     * to allow for hardware serial buffers to completely flush.
+
+     * This should be replaced with a better function that checks if the
+     * hardware buffers are empty. However, such an API does not exist now,
+     * so we'll use the wait_ms() function for now.
+     */
+    wait_ms(10);
+
     ticker_set_handler(lp_ticker_data, cb_done);
     ticker_remove_event(lp_ticker_data, &delay_event);
     delay_ts = lp_ticker_read() + 1000000;
 
-    /* 
-     * We use here lp_ticker_read() instead of us_ticker_read() for start and 
+    /*
+     * We use here lp_ticker_read() instead of us_ticker_read() for start and
      * end because the microseconds timer might be disable during deepsleep.
      */
     timestamp_t start = lp_ticker_read();


### PR DESCRIPTION
## Description
Since deepsleep() may shut down the UART peripheral, I added a wait for 10ms to allow for hardware serial buffers to completely flush.

This should be replaced with a better function that checks if the hardware buffers are empty. However, such an API does not exist now, so I'm using the wait_ms() function for now.

Should resolve some of the issues discussed here: https://github.com/ARMmbed/mbed-os/pull/2966


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [ ] Tests
- [x] Review by @bulislaw (since you originally submitted the tests)

FYI @sg- and @mmahadevan108 
