### PR TITLE
[Tools - Toolchains] Heed case in mbedignore unconditionally

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -508,7 +508,7 @@ class mbedToolchain:
 
     def is_ignored(self, file_path):
         for pattern in self.ignore_patterns:
-            if fnmatch.fnmatch(file_path, pattern):
+            if fnmatch.fnmatchcase(file_path, pattern):
                 return True
         return False
 


### PR DESCRIPTION
## Description
When developing on Windows or OSX, a developer may inadvertently create a `.mbedignore` file that does not work with another developer's Linux because case is ignored on those Operating Systems when processing ignores. This can manifest itself in CI, which commonly will use Linux.

## Status
**READY**


## Migrations
One might have to update `.mbedignore` files to heed case if the project in question has never been built on Linux before. This would be necessary to allow the project to be built on Linux the first time though.


## Reviews
- [x] @screamerbg (Toolchains affected)