### PR TITLE
Target stm init gcc alignement

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/device/TOOLCHAIN_GCC_ARM/startup_stm32f051x8.S
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/device/TOOLCHAIN_GCC_ARM/startup_stm32f051x8.S
@@ -55,10 +55,6 @@ defined in linker script */
 .word _sdata
 /* end address for the .data section. defined in linker script */
 .word _edata
-/* start address for the .bss section. defined in linker script */
-.word _sbss
-/* end address for the .bss section. defined in linker script */
-.word _ebss
 
   .section .text.Reset_Handler
   .weak Reset_Handler
@@ -83,19 +79,6 @@ LoopCopyDataInit:
   adds r2, r0, r1
   cmp r2, r3
   bcc CopyDataInit
-  ldr r2, =_sbss
-  b LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs r3, #0
-  str  r3, [r2]
-  adds r2, r2, #4
-
-
-LoopFillZerobss:
-  ldr r3, = _ebss
-  cmp r2, r3
-  bcc FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/device/TOOLCHAIN_GCC_ARM/startup_stm32f051x8.S
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/device/TOOLCHAIN_GCC_ARM/startup_stm32f051x8.S
@@ -99,11 +99,14 @@ LoopFillZerobss:
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit
-/* Call static constructors */
-  bl __libc_init_array
-/* Call the application's entry point.*/
-  bl main
-  bl exit
+
+/**
+ * Calling the crt0 'cold-start' entry point. There __libc_init_array is called
+ * and when existing hardware_init_hook() and software_init_hook() before 
+ * starting main(). software_init_hook() is available and has to be called due 
+ * to initializsation when using rtos.
+*/
+  bl _start
 LoopForever:
     b LoopForever
 

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/TOOLCHAIN_GCC_ARM/startup_stm32f030x8.S
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/TOOLCHAIN_GCC_ARM/startup_stm32f030x8.S
@@ -55,10 +55,6 @@ defined in linker script */
 .word _sdata
 /* end address for the .data section. defined in linker script */
 .word _edata
-/* start address for the .bss section. defined in linker script */
-.word _sbss
-/* end address for the .bss section. defined in linker script */
-.word _ebss
 
   .section .text.Reset_Handler
   .weak Reset_Handler
@@ -83,19 +79,6 @@ LoopCopyDataInit:
   adds r2, r0, r1
   cmp r2, r3
   bcc CopyDataInit
-  ldr r2, =_sbss
-  b LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs r3, #0
-  str  r3, [r2]
-  adds r2, r2, #4
-
-
-LoopFillZerobss:
-  ldr r3, = _ebss
-  cmp r2, r3
-  bcc FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/TOOLCHAIN_GCC_ARM/startup_stm32f030x8.S
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/TOOLCHAIN_GCC_ARM/startup_stm32f030x8.S
@@ -99,8 +99,7 @@ LoopFillZerobss:
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit
-/* Call static constructors */
-  bl __libc_init_array
+
 /* Call the application's entry point.*/
 //  bl main
   bl _start

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/device/TOOLCHAIN_GCC_ARM/startup_stm32f031x6.s
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/device/TOOLCHAIN_GCC_ARM/startup_stm32f031x6.s
@@ -55,10 +55,6 @@ defined in linker script */
 .word _sdata
 /* end address for the .data section. defined in linker script */
 .word _edata
-/* start address for the .bss section. defined in linker script */
-.word _sbss
-/* end address for the .bss section. defined in linker script */
-.word _ebss
 
   .section .text.Reset_Handler
   .weak Reset_Handler
@@ -83,19 +79,6 @@ LoopCopyDataInit:
   adds r2, r0, r1
   cmp r2, r3
   bcc CopyDataInit
