### PR TITLE
STM32F2 : map ST HAL assert into MBED assert

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_conf.h
@@ -382,9 +382,8 @@
   *         If expr is true, it returns no value.
   * @retval None
   */
-  #define assert_param(expr) ((expr) ? (void)0 : assert_failed((uint8_t *)__FILE__, __LINE__))
-/* Exported functions ------------------------------------------------------- */
-  void assert_failed(uint8_t* file, uint32_t line);
+  #include "mbed_assert.h"
+  #define assert_param(expr) MBED_ASSERT(expr)
 #else
   #define assert_param(expr) ((void)0)
 #endif /* USE_FULL_ASSERT */

--- a/targets/TARGET_STM/TARGET_STM32F2/gpio_irq_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/gpio_irq_api.c
@@ -304,7 +304,7 @@ void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
                 mode = STM_MODE_IT_FALLING;
                 obj->event = EDGE_FALL;
             } else { // NONE or RISE
-                mode = STM_MODE_IT_EVT_RESET;
+                mode = STM_MODE_INPUT;
                 obj->event = EDGE_NONE;
             }
         }
@@ -313,7 +313,7 @@ void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
                 mode = STM_MODE_IT_RISING;
                 obj->event = EDGE_RISE;
             } else { // NONE or FALL
-                mode = STM_MODE_IT_EVT_RESET;
+                mode = STM_MODE_INPUT;
                 obj->event = EDGE_NONE;
             }
         }


### PR DESCRIPTION
## Description
ST HAL assert is mapped onto MBED HAL assert, and can now be enabled easily.

Note for all STM32 targets:
- ST asserts are used to check each parameters in ST HAL function call
- They are not compiled by default, you have to define USE_FULL_ASSERT to enable them

## Test

OS2 and OS5 tests done.

Few updates have been needed to match ST HAL API.

## Status
READY

