### PR TITLE
[exporters] Fix traceback in SW4STM32 from incorrect use of core

### DIFF
--- a/tools/export/sw4stm32.py
+++ b/tools/export/sw4stm32.py
@@ -79,7 +79,7 @@ class Sw4STM32(Exporter):
     def generate(self):
         fp_hardware = "no"
         fp_abi = "soft"
-        core = self.target.core
+        core = self.toolchain.target.core
         if core == "Cortex-M4F" or core == "Cortex-M7F":
             fp_hardware = "fpv4-sp-d16"
             fp_abi = "soft-fp"


### PR DESCRIPTION
## Description
SW4STM32 exporter used to traceback. Now it does not.

## Status
**READY**

## Reviews
- [ ] @screamerbg 
- [x] @0xc0170 
- [ ] @sarahmarshy 
- [ ] @adustm (original reporter)
