### PR TITLE
NUCLEO_F429 - Increase IAR heap size

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_F429_F439/device/TOOLCHAIN_IAR/stm32f429xx_flash.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_F429_F439/device/TOOLCHAIN_IAR/stm32f429xx_flash.icf
@@ -13,9 +13,9 @@ define symbol __ICFEDIT_region_RAM_end__      = 0x2002FFFF;
 define symbol __ICFEDIT_region_CCMRAM_start__ = 0x10000000;
 define symbol __ICFEDIT_region_CCMRAM_end__   = 0x1000FFFF;
 /*-Sizes-*/
-/*Heap 1/4 of ram and stack 1/8*/
+/*Heap 1/3 of ram and stack 1/8*/
 define symbol __ICFEDIT_size_cstack__ = 0x6000;
-define symbol __ICFEDIT_size_heap__   = 0xC000;
+define symbol __ICFEDIT_size_heap__   = 0x10000;
 /**** End of ICF editor section. ###ICF###*/
 
 


### PR DESCRIPTION
Increase the IAR heap size from 48KiB to 64KiB. This give enough heap space to run the TLS encryption examples.