### PR TITLE
[Tools - Toolchains] Allow dependency parsing to fail, gracefully continuing

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -887,7 +887,10 @@ class mbedToolchain:
         if ext == '.c' or  ext == '.cpp':
             base, _ = splitext(object)
             dep_path = base + '.d'
-            deps = self.parse_dependencies(dep_path) if (exists(dep_path)) else []
+            try:
+                deps = self.parse_dependencies(dep_path) if (exists(dep_path)) else []
+            except IOError, IndexError:
+                deps = []
             if len(deps) == 0 or self.need_update(object, deps):
                 if ext == '.cpp' or self.COMPILE_C_AS_CPP:
                     return self.compile_cpp(source, object, includes)


### PR DESCRIPTION
## Description
If, say, you compile with gcc_arm and kill it at just the right time you will have an empty dependency file. This empty dependency file will cause a python traceback in dependency parsing, preventing you from compiling until you next clean.

This PR lets that weird corner case compile.

## Status
**READY**


## Reviews
- [x] @screamerbg (toolchains modified)
- [ ] @infinnovation (issue reporter)

should resolve #3226 

## Reproducing the issue

We can simulate the very precise timing needed to reproduce this bug by simply emptying a `.d` file
1) Run any mbed compile command using gcc_arm in a working project (any target will do).
2) Find any `.d` file for the project (for example I'll use `BUILD/k64f/gcc_arm/main.d`)
3) Run this command, replacing my example file with a file chosen in step 2
```bash
echo -n > BUILD/k64f/gcc_arm/main.d
```
4) Run the mbed compile again to see the failure.
```
...
Scan: mbed
Scan: env
[ERROR] list index out of range
[mbed] ERROR: "python" returned error code 1.
```