### PR TITLE
lwip - Fixed error codes for failed TCP connect

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -555,11 +555,12 @@ static nsapi_error_t mbed_lwip_err_remap(err_t err) {
     switch (err) {
         case ERR_OK:
         case ERR_CLSD:
-        case ERR_RST:
             return 0;
         case ERR_MEM:
             return NSAPI_ERROR_NO_MEMORY;
         case ERR_CONN:
+        case ERR_RST:
+        case ERR_ABRT:
             return NSAPI_ERROR_NO_CONNECTION;
         case ERR_TIMEOUT:
         case ERR_RTE:


### PR DESCRIPTION
Some error codes in TCP connect were being remapped incorrectly
```
condition               posix error     mbed error
good host, closed port  ECONNREFUSED    NSAPI_ERROR_NO_CONNECTION
bad host                EHOSTUNREACH    NSAPI_ERROR_NO_CONNECTION
bad network             ENETUNREACH     NSAPI_ERROR_NO_CONNECTION
```

Thanks to @infinnovation for finding this, verified with their test program in https://github.com/ARMmbed/mbed-os/issues/3246

cc @infinnovation, @c1728p9 
should resolve https://github.com/ARMmbed/mbed-os/issues/3246