### PR TITLE
WiFi: Make WiFi default networking interface on Odin board

### DIFF
--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/gethostbyname/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/gethostbyname/main.cpp
@@ -1,3 +1,7 @@
+#if DEVICE_EMAC
+    #error [NOT_SUPPORTED] Not supported for WiFi targets
+#endif
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"
@@ -5,7 +9,6 @@
 #include "EthernetInterface.h"
 
 using namespace utest::v1;
-
 
 // Hostname for testing against
 // Must have A and AAAA records

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/nist_internet_time_service/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/nist_internet_time_service/main.cpp
@@ -2,6 +2,10 @@
     #error [NOT_SUPPORTED] LWIP not supported for this target
 #endif
 
+#if DEVICE_EMAC
+    #error [NOT_SUPPORTED] Not supported for WiFi targets
+#endif
+
 #include "mbed.h"
 #include "EthernetInterface.h"
 #include "UDPSocket.h"

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_client_echo/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_client_echo/main.cpp
@@ -2,6 +2,10 @@
     #error [NOT_SUPPORTED] LWIP not supported for this target
 #endif
 
+#if DEVICE_EMAC
+    #error [NOT_SUPPORTED] Not supported for WiFi targets
+#endif
+
 #include "mbed.h"
 #include "EthernetInterface.h"
 #include "TCPSocket.h"

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_client_hello_world/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_client_hello_world/main.cpp
@@ -2,6 +2,10 @@
     #error [NOT_SUPPORTED] LWIP not supported for this target
 #endif
 
+#if DEVICE_EMAC
+    #error [NOT_SUPPORTED] Not supported for WiFi targets
+#endif
+
 #include <algorithm>
 #include "mbed.h"
 #include "EthernetInterface.h"

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_client/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_client/main.cpp
@@ -2,6 +2,10 @@
     #error [NOT_SUPPORTED] LWIP not supported for this target
 #endif
 
+#if DEVICE_EMAC
+    #error [NOT_SUPPORTED] Not supported for WiFi targets
+#endif
+
 #include "mbed.h"
 #include "EthernetInterface.h"
 #include "UDPSocket.h"

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1292,7 +1292,7 @@
         "extra_labels": ["STM", "STM32F4", "STM32F439", "STM32F439ZI","STM32F439xx"],
         "macros": ["HSE_VALUE=24000000", "HSE_STARTUP_TIMEOUT=5000", "CB_INTERFACE_SDIO","CB_CHIP_WL18XX","SUPPORT_80211D_ALWAYS","WLAN_ENABLED","MBEDTLS_ARC4_C","MBEDTLS_DES_C","MBEDTLS_MD4_C","MBEDTLS_MD5_C","MBEDTLS_SHA1_C"],
         "inherits": ["Target"],
-        "device_has": ["ANALOGIN", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG"],
+        "device_has": ["ANALOGIN", "CAN", "EMAC", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG"],
         "features": ["LWIP"],
         "release_versions": ["5"],
         "device_name": "STM32F439ZI"


### PR DESCRIPTION

## Description
That disables Ethernet by default and makes sure the Ethernet tests are
not failing when it's disabled.

## Status
**READY**

@sg- As mentioned in one of the tickets.
CC: @bridadan 