### PR TITLE
DISCO_L053C8 doesn't support LSE

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1179,6 +1179,7 @@
         "default_toolchain": "ARM",
         "extra_labels": ["STM", "STM32L0", "STM32L053C8"],
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "macros": ["RTC_LSI=1"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "default_lib": "small",
         "release_versions": ["2"],


### PR DESCRIPTION
## Description
DISCO_L053C8 doesn't support LSE

## Status
READY

## Test

MBED_16 OS2 test was previously FAIL, it is now OK

