### PR TITLE
Ensure isr cannot occur after NVIC_DisableIRQ

### DIFF
--- a/cmsis/core_cm0.h
+++ b/cmsis/core_cm0.h
@@ -589,6 +589,8 @@ __STATIC_INLINE void NVIC_EnableIRQ(IRQn_Type IRQn)
 __STATIC_INLINE void NVIC_DisableIRQ(IRQn_Type IRQn)
 {
   NVIC->ICER[0] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+  __DSB();
+  __ISB();
 }
 
 

--- a/cmsis/core_cm0plus.h
+++ b/cmsis/core_cm0plus.h
@@ -703,6 +703,8 @@ __STATIC_INLINE void NVIC_EnableIRQ(IRQn_Type IRQn)
 __STATIC_INLINE void NVIC_DisableIRQ(IRQn_Type IRQn)
 {
   NVIC->ICER[0] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+  __DSB();
+  __ISB();
 }
 
 

--- a/cmsis/core_cm3.h
+++ b/cmsis/core_cm3.h
@@ -1431,6 +1431,8 @@ __STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
 __STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
 {
   NVIC->ICER[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+  __DSB();
+  __ISB();
 }
 
 

--- a/cmsis/core_cm4.h
+++ b/cmsis/core_cm4.h
@@ -1597,6 +1597,8 @@ __STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
 __STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
 {
   NVIC->ICER[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+  __DSB();
+  __ISB();
 }
 
 

--- a/cmsis/core_cm7.h
+++ b/cmsis/core_cm7.h
@@ -1754,6 +1754,8 @@ __STATIC_INLINE void NVIC_EnableIRQ(IRQn_Type IRQn)
 __STATIC_INLINE void NVIC_DisableIRQ(IRQn_Type IRQn)
 {
   NVIC->ICER[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+  __DSB();
+  __ISB();
 }
 
 

--- a/cmsis/core_sc000.h
+++ b/cmsis/core_sc000.h
@@ -705,6 +705,8 @@ __STATIC_INLINE void NVIC_EnableIRQ(IRQn_Type IRQn)
 __STATIC_INLINE void NVIC_DisableIRQ(IRQn_Type IRQn)
 {
   NVIC->ICER[0] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+  __DSB();
+  __ISB();
 }
 
 

--- a/cmsis/core_sc300.h
+++ b/cmsis/core_sc300.h
@@ -1376,6 +1376,8 @@ __STATIC_INLINE void NVIC_EnableIRQ(IRQn_Type IRQn)
 __STATIC_INLINE void NVIC_DisableIRQ(IRQn_Type IRQn)
 {
   NVIC->ICER[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+  __DSB();
+  __ISB();
 }
 
 


### PR DESCRIPTION
Add data and instruction synchronization barriers to prevent interrupts from occurring after NVIC_DisableIRQ is called. This is a backport of changes made in CMSIS_5 [here](https://github.com/ARM-software/CMSIS_5/issues/110). This fixes #2242.