### PR TITLE
USB_4 : test OK with IAR ,GCC_ARM(limitation to ARM not needed)

### DIFF
--- a/tools/tests.py
+++ b/tools/tests.py
@@ -987,7 +987,6 @@ TESTS = [
         "id": "USB_4", "description": "Serial Port",
         "source_dir": join(TEST_DIR, "usb", "device", "serial"),
         "dependencies": [MBED_LIBRARIES, USB_LIBRARIES],
-        "supported": CORTEX_ARM_SUPPORT,
     },
     {
         "id": "USB_5", "description": "Generic HID",


### PR DESCRIPTION
## Description
Remove the limitation of USB_4 to ARM toolchain

## Status
Test is OK on  IAR and GCC_ARM .
READY


## Migrations
No 


