### PR TITLE
Fix wrong index at LPC43xx tx end ring assignment

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC43XX/ethernet_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/ethernet_api.c
@@ -432,7 +432,7 @@ static void txdscr_init()
         txdesc[i].Status = TX_LAST_SEGM | TX_FIRST_SEGM;;
         txdesc[i].Ctrl   = 0;
         txdesc[i].BufAddr1   = (uint32_t)&txbuf[i];
-        if (i == (NUM_RX_FRAG - 1)) {
+        if (i == (NUM_TX_FRAG - 1)) {
             txdesc[i].Status |= TX_END_RING;
         }
     }


### PR DESCRIPTION
## Description

NUM_TX_FRAG should be used instead of NUM_RX_FRAG, otherwise the tx_end_ring will never be set.
## Status

**READY**
## Migrations

NO
## Related PRs
## Todos
## Deploy notes
## Steps to test or reproduce
