### PR TITLE
[NUC472/M453] Support single UART shared by multiple serial objects and other updates

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M451/TARGET_NUMAKER_PFM_M453/device.h
+++ b/targets/TARGET_NUVOTON/TARGET_M451/TARGET_NUMAKER_PFM_M453/device.h
@@ -17,46 +17,7 @@
 #ifndef MBED_DEVICE_H
 #define MBED_DEVICE_H
 
-#define DEVICE_PORTIN           1
-#define DEVICE_PORTOUT          1
-#define DEVICE_PORTINOUT        1
-
-#define DEVICE_INTERRUPTIN      1
-
-#define DEVICE_ANALOGIN         1
-#define DEVICE_ANALOGOUT        0
-
-#define DEVICE_SERIAL           1
-#define DEVICE_SERIAL_FC        1
-#define DEVICE_SERIAL_ASYNCH    1
-
-#define DEVICE_I2C              1
-#define DEVICE_I2CSLAVE         1
-#define DEVICE_I2C_ASYNCH       1
-
-#define DEVICE_SPI              1
-#define DEVICE_SPI_ASYNCH       1
-#define DEVICE_SPISLAVE         1
-
-#define DEVICE_RTC              1
-
-#define DEVICE_ETHERNET         0
-
-#define DEVICE_PWMOUT           1
-
-#define DEVICE_SEMIHOST         0
-#define DEVICE_LOCALFILESYSTEM  0
 #define DEVICE_ID_LENGTH       24
