### PR TITLE
Exporters - Name the eclipse exporters and remove relpath computations

### DIFF
--- a/tools/export/cdt/__init__.py
+++ b/tools/export/cdt/__init__.py
@@ -41,11 +41,14 @@ class Eclipse(Makefile):
 
 class EclipseGcc(Eclipse, GccArm):
     LOAD_EXE = True
+    NAME = "Eclipse-GCC-ARM"
 
 class EclipseArmc5(Eclipse, Armc5):
     LOAD_EXE = False
+    NAME = "Eclipse-Armc5"
 
 class EclipseIAR(Eclipse, IAR):
     LOAD_EXE = True
+    NAME = "Eclipse-IAR"
 
 

--- a/tools/export/cdt/__init__.py
+++ b/tools/export/cdt/__init__.py
@@ -31,12 +31,8 @@ class Eclipse(Makefile):
         self.gen_file('cdt/necessary_software.tmpl', ctx,
                       join('eclipse-extras','necessary_software.p2f'))
 
-        cproj = relpath('.cproject',self.export_dir)
-        self.gen_file('cdt/.cproject.tmpl', ctx,
-                      cproj)
-        proj = relpath('.project',self.export_dir)
-        self.gen_file('cdt/.project.tmpl', ctx,
-                      proj)
+        self.gen_file('cdt/.cproject.tmpl', ctx, '.cproject')
+        self.gen_file('cdt/.project.tmpl', ctx, '.project')
 
 
 class EclipseGcc(Eclipse, GccArm):


### PR DESCRIPTION
## Description
Give a name to the Eclipse exporters that differs from the Make exporters.
Further, remove an pair extraneous relpath computations.


## Status
**READY**
**REQUIRED FOR ONLINE COMPILER**


## Migrations
None

## Todos
- [x] Review by @sarahmarshy 
- [x] Review by @screamerbg 
