### PR TITLE
OnSemi RAM usage fix

### DIFF
--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_ARM/NCS36510.sct
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_ARM/NCS36510.sct
@@ -1,7 +1,5 @@
 #! armcc -E
 
-#define Heap_Size                    0x0400
-
 LR_IROM1 0x00003000 0x0004F000  {    ; load region size_region
   ER_IROM1 0x00003000 0x0004F000  {  ; load address = execution address
    *.o (RESET, +First)
@@ -11,13 +9,8 @@ LR_IROM1 0x00003000 0x0004F000  {    ; load region size_region
 
   ; no uvisor support at this time
 
-  ;ARM_LIB_STACK AlignExpr(+0, 8) EMPTY 0x1000 {}
-   ARM_LIB_STACK 0x3FFF4000 EMPTY 0x1000 {}
-
-  RW_IRAM0 +0 {
+  RW_IRAM1 0x3FFF4000 {
     .ANY(+RW +ZI)
-  }
-  RW_IRAM1 ImageLimit(RW_IRAM0) EMPTY Heap_Size { ; Heap region growing up
   }
   ARM_LIB_HEAP AlignExpr(+0, 8) ALIGN 8 EMPTY (0x3FFF4000 + 0xC000 - AlignExpr(ImageLimit(RW_IRAM1),8) ) {}
 }

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_ARM/startup_NCS36510.s
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_ARM/startup_NCS36510.s
@@ -43,9 +43,9 @@
                 EXPORT  __Vectors
                 EXPORT  __Vectors_End
                 EXPORT  __Vectors_Size
-                IMPORT  |Image$$ARM_LIB_STACK$$ZI$$Limit|
+                IMPORT  |Image$$ARM_LIB_HEAP$$ZI$$Limit|
 
-__Vectors       DCD     |Image$$ARM_LIB_STACK$$ZI$$Limit|  ; Top of Stack
+__Vectors       DCD     |Image$$ARM_LIB_HEAP$$ZI$$Limit|  ; Top of RAM
                 DCD     Reset_Handler  ; Reset Handler
                 DCD     NMI_Handler  ; NMI Handler
                 DCD     HardFault_Handler  ; Hard Fault Handler


### PR DESCRIPTION
Notes:
* Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
* This is just a template, so feel free to use/remove the unnecessary things

## Description
Recovers 4K of precious RAM. Valid only for ARMCC. Similar fixes should be done to GCC and IAR too.


## Status
**READY/IN DEVELOPMENT/HOLD**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

YES | NO


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ ] Documentation


## Deploy notes
Notes regarding the deployment of this PR. These should note any
required changes in the build environment, tools, compilers, etc.


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.

Previous code base had been wasting almost 4K of precious RAM.

* Main stack allocation reduced from 4K to 1K
* Un-necessary breakdown of RAM regions is removed. This gives us back 2K of RAM.