### PR TITLE
Baudrate in test spec

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -134,7 +134,7 @@ def get_config(src_paths, target, toolchain_name):
         toolchain.config.add_config_files(resources.json_files)
 
         # Add features while we find new ones
-        features = toolchain.config.get_features()
+        features = set(toolchain.config.get_features())
         if features == prev_features:
             break
 

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -60,6 +60,7 @@ from tools.build_api import create_result
 from tools.build_api import add_result_to_report
 from tools.build_api import prepare_toolchain
 from tools.build_api import scan_resources
+from tools.build_api import get_config
 from tools.libraries import LIBRARIES, LIBRARY_MAP
 from tools.options import extract_profile
 from tools.toolchains import TOOLCHAIN_PATHS
@@ -2126,12 +2127,17 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
     base_path = norm_relative_path(build_path, execution_directory)
 
     target_name = target if isinstance(target, str) else target.name
-    
+    cfg, macros, features = get_config(base_source_paths, target_name, toolchain_name)
+
+    baud_rate = 9600
+    if 'platform.stdio-baud-rate' in cfg:
+        baud_rate = cfg['platform.stdio-baud-rate'].value
+
     test_build = {
         "platform": target_name,
         "toolchain": toolchain_name,
         "base_path": base_path,
-        "baud_rate": 9600,
+        "baud_rate": baud_rate,
         "binary_type": "bootable",
         "tests": {}
     }


### PR DESCRIPTION
## Description
This PR sets the baudrate in the test spec file (used by Greentea for automated testing) based on the mbed config setting for the stdio default baud rate: https://github.com/ARMmbed/mbed-os/blob/master/platform/mbed_lib.json#L9

There was another patch that was necessary to prevent an issue when getting the config data. Before, the `get_config` function in `build_api.py` was checking the equality of a set and a list. However the list's equality depends on order, so now it is casted it to a set to prevent an infinite loop.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [x] Tests
- [x] Review by @mazimkhan 
- [x] Review by @theotherjimmy (specifically on how I'm accessing the config data)


FYI @stevew817 