### PR TITLE
STM32F4 AnalogIn - Clear VBATE and TSVREFE bits before configuring ADC channels

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
@@ -183,13 +183,14 @@ static inline uint16_t adc_read(analogin_t *obj)
             return 0;
     }
 
+    ADC->CCR &= ~(ADC_CCR_VBATE | ADC_CCR_TSVREFE); // Workaround
     HAL_ADC_ConfigChannel(&AdcHandle, &sConfig);
 
     HAL_ADC_Start(&AdcHandle); // Start conversion
 
     // Wait end of conversion and get value
     if (HAL_ADC_PollForConversion(&AdcHandle, 10) == HAL_OK) {
-        return (HAL_ADC_GetValue(&AdcHandle));
+        return (uint16_t)HAL_ADC_GetValue(&AdcHandle);
     } else {
         return 0;
     }

--- a/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
@@ -183,7 +183,12 @@ static inline uint16_t adc_read(analogin_t *obj)
             return 0;
     }
 
-    ADC->CCR &= ~(ADC_CCR_VBATE | ADC_CCR_TSVREFE); // Workaround
+    // Measuring VBAT sets the ADC_CCR_VBATE bit in ADC->CCR, and there is not
+    // possibility with the ST HAL driver to clear it. If it isn't cleared,
+    // VBAT remains connected to the ADC channel in preference to temperature,
+    // so VBAT readings are returned in place of temperature.
+    ADC->CCR &= ~(ADC_CCR_VBATE | ADC_CCR_TSVREFE);
+
     HAL_ADC_ConfigChannel(&AdcHandle, &sConfig);
 
     HAL_ADC_Start(&AdcHandle); // Start conversion


### PR DESCRIPTION
## Description
This is a fix of Issue #1685:

Measuring VBAT sets the ADC_CCR_VBATE bit in ADC->CCR, and there is not possibility with the ST HAL driver to clear it. If it isn't cleared, VBAT remains connected to the ADC channel in preference to temperature, so VBAT readings are returned in place of temperature.

This is a workaround until a better solution is done in ST HAL driver.

## Status
READY

## Migrations
NO