### PR TITLE
Remove invalid thread::start example

### DIFF
--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -48,14 +48,14 @@ namespace rtos {
  *  void blink(DigitalOut *led) {
  *      while (running) {
  *          *led = !*led;
- *          Thread::wait(1000);
+ *          wait(1);
  *      }
  *  }
  *
  *  // Spawns a thread to run blink for 5 seconds
  *  int main() {
  *      thread.start(callback(blink, &led1));
- *      Thread::wait(5000);
+ *      wait(5);
  *      running = false;
  *      thread.join();
  *  }

--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -54,7 +54,7 @@ namespace rtos {
  *
  *  // Spawns a thread to run blink for 5 seconds
  *  int main() {
- *      thread.start(led1, blink);
+ *      thread.start(callback(blink, &led1));
  *      Thread::wait(5000);
  *      running = false;
  *      thread.join();


### PR DESCRIPTION
## Description
This change reflects the correct syntax for spawning a thread that will execute a local function with given parameters.

The currently provided example will not compile. Inspired by #3396.

@geky @0xc0170 


## Status
**READY**


## Steps to test or reproduce
Try to compile the currently provided example to view failure. 
