### PR TITLE
allow rtos idle loop to call sleep();

### DIFF
--- a/rtos/rtos_idle.c
+++ b/rtos/rtos_idle.c
@@ -24,11 +24,10 @@
 
 static void default_idle_hook(void)
 {
-    /* Sleep: ideally, we should put the chip to sleep.
-     Unfortunately, this usually requires disconnecting the interface chip (debugger).
-     This can be done, but it would break the local file system.
-    */
-    // sleep();
+    /* Sleep: Please note - for the most power savings, disconnect the.
+       interface chip (debugger).
+    */   
+     sleep();
 }
 static void (*idle_hook_fptr)(void) = &default_idle_hook;
 


### PR DESCRIPTION
## Description

To enable power efficiency, the rtos loop should call sleep().  To my knowledge, this can be done regardless if the debugger interface is connected (at least it can on the Kinetis MCUs).  If the debugger interface is connected, the device may not achieve as great of power savings, but it still can enter low power mode.  Something is better than nothing.  

Entering low power mode when idle is fundamental to low power / battery powered applications.
## Status

Needs CI
## Migrations

NO
## Related PRs

Same as https://github.com/ARMmbed/mbed-os/pull/2443.  Submitting this separate PR due to unknown/unrelated issue preventing the last one to pass CI.

| branch | PR |
| --- | --- |

N/A
## Todos

N/A
## Deploy notes

N/A
## Steps to test or reproduce

When RTOS idle executes, it will call sleep(), which is implementation specific to the platform.  In general, sleep is a very light low power mode, thus should not disrupt anything.  
