### PR TITLE
Fix project profile parsing

### DIFF
--- a/tools/project.py
+++ b/tools/project.py
@@ -15,13 +15,12 @@ from tools.export import EXPORTERS, mcu_ide_matrix
 from tools.tests import TESTS, TEST_MAP
 from tools.tests import test_known, test_name_known, Test
 from tools.targets import TARGET_NAMES
-from tools.utils import argparse_filestring_type, argparse_many, args_error
+from tools.utils import argparse_filestring_type, argparse_profile_filestring_type, argparse_many, args_error
 from tools.utils import argparse_force_lowercase_type
 from tools.utils import argparse_force_uppercase_type
 from tools.utils import print_large_string
 from tools.project_api import export_project, get_exporter_toolchain
-from tools.options import extract_profile
-
+from tools.options import extract_profile, list_profiles
 
 def setup_project(ide, target, program=None, source_dir=None, build=None, export_path=None):
     """Generate a name, if not provided, and find dependencies
@@ -172,10 +171,11 @@ def main():
                         dest="macros",
                         help="Add a macro definition")
 
-    parser.add_argument("--profile",
-                        type=argparse_filestring_type,
-                        default=[],
-                        help="Toolchain profile")
+    parser.add_argument("--profile", dest="profile", action="append",
+                        type=argparse_profile_filestring_type,
+                        help="Build profile to use. Can be either path to json" \
+                        "file or one of the default one ({})".format(", ".join(list_profiles())),
+                        default=[])
 
     parser.add_argument("--update-packs",
                         dest="update_packs",


### PR DESCRIPTION
## Description
Copied from #3313
>### Description
>- Type: Bug
>- Priority: Minor
>
>---------------------------------------------------------------
>## Bug
>
>**Target**
>Any
>
>**Toolchain:**
>GCC_ARM
>
>**Toolchain version:**
>Any
>
>**mbed-cli version:** 
>0.9.10
>
>**meed-os sha:**
>a1c0840b3d Merge pull request #3227 from ARMmbed/release-candidate
>
>**Expected behavior**
>```bash
>mbed export --profile ./mbed-os/tools/profiles/debug.json -i make_gcc_arm 
>```
>should use the debug profile when generating the Makefile.
>
>**Actual behavior**
>```bash
>Traceback (most recent call last):
>  File "/dev/mbed-os/tools/project.py", line 247, in <module>
>    main()
>  File "/dev/mbed-os/tools/project.py", line 239, in main
>    profile = extract_profile(parser, options, toolchain_name)
>  File "/dev/mbed-os/tools/options.py", line 107, in extract_profile
>    contents = load(open(filename))
>IOError: [Errno 2] No such file or directory: 'm'
>[mbed] ERROR: "python" returned error code 1.
>[mbed] ERROR: Command "python -u /dev/mbed-os/tools/project.py -i make_gcc_arm -m >MAX32550 --source . --profile mbed-os/tools/profiles/debug.json" in "/dev"
>```

## Status
**READY**

## Todos
- [ ] Tests

thanks @sdive!