### PR TITLE
Increase stack size in malloc test for Cortex-A

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/malloc/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/malloc/main.cpp
@@ -7,7 +7,11 @@
 #endif
 
 #define NUM_THREADS         5
+#if defined(__CORTEX_A9)
+#define THREAD_STACK_SIZE   DEFAULT_STACK_SIZE
+#else
 #define THREAD_STACK_SIZE   256
+#endif
 
 DigitalOut led1(LED1);
 volatile bool should_exit = false;


### PR DESCRIPTION
Increase the stack size used in the malloc test to prevent stack overflows on Cortex-A devices.