-  ldr r2, =_sbss
-  b LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs r3, #0
-  str  r3, [r2]
-  adds r2, r2, #4
-
-
-LoopFillZerobss:
-  ldr r3, = _ebss
-  cmp r2, r3
-  bcc FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/device/TOOLCHAIN_GCC_ARM/startup_stm32f031x6.s
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/device/TOOLCHAIN_GCC_ARM/startup_stm32f031x6.s
@@ -99,8 +99,7 @@ LoopFillZerobss:
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit
-/* Call static constructors */
-  bl __libc_init_array
+
 /* Call the application's entry point.*/
 //  bl main
   bl _start

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/device/TOOLCHAIN_GCC_ARM/startup_stm32f042x6.s
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/device/TOOLCHAIN_GCC_ARM/startup_stm32f042x6.s
@@ -131,8 +131,7 @@ LoopFillZerobss:
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit
-/* Call static constructors */
-  bl __libc_init_array
+
 /* Call the application's entry point.*/
 //  bl main
   bl _start

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/device/TOOLCHAIN_GCC_ARM/startup_stm32f042x6.s
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/device/TOOLCHAIN_GCC_ARM/startup_stm32f042x6.s
@@ -55,10 +55,6 @@ defined in linker script */
 .word _sdata
 /* end address for the .data section. defined in linker script */
 .word _edata
-/* start address for the .bss section. defined in linker script */
-.word _sbss
-/* end address for the .bss section. defined in linker script */
-.word _ebss
 
 /**
  * @brief  This is the code that gets called when the processor first
@@ -115,19 +111,6 @@ LoopCopyDataInit:
   adds r2, r0, r1
   cmp r2, r3
   bcc CopyDataInit
-  ldr r2, =_sbss
-  b LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs r3, #0
-  str  r3, [r2]
-  adds r2, r2, #4
-
-
-LoopFillZerobss:
-  ldr r3, = _ebss
-  cmp r2, r3
-  bcc FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_GCC_ARM/startup_stm32f070xb.S
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_GCC_ARM/startup_stm32f070xb.S
@@ -99,8 +99,7 @@ LoopFillZerobss:
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit
-/* Call static constructors */
-  bl __libc_init_array
+
 /* Call the application's entry point.*/
 //  bl main
   bl _start

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_GCC_ARM/startup_stm32f070xb.S
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_GCC_ARM/startup_stm32f070xb.S
@@ -55,10 +55,7 @@ defined in linker script */
 .word _sdata
 /* end address for the .data section. defined in linker script */
 .word _edata
-/* start address for the .bss section. defined in linker script */
-.word _sbss
-/* end address for the .bss section. defined in linker script */
-.word _ebss
+
 
   .section .text.Reset_Handler
   .weak Reset_Handler
@@ -83,19 +80,6 @@ LoopCopyDataInit:
   adds r2, r0, r1
   cmp r2, r3
   bcc CopyDataInit
-  ldr r2, =_sbss
-  b LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs r3, #0
-  str  r3, [r2]
-  adds r2, r2, #4
-
-
-LoopFillZerobss:
-  ldr r3, = _ebss
-  cmp r2, r3
-  bcc FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/TOOLCHAIN_GCC_ARM/startup_stm32f072xb.S
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/TOOLCHAIN_GCC_ARM/startup_stm32f072xb.S
@@ -55,10 +55,6 @@ defined in linker script */
 .word _sdata
 /* end address for the .data section. defined in linker script */
 .word _edata
-/* start address for the .bss section. defined in linker script */
-.word _sbss
-/* end address for the .bss section. defined in linker script */
-.word _ebss
 
   .section .text.Reset_Handler
   .weak Reset_Handler
@@ -83,19 +79,6 @@ LoopCopyDataInit:
   adds r2, r0, r1
   cmp r2, r3
   bcc CopyDataInit
-  ldr r2, =_sbss
-  b LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs r3, #0
-  str  r3, [r2]
-  adds r2, r2, #4
-
-
-LoopFillZerobss:
-  ldr r3, = _ebss
-  cmp r2, r3
-  bcc FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/device/TOOLCHAIN_GCC_ARM/startup_stm32f091xc.S
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/device/TOOLCHAIN_GCC_ARM/startup_stm32f091xc.S
@@ -55,10 +55,6 @@ defined in linker script */
 .word _sdata
 /* end address for the .data section. defined in linker script */
 .word _edata
-/* start address for the .bss section. defined in linker script */
-.word _sbss
-/* end address for the .bss section. defined in linker script */
-.word _ebss
 
   .section .text.Reset_Handler
   .weak Reset_Handler
@@ -83,19 +79,6 @@ LoopCopyDataInit:
   adds r2, r0, r1
   cmp r2, r3
   bcc CopyDataInit
