### PR TITLE
NUCLEO_F103RB - Add SERIAL_FC feature

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/PeripheralPins.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/PeripheralPins.h
@@ -51,6 +51,8 @@ extern const PinMap PinMap_PWM[];
 
 extern const PinMap PinMap_UART_TX[];
 extern const PinMap PinMap_UART_RX[];
+extern const PinMap PinMap_UART_RTS[];
+extern const PinMap PinMap_UART_CTS[];
 
 //*** SPI ***
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -721,7 +721,7 @@
         "inherits": ["Target"],
         "detect_code": ["0700"],
         "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2"],
-        "device_has": ["ANALOGIN", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F103RB"
     },


### PR DESCRIPTION
## Description
- Fix Issue #3266
- Add external declaration of UART_CTS/RTS const tables
- Add the SERIAL_FC in device_has field in targets.json

## Status
READY

## Migrations
NO