### PR TITLE
[Export - Make] Add message that informs the user which hex to flash

### DIFF
--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -13,10 +13,10 @@ else
     RM = '$(SHELL)' -c "rm -rf \"$(1)\""
 endif
 
-# Move to the build directory
-ifeq (,$(filter .build,$(notdir $(CURDIR))))
-.SUFFIXES:
 OBJDIR := .build
+# Move to the build directory
+ifeq (,$(filter $(OBJDIR),$(notdir $(CURDIR))))
+.SUFFIXES:
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 MAKETARGET = '$(MAKE)' --no-print-directory -C $(OBJDIR) -f '$(mkfile_path)' \
 		'SRCDIR=$(CURDIR)' $(MAKECMDGOALS)
@@ -127,6 +127,7 @@ $(PROJECT).elf: $(OBJECTS) $(SYS_OBJECTS) $(LINKER_SCRIPT)
 
 $(PROJECT).bin: $(PROJECT).elf
 {%- block elf2bin -%}{%- endblock %}
+{% if not hex_files %}	+@echo ===== bin file ready to flash: $(OBJDIR)/$@ ===== {% endif %}
 
 $(PROJECT).hex: $(PROJECT).elf
 {%- block elf2hex -%}{%- endblock %}
@@ -135,6 +136,7 @@ $(PROJECT).hex: $(PROJECT).elf
 $(PROJECT)-combined.hex: $(PROJECT).hex
 	+@echo "NOTE: the $(SREC_CAT) binary is required to be present in your PATH. Please see http://srecord.sourceforge.net/ for more information."
 	$(SREC_CAT) {% for f in hex_files %}{{f}} {% endfor %} -intel $(PROJECT).hex -intel -o $(PROJECT)-combined.hex -intel --line-length=44
+	+@echo ===== hex file ready to flash: $(OBJDIR)/$@ =====
 {% endif %}
 # Rules
 ###############################################################################


### PR DESCRIPTION
## Description
Resolves #2962 part B in a way that should be noticable

## Reviews
- [x] @0xc0170 
- [x] @pan-
- [x] @ashok-rao 

## Examples
It looks like this (k64f, no hex file merging):
```
$ make -j 
[SNIP]
Compile: port_api.c
Compile: sleep.c
Compile: i2c_api.c
Compile: rtc_api.c
../mbed-os/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/drivers/fsl_enet.c: In function 'ENET_SetTxBufferDescriptors':
../mbed-os/targets/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_MCU_K64F/drivers/fsl_enet.c:493:29: warning: comparison between pointer and integer
         if (txBuffSizeAlign != NULL)
                             ^
link: mbed-os-example-blinky.elf
'arm-none-eabi-objcopy' -O binary mbed-os-example-blinky.elf mbed-os-example-blinky.bin
'arm-none-eabi-objcopy' -O ihex mbed-os-example-blinky.elf mbed-os-example-blinky.hex
===== bin file ready to flash: .build/mbed-os-example-blinky.bin =====
```

OR this (nrf52_dk, hex file merging):
```
$ make -j
[SNIP]
link: mbed-os-example-blinky.elf
'arm-none-eabi-objcopy' -O binary mbed-os-example-blinky.elf mbed-os-example-blinky.bin
'arm-none-eabi-objcopy' -O ihex mbed-os-example-blinky.elf mbed-os-example-blinky.hex
NOTE: the srec_cat binary is required to be present in your PATH. Please see http://srecord.sourceforge.net/ for more information.
srec_cat .././mbed-os/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/sdk/softdevice/s132/hex/s132_nrf52_2.0.0_softdevice.hex  -intel mbed-os-example-blinky.hex -intel -o mbed-os-example-blinky-combined.hex -intel --line-length=44
===== hex file ready to flash: .build/mbed-os-example-blinky-combined.hex =====
```
