### PR TITLE
Using Popen for uVision and unifying the structure of the build function

### DIFF
--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -110,32 +110,41 @@ class Makefile(Exporter):
         """ Build Make project """
         # > Make -j
         cmd = ["make", "-j"]
-        p = Popen(cmd, stdout=PIPE, stderr=PIPE)
-        ret = p.communicate()
-        out, err = ret[0], ret[1]
-        ret_code = p.returncode
-        with open(log_name, 'w+') as f:
-            f.write("=" * 10 + "OUT" + "=" * 10 + "\n")
-            f.write(out)
-            f.write("=" * 10 + "ERR" + "=" * 10 + "\n")
-            f.write(err)
-            if ret_code == 0:
-                f.write("SUCCESS")
-            else:
-                f.write("FAILURE")
-        with open(log_name, 'r') as f:
-            print "\n".join(f.readlines())
-        sys.stdout.flush()
 
+        # Build the project
+        p = Popen(cmd, stdout=PIPE, stderr=PIPE)
+        out, err = p.communicate()
+        ret_code = p.returncode
+
+        out_string = "=" * 10 + "STDOUT" + "=" * 10 + "\n"
+        out_string += out
+        out_string += "=" * 10 + "STDERR" + "=" * 10 + "\n"
+        out_string += err
+
+        if ret_code == 0:
+            out_string += "SUCCESS"
+        else:
+            out_string += "FAILURE"
+
+        print out_string
+
+        if log_name:
+            # Write the output to the log file
+            with open(log_name, 'w+') as f:
+                f.write(out_string)
+
+        # Cleanup the exported and built files
         if cleanup:
             remove("Makefile")
             remove(log_name)
             if exists('.build'):
                 shutil.rmtree('.build')
+
         if ret_code != 0:
             # Seems like something went wrong.
             return -1
-        return 0
+        else:
+            return 0
 
 
 class GccArm(Makefile):


### PR DESCRIPTION
## Description
This transitions all build steps for the exporters to use a combination of the Python `Popen` and `communicate` functions to unify the calling of sub-processes.

It also helps standardize the logging functionality across all the build steps and makes the functions more consistent with each other.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [x] Exporter Tests
- [x] Review by @sarahmarshy 