### PR TITLE
Enabled example export building for more examples

### DIFF
--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -28,7 +28,7 @@
       "toolchains" : ["GCC_ARM", "ARM"],
       "exporters": [],
       "compile" : true,
-      "export": false,
+      "export": true,
       "auto-update" : true
     },
     {
@@ -37,12 +37,15 @@
       "mbed": [
           "https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-mesh-minimal"
       ],
-      "features" : ["IPV6"],
-      "targets" : [],
+      "features" : [],
+      "targets" : ["DISCO_F469NI", "DISCO_F746NG", "K64F", "K66F",
+                   "NUCLEO_F429ZI", "NUCLEO_F439ZI", "NUCLEO_F746ZG",
+                   "NUCLEO_F756ZG", "NUCLEO_F767ZI",
+                   "NUMAKER_PFM_NUC472", "UBLOX_EVK_ODIN_W2"],
       "toolchains" : [],
       "exporters": [],
       "compile" : true,
-      "export": false,
+      "export": true,
       "auto-update" : true
     },
     {
@@ -74,11 +77,11 @@
       "mbed": [
           "https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-client"
       ],
-      "features" : ["IPV6"],
+      "features" : ["LWIP"],
       "targets" : [],
       "toolchains" : [],
       "exporters": [],
-      "compile" : true,
+      "compile" : false,
       "export": false,
       "auto-update" : true
     },
@@ -87,12 +90,12 @@
       "github":"https://github.com/ARMmbed/mbed-os-example-sockets",
       "mbed": [
       ],
-      "features" : ["IPV6"],
+      "features" : ["LWIP"],
       "targets" : [],
       "toolchains" : [],
       "exporters": [],
       "compile" : true,
-      "export": false,
+      "export": true,
       "auto-update" : true
     },
     {
@@ -117,7 +120,7 @@
       "toolchains" : ["GCC_ARM"],
       "exporters": [],
       "compile" : true,
-      "export": false,
+      "export": true,
       "auto-update" : false
     },
     {
@@ -129,7 +132,7 @@
       "toolchains" : ["GCC_ARM"],
       "exporters": [],
       "compile" : true,
-      "export": false,
+      "export": true,
       "auto-update" : false
     },
     {
@@ -141,7 +144,7 @@
       "toolchains" : ["GCC_ARM"],
       "exporters": [],
       "compile" : true,
-      "export": false,
+      "export": true,
       "auto-update" : false
     }
   ]

--- a/tools/test/examples/examples_lib.py
+++ b/tools/test/examples/examples_lib.py
@@ -101,7 +101,7 @@ def target_cross_toolchain(allowed_targets, allowed_toolchains, features=[]):
                 yield target, toolchain
 
 
-def target_cross_ide(allowed_targets, allowed_ides, features=[]):
+def target_cross_ide(allowed_targets, allowed_ides, features=[], toolchains=[]):
     """Generate pairs of target and ides
 
     Args:
@@ -115,6 +115,7 @@ def target_cross_ide(allowed_targets, allowed_ides, features=[]):
     for target in allowed_targets:
         for ide in allowed_ides:
             if (target in EXPORTERS[ide].TARGETS and
+                (not toolchains or EXPORTERS[ide].TOOLCHAIN in toolchains) and
                 all(feature in TARGET_MAP[target].features
                     for feature in features)):
                 yield target, ide
@@ -268,7 +269,7 @@ def export_repos(config, ides, targets, examples):
                 # list of valid combinations to work through
                 for target, ide in target_cross_ide(valid_choices(example['targets'], targets),
                                                     valid_choices(example['exporters'], ides),
-                                                    example['features']):
+                                                    example['features'], example['toolchains']):
                     example_name = "{} {} {}".format(example_project_name, target,
                                                      ide)
                     def status(message):


### PR DESCRIPTION
## Description
Turns on export building for many examples that we should be building, and filters exporters with the toolchain specified in the example JSON file.

## TODO
- [x] CI!
- [x] Check that CI ran the additional tests that were turned on.