### PR TITLE
[make exporters] Adding quotes to echo statements

### DIFF
--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -127,7 +127,7 @@ $(PROJECT).elf: $(OBJECTS) $(SYS_OBJECTS) $(LINKER_SCRIPT)
 
 $(PROJECT).bin: $(PROJECT).elf
 {%- block elf2bin -%}{%- endblock %}
-{% if not hex_files %}	+@echo ===== bin file ready to flash: $(OBJDIR)/$@ ===== {% endif %}
+{% if not hex_files %}	+@echo "===== bin file ready to flash: $(OBJDIR)/$@ =====" {% endif %}
 
 $(PROJECT).hex: $(PROJECT).elf
 {%- block elf2hex -%}{%- endblock %}
@@ -136,7 +136,7 @@ $(PROJECT).hex: $(PROJECT).elf
 $(PROJECT)-combined.hex: $(PROJECT).hex
 	+@echo "NOTE: the $(SREC_CAT) binary is required to be present in your PATH. Please see http://srecord.sourceforge.net/ for more information."
 	$(SREC_CAT) {% for f in hex_files %}{{f}} {% endfor %} -intel $(PROJECT).hex -intel -o $(PROJECT)-combined.hex -intel --line-length=44
-	+@echo ===== hex file ready to flash: $(OBJDIR)/$@ =====
+	+@echo "===== hex file ready to flash: $(OBJDIR)/$@ ====="
 {% endif %}
 # Rules
 ###############################################################################


### PR DESCRIPTION
## Description
For some reason, make has issues issuing an `echo` command that doesn't use quotes when ran inside the Windows command prompt (not in bash). This PR adds quotes to the problematic `echo` commands.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [x] exporter tests
