### PR TITLE
Add mbed OS version macros

### DIFF
--- a/mbed.h
+++ b/mbed.h
@@ -19,6 +19,23 @@
 #define MBED_LIBRARY_VERSION 123
 
 #if MBED_CONF_RTOS_PRESENT
+// RTOS present, this is valid only for mbed OS 5
+#define MBED_MAJOR_VERSION 5
+#define MBED_MINOR_VERSION 2
+#define MBED_PATCH_VERSION 1
+
+#else
+// mbed 2
+#define MBED_MAJOR_VERSION 2
+#define MBED_MINOR_VERSION 0
+#define MBED_PATCH_VERSION MBED_LIBRARY_VERSION
+#endif
+
+#define MBED_ENCODE_VERSION(major, minor, patch) ((major)*10000 + (minor)*100 + (patch))
+
+#define MBED_VERSION MBED_ENCODE_VERSION(MBED_MAJOR_VERSION, MBED_MINOR_VERSION, MBED_PATCH_VERSION)
+
+#if MBED_CONF_RTOS_PRESENT
 #include "rtos/rtos.h"
 #endif
 


### PR DESCRIPTION
Allow compile-time tests on the version of mbed-os to cope with
e.g. API changes across versions.

To distinguish between mbed OS 2 and mbed OS 5, we use the
MBED_CONF_RTOS_PRESENT macro.

Note: mbed OS 2 versioning is 2.0.MBED_LIBRARY_VERSION

## Related PRs
This is #3096 rebased against master