-  ldr r2, =_sbss
-  b LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs r3, #0
-  str  r3, [r2]
-  adds r2, r2, #4
-
-
-LoopFillZerobss:
-  ldr r3, = _ebss
-  cmp r2, r3
-  bcc FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F0/mbed_overrides.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/mbed_overrides.c
@@ -31,8 +31,6 @@
 void mbed_sdk_init() {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
-#if !defined(TOOLCHAIN_GCC_ARM)
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
-#endif
 }

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/device/TOOLCHAIN_GCC_ARM/startup_stm32f103xb.S
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/device/TOOLCHAIN_GCC_ARM/startup_stm32f103xb.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word _sdata
 /* end address for the .data section. defined in linker script */
 .word _edata
-/* start address for the .bss section. defined in linker script */
-.word _sbss
-/* end address for the .bss section. defined in linker script */
-.word _ebss
 
 .equ  BootRAM, 0xF108F85F
 /**
@@ -96,17 +92,6 @@ LoopCopyDataInit:
   adds r2, r0, r1
   cmp r2, r3
   bcc CopyDataInit
-  ldr r2, =_sbss
-  b LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs r3, #0
-  str r3, [r2], #4
-
-LoopFillZerobss:
-  ldr r3, = _ebss
-  cmp r2, r3
-  bcc FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/device/TOOLCHAIN_GCC_ARM/startup_stm32f100xb.S
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/device/TOOLCHAIN_GCC_ARM/startup_stm32f100xb.S
@@ -58,10 +58,7 @@ defined in linker script */
 .word _sdata
 /* end address for the .data section. defined in linker script */
 .word _edata
-/* start address for the .bss section. defined in linker script */
-.word _sbss
-/* end address for the .bss section. defined in linker script */
-.word _ebss
+
 
 .equ  BootRAM, 0xF108F85F
 /**
@@ -94,17 +91,6 @@ LoopCopyDataInit:
   adds r2, r0, r1
   cmp r2, r3
   bcc CopyDataInit
-  ldr r2, =_sbss
-  b LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs r3, #0
-  str r3, [r2], #4
-
-LoopFillZerobss:
-  ldr r3, = _ebss
-  cmp r2, r3
-  bcc FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/TOOLCHAIN_GCC_ARM/startup_stm32f103xb.S
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/TOOLCHAIN_GCC_ARM/startup_stm32f103xb.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word _sdata
 /* end address for the .data section. defined in linker script */
 .word _edata
-/* start address for the .bss section. defined in linker script */
-.word _sbss
-/* end address for the .bss section. defined in linker script */
-.word _ebss
 
 .equ  BootRAM, 0xF108F85F
 /**
@@ -96,17 +92,6 @@ LoopCopyDataInit:
   adds r2, r0, r1
   cmp r2, r3
   bcc CopyDataInit
-  ldr r2, =_sbss
-  b LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs r3, #0
-  str r3, [r2], #4
-
-LoopFillZerobss:
-  ldr r3, = _ebss
-  cmp r2, r3
-  bcc FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F1/mbed_overrides.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/mbed_overrides.c
@@ -32,8 +32,6 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
-#if !defined(TOOLCHAIN_GCC_ARM)
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
-#endif
 }

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_GCC_ARM/startup_stm32f207xx.s
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_GCC_ARM/startup_stm32f207xx.s
@@ -57,10 +57,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -94,17 +90,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system initialization function.*/
   bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F303VC/device/TOOLCHAIN_GCC_ARM/startup_stm32f303xc.S
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F303VC/device/TOOLCHAIN_GCC_ARM/startup_stm32f303xc.S
@@ -50,10 +50,6 @@ defined in linker script */
 .word	_sdata
 /* end address for the .data section. defined in linker script */
 .word	_edata
