### PR TITLE
[Exporters] New export-build tests

### DIFF
--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -18,7 +18,6 @@
 from tools.export import codered, ds5_5, iar, makefile
 from tools.export import emblocks, coide, kds, simplicityv3, atmelstudio
 from tools.export import sw4stm32, e2studio, zip, cmsis, uvision, cdt
-from tools.export.exporters import OldLibrariesException, FailedBuildException
 from tools.targets import TARGET_NAMES
 
 EXPORTERS = {

--- a/tools/export/cmsis/__init__.py
+++ b/tools/export/cmsis/__init__.py
@@ -30,7 +30,8 @@ class DeviceCMSIS():
     """CMSIS Device class
 
     Encapsulates target information retrieved by arm-pack-manager"""
-    cache = Cache(True, False)
+
+    CACHE = Cache(True, False)
     def __init__(self, target):
         target_info = self.check_supported(target)
         if not target_info:
@@ -52,7 +53,7 @@ class DeviceCMSIS():
         t = TARGET_MAP[target]
         try:
             cpu_name = t.device_name
-            target_info = DeviceCMSIS.cache.index[cpu_name]
+            target_info = DeviceCMSIS.CACHE.index[cpu_name]
         # Target does not have device name or pdsc file
         except:
             try:

--- a/tools/export/cmsis/__init__.py
+++ b/tools/export/cmsis/__init__.py
@@ -30,6 +30,7 @@ class DeviceCMSIS():
     """CMSIS Device class
 
     Encapsulates target information retrieved by arm-pack-manager"""
+    cache = Cache(True, False)
     def __init__(self, target):
         target_info = self.check_supported(target)
         if not target_info:
@@ -48,17 +49,16 @@ class DeviceCMSIS():
 
     @staticmethod
     def check_supported(target):
-        cache = Cache(True, False)
         t = TARGET_MAP[target]
         try:
             cpu_name = t.device_name
-            target_info = cache.index[cpu_name]
+            target_info = DeviceCMSIS.cache.index[cpu_name]
         # Target does not have device name or pdsc file
         except:
             try:
                 # Try to find the core as a generic CMSIS target
                 cpu_name = DeviceCMSIS.cpu_cmsis(t.core)
-                target_info = cache.index[cpu_name]
+                target_info = DeviceCMSIS.index[cpu_name]
             except:
                 return False
         target_info["_cpu_name"] = cpu_name

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -11,16 +11,6 @@ import copy
 from tools.targets import TARGET_MAP
 
 
-class OldLibrariesException(Exception):
-    """Exception that indicates an export can not complete due to an out of date
-    library version.
-    """
-    pass
-
-class FailedBuildException(Exception):
-    """Exception that indicates that a build failed"""
-    pass
-
 class TargetNotSupportedException(Exception):
     """Indicates that an IDE does not support a particular MCU"""
     pass
@@ -146,9 +136,31 @@ class Exporter(object):
     def group_project_files(self, sources):
         """Group the source files by their encompassing directory
         Positional Arguments:
-        sources - array of sourc locations
+        sources - array of source locations
 
         Returns a dictionary of {group name: list of source locations}
         """
         data = sorted(sources, key=self.make_key)
         return {k: list(g) for k,g in groupby(data, self.make_key)}
+
+    @staticmethod
+    def build(project_name, log_name='build_log.txt', cleanup=True):
+        """Invoke exporters build command within a subprocess.
+        This method is assumed to be executed at the same level as exporter
+        project files and project source code.
+        See uvision/__init__.py, iar/__init__.py, and makefile/__init__.py for
+        example implemenation.
+
+        Positional Arguments:
+        project_name - the name of the project to build; often required by
+        exporter's build command.
+
+        Keyword Args:
+        log_name - name of the build log to create. Written and printed out,
+        deleted if cleanup = True
+        cleanup - a boolean dictating whether exported project files and
+        build log are removed after build
+
+        Returns -1 on failure and 0 on success
+        """
+        raise NotImplemented("Implement in derived Exporter class.")

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -119,13 +119,6 @@ class Exporter(object):
             source_files.extend(getattr(self.resources, key))
         return list(set([os.path.dirname(src) for src in source_files]))
 
-    def check_supported(self):
-        """Indicated if this combination of IDE and MCU is supported"""
-        if self.target not in self.TARGETS or \
-           self.TOOLCHAIN not in TARGET_MAP[self.target].supported_toolchains:
-            raise TargetNotSupportedException()
-        return True
-
     def gen_file(self, template_file, data, target_file):
         """Generates a project file from a template using jinja"""
         jinja_loader = FileSystemLoader(

--- a/tools/export/iar/__init__.py
+++ b/tools/export/iar/__init__.py
@@ -7,7 +7,7 @@ import re
 import sys
 
 from tools.targets import TARGET_MAP
-from tools.export.exporters import Exporter, FailedBuildException
+from tools.export.exporters import Exporter
 import json
 from tools.export.cmsis import DeviceCMSIS
 from multiprocessing import cpu_count

--- a/tools/export/iar/__init__.py
+++ b/tools/export/iar/__init__.py
@@ -122,7 +122,7 @@ class IAR(Exporter):
         self.gen_file(self.get_ewp_template(), ctx, self.project_name + ".ewp")
 
     @staticmethod
-    def build(project_name, clean=True):
+    def build(project_name, cleanup=True):
         """ Build IAR project """
         # > IarBuild [project_path] -build [project_name]
 
@@ -149,7 +149,7 @@ class IAR(Exporter):
             if m is not None:
                 num_errors = int(m.group(1))
 
-        if clean:
+        if cleanup:
             os.remove(project_name + ".ewp")
             os.remove(project_name + ".ewd")
             os.remove(project_name + ".eww")

--- a/tools/export/iar/__init__.py
+++ b/tools/export/iar/__init__.py
@@ -2,7 +2,7 @@ import os
 from os.path import sep, join, exists
 from collections import namedtuple
 from subprocess import Popen, PIPE
-from distutils.spawn import find_executable
+import shutil
 import re
 import sys
 
@@ -29,7 +29,8 @@ class IAR(Exporter):
     #iar_definitions.json
     TARGETS = [target for target, obj in TARGET_MAP.iteritems()
                if hasattr(obj, 'device_name') and
-               obj.device_name in IAR_DEFS.keys()]
+               obj.device_name in IAR_DEFS.keys() and "IAR" in obj.supported_toolchains
+               and DeviceCMSIS.check_supported(target)]
 
     SPECIAL_TEMPLATES = {
         'rz_a1h'  : 'iar/iar_rz_a1h.ewp.tmpl',
@@ -120,22 +121,13 @@ class IAR(Exporter):
         self.gen_file('iar/ewd.tmpl', ctx, self.project_name + ".ewd")
         self.gen_file(self.get_ewp_template(), ctx, self.project_name + ".ewp")
 
-    def build(self):
+    @staticmethod
+    def build(project_name, clean=True):
         """ Build IAR project """
         # > IarBuild [project_path] -build [project_name]
-        proj_file = join(self.export_dir, self.project_name + ".ewp")
 
-        if find_executable("IarBuild"):
-            iar_exe = "IarBuild.exe"
-        else:
-            iar_exe = join('C:', sep,
-                          'Program Files (x86)', 'IAR Systems',
-                          'Embedded Workbench 7.5', 'common', 'bin',
-                          'IarBuild.exe')
-            if not exists(iar_exe):
-                raise Exception("IarBuild.exe not found. Add to path.")
-
-        cmd = [iar_exe, proj_file, '-build', self.project_name]
+        proj_file = project_name + ".ewp"
+        cmd = ["IarBuild.exe", proj_file, '-build', project_name]
 
         # IAR does not support a '0' option to automatically use all
         # available CPUs, so we use Python's multiprocessing library
@@ -156,7 +148,14 @@ class IAR(Exporter):
             m = re.match(error_re, line)
             if m is not None:
                 num_errors = int(m.group(1))
+
+        if clean:
+            os.remove(project_name + ".ewp")
+            os.remove(project_name + ".ewd")
+            os.remove(project_name + ".eww")
+            shutil.rmtree('.build')
+
         if num_errors !=0:
             # Seems like something went wrong.
-            raise FailedBuildException("Project: %s build failed with %s erros" % (
-            proj_file, num_errors))
+            return -1
+        return 0

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -108,7 +108,7 @@ class Makefile(Exporter):
     @staticmethod
     def build(project_name, log_name="build_log.txt", cleanup=True):
         """ Build Make project """
-        # > Make -C [project directory] -j
+        # > Make -j
         cmd = ["make", "-j"]
         p = Popen(cmd, stdout=PIPE, stderr=PIPE)
         ret = p.communicate()

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -106,7 +106,7 @@ class Makefile(Exporter):
             raise NotSupportedException("This make tool is in development")
 
     @staticmethod
-    def build(project_name, build_log="build_log.txt", project_loc=None, clean=True):
+    def build(project_name, log_name="build_log.txt", cleanup=True):
         """ Build Make project """
         # > Make -C [project directory] -j
         cmd = ["make", "-j"]
@@ -114,7 +114,7 @@ class Makefile(Exporter):
         ret = p.communicate()
         out, err = ret[0], ret[1]
         ret_code = p.returncode
-        with open(build_log, 'w+') as f:
+        with open(log_name, 'w+') as f:
             f.write("=" * 10 + "OUT" + "=" * 10 + "\n")
             f.write(out)
             f.write("=" * 10 + "ERR" + "=" * 10 + "\n")
@@ -123,13 +123,13 @@ class Makefile(Exporter):
                 f.write("SUCCESS")
             else:
                 f.write("FAILURE")
-        with open(build_log, 'r') as f:
+        with open(log_name, 'r') as f:
             print "\n".join(f.readlines())
         sys.stdout.flush()
 
-        if clean:
+        if cleanup:
             remove("Makefile")
-            remove(build_log)
+            remove(log_name)
             if exists('.build'):
                 shutil.rmtree('.build')
         if ret_code != 0:

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -9,7 +9,7 @@ import re
 
 from tools.arm_pack_manager import Cache
 from tools.targets import TARGET_MAP
-from tools.export.exporters import Exporter, FailedBuildException
+from tools.export.exporters import Exporter
 from tools.export.cmsis import DeviceCMSIS
 
 cache_d = False
@@ -207,6 +207,8 @@ class Uvision(Exporter):
 
     @staticmethod
     def build(project_name, log_name='build_log.txt', cleanup=True):
+        """ Build Uvision project """
+        # > UV4.exe -r -j0 -o [log_name] [project_name].uvprojx
         success = 0
         warn  = 1
         cmd = ["UV4.exe", '-r', '-j0', '-o', log_name, project_name+".uvprojx"]

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -206,14 +206,14 @@ class Uvision(Exporter):
         self.gen_file('uvision/uvision_debug.tmpl', ctx, self.project_name + ".uvoptx")
 
     @staticmethod
-    def build(project_name, log_name='build_log.txt', clean=True):
+    def build(project_name, log_name='build_log.txt', cleanup=True):
         success = 0
         warn  = 1
         cmd = ["UV4.exe", '-r', '-j0', '-o', log_name, project_name+".uvprojx"]
         ret_code = subprocess.call(cmd)
         with open(log_name, 'r') as build_log:
             print build_log.read()
-        if clean:
+        if cleanup:
             os.remove(log_name)
             os.remove(project_name+".uvprojx")
             os.remove(project_name+".uvoptx")

--- a/tools/project.py
+++ b/tools/project.py
@@ -234,7 +234,7 @@ def main():
         # Export to selected toolchain
     exporter, toolchain_name = get_exporter_toolchain(options.ide)
     if options.mcu not in exporter.TARGETS:
-        args_error(parser, "%s not supported by %s")
+        args_error(parser, "%s not supported by %s"%(options.mcu,options.ide))
     profile = extract_profile(parser, options, toolchain_name)
     export(options.mcu, options.ide, build=options.build,
            src=options.source_dir, macros=options.macros,

--- a/tools/project.py
+++ b/tools/project.py
@@ -232,7 +232,9 @@ def main():
     if (options.program is None) and (not options.source_dir):
         args_error(parser, "one of -p, -n, or --source is required")
         # Export to selected toolchain
-    _, toolchain_name = get_exporter_toolchain(options.ide)
+    exporter, toolchain_name = get_exporter_toolchain(options.ide)
+    if options.mcu not in exporter.TARGETS:
+        args_error(parser, "%s not supported by %s")
     profile = extract_profile(parser, options, toolchain_name)
     export(options.mcu, options.ide, build=options.build,
            src=options.source_dir, macros=options.macros,

--- a/tools/project_api.py
+++ b/tools/project_api.py
@@ -86,7 +86,6 @@ def generate_project_files(resources, export_path, target, name, toolchain, ide,
     exporter_cls, _ = get_exporter_toolchain(ide)
     exporter = exporter_cls(target, export_path, name, toolchain,
                             extra_symbols=macros, resources=resources)
-    exporter.check_supported()
     exporter.generate()
     files = exporter.generated_files
     return files, exporter

--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -9,7 +9,9 @@
       "features" : [],
       "targets" : [],
       "toolchains" : [],
+      "exporters": [],
       "compile" : true,
+      "export": true,
       "auto-update" : true
     },
     {
@@ -24,7 +26,9 @@
       "features" : [],
       "targets" : ["K64F", "NUCLEO_F429ZI"],
       "toolchains" : ["GCC_ARM", "ARM"],
+      "exporters": [],
       "compile" : true,
+      "export": false,
       "auto-update" : true
     },
     {
@@ -36,7 +40,9 @@
       "features" : ["IPV6"],
       "targets" : [],
       "toolchains" : [],
+      "exporters": [],
       "compile" : true,
+      "export": false,
       "auto-update" : true
     },
     {
@@ -57,7 +63,9 @@
       "features" : ["BLE"],
       "targets" : ["NRF51_DK", "NRF52_DK", "K64F", "NUCLEO_F401RE"],
       "toolchains" : [],
+      "exporters": [],
       "compile" : true,
+      "export": false,
       "auto-update" : true
     },
     {
@@ -69,7 +77,9 @@
       "features" : ["IPV6"],
       "targets" : [],
       "toolchains" : [],
+      "exporters": [],
       "compile" : true,
+      "export": false,
       "auto-update" : true
     },
     {
@@ -80,7 +90,9 @@
       "features" : ["IPV6"],
       "targets" : [],
       "toolchains" : [],
+      "exporters": [],
       "compile" : true,
+      "export": false,
       "auto-update" : true
     },
     {
@@ -91,7 +103,9 @@
       "features" : [],
       "targets" : [],
       "toolchains" : [],
+      "exporters": [],
       "compile" : false,
+      "export": false,
       "auto-update" : true
     },
     {
@@ -102,7 +116,9 @@
       "features" : [],
       "targets" : ["K64F"],
       "toolchains" : ["GCC_ARM"],
+      "exporters": [],
       "compile" : true,
+      "export": false,
       "auto-update" : false
     }
   ]

--- a/tools/test/examples/examples.py
+++ b/tools/test/examples/examples.py
@@ -59,7 +59,9 @@ def target_cross_toolchain(allowed_toolchains,
 
 
 def target_cross_ide(allowed_ides,
-                    targets=TARGET_MAP.keys()):
+                     features=[],
+                     ides=SUPPORTED_IDES,
+                     toolchains=SUPPORTED_TOOLCHAINS):
     """Generate pairs of target and ides
 
     Args:
@@ -68,7 +70,11 @@ def target_cross_ide(allowed_ides,
     """
     for release_target, release_toolchains in get_mbed_official_release("5"):
         for ide in allowed_ides:
-            if release_target in EXPORTERS[ide].TARGETS:
+            if (release_target in EXPORTERS[ide].TARGETS and
+                EXPORTERS[ide].TOOLCHAIN in toolchains and
+                ide in ides and
+                all(feature in TARGET_MAP[release_target].features
+                    for feature in features)):
                 yield release_target, ide
 
 
@@ -101,7 +107,7 @@ def main():
 
 
 def do_export(args):
-
+    """Do export and build step"""
     def print_message(message, name):
         print(message+ " %s"%name)
         sys.stdout.flush()
@@ -114,7 +120,8 @@ def do_export(args):
         if ex_name != "mbed-os-example-blinky":
             continue
         os.chdir(ex_name)
-        for target, ide in target_cross_ide(args.ide):
+        for target, ide in target_cross_ide(args.ide,
+                                            **requirements):
             example_name = "{} {} {}".format(ex_name, target,
                                              ide)
             print_message("Export:",example_name)

--- a/tools/test/examples/examples.py
+++ b/tools/test/examples/examples.py
@@ -13,69 +13,10 @@ sys.path.insert(0, ROOT)
 
 from tools.utils import argparse_force_uppercase_type
 import examples_lib as lib
-from examples_lib import SUPPORTED_TOOLCHAINS
-from tools.export import EXPORTERS
-from tools.build_api import get_mbed_official_release
-from tools.targets import TARGET_MAP
+from examples_lib import SUPPORTED_TOOLCHAINS, SUPPORTED_IDES
 
 EXAMPLES = json.load(open(os.path.join(os.path.dirname(__file__),
                                        "examples.json")))
-
-def print_stuff(name, lst):
-    if lst:
-        print("#"*80)
-        print("# {} example combinations".format(name))
-        print("#")
-    for thing in lst:
-        print(thing)
-
-
-SUPPORTED_TOOLCHAINS = ["ARM", "IAR", "GCC_ARM"]
-SUPPORTED_IDES = ["iar", "uvision", "make_gcc_arm", "make_iar", "make_armc5"]
-
-
-def target_cross_toolchain(allowed_toolchains,
-                           features=[], targets=TARGET_MAP.keys(),
-                           toolchains=SUPPORTED_TOOLCHAINS):
-    """Generate pairs of target and toolchains
-
-    Args:
-    allowed_toolchains - a list of all possible toolchains
-
-    Kwargs:
-    features - the features that must be in the features array of a
-               target
-    targets - a list of available targets
-    toolchains - a list of available toolchains
-    """
-    for release_target, release_toolchains in get_mbed_official_release("5"):
-        for toolchain in release_toolchains:
-            if (toolchain in allowed_toolchains and
-                toolchain in toolchains and
-                release_target in targets and
-                all(feature in TARGET_MAP[release_target].features
-                    for feature in features)):
-                yield release_target, toolchain
-
-
-def target_cross_ide(allowed_ides,
-                     features=[],
-                     ides=SUPPORTED_IDES,
-                     toolchains=SUPPORTED_TOOLCHAINS):
-    """Generate pairs of target and ides
-
-    Args:
-    allowed_ides - a list of all possible IDEs
-
-    """
-    for release_target, release_toolchains in get_mbed_official_release("5"):
-        for ide in allowed_ides:
-            if (release_target in EXPORTERS[ide].TARGETS and
-                EXPORTERS[ide].TOOLCHAIN in toolchains and
-                ide in ides and
-                all(feature in TARGET_MAP[release_target].features
-                    for feature in features)):
-                yield release_target, ide
 
 
 def main():
@@ -106,57 +47,29 @@ def main():
     return args.fn(args, config)
 
 
-def do_export(args):
+def do_export(args, config):
     """Do export and build step"""
-    def print_message(message, name):
-        print(message+ " %s"%name)
-        sys.stdout.flush()
+    results = {}
+    results = lib.export_repos(config, args.ide)
 
-    export_failures = []
-    build_failures = []
-    sucesses = []
-    for example, requirements in EXAMPLES.iteritems():
-        ex_name = basename(example)
-        if ex_name != "mbed-os-example-blinky":
-            continue
-        os.chdir(ex_name)
-        for target, ide in target_cross_ide(args.ide,
-                                            **requirements):
-            example_name = "{} {} {}".format(ex_name, target,
-                                             ide)
-            print_message("Export:",example_name)
-            proc = subprocess.Popen(["mbed-cli", "export", "-i", ide,
-                                     "-m", target])
-            proc.wait()
-            if proc.returncode:
-                export_failures.append(example_name)
-                print_message("FAILURE Export:", example_name)
-            else:
-                print_message("SUCCESS Export:", example_name)
-                print_message("Build:", example_name)
-                if EXPORTERS[ide].build(ex_name):
-                    print_message("FAILURE Build:", example_name)
-                    build_failures.append(example_name)
-                else:
-                    print_message("SUCCESS Build:", example_name)
-                    sucesses.append(example_name)
-    print_stuff("Passed", sucesses)
-    print_stuff("Failed Export", export_failures)
-    print_stuff("Failed Building", build_failures)
-    return len(export_failures+build_failures)
+    lib.print_summary(results, export=True)
+    failures = lib.get_num_failures(results, export=True)
+    print("Number of failures = %d" % failures)
+    return failures
 
-    
+
 def do_import(_, config):
     """Do the import step of this process"""
     lib.source_repos(config)
     return 0
+
 
 def do_compile(args, config):
     """Do the compile step"""
     results = {}
     results = lib.compile_repos(config, args.toolchains)
     
-    lib.print_compilation_summary(results)
+    lib.print_summary(results)
     failures = lib.get_num_failures(results)
     print("Number of failures = %d" % failures)
     return failures 

--- a/tools/test/examples/examples.py
+++ b/tools/test/examples/examples.py
@@ -14,6 +14,62 @@ sys.path.insert(0, ROOT)
 from tools.utils import argparse_force_uppercase_type
 import examples_lib as lib
 from examples_lib import SUPPORTED_TOOLCHAINS
+from tools.export import EXPORTERS
+from tools.build_api import get_mbed_official_release
+from tools.targets import TARGET_MAP
+
+EXAMPLES = json.load(open(os.path.join(os.path.dirname(__file__),
+                                       "examples.json")))
+
+def print_stuff(name, lst):
+    if lst:
+        print("#"*80)
+        print("# {} example combinations".format(name))
+        print("#")
+    for thing in lst:
+        print(thing)
+
+
+SUPPORTED_TOOLCHAINS = ["ARM", "IAR", "GCC_ARM"]
+SUPPORTED_IDES = ["iar", "uvision", "make_gcc_arm", "make_iar", "make_armc5"]
+
+
+def target_cross_toolchain(allowed_toolchains,
+                           features=[], targets=TARGET_MAP.keys(),
+                           toolchains=SUPPORTED_TOOLCHAINS):
+    """Generate pairs of target and toolchains
+
+    Args:
+    allowed_toolchains - a list of all possible toolchains
+
+    Kwargs:
+    features - the features that must be in the features array of a
+               target
+    targets - a list of available targets
+    toolchains - a list of available toolchains
+    """
+    for release_target, release_toolchains in get_mbed_official_release("5"):
+        for toolchain in release_toolchains:
+            if (toolchain in allowed_toolchains and
+                toolchain in toolchains and
+                release_target in targets and
+                all(feature in TARGET_MAP[release_target].features
+                    for feature in features)):
+                yield release_target, toolchain
+
+
+def target_cross_ide(allowed_ides,
+                    targets=TARGET_MAP.keys()):
+    """Generate pairs of target and ides
+
+    Args:
+    allowed_ides - a list of all possible IDEs
+
+    """
+    for release_target, release_toolchains in get_mbed_official_release("5"):
+        for ide in allowed_ides:
+            if release_target in EXPORTERS[ide].TARGETS:
+                yield release_target, ide
 
 
 def main():
@@ -27,16 +83,60 @@ def main():
     version_cmd.add_argument("tag")
     version_cmd.set_defaults(fn=do_versionning)
     compile_cmd = subparsers.add_parser("compile")
-    compile_cmd.set_defaults(fn=do_compile)
+    compile_cmd.set_defaults(fn=do_compile),
     compile_cmd.add_argument(
         "toolchains", nargs="*", default=SUPPORTED_TOOLCHAINS,
         type=argparse_force_uppercase_type(SUPPORTED_TOOLCHAINS,
-                                           "toolchain"))
+                                           "toolchain")),
+    export_cmd = subparsers.add_parser("export")
+    export_cmd.set_defaults(fn=do_export),
+    export_cmd.add_argument(
+        "ide", nargs="*", default=SUPPORTED_IDES,
+        type=argparse_force_uppercase_type(SUPPORTED_IDES,
+                                           "ide"))
     args = parser.parse_args()
     config = json.load(open(os.path.join(os.path.dirname(__file__),
                                args.config)))
-
     return args.fn(args, config)
+
+
+def do_export(args):
+
+    def print_message(message, name):
+        print(message+ " %s"%name)
+        sys.stdout.flush()
+
+    export_failures = []
+    build_failures = []
+    sucesses = []
+    for example, requirements in EXAMPLES.iteritems():
+        ex_name = basename(example)
+        if ex_name != "mbed-os-example-blinky":
+            continue
+        os.chdir(ex_name)
+        for target, ide in target_cross_ide(args.ide):
+            example_name = "{} {} {}".format(ex_name, target,
+                                             ide)
+            print_message("Export:",example_name)
+            proc = subprocess.Popen(["mbed-cli", "export", "-i", ide,
+                                     "-m", target])
+            proc.wait()
+            if proc.returncode:
+                export_failures.append(example_name)
+                print_message("FAILURE Export:", example_name)
+            else:
+                print_message("SUCCESS Export:", example_name)
+                print_message("Build:", example_name)
+                if EXPORTERS[ide].build(ex_name):
+                    print_message("FAILURE Build:", example_name)
+                    build_failures.append(example_name)
+                else:
+                    print_message("SUCCESS Build:", example_name)
+                    sucesses.append(example_name)
+    print_stuff("Passed", sucesses)
+    print_stuff("Failed Export", export_failures)
+    print_stuff("Failed Building", build_failures)
+    return len(export_failures+build_failures)
 
     
 def do_import(_, config):

--- a/tools/test/examples/examples_lib.py
+++ b/tools/test/examples/examples_lib.py
@@ -81,6 +81,19 @@ def target_cross_toolchain(allowed_toolchains,
                     for feature in features)):
                 yield target, toolchain
 
