### PR TITLE
STM32F1 : map ST HAL assert into MBED assert

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_conf.h
@@ -350,9 +350,8 @@
   *         If expr is true, it returns no value.
   * @retval None
   */
-  #define assert_param(expr) ((expr) ? (void)0 : assert_failed((uint8_t *)__FILE__, __LINE__))
-/* Exported functions ------------------------------------------------------- */
-  void assert_failed(uint8_t* file, uint32_t line);
+  #include "mbed_assert.h"
+  #define assert_param(expr) MBED_ASSERT(expr)
 #else
   #define assert_param(expr) ((void)0)
 #endif /* USE_FULL_ASSERT */

--- a/targets/TARGET_STM/TARGET_STM32F1/gpio_irq_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/gpio_irq_api.c
@@ -304,7 +304,7 @@ void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
                 mode = STM_MODE_IT_FALLING;
                 obj->event = EDGE_FALL;
             } else { // NONE or RISE
-                mode = STM_MODE_IT_EVT_RESET;
+                mode = STM_MODE_INPUT;
                 obj->event = EDGE_NONE;
             }
         }
@@ -313,7 +313,7 @@ void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
                 mode = STM_MODE_IT_RISING;
                 obj->event = EDGE_RISE;
             } else { // NONE or FALL
-                mode = STM_MODE_IT_EVT_RESET;
+                mode = STM_MODE_INPUT;
                 obj->event = EDGE_NONE;
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F1/pinmap.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/pinmap.c
@@ -191,7 +191,7 @@ void pin_mode(PinName pin, PinMode mode)
             // set pull-up => bit=1, set pull-down => bit = 0
             if (mode == PullUp) {
                 gpio->ODR |= (0x01 << (pin_index)); // Set pull-up
-            } else{
+            } else {
                 gpio->ODR &= ~(0x01 << (pin_index)); // Set pull-down
             }
             break;
@@ -209,7 +209,8 @@ void pin_mode(PinName pin, PinMode mode)
 /*  Internal function for setting the gpiomode/function
  *  without changing Pull mode
  */
-void pin_function_gpiomode(PinName pin, uint32_t gpiomode) {
+void pin_function_gpiomode(PinName pin, uint32_t gpiomode)
+{
 
     /* Read current pull state from HW to avoid over-write*/
     uint32_t port_index = STM_PORT(pin);
@@ -228,13 +229,14 @@ void pin_function_gpiomode(PinName pin, uint32_t gpiomode) {
     }
 
     /*  Check if pull/pull down is active */
-    if ((!(*gpio_reg_hl & (0x03 << shift))) // input
-        && (!!(*gpio_reg_hl & (0x08 << shift))) // pull-up / down
-        && (!(*gpio_reg_hl & (0x04 << shift)))) { // GPIOx_CRL.CNFx.bit0 = 0
-        if (!!(gpio->ODR & (0x01 << pin_index))) {
-            pull = PullUp;
-        } else {
-            pull = PullDown;
+    if (!(*gpio_reg_hl & (0x03 << shift))) {// input
+        if((!!(*gpio_reg_hl & (0x08 << shift))) // pull-up / down
+                && (!(*gpio_reg_hl & (0x04 << shift)))) { // GPIOx_CRL.CNFx.bit0 = 0
+            if (!!(gpio->ODR & (0x01 << pin_index))) {
+                pull = PullUp;
+            } else {
+                pull = PullDown;
+            }
         }
     } else { //output
         if (!!(*gpio_reg_hl & (0x04 << shift))) { //open drain

--- a/targets/TARGET_STM/TARGET_STM32F1/rtc_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/rtc_api.c
@@ -159,7 +159,7 @@ time_t rtc_read(void)
     timeinfo.tm_wday = dateStruct.WeekDay;
     timeinfo.tm_mon  = dateStruct.Month - 1;
     timeinfo.tm_mday = dateStruct.Date;
-    timeinfo.tm_year = dateStruct.Year;
+    timeinfo.tm_year = dateStruct.Year + 68;
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
@@ -186,7 +186,7 @@ void rtc_write(time_t t)
     dateStruct.WeekDay        = timeinfo->tm_wday;
     dateStruct.Month          = timeinfo->tm_mon + 1;
     dateStruct.Date           = timeinfo->tm_mday;
-    dateStruct.Year           = timeinfo->tm_year;
+    dateStruct.Year           = timeinfo->tm_year - 68;
     timeStruct.Hours          = timeinfo->tm_hour;
     timeStruct.Minutes        = timeinfo->tm_min;
     timeStruct.Seconds        = timeinfo->tm_sec;


### PR DESCRIPTION
## Description
ST HAL assert is mapped onto MBED HAL assert, and can now be enabled easily.

Note for all STM32 targets:
- ST asserts are used to check each parameters in ST HAL function call
- They are not compiled by default, you have to define USE_FULL_ASSERT to enable them

## Test

OS2 and OS5 tests done.

Few updates have been needed to match ST HAL API.

## Status
READY
