### PR TITLE
[tools] Fixing project.py -S printing problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
   - python tools/test/pylint.py
   - py.test tools/test/toolchains/api.py
   - python tools/test/memap/memap_test.py
+  - python tools/project.py -S
   - python tools/build_travis.py
 before_install:
   - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
@@ -16,9 +17,7 @@ before_install:
   - arm-none-eabi-gcc --version
   - python --version
 install:
-  - sudo pip install colorama
-  - sudo pip install prettytable
-  - sudo pip install jinja2
+  - sudo pip install -r requirements.txt
   - sudo pip install pytest
   - sudo pip install pylint
   - sudo pip install hypothesis

--- a/tools/project.py
+++ b/tools/project.py
@@ -18,6 +18,7 @@ from tools.targets import TARGET_NAMES
 from tools.utils import argparse_filestring_type, argparse_many, args_error
 from tools.utils import argparse_force_lowercase_type
 from tools.utils import argparse_force_uppercase_type
+from tools.utils import print_large_string
 from tools.project_api import export_project, get_exporter_toolchain
 from tools.options import extract_profile
 
@@ -189,7 +190,7 @@ def main():
 
     # Only prints matrix of supported IDEs
     if options.supported_ides:
-        print mcu_ide_matrix()
+        print_large_string(mcu_ide_matrix())
         exit(0)
 
     # Only prints matrix of supported IDEs

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -24,6 +24,7 @@ from shutil import copyfile
 from os.path import isdir, join, exists, split, relpath, splitext, abspath
 from os.path import commonprefix, normpath, dirname
 from subprocess import Popen, PIPE, STDOUT, call
+from math import ceil
 import json
 from collections import OrderedDict
 import logging
@@ -486,3 +487,23 @@ def argparse_dir_not_parent(other):
         else:
             return not_parent
     return parse_type
+
+def print_large_string(large_string):
+    """ Breaks a string up into smaller pieces before print them
+
+    This is a limitation within Windows, as detailed here:
+    https://bugs.python.org/issue11395
+
+    Positional arguments:
+    large_string - the large string to print
+    """
+    string_limit = 1000
+    large_string_len = len(large_string)
+    num_parts = int(ceil(float(large_string_len) / float(string_limit)))
+    for string_part in range(num_parts):
+        start_index = string_part * string_limit
+        if string_part == num_parts - 1:
+            print large_string[start_index:]
+        else:
+            end_index = ((string_part + 1) * string_limit) - 1
+            print large_string[start_index:end_index],


### PR DESCRIPTION
## Description
Printing too large of a string can fail in Windows, as detailed here: https://bugs.python.org/issue11395. This works around the problem by adding a print_large_string function that breaks up the string into smaller pieces before printing it.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [x] Review by @theotherjimmy 
- [x] Review by @0xc0170 


## Steps to test or reproduce
Before this change, `mbed export -S` would fail with the following traceback:

```
Traceback (most recent call last):
  File "C:\Users\bridan01\Documents\dev\m_mbed\mbed\tools\project.py", line 244, in <module>
    main()
  File "C:\Users\bridan01\Documents\dev\m_mbed\mbed\tools\project.py", line 192, in main
    print mcu_ide_matrix()
IOError: [Errno 12] Not enough space
[mbed] ERROR: "python" returned error code 1.
[mbed] ERROR: Command "python -u C:\Users\bridan01\Documents\dev\m_mbed\mbed\tools\project.py -S" in "C:\Users\bridan01\Documents\dev\m_mbed\mbed"
```

