### PR TITLE
ISR register never re-evaluated in HAL_DMA_PollForTransfer for STM32F4

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_dma.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_dma.c
@@ -688,6 +688,7 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_Level
       /* Clear the Direct Mode error flag */
       regs->IFCR = DMA_FLAG_DMEIF0_4 << hdma->StreamIndex;
     }
+    tmpisr = regs->ISR;
   }
   
   if(hdma->ErrorCode != HAL_DMA_ERROR_NONE)


### PR DESCRIPTION
## Description
The ISR register is never re-evaluated in HAL_DMA_PollForTransfer for STM32F4.
This will cause the function to unnecessarily wait for timeout in some circumstances.
Putting 'tmpisr = regs->ISR;' at the end of the while loop solves it for the ODIN driver.

## Status
**READY**

## Migrations
NO

## Related PRs
https://github.com/ARMmbed/mbed-os/issues/3272

## Todos
Review by @LMESTM 

## Deploy notes
None

## Steps to test or reproduce
This has been reproduced with the private repo of the u-blox ODIN-drivers and the fix can therefore only be verified by u-blox for the UBLOX_EVK_ODIN_W2 target. The current ODIN-W2 driver binary for mbed-os v5.3.0 has a workaround therefore it's not affected.
- Get ublox ODIN drivers branch alar_sdio_optimizations
- Get mbed-os commit 9d8ec61
- Run WiFi and BT tests. WiFi will timeout because initialization is too slow(~15 sec)
The tests below have been run with the fix in the PR and without the workaround.
[test_report_arm.txt](https://github.com/ARMmbed/mbed-os/files/639118/test_report_arm.txt)
[test_report_gcc.txt](https://github.com/ARMmbed/mbed-os/files/639120/test_report_gcc.txt)
[test_report_iar.txt](https://github.com/ARMmbed/mbed-os/files/639119/test_report_iar.txt)
