### PR TITLE
Add mbed-os version macros

### DIFF
--- a/mbed.h
+++ b/mbed.h
@@ -18,13 +18,22 @@
 
 #define MBED_LIBRARY_VERSION 128
 
+#if MBED_CONF_RTOS_PRESENT
+// RTOS present, this is valid only for mbed OS 5
 #define MBED_MAJOR_VERSION 5
 #define MBED_MINOR_VERSION 2
-#define MBED_PATCH_VERSION 0
+#define MBED_PATCH_VERSION 1
 
-#define MBED_ENCODE_VERSION(major,minor,patch) ((major)*10000 + (minor)*100 + (patch))
+#else
+// mbed 2
+#define MBED_MAJOR_VERSION 2
+#define MBED_MINOR_VERSION 0
+#define MBED_PATCH_VERSION MBED_LIBRARY_VERSION
+#endif
 
-#define MBED_VERSION MBED_ENCODE_VERSION(MBED_MAJOR_VERSION,MBED_MINOR_VERSION,MBED_PATCH_VERSION)
+#define MBED_ENCODE_VERSION(major, minor, patch) ((major)*10000 + (minor)*100 + (patch))
+
+#define MBED_VERSION MBED_ENCODE_VERSION(MBED_MAJOR_VERSION, MBED_MINOR_VERSION, MBED_PATCH_VERSION)
 
 #if MBED_CONF_RTOS_PRESENT
 #include "rtos/rtos.h"

--- a/mbed.h
+++ b/mbed.h
@@ -18,6 +18,14 @@
 
 #define MBED_LIBRARY_VERSION 128
 
+#define MBED_MAJOR_VERSION 5
+#define MBED_MINOR_VERSION 2
+#define MBED_PATCH_VERSION 0
+
+#define MBED_ENCODE_VERSION(major,minor,patch) ((major)*10000 + (minor)*100 + (patch))
+
+#define MBED_VERSION MBED_ENCODE_VERSION(MBED_MAJOR_VERSION,MBED_MINOR_VERSION,MBED_PATCH_VERSION)
+
 #if MBED_CONF_RTOS_PRESENT
 #include "rtos/rtos.h"
 #endif


### PR DESCRIPTION
## Description

Allow compile-time tests on the version of mbed-os to cope with e.g. API changes across versions.
As suggested in #3091 
## Status

**READY**
## Migrations

NO
