### PR TITLE
Kinetis HAL: Remove clock initialization code from serial and ticker …

### DIFF
--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K22F/serial_api.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K22F/serial_api.c
@@ -47,10 +47,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     obj->index = pinmap_merge(uart_tx, uart_rx);
     MBED_ASSERT((int)obj->index != NC);
 
-    // Need to initialize the clocks here as ticker init gets called before mbed_sdk_init
-    if (SystemCoreClock == DEFAULT_SYSTEM_CLOCK)
-        BOARD_BootClockRUN();
-
     uart_config_t config;
 
     UART_GetDefaultConfig(&config);

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K22F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K22F/us_ticker.c
@@ -26,9 +26,6 @@ void us_ticker_init(void) {
         return;
     }
     us_ticker_inited = 1;
-    // Need to initialize the clocks here as ticker init gets called before mbed_sdk_init
-    if (SystemCoreClock == DEFAULT_SYSTEM_CLOCK)
-        BOARD_BootClockRUN();
     //Common for ticker/timer
     uint32_t busClock;
     // Structure to initialize PIT

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K66F/serial_api.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K66F/serial_api.c
@@ -47,10 +47,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     obj->index = pinmap_merge(uart_tx, uart_rx);
     MBED_ASSERT((int)obj->index != NC);
 
-    // Need to initialize the clocks here as ticker init gets called before mbed_sdk_init
-    if (SystemCoreClock == DEFAULT_SYSTEM_CLOCK)
-        BOARD_BootClockRUN();
-
     uart_config_t config;
 
     UART_GetDefaultConfig(&config);

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K66F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K66F/us_ticker.c
@@ -26,9 +26,6 @@ void us_ticker_init(void) {
         return;
     }
     us_ticker_inited = 1;
-    // Need to initialize the clocks here as ticker init gets called before mbed_sdk_init
-    if (SystemCoreClock == DEFAULT_SYSTEM_CLOCK)
-        BOARD_BootClockRUN();
     //Common for ticker/timer
     uint32_t busClock;
     // Structure to initialize PIT

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL27Z/serial_api.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL27Z/serial_api.c
@@ -46,10 +46,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     obj->index = pinmap_merge(uart_tx, uart_rx);
     MBED_ASSERT((int)obj->index != NC);
 
