### PR TITLE
STM32F0 : map ST HAL assert into MBED assert

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/device/stm32f042x6.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/device/stm32f042x6.h
@@ -10274,7 +10274,7 @@ typedef struct
 #define IS_ADC_COMMON_INSTANCE(INSTANCE) ((INSTANCE) == ADC)
 
 /******************************* CAN Instances ********************************/
-#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN)
+#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN1)
 
 /****************************** CEC Instances *********************************/
 #define IS_CEC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CEC)

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/stm32f072xb.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/stm32f072xb.h
@@ -10849,7 +10849,7 @@ typedef struct
 #define IS_ADC_COMMON_INSTANCE(INSTANCE) ((INSTANCE) == ADC)
 
 /******************************* CAN Instances ********************************/
-#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN)
+#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN1)
 
 /****************************** COMP Instances *********************************/
 #define IS_COMP_ALL_INSTANCE(INSTANCE) (((INSTANCE) == COMP1) || \

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/device/stm32f091xc.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/device/stm32f091xc.h
@@ -11384,7 +11384,7 @@ typedef struct
 #define IS_ADC_COMMON_INSTANCE(INSTANCE) ((INSTANCE) == ADC)
 
 /******************************* CAN Instances ********************************/
-#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN)
+#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN1)
 
 /****************************** COMP Instances *********************************/
 #define IS_COMP_ALL_INSTANCE(INSTANCE) (((INSTANCE) == COMP1) || \

--- a/targets/TARGET_STM/TARGET_STM32F0/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/analogin_api.c
@@ -71,7 +71,7 @@ void analogin_init(analogin_t *obj, PinName pin) {
         AdcHandle.Init.ClockPrescaler        = ADC_CLOCK_SYNC_PCLK_DIV4;
         AdcHandle.Init.Resolution            = ADC_RESOLUTION12b;
         AdcHandle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
-        AdcHandle.Init.ScanConvMode          = DISABLE;
+        AdcHandle.Init.ScanConvMode          = ADC_SCAN_DIRECTION_FORWARD;
         AdcHandle.Init.EOCSelection          = EOC_SINGLE_CONV;
         AdcHandle.Init.LowPowerAutoWait      = DISABLE;
         AdcHandle.Init.LowPowerAutoPowerOff  = DISABLE;

--- a/targets/TARGET_STM/TARGET_STM32F0/device/stm32f0xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/device/stm32f0xx_hal_conf.h
@@ -296,9 +296,8 @@
   *         If expr is true, it returns no value.
   * @retval None
   */
-  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
-/* Exported functions ------------------------------------------------------- */
-  void assert_failed(uint8_t* file, uint32_t line);
+  #include "mbed_assert.h"
+  #define assert_param(expr) MBED_ASSERT(expr)
 #else
   #define assert_param(expr) ((void)0U)
 #endif /* USE_FULL_ASSERT */    

--- a/targets/TARGET_STM/TARGET_STM32F0/gpio_irq_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/gpio_irq_api.c
@@ -240,7 +240,7 @@ void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
                 mode = STM_MODE_IT_FALLING;
                 obj->event = EDGE_FALL;
             } else { // NONE or RISE
-                mode = STM_MODE_IT_EVT_RESET;
+                mode = STM_MODE_INPUT;
                 obj->event = EDGE_NONE;
             }
         }
@@ -249,7 +249,7 @@ void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
                 mode = STM_MODE_IT_RISING;
                 obj->event = EDGE_RISE;
             } else { // NONE or FALL
-                mode = STM_MODE_IT_EVT_RESET;
+                mode = STM_MODE_INPUT;
                 obj->event = EDGE_NONE;
             }
         }


### PR DESCRIPTION
## Description
ST HAL assert is mapped onto MBED HAL assert, and can now be enabled easily.

Note for all STM32 targets:
- ST asserts are used to check each parameters in ST HAL function call
- They are not compiled by default, you have to define USE_FULL_ASSERT to enable them

## Test

OS2 and OS5 tests done.
Few updates have been needed to match ST HAL API.

## Status
READY
