### PR TITLE
lwip: Allow several configuration macros to be set externally (bis)

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwipopts.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwipopts.h
@@ -106,24 +106,35 @@
 #define LWIP_RAM_HEAP_POINTER       lwip_ram_heap
 
 #ifndef PBUF_POOL_SIZE
+/// Each requires 684 bytes of RAM.
 #define PBUF_POOL_SIZE              5
 #endif
 #ifndef MEMP_NUM_TCP_PCB_LISTEN
+/// One is needed for each TCPServer.
+/// Each requires 72 bytes of RAM.
 #define MEMP_NUM_TCP_PCB_LISTEN     4
 #endif
 #ifndef MEMP_NUM_TCP_PCB
+/// One is needed for each TCPSocket.
+/// Each requires 196 bytes of RAM.
 #define MEMP_NUM_TCP_PCB            4
 #endif
 #ifndef MEMP_NUM_UDP_PCB
+/// One is needed for each UDPSocket.
+/// Each requires 84 bytes of RAM (rounded to multiple of 512).
 #define MEMP_NUM_UDP_PCB            4
 #endif
 #ifndef MEMP_NUM_PBUF
+/// Each requires 92 bytes of RAM.
 #define MEMP_NUM_PBUF               8
 #endif
 #ifndef MEMP_NUM_NETBUF
+/// Each requires 64 bytes of RAM.
 #define MEMP_NUM_NETBUF             8
 #endif
 #ifndef MEMP_NUM_NETCONN
+/// One netconn is needed for each UDPSocket, TCPSocket or TCPServer.
+/// Each requires 236 bytes of RAM (rounded to multiple of 512).
 #define MEMP_NUM_NETCONN            4
 #endif
 

--- a/features/FEATURE_LWIP/lwip-interface/lwipopts.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwipopts.h
@@ -105,12 +105,27 @@
 
 #define LWIP_RAM_HEAP_POINTER       lwip_ram_heap
 
+#ifndef PBUF_POOL_SIZE
 #define PBUF_POOL_SIZE              5
+#endif
+#ifndef MEMP_NUM_TCP_PCB_LISTEN
 #define MEMP_NUM_TCP_PCB_LISTEN     4
+#endif
+#ifndef MEMP_NUM_TCP_PCB
 #define MEMP_NUM_TCP_PCB            4
+#endif
+#ifndef MEMP_NUM_UDP_PCB
 #define MEMP_NUM_UDP_PCB            4
+#endif
+#ifndef MEMP_NUM_PBUF
 #define MEMP_NUM_PBUF               8
+#endif
+#ifndef MEMP_NUM_NETBUF
 #define MEMP_NUM_NETBUF             8
+#endif
+#ifndef MEMP_NUM_NETCONN
+#define MEMP_NUM_NETCONN            4
+#endif
 
 #define TCP_QUEUE_OOSEQ             0
 #define TCP_OVERSIZE                0

--- a/features/FEATURE_LWIP/lwip-interface/lwipopts.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwipopts.h
@@ -105,36 +105,52 @@
 
 #define LWIP_RAM_HEAP_POINTER       lwip_ram_heap
 
+// Number of pool pbufs.
+// Each requires 684 bytes of RAM.
 #ifndef PBUF_POOL_SIZE
-/// Each requires 684 bytes of RAM.
 #define PBUF_POOL_SIZE              5
 #endif
-#ifndef MEMP_NUM_TCP_PCB_LISTEN
-/// One is needed for each TCPServer.
-/// Each requires 72 bytes of RAM.
+
+// One tcp_pcb_listen is needed for each TCPServer.
+// Each requires 72 bytes of RAM.
+#ifdef MBED_CONF_LWIP_TCP_SERVER_MAX
+#define MEMP_NUM_TCP_PCB_LISTEN     MBED_CONF_LWIP_TCP_SERVER_MAX
+#else
 #define MEMP_NUM_TCP_PCB_LISTEN     4
 #endif
