### PR TITLE
Add LOWPOWERTIMER for NUCLEO_F401RE and DISCO_F429ZI

### DIFF
--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -45,6 +45,14 @@ void lp_ticker_init(void)
 
     rtc_init();
     rtc_set_irq_handler((uint32_t) lp_ticker_irq_handler);
+
+#ifdef MBED_HEAP_STATS_ENABLED
+    /* rtc_read is using mktime function which is calling at the first time __wrap__free_r */
+    /* __wrap__free_r needs to initialize Singleton not in ISR */
+    /* rtc_read is called at each ticker setup which call core_util_critical_section_enter */
+    /* so rtc_read is called once once before other calls */
+    rtc_read();
+#endif /* MBED_HEAP_STATS_ENABLED */
 }
 
 uint32_t lp_ticker_read(void)

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -816,7 +816,7 @@
         "inherits": ["Target"],
         "detect_code": ["0720"],
         "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2", "USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "device_has": ["LOWPOWERTIMER", "ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F401RE"
     },
@@ -1169,7 +1169,7 @@
         "extra_labels": ["STM", "STM32F4", "STM32F429", "STM32F429ZI", "STM32F429xx"],
         "macros": ["RTC_LSI=1","TRANSACTION_QUEUE_SIZE_SPI=2", "USBHOST_OTHER"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "TRNG"],
+        "device_has": ["LOWPOWERTIMER", "ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "TRNG"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F429ZI"
     },


### PR DESCRIPTION
## Description
Add LOWPOWERTIMER for NUCLEO_F401RE and DISCO_F429ZI

## Status
READY

## Tests
Tests done on top of https://github.com/ARMmbed/mbed-os/pull/3316

Thx
