### PR TITLE
nsapi - Add standardized return types for size and errors

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/EthernetInterface.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/EthernetInterface.cpp
@@ -24,22 +24,22 @@ EthernetInterface::EthernetInterface()
 {
 }
 
-int EthernetInterface::set_network(const char *ip_address, const char *netmask, const char *gateway)
+nsapi_error_t EthernetInterface::set_network(const char *ip_address, const char *netmask, const char *gateway)
 {
     _dhcp = false;
     strncpy(_ip_address, ip_address ? ip_address : "", sizeof(_ip_address));
     strncpy(_netmask, netmask ? netmask : "", sizeof(_netmask));
     strncpy(_gateway, gateway ? gateway : "", sizeof(_gateway));
-    return 0;
+    return NSAPI_ERROR_OK;
 }
 
-int EthernetInterface::set_dhcp(bool dhcp)
+nsapi_error_t EthernetInterface::set_dhcp(bool dhcp)
 {
     _dhcp = dhcp;
-    return 0;
+    return NSAPI_ERROR_OK;
 }
 
-int EthernetInterface::connect()
+nsapi_error_t EthernetInterface::connect()
 {
     return mbed_lwip_bringup(_dhcp,
             _ip_address[0] ? _ip_address : 0,
@@ -47,7 +47,7 @@ int EthernetInterface::connect()
             _gateway[0] ? _gateway : 0);
 }
 
-int EthernetInterface::disconnect()
+nsapi_error_t EthernetInterface::disconnect()
 {
     return mbed_lwip_bringdown();
 }
@@ -63,7 +63,7 @@ const char *EthernetInterface::get_ip_address()
         return _ip_address;
     }
 
-    return 0;
+    return NULL;
 }
 
 const char *EthernetInterface::get_netmask()

--- a/features/FEATURE_LWIP/lwip-interface/EthernetInterface.h
+++ b/features/FEATURE_LWIP/lwip-interface/EthernetInterface.h
@@ -46,7 +46,8 @@ public:
      *  @param gateway  Null-terminated representation of the local gateway
      *  @return         0 on success, negative error code on failure
      */
-    virtual int set_network(const char *ip_address, const char *netmask, const char *gateway);
+    virtual nsapi_error_t set_network(
+            const char *ip_address, const char *netmask, const char *gateway);
 
     /** Enable or disable DHCP on the network
      *
@@ -55,17 +56,17 @@ public:
      *  @param dhcp     False to disable dhcp (defaults to enabled)
      *  @return         0 on success, negative error code on failure
      */
-    virtual int set_dhcp(bool dhcp);
+    virtual nsapi_error_t set_dhcp(bool dhcp);
 
     /** Start the interface
      *  @return             0 on success, negative on failure
      */
-    virtual int connect();
+    virtual nsapi_error_t connect();
 
     /** Stop the interface
      *  @return             0 on success, negative on failure
      */
-    virtual int disconnect();
+    virtual nsapi_error_t disconnect();
 
     /** Get the local MAC address
      *

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -326,7 +326,7 @@ const char *mbed_lwip_get_mac_address(void)
     return lwip_mac_address[0] ? lwip_mac_address : 0;
 }
 
-char *mbed_lwip_get_ip_address(char *buf, int buflen)
+char *mbed_lwip_get_ip_address(char *buf, nsapi_size_t buflen)
 {
     const ip_addr_t *addr = mbed_lwip_get_ip_addr(true, &lwip_netif);
     if (!addr) {
@@ -345,7 +345,7 @@ char *mbed_lwip_get_ip_address(char *buf, int buflen)
     return NULL;
 }
 
-const char *mbed_lwip_get_netmask(char *buf, int buflen)
+const char *mbed_lwip_get_netmask(char *buf, nsapi_size_t buflen)
 {
 #if LWIP_IPV4
     const ip4_addr_t *addr = netif_ip4_netmask(&lwip_netif);
@@ -359,7 +359,7 @@ const char *mbed_lwip_get_netmask(char *buf, int buflen)
 #endif
 }
 
-char *mbed_lwip_get_gateway(char *buf, int buflen)
+char *mbed_lwip_get_gateway(char *buf, nsapi_size_t buflen)
 {
 #if LWIP_IPV4
     const ip4_addr_t *addr = netif_ip4_gw(&lwip_netif);
@@ -373,7 +373,7 @@ char *mbed_lwip_get_gateway(char *buf, int buflen)
 #endif
 }
 
-int mbed_lwip_init(emac_interface_t *emac)
+nsapi_error_t mbed_lwip_init(emac_interface_t *emac)
 {
     // Check if we've already brought up lwip
     if (!mbed_lwip_get_mac_address()) {
@@ -409,7 +409,7 @@ int mbed_lwip_init(emac_interface_t *emac)
     return NSAPI_ERROR_OK;
 }
 
-int mbed_lwip_bringup(bool dhcp, const char *ip, const char *netmask, const char *gw)
+nsapi_error_t mbed_lwip_bringup(bool dhcp, const char *ip, const char *netmask, const char *gw)
 {
     // Check if we've already connected
     if (lwip_connected) {
@@ -509,7 +509,7 @@ int mbed_lwip_bringup(bool dhcp, const char *ip, const char *netmask, const char
     return 0;
 }
 
-int mbed_lwip_bringdown(void)
+nsapi_error_t mbed_lwip_bringdown(void)
 {
     // Check if we've connected
     if (!lwip_connected) {
@@ -533,7 +533,7 @@ int mbed_lwip_bringdown(void)
 }
 
 /* LWIP error remapping */
