### PR TITLE
Fix lwip_mac_address buffer overflow and set_ip_bytes out of bound access

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -104,7 +104,7 @@ static void mbed_lwip_socket_callback(struct netconn *nc, enum netconn_evt eh, u
 /* TCP/IP and Network Interface Initialisation */
 static struct netif lwip_netif;
 static bool lwip_dhcp = false;
-static char lwip_mac_address[NSAPI_MAC_SIZE] = "\0";
+static char lwip_mac_address[NSAPI_MAC_SIZE];
 
 #if !LWIP_IPV4 || !LWIP_IPV6
 static bool all_zeros(const uint8_t *p, int len)
@@ -309,13 +309,13 @@ static void mbed_lwip_netif_status_irq(struct netif *lwip_netif)
 static void mbed_lwip_set_mac_address(void)
 {
 #if (MBED_MAC_ADDRESS_SUM != MBED_MAC_ADDR_INTERFACE)
-    snprintf(lwip_mac_address, 19, "%02x:%02x:%02x:%02x:%02x:%02x",
+    snprintf(lwip_mac_address, NSAPI_MAC_SIZE, "%02x:%02x:%02x:%02x:%02x:%02x",
             MBED_MAC_ADDR_0, MBED_MAC_ADDR_1, MBED_MAC_ADDR_2,
             MBED_MAC_ADDR_3, MBED_MAC_ADDR_4, MBED_MAC_ADDR_5);
 #else
     char mac[6];
     mbed_mac_address(mac);
-    snprintf(lwip_mac_address, 19, "%02x:%02x:%02x:%02x:%02x:%02x",
+    snprintf(lwip_mac_address, NSAPI_MAC_SIZE, "%02x:%02x:%02x:%02x:%02x:%02x",
             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 #endif
 }

--- a/features/netsocket/SocketAddress.cpp
+++ b/features/netsocket/SocketAddress.cpp
@@ -203,8 +203,14 @@ bool SocketAddress::set_ip_address(const char *addr)
 void SocketAddress::set_ip_bytes(const void *bytes, nsapi_version_t version)
 {
     nsapi_addr_t addr;
+
+    addr = nsapi_addr_t();
     addr.version = version;
-    memcpy(addr.bytes, bytes, NSAPI_IP_BYTES);
+    if (version == NSAPI_IPv6) {
+        memcpy(addr.bytes, bytes, NSAPI_IPv6_BYTES);
+    } else if (version == NSAPI_IPv4) {
+        memcpy(addr.bytes, bytes, NSAPI_IPv4_BYTES);
+    }
     set_addr(addr);
 }
 


### PR DESCRIPTION
## Description

1.  Fix lwip_mac_address buffer overflow. 

The size of lwip_mac_address is NSAPI_MAC_SIZE, but in mbed_lwip_set_mac_address(), the max size in snprintf is set to 19. This might overflow the lwip_mac_address buffer.

This patch sets the size of lwip_mac_address to NSAPI_MAC_SIZE + 1, and sets snprintf limit to NSAPI_MAC_SIZE.

2. netsocket - Fix set_ip_bytes out-of-bound access

set_ip_bytes() does a 16-byte memcpy from the input buffer to
the local nsapi_addr_t despite the address version.

If the address version is ipv4, the input buffer may only be
4-byte in size. This causes a out-of-bound access on the input buffer.

## Status
READY

## Migrations
NO

## Deploy notes
NONE