### PR TITLE
STM32 - Add ADC_VREF label

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F303VC/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F303VC/PinNames.h
@@ -185,6 +185,7 @@ typedef enum {
     ADC_VREF2   = 0xF2,
     ADC_VREF3   = 0xF3,
     ADC_VREF4   = 0xF4,
+    ADC_VREF    = ADC_VREF1,
     ADC_VBAT    = 0xF5,
     ADC_VOPAMP1 = 0xF6,
     ADC_VOPAMP2 = 0xF7,

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F334C8/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F334C8/PinNames.h
@@ -122,6 +122,7 @@ typedef enum {
     ADC_TEMP    = 0xF0,
     ADC_VREF1   = 0xF1,
     ADC_VREF2   = 0xF2,
+    ADC_VREF    = ADC_VREF1,
     ADC_VBAT    = 0xF3,
     ADC_VOPAMP2 = 0xF4,
 

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/PinNames.h
@@ -109,6 +109,7 @@ typedef enum {
     ADC_TEMP    = 0xF0,
     ADC_VREF1   = 0xF1,
     ADC_VREF2   = 0xF2,
+    ADC_VREF    = ADC_VREF1,
     ADC_VBAT    = 0xF3,
     ADC_VOPAMP2 = 0xF4,
 

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303RE/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303RE/PinNames.h
@@ -139,6 +139,7 @@ typedef enum {
     ADC_VREF2   = 0xF2,
     ADC_VREF3   = 0xF3,
     ADC_VREF4   = 0xF4,
+    ADC_VREF    = ADC_VREF1,
     ADC_VBAT    = 0xF5,
     ADC_VOPAMP1 = 0xF6,
     ADC_VOPAMP2 = 0xF7,

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303ZE/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303ZE/PinNames.h
@@ -206,6 +206,7 @@ typedef enum {
     ADC_VREF2   = 0xF2,
     ADC_VREF3   = 0xF3,
     ADC_VREF4   = 0xF4,
+    ADC_VREF    = ADC_VREF1,
     ADC_VBAT    = 0xF5,
     ADC_VOPAMP1 = 0xF6,
     ADC_VOPAMP2 = 0xF7,

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F334R8/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F334R8/PinNames.h
@@ -137,6 +137,7 @@ typedef enum {
     ADC_TEMP    = 0xF0,
     ADC_VREF1   = 0xF1,
     ADC_VREF2   = 0xF2,
+    ADC_VREF    = ADC_VREF1,
     ADC_VBAT    = 0xF3,
     ADC_VOPAMP2 = 0xF4,
 


### PR DESCRIPTION
## Description
Add ADC_VREF label on some platforms where only ADC_VREF1, 2, etc... were defined. This is mainly to avoid compilation error with examples that use it.

## Status
READY

## Migrations
NO
