### PR TITLE
analog_loop tests update for STM32

### DIFF
--- a/features/unsupported/tests/mbed/analog/main.cpp
+++ b/features/unsupported/tests/mbed/analog/main.cpp
@@ -28,6 +28,8 @@ AnalogOut out(PTE30);
 AnalogIn in(A0);
 AnalogOut out(D12); //D12 is P0_12, the DAC output pin
 
+// no pin to access DAC on these targets:
+//TARGET_DISCO_F746NG
 // No DAC on these targets:
 //TARGET_NUCLEO_F030R8
 //TARGET_NUCLEO_F070RB
@@ -40,18 +42,23 @@ AnalogOut out(D12); //D12 is P0_12, the DAC output pin
       defined(TARGET_NUCLEO_F303RE) || \
       defined(TARGET_NUCLEO_F334R8) || \
       defined(TARGET_NUCLEO_F446RE) || \
-      defined(TARGET_NUCLEO_F446ZE) || \
       defined(TARGET_NUCLEO_L053R8) || \
       defined(TARGET_NUCLEO_L073RZ) || \
+      defined(TARGET_NUCLEO_L476RG) || \
       defined(TARGET_NUCLEO_L152RE)
 AnalogIn in(A0);
 AnalogOut out(A2);
 
-#elif defined(TARGET_NUCLEO_F746ZG)
+#elif defined(TARGET_NUCLEO_F303K8)
 AnalogIn in(A0);
-AnalogOut out(PA_4);
+AnalogOut out(A3);
 
-#elif defined(TARGET_NUCLEO_F207ZG)
+#elif defined(TARGET_NUCLEO_F207ZG) || \
+      defined(TARGET_NUCLEO_F746ZG) || \
+      defined(TARGET_NUCLEO_F303ZE) || \
+      defined(TARGET_NUCLEO_F410RB) || \
+      defined(TARGET_NUCLEO_F446ZE) || \
+      defined(TARGET_NUCLEO_F429ZI)
 AnalogIn in(A0);
 AnalogOut out(D13);
 
@@ -59,13 +66,18 @@ AnalogOut out(D13);
 AnalogIn in(PA_0);
 AnalogOut out(PA_4);
 
+#elif defined(TARGET_DISCO_L053C8) || \
+      defined(TARGET_DISCO_F334C8)
+AnalogIn in(PA_1);
+AnalogOut out(PA_4);
+
 #elif defined(TARGET_DISCO_F407VG) || \
       defined(TARGET_DISCO_F469NI)
 AnalogIn in(PC_5);
 AnalogOut out(PA_4);
 
-#elif defined(TARGET_NUCLEO_F303ZE)
-AnalogIn in(PC_5);
+#elif defined(TARGET_DISCO_L476VG)
+AnalogIn in(PA_0);
 AnalogOut out(PA_5);
 
 #elif defined(TARGET_DISCO_F429ZI)

--- a/tools/tests.py
+++ b/tools/tests.py
@@ -189,6 +189,13 @@ TESTS = [
         "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB],
         "automated": True,
         "peripherals": ["analog_loop"],
+        "mcu": ["LPC1768", "LPC2368", "LPC2460", "KL25Z", "K64F", "K66F", "K22F", "LPC4088", "LPC1549",
+                "NUCLEO_F072RB", "NUCLEO_F091RC", "NUCLEO_F302R8", "NUCLEO_F303K8", "NUCLEO_F303RE", "NUCLEO_F207ZG",
+                "NUCLEO_F334R8", "NUCLEO_F303ZE", "NUCLEO_L053R8", "NUCLEO_L073RZ", "NUCLEO_L152RE",
+                "NUCLEO_F410RB", "NUCLEO_F446RE", "NUCLEO_F446ZE", "NUCLEO_F429ZI",
+                "DISCO_F407VG", "NUCLEO_F746ZG", "NUCLEO_L476RG",
+                "DISCO_L053C8", "DISCO_F334C8", "DISCO_L476VG", "DISCO_F469NI", "DISCO_F429ZI",
+                "ARCH_MAX", "MAX32600MBED", "MOTE_L152RC", "B96B_F446VE"]
     },
     {
         "id": "MBED_A9", "description": "Serial Echo at 115200",

--- a/tools/tests.py
+++ b/tools/tests.py
@@ -70,6 +70,8 @@ Wiring:
 
   * analog_loop (AnalogIn, AnalogOut):
       * Arduino headers: (A0 <-> A5)
+      * NUCLEO64: (A0 <-> A2)
+      * NUCLEO144: (A0 <-> D13)
       * LPC1549: (A0 <-> D12)
       * LPC1*: (p17   <-> p18 )
       * KL25Z: (PTE30 <-> PTC2)
@@ -187,12 +189,6 @@ TESTS = [
         "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB],
         "automated": True,
         "peripherals": ["analog_loop"],
-        "mcu": ["LPC1768", "LPC2368", "LPC2460", "KL25Z", "K64F", "K66F", "K22F", "LPC4088", "LPC1549",
-                "NUCLEO_F072RB", "NUCLEO_F091RC", "NUCLEO_F302R8", "NUCLEO_F303K8", "NUCLEO_F303RE", "NUCLEO_F207ZG",
-                "NUCLEO_F334R8", "NUCLEO_F303ZE", "NUCLEO_L053R8", "NUCLEO_L073RZ", "NUCLEO_L152RE",
-                "NUCLEO_F410RB", "NUCLEO_F411RE", "NUCLEO_F446RE", "NUCLEO_F446ZE",
-                "DISCO_F407VG", "DISCO_F746NG", "NUCLEO_F746ZG",
-                "ARCH_MAX", "MAX32600MBED", "MOTE_L152RC", "B96B_F446VE"]
     },
     {
         "id": "MBED_A9", "description": "Serial Echo at 115200",


### PR DESCRIPTION
## Description
Make analog_loop OS2 tests available for all STM32 targets

## Status
READY

Tests OK
