### PR TITLE
[Exporters] Use correct names for library files in makefile exporter

### DIFF
--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -53,8 +53,8 @@ PROJECT := {{name}}
 {% endfor %}
 {% for path in include_paths %}INCLUDE_PATHS += -I{{path}}
 {% endfor %}
-LIBRARY_PATHS :={% for p in library_paths %} -L{{p}} {% endfor %}
-LIBRARIES :={% for lib in libraries %} -l{{lib}} {% endfor %}
+LIBRARY_PATHS :={% for p in library_paths %} {{user_library_flag}}{{p}} {% endfor %}
+LIBRARIES :={% for lib in libraries %} {{lib}} {% endfor %}
 LINKER_SCRIPT := {{linker_script}}
 {%- block additional_variables -%}{% endblock %}
 

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -44,7 +44,8 @@ class Makefile(Exporter):
                           self.resources.c_sources +
                           self.resources.cpp_sources]
 
-        libraries = [splitext(lib)[0][3:] for lib in self.resources.libraries]
+        libraries = [splitext(basename(lib))[0][3:] for lib
+                     in self.resources.libraries]
 
         ctx = {
             'name': self.project_name,

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -44,7 +44,7 @@ class Makefile(Exporter):
                           self.resources.c_sources +
                           self.resources.cpp_sources]
 
-        libraries = [splitext(basename(lib))[0][3:] for lib
+        libraries = [self.prepare_lib(basename(lib)) for lib
                      in self.resources.libraries]
 
         ctx = {
@@ -71,6 +71,7 @@ class Makefile(Exporter):
             'elf2bin_cmd': "\'" + self.toolchain.elf2bin + "\'",
             'link_script_ext': self.toolchain.LINKER_EXT,
             'link_script_option': self.LINK_SCRIPT_OPTION,
+            'user_library_flag': self.USER_LIBRARY_FLAG,
         }
 
         for key in ['include_paths', 'library_paths', 'linker_script',
@@ -109,6 +110,11 @@ class GccArm(Makefile):
     NAME = 'Make-GCC-ARM'
     TOOLCHAIN = "GCC_ARM"
     LINK_SCRIPT_OPTION = "-T"
+    USER_LIBRARY_FLAG = "-L"
+
+    @staticmethod
+    def prepare_lib(libname):
+        return "-l:" + libname
 
 
 class Armc5(Makefile):
@@ -118,6 +124,11 @@ class Armc5(Makefile):
     NAME = 'Make-ARMc5'
     TOOLCHAIN = "ARM"
     LINK_SCRIPT_OPTION = "--scatter"
+    USER_LIBRARY_FLAG = "--userlibpath "
+
+    @staticmethod
+    def prepare_lib(libname):
+        return libname
 
 
 class IAR(Makefile):
@@ -127,3 +138,10 @@ class IAR(Makefile):
     NAME = 'Make-IAR'
     TOOLCHAIN = "IAR"
     LINK_SCRIPT_OPTION = "--config"
+    USER_LIBRARY_FLAG = "-L"
+
+    @staticmethod
+    def prepare_lib(libname):
+        if "lib" == libname[:3]:
+            libname = libname[3:]
+        return "-l" + splitext(libname)[0]


### PR DESCRIPTION
## Description
In an unlikely corner-case, the make exporter would generate a bad name for a library. This should fix that incorrect naming.


## Status
**READY**

## Reviews
- [x] @screamerbg 
- [x] @sarahmarshy 
- [x] @0xc0170 
- [x] @toyowata (original reporter)

Resolves https://github.com/ARMmbed/oob-mbed-os-example-blinky/issues/20