-/* start address for the .bss section. defined in linker script */
-.word	_sbss
-/* end address for the .bss section. defined in linker script */
-.word	_ebss
 
 .equ  BootRAM,        0xF1E0F85F
 /**
@@ -87,18 +83,6 @@ LoopCopyDataInit:
 	adds	r2, r0, r1
 	cmp	r2, r3
 	bcc	CopyDataInit
-	ldr	r2, =_sbss
-	b	LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-	movs	r3, #0
-	str	r3, [r2], #4
-
-LoopFillZerobss:
-	ldr	r3, = _ebss
-	cmp	r2, r3
-	bcc	FillZerobss
-
 /* Call the clock system intitialization function.*/
     bl  SystemInit
 /* Call static constructors */

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F334C8/device/TOOLCHAIN_GCC_ARM/startup_stm32f334x8.S
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F334C8/device/TOOLCHAIN_GCC_ARM/startup_stm32f334x8.S
@@ -50,10 +50,6 @@ defined in linker script */
 .word	_sdata
 /* end address for the .data section. defined in linker script */
 .word	_edata
-/* start address for the .bss section. defined in linker script */
-.word	_sbss
-/* end address for the .bss section. defined in linker script */
-.word	_ebss
 
 .equ  BootRAM,        0xF1E0F85F
 /**
@@ -87,17 +83,6 @@ LoopCopyDataInit:
 	adds	r2, r0, r1
 	cmp	r2, r3
 	bcc	CopyDataInit
-	ldr	r2, =_sbss
-	b	LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-	movs	r3, #0
-	str	r3, [r2], #4
-
-LoopFillZerobss:
-	ldr	r3, = _ebss
-	cmp	r2, r3
-	bcc	FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F302R8/device/TOOLCHAIN_GCC_ARM/startup_stm32f302x8.S
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F302R8/device/TOOLCHAIN_GCC_ARM/startup_stm32f302x8.S
@@ -50,10 +50,6 @@ defined in linker script */
 .word	_sdata
 /* end address for the .data section. defined in linker script */
 .word	_edata
-/* start address for the .bss section. defined in linker script */
-.word	_sbss
-/* end address for the .bss section. defined in linker script */
-.word	_ebss
 
 .equ  BootRAM,        0xF1E0F85F
 /**
@@ -87,17 +83,6 @@ LoopCopyDataInit:
 	adds	r2, r0, r1
 	cmp	r2, r3
 	bcc	CopyDataInit
-	ldr	r2, =_sbss
-	b	LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-	movs	r3, #0
-	str	r3, [r2], #4
-
-LoopFillZerobss:
-	ldr	r3, = _ebss
-	cmp	r2, r3
-	bcc	FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/device/TOOLCHAIN_GCC_ARM/startup_stm32f303x8.S
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/device/TOOLCHAIN_GCC_ARM/startup_stm32f303x8.S
@@ -50,10 +50,6 @@ defined in linker script */
 .word	_sdata
 /* end address for the .data section. defined in linker script */
 .word	_edata
-/* start address for the .bss section. defined in linker script */
-.word	_sbss
-/* end address for the .bss section. defined in linker script */
-.word	_ebss
 
 .equ  BootRAM,        0xF1E0F85F
 /**
@@ -87,17 +83,6 @@ LoopCopyDataInit:
 	adds	r2, r0, r1
 	cmp	r2, r3
 	bcc	CopyDataInit
-	ldr	r2, =_sbss
-	b	LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-	movs	r3, #0
-	str	r3, [r2], #4
-
-LoopFillZerobss:
-	ldr	r3, = _ebss
-	cmp	r2, r3
-	bcc	FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303RE/device/TOOLCHAIN_GCC_ARM/startup_stm32f303xe.S
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303RE/device/TOOLCHAIN_GCC_ARM/startup_stm32f303xe.S
@@ -50,10 +50,6 @@ defined in linker script */
 .word	_sdata
 /* end address for the .data section. defined in linker script */
 .word	_edata
-/* start address for the .bss section. defined in linker script */
-.word	_sbss
-/* end address for the .bss section. defined in linker script */
-.word	_ebss
 
 .equ  BootRAM,        0xF1E0F85F
 /**
@@ -87,17 +83,6 @@ LoopCopyDataInit:
 	adds	r2, r0, r1
 	cmp	r2, r3
 	bcc	CopyDataInit
-	ldr	r2, =_sbss
-	b	LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-	movs	r3, #0
-	str	r3, [r2], #4
-
-LoopFillZerobss:
-	ldr	r3, = _ebss
-	cmp	r2, r3
-	bcc	FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303ZE/device/TOOLCHAIN_GCC_ARM/startup_stm32f303xe.S
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303ZE/device/TOOLCHAIN_GCC_ARM/startup_stm32f303xe.S
@@ -50,10 +50,6 @@ defined in linker script */
 .word	_sdata
 /* end address for the .data section. defined in linker script */
 .word	_edata
