### PR TITLE
K20xx Calculate PWM clock relative to bus clock

### DIFF
--- a/targets/TARGET_Freescale/TARGET_K20XX/pwmout_api.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/pwmout_api.c
@@ -27,8 +27,11 @@ void pwmout_init(pwmout_t* obj, PinName pin) {
     PWMName pwm = (PWMName)pinmap_peripheral(pin, PinMap_PWM);
     MBED_ASSERT(pwm != (PWMName)NC);
 
+    uint32_t MGCOUTClock = SystemCoreClock * (1u + ((SIM->CLKDIV1 & SIM_CLKDIV1_OUTDIV1_MASK) >> SIM_CLKDIV1_OUTDIV1_SHIFT));
+    uint32_t BusClock = MGCOUTClock / (1u + ((SIM->CLKDIV1 & SIM_CLKDIV1_OUTDIV2_MASK) >> SIM_CLKDIV1_OUTDIV2_SHIFT));
+
     uint32_t clkdiv = 0;
-    float clkval = SystemCoreClock / 1000000.0f;
+    float clkval = BusClock / 1000000.0f;
 
     while (clkval > 1) {
         clkdiv++;


### PR DESCRIPTION
## Description
Fix K20xx's PwmOut to calculate pwm clock from the bus clock instead of SystemCoreClock.

## Status
**READY**

## Migrations
NO

## Steps to test or reproduce
Build subtarget TARGET_TEENSY3_1 with CLOCK_SETUP defined as 0 and build again as 1. Create a user program setting PwmOut with a 1ms period, 50% duty cycle. Verify clock period with oscilloscope. Without this PR, the CLOCK_SETUP 1 config will produce a 2ms period.

