### PR TITLE
#3183 Compiler warning in trng_api.c with K64F 

### DIFF
--- a/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/trng_api.c
+++ b/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/trng_api.c
@@ -64,7 +64,6 @@ int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_l
 {
     (void)obj;
     size_t i;
-    int ret;
 
     /* Set "Interrupt Mask", "High Assurance" and "Go",
      * unset "Clear interrupt" and "Sleep" */


### PR DESCRIPTION
Notes:
* I agree to [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).

## Description

Remove one compiler warning in trng_api.c with K64F due to unused variable "ret".

## Status
**READY**


## Migrations
NO

## Related PRs
None. 

## Todos
- [ ] Tests
- [ ] Documentation


## Deploy notes
None

## Steps to test or reproduce

Just compile it  -  
```
mbed compile -m K64F -t GCC_ARM  -c

Compile [ 94.6%]: trng_api.c
[Warning] trng_api.c@67,9: unused variable 'ret' [-Wunused-variable]
```

Github issue #3183
