### PR TITLE
[Exporters][morph export-build] Adds build tests for make exporters and suppresses TargetNotSupported traceback

### DIFF
--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -68,9 +68,7 @@ class DeviceUvision(DeviceCMSIS):
         '''
         fl_count = 0
         def get_mem_no_x(mem_str):
-            mem_reg = "\dx(\w+)"
-            m = re.search(mem_reg, mem_str)
-            return m.group(1) if m else None
+            return mem_str[2:]
 
         RAMS = [(get_mem_no_x(info["start"]), get_mem_no_x(info["size"]))
                 for mem, info in self.target_info["memory"].items() if "RAM" in mem]

--- a/tools/project.py
+++ b/tools/project.py
@@ -12,6 +12,7 @@ from os.path import normpath, realpath
 
 from tools.paths import EXPORT_DIR, MBED_HAL, MBED_LIBRARIES
 from tools.export import EXPORTERS, mcu_ide_matrix
+from tools.export.exporters import TargetNotSupportedException
 from tools.tests import TESTS, TEST_MAP
 from tools.tests import test_known, test_name_known, Test
 from tools.targets import TARGET_NAMES
@@ -234,10 +235,13 @@ def main():
         # Export to selected toolchain
     _, toolchain_name = get_exporter_toolchain(options.ide)
     profile = extract_profile(parser, options, toolchain_name)
-    export(options.mcu, options.ide, build=options.build,
+    try:
+        export(options.mcu, options.ide, build=options.build,
            src=options.source_dir, macros=options.macros,
            project_id=options.program, clean=options.clean,
            zip_proj=zip_proj, build_profile=profile)
+    except TargetNotSupportedException:
+        print "Your target is not supported for the selected IDE."
 
 
 if __name__ == "__main__":

--- a/tools/project_api.py
+++ b/tools/project_api.py
@@ -229,10 +229,14 @@ def export_project(src_paths, export_path, target, ide,
                                              macros=macros)
     files.append(config_header)
     if zip_proj:
-        if isinstance(zip_proj, basestring):
-            zip_export(join(export_path, zip_proj), name, resource_dict, files, inc_repos)
-        else:
-            zip_export(zip_proj, name, resource_dict, files, inc_repos)
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            if isinstance(zip_proj, basestring):
+                zip_export(join(export_path, zip_proj), name, resource_dict, files, inc_repos)
+                exporter.zipfile = (join(export_path, zip_proj))
+            else:
+                zip_export(zip_proj, name, resource_dict, files, inc_repos)
 
     return exporter
 


### PR DESCRIPTION
## Description

Add export build tests for the new make exporters. In addition, I am suppressing the traceback for targets unsupported by IDEs. I am also suppressing the duplicate file warnings generated by the zip export.
## Status

**READY**
## Todos
- [ ] @bridadan change export-build command to test this PR
- [ ] @theotherjimmy review
## Steps to test or reproduce

`python build_test.py -m whatever -i make_gcc_arm,make_iar,make_armc5`

Traceback change:
Previously:

```
$ mbed export -m rz_a1h -i uvision
WARNING: MBED_ARM_PATH set as environment variable but doesn't exist
C:\Python27\lib\site-packages\fuzzywuzzy-0.11.1-py2.7.egg\fuzzywuzzy\fuzz.py:35: UserWarning: Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning
Scan: ..
Scan: FEATURE_BLE
Scan: FEATURE_COMMON_PAL
Scan: FEATURE_LWIP
Scan: FEATURE_UVISOR
Scan: FEATURE_LOWPAN_BORDER_ROUTER
Scan: FEATURE_LOWPAN_HOST
Scan: FEATURE_LOWPAN_ROUTER
Scan: FEATURE_NANOSTACK
Scan: FEATURE_NANOSTACK_FULL
Scan: FEATURE_THREAD_BORDER_ROUTER
Scan: FEATURE_THREAD_END_DEVICE
Scan: FEATURE_THREAD_ROUTER
Scan: FEATURE_STORAGE
Traceback (most recent call last):
  File "C:\repos\mbed-os-example-blinky\mbed-os\tools\project.py", line 248, in <module>
    main()
  File "C:\repos\mbed-os-example-blinky\mbed-os\tools\project.py", line 242, in main
    zip_proj=zip_proj, build_profile=profile)
  File "C:\repos\mbed-os-example-blinky\mbed-os\tools\project.py", line 94, in export
    build_profile=build_profile, silent=silent)
  File "C:\repos\mbed-os-example-blinky\mbed-os\tools\project_api.py", line 229, in export_project
    macros=macros)
  File "C:\repos\mbed-os-example-blinky\mbed-os\tools\project_api.py", line 90, in generate_project_files
    exporter.generate()
  File "C:\repos\mbed-os-example-blinky\mbed-os\tools\export\uvision\__init__.py", line 197, in generate
    'device': DeviceUvision(self.target),
  File "C:\repos\mbed-os-example-blinky\mbed-os\tools\export\uvision\__init__.py", line 23, in __init__
    DeviceCMSIS.__init__(self, target)
  File "C:\repos\mbed-os-example-blinky\mbed-os\tools\export\cmsis\__init__.py", line 48, in __init__
    raise TargetNotSupportedException("Target not in CMSIS packs")
tools.export.exporters.TargetNotSupportedException: Target not in CMSIS packs
[mbed] ERROR: "python" returned error code 1.
[mbed] ERROR: Command "python -u C:\repos\mbed-os-example-blinky\mbed-os\tools\project.py -i uvision -m rz_a1h --source .." in "C:\repos\mbed-os-example-blinky\mbed-os"
```

Now:

```
$ mbed export -m rz_a1h -i uvision
WARNING: MBED_ARM_PATH set as environment variable but doesn't exist
C:\Python27\lib\site-packages\fuzzywuzzy-0.11.1-py2.7.egg\fuzzywuzzy\fuzz.py:35: UserWarning: Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning
Scan: ..
Scan: FEATURE_BLE
Scan: FEATURE_COMMON_PAL
Scan: FEATURE_LWIP
Scan: FEATURE_UVISOR
Scan: FEATURE_LOWPAN_BORDER_ROUTER
Scan: FEATURE_LOWPAN_HOST
Scan: FEATURE_LOWPAN_ROUTER
Scan: FEATURE_NANOSTACK
Scan: FEATURE_NANOSTACK_FULL
Scan: FEATURE_THREAD_BORDER_ROUTER
Scan: FEATURE_THREAD_END_DEVICE
Scan: FEATURE_THREAD_ROUTER
Scan: FEATURE_STORAGE
Your target is not supported for the selected IDE.
```
