### PR TITLE
Don't send events on close()

### DIFF
--- a/features/netsocket/TCPServer.cpp
+++ b/features/netsocket/TCPServer.cpp
@@ -18,7 +18,7 @@
 #include "mbed.h"
 
 TCPServer::TCPServer()
-    : _pending(0), _accept_sem(0)
+    : _pending(1), _accept_sem(0)
 {
 }
 

--- a/features/netsocket/TCPServer.h
+++ b/features/netsocket/TCPServer.h
@@ -46,7 +46,7 @@ public:
      */
     template <typename S>
     TCPServer(S *stack)
-        : _pending(0), _accept_sem(0)
+        : _pending(1), _accept_sem(0)
     {
         open(stack);
     }

--- a/features/netsocket/TCPSocket.cpp
+++ b/features/netsocket/TCPSocket.cpp
@@ -19,7 +19,7 @@
 #include "mbed_assert.h"
 
 TCPSocket::TCPSocket()
-    : _pending(0), _read_sem(0), _write_sem(0),
+    : _pending(1), _read_sem(0), _write_sem(0),
       _read_in_progress(false), _write_in_progress(false)
 {
 }

--- a/features/netsocket/TCPSocket.h
+++ b/features/netsocket/TCPSocket.h
@@ -45,7 +45,7 @@ public:
      */
     template <typename S>
     TCPSocket(S *stack)
-        : _pending(0), _read_sem(0), _write_sem(0),
+        : _pending(1), _read_sem(0), _write_sem(0),
           _read_in_progress(false), _write_in_progress(false)
     {
         open(stack);

--- a/features/netsocket/UDPSocket.cpp
+++ b/features/netsocket/UDPSocket.cpp
@@ -19,7 +19,7 @@
 #include "mbed_assert.h"
 
 UDPSocket::UDPSocket()
-    : _pending(0), _read_sem(0), _write_sem(0)
+    : _pending(1), _read_sem(0), _write_sem(0)
 {
 }
 

--- a/features/netsocket/UDPSocket.h
+++ b/features/netsocket/UDPSocket.h
@@ -45,7 +45,7 @@ public:
      */
     template <typename S>
     UDPSocket(S *stack)
-        : _pending(0), _read_sem(0), _write_sem(0)
+        : _pending(1), _read_sem(0), _write_sem(0)
     {
         open(stack);
     }


### PR DESCRIPTION
Don't send events on close()
It's currently possible to generate a socket event when a non-blocking socket is closed:

1. _pending is set to 0 in https://github.com/ARMmbed/mbed-os/blob/master/features/netsocket/TCPSocket.cpp#L22
   when the socket is created.
2. close() calls event() in https://github.com/ARMmbed/mbed-os/blob/master/features/netsocket/Socket.cpp#L66
3. event() increments _pending, and since _pending is 1 it will call _callback() in https://github.com/ARMmbed/mbed-os/blob/master/features/netsocket/TCPSocket.cpp#L167

However, if send() (for example) is called, this can happen:

- send() is called and sets _pending to 0.
- when the data is sent, event() is called, which sets _pending to 1 and calls _callback().
- if close() is called at this point, there won't be an event generated for close() anymore,
  since _pending will be set to 2.

(same thing for recv)

This PR changes the initial value of _pending to 1 instead of 0, so that
events are never generated for close().