### PR TITLE
add ncs36510 exporter support for IAR

### DIFF
--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/swversion.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/swversion.c
@@ -7,11 +7,11 @@
 * $Rev: 2199 $
 * $Date: 2013-08-07 12:17:27 +0200 (Wed, 07 Aug 2013) $
 ******************************************************************************
- * Copyright 2016 Semiconductor Components Industries LLC (d/b/a “ON Semiconductor”).
+ * Copyright 2016 Semiconductor Components Industries LLC (d/b/a "ON Semiconductor").
  * All rights reserved.  This software and/or documentation is licensed by ON Semiconductor
  * under limited terms and conditions.  The terms and conditions pertaining to the software
  * and/or documentation are available at http://www.onsemi.com/site/pdf/ONSEMI_T&C.pdf
- * (“ON Semiconductor Standard Terms and Conditions of Sale, Section 8 Software”) and
+ * ("ON Semiconductor Standard Terms and Conditions of Sale, Section 8 Software") and
  * if applicable the software license agreement.  Do not use this software and/or
  * documentation unless you have carefully read and you agree to the limited terms and
  * conditions.  By using this software and/or documentation, you agree to the limited
@@ -37,7 +37,7 @@
 *                                                                                                *
 *************************************************************************************************/
 
-#ifdef IAR
+#ifdef __ICCARM__
 /** Define a fib table constant region, to be located at fixed offset in the binary
  * such that flash loader knows where to find it and gets the build dependent data
  * it needs for programming the new fib.

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2093,7 +2093,7 @@
         "core": "Cortex-M3",
         "extra_labels": ["ONSEMI"],
         "post_binary_hook": {"function": "NCS36510TargetCode.ncs36510_addfib"},
-        "macros": ["REVD", "CM3", "CPU_NCS36510", "TARGET_NCS36510"],
+        "macros": ["REVD", "CM3", "CPU_NCS36510", "TARGET_NCS36510", "LOAD_ADDRESS=0x3000"],
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
         "device_has": ["ANALOGIN", "SERIAL", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "LOWPOWERTIMER"],
         "device_name": "NCS36510",

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2096,6 +2096,7 @@
         "macros": ["REVD", "CM3", "CPU_NCS36510", "TARGET_NCS36510"],
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
         "device_has": ["ANALOGIN", "SERIAL", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "LOWPOWERTIMER"],
+        "device_name": "NCS36510",
         "release_versions": ["2", "5"]
     },
     "NUMAKER_PFM_M453": {

--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -149,5 +149,8 @@
     },
     "nRF52832_xxAA":{
         "OGChipSelectEditMenu": "nRF52832-xxAA\tNordicSemi nRF52832-xxAA"
+    },
+    "NCS36510":{
+        "OGChipSelectEditMenu": "Orion\tON Semiconductor NCS36510"
     }
 }


### PR DESCRIPTION
This fixes issue:
https://github.com/ARMmbed/mbed-os/issues/3025

## Description
add ncs36510 exporter support for IAR

## Status
it exports successfully and builds in IAR.


## Migrations
 NO


## Related PRs
n/a

branch | PR
------ | ------
n/a

## Todos
n/a

## Deploy notes

NCS36510 requires extra settings in IAR to add a few macros and the post build script stuff.  I am working with ON Semi to get the steps added to their platform page.  contact me for details.

## Steps to test or reproduce
mbed export -m NCS36510 -i IAR


