### PR TITLE
Corrected lwip TCP socket accept ipv6 address conversion

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -698,8 +698,9 @@ static int mbed_lwip_socket_accept(nsapi_stack_t *stack, nsapi_socket_t server, 
     netconn_set_recvtimeout(ns->conn, 1);
     *(struct lwip_socket **)handle = ns;
 
-    (void) netconn_peer(ns->conn, (ip_addr_t *)addr->bytes, port);
-    addr->version = NSAPI_IPv4;
+    ip_addr_t peer_addr;
+    (void) netconn_peer(ns->conn, &peer_addr, port);
+    convert_lwip_addr_to_mbed(addr, &peer_addr);
 
     return 0;
 }


### PR DESCRIPTION
## Description
Corrected lwip TCP socket accept to correctly convert remote ipv6 address to nsapi ipv6 address.


## Status
READY


## Migrations
NO


## Related PRs
None


## Todos
- [ ] Tests
- [ ] Documentation


## Deploy notes
None


## Steps to test or reproduce
None
