### PR TITLE
[Exporters] Add quick print to the makefile when srec_cat is required

### DIFF
--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -133,6 +133,7 @@ $(PROJECT).hex: $(PROJECT).elf
 
 {% if hex_files %}
 $(PROJECT)-combined.hex: $(PROJECT).hex
+	+@echo "NOTE: the $(SREC_CAT) binary is required to be present in your PATH. Please see http://srecord.sourceforge.net/ for more information."
 	$(SREC_CAT) {% for f in hex_files %}{{f}} {% endfor %} -intel $(PROJECT).hex -intel -o $(PROJECT)-combined.hex -intel --line-length=44
 {% endif %}
 # Rules


### PR DESCRIPTION
## Description
It just tells the user that they need srec_cat to build when they need it.


## Status
**READY**

## Reviews
- [x] @screamerbg 
- [x] @0xc0170 
- [x] @sarahmarshy 
- [x] @bridadan (suggester)
- [x] @pan- (original reporter)
