### PR TITLE
Add LOWPOWERTIMER capability for NUCLEO_F303ZE

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -758,9 +758,9 @@
         "inherits": ["Target"],
         "detect_code": ["0747"],
         "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "LOWPOWERTIMER"],
         "release_versions": ["2", "5"],
-        "device_name": "STM32F303RE"
+        "device_name": "STM32F303ZE"
     },
     "NUCLEO_F334R8": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],


### PR DESCRIPTION
## Description
Add LOWPOWERTIMER capability for NUCLEO_F303ZE


## Status
READY

Tests are OK:

| NUCLEO_F303ZE-GCC_ARM | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 1ms lp_ticker          | 1      | 0      | OK     | 0.04               |
| NUCLEO_F303ZE-GCC_ARM | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 1s lp_ticker           | 1      | 0      | OK     | 1.04               |
| NUCLEO_F303ZE-GCC_ARM | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 1s lp_ticker deepsleep | 1      | 0      | OK     | 1.07               |
| NUCLEO_F303ZE-GCC_ARM | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 1s lp_ticker sleep     | 1      | 0      | OK     | 1.05               |
| NUCLEO_F303ZE-GCC_ARM | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 500us lp_ticker        | 1      | 0      | OK     | 0.04               |
| NUCLEO_F303ZE-GCC_ARM | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 5s lp_ticker           | 1      | 0      | OK     | 5.04               |
| NUCLEO_F303ZE-GCC_ARM | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.09               |
| NUCLEO_F303ZE-GCC_ARM | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.11               |
| NUCLEO_F303ZE-GCC_ARM | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.07               |
| NUCLEO_F303ZE-GCC_ARM | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.07               |
| NUCLEO_F303ZE-GCC_ARM | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.09               |
| NUCLEO_F303ZE-GCC_ARM | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.11               |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 1ms lp_ticker          | 1      | 0      | OK     | 0.04               |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 1s lp_ticker           | 1      | 0      | OK     | 1.04               |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 1s lp_ticker deepsleep | 1      | 0      | OK     | 1.06               |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 1s lp_ticker sleep     | 1      | 0      | OK     | 1.04               |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 500us lp_ticker        | 1      | 0      | OK     | 0.03               |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 5s lp_ticker           | 1      | 0      | OK     | 5.04               |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.09               |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.11               |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.07               |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.07               |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.09               |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.11               |
| NUCLEO_F303ZE-IAR | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 1ms lp_ticker          | 1      | 0      | OK     | 0.04               |
| NUCLEO_F303ZE-IAR | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 1s lp_ticker           | 1      | 0      | OK     | 1.04               |
| NUCLEO_F303ZE-IAR | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 1s lp_ticker deepsleep | 1      | 0      | OK     | 1.06               |
| NUCLEO_F303ZE-IAR | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 1s lp_ticker sleep     | 1      | 0      | OK     | 1.05               |
| NUCLEO_F303ZE-IAR | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 500us lp_ticker        | 1      | 0      | OK     | 0.04               |
| NUCLEO_F303ZE-IAR | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker | 5s lp_ticker           | 1      | 0      | OK     | 5.05               |
| NUCLEO_F303ZE-IAR | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
| NUCLEO_F303ZE-IAR | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.04               |
| NUCLEO_F303ZE-IAR | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.07               |
| NUCLEO_F303ZE-IAR | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| NUCLEO_F303ZE-IAR | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.04               |
| NUCLEO_F303ZE-IAR | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.05               |

