### PR TITLE
nsapi - Fixed open/close issue in Socket

### DIFF
--- a/features/netsocket/Socket.cpp
+++ b/features/netsocket/Socket.cpp
@@ -60,6 +60,7 @@ nsapi_error_t Socket::close()
         _socket = 0;
         ret = _stack->socket_close(socket);
     }
+    _stack = 0;
 
     // Wakeup anything in a blocking operation
     // on this socket


### PR DESCRIPTION
During open, the socket checked the internal stack variable, assuming it would alway be null on a socket not connected to the network. However, when a socket is closed, the stack variable was not updated, causing the socket to incorrectly return a parameter error if reopened.

The simple fix was to set the stack to null on close. A non-null stack is a predicate for a non-null socket variable, so no additional checks are needed in socket functions.

Required for https://github.com/ARMmbed/mbed-os/pull/3265