### PR TITLE
nsapi - Add better heuristic for the default record of DNS queries

### DIFF
--- a/features/netsocket/NetworkStack.cpp
+++ b/features/netsocket/NetworkStack.cpp
@@ -33,6 +33,15 @@ int NetworkStack::gethostbyname(const char *name, SocketAddress *address, nsapi_
         return 0;
     }
 
+    // if the version is unspecified, try to guess the version from the
+    // ip address of the underlying stack
+    if (version == NSAPI_UNSPEC) {
+        SocketAddress testaddress;
+        if (testaddress.set_ip_address(this->get_ip_address())) {
+            version = testaddress.get_ip_version();
+        }
+    }
+
     return nsapi_dns_query(this, name, address, version);
 }
 


### PR DESCRIPTION
Add better heuristic for the default record of DNS queries.

Takes advantage of the get_ip_address function to predict the IP address version wanted by the underlying interface. The should avoid the need for most IPv6 interfaces to overload gethostbyname.

suggested by @kjbracey-arm
previous discussion https://github.com/ARMmbed/mbed-os/issues/3145
should resolve https://github.com/ARMmbed/mbed-os/issues/3145
