### PR TITLE
mbed TLS: threading support - DRAFT - Do not merge

### DIFF
--- a/features/mbedtls/importer/adjust-config.sh
+++ b/features/mbedtls/importer/adjust-config.sh
@@ -71,6 +71,10 @@ add_code                                                                        
     "    \"functionality is not available\"\n"                                        \
     "#endif\n"
 
+# mbed OS has an alternate threading implementation
+conf set MBEDTLS_THREADING_C
+conf set MBEDTLS_THREADING_ALT
+
 # not supported on mbed OS, nor used by mbed Client
 conf unset MBEDTLS_NET_C
 conf unset MBEDTLS_TIMING_C

--- a/features/mbedtls/importer/adjust-config.sh
+++ b/features/mbedtls/importer/adjust-config.sh
@@ -71,10 +71,6 @@ add_code                                                                        
     "    \"functionality is not available\"\n"                                        \
     "#endif\n"
 
-# mbed OS has an alternate threading implementation
-conf set MBEDTLS_THREADING_C
-conf set MBEDTLS_THREADING_ALT
-
 # not supported on mbed OS, nor used by mbed Client
 conf unset MBEDTLS_NET_C
 conf unset MBEDTLS_TIMING_C

--- a/features/mbedtls/inc/mbedtls/config.h
+++ b/features/mbedtls/inc/mbedtls/config.h
@@ -1289,7 +1289,7 @@
  *
  * Uncomment this to allow your own alternate threading implementation.
  */
-//#define MBEDTLS_THREADING_ALT
+#define MBEDTLS_THREADING_ALT
 
 /**
  * \def MBEDTLS_THREADING_PTHREAD
@@ -2337,7 +2337,7 @@
  *
  * Enable this layer to allow use of mutexes within mbed TLS
  */
-//#define MBEDTLS_THREADING_C
+#define MBEDTLS_THREADING_C
 
 /**
  * \def MBEDTLS_TIMING_C

--- a/features/mbedtls/platform/inc/platform_mbed.h
+++ b/features/mbedtls/platform/inc/platform_mbed.h
@@ -20,3 +20,11 @@
 #if defined(DEVICE_TRNG)
 #define MBEDTLS_ENTROPY_HARDWARE_ALT
 #endif
+
+/*
+ * Enable mbed TLS to use mbed OS mutexes
+ */
+#if defined(MBEDTLS_THREADING)
+#define MBEDTLS_THREADING_C
+#define MBEDTLS_THREADING_ALT
+#endif

--- a/features/mbedtls/platform/inc/threading_alt.h
+++ b/features/mbedtls/platform/inc/threading_alt.h
@@ -1,0 +1,49 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBEDTLS_THREADING_ALT_H
+#define MBEDTLS_THREADING_ALT_H
+
+#if defined(MBEDTLS_THREADING_ALT)
+
+#ifdef __cplusplus
+#include "Mutex.h"
+
+typedef struct
+{
+    rtos::Mutex* mutex;
+    char is_valid;
+} mbedtls_threading_mutex_t;
+#else
+typedef struct
+{
+    void* mutex;
+    char is_valid;
+} mbedtls_threading_mutex_t;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void mbedtls_threading_set_mbed( void );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_THREADING_ALT */
+#endif /* threading_alt.h */

--- a/features/mbedtls/platform/src/threading_alt.cpp
+++ b/features/mbedtls/platform/src/threading_alt.cpp
@@ -1,0 +1,79 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_THREADING_C)
+
+#include "mbedtls/threading.h"
+
+#if defined(MBEDTLS_THREADING_ALT)
+static void threading_mutex_init_mbed( mbedtls_threading_mutex_t *mutex )
+{
+    if( mutex == NULL )
+        return;
+
+    mutex->mutex = new rtos::Mutex();
+
+    mutex->is_valid = true;
+}
+
+static void threading_mutex_free_mbed( mbedtls_threading_mutex_t *mutex )
+{
+    if( mutex == NULL || mutex->is_valid != true )
+        return;
+
+    delete mutex->mutex;
+
+    mutex->is_valid = false;
+}
+
+static int threading_mutex_lock_mbed( mbedtls_threading_mutex_t *mutex )
+{
+    if( mutex == NULL || mutex->is_valid != true )
+        return( MBEDTLS_ERR_THREADING_BAD_INPUT_DATA );
+
+    if( mutex->mutex->lock() != osOK )
+        return( MBEDTLS_ERR_THREADING_MUTEX_ERROR );
+
+    return( 0 );
+}
+
+static int threading_mutex_unlock_mbed( mbedtls_threading_mutex_t *mutex )
+{
+    if( mutex == NULL || mutex->is_valid != true )
+        return( MBEDTLS_ERR_THREADING_BAD_INPUT_DATA );
+
+    if( mutex->mutex->unlock() != osOK )
+        return( MBEDTLS_ERR_THREADING_MUTEX_ERROR );
+
+    return( 0 );
+}
+
+void mbedtls_threading_set_mbed( void )
+{
+    mbedtls_threading_set_alt( threading_mutex_init_mbed,
+            threading_mutex_free_mbed, threading_mutex_lock_mbed,
+            threading_mutex_unlock_mbed );
+}
+
+#endif /* MBEDTLS_THREADING_ALT */
+
+#endif /* MBEDTLS_THREADING_C */


### PR DESCRIPTION
## Description

This is an implementation of mbed TLS threading abstraction layer using RTOS mutexes: The application developer has to call the `mbedtls_threading_set_mbed()` function before calling any mbed TLS functions and the library will use RTOS mutexes to provide thread safety where it is sopported. (see the corresponding [Knowledge Base article](https://tls.mbed.org/kb/development/thread-safety-and-multi-threading)).
## Status

**IN DEVELOPMENT**
## Migrations

This PR does not change any existing behaviour:
NO
## Todos
- [ ] Documentation
## Description:

This is an implementation of mbed TLS threading abstraction layer
using RTOS mutexes.

Design decisions:
- The is_valid flag is not checked in the init function, because it is a
  chance that an uninitialised variable has the value of one (it is a
  small chance, but it would result in incorrect behaviour)
- The checks on the is_valid flag are not abbreviated because an
  uninitialised variable is nonzero in most of the cases
- The type of a mutex is a pointer to void and not an incomplete struct,
  because we use definitions with mbedtls_threading_mutex_t in the
  library
- There is a wrapper for mbedtls_threading_set_alt to make it more user
  friendly and to enable the use of static functions