-/* start address for the .bss section. defined in linker script */
-.word	_sbss
-/* end address for the .bss section. defined in linker script */
-.word	_ebss
 
 .equ  BootRAM,        0xF1E0F85F
 /**
@@ -87,17 +83,6 @@ LoopCopyDataInit:
 	adds	r2, r0, r1
 	cmp	r2, r3
 	bcc	CopyDataInit
-	ldr	r2, =_sbss
-	b	LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-	movs	r3, #0
-	str	r3, [r2], #4
-
-LoopFillZerobss:
-	ldr	r3, = _ebss
-	cmp	r2, r3
-	bcc	FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F334R8/device/TOOLCHAIN_GCC_ARM/startup_stm32f334x8.S
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F334R8/device/TOOLCHAIN_GCC_ARM/startup_stm32f334x8.S
@@ -50,10 +50,6 @@ defined in linker script */
 .word	_sdata
 /* end address for the .data section. defined in linker script */
 .word	_edata
-/* start address for the .bss section. defined in linker script */
-.word	_sbss
-/* end address for the .bss section. defined in linker script */
-.word	_ebss
 
 .equ  BootRAM,        0xF1E0F85F
 /**
@@ -87,17 +83,6 @@ LoopCopyDataInit:
 	adds	r2, r0, r1
 	cmp	r2, r3
 	bcc	CopyDataInit
-	ldr	r2, =_sbss
-	b	LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-	movs	r3, #0
-	str	r3, [r2], #4
-
-LoopFillZerobss:
-	ldr	r3, = _ebss
-	cmp	r2, r3
-	bcc	FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32F3/mbed_overrides.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/mbed_overrides.c
@@ -32,8 +32,6 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
-#if !defined(TOOLCHAIN_GCC_ARM)
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
-#endif
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_B96B_F446VE/device/TOOLCHAIN_GCC_ARM/startup_stm32f446xx.S
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_B96B_F446VE/device/TOOLCHAIN_GCC_ARM/startup_stm32f446xx.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F401VC/device/TOOLCHAIN_GCC_ARM/startup_stm32f401xc.S
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F401VC/device/TOOLCHAIN_GCC_ARM/startup_stm32f401xc.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/device/TOOLCHAIN_GCC_ARM/startup_stm32f429xx.S
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/device/TOOLCHAIN_GCC_ARM/startup_stm32f429xx.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F469NI/device/TOOLCHAIN_GCC_ARM/startup_stm32f469xx.s
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F469NI/device/TOOLCHAIN_GCC_ARM/startup_stm32f469xx.s
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_ELMO_F411RE/device/TOOLCHAIN_GCC_ARM/startup_stm32f411xe.S
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_ELMO_F411RE/device/TOOLCHAIN_GCC_ARM/startup_stm32f411xe.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_F429_F439/device/TOOLCHAIN_GCC_ARM/startup_stm32f429xx.S
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_F429_F439/device/TOOLCHAIN_GCC_ARM/startup_stm32f429xx.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/device/TOOLCHAIN_GCC_ARM/startup_stm32f411xe.S
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/device/TOOLCHAIN_GCC_ARM/startup_stm32f411xe.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,18 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
-
 /* Call the clock system intitialization function.*/
   bl  SystemInit   
 /* Call static constructors */

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/device/TOOLCHAIN_GCC_ARM/startup_stm32f401xe.S
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/device/TOOLCHAIN_GCC_ARM/startup_stm32f401xe.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F410RB/device/TOOLCHAIN_GCC_ARM/startup_stm32f410rx.s
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F410RB/device/TOOLCHAIN_GCC_ARM/startup_stm32f410rx.s
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F411RE/device/TOOLCHAIN_GCC_ARM/startup_stm32f411xe.S
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F411RE/device/TOOLCHAIN_GCC_ARM/startup_stm32f411xe.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446RE/device/TOOLCHAIN_GCC_ARM/startup_stm32f446xx.S
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446RE/device/TOOLCHAIN_GCC_ARM/startup_stm32f446xx.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446ZE/device/TOOLCHAIN_GCC_ARM/startup_stm32f446xx.S
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446ZE/device/TOOLCHAIN_GCC_ARM/startup_stm32f446xx.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG/device/TOOLCHAIN_GCC_ARM/startup_stm32f407xx.S
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG/device/TOOLCHAIN_GCC_ARM/startup_stm32f407xx.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,18 +91,7 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
-
+ 
 /* Call the clock system intitialization function.*/
   bl  SystemInit   
 /* Call static constructors */

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/device/TOOLCHAIN_GCC_ARM/startup_stm32f439xx.S
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/device/TOOLCHAIN_GCC_ARM/startup_stm32f439xx.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F4/mbed_overrides.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/mbed_overrides.c
@@ -33,10 +33,8 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
-#if !defined(TOOLCHAIN_GCC_ARM)
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
-#endif
 }
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F746NG/device/TOOLCHAIN_GCC_ARM/startup_stm32f746xx.S
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F746NG/device/TOOLCHAIN_GCC_ARM/startup_stm32f746xx.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system initialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F769NI/device/TOOLCHAIN_GCC_ARM/startup_stm32f769xx.S
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F769NI/device/TOOLCHAIN_GCC_ARM/startup_stm32f769xx.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system initialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_F746_F756/device/TOOLCHAIN_GCC_ARM/startup_stm32f746xx.S
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_F746_F756/device/TOOLCHAIN_GCC_ARM/startup_stm32f746xx.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system initialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F767ZI/device/TOOLCHAIN_GCC_ARM/startup_stm32f769xx.s
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F767ZI/device/TOOLCHAIN_GCC_ARM/startup_stm32f769xx.s
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system initialization function.*/
   bl  SystemInit   