+def target_cross_ide(allowed_ides,
+                    targets=TARGET_MAP.keys()):
+    """Generate pairs of target and ides
+
+    Args:
+    allowed_ides - a list of all possible IDEs
+
+    """
+    for release_target, release_toolchains in get_mbed_official_release("5"):
+        for ide in allowed_ides:
+            if release_target in EXPORTERS[ide].TARGETS:
+                yield release_target, ide
+
 
 def get_repo_list(example):
     """ Returns a list of all the repos associated with the specific example in the json

--- a/tools/test/export/build_test.py
+++ b/tools/test/export/build_test.py
@@ -22,6 +22,7 @@ from os.path import join, dirname, exists, abspath
 ROOT = abspath(join(dirname(__file__), "..", "..", ".."))
 sys.path.insert(0, ROOT)
 import argparse
+import os
 from argparse import ArgumentTypeError
 import sys
 from shutil import rmtree
@@ -37,9 +38,8 @@ from tools.project import export
 from Queue import Queue
 from threading import Thread, Lock
 from tools.project_api import print_results, get_exporter_toolchain
-from tools.tests import test_name_known, test_known, Test
-from tools.export.exporters import FailedBuildException, \
-                                   TargetNotSupportedException
+from tools.tests import test_name_known, test_known
+from tools.export import EXPORTERS
 from tools.utils import argparse_force_lowercase_type, \
                         argparse_many, columnate, args_error, \
                         argparse_filestring_type
@@ -125,9 +125,12 @@ class ExportBuildTest(object):
                                  % (test_case.mcu,
                                     test_case.ide,
                                     test_case.name))
-            try:
-                exporter.build()
-            except FailedBuildException:
+
+            cwd = os.getcwd()
+            os.chdir(exporter.export_dir)
+            res = EXPORTERS[exporter.NAME.lower()].build(exporter.project_name, clean=False)
+            os.chdir(cwd)
+            if res:
                 self.failures.append("%s::%s\t%s" % (test_case.mcu,
                                                      test_case.ide,
                                                      test_case.name))
@@ -157,20 +160,19 @@ class ExportBuildTest(object):
         self.display_counter("Exporting test case  %s::%s\t%s" % (test_case.mcu,
                                                                   test_case.ide,
                                                                   test_case.name))
-
-        try:
-            _, toolchain = get_exporter_toolchain(test_case.ide)
-            profile = extract_profile(self.parser, self.options, toolchain)
-            exporter = export(test_case.mcu, test_case.ide,
+        exporter, toolchain = get_exporter_toolchain(test_case.ide)
+        if test_case.mcu not in exporter.TARGETS:
+            self.skips.append("%s::%s\t%s" % (test_case.mcu, test_case.ide,
+                                              test_case.name))
+            return
+        profile = extract_profile(self.parser, self.options, toolchain)
+        exporter = export(test_case.mcu, test_case.ide,
                               project_id=test_case.id, zip_proj=None,
                               clean=True, src=test_case.src,
                               export_path=join(EXPORT_DIR,name_str),
                               silent=True, build_profile=profile)
-            exporter.generated_files.append(join(EXPORT_DIR,name_str,test_case.log))
-            self.build_queue.put((exporter,test_case))
-        except TargetNotSupportedException:
-            self.skips.append("%s::%s\t%s" % (test_case.mcu, test_case.ide,
-                                              test_case.name))
+        exporter.generated_files.append(join(EXPORT_DIR,name_str,test_case.log))
+        self.build_queue.put((exporter,test_case))
             # Check if the specified name is in all_os_tests
 
 
@@ -265,7 +267,7 @@ def main():
     test_targets = options.mcu or targetnames
     if not all([t in targetnames for t in test_targets]):
         args_error(parser, "Only specify targets in release %s:\n%s"
-                   %(options.release, columnate(targetnames)))
+                   %(options.release, columnate(sorted(targetnames))))
 
     v2_tests, v5_tests = [],[]
     if options.release == '5':

--- a/tools/test/export/build_test.py
+++ b/tools/test/export/build_test.py
@@ -128,7 +128,7 @@ class ExportBuildTest(object):
 
             cwd = os.getcwd()
             os.chdir(exporter.export_dir)
-            res = EXPORTERS[exporter.NAME.lower()].build(exporter.project_name, clean=False)
+            res = EXPORTERS[exporter.NAME.lower()].build(exporter.project_name, cleanup=False)
             os.chdir(cwd)
             if res:
                 self.failures.append("%s::%s\t%s" % (test_case.mcu,


### PR DESCRIPTION
## Description
Adds additional export-build tests that use subprocess commands `mbed import` and `mbed export`. Additionally, I have revised how exporters store supported targets, and, as a result, how project.py handles unsupported targets. I did this to make supported targets more visible for the new tests.


## Status
**READY**


## Todos
- [x] @bridadan review
- [ ] @sg- review
- [x] @theotherjimmy - review


## Deploy notes
Build tests of any kind require the IDEs executable to be in the path.


## Steps to test or reproduce
In a clean subdirectory of `mbed-os\.build`
`python ..\..\tools\test\examples\examples.py import`
`python ..\..\tools\test\examples\examples.py export iar uvision make_armc5 make_iar make_gcc_arm`
