### PR TITLE
nsapi - Remove assertions on same-thread send/recv

### DIFF
--- a/features/netsocket/UDPSocket.cpp
+++ b/features/netsocket/UDPSocket.cpp
@@ -19,8 +19,7 @@
 #include "mbed_assert.h"
 
 UDPSocket::UDPSocket()
-    : _pending(0), _read_sem(0), _write_sem(0),
-      _read_in_progress(false), _write_in_progress(false)
+    : _pending(0), _read_sem(0), _write_sem(0)
 {
 }
 
@@ -53,12 +52,6 @@ int UDPSocket::sendto(const SocketAddress &address, const void *data, unsigned s
     _lock.lock();
     int ret;
 
-    // If this assert is hit then there are two threads
-    // performing a send at the same time which is undefined
-    // behavior
-    MBED_ASSERT(!_write_in_progress);
-    _write_in_progress = true;
-
     while (true) {
         if (!_socket) {
             ret = NSAPI_ERROR_NO_SOCKET;
@@ -87,7 +80,6 @@ int UDPSocket::sendto(const SocketAddress &address, const void *data, unsigned s
         }
     }
 
-    _write_in_progress = false;
     _lock.unlock();
     return ret;
 }
@@ -96,12 +88,6 @@ int UDPSocket::recvfrom(SocketAddress *address, void *buffer, unsigned size)
 {
     _lock.lock();
     int ret;
-
-    // If this assert is hit then there are two threads
-    // performing a recv at the same time which is undefined
-    // behavior
-    MBED_ASSERT(!_read_in_progress);
-    _read_in_progress = true;
 
     while (true) {
         if (!_socket) {
@@ -131,7 +117,6 @@ int UDPSocket::recvfrom(SocketAddress *address, void *buffer, unsigned size)
         }
     }
 
-    _read_in_progress = false;
     _lock.unlock();
     return ret;
 }

--- a/features/netsocket/UDPSocket.h
+++ b/features/netsocket/UDPSocket.h
@@ -45,8 +45,7 @@ public:
      */
     template <typename S>
     UDPSocket(S *stack)
-        : _pending(0), _read_sem(0), _write_sem(0),
-          _read_in_progress(false), _write_in_progress(false)
+        : _pending(0), _read_sem(0), _write_sem(0)
     {
         open(stack);
     }
@@ -117,8 +116,6 @@ protected:
     volatile unsigned _pending;
     rtos::Semaphore _read_sem;
     rtos::Semaphore _write_sem;
-    bool _read_in_progress;
-    bool _write_in_progress;
 };
 
 


### PR DESCRIPTION
Remove assertions on same-thread send/recv

Initially these assertions were added to protected simultaneous send/recv from the same socket when similarly purposed mutexes were removed.

However, simultaneous send/recv can still be useful if the payload is garunteed to be less than the MTU accross the entire connection. A good example is an application that sends small 4-byte updates from
multiple threads/interrupts but uses TCP to handle packet-loss and keep-alive.

related conversation https://github.com/ARMmbed/mbed-os/issues/3058
cc @c1728p9, @kjbracey-arm, @EduardPon
