### PR TITLE
callback - Relax type-deduction in callback class

### DIFF
--- a/TESTS/mbed_functional/callback/main.cpp
+++ b/TESTS/mbed_functional/callback/main.cpp
@@ -233,6 +233,11 @@ template <typename T>
 T const_volatile_void_func5(const volatile void *t, T a0, T a1, T a2, T a3, T a4)
     { return static_cast<const volatile Thing<T>*>(t)->t | a0 | a1 | a2 | a3 | a4; }
 
+// Inheriting class
+template <typename T>
+class Thing2 : public Thing<T> {
+};
+
 
 // function call and result verification
 template <typename T>
@@ -315,15 +320,18 @@ struct Verifier {
 template <typename T>
 void test_dispatch0() {
     Thing<T> thing;
+    Thing2<T> thing2;
     Verifier<T>::verify0(static_func0<T>);
     Verifier<T>::verify0(&thing, &Thing<T>::member_func0);
     Verifier<T>::verify0((const Thing<T>*)&thing, &Thing<T>::const_member_func0);
     Verifier<T>::verify0((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func0);
     Verifier<T>::verify0((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func0);
+    Verifier<T>::verify0(&thing2, &Thing2<T>::member_func0);
     Verifier<T>::verify0(&bound_func0<T>, &thing);
     Verifier<T>::verify0(&const_bound_func0<T>, (const Thing<T>*)&thing);
     Verifier<T>::verify0(&volatile_bound_func0<T>, (volatile Thing<T>*)&thing);
     Verifier<T>::verify0(&const_volatile_bound_func0<T>, (const volatile Thing<T>*)&thing);
+    Verifier<T>::verify0(&bound_func0<T>, &thing2);
     Verifier<T>::verify0(&void_func0<T>, &thing);
     Verifier<T>::verify0(&const_void_func0<T>, (const Thing<T>*)&thing);
     Verifier<T>::verify0(&volatile_void_func0<T>, (volatile Thing<T>*)&thing);
@@ -342,15 +350,18 @@ void test_dispatch0() {
 template <typename T>
 void test_dispatch1() {
     Thing<T> thing;
+    Thing2<T> thing2;
     Verifier<T>::verify1(static_func1<T>);
     Verifier<T>::verify1(&thing, &Thing<T>::member_func1);
     Verifier<T>::verify1((const Thing<T>*)&thing, &Thing<T>::const_member_func1);
     Verifier<T>::verify1((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func1);
     Verifier<T>::verify1((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func1);
+    Verifier<T>::verify1(&thing2, &Thing2<T>::member_func1);
     Verifier<T>::verify1(&bound_func1<T>, &thing);
     Verifier<T>::verify1(&const_bound_func1<T>, (const Thing<T>*)&thing);
     Verifier<T>::verify1(&volatile_bound_func1<T>, (volatile Thing<T>*)&thing);
     Verifier<T>::verify1(&const_volatile_bound_func1<T>, (const volatile Thing<T>*)&thing);
+    Verifier<T>::verify1(&bound_func1<T>, &thing2);
     Verifier<T>::verify1(&void_func1<T>, &thing);
     Verifier<T>::verify1(&const_void_func1<T>, (const Thing<T>*)&thing);
     Verifier<T>::verify1(&volatile_void_func1<T>, (volatile Thing<T>*)&thing);
@@ -369,15 +380,18 @@ void test_dispatch1() {
 template <typename T>
 void test_dispatch2() {
     Thing<T> thing;
+    Thing2<T> thing2;
     Verifier<T>::verify2(static_func2<T>);
     Verifier<T>::verify2(&thing, &Thing<T>::member_func2);
     Verifier<T>::verify2((const Thing<T>*)&thing, &Thing<T>::const_member_func2);
     Verifier<T>::verify2((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func2);
     Verifier<T>::verify2((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func2);
+    Verifier<T>::verify2(&thing2, &Thing2<T>::member_func2);
     Verifier<T>::verify2(&bound_func2<T>, &thing);
     Verifier<T>::verify2(&const_bound_func2<T>, (const Thing<T>*)&thing);
     Verifier<T>::verify2(&volatile_bound_func2<T>, (volatile Thing<T>*)&thing);
     Verifier<T>::verify2(&const_volatile_bound_func2<T>, (const volatile Thing<T>*)&thing);
+    Verifier<T>::verify2(&bound_func2<T>, &thing2);
     Verifier<T>::verify2(&void_func2<T>, &thing);
     Verifier<T>::verify2(&const_void_func2<T>, (const Thing<T>*)&thing);
     Verifier<T>::verify2(&volatile_void_func2<T>, (volatile Thing<T>*)&thing);
@@ -396,15 +410,18 @@ void test_dispatch2() {
 template <typename T>
 void test_dispatch3() {
     Thing<T> thing;
+    Thing2<T> thing2;
     Verifier<T>::verify3(static_func3<T>);
     Verifier<T>::verify3(&thing, &Thing<T>::member_func3);
     Verifier<T>::verify3((const Thing<T>*)&thing, &Thing<T>::const_member_func3);
     Verifier<T>::verify3((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func3);
     Verifier<T>::verify3((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func3);
+    Verifier<T>::verify3(&thing2, &Thing2<T>::member_func3);
     Verifier<T>::verify3(&bound_func3<T>, &thing);
     Verifier<T>::verify3(&const_bound_func3<T>, (const Thing<T>*)&thing);
     Verifier<T>::verify3(&volatile_bound_func3<T>, (volatile Thing<T>*)&thing);
     Verifier<T>::verify3(&const_volatile_bound_func3<T>, (const volatile Thing<T>*)&thing);
+    Verifier<T>::verify3(&bound_func3<T>, &thing2);
     Verifier<T>::verify3(&void_func3<T>, &thing);
     Verifier<T>::verify3(&const_void_func3<T>, (const Thing<T>*)&thing);
     Verifier<T>::verify3(&volatile_void_func3<T>, (volatile Thing<T>*)&thing);
@@ -423,15 +440,18 @@ void test_dispatch3() {
 template <typename T>
 void test_dispatch4() {
     Thing<T> thing;
+    Thing2<T> thing2;
     Verifier<T>::verify4(static_func4<T>);
     Verifier<T>::verify4(&thing, &Thing<T>::member_func4);
     Verifier<T>::verify4((const Thing<T>*)&thing, &Thing<T>::const_member_func4);
     Verifier<T>::verify4((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func4);
     Verifier<T>::verify4((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func4);
+    Verifier<T>::verify4(&thing2, &Thing2<T>::member_func4);
     Verifier<T>::verify4(&bound_func4<T>, &thing);
     Verifier<T>::verify4(&const_bound_func4<T>, (const Thing<T>*)&thing);
     Verifier<T>::verify4(&volatile_bound_func4<T>, (volatile Thing<T>*)&thing);
     Verifier<T>::verify4(&const_volatile_bound_func4<T>, (const volatile Thing<T>*)&thing);
+    Verifier<T>::verify4(&bound_func4<T>, &thing2);
     Verifier<T>::verify4(&void_func4<T>, &thing);
     Verifier<T>::verify4(&const_void_func4<T>, (const Thing<T>*)&thing);
     Verifier<T>::verify4(&volatile_void_func4<T>, (volatile Thing<T>*)&thing);
@@ -450,15 +470,18 @@ void test_dispatch4() {
 template <typename T>
 void test_dispatch5() {
     Thing<T> thing;
+    Thing2<T> thing2;
     Verifier<T>::verify5(static_func5<T>);
     Verifier<T>::verify5(&thing, &Thing<T>::member_func5);
     Verifier<T>::verify5((const Thing<T>*)&thing, &Thing<T>::const_member_func5);
     Verifier<T>::verify5((volatile Thing<T>*)&thing, &Thing<T>::volatile_member_func5);
     Verifier<T>::verify5((const volatile Thing<T>*)&thing, &Thing<T>::const_volatile_member_func5);
+    Verifier<T>::verify5(&thing2, &Thing2<T>::member_func5);
     Verifier<T>::verify5(&bound_func5<T>, &thing);
     Verifier<T>::verify5(&const_bound_func5<T>, (const Thing<T>*)&thing);
     Verifier<T>::verify5(&volatile_bound_func5<T>, (volatile Thing<T>*)&thing);
     Verifier<T>::verify5(&const_volatile_bound_func5<T>, (const volatile Thing<T>*)&thing);
+    Verifier<T>::verify5(&bound_func5<T>, &thing2);
     Verifier<T>::verify5(&void_func5<T>, &thing);
     Verifier<T>::verify5(&const_void_func5<T>, (const Thing<T>*)&thing);
     Verifier<T>::verify5(&volatile_void_func5<T>, (volatile Thing<T>*)&thing);

--- a/platform/Callback.h
+++ b/platform/Callback.h
@@ -124,42 +124,10 @@ public:
 
     /** Create a Callback with a static function and bound pointer
      *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(void*), void *arg) {
-        generate(function_context<R (*)(void*), void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(const void*), const void *arg) {
-        generate(function_context<R (*)(const void*), const void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(volatile void*), volatile void *arg) {
-        generate(function_context<R (*)(volatile void*), volatile void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(const volatile void*), const volatile void *arg) {
-        generate(function_context<R (*)(const volatile void*), const volatile void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(T*), T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(T*), U *arg) {
         generate(function_context<R (*)(T*), T>(func, arg));
     }
 
@@ -167,8 +135,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(const T*), const T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(const T*), const U *arg) {
         generate(function_context<R (*)(const T*), const T>(func, arg));
     }
 
@@ -176,8 +144,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(volatile T*), volatile T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(volatile T*), volatile U *arg) {
         generate(function_context<R (*)(volatile T*), volatile T>(func, arg));
     }
 
@@ -185,8 +153,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(const volatile T*), const volatile T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(const volatile T*), const volatile U *arg) {
         generate(function_context<R (*)(const volatile T*), const volatile T>(func, arg));
     }
 
@@ -244,9 +212,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(void *obj, R (*func)(void*)) {
+    Callback(U *obj, R (*func)(T*)) {
         new (this) Callback(func, obj);
     }
 
@@ -256,9 +225,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const void *obj, R (*func)(const void*)) {
+    Callback(const U *obj, R (*func)(const T*)) {
         new (this) Callback(func, obj);
     }
 
@@ -268,9 +238,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile void *obj, R (*func)(volatile void*)) {
+    Callback(volatile U *obj, R (*func)(volatile T*)) {
         new (this) Callback(func, obj);
     }
 
@@ -280,61 +251,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile void *obj, R (*func)(const volatile void*)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(T *obj, R (*func)(T*)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const T *obj, R (*func)(const T*)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile T *obj, R (*func)(volatile T*)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile T *obj, R (*func)(const volatile T*)) {
+    Callback(const volatile U *obj, R (*func)(const volatile T*)) {
         new (this) Callback(func, obj);
     }
 
@@ -406,7 +326,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(void*), void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(T*), U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -415,7 +336,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(const void*), const void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(const T*), const U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -424,7 +346,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(volatile void*), volatile void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(volatile T*), volatile U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -433,47 +356,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(const volatile void*), const volatile void *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(T*), T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(const T*), const T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(volatile T*), volatile T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(const volatile T*), const volatile T *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(const volatile T*), const volatile U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -536,9 +420,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(void *obj, R (*func)(void*)) {
+    void attach(U *obj, R (*func)(T*)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -549,9 +434,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const void *obj, R (*func)(const void*)) {
+    void attach(const U *obj, R (*func)(const T*)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -562,9 +448,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile void *obj, R (*func)(volatile void*)) {
+    void attach(volatile U *obj, R (*func)(volatile T*)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -575,65 +462,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile void *obj, R (*func)(const volatile void*)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(T *obj, R (*func)(T*)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const T *obj, R (*func)(const T*)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile T *obj, R (*func)(volatile T*)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile T *obj, R (*func)(const volatile T*)) {
+    void attach(const volatile U *obj, R (*func)(const volatile T*)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -831,42 +663,10 @@ public:
 
     /** Create a Callback with a static function and bound pointer
      *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(void*, A0), void *arg) {
-        generate(function_context<R (*)(void*, A0), void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(const void*, A0), const void *arg) {
-        generate(function_context<R (*)(const void*, A0), const void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(volatile void*, A0), volatile void *arg) {
-        generate(function_context<R (*)(volatile void*, A0), volatile void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(const volatile void*, A0), const volatile void *arg) {
-        generate(function_context<R (*)(const volatile void*, A0), const volatile void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(T*, A0), T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(T*, A0), U *arg) {
         generate(function_context<R (*)(T*, A0), T>(func, arg));
     }
 
@@ -874,8 +674,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(const T*, A0), const T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(const T*, A0), const U *arg) {
         generate(function_context<R (*)(const T*, A0), const T>(func, arg));
     }
 
@@ -883,8 +683,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(volatile T*, A0), volatile T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(volatile T*, A0), volatile U *arg) {
         generate(function_context<R (*)(volatile T*, A0), volatile T>(func, arg));
     }
 
@@ -892,8 +692,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(const volatile T*, A0), const volatile T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(const volatile T*, A0), const volatile U *arg) {
         generate(function_context<R (*)(const volatile T*, A0), const volatile T>(func, arg));
     }
 
@@ -951,9 +751,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(void *obj, R (*func)(void*, A0)) {
+    Callback(U *obj, R (*func)(T*, A0)) {
         new (this) Callback(func, obj);
     }
 
@@ -963,9 +764,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const void *obj, R (*func)(const void*, A0)) {
+    Callback(const U *obj, R (*func)(const T*, A0)) {
         new (this) Callback(func, obj);
     }
 
@@ -975,9 +777,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile void *obj, R (*func)(volatile void*, A0)) {
+    Callback(volatile U *obj, R (*func)(volatile T*, A0)) {
         new (this) Callback(func, obj);
     }
 
@@ -987,61 +790,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile void *obj, R (*func)(const volatile void*, A0)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(T *obj, R (*func)(T*, A0)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const T *obj, R (*func)(const T*, A0)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile T *obj, R (*func)(volatile T*, A0)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile T *obj, R (*func)(const volatile T*, A0)) {
+    Callback(const volatile U *obj, R (*func)(const volatile T*, A0)) {
         new (this) Callback(func, obj);
     }
 
@@ -1113,7 +865,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(void*, A0), void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(T*, A0), U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -1122,7 +875,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(const void*, A0), const void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(const T*, A0), const U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -1131,7 +885,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(volatile void*, A0), volatile void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(volatile T*, A0), volatile U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -1140,47 +895,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(const volatile void*, A0), const volatile void *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(T*, A0), T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(const T*, A0), const T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(volatile T*, A0), volatile T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(const volatile T*, A0), const volatile T *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(const volatile T*, A0), const volatile U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -1243,9 +959,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(void *obj, R (*func)(void*, A0)) {
+    void attach(U *obj, R (*func)(T*, A0)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -1256,9 +973,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const void *obj, R (*func)(const void*, A0)) {
+    void attach(const U *obj, R (*func)(const T*, A0)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -1269,9 +987,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile void *obj, R (*func)(volatile void*, A0)) {
+    void attach(volatile U *obj, R (*func)(volatile T*, A0)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -1282,65 +1001,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile void *obj, R (*func)(const volatile void*, A0)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(T *obj, R (*func)(T*, A0)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const T *obj, R (*func)(const T*, A0)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile T *obj, R (*func)(volatile T*, A0)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile T *obj, R (*func)(const volatile T*, A0)) {
+    void attach(const volatile U *obj, R (*func)(const volatile T*, A0)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -1538,42 +1202,10 @@ public:
 
     /** Create a Callback with a static function and bound pointer
      *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(void*, A0, A1), void *arg) {
-        generate(function_context<R (*)(void*, A0, A1), void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(const void*, A0, A1), const void *arg) {
-        generate(function_context<R (*)(const void*, A0, A1), const void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(volatile void*, A0, A1), volatile void *arg) {
-        generate(function_context<R (*)(volatile void*, A0, A1), volatile void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(const volatile void*, A0, A1), const volatile void *arg) {
-        generate(function_context<R (*)(const volatile void*, A0, A1), const volatile void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(T*, A0, A1), T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(T*, A0, A1), U *arg) {
         generate(function_context<R (*)(T*, A0, A1), T>(func, arg));
     }
 
@@ -1581,8 +1213,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(const T*, A0, A1), const T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(const T*, A0, A1), const U *arg) {
         generate(function_context<R (*)(const T*, A0, A1), const T>(func, arg));
     }
 
@@ -1590,8 +1222,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(volatile T*, A0, A1), volatile T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(volatile T*, A0, A1), volatile U *arg) {
         generate(function_context<R (*)(volatile T*, A0, A1), volatile T>(func, arg));
     }
 
@@ -1599,8 +1231,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(const volatile T*, A0, A1), const volatile T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(const volatile T*, A0, A1), const volatile U *arg) {
         generate(function_context<R (*)(const volatile T*, A0, A1), const volatile T>(func, arg));
     }
 
@@ -1658,9 +1290,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(void *obj, R (*func)(void*, A0, A1)) {
+    Callback(U *obj, R (*func)(T*, A0, A1)) {
         new (this) Callback(func, obj);
     }
 
@@ -1670,9 +1303,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const void *obj, R (*func)(const void*, A0, A1)) {
+    Callback(const U *obj, R (*func)(const T*, A0, A1)) {
         new (this) Callback(func, obj);
     }
 
@@ -1682,9 +1316,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile void *obj, R (*func)(volatile void*, A0, A1)) {
+    Callback(volatile U *obj, R (*func)(volatile T*, A0, A1)) {
         new (this) Callback(func, obj);
     }
 
@@ -1694,61 +1329,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(T *obj, R (*func)(T*, A0, A1)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const T *obj, R (*func)(const T*, A0, A1)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile T *obj, R (*func)(volatile T*, A0, A1)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1)) {
+    Callback(const volatile U *obj, R (*func)(const volatile T*, A0, A1)) {
         new (this) Callback(func, obj);
     }
 
@@ -1820,7 +1404,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(void*, A0, A1), void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(T*, A0, A1), U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -1829,7 +1414,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(const void*, A0, A1), const void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(const T*, A0, A1), const U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -1838,7 +1424,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(volatile void*, A0, A1), volatile void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(volatile T*, A0, A1), volatile U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -1847,47 +1434,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(const volatile void*, A0, A1), const volatile void *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(T*, A0, A1), T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(const T*, A0, A1), const T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(volatile T*, A0, A1), volatile T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(const volatile T*, A0, A1), const volatile T *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(const volatile T*, A0, A1), const volatile U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -1950,9 +1498,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(void *obj, R (*func)(void*, A0, A1)) {
+    void attach(U *obj, R (*func)(T*, A0, A1)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -1963,9 +1512,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const void *obj, R (*func)(const void*, A0, A1)) {
+    void attach(const U *obj, R (*func)(const T*, A0, A1)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -1976,9 +1526,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile void *obj, R (*func)(volatile void*, A0, A1)) {
+    void attach(volatile U *obj, R (*func)(volatile T*, A0, A1)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -1989,65 +1540,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile void *obj, R (*func)(const volatile void*, A0, A1)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(T *obj, R (*func)(T*, A0, A1)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const T *obj, R (*func)(const T*, A0, A1)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile T *obj, R (*func)(volatile T*, A0, A1)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile T *obj, R (*func)(const volatile T*, A0, A1)) {
+    void attach(const volatile U *obj, R (*func)(const volatile T*, A0, A1)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -2245,42 +1741,10 @@ public:
 
     /** Create a Callback with a static function and bound pointer
      *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(void*, A0, A1, A2), void *arg) {
-        generate(function_context<R (*)(void*, A0, A1, A2), void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(const void*, A0, A1, A2), const void *arg) {
-        generate(function_context<R (*)(const void*, A0, A1, A2), const void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(volatile void*, A0, A1, A2), volatile void *arg) {
-        generate(function_context<R (*)(volatile void*, A0, A1, A2), volatile void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(const volatile void*, A0, A1, A2), const volatile void *arg) {
-        generate(function_context<R (*)(const volatile void*, A0, A1, A2), const volatile void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(T*, A0, A1, A2), T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(T*, A0, A1, A2), U *arg) {
         generate(function_context<R (*)(T*, A0, A1, A2), T>(func, arg));
     }
 
@@ -2288,8 +1752,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(const T*, A0, A1, A2), const T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(const T*, A0, A1, A2), const U *arg) {
         generate(function_context<R (*)(const T*, A0, A1, A2), const T>(func, arg));
     }
 
@@ -2297,8 +1761,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(volatile T*, A0, A1, A2), volatile T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(volatile T*, A0, A1, A2), volatile U *arg) {
         generate(function_context<R (*)(volatile T*, A0, A1, A2), volatile T>(func, arg));
     }
 
@@ -2306,8 +1770,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(const volatile T*, A0, A1, A2), const volatile T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(const volatile T*, A0, A1, A2), const volatile U *arg) {
         generate(function_context<R (*)(const volatile T*, A0, A1, A2), const volatile T>(func, arg));
     }
 
@@ -2365,9 +1829,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(void *obj, R (*func)(void*, A0, A1, A2)) {
+    Callback(U *obj, R (*func)(T*, A0, A1, A2)) {
         new (this) Callback(func, obj);
     }
 
@@ -2377,9 +1842,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const void *obj, R (*func)(const void*, A0, A1, A2)) {
+    Callback(const U *obj, R (*func)(const T*, A0, A1, A2)) {
         new (this) Callback(func, obj);
     }
 
@@ -2389,9 +1855,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile void *obj, R (*func)(volatile void*, A0, A1, A2)) {
+    Callback(volatile U *obj, R (*func)(volatile T*, A0, A1, A2)) {
         new (this) Callback(func, obj);
     }
 
@@ -2401,61 +1868,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(T *obj, R (*func)(T*, A0, A1, A2)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const T *obj, R (*func)(const T*, A0, A1, A2)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2)) {
+    Callback(const volatile U *obj, R (*func)(const volatile T*, A0, A1, A2)) {
         new (this) Callback(func, obj);
     }
 
@@ -2527,7 +1943,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(void*, A0, A1, A2), void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(T*, A0, A1, A2), U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -2536,7 +1953,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(const void*, A0, A1, A2), const void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(const T*, A0, A1, A2), const U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -2545,7 +1963,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(volatile void*, A0, A1, A2), volatile void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(volatile T*, A0, A1, A2), volatile U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -2554,47 +1973,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(const volatile void*, A0, A1, A2), const volatile void *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(T*, A0, A1, A2), T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(const T*, A0, A1, A2), const T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(volatile T*, A0, A1, A2), volatile T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(const volatile T*, A0, A1, A2), const volatile T *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(const volatile T*, A0, A1, A2), const volatile U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -2657,9 +2037,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(void *obj, R (*func)(void*, A0, A1, A2)) {
+    void attach(U *obj, R (*func)(T*, A0, A1, A2)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -2670,9 +2051,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const void *obj, R (*func)(const void*, A0, A1, A2)) {
+    void attach(const U *obj, R (*func)(const T*, A0, A1, A2)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -2683,9 +2065,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile void *obj, R (*func)(volatile void*, A0, A1, A2)) {
+    void attach(volatile U *obj, R (*func)(volatile T*, A0, A1, A2)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -2696,65 +2079,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(T *obj, R (*func)(T*, A0, A1, A2)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const T *obj, R (*func)(const T*, A0, A1, A2)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile T *obj, R (*func)(volatile T*, A0, A1, A2)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2)) {
+    void attach(const volatile U *obj, R (*func)(const volatile T*, A0, A1, A2)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -2952,42 +2280,10 @@ public:
 
     /** Create a Callback with a static function and bound pointer
      *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(void*, A0, A1, A2, A3), void *arg) {
-        generate(function_context<R (*)(void*, A0, A1, A2, A3), void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(const void*, A0, A1, A2, A3), const void *arg) {
-        generate(function_context<R (*)(const void*, A0, A1, A2, A3), const void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(volatile void*, A0, A1, A2, A3), volatile void *arg) {
-        generate(function_context<R (*)(volatile void*, A0, A1, A2, A3), volatile void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(const volatile void*, A0, A1, A2, A3), const volatile void *arg) {
-        generate(function_context<R (*)(const volatile void*, A0, A1, A2, A3), const volatile void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(T*, A0, A1, A2, A3), T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(T*, A0, A1, A2, A3), U *arg) {
         generate(function_context<R (*)(T*, A0, A1, A2, A3), T>(func, arg));
     }
 
@@ -2995,8 +2291,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(const T*, A0, A1, A2, A3), const T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(const T*, A0, A1, A2, A3), const U *arg) {
         generate(function_context<R (*)(const T*, A0, A1, A2, A3), const T>(func, arg));
     }
 
@@ -3004,8 +2300,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(volatile T*, A0, A1, A2, A3), volatile T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(volatile T*, A0, A1, A2, A3), volatile U *arg) {
         generate(function_context<R (*)(volatile T*, A0, A1, A2, A3), volatile T>(func, arg));
     }
 
@@ -3013,8 +2309,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(const volatile T*, A0, A1, A2, A3), const volatile T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(const volatile T*, A0, A1, A2, A3), const volatile U *arg) {
         generate(function_context<R (*)(const volatile T*, A0, A1, A2, A3), const volatile T>(func, arg));
     }
 
@@ -3072,9 +2368,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(void *obj, R (*func)(void*, A0, A1, A2, A3)) {
+    Callback(U *obj, R (*func)(T*, A0, A1, A2, A3)) {
         new (this) Callback(func, obj);
     }
 
@@ -3084,9 +2381,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const void *obj, R (*func)(const void*, A0, A1, A2, A3)) {
+    Callback(const U *obj, R (*func)(const T*, A0, A1, A2, A3)) {
         new (this) Callback(func, obj);
     }
 
@@ -3096,9 +2394,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile void *obj, R (*func)(volatile void*, A0, A1, A2, A3)) {
+    Callback(volatile U *obj, R (*func)(volatile T*, A0, A1, A2, A3)) {
         new (this) Callback(func, obj);
     }
 
@@ -3108,61 +2407,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2, A3)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(T *obj, R (*func)(T*, A0, A1, A2, A3)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const T *obj, R (*func)(const T*, A0, A1, A2, A3)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3)) {
+    Callback(const volatile U *obj, R (*func)(const volatile T*, A0, A1, A2, A3)) {
         new (this) Callback(func, obj);
     }
 
@@ -3234,7 +2482,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(void*, A0, A1, A2, A3), void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(T*, A0, A1, A2, A3), U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -3243,7 +2492,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(const void*, A0, A1, A2, A3), const void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(const T*, A0, A1, A2, A3), const U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -3252,7 +2502,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(volatile void*, A0, A1, A2, A3), volatile void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(volatile T*, A0, A1, A2, A3), volatile U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -3261,47 +2512,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(const volatile void*, A0, A1, A2, A3), const volatile void *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(T*, A0, A1, A2, A3), T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(const T*, A0, A1, A2, A3), const T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(volatile T*, A0, A1, A2, A3), volatile T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(const volatile T*, A0, A1, A2, A3), const volatile T *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(const volatile T*, A0, A1, A2, A3), const volatile U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -3364,9 +2576,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(void *obj, R (*func)(void*, A0, A1, A2, A3)) {
+    void attach(U *obj, R (*func)(T*, A0, A1, A2, A3)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -3377,9 +2590,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const void *obj, R (*func)(const void*, A0, A1, A2, A3)) {
+    void attach(const U *obj, R (*func)(const T*, A0, A1, A2, A3)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -3390,9 +2604,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile void *obj, R (*func)(volatile void*, A0, A1, A2, A3)) {
+    void attach(volatile U *obj, R (*func)(volatile T*, A0, A1, A2, A3)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -3403,65 +2618,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2, A3)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(T *obj, R (*func)(T*, A0, A1, A2, A3)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const T *obj, R (*func)(const T*, A0, A1, A2, A3)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3)) {
+    void attach(const volatile U *obj, R (*func)(const volatile T*, A0, A1, A2, A3)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -3659,42 +2819,10 @@ public:
 
     /** Create a Callback with a static function and bound pointer
      *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(void*, A0, A1, A2, A3, A4), void *arg) {
-        generate(function_context<R (*)(void*, A0, A1, A2, A3, A4), void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(const void*, A0, A1, A2, A3, A4), const void *arg) {
-        generate(function_context<R (*)(const void*, A0, A1, A2, A3, A4), const void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(volatile void*, A0, A1, A2, A3, A4), volatile void *arg) {
-        generate(function_context<R (*)(volatile void*, A0, A1, A2, A3, A4), volatile void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    Callback(R (*func)(const volatile void*, A0, A1, A2, A3, A4), const volatile void *arg) {
-        generate(function_context<R (*)(const volatile void*, A0, A1, A2, A3, A4), const volatile void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(T*, A0, A1, A2, A3, A4), T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(T*, A0, A1, A2, A3, A4), U *arg) {
         generate(function_context<R (*)(T*, A0, A1, A2, A3, A4), T>(func, arg));
     }
 
@@ -3702,8 +2830,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(const T*, A0, A1, A2, A3, A4), const T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(const T*, A0, A1, A2, A3, A4), const U *arg) {
         generate(function_context<R (*)(const T*, A0, A1, A2, A3, A4), const T>(func, arg));
     }
 
@@ -3711,8 +2839,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(volatile T*, A0, A1, A2, A3, A4), volatile T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(volatile T*, A0, A1, A2, A3, A4), volatile U *arg) {
         generate(function_context<R (*)(volatile T*, A0, A1, A2, A3, A4), volatile T>(func, arg));
     }
 
@@ -3720,8 +2848,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
-    template<typename T>
-    Callback(R (*func)(const volatile T*, A0, A1, A2, A3, A4), const volatile T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(const volatile T*, A0, A1, A2, A3, A4), const volatile U *arg) {
         generate(function_context<R (*)(const volatile T*, A0, A1, A2, A3, A4), const volatile T>(func, arg));
     }
 
@@ -3779,9 +2907,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(void *obj, R (*func)(void*, A0, A1, A2, A3, A4)) {
+    Callback(U *obj, R (*func)(T*, A0, A1, A2, A3, A4)) {
         new (this) Callback(func, obj);
     }
 
@@ -3791,9 +2920,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const void *obj, R (*func)(const void*, A0, A1, A2, A3, A4)) {
+    Callback(const U *obj, R (*func)(const T*, A0, A1, A2, A3, A4)) {
         new (this) Callback(func, obj);
     }
 
@@ -3803,9 +2933,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile void *obj, R (*func)(volatile void*, A0, A1, A2, A3, A4)) {
+    Callback(volatile U *obj, R (*func)(volatile T*, A0, A1, A2, A3, A4)) {
         new (this) Callback(func, obj);
     }
 
@@ -3815,61 +2946,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to Callback(func, arg)
      */
+    template<typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2, A3, A4)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(T *obj, R (*func)(T*, A0, A1, A2, A3, A4)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const T *obj, R (*func)(const T*, A0, A1, A2, A3, A4)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3, A4)) {
-        new (this) Callback(func, obj);
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to Callback(func, arg)
-     */
-    template<typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to Callback(func, arg)")
-    Callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3, A4)) {
+    Callback(const volatile U *obj, R (*func)(const volatile T*, A0, A1, A2, A3, A4)) {
         new (this) Callback(func, obj);
     }
 
@@ -3941,7 +3021,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(void*, A0, A1, A2, A3, A4), void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(T*, A0, A1, A2, A3, A4), U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -3950,7 +3031,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(const void*, A0, A1, A2, A3, A4), const void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(const T*, A0, A1, A2, A3, A4), const U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -3959,7 +3041,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(volatile void*, A0, A1, A2, A3, A4), volatile void *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(volatile T*, A0, A1, A2, A3, A4), volatile U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -3968,47 +3051,8 @@ public:
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    void attach(R (*func)(const volatile void*, A0, A1, A2, A3, A4), const volatile void *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(T*, A0, A1, A2, A3, A4), T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(const T*, A0, A1, A2, A3, A4), const T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(volatile T*, A0, A1, A2, A3, A4), volatile T *arg) {
-        this->~Callback();
-        new (this) Callback(func, arg);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template <typename T>
-    void attach(R (*func)(const volatile T*, A0, A1, A2, A3, A4), const volatile T *arg) {
+    template <typename T, typename U>
+    void attach(R (*func)(const volatile T*, A0, A1, A2, A3, A4), const volatile U *arg) {
         this->~Callback();
         new (this) Callback(func, arg);
     }
@@ -4071,9 +3115,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(void *obj, R (*func)(void*, A0, A1, A2, A3, A4)) {
+    void attach(U *obj, R (*func)(T*, A0, A1, A2, A3, A4)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -4084,9 +3129,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const void *obj, R (*func)(const void*, A0, A1, A2, A3, A4)) {
+    void attach(const U *obj, R (*func)(const T*, A0, A1, A2, A3, A4)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -4097,9 +3143,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile void *obj, R (*func)(volatile void*, A0, A1, A2, A3, A4)) {
+    void attach(volatile U *obj, R (*func)(volatile T*, A0, A1, A2, A3, A4)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -4110,65 +3157,10 @@ public:
      *  @deprecated
      *      Arguments to callback have been reordered to attach(func, arg)
      */
+    template <typename T, typename U>
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2, A3, A4)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(T *obj, R (*func)(T*, A0, A1, A2, A3, A4)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const T *obj, R (*func)(const T*, A0, A1, A2, A3, A4)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3, A4)) {
-        this->~Callback();
-        new (this) Callback(func, obj);
-    }
-
-    /** Attach a static function with a bound pointer
-     *  @param obj  Pointer to object to bind to function
-     *  @param func Static function to attach
-     *  @deprecated
-     *      Arguments to callback have been reordered to attach(func, arg)
-     */
-    template <typename T>
-    MBED_DEPRECATED_SINCE("mbed-os-5.1",
-        "Arguments to callback have been reordered to attach(func, arg)")
-    void attach(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3, A4)) {
+    void attach(const volatile U *obj, R (*func)(const volatile T*, A0, A1, A2, A3, A4)) {
         this->~Callback();
         new (this) Callback(func, obj);
     }
@@ -4374,8 +3366,8 @@ Callback<R()> callback(const volatile U *obj, R (T::*method)() const volatile) {
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R>
-Callback<R()> callback(R (*func)(void*), void *arg) {
+template <typename T, typename U, typename R>
+Callback<R()> callback(R (*func)(T*), U *arg) {
     return Callback<R()>(func, arg);
 }
 
@@ -4385,8 +3377,8 @@ Callback<R()> callback(R (*func)(void*), void *arg) {
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R>
-Callback<R()> callback(R (*func)(const void*), const void *arg) {
+template <typename T, typename U, typename R>
+Callback<R()> callback(R (*func)(const T*), const U *arg) {
     return Callback<R()>(func, arg);
 }
 
@@ -4396,8 +3388,8 @@ Callback<R()> callback(R (*func)(const void*), const void *arg) {
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R>
-Callback<R()> callback(R (*func)(volatile void*), volatile void *arg) {
+template <typename T, typename U, typename R>
+Callback<R()> callback(R (*func)(volatile T*), volatile U *arg) {
     return Callback<R()>(func, arg);
 }
 
@@ -4407,52 +3399,8 @@ Callback<R()> callback(R (*func)(volatile void*), volatile void *arg) {
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R>
-Callback<R()> callback(R (*func)(const volatile void*), const volatile void *arg) {
-    return Callback<R()>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R>
-Callback<R()> callback(R (*func)(T*), T *arg) {
-    return Callback<R()>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R>
-Callback<R()> callback(R (*func)(const T*), const T *arg) {
-    return Callback<R()>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R>
-Callback<R()> callback(R (*func)(volatile T*), volatile T *arg) {
-    return Callback<R()>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R>
-Callback<R()> callback(R (*func)(const volatile T*), const volatile T *arg) {
+template <typename T, typename U, typename R>
+Callback<R()> callback(R (*func)(const volatile T*), const volatile U *arg) {
     return Callback<R()>(func, arg);
 }
 
@@ -4464,10 +3412,10 @@ Callback<R()> callback(R (*func)(const volatile T*), const volatile T *arg) {
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R>
+template <typename T, typename U, typename R>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R()> callback(void *obj, R (*func)(void*)) {
+Callback<R()> callback(U *obj, R (*func)(T*)) {
     return Callback<R()>(func, obj);
 }
 
@@ -4479,10 +3427,10 @@ Callback<R()> callback(void *obj, R (*func)(void*)) {
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R>
+template <typename T, typename U, typename R>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R()> callback(const void *obj, R (*func)(const void*)) {
+Callback<R()> callback(const U *obj, R (*func)(const T*)) {
     return Callback<R()>(func, obj);
 }
 
@@ -4494,10 +3442,10 @@ Callback<R()> callback(const void *obj, R (*func)(const void*)) {
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R>
+template <typename T, typename U, typename R>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R()> callback(volatile void *obj, R (*func)(volatile void*)) {
+Callback<R()> callback(volatile U *obj, R (*func)(volatile T*)) {
     return Callback<R()>(func, obj);
 }
 
@@ -4509,70 +3457,10 @@ Callback<R()> callback(volatile void *obj, R (*func)(volatile void*)) {
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R>
+template <typename T, typename U, typename R>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R()> callback(const volatile void *obj, R (*func)(const volatile void*)) {
-    return Callback<R()>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R()> callback(T *obj, R (*func)(T*)) {
-    return Callback<R()>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R()> callback(const T *obj, R (*func)(const T*)) {
-    return Callback<R()>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R()> callback(volatile T *obj, R (*func)(volatile T*)) {
-    return Callback<R()>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R()> callback(const volatile T *obj, R (*func)(const volatile T*)) {
+Callback<R()> callback(const volatile U *obj, R (*func)(const volatile T*)) {
     return Callback<R()>(func, obj);
 }
 
@@ -4647,8 +3535,8 @@ Callback<R(A0)> callback(const volatile U *obj, R (T::*method)(A0) const volatil
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0>
-Callback<R(A0)> callback(R (*func)(void*, A0), void *arg) {
+template <typename T, typename U, typename R, typename A0>
+Callback<R(A0)> callback(R (*func)(T*, A0), U *arg) {
     return Callback<R(A0)>(func, arg);
 }
 
@@ -4658,8 +3546,8 @@ Callback<R(A0)> callback(R (*func)(void*, A0), void *arg) {
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0>
-Callback<R(A0)> callback(R (*func)(const void*, A0), const void *arg) {
+template <typename T, typename U, typename R, typename A0>
+Callback<R(A0)> callback(R (*func)(const T*, A0), const U *arg) {
     return Callback<R(A0)>(func, arg);
 }
 
@@ -4669,8 +3557,8 @@ Callback<R(A0)> callback(R (*func)(const void*, A0), const void *arg) {
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0>
-Callback<R(A0)> callback(R (*func)(volatile void*, A0), volatile void *arg) {
+template <typename T, typename U, typename R, typename A0>
+Callback<R(A0)> callback(R (*func)(volatile T*, A0), volatile U *arg) {
     return Callback<R(A0)>(func, arg);
 }
 
@@ -4680,52 +3568,8 @@ Callback<R(A0)> callback(R (*func)(volatile void*, A0), volatile void *arg) {
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0>
-Callback<R(A0)> callback(R (*func)(const volatile void*, A0), const volatile void *arg) {
-    return Callback<R(A0)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0>
-Callback<R(A0)> callback(R (*func)(T*, A0), T *arg) {
-    return Callback<R(A0)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0>
-Callback<R(A0)> callback(R (*func)(const T*, A0), const T *arg) {
-    return Callback<R(A0)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0>
-Callback<R(A0)> callback(R (*func)(volatile T*, A0), volatile T *arg) {
-    return Callback<R(A0)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0>
-Callback<R(A0)> callback(R (*func)(const volatile T*, A0), const volatile T *arg) {
+template <typename T, typename U, typename R, typename A0>
+Callback<R(A0)> callback(R (*func)(const volatile T*, A0), const volatile U *arg) {
     return Callback<R(A0)>(func, arg);
 }
 
@@ -4737,10 +3581,10 @@ Callback<R(A0)> callback(R (*func)(const volatile T*, A0), const volatile T *arg
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0>
+template <typename T, typename U, typename R, typename A0>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0)> callback(void *obj, R (*func)(void*, A0)) {
+Callback<R(A0)> callback(U *obj, R (*func)(T*, A0)) {
     return Callback<R(A0)>(func, obj);
 }
 
@@ -4752,10 +3596,10 @@ Callback<R(A0)> callback(void *obj, R (*func)(void*, A0)) {
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0>
+template <typename T, typename U, typename R, typename A0>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0)> callback(const void *obj, R (*func)(const void*, A0)) {
+Callback<R(A0)> callback(const U *obj, R (*func)(const T*, A0)) {
     return Callback<R(A0)>(func, obj);
 }
 
@@ -4767,10 +3611,10 @@ Callback<R(A0)> callback(const void *obj, R (*func)(const void*, A0)) {
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0>
+template <typename T, typename U, typename R, typename A0>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0)> callback(volatile void *obj, R (*func)(volatile void*, A0)) {
+Callback<R(A0)> callback(volatile U *obj, R (*func)(volatile T*, A0)) {
     return Callback<R(A0)>(func, obj);
 }
 
@@ -4782,70 +3626,10 @@ Callback<R(A0)> callback(volatile void *obj, R (*func)(volatile void*, A0)) {
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0>
+template <typename T, typename U, typename R, typename A0>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0)> callback(const volatile void *obj, R (*func)(const volatile void*, A0)) {
-    return Callback<R(A0)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0)> callback(T *obj, R (*func)(T*, A0)) {
-    return Callback<R(A0)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0)> callback(const T *obj, R (*func)(const T*, A0)) {
-    return Callback<R(A0)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0)> callback(volatile T *obj, R (*func)(volatile T*, A0)) {
-    return Callback<R(A0)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0)> callback(const volatile T *obj, R (*func)(const volatile T*, A0)) {
+Callback<R(A0)> callback(const volatile U *obj, R (*func)(const volatile T*, A0)) {
     return Callback<R(A0)>(func, obj);
 }
 
@@ -4920,8 +3704,8 @@ Callback<R(A0, A1)> callback(const volatile U *obj, R (T::*method)(A0, A1) const
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(R (*func)(void*, A0, A1), void *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(R (*func)(T*, A0, A1), U *arg) {
     return Callback<R(A0, A1)>(func, arg);
 }
 
@@ -4931,8 +3715,8 @@ Callback<R(A0, A1)> callback(R (*func)(void*, A0, A1), void *arg) {
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(R (*func)(const void*, A0, A1), const void *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(R (*func)(const T*, A0, A1), const U *arg) {
     return Callback<R(A0, A1)>(func, arg);
 }
 
@@ -4942,8 +3726,8 @@ Callback<R(A0, A1)> callback(R (*func)(const void*, A0, A1), const void *arg) {
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(R (*func)(volatile void*, A0, A1), volatile void *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(R (*func)(volatile T*, A0, A1), volatile U *arg) {
     return Callback<R(A0, A1)>(func, arg);
 }
 
@@ -4953,52 +3737,8 @@ Callback<R(A0, A1)> callback(R (*func)(volatile void*, A0, A1), volatile void *a
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(R (*func)(const volatile void*, A0, A1), const volatile void *arg) {
-    return Callback<R(A0, A1)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(R (*func)(T*, A0, A1), T *arg) {
-    return Callback<R(A0, A1)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(R (*func)(const T*, A0, A1), const T *arg) {
-    return Callback<R(A0, A1)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(R (*func)(volatile T*, A0, A1), volatile T *arg) {
-    return Callback<R(A0, A1)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(R (*func)(const volatile T*, A0, A1), const volatile T *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(R (*func)(const volatile T*, A0, A1), const volatile U *arg) {
     return Callback<R(A0, A1)>(func, arg);
 }
 
@@ -5010,10 +3750,10 @@ Callback<R(A0, A1)> callback(R (*func)(const volatile T*, A0, A1), const volatil
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1>
+template <typename T, typename U, typename R, typename A0, typename A1>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1)> callback(void *obj, R (*func)(void*, A0, A1)) {
+Callback<R(A0, A1)> callback(U *obj, R (*func)(T*, A0, A1)) {
     return Callback<R(A0, A1)>(func, obj);
 }
 
@@ -5025,10 +3765,10 @@ Callback<R(A0, A1)> callback(void *obj, R (*func)(void*, A0, A1)) {
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1>
+template <typename T, typename U, typename R, typename A0, typename A1>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1)> callback(const void *obj, R (*func)(const void*, A0, A1)) {
+Callback<R(A0, A1)> callback(const U *obj, R (*func)(const T*, A0, A1)) {
     return Callback<R(A0, A1)>(func, obj);
 }
 
@@ -5040,10 +3780,10 @@ Callback<R(A0, A1)> callback(const void *obj, R (*func)(const void*, A0, A1)) {
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1>
+template <typename T, typename U, typename R, typename A0, typename A1>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1)> callback(volatile void *obj, R (*func)(volatile void*, A0, A1)) {
+Callback<R(A0, A1)> callback(volatile U *obj, R (*func)(volatile T*, A0, A1)) {
     return Callback<R(A0, A1)>(func, obj);
 }
 
@@ -5055,70 +3795,10 @@ Callback<R(A0, A1)> callback(volatile void *obj, R (*func)(volatile void*, A0, A
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1>
+template <typename T, typename U, typename R, typename A0, typename A1>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1)> callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1)) {
-    return Callback<R(A0, A1)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1)> callback(T *obj, R (*func)(T*, A0, A1)) {
-    return Callback<R(A0, A1)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1)> callback(const T *obj, R (*func)(const T*, A0, A1)) {
-    return Callback<R(A0, A1)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1)> callback(volatile T *obj, R (*func)(volatile T*, A0, A1)) {
-    return Callback<R(A0, A1)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1)> callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1)) {
+Callback<R(A0, A1)> callback(const volatile U *obj, R (*func)(const volatile T*, A0, A1)) {
     return Callback<R(A0, A1)>(func, obj);
 }
 
@@ -5193,8 +3873,8 @@ Callback<R(A0, A1, A2)> callback(const volatile U *obj, R (T::*method)(A0, A1, A
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(R (*func)(void*, A0, A1, A2), void *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(R (*func)(T*, A0, A1, A2), U *arg) {
     return Callback<R(A0, A1, A2)>(func, arg);
 }
 
@@ -5204,8 +3884,8 @@ Callback<R(A0, A1, A2)> callback(R (*func)(void*, A0, A1, A2), void *arg) {
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(R (*func)(const void*, A0, A1, A2), const void *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(R (*func)(const T*, A0, A1, A2), const U *arg) {
     return Callback<R(A0, A1, A2)>(func, arg);
 }
 
@@ -5215,8 +3895,8 @@ Callback<R(A0, A1, A2)> callback(R (*func)(const void*, A0, A1, A2), const void 
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(R (*func)(volatile void*, A0, A1, A2), volatile void *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(R (*func)(volatile T*, A0, A1, A2), volatile U *arg) {
     return Callback<R(A0, A1, A2)>(func, arg);
 }
 
@@ -5226,52 +3906,8 @@ Callback<R(A0, A1, A2)> callback(R (*func)(volatile void*, A0, A1, A2), volatile
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(R (*func)(const volatile void*, A0, A1, A2), const volatile void *arg) {
-    return Callback<R(A0, A1, A2)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(R (*func)(T*, A0, A1, A2), T *arg) {
-    return Callback<R(A0, A1, A2)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(R (*func)(const T*, A0, A1, A2), const T *arg) {
-    return Callback<R(A0, A1, A2)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(R (*func)(volatile T*, A0, A1, A2), volatile T *arg) {
-    return Callback<R(A0, A1, A2)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(R (*func)(const volatile T*, A0, A1, A2), const volatile T *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(R (*func)(const volatile T*, A0, A1, A2), const volatile U *arg) {
     return Callback<R(A0, A1, A2)>(func, arg);
 }
 
@@ -5283,10 +3919,10 @@ Callback<R(A0, A1, A2)> callback(R (*func)(const volatile T*, A0, A1, A2), const
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1, typename A2>
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2)> callback(void *obj, R (*func)(void*, A0, A1, A2)) {
+Callback<R(A0, A1, A2)> callback(U *obj, R (*func)(T*, A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(func, obj);
 }
 
@@ -5298,10 +3934,10 @@ Callback<R(A0, A1, A2)> callback(void *obj, R (*func)(void*, A0, A1, A2)) {
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1, typename A2>
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2)> callback(const void *obj, R (*func)(const void*, A0, A1, A2)) {
+Callback<R(A0, A1, A2)> callback(const U *obj, R (*func)(const T*, A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(func, obj);
 }
 
@@ -5313,10 +3949,10 @@ Callback<R(A0, A1, A2)> callback(const void *obj, R (*func)(const void*, A0, A1,
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1, typename A2>
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2)> callback(volatile void *obj, R (*func)(volatile void*, A0, A1, A2)) {
+Callback<R(A0, A1, A2)> callback(volatile U *obj, R (*func)(volatile T*, A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(func, obj);
 }
 
@@ -5328,70 +3964,10 @@ Callback<R(A0, A1, A2)> callback(volatile void *obj, R (*func)(volatile void*, A
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1, typename A2>
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2)> callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2)) {
-    return Callback<R(A0, A1, A2)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1, typename A2>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2)> callback(T *obj, R (*func)(T*, A0, A1, A2)) {
-    return Callback<R(A0, A1, A2)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1, typename A2>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2)> callback(const T *obj, R (*func)(const T*, A0, A1, A2)) {
-    return Callback<R(A0, A1, A2)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1, typename A2>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2)> callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2)) {
-    return Callback<R(A0, A1, A2)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1, typename A2>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2)> callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2)) {
+Callback<R(A0, A1, A2)> callback(const volatile U *obj, R (*func)(const volatile T*, A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(func, obj);
 }
 
@@ -5466,8 +4042,8 @@ Callback<R(A0, A1, A2, A3)> callback(const volatile U *obj, R (T::*method)(A0, A
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(R (*func)(void*, A0, A1, A2, A3), void *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(R (*func)(T*, A0, A1, A2, A3), U *arg) {
     return Callback<R(A0, A1, A2, A3)>(func, arg);
 }
 
@@ -5477,8 +4053,8 @@ Callback<R(A0, A1, A2, A3)> callback(R (*func)(void*, A0, A1, A2, A3), void *arg
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(R (*func)(const void*, A0, A1, A2, A3), const void *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(R (*func)(const T*, A0, A1, A2, A3), const U *arg) {
     return Callback<R(A0, A1, A2, A3)>(func, arg);
 }
 
@@ -5488,8 +4064,8 @@ Callback<R(A0, A1, A2, A3)> callback(R (*func)(const void*, A0, A1, A2, A3), con
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(R (*func)(volatile void*, A0, A1, A2, A3), volatile void *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(R (*func)(volatile T*, A0, A1, A2, A3), volatile U *arg) {
     return Callback<R(A0, A1, A2, A3)>(func, arg);
 }
 
@@ -5499,52 +4075,8 @@ Callback<R(A0, A1, A2, A3)> callback(R (*func)(volatile void*, A0, A1, A2, A3), 
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(R (*func)(const volatile void*, A0, A1, A2, A3), const volatile void *arg) {
-    return Callback<R(A0, A1, A2, A3)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(R (*func)(T*, A0, A1, A2, A3), T *arg) {
-    return Callback<R(A0, A1, A2, A3)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(R (*func)(const T*, A0, A1, A2, A3), const T *arg) {
-    return Callback<R(A0, A1, A2, A3)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(R (*func)(volatile T*, A0, A1, A2, A3), volatile T *arg) {
-    return Callback<R(A0, A1, A2, A3)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(R (*func)(const volatile T*, A0, A1, A2, A3), const volatile T *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(R (*func)(const volatile T*, A0, A1, A2, A3), const volatile U *arg) {
     return Callback<R(A0, A1, A2, A3)>(func, arg);
 }
 
@@ -5556,10 +4088,10 @@ Callback<R(A0, A1, A2, A3)> callback(R (*func)(const volatile T*, A0, A1, A2, A3
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3>
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3)> callback(void *obj, R (*func)(void*, A0, A1, A2, A3)) {
+Callback<R(A0, A1, A2, A3)> callback(U *obj, R (*func)(T*, A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(func, obj);
 }
 
@@ -5571,10 +4103,10 @@ Callback<R(A0, A1, A2, A3)> callback(void *obj, R (*func)(void*, A0, A1, A2, A3)
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3>
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3)> callback(const void *obj, R (*func)(const void*, A0, A1, A2, A3)) {
+Callback<R(A0, A1, A2, A3)> callback(const U *obj, R (*func)(const T*, A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(func, obj);
 }
 
@@ -5586,10 +4118,10 @@ Callback<R(A0, A1, A2, A3)> callback(const void *obj, R (*func)(const void*, A0,
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3>
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3)> callback(volatile void *obj, R (*func)(volatile void*, A0, A1, A2, A3)) {
+Callback<R(A0, A1, A2, A3)> callback(volatile U *obj, R (*func)(volatile T*, A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(func, obj);
 }
 
@@ -5601,70 +4133,10 @@ Callback<R(A0, A1, A2, A3)> callback(volatile void *obj, R (*func)(volatile void
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3>
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3)> callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2, A3)) {
-    return Callback<R(A0, A1, A2, A3)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3)> callback(T *obj, R (*func)(T*, A0, A1, A2, A3)) {
-    return Callback<R(A0, A1, A2, A3)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3)> callback(const T *obj, R (*func)(const T*, A0, A1, A2, A3)) {
-    return Callback<R(A0, A1, A2, A3)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3)> callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3)) {
-    return Callback<R(A0, A1, A2, A3)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3)> callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3)) {
+Callback<R(A0, A1, A2, A3)> callback(const volatile U *obj, R (*func)(const volatile T*, A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(func, obj);
 }
 
@@ -5739,8 +4211,8 @@ Callback<R(A0, A1, A2, A3, A4)> callback(const volatile U *obj, R (T::*method)(A
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(void*, A0, A1, A2, A3, A4), void *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(T*, A0, A1, A2, A3, A4), U *arg) {
     return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
 }
 
@@ -5750,8 +4222,8 @@ Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(void*, A0, A1, A2, A3, A4), v
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(const void*, A0, A1, A2, A3, A4), const void *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(const T*, A0, A1, A2, A3, A4), const U *arg) {
     return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
 }
 
@@ -5761,8 +4233,8 @@ Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(const void*, A0, A1, A2, A3, 
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(volatile void*, A0, A1, A2, A3, A4), volatile void *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(volatile T*, A0, A1, A2, A3, A4), volatile U *arg) {
     return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
 }
 
@@ -5772,52 +4244,8 @@ Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(volatile void*, A0, A1, A2, A
  *  @param arg      Pointer argument to function
  *  @return         Callback with infered type
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(const volatile void*, A0, A1, A2, A3, A4), const volatile void *arg) {
-    return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(T*, A0, A1, A2, A3, A4), T *arg) {
-    return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(const T*, A0, A1, A2, A3, A4), const T *arg) {
-    return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(volatile T*, A0, A1, A2, A3, A4), volatile T *arg) {
-    return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param func     Static function to attach
- *  @param arg      Pointer argument to function
- *  @return         Callback with infered type
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(const volatile T*, A0, A1, A2, A3, A4), const volatile T *arg) {
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(const volatile T*, A0, A1, A2, A3, A4), const volatile U *arg) {
     return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
 }
 
@@ -5829,10 +4257,10 @@ Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(const volatile T*, A0, A1, A2
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3, A4)> callback(void *obj, R (*func)(void*, A0, A1, A2, A3, A4)) {
+Callback<R(A0, A1, A2, A3, A4)> callback(U *obj, R (*func)(T*, A0, A1, A2, A3, A4)) {
     return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
 }
 
@@ -5844,10 +4272,10 @@ Callback<R(A0, A1, A2, A3, A4)> callback(void *obj, R (*func)(void*, A0, A1, A2,
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3, A4)> callback(const void *obj, R (*func)(const void*, A0, A1, A2, A3, A4)) {
+Callback<R(A0, A1, A2, A3, A4)> callback(const U *obj, R (*func)(const T*, A0, A1, A2, A3, A4)) {
     return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
 }
 
@@ -5859,10 +4287,10 @@ Callback<R(A0, A1, A2, A3, A4)> callback(const void *obj, R (*func)(const void*,
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3, A4)> callback(volatile void *obj, R (*func)(volatile void*, A0, A1, A2, A3, A4)) {
+Callback<R(A0, A1, A2, A3, A4)> callback(volatile U *obj, R (*func)(volatile T*, A0, A1, A2, A3, A4)) {
     return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
 }
 
@@ -5874,70 +4302,10 @@ Callback<R(A0, A1, A2, A3, A4)> callback(volatile void *obj, R (*func)(volatile 
  *  @deprecated
  *      Arguments to callback have been reordered to callback(func, arg)
  */
-template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+template <typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
 MBED_DEPRECATED_SINCE("mbed-os-5.1",
     "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3, A4)> callback(const volatile void *obj, R (*func)(const volatile void*, A0, A1, A2, A3, A4)) {
-    return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3, A4)> callback(T *obj, R (*func)(T*, A0, A1, A2, A3, A4)) {
-    return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3, A4)> callback(const T *obj, R (*func)(const T*, A0, A1, A2, A3, A4)) {
-    return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3, A4)> callback(volatile T *obj, R (*func)(volatile T*, A0, A1, A2, A3, A4)) {
-    return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
-}
-
-/** Create a callback class with type infered from the arguments
- *
- *  @param obj  Optional pointer to object to bind to function
- *  @param func Static function to attach
- *  @return     Callback with infered type
- *  @deprecated
- *      Arguments to callback have been reordered to callback(func, arg)
- */
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-MBED_DEPRECATED_SINCE("mbed-os-5.1",
-    "Arguments to callback have been reordered to callback(func, arg)")
-Callback<R(A0, A1, A2, A3, A4)> callback(const volatile T *obj, R (*func)(const volatile T*, A0, A1, A2, A3, A4)) {
+Callback<R(A0, A1, A2, A3, A4)> callback(const volatile U *obj, R (*func)(const volatile T*, A0, A1, A2, A3, A4)) {
     return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
 }
 

--- a/platform/Callback.h
+++ b/platform/Callback.h
@@ -90,8 +90,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(T *obj, R (T::*method)()) {
+    template<typename T, typename U>
+    Callback(U *obj, R (T::*method)()) {
         generate(method_context<T, R (T::*)()>(obj, method));
     }
 
@@ -99,8 +99,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(const T *obj, R (T::*method)() const) {
+    template<typename T, typename U>
+    Callback(const U *obj, R (T::*method)() const) {
         generate(method_context<const T, R (T::*)() const>(obj, method));
     }
 
@@ -108,8 +108,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(volatile T *obj, R (T::*method)() volatile) {
+    template<typename T, typename U>
+    Callback(volatile U *obj, R (T::*method)() volatile) {
         generate(method_context<volatile T, R (T::*)() volatile>(obj, method));
     }
 
@@ -117,8 +117,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(const volatile T *obj, R (T::*method)() const volatile) {
+    template<typename T, typename U>
+    Callback(const volatile U *obj, R (T::*method)() const volatile) {
         generate(method_context<const volatile T, R (T::*)() const volatile>(obj, method));
     }
 
@@ -366,8 +366,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(T *obj, R (T::*method)()) {
+    template<typename T, typename U>
+    void attach(U *obj, R (T::*method)()) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -376,8 +376,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(const T *obj, R (T::*method)() const) {
+    template<typename T, typename U>
+    void attach(const U *obj, R (T::*method)() const) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -386,8 +386,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(volatile T *obj, R (T::*method)() volatile) {
+    template<typename T, typename U>
+    void attach(volatile U *obj, R (T::*method)() volatile) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -396,8 +396,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(const volatile T *obj, R (T::*method)() const volatile) {
+    template<typename T, typename U>
+    void attach(const volatile U *obj, R (T::*method)() const volatile) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -797,8 +797,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(T *obj, R (T::*method)(A0)) {
+    template<typename T, typename U>
+    Callback(U *obj, R (T::*method)(A0)) {
         generate(method_context<T, R (T::*)(A0)>(obj, method));
     }
 
@@ -806,8 +806,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(const T *obj, R (T::*method)(A0) const) {
+    template<typename T, typename U>
+    Callback(const U *obj, R (T::*method)(A0) const) {
         generate(method_context<const T, R (T::*)(A0) const>(obj, method));
     }
 
@@ -815,8 +815,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(volatile T *obj, R (T::*method)(A0) volatile) {
+    template<typename T, typename U>
+    Callback(volatile U *obj, R (T::*method)(A0) volatile) {
         generate(method_context<volatile T, R (T::*)(A0) volatile>(obj, method));
     }
 
@@ -824,8 +824,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(const volatile T *obj, R (T::*method)(A0) const volatile) {
+    template<typename T, typename U>
+    Callback(const volatile U *obj, R (T::*method)(A0) const volatile) {
         generate(method_context<const volatile T, R (T::*)(A0) const volatile>(obj, method));
     }
 
@@ -1073,8 +1073,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(T *obj, R (T::*method)(A0)) {
+    template<typename T, typename U>
+    void attach(U *obj, R (T::*method)(A0)) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -1083,8 +1083,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(const T *obj, R (T::*method)(A0) const) {
+    template<typename T, typename U>
+    void attach(const U *obj, R (T::*method)(A0) const) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -1093,8 +1093,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(volatile T *obj, R (T::*method)(A0) volatile) {
+    template<typename T, typename U>
+    void attach(volatile U *obj, R (T::*method)(A0) volatile) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -1103,8 +1103,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(const volatile T *obj, R (T::*method)(A0) const volatile) {
+    template<typename T, typename U>
+    void attach(const volatile U *obj, R (T::*method)(A0) const volatile) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -1504,8 +1504,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(T *obj, R (T::*method)(A0, A1)) {
+    template<typename T, typename U>
+    Callback(U *obj, R (T::*method)(A0, A1)) {
         generate(method_context<T, R (T::*)(A0, A1)>(obj, method));
     }
 
@@ -1513,8 +1513,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(const T *obj, R (T::*method)(A0, A1) const) {
+    template<typename T, typename U>
+    Callback(const U *obj, R (T::*method)(A0, A1) const) {
         generate(method_context<const T, R (T::*)(A0, A1) const>(obj, method));
     }
 
@@ -1522,8 +1522,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(volatile T *obj, R (T::*method)(A0, A1) volatile) {
+    template<typename T, typename U>
+    Callback(volatile U *obj, R (T::*method)(A0, A1) volatile) {
         generate(method_context<volatile T, R (T::*)(A0, A1) volatile>(obj, method));
     }
 
@@ -1531,8 +1531,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(const volatile T *obj, R (T::*method)(A0, A1) const volatile) {
+    template<typename T, typename U>
+    Callback(const volatile U *obj, R (T::*method)(A0, A1) const volatile) {
         generate(method_context<const volatile T, R (T::*)(A0, A1) const volatile>(obj, method));
     }
 
@@ -1780,8 +1780,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(T *obj, R (T::*method)(A0, A1)) {
+    template<typename T, typename U>
+    void attach(U *obj, R (T::*method)(A0, A1)) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -1790,8 +1790,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(const T *obj, R (T::*method)(A0, A1) const) {
+    template<typename T, typename U>
+    void attach(const U *obj, R (T::*method)(A0, A1) const) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -1800,8 +1800,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(volatile T *obj, R (T::*method)(A0, A1) volatile) {
+    template<typename T, typename U>
+    void attach(volatile U *obj, R (T::*method)(A0, A1) volatile) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -1810,8 +1810,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(const volatile T *obj, R (T::*method)(A0, A1) const volatile) {
+    template<typename T, typename U>
+    void attach(const volatile U *obj, R (T::*method)(A0, A1) const volatile) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -2211,8 +2211,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(T *obj, R (T::*method)(A0, A1, A2)) {
+    template<typename T, typename U>
+    Callback(U *obj, R (T::*method)(A0, A1, A2)) {
         generate(method_context<T, R (T::*)(A0, A1, A2)>(obj, method));
     }
 
@@ -2220,8 +2220,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(const T *obj, R (T::*method)(A0, A1, A2) const) {
+    template<typename T, typename U>
+    Callback(const U *obj, R (T::*method)(A0, A1, A2) const) {
         generate(method_context<const T, R (T::*)(A0, A1, A2) const>(obj, method));
     }
 
@@ -2229,8 +2229,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(volatile T *obj, R (T::*method)(A0, A1, A2) volatile) {
+    template<typename T, typename U>
+    Callback(volatile U *obj, R (T::*method)(A0, A1, A2) volatile) {
         generate(method_context<volatile T, R (T::*)(A0, A1, A2) volatile>(obj, method));
     }
 
@@ -2238,8 +2238,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(const volatile T *obj, R (T::*method)(A0, A1, A2) const volatile) {
+    template<typename T, typename U>
+    Callback(const volatile U *obj, R (T::*method)(A0, A1, A2) const volatile) {
         generate(method_context<const volatile T, R (T::*)(A0, A1, A2) const volatile>(obj, method));
     }
 
@@ -2487,8 +2487,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(T *obj, R (T::*method)(A0, A1, A2)) {
+    template<typename T, typename U>
+    void attach(U *obj, R (T::*method)(A0, A1, A2)) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -2497,8 +2497,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(const T *obj, R (T::*method)(A0, A1, A2) const) {
+    template<typename T, typename U>
+    void attach(const U *obj, R (T::*method)(A0, A1, A2) const) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -2507,8 +2507,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(volatile T *obj, R (T::*method)(A0, A1, A2) volatile) {
+    template<typename T, typename U>
+    void attach(volatile U *obj, R (T::*method)(A0, A1, A2) volatile) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -2517,8 +2517,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(const volatile T *obj, R (T::*method)(A0, A1, A2) const volatile) {
+    template<typename T, typename U>
+    void attach(const volatile U *obj, R (T::*method)(A0, A1, A2) const volatile) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -2918,8 +2918,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(T *obj, R (T::*method)(A0, A1, A2, A3)) {
+    template<typename T, typename U>
+    Callback(U *obj, R (T::*method)(A0, A1, A2, A3)) {
         generate(method_context<T, R (T::*)(A0, A1, A2, A3)>(obj, method));
     }
 
@@ -2927,8 +2927,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(const T *obj, R (T::*method)(A0, A1, A2, A3) const) {
+    template<typename T, typename U>
+    Callback(const U *obj, R (T::*method)(A0, A1, A2, A3) const) {
         generate(method_context<const T, R (T::*)(A0, A1, A2, A3) const>(obj, method));
     }
 
@@ -2936,8 +2936,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(volatile T *obj, R (T::*method)(A0, A1, A2, A3) volatile) {
+    template<typename T, typename U>
+    Callback(volatile U *obj, R (T::*method)(A0, A1, A2, A3) volatile) {
         generate(method_context<volatile T, R (T::*)(A0, A1, A2, A3) volatile>(obj, method));
     }
 
@@ -2945,8 +2945,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(const volatile T *obj, R (T::*method)(A0, A1, A2, A3) const volatile) {
+    template<typename T, typename U>
+    Callback(const volatile U *obj, R (T::*method)(A0, A1, A2, A3) const volatile) {
         generate(method_context<const volatile T, R (T::*)(A0, A1, A2, A3) const volatile>(obj, method));
     }
 
@@ -3194,8 +3194,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(T *obj, R (T::*method)(A0, A1, A2, A3)) {
+    template<typename T, typename U>
+    void attach(U *obj, R (T::*method)(A0, A1, A2, A3)) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -3204,8 +3204,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(const T *obj, R (T::*method)(A0, A1, A2, A3) const) {
+    template<typename T, typename U>
+    void attach(const U *obj, R (T::*method)(A0, A1, A2, A3) const) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -3214,8 +3214,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(volatile T *obj, R (T::*method)(A0, A1, A2, A3) volatile) {
+    template<typename T, typename U>
+    void attach(volatile U *obj, R (T::*method)(A0, A1, A2, A3) volatile) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -3224,8 +3224,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(const volatile T *obj, R (T::*method)(A0, A1, A2, A3) const volatile) {
+    template<typename T, typename U>
+    void attach(const volatile U *obj, R (T::*method)(A0, A1, A2, A3) const volatile) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -3625,8 +3625,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(T *obj, R (T::*method)(A0, A1, A2, A3, A4)) {
+    template<typename T, typename U>
+    Callback(U *obj, R (T::*method)(A0, A1, A2, A3, A4)) {
         generate(method_context<T, R (T::*)(A0, A1, A2, A3, A4)>(obj, method));
     }
 
@@ -3634,8 +3634,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(const T *obj, R (T::*method)(A0, A1, A2, A3, A4) const) {
+    template<typename T, typename U>
+    Callback(const U *obj, R (T::*method)(A0, A1, A2, A3, A4) const) {
         generate(method_context<const T, R (T::*)(A0, A1, A2, A3, A4) const>(obj, method));
     }
 
@@ -3643,8 +3643,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(volatile T *obj, R (T::*method)(A0, A1, A2, A3, A4) volatile) {
+    template<typename T, typename U>
+    Callback(volatile U *obj, R (T::*method)(A0, A1, A2, A3, A4) volatile) {
         generate(method_context<volatile T, R (T::*)(A0, A1, A2, A3, A4) volatile>(obj, method));
     }
 
@@ -3652,8 +3652,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(const volatile T *obj, R (T::*method)(A0, A1, A2, A3, A4) const volatile) {
+    template<typename T, typename U>
+    Callback(const volatile U *obj, R (T::*method)(A0, A1, A2, A3, A4) const volatile) {
         generate(method_context<const volatile T, R (T::*)(A0, A1, A2, A3, A4) const volatile>(obj, method));
     }
 
@@ -3901,8 +3901,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(T *obj, R (T::*method)(A0, A1, A2, A3, A4)) {
+    template<typename T, typename U>
+    void attach(U *obj, R (T::*method)(A0, A1, A2, A3, A4)) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -3911,8 +3911,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(const T *obj, R (T::*method)(A0, A1, A2, A3, A4) const) {
+    template<typename T, typename U>
+    void attach(const U *obj, R (T::*method)(A0, A1, A2, A3, A4) const) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -3921,8 +3921,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(volatile T *obj, R (T::*method)(A0, A1, A2, A3, A4) volatile) {
+    template<typename T, typename U>
+    void attach(volatile U *obj, R (T::*method)(A0, A1, A2, A3, A4) volatile) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -3931,8 +3931,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    void attach(const volatile T *obj, R (T::*method)(A0, A1, A2, A3, A4) const volatile) {
+    template<typename T, typename U>
+    void attach(const volatile U *obj, R (T::*method)(A0, A1, A2, A3, A4) const volatile) {
         this->~Callback();
         new (this) Callback(obj, method);
     }
@@ -4330,9 +4330,9 @@ Callback<R()> callback(const Callback<R()> &func) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R>
-Callback<R()> callback(T *obj, R (T::*func)()) {
-    return Callback<R()>(obj, func);
+template<typename T, typename U, typename R>
+Callback<R()> callback(U *obj, R (T::*method)()) {
+    return Callback<R()>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -4341,9 +4341,9 @@ Callback<R()> callback(T *obj, R (T::*func)()) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R>
-Callback<R()> callback(const T *obj, R (T::*func)() const) {
-    return Callback<R()>(obj, func);
+template<typename T, typename U, typename R>
+Callback<R()> callback(const U *obj, R (T::*method)() const) {
+    return Callback<R()>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -4352,9 +4352,9 @@ Callback<R()> callback(const T *obj, R (T::*func)() const) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R>
-Callback<R()> callback(volatile T *obj, R (T::*func)() volatile) {
-    return Callback<R()>(obj, func);
+template<typename T, typename U, typename R>
+Callback<R()> callback(volatile U *obj, R (T::*method)() volatile) {
+    return Callback<R()>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -4363,9 +4363,9 @@ Callback<R()> callback(volatile T *obj, R (T::*func)() volatile) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R>
-Callback<R()> callback(const volatile T *obj, R (T::*func)() const volatile) {
-    return Callback<R()>(obj, func);
+template<typename T, typename U, typename R>
+Callback<R()> callback(const volatile U *obj, R (T::*method)() const volatile) {
+    return Callback<R()>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -4603,9 +4603,9 @@ Callback<R(A0)> callback(const Callback<R(A0)> &func) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0>
-Callback<R(A0)> callback(T *obj, R (T::*func)(A0)) {
-    return Callback<R(A0)>(obj, func);
+template<typename T, typename U, typename R, typename A0>
+Callback<R(A0)> callback(U *obj, R (T::*method)(A0)) {
+    return Callback<R(A0)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -4614,9 +4614,9 @@ Callback<R(A0)> callback(T *obj, R (T::*func)(A0)) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0>
-Callback<R(A0)> callback(const T *obj, R (T::*func)(A0) const) {
-    return Callback<R(A0)>(obj, func);
+template<typename T, typename U, typename R, typename A0>
+Callback<R(A0)> callback(const U *obj, R (T::*method)(A0) const) {
+    return Callback<R(A0)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -4625,9 +4625,9 @@ Callback<R(A0)> callback(const T *obj, R (T::*func)(A0) const) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0>
-Callback<R(A0)> callback(volatile T *obj, R (T::*func)(A0) volatile) {
-    return Callback<R(A0)>(obj, func);
+template<typename T, typename U, typename R, typename A0>
+Callback<R(A0)> callback(volatile U *obj, R (T::*method)(A0) volatile) {
+    return Callback<R(A0)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -4636,9 +4636,9 @@ Callback<R(A0)> callback(volatile T *obj, R (T::*func)(A0) volatile) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0>
-Callback<R(A0)> callback(const volatile T *obj, R (T::*func)(A0) const volatile) {
-    return Callback<R(A0)>(obj, func);
+template<typename T, typename U, typename R, typename A0>
+Callback<R(A0)> callback(const volatile U *obj, R (T::*method)(A0) const volatile) {
+    return Callback<R(A0)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -4876,9 +4876,9 @@ Callback<R(A0, A1)> callback(const Callback<R(A0, A1)> &func) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(T *obj, R (T::*func)(A0, A1)) {
-    return Callback<R(A0, A1)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(U *obj, R (T::*method)(A0, A1)) {
+    return Callback<R(A0, A1)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -4887,9 +4887,9 @@ Callback<R(A0, A1)> callback(T *obj, R (T::*func)(A0, A1)) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(const T *obj, R (T::*func)(A0, A1) const) {
-    return Callback<R(A0, A1)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(const U *obj, R (T::*method)(A0, A1) const) {
+    return Callback<R(A0, A1)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -4898,9 +4898,9 @@ Callback<R(A0, A1)> callback(const T *obj, R (T::*func)(A0, A1) const) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(volatile T *obj, R (T::*func)(A0, A1) volatile) {
-    return Callback<R(A0, A1)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(volatile U *obj, R (T::*method)(A0, A1) volatile) {
+    return Callback<R(A0, A1)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -4909,9 +4909,9 @@ Callback<R(A0, A1)> callback(volatile T *obj, R (T::*func)(A0, A1) volatile) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1>
-Callback<R(A0, A1)> callback(const volatile T *obj, R (T::*func)(A0, A1) const volatile) {
-    return Callback<R(A0, A1)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1>
+Callback<R(A0, A1)> callback(const volatile U *obj, R (T::*method)(A0, A1) const volatile) {
+    return Callback<R(A0, A1)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -5149,9 +5149,9 @@ Callback<R(A0, A1, A2)> callback(const Callback<R(A0, A1, A2)> &func) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(T *obj, R (T::*func)(A0, A1, A2)) {
-    return Callback<R(A0, A1, A2)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(U *obj, R (T::*method)(A0, A1, A2)) {
+    return Callback<R(A0, A1, A2)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -5160,9 +5160,9 @@ Callback<R(A0, A1, A2)> callback(T *obj, R (T::*func)(A0, A1, A2)) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(const T *obj, R (T::*func)(A0, A1, A2) const) {
-    return Callback<R(A0, A1, A2)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(const U *obj, R (T::*method)(A0, A1, A2) const) {
+    return Callback<R(A0, A1, A2)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -5171,9 +5171,9 @@ Callback<R(A0, A1, A2)> callback(const T *obj, R (T::*func)(A0, A1, A2) const) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(volatile T *obj, R (T::*func)(A0, A1, A2) volatile) {
-    return Callback<R(A0, A1, A2)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(volatile U *obj, R (T::*method)(A0, A1, A2) volatile) {
+    return Callback<R(A0, A1, A2)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -5182,9 +5182,9 @@ Callback<R(A0, A1, A2)> callback(volatile T *obj, R (T::*func)(A0, A1, A2) volat
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1, typename A2>
-Callback<R(A0, A1, A2)> callback(const volatile T *obj, R (T::*func)(A0, A1, A2) const volatile) {
-    return Callback<R(A0, A1, A2)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1, typename A2>
+Callback<R(A0, A1, A2)> callback(const volatile U *obj, R (T::*method)(A0, A1, A2) const volatile) {
+    return Callback<R(A0, A1, A2)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -5422,9 +5422,9 @@ Callback<R(A0, A1, A2, A3)> callback(const Callback<R(A0, A1, A2, A3)> &func) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(T *obj, R (T::*func)(A0, A1, A2, A3)) {
-    return Callback<R(A0, A1, A2, A3)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(U *obj, R (T::*method)(A0, A1, A2, A3)) {
+    return Callback<R(A0, A1, A2, A3)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -5433,9 +5433,9 @@ Callback<R(A0, A1, A2, A3)> callback(T *obj, R (T::*func)(A0, A1, A2, A3)) {
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(const T *obj, R (T::*func)(A0, A1, A2, A3) const) {
-    return Callback<R(A0, A1, A2, A3)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(const U *obj, R (T::*method)(A0, A1, A2, A3) const) {
+    return Callback<R(A0, A1, A2, A3)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -5444,9 +5444,9 @@ Callback<R(A0, A1, A2, A3)> callback(const T *obj, R (T::*func)(A0, A1, A2, A3) 
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(volatile T *obj, R (T::*func)(A0, A1, A2, A3) volatile) {
-    return Callback<R(A0, A1, A2, A3)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(volatile U *obj, R (T::*method)(A0, A1, A2, A3) volatile) {
+    return Callback<R(A0, A1, A2, A3)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -5455,9 +5455,9 @@ Callback<R(A0, A1, A2, A3)> callback(volatile T *obj, R (T::*func)(A0, A1, A2, A
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Callback<R(A0, A1, A2, A3)> callback(const volatile T *obj, R (T::*func)(A0, A1, A2, A3) const volatile) {
-    return Callback<R(A0, A1, A2, A3)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3>
+Callback<R(A0, A1, A2, A3)> callback(const volatile U *obj, R (T::*method)(A0, A1, A2, A3) const volatile) {
+    return Callback<R(A0, A1, A2, A3)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -5695,9 +5695,9 @@ Callback<R(A0, A1, A2, A3, A4)> callback(const Callback<R(A0, A1, A2, A3, A4)> &
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(T *obj, R (T::*func)(A0, A1, A2, A3, A4)) {
-    return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(U *obj, R (T::*method)(A0, A1, A2, A3, A4)) {
+    return Callback<R(A0, A1, A2, A3, A4)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -5706,9 +5706,9 @@ Callback<R(A0, A1, A2, A3, A4)> callback(T *obj, R (T::*func)(A0, A1, A2, A3, A4
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(const T *obj, R (T::*func)(A0, A1, A2, A3, A4) const) {
-    return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(const U *obj, R (T::*method)(A0, A1, A2, A3, A4) const) {
+    return Callback<R(A0, A1, A2, A3, A4)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -5717,9 +5717,9 @@ Callback<R(A0, A1, A2, A3, A4)> callback(const T *obj, R (T::*func)(A0, A1, A2, 
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(volatile T *obj, R (T::*func)(A0, A1, A2, A3, A4) volatile) {
-    return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(volatile U *obj, R (T::*method)(A0, A1, A2, A3, A4) volatile) {
+    return Callback<R(A0, A1, A2, A3, A4)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments
@@ -5728,9 +5728,9 @@ Callback<R(A0, A1, A2, A3, A4)> callback(volatile T *obj, R (T::*func)(A0, A1, A
  *  @param method   Member function to attach
  *  @return         Callback with infered type
  */
-template<typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Callback<R(A0, A1, A2, A3, A4)> callback(const volatile T *obj, R (T::*func)(A0, A1, A2, A3, A4) const volatile) {
-    return Callback<R(A0, A1, A2, A3, A4)>(obj, func);
+template<typename T, typename U, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Callback<R(A0, A1, A2, A3, A4)> callback(const volatile U *obj, R (T::*method)(A0, A1, A2, A3, A4) const volatile) {
+    return Callback<R(A0, A1, A2, A3, A4)>(obj, method);
 }
 
 /** Create a callback class with type infered from the arguments


### PR DESCRIPTION
This is a fix for a set of bugs related to using inherited member functions.

---

The type deduction for the callback constructors was to strict and prevented implicit casts for the context pointer stored internally.

As noted by @pan-, relaxing the contraints on the templated parameters allows C++ to correctly infer implicit casts such as conversions between child and parent classes when inheritance is
involved.

As an additional benefit, this may help the user experience by defering invalid type errors to when the types are expanded, limiting the number of error messages presented to users.

Also, adopting the same relaxed tpye-deduction in bound functions for consistency provides an alternative solution for the void pointer cast issue, which removes a larg amount of cruft.

---

Github is breaking on the diff, so here is a snippet of what has changed:

``` diff
--- a/platform/Callback.h
+++ b/platform/Callback.h
@@ -90,8 +90,8 @@ public:
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
-    template<typename T>
-    Callback(T *obj, R (T::*method)()) {
+    template<typename T, typename U>
+    Callback(U *obj, R (T::*method)()) {
         generate(method_context<T, R (T::*)()>(obj, method));
     }

@@ -117,49 +117,17 @@ public:
     /** Create a Callback with a static function and bound pointer
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      */
-    Callback(R (*func)(void*), void *arg) {
-        generate(function_context<R (*)(void*), void>(func, arg));
-    }
-
-    /** Create a Callback with a static function and bound pointer
-     *  @param func     Static function to attach
-     *  @param arg      Pointer argument to function
-     */
-    template<typename T>
-    Callback(R (*func)(T*), T *arg) {
+    template<typename T, typename U>
+    Callback(R (*func)(T*), U *arg) {
         generate(function_context<R (*)(T*), T>(func, arg));
     }
```

related https://github.com/ARMmbed/mbed-os/issues/3235
cc @pan- 