### PR TITLE
events - Fix unchaining of event queues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ python:
   - "2.7"
 
 script:
+  - make -C events/equeue test clean
   - PYTHONPATH=. python tools/test/config_test/config_test.py
   - PYTHONPATH=. python tools/test/build_api/build_api_test.py
   - python tools/test/pylint.py

--- a/events/equeue/Makefile
+++ b/events/equeue/Makefile
@@ -17,7 +17,7 @@ endif
 ifdef WORD
 CFLAGS += -m$(WORD)
 endif
-CFLAGS += -I.
+CFLAGS += -I. -I..
 CFLAGS += -std=c99
 CFLAGS += -Wall
 CFLAGS += -D_XOPEN_SOURCE=600

--- a/events/equeue/equeue.c
+++ b/events/equeue/equeue.c
@@ -558,6 +558,11 @@ static void equeue_chain_update(void *p, int ms) {
 }
 
 void equeue_chain(equeue_t *q, equeue_t *target) {
+    if (!target) {
+        equeue_background(q, 0, 0);
+        return;
+    }
+
     struct equeue_chain_context *c = equeue_alloc(q,
             sizeof(struct equeue_chain_context));
 

--- a/events/equeue/tests/tests.c
+++ b/events/equeue/tests/tests.c
@@ -557,6 +557,42 @@ void chain_test(void) {
     equeue_dispatch(&q1, 30);
 
     test_assert(touched == 6);
+
+    equeue_destroy(&q1);
+    equeue_destroy(&q2);
+}
+
+void unchain_test(void) {
+    equeue_t q1;
+    int err = equeue_create(&q1, 2048);
+    test_assert(!err);
+
+    equeue_t q2;
+    err = equeue_create(&q2, 2048);
+    test_assert(!err);
+
+    equeue_chain(&q2, &q1);
+
+    int touched = 0;
+    int id1 = equeue_call(&q1, simple_func, &touched);
+    int id2 = equeue_call(&q2, simple_func, &touched);
+    test_assert(id1 && id2);
+
+    equeue_dispatch(&q1, 0);
+    test_assert(touched == 2);
+
+    equeue_chain(&q2, 0);
+    equeue_chain(&q1, &q2);
+
+    id1 = equeue_call(&q1, simple_func, &touched);
+    id2 = equeue_call(&q2, simple_func, &touched);
+    test_assert(id1 && id2);
+
+    equeue_dispatch(&q2, 0);
+    test_assert(touched == 4);
+
+    equeue_destroy(&q1);
+    equeue_destroy(&q2);
 }
 
 // Barrage tests
@@ -671,6 +707,7 @@ int main() {
     test_run(sloth_test);
     test_run(background_test);
     test_run(chain_test);
+    test_run(unchain_test);
     test_run(multithread_test);
     test_run(simple_barrage_test, 20);
     test_run(fragmenting_barrage_test, 20);


### PR DESCRIPTION
The `equeue_chain` function is supposed to unchain the event queue from whatever queue it is chained to when passed a null target. Internally, this is accomplished by just calling `equeue_background` with null and letting the previously registered update function clean up the chaining.

However, `equeue_chain` did not appropriately check for null, causing it to unnecessarily allocate memory and leaving the update function in a bad state. Fixed with a simple null check.

should fix https://github.com/ARMmbed/mbed-os/issues/3277
cc @tommikas 