### PR TITLE
[tests] Replacing getchar with RawSerial getc in greentea-client

### DIFF
--- a/features/frameworks/greentea-client/source/test_env.cpp
+++ b/features/frameworks/greentea-client/source/test_env.cpp
@@ -533,7 +533,7 @@ enum Token {
  *
  */
 static int _get_char() {
-    return getchar();
+    return greentea_serial->getc();
 }
 
 /**


### PR DESCRIPTION
## Description
This change prevents the standard library from allocating a large buffer on the heap. On GCC_ARM, this is a saving of 1K in the most basic example (modified blinky). On ARM, this is a saving of 64 bytes.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [x] Tests
- [x] Review by @c1728p9 
- [x] Review by @mazimkhan 



## Steps to test or reproduce
You can turn on runtime heap stat tracking by running the following commands:

```
mbed test --compile -m <TARGET>-t <TOOLCHAIN> -DMBED_HEAP_STATS_ENABLED=1 -DMBED_STACK_STATS_ENABLED=1
mbed test --run -m <TARGET>-t <TOOLCHAIN> -v
```
 