-
-#define DEVICE_SLEEP            1
-
-#define DEVICE_DEBUG_AWARENESS  0
-
-#define DEVICE_STDIO_MESSAGES   1
-
-#define DEVICE_ERROR_RED        0
-
-#define DEVICE_LOWPOWERTIMER    1
 
 #include "objects.h"
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_MICRO/M453.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_MICRO/M453.sct
@@ -10,10 +10,10 @@ LR_IROM1 0x00000000 {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x1000 {
+  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
   }
   
-  ER_IRAMVEC 0x20001000 EMPTY (4*(16 + 64)) {  ; Reserve for vectors
+  ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 64)) {  ; Reserve for vectors
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_STD/M453.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_STD/M453.sct
@@ -10,10 +10,10 @@ LR_IROM1 0x00000000 {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x1000 {
+  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
   }
   
-  ER_IRAMVEC 0x20001000 EMPTY (4*(16 + 64)) {  ; Reserve for vectors
+  ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 64)) {  ; Reserve for vectors
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_GCC_ARM/M453.ld
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_GCC_ARM/M453.ld
@@ -2,7 +2,7 @@
  * Nuvoton M453 GCC linker script file
  */
 
-StackSize = 0x1000;
+StackSize = 0x800;
 
 MEMORY
 {

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_IAR/M453.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_IAR/M453.icf
@@ -9,7 +9,7 @@ define symbol __ICFEDIT_region_ROM_end__   = 0x00040000;
 define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_IRAM_end__   = 0x20008000;
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x1000;
+define symbol __ICFEDIT_size_cstack__ = 0x800;
 define symbol __ICFEDIT_size_heap__   = 0x4000;
 /**** End of ICF editor section. ###ICF###*/
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/device.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/device.h
@@ -17,47 +17,7 @@
 #ifndef MBED_DEVICE_H
 #define MBED_DEVICE_H
 
-#define DEVICE_PORTIN           1
-#define DEVICE_PORTOUT          1
-#define DEVICE_PORTINOUT        1
-
-#define DEVICE_INTERRUPTIN      1
-
-#define DEVICE_ANALOGIN         1
-#define DEVICE_ANALOGOUT        0
-
-#define DEVICE_SERIAL           1
-#define DEVICE_SERIAL_FC        1
-#define DEVICE_SERIAL_ASYNCH    1
-
-#define DEVICE_I2C              1
-#define DEVICE_I2CSLAVE         1
-#define DEVICE_I2C_ASYNCH       1
-
-#define DEVICE_SPI              1
-#define DEVICE_SPI_ASYNCH       1
-#define DEVICE_SPISLAVE         1
-
-
-#define DEVICE_RTC              1
-
-#define DEVICE_ETHERNET         0
-
-#define DEVICE_PWMOUT           1
-
-#define DEVICE_SEMIHOST         0
-#define DEVICE_LOCALFILESYSTEM  0
 #define DEVICE_ID_LENGTH       24
-
-#define DEVICE_SLEEP            1
-
-#define DEVICE_DEBUG_AWARENESS  0
-
-#define DEVICE_STDIO_MESSAGES   1
-
-#define DEVICE_ERROR_RED        0
-
-#define DEVICE_LOWPOWERTIMER    1
 
 #include "objects.h"
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/NUC472.sct
@@ -10,10 +10,10 @@ LR_IROM1 0x00000000 {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x3000 {
+  ARM_LIB_STACK 0x20000000 EMPTY 0x1000 {
   }
   
-  ER_IRAMVEC 0x20003000 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
+  ER_IRAMVEC 0x20001000 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/NUC472.sct
@@ -10,10 +10,10 @@ LR_IROM1 0x00000000 {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x1000 {
+  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
   }
   
-  ER_IRAMVEC 0x20001000 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
+  ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/NUC472.sct
@@ -10,10 +10,10 @@ LR_IROM1 0x00000000 {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x3000 {
+  ARM_LIB_STACK 0x20000000 EMPTY 0x1000 {
   }
   
-  ER_IRAMVEC 0x20003000 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
+  ER_IRAMVEC 0x20001000 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/NUC472.sct
@@ -10,10 +10,10 @@ LR_IROM1 0x00000000 {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x1000 {
+  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
   }
   
-  ER_IRAMVEC 0x20001000 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
+  ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_GCC_ARM/NUC472.ld
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_GCC_ARM/NUC472.ld
@@ -2,7 +2,7 @@
  * Nuvoton NUC472 GCC linker script file
  */
 
-StackSize = 0x1000;
+StackSize = 0x800;
 
 MEMORY
 {

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_GCC_ARM/NUC472.ld
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_GCC_ARM/NUC472.ld
@@ -2,7 +2,7 @@
  * Nuvoton NUC472 GCC linker script file
  */
 
-StackSize = 0x3000;
+StackSize = 0x1000;
 
 MEMORY
 {

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/NUC472_442.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/NUC472_442.icf
@@ -11,7 +11,7 @@ define symbol __ICFEDIT_region_IRAM_end__   = 0x20010000;
 define symbol __ICFEDIT_region_XRAM_start__ = 0x60000000;
 define symbol __ICFEDIT_region_XRAM_end__   = 0x60100000;
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x2000;
+define symbol __ICFEDIT_size_cstack__ = 0x1000;
 define symbol __ICFEDIT_size_heap__   = 0xC0000;
 /**** End of ICF editor section. ###ICF###*/
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/NUC472_442.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/NUC472_442.icf
@@ -11,7 +11,7 @@ define symbol __ICFEDIT_region_IRAM_end__   = 0x20010000;
 define symbol __ICFEDIT_region_XRAM_start__ = 0x60000000;
 define symbol __ICFEDIT_region_XRAM_end__   = 0x60100000;
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x1000;
+define symbol __ICFEDIT_size_cstack__ = 0x800;
 define symbol __ICFEDIT_size_heap__   = 0xC0000;
 /**** End of ICF editor section. ###ICF###*/
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
@@ -31,6 +31,7 @@
 #endif
 
 struct nu_uart_var {
+    uint32_t    ref_cnt;                // Reference count of the H/W module
     serial_t *  obj;
     uint32_t    fifo_size_tx;
     uint32_t    fifo_size_rx;
@@ -84,6 +85,7 @@ static int serial_is_irq_en(serial_t *obj, SerialIrq irq);
 #endif
 
 static struct nu_uart_var uart0_var = {
+    .ref_cnt            =   0,
     .obj                =   NULL,
     .fifo_size_tx       =   64,
     .fifo_size_rx       =   64,
@@ -95,6 +97,7 @@ static struct nu_uart_var uart0_var = {
 #endif
 };
 static struct nu_uart_var uart1_var = {
+    .ref_cnt            =   0,
     .obj                =   NULL,
     .fifo_size_tx       =   16,
     .fifo_size_rx       =   16,
@@ -106,6 +109,7 @@ static struct nu_uart_var uart1_var = {
 #endif
 };
 static struct nu_uart_var uart2_var = {
+    .ref_cnt            =   0,
     .obj                =   NULL,
     .fifo_size_tx       =   16,
     .fifo_size_rx       =   16,
@@ -117,6 +121,7 @@ static struct nu_uart_var uart2_var = {
 #endif
 };
 static struct nu_uart_var uart3_var = {
+    .ref_cnt            =   0,
     .obj                =   NULL,
     .fifo_size_tx       =   16,
     .fifo_size_rx       =   16,
@@ -128,6 +133,7 @@ static struct nu_uart_var uart3_var = {
 #endif
 };
 static struct nu_uart_var uart4_var = {
+    .ref_cnt            =   0,
     .obj                =   NULL,
     .fifo_size_tx       =   16,
     .fifo_size_rx       =   16,
@@ -139,6 +145,7 @@ static struct nu_uart_var uart4_var = {
 #endif
 };
 static struct nu_uart_var uart5_var = {
+    .ref_cnt            =   0,
     .obj                =   NULL,
     .fifo_size_tx       =   16,
     .fifo_size_rx       =   16,
@@ -170,7 +177,7 @@ extern void mbed_sdk_init(void);
 
 void serial_init(serial_t *obj, PinName tx, PinName rx)
 {
-    // NOTE: serial_init() gets called from _sys_open() timing of which is before main()/mbed_sdk_init().
+    // NOTE: With armcc, serial_init() gets called from _sys_open() timing of which is before main()/mbed_sdk_init().
     mbed_sdk_init();
     
     // Determine which UART_x the pins are used for
@@ -184,32 +191,31 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     MBED_ASSERT(modinit != NULL);
     MBED_ASSERT(modinit->modname == obj->serial.uart);
     
-    // Reset this module
-    SYS_ResetModule(modinit->rsetidx);
+    struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
     
-    // Select IP clock source
-    CLK_SetModuleClock(modinit->clkidx, modinit->clksrc, modinit->clkdiv);
-    // Enable IP clock
-    CLK_EnableModuleClock(modinit->clkidx);
+    if (! var->ref_cnt) {
+        // Reset this module
+        SYS_ResetModule(modinit->rsetidx);
+    
+        // Select IP clock source
+        CLK_SetModuleClock(modinit->clkidx, modinit->clksrc, modinit->clkdiv);
+        // Enable IP clock
+        CLK_EnableModuleClock(modinit->clkidx);
 
-    pinmap_pinout(tx, PinMap_UART_TX);
-    pinmap_pinout(rx, PinMap_UART_RX);
-    // FIXME: Why PullUp?
-    //if (tx != NC) {
-    //    pin_mode(tx, PullUp);
-    //}
-    //if (rx != NC) {
-    //    pin_mode(rx, PullUp);
-    //}
-    obj->serial.pin_tx = tx;
-    obj->serial.pin_rx = rx;
+        pinmap_pinout(tx, PinMap_UART_TX);
+        pinmap_pinout(rx, PinMap_UART_RX);
+    
+        obj->serial.pin_tx = tx;
+        obj->serial.pin_rx = rx;
+    }
+    var->ref_cnt ++;
     
     // Configure the UART module and set its baudrate
     serial_baud(obj, 9600);
     // Configure data bits, parity, and stop bits
     serial_format(obj, 8, ParityNone, 1);
     
-    obj->serial.vec = ((struct nu_uart_var *) modinit->var)->vec;
+    obj->serial.vec = var->vec;
     
 #if DEVICE_SERIAL_ASYNCH
     obj->serial.dma_usage_tx = DMA_USAGE_NEVER;
@@ -220,51 +226,61 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 #endif
 
     // For stdio management
-    if (obj == &stdio_uart) {
+    if (obj->serial.uart == STDIO_UART) {
         stdio_uart_inited = 1;
-        /* NOTE: Not required anymore because stdio_uart will be manually initialized in mbed-drivers/source/retarget.cpp from mbed beta */
-        //memcpy(&stdio_uart, obj, sizeof(serial_t));
+        memcpy(&stdio_uart, obj, sizeof(serial_t));
     }
     
-    // Mark this module to be inited.
-    int i = modinit - uart_modinit_tab;
-    uart_modinit_mask |= 1 << i;
+    if (var->ref_cnt) {
+        // Mark this module to be inited.
+        int i = modinit - uart_modinit_tab;
+        uart_modinit_mask |= 1 << i;
+    }
 }
 
 void serial_free(serial_t *obj)
 {
-#if DEVICE_SERIAL_ASYNCH
-    if (obj->serial.dma_chn_id_tx != DMA_ERROR_OUT_OF_CHANNELS) {
-        dma_channel_free(obj->serial.dma_chn_id_tx);
-        obj->serial.dma_chn_id_tx = DMA_ERROR_OUT_OF_CHANNELS;
-    }
-    if (obj->serial.dma_chn_id_rx != DMA_ERROR_OUT_OF_CHANNELS) {
-        dma_channel_free(obj->serial.dma_chn_id_rx);
-        obj->serial.dma_chn_id_rx = DMA_ERROR_OUT_OF_CHANNELS;
-    }
-#endif
-
-    UART_Close((UART_T *) NU_MODBASE(obj->serial.uart));
-    
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
     MBED_ASSERT(modinit->modname == obj->serial.uart);
     
-    UART_DISABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), (UART_INTEN_RDAIEN_Msk | UART_INTEN_THREIEN_Msk | UART_INTEN_RXTOIEN_Msk));
-    NVIC_DisableIRQ(modinit->irq_n);
+    struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
     
-    // Disable IP clock
-    CLK_DisableModuleClock(modinit->clkidx);
+    var->ref_cnt --;
+    if (! var->ref_cnt) {
+#if DEVICE_SERIAL_ASYNCH
+        if (obj->serial.dma_chn_id_tx != DMA_ERROR_OUT_OF_CHANNELS) {
+            dma_channel_free(obj->serial.dma_chn_id_tx);
+            obj->serial.dma_chn_id_tx = DMA_ERROR_OUT_OF_CHANNELS;
+        }
+        if (obj->serial.dma_chn_id_rx != DMA_ERROR_OUT_OF_CHANNELS) {
+            dma_channel_free(obj->serial.dma_chn_id_rx);
+            obj->serial.dma_chn_id_rx = DMA_ERROR_OUT_OF_CHANNELS;
+        }
+#endif
+
+        UART_Close((UART_T *) NU_MODBASE(obj->serial.uart));
     
-    ((struct nu_uart_var *) modinit->var)->obj = NULL;
+        UART_DISABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), (UART_INTEN_RDAIEN_Msk | UART_INTEN_THREIEN_Msk | UART_INTEN_RXTOIEN_Msk));
+        NVIC_DisableIRQ(modinit->irq_n);
     
-    if (obj == &stdio_uart) {
+        // Disable IP clock
+        CLK_DisableModuleClock(modinit->clkidx);
+    }
+    
+    if (var->obj == obj) {
+        var->obj = NULL;
+    }
+    
+    if (obj->serial.uart == STDIO_UART) {
         stdio_uart_inited = 0;
     }
     
-    // Mark this module to be deinited.
-    int i = modinit - uart_modinit_tab;
-    uart_modinit_mask &= ~(1 << i);
+    if (! var->ref_cnt) {
+        // Mark this module to be deinited.
+        int i = modinit - uart_modinit_tab;
+        uart_modinit_mask &= ~(1 << i);
+    }
 }
 
 void serial_baud(serial_t *obj, int baudrate) {
@@ -345,7 +361,6 @@ void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
     MBED_ASSERT(modinit != NULL);
     MBED_ASSERT(modinit->modname == obj->serial.uart);
     
-    ((struct nu_uart_var *) modinit->var)->obj = obj;
     obj->serial.irq_handler = (uint32_t) handler;
     obj->serial.irq_id = id;
     
@@ -362,6 +377,11 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
     
         NVIC_SetVector(modinit->irq_n, (uint32_t) obj->serial.vec);
         NVIC_EnableIRQ(modinit->irq_n);
+        
+        struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
+        // Multiple serial S/W objects for single UART H/W module possibly.
+        // Bind serial S/W object to UART H/W module as interrupt is enabled.
+        var->obj = obj;
         
         switch (irq) {
             // NOTE: Setting inten_msk first to avoid race condition
@@ -668,7 +688,7 @@ int serial_irq_handler_asynch(serial_t *obj)
     int event_rx = 0;
     int event_tx = 0;
     
-    // Necessary for both interrup way and DMA way
+    // Necessary for both interrupt way and DMA way
     if (serial_is_irq_en(obj, RxIrq)) {
         event_rx = serial_rx_event_check(obj);
         if (event_rx) {
@@ -1040,9 +1060,9 @@ static void serial_tx_enable_interrupt(serial_t *obj, uint32_t handler, uint8_t 
     MBED_ASSERT(modinit->modname == obj->serial.uart);
     
     // Necessary for both interrupt way and DMA way
-    ((struct nu_uart_var *) modinit->var)->obj = obj;
+    struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
     // With our own async vector, tx/rx handlers can be different.
-    obj->serial.vec = ((struct nu_uart_var *) modinit->var)->vec_async;
+    obj->serial.vec = var->vec_async;
     obj->serial.irq_handler_tx_async = (void (*)(void)) handler;
     serial_irq_set(obj, TxIrq, enable);
 }
@@ -1054,9 +1074,9 @@ static void serial_rx_enable_interrupt(serial_t *obj, uint32_t handler, uint8_t 
     MBED_ASSERT(modinit->modname == obj->serial.uart);
     
     // Necessary for both interrupt way and DMA way
-    ((struct nu_uart_var *) modinit->var)->obj = obj;
+    struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
     // With our own async vector, tx/rx handlers can be different.
-    obj->serial.vec = ((struct nu_uart_var *) modinit->var)->vec_async;
+    obj->serial.vec = var->vec_async;
     obj->serial.irq_handler_rx_async = (void (*) (void)) handler;
     serial_irq_set(obj, RxIrq, enable);
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2355,7 +2355,7 @@
         "is_disk_virtual": true,
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "inherits": ["Target"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "TRNG", "CAN"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "STDIO_MESSAGES", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "TRNG", "CAN"],
         "features": ["LWIP"],
         "release_versions": ["5"],
         "device_name": "NUC472HI8AE"
@@ -2379,7 +2379,7 @@
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "inherits": ["Target"],
         "progen": {"target": "numaker-pfm-m453"},
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "CAN"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "STDIO_MESSAGES", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "CAN"],
         "release_versions": ["2", "5"],
         "device_name": "M453VG6AE"
     },


### PR DESCRIPTION
## Description
This PR patches for the targets NuMaker-PFM-NUC472 and NuMaker-PFM-M453 and has the following modifications:
1. Fix greentea test failed. This is caused by no support for single UART H/W module shared by multiple serial S/W objects.
1. Reduce interrupt stack size from 12/4 KB to 2 KB.
1. Remove dead code in device.h.
