### PR TITLE
[Exporters] Append targets to scan list for exporting tests

### DIFF
--- a/tools/project.py
+++ b/tools/project.py
@@ -10,7 +10,7 @@ from shutil import move, rmtree
 from argparse import ArgumentParser
 from os.path import normpath, realpath
 
-from tools.paths import EXPORT_DIR, MBED_HAL, MBED_LIBRARIES
+from tools.paths import EXPORT_DIR, MBED_HAL, MBED_LIBRARIES, MBED_TARGETS_PATH
 from tools.export import EXPORTERS, mcu_ide_matrix
 from tools.tests import TESTS, TEST_MAP
 from tools.tests import test_known, test_name_known, Test
@@ -54,6 +54,7 @@ def setup_project(ide, target, program=None, source_dir=None, build=None, export
             if MBED_LIBRARIES in test.dependencies:
                 test.dependencies.remove(MBED_LIBRARIES)
                 test.dependencies.append(MBED_HAL)
+                test.dependencies.append(MBED_TARGETS_PATH)
 
 
         src_paths = [test.source_dir]


### PR DESCRIPTION
## Description
The tests were assuming that the `hal` directory would contain both target code and common code. After the restructure, the target code lives in targets, so we should scan that too.

## Status
**READY**

## Reviews
- [ ] @sarahmarshy 
- [x] @0xc0170 
- [x] @kgoveas (original reporter)

## Steps to test or reproduce

#3117