### PR TITLE
Change MBED_DEPRECATED def order to support Keil 4

### DIFF
--- a/platform/toolchain.h
+++ b/platform/toolchain.h
@@ -220,10 +220,10 @@
  *  @endcode
  */
 #ifndef MBED_DEPRECATED
-#if defined(__GNUC__) || defined(__clang__)
-#define MBED_DEPRECATED(M) __attribute__((deprecated(M)))
-#elif defined(__CC_ARM)
+#if defined(__CC_ARM)
 #define MBED_DEPRECATED(M) __attribute__((deprecated))
+#elif defined(__GNUC__) || defined(__clang__)
+#define MBED_DEPRECATED(M) __attribute__((deprecated(M)))
 #else
 #define MBED_DEPRECATED(M)
 #endif


### PR DESCRIPTION
Oringinally #3245 by @micromint 

## Description
MBED_DEPRECATED macro breaks builds using Keil uVision4. The 'deprecated' attribute does not allow arguments using ARMCC 5.03 on Keil 4.74. Changing #ifdef order reinstates support for Keil uVision4. Tested with Keil 4.74, Keil 5.21 and GCC ARM Embedded 5.4 2016q3.


## Status
**READY**


## Todos
 - [x] Review @geky 
 - [x] Review @c1728p9 
 - [x] Tests Passing