### PR TITLE
Fixed the emac_interface_t struct for wifi_emac_api.cpp

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/sdk/wifi_emac/wifi_emac_api.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/sdk/wifi_emac/wifi_emac_api.cpp
@@ -69,7 +69,7 @@ const emac_interface_ops_t wifi_emac_interface = {
     .set_link_state_cb = wifi_set_link_state_cb
 };
 
-static emac_interface_t _intf = { wifi_emac_interface, NULL };
+static emac_interface_t* _intf = NULL;
 
 static const cbWLANTARGET_Callback _wlanTargetCallback =
 {
@@ -318,7 +318,12 @@ static void wifi_set_link_state_cb(emac_interface_t *emac, emac_link_state_chang
 
 emac_interface_t* wifi_emac_get_interface()
 {
-    return &_intf;
+    if (_intf == NULL) {
+        _intf = new emac_interface_t();
+        _intf->hw = NULL;
+        memcpy((void*)&_intf->ops, &wifi_emac_interface, sizeof(wifi_emac_interface));
+    }
+   return _intf;
 }
 
 void wifi_emac_init_mem(void)


### PR DESCRIPTION
## Description
Fixed the emac_interface_t struct so that the struct constructor is not used.
We can not rely on the struct constructor to be run since wifi_emac_get_interface can be run from the OdinWiFiInterface constructor before that.

## Status
Only one basic test have been done for this i.e. verified that the application run as expected for GCC_ARM:
https://github.com/ARMmbed/oob-mbed-os-example-wifi

## Migrations
NO

## Related PRs
https://github.com/ARMmbed/oob-mbed-os-example-wifi/issues/10

## Todos
- [ ] Tests
- [ ] Documentation


## Deploy notes

## Steps to test or reproduce
