### PR TITLE
Fix DEBUG target keyword for GCC_ARM

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -472,7 +472,7 @@ class mbedToolchain:
 
             # This is a policy decision and it should /really/ be in the config system
             # ATM it's here for backward compatibility
-            if (("-g" in self.flags['common'] and
+            if ((("-g" in self.flags['common'] or "-g3" in self.flags['common']) and
                  "-O0") in self.flags['common'] or
                 ("-r" in self.flags['common'] and
                  "-On" in self.flags['common'])):


### PR DESCRIPTION
Fixes mbed-cli#402 bug. -g flag was changed to g3, thus this caused
a regression in producing TARGET_DEBUG for GCC_ARM.

Tested with all 3 toolchains, using TARGET_DEBUG/RELEASE folder and also getting labels to be certain they are correct.

@theotherjimmy @AlessandroA 