### PR TITLE
Updating IAR definition for the NCS36510 for IAR EW v7.8

### DIFF
--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -151,6 +151,6 @@
         "OGChipSelectEditMenu": "nRF52832-xxAA\tNordicSemi nRF52832-xxAA"
     },
     "NCS36510":{
-        "OGChipSelectEditMenu": "Orion\tON Semiconductor NCS36510"
+        "OGChipSelectEditMenu": "NCS36510\tONSemiconductor NCS36510"
     }
 }


### PR DESCRIPTION
## Description
The IAR definition for the NCS36510 is not up to date for IAR Embedded Workbench v7.8. This patches the definition.

@maclobdell This will probably affect you, will you please test these changes/check with ONSemiconductor?

## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [ ] Exporter tests
- [ ] Review by @maclobdell


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.

