### PR TITLE
NCS36510 - decrease IAR heap size to make room

### DIFF
--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_IAR/NCS36510.icf
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_IAR/NCS36510.icf
@@ -15,7 +15,7 @@ define region RAM_ALL = Mem:[from 0x3FFF4000 size 0xC000];
 define block CSTACK with size = 0x200, alignment = 8 { };
 
 /* No Heap is created for C library, all memory management should be handled by the application */
- define block HEAP with alignment = 8, size = 0x4000    { }; 
+ define block HEAP with alignment = 8, size = 0x2000    { }; 
 
 /* Handle initialization */
 do not initialize { section .noinit };


### PR DESCRIPTION
Decrease the heap size from 16KiB to 8KiB to make room for more RW and ZI data. This frees up enough space to allow the mesh minimal example to work on IAR.

@pradeep-gr, @radhika-raghavendran