### PR TITLE
Fix sleep function for NRF52.

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/sleep.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/sleep.c
@@ -31,6 +31,13 @@ void sleep(void)
     // the processor from disabled interrupts.
     SCB->SCR |= SCB_SCR_SEVONPEND_Msk;
 
+#ifdef NRF52
+    /* Clear exceptions and PendingIRQ from the FPU unit */
+    __set_FPSCR(__get_FPSCR()  & ~(FPU_EXCEPTION_MASK));
+    (void) __get_FPSCR();
+    NVIC_ClearPendingIRQ(FPU_IRQn);
+#endif
+
     // If the SoftDevice is enabled, its API must be used to go to sleep.
     if (softdevice_handler_isEnabled()) {
         sd_power_mode_set(NRF_POWER_MODE_LOWPWR);

--- a/targets/TARGET_NORDIC/TARGET_NRF5/sleep.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/sleep.c
@@ -23,6 +23,8 @@
 // In this case, bits which are equal to 0 are the bits reserved in this register
 #define SCB_ICSR_RESERVED_BITS_MASK     0x9E43F03F
 
+#define FPU_EXCEPTION_MASK 0x0000009F
+
 void sleep(void)
 {
     // ensure debug is disconnected if semihost is enabled....


### PR DESCRIPTION
## Description

An active IRQ from the FPU can prevent the micro to go to sleep, even if this
IRQ is not enabled and not implemented.
As a workaround, this patch clear the FPU IRQ before sleep is entered.