--- a/targets/TARGET_STM/TARGET_STM32F7/mbed_overrides.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/mbed_overrides.c
@@ -35,10 +35,8 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
-#if !defined(TOOLCHAIN_GCC_ARM)
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
-#endif
 }
 
 

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/device/TOOLCHAIN_GCC_ARM/startup_stm32l053xx.S
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/device/TOOLCHAIN_GCC_ARM/startup_stm32l053xx.S
@@ -55,10 +55,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 
     .section  .text.Reset_Handler
   .weak  Reset_Handler
@@ -83,19 +79,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2]
-  adds r2, r2, #4
-
-
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/device/TOOLCHAIN_GCC_ARM/startup_stm32l011xx.s
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/device/TOOLCHAIN_GCC_ARM/startup_stm32l011xx.s
@@ -55,10 +55,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 
     .section  .text.Reset_Handler
   .weak  Reset_Handler
@@ -83,19 +79,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2]
-  adds r2, r2, #4
-
-
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/device/TOOLCHAIN_GCC_ARM/startup_stm32l031xx.S
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/device/TOOLCHAIN_GCC_ARM/startup_stm32l031xx.S
@@ -55,10 +55,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 
     .section  .text.Reset_Handler
   .weak  Reset_Handler
@@ -83,20 +79,7 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2]
-  adds r2, r2, #4
-
-
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
-
+ 
 /* Call the clock system intitialization function.*/
   bl  SystemInit
 /* Call static constructors */

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/device/TOOLCHAIN_GCC_ARM/startup_stm32l053xx.S
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/device/TOOLCHAIN_GCC_ARM/startup_stm32l053xx.S
@@ -55,10 +55,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 
     .section  .text.Reset_Handler
   .weak  Reset_Handler
@@ -83,20 +79,7 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2]
-  adds r2, r2, #4
-
-
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
-
+ 
 /* Call the clock system intitialization function.*/
   bl  SystemInit
 /* Call static constructors */

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/device/TOOLCHAIN_GCC_ARM/startup_stm32l073xx.S
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/device/TOOLCHAIN_GCC_ARM/startup_stm32l073xx.S
@@ -55,10 +55,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 
     .section  .text.Reset_Handler
   .weak  Reset_Handler
@@ -83,19 +79,6 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2]
-  adds r2, r2, #4
-
-
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
   bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32L0/mbed_overrides.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/mbed_overrides.c
@@ -32,8 +32,6 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
-#if !defined(TOOLCHAIN_GCC_ARM)
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
-#endif
 }

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_GCC_ARM/startup_stm32l152xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_GCC_ARM/startup_stm32l152xc.S
@@ -59,10 +59,6 @@ defined in linker script */
 .word _sdata
 /* end address for the .data section. defined in linker script */
 .word _edata