-static int mbed_lwip_err_remap(err_t err) {
+static nsapi_error_t mbed_lwip_err_remap(err_t err) {
     switch (err) {
         case ERR_OK:
         case ERR_CLSD:
@@ -559,7 +559,7 @@ static int mbed_lwip_err_remap(err_t err) {
 }
 
 /* LWIP network stack implementation */
-static int mbed_lwip_gethostbyname(nsapi_stack_t *stack, const char *host, nsapi_addr_t *addr, nsapi_version_t version)
+static nsapi_error_t mbed_lwip_gethostbyname(nsapi_stack_t *stack, const char *host, nsapi_addr_t *addr, nsapi_version_t version)
 {
     ip_addr_t lwip_addr;
 
@@ -600,7 +600,7 @@ static int mbed_lwip_gethostbyname(nsapi_stack_t *stack, const char *host, nsapi
     return 0;
 }
 
-static int mbed_lwip_socket_open(nsapi_stack_t *stack, nsapi_socket_t *handle, nsapi_protocol_t proto)
+static nsapi_error_t mbed_lwip_socket_open(nsapi_stack_t *stack, nsapi_socket_t *handle, nsapi_protocol_t proto)
 {
     // check if network is connected
     if (!lwip_connected) {
@@ -643,7 +643,7 @@ static int mbed_lwip_socket_open(nsapi_stack_t *stack, nsapi_socket_t *handle, n
     return 0;
 }
 
-static int mbed_lwip_socket_close(nsapi_stack_t *stack, nsapi_socket_t handle)
+static nsapi_error_t mbed_lwip_socket_close(nsapi_stack_t *stack, nsapi_socket_t handle)
 {
     struct lwip_socket *s = (struct lwip_socket *)handle;
 
@@ -652,7 +652,7 @@ static int mbed_lwip_socket_close(nsapi_stack_t *stack, nsapi_socket_t handle)
     return mbed_lwip_err_remap(err);
 }
 
-static int mbed_lwip_socket_bind(nsapi_stack_t *stack, nsapi_socket_t handle, nsapi_addr_t addr, uint16_t port)
+static nsapi_error_t mbed_lwip_socket_bind(nsapi_stack_t *stack, nsapi_socket_t handle, nsapi_addr_t addr, uint16_t port)
 {
     struct lwip_socket *s = (struct lwip_socket *)handle;
     ip_addr_t ip_addr;
@@ -670,7 +670,7 @@ static int mbed_lwip_socket_bind(nsapi_stack_t *stack, nsapi_socket_t handle, ns
     return mbed_lwip_err_remap(err);
 }
 
-static int mbed_lwip_socket_listen(nsapi_stack_t *stack, nsapi_socket_t handle, int backlog)
+static nsapi_error_t mbed_lwip_socket_listen(nsapi_stack_t *stack, nsapi_socket_t handle, int backlog)
 {
     struct lwip_socket *s = (struct lwip_socket *)handle;
 
@@ -678,7 +678,7 @@ static int mbed_lwip_socket_listen(nsapi_stack_t *stack, nsapi_socket_t handle, 
     return mbed_lwip_err_remap(err);
 }
 
-static int mbed_lwip_socket_connect(nsapi_stack_t *stack, nsapi_socket_t handle, nsapi_addr_t addr, uint16_t port)
+static nsapi_error_t mbed_lwip_socket_connect(nsapi_stack_t *stack, nsapi_socket_t handle, nsapi_addr_t addr, uint16_t port)
 {
     struct lwip_socket *s = (struct lwip_socket *)handle;
     ip_addr_t ip_addr;
@@ -694,7 +694,7 @@ static int mbed_lwip_socket_connect(nsapi_stack_t *stack, nsapi_socket_t handle,
     return mbed_lwip_err_remap(err);
 }
 
-static int mbed_lwip_socket_accept(nsapi_stack_t *stack, nsapi_socket_t server, nsapi_socket_t *handle, nsapi_addr_t *addr, uint16_t *port)
+static nsapi_error_t mbed_lwip_socket_accept(nsapi_stack_t *stack, nsapi_socket_t server, nsapi_socket_t *handle, nsapi_addr_t *addr, uint16_t *port)
 {
     struct lwip_socket *s = (struct lwip_socket *)server;
     struct lwip_socket *ns = mbed_lwip_arena_alloc();
@@ -718,7 +718,7 @@ static int mbed_lwip_socket_accept(nsapi_stack_t *stack, nsapi_socket_t server, 
     return 0;
 }
 
-static int mbed_lwip_socket_send(nsapi_stack_t *stack, nsapi_socket_t handle, const void *data, unsigned size)
+static nsapi_size_or_error_t mbed_lwip_socket_send(nsapi_stack_t *stack, nsapi_socket_t handle, const void *data, nsapi_size_t size)
 {
     struct lwip_socket *s = (struct lwip_socket *)handle;
     size_t bytes_written = 0;
@@ -728,10 +728,10 @@ static int mbed_lwip_socket_send(nsapi_stack_t *stack, nsapi_socket_t handle, co
         return mbed_lwip_err_remap(err);
     }
 
-    return (int)bytes_written;
+    return (nsapi_size_or_error_t)bytes_written;
 }
 
-static int mbed_lwip_socket_recv(nsapi_stack_t *stack, nsapi_socket_t handle, void *data, unsigned size)
+static nsapi_size_or_error_t mbed_lwip_socket_recv(nsapi_stack_t *stack, nsapi_socket_t handle, void *data, nsapi_size_t size)
 {
     struct lwip_socket *s = (struct lwip_socket *)handle;
 
@@ -755,7 +755,7 @@ static int mbed_lwip_socket_recv(nsapi_stack_t *stack, nsapi_socket_t handle, vo
     return recv;
 }
 
-static int mbed_lwip_socket_sendto(nsapi_stack_t *stack, nsapi_socket_t handle, nsapi_addr_t addr, uint16_t port, const void *data, unsigned size)
+static nsapi_size_or_error_t mbed_lwip_socket_sendto(nsapi_stack_t *stack, nsapi_socket_t handle, nsapi_addr_t addr, uint16_t port, const void *data, nsapi_size_t size)
 {
     struct lwip_socket *s = (struct lwip_socket *)handle;
     ip_addr_t ip_addr;
@@ -780,7 +780,7 @@ static int mbed_lwip_socket_sendto(nsapi_stack_t *stack, nsapi_socket_t handle, 
     return size;
 }
 
-static int mbed_lwip_socket_recvfrom(nsapi_stack_t *stack, nsapi_socket_t handle, nsapi_addr_t *addr, uint16_t *port, void *data, unsigned size)
+static nsapi_size_or_error_t mbed_lwip_socket_recvfrom(nsapi_stack_t *stack, nsapi_socket_t handle, nsapi_addr_t *addr, uint16_t *port, void *data, nsapi_size_t size)
 {
     struct lwip_socket *s = (struct lwip_socket *)handle;
     struct netbuf *buf;
@@ -799,7 +799,7 @@ static int mbed_lwip_socket_recvfrom(nsapi_stack_t *stack, nsapi_socket_t handle
     return recv;
 }
 
-static int mbed_lwip_setsockopt(nsapi_stack_t *stack, nsapi_socket_t handle, int level, int optname, const void *optval, unsigned optlen)
+static nsapi_error_t mbed_lwip_setsockopt(nsapi_stack_t *stack, nsapi_socket_t handle, int level, int optname, const void *optval, unsigned optlen)
 {
     struct lwip_socket *s = (struct lwip_socket *)handle;
 

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
@@ -25,9 +25,9 @@ extern "C" {
 #endif
 
 // Access to lwip through the nsapi
-int mbed_lwip_init(emac_interface_t *emac);
-int mbed_lwip_bringup(bool dhcp, const char *ip, const char *netmask, const char *gw);
-int mbed_lwip_bringdown(void);
+nsapi_error_t mbed_lwip_init(emac_interface_t *emac);
+nsapi_error_t mbed_lwip_bringup(bool dhcp, const char *ip, const char *netmask, const char *gw);
+nsapi_error_t mbed_lwip_bringdown(void);
 
 const char *mbed_lwip_get_mac_address(void);
 char *mbed_lwip_get_ip_address(char *buf, int buflen);

--- a/features/nanostack/FEATURE_NANOSTACK/nanostack-interface/NanostackInterface.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/nanostack-interface/NanostackInterface.cpp
@@ -110,7 +110,7 @@ private:
 
 static NanostackSocket * socket_tbl[NS_INTERFACE_SOCKETS_MAX];
 
-static int map_mesh_error(mesh_error_t err)
+static nsapi_error_t map_mesh_error(mesh_error_t err)
 {
     switch (err) {
         case MESH_ERROR_NONE: return 0;
@@ -167,7 +167,7 @@ NanostackSocket::~NanostackSocket()
         close();
     }
     if (socket_id >= 0) {
-        int ret = socket_free(socket_id);
+        nsapi_error_t ret = socket_free(socket_id);
         MBED_ASSERT(0 == ret);
         MBED_ASSERT(socket_tbl[socket_id] == this);
         socket_tbl[socket_id] = NULL;
@@ -209,7 +209,7 @@ void NanostackSocket::close()
     MBED_ASSERT(mode != SOCKET_MODE_CLOSED);
 
     if (socket_id >= 0) {
-        int ret = socket_close(socket_id, (addr_valid ? &ns_address : NULL));
+        nsapi_error_t ret = socket_close(socket_id, (addr_valid ? &ns_address : NULL));
         MBED_ASSERT(0 == ret);
     } else {
         MBED_ASSERT(SOCKET_MODE_UNOPENED == mode);
@@ -466,7 +466,7 @@ MeshInterfaceNanostack::MeshInterfaceNanostack(NanostackRfPhy *phy)
     // Nothing to do
 }
 
-int MeshInterfaceNanostack::initialize(NanostackRfPhy *phy)
+nsapi_error_t MeshInterfaceNanostack::initialize(NanostackRfPhy *phy)
 {
     if (this->phy != NULL) {
         error("Phy already set");
@@ -486,7 +486,7 @@ void MeshInterfaceNanostack::mesh_network_handler(mesh_connection_status_t statu
     nanostack_unlock();
 }
 
-int MeshInterfaceNanostack::register_rf()
+nsapi_error_t MeshInterfaceNanostack::register_rf()
 {
     nanostack_lock();
 
@@ -504,7 +504,7 @@ int MeshInterfaceNanostack::register_rf()
     return 0;
 }
 
-int MeshInterfaceNanostack::actual_connect()
+nsapi_error_t MeshInterfaceNanostack::actual_connect()
 {
     nanostack_assert_locked();
 
@@ -532,7 +532,7 @@ NetworkStack * MeshInterfaceNanostack::get_stack()
     return NanostackInterface::get_stack();
 }
 
-int MeshInterfaceNanostack::disconnect()
+nsapi_error_t MeshInterfaceNanostack::disconnect()
 {
     nanostack_lock();
 
@@ -562,7 +562,7 @@ const char *MeshInterfaceNanostack::get_mac_address()
     return mac_addr_str;
 }
 
-int ThreadInterface::connect()
+nsapi_error_t ThreadInterface::connect()
 {
     // initialize mesh networking resources, memory, timers, etc...
     mesh_system_init();
@@ -586,14 +586,14 @@ int ThreadInterface::connect()
         nanostack_unlock();
         return map_mesh_error(status);
     }
-    int ret = this->actual_connect();
+    nsapi_error_t ret = this->actual_connect();
 
     nanostack_unlock();
 
     return ret;
 }
 
-int LoWPANNDInterface::connect()
+nsapi_error_t LoWPANNDInterface::connect()
 {
     // initialize mesh networking resources, memory, timers, etc...
     mesh_system_init();
@@ -617,7 +617,7 @@ int LoWPANNDInterface::connect()
         nanostack_unlock();
         return map_mesh_error(status);
     }
-    int ret = this->actual_connect();
+    nsapi_error_t ret = this->actual_connect();
 
     nanostack_unlock();
 
@@ -646,7 +646,7 @@ const char * NanostackInterface::get_ip_address()
     return NULL;
 }
 
-int NanostackInterface::socket_open(void **handle, nsapi_protocol_t protocol)
+nsapi_error_t NanostackInterface::socket_open(void **handle, nsapi_protocol_t protocol)
 {
     // Validate parameters
     if (NULL == handle) {
@@ -687,7 +687,7 @@ int NanostackInterface::socket_open(void **handle, nsapi_protocol_t protocol)
     return 0;
 }
 
-int NanostackInterface::socket_close(void *handle)
+nsapi_error_t NanostackInterface::socket_close(void *handle)
 {
     // Validate parameters
     NanostackSocket * socket = static_cast<NanostackSocket *>(handle);
@@ -707,7 +707,7 @@ int NanostackInterface::socket_close(void *handle)
 
 }
 
-int NanostackInterface::socket_sendto(void *handle, const SocketAddress &address, const void *data, unsigned int size)
+nsapi_size_or_error_t NanostackInterface::socket_sendto(void *handle, const SocketAddress &address, const void *data, nsapi_size_t size)
 {
     // Validate parameters
     NanostackSocket * socket = static_cast<NanostackSocket *>(handle);
@@ -718,7 +718,7 @@ int NanostackInterface::socket_sendto(void *handle, const SocketAddress &address
 
     nanostack_lock();
 
-    int ret;
+    nsapi_size_or_error_t ret;
     if (socket->closed()) {
         ret = NSAPI_ERROR_NO_CONNECTION;
     } else if (NANOSTACK_SOCKET_TCP == socket->proto) {
@@ -758,7 +758,7 @@ int NanostackInterface::socket_sendto(void *handle, const SocketAddress &address
     return ret;
 }
 
-int NanostackInterface::socket_recvfrom(void *handle, SocketAddress *address, void *buffer, unsigned size)
+nsapi_size_or_error_t NanostackInterface::socket_recvfrom(void *handle, SocketAddress *address, void *buffer, nsapi_size_t size)
 {
     // Validate parameters
     NanostackSocket * socket = static_cast<NanostackSocket *>(handle);
@@ -777,7 +777,7 @@ int NanostackInterface::socket_recvfrom(void *handle, SocketAddress *address, vo
 
     nanostack_lock();
 
-    int ret;
+    nsapi_size_or_error_t ret;
     if (socket->closed()) {
         ret = NSAPI_ERROR_NO_CONNECTION;
     } else if (NANOSTACK_SOCKET_TCP == socket->proto) {
@@ -796,7 +796,7 @@ int NanostackInterface::socket_recvfrom(void *handle, SocketAddress *address, vo
     return ret;
 }
 
-int NanostackInterface::socket_bind(void *handle, const SocketAddress &address)
+nsapi_error_t NanostackInterface::socket_bind(void *handle, const SocketAddress &address)
 {
     // Validate parameters
     NanostackSocket * socket = static_cast<NanostackSocket *>(handle);
@@ -812,7 +812,7 @@ int NanostackInterface::socket_bind(void *handle, const SocketAddress &address)
     ns_address.type = ADDRESS_IPV6;
     memset(ns_address.address, 0, sizeof ns_address.address);
     ns_address.identifier = address.get_port();
-    int ret = NSAPI_ERROR_DEVICE_ERROR;
+    nsapi_error_t ret = NSAPI_ERROR_DEVICE_ERROR;
     if (0 == ::socket_bind(socket->socket_id, &ns_address)) {
         socket->set_bound();
         ret = 0;
@@ -825,22 +825,22 @@ int NanostackInterface::socket_bind(void *handle, const SocketAddress &address)
     return ret;
 }
 
-int NanostackInterface::setsockopt(void *handle, int level, int optname, const void *optval, unsigned optlen)
+nsapi_error_t NanostackInterface::setsockopt(void *handle, int level, int optname, const void *optval, unsigned optlen)
 {
     return NSAPI_ERROR_UNSUPPORTED;
 }
 
-int NanostackInterface::getsockopt(void *handle, int level, int optname, void *optval, unsigned *optlen)
+nsapi_error_t NanostackInterface::getsockopt(void *handle, int level, int optname, void *optval, unsigned *optlen)
 {
     return NSAPI_ERROR_UNSUPPORTED;
 }
 
-int NanostackInterface::socket_listen(void *handle, int backlog)
+nsapi_error_t NanostackInterface::socket_listen(void *handle, int backlog)
 {
     return NSAPI_ERROR_UNSUPPORTED;
 }
 
-int NanostackInterface::socket_connect(void *handle, const SocketAddress &addr)
+nsapi_error_t NanostackInterface::socket_connect(void *handle, const SocketAddress &addr)
 {
     // Validate parameters
     NanostackSocket * socket = static_cast<NanostackSocket *>(handle);
@@ -851,7 +851,7 @@ int NanostackInterface::socket_connect(void *handle, const SocketAddress &addr)
 
     nanostack_lock();
 
-    int ret;
+    nsapi_error_t ret;
     ns_address_t ns_addr;
     int random_port = socket->is_bound() ? 0 : 1;
     convert_mbed_addr_to_ns(&ns_addr, &addr);
@@ -869,12 +869,12 @@ int NanostackInterface::socket_connect(void *handle, const SocketAddress &addr)
     return ret;
 }
 
-int NanostackInterface::socket_accept(void *server, void **handle, SocketAddress *address)
+nsapi_error_t NanostackInterface::socket_accept(void *server, void **handle, SocketAddress *address)
 {
     return NSAPI_ERROR_UNSUPPORTED;
 }
 
-int NanostackInterface::socket_send(void *handle, const void *p, unsigned size)
+nsapi_size_or_error_t NanostackInterface::socket_send(void *handle, const void *p, nsapi_size_t size)
 {
     // Validate parameters
     NanostackSocket * socket = static_cast<NanostackSocket *>(handle);
@@ -885,7 +885,7 @@ int NanostackInterface::socket_send(void *handle, const void *p, unsigned size)
 
     nanostack_lock();
 
-    int ret;
+    nsapi_size_or_error_t ret;
     if (socket->closed()) {
         ret = NSAPI_ERROR_NO_CONNECTION;
     } else if (socket->is_connecting()) {
@@ -918,7 +918,7 @@ int NanostackInterface::socket_send(void *handle, const void *p, unsigned size)
     return ret;
 }
 
-int NanostackInterface::socket_recv(void *handle, void *data, unsigned size)
+nsapi_size_or_error_t NanostackInterface::socket_recv(void *handle, void *data, nsapi_size_t size)
 {
     // Validate parameters
     NanostackSocket * socket = static_cast<NanostackSocket *>(handle);
@@ -929,7 +929,7 @@ int NanostackInterface::socket_recv(void *handle, void *data, unsigned size)
 
     nanostack_lock();
 
-    int ret;
+    nsapi_size_or_error_t ret;
     if (socket->closed()) {
         ret = NSAPI_ERROR_NO_CONNECTION;
     } else if (socket->data_available()) {

--- a/features/nanostack/FEATURE_NANOSTACK/nanostack-interface/NanostackInterface.h
+++ b/features/nanostack/FEATURE_NANOSTACK/nanostack-interface/NanostackInterface.h
@@ -37,7 +37,7 @@ protected:
      *  @param proto    Protocol of socket to open, NSAPI_TCP or NSAPI_UDP
      *  @return         0 on success, negative error code on failure
      */
-    virtual int socket_open(void **handle, nsapi_protocol_t proto);
+    virtual nsapi_error_t socket_open(void **handle, nsapi_protocol_t proto);
 
     /** Close the socket
      *
@@ -47,7 +47,7 @@ protected:
      *  @param handle   Socket handle
      *  @return         0 on success, negative error code on failure
      */
-    virtual int socket_close(void *handle);
+    virtual nsapi_error_t socket_close(void *handle);
 
     /** Bind a specific address to a socket
      *
@@ -58,7 +58,7 @@ protected:
      *  @param address  Local address to bind
      *  @return         0 on success, negative error code on failure.
      */
-    virtual int socket_bind(void *handle, const SocketAddress &address);
+    virtual nsapi_error_t socket_bind(void *handle, const SocketAddress &address);
 
     /** Listen for connections on a TCP socket
      *
@@ -70,7 +70,7 @@ protected:
      *                  simultaneously
      *  @return         0 on success, negative error code on failure
      */
-    virtual int socket_listen(void *handle, int backlog);
+    virtual nsapi_error_t socket_listen(void *handle, int backlog);
 
     /** Connects TCP socket to a remote host
      *
@@ -81,7 +81,7 @@ protected:
      *  @param address  The SocketAddress of the remote host
      *  @return         0 on success, negative error code on failure
      */
-    virtual int socket_connect(void *handle, const SocketAddress &address);
+    virtual nsapi_error_t socket_connect(void *handle, const SocketAddress &address);
 
     /** Accepts a connection on a TCP socket
      *
@@ -101,7 +101,7 @@ protected:
      *  @param address  Destination for the remote address or NULL
      *  @return         0 on success, negative error code on failure
      */
-    virtual int socket_accept(void *handle, void **server, SocketAddress *address);
+    virtual nsapi_error_t socket_accept(void *handle, void **server, SocketAddress *address);
 
     /** Send data over a TCP socket
      *
@@ -117,7 +117,7 @@ protected:
      *  @return         Number of sent bytes on success, negative error
      *                  code on failure
      */
-    virtual int socket_send(void *handle, const void *data, unsigned size);
+    virtual nsapi_size_or_error_t socket_send(void *handle, const void *data, nsapi_size_t size);
 
     /** Receive data over a TCP socket
      *
@@ -133,7 +133,7 @@ protected:
      *  @return         Number of received bytes on success, negative error
      *                  code on failure
      */
-    virtual int socket_recv(void *handle, void *data, unsigned size);
+    virtual nsapi_size_or_error_t socket_recv(void *handle, void *data, nsapi_size_t size);
 
     /** Send a packet over a UDP socket
      *
@@ -150,7 +150,7 @@ protected:
      *  @return         Number of sent bytes on success, negative error
      *                  code on failure
      */
-    virtual int socket_sendto(void *handle, const SocketAddress &address, const void *data, unsigned size);
+    virtual nsapi_size_or_error_t socket_sendto(void *handle, const SocketAddress &address, const void *data, nsapi_size_t size);
 
     /** Receive a packet over a UDP socket
      *
@@ -167,7 +167,7 @@ protected:
      *  @return         Number of received bytes on success, negative error
      *                  code on failure
      */
-    virtual int socket_recvfrom(void *handle, SocketAddress *address, void *buffer, unsigned size);
+    virtual nsapi_size_or_error_t socket_recvfrom(void *handle, SocketAddress *address, void *buffer, nsapi_size_t size);
 
     /** Register a callback on state change of the socket
      *
@@ -197,7 +197,7 @@ protected:
      *  @param optlen   Length of the option value
      *  @return         0 on success, negative error code on failure
      */
-    virtual int setsockopt(void *handle, int level, int optname, const void *optval, unsigned optlen);
+    virtual nsapi_error_t setsockopt(void *handle, int level, int optname, const void *optval, unsigned optlen);
 
     /*  Get stack-specific socket options
      *
@@ -212,7 +212,7 @@ protected:
      *  @param optlen   Length of the option value
      *  @return         0 on success, negative error code on failure
      */
-    virtual int getsockopt(void *handle, int level, int optname, void *optval, unsigned *optlen);
+    virtual nsapi_error_t getsockopt(void *handle, int level, int optname, void *optval, unsigned *optlen);
 
 private:
     static NanostackInterface * _ns_interface;
@@ -228,19 +228,19 @@ public:
      *
      *  @return     0 on success, negative on failure
      */
-    virtual int initialize(NanostackRfPhy *phy);
+    virtual nsapi_error_t initialize(NanostackRfPhy *phy);
 
     /** Start the interface
      *
      *  @return     0 on success, negative on failure
      */
-    virtual int connect() = 0;
+    virtual nsapi_error_t connect() = 0;
 
     /** Stop the interface
      *
      *  @return     0 on success, negative on failure
      */
-    virtual int disconnect();
+    virtual nsapi_error_t disconnect();
 
     /** Get the internally stored IP address
     /return     IP address of the interface or null if not yet connected
@@ -255,8 +255,8 @@ public:
 protected:
     MeshInterfaceNanostack();
     MeshInterfaceNanostack(NanostackRfPhy *phy);
-    int register_rf();
-    int actual_connect();
+    nsapi_error_t register_rf();
+    nsapi_error_t actual_connect();
     virtual NetworkStack * get_stack(void);
 
     void mesh_network_handler(mesh_connection_status_t status);
@@ -287,7 +287,7 @@ public:
 
     }
 
-    int connect();
+    nsapi_error_t connect();
 protected:
     Mesh6LoWPAN_ND *get_mesh_api() const { return static_cast<Mesh6LoWPAN_ND *>(mesh_api); }
 private:
@@ -312,7 +312,7 @@ public:
 
     }
 
-    int connect();
+    nsapi_error_t connect();
 protected:
     MeshThread *get_mesh_api() const { return static_cast<MeshThread *>(mesh_api); }
 private:

--- a/features/netsocket/CellularInterface.h
+++ b/features/netsocket/CellularInterface.h
@@ -39,8 +39,10 @@ public:
      *  @param apn      Optional name of the network to connect to
      *  @param user     Optional username for the APN
      *  @param pass     Optional password fot the APN
+     *  @return         0 on success, negative error code on failure
      */
-    virtual int set_credentials(const char *apn, const char *user = 0, const char *pass = 0) = 0;
+    virtual nsapi_error_t set_credentials(const char *apn,
+            const char *username = 0, const char *password = 0) = 0;
 
     /** Start the interface
      *
@@ -49,7 +51,8 @@ public:
      *  @param password Optional password for your APN 
      *  @return         0 on success, negative error code on failure
      */
-    virtual int connect(const char *apn, const char *username = 0, const char *password = 0) = 0;
+    virtual nsapi_error_t connect(const char *apn,
+            const char *username = 0, const char *password = 0) = 0;
 
     /** Start the interface
      *
@@ -57,13 +60,13 @@ public:
      *
      *  @return         0 on success, negative error code on failure
      */
-    virtual int connect() = 0;
+    virtual nsapi_error_t connect() = 0;
  
     /** Stop the interface
      *
      *  @return         0 on success, negative error code on failure
      */
-    virtual int disconnect() = 0;
+    virtual nsapi_error_t disconnect() = 0;
 };
 
  

--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -40,27 +40,27 @@ const char *NetworkInterface::get_gateway()
     return 0;
 }
 
-int NetworkInterface::set_network(const char *ip_address, const char *netmask, const char *gateway)
+nsapi_error_t NetworkInterface::set_network(const char *ip_address, const char *netmask, const char *gateway)
 {
     return NSAPI_ERROR_UNSUPPORTED;
 }
 
-int NetworkInterface::set_dhcp(bool dhcp)
+nsapi_error_t NetworkInterface::set_dhcp(bool dhcp)
 {
     if (!dhcp) {
         return NSAPI_ERROR_UNSUPPORTED;
     } else {
-        return 0;
+        return NSAPI_ERROR_OK;
     }
 }
 
 // DNS operations go through the underlying stack by default
-int NetworkInterface::gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version)
+nsapi_error_t NetworkInterface::gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version)
 {
     return get_stack()->gethostbyname(name, address, version);
 }
 
-int NetworkInterface::add_dns_server(const SocketAddress &address)
+nsapi_error_t NetworkInterface::add_dns_server(const SocketAddress &address)
 {
     return get_stack()->add_dns_server(address);
 }

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -78,7 +78,8 @@ public:
      *  @param gateway  Null-terminated representation of the local gateway
      *  @return         0 on success, negative error code on failure
      */
-    virtual int set_network(const char *ip_address, const char *netmask, const char *gateway);
+    virtual nsapi_error_t set_network(
+            const char *ip_address, const char *netmask, const char *gateway);
 
     /** Enable or disable DHCP on the network
      *
@@ -89,19 +90,19 @@ public:
      *  @param dhcp     True to enable DHCP
      *  @return         0 on success, negative error code on failure
      */
-    virtual int set_dhcp(bool dhcp);
+    virtual nsapi_error_t set_dhcp(bool dhcp);
 
     /** Start the interface
      *
      *  @return     0 on success, negative error code on failure
      */
-    virtual int connect() = 0;
+    virtual nsapi_error_t connect() = 0;
 
     /** Stop the interface
      *
      *  @return     0 on success, negative error code on failure
      */
-    virtual int disconnect() = 0;
+    virtual nsapi_error_t disconnect() = 0;
 
     /** Translates a hostname to an IP address with specific version
      *
@@ -117,14 +118,15 @@ public:
      *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
      *  @return         0 on success, negative error code on failure
      */
-    virtual int gethostbyname(const char *host, SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC);
+    virtual nsapi_error_t gethostbyname(const char *host,
+            SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC);
 
     /** Add a domain name server to list of servers to query
      *
      *  @param addr     Destination for the host address
      *  @return         0 on success, negative error code on failure
      */
-    virtual int add_dns_server(const SocketAddress &address);
+    virtual nsapi_error_t add_dns_server(const SocketAddress &address);
 
 protected:
     friend class Socket;

--- a/features/netsocket/NetworkStack.cpp
+++ b/features/netsocket/NetworkStack.cpp
@@ -22,7 +22,7 @@
 
 
 // Default NetworkStack operations
-int NetworkStack::gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version)
+nsapi_error_t NetworkStack::gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version)
 {
     // check for simple ip addresses
     if (address->set_ip_address(name)) {
@@ -30,7 +30,7 @@ int NetworkStack::gethostbyname(const char *name, SocketAddress *address, nsapi_
             return NSAPI_ERROR_DNS_FAILURE;
         }
 
-        return 0;
+        return NSAPI_ERROR_OK;
     }
 
     // if the version is unspecified, try to guess the version from the
@@ -45,27 +45,27 @@ int NetworkStack::gethostbyname(const char *name, SocketAddress *address, nsapi_
     return nsapi_dns_query(this, name, address, version);
 }
 
-int NetworkStack::add_dns_server(const SocketAddress &address)
+nsapi_error_t NetworkStack::add_dns_server(const SocketAddress &address)
 {
     return nsapi_dns_add_server(address);
 }
 
-int NetworkStack::setstackopt(int level, int optname, const void *optval, unsigned optlen)
+nsapi_error_t NetworkStack::setstackopt(int level, int optname, const void *optval, unsigned optlen)
 {
     return NSAPI_ERROR_UNSUPPORTED;
 }
 
-int NetworkStack::getstackopt(int level, int optname, void *optval, unsigned *optlen)
+nsapi_error_t NetworkStack::getstackopt(int level, int optname, void *optval, unsigned *optlen)
 {
     return NSAPI_ERROR_UNSUPPORTED;
 }
 
-int NetworkStack::setsockopt(void *handle, int level, int optname, const void *optval, unsigned optlen)
+nsapi_error_t NetworkStack::setsockopt(void *handle, int level, int optname, const void *optval, unsigned optlen)
 {
     return NSAPI_ERROR_UNSUPPORTED;
 }
 
-int NetworkStack::getsockopt(void *handle, int level, int optname, void *optval, unsigned *optlen)
+nsapi_error_t NetworkStack::getsockopt(void *handle, int level, int optname, void *optval, unsigned *optlen)
 {
     return NSAPI_ERROR_UNSUPPORTED;
 }
@@ -99,19 +99,19 @@ public:
         return address->get_ip_address();
     }
 
-    virtual int gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version)
+    virtual nsapi_error_t gethostbyname(const char *name, SocketAddress *address, nsapi_version_t version)
     {
         if (!_stack_api()->gethostbyname) {
             return NetworkStack::gethostbyname(name, address, version);
         }
 
         nsapi_addr_t addr = {NSAPI_UNSPEC, 0};
-        int err = _stack_api()->gethostbyname(_stack(), name, &addr, version);
+        nsapi_error_t err = _stack_api()->gethostbyname(_stack(), name, &addr, version);
         address->set_addr(addr);
         return err;
     }
 
-    virtual int add_dns_server(const SocketAddress &address)
+    virtual nsapi_error_t add_dns_server(const SocketAddress &address)
     {
         if (!_stack_api()->add_dns_server) {
             return NetworkStack::add_dns_server(address);
@@ -120,7 +120,7 @@ public:
         return _stack_api()->add_dns_server(_stack(), address.get_addr());
     }
 
-    virtual int setstackopt(int level, int optname, const void *optval, unsigned optlen)
+    virtual nsapi_error_t setstackopt(int level, int optname, const void *optval, unsigned optlen)
     {
         if (!_stack_api()->setstackopt) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -129,7 +129,7 @@ public:
         return _stack_api()->setstackopt(_stack(), level, optname, optval, optlen);
     }
 
-    virtual int getstackopt(int level, int optname, void *optval, unsigned *optlen)
+    virtual nsapi_error_t getstackopt(int level, int optname, void *optval, unsigned *optlen)
     {
         if (!_stack_api()->getstackopt) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -139,7 +139,7 @@ public:
     }
 
 protected:
-    virtual int socket_open(nsapi_socket_t *socket, nsapi_protocol_t proto)
+    virtual nsapi_error_t socket_open(nsapi_socket_t *socket, nsapi_protocol_t proto)
     {
         if (!_stack_api()->socket_open) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -148,7 +148,7 @@ protected:
         return _stack_api()->socket_open(_stack(), socket, proto);
     }
 
-    virtual int socket_close(nsapi_socket_t socket)
+    virtual nsapi_error_t socket_close(nsapi_socket_t socket)
     {
         if (!_stack_api()->socket_close) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -157,7 +157,7 @@ protected:
         return _stack_api()->socket_close(_stack(), socket);
     }
 
-    virtual int socket_bind(nsapi_socket_t socket, const SocketAddress &address)
+    virtual nsapi_error_t socket_bind(nsapi_socket_t socket, const SocketAddress &address)
     {
         if (!_stack_api()->socket_bind) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -166,7 +166,7 @@ protected:
         return _stack_api()->socket_bind(_stack(), socket, address.get_addr(), address.get_port());
     }
 
-    virtual int socket_listen(nsapi_socket_t socket, int backlog)
+    virtual nsapi_error_t socket_listen(nsapi_socket_t socket, int backlog)
     {
         if (!_stack_api()->socket_listen) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -175,7 +175,7 @@ protected:
         return _stack_api()->socket_listen(_stack(), socket, backlog);
     }
 
-    virtual int socket_connect(nsapi_socket_t socket, const SocketAddress &address)
+    virtual nsapi_error_t socket_connect(nsapi_socket_t socket, const SocketAddress &address)
     {
         if (!_stack_api()->socket_connect) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -184,7 +184,7 @@ protected:
         return _stack_api()->socket_connect(_stack(), socket, address.get_addr(), address.get_port());
     }
 
-    virtual int socket_accept(nsapi_socket_t server, nsapi_socket_t *socket, SocketAddress *address)
+    virtual nsapi_error_t socket_accept(nsapi_socket_t server, nsapi_socket_t *socket, SocketAddress *address)
     {
         if (!_stack_api()->socket_accept) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -193,7 +193,7 @@ protected:
         nsapi_addr_t addr = {NSAPI_IPv4, 0};
         uint16_t port = 0;
 
-        int err = _stack_api()->socket_accept(_stack(), server, socket, &addr, &port);
+        nsapi_error_t err = _stack_api()->socket_accept(_stack(), server, socket, &addr, &port);
 
         if (address) {
             address->set_addr(addr);
@@ -203,7 +203,7 @@ protected:
         return err;
     }
 
-    virtual int socket_send(nsapi_socket_t socket, const void *data, unsigned size)
+    virtual nsapi_size_or_error_t socket_send(nsapi_socket_t socket, const void *data, nsapi_size_t size)
     {
         if (!_stack_api()->socket_send) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -212,7 +212,7 @@ protected:
         return _stack_api()->socket_send(_stack(), socket, data, size);
     }
 
-    virtual int socket_recv(nsapi_socket_t socket, void *data, unsigned size)
+    virtual nsapi_size_or_error_t socket_recv(nsapi_socket_t socket, void *data, nsapi_size_t size)
     {
         if (!_stack_api()->socket_recv) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -221,7 +221,7 @@ protected:
         return _stack_api()->socket_recv(_stack(), socket, data, size);
     }
 
-    virtual int socket_sendto(nsapi_socket_t socket, const SocketAddress &address, const void *data, unsigned size)
+    virtual nsapi_size_or_error_t socket_sendto(nsapi_socket_t socket, const SocketAddress &address, const void *data, nsapi_size_t size)
     {
         if (!_stack_api()->socket_sendto) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -230,7 +230,7 @@ protected:
         return _stack_api()->socket_sendto(_stack(), socket, address.get_addr(), address.get_port(), data, size);
     }
 
-    virtual int socket_recvfrom(nsapi_socket_t socket, SocketAddress *address, void *data, unsigned size)
+    virtual nsapi_size_or_error_t socket_recvfrom(nsapi_socket_t socket, SocketAddress *address, void *data, nsapi_size_t size)
     {
         if (!_stack_api()->socket_recvfrom) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -239,7 +239,7 @@ protected:
         nsapi_addr_t addr = {NSAPI_IPv4, 0};
         uint16_t port = 0;
 
-        int err = _stack_api()->socket_recvfrom(_stack(), socket, &addr, &port, data, size);
+        nsapi_size_or_error_t err = _stack_api()->socket_recvfrom(_stack(), socket, &addr, &port, data, size);
 
         if (address) {
             address->set_addr(addr);
@@ -258,7 +258,7 @@ protected:
         return _stack_api()->socket_attach(_stack(), socket, callback, data);
     }
 
-    virtual int setsockopt(nsapi_socket_t socket, int level, int optname, const void *optval, unsigned optlen)
+    virtual nsapi_error_t setsockopt(nsapi_socket_t socket, int level, int optname, const void *optval, unsigned optlen)
     {
         if (!_stack_api()->setsockopt) {
             return NSAPI_ERROR_UNSUPPORTED;
@@ -267,7 +267,7 @@ protected:
         return _stack_api()->setsockopt(_stack(), socket, level, optname, optval, optlen);
     }
 
-    virtual int getsockopt(nsapi_socket_t socket, int level, int optname, void *optval, unsigned *optlen)
+    virtual nsapi_error_t getsockopt(nsapi_socket_t socket, int level, int optname, void *optval, unsigned *optlen)
     {
         if (!_stack_api()->getsockopt) {
             return NSAPI_ERROR_UNSUPPORTED;

--- a/features/netsocket/NetworkStack.h
+++ b/features/netsocket/NetworkStack.h
@@ -58,14 +58,15 @@ public:
      *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
      *  @return         0 on success, negative error code on failure
      */
-    virtual int gethostbyname(const char *host, SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC);
+    virtual nsapi_error_t gethostbyname(const char *host,
+            SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC);
 
     /** Add a domain name server to list of servers to query
      *
      *  @param addr     Destination for the host address
      *  @return         0 on success, negative error code on failure
      */
-    virtual int add_dns_server(const SocketAddress &address);
+    virtual nsapi_error_t add_dns_server(const SocketAddress &address);
 
     /*  Set stack-specific stack options
      *
@@ -79,7 +80,7 @@ public:
      *  @param optlen   Length of the option value
      *  @return         0 on success, negative error code on failure
      */
-    virtual int setstackopt(int level, int optname, const void *optval, unsigned optlen);
+    virtual nsapi_error_t setstackopt(int level, int optname, const void *optval, unsigned optlen);
 
     /*  Get stack-specific stack options
      *
@@ -93,7 +94,7 @@ public:
      *  @param optlen   Length of the option value
      *  @return         0 on success, negative error code on failure
      */
-    virtual int getstackopt(int level, int optname, void *optval, unsigned *optlen);
+    virtual nsapi_error_t getstackopt(int level, int optname, void *optval, unsigned *optlen);
 
 protected:
     friend class Socket;
@@ -113,7 +114,7 @@ protected:
      *  @param proto    Protocol of socket to open, NSAPI_TCP or NSAPI_UDP
      *  @return         0 on success, negative error code on failure
      */
-    virtual int socket_open(nsapi_socket_t *handle, nsapi_protocol_t proto) = 0;
+    virtual nsapi_error_t socket_open(nsapi_socket_t *handle, nsapi_protocol_t proto) = 0;
 
     /** Close the socket
      *
@@ -123,7 +124,7 @@ protected:
      *  @param handle   Socket handle
      *  @return         0 on success, negative error code on failure
      */
-    virtual int socket_close(nsapi_socket_t handle) = 0;
+    virtual nsapi_error_t socket_close(nsapi_socket_t handle) = 0;
 
     /** Bind a specific address to a socket
      *
@@ -134,7 +135,7 @@ protected:
      *  @param address  Local address to bind
      *  @return         0 on success, negative error code on failure.
      */
-    virtual int socket_bind(nsapi_socket_t handle, const SocketAddress &address) = 0;
+    virtual nsapi_error_t socket_bind(nsapi_socket_t handle, const SocketAddress &address) = 0;
 
     /** Listen for connections on a TCP socket
      *
@@ -146,7 +147,7 @@ protected:
      *                  simultaneously
      *  @return         0 on success, negative error code on failure
      */
-    virtual int socket_listen(nsapi_socket_t handle, int backlog) = 0;
+    virtual nsapi_error_t socket_listen(nsapi_socket_t handle, int backlog) = 0;
 
     /** Connects TCP socket to a remote host
      *
@@ -157,7 +158,7 @@ protected:
      *  @param address  The SocketAddress of the remote host
      *  @return         0 on success, negative error code on failure
      */
-    virtual int socket_connect(nsapi_socket_t handle, const SocketAddress &address) = 0;
+    virtual nsapi_error_t socket_connect(nsapi_socket_t handle, const SocketAddress &address) = 0;
 
     /** Accepts a connection on a TCP socket
      *
@@ -177,7 +178,8 @@ protected:
      *  @param address  Destination for the remote address or NULL
      *  @return         0 on success, negative error code on failure
      */
-    virtual int socket_accept(nsapi_socket_t server, nsapi_socket_t *handle, SocketAddress *address=0) = 0;
+    virtual nsapi_error_t socket_accept(nsapi_socket_t server,
+            nsapi_socket_t *handle, SocketAddress *address=0) = 0;
 
     /** Send data over a TCP socket
      *
@@ -193,7 +195,8 @@ protected:
      *  @return         Number of sent bytes on success, negative error
      *                  code on failure
      */
-    virtual int socket_send(nsapi_socket_t handle, const void *data, unsigned size) = 0;
+    virtual nsapi_size_or_error_t socket_send(nsapi_socket_t handle,
+            const void *data, nsapi_size_t size) = 0;
 
     /** Receive data over a TCP socket
      *
@@ -209,7 +212,8 @@ protected:
      *  @return         Number of received bytes on success, negative error
      *                  code on failure
      */
-    virtual int socket_recv(nsapi_socket_t handle, void *data, unsigned size) = 0;
+    virtual nsapi_size_or_error_t socket_recv(nsapi_socket_t handle,
+            void *data, nsapi_size_t size) = 0;
 
     /** Send a packet over a UDP socket
      *
@@ -226,7 +230,8 @@ protected:
      *  @return         Number of sent bytes on success, negative error
      *                  code on failure
      */
-    virtual int socket_sendto(nsapi_socket_t handle, const SocketAddress &address, const void *data, unsigned size) = 0;
+    virtual nsapi_size_or_error_t socket_sendto(nsapi_socket_t handle, const SocketAddress &address,
+            const void *data, nsapi_size_t size) = 0;
 
     /** Receive a packet over a UDP socket
      *
@@ -243,7 +248,8 @@ protected:
      *  @return         Number of received bytes on success, negative error
      *                  code on failure
      */
-    virtual int socket_recvfrom(nsapi_socket_t handle, SocketAddress *address, void *buffer, unsigned size) = 0;
+    virtual nsapi_size_or_error_t socket_recvfrom(nsapi_socket_t handle, SocketAddress *address,
+            void *buffer, nsapi_size_t size) = 0;
 
     /** Register a callback on state change of the socket
      *
@@ -273,7 +279,8 @@ protected:
      *  @param optlen   Length of the option value
      *  @return         0 on success, negative error code on failure
      */
-    virtual int setsockopt(nsapi_socket_t handle, int level, int optname, const void *optval, unsigned optlen);
+    virtual nsapi_error_t setsockopt(nsapi_socket_t handle, int level,
+            int optname, const void *optval, unsigned optlen);
 
     /*  Get stack-specific socket options
      *
@@ -288,7 +295,8 @@ protected:
      *  @param optlen   Length of the option value
      *  @return         0 on success, negative error code on failure
      */
-    virtual int getsockopt(nsapi_socket_t handle, int level, int optname, void *optval, unsigned *optlen);
+    virtual nsapi_error_t getsockopt(nsapi_socket_t handle, int level,
+            int optname, void *optval, unsigned *optlen);
 };
 
 

--- a/features/netsocket/Socket.cpp
+++ b/features/netsocket/Socket.cpp
@@ -24,7 +24,7 @@ Socket::Socket()
 {
 }
 
-int Socket::open(NetworkStack *stack)
+nsapi_error_t Socket::open(NetworkStack *stack)
 {
     _lock.lock();
 
@@ -35,7 +35,7 @@ int Socket::open(NetworkStack *stack)
     _stack = stack;
 
     nsapi_socket_t socket;
-    int err = _stack->socket_open(&socket, get_proto());
+    nsapi_error_t err = _stack->socket_open(&socket, get_proto());
     if (err) {
         _lock.unlock();
         return err;
@@ -46,14 +46,14 @@ int Socket::open(NetworkStack *stack)
     _stack->socket_attach(_socket, Callback<void()>::thunk, &_event);
 
     _lock.unlock();
-    return 0;
+    return NSAPI_ERROR_OK;
 }
 
-int Socket::close()
+nsapi_error_t Socket::close()
 {
     _lock.lock();
 
-    int ret = 0;
+    nsapi_error_t ret = NSAPI_ERROR_OK;
     if (_socket) {
         _stack->socket_attach(_socket, 0, 0);
         nsapi_socket_t socket = _socket;
@@ -69,24 +69,24 @@ int Socket::close()
     return ret;
 }
 
-int Socket::bind(uint16_t port)
+nsapi_error_t Socket::bind(uint16_t port)
 {
     // Underlying bind is thread safe
     SocketAddress addr(0, port);
     return bind(addr);
 }
 
-int Socket::bind(const char *address, uint16_t port)
+nsapi_error_t Socket::bind(const char *address, uint16_t port)
 {
     // Underlying bind is thread safe
     SocketAddress addr(address, port);
     return bind(addr);
 }
 
-int Socket::bind(const SocketAddress &address)
+nsapi_error_t Socket::bind(const SocketAddress &address)
 {
     _lock.lock();
-    int ret;
+    nsapi_error_t ret;
 
     if (!_socket) {
         ret = NSAPI_ERROR_NO_SOCKET;
@@ -117,10 +117,10 @@ void Socket::set_timeout(int timeout)
     _lock.unlock();
 }
 
-int Socket::setsockopt(int level, int optname, const void *optval, unsigned optlen)
+nsapi_error_t Socket::setsockopt(int level, int optname, const void *optval, unsigned optlen)
 {
     _lock.lock();
-    int ret;
+    nsapi_error_t ret;
 
     if (!_socket) {
         ret = NSAPI_ERROR_NO_SOCKET;
@@ -132,10 +132,10 @@ int Socket::setsockopt(int level, int optname, const void *optval, unsigned optl
     return ret;
 }
 
-int Socket::getsockopt(int level, int optname, void *optval, unsigned *optlen)
+nsapi_error_t Socket::getsockopt(int level, int optname, void *optval, unsigned *optlen)
 {
     _lock.lock();
-    int ret;
+    nsapi_error_t ret;
 
     if (!_socket) {
         ret = NSAPI_ERROR_NO_SOCKET;

--- a/features/netsocket/Socket.h
+++ b/features/netsocket/Socket.h
@@ -46,10 +46,10 @@ public:
      *  @param stack    Network stack as target for socket
      *  @return         0 on success, negative error code on failure
      */
-    int open(NetworkStack *stack);
+    nsapi_error_t open(NetworkStack *stack);
 
     template <typename S>
-    int open(S *stack) {
+    nsapi_error_t open(S *stack) {
         return open(nsapi_create_stack(stack));
     }
     
@@ -60,7 +60,7 @@ public:
      *
      *  @return         0 on success, negative error code on failure
      */
-    int close();
+    nsapi_error_t close();
     
     /** Bind a specific address to a socket
      *
@@ -70,7 +70,7 @@ public:
      *  @param port     Local port to bind
      *  @return         0 on success, negative error code on failure.
      */
-    int bind(uint16_t port);
+    nsapi_error_t bind(uint16_t port);
 
     /** Bind a specific address to a socket
      *
@@ -81,7 +81,7 @@ public:
      *  @param port     Local port to bind
      *  @return         0 on success, negative error code on failure.
      */
-    int bind(const char *address, uint16_t port);
+    nsapi_error_t bind(const char *address, uint16_t port);
 
     /** Bind a specific address to a socket
      *
@@ -91,7 +91,7 @@ public:
      *  @param address  Local address to bind
      *  @return         0 on success, negative error code on failure.
      */
-    int bind(const SocketAddress &address);
+    nsapi_error_t bind(const SocketAddress &address);
     
     /** Set blocking or non-blocking mode of the socket
      *
@@ -132,7 +132,7 @@ public:
      *  @param optlen   Length of the option value
      *  @return         0 on success, negative error code on failure
      */    
-    int setsockopt(int level, int optname, const void *optval, unsigned optlen);
+    nsapi_error_t setsockopt(int level, int optname, const void *optval, unsigned optlen);
 
     /*  Get stack-specific socket options
      *
@@ -146,7 +146,7 @@ public:
      *  @param optlen   Length of the option value
      *  @return         0 on success, negative error code on failure
      */    
-    int getsockopt(int level, int optname, void *optval, unsigned *optlen);
+    nsapi_error_t getsockopt(int level, int optname, void *optval, unsigned *optlen);
 
     /** Register a callback on state change of the socket
      *

--- a/features/netsocket/TCPServer.cpp
+++ b/features/netsocket/TCPServer.cpp
@@ -32,10 +32,10 @@ nsapi_protocol_t TCPServer::get_proto()
     return NSAPI_TCP;
 }
 
-int TCPServer::listen(int backlog)
+nsapi_error_t TCPServer::listen(int backlog)
 {
     _lock.lock();
-    int ret;
+    nsapi_error_t ret;
 
     if (!_socket) {
         ret = NSAPI_ERROR_NO_SOCKET;
@@ -47,10 +47,10 @@ int TCPServer::listen(int backlog)
     return ret;
 }
 
-int TCPServer::accept(TCPSocket *connection, SocketAddress *address)
+nsapi_error_t TCPServer::accept(TCPSocket *connection, SocketAddress *address)
 {
     _lock.lock();
-    int ret;
+    nsapi_error_t ret;
 
     while (true) {
         if (!_socket) {

--- a/features/netsocket/TCPServer.h
+++ b/features/netsocket/TCPServer.h
@@ -66,7 +66,7 @@ public:
      *                  simultaneously, defaults to 1
      *  @return         0 on success, negative error code on failure
      */
-    int listen(int backlog = 1);
+    nsapi_error_t listen(int backlog = 1);
     
     /** Accepts a connection on a TCP socket
      *
@@ -82,7 +82,7 @@ public:
      *  @param address  Destination for the remote address or NULL
      *  @return         0 on success, negative error code on failure
      */
-    int accept(TCPSocket *connection, SocketAddress *address = NULL);
+    nsapi_error_t accept(TCPSocket *connection, SocketAddress *address = NULL);
 
 protected:
     virtual nsapi_protocol_t get_proto();

--- a/features/netsocket/TCPSocket.cpp
+++ b/features/netsocket/TCPSocket.cpp
@@ -34,10 +34,10 @@ nsapi_protocol_t TCPSocket::get_proto()
     return NSAPI_TCP;
 }
 
-int TCPSocket::connect(const SocketAddress &address)
+nsapi_error_t TCPSocket::connect(const SocketAddress &address)
 {
     _lock.lock();
-    int ret;
+    nsapi_error_t ret;
 
     if (!_socket) {
         ret = NSAPI_ERROR_NO_SOCKET;
@@ -49,10 +49,10 @@ int TCPSocket::connect(const SocketAddress &address)
     return ret;
 }
 
-int TCPSocket::connect(const char *host, uint16_t port)
+nsapi_error_t TCPSocket::connect(const char *host, uint16_t port)
 {
     SocketAddress address;
-    int err = _stack->gethostbyname(host, &address);
+    nsapi_error_t err = _stack->gethostbyname(host, &address);
     if (err) {
         return NSAPI_ERROR_DNS_FAILURE;
     }
@@ -63,10 +63,10 @@ int TCPSocket::connect(const char *host, uint16_t port)
     return connect(address);
 }
 
-int TCPSocket::send(const void *data, unsigned size)
+nsapi_size_or_error_t TCPSocket::send(const void *data, nsapi_size_t size)
 {
     _lock.lock();
-    int ret;
+    nsapi_size_or_error_t ret;
 
     // If this assert is hit then there are two threads
     // performing a send at the same time which is undefined
@@ -81,7 +81,7 @@ int TCPSocket::send(const void *data, unsigned size)
         }
 
         _pending = 0;
-        int sent = _stack->socket_send(_socket, data, size);
+        nsapi_size_or_error_t sent = _stack->socket_send(_socket, data, size);
         if ((0 == _timeout) || (NSAPI_ERROR_WOULD_BLOCK != sent)) {
             ret = sent;
             break;
@@ -107,10 +107,10 @@ int TCPSocket::send(const void *data, unsigned size)
     return ret;
 }
 
-int TCPSocket::recv(void *data, unsigned size)
+nsapi_size_or_error_t TCPSocket::recv(void *data, nsapi_size_t size)
 {
     _lock.lock();
-    int ret;
+    nsapi_size_or_error_t ret;
 
     // If this assert is hit then there are two threads
     // performing a recv at the same time which is undefined
@@ -125,7 +125,7 @@ int TCPSocket::recv(void *data, unsigned size)
         }
 
         _pending = 0;
-        int recv = _stack->socket_recv(_socket, data, size);
+        nsapi_size_or_error_t recv = _stack->socket_recv(_socket, data, size);
         if ((0 == _timeout) || (NSAPI_ERROR_WOULD_BLOCK != recv)) {
             ret = recv;
             break;

--- a/features/netsocket/TCPSocket.h
+++ b/features/netsocket/TCPSocket.h
@@ -66,7 +66,7 @@ public:
      *  @param port     Port of the remote host
      *  @return         0 on success, negative error code on failure
      */
-    int connect(const char *host, uint16_t port);
+    nsapi_error_t connect(const char *host, uint16_t port);
 
     /** Connects TCP socket to a remote host
      *
@@ -76,7 +76,7 @@ public:
      *  @param address  The SocketAddress of the remote host
      *  @return         0 on success, negative error code on failure
      */
-    int connect(const SocketAddress &address);
+    nsapi_error_t connect(const SocketAddress &address);
     
     /** Send data over a TCP socket
      *
@@ -92,7 +92,7 @@ public:
      *  @return         Number of sent bytes on success, negative error
      *                  code on failure
      */
-    int send(const void *data, unsigned size);
+    nsapi_size_or_error_t send(const void *data, nsapi_size_t size);
     
     /** Receive data over a TCP socket
      *
@@ -108,7 +108,7 @@ public:
      *  @return         Number of received bytes on success, negative error
      *                  code on failure
      */
-    int recv(void *data, unsigned size);
+    nsapi_size_or_error_t recv(void *data, nsapi_size_t size);
 
 protected:
     friend class TCPServer;

--- a/features/netsocket/UDPSocket.cpp
+++ b/features/netsocket/UDPSocket.cpp
@@ -34,10 +34,10 @@ nsapi_protocol_t UDPSocket::get_proto()
     return NSAPI_UDP;
 }
 
-int UDPSocket::sendto(const char *host, uint16_t port, const void *data, unsigned size)
+nsapi_size_or_error_t UDPSocket::sendto(const char *host, uint16_t port, const void *data, nsapi_size_t size)
 {
     SocketAddress address;
-    int err = _stack->gethostbyname(host, &address);
+    nsapi_size_or_error_t err = _stack->gethostbyname(host, &address);
     if (err) {
         return NSAPI_ERROR_DNS_FAILURE;
     }
@@ -48,10 +48,10 @@ int UDPSocket::sendto(const char *host, uint16_t port, const void *data, unsigne
     return sendto(address, data, size);
 }
 
-int UDPSocket::sendto(const SocketAddress &address, const void *data, unsigned size)
+nsapi_size_or_error_t UDPSocket::sendto(const SocketAddress &address, const void *data, nsapi_size_t size)
 {
     _lock.lock();
-    int ret;
+    nsapi_size_or_error_t ret;
 
     // If this assert is hit then there are two threads
     // performing a send at the same time which is undefined
@@ -66,7 +66,7 @@ int UDPSocket::sendto(const SocketAddress &address, const void *data, unsigned s
         }
 
         _pending = 0;
-        int sent = _stack->socket_sendto(_socket, address, data, size);
+        nsapi_size_or_error_t sent = _stack->socket_sendto(_socket, address, data, size);
         if ((0 == _timeout) || (NSAPI_ERROR_WOULD_BLOCK != sent)) {
             ret = sent;
             break;
@@ -92,10 +92,10 @@ int UDPSocket::sendto(const SocketAddress &address, const void *data, unsigned s
     return ret;
 }
 
-int UDPSocket::recvfrom(SocketAddress *address, void *buffer, unsigned size)
+nsapi_size_or_error_t UDPSocket::recvfrom(SocketAddress *address, void *buffer, nsapi_size_t size)
 {
     _lock.lock();
-    int ret;
+    nsapi_size_or_error_t ret;
 
     // If this assert is hit then there are two threads
     // performing a recv at the same time which is undefined
@@ -110,7 +110,7 @@ int UDPSocket::recvfrom(SocketAddress *address, void *buffer, unsigned size)
         }
 
         _pending = 0;
-        int recv = _stack->socket_recvfrom(_socket, address, buffer, size);
+        nsapi_size_or_error_t recv = _stack->socket_recvfrom(_socket, address, buffer, size);
         if ((0 == _timeout) || (NSAPI_ERROR_WOULD_BLOCK != recv)) {
             ret = recv;
             break;

--- a/features/netsocket/UDPSocket.h
+++ b/features/netsocket/UDPSocket.h
@@ -74,7 +74,8 @@ public:
      *  @return         Number of sent bytes on success, negative error
      *                  code on failure
      */
-    int sendto(const char *host, uint16_t port, const void *data, unsigned size);
+    nsapi_size_or_error_t sendto(const char *host, uint16_t port,
+            const void *data, nsapi_size_t size);
 
     /** Send a packet over a UDP socket
      *
@@ -91,7 +92,8 @@ public:
      *  @return         Number of sent bytes on success, negative error
      *                  code on failure
      */
-    int sendto(const SocketAddress &address, const void *data, unsigned size);
+    nsapi_size_or_error_t sendto(const SocketAddress &address,
+            const void *data, nsapi_size_t size);
 
     /** Receive a packet over a UDP socket
      *
@@ -108,7 +110,8 @@ public:
      *  @return         Number of received bytes on success, negative error
      *                  code on failure
      */
-    int recvfrom(SocketAddress *address, void *data, unsigned size);
+    nsapi_size_or_error_t recvfrom(SocketAddress *address,
+            void *data, nsapi_size_t size);
 
 protected:
     virtual nsapi_protocol_t get_proto();

--- a/features/netsocket/WiFiInterface.h
+++ b/features/netsocket/WiFiInterface.h
@@ -44,14 +44,15 @@ public:
      *                   (defaults to NSAPI_SECURITY_NONE)
      *  @return          0 on success, or error code on failure
      */
-    virtual int set_credentials(const char *ssid, const char *pass, nsapi_security_t security = NSAPI_SECURITY_NONE) = 0;
+    virtual nsapi_error_t set_credentials(const char *ssid, const char *pass,
+            nsapi_security_t security = NSAPI_SECURITY_NONE) = 0;
 
     /** Set the WiFi network channel
      *
      *  @param channel   Channel on which the connection is to be made, or 0 for any (Default: 0)
      *  @return          0 on success, or error code on failure
      */
-    virtual int set_channel(uint8_t channel) = 0;
+    virtual nsapi_error_t set_channel(uint8_t channel) = 0;
 
     /** Gets the current radio signal strength for active connection
      *
@@ -70,9 +71,8 @@ public:
      *  @param channel   Channel on which the connection is to be made, or 0 for any (Default: 0)
      *  @return          0 on success, or error code on failure
      */
-    virtual int connect(const char *ssid, const char *pass,
-            nsapi_security_t security = NSAPI_SECURITY_NONE,
-            uint8_t channel = 0) = 0;
+    virtual nsapi_error_t connect(const char *ssid, const char *pass,
+            nsapi_security_t security = NSAPI_SECURITY_NONE, uint8_t channel = 0) = 0;
 
     /** Start the interface
      *
@@ -81,13 +81,13 @@ public:
      *
      *  @return         0 on success, negative error code on failure
      */
-    virtual int connect() = 0;
+    virtual nsapi_error_t connect() = 0;
 
     /** Stop the interface
      *
      *  @return         0 on success, or error code on failure
      */
-    virtual int disconnect() = 0;
+    virtual nsapi_error_t disconnect() = 0;
 
     /** Scan for available networks
      *
@@ -99,10 +99,11 @@ public:
      * @param  ap       Pointer to allocated array to store discovered AP
      * @param  count    Size of allocated @a res array, or 0 to only count available AP
      * @param  timeout  Timeout in milliseconds; 0 for no timeout (Default: 0)
-     * @return          Number of entries in @a, or if @a count was 0 number of available networks, negative on error
+     * @return          Number of entries in @a, or if @a count was 0 number of available networks, 
+     *                  negative on error
      *                  see @a nsapi_error
      */
-    virtual int scan(WiFiAccessPoint *res, unsigned count) = 0;
+    virtual nsapi_size_or_error_t scan(WiFiAccessPoint *res, nsapi_size_t count) = 0;
 };
 
 #endif

--- a/features/netsocket/nsapi_dns.h
+++ b/features/netsocket/nsapi_dns.h
@@ -37,7 +37,7 @@
  *  @return         0 on success, negative error code on failure
  *                  NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
  */
-int nsapi_dns_query(nsapi_stack_t *stack, const char *host,
+nsapi_error_t nsapi_dns_query(nsapi_stack_t *stack, const char *host,
         nsapi_addr_t *addr, nsapi_version_t version);
 
 /** Query a domain name server for multiple IP address of a given hostname
@@ -50,15 +50,15 @@ int nsapi_dns_query(nsapi_stack_t *stack, const char *host,
  *  @return           Number of addresses found on success, negative error code on failure
  *                    NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
  */
-int nsapi_dns_query_multiple(nsapi_stack_t *stack, const char *host,
-        nsapi_addr_t *addr, unsigned addr_count, nsapi_version_t version);
+nsapi_size_or_error_t nsapi_dns_query_multiple(nsapi_stack_t *stack, const char *host,
+        nsapi_addr_t *addr, nsapi_size_t addr_count, nsapi_version_t version);
 
 /** Add a domain name server to list of servers to query
  *
  *  @param addr     Destination for the host address
  *  @return         0 on success, negative error code on failure
  */
-int nsapi_dns_add_server(nsapi_addr_t addr);
+nsapi_error_t nsapi_dns_add_server(nsapi_addr_t addr);
 
 
 #else
@@ -73,7 +73,7 @@ int nsapi_dns_add_server(nsapi_addr_t addr);
  *  @return         0 on success, negative error code on failure
  *                  NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
  */
-int nsapi_dns_query(NetworkStack *stack, const char *host,
+nsapi_error_t nsapi_dns_query(NetworkStack *stack, const char *host,
         SocketAddress *addr, nsapi_version_t version = NSAPI_IPv4);
 
 /** Query a domain name server for an IP address of a given hostname
@@ -85,7 +85,7 @@ int nsapi_dns_query(NetworkStack *stack, const char *host,
  *  @return         0 on success, negative error code on failure
  *                  NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
  */
-extern "C" int nsapi_dns_query(nsapi_stack_t *stack, const char *host,
+extern "C" nsapi_error_t nsapi_dns_query(nsapi_stack_t *stack, const char *host,
         nsapi_addr_t *addr, nsapi_version_t version = NSAPI_IPv4);
 
 /** Query a domain name server for an IP address of a given hostname
@@ -98,7 +98,7 @@ extern "C" int nsapi_dns_query(nsapi_stack_t *stack, const char *host,
  *                  NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
  */
 template <typename S>
-int nsapi_dns_query(S *stack, const char *host,
+nsapi_error_t nsapi_dns_query(S *stack, const char *host,
         SocketAddress *addr, nsapi_version_t version = NSAPI_IPv4)
 {
     return nsapi_dns_query(nsapi_create_stack(stack), host, addr, version);
@@ -114,8 +114,8 @@ int nsapi_dns_query(S *stack, const char *host,
  *  @return           Number of addresses found on success, negative error code on failure
  *                    NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
  */
-int nsapi_dns_query_multiple(NetworkStack *stack, const char *host,
-        SocketAddress *addr, unsigned addr_count, nsapi_version_t version = NSAPI_IPv4);
+nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const char *host,
+        SocketAddress *addr, nsapi_size_t addr_count, nsapi_version_t version = NSAPI_IPv4);
 
 /** Query a domain name server for multiple IP address of a given hostname
  *
@@ -127,8 +127,8 @@ int nsapi_dns_query_multiple(NetworkStack *stack, const char *host,
  *  @return           Number of addresses found on success, negative error code on failure
  *                    NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
  */
-extern "C" int nsapi_dns_query_multiple(nsapi_stack_t *stack, const char *host,
-        nsapi_addr_t *addr, unsigned addr_count, nsapi_version_t version = NSAPI_IPv4);
+extern "C" nsapi_size_or_error_t nsapi_dns_query_multiple(nsapi_stack_t *stack, const char *host,
+        nsapi_addr_t *addr, nsapi_size_t addr_count, nsapi_version_t version = NSAPI_IPv4);
 
 /** Query a domain name server for multiple IP address of a given hostname
  *
@@ -141,8 +141,8 @@ extern "C" int nsapi_dns_query_multiple(nsapi_stack_t *stack, const char *host,
  *                    NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
  */
 template <typename S>
-int nsapi_dns_query_multiple(S *stack, const char *host,
-        SocketAddress *addr, unsigned addr_count, nsapi_version_t version = NSAPI_IPv4)
+nsapi_size_or_error_t nsapi_dns_query_multiple(S *stack, const char *host,
+        SocketAddress *addr, nsapi_size_t addr_count, nsapi_version_t version = NSAPI_IPv4)
 {
     return nsapi_dns_query_multiple(nsapi_create_stack(stack),
                 host, addr, addr_count, version);
@@ -153,14 +153,14 @@ int nsapi_dns_query_multiple(S *stack, const char *host,
  *  @param addr     Destination for the host address
  *  @return         0 on success, negative error code on failure
  */
-extern "C" int nsapi_dns_add_server(nsapi_addr_t addr);
+extern "C" nsapi_error_t nsapi_dns_add_server(nsapi_addr_t addr);
 
 /** Add a domain name server to list of servers to query
  *
  *  @param addr     Destination for the host address
  *  @return         0 on success, negative error code on failure
  */
-static inline int nsapi_dns_add_server(const SocketAddress &address)
+static inline nsapi_error_t nsapi_dns_add_server(const SocketAddress &address)
 {
     return nsapi_dns_add_server(address.get_addr());
 }
@@ -170,7 +170,7 @@ static inline int nsapi_dns_add_server(const SocketAddress &address)
  *  @param addr     Destination for the host address
  *  @return         0 on success, negative error code on failure
  */
-static inline int nsapi_dns_add_server(const char *address)
+static inline nsapi_error_t nsapi_dns_add_server(const char *address)
 {
     return nsapi_dns_add_server(SocketAddress(address));
 }

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -34,7 +34,7 @@ extern "C" {
  *
  *  @enum nsapi_error_t
  */
-typedef enum nsapi_error {
+enum nsapi_error {
     NSAPI_ERROR_OK            =  0,        /*!< no error */
     NSAPI_ERROR_WOULD_BLOCK   = -3001,     /*!< no data is not available but call is non-blocking */
     NSAPI_ERROR_UNSUPPORTED   = -3002,     /*!< unsupported functionality */
@@ -48,7 +48,25 @@ typedef enum nsapi_error {
     NSAPI_ERROR_DHCP_FAILURE  = -3010,     /*!< DHCP failed to complete successfully */
     NSAPI_ERROR_AUTH_FAILURE  = -3011,     /*!< connection to access point failed */
     NSAPI_ERROR_DEVICE_ERROR  = -3012,     /*!< failure interfacing with the network processor */
-} nsapi_error_t;
+};
+
+/** Type used to represent error codes
+ *
+ *  This is a separate type from enum nsapi_error to avoid breaking
+ *  compatibility in type-sensitive overloads
+ */
+typedef signed int nsapi_error_t;
+
+/** Type used to represent the size of data passed through sockets
+ */
+typedef unsigned int nsapi_size_t;
+
+/** Type used to represent either a size or error pased through sockets
+ *
+ *  A valid nsapi_size_or_error_t is either a non-negative size or a
+ *  negative error code from the nsapi_error_t
+ */
+typedef signed int nsapi_size_or_error_t;
 
 /** Enum of encryption types
  *
@@ -233,14 +251,14 @@ typedef struct nsapi_stack_api
      *  @param version  Address family
      *  @return         0 on success, negative error code on failure
      */
-    int (*gethostbyname)(nsapi_stack_t *stack, const char *host, nsapi_addr_t *addr, nsapi_version_t version);
+    nsapi_error_t (*gethostbyname)(nsapi_stack_t *stack, const char *host, nsapi_addr_t *addr, nsapi_version_t version);
 
     /** Add a domain name server to list of servers to query
      *
      *  @param addr     Destination for the host address
      *  @return         0 on success, negative error code on failure
      */
-    int (*add_dns_server)(nsapi_stack_t *stack, nsapi_addr_t addr);
+    nsapi_error_t (*add_dns_server)(nsapi_stack_t *stack, nsapi_addr_t addr);
 
     /*  Set stack-specific stack options
      *
@@ -255,7 +273,8 @@ typedef struct nsapi_stack_api
      *  @param optlen   Length of the option value
      *  @return         0 on success, negative error code on failure
      */
-    int (*setstackopt)(nsapi_stack_t *stack, int level, int optname, const void *optval, unsigned optlen);
+    nsapi_error_t (*setstackopt)(nsapi_stack_t *stack, int level,
+            int optname, const void *optval, unsigned optlen);
 
     /*  Get stack-specific stack options
      *
@@ -270,7 +289,8 @@ typedef struct nsapi_stack_api
      *  @param optlen   Length of the option value
      *  @return         0 on success, negative error code on failure
      */    
-    int (*getstackopt)(nsapi_stack_t *stack, int level, int optname, void *optval, unsigned *optlen);
+    nsapi_error_t (*getstackopt)(nsapi_stack_t *stack, int level,
+            int optname, void *optval, unsigned *optlen);
 
     /** Opens a socket
      *
@@ -285,7 +305,8 @@ typedef struct nsapi_stack_api
      *  @param proto    Protocol of socket to open, NSAPI_TCP or NSAPI_UDP
      *  @return         0 on success, negative error code on failure
      */
-    int (*socket_open)(nsapi_stack_t *stack, nsapi_socket_t *socket, nsapi_protocol_t proto);
+    nsapi_error_t (*socket_open)(nsapi_stack_t *stack, nsapi_socket_t *socket,
+            nsapi_protocol_t proto);
 
     /** Close the socket
      *
@@ -296,7 +317,7 @@ typedef struct nsapi_stack_api
      *  @param socket   Socket handle
      *  @return         0 on success, negative error code on failure
      */
-    int (*socket_close)(nsapi_stack_t *stack, nsapi_socket_t socket);
+    nsapi_error_t (*socket_close)(nsapi_stack_t *stack, nsapi_socket_t socket);
 
     /** Bind a specific address to a socket
      *
@@ -309,7 +330,8 @@ typedef struct nsapi_stack_api
      *  @param port     Local port to bind
      *  @return         0 on success, negative error code on failure.
      */
-    int (*socket_bind)(nsapi_stack_t *stack, nsapi_socket_t socket, nsapi_addr_t addr, uint16_t port);
+    nsapi_error_t (*socket_bind)(nsapi_stack_t *stack, nsapi_socket_t socket,
+            nsapi_addr_t addr, uint16_t port);
 
     /** Listen for connections on a TCP socket
      *
@@ -322,7 +344,7 @@ typedef struct nsapi_stack_api
      *                  simultaneously
      *  @return         0 on success, negative error code on failure
      */
-    int (*socket_listen)(nsapi_stack_t *stack, nsapi_socket_t socket, int backlog);
+    nsapi_error_t (*socket_listen)(nsapi_stack_t *stack, nsapi_socket_t socket, int backlog);
 
     /** Connects TCP socket to a remote host
      *
@@ -335,7 +357,8 @@ typedef struct nsapi_stack_api
      *  @param port     The port of the remote host
      *  @return         0 on success, negative error code on failure
      */
-    int (*socket_connect)(nsapi_stack_t *stack, nsapi_socket_t socket, nsapi_addr_t addr, uint16_t port);
+    nsapi_error_t (*socket_connect)(nsapi_stack_t *stack, nsapi_socket_t socket,
+            nsapi_addr_t addr, uint16_t port);
 
     /** Accepts a connection on a TCP socket
      *
@@ -357,7 +380,8 @@ typedef struct nsapi_stack_api
      *  @param port     Destination for the port of the remote host
      *  @return         0 on success, negative error code on failure
      */
-    int (*socket_accept)(nsapi_stack_t *stack, nsapi_socket_t server, nsapi_socket_t *socket, nsapi_addr_t *addr, uint16_t *port);
+    nsapi_error_t (*socket_accept)(nsapi_stack_t *stack, nsapi_socket_t server,
+            nsapi_socket_t *socket, nsapi_addr_t *addr, uint16_t *port);
 
     /** Send data over a TCP socket
      *
@@ -374,7 +398,8 @@ typedef struct nsapi_stack_api
      *  @return         Number of sent bytes on success, negative error
      *                  code on failure
      */
-    int (*socket_send)(nsapi_stack_t *stack, nsapi_socket_t socket, const void *data, unsigned size);
+    nsapi_size_or_error_t (*socket_send)(nsapi_stack_t *stack, nsapi_socket_t socket,
+            const void *data, nsapi_size_t size);
 
     /** Receive data over a TCP socket
      *
@@ -391,7 +416,8 @@ typedef struct nsapi_stack_api
      *  @return         Number of received bytes on success, negative error
      *                  code on failure
      */
-    int (*socket_recv)(nsapi_stack_t *stack, nsapi_socket_t socket, void *data, unsigned size);
+    nsapi_size_or_error_t (*socket_recv)(nsapi_stack_t *stack, nsapi_socket_t socket,
+            void *data, nsapi_size_t size);
 
     /** Send a packet over a UDP socket
      *
@@ -410,7 +436,8 @@ typedef struct nsapi_stack_api
      *  @return         Number of sent bytes on success, negative error
      *                  code on failure
      */
-    int (*socket_sendto)(nsapi_stack_t *stack, nsapi_socket_t socket, nsapi_addr_t addr, uint16_t port, const void *data, unsigned size);
+    nsapi_size_or_error_t (*socket_sendto)(nsapi_stack_t *stack, nsapi_socket_t socket,
+            nsapi_addr_t addr, uint16_t port, const void *data, nsapi_size_t size);
 
     /** Receive a packet over a UDP socket
      *
@@ -429,7 +456,8 @@ typedef struct nsapi_stack_api
      *  @return         Number of received bytes on success, negative error
      *                  code on failure
      */
-    int (*socket_recvfrom)(nsapi_stack_t *stack, nsapi_socket_t socket, nsapi_addr_t *addr, uint16_t *port, void *buffer, unsigned size);
+    nsapi_size_or_error_t (*socket_recvfrom)(nsapi_stack_t *stack, nsapi_socket_t socket,
+            nsapi_addr_t *addr, uint16_t *port, void *buffer, nsapi_size_t size);
 
     /** Register a callback on state change of the socket
      *
@@ -445,7 +473,8 @@ typedef struct nsapi_stack_api
      *  @param callback Function to call on state change
      *  @param data     Argument to pass to callback
      */
-    void (*socket_attach)(nsapi_stack_t *stack, nsapi_socket_t socket, void (*callback)(void *), void *data);
+    void (*socket_attach)(nsapi_stack_t *stack, nsapi_socket_t socket,
+            void (*callback)(void *), void *data);
 
     /*  Set stack-specific socket options
      *
@@ -461,7 +490,8 @@ typedef struct nsapi_stack_api
      *  @param optlen   Length of the option value
      *  @return         0 on success, negative error code on failure
      */    
-    int (*setsockopt)(nsapi_stack_t *stack, nsapi_socket_t socket, int level, int optname, const void *optval, unsigned optlen);
+    nsapi_error_t (*setsockopt)(nsapi_stack_t *stack, nsapi_socket_t socket, int level,
+            int optname, const void *optval, unsigned optlen);
 
     /*  Get stack-specific socket options
      *
@@ -477,7 +507,8 @@ typedef struct nsapi_stack_api
      *  @param optlen   Length of the option value
      *  @return         0 on success, negative error code on failure
      */    
-    int (*getsockopt)(nsapi_stack_t *stack, nsapi_socket_t socket, int level, int optname, void *optval, unsigned *optlen);
+    nsapi_error_t (*getsockopt)(nsapi_stack_t *stack, nsapi_socket_t socket, int level,
+            int optname, void *optval, unsigned *optlen);
 } nsapi_stack_api_t;
 
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.h
@@ -54,14 +54,14 @@ public:
      *                   (defaults to NSAPI_SECURITY_NONE)
      *  @return          0 on success, or error code on failure
      */
-    virtual int set_credentials(const char *ssid, const char *pass, nsapi_security_t security = NSAPI_SECURITY_NONE);
+    virtual nsapi_error_t set_credentials(const char *ssid, const char *pass, nsapi_security_t security = NSAPI_SECURITY_NONE);
     
     /** Set the WiFi network channel
      *
      *  @param channel   Channel on which the connection is to be made, or 0 for any (Default: 0)
      *  @return          0 on success, or error code on failure
      */
-    virtual int set_channel(uint8_t channel);
+    virtual nsapi_error_t set_channel(uint8_t channel);
     
     /** Start the interface
      *
@@ -73,7 +73,7 @@ public:
      *  @param channel   Channel on which the connection is to be made, or 0 for any (Default: 0)
      *  @return          0 on success, or error code on failure
      */
-    virtual int connect(const char *ssid,
+    virtual nsapi_error_t connect(const char *ssid,
         const char *pass,
         nsapi_security_t security = NSAPI_SECURITY_NONE,
         uint8_t channel = 0);
@@ -85,13 +85,13 @@ public:
      *
      *  @return         0 on success, negative error code on failure
      */
-    virtual int connect();
+    virtual nsapi_error_t connect();
 
     /** Stop the interface
      *
      *  @return         0 on success, or error code on failure
      */
-    virtual int disconnect();
+    virtual nsapi_error_t disconnect();
 
     /** Get the local MAC address
      *
@@ -136,7 +136,7 @@ public:
      *  @param gateway  Null-terminated representation of the local gateway
      *  @return         0 on success, negative error code on failure
      */
-    virtual int set_network(const char *ip_address, const char *netmask, const char *gateway);
+    virtual nsapi_error_t set_network(const char *ip_address, const char *netmask, const char *gateway);
 
     /** Enable or disable DHCP on the network
      *
@@ -147,7 +147,7 @@ public:
      *  @param dhcp     True to enable DHCP
      *  @return         0 on success, negative error code on failure
      */
-    virtual int set_dhcp(bool dhcp);
+    virtual nsapi_error_t set_dhcp(bool dhcp);
     
     /** Gets the current radio signal strength for active connection
      *
@@ -168,7 +168,7 @@ public:
      * @return          Number of entries in @a, or if @a count was 0 number of available networks, negative on error
      *                  see @a nsapi_error
      */
-    virtual int scan(WiFiAccessPoint *res, unsigned count);
+    virtual nsapi_size_or_error_t scan(WiFiAccessPoint *res, nsapi_size_t count);
 
     /** Sets timeout for connection setup. Note that the time for DHCP retrieval is not included.
      *
@@ -184,7 +184,7 @@ protected:
 
 private:
     
-    int connect_async(const char *ssid,
+    nsapi_error_t connect_async(const char *ssid,
         const char *pass,
         nsapi_security_t security = NSAPI_SECURITY_NONE,
         uint8_t channel = 0,


### PR DESCRIPTION
**Note:** Backwards compatible user API
**Note:** Backwards compatible implementation API

Add standardized return types for size and errors:

```
nsapi_error_t         - enum of errors or 0 for NSAPI_ERROR_OK
nsapi_size_t          - unsigned size of data that could be sent
nsapi_size_or_error_t - either a non-negative size or negative error
```

Unfortunately, compatibility concerns limit this types to signed/unsigned ints. It may be worthwhile in the future to switch these types to stricter variants.

As pointed out by @bulislaw, we should also adopt these types in the interfaces that exist in mbed-os:
- [x] LWIP
- [x] Nanostack
- [x] Odin WiFi

from this discusson https://github.com/ARMmbed/mbed-os/pull/2627#r78072433
cc @bulislaw, @kjbracey-arm, @sg- 
