### PR TITLE
stats - Add cleaner stats API for stack usage

### DIFF
--- a/platform/mbed_alloc_wrappers.cpp
+++ b/platform/mbed_alloc_wrappers.cpp
@@ -57,6 +57,9 @@ static mbed_stats_heap_t heap_stats = {0, 0, 0, 0, 0};
 void mbed_stats_heap_get(mbed_stats_heap_t *stats)
 {
 #ifdef MBED_HEAP_STATS_ENABLED
+    extern uint32_t mbed_heap_size;
+    heap_stats.reserved_size = mbed_heap_size;
+
     malloc_stats_mutex->lock();
     memcpy(stats, &heap_stats, sizeof(mbed_stats_heap_t));
     malloc_stats_mutex->unlock();

--- a/platform/mbed_stats.c
+++ b/platform/mbed_stats.c
@@ -1,0 +1,37 @@
+#include "mbed_stats.h"
+#include <string.h>
+
+#if MBED_CONF_RTOS_PRESENT
+#include "cmsis_os.h"
+#endif
+
+// note: mbed_stats_heap_get defined in mbed_alloc_wrappers.cpp
+
+void mbed_stats_stack_get(mbed_stats_stack_t *stats)
+{
+    memset(stats, 0, sizeof(mbed_stats_stack_t));
+
+#if MBED_STACK_STATS_ENABLED && MBED_CONF_RTOS_PRESENT
+    osThreadEnumId enumid = _osThreadsEnumStart();
+    osThreadId threadid;
+
+    while ((threadid = _osThreadEnumNext(enumid))) {
+        osEvent e;
+
+        e = _osThreadGetInfo(threadid, osThreadInfoStackMax);
+        if (e.status == osOK) {
+           stats->max_size += (uint32_t)e.value.p;
+        }
+
+        e = _osThreadGetInfo(threadid, osThreadInfoStackSize);
+        if (e.status == osOK) {
+           stats->reserved_size += (uint32_t)e.value.p;
+        }
+
+        stats->stack_cnt += 1;
+    }
+#elif MBED_STACK_STATS_ENABLED
+#warning Stack statistics are not supported without the rtos.
+#endif
+}
+

--- a/platform/mbed_stats.h
+++ b/platform/mbed_stats.h
@@ -28,6 +28,7 @@ typedef struct {
     uint32_t current_size;      /**< Bytes allocated currently. */
     uint32_t max_size;          /**< Max bytes allocated at a given time. */
     uint32_t total_size;        /**< Cumulative sum of bytes ever allocated. */
+    uint32_t reserved_size;     /**< Current number of bytes allocated for the heap. */
     uint32_t alloc_cnt;         /**< Current number of allocations. */
     uint32_t alloc_fail_cnt;    /**< Number of failed allocations. */
 } mbed_stats_heap_t;

--- a/platform/mbed_stats.h
+++ b/platform/mbed_stats.h
@@ -35,7 +35,9 @@ typedef struct {
 } mbed_stats_heap_t;
 
 /**
- * Fill the passed in structure with heap stats.
+ *  Fill the passed in heap stat structure with heap stats.
+ *
+ *  @param stats    A pointer to the mbed_stats_heap_t structure to fill
  */
 void mbed_stats_heap_get(mbed_stats_heap_t *stats);
 
@@ -47,13 +49,20 @@ typedef struct {
 } mbed_stats_stack_t;
 
 /**
- * Fill the passed in structure with stack stats.
+ *  Fill the passed in structure with stack stats.
+ *
+ *  @param stats    A pointer to the mbed_stats_stack_t structure to fill
  */
 void mbed_stats_stack_get(mbed_stats_stack_t *stats);
 
 /**
- * Fill the passed array of stat structures with the stack stats
- * for each available stack.
+ *  Fill the passed array of stat structures with the stack stats
+ *  for each available stack.
+ *
+ *  @param stats    A pointer to an array of mbed_stats_stack_t structures to fill
+ *  @param count    The number of mbed_stats_stack_t structures in the provided array
+ *  @return         The number of mbed_stats_stack_t structures that have been filled,
+ *                  this is equal to the number of stacks on the system.
  */
 size_t mbed_stats_stack_get_each(mbed_stats_stack_t *stats, size_t count);
 

--- a/platform/mbed_stats.h
+++ b/platform/mbed_stats.h
@@ -18,6 +18,7 @@
  */
 #ifndef MBED_STATS_H
 #define MBED_STATS_H
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,6 +36,17 @@ typedef struct {
  * Fill the passed in structure with heap stats.
  */
 void mbed_stats_heap_get(mbed_stats_heap_t *stats);
+
+typedef struct {
+    uint32_t max_size;          /**< Sum of the maximum number of bytes used in each stack. */
+    uint32_t reserved_size;     /**< Current number of bytes allocated for all stacks. */
+    uint32_t stack_cnt;         /**< Number of stacks currently allocated. */
+} mbed_stats_stack_t;
+
+/**
+ * Fill the passed in structure with stack stats.
+ */
+void mbed_stats_stack_get(mbed_stats_stack_t *stats);
 
 #ifdef __cplusplus
 }

--- a/platform/mbed_stats.h
+++ b/platform/mbed_stats.h
@@ -19,6 +19,7 @@
 #ifndef MBED_STATS_H
 #define MBED_STATS_H
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,6 +40,7 @@ typedef struct {
 void mbed_stats_heap_get(mbed_stats_heap_t *stats);
 
 typedef struct {
+    uint32_t thread_id;         /**< Identifier for thread that owns the stack. */
     uint32_t max_size;          /**< Sum of the maximum number of bytes used in each stack. */
     uint32_t reserved_size;     /**< Current number of bytes allocated for all stacks. */
     uint32_t stack_cnt;         /**< Number of stacks currently allocated. */
@@ -48,6 +50,12 @@ typedef struct {
  * Fill the passed in structure with stack stats.
  */
 void mbed_stats_stack_get(mbed_stats_stack_t *stats);
+
+/**
+ * Fill the passed array of stat structures with the stack stats
+ * for each available stack.
+ */
+size_t mbed_stats_stack_get_each(mbed_stats_stack_t *stats, size_t count);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add clean stats api for stack usage, based on existing api for heap usage.

Returns cumulative values for all stacks to keep the api simple. Stack-specific stats could be added in the future.

Example:

``` cpp
#include "mbed.h"
#include "mbed_stats.h"

DigitalOut led1(LED1);

// main() runs in its own thread in the OS
// (note the calls to Thread::wait below for delays)
int main() {
    for (int i = 0; i < 5; i++) {
        led1 = !led1;
        Thread::wait(500);
    }

    mbed_stats_heap_t heap_stats;
    mbed_stats_heap_get(&heap_stats);

    mbed_stats_stack_t stack_stats;
    mbed_stats_stack_get(&stack_stats);

    printf("------ stats ------\n");

    printf("heap current size: %ld\n", heap_stats.current_size);
    printf("heap max size: %ld\n", heap_stats.max_size);
    printf("heap total size: %ld\n", heap_stats.total_size);
    printf("heap reserved size: %ld\n", heap_stats.reserved_size);
    printf("heap alloc cnt: %ld\n", heap_stats.alloc_cnt);
    printf("heap alloc fail cnt: %ld\n", heap_stats.alloc_fail_cnt);

    printf("stack current size: %ld\n", stack_stats.current_size);
    printf("stack max size: %ld\n", stack_stats.max_size);
    printf("stack reserved size: %ld\n", stack_stats.reserved_size);
    printf("stack stack cnt: %ld\n", stack_stats.stack_cnt);
}
```

Output (k64f and gcc):

```
------ stats ------
heap current size: 0
heap max size: 0
heap total size: 0
heap reserved size: 180104
heap alloc cnt: 0
heap alloc fail cnt: 0
stack current size: 204
stack max size: 332
stack reserved size: 5408
stack stack cnt: 3
```

tested on K64F and RZ_A1H
cc @c1728p9, @bridadan 
