### PR TITLE
Support building mbed_critical.c with C++ compiler

### DIFF
--- a/platform/mbed_critical.c
+++ b/platform/mbed_critical.c
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+/* Declare __STDC_LIMIT_MACROS so stdint.h defines UINT32_MAX when using C++ */
+#define __STDC_LIMIT_MACROS
 #include "platform/critical.h"
 
 #include "cmsis.h"


### PR DESCRIPTION
## Description
Some developers prefer using a C++ compiler with C sources due to stricter syntax checking and other benefits. Currently [mbed_critical.c](https://github.com/ARMmbed/mbed-os/blob/master/platform/mbed_critical.c) is the only C source file in the mbed base library that does not build properly with a C++ compiler due to use of UINT32_MAX on an assertion. This change declares __STDC_LIMIT_MACROS on mbed_critical.c before the include of [critical.h](https://github.com/ARMmbed/mbed-os/blob/master/platform/critical.h) so the standard C limit macros are defined in stdint.h.

## Status
**READY**

## Related PRs
Discussed in #3276 and proposal by @0xc0170 selected for this PR
__STDC_LIMIT_MACROS declaration previously added in #1920 and removed in #2054
