### PR TITLE
i2c_loop tests update for STM32

### DIFF
--- a/features/unsupported/tests/mbed/i2c_master_slave/main.cpp
+++ b/features/unsupported/tests/mbed/i2c_master_slave/main.cpp
@@ -2,29 +2,79 @@
 #include "test_env.h"
 #include <stdio.h>
 
+#if !DEVICE_I2C
+  #error [NOT_SUPPORTED] I2C is not supported
+#endif
+
+#if !DEVICE_I2CSLAVE
+  #error [NOT_SUPPORTED] I2C Slave is not supported
+#endif
+
+#if defined(TARGET_NUCLEO_F031K6) || \
+    defined (TARGET_NUCLEO_L011K4) || \
+    defined (TARGET_NUCLEO_L031K6) || \
+    defined (TARGET_DISCO_F746NG) || \
+    defined (TARGET_DISCO_L476VG) || \
+    defined (TARGET_NUCLEO_F303K8) || \
+    defined (TARGET_NUCLEO_F334R8) || \
+    defined (TARGET_DISCO_F334C8) || \
+    defined (TARGET_NUCLEO_F042K6)
+  #error [NOT_SUPPORTED] Target has only one I2C instance
+#endif
+
 #define ADDR (0xA0)
 #define FREQ 100000
 
 // ********************************************************
 // This tests data transfer between two I2C interfaces on
 // the same chip, one configured as master, the other as
-// slave. Works on:
+// slave.
 //
-// *LPC1768 mbed
-//   p28 <-> p9
-//   p27 <-> p10
-//   pull-up resistors on both lines
-// *STM32F4 boards
-//   cf below for wiring
-//
+// Wiring: connect master SCL to slave SCL, and master SDA to slave SDA
 // ********************************************************
 
-#if defined(TARGET_NUCLEO_F411RE) || defined (TARGET_NUCLEO_F446RE) || defined (TARGET_NUCLEO_F410RB) || defined (TARGET_NUCLEO_F401RE)
-I2C master(PB_9, PB_8); // I2C_1 (Arduino: D14/D15)
-I2CSlave slave(PB_3, PB_10); // I2C_2 (Arduino: D3/D6)
-#elif defined (TARGET_NUCLEO_F429ZI) || defined (TARGET_DISCO_F429ZI) || defined (TARGET_NUCLEO_F446ZE)
-I2C master(PB_9, PB_8); // I2C_1 (Arduino: D14/D15)
-I2CSlave slave(PB_11, PB_10); // I2C_2
+#if defined (TARGET_DISCO_F429ZI) || \
+    defined (TARGET_DISCO_L053C8)
+I2C master(PB_9, PB_8);
+
+#elif defined(TARGET_FF_ARDUINO)
+I2C master(D14, D15); // I2C_SDA, I2C_SCL
+#endif
+
+
+#if defined (TARGET_NUCLEO_F429ZI) || \
+    defined (TARGET_NUCLEO_F767ZI) || \
+    defined (TARGET_NUCLEO_L053R8) || \
+    defined (TARGET_NUCLEO_L073RZ) || \
+    defined (TARGET_NUCLEO_L152RE) || \
+    defined (TARGET_NUCLEO_L476RG) || \
+    defined (TARGET_NUCLEO_F207ZG) || \
+    defined (TARGET_NUCLEO_F103RB) || \
+    defined (TARGET_NUCLEO_F091RC) || \
+    defined (TARGET_DISCO_F429ZI) || \
+    defined (TARGET_DISCO_F469NI) || \
+    defined (TARGET_DISCO_L053C8) || \
+    defined (TARGET_NUCLEO_F446ZE)
+I2CSlave slave(PB_11, PB_10);
+
+#elif defined (TARGET_NUCLEO_F303RE) || \
+    defined (TARGET_NUCLEO_F302R8)
+I2CSlave slave(D2, D8);
+
+#elif defined (TARGET_NUCLEO_F303ZE)
+I2CSlave slave(PC_9, PA_8);
+
+#elif defined (TARGET_NUCLEO_F746ZG)
+I2CSlave slave(D2, D4);
+
+#elif defined (TARGET_NUCLEO_F030R8) || \
+    defined (TARGET_NUCLEO_F070RB) || \
+    defined (TARGET_NUCLEO_F072RB)
+I2CSlave slave(PB_11, D6);
+
+#else
+I2CSlave slave(D3, D6);
+
 #endif
 
 int main()

--- a/features/unsupported/tests/mbed/i2c_master_slave_asynch/main.cpp
+++ b/features/unsupported/tests/mbed/i2c_master_slave_asynch/main.cpp
@@ -2,6 +2,18 @@
 #include "test_env.h"
 #include <stdio.h>
 