-/* start address for the .bss section. defined in linker script */
-.word _sbss
-/* end address for the .bss section. defined in linker script */
-.word _ebss
 
 .equ  BootRAM, 0xF108F85F
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds r2, r0, r1
   cmp r2, r3
   bcc CopyDataInit
-  ldr r2, =_sbss
-  b LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs r3, #0
-  str r3, [r2], #4
-
-LoopFillZerobss:
-  ldr r3, = _ebss
-  cmp r2, r3
-  bcc FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_GCC_ARM/startup_stm32l152xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_GCC_ARM/startup_stm32l152xc.S
@@ -109,11 +109,16 @@ LoopFillZerobss:
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit
-/* Call static constructors */
-    bl __libc_init_array
-/* Call the application's entry point.*/
-  bl main
+
+/**
+ * Calling the crt0 'cold-start' entry point. There __libc_init_array is called
+ * and when existing hardware_init_hook() and software_init_hook() before 
+ * starting main(). software_init_hook() is available and has to be called due 
+ * to initializsation when using rtos.
+*/
+  bl _start
   bx lr
+
 .size Reset_Handler, .-Reset_Handler
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_GCC_ARM/startup_stm32l152xe.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_GCC_ARM/startup_stm32l152xe.S
@@ -59,10 +59,6 @@ defined in linker script */
 .word _sdata
 /* end address for the .data section. defined in linker script */
 .word _edata
-/* start address for the .bss section. defined in linker script */
-.word _sbss
-/* end address for the .bss section. defined in linker script */
-.word _ebss
 
 .equ  BootRAM, 0xF108F85F
 /**
@@ -97,17 +93,6 @@ LoopCopyDataInit:
   adds r2, r0, r1
   cmp r2, r3
   bcc CopyDataInit
-  ldr r2, =_sbss
-  b LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs r3, #0
-  str r3, [r2], #4
-
-LoopFillZerobss:
-  ldr r3, = _ebss
-  cmp r2, r3
-  bcc FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_GCC_ARM/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_GCC_ARM/startup_stm32l151xc.S
@@ -59,10 +59,6 @@ defined in linker script */
 .word _sdata
 /* end address for the .data section. defined in linker script */
 .word _edata
-/* start address for the .bss section. defined in linker script */
-.word _sbss
-/* end address for the .bss section. defined in linker script */
-.word _ebss
 
 .equ  BootRAM, 0xF108F85F
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds r2, r0, r1
   cmp r2, r3
   bcc CopyDataInit
-  ldr r2, =_sbss
-  b LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs r3, #0
-  str r3, [r2], #4
-
-LoopFillZerobss:
-  ldr r3, = _ebss
-  cmp r2, r3
-  bcc FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_GCC_ARM/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_GCC_ARM/startup_stm32l151xc.S
@@ -109,11 +109,15 @@ LoopFillZerobss:
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit
-/* Call static constructors */
-    bl __libc_init_array
-/* Call the application's entry point.*/
-  bl main
-  bx lr
+
+/**
+ * Calling the crt0 'cold-start' entry point. There __libc_init_array is called
+ * and when existing hardware_init_hook() and software_init_hook() before 
+ * starting main(). software_init_hook() is available and has to be called due 
+ * to initializsation when using rtos.
+*/
+    bl _start
+    bx lr
 .size Reset_Handler, .-Reset_Handler
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_GCC_ARM/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_GCC_ARM/startup_stm32l151xc.S
@@ -59,10 +59,6 @@ defined in linker script */
 .word _sdata
 /* end address for the .data section. defined in linker script */
 .word _edata
