### PR TITLE
STM32F3 : map ST HAL assert into MBED assert

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F302R8/device/stm32f302x8.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F302R8/device/stm32f302x8.h
@@ -11857,7 +11857,7 @@ typedef struct
 #define IS_ADC_COMMON_INSTANCE(INSTANCE) ((INSTANCE) == ADC1_COMMON)
 
 /****************************** CAN Instances *********************************/
-#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN)
+#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN1)
 
 /****************************** COMP Instances ********************************/
 #define IS_COMP_ALL_INSTANCE(INSTANCE) (((INSTANCE) == COMP2) || \

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/device/stm32f303x8.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/device/stm32f303x8.h
@@ -11626,7 +11626,7 @@ typedef struct
 
 #define IS_ADC_COMMON_INSTANCE(INSTANCE) ((INSTANCE) == ADC12_COMMON)
 /****************************** CAN Instances *********************************/
-#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN)
+#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN1)
 
 /****************************** COMP Instances ********************************/
 #define IS_COMP_ALL_INSTANCE(INSTANCE) (((INSTANCE) == COMP2) || \

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303RE/device/stm32f303xe.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303RE/device/stm32f303xe.h
@@ -14509,7 +14509,7 @@ typedef struct
                                           ((INSTANCE) == ADC34_COMMON))
 
 /****************************** CAN Instances *********************************/
-#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN)
+#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN1)
 
 /****************************** COMP Instances ********************************/
 #define IS_COMP_ALL_INSTANCE(INSTANCE) (((INSTANCE) == COMP1) || \

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303ZE/device/stm32f303xe.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303ZE/device/stm32f303xe.h
@@ -14509,7 +14509,7 @@ typedef struct
                                           ((INSTANCE) == ADC34_COMMON))
 
 /****************************** CAN Instances *********************************/
-#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN)
+#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN1)
 
 /****************************** COMP Instances ********************************/
 #define IS_COMP_ALL_INSTANCE(INSTANCE) (((INSTANCE) == COMP1) || \

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F334R8/device/stm32f334x8.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F334R8/device/stm32f334x8.h
@@ -14581,7 +14581,7 @@ typedef struct
 
 #define IS_ADC_COMMON_INSTANCE(INSTANCE) ((INSTANCE) == ADC12_COMMON)
 /****************************** CAN Instances *********************************/
-#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN)
+#define IS_CAN_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CAN1)
 
 /****************************** COMP Instances ********************************/
 #define IS_COMP_ALL_INSTANCE(INSTANCE) (((INSTANCE) == COMP2) || \

--- a/targets/TARGET_STM/TARGET_STM32F3/device/stm32f3xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/device/stm32f3xx_hal_conf.h
@@ -321,9 +321,8 @@
   *         If expr is true, it returns no value.
   * @retval None
   */
-  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
-/* Exported functions ------------------------------------------------------- */
-  void assert_failed(uint8_t* file, uint32_t line);
+  #include "mbed_assert.h"
+  #define assert_param(expr) MBED_ASSERT(expr)
 #else
   #define assert_param(expr) ((void)0U)
 #endif /* USE_FULL_ASSERT */    

--- a/targets/TARGET_STM/TARGET_STM32F3/gpio_irq_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/gpio_irq_api.c
@@ -277,7 +277,7 @@ void gpio_irq_free(gpio_irq_t *obj)
 
 void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
 {
-    uint32_t mode = STM_MODE_IT_EVT_RESET;
+    uint32_t mode = STM_MODE_INPUT;
 
     if (enable) {
         if (event == IRQ_RISE) {
@@ -304,7 +304,7 @@ void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
                 mode = STM_MODE_IT_FALLING;
                 obj->event = EDGE_FALL;
             } else { // NONE or RISE
-                mode = STM_MODE_IT_EVT_RESET;
+                mode = STM_MODE_INPUT;
                 obj->event = EDGE_NONE;
             }
         }
@@ -313,7 +313,7 @@ void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
                 mode = STM_MODE_IT_RISING;
                 obj->event = EDGE_RISE;
             } else { // NONE or FALL
-                mode = STM_MODE_IT_EVT_RESET;
+                mode = STM_MODE_INPUT;
                 obj->event = EDGE_NONE;
             }
         }


### PR DESCRIPTION
## Description
ST HAL assert is mapped onto MBED HAL assert, and can now be enabled easily.

Note for all STM32 targets:
- ST asserts are used to check each parameters in ST HAL function call
- They are not compiled by default, you have to define USE_FULL_ASSERT to enable them

## Test

OS2 and OS5 tests done.

Few updates have been needed to match ST HAL API.

## Status
READY
