### PR TITLE
STM32F3: Correct UART4 and UART5 defines when using DEVICE_SERIAL_ASYNCH

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F3/serial_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/serial_api.c
@@ -292,6 +292,7 @@ static void uart_irq(int id)
             if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET) {
             irq_handler(serial_irq_ids[id], RxIrq);
                 volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE flag
+                UNUSED(tmpval);
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
@@ -875,6 +876,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     // clear flags
     __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_OREF);
     volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE flag
+    UNUSED(tmpval);
     
     // reset states
     huart->RxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32F3/serial_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/serial_api.c
@@ -578,14 +578,14 @@ static IRQn_Type serial_get_irq_n(serial_t *obj)
             irq_n = USART3_IRQn;
             break;
 #endif
-#if defined(USART4_BASE)
+#if defined(UART4_BASE)
         case 3:
-            irq_n = USART4_IRQn;
+            irq_n = UART4_IRQn;
             break;
 #endif
-#if defined(USART5_BASE)
+#if defined(UART5_BASE)
         case 4:
-            irq_n = USART5_IRQn;
+            irq_n = UART5_IRQn;
             break;
 #endif
         default:


### PR DESCRIPTION
## Description
When DEVICE_SERIAL_ASYNCH is defined during compile of an STM32F3 target, SerialBase::write() for UART4 and UART5 can't be used because UART4 and UART5 were referenced in serial_api.c as USART4 and USART5 but the real defines were created using UART4 and UART5 names.


## Status
READY


## Migrations
NO


## Related PRs
None


## Todos
None


## Deploy notes
None


## Steps to test or reproduce
Create a build for an STM32F3 based target device and define DEVICE_SERIAL_ASYNCH.
Create a Serial object using pins associated with UART4 or UART5.
Attempt to use the write() member function to transmit data using an IRQ.
Nothing gets transmitted and transmit complete event is never generated because the IRQ to use was not determined due to the bug.