### PR TITLE
Fix #2956 #2939 #2957 #2959 #2960: Add HAL_DeInit function in gpio_irq destructor

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/gpio_irq_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/gpio_irq_api.c
@@ -82,7 +82,8 @@ static uint32_t pin_base_nr[16] = {
 
 static gpio_irq_handler irq_handler;
 
-static void handle_interrupt_in(uint32_t irq_index, uint32_t max_num_pin_line) {
+static void handle_interrupt_in(uint32_t irq_index, uint32_t max_num_pin_line)
+{
     gpio_channel_t *gpio_channel = &channels[irq_index];
     uint32_t gpio_idx;
 
@@ -112,24 +113,28 @@ static void handle_interrupt_in(uint32_t irq_index, uint32_t max_num_pin_line) {
 }
 
 // EXTI lines 0 to 1
-static void gpio_irq0(void) {
+static void gpio_irq0(void)
+{
     handle_interrupt_in(0, 2);
 }
 
 // EXTI lines 2 to 3
-static void gpio_irq1(void) {
+static void gpio_irq1(void)
+{
     handle_interrupt_in(1, 2);
 }
 
 // EXTI lines 4 to 15
-static void gpio_irq2(void) {
+static void gpio_irq2(void)
+{
     handle_interrupt_in(2, 12);
 }
 
 extern uint32_t Set_GPIO_Clock(uint32_t port_idx);
 extern void pin_function_gpiomode(PinName pin, uint32_t gpiomode);
 
-int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id) {
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
+{
     IRQn_Type irq_n = (IRQn_Type)0;
     uint32_t vector = 0;
     uint32_t irq_index;
@@ -187,11 +192,14 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     return 0;
 }
 
-void gpio_irq_free(gpio_irq_t *obj) {
+void gpio_irq_free(gpio_irq_t *obj)
+{
     gpio_channel_t *gpio_channel = &channels[obj->irq_index];
     uint32_t pin_index  = STM_PIN(obj->pin);
+    uint32_t gpio_addr = GPIOA_BASE + (GPIOB_BASE-GPIOA_BASE) * STM_PORT(obj->pin);
     uint32_t gpio_idx = pin_base_nr[pin_index];
-
+    
+    HAL_GPIO_DeInit((GPIO_TypeDef *)gpio_addr, (1<<pin_index));
     gpio_channel->pin_mask &= ~(1 << gpio_idx);
     gpio_channel->channel_ids[gpio_idx] = 0;
     gpio_channel->channel_gpio[gpio_idx] = 0;
@@ -202,7 +210,8 @@ void gpio_irq_free(gpio_irq_t *obj) {
     obj->event = EDGE_NONE;
 }
 
-void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable) {
+void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
+{
     uint32_t mode = STM_MODE_IT_EVT_RESET;
     uint32_t pull = GPIO_NOPULL;
 
@@ -249,11 +258,13 @@ void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable) {
     pin_function_gpiomode(obj->pin, mode);
 }
 
-void gpio_irq_enable(gpio_irq_t *obj) {
+void gpio_irq_enable(gpio_irq_t *obj)
+{
     NVIC_EnableIRQ(obj->irq_n);
 }
 
-void gpio_irq_disable(gpio_irq_t *obj) {
+void gpio_irq_disable(gpio_irq_t *obj)
+{
     NVIC_DisableIRQ(obj->irq_n);
     obj->event = EDGE_NONE;
 }

--- a/targets/TARGET_STM/TARGET_STM32F1/gpio_irq_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/gpio_irq_api.c
@@ -261,8 +261,10 @@ void gpio_irq_free(gpio_irq_t *obj)
 {
     gpio_channel_t *gpio_channel = &channels[obj->irq_index];
     uint32_t pin_index  = STM_PIN(obj->pin);
+    uint32_t gpio_addr = GPIOA_BASE + (GPIOB_BASE-GPIOA_BASE) * STM_PORT(obj->pin);
     uint32_t gpio_idx = pin_base_nr[pin_index];
-
+    
+    HAL_GPIO_DeInit((GPIO_TypeDef *)gpio_addr, (1<<pin_index));
     gpio_channel->pin_mask &= ~(1 << gpio_idx);
     gpio_channel->channel_ids[gpio_idx] = 0;
     gpio_channel->channel_gpio[gpio_idx] = 0;

--- a/targets/TARGET_STM/TARGET_STM32F2/gpio_irq_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/gpio_irq_api.c
@@ -261,8 +261,10 @@ void gpio_irq_free(gpio_irq_t *obj)
 {
     gpio_channel_t *gpio_channel = &channels[obj->irq_index];
     uint32_t pin_index  = STM_PIN(obj->pin);
+    uint32_t gpio_addr = GPIOA_BASE + (GPIOB_BASE-GPIOA_BASE) * STM_PORT(obj->pin);
     uint32_t gpio_idx = pin_base_nr[pin_index];
-
+    
+    HAL_GPIO_DeInit((GPIO_TypeDef *)gpio_addr, (1<<pin_index));
     gpio_channel->pin_mask &= ~(1 << gpio_idx);
     gpio_channel->channel_ids[gpio_idx] = 0;
     gpio_channel->channel_gpio[gpio_idx] = 0;

--- a/targets/TARGET_STM/TARGET_STM32F3/gpio_irq_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/gpio_irq_api.c
@@ -261,8 +261,10 @@ void gpio_irq_free(gpio_irq_t *obj)
 {
     gpio_channel_t *gpio_channel = &channels[obj->irq_index];
     uint32_t pin_index  = STM_PIN(obj->pin);
+    uint32_t gpio_addr = GPIOA_BASE + (GPIOB_BASE-GPIOA_BASE) * STM_PORT(obj->pin);
     uint32_t gpio_idx = pin_base_nr[pin_index];
-
+    
+    HAL_GPIO_DeInit((GPIO_TypeDef *)gpio_addr, (1<<pin_index));
     gpio_channel->pin_mask &= ~(1 << gpio_idx);
     gpio_channel->channel_ids[gpio_idx] = 0;
     gpio_channel->channel_gpio[gpio_idx] = 0;

--- a/targets/TARGET_STM/TARGET_STM32F4/gpio_irq_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/gpio_irq_api.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2014, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -261,8 +261,10 @@ void gpio_irq_free(gpio_irq_t *obj)
 {
     gpio_channel_t *gpio_channel = &channels[obj->irq_index];
     uint32_t pin_index  = STM_PIN(obj->pin);
+    uint32_t gpio_addr = GPIOA_BASE + (GPIOB_BASE-GPIOA_BASE) * STM_PORT(obj->pin);
     uint32_t gpio_idx = pin_base_nr[pin_index];
-
+    
+    HAL_GPIO_DeInit((GPIO_TypeDef *)gpio_addr, (1<<pin_index));
     gpio_channel->pin_mask &= ~(1 << gpio_idx);
     gpio_channel->channel_ids[gpio_idx] = 0;
     gpio_channel->channel_gpio[gpio_idx] = 0;

--- a/targets/TARGET_STM/TARGET_STM32F7/gpio_irq_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/gpio_irq_api.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -261,8 +261,10 @@ void gpio_irq_free(gpio_irq_t *obj)
 {
     gpio_channel_t *gpio_channel = &channels[obj->irq_index];
     uint32_t pin_index  = STM_PIN(obj->pin);
+    uint32_t gpio_addr = GPIOA_BASE + (GPIOB_BASE-GPIOA_BASE) * STM_PORT(obj->pin);
     uint32_t gpio_idx = pin_base_nr[pin_index];
-
+    
+    HAL_GPIO_DeInit((GPIO_TypeDef *)gpio_addr, (1<<pin_index));
     gpio_channel->pin_mask &= ~(1 << gpio_idx);
     gpio_channel->channel_ids[gpio_idx] = 0;
     gpio_channel->channel_gpio[gpio_idx] = 0;

--- a/targets/TARGET_STM/TARGET_STM32L0/gpio_irq_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/gpio_irq_api.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -196,8 +196,10 @@ void gpio_irq_free(gpio_irq_t *obj)
 {
     gpio_channel_t *gpio_channel = &channels[obj->irq_index];
     uint32_t pin_index  = STM_PIN(obj->pin);
+    uint32_t gpio_addr = GPIOA_BASE + (GPIOB_BASE-GPIOA_BASE) * STM_PORT(obj->pin);
     uint32_t gpio_idx = pin_base_nr[pin_index];
-
+    
+    HAL_GPIO_DeInit((GPIO_TypeDef *)gpio_addr, (1<<pin_index));
     gpio_channel->pin_mask &= ~(1 << gpio_idx);
     gpio_channel->channel_ids[gpio_idx] = 0;
     gpio_channel->channel_gpio[gpio_idx] = 0;

--- a/targets/TARGET_STM/TARGET_STM32L1/gpio_irq_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/gpio_irq_api.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2014, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -261,8 +261,10 @@ void gpio_irq_free(gpio_irq_t *obj)
 {
     gpio_channel_t *gpio_channel = &channels[obj->irq_index];
     uint32_t pin_index  = STM_PIN(obj->pin);
+    uint32_t gpio_addr = GPIOA_BASE + (GPIOB_BASE-GPIOA_BASE) * STM_PORT(obj->pin);
     uint32_t gpio_idx = pin_base_nr[pin_index];
-
+    
+    HAL_GPIO_DeInit((GPIO_TypeDef *)gpio_addr, (1<<pin_index));
     gpio_channel->pin_mask &= ~(1 << gpio_idx);
     gpio_channel->channel_ids[gpio_idx] = 0;
     gpio_channel->channel_gpio[gpio_idx] = 0;

--- a/targets/TARGET_STM/TARGET_STM32L4/gpio_irq_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/gpio_irq_api.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2016, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -225,7 +225,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
             irq_index = 6;
             break;
         default:
-            error("InterruptIn error: pin not supported\n");
+            error("InterruptIn error: pin not supported.\n");
             return -1;
     }
 
@@ -261,8 +261,10 @@ void gpio_irq_free(gpio_irq_t *obj)
 {
     gpio_channel_t *gpio_channel = &channels[obj->irq_index];
     uint32_t pin_index  = STM_PIN(obj->pin);
+    uint32_t gpio_addr = GPIOA_BASE + (GPIOB_BASE-GPIOA_BASE) * STM_PORT(obj->pin);
     uint32_t gpio_idx = pin_base_nr[pin_index];
-
+    
+    HAL_GPIO_DeInit((GPIO_TypeDef *)gpio_addr, (1<<pin_index));
     gpio_channel->pin_mask &= ~(1 << gpio_idx);
     gpio_channel->channel_ids[gpio_idx] = 0;
     gpio_channel->channel_gpio[gpio_idx] = 0;


### PR DESCRIPTION
## Description
This PR allows ci-test-shield interrupt-in test to pass on every STM32 platforms.
Issue: the code creates several `InterruptIn intin(int_pin); `with pins that are on the same interrupt line (EXTI ). The `gpio_irq_free` function called by `~InterruptIn()` was not clearing correctly the SYSCFG and EXTI registers. I have added the call to HAL_GPIO_DeInit in `gpio_irq_free ` so that those HW registers are correctly cleared.

ci-test-shield interrupt-in test has been validated the following targets:
- NUCLEO_F429ZI
- NUCLEO_F411RE
- NUCLEO_F070RB
- NUCLEO_L073RZ
- NUCLEO_F103RB
- NUCLEO_F207ZG
- NUCLEO_F746ZG
- NUCLEO_L476RG
- NUCLEO_F303RE

```
+-------------------+-----------------------+----------------------+--------+--------+--------+--------------------+
| target            | test suite            | test case            | passed | failed | result | elapsed_time (sec) |
+-------------------+-----------------------+----------------------+--------+--------+--------+--------------------+
| NUCLEO_L476RG-ARM | tests-api-interruptin | InterruptIn on DIO_2 | 1      | 0      | OK     | 0.05               |
| NUCLEO_L476RG-ARM | tests-api-interruptin | InterruptIn on DIO_3 | 1      | 0      | OK     | 0.05               |
| NUCLEO_L476RG-ARM | tests-api-interruptin | InterruptIn on DIO_4 | 1      | 0      | OK     | 0.05               |
| NUCLEO_L476RG-ARM | tests-api-interruptin | InterruptIn on DIO_5 | 1      | 0      | OK     | 0.06               |
| NUCLEO_L476RG-ARM | tests-api-interruptin | InterruptIn on DIO_6 | 1      | 0      | OK     | 0.05               |
| NUCLEO_L476RG-ARM | tests-api-interruptin | InterruptIn on DIO_7 | 1      | 0      | OK     | 0.06               |
| NUCLEO_L476RG-ARM | tests-api-interruptin | InterruptIn on DIO_8 | 1      | 0      | OK     | 0.05               |
| NUCLEO_L476RG-ARM | tests-api-interruptin | InterruptIn on DIO_9 | 1      | 0      | OK     | 0.05               |
+-------------------+-----------------------+----------------------+--------+--------+--------+--------------------+
```
This means that this PR is fixing the 'InterruptIn' part of the following issues : #2956 #2939 #2957 #2959 #2960
## Status
READY

## Migrations
NO

## Steps to test or reproduce
Refer to #2956 
@screamerbg @BlackstoneEngineering , you might be interested :) 