### PR TITLE
Fix ci shield eeprom test

### DIFF
--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -634,8 +634,15 @@ void i2c_reset(i2c_t *obj) {
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop) {
     struct i2c_s *obj_s = I2C_S(obj);
     I2C_HandleTypeDef *handle = &(obj_s->handle);
-    int count = 0, ret = 0;
+    int count = I2C_ERROR_BUS_BUSY, ret = 0;
     uint32_t timeout = 0;
+
+    if((length == 0) || (data == 0)) {
+        if(HAL_I2C_IsDeviceReady(handle, address, 1, 10) == HAL_OK)
+            return 0;
+        else
+            return I2C_ERROR_BUS_BUSY;
+    }
 
     if ((obj_s->XferOperation == I2C_FIRST_AND_LAST_FRAME) ||
         (obj_s->XferOperation == I2C_LAST_FRAME)) {
@@ -686,8 +693,15 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop) {
 int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop) {
     struct i2c_s *obj_s = I2C_S(obj);
     I2C_HandleTypeDef *handle = &(obj_s->handle);
-    int count = 0, ret = 0;
+    int count = I2C_ERROR_BUS_BUSY, ret = 0;
     uint32_t timeout = 0;
+
+    if((length == 0) || (data == 0)) {
+        if(HAL_I2C_IsDeviceReady(handle, address, 1, 10) == HAL_OK)
+            return 0;
+        else
+            return I2C_ERROR_BUS_BUSY;
+    }
 
     if ((obj_s->XferOperation == I2C_FIRST_AND_LAST_FRAME) ||
         (obj_s->XferOperation == I2C_LAST_FRAME)) {

--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -483,9 +483,17 @@ int i2c_start(i2c_t *obj) {
 int i2c_stop(i2c_t *obj) {
     struct i2c_s *obj_s = I2C_S(obj);
     I2C_TypeDef *i2c = (I2C_TypeDef *)obj_s->i2c;
+    I2C_HandleTypeDef *handle = &(obj_s->handle);
+    int timeout;
 
     // Generate the STOP condition
     i2c->CR1 |= I2C_CR1_STOP;
+
+    /*  In case of mixed usage of the APIs (unitary + SYNC)
+     *  re-inti HAL state
+     */
+    if(obj_s->XferOperation != I2C_FIRST_AND_LAST_FRAME)
+            i2c_init(obj, obj_s->sda, obj_s->scl);
 
     return 0;
 }

--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -668,7 +668,7 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop) {
     ret = HAL_I2C_Master_Sequential_Receive_IT(handle, address, (uint8_t *) data, length, obj_s->XferOperation);
 
     if(ret == HAL_OK) {
-        timeout = BYTE_TIMEOUT_US * length;
+        timeout = BYTE_TIMEOUT_US * (length + 1);
         /*  transfer started : wait completion or timeout */
         while(!(obj_s->event & I2C_EVENT_ALL) && (--timeout != 0)) {
             wait_us(1);
@@ -724,7 +724,7 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop) {
     ret = HAL_I2C_Master_Sequential_Transmit_IT(handle, address, (uint8_t *) data, length, obj_s->XferOperation); 
 
     if(ret == HAL_OK) {
-        timeout = BYTE_TIMEOUT_US * length;
+        timeout = BYTE_TIMEOUT_US * (length + 1);
         /*  transfer started : wait completion or timeout */
         while(!(obj_s->event & I2C_EVENT_ALL) && (--timeout != 0)) {
             wait_us(1);
@@ -903,7 +903,7 @@ int i2c_slave_read(i2c_t *obj, char *data, int length) {
     ret = HAL_I2C_Slave_Sequential_Receive_IT(handle, (uint8_t *) data, length, I2C_NEXT_FRAME);
 
     if(ret == HAL_OK) {
-        timeout = BYTE_TIMEOUT_US * length;
+        timeout = BYTE_TIMEOUT_US * (length + 1);
         while(obj_s->pending_slave_rx_maxter_tx && (--timeout != 0)) {
             wait_us(1);
         }
@@ -928,7 +928,7 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length) {
     ret = HAL_I2C_Slave_Sequential_Transmit_IT(handle, (uint8_t *) data, length, I2C_NEXT_FRAME);
 
     if(ret == HAL_OK) {
-        timeout = BYTE_TIMEOUT_US * length;
+        timeout = BYTE_TIMEOUT_US * (length + 1);
         while(obj_s->pending_slave_tx_master_rx && (--timeout != 0)) {
             wait_us(1);
         }


### PR DESCRIPTION
## Description

With ci test shiled tests, a few issues were faced and needed to be solved 
- the reference I2C test makes a mixed usage for unitary MBED APIs (start / stop / send & read bytes) and more advanced read and write APIs which autonomously manage start and stop. The code needed update to cope with this API use.
- also the eeprom driver checks if eeprom is ready by sending data of length = 0, the STM32 HAL provides a dedicated API for such case which we're using now

This allows to have the I2C eeprom test to pass on F1, F2, F4 and L1 families. 

Other families have not passed the tests yet - further work is needed as they embed a different I2C IP version - this will be done in a later PR.

## Status
**READY**

+-------------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+
| target            | platform_name | test suite    | test case                          | passed | failed | result | elapsed_time (sec) |
+-------------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+
| NUCLEO_F103RB-ARM | NUCLEO_F103RB | tests-api-i2c | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.06               |
| NUCLEO_F103RB-ARM | NUCLEO_F103RB | tests-api-i2c | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.08               |
| NUCLEO_F103RB-ARM | NUCLEO_F103RB | tests-api-i2c | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.05               |
| NUCLEO_F103RB-ARM | NUCLEO_F103RB | tests-api-i2c | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.07               |
| NUCLEO_F103RB-ARM | NUCLEO_F103RB | tests-api-i2c | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.07               |
| NUCLEO_F103RB-ARM | NUCLEO_F103RB | tests-api-i2c | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.06               |
+-------------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+


+-------------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+
| target            | platform_name | test suite    | test case                          | passed | failed | result | elapsed_time (sec) |
+-------------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+
| NUCLEO_F207ZG-ARM | NUCLEO_F207ZG | tests-api-i2c | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.07               |
| NUCLEO_F207ZG-ARM | NUCLEO_F207ZG | tests-api-i2c | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.05               |
| NUCLEO_F207ZG-ARM | NUCLEO_F207ZG | tests-api-i2c | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.07               |
| NUCLEO_F207ZG-ARM | NUCLEO_F207ZG | tests-api-i2c | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.06               |
| NUCLEO_F207ZG-ARM | NUCLEO_F207ZG | tests-api-i2c | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.06               |
| NUCLEO_F207ZG-ARM | NUCLEO_F207ZG | tests-api-i2c | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.07               |
+-------------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+

+-------------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+
| target            | platform_name | test suite    | test case                          | passed | failed | result | elapsed_time (sec) |
+-------------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-api-i2c | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.07               |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-api-i2c | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.08               |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-api-i2c | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.06               |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-api-i2c | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.06               |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-api-i2c | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.06               |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-api-i2c | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.05               |
+-------------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+

+-------------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+
| target            | platform_name | test suite    | test case                          | passed | failed | result | elapsed_time (sec) |
+-------------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+
| NUCLEO_F446ZE-ARM | NUCLEO_F446ZE | tests-api-i2c | I2C -  EEProm WR 10  Bytes         | 1      | 0      | OK     | 0.07               |
| NUCLEO_F446ZE-ARM | NUCLEO_F446ZE | tests-api-i2c | I2C -  EEProm WR 100 Bytes         | 1      | 0      | OK     | 0.06               |
| NUCLEO_F446ZE-ARM | NUCLEO_F446ZE | tests-api-i2c | I2C -  EEProm WR 2 Bytes           | 1      | 0      | OK     | 0.06               |
| NUCLEO_F446ZE-ARM | NUCLEO_F446ZE | tests-api-i2c | I2C -  EEProm WR Single Byte       | 1      | 0      | OK     | 0.06               |
| NUCLEO_F446ZE-ARM | NUCLEO_F446ZE | tests-api-i2c | I2C -  Instantiation of I2C Object | 1      | 0      | OK     | 0.06               |
| NUCLEO_F446ZE-ARM | NUCLEO_F446ZE | tests-api-i2c | I2C -  LM75B Temperature Read      | 1      | 0      | OK     | 0.06               |
+-------------------+---------------+---------------+------------------------------------+--------+--------+--------+--------------------+