-    // Need to initialize the clocks here as ticker init gets called before mbed_sdk_init
-    if (SystemCoreClock == DEFAULT_SYSTEM_CLOCK)
-        BOARD_BootClockRUN();
-
     /* Set the LPUART clock source */
     if (obj->index == LPUART_0) {
         CLOCK_SetLpuart0Clock(1U);

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL27Z/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL27Z/us_ticker.c
@@ -28,10 +28,6 @@ void us_ticker_init(void) {
     }
     us_ticker_inited = 1;
 
-    // Need to initialize the clocks here as ticker init gets called before mbed_sdk_init
-    if (SystemCoreClock == DEFAULT_SYSTEM_CLOCK)
-        BOARD_BootClockRUN();
-
     //Timer uses PIT
     //Common for ticker/timer
     uint32_t busClock;

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL43Z/serial_api.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL43Z/serial_api.c
@@ -46,10 +46,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     obj->index = pinmap_merge(uart_tx, uart_rx);
     MBED_ASSERT((int)obj->index != NC);
 
-    // Need to initialize the clocks here as ticker init gets called before mbed_sdk_init
-    if (SystemCoreClock == DEFAULT_SYSTEM_CLOCK)
-        BOARD_BootClockRUN();
-
     /* Set the LPUART clock source */
     if (obj->index == LPUART_0) {
         CLOCK_SetLpuart0Clock(1U);

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL43Z/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL43Z/us_ticker.c
@@ -28,10 +28,6 @@ void us_ticker_init(void) {
     }
     us_ticker_inited = 1;
 
-    // Need to initialize the clocks here as ticker init gets called before mbed_sdk_init
-    if (SystemCoreClock == DEFAULT_SYSTEM_CLOCK)
-        BOARD_BootClockRUN();
-
     //Timer uses PIT
     //Common for ticker/timer
     uint32_t busClock;

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL82Z/serial_api.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL82Z/serial_api.c
@@ -46,10 +46,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     obj->index = pinmap_merge(uart_tx, uart_rx);
     MBED_ASSERT((int)obj->index != NC);
 
-    // Need to initialize the clocks here as ticker init gets called before mbed_sdk_init
-    if (SystemCoreClock == DEFAULT_SYSTEM_CLOCK)
-        BOARD_BootClockRUN();
-
     /* Set the LPUART clock source */
     CLOCK_SetLpuartClock(2U);
 

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL82Z/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL82Z/us_ticker.c
@@ -26,9 +26,6 @@ void us_ticker_init(void) {
         return;
     }
     us_ticker_inited = 1;
-    // Need to initialize the clocks here as ticker init gets called before mbed_sdk_init
-    if (SystemCoreClock == DEFAULT_SYSTEM_CLOCK)
-        BOARD_BootClockRUN();
     //Common for ticker/timer
     uint32_t busClock;
     // Structure to initialize PIT

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KW24D/serial_api.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KW24D/serial_api.c
@@ -47,10 +47,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     obj->index = pinmap_merge(uart_tx, uart_rx);
     MBED_ASSERT((int)obj->index != NC);
 
-    // Need to initialize the clocks here as ticker init gets called before mbed_sdk_init
-    if (SystemCoreClock == DEFAULT_SYSTEM_CLOCK)
-        BOARD_BootClockRUN();
-
     uart_config_t config;
 
     UART_GetDefaultConfig(&config);
@@ -99,7 +95,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
         if (parity == ParityOdd) {
             temp |= UART_C1_PT_MASK;
         } else if (parity == ParityEven) {
-            // PT=0 so nothing more to do  
+            // PT=0 so nothing more to do
         } else {
             // Hardware does not support forced parity
             MBED_ASSERT(0);

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KW24D/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KW24D/us_ticker.c
@@ -26,9 +26,6 @@ void us_ticker_init(void) {
         return;
     }
     us_ticker_inited = 1;
-    // Need to initialize the clocks here as ticker init gets called before mbed_sdk_init
-    if (SystemCoreClock == DEFAULT_SYSTEM_CLOCK)
-        BOARD_BootClockRUN();
     //Common for ticker/timer
     uint32_t busClock;
     // Structure to initialize PIT

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/serial_api.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/serial_api.c
@@ -47,10 +47,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     obj->index = pinmap_merge(uart_tx, uart_rx);
     MBED_ASSERT((int)obj->index != NC);
 
-    // Need to initialize the clocks here as ticker init gets called before mbed_sdk_init
-    if (SystemCoreClock == DEFAULT_SYSTEM_CLOCK)
-        BOARD_BootClockRUN();
-
     uart_config_t config;
 
     UART_GetDefaultConfig(&config);
@@ -99,7 +95,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
         if (parity == ParityOdd) {
             temp |= UART_C1_PT_MASK;
         } else if (parity == ParityEven) {
-            // PT=0 so nothing more to do  
+            // PT=0 so nothing more to do
         } else {
             // Hardware does not support forced parity
             MBED_ASSERT(0);

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/us_ticker.c
@@ -26,9 +26,6 @@ void us_ticker_init(void) {
         return;
     }
     us_ticker_inited = 1;
-    // Need to initialize the clocks here as ticker init gets called before mbed_sdk_init
-    if (SystemCoreClock == DEFAULT_SYSTEM_CLOCK)
-        BOARD_BootClockRUN();
     //Common for ticker/timer
     uint32_t busClock;
     // Structure to initialize PIT


### PR DESCRIPTION
## Description
 Remove clock initialization code from serial and ticker HAL drivers after updates to the mbed startup code

## Status
**READY
