### PR TITLE
Error if Nanostack is used without entropy 

### DIFF
--- a/features/nanostack/FEATURE_NANOSTACK/nanostack_entropy_check.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/nanostack_entropy_check.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2015 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbedtls/platform.h"
+
+#if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT) && !defined(MBEDTLS_TEST_NULL_ENTROPY)
+#error "Nanostack requires an entropy source to compile."
+#endif


### PR DESCRIPTION
Switch out the coap code that depends on TLS if there is no entropy source present. This allow configurations of Nanostack which don't use security to work without an entropy source.
