### PR TITLE
Fix stm i2c slave

### DIFF
--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -751,11 +751,23 @@ void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c){
     /* Get object ptr based on handler ptr */
     i2c_t *obj = get_i2c_obj(hi2c);
     struct i2c_s *obj_s = I2C_S(obj);
+#if DEVICE_I2CSLAVE
+    I2C_HandleTypeDef *handle = &(obj_s->handle);
+    uint32_t address = 0;
+    /*  Store address to handle it after reset */
+    if(obj_s->slave)
+        address = handle->Init.OwnAddress1;
+#endif
 
     DEBUG_PRINTF("HAL_I2C_ErrorCallback:%d, index=%d\r\n", (int) hi2c->ErrorCode, obj_s->index);
 
     /* re-init IP to try and get back in a working state */
     i2c_init(obj, obj_s->sda, obj_s->scl);
+
+#if DEVICE_I2CSLAVE
+    /*  restore slave address */
+    i2c_slave_address(obj, 0, address, 0);
+#endif
 
     /* Keep Set event flag */
     obj_s->event = I2C_EVENT_ERROR;


### PR DESCRIPTION
Having a master I2C and a slave I2C communicating together on the same device is maybe not a real use case, but this PR allows to pass "master slave asynch" tests at higher frequencies than the default 100kHz for boards like NUCLEO_L152RE (32MHz) and NUCLEO_F042K6  (48MHz)

The 2nd commit restores the slave address in error cases, when no devices is found for instance or when bus is locked in a busy state.

## Status
**READY**

TESTED OK with  MBED_A29: i2c_master_slave_asynch.