### PR TITLE
Coverage

### DIFF
--- a/features/frameworks/greentea-client/source/test_env.cpp
+++ b/features/frameworks/greentea-client/source/test_env.cpp
@@ -24,6 +24,10 @@
 #include "greentea-client/greentea_metrics.h"
 
 
+#ifdef MBED_CFG_DEBUG_OPTIONS_COVERAGE
+extern "C" void __gcov_init(void);
+extern bool coverage_report;
+#endif
 /**
  *   Generic test suite transport protocol keys
  */
@@ -86,6 +90,10 @@ void GREENTEA_SETUP(const int timeout, const char *host_test_name) {
     greentea_notify_version();
     greentea_notify_timeout(timeout);
     greentea_notify_hosttest(host_test_name);
+#ifdef MBED_CFG_DEBUG_OPTIONS_COVERAGE
+    //coverage_report = true;
+    //__gcov_init();
+#endif
 }
 
 /** \brief Notify host (__exit message) side that test suite execution was complete
@@ -129,6 +137,9 @@ void GREENTEA_TESTCASE_FINISH(const char *test_case_name, const size_t passes, c
  */
 #ifdef MBED_CFG_DEBUG_OPTIONS_COVERAGE
 extern "C" void __gcov_flush(void);
+extern "C" void __gcov_init(void);
+extern "C" void gcov_exit(void);
+extern "C" int gcov_close(void);
 extern bool coverage_report;
 
 /**
@@ -148,6 +159,7 @@ extern bool coverage_report;
  *
  */
 void greentea_notify_coverage_start(const char *path) {
+    printf("Starting coverage\n");
     printf("{{%s;%s;", GREENTEA_TEST_ENV_LCOV_START, path);
 }
 
