### PR TITLE
Update MBED_LIBRARY_VERSION to 131 and mbed version macros for mbed-os-5.3.0

### DIFF
--- a/mbed.h
+++ b/mbed.h
@@ -16,13 +16,13 @@
 #ifndef MBED_H
 #define MBED_H
 
-#define MBED_LIBRARY_VERSION 123
+#define MBED_LIBRARY_VERSION 131
 
 #if MBED_CONF_RTOS_PRESENT
 // RTOS present, this is valid only for mbed OS 5
 #define MBED_MAJOR_VERSION 5
-#define MBED_MINOR_VERSION 2
-#define MBED_PATCH_VERSION 1
+#define MBED_MINOR_VERSION 3
+#define MBED_PATCH_VERSION 0
 
 #else
 // mbed 2


### PR DESCRIPTION
As well as updating the versionning in mbed.h ready for the release, this PR also kicks off the creation and testing of the associated mbed-os 2 build. 