+#if !DEVICE_I2C
+  #error [NOT_SUPPORTED] I2C is not supported
+#endif
+
+#if !DEVICE_I2CSLAVE
+  #error [NOT_SUPPORTED] I2C Slave is not supported
+#endif
+
+#if !DEVICE_I2C_ASYNCH
+  #error [NOT_SUPPORTED] I2C Async is not supported
+#endif
+
 #define ADDR (0x90)
 #define FREQ 100000
 #define SIZE 10
@@ -11,15 +23,23 @@
 // the same chip, one configured as master, the other as
 // slave.
 //
-// Wiring: cf below
+// Wiring: connect master SCL to slave SCL, and master SDA to slave SDA
 // ********************************************************
 
-#if defined (TARGET_NUCLEO_F411RE) || defined (TARGET_NUCLEO_F446RE) || defined (TARGET_NUCLEO_F410RB)  || defined (TARGET_NUCLEO_F401RE)
-I2C master(PB_9, PB_8); // I2C_1 (Arduino: D14/D15)
-I2CSlave slave(PB_3, PB_10); // I2C_2 (Arduino: D3/D6)
-#elif defined (TARGET_NUCLEO_F429ZI) || defined (TARGET_DISCO_F429ZI) || defined (TARGET_NUCLEO_F446ZE)
-I2C master(PB_9, PB_8); // I2C_1 (Arduino: D14/D15)
-I2CSlave slave(PB_11, PB_10); // I2C_2 
+#if defined (TARGET_DISCO_F429ZI)
+I2C master(PB_9, PB_8);
+#elif defined(TARGET_FF_ARDUINO)
+I2C master(D14, D15); // I2C_SDA, I2C_SCL
+#endif
+
+#if defined (TARGET_NUCLEO_F429ZI) || \
+    defined (TARGET_DISCO_F429ZI) || \
+    defined (TARGET_NUCLEO_F446ZE)
+I2CSlave slave(PB_11, PB_10);
+
+#else
+I2CSlave slave(D3, D6);
+
 #endif
 
 volatile int why;

--- a/tools/tests.py
+++ b/tools/tests.py
@@ -87,13 +87,8 @@ Wiring:
 
   * i2c_loop:
       * LPC1768: (p28 <-> p9), (p27 <-> p10)
-      * NUCLEO_F401RE: (PB_9 <-> PB_3), (PB_8 <-> PB_10)
-      * NUCLEO_F410RB: (PB_9 <-> PB_3), (PB_8 <-> PB_10)
-      * NUCLEO_F411RE: (PB_9 <-> PB_3), (PB_8 <-> PB_10)
-      * NUCLEO_F446RE: (PB_9 <-> PB_3), (PB_8 <-> PB_10)
-      * NUCLEO_F429ZI: (PB_9 <-> PB_11), (PB_8 <-> PB_10)
-      * NUCLEO_F446ZE: (PB_9 <-> PB_11), (PB_8 <-> PB_10)
-      * DISCO_F429ZI: (PB_9 <-> PB_11), (PB_8 <-> PB_10)
+      * NUCLEO64: (D14 <-> D3), (D15 <-> D6)
+      * NUCLEO144: (D14 <-> PB_11), (D15 <-> PB_10)
 
   * i2c_eeprom:
       * LPC1*: (SDA=p28 , SCL=p27)
@@ -271,7 +266,7 @@ TESTS = [
         "id": "MBED_A20", "description": "I2C master/slave test",
         "source_dir": join(TEST_DIR, "mbed", "i2c_master_slave"),
         "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB,],
-        "mcu": ["LPC1768", "RZ_A1H", "NUCLEO_F411RE", "NUCLEO_F446RE", "NUCLEO_F429ZI", "DISCO_F429ZI", "NUCLEO_F446ZE",  "NUCLEO_F410RB", "NUCLEO_F401RE"],
+        "automated": True,
         "peripherals": ["i2c_loop"]
     },
     {
@@ -352,7 +347,6 @@ TESTS = [
         "id": "MBED_A29", "description": "i2c_master_slave_asynch",
         "source_dir": join(TEST_DIR, "mbed", "i2c_master_slave_asynch"),
         "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB],
-        "mcu": ["NUCLEO_F411RE", "NUCLEO_F446RE", "NUCLEO_F429ZI", "DISCO_F429ZI", "NUCLEO_F446ZE",  "NUCLEO_F410RB", "NUCLEO_F401RE"],
         "automated": True,
         "peripherals": ["i2c_loop"]
     },


### PR DESCRIPTION
## Description

Make i2c_loop OS2 tests available for all STM32 targets

Note that I could remove mcu list in the tests.py file as other boards than STM32 one were not defined in the test main.cpp file...
## Status

READY

Our test bench is already connected with that configuration
Tests have been done with all STM32 families
