### PR TITLE
[Exporters] Fix generic ARM CPU target in uvision

### DIFF
--- a/tools/export/cmsis/__init__.py
+++ b/tools/export/cmsis/__init__.py
@@ -58,7 +58,7 @@ class DeviceCMSIS():
             try:
                 # Try to find the core as a generic CMSIS target
                 cpu_name = DeviceCMSIS.cpu_cmsis(t.core)
-                target_info = DeviceCMSIS.index[cpu_name]
+                target_info = DeviceCMSIS.CACHE.index[cpu_name]
             except:
                 return False
         target_info["_cpu_name"] = cpu_name


### PR DESCRIPTION
When a target does not have a device name, we want to use a generic ARM cpu export target. This fixes a bug in the implementation of that functionality.

Reproduce:
Run `mbed export` on a target without a device name. It should not fail, as the intended logic was for this line to find a generic CPU target. However, as it is, it will fail.

@theotherjimmy