### PR TITLE
Add sys import to config

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -17,6 +17,7 @@ limitations under the License.
 
 from copy import deepcopy
 import os
+import sys
 # Implementation of mbed configuration mechanism
 from tools.utils import json_file_to_dict
 from tools.targets import CUMULATIVE_ATTRIBUTES, TARGET_MAP, \


### PR DESCRIPTION
## Description
import sys into `config.py`, something that I aparently forgot to do some time ago. This change should allow the config system to print the precise location of a config error in an app config instead of simply breaking with a 'sys not defined'-like error


## Status
**READY**

## Todos
- [ ] Tests
- [ ] Review by @grbd

Should resolve #3281
