### PR TITLE
Remove k64f defines from IAR templates

### DIFF
--- a/tools/export/iar/ewp.tmpl
+++ b/tools/export/iar/ewp.tmpl
@@ -171,14 +171,7 @@
 				</option>
 				<option>
 					<name>CCDefines</name>
-					<state>TARGET_K64F</state>
-					<state>TARGET_M4</state>
-					<state>TARGET_Freescale</state>
-					<state>__CORTEX_M4</state>
-					<state>ARM_MATH_CM4</state>
-					<state>__MBED__=1</state>
-					<state>CPU_MK64FN1M0VMD12</state>
-					<state>FSL_RTOS_MBED</state>
+					<state></state>
 				</option>
 				<option>
 					<name>CCPreprocFile</name>


### PR DESCRIPTION
## Description
Remove K64F macros from IAR template.  This was an oversight missed after copying progen's template file https://github.com/project-generator/project_generator/blob/master/project_generator/templates/iar.ewp#L173. 

Fixes https://github.com/ARMmbed/mbed-os/issues/3026


## Status
**READY**
