### PR TITLE
Repair the transmit mailbox (0,1,2) empty interrupt flag not clear BUG

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/can_api.c
@@ -377,6 +377,15 @@ static void can_irq(CANName name, int id)
         tmp1 = __HAL_CAN_TRANSMIT_STATUS(&CanHandle, CAN_TXMAILBOX_0);
         tmp2 = __HAL_CAN_TRANSMIT_STATUS(&CanHandle, CAN_TXMAILBOX_1);
         tmp3 = __HAL_CAN_TRANSMIT_STATUS(&CanHandle, CAN_TXMAILBOX_2);
+        if (tmp1){
+            CanHandle.Instance->TSR |= CAN_TSR_RQCP0;
+        }
+        if (tmp2){
+            CanHandle.Instance->TSR |= CAN_TSR_RQCP1;
+        }
+        if (tmp3){
+            CanHandle.Instance->TSR |= CAN_TSR_RQCP2;
+        }
         if(tmp1 || tmp2 || tmp3)  
         {
             irq_handler(can_irq_ids[id], IRQ_TX);

--- a/targets/TARGET_STM/TARGET_STM32F1/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/can_api.c
@@ -378,13 +378,13 @@ static void can_irq(CANName name, int id)
         tmp2 = __HAL_CAN_TRANSMIT_STATUS(&CanHandle, CAN_TXMAILBOX_1);
         tmp3 = __HAL_CAN_TRANSMIT_STATUS(&CanHandle, CAN_TXMAILBOX_2);
         if (tmp1){
-            CanHandle.Instance->TSR |= CAN_TSR_RQCP0;
+            __HAL_CAN_CLEAR_FLAG(&CanHandle, CAN_FLAG_RQCP0);
         }
         if (tmp2){
-            CanHandle.Instance->TSR |= CAN_TSR_RQCP1;
+            __HAL_CAN_CLEAR_FLAG(&CanHandle, CAN_FLAG_RQCP1);
         }
         if (tmp3){
-            CanHandle.Instance->TSR |= CAN_TSR_RQCP2;
+            __HAL_CAN_CLEAR_FLAG(&CanHandle, CAN_FLAG_RQCP2);
         }
         if(tmp1 || tmp2 || tmp3)  
         {

--- a/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_can.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_can.h
@@ -572,9 +572,9 @@ typedef struct
   * @param  __HANDLE__: specifies the CAN Handle.
   * @param  __FLAG__: specifies the flag to check.
   *         This parameter can be one of the following values:
-  *            @arg CAN_TSR_RQCP0: Request MailBox0 Flag
-  *            @arg CAN_TSR_RQCP1: Request MailBox1 Flag
-  *            @arg CAN_TSR_RQCP2: Request MailBox2 Flag
+  *            @arg CAN_FLAG_RQCP0: Request MailBox0 Flag
+  *            @arg CAN_FLAG_RQCP1: Request MailBox1 Flag
+  *            @arg CAN_FLAG_RQCP2: Request MailBox2 Flag
   *            @arg CAN_FLAG_TXOK0: Transmission OK MailBox0 Flag
   *            @arg CAN_FLAG_TXOK1: Transmission OK MailBox1 Flag
   *            @arg CAN_FLAG_TXOK2: Transmission OK MailBox2 Flag
@@ -606,9 +606,9 @@ typedef struct
   * @param  __HANDLE__: specifies the CAN Handle.
   * @param  __FLAG__: specifies the flag to check.
   *         This parameter can be one of the following values:
-  *            @arg CAN_TSR_RQCP0: Request MailBox0 Flag
-  *            @arg CAN_TSR_RQCP1: Request MailBox1 Flag
-  *            @arg CAN_TSR_RQCP2: Request MailBox2 Flag
+  *            @arg CAN_FLAG_RQCP0: Request MailBox0 Flag
+  *            @arg CAN_FLAG_RQCP1: Request MailBox1 Flag
+  *            @arg CAN_FLAG_RQCP2: Request MailBox2 Flag
   *            @arg CAN_FLAG_TXOK0: Transmission OK MailBox0 Flag
   *            @arg CAN_FLAG_TXOK1: Transmission OK MailBox1 Flag
   *            @arg CAN_FLAG_TXOK2: Transmission OK MailBox2 Flag


### PR DESCRIPTION
Notes:
*  The transmit mailbox empty interrupt flag always keep if IRQ_TX interrupt enabled from can.write(...)

## Description
Repair the transmit mailbox (0,1,2) empty interrupt flag not clear BUG


## Status
**READY**

