### PR TITLE
Unify output directory for mbed-cli and exporters

### DIFF
--- a/tools/export/cdt/__init__.py
+++ b/tools/export/cdt/__init__.py
@@ -14,7 +14,7 @@ class Eclipse(Makefile):
         super(Eclipse, self).generate()
         ctx = {
             'name': self.project_name,
-            'elf_location': join('.build',self.project_name)+'.elf',
+            'elf_location': join('BUILD',self.project_name)+'.elf',
             'c_symbols': self.toolchain.get_symbols(),
             'asm_symbols': self.toolchain.get_symbols(True),
             'target': self.target,

--- a/tools/export/iar/__init__.py
+++ b/tools/export/iar/__init__.py
@@ -165,8 +165,11 @@ class IAR(Exporter):
             os.remove(project_name + ".ewp")
             os.remove(project_name + ".ewd")
             os.remove(project_name + ".eww")
+            # legacy output file location
             if exists('.build'):
                 shutil.rmtree('.build')
+            if exists('BUILD'):
+                shutil.rmtree('BUILD')
 
         if ret_code !=0:
             # Seems like something went wrong.

--- a/tools/export/iar/ewp.tmpl
+++ b/tools/export/iar/ewp.tmpl
@@ -20,15 +20,15 @@
 				</option>
 				<option>
 					<name>ExePath</name>
-					<state>$PROJ_DIR$\.build\Exe</state>
+					<state>$PROJ_DIR$\BUILD\Exe</state>
 				</option>
 				<option>
 					<name>ObjPath</name>
-					<state>$PROJ_DIR$\.build\Obj</state>
+					<state>$PROJ_DIR$\BUILD\Obj</state>
 				</option>
 				<option>
 					<name>ListPath</name>
-					<state>$PROJ_DIR$\.build\List</state>
+					<state>$PROJ_DIR$\BUILD\List</state>
 				</option>
 				<option>
 					<name>Variant</name>

--- a/tools/export/iar/iar_nucleo_f746zg.ewp.tmpl
+++ b/tools/export/iar/iar_nucleo_f746zg.ewp.tmpl
@@ -16,15 +16,15 @@
         <wantNonLocal>1</wantNonLocal>
         <debug>1</debug>
         <option>
-          <state>$PROJ_DIR$\.build\iar_arm\Exe</state>
+          <state>$PROJ_DIR$\BUILD\Exe</state>
           <name>ExePath</name>
         </option>
         <option>
-          <state>$PROJ_DIR$\.build\iar_arm\Obj</state>
+          <state>$PROJ_DIR$\BUILD\Obj</state>
           <name>ObjPath</name>
         </option>
         <option>
-          <state>$PROJ_DIR$\.build\iar_arm\List</state>
+          <state>$PROJ_DIR$\BUILD\List</state>
           <name>ListPath</name>
         </option>
         <option>

--- a/tools/export/iar/iar_rz_a1h.ewp.tmpl
+++ b/tools/export/iar/iar_rz_a1h.ewp.tmpl
@@ -16,15 +16,15 @@
         <wantNonLocal>1</wantNonLocal>
         <debug>1</debug>
         <option>
-          <state>$PROJ_DIR$\.build\iar_arm\Exe</state>
+          <state>$PROJ_DIR$\BUILD\Exe</state>
           <name>ExePath</name>
         </option>
         <option>
-          <state>$PROJ_DIR$\.build\iar_arm\Obj</state>
+          <state>$PROJ_DIR$\BUILD\Obj</state>
           <name>ObjPath</name>
         </option>
         <option>
-          <state>$PROJ_DIR$\.build\iar_arm\List</state>
+          <state>$PROJ_DIR$\BUILD\List</state>
           <name>ListPath</name>
         </option>
         <option>

--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -13,7 +13,7 @@ else
     RM = '$(SHELL)' -c "rm -rf \"$(1)\""
 endif
 
-OBJDIR := .build
+OBJDIR := BUILD
 # Move to the build directory
 ifeq (,$(filter $(OBJDIR),$(notdir $(CURDIR))))
 .SUFFIXES:

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -141,8 +141,11 @@ class Makefile(Exporter):
         if cleanup:
             remove("Makefile")
             remove(log_name)
+            # legacy .build directory cleaned if exists
             if exists('.build'):
                 shutil.rmtree('.build')
+            if exists('BUILD'):
+                shutil.rmtree('BUILD')
 
         if ret_code != 0:
             # Seems like something went wrong.

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -226,8 +226,11 @@ class Uvision(Exporter):
             os.remove(log_name)
             os.remove(project_name+".uvprojx")
             os.remove(project_name+".uvoptx")
+            # legacy .build directory cleaned if exists
             if exists('.build'):
-                shutil.rmtree(".build")
+                shutil.rmtree('.build')
+            if exists('BUILD'):
+                shutil.rmtree('BUILD')
 
         # Returns 0 upon success, 1 upon a warning, and neither upon an error
         if ret_code != 0 and ret_code != 1:

--- a/tools/export/uvision/uvision.tmpl
+++ b/tools/export/uvision/uvision.tmpl
@@ -46,14 +46,14 @@
             <NotGenerated>0</NotGenerated>
             <InvalidFlash>1</InvalidFlash>
           </TargetStatus>
-          <OutputDirectory>.\.build\uvision5\</OutputDirectory>
+          <OutputDirectory>.\BUILD\</OutputDirectory>
           <OutputName>{{name}}</OutputName>
           <CreateExecutable>1</CreateExecutable>
           <CreateLib>0</CreateLib>
           <CreateHexFile>0</CreateHexFile>
           <DebugInformation>1</DebugInformation>
           <BrowseInformation>1</BrowseInformation>
-          <ListingPath>.\.build\uvision5\</ListingPath>
+          <ListingPath>.\BUILD\</ListingPath>
           <HexFormatSelection>1</HexFormatSelection>
           <Merge32K>0</Merge32K>
           <CreateBatchFile>0</CreateBatchFile>

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -138,8 +138,8 @@ class MemapParser(object):
         """ Parse data from a section of gcc map file
 
         examples:
-                        0x00004308       0x7c ./.build/K64F/GCC_ARM/mbed-os/hal/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/spi_api.o
-         .text          0x00000608      0x198 ./.build/K64F/GCC_ARM/mbed-os/core/mbed-rtos/rtx/TARGET_CORTEX_M/TARGET_RTOS_M4_M7/TOOLCHAIN_GCC/HAL_CM4.o
+                        0x00004308       0x7c ./BUILD/K64F/GCC_ARM/mbed-os/hal/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/spi_api.o
+         .text          0x00000608      0x198 ./BUILD/K64F/GCC_ARM/mbed-os/core/mbed-rtos/rtx/TARGET_CORTEX_M/TARGET_RTOS_M4_M7/TOOLCHAIN_GCC/HAL_CM4.o
 
         Positional arguments:
         line - the line to parse a section from

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -25,7 +25,7 @@ ROOT = abspath(join(dirname(__file__), ".."))
 ##############################################################################
 # Toolchains and Build System Settings
 ##############################################################################
-BUILD_DIR = abspath(join(ROOT, ".build"))
+BUILD_DIR = abspath(join(ROOT, "BUILD"))
 
 # ARM Compiler 5
 ARM_PATH = "C:/Keil_v5/ARM/ARMCC"


### PR DESCRIPTION
## Description
Exporters should build into BUILD as mbed-cli does with the exception of target awareness
```
BUILD\<export builds things here>
BUILD\<target>\<toolchain>\<mbed-cli builds things here>
```

## Status
**READY**


## Migrations
Example program docs may need to be update and possibly any hardcoded scripts that CI uses


## Todos
- [x] Tests
