### PR TITLE
[example tests] Adding a clone and a deploy step to allow optimizations in CI.

### DIFF
--- a/tools/test/examples/examples.py
+++ b/tools/test/examples/examples.py
@@ -26,6 +26,10 @@ def main():
     subparsers = parser.add_subparsers()
     import_cmd = subparsers.add_parser("import")
     import_cmd.set_defaults(fn=do_import)
+    clone_cmd = subparsers.add_parser("clone")
+    clone_cmd.set_defaults(fn=do_clone)
+    deploy_cmd = subparsers.add_parser("deploy")
+    deploy_cmd.set_defaults(fn=do_deploy)
     version_cmd = subparsers.add_parser("tag")
     version_cmd.add_argument("tag")
     version_cmd.set_defaults(fn=do_versionning)
@@ -61,6 +65,18 @@ def do_export(args, config):
 def do_import(_, config):
     """Do the import step of this process"""
     lib.source_repos(config)
+    return 0
+
+
+def do_clone(_, config):
+    """Do the clone step of this process"""
+    lib.clone_repos(config)
+    return 0
+
+
+def do_deploy(_, config):
+    """Do the deploy step of this process"""
+    lib.deploy_repos(config)
     return 0
 
 


### PR DESCRIPTION
## Description
This adds an example clone and deploy step that allows you to modify
each top level repository before pulling in the rest of the example's
dependencies. This allows us to not pull in a copy of mbed-os for each
example in CI and instead symbolic link the already cloned copy, saving
valuable time and disk space


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [x] morph test
- [x] Please review @adbridge 


## How to use

These changes are intended mostly for use in CI. Currently importing the examples and their dependencies (including mbed-os for every example) takes upwards of 10 minutes and multiple GBs of disk space. This will both reduce the time and disk space for testing with one common mbed-os revision by allowing you to symbolic link to one specific repository. The flow would look like the following.

1. Clone mbed-os into "mbed-os"
2. In the same directory, create a directory called "examples"
3. `cd examples`
4. Execute the `clone` command: `python ../mbed-os/tools/examples/examples.py clone`
    1. This will do the appropriate `git` or `hg` command to clone just the top level example repo
5. For each cloned example, symbolic link your already cloned "mbed-os" repo: `ln -s ../../mbed-os mbed-os` or use the equivalent command on your OS
6. Execute the `deploy` command to finish pulling in each examples' dependencies (in this case, mbed-os is already present so it is not cloned): `python ../mbed-os/tools/examples/examples.py deploy`

At this point, the examples are fully cloned. You can now use the rest of `examples.py` as you normally would.

