### PR TITLE
Bug fix of initial value of interrupt edge in "gpio_irq_init" function.

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1H/gpio_irq_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1H/gpio_irq_api.c
@@ -165,7 +165,6 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     // INTC settings
     InterruptHandlerRegister((IRQn_Type)(nIRQn_h+obj->ch), (void (*)(uint32_t))irq_tbl[obj->ch]);
     INTCICR1 &= ~(0x3 << shift);
-    INTCICR1 |= (0x3 << shift);
     GIC_SetPriority((IRQn_Type)(nIRQn_h+obj->ch), 5);
     GIC_EnableIRQ((IRQn_Type)(nIRQn_h+obj->ch));
     obj->int_enable = 1;


### PR DESCRIPTION
Renesas modified the  initial value of interrupt edge in "gpio_irq_init" function.
The value was "both egde(rise and fall)".So we modified it to "low revel".