### PR TITLE
STM32F4 - FIX to add the update of hdma->State variable

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_dma.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_dma.c
@@ -761,6 +761,9 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
       
       /* Update error code */
       hdma->ErrorCode |= HAL_DMA_ERROR_TE;
+
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_ERROR; // FIX
     }
   }
   /* FIFO Error Interrupt management ******************************************/
@@ -773,6 +776,9 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
 
       /* Update error code */
       hdma->ErrorCode |= HAL_DMA_ERROR_FE;
+
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_ERROR; // FIX
     }
   }
   /* Direct Mode Error Interrupt management ***********************************/
@@ -785,6 +791,9 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
 
       /* Update error code */
       hdma->ErrorCode |= HAL_DMA_ERROR_DME;
+
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_ERROR; // FIX
     }
   }
   /* Half Transfer Complete Interrupt management ******************************/
@@ -801,6 +810,9 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
         /* Current memory buffer used is Memory 0 */
         if((hdma->Instance->CR & DMA_SxCR_CT) == RESET)
         {
+          /* Change DMA peripheral state */
+          hdma->State = HAL_DMA_STATE_READY_HALF_MEM0; // FIX
+
           if(hdma->XferHalfCpltCallback != NULL)
           {
             /* Half transfer callback */
@@ -810,6 +822,9 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
         /* Current memory buffer used is Memory 1 */
         else
         {
+          /* Change DMA peripheral state */
+          hdma->State = HAL_DMA_STATE_READY_HALF_MEM1; // FIX
+
           if(hdma->XferM1HalfCpltCallback != NULL)
           {
             /* Half transfer callback */
@@ -826,6 +841,9 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
           hdma->Instance->CR  &= ~(DMA_IT_HT);
         }
         
+        /* Change DMA peripheral state */
+        hdma->State = HAL_DMA_STATE_READY_HALF_MEM0; // FIX
+
         if(hdma->XferHalfCpltCallback != NULL)
         {
           /* Half transfer callback */
@@ -874,6 +892,9 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
         /* Current memory buffer used is Memory 0 */
         if((hdma->Instance->CR & DMA_SxCR_CT) == RESET)
         {
+          /* Change DMA peripheral state */
+          hdma->State = HAL_DMA_STATE_READY_MEM1; // FIX
+     
           if(hdma->XferM1CpltCallback != NULL)
           {
             /* Transfer complete Callback for memory1 */
@@ -883,6 +904,9 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
         /* Current memory buffer used is Memory 1 */
         else
         {
+          /* Change DMA peripheral state */
+          hdma->State = HAL_DMA_STATE_READY_MEM0; // FIX
+     
           if(hdma->XferCpltCallback != NULL)
           {
             /* Transfer complete Callback for memory0 */
@@ -893,6 +917,9 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
       /* Disable the transfer complete interrupt if the DMA mode is not CIRCULAR */
       else
       {
+    	/* Change DMA peripheral state */
+    	hdma->State = HAL_DMA_STATE_READY_MEM0; // FIX
+     
         if((hdma->Instance->CR & DMA_SxCR_CIRC) == RESET)
         {
           /* Disable the transfer complete interrupt */

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_dma.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_dma.h
@@ -122,7 +122,13 @@ typedef enum
 {
   HAL_DMA_STATE_RESET             = 0x00U,  /*!< DMA not yet initialized or disabled */
   HAL_DMA_STATE_READY             = 0x01U,  /*!< DMA initialized and ready for use   */
+  HAL_DMA_STATE_READY_MEM0        = 0x11U,  /*!< DMA Mem0 process success            */ // FIX
+  HAL_DMA_STATE_READY_MEM1        = 0x21U,  /*!< DMA Mem1 process success            */ // FIX
+  HAL_DMA_STATE_READY_HALF_MEM0   = 0x31U,  /*!< DMA Mem0 Half process success       */ // FIX
+  HAL_DMA_STATE_READY_HALF_MEM1   = 0x41U,  /*!< DMA Mem1 Half process success       */ // FIX
   HAL_DMA_STATE_BUSY              = 0x02U,  /*!< DMA process is ongoing              */
+  HAL_DMA_STATE_BUSY_MEM0         = 0x12U,  /*!< DMA Mem0 process is ongoing         */ // FIX
+  HAL_DMA_STATE_BUSY_MEM1         = 0x22U,  /*!< DMA Mem1 process is ongoing         */ // FIX
   HAL_DMA_STATE_TIMEOUT           = 0x03U,  /*!< DMA timeout state                   */
   HAL_DMA_STATE_ERROR             = 0x04U,  /*!< DMA error state                     */
   HAL_DMA_STATE_ABORT             = 0x05U,  /*!< DMA Abort state                     */


### PR DESCRIPTION
## Description
This is a fix to add the update of hdma->State variable as it was done in a previous version of HAL driver.

This change is required as we need to figure out which kind of event has triggered the IRQ (for example to know if it was a TX/RX buffer half-complete or a full-complete event) in order to call the right callback (specified by the mbed application programmer) with the right parameters.

With the old HAL DMA API we could figure this easily out by first calling HAL_DMA_IRQHandler() and then analyzing the states of the DMA stream (by using HAL_DMA_GetState()).

With the new HAL DMA API this approach does not work anymore. The state is not updated in the HAL_DMA_IRQHandler(), the state machine will stay in a Busy State until we abort the transfer. These states information have been removed.

## Status
READY

## Migrations
NO

CC @betzw 