### PR TITLE
I2C - correct return values for write functions (docs) - part 1

### DIFF
--- a/drivers/I2C.h
+++ b/drivers/I2C.h
@@ -117,8 +117,8 @@ public:
      *  @param repeated Repeated start, true - do not send stop at end
      *
      *  @returns
-     *       0 on success (ack),
-     *   non-0 on failure (nack)
+     *      0 or non-zero - written number of bytes,
+     *      negative - I2C_ERROR_XXX status
      */
     int write(int address, const char *data, int length, bool repeated = false);
 
@@ -127,8 +127,9 @@ public:
      *  @param data data to write out on bus
      *
      *  @returns
-     *    '1' if an ACK was received,
-     *    '0' otherwise
+     *    '0' - NAK was received
+     *    '1' - ACK was received,
+     *    '2' - timeout
      */
     int write(int data);
 

--- a/hal/i2c_api.h
+++ b/hal/i2c_api.h
@@ -117,7 +117,9 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop);
  *  @param data    The buffer for sending
  *  @param length  Number of bytes to write
  *  @param stop    Stop to be generated after the transfer is done
- *  @return Number of written bytes
+ *  @return 
+ *      zero or non-zero - Number of written bytes
+ *      negative - I2C_ERROR_XXX status
  */
 int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop);
 


### PR DESCRIPTION
This yet does not completely fixes the issue #2725. It's first step. The documentation corrections. HAL said that it write() returns bytes written that was partially true, it also returns failures (negative values). Based on that , I2C driver doc were updated to reflect this.

The second step would be to write tests to see if there are number of bytes written reported and failures. looking at targets, they vary in return values.

References:

- https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_Silicon_Labs/TARGET_EFM32/i2c_api.c#L270
- https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_STM/TARGET_STM32F4/i2c_api.c#L646 (this errors on non valid bytes written returned)
- https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_NORDIC/TARGET_NRF5/i2c_api.c#L246

While browsing files, HAL functions like stop, start return int but it's not documented, and I2C::stop is void.

I am mentioning maintainers here, to review this and look at the code to see if this is correct: 
cc @LMESTM @mmahadevan108 @nvlsianpu @radhika-raghavendran @fvincenzo @TomoYamanaka @jeremybrodt @ccli8 