### PR TITLE
Targets- NUMAKER_PFM_NUC47216 remove mbed 2

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2320,7 +2320,7 @@
         "inherits": ["Target"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "TRNG"],
         "features": ["LWIP"],
-        "release_versions": ["2", "5"],
+        "release_versions": ["5"],
         "device_name": "NUC472HI8AE"
     },
     "NCS36510": {


### PR DESCRIPTION
This platform currently fails to build for mbed 2 due to the mbedtls dependency. We remove it until it's fixed. I'll create a tracking issue soon.

Error:
```
\targets\TARGET_NUVOTON\TARGET_NUC472\crypto\aes\aes_alt.c:25:28: fatal error: mbedtls/config.h: No such file or directory
 #include "mbedtls/config.h"
```

@cyliangtw @adbridge 