-/* start address for the .bss section. defined in linker script */
-.word _sbss
-/* end address for the .bss section. defined in linker script */
-.word _ebss
 
 .equ  BootRAM, 0xF108F85F
 /**
@@ -95,17 +91,6 @@ LoopCopyDataInit:
   adds r2, r0, r1
   cmp r2, r3
   bcc CopyDataInit
-  ldr r2, =_sbss
-  b LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-  movs r3, #0
-  str r3, [r2], #4
-
-LoopFillZerobss:
-  ldr r3, = _ebss
-  cmp r2, r3
-  bcc FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32L1/mbed_overrides.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/mbed_overrides.c
@@ -35,10 +35,8 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
-#if !defined(TOOLCHAIN_GCC_ARM)
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
-#endif
 
 #if defined(TARGET_XDOT_L151CC)
     if (PWR->CSR & PWR_CSR_SBF) {

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/device/TOOLCHAIN_GCC_ARM/startup_stm32l476xx.S
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/device/TOOLCHAIN_GCC_ARM/startup_stm32l476xx.S
@@ -59,10 +59,6 @@ defined in linker script */
 .word	_sdata
 /* end address for the .data section. defined in linker script */
 .word	_edata
-/* start address for the .bss section. defined in linker script */
-.word	_sbss
-/* end address for the .bss section. defined in linker script */
-.word	_ebss
 
 .equ  BootRAM,        0xF1E0F85F
 /**
@@ -96,17 +92,6 @@ LoopCopyDataInit:
 	adds	r2, r0, r1
 	cmp	r2, r3
 	bcc	CopyDataInit
-	ldr	r2, =_sbss
-	b	LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-	movs	r3, #0
-	str	r3, [r2], #4
-
-LoopFillZerobss:
-	ldr	r3, = _ebss
-	cmp	r2, r3
-	bcc	FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_L476_L486/device/TOOLCHAIN_GCC_ARM/startup_stm32l476xx.S
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_L476_L486/device/TOOLCHAIN_GCC_ARM/startup_stm32l476xx.S
@@ -59,11 +59,6 @@ defined in linker script */
 .word	_sdata
 /* end address for the .data section. defined in linker script */
 .word	_edata
-/* start address for the .bss section. defined in linker script */
-.word	_sbss
-/* end address for the .bss section. defined in linker script */
-.word	_ebss
-
 .equ  BootRAM,        0xF1E0F85F
 /**
  * @brief  This is the code that gets called when the processor first
@@ -96,17 +91,6 @@ LoopCopyDataInit:
 	adds	r2, r0, r1
 	cmp	r2, r3
 	bcc	CopyDataInit
-	ldr	r2, =_sbss
-	b	LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-	movs	r3, #0
-	str	r3, [r2], #4
-
-LoopFillZerobss:
-	ldr	r3, = _ebss
-	cmp	r2, r3
-	bcc	FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L432KC/device/TOOLCHAIN_GCC_ARM/startup_stm32l432xx.S
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L432KC/device/TOOLCHAIN_GCC_ARM/startup_stm32l432xx.S
@@ -59,11 +59,6 @@ defined in linker script */
 .word	_sdata
 /* end address for the .data section. defined in linker script */
 .word	_edata
-/* start address for the .bss section. defined in linker script */
-.word	_sbss
-/* end address for the .bss section. defined in linker script */
-.word	_ebss
-
 .equ  BootRAM,        0xF1E0F85F
 /**
  * @brief  This is the code that gets called when the processor first
@@ -96,17 +91,6 @@ LoopCopyDataInit:
 	adds	r2, r0, r1
 	cmp	r2, r3
 	bcc	CopyDataInit
-	ldr	r2, =_sbss
-	b	LoopFillZerobss
-/* Zero fill the bss segment. */
-FillZerobss:
-	movs	r3, #0
-	str	r3, [r2], #4
-
-LoopFillZerobss:
-	ldr	r3, = _ebss
-	cmp	r2, r3
-	bcc	FillZerobss
 
 /* Call the clock system intitialization function.*/
     bl  SystemInit

--- a/targets/TARGET_STM/TARGET_STM32L4/mbed_overrides.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/mbed_overrides.c
@@ -32,8 +32,6 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemCoreClockUpdate();
-#if !defined(TOOLCHAIN_GCC_ARM)
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
-#endif
 }


### PR DESCRIPTION

## Description
With TOOLCHAIN GCC, Zero initialization is done twice for some STM target (at startup and in __start) 
To Align the startup with other toolchain, the zero bss in startup is removed and mbed_sdk_init is performing again some init already done in SystemInit as for other toolchain

## Status
READY




## Steps to test or reproduce
All tests relative to STM target on TOOLCHAIN GCC_ARM are passed
