### PR TITLE
lwip/nsapi - Clean up warnings in network code

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/cc.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/cc.h
@@ -54,7 +54,12 @@ typedef uintptr_t          mem_ptr_t;
 #define SZT_F "uz"
 
 /* ARM/LPC17xx is little endian only */
+#if !defined(BYTE_ORDER) || (BYTE_ORDER != LITTLE_ENDIAN && BYTE_ORDER != BIG_ENDIAN)
+#ifdef BYTE_ORDER
+#undef BYTE_ORDER
+#endif
 #define BYTE_ORDER LITTLE_ENDIAN
+#endif
 
 /* Use LWIP error codes */
 #define LWIP_PROVIDE_ERRNO
@@ -92,7 +97,7 @@ typedef uintptr_t          mem_ptr_t;
     #define LWIP_CHKSUM_ALGORITHM   0
 
     void* thumb2_memcpy(void* pDest, const void* pSource, size_t length);
-    u16_t thumb2_checksum(void* pData, int length);
+    u16_t thumb2_checksum(const void* pData, int length);
 #else
     /* Used with IP headers only */
     #define LWIP_CHKSUM_ALGORITHM   1

--- a/features/FEATURE_LWIP/lwip-interface/lwip/src/core/lwip_pbuf.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip/src/core/lwip_pbuf.c
@@ -1179,6 +1179,7 @@ pbuf_coalesce(struct pbuf *p, pbuf_layer layer)
     return p;
   }
   err = pbuf_copy(q, p);
+  LWIP_UNUSED_ARG(err);
   LWIP_ASSERT("pbuf_copy failed", err == ERR_OK);
   pbuf_free(p);
   return q;

--- a/features/netsocket/SocketAddress.cpp
+++ b/features/netsocket/SocketAddress.cpp
@@ -290,6 +290,8 @@ bool operator==(const SocketAddress &a, const SocketAddress &b)
     } else if (a._addr.version == NSAPI_IPv6) {
         return memcmp(a._addr.bytes, b._addr.bytes, NSAPI_IPv6_BYTES) == 0;
     }
+
+    MBED_UNREACHABLE;
 }
 
 bool operator!=(const SocketAddress &a, const SocketAddress &b)


### PR DESCRIPTION
Clean up warnings in network code

```
- cc.h@57,1: "BYTE_ORDER" redefined
- lwip_inet_chksum.c@560,44: passing argument 1 of 'thumb2_checksum'
  discards 'const' qualifier from pointer target type
- lwip_pbuf.c@1172,9: variable 'err' set but not used
- SocketAddress.cpp@293,1: control reaches end of non-void function
```

cc @c1728p9, @kjbracey-arm 