@@ -452,8 +464,10 @@ static void greentea_notify_hosttest(const char *host_test_name) {
 static void greentea_notify_completion(const int result) {
     const char *val = result ? GREENTEA_TEST_ENV_SUCCESS : GREENTEA_TEST_ENV_FAILURE;
 #ifdef MBED_CFG_DEBUG_OPTIONS_COVERAGE
+    greentea_write_string("Calling __gcov_flush()\n");
     coverage_report = true;
-    __gcov_flush();
+    //__gcov_flush();
+    gcov_exit();
     coverage_report = false;
 #endif
     greentea_metrics_report();

--- a/features/frameworks/greentea-client/source/test_env.cpp
+++ b/features/frameworks/greentea-client/source/test_env.cpp
@@ -24,10 +24,6 @@
 #include "greentea-client/greentea_metrics.h"
 
 
-#ifdef MBED_CFG_DEBUG_OPTIONS_COVERAGE
-extern "C" void __gcov_init(void);
-extern bool coverage_report;
-#endif
 /**
  *   Generic test suite transport protocol keys
  */
@@ -90,10 +86,6 @@ void GREENTEA_SETUP(const int timeout, const char *host_test_name) {
     greentea_notify_version();
     greentea_notify_timeout(timeout);
     greentea_notify_hosttest(host_test_name);
-#ifdef MBED_CFG_DEBUG_OPTIONS_COVERAGE
-    //coverage_report = true;
-    //__gcov_init();
-#endif
 }
 
 /** \brief Notify host (__exit message) side that test suite execution was complete
@@ -137,9 +129,6 @@ void GREENTEA_TESTCASE_FINISH(const char *test_case_name, const size_t passes, c
  */
 #ifdef MBED_CFG_DEBUG_OPTIONS_COVERAGE
 extern "C" void __gcov_flush(void);
-extern "C" void __gcov_init(void);
-extern "C" void gcov_exit(void);
-extern "C" int gcov_close(void);
 extern bool coverage_report;
 
 /**
@@ -159,7 +148,6 @@ extern bool coverage_report;
  *
  */
 void greentea_notify_coverage_start(const char *path) {
-    printf("Starting coverage\n");
     printf("{{%s;%s;", GREENTEA_TEST_ENV_LCOV_START, path);
 }
 
@@ -464,10 +452,8 @@ static void greentea_notify_hosttest(const char *host_test_name) {
 static void greentea_notify_completion(const int result) {
     const char *val = result ? GREENTEA_TEST_ENV_SUCCESS : GREENTEA_TEST_ENV_FAILURE;
 #ifdef MBED_CFG_DEBUG_OPTIONS_COVERAGE
-    greentea_write_string("Calling __gcov_flush()\n");
     coverage_report = true;
-    //__gcov_flush();
-    gcov_exit();
+    __gcov_flush();
     coverage_report = false;
 #endif
     greentea_metrics_report();

--- a/platform/retarget.cpp
+++ b/platform/retarget.cpp
@@ -162,11 +162,6 @@ extern "C" WEAK void mbed_sdk_init(void) {
 }
 
 extern "C" FILEHANDLE PREFIX(_open)(const char* name, int openmode) {
-#if defined MBED_CFG_DEBUG_OPTIONS_COVERAGE
-    if (coverage_report) {
-        printf ("_open called!\n");
-    }
-#endif
     #if defined(__MICROLIB) && (__ARMCC_VERSION>5030000)
     // Before version 5.03, we were using a patched version of microlib with proper names
     // This is the workaround that the microlib author suggested us
@@ -192,9 +187,8 @@ extern "C" FILEHANDLE PREFIX(_open)(const char* name, int openmode) {
     }
 #if defined MBED_CFG_DEBUG_OPTIONS_COVERAGE
     else if(coverage_report) {
-        //init_serial();
-        printf ("Calling greentea_notify_coverage_end()\n");
-        //greentea_notify_coverage_start(name);
+        init_serial();
+        greentea_notify_coverage_start(name);
         return gcov_fd;
     }
 #endif
@@ -294,9 +288,8 @@ extern "C" int PREFIX(_write)(FILEHANDLE fh, const unsigned char *buffer, unsign
 #endif
 #endif
         n = length;
-    }
 #if defined MBED_CFG_DEBUG_OPTIONS_COVERAGE
-    else if (coverage_report && fh == gcov_fd){
+    } else if (coverage_report && fh == gcov_fd){
         for (unsigned int i = 0; i < length; i++) {
             if (0 == buffer[i]){
                 printf(".");
@@ -305,9 +298,8 @@ extern "C" int PREFIX(_write)(FILEHANDLE fh, const unsigned char *buffer, unsign
             }
         }
         n = length;
-    }
 #endif
-    else {
+    } else {
         FileHandle* fhc = filehandles[fh-3];
         if (fhc == NULL) return -1;
 
@@ -354,13 +346,11 @@ extern "C" int PREFIX(_read)(FILEHANDLE fh, unsigned char *buffer, unsigned int 
 #endif
 #endif
         n = 1;
-    }
 #if defined MBED_CFG_DEBUG_OPTIONS_COVERAGE
-    else if (coverage_report && fh == gcov_fd){
+    } else if (coverage_report && fh == gcov_fd){
         n = 0;
-    }
 #endif
-    else {
+    } else {
         FileHandle* fhc = filehandles[fh-3];
         if (fhc == NULL) return -1;
 

--- a/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
@@ -89,7 +89,7 @@
 #define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE/2)
 #else
 #if defined (MBED_CFG_DEBUG_OPTIONS_COVERAGE)
-#define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE*4*16)
+#define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE*4*8)
 #else
 #define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE*4)
 #endif

--- a/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
@@ -89,6 +89,7 @@
 #define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE/2)
 #else
 #if defined (MBED_CFG_DEBUG_OPTIONS_COVERAGE)
+/* GCOV works with stack size approx. 32K. */
 #define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE*4*8)
 #else
 #define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE*4)

--- a/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
@@ -88,7 +88,11 @@
 #if defined(TARGET_XDOT_L151CC)
 #define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE/2)
 #else
+#if defined (MBED_CFG_DEBUG_OPTIONS_COVERAGE)
+#define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE*4*16)
+#else
 #define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE*4)
+#endif
 #endif
 
 #define osCMSIS           0x10002U     ///< CMSIS-RTOS API version (main [31:16] .sub [15:0])

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
@@ -53,8 +53,8 @@ ENTRY(Reset_Handler)
 __ram_vector_table__ = 1;
 
 /* Heap 1/4 of ram and stack 1/8 */
-__stack_size__ = 0x8000;
-__heap_size__ = 0x10000;
+__stack_size__ = 0x7000;
+__heap_size__ = 0x09000;
 
 HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x0400;
 STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;

--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
@@ -52,7 +52,9 @@ ENTRY(Reset_Handler)
 
 __ram_vector_table__ = 1;
 
-/* Heap 1/4 of ram and stack 1/8 */
+/* Heap 1/4 of ram and stack 1/8. 0x1000 is reduced from both heap
+ * and stack to accomodate static data introduced by GCOV.
+ */
 __stack_size__ = 0x7000;
 __heap_size__ = 0x09000;
 

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -280,7 +280,7 @@ def prepare_toolchain(src_paths, target, toolchain_name,
                       notify=None, silent=False, verbose=False,
                       extra_verbose=False, config=None,
                       app_config=None, build_profile=None,
-                      coverage_filter=None):
+                      coverage_filter=[]):
     """ Prepares resource related objects - toolchain, target, config
 
     Positional arguments:
@@ -371,7 +371,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
                   macros=None, inc_dirs=None, jobs=1, silent=False,
                   report=None, properties=None, project_id=None,
                   project_description=None, extra_verbose=False, config=None,
-                  app_config=None, build_profile=None, coverage_filter=None):
+                  app_config=None, build_profile=None, coverage_filter=[]):
     """ Build a project. A project may be a test or a user program.
 
     Positional arguments:

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -314,12 +314,12 @@ def prepare_toolchain(src_paths, target, toolchain_name,
     try:
         if toolchain_name == "GCC_ARM":
             toolchain = TOOLCHAIN_CLASSES[toolchain_name](
-                target, options, notify, macros, silent,
+                target, notify, macros, silent,
                 extra_verbose=extra_verbose, build_profile=build_profile,
                 coverage_filter=coverage_filter)
         else:
             toolchain = TOOLCHAIN_CLASSES[toolchain_name](
-                target, options, notify, macros, silent,
+                target, notify, macros, silent,
                 extra_verbose=extra_verbose, build_profile=build_profile,
                 coverage_filter=coverage_filter)
     except KeyError:

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -312,10 +312,16 @@ def prepare_toolchain(src_paths, target, toolchain_name,
 
     # Toolchain instance
     try:
-        toolchain = TOOLCHAIN_CLASSES[toolchain_name](
-            target, notify, macros, silent,
-            extra_verbose=extra_verbose, build_profile=build_profile,
-            coverage_filter=coverage_filter)
+        if toolchain_name == "GCC_ARM":
+            toolchain = TOOLCHAIN_CLASSES[toolchain_name](
+                target, options, notify, macros, silent,
+                extra_verbose=extra_verbose, build_profile=build_profile,
+                coverage_filter=coverage_filter)
+        else:
+            toolchain = TOOLCHAIN_CLASSES[toolchain_name](
+                target, options, notify, macros, silent,
+                extra_verbose=extra_verbose, build_profile=build_profile,
+                coverage_filter=coverage_filter)
     except KeyError:
         raise KeyError("Toolchain %s not supported" % toolchain_name)
 

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -279,7 +279,8 @@ def prepare_toolchain(src_paths, target, toolchain_name,
                       macros=None, clean=False, jobs=1,
                       notify=None, silent=False, verbose=False,
                       extra_verbose=False, config=None,
-                      app_config=None, build_profile=None):
+                      app_config=None, build_profile=None,
+                      coverage_filter=None):
     """ Prepares resource related objects - toolchain, target, config
 
     Positional arguments:
@@ -312,7 +313,8 @@ def prepare_toolchain(src_paths, target, toolchain_name,
     try:
         toolchain = TOOLCHAIN_CLASSES[toolchain_name](
             target, notify, macros, silent,
-            extra_verbose=extra_verbose, build_profile=build_profile)
+            extra_verbose=extra_verbose, build_profile=build_profile,
+            coverage_filter=coverage_filter)
     except KeyError:
         raise KeyError("Toolchain %s not supported" % toolchain_name)
 
@@ -362,13 +364,14 @@ def scan_resources(src_paths, toolchain, dependencies_paths=None,
 
     return resources
 
+
 def build_project(src_paths, build_path, target, toolchain_name,
                   libraries_paths=None, linker_script=None,
                   clean=False, notify=None, verbose=False, name=None,
                   macros=None, inc_dirs=None, jobs=1, silent=False,
                   report=None, properties=None, project_id=None,
                   project_description=None, extra_verbose=False, config=None,
-                  app_config=None, build_profile=None):
+                  app_config=None, build_profile=None, coverage_filter=None):
     """ Build a project. A project may be a test or a user program.
 
     Positional arguments:
@@ -417,7 +420,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
         src_paths, target, toolchain_name, macros=macros, clean=clean,
         jobs=jobs, notify=notify, silent=silent, verbose=verbose,
         extra_verbose=extra_verbose, config=config, app_config=app_config,
-        build_profile=build_profile)
+        build_profile=build_profile, coverage_filter=coverage_filter)
 
     # The first path will give the name to the library
     if name is None:
@@ -505,13 +508,14 @@ def build_project(src_paths, build_path, target, toolchain_name,
         # Let Exception propagate
         raise
 
+
 def build_library(src_paths, build_path, target, toolchain_name,
                   dependencies_paths=None, name=None, clean=False,
                   archive=True, notify=None, verbose=False, macros=None,
                   inc_dirs=None, jobs=1, silent=False, report=None,
                   properties=None, extra_verbose=False, project_id=None,
                   remove_config_header_file=False, app_config=None,
-                  build_profile=None):
+                  build_profile=None, coverage_filter=None):
     """ Build a library
 
     Positional arguments:
@@ -563,7 +567,7 @@ def build_library(src_paths, build_path, target, toolchain_name,
         src_paths, target, toolchain_name, macros=macros, clean=clean,
         jobs=jobs, notify=notify, silent=silent, verbose=verbose,
         extra_verbose=extra_verbose, app_config=app_config,
-        build_profile=build_profile)
+        build_profile=build_profile, coverage_filter=coverage_filter)
 
     # The first path will give the name to the library
     if name is None:

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -299,6 +299,7 @@ def prepare_toolchain(src_paths, target, toolchain_name,
     config - a Config object to use instead of creating one
     app_config - location of a chosen mbed_app.json file
     build_profile - a dict of flags that will be passed to the compiler
+    coverage_filter - list of regex to filter source files for enabling coverage
     """
 
     # We need to remove all paths which are repeated to avoid
@@ -400,6 +401,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
     config - a Config object to use instead of creating one
     app_config - location of a chosen mbed_app.json file
     build_profile - a dict of flags that will be passed to the compiler
+    coverage_filter - list of regex to filter source files for enabling coverage
     """
 
     # Convert src_path to a list if needed
@@ -540,6 +542,7 @@ def build_library(src_paths, build_path, target, toolchain_name,
     properties - UUUUHHHHH beats me
     extra_verbose - even more output!
     project_id - the name that goes in the report
+    coverage_filter - list of regex to filter source files for enabling coverage
     remove_config_header_file - delete config header file when done building
     app_config - location of a chosen mbed_app.json file
     build_profile - a dict of flags that will be passed to the compiler

--- a/tools/options.py
+++ b/tools/options.py
@@ -82,7 +82,7 @@ def get_default_options_parser(add_clean=True, add_options=True,
         parser.add_argument("--app-config", default=None, dest="app_config",
                             type=argparse_filestring_type,
                             help="Path of an app configuration file (Default is to look for 'mbed_app.json')")
-    parser.add_argument("--coverage-filter", default=None, dest="coverage_filter",
+    parser.add_argument("--coverage-filter", default=[], action="append", dest="coverage_filter",
                         help="Enable coverage on path that contains filter expression.")
 
     return parser

--- a/tools/options.py
+++ b/tools/options.py
@@ -82,6 +82,8 @@ def get_default_options_parser(add_clean=True, add_options=True,
         parser.add_argument("--app-config", default=None, dest="app_config",
                             type=argparse_filestring_type,
                             help="Path of an app configuration file (Default is to look for 'mbed_app.json')")
+    parser.add_argument("--coverage-filter", default=None, dest="coverage_filter",
+                        help="Enable coverage on path that contains filter expression.")
 
     return parser
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -194,7 +194,8 @@ if __name__ == '__main__':
                                                 notify=notify,
                                                 archive=False,
                                                 app_config=options.app_config,
-                              build_profile=profile)
+                                                build_profile=profile,
+                                                coverage_filter=options.coverage_filter)
 
                 library_build_success = True
             except ToolException, e:
@@ -221,8 +222,9 @@ if __name__ == '__main__':
                         notify=notify,
                         jobs=options.jobs,
                         continue_on_build_fail=options.continue_on_build_fail,
-                                                             app_config=options.app_config,
-                                                             build_profile=profile)
+                        app_config=options.app_config,
+                        build_profile=profile,
+                        coverage_filter=options.coverage_filter)
 
                 # If a path to a test spec is provided, write it to a file
                 if options.test_spec:

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2147,6 +2147,7 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
         bin_file = None
         test_case_folder_name = os.path.basename(test_path)
         
+<<<<<<< 205a97083e8ff9c0fdf55d0221675efacf6e0a88
         args = (src_path, test_build_path, target, toolchain_name)
         kwargs = {
             'jobs': jobs,
@@ -2160,7 +2161,8 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
             'app_config': app_config,
             'build_profile': build_profile,
             'silent': True,
-            'coverage_filter': coverage_filter
+            # Coverage requires main(). So if enabled on any module, enable it on test as well.
+            'coverage_filter': ".*" if coverage_filter else [])
         }
         
         results.append(p.apply_async(build_test_worker, args, kwargs))

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2115,7 +2115,7 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
                 clean=False, notify=None, verbose=False, jobs=1, macros=None,
                 silent=False, report=None, properties=None,
                 continue_on_build_fail=False, app_config=None,
-                build_profile=None):
+                build_profile=None, coverage_filter=None):
     """Given the data structure from 'find_tests' and the typical build parameters,
     build all the tests
 
@@ -2159,7 +2159,8 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
             'verbose': verbose,
             'app_config': app_config,
             'build_profile': build_profile,
-            'silent': True
+            'silent': True,
+            'coverage_filter': coverage_filter
         }
         
         results.append(p.apply_async(build_test_worker, args, kwargs))

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2119,6 +2119,9 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
     """Given the data structure from 'find_tests' and the typical build parameters,
     build all the tests
 
+    Keyword arguments:
+        coverage_filter - list of regex to filter source files for enabling coverage
+
     Returns a tuple of the build result (True or False) followed by the test
     build data structure"""
 

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -18,7 +18,6 @@ Author: Przemyslaw Wirkus <Przemyslaw.wirkus@arm.com>
 """
 
 import os
-import re
 import sys
 import json
 import uuid
@@ -2150,7 +2149,6 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
         bin_file = None
         test_case_folder_name = os.path.basename(test_path)
         
-<<<<<<< 205a97083e8ff9c0fdf55d0221675efacf6e0a88
         args = (src_path, test_build_path, target, toolchain_name)
         kwargs = {
             'jobs': jobs,
@@ -2165,7 +2163,7 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
             'build_profile': build_profile,
             'silent': True,
             # Coverage requires main(). So if enabled on any module, enable it on test as well.
-            'coverage_filter': ".*" if coverage_filter else [])
+            'coverage_filter': ".*" if coverage_filter else []
         }
         
         results.append(p.apply_async(build_test_worker, args, kwargs))

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2115,7 +2115,7 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
                 clean=False, notify=None, verbose=False, jobs=1, macros=None,
                 silent=False, report=None, properties=None,
                 continue_on_build_fail=False, app_config=None,
-                build_profile=None, coverage_filter=None):
+                build_profile=None, coverage_filter=[]):
     """Given the data structure from 'find_tests' and the typical build parameters,
     build all the tests
 

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -84,6 +84,11 @@ class GCC(mbedToolchain):
             self.cpu.append("-mfloat-abi=hard")
             self.cpu.append("-mno-unaligned-access")
 
+        # Coverage is turned On if coverage_filter is not empty. This means all sources are compiled with coverage
+        # macro and application is linked with coverage flags.
+        # Only source files that match regex from coverage_filter list are compiled with coverage flags. Since turning
+        # On code coverage on all sources increases static data size it overlaps with stack allocation and causes linker
+        # error.
         self.coverage_filter = coverage_filter
         if self.coverage_filter:
             self.macros.append(self.COVERAGE_MACRO)

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -29,8 +29,7 @@ class GCC(mbedToolchain):
     DIAGNOSTIC_PATTERN = re.compile('((?P<file>[^:]+):(?P<line>\d+):)(\d+:)? (?P<severity>warning|error): (?P<message>.+)')
     INDEX_PATTERN  = re.compile('(?P<col>\s*)\^')
 
-    COVERAGE_COMPILE_FLAGS = ["-fprofile-arcs", "-ftest-coverage", "-fprofile-dir=."]
-    COVERAGE_LINK_FLAGS = ["-fprofile-arcs", "-ftest-coverage", "-fprofile-dir=."]
+    COVERAGE_FLAGS = ["-fprofile-arcs", "-ftest-coverage"]
     COVERAGE_MACRO = 'MBED_CFG_DEBUG_OPTIONS_COVERAGE'
 
     def __init__(self, target,  notify=None, macros=None,
@@ -191,7 +190,7 @@ class GCC(mbedToolchain):
     def assemble(self, source, object, includes):
         # Build assemble command
         if self.check_if_coverage_enabled(source):
-            cmd = self.asm + self.COVERAGE_COMPILE_FLAGS + self.get_compile_options(self.get_symbols(True), includes) + ["-o", object, source]
+            cmd = self.asm + self.COVERAGE_FLAGS + self.get_compile_options(self.get_symbols(True), includes) + ["-o", object, source]
         else:
             cmd = self.asm + self.get_compile_options(self.get_symbols(True), includes) + ["-o", object, source]
 
@@ -205,7 +204,7 @@ class GCC(mbedToolchain):
     def compile(self, cc, source, object, includes):
         # Build compile command
         if self.check_if_coverage_enabled(source):
-            cmd = cc + self.COVERAGE_COMPILE_FLAGS + self.get_compile_options(self.get_symbols(), includes)
+            cmd = cc + self.COVERAGE_FLAGS + self.get_compile_options(self.get_symbols(), includes)
         else:
             cmd = cc + self.get_compile_options(self.get_symbols(), includes)
 
@@ -236,7 +235,7 @@ class GCC(mbedToolchain):
         map_file = splitext(output)[0] + ".map"
 
         if self.coverage_filter:
-            cmd = self.ld + self.COVERAGE_LINK_FLAGS + ["-o", output, "-Wl,-Map=%s" % map_file] + objects + ["-Wl,--start-group"] + libs + ["-Wl,--end-group"]
+            cmd = self.ld + self.COVERAGE_FLAGS + ["-o", output, "-Wl,-Map=%s" % map_file] + objects + ["-Wl,--start-group"] + libs + ["-Wl,--end-group"]
         else:
             cmd = self.ld + ["-o", output, "-Wl,-Map=%s" % map_file] + objects + ["-Wl,--start-group"] + libs + ["-Wl,--end-group"]
         if mem_map:


### PR DESCRIPTION
# Code Coverage (GCOV)

GCOV based code coverage can be enabled by compiling and linking code with flags `-fprofile-arcs -ftest-coverage`. Optimisation should be disabled with flag `-O0` and debug symbols added with `-g` flags. An additional coverage macro `-DMBED_CFG_DEBUG_OPTIONS_COVERAGE` is added to code the instrumentation required for moving coverage data from embedded platform to the host machine under it.
## GCOV Impact on application

Enabling gcov profiling has an impact on binary size and stack requirement. Stack size has been increased in `rtos/rtx/TARGET_CORTEX_M/cmsis_os.h` under coverage macro. 

It has not been possible to compile whole of mbed-os with coverage flags as it increases static data part of the binary making heap and stack overlap. Typically giving following error:

```
[DEBUG] Errors: c:/program files (x86)/gnu tools arm embedded/4.9 2015q3/bin/../lib/gcc/arm-none-eabi/4.9.3/../../../../arm-none-eabi/bin/ld.exe: region m_data_2 overflowed with stack and
 heap
```

or

```
[DEBUG] Errors: c:/program files (x86)/gnu tools arm embedded/4.9 2015q3/bin/../lib/gcc/arm-none-eabi/4.9.3/../../../../arm-none-eabi/bin/ld.exe: C:/Users/azikha01/Documents/GitHub/mazimkhan/mbed
-os/.build/tests/K64F/GCC_ARM/./TESTS/integration/basic/basic.elf section `.bss' will not fit in region `m_data_2'
```

Heap and stack size are reduced a little in below file to fit individual modules: `hal/targets/cmsis/TARGET_Freescale/TARGET_MCU_K64F/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld`.

Still whole mbed-os does not fit the memory. For this reason below build tool changes are made to selectively turn On coverage on parts mbed-os source.
## Build tools changes

A new option is passed down `test.py` to `class GCC` that adds coverage flags to `gcc` compiler:
Option synopsis:
`--coverage-filter <regex to match source path> [--coverage-filter <regex to match source path>]` 
This new option collects all supplied filters (regex) into a list. Coverage is turned on if list is not empty.

`test.py` also enables coverage on test case sources when coverage filter is supplied. This is because for gcov to initialise it should also be enabled on the file containing `main()`.
## Code changes

gcov flags make the application write profiling data on disk per source file profiled. Embedded applications that do not have file-system require instrumentation to print coverage report on serial console that can be read and consolidated by a host application (greentea). 
Mainly `open`, `write` and `close` wrappers in `retartget.cpp` are modified to channel gcov file data to serial console.
