### PR TITLE
Adding mbed enabled Maker board with NINA-B1 and EVA-M8Q

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TARGET_UBLOX_EVA_NINA/PinNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TARGET_UBLOX_EVA_NINA/PinNames.h
@@ -74,7 +74,7 @@ typedef enum {
     NINA_B1_GPIO_29 = p10,
     
     // Board pins
-    LED1 = NINA-B1_GPIO_7, // ORANGE
+    LED1 = NINA_B1_GPIO_7, // ORANGE
     LED2 = NC,
     LED3 = NC,
     LED4 = NC,

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TARGET_UBLOX_EVA_NINA/PinNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TARGET_UBLOX_EVA_NINA/PinNames.h
@@ -1,0 +1,106 @@
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+#define PORT_SHIFT 3
+
+typedef enum {
+    // nRF52 pin names
+    p0  = 0,
+    p1  = 1,
+    p2  = 2,
+    p3  = 3,
+    p4  = 4,
+    p5  = 5,
+    p6  = 6,
+    p7  = 7,
+    p8  = 8,
+    p9  = 9,
+    p10 = 10,
+    p11 = 11,
+    p12 = 12,
+    p13 = 13,
+    p14 = 14,
+    p15 = 15,
+    p16 = 16,
+    p17 = 17,
+    p18 = 18,
+    p19 = 19,
+    p20 = 20,
+    p21 = 21,
+    p22 = 22,
+    p23 = 23,
+    p24 = 24,
+    p25 = 25,
+    p26 = 26,
+    p27 = 27,
+    p28 = 28,
+    p29 = 29,
+    p30 = 30,
+    p31 = 31,
+    NC = (int)0xFFFFFFFF, // Not connected
+
+    //NINA-B1 module pin names
+    NINA_B1_GPIO_1 = p8,
+    NINA_B1_GPIO_2 = p11,
+    NINA_B1_GPIO_3 = p12,
+    NINA_B1_GPIO_4 = p13,
+    NINA_B1_GPIO_5 = p14,
+    NINA_B1_GPIO_7 = p16,
+    NINA_B1_GPIO_8 = p18,
+
+    NINA_B1_GPIO_16 = p28,
+    NINA_B1_GPIO_17 = p29,
+    NINA_B1_GPIO_18 = p30,
+
+    NINA_B1_GPIO_20 = p31,
+    NINA_B1_GPIO_21 = p7,
+    NINA_B1_GPIO_22 = p6,
+    NINA_B1_GPIO_23 = p5,
+    NINA_B1_GPIO_24 = p2,
+    NINA_B1_GPIO_25 = p3,
+    NINA_B1_GPIO_27 = p4,
+    NINA_B1_GPIO_28 = p9,
+    NINA_B1_GPIO_29 = p10,
+    
+    // Board pins
+    LED1 = NINA-B1_GPIO_7, // ORANGE
+    LED2 = NC,
+    LED3 = NC,
+    LED4 = NC,
+    
+    // Nordic SDK pin names
+    RX_PIN_NUMBER = p5,
+    TX_PIN_NUMBER = p6,
+    CTS_PIN_NUMBER = p7,
+    RTS_PIN_NUMBER = p31,
+    I2C_SDA0 = p2,
+    I2C_SCL0 = p3,
+
+    // mBed interface pins
+    USBTX = TX_PIN_NUMBER,
+    USBRX = RX_PIN_NUMBER
+} PinName;
+
+typedef enum {
+    PullNone = 0,
+    PullDown = 1,
+    PullUp = 3,
+    PullDefault = PullUp
+} PinMode;
+
+#ifdef __cplusplus
+}
+
+#endif
+#endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TARGET_UBLOX_EVA_NINA/device.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TARGET_UBLOX_EVA_NINA/device.h
@@ -1,0 +1,23 @@
+// The 'features' section in 'target.json' is now used to create the device's hardware preprocessor switches.
+// Check the 'features' section of the target description in 'targets.json' for more details.
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+#include "objects.h"
+
+#endif

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2332,6 +2332,14 @@
         "release_versions": ["2", "5"],
         "device_name": "nRF52832_xxAA"
     },
+    "UBLOX_EVA_NINA": {
+        "inherits": ["MCU_NRF52"],
+        "macros_add": ["BOARD_PCA10040", "NRF52_PAN_12", "NRF52_PAN_15", "NRF52_PAN_58", "NRF52_PAN_55", "NRF52_PAN_54", "NRF52_PAN_31", "NRF52_PAN_30", "NRF52_PAN_51", "NRF52_PAN_36", "NRF52_PAN_53", "S132", "CONFIG_GPIO_AS_PINRESET", "BLE_STACK_SUPPORT_REQD", "SWI_DISABLE0", "NRF52_PAN_20", "NRF52_PAN_64", "NRF52_PAN_62", "NRF52_PAN_63"],
+        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
+        "release_versions": ["2", "5"],
+        "overrides": {"uart_hwfc": 0},
+        "device_name": "nRF52832_xxAA"
+    },
     "DELTA_DFBM_NQ620": {
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF52"],


### PR DESCRIPTION
## Description
Adding new Maker board platform with mbed enabled with BLE, GNSS and Sensors.
The board implements: 
- NINA-B1 Bluetooth Low Energy module 
- EVA-M8Q GPS and GLONASS receiver
- MPU9250 9DOF IMU
- MKL26Z based CMSIS-DAP interface. 

## Status
**IN DEVELOPMENT**
