### PR TITLE
[tests] Preventing test from printing before Greentea __sync

### DIFF
--- a/TESTS/mbedmicro-mbed/cpp/main.cpp
+++ b/TESTS/mbedmicro-mbed/cpp/main.cpp
@@ -9,8 +9,10 @@ private:
     const int pattern;
 
 public:
-    Test(const char* _name) : name(_name), pattern(PATTERN_CHECK_VALUE)  {
-        print("init");
+    Test(const char* _name, bool print_message=true) : name(_name), pattern(PATTERN_CHECK_VALUE)  {
+        if (print_message) {
+            print("init");
+        }
     }
 
     void print(const char *message) {
@@ -39,7 +41,7 @@ public:
 };
 
 /* Check C++ startup initialisation */
-Test s("Static");
+Test s("Static", false);
 
 /* EXPECTED OUTPUT:
 *******************
@@ -59,6 +61,7 @@ int main (void) {
     bool result = true;
     for (;;)
     {
+        s.print("init");
         // Global stack object simple test
         s.stack_test();
         if (s.check_init() == false)


### PR DESCRIPTION
## Description
The `tests-mbedmicro-mbed-cpp` test was causing issues on some platforms because the serial output would get garbled and cause exceptions to occur in the testing tools when using the reporting functionality. This corrects the behavior to follow the other tests. It will now defer all printing until after the `__sync` event occurs.

I've also made a PR against Greentea to scrub these 'unprintable' characters from the log to prevent the traceback: https://github.com/ARMmbed/greentea/pull/200

## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [ ] Tests


## Steps to test or reproduce
Using commit 8a9a2463563af3ffb8d289905d3f7073a46ecc80 of mbed-os, run the following commands:

```
mbed test --compile -m NCS36510 -t GCC_ARM -n tests-mbedmicro-mbed-cpp
[...]
mbed test --run -m NCS36510 -t GCC_ARM -n tests-mbedmicro-mbed-cpp --report-html report.html -v
[...]
```