### PR TITLE
Fix stm i2c fix init

### DIFF
--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -203,6 +203,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
     // Enable I2C1 clock and pinout if not done
     if (obj_s->i2c == I2C_1) {
         obj_s->index = 0;
+        __HAL_RCC_I2C1_CLK_ENABLE();
         // Configure I2C pins
         pinmap_pinout(sda, PinMap_I2C_SDA);
         pinmap_pinout(scl, PinMap_I2C_SCL);
@@ -210,13 +211,13 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
         pin_mode(scl, PullUp);
         obj_s->event_i2cIRQ = I2C1_EV_IRQn;
         obj_s->error_i2cIRQ = I2C1_ER_IRQn;
-        __HAL_RCC_I2C1_CLK_ENABLE();
     }
 #endif
 #if defined I2C2_BASE
     // Enable I2C2 clock and pinout if not done
     if (obj_s->i2c == I2C_2) {
         obj_s->index = 1;
+        __HAL_RCC_I2C2_CLK_ENABLE();
         // Configure I2C pins
         pinmap_pinout(sda, PinMap_I2C_SDA);
         pinmap_pinout(scl, PinMap_I2C_SCL);
@@ -224,13 +225,13 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
         pin_mode(scl, PullUp);
         obj_s->event_i2cIRQ = I2C2_EV_IRQn;
         obj_s->error_i2cIRQ = I2C2_ER_IRQn;
-        __HAL_RCC_I2C2_CLK_ENABLE();
     }
 #endif
 #if defined I2C3_BASE
     // Enable I2C3 clock and pinout if not done
     if (obj_s->i2c == I2C_3) {
         obj_s->index = 2;
+        __HAL_RCC_I2C3_CLK_ENABLE();
         // Configure I2C pins
         pinmap_pinout(sda, PinMap_I2C_SDA);
         pinmap_pinout(scl, PinMap_I2C_SCL);
@@ -238,13 +239,13 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
         pin_mode(scl, PullUp);
         obj_s->event_i2cIRQ = I2C3_EV_IRQn;
         obj_s->error_i2cIRQ = I2C3_ER_IRQn;
-        __HAL_RCC_I2C3_CLK_ENABLE();
     }
 #endif
 #if defined I2C4_BASE
     // Enable I2C3 clock and pinout if not done
     if (obj_s->i2c == I2C_4) {
         obj_s->index = 3;
+        __HAL_RCC_I2C4_CLK_ENABLE();
         // Configure I2C pins
         pinmap_pinout(sda, PinMap_I2C_SDA);
         pinmap_pinout(scl, PinMap_I2C_SCL);
@@ -252,13 +253,13 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
         pin_mode(scl, PullUp);
         obj_s->event_i2cIRQ = I2C4_EV_IRQn;
         obj_s->error_i2cIRQ = I2C4_ER_IRQn;
-        __HAL_RCC_I2C4_CLK_ENABLE();
     }
 #endif
 #if defined FMPI2C1_BASE
     // Enable I2C3 clock and pinout if not done
     if (obj_s->i2c == FMPI2C_1) {
         obj_s->index = 4;
+        __HAL_RCC_FMPI2C1_CLK_ENABLE();
         // Configure I2C pins
         pinmap_pinout(sda, PinMap_I2C_SDA);
         pinmap_pinout(scl, PinMap_I2C_SCL);
@@ -266,7 +267,6 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
         pin_mode(scl, PullUp);
         obj_s->event_i2cIRQ = FMPI2C1_EV_IRQn;
         obj_s->error_i2cIRQ = FMPI2C1_ER_IRQn;
-        __HAL_RCC_FMPI2C1_CLK_ENABLE();
     }
 #endif
 

--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -270,12 +270,13 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
     }
 #endif
 
-    // Reset to clear pending flags if any
-    i2c_reset(obj);
-
     // I2C configuration
+    // Default hz value used for timeout computation
     if(!obj_s->hz)
         obj_s->hz = 100000; // 100 kHz per default
+
+    // Reset to clear pending flags if any
+    i2c_reset(obj);
     i2c_frequency(obj, obj_s->hz );
 
 #if DEVICE_I2CSLAVE


### PR DESCRIPTION
This is PR contains a clean-up of the init phases which was not seen before but has been seen while moving F1 family to the common I2C code as well. So this PR is a pre-requisite to later introduction of F1 to common code (and F1 asynch I2C support at the same time)

## Status
**READY**

I2C non regression tests passed OK 
