### PR TITLE
Add checks for NULL_ENTROPY and SSL_TLS in mbed OS

### DIFF
--- a/features/mbedtls/importer/adjust-config.sh
+++ b/features/mbedtls/importer/adjust-config.sh
@@ -55,10 +55,21 @@ add_code                                                                        
     "\n"                                                                                  \
     "#else\n"
 
-add_code                                                                         \
-    "#include \"check_config.h\"\n"                                              \
-    "\n"                                                                         \
-    "#endif \/* !MBEDTLS_ENTROPY_HARDWARE_ALT && !MBEDTLS_TEST_NULL_ENTROPY *\/"
+add_code                                                                              \
+    "#include \"check_config.h\"\n"                                                   \
+    "\n"                                                                              \
+    "#endif \/* !MBEDTLS_ENTROPY_HARDWARE_ALT && !MBEDTLS_TEST_NULL_ENTROPY *\/\n"    \
+    "\n"                                                                              \
+    "#if defined(MBEDTLS_TEST_NULL_ENTROPY)\n"                                        \
+    "#warning \"MBEDTLS_TEST_NULL_ENTROPY has been enabled. This \" \\\\\n"           \
+    "    \"configuration is not secure and is not suitable for production use\"\n"    \
+    "#endif\n"                                                                        \
+    "\n"                                                                              \
+    "#if defined(MBEDTLS_SSL_TLS_C) && !defined(MBEDTLS_TEST_NULL_ENTROPY) && \\\\\n" \
+    "    !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)\n"                                    \
+    "#error \"No entropy source was found at build time, so TLS \" \\\\\n"            \
+    "    \"functionality is not available\"\n"                                        \
+    "#endif\n"
 
 # not supported on mbed OS, nor used by mbed Client
 conf unset MBEDTLS_NET_C

--- a/features/mbedtls/inc/mbedtls/config.h
+++ b/features/mbedtls/inc/mbedtls/config.h
@@ -2613,4 +2613,16 @@
 #include "check_config.h"
 
 #endif /* !MBEDTLS_ENTROPY_HARDWARE_ALT && !MBEDTLS_TEST_NULL_ENTROPY */
+
+#if defined(MBEDTLS_TEST_NULL_ENTROPY)
+#warning "MBEDTLS_TEST_NULL_ENTROPY has been enabled. This " \
+    "configuration is not secure and is not suitable for production use"
+#endif
+
+#if defined(MBEDTLS_SSL_TLS_C) && !defined(MBEDTLS_TEST_NULL_ENTROPY) && \
+    !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+#error "No entropy source was found at build time, so TLS " \
+    "functionality is not available"
+#endif
+
 #endif /* MBEDTLS_CONFIG_H */


### PR DESCRIPTION
## Description
Add preprocessor checks to mbed TLS through the importer scripts to ensure that compilation fails for targets that attempt to use SSL or entropy, but these are not supported by the target.

## Status
READY

## Migrations
NO

## Todos
- [ ] Tests

## Deploy notes
This causes build errors while trying to build applications that require SSL or entropy sources but the target does not support it.