### PR TITLE
Add '-g3' flag to gcc debug flags

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -5,7 +5,7 @@
                    "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
                    "-MMD", "-fno-delete-null-pointer-checks",
-                   "-fomit-frame-pointer", "-O0", "-g"],
+                   "-fomit-frame-pointer", "-O0", "-g3"],
         "asm": ["-x", "assembler-with-cpp"],
         "c": ["-std=gnu99"],
         "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],


### PR DESCRIPTION
This is a gcc specific flag that increases debug information, most useful is allowing the expansion of macros.

http://stackoverflow.com/questions/10475040/gcc-g-vs-g3-gdb-flag-what-is-the-difference/10475077#10475077
> Level 3 includes extra information, such as all the macro definitions present in the program. Some debuggers support macro expansion when you use -g3.

cc @theotherjimmy, @c1728p9 