### PR TITLE
NUCLEO_F103RB - Add RTS/CTS pins for Serial Flow Control

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/PeripheralPins.c
@@ -136,6 +136,20 @@ const PinMap PinMap_UART_RX[] = {
     {NC,    NC,     0}
 };
 
+const PinMap PinMap_UART_RTS[] = {
+    {PA_1,  UART_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, 0)},
+    {PA_12, UART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, 0)},
+    {PB_14, UART_3, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, 0)},
+    {NC,    NC,    0}
+};
+
+const PinMap PinMap_UART_CTS[] = {
+    {PA_0,  UART_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, 0)},
+    {PA_11, UART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, 0)},
+    {PB_13, UART_3, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, 0)},
+    {NC,    NC,    0}
+};
+
 //*** SPI ***
 
 const PinMap PinMap_SPI_MOSI[] = {


### PR DESCRIPTION
## Description
Add CTS and RTS pins used for the Serial Flow Control.

## Status
READY

## Migrations
NO