-#ifndef MEMP_NUM_TCP_PCB
-/// One is needed for each TCPSocket.
-/// Each requires 196 bytes of RAM.
+
+// One is tcp_pcb needed for each TCPSocket.
+// Each requires 196 bytes of RAM.
+#ifdef MBED_CONF_LWIP_TCP_SOCKET_MAX
+#define MEMP_NUM_TCP_PCB            MBED_CONF_LWIP_TCP_SOCKET_MAX
+#else
 #define MEMP_NUM_TCP_PCB            4
 #endif
-#ifndef MEMP_NUM_UDP_PCB
-/// One is needed for each UDPSocket.
-/// Each requires 84 bytes of RAM (rounded to multiple of 512).
+
+// One udp_pcb is needed for each UDPSocket.
+// Each requires 84 bytes of RAM (total rounded to multiple of 512).
+#ifdef MBED_CONF_LWIP_UDP_SOCKET_MAX
+#define MEMP_NUM_UDP_PCB            MBED_CONF_LWIP_UDP_SOCKET_MAX
+#else
 #define MEMP_NUM_UDP_PCB            4
 #endif
+
+// Number of non-pool pbufs.
+// Each requires 92 bytes of RAM.
 #ifndef MEMP_NUM_PBUF
-/// Each requires 92 bytes of RAM.
 #define MEMP_NUM_PBUF               8
 #endif
+
+// Each netbuf requires 64 bytes of RAM.
 #ifndef MEMP_NUM_NETBUF
-/// Each requires 64 bytes of RAM.
 #define MEMP_NUM_NETBUF             8
 #endif
-#ifndef MEMP_NUM_NETCONN
-/// One netconn is needed for each UDPSocket, TCPSocket or TCPServer.
-/// Each requires 236 bytes of RAM (rounded to multiple of 512).
+
+// One netconn is needed for each UDPSocket, TCPSocket or TCPServer.
+// Each requires 236 bytes of RAM (total rounded to multiple of 512).
+#ifdef MBED_CONF_LWIP_SOCKET_MAX
+#define MEMP_NUM_NETCONN            MBED_CONF_LWIP_SOCKET_MAX
+#else
 #define MEMP_NUM_NETCONN            4
 #endif
 

--- a/features/FEATURE_LWIP/lwip-interface/mbed_lib.json
+++ b/features/FEATURE_LWIP/lwip-interface/mbed_lib.json
@@ -16,6 +16,22 @@
         "addr-timeout": {
             "help": "On dual stack system how long to wait preferred stack's address in seconds",
             "value": 5
+        },
+        "socket-max": {
+            "help": "Maximum number of open TCPServer, TCPSocket and UDPSocket instances allowed, including one used internally for DNS.  Each requires 236 bytes of pre-allocated RAM",
+            "value": 4
+        },
+        "tcp-server-max": {
+            "help": "Maximum number of open TCPServer instances allowed.  Each requires 72 bytes of pre-allocated RAM",
+            "value": 4
+        },
+        "tcp-socket-max": {
+            "help": "Maximum number of open TCPSocket instances allowed.  Each requires 196 bytes of pre-allocated RAM",
+            "value": 4
+        },
+        "udp-socket-max": {
+            "help": "Maximum number of open UDPSocket instances allowed, including one used internally for DNS.  Each requires 84 bytes of pre-allocated RAM",
+            "value": 4
         }
     }
 }


### PR DESCRIPTION
## Description

The file lwipopts.h defines various values configuring the lwIP library. These were chosen with quite small values, presumably to allow basic functionality but with a modest RAM footprint suitable for an embedded platform.

Depending on the application or target platform, a user may wish to modify the values, for example to allow more than 4 sockets open at once.  The principal values are made available to the configuration system, with information on the RAM penalty from increasing them.
## Status

**READY**
## Migrations

NO
## Related PRs

Reworking of #2550, rebased.
