### PR TITLE
[nrf5] fix in Digital I/O : a gpioe pin was uninitialized badly

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/gpio_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/gpio_api.c
@@ -86,8 +86,7 @@ int gpio_read(gpio_t *obj)
     }
 }
 
-
-static void gpio_apply_config(uint8_t pin)
+static void gpiote_pin_uninit(uint8_t pin)
 {
     if (m_gpio_initialized & (1UL << pin)) {
         if ((m_gpio_cfg[pin].direction == PIN_OUTPUT) && (!m_gpio_cfg[pin].used_as_irq)) {
@@ -97,7 +96,10 @@ static void gpio_apply_config(uint8_t pin)
             nrf_drv_gpiote_in_uninit(pin);
         }
     }
+}
 
+static void gpio_apply_config(uint8_t pin)
+{
     if (m_gpio_cfg[pin].used_as_gpio || m_gpio_cfg[pin].used_as_irq) {
         if ((m_gpio_cfg[pin].direction == PIN_INPUT)
             || (m_gpio_cfg[pin].used_as_irq)) {
@@ -147,6 +149,9 @@ static void gpio_apply_config(uint8_t pin)
 void gpio_mode(gpio_t *obj, PinMode mode)
 {
     MBED_ASSERT(obj->pin <= GPIO_PIN_COUNT);
+    
+    gpiote_pin_uninit(obj->pin); // try to uninitialize gpio before a change.
+    
     m_gpio_cfg[obj->pin].pull = mode;
     gpio_apply_config(obj->pin);
 }
@@ -155,6 +160,9 @@ void gpio_mode(gpio_t *obj, PinMode mode)
 void gpio_dir(gpio_t *obj, PinDirection direction)
 {
     MBED_ASSERT(obj->pin <= GPIO_PIN_COUNT);
+    
+    gpiote_pin_uninit(obj->pin); // try to uninitialize gpio before a change.
+    
     m_gpio_cfg[obj->pin].direction = direction;
     gpio_apply_config(obj->pin);
 }
@@ -172,6 +180,8 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     MBED_ASSERT((uint32_t)pin < GPIO_PIN_COUNT);
     (void) nrf_drv_gpiote_init();
 
+    gpiote_pin_uninit(pin); // try to uninitialize gpio before a change.
+    
     m_gpio_cfg[pin].used_as_irq = true;
     m_channel_ids[pin] = id;
     obj->ch            = pin;


### PR DESCRIPTION
A gpioe pin might have been uninitialized badly for a new settings - should been uninitialized for an old     settings.