### PR TITLE
STM32 NUCLEO-L152RE Update system core clock to 32MHz

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/system_stm32l1xx.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/system_stm32l1xx.c
@@ -27,13 +27,13 @@
   *                                    | 2- PLL_HSE_XTAL        |
   *                                    | (external 8 MHz xtal)  |
   *-----------------------------------------------------------------------------
-  * SYSCLK(MHz)                        | 24                     | 32
+  * SYSCLK(MHz)                        | 32                     | 32
   *-----------------------------------------------------------------------------
-  * AHBCLK (MHz)                       | 24                     | 32
+  * AHBCLK (MHz)                       | 32                     | 32
   *-----------------------------------------------------------------------------
-  * APB1CLK (MHz)                      | 24                     | 32
+  * APB1CLK (MHz)                      | 32                     | 32
   *-----------------------------------------------------------------------------
-  * APB2CLK (MHz)                      | 24                     | 32
+  * APB2CLK (MHz)                      | 32                     | 32
   *-----------------------------------------------------------------------------
   * USB capable (48 MHz precise clock) | YES                    | NO
   *-----------------------------------------------------------------------------
@@ -540,8 +540,8 @@ uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
   // USBCLK = 48 MHz (8 MHz * 6) --> USB OK
   RCC_OscInitStruct.PLL.PLLState        = RCC_PLL_ON;
   RCC_OscInitStruct.PLL.PLLSource       = RCC_PLLSOURCE_HSE;
-  RCC_OscInitStruct.PLL.PLLMUL          = RCC_PLL_MUL6;
-  RCC_OscInitStruct.PLL.PLLDIV          = RCC_PLL_DIV2;
+  RCC_OscInitStruct.PLL.PLLMUL          = RCC_PLL_MUL12;
+  RCC_OscInitStruct.PLL.PLLDIV          = RCC_PLL_DIV3;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
   {
     return 0; // FAIL
@@ -549,10 +549,10 @@ uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
  
   /* Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2 clocks dividers */
   RCC_ClkInitStruct.ClockType      = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
-  RCC_ClkInitStruct.SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK; // 24 MHz
-  RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;         // 24 MHz
-  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;           // 24 MHz
-  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;           // 24 MHz
+  RCC_ClkInitStruct.SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK; // 32 MHz
+  RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;         // 32 MHz
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;           // 32 MHz
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;           // 32 MHz
   if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1) != HAL_OK)
   {
     return 0; // FAIL

--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -584,7 +584,7 @@
 #define OS_MAINSTKSIZE          256
 #endif
 #ifndef OS_CLOCK
-#define OS_CLOCK                24000000
+#define OS_CLOCK                32000000
 #endif
 
 #elif defined(TARGET_NZ32_SC151)


### PR DESCRIPTION
## Description

The NUCLEO-L152RE can run up to 32 MHz even if clocked from HSE as can be configured in cubeMX

![image](https://cloud.githubusercontent.com/assets/17590297/20936866/94ce18a6-bbe4-11e6-9742-107471ecbdea.png)

## Status
**READY**

Full non regression OK 

[report__mbed_os_non_regression_L1_fix_RCC__2016_12_06_12_02__ARM_IAR_GCC.zip](https://github.com/ARMmbed/mbed-os/files/634602/report__mbed_os_non_regression_L1_fix_RCC__2016_12_06_12_02__ARM_IAR_GCC.zip)



