### PR TITLE
Fix network echo test host scripts for Mac

### DIFF
--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/host_tests/tcp_echo_client.py
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/host_tests/tcp_echo_client.py
@@ -128,7 +128,10 @@ class TCPEchoClientTest(BaseHostTest):
         :return:
         """
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect((target_ip, 8000)) # Target IP, 'random' port
+        try:
+            s.connect((target_ip, 0)) # Target IP, any port
+        except socket.error:
+            s.connect((target_ip, 8000)) # Target IP, 'random' port
         ip = s.getsockname()[0]
         s.close()
         return ip

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/host_tests/tcp_echo_client.py
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/host_tests/tcp_echo_client.py
@@ -128,7 +128,7 @@ class TCPEchoClientTest(BaseHostTest):
         :return:
         """
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect((target_ip, 0)) # Target IP, Any port
+        s.connect((target_ip, 8000)) # Target IP, 'random' port
         ip = s.getsockname()[0]
         s.close()
         return ip

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/host_tests/udp_echo_client.py
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/host_tests/udp_echo_client.py
@@ -55,7 +55,10 @@ class UDPEchoClientTest(BaseHostTest):
         :return:
         """
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect((target_ip, 8000)) # Target IP, 'random' port
+        try:
+            s.connect((target_ip, 0)) # Target IP, any port
+        except socket.error:
+            s.connect((target_ip, 8000)) # Target IP, 'random' port
         ip = s.getsockname()[0]
         s.close()
         return ip

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/host_tests/udp_echo_client.py
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/host_tests/udp_echo_client.py
@@ -55,7 +55,7 @@ class UDPEchoClientTest(BaseHostTest):
         :return:
         """
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect((target_ip, 0)) # Target IP, Any port
+        s.connect((target_ip, 8000)) # Target IP, 'random' port
         ip = s.getsockname()[0]
         s.close()
         return ip


### PR DESCRIPTION

## Status
**READY**

It seems that the 0 aka 'any port' doesn't work well on Mac, causing
[Errno 49] Can't assign requested address errors.

```
[1481634494.19][HTST][ERR] something went wrong in event main loop!
[1481634494.19][HTST][INF] ==== Traceback start ====
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/mbed_host_tests/host_tests_runner/host_test_default.py", line 364, in run_test
    callbacks[key](key, value, timestamp)
  File "/Users/barsza01/devel/mbed/code/mbed-os/features/FEATURE_LWIP/TESTS/mbedmicro-net/host_tests/udp_echo_client.py", line 104, in _callback_target_ip
    self.SERVER_IP = self.find_interface_to_target_addr(self.target_ip)
  File "/Users/barsza01/devel/mbed/code/mbed-os/features/FEATURE_LWIP/TESTS/mbedmicro-net/host_tests/udp_echo_client.py", line 58, in find_interface_to_target_addr
    s.connect((target_ip, 0)) # Target IP, Any port
  File "/usr/local/Cellar/python/2.7.12_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
error: [Errno 49] Can't assign requested address
```

This PR makes connection to a random port (8000) to get the local if address.

CC: @geky @bridadan 