### PR TITLE
Remove deprecated flags args

### DIFF
--- a/tools/options.py
+++ b/tools/options.py
@@ -22,7 +22,12 @@ from tools.toolchains import TOOLCHAINS
 from tools.targets import TARGET_NAMES
 from tools.utils import argparse_force_uppercase_type, \
     argparse_lowercase_hyphen_type, argparse_many, \
-    argparse_filestring_type, args_error, argparse_profile_filestring_type
+    argparse_filestring_type, args_error, argparse_profile_filestring_type,\
+    argparse_deprecate
+
+FLAGS_DEPRECATION_MESSAGE = "Please use the --profile argument instead.\n"\
+                            "Documentation may be found in "\
+                            "docs/Toolchain_Profiles.md"
 
 def get_default_options_parser(add_clean=True, add_options=True,
                                add_app_config=False):
@@ -59,14 +64,17 @@ def get_default_options_parser(add_clean=True, add_options=True,
                         help="print Warnings, and Errors in color",
                         action="store_true", default=False)
 
-    parser.add_argument("--cflags", default=[], action="append",
-                        help="Extra flags to provide to the C compiler")
+    parser.add_argument("--cflags",
+                        type=argparse_deprecate(FLAGS_DEPRECATION_MESSAGE),
+                        help="Deprecated. " + FLAGS_DEPRECATION_MESSAGE)
 
-    parser.add_argument("--asmflags", default=[], action="append",
-                        help="Extra flags to provide to the assembler")
+    parser.add_argument("--asmflags",
+                        type=argparse_deprecate(FLAGS_DEPRECATION_MESSAGE),
+                        help="Deprecated. " + FLAGS_DEPRECATION_MESSAGE)
 
-    parser.add_argument("--ldflags", default=[], action="append",
-                        help="Extra flags to provide to the linker")
+    parser.add_argument("--ldflags",
+                        type=argparse_deprecate(FLAGS_DEPRECATION_MESSAGE),
+                        help="Deprecated. " + FLAGS_DEPRECATION_MESSAGE)
 
     if add_clean:
         parser.add_argument("-c", "--clean", action="store_true", default=False,

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -488,6 +488,13 @@ def argparse_dir_not_parent(other):
             return not_parent
     return parse_type
 
+def argparse_deprecate(replacement_message):
+    """fail if argument is provided with deprecation warning"""
+    def parse_type(_):
+        """The parser type"""
+        raise argparse.ArgumentTypeError("Deprecated." + replacement_message)
+    return parse_type
+
 def print_large_string(large_string):
     """ Breaks a string up into smaller pieces before print them
 


### PR DESCRIPTION
## Status
**READY**


## Migrations
YES

Anyone using the `--cflags`, `--cppflags`, or `--ldflags` arguments are advised that they have no affect, and should stop passing them. Please migrate any flag shenanigans to using `--profile`

## TODOs
- [ ] CI