### PR TITLE
Dev i2c stm32f4hal

### DIFF
--- a/features/unsupported/tests/mbed/i2c_master_slave_asynch/main.cpp
+++ b/features/unsupported/tests/mbed/i2c_master_slave_asynch/main.cpp
@@ -69,7 +69,8 @@ int main()
 
     // First transfer: master to slave
     printf("\nFirst transfer: Master Tx, Repeated Start\n");
-    master.transfer(ADDR, buf_master, SIZE, 0, 0, callback, I2C_EVENT_ALL, true);
+    if(master.transfer(ADDR, buf_master, SIZE, 0, 0, callback, I2C_EVENT_ALL, true) != 0)
+            notify_completion(false);
 
     while (!master_complete) {
         if(slave.receive() == I2CSlave::WriteAddressed) {
@@ -89,7 +90,8 @@ int main()
 
     // Second transfer: slave to master
     printf("\nSecond transfer: Master Rx\n");
-    master.transfer(ADDR, 0, 0, res_master, SIZE, callback, I2C_EVENT_ALL, true);
+    if(master.transfer(ADDR, 0, 0, res_master, SIZE, callback, I2C_EVENT_ALL, true) != 0)
+            notify_completion(false);
 
     while (!master_complete) {
         if(slave.receive() == I2CSlave::ReadAddressed) {
@@ -117,7 +119,8 @@ int main()
 
     // Third transfer: Tx/Rx
     printf("\nThird transfer: Master Tx/Rx\n");
-    master.transfer(ADDR, buf_master_tx, SIZE, buf_master_rx, SIZE, callback, I2C_EVENT_ALL, false);
+    if(master.transfer(ADDR, buf_master_tx, SIZE, buf_master_rx, SIZE, callback, I2C_EVENT_ALL, false) != 0)
+            notify_completion(false);
 
     while (!master_complete) {
 
@@ -129,6 +132,7 @@ int main()
                 buf_slave_txrx[i]++;
             }
         }
+
         if((i == I2CSlave::ReadAddressed) ) {
             slave.write(buf_slave_txrx, SIZE);
         }

--- a/features/unsupported/tests/mbed/i2c_master_slave_asynch/main.cpp
+++ b/features/unsupported/tests/mbed/i2c_master_slave_asynch/main.cpp
@@ -45,7 +45,6 @@ I2CSlave slave(D3, D6);
 volatile int why;
 volatile bool master_complete = false;
 void cbmaster_done(int event) {
-    printf("cbmaster_done\n");
     master_complete = true;
     why = event;
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
@@ -93,10 +93,14 @@ struct i2c_s {
     uint8_t index;
     IRQn_Type event_i2cIRQ;
     IRQn_Type error_i2cIRQ;
+    volatile uint8_t event;
+#if DEVICE_I2CSLAVE
     uint8_t slave;
+    volatile uint8_t pending_slave_tx_master_rx;
+    volatile uint8_t pending_slave_rx_maxter_tx;
+#endif
 #if DEVICE_I2C_ASYNCH
     uint32_t address;
-    uint8_t event;
     uint8_t stop;
     uint8_t available_events;
     uint8_t XferOperation;

--- a/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
@@ -95,6 +95,7 @@ struct i2c_s {
     PinName scl;
     IRQn_Type event_i2cIRQ;
     IRQn_Type error_i2cIRQ;
+    uint8_t XferOperation;
     volatile uint8_t event;
 #if DEVICE_I2CSLAVE
     uint8_t slave;
@@ -105,7 +106,6 @@ struct i2c_s {
     uint32_t address;
     uint8_t stop;
     uint8_t available_events;
-    uint8_t XferOperation;
 #endif
 };
 

--- a/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
@@ -87,6 +87,7 @@ struct i2c_s {
     /*  The 1st 2 members I2CName i2c
      *  and I2C_HandleTypeDef handle should
      *  be kept as the first members of this struct
+     *  to have get_i2c_obj() function work as expected
      */
     I2CName  i2c;
     I2C_HandleTypeDef handle;

--- a/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
@@ -84,6 +84,10 @@ struct spi_s {
 };
 
 struct i2c_s {
+    /*  The 1st 2 members I2CName i2c
+     *  and I2C_HandleTypeDef handle should
+     *  be kept as the first members of this struct
+     */
     I2CName  i2c;
     I2C_HandleTypeDef handle;
     IRQn_Type event_i2cIRQ;

--- a/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
@@ -91,6 +91,8 @@ struct i2c_s {
     I2CName  i2c;
     I2C_HandleTypeDef handle;
     uint8_t index;
+    PinName sda;
+    PinName scl;
     IRQn_Type event_i2cIRQ;
     IRQn_Type error_i2cIRQ;
     volatile uint8_t event;

--- a/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
@@ -90,6 +90,7 @@ struct i2c_s {
      */
     I2CName  i2c;
     I2C_HandleTypeDef handle;
+    uint8_t index;
     IRQn_Type event_i2cIRQ;
     IRQn_Type error_i2cIRQ;
     uint8_t slave;

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_i2c.c
@@ -3960,7 +3960,8 @@ static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
     __HAL_I2C_DISABLE_IT(hi2c, I2C_IT_EVT | I2C_IT_ERR);
 
     hi2c->State = HAL_I2C_STATE_READY;
-    
+    hi2c->PreviousState = I2C_STATE_NONE;
+
     if(hi2c->Mode == HAL_I2C_MODE_MEM)
     {
       hi2c->Mode = HAL_I2C_MODE_NONE;

--- a/targets/TARGET_STM/TARGET_STM32F4/i2c_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/i2c_api.c
@@ -404,19 +404,13 @@ void i2c_reset(i2c_t *obj) {
 #if DEVICE_I2CSLAVE
 
 void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask) {
-
-    uint16_t tmpreg = 0;
     struct i2c_s *obj_s = I2C_S(obj);
+    I2C_HandleTypeDef *handle = &(obj_s->handle);
     I2C_TypeDef *i2c = (I2C_TypeDef *)obj_s->i2c;
 
-    // Get the old register value
-    tmpreg = i2c->OAR1;
-    // Reset address bits
-    tmpreg &= 0xFC00;
-    // Set new address
-    tmpreg |= (uint16_t)((uint16_t)address & (uint16_t)0x00FE); // 7-bits
-    // Store the new register value
-    i2c->OAR1 = tmpreg;
+    // I2C configuration
+    handle->Init.OwnAddress1     = address;
+    HAL_I2C_Init(handle);
 }
 
 void i2c_slave_mode(i2c_t *obj, int enable_slave) {
@@ -429,6 +423,8 @@ void i2c_slave_mode(i2c_t *obj, int enable_slave) {
 
         /* Enable Address Acknowledge */
         i2c->CR1 |= I2C_CR1_ACK;
+    } else {
+        obj_s->slave = 0;
     }
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/i2c_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/i2c_api.c
@@ -787,18 +787,7 @@ void i2c_transfer_asynch(i2c_t *obj, const void *tx, size_t tx_length, void *rx,
     obj_s->address = address;
     obj_s->stop = stop;
 
-    IRQn_Type irq_event_n = obj_s->event_i2cIRQ;
-    IRQn_Type irq_error_n = obj_s->error_i2cIRQ;
-
-    /* Set up event IT using IRQ and handler tables */
-    NVIC_SetVector(irq_event_n, handler);
-    HAL_NVIC_SetPriority(irq_event_n, 0, 1);
-    HAL_NVIC_EnableIRQ(irq_event_n);
-
-    /* Set up error IT using IRQ and handler tables */
-    NVIC_SetVector(irq_error_n, handler);
-    HAL_NVIC_SetPriority(irq_error_n, 0, 0);
-    HAL_NVIC_EnableIRQ(irq_error_n);
+    i2c_ev_err_enable(obj, handler);
 
     /* Set operation step depending if stop sending required or not */
     if ((tx_length && !rx_length) || (!tx_length && rx_length)) {

--- a/targets/TARGET_STM/TARGET_STM32F4/i2c_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/i2c_api.c
@@ -42,11 +42,6 @@
 #define FLAG_TIMEOUT ((int)0x1000)
 #define LONG_TIMEOUT ((int)0x8000)
 
-int i2c1_inited = 0;
-int i2c2_inited = 0;
-int i2c3_inited = 0;
-int fmpi2c1_inited = 0;
-
 #if DEVICE_I2C_ASYNCH
     #define I2C_S(obj) (struct i2c_s *) (&((obj)->i2c))
 #else
@@ -66,8 +61,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
     MBED_ASSERT(obj_s->i2c != (I2CName)NC);
 
     // Enable I2C1 clock and pinout if not done
-    if ((obj_s->i2c == I2C_1) && !i2c1_inited) {
-        i2c1_inited = 1;
+    if (obj_s->i2c == I2C_1) {
         // Configure I2C pins
         pinmap_pinout(sda, PinMap_I2C_SDA);
         pinmap_pinout(scl, PinMap_I2C_SCL);
@@ -80,8 +74,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
         __I2C1_CLK_ENABLE();
     }
     // Enable I2C2 clock and pinout if not done
-    if ((obj_s->i2c == I2C_2) && !i2c2_inited) {
-        i2c2_inited = 1;
+    if (obj_s->i2c == I2C_2) {
         // Configure I2C pins
         pinmap_pinout(sda, PinMap_I2C_SDA);
         pinmap_pinout(scl, PinMap_I2C_SCL);
@@ -95,8 +88,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
     }
 #if defined I2C3_BASE
     // Enable I2C3 clock and pinout if not done
-    if ((obj_s->i2c == I2C_3) && !i2c3_inited) {
-        i2c3_inited = 1;
+    if (obj_s->i2c == I2C_3) {
         // Configure I2C pins
         pinmap_pinout(sda, PinMap_I2C_SDA);
         pinmap_pinout(scl, PinMap_I2C_SCL);
@@ -112,8 +104,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
 
 #if defined FMPI2C1_BASE
     // Enable I2C3 clock and pinout if not done
-    if ((obj_s->i2c == FMPI2C_1) && !fmpi2c1_inited) {
-        fmpi2c1_inited = 1;
+    if (obj_s->i2c == FMPI2C_1) {
         // Configure I2C pins
         pinmap_pinout(sda, PinMap_I2C_SDA);
         pinmap_pinout(scl, PinMap_I2C_SCL);

--- a/targets/TARGET_STM/TARGET_STM32F4/i2c_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/i2c_api.c
@@ -174,6 +174,8 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
     // Determine the I2C to use
     I2CName i2c_sda = (I2CName)pinmap_peripheral(sda, PinMap_I2C_SDA);
     I2CName i2c_scl = (I2CName)pinmap_peripheral(scl, PinMap_I2C_SCL);
+    obj_s->sda = sda;
+    obj_s->scl = scl;
 
     obj_s->i2c = (I2CName)pinmap_merge(i2c_sda, i2c_scl);
     MBED_ASSERT(obj_s->i2c != (I2CName)NC);
@@ -710,12 +712,11 @@ void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c){
     /* Get object ptr based on handler ptr */
     i2c_t *obj = get_i2c_obj(hi2c);
     struct i2c_s *obj_s = I2C_S(obj);
-    I2C_HandleTypeDef *handle = &(obj_s->handle);
 
-    /* Disable IT. Not always done before calling macro */
-    __HAL_I2C_DISABLE_IT(handle, I2C_IT_EVT | I2C_IT_BUF | I2C_IT_ERR);
+    /* re-init IP to try and get back in a working state */
+    i2c_init(obj, obj_s->sda, obj_s->scl);
 
-    /* Set event flag */
+    /* Keep Set event flag */
     obj_s->event = I2C_EVENT_ERROR;
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/i2c_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/i2c_api.c
@@ -165,7 +165,20 @@ void i2c_frequency(i2c_t *obj, int hz)
         handle->Instance->CR1 |= I2C_CR1_ACK;
     }
 #endif
+}
 
+i2c_t *get_i2c_obj(I2C_HandleTypeDef *hi2c){
+
+    /* Aim of the function is to get i2c_s pointer using hi2c pointer */
+    /* Highly inspired from magical linux kernel's "container_of" */
+    /* (which was not directly used since not compatible with IAR toolchain) */
+    struct i2c_s *obj_s;
+    i2c_t *obj;
+
+    obj_s = (struct i2c_s *)( (char *)hi2c - offsetof(struct i2c_s,handle));
+    obj = (i2c_t *)( (char *)obj_s - offsetof(i2c_t,i2c));
+
+    return (obj);
 }
 
 inline int i2c_start(i2c_t *obj) {
@@ -569,21 +582,6 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length) {
 #endif // DEVICE_I2CSLAVE
 
 #if DEVICE_I2C_ASYNCH
-
-
-i2c_t *get_i2c_obj(I2C_HandleTypeDef *hi2c){
-
-    /* Aim of the function is to get i2c_s pointer using hi2c pointer */
-    /* Highly inspired from magical linux kernel's "container_of" */
-    /* (which was not directly used since not compatible with IAR toolchain) */
-    struct i2c_s *obj_s;
-    i2c_t *obj;
-
-     obj_s = (struct i2c_s *)( (char *)hi2c - offsetof(struct i2c_s,handle));
-    obj = (i2c_t *)( (char *)obj_s - offsetof(i2c_t,i2c));
-
-    return (obj);
-}
 
 void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c){
     /* Get object ptr based on handler ptr */


### PR DESCRIPTION
## Description
This PR contains rework of F4 I2C driver to move most of the drivers functions to call STM32 cube HAL API instead of direct registers access . 
Because this API is common to all STM32 families, this is a first step towards merging the various (x9) i2c_api.c files into a common file. 
During the rework, other functionalities have been added: like usage of Interrupts as well in sync mode (not visible fro MBED API user), reset of IP in case of error, timeout calculated based on SystemCoreClock and I2C frequency

## Status
**READY**

- [ ] Tests report

IKS01A1 Hello world has been tested succesfully.

Also non regression tests results available here: 
![image](https://cloud.githubusercontent.com/assets/17590297/20145823/c7790368-a6a1-11e6-8fae-9bb9db42d919.png)



