### PR TITLE
Move crypto hardware acceleration configuration.

### DIFF
--- a/features/mbedtls/importer/Makefile
+++ b/features/mbedtls/importer/Makefile
@@ -93,7 +93,6 @@ clean:
 	rm -f $(TARGET_PREFIX)apache-2.0.txt
 	rm -f $(TARGET_PREFIX)VERSION.txt
 	rm -f $(TARGET_PREFIX)AUTHORS.txt
-	rm -rf $(TARGET_PREFIX)/targets
 	rm -rf $(TARGET_SRC)
 	rm -rf $(TARGET_INC)
 	rm -rf $(MBED_TLS_DIR)

--- a/features/mbedtls/platform/inc/platform_mbed.h
+++ b/features/mbedtls/platform/inc/platform_mbed.h
@@ -21,6 +21,6 @@
 #define MBEDTLS_ENTROPY_HARDWARE_ALT
 #endif
 
-#if defined(MBEDTLS_HW_SUPPORT)
+#if defined(MBEDTLS_CONFIG_HW_SUPPORT)
 #include "mbedtls_device.h"
 #endif

--- a/features/mbedtls/platform/inc/platform_mbed.h
+++ b/features/mbedtls/platform/inc/platform_mbed.h
@@ -21,6 +21,6 @@
 #define MBEDTLS_ENTROPY_HARDWARE_ALT
 #endif
 
-#if defined(DEVICE_CRYPTO)
+#if defined(MBEDTLS_HW_SUPPORT)
 #include "mbedtls_device.h"
 #endif

--- a/features/mbedtls/platform/inc/platform_mbed.h
+++ b/features/mbedtls/platform/inc/platform_mbed.h
@@ -20,3 +20,7 @@
 #if defined(DEVICE_TRNG)
 #define MBEDTLS_ENTROPY_HARDWARE_ALT
 #endif
+
+#if defined(DEVICE_CRYPTO)
+#include "mbedtls_device.h"
+#endif


### PR DESCRIPTION
## Description

    The crypto hardware acceleration might require defining a lot of mbed
    TLS specific macros. Enumerating all of them in `targets.json` creates
    too much noise, therefore we move it into a target specific mbed TLS
    header.
    
    The target with crypto hardware acceleration has to
            - indicate its capability in `targets.json` by adding "MBEDTLS_CONFIG_HW_SUPPORT"
              to the "macros" section
            - has to define his crypto hardware acceleration related macros
              in an `mbedtls_device.h` header
            - place the `mbedtls_device.h` file in the
              `features/mbedtls/targets/TARGET_XXXX`
              directory specific to the target

## Status
**READY**

## Migrations
NO

## Related PRs
-

## Todos
-

## Deploy notes
-

## Steps to test or reproduce
 To test this PR, add crypto hardware acceleration code to your target:
- indicate this capability in `targets.json` by adding "MBEDTLS_CONFIG_HW_SUPPORT"
              to the "macros" section
- define your crypto hardware acceleration related mbed TLS macros
              in an `mbedtls_device.h` header
- place the `mbedtls_device.h` file along with the acceleration code in the
              `features/mbedtls/targets/TARGET_XXXX`
              directory specific to the target