### PR TITLE
[Exporters] Add a device_name to microbit entry in targets.json

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1616,7 +1616,8 @@
     "NRF51_MICROBIT": {
         "inherits": ["MCU_NRF51_16K_S110"],
         "macros_add": ["TARGET_NRF_LFCLK_RC"],
-        "release_versions": ["2"]
+        "release_versions": ["2"],
+        "device_name": "nRF51822_xxAA"
     },
     "NRF51_MICROBIT_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT_S110"],


### PR DESCRIPTION
## Description
Add a device name field for the microbit so that its target information may be picked up from CMSIS description files, and it can be used in export.
## Status
**READY**


## Steps to test or reproduce
`mbed export -m nrf51_microbit -i uvision5`

@0xc0170 @screamerbg @jaustin 
