### PR TITLE
[Export-Make] Use internal class variable for resolving templates in makefiles

### DIFF
--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -88,12 +88,12 @@ class Makefile(Exporter):
         ctx.update(self.flags)
 
         for templatefile in \
-            ['makefile/%s_%s.tmpl' % (self.NAME.lower(),
+            ['makefile/%s_%s.tmpl' % (self.TEMPLATE,
                                       self.target.lower())] + \
-            ['makefile/%s_%s.tmpl' % (self.NAME.lower(),
+            ['makefile/%s_%s.tmpl' % (self.TEMPLATE,
                                       label.lower()) for label
              in self.toolchain.target.extra_labels] +\
-            ['makefile/%s.tmpl' % self.NAME.lower()]:
+            ['makefile/%s.tmpl' % self.TEMPLATE]:
             try:
                 self.gen_file(templatefile, ctx, 'Makefile')
                 break
@@ -108,6 +108,7 @@ class GccArm(Makefile):
     TARGETS = [target for target, obj in TARGET_MAP.iteritems()
                if "GCC_ARM" in obj.supported_toolchains]
     NAME = 'Make-GCC-ARM'
+    TEMPLATE = 'make-gcc-arm'
     TOOLCHAIN = "GCC_ARM"
     LINK_SCRIPT_OPTION = "-T"
     USER_LIBRARY_FLAG = "-L"
@@ -122,6 +123,7 @@ class Armc5(Makefile):
     TARGETS = [target for target, obj in TARGET_MAP.iteritems()
                if "ARM" in obj.supported_toolchains]
     NAME = 'Make-ARMc5'
+    TEMPLATE = 'make-armc5'
     TOOLCHAIN = "ARM"
     LINK_SCRIPT_OPTION = "--scatter"
     USER_LIBRARY_FLAG = "--userlibpath "
@@ -136,6 +138,7 @@ class IAR(Makefile):
     TARGETS = [target for target, obj in TARGET_MAP.iteritems()
                if "IAR" in obj.supported_toolchains]
     NAME = 'Make-IAR'
+    TEMPLATE = 'make-iar'
     TOOLCHAIN = "IAR"
     LINK_SCRIPT_OPTION = "--config"
     USER_LIBRARY_FLAG = "-L"


### PR DESCRIPTION
## Status
**READY**

## Reviews
- [x] @sarahmarshy (issue reporter)
- [x] @0xc0170 

## Steps to test or reproduce
Before:
```
$ mbed export -i make_gcc_arm -m <any>
[mbed] Auto-installing missing Python modules...
Scan: .
Scan: FEATURE_LWIP
Scan: FEATURE_COMMON_PAL
Scan: FEATURE_UVISOR
Scan: FEATURE_BLE
Scan: FEATURE_LOWPAN_ROUTER
Scan: FEATURE_NANOSTACK
Scan: FEATURE_THREAD_END_DEVICE
Scan: FEATURE_THREAD_ROUTER
Scan: FEATURE_THREAD_BORDER_ROUTER
Scan: FEATURE_LOWPAN_BORDER_ROUTER
Scan: FEATURE_NANOSTACK_FULL
Scan: FEATURE_LOWPAN_HOST
Scan: FEATURE_STORAGE
Traceback (most recent call last):
  File "/home/jimbri01/src/arm-mbed/oob-mbed-os-example-wifi/mbed-os/tools/project.py", line 244, in <module>
    main()
  File "/home/jimbri01/src/arm-mbed/oob-mbed-os-example-wifi/mbed-os/tools/project.py", line 240, in main
    zip_proj=zip_proj, build_profile=profile)
  File "/home/jimbri01/src/arm-mbed/oob-mbed-os-example-wifi/mbed-os/tools/project.py", line 93, in export
    build_profile=build_profile, silent=silent)
  File "/home/jimbri01/src/arm-mbed/oob-mbed-os-example-wifi/mbed-os/tools/project_api.py", line 229, in export_project
    macros=macros)
  File "/home/jimbri01/src/arm-mbed/oob-mbed-os-example-wifi/mbed-os/tools/project_api.py", line 90, in generate_project_files
    exporter.generate()
  File "/home/jimbri01/src/arm-mbed/oob-mbed-os-example-wifi/mbed-os/tools/export/cdt/__init__.py", line 14, in generate
    super(Eclipse, self).generate()
  File "/home/jimbri01/src/arm-mbed/oob-mbed-os-example-wifi/mbed-os/tools/export/makefile/__init__.py", line 103, in generate
    raise NotSupportedException("This make tool is in development")
tools.utils.NotSupportedException: This make tool is in development
[mbed] ERROR: "python" returned error code 1.
[mbed] ERROR: Command "python -u /home/jimbri01/src/arm-mbed/oob-mbed-os-example-wifi/mbed-os/tools/project.py -i eclipse_gcc_arm -m K64F --source ." in "/home/jimbri01/src/arm-mbed/oob-mbed-os-example-wifi"
---
```

After:
```
$ mbed export -i eclipse_gcc_arm -m k64f
[mbed] Auto-installing missing Python modules...
Scan: .
Scan: FEATURE_LWIP
Scan: FEATURE_COMMON_PAL
Scan: FEATURE_UVISOR
Scan: FEATURE_BLE
Scan: FEATURE_LOWPAN_ROUTER
Scan: FEATURE_NANOSTACK
Scan: FEATURE_THREAD_END_DEVICE
Scan: FEATURE_THREAD_ROUTER
Scan: FEATURE_THREAD_BORDER_ROUTER
Scan: FEATURE_LOWPAN_BORDER_ROUTER
Scan: FEATURE_NANOSTACK_FULL
Scan: FEATURE_LOWPAN_HOST
Scan: FEATURE_STORAGE
```