### PR TITLE
[Tools] Adding Target and Toolchain definitions to assembly commands.

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -413,7 +413,10 @@ class mbedToolchain:
     def get_symbols(self, for_asm=False):
         if for_asm:
             if self.asm_symbols is None:
-                self.asm_symbols = []
+                # Target and Toolchain symbols
+                labels = self.get_labels()
+                self.asm_symbols = ["TARGET_%s" % t for t in labels['TARGET']]
+                self.asm_symbols.extend(["TOOLCHAIN_%s" % t for t in labels['TOOLCHAIN']])
 
                 # Cortex CPU symbols
                 if self.target.core in mbedToolchain.CORTEX_SYMBOLS:


### PR DESCRIPTION
## Description
Adding TARGET and TOOLCHAIN definitions to the build rules for assembly files.

## Status
READY

## Migrations
NO

## Related PRs
None

## Todos
None

## Deploy notes
None

## Steps to test or reproduce
This issue arose when building the following assembly file. In order to keep the correct syntax for the different compilers, the assembly file uses different macros depending on the defined assembler. 

https://developer.mbed.org/teams/Maxim-Integrated/code/OneWire/file/1635f247ceae/OneWire_Masters/GPIO/owlink.s
