### PR TITLE
STM32 - Remove TIM_IT_UPDATE flag in HAL_Suspend/ResumeTick functions

### DIFF
--- a/targets/TARGET_STM/hal_tick_16b.c
+++ b/targets/TARGET_STM/hal_tick_16b.c
@@ -167,15 +167,13 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 void HAL_SuspendTick(void)
 {
     TimMasterHandle.Instance = TIM_MST;
-    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
-    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
 }
 
 void HAL_ResumeTick(void)
 {
     TimMasterHandle.Instance = TIM_MST;
-    // Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
 }
 
 #endif // TIM_MST_16BIT

--- a/targets/TARGET_STM/hal_tick_32b.c
+++ b/targets/TARGET_STM/hal_tick_32b.c
@@ -130,15 +130,13 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 void HAL_SuspendTick(void)
 {
     TimMasterHandle.Instance = TIM_MST;
-    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
-    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
 }
 
 void HAL_ResumeTick(void)
 {
     TimMasterHandle.Instance = TIM_MST;
-    // Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
 }
 
 #endif // !TIM_MST_16BIT


### PR DESCRIPTION
## Description
After PR #3213 has been merged we discovered that LPT tests were failed. This was due to the TIM_IT_UPDATE flag added in the HAL_Suspend/ResumeTick functions. With this PR, the LPT tests are now pass.

## Status
READY

## Migrations
NO
