### PR TITLE
adding option to change stack size from compilation

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
@@ -69,12 +69,13 @@
 #endif
 
 // The stack space occupied is mainly dependent on the underling C standard library
-#if defined(TOOLCHAIN_GCC) || defined(TOOLCHAIN_ARM_STD) || defined(TOOLCHAIN_IAR)
-#    define WORDS_STACK_SIZE   512
-#elif defined(TOOLCHAIN_ARM_MICRO)
-#    define WORDS_STACK_SIZE   128
+#ifndef WORDS_STACK_SIZE
+#	if defined(TOOLCHAIN_GCC) || defined(TOOLCHAIN_ARM_STD) || defined(TOOLCHAIN_IAR)
+#	    define WORDS_STACK_SIZE   512
+#	elif defined(TOOLCHAIN_ARM_MICRO)
+#	    define WORDS_STACK_SIZE   128
+#	endif
 #endif
-
 #ifdef __MBED_CMSIS_RTOS_CM
 
 /* Single thread - disable timers and set task count to one */


### PR DESCRIPTION
Notes:
* Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
* This is just a template, so feel free to use/remove the unnecessary things

## Description
enable defining the WORDS_STACK_SIZE from compilation
this will create easier way to change the stack size without touching the code


## Status
READY

email :netgon01@arm.com

adding option to change stack size from compilation.

this will give easier way to change the stack size without
changing the code.