### PR TITLE
[RZ/A1H]Support RTX v4.80 for Cortex-A and a few Malloc API

### DIFF
--- a/rtos/RtosTimer.h
+++ b/rtos/RtosTimer.h
@@ -144,9 +144,7 @@ private:
     mbed::Callback<void()> _function;
     osTimerId _timer_id;
     osTimerDef_t _timer;
-#if defined(CMSIS_OS_RTX) && !defined(__MBED_CMSIS_RTOS_CM)
-    uint32_t _timer_data[5];
-#else
+#ifdef CMSIS_OS_RTX
     uint32_t _timer_data[6];
 #endif
 };

--- a/rtos/RtosTimer.h
+++ b/rtos/RtosTimer.h
@@ -144,7 +144,9 @@ private:
     mbed::Callback<void()> _function;
     osTimerId _timer_id;
     osTimerDef_t _timer;
-#ifdef CMSIS_OS_RTX
+#if defined(CMSIS_OS_RTX) && !defined(__MBED_CMSIS_RTOS_CM)
+    uint32_t _timer_data[5];
+#else
     uint32_t _timer_data[6];
 #endif
 };

--- a/rtos/rtx/TARGET_CORTEX_A/HAL_CA.c
+++ b/rtos/rtx/TARGET_CORTEX_A/HAL_CA.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    HAL_CA.C
  *      Purpose: Hardware Abstraction Layer for Cortex-A
- *      Rev.:
+ *      Rev.:    V4.77 plus changes for RTX-Ax
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 2012 ARM Limited
+ * Copyright (c) 1999-2009 KEIL, 2009-2012 ARM Germany GmbH, 2012-2015 ARM Limited
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -44,14 +44,14 @@ void rt_init_stack (P_TCB p_TCB, FUNCP task_body) {
 
   /* Prepare a complete interrupt frame for first task start */
   size = p_TCB->priv_stack >> 2;
-  if (size == 0) {
+  if (size == 0U) {
     size = (U16)os_stackinfo >> 2;
   }
   /* Write to the top of stack. */
   stk = &p_TCB->stack[size];
 
   /* Auto correct to 8-byte ARM stack alignment. */
-  if ((U32)stk & 0x04) {
+  if ((U32)stk & 0x04U) {
     stk--;
   }
 
@@ -69,10 +69,10 @@ void rt_init_stack (P_TCB p_TCB, FUNCP task_body) {
   /* Assign a void pointer to R0. */
   stk[8]  = (U32)p_TCB->msg;
   /* Clear R1-R12,LR registers. */
-  for (i = 0; i < 8; i++) {
-    stk[i] = 0;
+  for (i = 0U; i < 8U; i++) {
+    stk[i] = 0U;
   }
-  for (i = 9; i < 14; i++) {
+  for (i = 9U; i < 14U; i++) {
     stk[i] = 0;
   }
 
@@ -81,6 +81,20 @@ void rt_init_stack (P_TCB p_TCB, FUNCP task_body) {
 
   /* Task entry point. */
   p_TCB->ptask = task_body;
+
+  /* Initialize stack with magic pattern. */
+  if (os_stackinfo & 0x10000000U) {
+    if (size > (16U+1U)) {
+      for (i = ((size - 16U)/2U) - 1U; i; i--) {
+        stk -= 2U;
+        stk[1] = MAGIC_PATTERN;
+        stk[0] = MAGIC_PATTERN;
+      }
+      if (--stk > p_TCB->stack) {
+        *stk = MAGIC_PATTERN;
+      }
+    }
+  }
 
   /* Set a magic word for checking of stack overflow. */
   p_TCB->stack[0] = MAGIC_WORD;
@@ -93,13 +107,13 @@ static __inline U32 *rt_ret_regs (P_TCB p_TCB) {
   /* Get pointer to task return value registers (R0..R3) in Stack */
   if (p_TCB->stack_frame & 0x4) {
     /* NEON/D32 Stack Frame: D0-31,FPSCR,Reserved,R4-R11,R0-R3,R12,LR,PC,xPSR */
-    return (U32 *)(p_TCB->tsk_stack + 8*4 + 2*4 + 32*8);
+    return (U32 *)(p_TCB->tsk_stack + (8U*4U) + (2U*4U) + (32U*8U));
   } else if (p_TCB->stack_frame & 0x2) {
     /* VFP/D16 Stack Frame: D0-D15/S0-31,FPSCR,Reserved,R4-R11,R0-R3,R12,LR,PC,xPSR */
-    return (U32 *)(p_TCB->tsk_stack + 8*4 + 2*4 + 32*4);
+    return (U32 *)(p_TCB->tsk_stack + (8U*4U) + (2U*4U) + (32U*4U));
   } else {
     /* Basic Stack Frame: R4-R11,R0-R3,R12,LR,PC,xPSR */
-    return (U32 *)(p_TCB->tsk_stack + 8*4);
+    return (U32 *)(p_TCB->tsk_stack + (8U*4U));
   }
 }
 

--- a/rtos/rtx/TARGET_CORTEX_A/HAL_CA.c
+++ b/rtos/rtx/TARGET_CORTEX_A/HAL_CA.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    HAL_CA.C
  *      Purpose: Hardware Abstraction Layer for Cortex-A
- *      Rev.:    V4.77 plus changes for RTX-Ax
+ *      Rev.:
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2012 ARM Germany GmbH, 2012-2015 ARM Limited
+ * Copyright (c) 2012 ARM Limited
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -44,14 +44,14 @@ void rt_init_stack (P_TCB p_TCB, FUNCP task_body) {
 
   /* Prepare a complete interrupt frame for first task start */
   size = p_TCB->priv_stack >> 2;
-  if (size == 0U) {
+  if (size == 0) {
     size = (U16)os_stackinfo >> 2;
   }
   /* Write to the top of stack. */
   stk = &p_TCB->stack[size];
 
   /* Auto correct to 8-byte ARM stack alignment. */
-  if ((U32)stk & 0x04U) {
+  if ((U32)stk & 0x04) {
     stk--;
   }
 
@@ -69,10 +69,10 @@ void rt_init_stack (P_TCB p_TCB, FUNCP task_body) {
   /* Assign a void pointer to R0. */
   stk[8]  = (U32)p_TCB->msg;
   /* Clear R1-R12,LR registers. */
-  for (i = 0U; i < 8U; i++) {
-    stk[i] = 0U;
+  for (i = 0; i < 8; i++) {
+    stk[i] = 0;
   }
-  for (i = 9U; i < 14U; i++) {
+  for (i = 9; i < 14; i++) {
     stk[i] = 0;
   }
 
@@ -81,20 +81,6 @@ void rt_init_stack (P_TCB p_TCB, FUNCP task_body) {
 
   /* Task entry point. */
   p_TCB->ptask = task_body;
-
-  /* Initialize stack with magic pattern. */
-  if (os_stackinfo & 0x10000000U) {
-    if (size > (16U+1U)) {
-      for (i = ((size - 16U)/2U) - 1U; i; i--) {
-        stk -= 2U;
-        stk[1] = MAGIC_PATTERN;
-        stk[0] = MAGIC_PATTERN;
-      }
-      if (--stk > p_TCB->stack) {
-        *stk = MAGIC_PATTERN;
-      }
-    }
-  }
 
   /* Set a magic word for checking of stack overflow. */
   p_TCB->stack[0] = MAGIC_WORD;
@@ -107,13 +93,13 @@ static __inline U32 *rt_ret_regs (P_TCB p_TCB) {
   /* Get pointer to task return value registers (R0..R3) in Stack */
   if (p_TCB->stack_frame & 0x4) {
     /* NEON/D32 Stack Frame: D0-31,FPSCR,Reserved,R4-R11,R0-R3,R12,LR,PC,xPSR */
-    return (U32 *)(p_TCB->tsk_stack + (8U*4U) + (2U*4U) + (32U*8U));
+    return (U32 *)(p_TCB->tsk_stack + 8*4 + 2*4 + 32*8);
   } else if (p_TCB->stack_frame & 0x2) {
     /* VFP/D16 Stack Frame: D0-D15/S0-31,FPSCR,Reserved,R4-R11,R0-R3,R12,LR,PC,xPSR */
-    return (U32 *)(p_TCB->tsk_stack + (8U*4U) + (2U*4U) + (32U*4U));
+    return (U32 *)(p_TCB->tsk_stack + 8*4 + 2*4 + 32*4);
   } else {
     /* Basic Stack Frame: R4-R11,R0-R3,R12,LR,PC,xPSR */
-    return (U32 *)(p_TCB->tsk_stack + (8U*4U));
+    return (U32 *)(p_TCB->tsk_stack + 8*4);
   }
 }
 

--- a/rtos/rtx/TARGET_CORTEX_A/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_A/RTX_CM_lib.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RTX_CM_LIB.H
  *      Purpose: RTX Kernel System Configuration
- *      Rev.:    V4.79
+ *      Rev.:    V4.73
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -63,10 +63,9 @@ typedef uint32_t OS_RESULT;
 
 #define runtask_id()    rt_tsk_self()
 #define mutex_init(m)   rt_mut_init(m)
-#define mutex_wait(m)   os_mut_wait(m,0xFFFFU)
+#define mutex_wait(m)   os_mut_wait(m,0xFFFF)
 #define mutex_rel(m)    os_mut_release(m)
 
-extern uint8_t   os_running;
 extern OS_TID    rt_tsk_self    (void);
 extern void      rt_mut_init    (OS_ID mutex);
 extern OS_RESULT rt_mut_release (OS_ID mutex);
@@ -141,14 +140,6 @@ void __iar_system_Mtxunlock(__iar_Rmtx *);
  *      Global Variables
  *---------------------------------------------------------------------------*/
 
-#if (OS_TASKCNT == 0)
-#error "Invalid number of concurrent running threads!"
-#endif
-
-#if (OS_PRIVCNT >= OS_TASKCNT)
-#error "Too many threads with user-provided stack size!"
-#endif
-
 #if (OS_TIMERS != 0)
 #define OS_TASK_CNT (OS_TASKCNT + 1)
 #ifndef __MBED_CMSIS_RTOS_CA9
@@ -163,32 +154,24 @@ void __iar_system_Mtxunlock(__iar_Rmtx *);
 #endif
 #endif
 
-#ifndef OS_STKINIT
-#define OS_STKINIT  0
-#endif
-
 uint16_t const os_maxtaskrun = OS_TASK_CNT;
 #ifdef __MBED_CMSIS_RTOS_CA9
-uint32_t const os_stackinfo  = (OS_STKINIT<<28) | (OS_STKCHECK<<24) | (OS_IDLESTKSIZE*4);
+uint32_t const os_stackinfo  = (OS_STKCHECK<<24)| (OS_IDLESTKSIZE*4);
 #else
-uint32_t const os_stackinfo  = (OS_STKINIT<<28) | (OS_STKCHECK<<24) | (OS_PRIV_CNT<<16) | (OS_STKSIZE*4);
+uint32_t const os_stackinfo  = (OS_STKCHECK<<24)| (OS_PRIV_CNT<<16) | (OS_STKSIZE*4);
 #endif
 uint32_t const os_rrobin     = (OS_ROBIN << 16) | OS_ROBINTOUT;
 uint32_t const os_tickfreq   = OS_CLOCK;
 uint16_t const os_tickus_i   = OS_CLOCK/1000000;
 uint16_t const os_tickus_f   = (((uint64_t)(OS_CLOCK-1000000*(OS_CLOCK/1000000)))<<16)/1000000;
 uint32_t const os_trv        = OS_TRV;
-#if       defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED)
-uint8_t  const os_flags      = 0;
-#else  /* defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED) */
 uint8_t  const os_flags      = OS_RUNPRIV;
-#endif /* defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED) */
 
 /* Export following defines to uVision debugger. */
 __USED uint32_t const CMSIS_RTOS_API_Version = osCMSIS;
 __USED uint32_t const CMSIS_RTOS_RTX_Version = osCMSIS_RTX;
 __USED uint32_t const os_clockrate = OS_TICK;
-__USED uint32_t const os_timernum  = 0U;
+__USED uint32_t const os_timernum  = 0;
 
 /* Memory pool for TCB allocation    */
 _declare_box  (mp_tcb, OS_TCB_SIZE, OS_TASK_CNT);
@@ -233,14 +216,14 @@ osMessageQId osMessageQId_osTimerMessageQ;
 #else
 osThreadDef_t os_thread_def_osTimerThread = { NULL };
 osThreadId osThreadId_osTimerThread;
-osMessageQDef(osTimerMessageQ, 0U, void *);
+osMessageQDef(osTimerMessageQ, 0, void *);
 osMessageQId osMessageQId_osTimerMessageQ;
 #endif
 
 /* Legacy RTX User Timers not used */
-uint32_t       os_tmr = 0U; 
+uint32_t       os_tmr = 0;
 uint32_t const *m_tmr = NULL;
-uint16_t const mp_tmr_size = 0U;
+uint16_t const mp_tmr_size = 0;
 
 /* singleton mutex */
 osMutexId singleton_mutex_id;
@@ -289,8 +272,8 @@ void *__user_perthread_libspace (void) {
   /* Provide a separate libspace for each task. */
   uint32_t idx;
 
-  idx = (os_running != 0U) ? runtask_id () : 0U;
-  if (idx == 0U) {
+  idx = runtask_id ();
+  if (idx == 0) {
     /* RTX not running yet. */
     return (&__libspace_start);
   }
@@ -316,7 +299,7 @@ int _mutex_initialize (OS_ID *mutex) {
 
 __attribute__((used)) void _mutex_acquire (OS_ID *mutex) {
   /* Acquire a system mutex, lock stdlib resources. */
-  if (os_running) {
+  if (runtask_id ()) {
     /* RTX running, acquire a mutex. */
     mutex_wait (*mutex);
   }
@@ -327,7 +310,7 @@ __attribute__((used)) void _mutex_acquire (OS_ID *mutex) {
 
 __attribute__((used)) void _mutex_release (OS_ID *mutex) {
   /* Release a system mutex, unlock stdlib resources. */
-  if (os_running) {
+  if (runtask_id ()) {
     /* RTX running, release a mutex. */
     mutex_rel (*mutex);
   }
@@ -420,9 +403,9 @@ void __iar_system_Mtxunlock(__iar_Rmtx *mutex)
 extern void pre_main (void);
 #ifdef __MBED_CMSIS_RTOS_CA9
 uint32_t os_thread_def_stack_main [(4 * OS_MAINSTKSIZE) / sizeof(uint32_t)];
-osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1U, 4*OS_MAINSTKSIZE, os_thread_def_stack_main };
+osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1, 4*OS_MAINSTKSIZE, os_thread_def_stack_main };
 #else
-osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1U, 4*OS_MAINSTKSIZE };
+osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1, 4*OS_MAINSTKSIZE };
 #endif
 
 #if defined (__CC_ARM)
@@ -502,12 +485,6 @@ __asm void __rt_entry (void) {
 #endif
 
 #elif defined (__GNUC__)
-
-osMutexDef(malloc_mutex);
-static osMutexId malloc_mutex_id;
-osMutexDef(env_mutex);
-static osMutexId env_mutex_id;
-
 extern int atexit(void (*func)(void));
 extern void __libc_fini_array(void);
 extern void __libc_init_array (void);
@@ -515,8 +492,7 @@ extern int main(int argc, char **argv);
 
 void pre_main(void) {
     singleton_mutex_id = osMutexCreate(osMutex(singleton_mutex));
-    malloc_mutex_id = osMutexCreate(osMutex(malloc_mutex));
-    env_mutex_id = osMutexCreate(osMutex(env_mutex));
+    atexit(__libc_fini_array);
     __libc_init_array();
     main(0, NULL);
 }
@@ -533,29 +509,6 @@ __attribute__((naked)) void software_init_hook_rtos (void) {
     /* osKernelStart should not return */ 
     "B       .\n"
   );
-}
-
-// Opaque declaration of _reent structure
-struct _reent;
-
-void __rtos_malloc_lock( struct _reent *_r )
-{
-    osMutexWait(malloc_mutex_id, osWaitForever);
-}
-
-void __rtos_malloc_unlock( struct _reent *_r )
-{
-    osMutexRelease(malloc_mutex_id);
-}
-
-void __rtos_env_lock( struct _reent *_r )
-{
-    osMutexWait(env_mutex_id, osWaitForever);
-}
-
-void __rtos_env_unlock( struct _reent *_r )
-{
-    osMutexRelease(env_mutex_id);
 }
 
 #elif defined (__ICCARM__)
@@ -580,7 +533,7 @@ void pre_main(void) {
 }
 
 #pragma required=__vector_core_a9
-void __iar_program_start(void)
+void __iar_program_start( void )
 {
   __iar_init_core();
   __iar_init_vfp();
@@ -603,6 +556,8 @@ void __iar_program_start(void)
 
 #endif
 
+
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/RTX_Conf_CA.c
+++ b/rtos/rtx/TARGET_CORTEX_A/RTX_Conf_CA.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RTX_Conf_CM.C
  *      Purpose: Configuration of CMSIS RTX Kernel
- *      Rev.:    V4.60
+ *      Rev.:    V4.80
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -51,8 +51,8 @@
 // <h>Thread Configuration
 // =======================
 //
-//   <o>Number of concurrent running threads <0-250>
-//   <i> Defines max. number of threads that will run at the same time.
+//   <o>Number of concurrent running user threads <1-250>
+//   <i> Defines max. number of user threads that will run at the same time.
 //   <i> Default: 6
 #ifndef OS_TASKCNT
  #define OS_TASKCNT     25
@@ -69,7 +69,7 @@
 //   <i> Defines default stack size for threads with osThreadDef stacksz = 0
 //   <i> Default: 200
 #ifndef OS_STKSIZE
- #define OS_STKSIZE     200
+ #define OS_STKSIZE     200     // this stack size value is in words
 #endif
 #endif // __MBED_CMSIS_RTOS_CA9
 
@@ -77,7 +77,7 @@
 //   <i> Defines stack size for main thread.
 //   <i> Default: 4096
 #ifndef OS_MAINSTKSIZE
- #define OS_MAINSTKSIZE 4096
+ #define OS_MAINSTKSIZE 4096	// this stack size value is in words
 #endif
 
 #ifndef __MBED_CMSIS_RTOS_CA9
@@ -92,21 +92,28 @@
 //   <i> Defines the combined stack size for threads with user-provided stack size.
 //   <i> Default: 0
 #ifndef OS_PRIVSTKSIZE
- #define OS_PRIVSTKSIZE 0
+ #define OS_PRIVSTKSIZE 0       // this stack size value is in words
 #endif
 #endif // __MBED_CMSIS_RTOS_CA9
 
-// <q>Check for stack overflow
-// <i> Includes the stack checking code for stack overflow.
-// <i> Note that additional code reduces the Kernel performance.
+//   <q>Stack overflow checking
+//   <i> Enable stack overflow checks at thread switch.
+//   <i> Enabling this option increases slightly the execution time of a thread switch.
 #ifndef OS_STKCHECK
  #define OS_STKCHECK    1
 #endif
 
-// <o>Processor mode for thread execution
-//   <0=> Unprivileged mode
-//   <1=> Privileged mode
-// <i> Default: Privileged mode
+//   <q>Stack usage watermark
+//   <i> Initialize thread stack with watermark pattern for analyzing stack usage (current/maximum) in System and Thread Viewer.
+//   <i> Enabling this option increases significantly the execution time of osThreadCreate.
+#ifndef OS_STKINIT
+#define OS_STKINIT      0
+#endif
+
+//   <o>Processor mode for thread execution
+//     <0=> Unprivileged mode
+//     <1=> Privileged mode
+//   <i> Default: Privileged mode
 #ifndef OS_RUNPRIV
  #define OS_RUNPRIV     1
 #endif
@@ -115,21 +122,23 @@
 
 // <h>RTX Kernel Timer Tick Configuration
 // ======================================
-// <q> Use Cortex-M SysTick timer as RTX Kernel Timer
-// <i> Use the Cortex-M SysTick timer as a time-base for RTX.
+//   <q> Use Cortex-M SysTick timer as RTX Kernel Timer
+//   <i> Cortex-M processors provide in most cases a SysTick timer that can be used as 
+//   <i> as time-base for RTX.
 #ifndef OS_SYSTICK
  #define OS_SYSTICK     0
 #endif
 //
-//   <o>Timer clock value [Hz] <1-1000000000>
-//   <i> Defines the timer clock value.
+//   <o>RTOS Kernel Timer input clock frequency [Hz] <1-1000000000>
+//   <i> Defines the input frequency of the RTOS Kernel Timer.  
 //   <i> Default: 12000000  (12MHz)
+//   <i> is on most systems identical with the core clock.
 #ifndef OS_CLOCK
  #error "no target defined"
 #endif
 
-//   <o>Timer tick value [us] <1-1000000>
-//   <i> Defines the timer tick value.
+//   <o>RTX Timer tick interval value [us] <1-1000000>
+//   <i> The RTX Timer tick interval value is used to calculate timeout values.
 //   <i> Default: 1000  (1ms)
 #ifndef OS_TICK
  #define OS_TICK        1000
@@ -179,7 +188,7 @@
 //   <i> Defines stack size for Timer thread.
 //   <i> Default: 200
 #ifndef OS_TIMERSTKSZ
- #define OS_TIMERSTKSZ  WORDS_STACK_SIZE
+ #define OS_TIMERSTKSZ  WORDS_STACK_SIZE	    // this stack size value is in words
 #endif
 
 //   <o>Timer Callback Queue size <1-32>
@@ -209,7 +218,7 @@
 
 // Standard library system mutexes
 // ===============================
-//  Define max. number system mutexes that are used to protect
+//  Define max. number system mutexes that are used to protect 
 //  the arm standard runtime library. For microlib they are not used.
 #ifndef OS_MUTEXCNT
  #define OS_MUTEXCNT    12
@@ -229,9 +238,8 @@
 /*--------------------------- os_idle_demon ---------------------------------*/
 extern void rtos_idle_loop(void);
 
+/// \brief The idle demon is running when no other thread is ready to run
 void os_idle_demon (void) {
-  /* The idle demon is a system thread, running when no other thread is      */
-  /* ready to run.                                                           */
   rtos_idle_loop();
 }
 
@@ -276,8 +284,8 @@ extern void OS_Tick_Handler(uint32_t);
 extern uint32_t InterruptHandlerRegister (IRQn_Type irq, IRQHandler handler);
 #endif
 
-// Initialize alternative hardware timer as RTX kernel timer
-// Return: IRQ number of the alternative hardware timer
+/// \brief Initializes an alternative hardware timer as RTX kernel timer
+/// \return                             IRQ number of the alternative hardware timer
 int os_tick_init (void) {
 #if defined(TARGET_RZ_A1H) || defined(TARGET_VK_RZ_A1H)
   CPGSTBCR5 &= ~(CPG_STBCR5_BIT_MSTP51); /* enable OSTM0 clock */
@@ -300,7 +308,7 @@ int os_tick_init (void) {
 
 /*--------------------------- os_tick_irqack --------------------------------*/
 
-// Acknowledge alternative hardware timer interrupt
+/// \brief Acknowledge alternative hardware timer interrupt
 void os_tick_irqack (void) {
   /* ... */
 }
@@ -308,12 +316,14 @@ void os_tick_irqack (void) {
 #endif   // (OS_SYSTICK == 0)
 
 /*--------------------------- os_error --------------------------------------*/
-extern void mbed_die(void);
+extern void error(const char* format, ...);
+extern osThreadId svcThreadGetId (void);
 
 void os_error (uint32_t err_code) {
-  /* This function is called when a runtime error is detected. Parameter */
-  /* 'err_code' holds the runtime error code (defined in RTL.H).         */
-    mbed_die();
+    /* This function is called when a runtime error is detected. Parameter     */
+    /* 'err_code' holds the runtime error code (defined in RTX_Config.h).      */
+    osThreadId err_task = svcThreadGetId();
+    error("RTX error code: 0x%08X, task ID: 0x%08X\n", err_code, err_task);
 
   /* HERE: include optional code to be executed on runtime error. */
   for (;;);

--- a/rtos/rtx/TARGET_CORTEX_A/RTX_Conf_CA.c
+++ b/rtos/rtx/TARGET_CORTEX_A/RTX_Conf_CA.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RTX_Conf_CM.C
  *      Purpose: Configuration of CMSIS RTX Kernel
- *      Rev.:    V4.80
+ *      Rev.:    V4.60
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -51,8 +51,8 @@
 // <h>Thread Configuration
 // =======================
 //
-//   <o>Number of concurrent running user threads <1-250>
-//   <i> Defines max. number of user threads that will run at the same time.
+//   <o>Number of concurrent running threads <0-250>
+//   <i> Defines max. number of threads that will run at the same time.
 //   <i> Default: 6
 #ifndef OS_TASKCNT
  #define OS_TASKCNT     25
@@ -69,7 +69,7 @@
 //   <i> Defines default stack size for threads with osThreadDef stacksz = 0
 //   <i> Default: 200
 #ifndef OS_STKSIZE
- #define OS_STKSIZE     200     // this stack size value is in words
+ #define OS_STKSIZE     200
 #endif
 #endif // __MBED_CMSIS_RTOS_CA9
 
@@ -77,7 +77,7 @@
 //   <i> Defines stack size for main thread.
 //   <i> Default: 4096
 #ifndef OS_MAINSTKSIZE
- #define OS_MAINSTKSIZE 4096	// this stack size value is in words
+ #define OS_MAINSTKSIZE 4096
 #endif
 
 #ifndef __MBED_CMSIS_RTOS_CA9
@@ -92,28 +92,21 @@
 //   <i> Defines the combined stack size for threads with user-provided stack size.
 //   <i> Default: 0
 #ifndef OS_PRIVSTKSIZE
- #define OS_PRIVSTKSIZE 0       // this stack size value is in words
+ #define OS_PRIVSTKSIZE 0
 #endif
 #endif // __MBED_CMSIS_RTOS_CA9
 
-//   <q>Stack overflow checking
-//   <i> Enable stack overflow checks at thread switch.
-//   <i> Enabling this option increases slightly the execution time of a thread switch.
+// <q>Check for stack overflow
+// <i> Includes the stack checking code for stack overflow.
+// <i> Note that additional code reduces the Kernel performance.
 #ifndef OS_STKCHECK
  #define OS_STKCHECK    1
 #endif
 
-//   <q>Stack usage watermark
-//   <i> Initialize thread stack with watermark pattern for analyzing stack usage (current/maximum) in System and Thread Viewer.
-//   <i> Enabling this option increases significantly the execution time of osThreadCreate.
-#ifndef OS_STKINIT
-#define OS_STKINIT      0
-#endif
-
-//   <o>Processor mode for thread execution
-//     <0=> Unprivileged mode
-//     <1=> Privileged mode
-//   <i> Default: Privileged mode
+// <o>Processor mode for thread execution
+//   <0=> Unprivileged mode
+//   <1=> Privileged mode
+// <i> Default: Privileged mode
 #ifndef OS_RUNPRIV
  #define OS_RUNPRIV     1
 #endif
@@ -122,23 +115,21 @@
 
 // <h>RTX Kernel Timer Tick Configuration
 // ======================================
-//   <q> Use Cortex-M SysTick timer as RTX Kernel Timer
-//   <i> Cortex-M processors provide in most cases a SysTick timer that can be used as 
-//   <i> as time-base for RTX.
+// <q> Use Cortex-M SysTick timer as RTX Kernel Timer
+// <i> Use the Cortex-M SysTick timer as a time-base for RTX.
 #ifndef OS_SYSTICK
  #define OS_SYSTICK     0
 #endif
 //
-//   <o>RTOS Kernel Timer input clock frequency [Hz] <1-1000000000>
-//   <i> Defines the input frequency of the RTOS Kernel Timer.  
+//   <o>Timer clock value [Hz] <1-1000000000>
+//   <i> Defines the timer clock value.
 //   <i> Default: 12000000  (12MHz)
-//   <i> is on most systems identical with the core clock.
 #ifndef OS_CLOCK
  #error "no target defined"
 #endif
 
-//   <o>RTX Timer tick interval value [us] <1-1000000>
-//   <i> The RTX Timer tick interval value is used to calculate timeout values.
+//   <o>Timer tick value [us] <1-1000000>
+//   <i> Defines the timer tick value.
 //   <i> Default: 1000  (1ms)
 #ifndef OS_TICK
  #define OS_TICK        1000
@@ -188,7 +179,7 @@
 //   <i> Defines stack size for Timer thread.
 //   <i> Default: 200
 #ifndef OS_TIMERSTKSZ
- #define OS_TIMERSTKSZ  WORDS_STACK_SIZE	    // this stack size value is in words
+ #define OS_TIMERSTKSZ  WORDS_STACK_SIZE
 #endif
 
 //   <o>Timer Callback Queue size <1-32>
@@ -218,7 +209,7 @@
 
 // Standard library system mutexes
 // ===============================
-//  Define max. number system mutexes that are used to protect 
+//  Define max. number system mutexes that are used to protect
 //  the arm standard runtime library. For microlib they are not used.
 #ifndef OS_MUTEXCNT
  #define OS_MUTEXCNT    12
@@ -238,8 +229,9 @@
 /*--------------------------- os_idle_demon ---------------------------------*/
 extern void rtos_idle_loop(void);
 
-/// \brief The idle demon is running when no other thread is ready to run
 void os_idle_demon (void) {
+  /* The idle demon is a system thread, running when no other thread is      */
+  /* ready to run.                                                           */
   rtos_idle_loop();
 }
 
@@ -284,8 +276,8 @@ extern void OS_Tick_Handler(uint32_t);
 extern uint32_t InterruptHandlerRegister (IRQn_Type irq, IRQHandler handler);
 #endif
 
-/// \brief Initializes an alternative hardware timer as RTX kernel timer
-/// \return                             IRQ number of the alternative hardware timer
+// Initialize alternative hardware timer as RTX kernel timer
+// Return: IRQ number of the alternative hardware timer
 int os_tick_init (void) {
 #if defined(TARGET_RZ_A1H) || defined(TARGET_VK_RZ_A1H)
   CPGSTBCR5 &= ~(CPG_STBCR5_BIT_MSTP51); /* enable OSTM0 clock */
@@ -308,7 +300,7 @@ int os_tick_init (void) {
 
 /*--------------------------- os_tick_irqack --------------------------------*/
 
-/// \brief Acknowledge alternative hardware timer interrupt
+// Acknowledge alternative hardware timer interrupt
 void os_tick_irqack (void) {
   /* ... */
 }
@@ -316,14 +308,12 @@ void os_tick_irqack (void) {
 #endif   // (OS_SYSTICK == 0)
 
 /*--------------------------- os_error --------------------------------------*/
-extern void error(const char* format, ...);
-extern osThreadId svcThreadGetId (void);
+extern void mbed_die(void);
 
 void os_error (uint32_t err_code) {
-    /* This function is called when a runtime error is detected. Parameter     */
-    /* 'err_code' holds the runtime error code (defined in RTX_Config.h).      */
-    osThreadId err_task = svcThreadGetId();
-    error("RTX error code: 0x%08X, task ID: 0x%08X\n", err_code, err_task);
+  /* This function is called when a runtime error is detected. Parameter */
+  /* 'err_code' holds the runtime error code (defined in RTL.H).         */
+    mbed_die();
 
   /* HERE: include optional code to be executed on runtime error. */
   for (;;);

--- a/rtos/rtx/TARGET_CORTEX_A/RTX_Config.h
+++ b/rtos/rtx/TARGET_CORTEX_A/RTX_Config.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RTX_CONFIG.H
  *      Purpose: Exported functions of RTX_Config.c
- *      Rev.:    V4.70
+ *      Rev.:    V4.79
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,31 +15,32 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
 
 
 /* Error Codes */
-#define OS_ERR_STK_OVF          1
-#define OS_ERR_FIFO_OVF         2
-#define OS_ERR_MBX_OVF          3
+#define OS_ERR_STK_OVF          1U
+#define OS_ERR_FIFO_OVF         2U
+#define OS_ERR_MBX_OVF          3U
+#define OS_ERR_TIMER_OVF        4U
 
 /* Definitions */
-#define BOX_ALIGN_8                   0x80000000
+#define BOX_ALIGN_8                   0x80000000U
 #define _declare_box(pool,size,cnt)   U32 pool[(((size)+3)/4)*(cnt) + 3]
 #define _declare_box8(pool,size,cnt)  U64 pool[(((size)+7)/8)*(cnt) + 2]
 #define _init_box8(pool,size,bsize)   _init_box (pool,size,(bsize) | BOX_ALIGN_8)
@@ -66,7 +67,7 @@ extern U8  const os_fifo_size;
 
 /* Functions */
 extern void os_idle_demon   (void);
-extern int  os_tick_init    (void);
+extern S32  os_tick_init    (void);
 extern U32  os_tick_val     (void);
 extern U32  os_tick_ovf     (void);
 extern void os_tick_irqack  (void);

--- a/rtos/rtx/TARGET_CORTEX_A/RTX_Config.h
+++ b/rtos/rtx/TARGET_CORTEX_A/RTX_Config.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RTX_CONFIG.H
  *      Purpose: Exported functions of RTX_Config.c
- *      Rev.:    V4.79
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,32 +15,31 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
 
 
 /* Error Codes */
-#define OS_ERR_STK_OVF          1U
-#define OS_ERR_FIFO_OVF         2U
-#define OS_ERR_MBX_OVF          3U
-#define OS_ERR_TIMER_OVF        4U
+#define OS_ERR_STK_OVF          1
+#define OS_ERR_FIFO_OVF         2
+#define OS_ERR_MBX_OVF          3
 
 /* Definitions */
-#define BOX_ALIGN_8                   0x80000000U
+#define BOX_ALIGN_8                   0x80000000
 #define _declare_box(pool,size,cnt)   U32 pool[(((size)+3)/4)*(cnt) + 3]
 #define _declare_box8(pool,size,cnt)  U64 pool[(((size)+7)/8)*(cnt) + 2]
 #define _init_box8(pool,size,bsize)   _init_box (pool,size,(bsize) | BOX_ALIGN_8)
@@ -67,7 +66,7 @@ extern U8  const os_fifo_size;
 
 /* Functions */
 extern void os_idle_demon   (void);
-extern S32  os_tick_init    (void);
+extern int  os_tick_init    (void);
 extern U32  os_tick_val     (void);
 extern U32  os_tick_ovf     (void);
 extern void os_tick_irqack  (void);

--- a/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_ARM/HAL_CA9.c
+++ b/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_ARM/HAL_CA9.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    HAL_CA9.c
- *      Purpose: Hardware Abstraction Layer for Cortex-A9 (GICv1)
- *      Rev.:    28 April 2016
+ *      Purpose: Hardware Abstraction Layer for Cortex-A9
+ *      Rev.:    8 April 2015
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 2012 - 2016 ARM Limited
+ * Copyright (c) 2012 - 2015 ARM Limited
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
  * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -87,7 +87,7 @@ __asm void *_alloc_box (void *box_mem) {
 
 
 /*--------------------------- _free_box -------------------------------------*/
-__asm U32 _free_box (void *box_mem, void *box) {
+__asm int _free_box (void *box_mem, void *box) {
    /* Function wrapper for Unprivileged/Privileged mode. */
         ARM
 
@@ -114,7 +114,7 @@ __asm void SVC_Handler (void) {
         IMPORT  SVC_Table
         IMPORT  rt_stk_check
         IMPORT  FPUEnable
-        IMPORT  scheduler_suspended    ; Flag set by rt_suspend, cleared by rt_resume, read by SVC_Handler
+        IMPORT  scheduler_suspended    ; flag set by rt_suspend, cleared by rt_resume, read by SVC_Handler
 
 Mode_SVC        EQU     0x13
 
@@ -353,7 +353,7 @@ __asm void PendSV_Handler (U32 IRQn) {
 
     IMPORT  rt_tsk_lock
     IMPORT  IRQNestLevel                ; Flag indicates whether inside an ISR, and the depth of nesting.  0 = not in ISR.
-    IMPORT  seen_id0_active             ; Flag used to workaround GIC 390 errata 733075 (set in startup_<board>.s)
+    IMPORT  seen_id0_active             ; Flag used to workaround GIC 390 errata 733075 - set in startup_Renesas_RZ_A1.s
 
     ADD     SP,SP,#8 //fix up stack pointer (R0 has been pushed and will never be popped, R1 was pushed for stack alignment)
 
@@ -363,7 +363,7 @@ __asm void PendSV_Handler (U32 IRQn) {
     POP     {R0, R1}
     LDR     R1, =__cpp(&GICInterface_BASE)
     LDR     R1, [R1, #0]
-    STR     R0, [R1, #0x10]             ; Write End Of Interrupt ID to GICC_EOIR
+    STR     R0, [R1, #0x10]
 
     ; If it was interrupt ID0, clear the seen flag, otherwise return as normal
     CMP     R0, #0
@@ -396,17 +396,16 @@ __asm void OS_Tick_Handler (U32 IRQn) {
 
     IMPORT  rt_tsk_lock
     IMPORT  IRQNestLevel                ; Flag indicates whether inside an ISR, and the depth of nesting.  0 = not in ISR.
-    IMPORT  seen_id0_active             ; Flag used to workaround GIC 390 errata 733075 (set in startup_<board>.s)
+    IMPORT  seen_id0_active             ; Flag used to workaround GIC 390 errata 733075 - set in startup_Renesas_RZ_A1.s
 
     ADD     SP,SP,#8 //fix up stack pointer (R0 has been pushed and will never be popped, R1 was pushed for stack alignment)
 
-    //Disable systick interrupts, then write EOIR. We want interrupts disabled before we enter the context switcher.
     PUSH    {R0, R1}
     BLX     rt_tsk_lock
     POP     {R0, R1}
     LDR     R1, =__cpp(&GICInterface_BASE)
     LDR     R1, [R1, #0]
-    STR     R0, [R1, #0x10]             ; Write End Of Interrupt ID to GICC_EOIR
+    STR     R0, [R1, #0x10]
 
     ; If it was interrupt ID0, clear the seen flag, otherwise return as normal
     CMP     R0, #0

--- a/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_ARM/SVC_Table.S
+++ b/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_ARM/SVC_Table.S
@@ -1,12 +1,12 @@
 ;/*----------------------------------------------------------------------------
-; *      RL-ARM - RTX
+; *      CMSIS-RTOS  -  RTX
 ; *----------------------------------------------------------------------------
 ; *      Name:    SVC_TABLE.S
-; *      Purpose: Pre-defined SVC Table for Cortex-M
-; *      Rev.:    V4.70
+; *      Purpose: Pre-defined SVC Table
+; *      Rev.:    V4.70, with additions for Cortex-A
 ; *----------------------------------------------------------------------------
 ; *
-; * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+; * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH, 2014-2015 ARM Ltd
 ; * All rights reserved.
 ; * Redistribution and use in source and binary forms, with or without
 ; * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
 ; *  - Redistributions in binary form must reproduce the above copyright
 ; *    notice, this list of conditions and the following disclaimer in the
 ; *    documentation and/or other materials provided with the distribution.
-; *  - Neither the name of ARM  nor the names of its contributors may be used
-; *    to endorse or promote products derived from this software without
+; *  - Neither the name of ARM  nor the names of its contributors may be used 
+; *    to endorse or promote products derived from this software without 
 ; *    specific prior written permission.
 ; *
-; * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-; * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+; * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+; * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
 ; * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 ; * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
 ; * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-; * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-; * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-; * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-; * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+; * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+; * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+; * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+; * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
 ; * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 ; * POSSIBILITY OF SUCH DAMAGE.
 ; *---------------------------------------------------------------------------*/
@@ -45,8 +45,8 @@ SVC_Count       DCD     SVC_Cnt
 
                 EXPORT  SVC_Table
 SVC_Table
-; Insert user SVC functions here. SVC 0 used by RTL Kernel.
-;                DCD     __SVC_1                 ; InitMemorySubsystem
+; Insert user SVC functions here. SVC 0 used by RTX Kernel.
+;                DCD     __SVC_1                 ; EnableCaches
 
 SVC_End
 

--- a/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_ARM/SVC_Table.S
+++ b/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_ARM/SVC_Table.S
@@ -1,12 +1,12 @@
 ;/*----------------------------------------------------------------------------
-; *      CMSIS-RTOS  -  RTX
+; *      RL-ARM - RTX
 ; *----------------------------------------------------------------------------
 ; *      Name:    SVC_TABLE.S
-; *      Purpose: Pre-defined SVC Table
-; *      Rev.:    V4.70, with additions for Cortex-A
+; *      Purpose: Pre-defined SVC Table for Cortex-M
+; *      Rev.:    V4.70
 ; *----------------------------------------------------------------------------
 ; *
-; * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH, 2014-2015 ARM Ltd
+; * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
 ; * All rights reserved.
 ; * Redistribution and use in source and binary forms, with or without
 ; * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
 ; *  - Redistributions in binary form must reproduce the above copyright
 ; *    notice, this list of conditions and the following disclaimer in the
 ; *    documentation and/or other materials provided with the distribution.
-; *  - Neither the name of ARM  nor the names of its contributors may be used 
-; *    to endorse or promote products derived from this software without 
+; *  - Neither the name of ARM  nor the names of its contributors may be used
+; *    to endorse or promote products derived from this software without
 ; *    specific prior written permission.
 ; *
-; * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-; * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+; * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+; * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 ; * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 ; * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
 ; * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-; * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-; * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-; * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-; * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+; * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+; * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+; * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+; * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ; * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 ; * POSSIBILITY OF SUCH DAMAGE.
 ; *---------------------------------------------------------------------------*/
@@ -45,8 +45,8 @@ SVC_Count       DCD     SVC_Cnt
 
                 EXPORT  SVC_Table
 SVC_Table
-; Insert user SVC functions here. SVC 0 used by RTX Kernel.
-;                DCD     __SVC_1                 ; EnableCaches
+; Insert user SVC functions here. SVC 0 used by RTL Kernel.
+;                DCD     __SVC_1                 ; InitMemorySubsystem
 
 SVC_End
 

--- a/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_GCC/HAL_CA9.S
+++ b/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_GCC/HAL_CA9.S
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    HAL_CA9.c
- *      Purpose: Hardware Abstraction Layer for Cortex-A9
- *      Rev.:    8 April 2015
+ *      Purpose: Hardware Abstraction Layer for Cortex-A9 (GICv1)
+ *      Rev.:    28 April 2016
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 2012 - 2015 ARM Limited
+ * Copyright (c) 2012 - 2016 ARM Limited
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
  * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -117,7 +117,7 @@ _alloc_box:
 
 
 /*--------------------------- _free_box -------------------------------------*/
-@ __asm int _free_box (void *box_mem, void *box) {
+@ __asm U32 _free_box (void *box_mem, void *box) {
 _free_box:
    /* Function wrapper for Unprivileged/Privileged mode. */
         .ARM
@@ -386,7 +386,7 @@ PendSV_Handler:
 
     .extern  rt_tsk_lock
     .extern  IRQNestLevel                @ Flag indicates whether inside an ISR, and the depth of nesting.  0 = not in ISR.
-    .extern  seen_id0_active             @ Flag used to workaround GIC 390 errata 733075 - set in startup_Renesas_RZ_A1.s
+    .extern  seen_id0_active             @ Flag used to workaround GIC 390 errata 733075 (set in startup_<board>.s)
 
     ADD     SP,SP,#8 @ fix up stack pointer (R0 has been pushed and will never be popped, R1 was pushed for stack alignment)
 
@@ -396,7 +396,7 @@ PendSV_Handler:
     POP     {R0, R1}
     LDR     R1, =GICInterface_BASE
     LDR     R1, [R1, #0]
-    STR     R0, [R1, #0x10]
+    STR     R0, [R1, #0x10]             @ Write End Of Interrupt ID to GICC_EOIR
 
     @ If it was interrupt ID0, clear the seen flag, otherwise return as normal
     CMP     R0, #0
@@ -430,16 +430,17 @@ OS_Tick_Handler:
 
     .extern  rt_tsk_lock
     .extern  IRQNestLevel                @ Flag indicates whether inside an ISR, and the depth of nesting.  0 = not in ISR.
-    .extern  seen_id0_active             @ Flag used to workaround GIC 390 errata 733075 - set in startup_Renesas_RZ_A1.s
+    .extern  seen_id0_active             @ Flag used to workaround GIC 390 errata 733075 (set in startup_<board>.s)
 
     ADD     SP,SP,#8 @ fix up stack pointer (R0 has been pushed and will never be popped, R1 was pushed for stack alignment)
 
+    @ Disable systick interrupts, then write EOIR. We want interrupts disabled before we enter the context switcher.
     PUSH    {R0, R1}
     BLX     rt_tsk_lock
     POP     {R0, R1}
     LDR     R1, =GICInterface_BASE
     LDR     R1, [R1, #0]
-    STR     R0, [R1, #0x10]
+    STR     R0, [R1, #0x10]             @ Write End Of Interrupt ID to GICC_EOIR
 
     @ If it was interrupt ID0, clear the seen flag, otherwise return as normal
     CMP     R0, #0

--- a/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_GCC/HAL_CA9.S
+++ b/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_GCC/HAL_CA9.S
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    HAL_CA9.c
- *      Purpose: Hardware Abstraction Layer for Cortex-A9 (GICv1)
- *      Rev.:    28 April 2016
+ *      Purpose: Hardware Abstraction Layer for Cortex-A9
+ *      Rev.:    8 April 2015
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 2012 - 2016 ARM Limited
+ * Copyright (c) 2012 - 2015 ARM Limited
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
  * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -117,7 +117,7 @@ _alloc_box:
 
 
 /*--------------------------- _free_box -------------------------------------*/
-@ __asm U32 _free_box (void *box_mem, void *box) {
+@ __asm int _free_box (void *box_mem, void *box) {
 _free_box:
    /* Function wrapper for Unprivileged/Privileged mode. */
         .ARM
@@ -386,7 +386,7 @@ PendSV_Handler:
 
     .extern  rt_tsk_lock
     .extern  IRQNestLevel                @ Flag indicates whether inside an ISR, and the depth of nesting.  0 = not in ISR.
-    .extern  seen_id0_active             @ Flag used to workaround GIC 390 errata 733075 (set in startup_<board>.s)
+    .extern  seen_id0_active             @ Flag used to workaround GIC 390 errata 733075 - set in startup_Renesas_RZ_A1.s
 
     ADD     SP,SP,#8 @ fix up stack pointer (R0 has been pushed and will never be popped, R1 was pushed for stack alignment)
 
@@ -396,7 +396,7 @@ PendSV_Handler:
     POP     {R0, R1}
     LDR     R1, =GICInterface_BASE
     LDR     R1, [R1, #0]
-    STR     R0, [R1, #0x10]             @ Write End Of Interrupt ID to GICC_EOIR
+    STR     R0, [R1, #0x10]
 
     @ If it was interrupt ID0, clear the seen flag, otherwise return as normal
     CMP     R0, #0
@@ -430,17 +430,16 @@ OS_Tick_Handler:
 
     .extern  rt_tsk_lock
     .extern  IRQNestLevel                @ Flag indicates whether inside an ISR, and the depth of nesting.  0 = not in ISR.
-    .extern  seen_id0_active             @ Flag used to workaround GIC 390 errata 733075 (set in startup_<board>.s)
+    .extern  seen_id0_active             @ Flag used to workaround GIC 390 errata 733075 - set in startup_Renesas_RZ_A1.s
 
     ADD     SP,SP,#8 @ fix up stack pointer (R0 has been pushed and will never be popped, R1 was pushed for stack alignment)
 
-    @ Disable systick interrupts, then write EOIR. We want interrupts disabled before we enter the context switcher.
     PUSH    {R0, R1}
     BLX     rt_tsk_lock
     POP     {R0, R1}
     LDR     R1, =GICInterface_BASE
     LDR     R1, [R1, #0]
-    STR     R0, [R1, #0x10]             @ Write End Of Interrupt ID to GICC_EOIR
+    STR     R0, [R1, #0x10]
 
     @ If it was interrupt ID0, clear the seen flag, otherwise return as normal
     CMP     R0, #0

--- a/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_GCC/SVC_Table.S
+++ b/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_GCC/SVC_Table.S
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    SVC_TABLE.S
- *      Purpose: Pre-defined SVC Table for Cortex-M
- *      Rev.:    V4.70
+ *      Purpose: Pre-defined SVC Table
+ *      Rev.:    V4.70, with additions for Cortex-A
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH, 2014-2015 ARM Ltd
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -45,8 +45,8 @@ SVC_Count:      .word   SVC_Cnt
 
                 .global SVC_Table
 SVC_Table:
-@ Insert user SVC functions here. SVC 0 used by RTL Kernel.
-@                .word   __SVC_1                 @ InitMemorySubsystem
+@ Insert user SVC functions here. SVC 0 used by RTX Kernel.
+@                .word   __SVC_1                 @ EnableCaches
 
 SVC_End:
 

--- a/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_GCC/SVC_Table.S
+++ b/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_GCC/SVC_Table.S
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    SVC_TABLE.S
- *      Purpose: Pre-defined SVC Table
- *      Rev.:    V4.70, with additions for Cortex-A
+ *      Purpose: Pre-defined SVC Table for Cortex-M
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH, 2014-2015 ARM Ltd
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -45,8 +45,8 @@ SVC_Count:      .word   SVC_Cnt
 
                 .global SVC_Table
 SVC_Table:
-@ Insert user SVC functions here. SVC 0 used by RTX Kernel.
-@                .word   __SVC_1                 @ EnableCaches
+@ Insert user SVC functions here. SVC 0 used by RTL Kernel.
+@                .word   __SVC_1                 @ InitMemorySubsystem
 
 SVC_End:
 

--- a/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_IAR/HAL_CA9_asm.s
+++ b/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_IAR/HAL_CA9_asm.s
@@ -122,7 +122,7 @@ _alloc_box:
 
 
 /*--------------------------- _free_box -------------------------------------*/
-//__asm int _free_box (void *box_mem, void *box) {
+//__asm U32 _free_box (void *box_mem, void *box) {
 _free_box:
    /* Function wrapper for Unprivileged/Privileged mode. */
 

--- a/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_IAR/HAL_CA9_asm.s
+++ b/rtos/rtx/TARGET_CORTEX_A/TOOLCHAIN_IAR/HAL_CA9_asm.s
@@ -122,7 +122,7 @@ _alloc_box:
 
 
 /*--------------------------- _free_box -------------------------------------*/
-//__asm U32 _free_box (void *box_mem, void *box) {
+//__asm int _free_box (void *box_mem, void *box) {
 _free_box:
    /* Function wrapper for Unprivileged/Privileged mode. */
 

--- a/rtos/rtx/TARGET_CORTEX_A/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_A/cmsis_os.h
@@ -50,94 +50,15 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
 
-/**
-\page cmsis_os_h Header File Template: cmsis_os.h
-
-The file \b cmsis_os.h is a template header file for a CMSIS-RTOS compliant Real-Time Operating System (RTOS).
-Each RTOS that is compliant with CMSIS-RTOS shall provide a specific \b cmsis_os.h header file that represents
-its implementation.
-
-The file cmsis_os.h contains:
- - CMSIS-RTOS API function definitions
- - struct definitions for parameters and return types
- - status and priority values used by CMSIS-RTOS API functions
- - macros for defining threads and other kernel objects
-
-
-<b>Name conventions and header file modifications</b>
-
-All definitions are prefixed with \b os to give an unique name space for CMSIS-RTOS functions.
-Definitions that are prefixed \b os_ are not used in the application code but local to this header file.
-All definitions and functions that belong to a module are grouped and have a common prefix, i.e. \b osThread.
-
-Definitions that are marked with <b>CAN BE CHANGED</b> can be adapted towards the needs of the actual CMSIS-RTOS implementation.
-These definitions can be specific to the underlying RTOS kernel.
-
-Definitions that are marked with <b>MUST REMAIN UNCHANGED</b> cannot be altered. Otherwise the CMSIS-RTOS implementation is no longer
-compliant to the standard. Note that some functions are optional and need not to be provided by every CMSIS-RTOS implementation.
-
-
-<b>Function calls from interrupt service routines</b>
-
-The following CMSIS-RTOS functions can be called from threads and interrupt service routines (ISR):
-  - \ref osSignalSet
-  - \ref osSemaphoreRelease
-  - \ref osPoolAlloc, \ref osPoolCAlloc, \ref osPoolFree
-  - \ref osMessagePut, \ref osMessageGet
-  - \ref osMailAlloc, \ref osMailCAlloc, \ref osMailGet, \ref osMailPut, \ref osMailFree
-
-Functions that cannot be called from an ISR are verifying the interrupt status and return in case that they are called
-from an ISR context the status code \b osErrorISR. In some implementations this condition might be caught using the HARD FAULT vector.
-
-Some CMSIS-RTOS implementations support CMSIS-RTOS function calls from multiple ISR at the same time.
-If this is impossible, the CMSIS-RTOS rejects calls by nested ISR functions with the status code \b osErrorISRRecursive.
-
-
-<b>Define and reference object definitions</b>
-
-With <b>\#define osObjectsExternal</b> objects are defined as external symbols. This allows to create a consistent header file
-that is used throughout a project as shown below:
-
-<i>Header File</i>
-\code
-#include <cmsis_os.h>                                         // CMSIS RTOS header file
-
-// Thread definition
-extern void thread_sample (void const *argument);             // function prototype
-osThreadDef (thread_sample, osPriorityBelowNormal, 1, 100);
-
-// Pool definition
-osPoolDef(MyPool, 10, long);
-\endcode
-
-
-This header file defines all objects when included in a C/C++ source file. When <b>\#define osObjectsExternal</b> is
-present before the header file, the objects are defined as external symbols. A single consistent header file can therefore be
-used throughout the whole project.
-
-<i>Example</i>
-\code
-#include "osObjects.h"     // Definition of the CMSIS-RTOS objects
-\endcode
-
-\code
-#define osObjectExternal   // Objects will be defined as external symbols
-#include "osObjects.h"     // Reference to the CMSIS-RTOS objects
-\endcode
-
-*/
 
 #ifndef _CMSIS_OS_H
 #define _CMSIS_OS_H
 
-/// \note MUST REMAIN UNCHANGED: \b osCMSIS identifies the CMSIS-RTOS API version.
-#define osCMSIS           0x10002      ///< API version (main [31:16] .sub [15:0])
+#define osCMSIS           0x10002U     ///< CMSIS-RTOS API version (main [31:16] .sub [15:0])
 
-/// \note CAN BE CHANGED: \b osCMSIS_KERNEL identifies the underlying RTOS kernel and version number.
-#define osCMSIS_RTX     ((4<<16)|74)   ///< RTOS identification and version (main [31:16] .sub [15:0])
+#define osCMSIS_RTX     ((4<<16)|80)   ///< RTOS identification and version (main [31:16] .sub [15:0])
 
-/// \note MUST REMAIN UNCHANGED: \b osKernelSystemId shall be consistent in every CMSIS-RTOS.
-#define osKernelSystemId "RTX V4.74"   ///< RTOS identification string
+#define osKernelSystemId "RTX V4.80"   ///< RTOS identification string
 
 #define CMSIS_OS_RTX
 #define CMSIS_OS_RTX_CA          /* new define for Coretex-A */
@@ -151,15 +72,14 @@ used throughout the whole project.
 
 #define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE*4)
 
-/// \note MUST REMAIN UNCHANGED: \b osFeature_xxx shall be consistent in every CMSIS-RTOS.
-#define osFeature_MainThread   1       ///< main thread      1=main can be thread, 0=not available
-#define osFeature_Pool         1       ///< Memory Pools:    1=available, 0=not available
-#define osFeature_MailQ        1       ///< Mail Queues:     1=available, 0=not available
-#define osFeature_MessageQ     1       ///< Message Queues:  1=available, 0=not available
-#define osFeature_Signals      16      ///< maximum number of Signal Flags available per thread
-#define osFeature_Semaphore    65535   ///< maximum count for \ref osSemaphoreCreate function
-#define osFeature_Wait         0       ///< osWait function: 1=available, 0=not available
-#define osFeature_SysTick      1       ///< osKernelSysTick functions: 1=available, 0=not available
+#define osFeature_MainThread   1       ///< main can be thread
+#define osFeature_Pool         1       ///< Memory Pools available
+#define osFeature_MailQ        1       ///< Mail Queues available
+#define osFeature_MessageQ     1       ///< Message Queues available
+#define osFeature_Signals      16      ///< 16 Signal Flags available per thread
+#define osFeature_Semaphore    65535   ///< Maximum count for \ref osSemaphoreCreate function
+#define osFeature_Wait         0       ///< osWait not available
+#define osFeature_SysTick      1       ///< osKernelSysTick functions available
 #define osFeature_ThreadEnum   1       ///< Thread enumeration available
 
 #if defined (__CC_ARM)
@@ -180,7 +100,6 @@ extern "C"
 // ==== Enumeration, structures, defines ====
 
 /// Priority used for thread control.
-/// \note MUST REMAIN UNCHANGED: \b osPriority shall be consistent in every CMSIS-RTOS.
 typedef enum  {
   osPriorityIdle          = -3,          ///< priority: idle (lowest)
   osPriorityLow           = -2,          ///< priority: low
@@ -193,11 +112,9 @@ typedef enum  {
 } osPriority;
 
 /// Timeout value.
-/// \note MUST REMAIN UNCHANGED: \b osWaitForever shall be consistent in every CMSIS-RTOS.
-#define osWaitForever     0xFFFFFFFF     ///< wait forever timeout value
+#define osWaitForever     0xFFFFFFFFU    ///< wait forever timeout value
 
 /// Status code values returned by CMSIS-RTOS functions.
-/// \note MUST REMAIN UNCHANGED: \b osStatus shall be consistent in every CMSIS-RTOS.
 typedef enum  {
   osOK                    =     0,       ///< function completed; no error or event occurred.
   osEventSignal           =  0x08,       ///< function completed; signal event occurred.
@@ -218,7 +135,6 @@ typedef enum  {
 
 
 /// Timer type value for the timer definition.
-/// \note MUST REMAIN UNCHANGED: \b os_timer_type shall be consistent in every CMSIS-RTOS.
 typedef enum  {
   osTimerOnce             =     0,       ///< one-shot timer
   osTimerPeriodic         =     1        ///< repeating timer
@@ -235,48 +151,38 @@ typedef enum {
 } osThreadInfo;
 
 /// Entry point of a thread.
-/// \note MUST REMAIN UNCHANGED: \b os_pthread shall be consistent in every CMSIS-RTOS.
 typedef void (*os_pthread) (void const *argument);
 
 /// Entry point of a timer call back function.
-/// \note MUST REMAIN UNCHANGED: \b os_ptimer shall be consistent in every CMSIS-RTOS.
 typedef void (*os_ptimer) (void const *argument);
 
 // >>> the following data type definitions may shall adapted towards a specific RTOS
 
 /// Thread ID identifies the thread (pointer to a thread control block).
-/// \note CAN BE CHANGED: \b os_thread_cb is implementation specific in every CMSIS-RTOS.
 typedef struct os_thread_cb *osThreadId;
 
 /// Timer ID identifies the timer (pointer to a timer control block).
-/// \note CAN BE CHANGED: \b os_timer_cb is implementation specific in every CMSIS-RTOS.
 typedef struct os_timer_cb *osTimerId;
 
 /// Mutex ID identifies the mutex (pointer to a mutex control block).
-/// \note CAN BE CHANGED: \b os_mutex_cb is implementation specific in every CMSIS-RTOS.
 typedef struct os_mutex_cb *osMutexId;
 
 /// Semaphore ID identifies the semaphore (pointer to a semaphore control block).
-/// \note CAN BE CHANGED: \b os_semaphore_cb is implementation specific in every CMSIS-RTOS.
 typedef struct os_semaphore_cb *osSemaphoreId;
 
 /// Pool ID identifies the memory pool (pointer to a memory pool control block).
-/// \note CAN BE CHANGED: \b os_pool_cb is implementation specific in every CMSIS-RTOS.
 typedef struct os_pool_cb *osPoolId;
 
 /// Message ID identifies the message queue (pointer to a message queue control block).
-/// \note CAN BE CHANGED: \b os_messageQ_cb is implementation specific in every CMSIS-RTOS.
 typedef struct os_messageQ_cb *osMessageQId;
 
 /// Mail ID identifies the mail queue (pointer to a mail queue control block).
-/// \note CAN BE CHANGED: \b os_mailQ_cb is implementation specific in every CMSIS-RTOS.
 typedef struct os_mailQ_cb *osMailQId;
 
 /// Thread enumeration ID identifies the enumeration (pointer to a thread enumeration control block).
 typedef uint32_t *osThreadEnumId;
 
 /// Thread Definition structure contains startup information of a thread.
-/// \note CAN BE CHANGED: \b os_thread_def is implementation specific in every CMSIS-RTOS.
 typedef struct os_thread_def  {
   os_pthread               pthread;    ///< start address of thread function
   osPriority             tpriority;    ///< initial thread priority
@@ -288,26 +194,22 @@ typedef struct os_thread_def  {
 } osThreadDef_t;
 
 /// Timer Definition structure contains timer parameters.
-/// \note CAN BE CHANGED: \b os_timer_def is implementation specific in every CMSIS-RTOS.
 typedef struct os_timer_def  {
   os_ptimer                 ptimer;    ///< start address of a timer function
   void                      *timer;    ///< pointer to internal data
 } osTimerDef_t;
 
 /// Mutex Definition structure contains setup information for a mutex.
-/// \note CAN BE CHANGED: \b os_mutex_def is implementation specific in every CMSIS-RTOS.
 typedef struct os_mutex_def  {
   void                      *mutex;    ///< pointer to internal data
 } osMutexDef_t;
 
 /// Semaphore Definition structure contains setup information for a semaphore.
-/// \note CAN BE CHANGED: \b os_semaphore_def is implementation specific in every CMSIS-RTOS.
 typedef struct os_semaphore_def  {
   void                  *semaphore;    ///< pointer to internal data
 } osSemaphoreDef_t;
 
 /// Definition structure for memory block allocation.
-/// \note CAN BE CHANGED: \b os_pool_def is implementation specific in every CMSIS-RTOS.
 typedef struct os_pool_def  {
   uint32_t                 pool_sz;    ///< number of items (elements) in the pool
   uint32_t                 item_sz;    ///< size of an item
@@ -315,14 +217,12 @@ typedef struct os_pool_def  {
 } osPoolDef_t;
 
 /// Definition structure for message queue.
-/// \note CAN BE CHANGED: \b os_messageQ_def is implementation specific in every CMSIS-RTOS.
 typedef struct os_messageQ_def  {
   uint32_t                queue_sz;    ///< number of elements in the queue
   void                       *pool;    ///< memory array for messages
 } osMessageQDef_t;
 
 /// Definition structure for mail queue.
-/// \note CAN BE CHANGED: \b os_mailQ_def is implementation specific in every CMSIS-RTOS.
 typedef struct os_mailQ_def  {
   uint32_t                queue_sz;    ///< number of elements in the queue
   uint32_t                 item_sz;    ///< size of an item
@@ -330,8 +230,6 @@ typedef struct os_mailQ_def  {
 } osMailQDef_t;
 
 /// Event structure contains detailed information about an event.
-/// \note MUST REMAIN UNCHANGED: \b os_event shall be consistent in every CMSIS-RTOS.
-///       However the struct may be extended at the end.
 typedef struct  {
   osStatus                 status;     ///< status code: event or error information
   union  {
@@ -350,27 +248,25 @@ typedef struct  {
 
 /// Initialize the RTOS Kernel for creating objects.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osKernelInitialize shall be consistent in every CMSIS-RTOS.
 osStatus osKernelInitialize (void);
 
 /// Start the RTOS Kernel.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osKernelStart shall be consistent in every CMSIS-RTOS.
 osStatus osKernelStart (void);
 
 /// Check if the RTOS kernel is already started.
-/// \note MUST REMAIN UNCHANGED: \b osKernelRunning shall be consistent in every CMSIS-RTOS.
 /// \return 0 RTOS is not started, 1 RTOS is started.
 int32_t osKernelRunning(void);
 
 #if (defined (osFeature_SysTick)  &&  (osFeature_SysTick != 0))     // System Timer available
 
+/// \cond INTERNAL_VARIABLES
 extern uint32_t const os_tickfreq;
 extern uint16_t const os_tickus_i;
 extern uint16_t const os_tickus_f;
+/// \endcond
 
 /// Get the RTOS kernel system timer counter.
-/// \note MUST REMAIN UNCHANGED: \b osKernelSysTick shall be consistent in every CMSIS-RTOS.
 /// \return RTOS kernel system timer as 32-bit value 
 uint32_t osKernelSysTick (void);
 
@@ -395,7 +291,6 @@ uint32_t osKernelSysTick (void);
 /// \param         priority     initial priority of the thread function.
 /// \param         instances    number of possible thread instances.
 /// \param         stacksz      stack size (in bytes) requirements for the thread function.
-/// \note CAN BE CHANGED: The parameters to \b osThreadDef shall be consistent but the
 ///       macro body is implementation specific in every CMSIS-RTOS.
 #if defined (osObjectsExternal)  // object is external
 #define osThreadDef(name, priority, instances, stacksz)  \
@@ -415,7 +310,6 @@ const osThreadDef_t os_thread_def_##name = \
 
 /// Access a Thread definition.
 /// \param         name          name of the thread definition object.
-/// \note CAN BE CHANGED: The parameter to \b osThread shall be consistent but the
 ///       macro body is implementation specific in every CMSIS-RTOS.
 #define osThread(name)  \
 &os_thread_def_##name
@@ -424,36 +318,30 @@ const osThreadDef_t os_thread_def_##name = \
 /// \param[in]     thread_def    thread definition referenced with \ref osThread.
 /// \param[in]     argument      pointer that is passed to the thread function as start argument.
 /// \return thread ID for reference by other functions or NULL in case of error.
-/// \note MUST REMAIN UNCHANGED: \b osThreadCreate shall be consistent in every CMSIS-RTOS.
 osThreadId osThreadCreate (const osThreadDef_t *thread_def, void *argument);
 
 /// Return the thread ID of the current running thread.
 /// \return thread ID for reference by other functions or NULL in case of error.
-/// \note MUST REMAIN UNCHANGED: \b osThreadGetId shall be consistent in every CMSIS-RTOS.
 osThreadId osThreadGetId (void);
 
 /// Terminate execution of a thread and remove it from Active Threads.
 /// \param[in]     thread_id   thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osThreadTerminate shall be consistent in every CMSIS-RTOS.
 osStatus osThreadTerminate (osThreadId thread_id);
 
 /// Pass control to next thread that is in state \b READY.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osThreadYield shall be consistent in every CMSIS-RTOS.
 osStatus osThreadYield (void);
 
 /// Change priority of an active thread.
 /// \param[in]     thread_id     thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
 /// \param[in]     priority      new priority value for the thread function.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osThreadSetPriority shall be consistent in every CMSIS-RTOS.
 osStatus osThreadSetPriority (osThreadId thread_id, osPriority priority);
 
 /// Get current priority of an active thread.
 /// \param[in]     thread_id     thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
 /// \return current priority value of the thread function.
-/// \note MUST REMAIN UNCHANGED: \b osThreadGetPriority shall be consistent in every CMSIS-RTOS.
 osPriority osThreadGetPriority (osThreadId thread_id);
 
 #ifdef __MBED_CMSIS_RTOS_CA9
@@ -471,16 +359,15 @@ os_InRegs osEvent _osThreadGetInfo(osThreadId thread_id, osThreadInfo info);
 //  ==== Generic Wait Functions ====
 
 /// Wait for Timeout (Time Delay).
-/// \param[in]     millisec      time delay value
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue "Time delay" value
 /// \return status code that indicates the execution status of the function.
 osStatus osDelay (uint32_t millisec);
 
 #if (defined (osFeature_Wait)  &&  (osFeature_Wait != 0))     // Generic Wait available
 
 /// Wait for Signal, Message, Mail, or Timeout.
-/// \param[in] millisec          timeout value or 0 in case of no time-out
+/// \param[in] millisec          \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out
 /// \return event that contains signal, message, or mail information or error code.
-/// \note MUST REMAIN UNCHANGED: \b osWait shall be consistent in every CMSIS-RTOS.
 os_InRegs osEvent osWait (uint32_t millisec);
 
 #endif  // Generic Wait available
@@ -490,22 +377,18 @@ os_InRegs osEvent osWait (uint32_t millisec);
 /// Define a Timer object.
 /// \param         name          name of the timer object.
 /// \param         function      name of the timer call back function.
-/// \note CAN BE CHANGED: The parameter to \b osTimerDef shall be consistent but the
-///       macro body is implementation specific in every CMSIS-RTOS.
 #if defined (osObjectsExternal)  // object is external
 #define osTimerDef(name, function)  \
 extern const osTimerDef_t os_timer_def_##name
 #else                            // define the object
 #define osTimerDef(name, function)  \
-uint32_t os_timer_cb_##name[5]; \
+uint32_t os_timer_cb_##name[6]; \
 const osTimerDef_t os_timer_def_##name = \
 { (function), (os_timer_cb_##name) }
 #endif
 
 /// Access a Timer definition.
 /// \param         name          name of the timer object.
-/// \note CAN BE CHANGED: The parameter to \b osTimer shall be consistent but the
-///       macro body is implementation specific in every CMSIS-RTOS.
 #define osTimer(name) \
 &os_timer_def_##name
 
@@ -514,26 +397,22 @@ const osTimerDef_t os_timer_def_##name = \
 /// \param[in]     type          osTimerOnce for one-shot or osTimerPeriodic for periodic behavior.
 /// \param[in]     argument      argument to the timer call back function.
 /// \return timer ID for reference by other functions or NULL in case of error.
-/// \note MUST REMAIN UNCHANGED: \b osTimerCreate shall be consistent in every CMSIS-RTOS.
 osTimerId osTimerCreate (const osTimerDef_t *timer_def, os_timer_type type, void *argument);
 
 /// Start or restart a timer.
 /// \param[in]     timer_id      timer ID obtained by \ref osTimerCreate.
-/// \param[in]     millisec      time delay value of the timer.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue "Time delay" value of the timer.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osTimerStart shall be consistent in every CMSIS-RTOS.
 osStatus osTimerStart (osTimerId timer_id, uint32_t millisec);
 
 /// Stop the timer.
 /// \param[in]     timer_id      timer ID obtained by \ref osTimerCreate.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osTimerStop shall be consistent in every CMSIS-RTOS.
 osStatus osTimerStop (osTimerId timer_id);
 
 /// Delete a timer that was created by \ref osTimerCreate.
 /// \param[in]     timer_id      timer ID obtained by \ref osTimerCreate.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osTimerDelete shall be consistent in every CMSIS-RTOS.
 osStatus osTimerDelete (osTimerId timer_id);
 
 
@@ -543,21 +422,18 @@ osStatus osTimerDelete (osTimerId timer_id);
 /// \param[in]     thread_id     thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
 /// \param[in]     signals       specifies the signal flags of the thread that should be set.
 /// \return previous signal flags of the specified thread or 0x80000000 in case of incorrect parameters.
-/// \note MUST REMAIN UNCHANGED: \b osSignalSet shall be consistent in every CMSIS-RTOS.
 int32_t osSignalSet (osThreadId thread_id, int32_t signals);
 
 /// Clear the specified Signal Flags of an active thread.
 /// \param[in]     thread_id     thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
 /// \param[in]     signals       specifies the signal flags of the thread that shall be cleared.
-/// \return previous signal flags of the specified thread or 0x80000000 in case of incorrect parameters.
-/// \note MUST REMAIN UNCHANGED: \b osSignalClear shall be consistent in every CMSIS-RTOS.
+/// \return previous signal flags of the specified thread or 0x80000000 in case of incorrect parameters or call from ISR.
 int32_t osSignalClear (osThreadId thread_id, int32_t signals);
 
 /// Wait for one or more Signal Flags to become signaled for the current \b RUNNING thread.
 /// \param[in]     signals       wait until all specified signal flags set or 0 for any single signal flag.
-/// \param[in]     millisec      timeout value or 0 in case of no time-out.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
 /// \return event flag information or error code.
-/// \note MUST REMAIN UNCHANGED: \b osSignalWait shall be consistent in every CMSIS-RTOS.
 os_InRegs osEvent osSignalWait (int32_t signals, uint32_t millisec);
 
 
@@ -565,8 +441,6 @@ os_InRegs osEvent osSignalWait (int32_t signals, uint32_t millisec);
 
 /// Define a Mutex.
 /// \param         name          name of the mutex object.
-/// \note CAN BE CHANGED: The parameter to \b osMutexDef shall be consistent but the
-///       macro body is implementation specific in every CMSIS-RTOS.
 #if defined (osObjectsExternal)  // object is external
 #define osMutexDef(name)  \
 extern const osMutexDef_t os_mutex_def_##name
@@ -578,34 +452,28 @@ const osMutexDef_t os_mutex_def_##name = { (os_mutex_cb_##name) }
 
 /// Access a Mutex definition.
 /// \param         name          name of the mutex object.
-/// \note CAN BE CHANGED: The parameter to \b osMutex shall be consistent but the
-///       macro body is implementation specific in every CMSIS-RTOS.
 #define osMutex(name)  \
 &os_mutex_def_##name
 
 /// Create and Initialize a Mutex object.
 /// \param[in]     mutex_def     mutex definition referenced with \ref osMutex.
 /// \return mutex ID for reference by other functions or NULL in case of error.
-/// \note MUST REMAIN UNCHANGED: \b osMutexCreate shall be consistent in every CMSIS-RTOS.
 osMutexId osMutexCreate (const osMutexDef_t *mutex_def);
 
 /// Wait until a Mutex becomes available.
 /// \param[in]     mutex_id      mutex ID obtained by \ref osMutexCreate.
-/// \param[in]     millisec      timeout value or 0 in case of no time-out.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osMutexWait shall be consistent in every CMSIS-RTOS.
 osStatus osMutexWait (osMutexId mutex_id, uint32_t millisec);
 
 /// Release a Mutex that was obtained by \ref osMutexWait.
 /// \param[in]     mutex_id      mutex ID obtained by \ref osMutexCreate.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osMutexRelease shall be consistent in every CMSIS-RTOS.
 osStatus osMutexRelease (osMutexId mutex_id);
 
 /// Delete a Mutex that was created by \ref osMutexCreate.
 /// \param[in]     mutex_id      mutex ID obtained by \ref osMutexCreate.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osMutexDelete shall be consistent in every CMSIS-RTOS.
 osStatus osMutexDelete (osMutexId mutex_id);
 
 
@@ -615,8 +483,6 @@ osStatus osMutexDelete (osMutexId mutex_id);
 
 /// Define a Semaphore object.
 /// \param         name          name of the semaphore object.
-/// \note CAN BE CHANGED: The parameter to \b osSemaphoreDef shall be consistent but the
-///       macro body is implementation specific in every CMSIS-RTOS.
 #if defined (osObjectsExternal)  // object is external
 #define osSemaphoreDef(name)  \
 extern const osSemaphoreDef_t os_semaphore_def_##name
@@ -628,8 +494,6 @@ const osSemaphoreDef_t os_semaphore_def_##name = { (os_semaphore_cb_##name) }
 
 /// Access a Semaphore definition.
 /// \param         name          name of the semaphore object.
-/// \note CAN BE CHANGED: The parameter to \b osSemaphore shall be consistent but the
-///       macro body is implementation specific in every CMSIS-RTOS.
 #define osSemaphore(name)  \
 &os_semaphore_def_##name
 
@@ -637,26 +501,22 @@ const osSemaphoreDef_t os_semaphore_def_##name = { (os_semaphore_cb_##name) }
 /// \param[in]     semaphore_def semaphore definition referenced with \ref osSemaphore.
 /// \param[in]     count         number of available resources.
 /// \return semaphore ID for reference by other functions or NULL in case of error.
-/// \note MUST REMAIN UNCHANGED: \b osSemaphoreCreate shall be consistent in every CMSIS-RTOS.
 osSemaphoreId osSemaphoreCreate (const osSemaphoreDef_t *semaphore_def, int32_t count);
 
 /// Wait until a Semaphore token becomes available.
 /// \param[in]     semaphore_id  semaphore object referenced with \ref osSemaphoreCreate.
-/// \param[in]     millisec      timeout value or 0 in case of no time-out.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
 /// \return number of available tokens, or -1 in case of incorrect parameters.
-/// \note MUST REMAIN UNCHANGED: \b osSemaphoreWait shall be consistent in every CMSIS-RTOS.
 int32_t osSemaphoreWait (osSemaphoreId semaphore_id, uint32_t millisec);
 
 /// Release a Semaphore token.
 /// \param[in]     semaphore_id  semaphore object referenced with \ref osSemaphoreCreate.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osSemaphoreRelease shall be consistent in every CMSIS-RTOS.
 osStatus osSemaphoreRelease (osSemaphoreId semaphore_id);
 
 /// Delete a Semaphore that was created by \ref osSemaphoreCreate.
 /// \param[in]     semaphore_id  semaphore object referenced with \ref osSemaphoreCreate.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osSemaphoreDelete shall be consistent in every CMSIS-RTOS.
 osStatus osSemaphoreDelete (osSemaphoreId semaphore_id);
 
 #endif     // Semaphore available
@@ -670,8 +530,6 @@ osStatus osSemaphoreDelete (osSemaphoreId semaphore_id);
 /// \param         name          name of the memory pool.
 /// \param         no            maximum number of blocks (objects) in the memory pool.
 /// \param         type          data type of a single block (object).
-/// \note CAN BE CHANGED: The parameter to \b osPoolDef shall be consistent but the
-///       macro body is implementation specific in every CMSIS-RTOS.
 #if defined (osObjectsExternal)  // object is external
 #define osPoolDef(name, no, type)   \
 extern const osPoolDef_t os_pool_def_##name
@@ -684,34 +542,28 @@ const osPoolDef_t os_pool_def_##name = \
 
 /// \brief Access a Memory Pool definition.
 /// \param         name          name of the memory pool
-/// \note CAN BE CHANGED: The parameter to \b osPool shall be consistent but the
-///       macro body is implementation specific in every CMSIS-RTOS.
 #define osPool(name) \
 &os_pool_def_##name
 
 /// Create and Initialize a memory pool.
 /// \param[in]     pool_def      memory pool definition referenced with \ref osPool.
 /// \return memory pool ID for reference by other functions or NULL in case of error.
-/// \note MUST REMAIN UNCHANGED: \b osPoolCreate shall be consistent in every CMSIS-RTOS.
 osPoolId osPoolCreate (const osPoolDef_t *pool_def);
 
 /// Allocate a memory block from a memory pool.
 /// \param[in]     pool_id       memory pool ID obtain referenced with \ref osPoolCreate.
 /// \return address of the allocated memory block or NULL in case of no memory available.
-/// \note MUST REMAIN UNCHANGED: \b osPoolAlloc shall be consistent in every CMSIS-RTOS.
 void *osPoolAlloc (osPoolId pool_id);
 
 /// Allocate a memory block from a memory pool and set memory block to zero.
 /// \param[in]     pool_id       memory pool ID obtain referenced with \ref osPoolCreate.
 /// \return address of the allocated memory block or NULL in case of no memory available.
-/// \note MUST REMAIN UNCHANGED: \b osPoolCAlloc shall be consistent in every CMSIS-RTOS.
 void *osPoolCAlloc (osPoolId pool_id);
 
 /// Return an allocated memory block back to a specific memory pool.
 /// \param[in]     pool_id       memory pool ID obtain referenced with \ref osPoolCreate.
 /// \param[in]     block         address of the allocated memory block that is returned to the memory pool.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osPoolFree shall be consistent in every CMSIS-RTOS.
 osStatus osPoolFree (osPoolId pool_id, void *block);
 
 #endif   // Memory Pool Management available
@@ -725,8 +577,6 @@ osStatus osPoolFree (osPoolId pool_id, void *block);
 /// \param         name          name of the queue.
 /// \param         queue_sz      maximum number of messages in the queue.
 /// \param         type          data type of a single message element (for debugger).
-/// \note CAN BE CHANGED: The parameter to \b osMessageQDef shall be consistent but the
-///       macro body is implementation specific in every CMSIS-RTOS.
 #if defined (osObjectsExternal)  // object is external
 #define osMessageQDef(name, queue_sz, type)   \
 extern const osMessageQDef_t os_messageQ_def_##name
@@ -739,8 +589,6 @@ const osMessageQDef_t os_messageQ_def_##name = \
 
 /// \brief Access a Message Queue Definition.
 /// \param         name          name of the queue
-/// \note CAN BE CHANGED: The parameter to \b osMessageQ shall be consistent but the
-///       macro body is implementation specific in every CMSIS-RTOS.
 #define osMessageQ(name) \
 &os_messageQ_def_##name
 
@@ -748,22 +596,19 @@ const osMessageQDef_t os_messageQ_def_##name = \
 /// \param[in]     queue_def     queue definition referenced with \ref osMessageQ.
 /// \param[in]     thread_id     thread ID (obtained by \ref osThreadCreate or \ref osThreadGetId) or NULL.
 /// \return message queue ID for reference by other functions or NULL in case of error.
-/// \note MUST REMAIN UNCHANGED: \b osMessageCreate shall be consistent in every CMSIS-RTOS.
 osMessageQId osMessageCreate (const osMessageQDef_t *queue_def, osThreadId thread_id);
 
 /// Put a Message to a Queue.
 /// \param[in]     queue_id      message queue ID obtained with \ref osMessageCreate.
 /// \param[in]     info          message information.
-/// \param[in]     millisec      timeout value or 0 in case of no time-out.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osMessagePut shall be consistent in every CMSIS-RTOS.
 osStatus osMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec);
 
 /// Get a Message or Wait for a Message from a Queue.
 /// \param[in]     queue_id      message queue ID obtained with \ref osMessageCreate.
-/// \param[in]     millisec      timeout value or 0 in case of no time-out.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
 /// \return event information that includes status code.
-/// \note MUST REMAIN UNCHANGED: \b osMessageGet shall be consistent in every CMSIS-RTOS.
 os_InRegs osEvent osMessageGet (osMessageQId queue_id, uint32_t millisec);
 
 #endif     // Message Queues available
@@ -777,8 +622,6 @@ os_InRegs osEvent osMessageGet (osMessageQId queue_id, uint32_t millisec);
 /// \param         name          name of the queue
 /// \param         queue_sz      maximum number of messages in queue
 /// \param         type          data type of a single message element
-/// \note CAN BE CHANGED: The parameter to \b osMailQDef shall be consistent but the
-///       macro body is implementation specific in every CMSIS-RTOS.
 #if defined (osObjectsExternal)  // object is external
 #define osMailQDef(name, queue_sz, type) \
 extern const osMailQDef_t os_mailQ_def_##name
@@ -793,8 +636,6 @@ const osMailQDef_t os_mailQ_def_##name =  \
 
 /// \brief Access a Mail Queue Definition.
 /// \param         name          name of the queue
-/// \note CAN BE CHANGED: The parameter to \b osMailQ shall be consistent but the
-///       macro body is implementation specific in every CMSIS-RTOS.
 #define osMailQ(name)  \
 &os_mailQ_def_##name
 
@@ -802,42 +643,36 @@ const osMailQDef_t os_mailQ_def_##name =  \
 /// \param[in]     queue_def     reference to the mail queue definition obtain with \ref osMailQ
 /// \param[in]     thread_id     thread ID (obtained by \ref osThreadCreate or \ref osThreadGetId) or NULL.
 /// \return mail queue ID for reference by other functions or NULL in case of error.
-/// \note MUST REMAIN UNCHANGED: \b osMailCreate shall be consistent in every CMSIS-RTOS.
 osMailQId osMailCreate (const osMailQDef_t *queue_def, osThreadId thread_id);
 
 /// Allocate a memory block from a mail.
 /// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
-/// \param[in]     millisec      timeout value or 0 in case of no time-out
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out
 /// \return pointer to memory block that can be filled with mail or NULL in case of error.
-/// \note MUST REMAIN UNCHANGED: \b osMailAlloc shall be consistent in every CMSIS-RTOS.
 void *osMailAlloc (osMailQId queue_id, uint32_t millisec);
 
 /// Allocate a memory block from a mail and set memory block to zero.
 /// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
-/// \param[in]     millisec      timeout value or 0 in case of no time-out
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out
 /// \return pointer to memory block that can be filled with mail or NULL in case of error.
-/// \note MUST REMAIN UNCHANGED: \b osMailCAlloc shall be consistent in every CMSIS-RTOS.
 void *osMailCAlloc (osMailQId queue_id, uint32_t millisec);
 
 /// Put a mail to a queue.
 /// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
 /// \param[in]     mail          memory block previously allocated with \ref osMailAlloc or \ref osMailCAlloc.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osMailPut shall be consistent in every CMSIS-RTOS.
 osStatus osMailPut (osMailQId queue_id, void *mail);
 
 /// Get a mail from a queue.
 /// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
-/// \param[in]     millisec      timeout value or 0 in case of no time-out
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out
 /// \return event that contains mail information or error code.
-/// \note MUST REMAIN UNCHANGED: \b osMailGet shall be consistent in every CMSIS-RTOS.
 os_InRegs osEvent osMailGet (osMailQId queue_id, uint32_t millisec);
 
 /// Free a memory block from a mail.
 /// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
 /// \param[in]     mail          pointer to the memory block that was obtained with \ref osMailGet.
 /// \return status code that indicates the execution status of the function.
-/// \note MUST REMAIN UNCHANGED: \b osMailFree shall be consistent in every CMSIS-RTOS.
 osStatus osMailFree (osMailQId queue_id, void *mail);
 
 #endif  // Mail Queues available
@@ -865,10 +700,12 @@ osStatus _osThreadEnumFree(osThreadEnumId enum_id);
 
 //  ==== RTX Extensions ====
 
-/// os_suspend: http://www.keil.com/support/man/docs/rlarm/rlarm_os_suspend.htm
+/// Suspend the RTX task scheduler.
+/// \return number of ticks, for how long the system can sleep or power-down.
 uint32_t os_suspend (void);
 
-/// os_resume: http://www.keil.com/support/man/docs/rlarm/rlarm_os_resume.htm
+/// Resume the RTX task scheduler
+/// \param[in]     sleep_time    specifies how long the system was in sleep or power-down mode.
 void os_resume (uint32_t sleep_time);
 
 

--- a/rtos/rtx/TARGET_CORTEX_A/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_A/cmsis_os.h
@@ -50,15 +50,94 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
 
+/**
+\page cmsis_os_h Header File Template: cmsis_os.h
+
+The file \b cmsis_os.h is a template header file for a CMSIS-RTOS compliant Real-Time Operating System (RTOS).
+Each RTOS that is compliant with CMSIS-RTOS shall provide a specific \b cmsis_os.h header file that represents
+its implementation.
+
+The file cmsis_os.h contains:
+ - CMSIS-RTOS API function definitions
+ - struct definitions for parameters and return types
+ - status and priority values used by CMSIS-RTOS API functions
+ - macros for defining threads and other kernel objects
+
+
+<b>Name conventions and header file modifications</b>
+
+All definitions are prefixed with \b os to give an unique name space for CMSIS-RTOS functions.
+Definitions that are prefixed \b os_ are not used in the application code but local to this header file.
+All definitions and functions that belong to a module are grouped and have a common prefix, i.e. \b osThread.
+
+Definitions that are marked with <b>CAN BE CHANGED</b> can be adapted towards the needs of the actual CMSIS-RTOS implementation.
+These definitions can be specific to the underlying RTOS kernel.
+
+Definitions that are marked with <b>MUST REMAIN UNCHANGED</b> cannot be altered. Otherwise the CMSIS-RTOS implementation is no longer
+compliant to the standard. Note that some functions are optional and need not to be provided by every CMSIS-RTOS implementation.
+
+
+<b>Function calls from interrupt service routines</b>
+
+The following CMSIS-RTOS functions can be called from threads and interrupt service routines (ISR):
+  - \ref osSignalSet
+  - \ref osSemaphoreRelease
+  - \ref osPoolAlloc, \ref osPoolCAlloc, \ref osPoolFree
+  - \ref osMessagePut, \ref osMessageGet
+  - \ref osMailAlloc, \ref osMailCAlloc, \ref osMailGet, \ref osMailPut, \ref osMailFree
+
+Functions that cannot be called from an ISR are verifying the interrupt status and return in case that they are called
+from an ISR context the status code \b osErrorISR. In some implementations this condition might be caught using the HARD FAULT vector.
+
+Some CMSIS-RTOS implementations support CMSIS-RTOS function calls from multiple ISR at the same time.
+If this is impossible, the CMSIS-RTOS rejects calls by nested ISR functions with the status code \b osErrorISRRecursive.
+
+
+<b>Define and reference object definitions</b>
+
+With <b>\#define osObjectsExternal</b> objects are defined as external symbols. This allows to create a consistent header file
+that is used throughout a project as shown below:
+
+<i>Header File</i>
+\code
+#include <cmsis_os.h>                                         // CMSIS RTOS header file
+
+// Thread definition
+extern void thread_sample (void const *argument);             // function prototype
+osThreadDef (thread_sample, osPriorityBelowNormal, 1, 100);
+
+// Pool definition
+osPoolDef(MyPool, 10, long);
+\endcode
+
+
+This header file defines all objects when included in a C/C++ source file. When <b>\#define osObjectsExternal</b> is
+present before the header file, the objects are defined as external symbols. A single consistent header file can therefore be
+used throughout the whole project.
+
+<i>Example</i>
+\code
+#include "osObjects.h"     // Definition of the CMSIS-RTOS objects
+\endcode
+
+\code
+#define osObjectExternal   // Objects will be defined as external symbols
+#include "osObjects.h"     // Reference to the CMSIS-RTOS objects
+\endcode
+
+*/
 
 #ifndef _CMSIS_OS_H
 #define _CMSIS_OS_H
 
-#define osCMSIS           0x10002U     ///< CMSIS-RTOS API version (main [31:16] .sub [15:0])
+/// \note MUST REMAIN UNCHANGED: \b osCMSIS identifies the CMSIS-RTOS API version.
+#define osCMSIS           0x10002      ///< API version (main [31:16] .sub [15:0])
 
-#define osCMSIS_RTX     ((4<<16)|80)   ///< RTOS identification and version (main [31:16] .sub [15:0])
+/// \note CAN BE CHANGED: \b osCMSIS_KERNEL identifies the underlying RTOS kernel and version number.
+#define osCMSIS_RTX     ((4<<16)|74)   ///< RTOS identification and version (main [31:16] .sub [15:0])
 
-#define osKernelSystemId "RTX V4.80"   ///< RTOS identification string
+/// \note MUST REMAIN UNCHANGED: \b osKernelSystemId shall be consistent in every CMSIS-RTOS.
+#define osKernelSystemId "RTX V4.74"   ///< RTOS identification string
 
 #define CMSIS_OS_RTX
 #define CMSIS_OS_RTX_CA          /* new define for Coretex-A */
@@ -72,14 +151,15 @@
 
 #define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE*4)
 
-#define osFeature_MainThread   1       ///< main can be thread
-#define osFeature_Pool         1       ///< Memory Pools available
-#define osFeature_MailQ        1       ///< Mail Queues available
-#define osFeature_MessageQ     1       ///< Message Queues available
-#define osFeature_Signals      16      ///< 16 Signal Flags available per thread
-#define osFeature_Semaphore    65535   ///< Maximum count for \ref osSemaphoreCreate function
-#define osFeature_Wait         0       ///< osWait not available
-#define osFeature_SysTick      1       ///< osKernelSysTick functions available
+/// \note MUST REMAIN UNCHANGED: \b osFeature_xxx shall be consistent in every CMSIS-RTOS.
+#define osFeature_MainThread   1       ///< main thread      1=main can be thread, 0=not available
+#define osFeature_Pool         1       ///< Memory Pools:    1=available, 0=not available
+#define osFeature_MailQ        1       ///< Mail Queues:     1=available, 0=not available
+#define osFeature_MessageQ     1       ///< Message Queues:  1=available, 0=not available
+#define osFeature_Signals      16      ///< maximum number of Signal Flags available per thread
+#define osFeature_Semaphore    65535   ///< maximum count for \ref osSemaphoreCreate function
+#define osFeature_Wait         0       ///< osWait function: 1=available, 0=not available
+#define osFeature_SysTick      1       ///< osKernelSysTick functions: 1=available, 0=not available
 #define osFeature_ThreadEnum   1       ///< Thread enumeration available
 
 #if defined (__CC_ARM)
@@ -100,6 +180,7 @@ extern "C"
 // ==== Enumeration, structures, defines ====
 
 /// Priority used for thread control.
+/// \note MUST REMAIN UNCHANGED: \b osPriority shall be consistent in every CMSIS-RTOS.
 typedef enum  {
   osPriorityIdle          = -3,          ///< priority: idle (lowest)
   osPriorityLow           = -2,          ///< priority: low
@@ -112,9 +193,11 @@ typedef enum  {
 } osPriority;
 
 /// Timeout value.
-#define osWaitForever     0xFFFFFFFFU    ///< wait forever timeout value
+/// \note MUST REMAIN UNCHANGED: \b osWaitForever shall be consistent in every CMSIS-RTOS.
+#define osWaitForever     0xFFFFFFFF     ///< wait forever timeout value
 
 /// Status code values returned by CMSIS-RTOS functions.
+/// \note MUST REMAIN UNCHANGED: \b osStatus shall be consistent in every CMSIS-RTOS.
 typedef enum  {
   osOK                    =     0,       ///< function completed; no error or event occurred.
   osEventSignal           =  0x08,       ///< function completed; signal event occurred.
@@ -135,6 +218,7 @@ typedef enum  {
 
 
 /// Timer type value for the timer definition.
+/// \note MUST REMAIN UNCHANGED: \b os_timer_type shall be consistent in every CMSIS-RTOS.
 typedef enum  {
   osTimerOnce             =     0,       ///< one-shot timer
   osTimerPeriodic         =     1        ///< repeating timer
@@ -151,38 +235,48 @@ typedef enum {
 } osThreadInfo;
 
 /// Entry point of a thread.
+/// \note MUST REMAIN UNCHANGED: \b os_pthread shall be consistent in every CMSIS-RTOS.
 typedef void (*os_pthread) (void const *argument);
 
 /// Entry point of a timer call back function.
+/// \note MUST REMAIN UNCHANGED: \b os_ptimer shall be consistent in every CMSIS-RTOS.
 typedef void (*os_ptimer) (void const *argument);
 
 // >>> the following data type definitions may shall adapted towards a specific RTOS
 
 /// Thread ID identifies the thread (pointer to a thread control block).
+/// \note CAN BE CHANGED: \b os_thread_cb is implementation specific in every CMSIS-RTOS.
 typedef struct os_thread_cb *osThreadId;
 
 /// Timer ID identifies the timer (pointer to a timer control block).
+/// \note CAN BE CHANGED: \b os_timer_cb is implementation specific in every CMSIS-RTOS.
 typedef struct os_timer_cb *osTimerId;
 
 /// Mutex ID identifies the mutex (pointer to a mutex control block).
+/// \note CAN BE CHANGED: \b os_mutex_cb is implementation specific in every CMSIS-RTOS.
 typedef struct os_mutex_cb *osMutexId;
 
 /// Semaphore ID identifies the semaphore (pointer to a semaphore control block).
+/// \note CAN BE CHANGED: \b os_semaphore_cb is implementation specific in every CMSIS-RTOS.
 typedef struct os_semaphore_cb *osSemaphoreId;
 
 /// Pool ID identifies the memory pool (pointer to a memory pool control block).
+/// \note CAN BE CHANGED: \b os_pool_cb is implementation specific in every CMSIS-RTOS.
 typedef struct os_pool_cb *osPoolId;
 
 /// Message ID identifies the message queue (pointer to a message queue control block).
+/// \note CAN BE CHANGED: \b os_messageQ_cb is implementation specific in every CMSIS-RTOS.
 typedef struct os_messageQ_cb *osMessageQId;
 
 /// Mail ID identifies the mail queue (pointer to a mail queue control block).
+/// \note CAN BE CHANGED: \b os_mailQ_cb is implementation specific in every CMSIS-RTOS.
 typedef struct os_mailQ_cb *osMailQId;
 
 /// Thread enumeration ID identifies the enumeration (pointer to a thread enumeration control block).
 typedef uint32_t *osThreadEnumId;
 
 /// Thread Definition structure contains startup information of a thread.
+/// \note CAN BE CHANGED: \b os_thread_def is implementation specific in every CMSIS-RTOS.
 typedef struct os_thread_def  {
   os_pthread               pthread;    ///< start address of thread function
   osPriority             tpriority;    ///< initial thread priority
@@ -194,22 +288,26 @@ typedef struct os_thread_def  {
 } osThreadDef_t;
 
 /// Timer Definition structure contains timer parameters.
+/// \note CAN BE CHANGED: \b os_timer_def is implementation specific in every CMSIS-RTOS.
 typedef struct os_timer_def  {
   os_ptimer                 ptimer;    ///< start address of a timer function
   void                      *timer;    ///< pointer to internal data
 } osTimerDef_t;
 
 /// Mutex Definition structure contains setup information for a mutex.
+/// \note CAN BE CHANGED: \b os_mutex_def is implementation specific in every CMSIS-RTOS.
 typedef struct os_mutex_def  {
   void                      *mutex;    ///< pointer to internal data
 } osMutexDef_t;
 
 /// Semaphore Definition structure contains setup information for a semaphore.
+/// \note CAN BE CHANGED: \b os_semaphore_def is implementation specific in every CMSIS-RTOS.
 typedef struct os_semaphore_def  {
   void                  *semaphore;    ///< pointer to internal data
 } osSemaphoreDef_t;
 
 /// Definition structure for memory block allocation.
+/// \note CAN BE CHANGED: \b os_pool_def is implementation specific in every CMSIS-RTOS.
 typedef struct os_pool_def  {
   uint32_t                 pool_sz;    ///< number of items (elements) in the pool
   uint32_t                 item_sz;    ///< size of an item
@@ -217,12 +315,14 @@ typedef struct os_pool_def  {
 } osPoolDef_t;
 
 /// Definition structure for message queue.
+/// \note CAN BE CHANGED: \b os_messageQ_def is implementation specific in every CMSIS-RTOS.
 typedef struct os_messageQ_def  {
   uint32_t                queue_sz;    ///< number of elements in the queue
   void                       *pool;    ///< memory array for messages
 } osMessageQDef_t;
 
 /// Definition structure for mail queue.
+/// \note CAN BE CHANGED: \b os_mailQ_def is implementation specific in every CMSIS-RTOS.
 typedef struct os_mailQ_def  {
   uint32_t                queue_sz;    ///< number of elements in the queue
   uint32_t                 item_sz;    ///< size of an item
@@ -230,6 +330,8 @@ typedef struct os_mailQ_def  {
 } osMailQDef_t;
 
 /// Event structure contains detailed information about an event.
+/// \note MUST REMAIN UNCHANGED: \b os_event shall be consistent in every CMSIS-RTOS.
+///       However the struct may be extended at the end.
 typedef struct  {
   osStatus                 status;     ///< status code: event or error information
   union  {
@@ -248,25 +350,27 @@ typedef struct  {
 
 /// Initialize the RTOS Kernel for creating objects.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osKernelInitialize shall be consistent in every CMSIS-RTOS.
 osStatus osKernelInitialize (void);
 
 /// Start the RTOS Kernel.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osKernelStart shall be consistent in every CMSIS-RTOS.
 osStatus osKernelStart (void);
 
 /// Check if the RTOS kernel is already started.
+/// \note MUST REMAIN UNCHANGED: \b osKernelRunning shall be consistent in every CMSIS-RTOS.
 /// \return 0 RTOS is not started, 1 RTOS is started.
 int32_t osKernelRunning(void);
 
 #if (defined (osFeature_SysTick)  &&  (osFeature_SysTick != 0))     // System Timer available
 
-/// \cond INTERNAL_VARIABLES
 extern uint32_t const os_tickfreq;
 extern uint16_t const os_tickus_i;
 extern uint16_t const os_tickus_f;
-/// \endcond
 
 /// Get the RTOS kernel system timer counter.
+/// \note MUST REMAIN UNCHANGED: \b osKernelSysTick shall be consistent in every CMSIS-RTOS.
 /// \return RTOS kernel system timer as 32-bit value 
 uint32_t osKernelSysTick (void);
 
@@ -291,6 +395,7 @@ uint32_t osKernelSysTick (void);
 /// \param         priority     initial priority of the thread function.
 /// \param         instances    number of possible thread instances.
 /// \param         stacksz      stack size (in bytes) requirements for the thread function.
+/// \note CAN BE CHANGED: The parameters to \b osThreadDef shall be consistent but the
 ///       macro body is implementation specific in every CMSIS-RTOS.
 #if defined (osObjectsExternal)  // object is external
 #define osThreadDef(name, priority, instances, stacksz)  \
@@ -310,6 +415,7 @@ const osThreadDef_t os_thread_def_##name = \
 
 /// Access a Thread definition.
 /// \param         name          name of the thread definition object.
+/// \note CAN BE CHANGED: The parameter to \b osThread shall be consistent but the
 ///       macro body is implementation specific in every CMSIS-RTOS.
 #define osThread(name)  \
 &os_thread_def_##name
@@ -318,30 +424,36 @@ const osThreadDef_t os_thread_def_##name = \
 /// \param[in]     thread_def    thread definition referenced with \ref osThread.
 /// \param[in]     argument      pointer that is passed to the thread function as start argument.
 /// \return thread ID for reference by other functions or NULL in case of error.
+/// \note MUST REMAIN UNCHANGED: \b osThreadCreate shall be consistent in every CMSIS-RTOS.
 osThreadId osThreadCreate (const osThreadDef_t *thread_def, void *argument);
 
 /// Return the thread ID of the current running thread.
 /// \return thread ID for reference by other functions or NULL in case of error.
+/// \note MUST REMAIN UNCHANGED: \b osThreadGetId shall be consistent in every CMSIS-RTOS.
 osThreadId osThreadGetId (void);
 
 /// Terminate execution of a thread and remove it from Active Threads.
 /// \param[in]     thread_id   thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osThreadTerminate shall be consistent in every CMSIS-RTOS.
 osStatus osThreadTerminate (osThreadId thread_id);
 
 /// Pass control to next thread that is in state \b READY.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osThreadYield shall be consistent in every CMSIS-RTOS.
 osStatus osThreadYield (void);
 
 /// Change priority of an active thread.
 /// \param[in]     thread_id     thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
 /// \param[in]     priority      new priority value for the thread function.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osThreadSetPriority shall be consistent in every CMSIS-RTOS.
 osStatus osThreadSetPriority (osThreadId thread_id, osPriority priority);
 
 /// Get current priority of an active thread.
 /// \param[in]     thread_id     thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
 /// \return current priority value of the thread function.
+/// \note MUST REMAIN UNCHANGED: \b osThreadGetPriority shall be consistent in every CMSIS-RTOS.
 osPriority osThreadGetPriority (osThreadId thread_id);
 
 #ifdef __MBED_CMSIS_RTOS_CA9
@@ -359,15 +471,16 @@ os_InRegs osEvent _osThreadGetInfo(osThreadId thread_id, osThreadInfo info);
 //  ==== Generic Wait Functions ====
 
 /// Wait for Timeout (Time Delay).
-/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue "Time delay" value
+/// \param[in]     millisec      time delay value
 /// \return status code that indicates the execution status of the function.
 osStatus osDelay (uint32_t millisec);
 
 #if (defined (osFeature_Wait)  &&  (osFeature_Wait != 0))     // Generic Wait available
 
 /// Wait for Signal, Message, Mail, or Timeout.
-/// \param[in] millisec          \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out
+/// \param[in] millisec          timeout value or 0 in case of no time-out
 /// \return event that contains signal, message, or mail information or error code.
+/// \note MUST REMAIN UNCHANGED: \b osWait shall be consistent in every CMSIS-RTOS.
 os_InRegs osEvent osWait (uint32_t millisec);
 
 #endif  // Generic Wait available
@@ -377,18 +490,22 @@ os_InRegs osEvent osWait (uint32_t millisec);
 /// Define a Timer object.
 /// \param         name          name of the timer object.
 /// \param         function      name of the timer call back function.
+/// \note CAN BE CHANGED: The parameter to \b osTimerDef shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
 #if defined (osObjectsExternal)  // object is external
 #define osTimerDef(name, function)  \
 extern const osTimerDef_t os_timer_def_##name
 #else                            // define the object
 #define osTimerDef(name, function)  \
-uint32_t os_timer_cb_##name[6]; \
+uint32_t os_timer_cb_##name[5]; \
 const osTimerDef_t os_timer_def_##name = \
 { (function), (os_timer_cb_##name) }
 #endif
 
 /// Access a Timer definition.
 /// \param         name          name of the timer object.
+/// \note CAN BE CHANGED: The parameter to \b osTimer shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
 #define osTimer(name) \
 &os_timer_def_##name
 
@@ -397,22 +514,26 @@ const osTimerDef_t os_timer_def_##name = \
 /// \param[in]     type          osTimerOnce for one-shot or osTimerPeriodic for periodic behavior.
 /// \param[in]     argument      argument to the timer call back function.
 /// \return timer ID for reference by other functions or NULL in case of error.
+/// \note MUST REMAIN UNCHANGED: \b osTimerCreate shall be consistent in every CMSIS-RTOS.
 osTimerId osTimerCreate (const osTimerDef_t *timer_def, os_timer_type type, void *argument);
 
 /// Start or restart a timer.
 /// \param[in]     timer_id      timer ID obtained by \ref osTimerCreate.
-/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue "Time delay" value of the timer.
+/// \param[in]     millisec      time delay value of the timer.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osTimerStart shall be consistent in every CMSIS-RTOS.
 osStatus osTimerStart (osTimerId timer_id, uint32_t millisec);
 
 /// Stop the timer.
 /// \param[in]     timer_id      timer ID obtained by \ref osTimerCreate.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osTimerStop shall be consistent in every CMSIS-RTOS.
 osStatus osTimerStop (osTimerId timer_id);
 
 /// Delete a timer that was created by \ref osTimerCreate.
 /// \param[in]     timer_id      timer ID obtained by \ref osTimerCreate.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osTimerDelete shall be consistent in every CMSIS-RTOS.
 osStatus osTimerDelete (osTimerId timer_id);
 
 
@@ -422,18 +543,21 @@ osStatus osTimerDelete (osTimerId timer_id);
 /// \param[in]     thread_id     thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
 /// \param[in]     signals       specifies the signal flags of the thread that should be set.
 /// \return previous signal flags of the specified thread or 0x80000000 in case of incorrect parameters.
+/// \note MUST REMAIN UNCHANGED: \b osSignalSet shall be consistent in every CMSIS-RTOS.
 int32_t osSignalSet (osThreadId thread_id, int32_t signals);
 
 /// Clear the specified Signal Flags of an active thread.
 /// \param[in]     thread_id     thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
 /// \param[in]     signals       specifies the signal flags of the thread that shall be cleared.
-/// \return previous signal flags of the specified thread or 0x80000000 in case of incorrect parameters or call from ISR.
+/// \return previous signal flags of the specified thread or 0x80000000 in case of incorrect parameters.
+/// \note MUST REMAIN UNCHANGED: \b osSignalClear shall be consistent in every CMSIS-RTOS.
 int32_t osSignalClear (osThreadId thread_id, int32_t signals);
 
 /// Wait for one or more Signal Flags to become signaled for the current \b RUNNING thread.
 /// \param[in]     signals       wait until all specified signal flags set or 0 for any single signal flag.
-/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \param[in]     millisec      timeout value or 0 in case of no time-out.
 /// \return event flag information or error code.
+/// \note MUST REMAIN UNCHANGED: \b osSignalWait shall be consistent in every CMSIS-RTOS.
 os_InRegs osEvent osSignalWait (int32_t signals, uint32_t millisec);
 
 
@@ -441,6 +565,8 @@ os_InRegs osEvent osSignalWait (int32_t signals, uint32_t millisec);
 
 /// Define a Mutex.
 /// \param         name          name of the mutex object.
+/// \note CAN BE CHANGED: The parameter to \b osMutexDef shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
 #if defined (osObjectsExternal)  // object is external
 #define osMutexDef(name)  \
 extern const osMutexDef_t os_mutex_def_##name
@@ -452,28 +578,34 @@ const osMutexDef_t os_mutex_def_##name = { (os_mutex_cb_##name) }
 
 /// Access a Mutex definition.
 /// \param         name          name of the mutex object.
+/// \note CAN BE CHANGED: The parameter to \b osMutex shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
 #define osMutex(name)  \
 &os_mutex_def_##name
 
 /// Create and Initialize a Mutex object.
 /// \param[in]     mutex_def     mutex definition referenced with \ref osMutex.
 /// \return mutex ID for reference by other functions or NULL in case of error.
+/// \note MUST REMAIN UNCHANGED: \b osMutexCreate shall be consistent in every CMSIS-RTOS.
 osMutexId osMutexCreate (const osMutexDef_t *mutex_def);
 
 /// Wait until a Mutex becomes available.
 /// \param[in]     mutex_id      mutex ID obtained by \ref osMutexCreate.
-/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \param[in]     millisec      timeout value or 0 in case of no time-out.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osMutexWait shall be consistent in every CMSIS-RTOS.
 osStatus osMutexWait (osMutexId mutex_id, uint32_t millisec);
 
 /// Release a Mutex that was obtained by \ref osMutexWait.
 /// \param[in]     mutex_id      mutex ID obtained by \ref osMutexCreate.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osMutexRelease shall be consistent in every CMSIS-RTOS.
 osStatus osMutexRelease (osMutexId mutex_id);
 
 /// Delete a Mutex that was created by \ref osMutexCreate.
 /// \param[in]     mutex_id      mutex ID obtained by \ref osMutexCreate.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osMutexDelete shall be consistent in every CMSIS-RTOS.
 osStatus osMutexDelete (osMutexId mutex_id);
 
 
@@ -483,6 +615,8 @@ osStatus osMutexDelete (osMutexId mutex_id);
 
 /// Define a Semaphore object.
 /// \param         name          name of the semaphore object.
+/// \note CAN BE CHANGED: The parameter to \b osSemaphoreDef shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
 #if defined (osObjectsExternal)  // object is external
 #define osSemaphoreDef(name)  \
 extern const osSemaphoreDef_t os_semaphore_def_##name
@@ -494,6 +628,8 @@ const osSemaphoreDef_t os_semaphore_def_##name = { (os_semaphore_cb_##name) }
 
 /// Access a Semaphore definition.
 /// \param         name          name of the semaphore object.
+/// \note CAN BE CHANGED: The parameter to \b osSemaphore shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
 #define osSemaphore(name)  \
 &os_semaphore_def_##name
 
@@ -501,22 +637,26 @@ const osSemaphoreDef_t os_semaphore_def_##name = { (os_semaphore_cb_##name) }
 /// \param[in]     semaphore_def semaphore definition referenced with \ref osSemaphore.
 /// \param[in]     count         number of available resources.
 /// \return semaphore ID for reference by other functions or NULL in case of error.
+/// \note MUST REMAIN UNCHANGED: \b osSemaphoreCreate shall be consistent in every CMSIS-RTOS.
 osSemaphoreId osSemaphoreCreate (const osSemaphoreDef_t *semaphore_def, int32_t count);
 
 /// Wait until a Semaphore token becomes available.
 /// \param[in]     semaphore_id  semaphore object referenced with \ref osSemaphoreCreate.
-/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \param[in]     millisec      timeout value or 0 in case of no time-out.
 /// \return number of available tokens, or -1 in case of incorrect parameters.
+/// \note MUST REMAIN UNCHANGED: \b osSemaphoreWait shall be consistent in every CMSIS-RTOS.
 int32_t osSemaphoreWait (osSemaphoreId semaphore_id, uint32_t millisec);
 
 /// Release a Semaphore token.
 /// \param[in]     semaphore_id  semaphore object referenced with \ref osSemaphoreCreate.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osSemaphoreRelease shall be consistent in every CMSIS-RTOS.
 osStatus osSemaphoreRelease (osSemaphoreId semaphore_id);
 
 /// Delete a Semaphore that was created by \ref osSemaphoreCreate.
 /// \param[in]     semaphore_id  semaphore object referenced with \ref osSemaphoreCreate.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osSemaphoreDelete shall be consistent in every CMSIS-RTOS.
 osStatus osSemaphoreDelete (osSemaphoreId semaphore_id);
 
 #endif     // Semaphore available
@@ -530,6 +670,8 @@ osStatus osSemaphoreDelete (osSemaphoreId semaphore_id);
 /// \param         name          name of the memory pool.
 /// \param         no            maximum number of blocks (objects) in the memory pool.
 /// \param         type          data type of a single block (object).
+/// \note CAN BE CHANGED: The parameter to \b osPoolDef shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
 #if defined (osObjectsExternal)  // object is external
 #define osPoolDef(name, no, type)   \
 extern const osPoolDef_t os_pool_def_##name
@@ -542,28 +684,34 @@ const osPoolDef_t os_pool_def_##name = \
 
 /// \brief Access a Memory Pool definition.
 /// \param         name          name of the memory pool
+/// \note CAN BE CHANGED: The parameter to \b osPool shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
 #define osPool(name) \
 &os_pool_def_##name
 
 /// Create and Initialize a memory pool.
 /// \param[in]     pool_def      memory pool definition referenced with \ref osPool.
 /// \return memory pool ID for reference by other functions or NULL in case of error.
+/// \note MUST REMAIN UNCHANGED: \b osPoolCreate shall be consistent in every CMSIS-RTOS.
 osPoolId osPoolCreate (const osPoolDef_t *pool_def);
 
 /// Allocate a memory block from a memory pool.
 /// \param[in]     pool_id       memory pool ID obtain referenced with \ref osPoolCreate.
 /// \return address of the allocated memory block or NULL in case of no memory available.
+/// \note MUST REMAIN UNCHANGED: \b osPoolAlloc shall be consistent in every CMSIS-RTOS.
 void *osPoolAlloc (osPoolId pool_id);
 
 /// Allocate a memory block from a memory pool and set memory block to zero.
 /// \param[in]     pool_id       memory pool ID obtain referenced with \ref osPoolCreate.
 /// \return address of the allocated memory block or NULL in case of no memory available.
+/// \note MUST REMAIN UNCHANGED: \b osPoolCAlloc shall be consistent in every CMSIS-RTOS.
 void *osPoolCAlloc (osPoolId pool_id);
 
 /// Return an allocated memory block back to a specific memory pool.
 /// \param[in]     pool_id       memory pool ID obtain referenced with \ref osPoolCreate.
 /// \param[in]     block         address of the allocated memory block that is returned to the memory pool.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osPoolFree shall be consistent in every CMSIS-RTOS.
 osStatus osPoolFree (osPoolId pool_id, void *block);
 
 #endif   // Memory Pool Management available
@@ -577,6 +725,8 @@ osStatus osPoolFree (osPoolId pool_id, void *block);
 /// \param         name          name of the queue.
 /// \param         queue_sz      maximum number of messages in the queue.
 /// \param         type          data type of a single message element (for debugger).
+/// \note CAN BE CHANGED: The parameter to \b osMessageQDef shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
 #if defined (osObjectsExternal)  // object is external
 #define osMessageQDef(name, queue_sz, type)   \
 extern const osMessageQDef_t os_messageQ_def_##name
@@ -589,6 +739,8 @@ const osMessageQDef_t os_messageQ_def_##name = \
 
 /// \brief Access a Message Queue Definition.
 /// \param         name          name of the queue
+/// \note CAN BE CHANGED: The parameter to \b osMessageQ shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
 #define osMessageQ(name) \
 &os_messageQ_def_##name
 
@@ -596,19 +748,22 @@ const osMessageQDef_t os_messageQ_def_##name = \
 /// \param[in]     queue_def     queue definition referenced with \ref osMessageQ.
 /// \param[in]     thread_id     thread ID (obtained by \ref osThreadCreate or \ref osThreadGetId) or NULL.
 /// \return message queue ID for reference by other functions or NULL in case of error.
+/// \note MUST REMAIN UNCHANGED: \b osMessageCreate shall be consistent in every CMSIS-RTOS.
 osMessageQId osMessageCreate (const osMessageQDef_t *queue_def, osThreadId thread_id);
 
 /// Put a Message to a Queue.
 /// \param[in]     queue_id      message queue ID obtained with \ref osMessageCreate.
 /// \param[in]     info          message information.
-/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \param[in]     millisec      timeout value or 0 in case of no time-out.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osMessagePut shall be consistent in every CMSIS-RTOS.
 osStatus osMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec);
 
 /// Get a Message or Wait for a Message from a Queue.
 /// \param[in]     queue_id      message queue ID obtained with \ref osMessageCreate.
-/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \param[in]     millisec      timeout value or 0 in case of no time-out.
 /// \return event information that includes status code.
+/// \note MUST REMAIN UNCHANGED: \b osMessageGet shall be consistent in every CMSIS-RTOS.
 os_InRegs osEvent osMessageGet (osMessageQId queue_id, uint32_t millisec);
 
 #endif     // Message Queues available
@@ -622,6 +777,8 @@ os_InRegs osEvent osMessageGet (osMessageQId queue_id, uint32_t millisec);
 /// \param         name          name of the queue
 /// \param         queue_sz      maximum number of messages in queue
 /// \param         type          data type of a single message element
+/// \note CAN BE CHANGED: The parameter to \b osMailQDef shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
 #if defined (osObjectsExternal)  // object is external
 #define osMailQDef(name, queue_sz, type) \
 extern const osMailQDef_t os_mailQ_def_##name
@@ -636,6 +793,8 @@ const osMailQDef_t os_mailQ_def_##name =  \
 
 /// \brief Access a Mail Queue Definition.
 /// \param         name          name of the queue
+/// \note CAN BE CHANGED: The parameter to \b osMailQ shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
 #define osMailQ(name)  \
 &os_mailQ_def_##name
 
@@ -643,36 +802,42 @@ const osMailQDef_t os_mailQ_def_##name =  \
 /// \param[in]     queue_def     reference to the mail queue definition obtain with \ref osMailQ
 /// \param[in]     thread_id     thread ID (obtained by \ref osThreadCreate or \ref osThreadGetId) or NULL.
 /// \return mail queue ID for reference by other functions or NULL in case of error.
+/// \note MUST REMAIN UNCHANGED: \b osMailCreate shall be consistent in every CMSIS-RTOS.
 osMailQId osMailCreate (const osMailQDef_t *queue_def, osThreadId thread_id);
 
 /// Allocate a memory block from a mail.
 /// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
-/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out
+/// \param[in]     millisec      timeout value or 0 in case of no time-out
 /// \return pointer to memory block that can be filled with mail or NULL in case of error.
+/// \note MUST REMAIN UNCHANGED: \b osMailAlloc shall be consistent in every CMSIS-RTOS.
 void *osMailAlloc (osMailQId queue_id, uint32_t millisec);
 
 /// Allocate a memory block from a mail and set memory block to zero.
 /// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
-/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out
+/// \param[in]     millisec      timeout value or 0 in case of no time-out
 /// \return pointer to memory block that can be filled with mail or NULL in case of error.
+/// \note MUST REMAIN UNCHANGED: \b osMailCAlloc shall be consistent in every CMSIS-RTOS.
 void *osMailCAlloc (osMailQId queue_id, uint32_t millisec);
 
 /// Put a mail to a queue.
 /// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
 /// \param[in]     mail          memory block previously allocated with \ref osMailAlloc or \ref osMailCAlloc.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osMailPut shall be consistent in every CMSIS-RTOS.
 osStatus osMailPut (osMailQId queue_id, void *mail);
 
 /// Get a mail from a queue.
 /// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
-/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out
+/// \param[in]     millisec      timeout value or 0 in case of no time-out
 /// \return event that contains mail information or error code.
+/// \note MUST REMAIN UNCHANGED: \b osMailGet shall be consistent in every CMSIS-RTOS.
 os_InRegs osEvent osMailGet (osMailQId queue_id, uint32_t millisec);
 
 /// Free a memory block from a mail.
 /// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
 /// \param[in]     mail          pointer to the memory block that was obtained with \ref osMailGet.
 /// \return status code that indicates the execution status of the function.
+/// \note MUST REMAIN UNCHANGED: \b osMailFree shall be consistent in every CMSIS-RTOS.
 osStatus osMailFree (osMailQId queue_id, void *mail);
 
 #endif  // Mail Queues available
@@ -700,12 +865,10 @@ osStatus _osThreadEnumFree(osThreadEnumId enum_id);
 
 //  ==== RTX Extensions ====
 
-/// Suspend the RTX task scheduler.
-/// \return number of ticks, for how long the system can sleep or power-down.
+/// os_suspend: http://www.keil.com/support/man/docs/rlarm/rlarm_os_suspend.htm
 uint32_t os_suspend (void);
 
-/// Resume the RTX task scheduler
-/// \param[in]     sleep_time    specifies how long the system was in sleep or power-down mode.
+/// os_resume: http://www.keil.com/support/man/docs/rlarm/rlarm_os_resume.htm
 void os_resume (uint32_t sleep_time);
 
 

--- a/rtos/rtx/TARGET_CORTEX_A/rt_CMSIS.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_CMSIS.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    rt_CMSIS.c
  *      Purpose: CMSIS RTOS API
- *      Rev.:    V4.74
+ *      Rev.:    V4.80 plus changes for RTX-Ax
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH, 2012-2016 ARM Limited
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -16,18 +16,18 @@
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
  *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -140,9 +140,9 @@ static __inline   t __##f (t1 a1, t2 a2, t3 a3, t4 a4) {                       \
   return _##f(f,a1,a2,a3,a4);                                                  \
 }
 
-#define SVC_1_2 SVC_1_1
-#define SVC_1_3 SVC_1_1
-#define SVC_2_3 SVC_2_1
+#define SVC_1_2 SVC_1_1 
+#define SVC_1_3 SVC_1_1 
+#define SVC_2_3 SVC_2_1 
 
 #elif defined (__GNUC__)        /* GNU Compiler */
 
@@ -159,67 +159,14 @@ typedef uint32_t __attribute__((vector_size(16))) ret128;
 #define RET_osEvent    {(osStatus)__r0, {(uint32_t)__r1}, {(void *)__r2}}
 #define RET_osCallback {(void *)__r0, (void *)__r1}
 
-#if defined (__ARM_PCS_VFP)
-
-#define osEvent_type        void
-#define osEvent_ret_status {  __asm ("MOV r0, %0;"      \
-                                     : /* no outputs */ \
-                                     : "r"(ret.status)  \
-                                     : "r0"             \
-                                     );                 \
-                           }
-#define osEvent_ret_value  {  __asm ("MOV r1, %0;"         \
-                                     "MOV r0, %1;"         \
-                                     :   /* no outputs */  \
-                                     :   "r"(ret.value.v), \
-                                         "r"(ret.status)   \
-                                     : "r0", "r1"          \
-                                     );                    \
-                           }
-#define osEvent_ret_msg    {  __asm ("MOV r2, %0;"                \
-                                     "MOV r1, %1;"                \
-                                     "MOV r0, %2;"                \
-                                     : /* no outputs */           \
-                                     :   "r"(ret.def.message_id), \
-                                         "r"(ret.value.v),        \
-                                         "r"(ret.status)          \
-                                     : "r0", "r1" , "r2"          \
-                                     );                           \
-                           }
-
-#define osEvent_ret_mail   {  __asm ("MOV r2, %0;"             \
-                                     "MOV r1, %1;"             \
-                                     "MOV r0, %2;"             \
-                                     : /* no outputs */        \
-                                     :   "r"(ret.def.mail_id), \
-                                         "r"(ret.value.v),     \
-                                         "r"(ret.status)       \
-                                     : "r0", "r1" , "r2"       \
-                                     );                        \
-                           }
-
-#define osCallback_type     void
-#define osCallback_ret     {  __asm ("MOV r1, %0;"      \
-                                     "MOV r0, %1;"      \
-                                     : /* no outputs */ \
-                                     : "r"(ret.arg),    \
-                                       "r"(ret.fp)      \
-                                     : "r0", "r1"       \
-                                     );                 \
-                           }
-
-#else /* defined (__ARM_PCS_VFP) */
-
-#define osEvent_type        ret128
+#define osEvent_type       __attribute__((pcs("aapcs"))) ret128
 #define osEvent_ret_status (ret128){ret.status}
 #define osEvent_ret_value  (ret128){ret.status, ret.value.v}
 #define osEvent_ret_msg    (ret128){ret.status, ret.value.v, (uint32_t)ret.def.message_id}
 #define osEvent_ret_mail   (ret128){ret.status, ret.value.v, (uint32_t)ret.def.mail_id}
 
-#define osCallback_type     ret64
+#define osCallback_type    __attribute__((pcs("aapcs"))) ret64
 #define osCallback_ret     (ret64) {(uint32_t)ret.fp, (uint32_t)ret.arg}
-
-#endif /* defined (__ARM_PCS_VFP) */
 
 #define SVC_ArgN(n) \
   register int __r##n __asm("r"#n);
@@ -259,7 +206,7 @@ typedef uint32_t __attribute__((vector_size(16))) ret128;
 
 #if (defined (__CORTEX_M0))
 #define SVC_Call(f)                                                            \
-  __asm volatile                                                                 \
+  __asm volatile                                                               \
   (                                                                            \
     "ldr r7,="#f"\n\t"                                                         \
     "mov r12,r7\n\t"                                                           \
@@ -270,7 +217,7 @@ typedef uint32_t __attribute__((vector_size(16))) ret128;
   );
 #else
 #define SVC_Call(f)                                                            \
-  __asm volatile                                                                 \
+  __asm volatile                                                               \
   (                                                                            \
     "ldr r12,="#f"\n\t"                                                        \
     "svc 0"                                                                    \
@@ -327,9 +274,9 @@ static inline  t __##f (t1 a1, t2 a2, t3 a3, t4 a4) {                          \
   return (t) rv;                                                               \
 }
 
-#define SVC_1_2 SVC_1_1
-#define SVC_1_3 SVC_1_1
-#define SVC_2_3 SVC_2_1
+#define SVC_1_2 SVC_1_1 
+#define SVC_1_3 SVC_1_1 
+#define SVC_2_3 SVC_2_1 
 
 #elif defined (__ICCARM__)      /* IAR Compiler */
 
@@ -348,13 +295,13 @@ static inline  t __##f (t1 a1, t2 a2, t3 a3, t4 a4) {                          \
 #define osCallback_ret     ((uint64_t)ret.fp | ((uint64_t)ret.arg)<<32)
 
 #define SVC_Setup(f)                                                           \
-  __asm(                                                                         \
+  __asm(                                                                       \
     "mov r12,%0\n"                                                             \
     :: "r"(&f): "r12"                                                          \
   );
 
 #define SVC_Ret3()                                                             \
-  __asm(                                                                         \
+  __asm(                                                                       \
     "ldr r0,[sp,#0]\n"                                                         \
     "ldr r1,[sp,#4]\n"                                                         \
     "ldr r2,[sp,#8]\n"                                                         \
@@ -415,7 +362,7 @@ static inline t __##f (t1 a1) {                                                \
   t ret;                                                                       \
   SVC_Setup(f);                                                                \
   _##f(a1);                                                                    \
-  __asm("" : rr : :);                                                            \
+  __asm("" : rr : :);                                                          \
   return ret;                                                                  \
 }
 
@@ -430,7 +377,7 @@ static inline t __##f (t1 a1) {                                                \
   t ret;                                                                       \
   SVC_Setup(f##_);                                                             \
   _##f(a1);                                                                    \
-  __asm("" : rr : :);                                                            \
+  __asm("" : rr : :);                                                          \
   return ret;                                                                  \
 }
 
@@ -445,7 +392,7 @@ static inline t __##f (t1 a1, t2 a2) {                                         \
   t ret;                                                                       \
   SVC_Setup(f##_);                                                             \
   _##f(a1,a2);                                                                 \
-  __asm("" : rr : :);                                                            \
+  __asm("" : rr : :);                                                          \
   return ret;                                                                  \
 }
 
@@ -487,36 +434,37 @@ void sysThreadTerminate(osThreadId id);
 // ==== Helper Functions ====
 
 /// Convert timeout in millisec to system ticks
-static uint32_t rt_ms2tick (uint32_t millisec) {
+static uint16_t rt_ms2tick (uint32_t millisec) {
   uint32_t tick;
 
-  if (millisec == osWaitForever) return 0xFFFF; // Indefinite timeout
-  if (millisec > 4000000) return 0xFFFE;        // Max ticks supported
+  if (millisec == 0U) { return 0x0U; }                  // No timeout
+  if (millisec == osWaitForever) { return 0xFFFFU; }    // Indefinite timeout
+  if (millisec > 4000000U) { return 0xFFFEU; }          // Max ticks supported
 
-  tick = ((1000 * millisec) + os_clockrate - 1)  / os_clockrate;
-  if (tick > 0xFFFE) return 0xFFFE;
-
-  return tick;
+  tick = ((1000U * millisec) + os_clockrate - 1U)  / os_clockrate;
+  if (tick > 0xFFFEU) { return 0xFFFEU; }
+  
+  return (uint16_t)tick;
 }
 
 /// Convert Thread ID to TCB pointer
-static P_TCB rt_tid2ptcb (osThreadId thread_id) {
+P_TCB rt_tid2ptcb (osThreadId thread_id) {
   P_TCB ptcb;
 
-  if (thread_id == NULL) return NULL;
+  if (thread_id == NULL) { return NULL; }
 
-  if ((uint32_t)thread_id & 3) return NULL;
+  if ((uint32_t)thread_id & 3U) { return NULL; }
 
 #ifdef OS_SECTIONS_LINK_INFO
-  if ((os_section_id$$Base != 0) && (os_section_id$$Limit != 0)) {
-    if (thread_id  < (osThreadId)os_section_id$$Base)  return NULL;
-    if (thread_id >= (osThreadId)os_section_id$$Limit) return NULL;
+  if ((os_section_id$$Base != 0U) && (os_section_id$$Limit != 0U)) {
+    if (thread_id  < (osThreadId)os_section_id$$Base)  { return NULL; }
+    if (thread_id >= (osThreadId)os_section_id$$Limit) { return NULL; }
   }
 #endif
 
   ptcb = thread_id;
 
-  if (ptcb->cb_type != TCB) return NULL;
+  if (ptcb->cb_type != TCB) { return NULL; }
 
   return ptcb;
 }
@@ -524,12 +472,12 @@ static P_TCB rt_tid2ptcb (osThreadId thread_id) {
 /// Convert ID pointer to Object pointer
 static void *rt_id2obj (void *id) {
 
-  if ((uint32_t)id & 3) return NULL;
+  if ((uint32_t)id & 3U) { return NULL; }
 
 #ifdef OS_SECTIONS_LINK_INFO
-  if ((os_section_id$$Base != 0) && (os_section_id$$Limit != 0)) {
-    if (id  < (void *)os_section_id$$Base)  return NULL;
-    if (id >= (void *)os_section_id$$Limit) return NULL;
+  if ((os_section_id$$Base != 0U) && (os_section_id$$Limit != 0U)) {
+    if (id  < (void *)os_section_id$$Base)  { return NULL; }
+    if (id >= (void *)os_section_id$$Limit) { return NULL; }
   }
 #endif
 
@@ -539,7 +487,7 @@ static void *rt_id2obj (void *id) {
 // === Helper functions for system call interface ===
 
 static __inline char __get_mode(void) {
-    return (char)(__get_CPSR() & 0x1f);
+    return (char)(__get_CPSR() & 0x1FU);
 }
 
 static __inline char __exceptional_mode(void) {
@@ -551,14 +499,14 @@ static __inline char __exceptional_mode(void) {
     switch(__get_mode()) {
         case MODE_USR:
         case MODE_SYS:
-            return 0;
+            return 0U;
         case MODE_SVC:
-            if (IRQNestLevel == 0)
-                return 0; /* handling a regular service call */
+            if (IRQNestLevel == 0U)
+                return 0U; /* handling a regular service call */
             else
-                return 1; /* handling an ISR in SVC mode */
+                return 1U; /* handling an ISR in SVC mode */
         default:
-            return 1;
+            return 1U;
     }
 }
 
@@ -586,22 +534,22 @@ osStatus svcKernelInitialize (void) {
     rt_sys_init();                              // RTX System Initialization
   }
 #else
-  int ret;
+  uint32_t ret;
 
-  if (!os_initialized) {
+  if (os_initialized == 0U) {
 
     // Init Thread Stack Memory (must be 8-byte aligned)
-    if ((uint32_t)os_stack_mem & 7) return osErrorNoMemory;
+    if (((uint32_t)os_stack_mem & 7U) != 0U) { return osErrorNoMemory; }
     ret = rt_init_mem(os_stack_mem, os_stack_sz);
-    if (ret != 0) return osErrorNoMemory;
+    if (ret != 0U) { return osErrorNoMemory; }
 
     rt_sys_init();                              // RTX System Initialization
   }
 #endif
 
-  os_tsk.run->prio = 255;                       // Highest priority
+  os_tsk.run->prio = 255U;                      // Highest priority
 
-  if (!os_initialized) {
+  if (os_initialized == 0U) {
     // Create OS Timers resources (Message Queue & Thread)
     osMessageQId_osTimerMessageQ = svcMessageCreate (&os_messageQ_def_osTimerMessageQ, NULL);
     osThreadId_osTimerThread = svcThreadCreate(&os_thread_def_osTimerThread, NULL);
@@ -611,8 +559,8 @@ osStatus svcKernelInitialize (void) {
 
   sysThreadError(osOK);
 
-  os_initialized = 1;
-  os_running = 0;
+  os_initialized = 1U;
+  os_running = 0U;
 
   return osOK;
 }
@@ -620,24 +568,24 @@ osStatus svcKernelInitialize (void) {
 /// Start the RTOS Kernel
 osStatus svcKernelStart (void) {
 
-  if (os_running) return osOK;
+  if (os_running) { return osOK; }
 
-  rt_tsk_prio(0, os_tsk.run->prio_base);        // Restore priority
-  if (os_tsk.run->task_id == 0xFF) {            // Idle Thread
-    __set_PSP(os_tsk.run->tsk_stack + 8*4);     // Setup PSP
+  rt_tsk_prio(0U, os_tsk.run->prio_base);       // Restore priority
+  if (os_tsk.run->task_id == 0xFFU) {           // Idle Thread
+    __set_PSP(os_tsk.run->tsk_stack + (8U*4U)); // Setup PSP
   }
   os_tsk.run = NULL;                            // Force context switch
 
   rt_sys_start();
 
-  os_running = 1;
+  os_running = 1U;
 
   return osOK;
 }
 
 /// Check if the RTOS kernel is already started
-int32_t svcKernelRunning(void) {
-  return os_running;
+int32_t svcKernelRunning (void) {
+  return (int32_t)os_running;
 }
 
 /// Get the RTOS kernel system timer counter
@@ -647,10 +595,10 @@ uint32_t svcKernelSysTick (void) {
   tick = os_tick_val();
   if (os_tick_ovf()) {
     tick0 = os_tick_val();
-    if (tick0 < tick) tick = tick0;
-    tick += (os_trv + 1) * (os_time + 1);
+    if (tick0 < tick) { tick = tick0; }
+    tick += (os_trv + 1U) * (os_time + 1U);
   } else {
-    tick += (os_trv + 1) *  os_time;
+    tick += (os_trv + 1U) *  os_time;
   }
 
   return tick;
@@ -660,7 +608,9 @@ uint32_t svcKernelSysTick (void) {
 
 /// Initialize the RTOS Kernel for creating objects
 osStatus osKernelInitialize (void) {
-  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return osErrorISR;                      // Not allowed in ISR
+  }
   if (__get_mode() != MODE_USR) {
     return   svcKernelInitialize();
   } else {
@@ -674,21 +624,21 @@ osStatus osKernelStart (void) {
 
   switch(mode) {
     case MODE_USR:
-      if (os_flags & 1) return osErrorOS;  // Privileged Thread mode requested from Unprivileged
+      if (os_flags & 1U) return osErrorOS;  // Privileged Thread mode requested from Unprivileged
       break;
     case MODE_SYS:
-      if (!(os_flags & 1)) {
+      if (!(os_flags & 1U)) {
         __set_CPS_USR();
       }
       break;
     default:
-      return osErrorISR;                   // Not allowed in ISR
+      return osErrorISR;                    // Not allowed in ISR
   }
   return __svcKernelStart();
 }
 
 /// Check if the RTOS kernel is already started
-int32_t osKernelRunning(void) {
+int32_t osKernelRunning (void) {
   if(__get_mode() != MODE_USR) {
     return os_running;
   } else {
@@ -698,7 +648,7 @@ int32_t osKernelRunning(void) {
 
 /// Get the RTOS kernel system timer counter
 uint32_t osKernelSysTick (void) {
-  if (__exceptional_mode()) return 0;              // Not allowed in ISR
+  if (__exceptional_mode()) { return 0U; }              // Not allowed in ISR
   return __svcKernelSysTick();
 }
 
@@ -733,23 +683,23 @@ osThreadId svcThreadCreate (const osThreadDef_t *thread_def, void *argument) {
       (thread_def->pthread == NULL) ||
       (thread_def->tpriority < osPriorityIdle) ||
       (thread_def->tpriority > osPriorityRealtime)) {
-    sysThreadError(osErrorParameter);
-    return NULL;
+    sysThreadError(osErrorParameter); 
+    return NULL; 
   }
 
 #ifdef __MBED_CMSIS_RTOS_CA9
-  if (thread_def->stacksize != 0) {             // Custom stack size
+  if (thread_def->stacksize != 0U) {            // Custom stack size
     stk = (void *)thread_def->stack_pointer;
   } else {                                      // Default stack size
     stk = NULL;
   }
 #else
-  if (thread_def->stacksize != 0) {             // Custom stack size
+  if (thread_def->stacksize != 0U) {            // Custom stack size
     stk = rt_alloc_mem(                         // Allocate stack
       os_stack_mem,
       thread_def->stacksize
     );
-    if (stk == NULL) {
+    if (stk == NULL) { 
       sysThreadError(osErrorNoMemory);          // Out of memory
       return NULL;
     }
@@ -760,13 +710,14 @@ osThreadId svcThreadCreate (const osThreadDef_t *thread_def, void *argument) {
 
   tsk = rt_tsk_create(                          // Create task
     (FUNCP)thread_def->pthread,                 // Task function pointer
+    (uint32_t)
     (thread_def->tpriority-osPriorityIdle+1) |  // Task priority
     (thread_def->stacksize << 8),               // Task stack size in bytes
     stk,                                        // Pointer to task's stack
     argument                                    // Argument to the task
   );
 
-  if (tsk == 0) {                               // Invalid task ID
+  if (tsk == 0U) {                              // Invalid task ID
 #ifndef __MBED_CMSIS_RTOS_CA9
     if (stk != NULL) {
       rt_free_mem(os_stack_mem, stk);           // Free allocated stack
@@ -776,7 +727,7 @@ osThreadId svcThreadCreate (const osThreadDef_t *thread_def, void *argument) {
     return NULL;
   }
 
-  ptcb = (P_TCB)os_active_TCB[tsk - 1];         // TCB pointer
+  ptcb = (P_TCB)os_active_TCB[tsk - 1U];        // TCB pointer
 
   *((uint32_t *)ptcb->tsk_stack + 13) = (uint32_t)osThreadExit;
 
@@ -788,8 +739,8 @@ osThreadId svcThreadGetId (void) {
   OS_TID tsk;
 
   tsk = rt_tsk_self();
-  if (tsk == 0) return NULL;
-  return (P_TCB)os_active_TCB[tsk - 1];
+  if (tsk == 0U) { return NULL; }
+  return (P_TCB)os_active_TCB[tsk - 1U];
 }
 
 /// Terminate execution of a thread and remove it from ActiveThreads
@@ -801,7 +752,9 @@ osStatus svcThreadTerminate (osThreadId thread_id) {
 #endif
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) return osErrorParameter;
+  if (ptcb == NULL) { 
+    return osErrorParameter;
+  }
 
 #ifndef __MBED_CMSIS_RTOS_CA9
   stk = ptcb->priv_stack ? ptcb->stack : NULL;  // Private stack
@@ -809,10 +762,12 @@ osStatus svcThreadTerminate (osThreadId thread_id) {
 
   res = rt_tsk_delete(ptcb->task_id);           // Delete task
 
-  if (res == OS_R_NOK) return osErrorResource;  // Delete task failed
+  if (res == OS_R_NOK) {
+    return osErrorResource;                     // Delete task failed
+  }
 
 #ifndef __MBED_CMSIS_RTOS_CA9
-  if (stk != NULL) {
+  if (stk != NULL) {                            
     rt_free_mem(os_stack_mem, stk);             // Free private stack
   }
 #endif
@@ -832,7 +787,9 @@ osStatus svcThreadSetPriority (osThreadId thread_id, osPriority priority) {
   P_TCB     ptcb;
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) return osErrorParameter;
+  if (ptcb == NULL) { 
+    return osErrorParameter; 
+  }
 
   if ((priority < osPriorityIdle) || (priority > osPriorityRealtime)) {
     return osErrorValue;
@@ -840,10 +797,12 @@ osStatus svcThreadSetPriority (osThreadId thread_id, osPriority priority) {
 
   res = rt_tsk_prio(                            // Change task priority
     ptcb->task_id,                              // Task ID
-    priority - osPriorityIdle + 1               // New task priority
+    (uint8_t)(priority - osPriorityIdle + 1)    // New task priority
   );
 
-  if (res == OS_R_NOK) return osErrorResource;  // Change task priority failed
+  if (res == OS_R_NOK) {
+    return osErrorResource;                     // Change task priority failed
+  }
 
   return osOK;
 }
@@ -853,9 +812,11 @@ osPriority svcThreadGetPriority (osThreadId thread_id) {
   P_TCB ptcb;
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) return osPriorityError;
+  if (ptcb == NULL) {
+    return osPriorityError;
+  }
 
-  return (osPriority)(ptcb->prio - 1 + osPriorityIdle);
+  return (osPriority)(ptcb->prio - 1 + osPriorityIdle); 
 }
 
 /// Get info from an active thread
@@ -867,78 +828,50 @@ os_InRegs osEvent_type svcThreadGetInfo (osThreadId thread_id, osThreadInfo info
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
   if (ptcb == NULL) {
     ret.status = osErrorValue;
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-    osEvent_ret_status;
-    return;
-#else
     return osEvent_ret_status;
-#endif
   }
 
   if (osThreadInfoStackSize == info) {
     uint32_t size;
     size = ptcb->priv_stack;
-    if (0 == size) {
+    if (0U == size) {
       // This is an OS task - always a fixed size
-      size = os_stackinfo & 0x3FFFF;
+      size = os_stackinfo & 0x3FFFFU;
     }
     ret.value.v = size;
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-    osEvent_ret_value;
-    return;
-#else
     return osEvent_ret_value;
-#endif
   }
 
   if (osThreadInfoStackMax == info) {
     // Cortex-A RTX does not have stack init so
     // the maximum stack usage cannot be obtained.
     ret.status = osErrorResource;
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-    osEvent_ret_status;
-    return;
-#else
     return osEvent_ret_status;
-#endif
   }
 
   if (osThreadInfoEntry == info) {
     ret.value.p = (void*)ptcb->ptask;
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-    osEvent_ret_value;
-    return;
-#else
     return osEvent_ret_value;
-#endif
   }
 
   if (osThreadInfoArg == info) {
     ret.value.p = (void*)ptcb->argv;
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-    osEvent_ret_value;
-    return;
-#else
     return osEvent_ret_value;
-#endif
   }
 
   // Unsupported option so return error
   ret.status = osErrorParameter;
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-    osEvent_ret_status;
-    return;
-#else
-    return osEvent_ret_status;
-#endif
+  return osEvent_ret_status;
 }
 
 // Thread Public API
 
 /// Create a thread and add it to Active Threads and set it to state READY
 osThreadId osThreadCreate (const osThreadDef_t *thread_def, void *argument) {
-  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
-  if ((__get_mode() != MODE_USR) && (os_running == 0)) {
+  if (__exceptional_mode()) {
+    return NULL;           // Not allowed in ISR
+  }
+  if ((__get_mode() != MODE_USR) && (os_running == 0U)) {
     // Privileged and not running
     return   svcThreadCreate(thread_def, argument);
   } else {
@@ -953,14 +886,18 @@ osThreadId osThreadCreate (const osThreadDef_t *thread_def, void *argument) {
 
 /// Return the thread ID of the current running thread
 osThreadId osThreadGetId (void) {
-  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return NULL;           // Not allowed in ISR
+  }
   return __svcThreadGetId();
 }
 
 /// Terminate execution of a thread and remove it from ActiveThreads
 osStatus osThreadTerminate (osThreadId thread_id) {
   osStatus status;
-  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return osErrorISR;     // Not allowed in ISR
+  }
   osMutexWait(osMutexId_osThreadMutex, osWaitForever);
   sysThreadTerminate(thread_id);
   // Thread mutex must be held when a thread is created or terminated
@@ -971,25 +908,31 @@ osStatus osThreadTerminate (osThreadId thread_id) {
 
 /// Pass control to next thread that is in state READY
 osStatus osThreadYield (void) {
-  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return osErrorISR;     // Not allowed in ISR
+  }
   return __svcThreadYield();
 }
 
 /// Change priority of an active thread
 osStatus osThreadSetPriority (osThreadId thread_id, osPriority priority) {
-  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return osErrorISR;     // Not allowed in ISR
+  }
   return __svcThreadSetPriority(thread_id, priority);
 }
 
 /// Get current priority of an active thread
 osPriority osThreadGetPriority (osThreadId thread_id) {
-  if (__exceptional_mode()) return osPriorityError;// Not allowed in ISR
+  if (__exceptional_mode()) {
+    return osPriorityError;// Not allowed in ISR
+  }
   return __svcThreadGetPriority(thread_id);
 }
 
 /// INTERNAL - Not Public
 /// Auto Terminate Thread on exit (used implicitly when thread exists)
-__NO_RETURN void osThreadExit (void) {
+__NO_RETURN void osThreadExit (void) { 
   osThreadId id;
   // Thread mutex must be held when a thread is created or terminated
   // Note - the mutex will be released automatically by the os when
@@ -997,7 +940,7 @@ __NO_RETURN void osThreadExit (void) {
   osMutexWait(osMutexId_osThreadMutex, osWaitForever);
   id = __svcThreadGetId();
   sysThreadTerminate(id);
-  __svcThreadTerminate(id);
+  __svcThreadTerminate(id); 
   for (;;);                                     // Should never come here
 }
 
@@ -1006,10 +949,14 @@ __NO_RETURN void osThreadExit (void) {
 uint8_t osThreadGetState (osThreadId thread_id) {
   P_TCB ptcb;
 
-  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return osErrorISR;     // Not allowed in ISR
+  }
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) return INACTIVE;
+  if (ptcb == NULL) {
+  	return INACTIVE;
+  }
 
   return ptcb->state;
 }
@@ -1046,13 +993,13 @@ osThreadId _osThreadEnumNext(osThreadEnumId enum_id) {
     // Include the idle task at the end of the enumeration
     id = &os_idle_TCB;
   }
-  *index = i + 1;
+  *index = i + 1U;
   return id;
 }
 
 osStatus _osThreadEnumFree(osThreadEnumId enum_id) {
   uint32_t *index = (uint32_t*)enum_id;
-  *index = 0;
+  *index = 0U;
   osMutexRelease(osMutexId_osThreadMutex);
   return osOK;
 }
@@ -1069,7 +1016,7 @@ SVC_1_3(svcWait,  os_InRegs osEvent,  uint32_t, RET_osEvent)
 
 /// Wait for Timeout (Time Delay)
 osStatus svcDelay (uint32_t millisec) {
-  if (millisec == 0) return osOK;
+  if (millisec == 0U) { return osOK; }
   rt_dly_wait(rt_ms2tick(millisec));
   return osEventTimeout;
 }
@@ -1079,26 +1026,16 @@ osStatus svcDelay (uint32_t millisec) {
 os_InRegs osEvent_type svcWait (uint32_t millisec) {
   osEvent ret;
 
-  if (millisec == 0) {
+  if (millisec == 0U) {
     ret.status = osOK;
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-    osEvent_ret_status;
-    return;
-#else
     return osEvent_ret_status;
-#endif
   }
 
   /* To Do: osEventSignal, osEventMessage, osEventMail */
   rt_dly_wait(rt_ms2tick(millisec));
   ret.status = osEventTimeout;
 
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-  osEvent_ret_status;
-  return;
-#else
   return osEvent_ret_status;
-#endif
 }
 #endif
 
@@ -1107,7 +1044,9 @@ os_InRegs osEvent_type svcWait (uint32_t millisec) {
 
 /// Wait for Timeout (Time Delay)
 osStatus osDelay (uint32_t millisec) {
-  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return osErrorISR;                          // Not allowed in ISR
+  }
   return __svcDelay(millisec);
 }
 
@@ -1119,7 +1058,7 @@ os_InRegs osEvent osWait (uint32_t millisec) {
   ret.status = osErrorOS;
   return ret;
 #else
-  if (__exceptional_mode()) {                      // Not allowed in ISR
+  if (__exceptional_mode()) {                   // Not allowed in ISR
     ret.status = osErrorISR;
     return ret;
   }
@@ -1131,9 +1070,9 @@ os_InRegs osEvent osWait (uint32_t millisec) {
 // ==== Timer Management ====
 
 // Timer definitions
-#define osTimerInvalid  0
-#define osTimerStopped  1
-#define osTimerRunning  2
+#define osTimerInvalid  0U
+#define osTimerStopped  1U
+#define osTimerRunning  2U
 
 // Timer structures
 
@@ -1142,8 +1081,8 @@ typedef struct os_timer_cb_ {                   // Timer Control Block
   uint8_t             state;                    // Timer State
   uint8_t              type;                    // Timer Type (Periodic/One-shot)
   uint16_t         reserved;                    // Reserved
-  uint16_t             tcnt;                    // Timer Delay Count
-  uint16_t             icnt;                    // Timer Initial Count
+  uint32_t             tcnt;                    // Timer Delay Count
+  uint32_t             icnt;                    // Timer Initial Count 
   void                 *arg;                    // Timer Function Argument
   const osTimerDef_t *timer;                    // Pointer to Timer definition
 } os_timer_cb;
@@ -1161,13 +1100,13 @@ static void rt_timer_insert (os_timer_cb *pt, uint32_t tcnt) {
   prev = NULL;
   p = os_timer_head;
   while (p != NULL) {
-    if (tcnt < p->tcnt) break;
+    if (tcnt < p->tcnt) { break; }
     tcnt -= p->tcnt;
     prev = p;
     p = p->next;
   }
   pt->next = p;
-  pt->tcnt = (uint16_t)tcnt;
+  pt->tcnt = tcnt;
   if (p != NULL) {
     p->tcnt -= pt->tcnt;
   }
@@ -1179,17 +1118,17 @@ static void rt_timer_insert (os_timer_cb *pt, uint32_t tcnt) {
 }
 
 // Remove Timer from the list
-static int rt_timer_remove (os_timer_cb *pt) {
+static int32_t rt_timer_remove (os_timer_cb *pt) {
   os_timer_cb *p, *prev;
 
   prev = NULL;
   p = os_timer_head;
   while (p != NULL) {
-    if (p == pt) break;
+    if (p == pt) { break; }
     prev = p;
     p = p->next;
   }
-  if (p == NULL) return -1;
+  if (p == NULL) { return -1; }
   if (prev != NULL) {
     prev->next = pt->next;
   } else {
@@ -1257,10 +1196,13 @@ osStatus svcTimerStart (osTimerId timer_id, uint32_t millisec) {
   uint32_t     tcnt;
 
   pt = rt_id2obj(timer_id);
-  if (pt == NULL) return osErrorParameter;
+  if (pt == NULL) {
+    return osErrorParameter;
+  }
 
-  tcnt = rt_ms2tick(millisec);
-  if (tcnt == 0) return osErrorValue;
+  if (millisec == 0U) { return osErrorValue; }
+
+  tcnt = (uint32_t)(((1000U * (uint64_t)millisec) + os_clockrate - 1U)  / os_clockrate);
 
   switch (pt->state) {
     case osTimerRunning:
@@ -1270,12 +1212,12 @@ osStatus svcTimerStart (osTimerId timer_id, uint32_t millisec) {
       break;
     case osTimerStopped:
       pt->state = osTimerRunning;
-      pt->icnt  = (uint16_t)tcnt;
+      pt->icnt  = tcnt;
       break;
     default:
       return osErrorResource;
   }
-
+  
   rt_timer_insert(pt, tcnt);
 
   return osOK;
@@ -1286,9 +1228,11 @@ osStatus svcTimerStop (osTimerId timer_id) {
   os_timer_cb *pt;
 
   pt = rt_id2obj(timer_id);
-  if (pt == NULL) return osErrorParameter;
+  if (pt == NULL) {
+    return osErrorParameter;
+  }
 
-  if (pt->state != osTimerRunning) return osErrorResource;
+  if (pt->state != osTimerRunning) { return osErrorResource; }
 
   pt->state = osTimerStopped;
 
@@ -1304,7 +1248,9 @@ osStatus svcTimerDelete (osTimerId timer_id) {
   os_timer_cb *pt;
 
   pt = rt_id2obj(timer_id);
-  if (pt == NULL) return osErrorParameter;
+  if (pt == NULL) {
+    return osErrorParameter;
+  }
 
   switch (pt->state) {
     case osTimerRunning:
@@ -1330,41 +1276,35 @@ os_InRegs osCallback_type svcTimerCall (osTimerId timer_id) {
   if (pt == NULL) {
     ret.fp  = NULL;
     ret.arg = NULL;
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-    osCallback_ret;
-    return;
-#else
     return osCallback_ret;
-#endif
   }
 
   ret.fp  = (void *)pt->timer->ptimer;
   ret.arg = pt->arg;
 
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-  osCallback_ret;
-  return;
-#else
   return osCallback_ret;
-#endif
 }
 
-static __INLINE osStatus isrMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec);
+osStatus isrMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec);
 
 /// Timer Tick (called each SysTick)
 void sysTimerTick (void) {
   os_timer_cb *pt, *p;
+  osStatus     status;
 
   p = os_timer_head;
-  if (p == NULL) return;
+  if (p == NULL) { return; }
 
   p->tcnt--;
-  while ((p != NULL) && (p->tcnt == 0)) {
+  while ((p != NULL) && (p->tcnt == 0U)) {
     pt = p;
     p = p->next;
     os_timer_head = p;
-    isrMessagePut(osMessageQId_osTimerMessageQ, (uint32_t)pt, 0);
-    if (pt->type == osTimerPeriodic) {
+    status = isrMessagePut(osMessageQId_osTimerMessageQ, (uint32_t)pt, 0U);
+    if (status != osOK) {
+      os_error(OS_ERR_TIMER_OVF);
+    }
+    if (pt->type == (uint8_t)osTimerPeriodic) {
       rt_timer_insert(pt, pt->icnt);
     } else {
       pt->state = osTimerStopped;
@@ -1378,16 +1318,16 @@ uint32_t sysUserTimerWakeupTime (void) {
   if (os_timer_head) {
     return os_timer_head->tcnt;
   }
-  return 0xFFFF;
+  return 0xFFFFFFFFU;
 }
 
 /// Update user timers on resume
 void sysUserTimerUpdate (uint32_t sleep_time) {
 
-  while (os_timer_head && sleep_time) {
+  while ((os_timer_head != NULL) && (sleep_time != 0U)) {
     if (sleep_time >= os_timer_head->tcnt) {
       sleep_time -= os_timer_head->tcnt;
-      os_timer_head->tcnt = 1;
+      os_timer_head->tcnt = 1U;
       sysTimerTick();
     } else {
       os_timer_head->tcnt -= sleep_time;
@@ -1401,8 +1341,10 @@ void sysUserTimerUpdate (uint32_t sleep_time) {
 
 /// Create timer
 osTimerId osTimerCreate (const osTimerDef_t *timer_def, os_timer_type type, void *argument) {
-  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
-  if ((__get_mode() != MODE_USR) && (os_running == 0)) {
+  if (__exceptional_mode()) {
+    return NULL;           // Not allowed in ISR
+  }
+  if ((__get_mode() != MODE_USR) && (os_running == 0U)) {
     // Privileged and not running
     return   svcTimerCreate(timer_def, type, argument);
   } else {
@@ -1412,26 +1354,32 @@ osTimerId osTimerCreate (const osTimerDef_t *timer_def, os_timer_type type, void
 
 /// Start or restart timer
 osStatus osTimerStart (osTimerId timer_id, uint32_t millisec) {
-  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return osErrorISR;     // Not allowed in ISR
+  }
   return __svcTimerStart(timer_id, millisec);
 }
 
 /// Stop timer
 osStatus osTimerStop (osTimerId timer_id) {
-  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
+  if (__exceptional_mode()) {
+  return osErrorISR;     // Not allowed in ISR
+  }
   return __svcTimerStop(timer_id);
 }
 
 /// Delete timer
 osStatus osTimerDelete (osTimerId timer_id) {
-  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return osErrorISR;     // Not allowed in ISR
+  }
   return __svcTimerDelete(timer_id);
 }
 
 /// INTERNAL - Not Public
 /// Get timer callback parameters (used by OS Timer Thread)
-os_InRegs osCallback osTimerCall (osTimerId timer_id) {
-  return __svcTimerCall(timer_id);
+os_InRegs osCallback osTimerCall (osTimerId timer_id) { 
+  return __svcTimerCall(timer_id); 
 }
 
 
@@ -1467,13 +1415,17 @@ int32_t svcSignalSet (osThreadId thread_id, int32_t signals) {
   int32_t sig;
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) return 0x80000000;
+  if (ptcb == NULL) {
+    return (int32_t)0x80000000U;
+  }
 
-  if (signals & (0xFFFFFFFF << osFeature_Signals)) return 0x80000000;
+  if ((uint32_t)signals & (0xFFFFFFFFU << osFeature_Signals)) {
+    return (int32_t)0x80000000U;
+  }
 
-  sig = ptcb->events;                           // Previous signal flags
+  sig = (int32_t)ptcb->events;                  // Previous signal flags
 
-  rt_evt_set(signals, ptcb->task_id);           // Set event flags
+  rt_evt_set((uint16_t)signals, ptcb->task_id); // Set event flags
 
   return sig;
 }
@@ -1484,13 +1436,17 @@ int32_t svcSignalClear (osThreadId thread_id, int32_t signals) {
   int32_t sig;
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) return 0x80000000;
+  if (ptcb == NULL) {
+    return (int32_t)0x80000000U;
+  }
 
-  if (signals & (0xFFFFFFFF << osFeature_Signals)) return 0x80000000;
+  if ((uint32_t)signals & (0xFFFFFFFFU << osFeature_Signals)) {
+    return (int32_t)0x80000000U;
+  }
 
-  sig = ptcb->events;                           // Previous signal flags
+  sig = (int32_t)ptcb->events;                  // Previous signal flags
 
-  rt_evt_clr(signals, ptcb->task_id);           // Clear event flags
+  rt_evt_clr((uint16_t)signals, ptcb->task_id); // Clear event flags
 
   return sig;
 }
@@ -1500,54 +1456,48 @@ os_InRegs osEvent_type svcSignalWait (int32_t signals, uint32_t millisec) {
   OS_RESULT res;
   osEvent   ret;
 
-  if (signals & (0xFFFFFFFF << osFeature_Signals)) {
+  if ((uint32_t)signals & (0xFFFFFFFFU << osFeature_Signals)) {
     ret.status = osErrorValue;
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-    osEvent_ret_status;
-    return;
-#else
     return osEvent_ret_status;
-#endif
   }
 
   if (signals != 0) {                           // Wait for all specified signals
-    res = rt_evt_wait(signals, rt_ms2tick(millisec), __TRUE);
+    res = rt_evt_wait((uint16_t)signals, rt_ms2tick(millisec), __TRUE);
   } else {                                      // Wait for any signal
-    res = rt_evt_wait(0xFFFF,  rt_ms2tick(millisec), __FALSE);
+    res = rt_evt_wait(0xFFFFU,           rt_ms2tick(millisec), __FALSE);
   }
 
   if (res == OS_R_EVT) {
     ret.status = osEventSignal;
-    ret.value.signals = signals ? signals : os_tsk.run->waits;
+    ret.value.signals = (signals != 0) ? signals : (int32_t)os_tsk.run->waits;
   } else {
-    ret.status = millisec ? osEventTimeout : osOK;
+    ret.status = (millisec != 0U) ? osEventTimeout : osOK;
     ret.value.signals = 0;
   }
 
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-  osEvent_ret_value;
-  return;
-#else
   return osEvent_ret_value;
-#endif
 }
 
 
 // Signal ISR Calls
 
 /// Set the specified Signal Flags of an active thread
-static __INLINE int32_t isrSignalSet (osThreadId thread_id, int32_t signals) {
+int32_t isrSignalSet (osThreadId thread_id, int32_t signals) {
   P_TCB   ptcb;
   int32_t sig;
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) return 0x80000000;
+  if (ptcb == NULL) {
+    return (int32_t)0x80000000U;
+  }
 
-  if (signals & (0xFFFFFFFF << osFeature_Signals)) return 0x80000000;
+  if ((uint32_t)signals & (0xFFFFFFFFU << osFeature_Signals)) {
+    return (int32_t)0x80000000U;
+  }
 
-  sig = ptcb->events;                           // Previous signal flags
+  sig = (int32_t)ptcb->events;                  // Previous signal flags
 
-  isr_evt_set(signals, ptcb->task_id);          // Set event flags
+  isr_evt_set((uint16_t)signals, ptcb->task_id);// Set event flags
 
   return sig;
 }
@@ -1558,7 +1508,7 @@ static __INLINE int32_t isrSignalSet (osThreadId thread_id, int32_t signals) {
 /// Set the specified Signal Flags of an active thread
 int32_t osSignalSet (osThreadId thread_id, int32_t signals) {
   if (__exceptional_mode()) {                      // in ISR
-    return   isrSignalSet(thread_id, signals);
+    return   isrSignalSet(thread_id, signals); 
   } else {                                      // in Thread
     return __svcSignalSet(thread_id, signals);
   }
@@ -1566,7 +1516,9 @@ int32_t osSignalSet (osThreadId thread_id, int32_t signals) {
 
 /// Clear the specified Signal Flags of an active thread
 int32_t osSignalClear (osThreadId thread_id, int32_t signals) {
-  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return (int32_t)0x80000000U;     // Not allowed in ISR
+  }
   return __svcSignalClear(thread_id, signals);
 }
 
@@ -1607,7 +1559,7 @@ osMutexId svcMutexCreate (const osMutexDef_t *mutex_def) {
     return NULL;
   }
 
-  if (((P_MUCB)mut)->cb_type != 0) {
+  if (((P_MUCB)mut)->cb_type != 0U) {
     sysThreadError(osErrorParameter);
     return NULL;
   }
@@ -1623,14 +1575,18 @@ osStatus svcMutexWait (osMutexId mutex_id, uint32_t millisec) {
   OS_RESULT res;
 
   mut = rt_id2obj(mutex_id);
-  if (mut == NULL) return osErrorParameter;
+  if (mut == NULL) {
+    return osErrorParameter;
+  }
 
-  if (((P_MUCB)mut)->cb_type != MUCB) return osErrorParameter;
+  if (((P_MUCB)mut)->cb_type != MUCB) {
+    return osErrorParameter;
+  }
 
   res = rt_mut_wait(mut, rt_ms2tick(millisec)); // Wait for Mutex
 
   if (res == OS_R_TMO) {
-    return (millisec ? osErrorTimeoutResource : osErrorResource);
+    return ((millisec != 0U) ? osErrorTimeoutResource : osErrorResource);
   }
 
   return osOK;
@@ -1642,13 +1598,19 @@ osStatus svcMutexRelease (osMutexId mutex_id) {
   OS_RESULT res;
 
   mut = rt_id2obj(mutex_id);
-  if (mut == NULL) return osErrorParameter;
+  if (mut == NULL) {
+    return osErrorParameter;
+  }
 
-  if (((P_MUCB)mut)->cb_type != MUCB) return osErrorParameter;
+  if (((P_MUCB)mut)->cb_type != MUCB) {
+    return osErrorParameter;
+  }
 
   res = rt_mut_release(mut);                    // Release Mutex
 
-  if (res == OS_R_NOK) return osErrorResource;  // Thread not owner or Zero Counter
+  if (res == OS_R_NOK) {
+    return osErrorResource;                     // Thread not owner or Zero Counter
+  }
 
   return osOK;
 }
@@ -1658,9 +1620,13 @@ osStatus svcMutexDelete (osMutexId mutex_id) {
   OS_ID mut;
 
   mut = rt_id2obj(mutex_id);
-  if (mut == NULL) return osErrorParameter;
+  if (mut == NULL) {
+    return osErrorParameter;
+  }
 
-  if (((P_MUCB)mut)->cb_type != MUCB) return osErrorParameter;
+  if (((P_MUCB)mut)->cb_type != MUCB) {
+    return osErrorParameter;
+  }
 
   rt_mut_delete(mut);                           // Release Mutex
 
@@ -1672,8 +1638,10 @@ osStatus svcMutexDelete (osMutexId mutex_id) {
 
 /// Create and Initialize a Mutex object
 osMutexId osMutexCreate (const osMutexDef_t *mutex_def) {
-  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
-  if ((__get_mode() != MODE_USR) && (os_running == 0)) {
+  if (__exceptional_mode()) {
+    return NULL;           // Not allowed in ISR
+  }
+  if ((__get_mode() != MODE_USR) && (os_running == 0U)) {
     // Privileged and not running
     return    svcMutexCreate(mutex_def);
   } else {
@@ -1683,19 +1651,25 @@ osMutexId osMutexCreate (const osMutexDef_t *mutex_def) {
 
 /// Wait until a Mutex becomes available
 osStatus osMutexWait (osMutexId mutex_id, uint32_t millisec) {
-  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return osErrorISR;     // Not allowed in ISR
+  }
   return __svcMutexWait(mutex_id, millisec);
 }
 
 /// Release a Mutex that was obtained with osMutexWait
 osStatus osMutexRelease (osMutexId mutex_id) {
-  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return osErrorISR;     // Not allowed in ISR
+  }
   return __svcMutexRelease(mutex_id);
 }
 
 /// Delete a Mutex that was created by osMutexCreate
 osStatus osMutexDelete (osMutexId mutex_id) {
-  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return osErrorISR;     // Not allowed in ISR
+  }
   return __svcMutexDelete(mutex_id);
 }
 
@@ -1725,7 +1699,7 @@ osSemaphoreId svcSemaphoreCreate (const osSemaphoreDef_t *semaphore_def, int32_t
     return NULL;
   }
 
-  if (((P_SCB)sem)->cb_type != 0) {
+  if (((P_SCB)sem)->cb_type != 0U) {
     sysThreadError(osErrorParameter);
     return NULL;
   }
@@ -1735,8 +1709,8 @@ osSemaphoreId svcSemaphoreCreate (const osSemaphoreDef_t *semaphore_def, int32_t
     return NULL;
   }
 
-  rt_sem_init(sem, count);                      // Initialize Semaphore
-
+  rt_sem_init(sem, (uint16_t)count);            // Initialize Semaphore
+  
   return sem;
 }
 
@@ -1746,15 +1720,19 @@ int32_t svcSemaphoreWait (osSemaphoreId semaphore_id, uint32_t millisec) {
   OS_RESULT res;
 
   sem = rt_id2obj(semaphore_id);
-  if (sem == NULL) return -1;
+  if (sem == NULL) {
+    return -1;
+  }
 
-  if (((P_SCB)sem)->cb_type != SCB) return -1;
+  if (((P_SCB)sem)->cb_type != SCB) {
+    return -1;
+  }
 
   res = rt_sem_wait(sem, rt_ms2tick(millisec)); // Wait for Semaphore
 
-  if (res == OS_R_TMO) return 0;                // Timeout
+  if (res == OS_R_TMO) { return 0; }            // Timeout
 
-  return (((P_SCB)sem)->tokens + 1);
+  return (int32_t)(((P_SCB)sem)->tokens + 1U);
 }
 
 /// Release a Semaphore
@@ -1762,12 +1740,18 @@ osStatus svcSemaphoreRelease (osSemaphoreId semaphore_id) {
   OS_ID sem;
 
   sem = rt_id2obj(semaphore_id);
-  if (sem == NULL) return osErrorParameter;
+  if (sem == NULL) {
+    return osErrorParameter;
+  }
 
-  if (((P_SCB)sem)->cb_type != SCB) return osErrorParameter;
+  if (((P_SCB)sem)->cb_type != SCB) {
+    return osErrorParameter;
+  }
 
-  if (((P_SCB)sem)->tokens == osFeature_Semaphore) return osErrorResource;
-
+  if ((int32_t)((P_SCB)sem)->tokens == osFeature_Semaphore) {
+    return osErrorResource;
+  }
+  
   rt_sem_send(sem);                             // Release Semaphore
 
   return osOK;
@@ -1778,9 +1762,13 @@ osStatus svcSemaphoreDelete (osSemaphoreId semaphore_id) {
   OS_ID sem;
 
   sem = rt_id2obj(semaphore_id);
-  if (sem == NULL) return osErrorParameter;
+  if (sem == NULL) {
+    return osErrorParameter;
+  }
 
-  if (((P_SCB)sem)->cb_type != SCB) return osErrorParameter;
+  if (((P_SCB)sem)->cb_type != SCB) {
+    return osErrorParameter;
+  }
 
   rt_sem_delete(sem);                           // Delete Semaphore
 
@@ -1791,15 +1779,21 @@ osStatus svcSemaphoreDelete (osSemaphoreId semaphore_id) {
 // Semaphore ISR Calls
 
 /// Release a Semaphore
-static __INLINE osStatus isrSemaphoreRelease (osSemaphoreId semaphore_id) {
+osStatus isrSemaphoreRelease (osSemaphoreId semaphore_id) {
   OS_ID sem;
 
   sem = rt_id2obj(semaphore_id);
-  if (sem == NULL) return osErrorParameter;
+  if (sem == NULL) {
+    return osErrorParameter;
+  }
 
-  if (((P_SCB)sem)->cb_type != SCB) return osErrorParameter;
+  if (((P_SCB)sem)->cb_type != SCB) {
+    return osErrorParameter;
+  }
 
-  if (((P_SCB)sem)->tokens == osFeature_Semaphore) return osErrorResource;
+  if ((int32_t)((P_SCB)sem)->tokens == osFeature_Semaphore) {
+    return osErrorResource;
+  }
 
   isr_sem_send(sem);                            // Release Semaphore
 
@@ -1811,8 +1805,10 @@ static __INLINE osStatus isrSemaphoreRelease (osSemaphoreId semaphore_id) {
 
 /// Create and Initialize a Semaphore object
 osSemaphoreId osSemaphoreCreate (const osSemaphoreDef_t *semaphore_def, int32_t count) {
-  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
-  if ((__get_mode() != MODE_USR) && (os_running == 0)) {
+  if (__exceptional_mode()) {
+    return NULL;           // Not allowed in ISR
+  }
+  if ((__get_mode() != MODE_USR) && (os_running == 0U)) {
     // Privileged and not running
     return   svcSemaphoreCreate(semaphore_def, count);
   } else {
@@ -1822,7 +1818,9 @@ osSemaphoreId osSemaphoreCreate (const osSemaphoreDef_t *semaphore_def, int32_t 
 
 /// Wait until a Semaphore becomes available
 int32_t osSemaphoreWait (osSemaphoreId semaphore_id, uint32_t millisec) {
-  if (__exceptional_mode()) return -1;             // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return -1;             // Not allowed in ISR
+  }
   return __svcSemaphoreWait(semaphore_id, millisec);
 }
 
@@ -1837,7 +1835,9 @@ osStatus osSemaphoreRelease (osSemaphoreId semaphore_id) {
 
 /// Delete a Semaphore that was created by osSemaphoreCreate
 osStatus osSemaphoreDelete (osSemaphoreId semaphore_id) {
-  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
+  if (__exceptional_mode()) {
+    return osErrorISR;     // Not allowed in ISR
+  }
   return __svcSemaphoreDelete(semaphore_id);
 }
 
@@ -1850,18 +1850,18 @@ osStatus osSemaphoreDelete (osSemaphoreId semaphore_id) {
 static void rt_clr_box (void *box_mem, void *box) {
   uint32_t *p, n;
 
-  if (box) {
+  if ((box_mem != NULL) && (box != NULL)) {
     p = box;
-    for (n = ((P_BM)box_mem)->blk_size; n; n -= 4) {
-      *p++ = 0;
+    for (n = ((P_BM)box_mem)->blk_size; n; n -= 4U) {
+      *p++ = 0U;
     }
   }
 }
 
 // Memory Management Service Calls declarations
-SVC_1_1(svcPoolCreate, osPoolId, const osPoolDef_t *,           RET_pointer)
-SVC_2_1(sysPoolAlloc,  void *,         osPoolId,      uint32_t, RET_pointer)
-SVC_2_1(sysPoolFree,   osStatus,       osPoolId,      void *,   RET_osStatus)
+SVC_1_1(svcPoolCreate, osPoolId, const osPoolDef_t *,         RET_pointer)
+SVC_1_1(sysPoolAlloc,  void *,         osPoolId,              RET_pointer)
+SVC_2_1(sysPoolFree,   osStatus,       osPoolId,      void *, RET_osStatus)
 
 // Memory Management Service & ISR Calls
 
@@ -1870,42 +1870,45 @@ osPoolId svcPoolCreate (const osPoolDef_t *pool_def) {
   uint32_t blk_sz;
 
   if ((pool_def == NULL) ||
-      (pool_def->pool_sz == 0) ||
-      (pool_def->item_sz == 0) ||
+      (pool_def->pool_sz == 0U) ||
+      (pool_def->item_sz == 0U) ||
       (pool_def->pool == NULL)) {
     sysThreadError(osErrorParameter);
     return NULL;
   }
 
-  blk_sz = (pool_def->item_sz + 3) & ~3;
+  blk_sz = (pool_def->item_sz + 3U) & (uint32_t)~3U;
 
-  _init_box(pool_def->pool, sizeof(struct OS_BM) + pool_def->pool_sz * blk_sz, blk_sz);
+  _init_box(pool_def->pool, sizeof(struct OS_BM) + (pool_def->pool_sz * blk_sz), blk_sz);
 
   return pool_def->pool;
 }
 
 /// Allocate a memory block from a memory pool
-void *sysPoolAlloc (osPoolId pool_id, uint32_t clr) {
-  void *ptr;
+void *sysPoolAlloc (osPoolId pool_id) {
+  void *mem;
 
-  if (pool_id == NULL) return NULL;
-
-  ptr = rt_alloc_box(pool_id);
-  if (clr) {
-    rt_clr_box(pool_id, ptr);
+  if (pool_id == NULL) {
+    return NULL;
   }
 
-  return ptr;
+  mem = rt_alloc_box(pool_id);
+
+  return mem;
 }
 
 /// Return an allocated memory block back to a specific memory pool
 osStatus sysPoolFree (osPoolId pool_id, void *block) {
-  int32_t res;
-
-  if (pool_id == NULL) return osErrorParameter;
+  uint32_t res;
+    
+  if (pool_id == NULL) {
+    return osErrorParameter;
+  }
 
   res = rt_free_box(pool_id, block);
-  if (res != 0) return osErrorValue;
+  if (res != 0) {
+    return osErrorValue;
+  }
 
   return osOK;
 }
@@ -1915,8 +1918,10 @@ osStatus sysPoolFree (osPoolId pool_id, void *block) {
 
 /// Create and Initialize memory pool
 osPoolId osPoolCreate (const osPoolDef_t *pool_def) {
-  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
-  if ((__get_mode() != MODE_USR) && (os_running == 0)) {
+  if (__exceptional_mode()) {
+    return NULL;           // Not allowed in ISR
+  }
+  if ((__get_mode() != MODE_USR) && (os_running == 0U)) {
     // Privileged and not running
     return   svcPoolCreate(pool_def);
   } else {
@@ -1927,19 +1932,25 @@ osPoolId osPoolCreate (const osPoolDef_t *pool_def) {
 /// Allocate a memory block from a memory pool
 void *osPoolAlloc (osPoolId pool_id) {
   if (__get_mode() != MODE_USR) {               // in ISR or Privileged
-    return   sysPoolAlloc(pool_id, 0);
+    return   sysPoolAlloc(pool_id);
   } else {                                      // in Thread
-    return __sysPoolAlloc(pool_id, 0);
+    return __sysPoolAlloc(pool_id);
   }
 }
 
 /// Allocate a memory block from a memory pool and set memory block to zero
 void *osPoolCAlloc (osPoolId pool_id) {
+  void *mem;
+
   if (__get_mode() != MODE_USR) {               // in ISR or Privileged
-    return   sysPoolAlloc(pool_id, 1);
+    mem =   sysPoolAlloc(pool_id);
   } else {                                      // in Thread
-    return __sysPoolAlloc(pool_id, 1);
+    mem = __sysPoolAlloc(pool_id);
   }
+
+  rt_clr_box(pool_id, mem);
+
+  return mem;
 }
 
 /// Return an allocated memory block back to a specific memory pool
@@ -1965,18 +1976,18 @@ SVC_2_3(svcMessageGet, os_InRegs osEvent,            osMessageQId,      uint32_t
 osMessageQId svcMessageCreate (const osMessageQDef_t *queue_def, osThreadId thread_id) {
 
   if ((queue_def == NULL) ||
-      (queue_def->queue_sz == 0) ||
+      (queue_def->queue_sz == 0U) ||
       (queue_def->pool == NULL)) {
     sysThreadError(osErrorParameter);
     return NULL;
   }
-
-  if (((P_MCB)queue_def->pool)->cb_type != 0) {
+  
+  if (((P_MCB)queue_def->pool)->cb_type != 0U) {
     sysThreadError(osErrorParameter);
     return NULL;
   }
 
-  rt_mbx_init(queue_def->pool, 4*(queue_def->queue_sz + 4));
+  rt_mbx_init(queue_def->pool, (uint16_t)(4U*(queue_def->queue_sz + 4U)));
 
   return queue_def->pool;
 }
@@ -1985,14 +1996,18 @@ osMessageQId svcMessageCreate (const osMessageQDef_t *queue_def, osThreadId thre
 osStatus svcMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec) {
   OS_RESULT res;
 
-  if (queue_id == NULL) return osErrorParameter;
+  if (queue_id == NULL) {
+    return osErrorParameter;
+  }
 
-  if (((P_MCB)queue_id)->cb_type != MCB) return osErrorParameter;
+  if (((P_MCB)queue_id)->cb_type != MCB) {
+    return osErrorParameter;
+  }
 
   res = rt_mbx_send(queue_id, (void *)info, rt_ms2tick(millisec));
 
   if (res == OS_R_TMO) {
-    return (millisec ? osErrorTimeoutResource : osErrorResource);
+    return ((millisec != 0U) ? osErrorTimeoutResource : osErrorResource);
   }
 
   return osOK;
@@ -2005,59 +2020,41 @@ os_InRegs osEvent_type svcMessageGet (osMessageQId queue_id, uint32_t millisec) 
 
   if (queue_id == NULL) {
     ret.status = osErrorParameter;
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-    osEvent_ret_status;
-    return;
-#else
     return osEvent_ret_status;
-#endif
   }
 
   if (((P_MCB)queue_id)->cb_type != MCB) {
     ret.status = osErrorParameter;
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-    osEvent_ret_status;
-    return;
-#else
     return osEvent_ret_status;
-#endif
   }
 
   res = rt_mbx_wait(queue_id, &ret.value.p, rt_ms2tick(millisec));
-
+  
   if (res == OS_R_TMO) {
-    ret.status = millisec ? osEventTimeout : osOK;
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-    osEvent_ret_value;
-    return;
-#else
+    ret.status = (millisec != 0U) ? osEventTimeout : osOK;
     return osEvent_ret_value;
-#endif
   }
 
   ret.status = osEventMessage;
 
-#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
-  osEvent_ret_value;
-  return;
-#else
   return osEvent_ret_value;
-#endif
 }
 
 
 // Message Queue ISR Calls
 
 /// Put a Message to a Queue
-static __INLINE osStatus isrMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec) {
+osStatus isrMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec) {
 
-  if ((queue_id == NULL) || (millisec != 0)) {
+  if ((queue_id == NULL) || (millisec != 0U)) {
     return osErrorParameter;
   }
 
-  if (((P_MCB)queue_id)->cb_type != MCB) return osErrorParameter;
+  if (((P_MCB)queue_id)->cb_type != MCB) {
+    return osErrorParameter;
+  }
 
-  if (rt_mbx_check(queue_id) == 0) {            // Check if Queue is full
+  if (rt_mbx_check(queue_id) == 0U) {           // Check if Queue is full
     return osErrorResource;
   }
 
@@ -2067,11 +2064,11 @@ static __INLINE osStatus isrMessagePut (osMessageQId queue_id, uint32_t info, ui
 }
 
 /// Get a Message or Wait for a Message from a Queue
-static __INLINE os_InRegs osEvent isrMessageGet (osMessageQId queue_id, uint32_t millisec) {
+os_InRegs osEvent isrMessageGet (osMessageQId queue_id, uint32_t millisec) {
   OS_RESULT res;
   osEvent   ret;
 
-  if ((queue_id == NULL) || (millisec != 0)) {
+  if ((queue_id == NULL) || (millisec != 0U)) {
     ret.status = osErrorParameter;
     return ret;
   }
@@ -2082,13 +2079,13 @@ static __INLINE os_InRegs osEvent isrMessageGet (osMessageQId queue_id, uint32_t
   }
 
   res = isr_mbx_receive(queue_id, &ret.value.p);
-
+  
   if (res != OS_R_MBX) {
     ret.status = osOK;
     return ret;
   }
 
-  ret.status = osEventMessage;
+  ret.status = osEventMessage; 
 
   return ret;
 }
@@ -2098,8 +2095,10 @@ static __INLINE os_InRegs osEvent isrMessageGet (osMessageQId queue_id, uint32_t
 
 /// Create and Initialize Message Queue
 osMessageQId osMessageCreate (const osMessageQDef_t *queue_def, osThreadId thread_id) {
-  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
-  if ((__get_mode() != MODE_USR) && (os_running == 0)) {
+  if (__exceptional_mode()) {
+    return NULL;           // Not allowed in ISR
+  }
+  if ((__get_mode() != MODE_USR) && (os_running == 0U)) {
     // Privileged and not running
     return   svcMessageCreate(queue_def, thread_id);
   } else {
@@ -2129,9 +2128,9 @@ os_InRegs osEvent osMessageGet (osMessageQId queue_id, uint32_t millisec) {
 // ==== Mail Queue Management Functions ====
 
 // Mail Queue Management Service Calls declarations
-SVC_2_1(svcMailCreate, osMailQId, const osMailQDef_t *, osThreadId,                   RET_pointer)
-SVC_4_1(sysMailAlloc,  void *,          osMailQId,      uint32_t, uint32_t, uint32_t, RET_pointer)
-SVC_3_1(sysMailFree,   osStatus,        osMailQId,      void *,   uint32_t,           RET_osStatus)
+SVC_2_1(svcMailCreate, osMailQId, const osMailQDef_t *, osThreadId,         RET_pointer)
+SVC_3_1(sysMailAlloc,  void *,          osMailQId,      uint32_t, uint32_t, RET_pointer)
+SVC_3_1(sysMailFree,   osStatus,        osMailQId,      void *,   uint32_t, RET_osStatus)
 
 // Mail Queue Management Service & ISR Calls
 
@@ -2142,8 +2141,8 @@ osMailQId svcMailCreate (const osMailQDef_t *queue_def, osThreadId thread_id) {
   void    *pool;
 
   if ((queue_def == NULL) ||
-      (queue_def->queue_sz == 0) ||
-      (queue_def->item_sz  == 0) ||
+      (queue_def->queue_sz == 0U) ||
+      (queue_def->item_sz  == 0U) ||
       (queue_def->pool == NULL)) {
     sysThreadError(osErrorParameter);
     return NULL;
@@ -2152,41 +2151,44 @@ osMailQId svcMailCreate (const osMailQDef_t *queue_def, osThreadId thread_id) {
   pmcb = *(((void **)queue_def->pool) + 0);
   pool = *(((void **)queue_def->pool) + 1);
 
-  if ((pool == NULL) || (pmcb == NULL) || (pmcb->cb_type != 0)) {
+  if ((pool == NULL) || (pmcb == NULL) || (pmcb->cb_type != 0U)) {
     sysThreadError(osErrorParameter);
     return NULL;
   }
 
-  blk_sz = (queue_def->item_sz + 3) & ~3;
+  blk_sz = (queue_def->item_sz + 3U) & (uint32_t)~3U;
 
-  _init_box(pool, sizeof(struct OS_BM) + queue_def->queue_sz * blk_sz, blk_sz);
+  _init_box(pool, sizeof(struct OS_BM) + (queue_def->queue_sz * blk_sz), blk_sz);
 
-  rt_mbx_init(pmcb, 4*(queue_def->queue_sz + 4));
+  rt_mbx_init(pmcb, (uint16_t)(4U*(queue_def->queue_sz + 4U)));
 
   return queue_def->pool;
 }
 
 /// Allocate a memory block from a mail
-void *sysMailAlloc (osMailQId queue_id, uint32_t millisec, uint32_t isr, uint32_t clr) {
+void *sysMailAlloc (osMailQId queue_id, uint32_t millisec, uint32_t isr) {
   P_MCB pmcb;
   void *pool;
   void *mem;
 
-  if (queue_id == NULL) return NULL;
+  if (queue_id == NULL) {
+    return NULL;
+  }
 
   pmcb = *(((void **)queue_id) + 0);
   pool = *(((void **)queue_id) + 1);
 
-  if ((pool == NULL) || (pmcb == NULL)) return NULL;
-
-  if (isr && (millisec != 0)) return NULL;
-
-  mem = rt_alloc_box(pool);
-  if (clr) {
-    rt_clr_box(pool, mem);
+  if ((pool == NULL) || (pmcb == NULL)) {
+    return NULL; 
   }
 
-  if ((mem == NULL) && (millisec != 0)) {
+  if ((isr != 0U) && (millisec != 0U)) {
+    return NULL;
+  }
+
+  mem = rt_alloc_box(pool);
+
+  if ((mem == NULL) && (millisec != 0U)) {
     // Put Task to sleep when Memory not available
     if (pmcb->p_lnk != NULL) {
       rt_put_prio((P_XCB)pmcb, os_tsk.run);
@@ -2195,36 +2197,42 @@ void *sysMailAlloc (osMailQId queue_id, uint32_t millisec, uint32_t isr, uint32_
       os_tsk.run->p_lnk = NULL;
       os_tsk.run->p_rlnk = (P_TCB)pmcb;
       // Task is waiting to allocate a message
-      pmcb->state = 3;
+      pmcb->state = 3U;
     }
     rt_block(rt_ms2tick(millisec), WAIT_MBX);
   }
 
-  return mem;
+  return mem;  
 }
 
 /// Free a memory block from a mail
 osStatus sysMailFree (osMailQId queue_id, void *mail, uint32_t isr) {
-  P_MCB   pmcb;
-  P_TCB   ptcb;
-  void   *pool;
-  void   *mem;
-  int32_t res;
+  P_MCB    pmcb;
+  P_TCB    ptcb;
+  void    *pool;
+  void    *mem;
+  uint32_t res;
 
-  if (queue_id == NULL) return osErrorParameter;
+  if (queue_id == NULL) {
+    return osErrorParameter;
+  }
 
   pmcb = *(((void **)queue_id) + 0);
   pool = *(((void **)queue_id) + 1);
 
-  if ((pmcb == NULL) || (pool == NULL)) return osErrorParameter;
+  if ((pmcb == NULL) || (pool == NULL)) {
+    return osErrorParameter;
+  }
 
   res = rt_free_box(pool, mail);
 
-  if (res != 0) return osErrorValue;
+  if (res != 0U) {
+    return osErrorValue;
+  }
 
-  if ((pmcb->p_lnk != NULL) && (pmcb->state == 3)) {
+  if ((pmcb->p_lnk != NULL) && (pmcb->state == 3U)) {
     // Task is waiting to allocate a message
-    if (isr) {
+    if (isr != 0U) {
       rt_psq_enq (pmcb, (U32)pool);
       rt_psh_req ();
     } else {
@@ -2246,8 +2254,10 @@ osStatus sysMailFree (osMailQId queue_id, void *mail, uint32_t isr) {
 
 /// Create and Initialize mail queue
 osMailQId osMailCreate (const osMailQDef_t *queue_def, osThreadId thread_id) {
-  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
-  if ((__get_mode() != MODE_USR) && (os_running == 0)) {
+  if (__exceptional_mode()) {
+    return NULL;           // Not allowed in ISR
+  }
+  if ((__get_mode() != MODE_USR) && (os_running == 0U)) {
     // Privileged and not running
     return   svcMailCreate(queue_def, thread_id);
   } else {
@@ -2258,35 +2268,48 @@ osMailQId osMailCreate (const osMailQDef_t *queue_def, osThreadId thread_id) {
 /// Allocate a memory block from a mail
 void *osMailAlloc (osMailQId queue_id, uint32_t millisec) {
   if (__exceptional_mode()) {                      // in ISR
-    return   sysMailAlloc(queue_id, millisec, 1, 0);
+    return   sysMailAlloc(queue_id, millisec, 1U);
   } else {                                      // in Thread
-    return __sysMailAlloc(queue_id, millisec, 0, 0);
+    return __sysMailAlloc(queue_id, millisec, 0U);
   }
 }
 
 /// Allocate a memory block from a mail and set memory block to zero
 void *osMailCAlloc (osMailQId queue_id, uint32_t millisec) {
+  void *pool;
+  void *mem;
+
   if (__exceptional_mode()) {                      // in ISR
-    return   sysMailAlloc(queue_id, millisec, 1, 1);
+    mem =   sysMailAlloc(queue_id, millisec, 1U);
   } else {                                      // in Thread
-    return __sysMailAlloc(queue_id, millisec, 0, 1);
+    mem = __sysMailAlloc(queue_id, millisec, 0U);
   }
+
+  pool = *(((void **)queue_id) + 1);
+
+  rt_clr_box(pool, mem);
+
+  return mem;
 }
 
 /// Free a memory block from a mail
 osStatus osMailFree (osMailQId queue_id, void *mail) {
   if (__exceptional_mode()) {                      // in ISR
-    return   sysMailFree(queue_id, mail, 1);
+    return   sysMailFree(queue_id, mail, 1U);
   } else {                                      // in Thread
-    return __sysMailFree(queue_id, mail, 0);
+    return __sysMailFree(queue_id, mail, 0U);
   }
 }
 
 /// Put a mail to a queue
 osStatus osMailPut (osMailQId queue_id, void *mail) {
-  if (queue_id == NULL) return osErrorParameter;
-  if (mail == NULL)     return osErrorValue;
-  return osMessagePut(*((void **)queue_id), (uint32_t)mail, 0);
+  if (queue_id == NULL) {
+    return osErrorParameter;
+  }
+  if (mail == NULL) {
+    return osErrorValue;
+  }
+  return osMessagePut(*((void **)queue_id), (uint32_t)mail, 0U);
 }
 
 #ifdef __CC_ARM

--- a/rtos/rtx/TARGET_CORTEX_A/rt_CMSIS.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_CMSIS.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    rt_CMSIS.c
  *      Purpose: CMSIS RTOS API
- *      Rev.:    V4.80 plus changes for RTX-Ax
+ *      Rev.:    V4.74
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH, 2012-2016 ARM Limited
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -16,18 +16,18 @@
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
  *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without 
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -140,9 +140,9 @@ static __inline   t __##f (t1 a1, t2 a2, t3 a3, t4 a4) {                       \
   return _##f(f,a1,a2,a3,a4);                                                  \
 }
 
-#define SVC_1_2 SVC_1_1 
-#define SVC_1_3 SVC_1_1 
-#define SVC_2_3 SVC_2_1 
+#define SVC_1_2 SVC_1_1
+#define SVC_1_3 SVC_1_1
+#define SVC_2_3 SVC_2_1
 
 #elif defined (__GNUC__)        /* GNU Compiler */
 
@@ -159,14 +159,67 @@ typedef uint32_t __attribute__((vector_size(16))) ret128;
 #define RET_osEvent    {(osStatus)__r0, {(uint32_t)__r1}, {(void *)__r2}}
 #define RET_osCallback {(void *)__r0, (void *)__r1}
 
-#define osEvent_type       __attribute__((pcs("aapcs"))) ret128
+#if defined (__ARM_PCS_VFP)
+
+#define osEvent_type        void
+#define osEvent_ret_status {  __asm ("MOV r0, %0;"      \
+                                     : /* no outputs */ \
+                                     : "r"(ret.status)  \
+                                     : "r0"             \
+                                     );                 \
+                           }
+#define osEvent_ret_value  {  __asm ("MOV r1, %0;"         \
+                                     "MOV r0, %1;"         \
+                                     :   /* no outputs */  \
+                                     :   "r"(ret.value.v), \
+                                         "r"(ret.status)   \
+                                     : "r0", "r1"          \
+                                     );                    \
+                           }
+#define osEvent_ret_msg    {  __asm ("MOV r2, %0;"                \
+                                     "MOV r1, %1;"                \
+                                     "MOV r0, %2;"                \
+                                     : /* no outputs */           \
+                                     :   "r"(ret.def.message_id), \
+                                         "r"(ret.value.v),        \
+                                         "r"(ret.status)          \
+                                     : "r0", "r1" , "r2"          \
+                                     );                           \
+                           }
+
+#define osEvent_ret_mail   {  __asm ("MOV r2, %0;"             \
+                                     "MOV r1, %1;"             \
+                                     "MOV r0, %2;"             \
+                                     : /* no outputs */        \
+                                     :   "r"(ret.def.mail_id), \
+                                         "r"(ret.value.v),     \
+                                         "r"(ret.status)       \
+                                     : "r0", "r1" , "r2"       \
+                                     );                        \
+                           }
+
+#define osCallback_type     void
+#define osCallback_ret     {  __asm ("MOV r1, %0;"      \
+                                     "MOV r0, %1;"      \
+                                     : /* no outputs */ \
+                                     : "r"(ret.arg),    \
+                                       "r"(ret.fp)      \
+                                     : "r0", "r1"       \
+                                     );                 \
+                           }
+
+#else /* defined (__ARM_PCS_VFP) */
+
+#define osEvent_type        ret128
 #define osEvent_ret_status (ret128){ret.status}
 #define osEvent_ret_value  (ret128){ret.status, ret.value.v}
 #define osEvent_ret_msg    (ret128){ret.status, ret.value.v, (uint32_t)ret.def.message_id}
 #define osEvent_ret_mail   (ret128){ret.status, ret.value.v, (uint32_t)ret.def.mail_id}
 
-#define osCallback_type    __attribute__((pcs("aapcs"))) ret64
+#define osCallback_type     ret64
 #define osCallback_ret     (ret64) {(uint32_t)ret.fp, (uint32_t)ret.arg}
+
+#endif /* defined (__ARM_PCS_VFP) */
 
 #define SVC_ArgN(n) \
   register int __r##n __asm("r"#n);
@@ -206,7 +259,7 @@ typedef uint32_t __attribute__((vector_size(16))) ret128;
 
 #if (defined (__CORTEX_M0))
 #define SVC_Call(f)                                                            \
-  __asm volatile                                                               \
+  __asm volatile                                                                 \
   (                                                                            \
     "ldr r7,="#f"\n\t"                                                         \
     "mov r12,r7\n\t"                                                           \
@@ -217,7 +270,7 @@ typedef uint32_t __attribute__((vector_size(16))) ret128;
   );
 #else
 #define SVC_Call(f)                                                            \
-  __asm volatile                                                               \
+  __asm volatile                                                                 \
   (                                                                            \
     "ldr r12,="#f"\n\t"                                                        \
     "svc 0"                                                                    \
@@ -274,9 +327,9 @@ static inline  t __##f (t1 a1, t2 a2, t3 a3, t4 a4) {                          \
   return (t) rv;                                                               \
 }
 
-#define SVC_1_2 SVC_1_1 
-#define SVC_1_3 SVC_1_1 
-#define SVC_2_3 SVC_2_1 
+#define SVC_1_2 SVC_1_1
+#define SVC_1_3 SVC_1_1
+#define SVC_2_3 SVC_2_1
 
 #elif defined (__ICCARM__)      /* IAR Compiler */
 
@@ -295,13 +348,13 @@ static inline  t __##f (t1 a1, t2 a2, t3 a3, t4 a4) {                          \
 #define osCallback_ret     ((uint64_t)ret.fp | ((uint64_t)ret.arg)<<32)
 
 #define SVC_Setup(f)                                                           \
-  __asm(                                                                       \
+  __asm(                                                                         \
     "mov r12,%0\n"                                                             \
     :: "r"(&f): "r12"                                                          \
   );
 
 #define SVC_Ret3()                                                             \
-  __asm(                                                                       \
+  __asm(                                                                         \
     "ldr r0,[sp,#0]\n"                                                         \
     "ldr r1,[sp,#4]\n"                                                         \
     "ldr r2,[sp,#8]\n"                                                         \
@@ -362,7 +415,7 @@ static inline t __##f (t1 a1) {                                                \
   t ret;                                                                       \
   SVC_Setup(f);                                                                \
   _##f(a1);                                                                    \
-  __asm("" : rr : :);                                                          \
+  __asm("" : rr : :);                                                            \
   return ret;                                                                  \
 }
 
@@ -377,7 +430,7 @@ static inline t __##f (t1 a1) {                                                \
   t ret;                                                                       \
   SVC_Setup(f##_);                                                             \
   _##f(a1);                                                                    \
-  __asm("" : rr : :);                                                          \
+  __asm("" : rr : :);                                                            \
   return ret;                                                                  \
 }
 
@@ -392,7 +445,7 @@ static inline t __##f (t1 a1, t2 a2) {                                         \
   t ret;                                                                       \
   SVC_Setup(f##_);                                                             \
   _##f(a1,a2);                                                                 \
-  __asm("" : rr : :);                                                          \
+  __asm("" : rr : :);                                                            \
   return ret;                                                                  \
 }
 
@@ -434,37 +487,36 @@ void sysThreadTerminate(osThreadId id);
 // ==== Helper Functions ====
 
 /// Convert timeout in millisec to system ticks
-static uint16_t rt_ms2tick (uint32_t millisec) {
+static uint32_t rt_ms2tick (uint32_t millisec) {
   uint32_t tick;
 
-  if (millisec == 0U) { return 0x0U; }                  // No timeout
-  if (millisec == osWaitForever) { return 0xFFFFU; }    // Indefinite timeout
-  if (millisec > 4000000U) { return 0xFFFEU; }          // Max ticks supported
+  if (millisec == osWaitForever) return 0xFFFF; // Indefinite timeout
+  if (millisec > 4000000) return 0xFFFE;        // Max ticks supported
 
-  tick = ((1000U * millisec) + os_clockrate - 1U)  / os_clockrate;
-  if (tick > 0xFFFEU) { return 0xFFFEU; }
-  
-  return (uint16_t)tick;
+  tick = ((1000 * millisec) + os_clockrate - 1)  / os_clockrate;
+  if (tick > 0xFFFE) return 0xFFFE;
+
+  return tick;
 }
 
 /// Convert Thread ID to TCB pointer
-P_TCB rt_tid2ptcb (osThreadId thread_id) {
+static P_TCB rt_tid2ptcb (osThreadId thread_id) {
   P_TCB ptcb;
 
-  if (thread_id == NULL) { return NULL; }
+  if (thread_id == NULL) return NULL;
 
-  if ((uint32_t)thread_id & 3U) { return NULL; }
+  if ((uint32_t)thread_id & 3) return NULL;
 
 #ifdef OS_SECTIONS_LINK_INFO
-  if ((os_section_id$$Base != 0U) && (os_section_id$$Limit != 0U)) {
-    if (thread_id  < (osThreadId)os_section_id$$Base)  { return NULL; }
-    if (thread_id >= (osThreadId)os_section_id$$Limit) { return NULL; }
+  if ((os_section_id$$Base != 0) && (os_section_id$$Limit != 0)) {
+    if (thread_id  < (osThreadId)os_section_id$$Base)  return NULL;
+    if (thread_id >= (osThreadId)os_section_id$$Limit) return NULL;
   }
 #endif
 
   ptcb = thread_id;
 
-  if (ptcb->cb_type != TCB) { return NULL; }
+  if (ptcb->cb_type != TCB) return NULL;
 
   return ptcb;
 }
@@ -472,12 +524,12 @@ P_TCB rt_tid2ptcb (osThreadId thread_id) {
 /// Convert ID pointer to Object pointer
 static void *rt_id2obj (void *id) {
 
-  if ((uint32_t)id & 3U) { return NULL; }
+  if ((uint32_t)id & 3) return NULL;
 
 #ifdef OS_SECTIONS_LINK_INFO
-  if ((os_section_id$$Base != 0U) && (os_section_id$$Limit != 0U)) {
-    if (id  < (void *)os_section_id$$Base)  { return NULL; }
-    if (id >= (void *)os_section_id$$Limit) { return NULL; }
+  if ((os_section_id$$Base != 0) && (os_section_id$$Limit != 0)) {
+    if (id  < (void *)os_section_id$$Base)  return NULL;
+    if (id >= (void *)os_section_id$$Limit) return NULL;
   }
 #endif
 
@@ -487,7 +539,7 @@ static void *rt_id2obj (void *id) {
 // === Helper functions for system call interface ===
 
 static __inline char __get_mode(void) {
-    return (char)(__get_CPSR() & 0x1FU);
+    return (char)(__get_CPSR() & 0x1f);
 }
 
 static __inline char __exceptional_mode(void) {
@@ -499,14 +551,14 @@ static __inline char __exceptional_mode(void) {
     switch(__get_mode()) {
         case MODE_USR:
         case MODE_SYS:
-            return 0U;
+            return 0;
         case MODE_SVC:
-            if (IRQNestLevel == 0U)
-                return 0U; /* handling a regular service call */
+            if (IRQNestLevel == 0)
+                return 0; /* handling a regular service call */
             else
-                return 1U; /* handling an ISR in SVC mode */
+                return 1; /* handling an ISR in SVC mode */
         default:
-            return 1U;
+            return 1;
     }
 }
 
@@ -534,22 +586,22 @@ osStatus svcKernelInitialize (void) {
     rt_sys_init();                              // RTX System Initialization
   }
 #else
-  uint32_t ret;
+  int ret;
 
-  if (os_initialized == 0U) {
+  if (!os_initialized) {
 
     // Init Thread Stack Memory (must be 8-byte aligned)
-    if (((uint32_t)os_stack_mem & 7U) != 0U) { return osErrorNoMemory; }
+    if ((uint32_t)os_stack_mem & 7) return osErrorNoMemory;
     ret = rt_init_mem(os_stack_mem, os_stack_sz);
-    if (ret != 0U) { return osErrorNoMemory; }
+    if (ret != 0) return osErrorNoMemory;
 
     rt_sys_init();                              // RTX System Initialization
   }
 #endif
 
-  os_tsk.run->prio = 255U;                      // Highest priority
+  os_tsk.run->prio = 255;                       // Highest priority
 
-  if (os_initialized == 0U) {
+  if (!os_initialized) {
     // Create OS Timers resources (Message Queue & Thread)
     osMessageQId_osTimerMessageQ = svcMessageCreate (&os_messageQ_def_osTimerMessageQ, NULL);
     osThreadId_osTimerThread = svcThreadCreate(&os_thread_def_osTimerThread, NULL);
@@ -559,8 +611,8 @@ osStatus svcKernelInitialize (void) {
 
   sysThreadError(osOK);
 
-  os_initialized = 1U;
-  os_running = 0U;
+  os_initialized = 1;
+  os_running = 0;
 
   return osOK;
 }
@@ -568,24 +620,24 @@ osStatus svcKernelInitialize (void) {
 /// Start the RTOS Kernel
 osStatus svcKernelStart (void) {
 
-  if (os_running) { return osOK; }
+  if (os_running) return osOK;
 
-  rt_tsk_prio(0U, os_tsk.run->prio_base);       // Restore priority
-  if (os_tsk.run->task_id == 0xFFU) {           // Idle Thread
-    __set_PSP(os_tsk.run->tsk_stack + (8U*4U)); // Setup PSP
+  rt_tsk_prio(0, os_tsk.run->prio_base);        // Restore priority
+  if (os_tsk.run->task_id == 0xFF) {            // Idle Thread
+    __set_PSP(os_tsk.run->tsk_stack + 8*4);     // Setup PSP
   }
   os_tsk.run = NULL;                            // Force context switch
 
   rt_sys_start();
 
-  os_running = 1U;
+  os_running = 1;
 
   return osOK;
 }
 
 /// Check if the RTOS kernel is already started
-int32_t svcKernelRunning (void) {
-  return (int32_t)os_running;
+int32_t svcKernelRunning(void) {
+  return os_running;
 }
 
 /// Get the RTOS kernel system timer counter
@@ -595,10 +647,10 @@ uint32_t svcKernelSysTick (void) {
   tick = os_tick_val();
   if (os_tick_ovf()) {
     tick0 = os_tick_val();
-    if (tick0 < tick) { tick = tick0; }
-    tick += (os_trv + 1U) * (os_time + 1U);
+    if (tick0 < tick) tick = tick0;
+    tick += (os_trv + 1) * (os_time + 1);
   } else {
-    tick += (os_trv + 1U) *  os_time;
+    tick += (os_trv + 1) *  os_time;
   }
 
   return tick;
@@ -608,9 +660,7 @@ uint32_t svcKernelSysTick (void) {
 
 /// Initialize the RTOS Kernel for creating objects
 osStatus osKernelInitialize (void) {
-  if (__exceptional_mode()) {
-    return osErrorISR;                      // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
   if (__get_mode() != MODE_USR) {
     return   svcKernelInitialize();
   } else {
@@ -624,21 +674,21 @@ osStatus osKernelStart (void) {
 
   switch(mode) {
     case MODE_USR:
-      if (os_flags & 1U) return osErrorOS;  // Privileged Thread mode requested from Unprivileged
+      if (os_flags & 1) return osErrorOS;  // Privileged Thread mode requested from Unprivileged
       break;
     case MODE_SYS:
-      if (!(os_flags & 1U)) {
+      if (!(os_flags & 1)) {
         __set_CPS_USR();
       }
       break;
     default:
-      return osErrorISR;                    // Not allowed in ISR
+      return osErrorISR;                   // Not allowed in ISR
   }
   return __svcKernelStart();
 }
 
 /// Check if the RTOS kernel is already started
-int32_t osKernelRunning (void) {
+int32_t osKernelRunning(void) {
   if(__get_mode() != MODE_USR) {
     return os_running;
   } else {
@@ -648,7 +698,7 @@ int32_t osKernelRunning (void) {
 
 /// Get the RTOS kernel system timer counter
 uint32_t osKernelSysTick (void) {
-  if (__exceptional_mode()) { return 0U; }              // Not allowed in ISR
+  if (__exceptional_mode()) return 0;              // Not allowed in ISR
   return __svcKernelSysTick();
 }
 
@@ -683,23 +733,23 @@ osThreadId svcThreadCreate (const osThreadDef_t *thread_def, void *argument) {
       (thread_def->pthread == NULL) ||
       (thread_def->tpriority < osPriorityIdle) ||
       (thread_def->tpriority > osPriorityRealtime)) {
-    sysThreadError(osErrorParameter); 
-    return NULL; 
+    sysThreadError(osErrorParameter);
+    return NULL;
   }
 
 #ifdef __MBED_CMSIS_RTOS_CA9
-  if (thread_def->stacksize != 0U) {            // Custom stack size
+  if (thread_def->stacksize != 0) {             // Custom stack size
     stk = (void *)thread_def->stack_pointer;
   } else {                                      // Default stack size
     stk = NULL;
   }
 #else
-  if (thread_def->stacksize != 0U) {            // Custom stack size
+  if (thread_def->stacksize != 0) {             // Custom stack size
     stk = rt_alloc_mem(                         // Allocate stack
       os_stack_mem,
       thread_def->stacksize
     );
-    if (stk == NULL) { 
+    if (stk == NULL) {
       sysThreadError(osErrorNoMemory);          // Out of memory
       return NULL;
     }
@@ -710,14 +760,13 @@ osThreadId svcThreadCreate (const osThreadDef_t *thread_def, void *argument) {
 
   tsk = rt_tsk_create(                          // Create task
     (FUNCP)thread_def->pthread,                 // Task function pointer
-    (uint32_t)
     (thread_def->tpriority-osPriorityIdle+1) |  // Task priority
     (thread_def->stacksize << 8),               // Task stack size in bytes
     stk,                                        // Pointer to task's stack
     argument                                    // Argument to the task
   );
 
-  if (tsk == 0U) {                              // Invalid task ID
+  if (tsk == 0) {                               // Invalid task ID
 #ifndef __MBED_CMSIS_RTOS_CA9
     if (stk != NULL) {
       rt_free_mem(os_stack_mem, stk);           // Free allocated stack
@@ -727,7 +776,7 @@ osThreadId svcThreadCreate (const osThreadDef_t *thread_def, void *argument) {
     return NULL;
   }
 
-  ptcb = (P_TCB)os_active_TCB[tsk - 1U];        // TCB pointer
+  ptcb = (P_TCB)os_active_TCB[tsk - 1];         // TCB pointer
 
   *((uint32_t *)ptcb->tsk_stack + 13) = (uint32_t)osThreadExit;
 
@@ -739,8 +788,8 @@ osThreadId svcThreadGetId (void) {
   OS_TID tsk;
 
   tsk = rt_tsk_self();
-  if (tsk == 0U) { return NULL; }
-  return (P_TCB)os_active_TCB[tsk - 1U];
+  if (tsk == 0) return NULL;
+  return (P_TCB)os_active_TCB[tsk - 1];
 }
 
 /// Terminate execution of a thread and remove it from ActiveThreads
@@ -752,9 +801,7 @@ osStatus svcThreadTerminate (osThreadId thread_id) {
 #endif
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) { 
-    return osErrorParameter;
-  }
+  if (ptcb == NULL) return osErrorParameter;
 
 #ifndef __MBED_CMSIS_RTOS_CA9
   stk = ptcb->priv_stack ? ptcb->stack : NULL;  // Private stack
@@ -762,12 +809,10 @@ osStatus svcThreadTerminate (osThreadId thread_id) {
 
   res = rt_tsk_delete(ptcb->task_id);           // Delete task
 
-  if (res == OS_R_NOK) {
-    return osErrorResource;                     // Delete task failed
-  }
+  if (res == OS_R_NOK) return osErrorResource;  // Delete task failed
 
 #ifndef __MBED_CMSIS_RTOS_CA9
-  if (stk != NULL) {                            
+  if (stk != NULL) {
     rt_free_mem(os_stack_mem, stk);             // Free private stack
   }
 #endif
@@ -787,9 +832,7 @@ osStatus svcThreadSetPriority (osThreadId thread_id, osPriority priority) {
   P_TCB     ptcb;
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) { 
-    return osErrorParameter; 
-  }
+  if (ptcb == NULL) return osErrorParameter;
 
   if ((priority < osPriorityIdle) || (priority > osPriorityRealtime)) {
     return osErrorValue;
@@ -797,12 +840,10 @@ osStatus svcThreadSetPriority (osThreadId thread_id, osPriority priority) {
 
   res = rt_tsk_prio(                            // Change task priority
     ptcb->task_id,                              // Task ID
-    (uint8_t)(priority - osPriorityIdle + 1)    // New task priority
+    priority - osPriorityIdle + 1               // New task priority
   );
 
-  if (res == OS_R_NOK) {
-    return osErrorResource;                     // Change task priority failed
-  }
+  if (res == OS_R_NOK) return osErrorResource;  // Change task priority failed
 
   return osOK;
 }
@@ -812,11 +853,9 @@ osPriority svcThreadGetPriority (osThreadId thread_id) {
   P_TCB ptcb;
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) {
-    return osPriorityError;
-  }
+  if (ptcb == NULL) return osPriorityError;
 
-  return (osPriority)(ptcb->prio - 1 + osPriorityIdle); 
+  return (osPriority)(ptcb->prio - 1 + osPriorityIdle);
 }
 
 /// Get info from an active thread
@@ -828,50 +867,78 @@ os_InRegs osEvent_type svcThreadGetInfo (osThreadId thread_id, osThreadInfo info
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
   if (ptcb == NULL) {
     ret.status = osErrorValue;
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+    osEvent_ret_status;
+    return;
+#else
     return osEvent_ret_status;
+#endif
   }
 
   if (osThreadInfoStackSize == info) {
     uint32_t size;
     size = ptcb->priv_stack;
-    if (0U == size) {
+    if (0 == size) {
       // This is an OS task - always a fixed size
-      size = os_stackinfo & 0x3FFFFU;
+      size = os_stackinfo & 0x3FFFF;
     }
     ret.value.v = size;
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+    osEvent_ret_value;
+    return;
+#else
     return osEvent_ret_value;
+#endif
   }
 
   if (osThreadInfoStackMax == info) {
     // Cortex-A RTX does not have stack init so
     // the maximum stack usage cannot be obtained.
     ret.status = osErrorResource;
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+    osEvent_ret_status;
+    return;
+#else
     return osEvent_ret_status;
+#endif
   }
 
   if (osThreadInfoEntry == info) {
     ret.value.p = (void*)ptcb->ptask;
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+    osEvent_ret_value;
+    return;
+#else
     return osEvent_ret_value;
+#endif
   }
 
   if (osThreadInfoArg == info) {
     ret.value.p = (void*)ptcb->argv;
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+    osEvent_ret_value;
+    return;
+#else
     return osEvent_ret_value;
+#endif
   }
 
   // Unsupported option so return error
   ret.status = osErrorParameter;
-  return osEvent_ret_status;
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+    osEvent_ret_status;
+    return;
+#else
+    return osEvent_ret_status;
+#endif
 }
 
 // Thread Public API
 
 /// Create a thread and add it to Active Threads and set it to state READY
 osThreadId osThreadCreate (const osThreadDef_t *thread_def, void *argument) {
-  if (__exceptional_mode()) {
-    return NULL;           // Not allowed in ISR
-  }
-  if ((__get_mode() != MODE_USR) && (os_running == 0U)) {
+  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
+  if ((__get_mode() != MODE_USR) && (os_running == 0)) {
     // Privileged and not running
     return   svcThreadCreate(thread_def, argument);
   } else {
@@ -886,18 +953,14 @@ osThreadId osThreadCreate (const osThreadDef_t *thread_def, void *argument) {
 
 /// Return the thread ID of the current running thread
 osThreadId osThreadGetId (void) {
-  if (__exceptional_mode()) {
-    return NULL;           // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
   return __svcThreadGetId();
 }
 
 /// Terminate execution of a thread and remove it from ActiveThreads
 osStatus osThreadTerminate (osThreadId thread_id) {
   osStatus status;
-  if (__exceptional_mode()) {
-    return osErrorISR;     // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
   osMutexWait(osMutexId_osThreadMutex, osWaitForever);
   sysThreadTerminate(thread_id);
   // Thread mutex must be held when a thread is created or terminated
@@ -908,31 +971,25 @@ osStatus osThreadTerminate (osThreadId thread_id) {
 
 /// Pass control to next thread that is in state READY
 osStatus osThreadYield (void) {
-  if (__exceptional_mode()) {
-    return osErrorISR;     // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
   return __svcThreadYield();
 }
 
 /// Change priority of an active thread
 osStatus osThreadSetPriority (osThreadId thread_id, osPriority priority) {
-  if (__exceptional_mode()) {
-    return osErrorISR;     // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
   return __svcThreadSetPriority(thread_id, priority);
 }
 
 /// Get current priority of an active thread
 osPriority osThreadGetPriority (osThreadId thread_id) {
-  if (__exceptional_mode()) {
-    return osPriorityError;// Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osPriorityError;// Not allowed in ISR
   return __svcThreadGetPriority(thread_id);
 }
 
 /// INTERNAL - Not Public
 /// Auto Terminate Thread on exit (used implicitly when thread exists)
-__NO_RETURN void osThreadExit (void) { 
+__NO_RETURN void osThreadExit (void) {
   osThreadId id;
   // Thread mutex must be held when a thread is created or terminated
   // Note - the mutex will be released automatically by the os when
@@ -940,7 +997,7 @@ __NO_RETURN void osThreadExit (void) {
   osMutexWait(osMutexId_osThreadMutex, osWaitForever);
   id = __svcThreadGetId();
   sysThreadTerminate(id);
-  __svcThreadTerminate(id); 
+  __svcThreadTerminate(id);
   for (;;);                                     // Should never come here
 }
 
@@ -949,14 +1006,10 @@ __NO_RETURN void osThreadExit (void) {
 uint8_t osThreadGetState (osThreadId thread_id) {
   P_TCB ptcb;
 
-  if (__exceptional_mode()) {
-    return osErrorISR;     // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) {
-  	return INACTIVE;
-  }
+  if (ptcb == NULL) return INACTIVE;
 
   return ptcb->state;
 }
@@ -993,13 +1046,13 @@ osThreadId _osThreadEnumNext(osThreadEnumId enum_id) {
     // Include the idle task at the end of the enumeration
     id = &os_idle_TCB;
   }
-  *index = i + 1U;
+  *index = i + 1;
   return id;
 }
 
 osStatus _osThreadEnumFree(osThreadEnumId enum_id) {
   uint32_t *index = (uint32_t*)enum_id;
-  *index = 0U;
+  *index = 0;
   osMutexRelease(osMutexId_osThreadMutex);
   return osOK;
 }
@@ -1016,7 +1069,7 @@ SVC_1_3(svcWait,  os_InRegs osEvent,  uint32_t, RET_osEvent)
 
 /// Wait for Timeout (Time Delay)
 osStatus svcDelay (uint32_t millisec) {
-  if (millisec == 0U) { return osOK; }
+  if (millisec == 0) return osOK;
   rt_dly_wait(rt_ms2tick(millisec));
   return osEventTimeout;
 }
@@ -1026,16 +1079,26 @@ osStatus svcDelay (uint32_t millisec) {
 os_InRegs osEvent_type svcWait (uint32_t millisec) {
   osEvent ret;
 
-  if (millisec == 0U) {
+  if (millisec == 0) {
     ret.status = osOK;
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+    osEvent_ret_status;
+    return;
+#else
     return osEvent_ret_status;
+#endif
   }
 
   /* To Do: osEventSignal, osEventMessage, osEventMail */
   rt_dly_wait(rt_ms2tick(millisec));
   ret.status = osEventTimeout;
 
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+  osEvent_ret_status;
+  return;
+#else
   return osEvent_ret_status;
+#endif
 }
 #endif
 
@@ -1044,9 +1107,7 @@ os_InRegs osEvent_type svcWait (uint32_t millisec) {
 
 /// Wait for Timeout (Time Delay)
 osStatus osDelay (uint32_t millisec) {
-  if (__exceptional_mode()) {
-    return osErrorISR;                          // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
   return __svcDelay(millisec);
 }
 
@@ -1058,7 +1119,7 @@ os_InRegs osEvent osWait (uint32_t millisec) {
   ret.status = osErrorOS;
   return ret;
 #else
-  if (__exceptional_mode()) {                   // Not allowed in ISR
+  if (__exceptional_mode()) {                      // Not allowed in ISR
     ret.status = osErrorISR;
     return ret;
   }
@@ -1070,9 +1131,9 @@ os_InRegs osEvent osWait (uint32_t millisec) {
 // ==== Timer Management ====
 
 // Timer definitions
-#define osTimerInvalid  0U
-#define osTimerStopped  1U
-#define osTimerRunning  2U
+#define osTimerInvalid  0
+#define osTimerStopped  1
+#define osTimerRunning  2
 
 // Timer structures
 
@@ -1081,8 +1142,8 @@ typedef struct os_timer_cb_ {                   // Timer Control Block
   uint8_t             state;                    // Timer State
   uint8_t              type;                    // Timer Type (Periodic/One-shot)
   uint16_t         reserved;                    // Reserved
-  uint32_t             tcnt;                    // Timer Delay Count
-  uint32_t             icnt;                    // Timer Initial Count 
+  uint16_t             tcnt;                    // Timer Delay Count
+  uint16_t             icnt;                    // Timer Initial Count
   void                 *arg;                    // Timer Function Argument
   const osTimerDef_t *timer;                    // Pointer to Timer definition
 } os_timer_cb;
@@ -1100,13 +1161,13 @@ static void rt_timer_insert (os_timer_cb *pt, uint32_t tcnt) {
   prev = NULL;
   p = os_timer_head;
   while (p != NULL) {
-    if (tcnt < p->tcnt) { break; }
+    if (tcnt < p->tcnt) break;
     tcnt -= p->tcnt;
     prev = p;
     p = p->next;
   }
   pt->next = p;
-  pt->tcnt = tcnt;
+  pt->tcnt = (uint16_t)tcnt;
   if (p != NULL) {
     p->tcnt -= pt->tcnt;
   }
@@ -1118,17 +1179,17 @@ static void rt_timer_insert (os_timer_cb *pt, uint32_t tcnt) {
 }
 
 // Remove Timer from the list
-static int32_t rt_timer_remove (os_timer_cb *pt) {
+static int rt_timer_remove (os_timer_cb *pt) {
   os_timer_cb *p, *prev;
 
   prev = NULL;
   p = os_timer_head;
   while (p != NULL) {
-    if (p == pt) { break; }
+    if (p == pt) break;
     prev = p;
     p = p->next;
   }
-  if (p == NULL) { return -1; }
+  if (p == NULL) return -1;
   if (prev != NULL) {
     prev->next = pt->next;
   } else {
@@ -1196,13 +1257,10 @@ osStatus svcTimerStart (osTimerId timer_id, uint32_t millisec) {
   uint32_t     tcnt;
 
   pt = rt_id2obj(timer_id);
-  if (pt == NULL) {
-    return osErrorParameter;
-  }
+  if (pt == NULL) return osErrorParameter;
 
-  if (millisec == 0U) { return osErrorValue; }
-
-  tcnt = (uint32_t)(((1000U * (uint64_t)millisec) + os_clockrate - 1U)  / os_clockrate);
+  tcnt = rt_ms2tick(millisec);
+  if (tcnt == 0) return osErrorValue;
 
   switch (pt->state) {
     case osTimerRunning:
@@ -1212,12 +1270,12 @@ osStatus svcTimerStart (osTimerId timer_id, uint32_t millisec) {
       break;
     case osTimerStopped:
       pt->state = osTimerRunning;
-      pt->icnt  = tcnt;
+      pt->icnt  = (uint16_t)tcnt;
       break;
     default:
       return osErrorResource;
   }
-  
+
   rt_timer_insert(pt, tcnt);
 
   return osOK;
@@ -1228,11 +1286,9 @@ osStatus svcTimerStop (osTimerId timer_id) {
   os_timer_cb *pt;
 
   pt = rt_id2obj(timer_id);
-  if (pt == NULL) {
-    return osErrorParameter;
-  }
+  if (pt == NULL) return osErrorParameter;
 
-  if (pt->state != osTimerRunning) { return osErrorResource; }
+  if (pt->state != osTimerRunning) return osErrorResource;
 
   pt->state = osTimerStopped;
 
@@ -1248,9 +1304,7 @@ osStatus svcTimerDelete (osTimerId timer_id) {
   os_timer_cb *pt;
 
   pt = rt_id2obj(timer_id);
-  if (pt == NULL) {
-    return osErrorParameter;
-  }
+  if (pt == NULL) return osErrorParameter;
 
   switch (pt->state) {
     case osTimerRunning:
@@ -1276,35 +1330,41 @@ os_InRegs osCallback_type svcTimerCall (osTimerId timer_id) {
   if (pt == NULL) {
     ret.fp  = NULL;
     ret.arg = NULL;
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+    osCallback_ret;
+    return;
+#else
     return osCallback_ret;
+#endif
   }
 
   ret.fp  = (void *)pt->timer->ptimer;
   ret.arg = pt->arg;
 
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+  osCallback_ret;
+  return;
+#else
   return osCallback_ret;
+#endif
 }
 
-osStatus isrMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec);
+static __INLINE osStatus isrMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec);
 
 /// Timer Tick (called each SysTick)
 void sysTimerTick (void) {
   os_timer_cb *pt, *p;
-  osStatus     status;
 
   p = os_timer_head;
-  if (p == NULL) { return; }
+  if (p == NULL) return;
 
   p->tcnt--;
-  while ((p != NULL) && (p->tcnt == 0U)) {
+  while ((p != NULL) && (p->tcnt == 0)) {
     pt = p;
     p = p->next;
     os_timer_head = p;
-    status = isrMessagePut(osMessageQId_osTimerMessageQ, (uint32_t)pt, 0U);
-    if (status != osOK) {
-      os_error(OS_ERR_TIMER_OVF);
-    }
-    if (pt->type == (uint8_t)osTimerPeriodic) {
+    isrMessagePut(osMessageQId_osTimerMessageQ, (uint32_t)pt, 0);
+    if (pt->type == osTimerPeriodic) {
       rt_timer_insert(pt, pt->icnt);
     } else {
       pt->state = osTimerStopped;
@@ -1318,16 +1378,16 @@ uint32_t sysUserTimerWakeupTime (void) {
   if (os_timer_head) {
     return os_timer_head->tcnt;
   }
-  return 0xFFFFFFFFU;
+  return 0xFFFF;
 }
 
 /// Update user timers on resume
 void sysUserTimerUpdate (uint32_t sleep_time) {
 
-  while ((os_timer_head != NULL) && (sleep_time != 0U)) {
+  while (os_timer_head && sleep_time) {
     if (sleep_time >= os_timer_head->tcnt) {
       sleep_time -= os_timer_head->tcnt;
-      os_timer_head->tcnt = 1U;
+      os_timer_head->tcnt = 1;
       sysTimerTick();
     } else {
       os_timer_head->tcnt -= sleep_time;
@@ -1341,10 +1401,8 @@ void sysUserTimerUpdate (uint32_t sleep_time) {
 
 /// Create timer
 osTimerId osTimerCreate (const osTimerDef_t *timer_def, os_timer_type type, void *argument) {
-  if (__exceptional_mode()) {
-    return NULL;           // Not allowed in ISR
-  }
-  if ((__get_mode() != MODE_USR) && (os_running == 0U)) {
+  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
+  if ((__get_mode() != MODE_USR) && (os_running == 0)) {
     // Privileged and not running
     return   svcTimerCreate(timer_def, type, argument);
   } else {
@@ -1354,32 +1412,26 @@ osTimerId osTimerCreate (const osTimerDef_t *timer_def, os_timer_type type, void
 
 /// Start or restart timer
 osStatus osTimerStart (osTimerId timer_id, uint32_t millisec) {
-  if (__exceptional_mode()) {
-    return osErrorISR;     // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
   return __svcTimerStart(timer_id, millisec);
 }
 
 /// Stop timer
 osStatus osTimerStop (osTimerId timer_id) {
-  if (__exceptional_mode()) {
-  return osErrorISR;     // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
   return __svcTimerStop(timer_id);
 }
 
 /// Delete timer
 osStatus osTimerDelete (osTimerId timer_id) {
-  if (__exceptional_mode()) {
-    return osErrorISR;     // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
   return __svcTimerDelete(timer_id);
 }
 
 /// INTERNAL - Not Public
 /// Get timer callback parameters (used by OS Timer Thread)
-os_InRegs osCallback osTimerCall (osTimerId timer_id) { 
-  return __svcTimerCall(timer_id); 
+os_InRegs osCallback osTimerCall (osTimerId timer_id) {
+  return __svcTimerCall(timer_id);
 }
 
 
@@ -1415,17 +1467,13 @@ int32_t svcSignalSet (osThreadId thread_id, int32_t signals) {
   int32_t sig;
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) {
-    return (int32_t)0x80000000U;
-  }
+  if (ptcb == NULL) return 0x80000000;
 
-  if ((uint32_t)signals & (0xFFFFFFFFU << osFeature_Signals)) {
-    return (int32_t)0x80000000U;
-  }
+  if (signals & (0xFFFFFFFF << osFeature_Signals)) return 0x80000000;
 
-  sig = (int32_t)ptcb->events;                  // Previous signal flags
+  sig = ptcb->events;                           // Previous signal flags
 
-  rt_evt_set((uint16_t)signals, ptcb->task_id); // Set event flags
+  rt_evt_set(signals, ptcb->task_id);           // Set event flags
 
   return sig;
 }
@@ -1436,17 +1484,13 @@ int32_t svcSignalClear (osThreadId thread_id, int32_t signals) {
   int32_t sig;
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) {
-    return (int32_t)0x80000000U;
-  }
+  if (ptcb == NULL) return 0x80000000;
 
-  if ((uint32_t)signals & (0xFFFFFFFFU << osFeature_Signals)) {
-    return (int32_t)0x80000000U;
-  }
+  if (signals & (0xFFFFFFFF << osFeature_Signals)) return 0x80000000;
 
-  sig = (int32_t)ptcb->events;                  // Previous signal flags
+  sig = ptcb->events;                           // Previous signal flags
 
-  rt_evt_clr((uint16_t)signals, ptcb->task_id); // Clear event flags
+  rt_evt_clr(signals, ptcb->task_id);           // Clear event flags
 
   return sig;
 }
@@ -1456,48 +1500,54 @@ os_InRegs osEvent_type svcSignalWait (int32_t signals, uint32_t millisec) {
   OS_RESULT res;
   osEvent   ret;
 
-  if ((uint32_t)signals & (0xFFFFFFFFU << osFeature_Signals)) {
+  if (signals & (0xFFFFFFFF << osFeature_Signals)) {
     ret.status = osErrorValue;
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+    osEvent_ret_status;
+    return;
+#else
     return osEvent_ret_status;
+#endif
   }
 
   if (signals != 0) {                           // Wait for all specified signals
-    res = rt_evt_wait((uint16_t)signals, rt_ms2tick(millisec), __TRUE);
+    res = rt_evt_wait(signals, rt_ms2tick(millisec), __TRUE);
   } else {                                      // Wait for any signal
-    res = rt_evt_wait(0xFFFFU,           rt_ms2tick(millisec), __FALSE);
+    res = rt_evt_wait(0xFFFF,  rt_ms2tick(millisec), __FALSE);
   }
 
   if (res == OS_R_EVT) {
     ret.status = osEventSignal;
-    ret.value.signals = (signals != 0) ? signals : (int32_t)os_tsk.run->waits;
+    ret.value.signals = signals ? signals : os_tsk.run->waits;
   } else {
-    ret.status = (millisec != 0U) ? osEventTimeout : osOK;
+    ret.status = millisec ? osEventTimeout : osOK;
     ret.value.signals = 0;
   }
 
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+  osEvent_ret_value;
+  return;
+#else
   return osEvent_ret_value;
+#endif
 }
 
 
 // Signal ISR Calls
 
 /// Set the specified Signal Flags of an active thread
-int32_t isrSignalSet (osThreadId thread_id, int32_t signals) {
+static __INLINE int32_t isrSignalSet (osThreadId thread_id, int32_t signals) {
   P_TCB   ptcb;
   int32_t sig;
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) {
-    return (int32_t)0x80000000U;
-  }
+  if (ptcb == NULL) return 0x80000000;
 
-  if ((uint32_t)signals & (0xFFFFFFFFU << osFeature_Signals)) {
-    return (int32_t)0x80000000U;
-  }
+  if (signals & (0xFFFFFFFF << osFeature_Signals)) return 0x80000000;
 
-  sig = (int32_t)ptcb->events;                  // Previous signal flags
+  sig = ptcb->events;                           // Previous signal flags
 
-  isr_evt_set((uint16_t)signals, ptcb->task_id);// Set event flags
+  isr_evt_set(signals, ptcb->task_id);          // Set event flags
 
   return sig;
 }
@@ -1508,7 +1558,7 @@ int32_t isrSignalSet (osThreadId thread_id, int32_t signals) {
 /// Set the specified Signal Flags of an active thread
 int32_t osSignalSet (osThreadId thread_id, int32_t signals) {
   if (__exceptional_mode()) {                      // in ISR
-    return   isrSignalSet(thread_id, signals); 
+    return   isrSignalSet(thread_id, signals);
   } else {                                      // in Thread
     return __svcSignalSet(thread_id, signals);
   }
@@ -1516,9 +1566,7 @@ int32_t osSignalSet (osThreadId thread_id, int32_t signals) {
 
 /// Clear the specified Signal Flags of an active thread
 int32_t osSignalClear (osThreadId thread_id, int32_t signals) {
-  if (__exceptional_mode()) {
-    return (int32_t)0x80000000U;     // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
   return __svcSignalClear(thread_id, signals);
 }
 
@@ -1559,7 +1607,7 @@ osMutexId svcMutexCreate (const osMutexDef_t *mutex_def) {
     return NULL;
   }
 
-  if (((P_MUCB)mut)->cb_type != 0U) {
+  if (((P_MUCB)mut)->cb_type != 0) {
     sysThreadError(osErrorParameter);
     return NULL;
   }
@@ -1575,18 +1623,14 @@ osStatus svcMutexWait (osMutexId mutex_id, uint32_t millisec) {
   OS_RESULT res;
 
   mut = rt_id2obj(mutex_id);
-  if (mut == NULL) {
-    return osErrorParameter;
-  }
+  if (mut == NULL) return osErrorParameter;
 
-  if (((P_MUCB)mut)->cb_type != MUCB) {
-    return osErrorParameter;
-  }
+  if (((P_MUCB)mut)->cb_type != MUCB) return osErrorParameter;
 
   res = rt_mut_wait(mut, rt_ms2tick(millisec)); // Wait for Mutex
 
   if (res == OS_R_TMO) {
-    return ((millisec != 0U) ? osErrorTimeoutResource : osErrorResource);
+    return (millisec ? osErrorTimeoutResource : osErrorResource);
   }
 
   return osOK;
@@ -1598,19 +1642,13 @@ osStatus svcMutexRelease (osMutexId mutex_id) {
   OS_RESULT res;
 
   mut = rt_id2obj(mutex_id);
-  if (mut == NULL) {
-    return osErrorParameter;
-  }
+  if (mut == NULL) return osErrorParameter;
 
-  if (((P_MUCB)mut)->cb_type != MUCB) {
-    return osErrorParameter;
-  }
+  if (((P_MUCB)mut)->cb_type != MUCB) return osErrorParameter;
 
   res = rt_mut_release(mut);                    // Release Mutex
 
-  if (res == OS_R_NOK) {
-    return osErrorResource;                     // Thread not owner or Zero Counter
-  }
+  if (res == OS_R_NOK) return osErrorResource;  // Thread not owner or Zero Counter
 
   return osOK;
 }
@@ -1620,13 +1658,9 @@ osStatus svcMutexDelete (osMutexId mutex_id) {
   OS_ID mut;
 
   mut = rt_id2obj(mutex_id);
-  if (mut == NULL) {
-    return osErrorParameter;
-  }
+  if (mut == NULL) return osErrorParameter;
 
-  if (((P_MUCB)mut)->cb_type != MUCB) {
-    return osErrorParameter;
-  }
+  if (((P_MUCB)mut)->cb_type != MUCB) return osErrorParameter;
 
   rt_mut_delete(mut);                           // Release Mutex
 
@@ -1638,10 +1672,8 @@ osStatus svcMutexDelete (osMutexId mutex_id) {
 
 /// Create and Initialize a Mutex object
 osMutexId osMutexCreate (const osMutexDef_t *mutex_def) {
-  if (__exceptional_mode()) {
-    return NULL;           // Not allowed in ISR
-  }
-  if ((__get_mode() != MODE_USR) && (os_running == 0U)) {
+  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
+  if ((__get_mode() != MODE_USR) && (os_running == 0)) {
     // Privileged and not running
     return    svcMutexCreate(mutex_def);
   } else {
@@ -1651,25 +1683,19 @@ osMutexId osMutexCreate (const osMutexDef_t *mutex_def) {
 
 /// Wait until a Mutex becomes available
 osStatus osMutexWait (osMutexId mutex_id, uint32_t millisec) {
-  if (__exceptional_mode()) {
-    return osErrorISR;     // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
   return __svcMutexWait(mutex_id, millisec);
 }
 
 /// Release a Mutex that was obtained with osMutexWait
 osStatus osMutexRelease (osMutexId mutex_id) {
-  if (__exceptional_mode()) {
-    return osErrorISR;     // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
   return __svcMutexRelease(mutex_id);
 }
 
 /// Delete a Mutex that was created by osMutexCreate
 osStatus osMutexDelete (osMutexId mutex_id) {
-  if (__exceptional_mode()) {
-    return osErrorISR;     // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
   return __svcMutexDelete(mutex_id);
 }
 
@@ -1699,7 +1725,7 @@ osSemaphoreId svcSemaphoreCreate (const osSemaphoreDef_t *semaphore_def, int32_t
     return NULL;
   }
 
-  if (((P_SCB)sem)->cb_type != 0U) {
+  if (((P_SCB)sem)->cb_type != 0) {
     sysThreadError(osErrorParameter);
     return NULL;
   }
@@ -1709,8 +1735,8 @@ osSemaphoreId svcSemaphoreCreate (const osSemaphoreDef_t *semaphore_def, int32_t
     return NULL;
   }
 
-  rt_sem_init(sem, (uint16_t)count);            // Initialize Semaphore
-  
+  rt_sem_init(sem, count);                      // Initialize Semaphore
+
   return sem;
 }
 
@@ -1720,19 +1746,15 @@ int32_t svcSemaphoreWait (osSemaphoreId semaphore_id, uint32_t millisec) {
   OS_RESULT res;
 
   sem = rt_id2obj(semaphore_id);
-  if (sem == NULL) {
-    return -1;
-  }
+  if (sem == NULL) return -1;
 
-  if (((P_SCB)sem)->cb_type != SCB) {
-    return -1;
-  }
+  if (((P_SCB)sem)->cb_type != SCB) return -1;
 
   res = rt_sem_wait(sem, rt_ms2tick(millisec)); // Wait for Semaphore
 
-  if (res == OS_R_TMO) { return 0; }            // Timeout
+  if (res == OS_R_TMO) return 0;                // Timeout
 
-  return (int32_t)(((P_SCB)sem)->tokens + 1U);
+  return (((P_SCB)sem)->tokens + 1);
 }
 
 /// Release a Semaphore
@@ -1740,18 +1762,12 @@ osStatus svcSemaphoreRelease (osSemaphoreId semaphore_id) {
   OS_ID sem;
 
   sem = rt_id2obj(semaphore_id);
-  if (sem == NULL) {
-    return osErrorParameter;
-  }
+  if (sem == NULL) return osErrorParameter;
 
-  if (((P_SCB)sem)->cb_type != SCB) {
-    return osErrorParameter;
-  }
+  if (((P_SCB)sem)->cb_type != SCB) return osErrorParameter;
 
-  if ((int32_t)((P_SCB)sem)->tokens == osFeature_Semaphore) {
-    return osErrorResource;
-  }
-  
+  if (((P_SCB)sem)->tokens == osFeature_Semaphore) return osErrorResource;
+
   rt_sem_send(sem);                             // Release Semaphore
 
   return osOK;
@@ -1762,13 +1778,9 @@ osStatus svcSemaphoreDelete (osSemaphoreId semaphore_id) {
   OS_ID sem;
 
   sem = rt_id2obj(semaphore_id);
-  if (sem == NULL) {
-    return osErrorParameter;
-  }
+  if (sem == NULL) return osErrorParameter;
 
-  if (((P_SCB)sem)->cb_type != SCB) {
-    return osErrorParameter;
-  }
+  if (((P_SCB)sem)->cb_type != SCB) return osErrorParameter;
 
   rt_sem_delete(sem);                           // Delete Semaphore
 
@@ -1779,21 +1791,15 @@ osStatus svcSemaphoreDelete (osSemaphoreId semaphore_id) {
 // Semaphore ISR Calls
 
 /// Release a Semaphore
-osStatus isrSemaphoreRelease (osSemaphoreId semaphore_id) {
+static __INLINE osStatus isrSemaphoreRelease (osSemaphoreId semaphore_id) {
   OS_ID sem;
 
   sem = rt_id2obj(semaphore_id);
-  if (sem == NULL) {
-    return osErrorParameter;
-  }
+  if (sem == NULL) return osErrorParameter;
 
-  if (((P_SCB)sem)->cb_type != SCB) {
-    return osErrorParameter;
-  }
+  if (((P_SCB)sem)->cb_type != SCB) return osErrorParameter;
 
-  if ((int32_t)((P_SCB)sem)->tokens == osFeature_Semaphore) {
-    return osErrorResource;
-  }
+  if (((P_SCB)sem)->tokens == osFeature_Semaphore) return osErrorResource;
 
   isr_sem_send(sem);                            // Release Semaphore
 
@@ -1805,10 +1811,8 @@ osStatus isrSemaphoreRelease (osSemaphoreId semaphore_id) {
 
 /// Create and Initialize a Semaphore object
 osSemaphoreId osSemaphoreCreate (const osSemaphoreDef_t *semaphore_def, int32_t count) {
-  if (__exceptional_mode()) {
-    return NULL;           // Not allowed in ISR
-  }
-  if ((__get_mode() != MODE_USR) && (os_running == 0U)) {
+  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
+  if ((__get_mode() != MODE_USR) && (os_running == 0)) {
     // Privileged and not running
     return   svcSemaphoreCreate(semaphore_def, count);
   } else {
@@ -1818,9 +1822,7 @@ osSemaphoreId osSemaphoreCreate (const osSemaphoreDef_t *semaphore_def, int32_t 
 
 /// Wait until a Semaphore becomes available
 int32_t osSemaphoreWait (osSemaphoreId semaphore_id, uint32_t millisec) {
-  if (__exceptional_mode()) {
-    return -1;             // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return -1;             // Not allowed in ISR
   return __svcSemaphoreWait(semaphore_id, millisec);
 }
 
@@ -1835,9 +1837,7 @@ osStatus osSemaphoreRelease (osSemaphoreId semaphore_id) {
 
 /// Delete a Semaphore that was created by osSemaphoreCreate
 osStatus osSemaphoreDelete (osSemaphoreId semaphore_id) {
-  if (__exceptional_mode()) {
-    return osErrorISR;     // Not allowed in ISR
-  }
+  if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
   return __svcSemaphoreDelete(semaphore_id);
 }
 
@@ -1850,18 +1850,18 @@ osStatus osSemaphoreDelete (osSemaphoreId semaphore_id) {
 static void rt_clr_box (void *box_mem, void *box) {
   uint32_t *p, n;
 
-  if ((box_mem != NULL) && (box != NULL)) {
+  if (box) {
     p = box;
-    for (n = ((P_BM)box_mem)->blk_size; n; n -= 4U) {
-      *p++ = 0U;
+    for (n = ((P_BM)box_mem)->blk_size; n; n -= 4) {
+      *p++ = 0;
     }
   }
 }
 
 // Memory Management Service Calls declarations
-SVC_1_1(svcPoolCreate, osPoolId, const osPoolDef_t *,         RET_pointer)
-SVC_1_1(sysPoolAlloc,  void *,         osPoolId,              RET_pointer)
-SVC_2_1(sysPoolFree,   osStatus,       osPoolId,      void *, RET_osStatus)
+SVC_1_1(svcPoolCreate, osPoolId, const osPoolDef_t *,           RET_pointer)
+SVC_2_1(sysPoolAlloc,  void *,         osPoolId,      uint32_t, RET_pointer)
+SVC_2_1(sysPoolFree,   osStatus,       osPoolId,      void *,   RET_osStatus)
 
 // Memory Management Service & ISR Calls
 
@@ -1870,45 +1870,42 @@ osPoolId svcPoolCreate (const osPoolDef_t *pool_def) {
   uint32_t blk_sz;
 
   if ((pool_def == NULL) ||
-      (pool_def->pool_sz == 0U) ||
-      (pool_def->item_sz == 0U) ||
+      (pool_def->pool_sz == 0) ||
+      (pool_def->item_sz == 0) ||
       (pool_def->pool == NULL)) {
     sysThreadError(osErrorParameter);
     return NULL;
   }
 
-  blk_sz = (pool_def->item_sz + 3U) & (uint32_t)~3U;
+  blk_sz = (pool_def->item_sz + 3) & ~3;
 
-  _init_box(pool_def->pool, sizeof(struct OS_BM) + (pool_def->pool_sz * blk_sz), blk_sz);
+  _init_box(pool_def->pool, sizeof(struct OS_BM) + pool_def->pool_sz * blk_sz, blk_sz);
 
   return pool_def->pool;
 }
 
 /// Allocate a memory block from a memory pool
-void *sysPoolAlloc (osPoolId pool_id) {
-  void *mem;
+void *sysPoolAlloc (osPoolId pool_id, uint32_t clr) {
+  void *ptr;
 
-  if (pool_id == NULL) {
-    return NULL;
+  if (pool_id == NULL) return NULL;
+
+  ptr = rt_alloc_box(pool_id);
+  if (clr) {
+    rt_clr_box(pool_id, ptr);
   }
 
-  mem = rt_alloc_box(pool_id);
-
-  return mem;
+  return ptr;
 }
 
 /// Return an allocated memory block back to a specific memory pool
 osStatus sysPoolFree (osPoolId pool_id, void *block) {
-  uint32_t res;
-    
-  if (pool_id == NULL) {
-    return osErrorParameter;
-  }
+  int32_t res;
+
+  if (pool_id == NULL) return osErrorParameter;
 
   res = rt_free_box(pool_id, block);
-  if (res != 0) {
-    return osErrorValue;
-  }
+  if (res != 0) return osErrorValue;
 
   return osOK;
 }
@@ -1918,10 +1915,8 @@ osStatus sysPoolFree (osPoolId pool_id, void *block) {
 
 /// Create and Initialize memory pool
 osPoolId osPoolCreate (const osPoolDef_t *pool_def) {
-  if (__exceptional_mode()) {
-    return NULL;           // Not allowed in ISR
-  }
-  if ((__get_mode() != MODE_USR) && (os_running == 0U)) {
+  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
+  if ((__get_mode() != MODE_USR) && (os_running == 0)) {
     // Privileged and not running
     return   svcPoolCreate(pool_def);
   } else {
@@ -1932,25 +1927,19 @@ osPoolId osPoolCreate (const osPoolDef_t *pool_def) {
 /// Allocate a memory block from a memory pool
 void *osPoolAlloc (osPoolId pool_id) {
   if (__get_mode() != MODE_USR) {               // in ISR or Privileged
-    return   sysPoolAlloc(pool_id);
+    return   sysPoolAlloc(pool_id, 0);
   } else {                                      // in Thread
-    return __sysPoolAlloc(pool_id);
+    return __sysPoolAlloc(pool_id, 0);
   }
 }
 
 /// Allocate a memory block from a memory pool and set memory block to zero
 void *osPoolCAlloc (osPoolId pool_id) {
-  void *mem;
-
   if (__get_mode() != MODE_USR) {               // in ISR or Privileged
-    mem =   sysPoolAlloc(pool_id);
+    return   sysPoolAlloc(pool_id, 1);
   } else {                                      // in Thread
-    mem = __sysPoolAlloc(pool_id);
+    return __sysPoolAlloc(pool_id, 1);
   }
-
-  rt_clr_box(pool_id, mem);
-
-  return mem;
 }
 
 /// Return an allocated memory block back to a specific memory pool
@@ -1976,18 +1965,18 @@ SVC_2_3(svcMessageGet, os_InRegs osEvent,            osMessageQId,      uint32_t
 osMessageQId svcMessageCreate (const osMessageQDef_t *queue_def, osThreadId thread_id) {
 
   if ((queue_def == NULL) ||
-      (queue_def->queue_sz == 0U) ||
+      (queue_def->queue_sz == 0) ||
       (queue_def->pool == NULL)) {
     sysThreadError(osErrorParameter);
     return NULL;
   }
-  
-  if (((P_MCB)queue_def->pool)->cb_type != 0U) {
+
+  if (((P_MCB)queue_def->pool)->cb_type != 0) {
     sysThreadError(osErrorParameter);
     return NULL;
   }
 
-  rt_mbx_init(queue_def->pool, (uint16_t)(4U*(queue_def->queue_sz + 4U)));
+  rt_mbx_init(queue_def->pool, 4*(queue_def->queue_sz + 4));
 
   return queue_def->pool;
 }
@@ -1996,18 +1985,14 @@ osMessageQId svcMessageCreate (const osMessageQDef_t *queue_def, osThreadId thre
 osStatus svcMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec) {
   OS_RESULT res;
 
-  if (queue_id == NULL) {
-    return osErrorParameter;
-  }
+  if (queue_id == NULL) return osErrorParameter;
 
-  if (((P_MCB)queue_id)->cb_type != MCB) {
-    return osErrorParameter;
-  }
+  if (((P_MCB)queue_id)->cb_type != MCB) return osErrorParameter;
 
   res = rt_mbx_send(queue_id, (void *)info, rt_ms2tick(millisec));
 
   if (res == OS_R_TMO) {
-    return ((millisec != 0U) ? osErrorTimeoutResource : osErrorResource);
+    return (millisec ? osErrorTimeoutResource : osErrorResource);
   }
 
   return osOK;
@@ -2020,41 +2005,59 @@ os_InRegs osEvent_type svcMessageGet (osMessageQId queue_id, uint32_t millisec) 
 
   if (queue_id == NULL) {
     ret.status = osErrorParameter;
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+    osEvent_ret_status;
+    return;
+#else
     return osEvent_ret_status;
+#endif
   }
 
   if (((P_MCB)queue_id)->cb_type != MCB) {
     ret.status = osErrorParameter;
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+    osEvent_ret_status;
+    return;
+#else
     return osEvent_ret_status;
+#endif
   }
 
   res = rt_mbx_wait(queue_id, &ret.value.p, rt_ms2tick(millisec));
-  
+
   if (res == OS_R_TMO) {
-    ret.status = (millisec != 0U) ? osEventTimeout : osOK;
+    ret.status = millisec ? osEventTimeout : osOK;
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+    osEvent_ret_value;
+    return;
+#else
     return osEvent_ret_value;
+#endif
   }
 
   ret.status = osEventMessage;
 
+#if defined (__GNUC__) && defined (__ARM_PCS_VFP)
+  osEvent_ret_value;
+  return;
+#else
   return osEvent_ret_value;
+#endif
 }
 
 
 // Message Queue ISR Calls
 
 /// Put a Message to a Queue
-osStatus isrMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec) {
+static __INLINE osStatus isrMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec) {
 
-  if ((queue_id == NULL) || (millisec != 0U)) {
+  if ((queue_id == NULL) || (millisec != 0)) {
     return osErrorParameter;
   }
 
-  if (((P_MCB)queue_id)->cb_type != MCB) {
-    return osErrorParameter;
-  }
+  if (((P_MCB)queue_id)->cb_type != MCB) return osErrorParameter;
 
-  if (rt_mbx_check(queue_id) == 0U) {           // Check if Queue is full
+  if (rt_mbx_check(queue_id) == 0) {            // Check if Queue is full
     return osErrorResource;
   }
 
@@ -2064,11 +2067,11 @@ osStatus isrMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec)
 }
 
 /// Get a Message or Wait for a Message from a Queue
-os_InRegs osEvent isrMessageGet (osMessageQId queue_id, uint32_t millisec) {
+static __INLINE os_InRegs osEvent isrMessageGet (osMessageQId queue_id, uint32_t millisec) {
   OS_RESULT res;
   osEvent   ret;
 
-  if ((queue_id == NULL) || (millisec != 0U)) {
+  if ((queue_id == NULL) || (millisec != 0)) {
     ret.status = osErrorParameter;
     return ret;
   }
@@ -2079,13 +2082,13 @@ os_InRegs osEvent isrMessageGet (osMessageQId queue_id, uint32_t millisec) {
   }
 
   res = isr_mbx_receive(queue_id, &ret.value.p);
-  
+
   if (res != OS_R_MBX) {
     ret.status = osOK;
     return ret;
   }
 
-  ret.status = osEventMessage; 
+  ret.status = osEventMessage;
 
   return ret;
 }
@@ -2095,10 +2098,8 @@ os_InRegs osEvent isrMessageGet (osMessageQId queue_id, uint32_t millisec) {
 
 /// Create and Initialize Message Queue
 osMessageQId osMessageCreate (const osMessageQDef_t *queue_def, osThreadId thread_id) {
-  if (__exceptional_mode()) {
-    return NULL;           // Not allowed in ISR
-  }
-  if ((__get_mode() != MODE_USR) && (os_running == 0U)) {
+  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
+  if ((__get_mode() != MODE_USR) && (os_running == 0)) {
     // Privileged and not running
     return   svcMessageCreate(queue_def, thread_id);
   } else {
@@ -2128,9 +2129,9 @@ os_InRegs osEvent osMessageGet (osMessageQId queue_id, uint32_t millisec) {
 // ==== Mail Queue Management Functions ====
 
 // Mail Queue Management Service Calls declarations
-SVC_2_1(svcMailCreate, osMailQId, const osMailQDef_t *, osThreadId,         RET_pointer)
-SVC_3_1(sysMailAlloc,  void *,          osMailQId,      uint32_t, uint32_t, RET_pointer)
-SVC_3_1(sysMailFree,   osStatus,        osMailQId,      void *,   uint32_t, RET_osStatus)
+SVC_2_1(svcMailCreate, osMailQId, const osMailQDef_t *, osThreadId,                   RET_pointer)
+SVC_4_1(sysMailAlloc,  void *,          osMailQId,      uint32_t, uint32_t, uint32_t, RET_pointer)
+SVC_3_1(sysMailFree,   osStatus,        osMailQId,      void *,   uint32_t,           RET_osStatus)
 
 // Mail Queue Management Service & ISR Calls
 
@@ -2141,8 +2142,8 @@ osMailQId svcMailCreate (const osMailQDef_t *queue_def, osThreadId thread_id) {
   void    *pool;
 
   if ((queue_def == NULL) ||
-      (queue_def->queue_sz == 0U) ||
-      (queue_def->item_sz  == 0U) ||
+      (queue_def->queue_sz == 0) ||
+      (queue_def->item_sz  == 0) ||
       (queue_def->pool == NULL)) {
     sysThreadError(osErrorParameter);
     return NULL;
@@ -2151,44 +2152,41 @@ osMailQId svcMailCreate (const osMailQDef_t *queue_def, osThreadId thread_id) {
   pmcb = *(((void **)queue_def->pool) + 0);
   pool = *(((void **)queue_def->pool) + 1);
 
-  if ((pool == NULL) || (pmcb == NULL) || (pmcb->cb_type != 0U)) {
+  if ((pool == NULL) || (pmcb == NULL) || (pmcb->cb_type != 0)) {
     sysThreadError(osErrorParameter);
     return NULL;
   }
 
-  blk_sz = (queue_def->item_sz + 3U) & (uint32_t)~3U;
+  blk_sz = (queue_def->item_sz + 3) & ~3;
 
-  _init_box(pool, sizeof(struct OS_BM) + (queue_def->queue_sz * blk_sz), blk_sz);
+  _init_box(pool, sizeof(struct OS_BM) + queue_def->queue_sz * blk_sz, blk_sz);
 
-  rt_mbx_init(pmcb, (uint16_t)(4U*(queue_def->queue_sz + 4U)));
+  rt_mbx_init(pmcb, 4*(queue_def->queue_sz + 4));
 
   return queue_def->pool;
 }
 
 /// Allocate a memory block from a mail
-void *sysMailAlloc (osMailQId queue_id, uint32_t millisec, uint32_t isr) {
+void *sysMailAlloc (osMailQId queue_id, uint32_t millisec, uint32_t isr, uint32_t clr) {
   P_MCB pmcb;
   void *pool;
   void *mem;
 
-  if (queue_id == NULL) {
-    return NULL;
-  }
+  if (queue_id == NULL) return NULL;
 
   pmcb = *(((void **)queue_id) + 0);
   pool = *(((void **)queue_id) + 1);
 
-  if ((pool == NULL) || (pmcb == NULL)) {
-    return NULL; 
-  }
+  if ((pool == NULL) || (pmcb == NULL)) return NULL;
 
-  if ((isr != 0U) && (millisec != 0U)) {
-    return NULL;
-  }
+  if (isr && (millisec != 0)) return NULL;
 
   mem = rt_alloc_box(pool);
+  if (clr) {
+    rt_clr_box(pool, mem);
+  }
 
-  if ((mem == NULL) && (millisec != 0U)) {
+  if ((mem == NULL) && (millisec != 0)) {
     // Put Task to sleep when Memory not available
     if (pmcb->p_lnk != NULL) {
       rt_put_prio((P_XCB)pmcb, os_tsk.run);
@@ -2197,42 +2195,36 @@ void *sysMailAlloc (osMailQId queue_id, uint32_t millisec, uint32_t isr) {
       os_tsk.run->p_lnk = NULL;
       os_tsk.run->p_rlnk = (P_TCB)pmcb;
       // Task is waiting to allocate a message
-      pmcb->state = 3U;
+      pmcb->state = 3;
     }
     rt_block(rt_ms2tick(millisec), WAIT_MBX);
   }
 
-  return mem;  
+  return mem;
 }
 
 /// Free a memory block from a mail
 osStatus sysMailFree (osMailQId queue_id, void *mail, uint32_t isr) {
-  P_MCB    pmcb;
-  P_TCB    ptcb;
-  void    *pool;
-  void    *mem;
-  uint32_t res;
+  P_MCB   pmcb;
+  P_TCB   ptcb;
+  void   *pool;
+  void   *mem;
+  int32_t res;
 
-  if (queue_id == NULL) {
-    return osErrorParameter;
-  }
+  if (queue_id == NULL) return osErrorParameter;
 
   pmcb = *(((void **)queue_id) + 0);
   pool = *(((void **)queue_id) + 1);
 
-  if ((pmcb == NULL) || (pool == NULL)) {
-    return osErrorParameter;
-  }
+  if ((pmcb == NULL) || (pool == NULL)) return osErrorParameter;
 
   res = rt_free_box(pool, mail);
 
-  if (res != 0U) {
-    return osErrorValue;
-  }
+  if (res != 0) return osErrorValue;
 
-  if ((pmcb->p_lnk != NULL) && (pmcb->state == 3U)) {
+  if ((pmcb->p_lnk != NULL) && (pmcb->state == 3)) {
     // Task is waiting to allocate a message
-    if (isr != 0U) {
+    if (isr) {
       rt_psq_enq (pmcb, (U32)pool);
       rt_psh_req ();
     } else {
@@ -2254,10 +2246,8 @@ osStatus sysMailFree (osMailQId queue_id, void *mail, uint32_t isr) {
 
 /// Create and Initialize mail queue
 osMailQId osMailCreate (const osMailQDef_t *queue_def, osThreadId thread_id) {
-  if (__exceptional_mode()) {
-    return NULL;           // Not allowed in ISR
-  }
-  if ((__get_mode() != MODE_USR) && (os_running == 0U)) {
+  if (__exceptional_mode()) return NULL;           // Not allowed in ISR
+  if ((__get_mode() != MODE_USR) && (os_running == 0)) {
     // Privileged and not running
     return   svcMailCreate(queue_def, thread_id);
   } else {
@@ -2268,48 +2258,35 @@ osMailQId osMailCreate (const osMailQDef_t *queue_def, osThreadId thread_id) {
 /// Allocate a memory block from a mail
 void *osMailAlloc (osMailQId queue_id, uint32_t millisec) {
   if (__exceptional_mode()) {                      // in ISR
-    return   sysMailAlloc(queue_id, millisec, 1U);
+    return   sysMailAlloc(queue_id, millisec, 1, 0);
   } else {                                      // in Thread
-    return __sysMailAlloc(queue_id, millisec, 0U);
+    return __sysMailAlloc(queue_id, millisec, 0, 0);
   }
 }
 
 /// Allocate a memory block from a mail and set memory block to zero
 void *osMailCAlloc (osMailQId queue_id, uint32_t millisec) {
-  void *pool;
-  void *mem;
-
   if (__exceptional_mode()) {                      // in ISR
-    mem =   sysMailAlloc(queue_id, millisec, 1U);
+    return   sysMailAlloc(queue_id, millisec, 1, 1);
   } else {                                      // in Thread
-    mem = __sysMailAlloc(queue_id, millisec, 0U);
+    return __sysMailAlloc(queue_id, millisec, 0, 1);
   }
-
-  pool = *(((void **)queue_id) + 1);
-
-  rt_clr_box(pool, mem);
-
-  return mem;
 }
 
 /// Free a memory block from a mail
 osStatus osMailFree (osMailQId queue_id, void *mail) {
   if (__exceptional_mode()) {                      // in ISR
-    return   sysMailFree(queue_id, mail, 1U);
+    return   sysMailFree(queue_id, mail, 1);
   } else {                                      // in Thread
-    return __sysMailFree(queue_id, mail, 0U);
+    return __sysMailFree(queue_id, mail, 0);
   }
 }
 
 /// Put a mail to a queue
 osStatus osMailPut (osMailQId queue_id, void *mail) {
-  if (queue_id == NULL) {
-    return osErrorParameter;
-  }
-  if (mail == NULL) {
-    return osErrorValue;
-  }
-  return osMessagePut(*((void **)queue_id), (uint32_t)mail, 0U);
+  if (queue_id == NULL) return osErrorParameter;
+  if (mail == NULL)     return osErrorValue;
+  return osMessagePut(*((void **)queue_id), (uint32_t)mail, 0);
 }
 
 #ifdef __CC_ARM

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Event.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Event.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_EVENT.C
  *      Purpose: Implements waits and wake-ups for event flags
- *      Rev.:    V4.70
+ *      Rev.:    V4.79
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -90,7 +90,7 @@ void rt_evt_set (U16 event_flags, OS_TID task_id) {
   /* Set one or more event flags of a selectable task. */
   P_TCB p_tcb;
 
-  p_tcb = os_active_TCB[task_id-1];
+  p_tcb = os_active_TCB[task_id-1U];
   if (p_tcb == NULL) {
     return;
   }
@@ -112,7 +112,7 @@ wkup: p_tcb->events &= ~event_flags;
       rt_rmv_dly (p_tcb);
       p_tcb->state   = READY;
 #ifdef __CMSIS_RTOS
-      rt_ret_val2(p_tcb, 0x08/*osEventSignal*/, p_tcb->waits);
+      rt_ret_val2(p_tcb, 0x08U/*osEventSignal*/, p_tcb->waits);
 #else
       rt_ret_val (p_tcb, OS_R_EVT);
 #endif
@@ -127,7 +127,7 @@ wkup: p_tcb->events &= ~event_flags;
 void rt_evt_clr (U16 clear_flags, OS_TID task_id) {
   /* Clear one or more event flags (identified by "clear_flags") of a */
   /* selectable task (identified by "task"). */
-  P_TCB task = os_active_TCB[task_id-1];
+  P_TCB task = os_active_TCB[task_id-1U];
 
   if (task == NULL) {
     return;
@@ -140,7 +140,7 @@ void rt_evt_clr (U16 clear_flags, OS_TID task_id) {
 
 void isr_evt_set (U16 event_flags, OS_TID task_id) {
   /* Same function as "os_evt_set", but to be called by ISRs. */
-  P_TCB p_tcb = os_active_TCB[task_id-1];
+  P_TCB p_tcb = os_active_TCB[task_id-1U];
 
   if (p_tcb == NULL) {
     return;
@@ -180,7 +180,7 @@ rdy:  p_CB->events &= ~event_flags;
       rt_rmv_dly (p_CB);
       p_CB->state   = READY;
 #ifdef __CMSIS_RTOS
-      rt_ret_val2(p_CB, 0x08/*osEventSignal*/, p_CB->waits);
+      rt_ret_val2(p_CB, 0x08U/*osEventSignal*/, p_CB->waits); 
 #else
       rt_ret_val (p_CB, OS_R_EVT);
 #endif

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Event.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Event.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_EVENT.C
  *      Purpose: Implements waits and wake-ups for event flags
- *      Rev.:    V4.79
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -90,7 +90,7 @@ void rt_evt_set (U16 event_flags, OS_TID task_id) {
   /* Set one or more event flags of a selectable task. */
   P_TCB p_tcb;
 
-  p_tcb = os_active_TCB[task_id-1U];
+  p_tcb = os_active_TCB[task_id-1];
   if (p_tcb == NULL) {
     return;
   }
@@ -112,7 +112,7 @@ wkup: p_tcb->events &= ~event_flags;
       rt_rmv_dly (p_tcb);
       p_tcb->state   = READY;
 #ifdef __CMSIS_RTOS
-      rt_ret_val2(p_tcb, 0x08U/*osEventSignal*/, p_tcb->waits);
+      rt_ret_val2(p_tcb, 0x08/*osEventSignal*/, p_tcb->waits);
 #else
       rt_ret_val (p_tcb, OS_R_EVT);
 #endif
@@ -127,7 +127,7 @@ wkup: p_tcb->events &= ~event_flags;
 void rt_evt_clr (U16 clear_flags, OS_TID task_id) {
   /* Clear one or more event flags (identified by "clear_flags") of a */
   /* selectable task (identified by "task"). */
-  P_TCB task = os_active_TCB[task_id-1U];
+  P_TCB task = os_active_TCB[task_id-1];
 
   if (task == NULL) {
     return;
@@ -140,7 +140,7 @@ void rt_evt_clr (U16 clear_flags, OS_TID task_id) {
 
 void isr_evt_set (U16 event_flags, OS_TID task_id) {
   /* Same function as "os_evt_set", but to be called by ISRs. */
-  P_TCB p_tcb = os_active_TCB[task_id-1U];
+  P_TCB p_tcb = os_active_TCB[task_id-1];
 
   if (p_tcb == NULL) {
     return;
@@ -180,7 +180,7 @@ rdy:  p_CB->events &= ~event_flags;
       rt_rmv_dly (p_CB);
       p_CB->state   = READY;
 #ifdef __CMSIS_RTOS
-      rt_ret_val2(p_CB, 0x08U/*osEventSignal*/, p_CB->waits); 
+      rt_ret_val2(p_CB, 0x08/*osEventSignal*/, p_CB->waits);
 #else
       rt_ret_val (p_CB, OS_R_EVT);
 #endif

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Event.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Event.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_EVENT.H
  *      Purpose: Implements waits and wake-ups for event flags
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -43,4 +43,3 @@ extern void      rt_evt_psh  (P_TCB p_CB, U16 set_flags);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Event.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Event.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_EVENT.H
  *      Purpose: Implements waits and wake-ups for event flags
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -43,3 +43,4 @@ extern void      rt_evt_psh  (P_TCB p_CB, U16 set_flags);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_HAL_CA.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_HAL_CA.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_HAL_CA.H
  *      Purpose: Hardware Abstraction Layer for Cortex-A definitions
- *      Rev.:    V4.79 plus changes for RTX-Ax
+ *      Rev.:    14th Jan 2014
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH, 2012-2016 ARM Limited
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -49,13 +49,12 @@
 #define MODE_SYS        0x1F
 
 #define MAGIC_WORD      0xE25A2EA5
-#define MAGIC_PATTERN   0xCCCCCCCC
 
 #include "core_ca9.h"
 
 #if defined (__CC_ARM)          /* ARM Compiler */
 
-#if ((defined(__TARGET_ARCH_7_M) || defined(__TARGET_ARCH_7E_M) || defined(__TARGET_ARCH_7_A)) && !defined(NO_EXCLUSIVE_ACCESS))
+#if ((__TARGET_ARCH_7_M || __TARGET_ARCH_7E_M || __TARGET_ARCH_7_A) && !defined(NO_EXCLUSIVE_ACCESS))
  #define __USE_EXCLUSIVE_ACCESS
 #else
  #undef  __USE_EXCLUSIVE_ACCESS
@@ -81,11 +80,9 @@
 
 #elif defined (__ICCARM__)      /* IAR Compiler */
 
-//#error IAR Compiler support not implemented for Cortex-A
-
 #endif
 
-static U8 priority = 0xffU;
+static U8 priority = 0xff;
 
 extern const U32 GICDistributor_BASE;
 extern const U32 GICInterface_BASE;
@@ -101,8 +98,8 @@ extern const U32 GICInterface_BASE;
 /* GIC register  - CPU Interface  */
 #define GICI_ICCPMR     (*((volatile U32 *)(GICInterface_BASE + 0x004))) /* - RW - Interrupt Priority Mask Register */
 
-#define SGI_PENDSV      0U /* SGI0 */
-#define SGI_PENDSV_BIT  ((U32)(1U << (SGI_PENDSV & 0xfU)))
+#define SGI_PENDSV      0 /* SGI0 */
+#define SGI_PENDSV_BIT  ((U32)(1 << (SGI_PENDSV & 0xf)))
 
 //Increase priority filter to prevent timer and PendSV interrupts signaling. Guarantees that interrupts will not be forwarded.
 #if defined (__ICCARM__)
@@ -131,14 +128,14 @@ extern const U32 GICInterface_BASE;
 #define OS_PEND(fl,p) if(p) OS_PEND_IRQ();
 #define OS_UNPEND(fl)
 
-/* HW initialization needs to be done in os_tick_init() in RTX_Conf_CM.c
+/* HW initialization needs to be done in os_tick_init (void) -RTX_Conf_CM.c-
  * OS_X_INIT enables the IRQ n in the GIC */
 #define OS_X_INIT(n) volatile char *reg; \
                      reg = (char *)(&GICD_ICDIPR0 + n / 4); \
                      reg += n % 4; \
                      *reg = (char)0xff; \
                      *reg = *reg - 1; \
-                     GICD_ICDISERx(n) = (U32)(1U << n % 32);
+                     GICD_ICDISERx(n) = (U32)(1 << n % 32);
 #define OS_X_LOCK(n) OS_LOCK()
 #define OS_X_UNLOCK(n) OS_UNLOCK()
 #define OS_X_PEND_IRQ() OS_PEND_IRQ()
@@ -148,8 +145,8 @@ extern const U32 GICInterface_BASE;
 
 /* Functions */
 #ifdef __USE_EXCLUSIVE_ACCESS
- #define rt_inc(p)     while(__strex((__ldrex(p)+1U),p))
- #define rt_dec(p)     while(__strex((__ldrex(p)-1U),p))
+ #define rt_inc(p)     while(__strex((__ldrex(p)+1),p))
+ #define rt_dec(p)     while(__strex((__ldrex(p)-1),p))
 #else
 #if defined (__ICCARM__)
  #define rt_inc(p)     { int irq_dis = __disable_irq_iar();(*p)++;if(!irq_dis) __enable_irq(); }
@@ -167,10 +164,10 @@ __inline static U32 rt_inc_qi (U32 size, U8 *count, U8 *first) {
     if ((cnt = __ldrex(count)) == size) {
       __clrex();
       return (cnt); }
-  } while (__strex(cnt+1U, count));
+  } while (__strex(cnt+1, count));
   do {
-    c2 = (cnt = __ldrex(first)) + 1U;
-    if (c2 == size) { c2 = 0U; }
+    c2 = (cnt = __ldrex(first)) + 1;
+    if (c2 == size) c2 = 0;
   } while (__strex(c2, first));
 #else
   int irq_dis;
@@ -180,10 +177,10 @@ __inline static U32 rt_inc_qi (U32 size, U8 *count, U8 *first) {
   irq_dis = __disable_irq();
  #endif /* __ICCARM__ */
   if ((cnt = *count) < size) {
-    *count = (U8)(cnt+1U);
-    c2 = (cnt = *first) + 1U;
-    if (c2 == size) { c2 = 0U; }
-    *first = (U8)c2; 
+    *count = cnt+1;
+    c2 = (cnt = *first) + 1;
+    if (c2 == size) c2 = 0;
+    *first = c2;
   }
   if(!irq_dis) __enable_irq ();
 #endif
@@ -192,19 +189,19 @@ __inline static U32 rt_inc_qi (U32 size, U8 *count, U8 *first) {
 
 __inline static void rt_systick_init (void) {
   /* Cortex-A doesn't have a Systick. User needs to provide an alternative timer using RTX_Conf_CM configuration */
-  /* HW initialization needs to be done in os_tick_init() in RTX_Conf_CM.c */
+  /* HW initialization needs to be done in os_tick_init (void) -RTX_Conf_CM.c- */
 }
 
 __inline static U32 rt_systick_val (void) {
   /* Cortex-A doesn't have a Systick. User needs to provide an alternative timer using RTX_Conf_CM configuration */
-  /* HW initialization needs to be done in os_tick_init() in RTX_Conf_CM.c */
-  return 0U;
+  /* HW initialization needs to be done in os_tick_init (void) -RTX_Conf_CM.c- */
+  return 0;
 }
 
 __inline static U32 rt_systick_ovf (void) {
   /* Cortex-A doesn't have a Systick. User needs to provide an alternative timer using RTX_Conf_CM configuration */
-  /* HW initialization needs to be done in os_tick_init() in RTX_Conf_CM.c */
-  return 0U;
+  /* HW initialization needs to be done in os_tick_init (void) -RTX_Conf_CM.c- */
+  return 0;
 }
 
 __inline static void rt_svc_init (void) {
@@ -212,7 +209,7 @@ __inline static void rt_svc_init (void) {
   volatile char *reg;
 
   reg = (char *)(&GICD_ICDIPR0 + SGI_PENDSV/4);
-  reg += SGI_PENDSV % 4U;
+  reg += SGI_PENDSV % 4;
   /* Write 0xff to read priority level */
   *reg = (char)0xff;
   /* Read priority level and set the lowest possible*/
@@ -225,7 +222,7 @@ extern void rt_set_PSP (U32 stack);
 extern U32  rt_get_PSP (void);
 extern void os_set_env (P_TCB p_TCB);
 extern void *_alloc_box (void *box_mem);
-extern U32  _free_box (void *box_mem, void *box);
+extern int  _free_box (void *box_mem, void *box);
 
 extern void rt_init_stack (P_TCB p_TCB, FUNCP task_body);
 extern void rt_ret_val  (P_TCB p_TCB, U32 v0);
@@ -235,17 +232,11 @@ extern void dbg_init (void);
 extern void dbg_task_notify (P_TCB p_tcb, BOOL create);
 extern void dbg_task_switch (U32 task_id);
 
-#ifdef DBG_MSG
-#define DBG_INIT() dbg_init()
-#define DBG_TASK_NOTIFY(p_tcb,create) if (dbg_msg) dbg_task_notify(p_tcb,create)
-#define DBG_TASK_SWITCH(task_id)      if (dbg_msg && (os_tsk.new!=os_tsk.run)) \
-                                        dbg_task_switch(task_id)
-#else
 #define DBG_INIT()
 #define DBG_TASK_NOTIFY(p_tcb,create)
 #define DBG_TASK_SWITCH(task_id)
-#endif
 
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_HAL_CM.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_HAL_CM.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_HAL_CM.H
  *      Purpose: Hardware Abstraction Layer for Cortex-M definitions
- *      Rev.:    V4.70
+ *      Rev.:    V4.79
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,32 +15,33 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
 
 /* Definitions */
-#define INITIAL_xPSR    0x01000000
-#define DEMCR_TRCENA    0x01000000
-#define ITM_ITMENA      0x00000001
-#define MAGIC_WORD      0xE25A2EA5
+#define INITIAL_xPSR    0x01000000U
+#define DEMCR_TRCENA    0x01000000U
+#define ITM_ITMENA      0x00000001U
+#define MAGIC_WORD      0xE25A2EA5U
+#define MAGIC_PATTERN   0xCCCCCCCCU
 
 #if defined (__CC_ARM)          /* ARM Compiler */
 
-#if ((__TARGET_ARCH_7_M || __TARGET_ARCH_7E_M) && !defined(NO_EXCLUSIVE_ACCESS))
+#if ((defined(__TARGET_ARCH_7_M) || defined(__TARGET_ARCH_7E_M)) && !defined(NO_EXCLUSIVE_ACCESS))
  #define __USE_EXCLUSIVE_ACCESS
 #else
  #undef  __USE_EXCLUSIVE_ACCESS
@@ -51,20 +52,24 @@
 #pragma diag_suppress 3731
 #endif
 
+#ifndef __CMSIS_GENERIC
+#define __DMB() do {\
+                   __schedule_barrier();\
+                   __dmb(0xF);\
+                   __schedule_barrier();\
+                } while (0)
+#endif
+
 #elif defined (__GNUC__)        /* GNU Compiler */
 
 #undef  __USE_EXCLUSIVE_ACCESS
 
 #if defined (__CORTEX_M0)
-#define __TARGET_ARCH_6S_M 1
-#else
-#define __TARGET_ARCH_6S_M 0
+#define __TARGET_ARCH_6S_M
 #endif
 
 #if defined (__VFP_FP__) && !defined(__SOFTFP__)
-#define __TARGET_FPU_VFP 1
-#else
-#define __TARGET_FPU_VFP 0
+#define __TARGET_FPU_VFP
 #endif
 
 #define __inline inline
@@ -86,12 +91,17 @@ __attribute__((always_inline)) static inline U32 __disable_irq(void)
   return(result & 1);
 }
 
+__attribute__((always_inline)) static inline void __DMB(void)
+{
+  __asm volatile ("dmb 0xF":::"memory");
+}
+
 #endif
 
 __attribute__(( always_inline)) static inline U8 __clz(U32 value)
 {
   U8 result;
-
+  
   __asm volatile ("clz %0, %1" : "=r" (result) : "r" (value));
   return(result);
 }
@@ -102,14 +112,10 @@ __attribute__(( always_inline)) static inline U8 __clz(U32 value)
 
 #if (__CORE__ == __ARM6M__)
 #define __TARGET_ARCH_6S_M 1
-#else
-#define __TARGET_ARCH_6S_M 0
 #endif
 
 #if defined __ARMVFP__
 #define __TARGET_FPU_VFP 1
-#else
-#define __TARGET_FPU_VFP 0
 #endif
 
 #define __inline inline
@@ -124,7 +130,7 @@ static inline void __enable_irq(void)
 static inline U32 __disable_irq(void)
 {
   U32 result;
-
+  
   __asm volatile ("mrs %0, primask" : "=r" (result));
   __asm volatile ("cpsid i");
   return(result & 1);
@@ -135,7 +141,7 @@ static inline U32 __disable_irq(void)
 static inline U8 __clz(U32 value)
 {
   U8 result;
-
+  
   __asm volatile ("clz %0, %1" : "=r" (result) : "r" (value));
   return(result);
 }
@@ -143,59 +149,59 @@ static inline U8 __clz(U32 value)
 #endif
 
 /* NVIC registers */
-#define NVIC_ST_CTRL    (*((volatile U32 *)0xE000E010))
-#define NVIC_ST_RELOAD  (*((volatile U32 *)0xE000E014))
-#define NVIC_ST_CURRENT (*((volatile U32 *)0xE000E018))
-#define NVIC_ISER         ((volatile U32 *)0xE000E100)
-#define NVIC_ICER         ((volatile U32 *)0xE000E180)
-#if (__TARGET_ARCH_6S_M)
-#define NVIC_IP           ((volatile U32 *)0xE000E400)
+#define NVIC_ST_CTRL    (*((volatile U32 *)0xE000E010U))
+#define NVIC_ST_RELOAD  (*((volatile U32 *)0xE000E014U))
+#define NVIC_ST_CURRENT (*((volatile U32 *)0xE000E018U))
+#define NVIC_ISER         ((volatile U32 *)0xE000E100U)
+#define NVIC_ICER         ((volatile U32 *)0xE000E180U)
+#if defined(__TARGET_ARCH_6S_M)
+#define NVIC_IP           ((volatile U32 *)0xE000E400U)
 #else
-#define NVIC_IP           ((volatile U8  *)0xE000E400)
+#define NVIC_IP           ((volatile U8  *)0xE000E400U)
 #endif
-#define NVIC_INT_CTRL   (*((volatile U32 *)0xE000ED04))
-#define NVIC_AIR_CTRL   (*((volatile U32 *)0xE000ED0C))
-#define NVIC_SYS_PRI2   (*((volatile U32 *)0xE000ED1C))
-#define NVIC_SYS_PRI3   (*((volatile U32 *)0xE000ED20))
+#define NVIC_INT_CTRL   (*((volatile U32 *)0xE000ED04U))
+#define NVIC_AIR_CTRL   (*((volatile U32 *)0xE000ED0CU))
+#define NVIC_SYS_PRI2   (*((volatile U32 *)0xE000ED1CU))
+#define NVIC_SYS_PRI3   (*((volatile U32 *)0xE000ED20U))
 
-#define OS_PEND_IRQ()   NVIC_INT_CTRL  = (1<<28)
-#define OS_PENDING      ((NVIC_INT_CTRL >> 26) & (1<<2 | 1))
-#define OS_UNPEND(fl)   NVIC_INT_CTRL  = (*fl = OS_PENDING) << 25
-#define OS_PEND(fl,p)   NVIC_INT_CTRL  = (fl | p<<2) << 26
-#define OS_LOCK()       NVIC_ST_CTRL   =  0x0005
-#define OS_UNLOCK()     NVIC_ST_CTRL   =  0x0007
+#define OS_PEND_IRQ()   NVIC_INT_CTRL  = (1UL<<28)
+#define OS_PENDING      ((NVIC_INT_CTRL >> 26) & 5U)
+#define OS_UNPEND(fl)   NVIC_INT_CTRL  = (U32)(fl = (U8)OS_PENDING) << 25
+#define OS_PEND(fl,p)   NVIC_INT_CTRL  = (U32)(fl | (U8)(p<<2)) << 26
+#define OS_LOCK()       NVIC_ST_CTRL   =  0x0005U
+#define OS_UNLOCK()     NVIC_ST_CTRL   =  0x0007U
 
-#define OS_X_PENDING    ((NVIC_INT_CTRL >> 28) & 1)
-#define OS_X_UNPEND(fl) NVIC_INT_CTRL  = (*fl = OS_X_PENDING) << 27
-#define OS_X_PEND(fl,p) NVIC_INT_CTRL  = (fl | p) << 28
-#if (__TARGET_ARCH_6S_M)
-#define OS_X_INIT(n)    NVIC_IP[n>>2] |= 0xFF << (8*(n & 0x03)); \
-                        NVIC_ISER[n>>5] = 1 << (n & 0x1F)
+#define OS_X_PENDING    ((NVIC_INT_CTRL >> 28) & 1U)
+#define OS_X_UNPEND(fl) NVIC_INT_CTRL  = (U32)(fl = (U8)OS_X_PENDING) << 27
+#define OS_X_PEND(fl,p) NVIC_INT_CTRL  = (U32)(fl | p) << 28
+#if defined(__TARGET_ARCH_6S_M)
+#define OS_X_INIT(n)    NVIC_IP[n>>2] |=  (U32)0xFFU << ((n & 0x03U) << 3); \
+                        NVIC_ISER[n>>5] = (U32)1U << (n & 0x1FU)
 #else
-#define OS_X_INIT(n)    NVIC_IP[n] = 0xFF; \
-                        NVIC_ISER[n>>5] = 1 << (n & 0x1F)
+#define OS_X_INIT(n)    NVIC_IP[n] = 0xFFU; \
+                        NVIC_ISER[n>>5] = (U32)1U << (n & 0x1FU)
 #endif
-#define OS_X_LOCK(n)    NVIC_ICER[n>>5] = 1 << (n & 0x1F)
-#define OS_X_UNLOCK(n)  NVIC_ISER[n>>5] = 1 << (n & 0x1F)
+#define OS_X_LOCK(n)    NVIC_ICER[n>>5] = (U32)1U << (n & 0x1FU)
+#define OS_X_UNLOCK(n)  NVIC_ISER[n>>5] = (U32)1U << (n & 0x1FU)
 
 /* Core Debug registers */
-#define DEMCR           (*((volatile U32 *)0xE000EDFC))
+#define DEMCR           (*((volatile U32 *)0xE000EDFCU))
 
 /* ITM registers */
-#define ITM_CONTROL     (*((volatile U32 *)0xE0000E80))
-#define ITM_ENABLE      (*((volatile U32 *)0xE0000E00))
-#define ITM_PORT30_U32  (*((volatile U32 *)0xE0000078))
-#define ITM_PORT31_U32  (*((volatile U32 *)0xE000007C))
-#define ITM_PORT31_U16  (*((volatile U16 *)0xE000007C))
-#define ITM_PORT31_U8   (*((volatile U8  *)0xE000007C))
+#define ITM_CONTROL     (*((volatile U32 *)0xE0000E80U))
+#define ITM_ENABLE      (*((volatile U32 *)0xE0000E00U))
+#define ITM_PORT30_U32  (*((volatile U32 *)0xE0000078U))
+#define ITM_PORT31_U32  (*((volatile U32 *)0xE000007CU))
+#define ITM_PORT31_U16  (*((volatile U16 *)0xE000007CU))
+#define ITM_PORT31_U8   (*((volatile U8  *)0xE000007CU))
 
 /* Variables */
 extern BIT dbg_msg;
 
 /* Functions */
 #ifdef __USE_EXCLUSIVE_ACCESS
- #define rt_inc(p)     while(__strex((__ldrex(p)+1),p))
- #define rt_dec(p)     while(__strex((__ldrex(p)-1),p))
+ #define rt_inc(p)     while(__strex((__ldrex(p)+1U),p))
+ #define rt_dec(p)     while(__strex((__ldrex(p)-1U),p))
 #else
  #define rt_inc(p)     __disable_irq();(*p)++;__enable_irq();
  #define rt_dec(p)     __disable_irq();(*p)--;__enable_irq();
@@ -208,18 +214,18 @@ __inline static U32 rt_inc_qi (U32 size, U8 *count, U8 *first) {
     if ((cnt = __ldrex(count)) == size) {
       __clrex();
       return (cnt); }
-  } while (__strex(cnt+1, count));
+  } while (__strex(cnt+1U, count));
   do {
-    c2 = (cnt = __ldrex(first)) + 1;
-    if (c2 == size) c2 = 0;
+    c2 = (cnt = __ldrex(first)) + 1U;
+    if (c2 == size) { c2 = 0U; }
   } while (__strex(c2, first));
 #else
   __disable_irq();
   if ((cnt = *count) < size) {
-    *count = cnt+1;
-    c2 = (cnt = *first) + 1;
-    if (c2 == size) c2 = 0;
-    *first = c2;
+    *count = (U8)(cnt+1U);
+    c2 = (cnt = *first) + 1U;
+    if (c2 == size) { c2 = 0U; }
+    *first = (U8)c2; 
   }
   __enable_irq ();
 #endif
@@ -228,9 +234,9 @@ __inline static U32 rt_inc_qi (U32 size, U8 *count, U8 *first) {
 
 __inline static void rt_systick_init (void) {
   NVIC_ST_RELOAD  = os_trv;
-  NVIC_ST_CURRENT = 0;
-  NVIC_ST_CTRL    = 0x0007;
-  NVIC_SYS_PRI3  |= 0xFF000000;
+  NVIC_ST_CURRENT = 0U;
+  NVIC_ST_CTRL    = 0x0007U;
+  NVIC_SYS_PRI3  |= 0xFF000000U;
 }
 
 __inline static U32 rt_systick_val (void) {
@@ -238,23 +244,27 @@ __inline static U32 rt_systick_val (void) {
 }
 
 __inline static U32 rt_systick_ovf (void) {
-  return ((NVIC_INT_CTRL >> 26) & 1);
+  return ((NVIC_INT_CTRL >> 26) & 1U);
 }
 
 __inline static void rt_svc_init (void) {
-#if !(__TARGET_ARCH_6S_M)
-  int sh,prigroup;
+#if !defined(__TARGET_ARCH_6S_M)
+  U32 sh,prigroup;
 #endif
-  NVIC_SYS_PRI3 |= 0x00FF0000;
-#if (__TARGET_ARCH_6S_M)
-  NVIC_SYS_PRI2 |= (NVIC_SYS_PRI3<<(8+1)) & 0xFC000000;
+  NVIC_SYS_PRI3 |= 0x00FF0000U;
+#if defined(__TARGET_ARCH_6S_M)
+  NVIC_SYS_PRI2 |= (NVIC_SYS_PRI3<<(8+1)) & 0xFC000000U;
 #else
-  sh       = 8 - __clz (~((NVIC_SYS_PRI3 << 8) & 0xFF000000));
-  prigroup = ((NVIC_AIR_CTRL >> 8) & 0x07);
+  sh       = 8U - __clz(~((NVIC_SYS_PRI3 << 8) & 0xFF000000U));
+  prigroup = ((NVIC_AIR_CTRL >> 8) & 0x07U);
   if (prigroup >= sh) {
-    sh = prigroup + 1;
+    sh = prigroup + 1U;
   }
-  NVIC_SYS_PRI2 = ((0xFEFFFFFF << sh) & 0xFF000000) | (NVIC_SYS_PRI2 & 0x00FFFFFF);
+
+/* Only change the SVCall priority if uVisor is not present. */
+#if !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED))
+  NVIC_SYS_PRI2 = ((0xFEFFFFFFU << sh) & 0xFF000000U) | (NVIC_SYS_PRI2 & 0x00FFFFFFU);
+#endif /* !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED)) */
 #endif
 }
 
@@ -262,7 +272,7 @@ extern void rt_set_PSP (U32 stack);
 extern U32  rt_get_PSP (void);
 extern void os_set_env (void);
 extern void *_alloc_box (void *box_mem);
-extern int  _free_box (void *box_mem, void *box);
+extern U32  _free_box (void *box_mem, void *box);
 
 extern void rt_init_stack (P_TCB p_TCB, FUNCP task_body);
 extern void rt_ret_val  (P_TCB p_TCB, U32 v0);
@@ -276,7 +286,7 @@ extern void dbg_task_switch (U32 task_id);
 #define DBG_INIT() dbg_init()
 #define DBG_TASK_NOTIFY(p_tcb,create) if (dbg_msg) dbg_task_notify(p_tcb,create)
 #define DBG_TASK_SWITCH(task_id)      if (dbg_msg && (os_tsk.new_tsk!=os_tsk.run)) \
-                                                   dbg_task_switch(task_id)
+                                        dbg_task_switch(task_id)
 #else
 #define DBG_INIT()
 #define DBG_TASK_NOTIFY(p_tcb,create)
@@ -286,4 +296,3 @@ extern void dbg_task_switch (U32 task_id);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_HAL_CM.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_HAL_CM.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_HAL_CM.H
  *      Purpose: Hardware Abstraction Layer for Cortex-M definitions
- *      Rev.:    V4.79
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,33 +15,32 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
 
 /* Definitions */
-#define INITIAL_xPSR    0x01000000U
-#define DEMCR_TRCENA    0x01000000U
-#define ITM_ITMENA      0x00000001U
-#define MAGIC_WORD      0xE25A2EA5U
-#define MAGIC_PATTERN   0xCCCCCCCCU
+#define INITIAL_xPSR    0x01000000
+#define DEMCR_TRCENA    0x01000000
+#define ITM_ITMENA      0x00000001
+#define MAGIC_WORD      0xE25A2EA5
 
 #if defined (__CC_ARM)          /* ARM Compiler */
 
-#if ((defined(__TARGET_ARCH_7_M) || defined(__TARGET_ARCH_7E_M)) && !defined(NO_EXCLUSIVE_ACCESS))
+#if ((__TARGET_ARCH_7_M || __TARGET_ARCH_7E_M) && !defined(NO_EXCLUSIVE_ACCESS))
  #define __USE_EXCLUSIVE_ACCESS
 #else
  #undef  __USE_EXCLUSIVE_ACCESS
@@ -52,24 +51,20 @@
 #pragma diag_suppress 3731
 #endif
 
-#ifndef __CMSIS_GENERIC
-#define __DMB() do {\
-                   __schedule_barrier();\
-                   __dmb(0xF);\
-                   __schedule_barrier();\
-                } while (0)
-#endif
-
 #elif defined (__GNUC__)        /* GNU Compiler */
 
 #undef  __USE_EXCLUSIVE_ACCESS
 
 #if defined (__CORTEX_M0)
-#define __TARGET_ARCH_6S_M
+#define __TARGET_ARCH_6S_M 1
+#else
+#define __TARGET_ARCH_6S_M 0
 #endif
 
 #if defined (__VFP_FP__) && !defined(__SOFTFP__)
-#define __TARGET_FPU_VFP
+#define __TARGET_FPU_VFP 1
+#else
+#define __TARGET_FPU_VFP 0
 #endif
 
 #define __inline inline
@@ -91,17 +86,12 @@ __attribute__((always_inline)) static inline U32 __disable_irq(void)
   return(result & 1);
 }
 
-__attribute__((always_inline)) static inline void __DMB(void)
-{
-  __asm volatile ("dmb 0xF":::"memory");
-}
-
 #endif
 
 __attribute__(( always_inline)) static inline U8 __clz(U32 value)
 {
   U8 result;
-  
+
   __asm volatile ("clz %0, %1" : "=r" (result) : "r" (value));
   return(result);
 }
@@ -112,10 +102,14 @@ __attribute__(( always_inline)) static inline U8 __clz(U32 value)
 
 #if (__CORE__ == __ARM6M__)
 #define __TARGET_ARCH_6S_M 1
+#else
+#define __TARGET_ARCH_6S_M 0
 #endif
 
 #if defined __ARMVFP__
 #define __TARGET_FPU_VFP 1
+#else
+#define __TARGET_FPU_VFP 0
 #endif
 
 #define __inline inline
@@ -130,7 +124,7 @@ static inline void __enable_irq(void)
 static inline U32 __disable_irq(void)
 {
   U32 result;
-  
+
   __asm volatile ("mrs %0, primask" : "=r" (result));
   __asm volatile ("cpsid i");
   return(result & 1);
@@ -141,7 +135,7 @@ static inline U32 __disable_irq(void)
 static inline U8 __clz(U32 value)
 {
   U8 result;
-  
+
   __asm volatile ("clz %0, %1" : "=r" (result) : "r" (value));
   return(result);
 }
@@ -149,59 +143,59 @@ static inline U8 __clz(U32 value)
 #endif
 
 /* NVIC registers */
-#define NVIC_ST_CTRL    (*((volatile U32 *)0xE000E010U))
-#define NVIC_ST_RELOAD  (*((volatile U32 *)0xE000E014U))
-#define NVIC_ST_CURRENT (*((volatile U32 *)0xE000E018U))
-#define NVIC_ISER         ((volatile U32 *)0xE000E100U)
-#define NVIC_ICER         ((volatile U32 *)0xE000E180U)
-#if defined(__TARGET_ARCH_6S_M)
-#define NVIC_IP           ((volatile U32 *)0xE000E400U)
+#define NVIC_ST_CTRL    (*((volatile U32 *)0xE000E010))
+#define NVIC_ST_RELOAD  (*((volatile U32 *)0xE000E014))
+#define NVIC_ST_CURRENT (*((volatile U32 *)0xE000E018))
+#define NVIC_ISER         ((volatile U32 *)0xE000E100)
+#define NVIC_ICER         ((volatile U32 *)0xE000E180)
+#if (__TARGET_ARCH_6S_M)
+#define NVIC_IP           ((volatile U32 *)0xE000E400)
 #else
-#define NVIC_IP           ((volatile U8  *)0xE000E400U)
+#define NVIC_IP           ((volatile U8  *)0xE000E400)
 #endif
-#define NVIC_INT_CTRL   (*((volatile U32 *)0xE000ED04U))
-#define NVIC_AIR_CTRL   (*((volatile U32 *)0xE000ED0CU))
-#define NVIC_SYS_PRI2   (*((volatile U32 *)0xE000ED1CU))
-#define NVIC_SYS_PRI3   (*((volatile U32 *)0xE000ED20U))
+#define NVIC_INT_CTRL   (*((volatile U32 *)0xE000ED04))
+#define NVIC_AIR_CTRL   (*((volatile U32 *)0xE000ED0C))
+#define NVIC_SYS_PRI2   (*((volatile U32 *)0xE000ED1C))
+#define NVIC_SYS_PRI3   (*((volatile U32 *)0xE000ED20))
 
-#define OS_PEND_IRQ()   NVIC_INT_CTRL  = (1UL<<28)
-#define OS_PENDING      ((NVIC_INT_CTRL >> 26) & 5U)
-#define OS_UNPEND(fl)   NVIC_INT_CTRL  = (U32)(fl = (U8)OS_PENDING) << 25
-#define OS_PEND(fl,p)   NVIC_INT_CTRL  = (U32)(fl | (U8)(p<<2)) << 26
-#define OS_LOCK()       NVIC_ST_CTRL   =  0x0005U
-#define OS_UNLOCK()     NVIC_ST_CTRL   =  0x0007U
+#define OS_PEND_IRQ()   NVIC_INT_CTRL  = (1<<28)
+#define OS_PENDING      ((NVIC_INT_CTRL >> 26) & (1<<2 | 1))
+#define OS_UNPEND(fl)   NVIC_INT_CTRL  = (*fl = OS_PENDING) << 25
+#define OS_PEND(fl,p)   NVIC_INT_CTRL  = (fl | p<<2) << 26
+#define OS_LOCK()       NVIC_ST_CTRL   =  0x0005
+#define OS_UNLOCK()     NVIC_ST_CTRL   =  0x0007
 
-#define OS_X_PENDING    ((NVIC_INT_CTRL >> 28) & 1U)
-#define OS_X_UNPEND(fl) NVIC_INT_CTRL  = (U32)(fl = (U8)OS_X_PENDING) << 27
-#define OS_X_PEND(fl,p) NVIC_INT_CTRL  = (U32)(fl | p) << 28
-#if defined(__TARGET_ARCH_6S_M)
-#define OS_X_INIT(n)    NVIC_IP[n>>2] |=  (U32)0xFFU << ((n & 0x03U) << 3); \
-                        NVIC_ISER[n>>5] = (U32)1U << (n & 0x1FU)
+#define OS_X_PENDING    ((NVIC_INT_CTRL >> 28) & 1)
+#define OS_X_UNPEND(fl) NVIC_INT_CTRL  = (*fl = OS_X_PENDING) << 27
+#define OS_X_PEND(fl,p) NVIC_INT_CTRL  = (fl | p) << 28
+#if (__TARGET_ARCH_6S_M)
+#define OS_X_INIT(n)    NVIC_IP[n>>2] |= 0xFF << (8*(n & 0x03)); \
+                        NVIC_ISER[n>>5] = 1 << (n & 0x1F)
 #else
-#define OS_X_INIT(n)    NVIC_IP[n] = 0xFFU; \
-                        NVIC_ISER[n>>5] = (U32)1U << (n & 0x1FU)
+#define OS_X_INIT(n)    NVIC_IP[n] = 0xFF; \
+                        NVIC_ISER[n>>5] = 1 << (n & 0x1F)
 #endif
-#define OS_X_LOCK(n)    NVIC_ICER[n>>5] = (U32)1U << (n & 0x1FU)
-#define OS_X_UNLOCK(n)  NVIC_ISER[n>>5] = (U32)1U << (n & 0x1FU)
+#define OS_X_LOCK(n)    NVIC_ICER[n>>5] = 1 << (n & 0x1F)
+#define OS_X_UNLOCK(n)  NVIC_ISER[n>>5] = 1 << (n & 0x1F)
 
 /* Core Debug registers */
-#define DEMCR           (*((volatile U32 *)0xE000EDFCU))
+#define DEMCR           (*((volatile U32 *)0xE000EDFC))
 
 /* ITM registers */
-#define ITM_CONTROL     (*((volatile U32 *)0xE0000E80U))
-#define ITM_ENABLE      (*((volatile U32 *)0xE0000E00U))
-#define ITM_PORT30_U32  (*((volatile U32 *)0xE0000078U))
-#define ITM_PORT31_U32  (*((volatile U32 *)0xE000007CU))
-#define ITM_PORT31_U16  (*((volatile U16 *)0xE000007CU))
-#define ITM_PORT31_U8   (*((volatile U8  *)0xE000007CU))
+#define ITM_CONTROL     (*((volatile U32 *)0xE0000E80))
+#define ITM_ENABLE      (*((volatile U32 *)0xE0000E00))
+#define ITM_PORT30_U32  (*((volatile U32 *)0xE0000078))
+#define ITM_PORT31_U32  (*((volatile U32 *)0xE000007C))
+#define ITM_PORT31_U16  (*((volatile U16 *)0xE000007C))
+#define ITM_PORT31_U8   (*((volatile U8  *)0xE000007C))
 
 /* Variables */
 extern BIT dbg_msg;
 
 /* Functions */
 #ifdef __USE_EXCLUSIVE_ACCESS
- #define rt_inc(p)     while(__strex((__ldrex(p)+1U),p))
- #define rt_dec(p)     while(__strex((__ldrex(p)-1U),p))
+ #define rt_inc(p)     while(__strex((__ldrex(p)+1),p))
+ #define rt_dec(p)     while(__strex((__ldrex(p)-1),p))
 #else
  #define rt_inc(p)     __disable_irq();(*p)++;__enable_irq();
  #define rt_dec(p)     __disable_irq();(*p)--;__enable_irq();
@@ -214,18 +208,18 @@ __inline static U32 rt_inc_qi (U32 size, U8 *count, U8 *first) {
     if ((cnt = __ldrex(count)) == size) {
       __clrex();
       return (cnt); }
-  } while (__strex(cnt+1U, count));
+  } while (__strex(cnt+1, count));
   do {
-    c2 = (cnt = __ldrex(first)) + 1U;
-    if (c2 == size) { c2 = 0U; }
+    c2 = (cnt = __ldrex(first)) + 1;
+    if (c2 == size) c2 = 0;
   } while (__strex(c2, first));
 #else
   __disable_irq();
   if ((cnt = *count) < size) {
-    *count = (U8)(cnt+1U);
-    c2 = (cnt = *first) + 1U;
-    if (c2 == size) { c2 = 0U; }
-    *first = (U8)c2; 
+    *count = cnt+1;
+    c2 = (cnt = *first) + 1;
+    if (c2 == size) c2 = 0;
+    *first = c2;
   }
   __enable_irq ();
 #endif
@@ -234,9 +228,9 @@ __inline static U32 rt_inc_qi (U32 size, U8 *count, U8 *first) {
 
 __inline static void rt_systick_init (void) {
   NVIC_ST_RELOAD  = os_trv;
-  NVIC_ST_CURRENT = 0U;
-  NVIC_ST_CTRL    = 0x0007U;
-  NVIC_SYS_PRI3  |= 0xFF000000U;
+  NVIC_ST_CURRENT = 0;
+  NVIC_ST_CTRL    = 0x0007;
+  NVIC_SYS_PRI3  |= 0xFF000000;
 }
 
 __inline static U32 rt_systick_val (void) {
@@ -244,27 +238,23 @@ __inline static U32 rt_systick_val (void) {
 }
 
 __inline static U32 rt_systick_ovf (void) {
-  return ((NVIC_INT_CTRL >> 26) & 1U);
+  return ((NVIC_INT_CTRL >> 26) & 1);
 }
 
 __inline static void rt_svc_init (void) {
-#if !defined(__TARGET_ARCH_6S_M)
-  U32 sh,prigroup;
+#if !(__TARGET_ARCH_6S_M)
+  int sh,prigroup;
 #endif
-  NVIC_SYS_PRI3 |= 0x00FF0000U;
-#if defined(__TARGET_ARCH_6S_M)
-  NVIC_SYS_PRI2 |= (NVIC_SYS_PRI3<<(8+1)) & 0xFC000000U;
+  NVIC_SYS_PRI3 |= 0x00FF0000;
+#if (__TARGET_ARCH_6S_M)
+  NVIC_SYS_PRI2 |= (NVIC_SYS_PRI3<<(8+1)) & 0xFC000000;
 #else
-  sh       = 8U - __clz(~((NVIC_SYS_PRI3 << 8) & 0xFF000000U));
-  prigroup = ((NVIC_AIR_CTRL >> 8) & 0x07U);
+  sh       = 8 - __clz (~((NVIC_SYS_PRI3 << 8) & 0xFF000000));
+  prigroup = ((NVIC_AIR_CTRL >> 8) & 0x07);
   if (prigroup >= sh) {
-    sh = prigroup + 1U;
+    sh = prigroup + 1;
   }
-
-/* Only change the SVCall priority if uVisor is not present. */
-#if !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED))
-  NVIC_SYS_PRI2 = ((0xFEFFFFFFU << sh) & 0xFF000000U) | (NVIC_SYS_PRI2 & 0x00FFFFFFU);
-#endif /* !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED)) */
+  NVIC_SYS_PRI2 = ((0xFEFFFFFF << sh) & 0xFF000000) | (NVIC_SYS_PRI2 & 0x00FFFFFF);
 #endif
 }
 
@@ -272,7 +262,7 @@ extern void rt_set_PSP (U32 stack);
 extern U32  rt_get_PSP (void);
 extern void os_set_env (void);
 extern void *_alloc_box (void *box_mem);
-extern U32  _free_box (void *box_mem, void *box);
+extern int  _free_box (void *box_mem, void *box);
 
 extern void rt_init_stack (P_TCB p_TCB, FUNCP task_body);
 extern void rt_ret_val  (P_TCB p_TCB, U32 v0);
@@ -286,7 +276,7 @@ extern void dbg_task_switch (U32 task_id);
 #define DBG_INIT() dbg_init()
 #define DBG_TASK_NOTIFY(p_tcb,create) if (dbg_msg) dbg_task_notify(p_tcb,create)
 #define DBG_TASK_SWITCH(task_id)      if (dbg_msg && (os_tsk.new_tsk!=os_tsk.run)) \
-                                        dbg_task_switch(task_id)
+                                                   dbg_task_switch(task_id)
 #else
 #define DBG_INIT()
 #define DBG_TASK_NOTIFY(p_tcb,create)
@@ -296,3 +286,4 @@ extern void dbg_task_switch (U32 task_id);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_List.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_List.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_LIST.C
  *      Purpose: Functions for the management of different lists
- *      Rev.:    V4.70
+ *      Rev.:    V4.79
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -69,13 +69,13 @@ void rt_put_prio (P_XCB p_CB, P_TCB p_task) {
   U32 prio;
   BOOL sem_mbx = __FALSE;
 
-  if (p_CB->cb_type == SCB || p_CB->cb_type == MCB || p_CB->cb_type == MUCB) {
+  if ((p_CB->cb_type == SCB) || (p_CB->cb_type == MCB) || (p_CB->cb_type == MUCB)) {
     sem_mbx = __TRUE;
   }
   prio = p_task->prio;
   p_CB2 = p_CB->p_lnk;
   /* Search for an entry in the list */
-  while (p_CB2 != NULL && prio <= p_CB2->prio) {
+  while ((p_CB2 != NULL) && (prio <= p_CB2->prio)) {
     p_CB = (P_XCB)p_CB2;
     p_CB2 = p_CB2->p_lnk;
   }
@@ -103,7 +103,7 @@ P_TCB rt_get_first (P_XCB p_CB) {
 
   p_first = p_CB->p_lnk;
   p_CB->p_lnk = p_first->p_lnk;
-  if (p_CB->cb_type == SCB || p_CB->cb_type == MCB || p_CB->cb_type == MUCB) {
+  if ((p_CB->cb_type == SCB) || (p_CB->cb_type == MCB) || (p_CB->cb_type == MUCB)) {
     if (p_first->p_lnk != NULL) {
       p_first->p_lnk->p_rlnk = (P_TCB)p_CB;
       p_first->p_lnk = NULL;
@@ -180,7 +180,7 @@ void rt_put_dly (P_TCB p_task, U16 delay) {
   p = (P_TCB)&os_dly;
   if (p->p_dlnk == NULL) {
     /* Delay list empty */
-    delta = 0;
+    delta = 0U;
     goto last;
   }
   delta = os_dly.delta_time;
@@ -191,7 +191,7 @@ last: p_task->p_dlnk = NULL;
       p->p_dlnk = p_task;
       p_task->p_blnk = p;
       p->delta_time = (U16)(idelay - delta);
-      p_task->delta_time = 0;
+      p_task->delta_time = 0U;
       return;
     }
     p = p->p_dlnk;
@@ -219,7 +219,7 @@ void rt_dec_dly (void) {
     return;
   }
   os_dly.delta_time--;
-  while ((os_dly.delta_time == 0) && (os_dly.p_dlnk != NULL)) {
+  while ((os_dly.delta_time == 0U) && (os_dly.p_dlnk != NULL)) {
     p_rdy = os_dly.p_dlnk;
     if (p_rdy->p_rlnk != NULL) {
       /* Task is really enqueued, remove task from semaphore/mailbox */
@@ -240,7 +240,7 @@ void rt_dec_dly (void) {
     p_rdy->state   = READY;
     os_dly.p_dlnk = p_rdy->p_dlnk;
     if (p_rdy->p_dlnk != NULL) {
-      p_rdy->p_dlnk->p_blnk =  (P_TCB)&os_dly;
+      p_rdy->p_dlnk->p_blnk = (P_TCB)&os_dly;
       p_rdy->p_dlnk = NULL;
     }
     p_rdy->p_blnk = NULL;
@@ -294,7 +294,7 @@ void rt_rmv_dly (P_TCB p_task) {
     }
     else {
       /* 'p_task' is at the end of list */
-      p_b->delta_time = 0;
+      p_b->delta_time = 0U;
     }
     p_task->p_blnk = NULL;
   }
@@ -317,8 +317,6 @@ void rt_psq_enq (OS_ID entry, U32 arg) {
   }
 }
 
-
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_List.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_List.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_LIST.C
  *      Purpose: Functions for the management of different lists
- *      Rev.:    V4.79
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -69,13 +69,13 @@ void rt_put_prio (P_XCB p_CB, P_TCB p_task) {
   U32 prio;
   BOOL sem_mbx = __FALSE;
 
-  if ((p_CB->cb_type == SCB) || (p_CB->cb_type == MCB) || (p_CB->cb_type == MUCB)) {
+  if (p_CB->cb_type == SCB || p_CB->cb_type == MCB || p_CB->cb_type == MUCB) {
     sem_mbx = __TRUE;
   }
   prio = p_task->prio;
   p_CB2 = p_CB->p_lnk;
   /* Search for an entry in the list */
-  while ((p_CB2 != NULL) && (prio <= p_CB2->prio)) {
+  while (p_CB2 != NULL && prio <= p_CB2->prio) {
     p_CB = (P_XCB)p_CB2;
     p_CB2 = p_CB2->p_lnk;
   }
@@ -103,7 +103,7 @@ P_TCB rt_get_first (P_XCB p_CB) {
 
   p_first = p_CB->p_lnk;
   p_CB->p_lnk = p_first->p_lnk;
-  if ((p_CB->cb_type == SCB) || (p_CB->cb_type == MCB) || (p_CB->cb_type == MUCB)) {
+  if (p_CB->cb_type == SCB || p_CB->cb_type == MCB || p_CB->cb_type == MUCB) {
     if (p_first->p_lnk != NULL) {
       p_first->p_lnk->p_rlnk = (P_TCB)p_CB;
       p_first->p_lnk = NULL;
@@ -180,7 +180,7 @@ void rt_put_dly (P_TCB p_task, U16 delay) {
   p = (P_TCB)&os_dly;
   if (p->p_dlnk == NULL) {
     /* Delay list empty */
-    delta = 0U;
+    delta = 0;
     goto last;
   }
   delta = os_dly.delta_time;
@@ -191,7 +191,7 @@ last: p_task->p_dlnk = NULL;
       p->p_dlnk = p_task;
       p_task->p_blnk = p;
       p->delta_time = (U16)(idelay - delta);
-      p_task->delta_time = 0U;
+      p_task->delta_time = 0;
       return;
     }
     p = p->p_dlnk;
@@ -219,7 +219,7 @@ void rt_dec_dly (void) {
     return;
   }
   os_dly.delta_time--;
-  while ((os_dly.delta_time == 0U) && (os_dly.p_dlnk != NULL)) {
+  while ((os_dly.delta_time == 0) && (os_dly.p_dlnk != NULL)) {
     p_rdy = os_dly.p_dlnk;
     if (p_rdy->p_rlnk != NULL) {
       /* Task is really enqueued, remove task from semaphore/mailbox */
@@ -240,7 +240,7 @@ void rt_dec_dly (void) {
     p_rdy->state   = READY;
     os_dly.p_dlnk = p_rdy->p_dlnk;
     if (p_rdy->p_dlnk != NULL) {
-      p_rdy->p_dlnk->p_blnk = (P_TCB)&os_dly;
+      p_rdy->p_dlnk->p_blnk =  (P_TCB)&os_dly;
       p_rdy->p_dlnk = NULL;
     }
     p_rdy->p_blnk = NULL;
@@ -294,7 +294,7 @@ void rt_rmv_dly (P_TCB p_task) {
     }
     else {
       /* 'p_task' is at the end of list */
-      p_b->delta_time = 0U;
+      p_b->delta_time = 0;
     }
     p_task->p_blnk = NULL;
   }
@@ -317,6 +317,8 @@ void rt_psq_enq (OS_ID entry, U32 arg) {
   }
 }
 
+
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_List.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_List.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_LIST.H
  *      Purpose: Functions for the management of different lists
- *      Rev.:    V4.70
+ *      Rev.:    V4.79
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -35,11 +35,11 @@
 /* Definitions */
 
 /* Values for 'cb_type' */
-#define TCB             0
-#define MCB             1
-#define SCB             2
-#define MUCB            3
-#define HCB             4
+#define TCB             0U
+#define MCB             1U
+#define SCB             2U
+#define MUCB            3U
+#define HCB             4U
 
 /* Variables */
 extern struct OS_XCB os_rdy;
@@ -60,8 +60,6 @@ extern void  rt_psq_enq       (OS_ID entry, U32 arg);
 /* This is a fast macro generating in-line code */
 #define rt_rdy_prio(void) (os_rdy.p_lnk->prio)
 
-
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_List.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_List.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_LIST.H
  *      Purpose: Functions for the management of different lists
- *      Rev.:    V4.79
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -35,11 +35,11 @@
 /* Definitions */
 
 /* Values for 'cb_type' */
-#define TCB             0U
-#define MCB             1U
-#define SCB             2U
-#define MUCB            3U
-#define HCB             4U
+#define TCB             0
+#define MCB             1
+#define SCB             2
+#define MUCB            3
+#define HCB             4
 
 /* Variables */
 extern struct OS_XCB os_rdy;
@@ -60,6 +60,8 @@ extern void  rt_psq_enq       (OS_ID entry, U32 arg);
 /* This is a fast macro generating in-line code */
 #define rt_rdy_prio(void) (os_rdy.p_lnk->prio)
 
+
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Mailbox.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Mailbox.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MAILBOX.C
  *      Purpose: Implements waits and wake-ups for mailbox messages
- *      Rev.:    V4.70
+ *      Rev.:    V4.79
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -58,14 +58,14 @@ void rt_mbx_init (OS_ID mailbox, U16 mbx_size) {
   P_MCB p_MCB = mailbox;
 
   p_MCB->cb_type = MCB;
-  p_MCB->state   = 0;
-  p_MCB->isr_st  = 0;
+  p_MCB->state   = 0U;
+  p_MCB->isr_st  = 0U;
   p_MCB->p_lnk   = NULL;
-  p_MCB->first   = 0;
-  p_MCB->last    = 0;
-  p_MCB->count   = 0;
-  p_MCB->size    = (mbx_size + sizeof(void *) - sizeof(struct OS_MCB)) /
-                                                     (U32)sizeof (void *);
+  p_MCB->first   = 0U;
+  p_MCB->last    = 0U;
+  p_MCB->count   = 0U;
+  p_MCB->size    = (U16)((mbx_size - (sizeof(struct OS_MCB) - (sizeof(void *))))
+                         / sizeof(void *));
 }
 
 
@@ -76,11 +76,11 @@ OS_RESULT rt_mbx_send (OS_ID mailbox, void *p_msg, U16 timeout) {
   P_MCB p_MCB = mailbox;
   P_TCB p_TCB;
 
-  if ((p_MCB->p_lnk != NULL) && (p_MCB->state == 1)) {
+  if ((p_MCB->p_lnk != NULL) && (p_MCB->state == 1U)) {
     /* A task is waiting for message */
     p_TCB = rt_get_first ((P_XCB)p_MCB);
 #ifdef __CMSIS_RTOS
-    rt_ret_val2(p_TCB, 0x10/*osEventMessage*/, (U32)p_msg);
+    rt_ret_val2(p_TCB, 0x10U/*osEventMessage*/, (U32)p_msg);
 #else
     *p_TCB->msg = p_msg;
     rt_ret_val (p_TCB, OS_R_MBX);
@@ -94,7 +94,7 @@ OS_RESULT rt_mbx_send (OS_ID mailbox, void *p_msg, U16 timeout) {
       /* No free message entry, wait for one. If message queue is full, */
       /* then no task is waiting for message. The 'p_MCB->p_lnk' list   */
       /* pointer can now be reused for send message waits task list.    */
-      if (timeout == 0) {
+      if (timeout == 0U) {
         return (OS_R_TMO);
       }
       if (p_MCB->p_lnk != NULL) {
@@ -104,8 +104,8 @@ OS_RESULT rt_mbx_send (OS_ID mailbox, void *p_msg, U16 timeout) {
         p_MCB->p_lnk = os_tsk.run;
         os_tsk.run->p_lnk  = NULL;
         os_tsk.run->p_rlnk = (P_TCB)p_MCB;
-        /* Task is waiting to send a message */
-        p_MCB->state = 2;
+        /* Task is waiting to send a message */      
+        p_MCB->state = 2U;
       }
       os_tsk.run->msg = p_msg;
       rt_block (timeout, WAIT_MBX);
@@ -115,7 +115,7 @@ OS_RESULT rt_mbx_send (OS_ID mailbox, void *p_msg, U16 timeout) {
     p_MCB->msg[p_MCB->first] = p_msg;
     rt_inc (&p_MCB->count);
     if (++p_MCB->first == p_MCB->size) {
-      p_MCB->first = 0;
+      p_MCB->first = 0U;
     }
   }
   return (OS_R_OK);
@@ -134,19 +134,19 @@ OS_RESULT rt_mbx_wait (OS_ID mailbox, void **message, U16 timeout) {
   if (p_MCB->count) {
     *message = p_MCB->msg[p_MCB->last];
     if (++p_MCB->last == p_MCB->size) {
-      p_MCB->last = 0;
+      p_MCB->last = 0U;
     }
-    if ((p_MCB->p_lnk != NULL) && (p_MCB->state == 2)) {
+    if ((p_MCB->p_lnk != NULL) && (p_MCB->state == 2U)) {
       /* A task is waiting to send message */
       p_TCB = rt_get_first ((P_XCB)p_MCB);
 #ifdef __CMSIS_RTOS
-      rt_ret_val(p_TCB, 0/*osOK*/);
+      rt_ret_val(p_TCB, 0U/*osOK*/);
 #else
       rt_ret_val(p_TCB, OS_R_OK);
 #endif
       p_MCB->msg[p_MCB->first] = p_TCB->msg;
       if (++p_MCB->first == p_MCB->size) {
-        p_MCB->first = 0;
+        p_MCB->first = 0U;
       }
       rt_rmv_dly (p_TCB);
       rt_dispatch (p_TCB);
@@ -157,7 +157,7 @@ OS_RESULT rt_mbx_wait (OS_ID mailbox, void **message, U16 timeout) {
     return (OS_R_OK);
   }
   /* No message available: wait for one */
-  if (timeout == 0) {
+  if (timeout == 0U) {
     return (OS_R_TMO);
   }
   if (p_MCB->p_lnk != NULL) {
@@ -167,8 +167,8 @@ OS_RESULT rt_mbx_wait (OS_ID mailbox, void **message, U16 timeout) {
     p_MCB->p_lnk = os_tsk.run;
     os_tsk.run->p_lnk = NULL;
     os_tsk.run->p_rlnk = (P_TCB)p_MCB;
-    /* Task is waiting to receive a message */
-    p_MCB->state = 1;
+    /* Task is waiting to receive a message */      
+    p_MCB->state = 1U;
   }
   rt_block(timeout, WAIT_MBX);
 #ifndef __CMSIS_RTOS
@@ -185,7 +185,7 @@ OS_RESULT rt_mbx_check (OS_ID mailbox) {
   /* that can be stored to a mailbox. It returns 0 when mailbox is full.   */
   P_MCB p_MCB = mailbox;
 
-  return (p_MCB->size - p_MCB->count);
+  return ((U32)(p_MCB->size - p_MCB->count));
 }
 
 
@@ -210,14 +210,14 @@ OS_RESULT isr_mbx_receive (OS_ID mailbox, void **message) {
   if (p_MCB->count) {
     /* A message is available in the fifo buffer. */
     *message = p_MCB->msg[p_MCB->last];
-    if (p_MCB->state == 2) {
+    if (p_MCB->state == 2U) {
       /* A task is locked waiting to send message */
-      rt_psq_enq (p_MCB, 0);
+      rt_psq_enq (p_MCB, 0U);
       rt_psh_req ();
     }
     rt_dec (&p_MCB->count);
     if (++p_MCB->last == p_MCB->size) {
-      p_MCB->last = 0;
+      p_MCB->last = 0U;
     }
     return (OS_R_MBX);
   }
@@ -237,7 +237,7 @@ void rt_mbx_psh (P_MCB p_CB, void *p_msg) {
     case 3:
       /* Task is waiting to allocate memory, remove it from the waiting list */
       mem = rt_alloc_box(p_msg);
-      if (mem == NULL) break;
+      if (mem == NULL) { break; }
       p_TCB = rt_get_first ((P_XCB)p_CB);
       rt_ret_val(p_TCB, (U32)mem);
       p_TCB->state = READY;
@@ -249,14 +249,14 @@ void rt_mbx_psh (P_MCB p_CB, void *p_msg) {
       /* Task is waiting to send a message, remove it from the waiting list */
       p_TCB = rt_get_first ((P_XCB)p_CB);
 #ifdef __CMSIS_RTOS
-      rt_ret_val(p_TCB, 0/*osOK*/);
+      rt_ret_val(p_TCB, 0U/*osOK*/);
 #else
       rt_ret_val(p_TCB, OS_R_OK);
 #endif
       p_CB->msg[p_CB->first] = p_TCB->msg;
       rt_inc (&p_CB->count);
       if (++p_CB->first == p_CB->size) {
-        p_CB->first = 0;
+        p_CB->first = 0U;
       }
       p_TCB->state = READY;
       rt_rmv_dly (p_TCB);
@@ -266,7 +266,7 @@ void rt_mbx_psh (P_MCB p_CB, void *p_msg) {
       /* Task is waiting for a message, pass the message to the task directly */
       p_TCB = rt_get_first ((P_XCB)p_CB);
 #ifdef __CMSIS_RTOS
-      rt_ret_val2(p_TCB, 0x10/*osEventMessage*/, (U32)p_msg);
+      rt_ret_val2(p_TCB, 0x10U/*osEventMessage*/, (U32)p_msg);
 #else
       *p_TCB->msg = p_msg;
       rt_ret_val (p_TCB, OS_R_MBX);
@@ -275,13 +275,15 @@ void rt_mbx_psh (P_MCB p_CB, void *p_msg) {
       rt_rmv_dly (p_TCB);
       rt_put_prio (&os_rdy, p_TCB);
       break;
+    default:
+      break;
   } else {
     /* No task is waiting for a message, store it to the mailbox queue */
     if (p_CB->count < p_CB->size) {
       p_CB->msg[p_CB->first] = p_msg;
       rt_inc (&p_CB->count);
       if (++p_CB->first == p_CB->size) {
-        p_CB->first = 0;
+        p_CB->first = 0U;
       }
     }
     else {
@@ -293,4 +295,3 @@ void rt_mbx_psh (P_MCB p_CB, void *p_msg) {
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Mailbox.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Mailbox.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MAILBOX.C
  *      Purpose: Implements waits and wake-ups for mailbox messages
- *      Rev.:    V4.79
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -58,14 +58,14 @@ void rt_mbx_init (OS_ID mailbox, U16 mbx_size) {
   P_MCB p_MCB = mailbox;
 
   p_MCB->cb_type = MCB;
-  p_MCB->state   = 0U;
-  p_MCB->isr_st  = 0U;
+  p_MCB->state   = 0;
+  p_MCB->isr_st  = 0;
   p_MCB->p_lnk   = NULL;
-  p_MCB->first   = 0U;
-  p_MCB->last    = 0U;
-  p_MCB->count   = 0U;
-  p_MCB->size    = (U16)((mbx_size - (sizeof(struct OS_MCB) - (sizeof(void *))))
-                         / sizeof(void *));
+  p_MCB->first   = 0;
+  p_MCB->last    = 0;
+  p_MCB->count   = 0;
+  p_MCB->size    = (mbx_size + sizeof(void *) - sizeof(struct OS_MCB)) /
+                                                     (U32)sizeof (void *);
 }
 
 
@@ -76,11 +76,11 @@ OS_RESULT rt_mbx_send (OS_ID mailbox, void *p_msg, U16 timeout) {
   P_MCB p_MCB = mailbox;
   P_TCB p_TCB;
 
-  if ((p_MCB->p_lnk != NULL) && (p_MCB->state == 1U)) {
+  if ((p_MCB->p_lnk != NULL) && (p_MCB->state == 1)) {
     /* A task is waiting for message */
     p_TCB = rt_get_first ((P_XCB)p_MCB);
 #ifdef __CMSIS_RTOS
-    rt_ret_val2(p_TCB, 0x10U/*osEventMessage*/, (U32)p_msg);
+    rt_ret_val2(p_TCB, 0x10/*osEventMessage*/, (U32)p_msg);
 #else
     *p_TCB->msg = p_msg;
     rt_ret_val (p_TCB, OS_R_MBX);
@@ -94,7 +94,7 @@ OS_RESULT rt_mbx_send (OS_ID mailbox, void *p_msg, U16 timeout) {
       /* No free message entry, wait for one. If message queue is full, */
       /* then no task is waiting for message. The 'p_MCB->p_lnk' list   */
       /* pointer can now be reused for send message waits task list.    */
-      if (timeout == 0U) {
+      if (timeout == 0) {
         return (OS_R_TMO);
       }
       if (p_MCB->p_lnk != NULL) {
@@ -104,8 +104,8 @@ OS_RESULT rt_mbx_send (OS_ID mailbox, void *p_msg, U16 timeout) {
         p_MCB->p_lnk = os_tsk.run;
         os_tsk.run->p_lnk  = NULL;
         os_tsk.run->p_rlnk = (P_TCB)p_MCB;
-        /* Task is waiting to send a message */      
-        p_MCB->state = 2U;
+        /* Task is waiting to send a message */
+        p_MCB->state = 2;
       }
       os_tsk.run->msg = p_msg;
       rt_block (timeout, WAIT_MBX);
@@ -115,7 +115,7 @@ OS_RESULT rt_mbx_send (OS_ID mailbox, void *p_msg, U16 timeout) {
     p_MCB->msg[p_MCB->first] = p_msg;
     rt_inc (&p_MCB->count);
     if (++p_MCB->first == p_MCB->size) {
-      p_MCB->first = 0U;
+      p_MCB->first = 0;
     }
   }
   return (OS_R_OK);
@@ -134,19 +134,19 @@ OS_RESULT rt_mbx_wait (OS_ID mailbox, void **message, U16 timeout) {
   if (p_MCB->count) {
     *message = p_MCB->msg[p_MCB->last];
     if (++p_MCB->last == p_MCB->size) {
-      p_MCB->last = 0U;
+      p_MCB->last = 0;
     }
-    if ((p_MCB->p_lnk != NULL) && (p_MCB->state == 2U)) {
+    if ((p_MCB->p_lnk != NULL) && (p_MCB->state == 2)) {
       /* A task is waiting to send message */
       p_TCB = rt_get_first ((P_XCB)p_MCB);
 #ifdef __CMSIS_RTOS
-      rt_ret_val(p_TCB, 0U/*osOK*/);
+      rt_ret_val(p_TCB, 0/*osOK*/);
 #else
       rt_ret_val(p_TCB, OS_R_OK);
 #endif
       p_MCB->msg[p_MCB->first] = p_TCB->msg;
       if (++p_MCB->first == p_MCB->size) {
-        p_MCB->first = 0U;
+        p_MCB->first = 0;
       }
       rt_rmv_dly (p_TCB);
       rt_dispatch (p_TCB);
@@ -157,7 +157,7 @@ OS_RESULT rt_mbx_wait (OS_ID mailbox, void **message, U16 timeout) {
     return (OS_R_OK);
   }
   /* No message available: wait for one */
-  if (timeout == 0U) {
+  if (timeout == 0) {
     return (OS_R_TMO);
   }
   if (p_MCB->p_lnk != NULL) {
@@ -167,8 +167,8 @@ OS_RESULT rt_mbx_wait (OS_ID mailbox, void **message, U16 timeout) {
     p_MCB->p_lnk = os_tsk.run;
     os_tsk.run->p_lnk = NULL;
     os_tsk.run->p_rlnk = (P_TCB)p_MCB;
-    /* Task is waiting to receive a message */      
-    p_MCB->state = 1U;
+    /* Task is waiting to receive a message */
+    p_MCB->state = 1;
   }
   rt_block(timeout, WAIT_MBX);
 #ifndef __CMSIS_RTOS
@@ -185,7 +185,7 @@ OS_RESULT rt_mbx_check (OS_ID mailbox) {
   /* that can be stored to a mailbox. It returns 0 when mailbox is full.   */
   P_MCB p_MCB = mailbox;
 
-  return ((U32)(p_MCB->size - p_MCB->count));
+  return (p_MCB->size - p_MCB->count);
 }
 
 
@@ -210,14 +210,14 @@ OS_RESULT isr_mbx_receive (OS_ID mailbox, void **message) {
   if (p_MCB->count) {
     /* A message is available in the fifo buffer. */
     *message = p_MCB->msg[p_MCB->last];
-    if (p_MCB->state == 2U) {
+    if (p_MCB->state == 2) {
       /* A task is locked waiting to send message */
-      rt_psq_enq (p_MCB, 0U);
+      rt_psq_enq (p_MCB, 0);
       rt_psh_req ();
     }
     rt_dec (&p_MCB->count);
     if (++p_MCB->last == p_MCB->size) {
-      p_MCB->last = 0U;
+      p_MCB->last = 0;
     }
     return (OS_R_MBX);
   }
@@ -237,7 +237,7 @@ void rt_mbx_psh (P_MCB p_CB, void *p_msg) {
     case 3:
       /* Task is waiting to allocate memory, remove it from the waiting list */
       mem = rt_alloc_box(p_msg);
-      if (mem == NULL) { break; }
+      if (mem == NULL) break;
       p_TCB = rt_get_first ((P_XCB)p_CB);
       rt_ret_val(p_TCB, (U32)mem);
       p_TCB->state = READY;
@@ -249,14 +249,14 @@ void rt_mbx_psh (P_MCB p_CB, void *p_msg) {
       /* Task is waiting to send a message, remove it from the waiting list */
       p_TCB = rt_get_first ((P_XCB)p_CB);
 #ifdef __CMSIS_RTOS
-      rt_ret_val(p_TCB, 0U/*osOK*/);
+      rt_ret_val(p_TCB, 0/*osOK*/);
 #else
       rt_ret_val(p_TCB, OS_R_OK);
 #endif
       p_CB->msg[p_CB->first] = p_TCB->msg;
       rt_inc (&p_CB->count);
       if (++p_CB->first == p_CB->size) {
-        p_CB->first = 0U;
+        p_CB->first = 0;
       }
       p_TCB->state = READY;
       rt_rmv_dly (p_TCB);
@@ -266,7 +266,7 @@ void rt_mbx_psh (P_MCB p_CB, void *p_msg) {
       /* Task is waiting for a message, pass the message to the task directly */
       p_TCB = rt_get_first ((P_XCB)p_CB);
 #ifdef __CMSIS_RTOS
-      rt_ret_val2(p_TCB, 0x10U/*osEventMessage*/, (U32)p_msg);
+      rt_ret_val2(p_TCB, 0x10/*osEventMessage*/, (U32)p_msg);
 #else
       *p_TCB->msg = p_msg;
       rt_ret_val (p_TCB, OS_R_MBX);
@@ -275,15 +275,13 @@ void rt_mbx_psh (P_MCB p_CB, void *p_msg) {
       rt_rmv_dly (p_TCB);
       rt_put_prio (&os_rdy, p_TCB);
       break;
-    default:
-      break;
   } else {
     /* No task is waiting for a message, store it to the mailbox queue */
     if (p_CB->count < p_CB->size) {
       p_CB->msg[p_CB->first] = p_msg;
       rt_inc (&p_CB->count);
       if (++p_CB->first == p_CB->size) {
-        p_CB->first = 0U;
+        p_CB->first = 0;
       }
     }
     else {
@@ -295,3 +293,4 @@ void rt_mbx_psh (P_MCB p_CB, void *p_msg) {
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Mailbox.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Mailbox.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MAILBOX.H
  *      Purpose: Implements waits and wake-ups for mailbox messages
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -41,8 +41,6 @@ extern void      isr_mbx_send (OS_ID mailbox, void *p_msg);
 extern OS_RESULT isr_mbx_receive (OS_ID mailbox, void **message);
 extern void      rt_mbx_psh   (P_MCB p_CB,    void *p_msg);
 
-
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Mailbox.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Mailbox.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MAILBOX.H
  *      Purpose: Implements waits and wake-ups for mailbox messages
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -41,6 +41,8 @@ extern void      isr_mbx_send (OS_ID mailbox, void *p_msg);
 extern OS_RESULT isr_mbx_receive (OS_ID mailbox, void **message);
 extern void      rt_mbx_psh   (P_MCB p_CB,    void *p_msg);
 
+
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_MemBox.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_MemBox.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MEMBOX.C
  *      Purpose: Interface functions for fixed memory block management system
- *      Rev.:    V4.70
+ *      Rev.:    V4.79 plus changes for RTX-Ax
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH, 2015 ARM Limited
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -49,7 +49,7 @@
 
 /*--------------------------- _init_box -------------------------------------*/
 
-int _init_box  (void *box_mem, U32 box_size, U32 blk_size) {
+U32 _init_box  (void *box_mem, U32 box_size, U32 blk_size) {
   /* Initialize memory block system, returns 0 if OK, 1 if fails. */
   void *end;
   void *blk;
@@ -58,20 +58,20 @@ int _init_box  (void *box_mem, U32 box_size, U32 blk_size) {
 
   /* Create memory structure. */
   if (blk_size & BOX_ALIGN_8) {
-    /* Memory blocks 8-byte aligned. */
-    blk_size = ((blk_size & ~BOX_ALIGN_8) + 7) & ~7;
-    sizeof_bm = (sizeof (struct OS_BM) + 7) & ~7;
+    /* Memory blocks 8-byte aligned. */ 
+    blk_size = ((blk_size & ~BOX_ALIGN_8) + 7U) & ~(U32)7U;
+    sizeof_bm = (sizeof (struct OS_BM) + 7U) & ~(U32)7U;
   }
   else {
     /* Memory blocks 4-byte aligned. */
-    blk_size = (blk_size + 3) & ~3;
+    blk_size = (blk_size + 3U) & ~(U32)3U;
     sizeof_bm = sizeof (struct OS_BM);
   }
-  if (blk_size == 0) {
-    return (1);
+  if (blk_size == 0U) {
+    return (1U);
   }
   if ((blk_size + sizeof_bm) > box_size) {
-    return (1);
+    return (1U);
   }
   /* Create a Memory structure. */
   blk = ((U8 *) box_mem) + sizeof_bm;
@@ -84,13 +84,13 @@ int _init_box  (void *box_mem, U32 box_size, U32 blk_size) {
   end = ((U8 *) end) - blk_size;
   while (1)  {
     next = ((U8 *) blk) + blk_size;
-    if (next > end)  break;
+    if (next > end) { break; }
     *((void **)blk) = next;
     blk = next;
   }
   /* end marker */
-  *((void **)blk) = 0;
-  return (0);
+  *((void **)blk) = 0U;
+  return (0U);
 }
 
 /*--------------------------- rt_alloc_box ----------------------------------*/
@@ -99,22 +99,22 @@ void *rt_alloc_box (void *box_mem) {
   /* Allocate a memory block and return start address. */
   void **free;
 #ifndef __USE_EXCLUSIVE_ACCESS
-  int  irq_dis;
+  U32  irq_mask;
 
 
 #if defined (__ICCARM__)
-  irq_dis = __disable_irq_iar();
+  irq_mask = (U32)__disable_irq_iar();
 #else
-  irq_dis = __disable_irq ();
+  irq_mask = (U32)__disable_irq ();
 #endif /* __ICCARM__ */
   free = ((P_BM) box_mem)->free;
   if (free) {
     ((P_BM) box_mem)->free = *free;
   }
-  if (!irq_dis) __enable_irq ();
+  if (irq_mask == 0U) { __enable_irq (); }
 #else
   do {
-    if ((free = (void **)__ldrex(&((P_BM) box_mem)->free)) == 0) {
+    if ((free = (void **)__ldrex(&((P_BM) box_mem)->free)) == 0U) {
       __clrex();
       break;
     }
@@ -135,8 +135,8 @@ void *_calloc_box (void *box_mem)  {
   free = _alloc_box (box_mem);
   if (free)  {
     p = free;
-    for (i = ((P_BM) box_mem)->blk_size; i; i -= 4)  {
-      *p = 0;
+    for (i = ((P_BM) box_mem)->blk_size; i; i -= 4U)  {
+      *p = 0U;
       p++;
     }
   }
@@ -146,34 +146,36 @@ void *_calloc_box (void *box_mem)  {
 
 /*--------------------------- rt_free_box -----------------------------------*/
 
-int rt_free_box (void *box_mem, void *box) {
+U32 rt_free_box (void *box_mem, void *box) {
   /* Free a memory block, returns 0 if OK, 1 if box does not belong to box_mem */
 #ifndef __USE_EXCLUSIVE_ACCESS
-  int irq_dis;
+  U32 irq_mask;
 #endif
 
-  if (box < box_mem || box >= ((P_BM) box_mem)->end) {
-    return (1);
+  if ((box < box_mem) || (box >= ((P_BM) box_mem)->end)) {
+    return (1U);
   }
 
 #ifndef __USE_EXCLUSIVE_ACCESS
 #if defined (__ICCARM__)
-  irq_dis = __disable_irq_iar();
+  irq_mask = (U32)__disable_irq_iar();
 #else
-  irq_dis = __disable_irq ();
+  irq_mask = (U32)__disable_irq ();
 #endif /* __ICCARM__ */
   *((void **)box) = ((P_BM) box_mem)->free;
   ((P_BM) box_mem)->free = box;
-  if (!irq_dis) __enable_irq ();
+  if (irq_mask == 0U) { __enable_irq (); }
 #else
   do {
-    *((void **)box) = (void *)__ldrex(&((P_BM) box_mem)->free);
+    do {
+      *((void **)box) = ((P_BM) box_mem)->free;
+      __DMB();
+    } while (*(void**)box != (void *)__ldrex(&((P_BM) box_mem)->free));
   } while (__strex ((U32)box, &((P_BM) box_mem)->free));
 #endif
-  return (0);
+  return (0U);
 }
 
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_MemBox.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_MemBox.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MEMBOX.H
  *      Purpose: Interface functions for fixed memory block management system
- *      Rev.:    V4.70
+ *      Rev.:    V4.79
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -35,12 +35,11 @@
 /* Functions */
 #define rt_init_box     _init_box
 #define rt_calloc_box   _calloc_box
-extern int     _init_box   (void *box_mem, U32 box_size, U32 blk_size);
+extern U32     _init_box   (void *box_mem, U32 box_size, U32 blk_size);
 extern void *rt_alloc_box  (void *box_mem);
 extern void *  _calloc_box (void *box_mem);
-extern int   rt_free_box   (void *box_mem, void *box);
+extern U32   rt_free_box   (void *box_mem, void *box);
 
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_MemBox.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_MemBox.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MEMBOX.H
  *      Purpose: Interface functions for fixed memory block management system
- *      Rev.:    V4.79
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -35,11 +35,12 @@
 /* Functions */
 #define rt_init_box     _init_box
 #define rt_calloc_box   _calloc_box
-extern U32     _init_box   (void *box_mem, U32 box_size, U32 blk_size);
+extern int     _init_box   (void *box_mem, U32 box_size, U32 blk_size);
 extern void *rt_alloc_box  (void *box_mem);
 extern void *  _calloc_box (void *box_mem);
-extern U32   rt_free_box   (void *box_mem, void *box);
+extern int   rt_free_box   (void *box_mem, void *box);
 
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Memory.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Memory.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MEMORY.C
  *      Purpose: Interface functions for Dynamic Memory Management System
- *      Rev.:    V4.70
+ *      Rev.:    V4.79
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -44,17 +44,17 @@
 //     size:    Size of memory pool in bytes
 //   Return:    0 - OK, 1 - Error
 
-int rt_init_mem (void *pool, U32 size) {
+U32 rt_init_mem (void *pool, U32 size) {
   MEMP *ptr;
 
-  if ((pool == NULL) || (size < sizeof(MEMP))) return (1);
+  if ((pool == NULL) || (size < sizeof(MEMP))) { return (1U); }
 
   ptr = (MEMP *)pool;
   ptr->next = (MEMP *)((U32)pool + size - sizeof(MEMP *));
   ptr->next->next = NULL;
-  ptr->len = 0;
+  ptr->len = 0U; 
 
-  return (0);
+  return (0U);
 }
 
 // Allocate Memory from Memory pool
@@ -67,19 +67,19 @@ void *rt_alloc_mem (void *pool, U32 size) {
   MEMP *p, *p_search, *p_new;
   U32   hole_size;
 
-  if ((pool == NULL) || (size == 0)) return NULL;
+  if ((pool == NULL) || (size == 0U)) { return NULL; }
 
   /* Add header offset to 'size' */
   size += sizeof(MEMP);
   /* Make sure that block is 4-byte aligned  */
-  size = (size + 3) & ~3;
+  size = (size + 3U) & ~(U32)3U;
 
   p_search = (MEMP *)pool;
   while (1) {
     hole_size  = (U32)p_search->next - (U32)p_search;
     hole_size -= p_search->len;
     /* Check if hole size is big enough */
-    if (hole_size >= size) break;
+    if (hole_size >= size) { break; }
     p_search = p_search->next;
     if (p_search->next == NULL) {
       /* Failed, we are at the end of the list */
@@ -87,7 +87,7 @@ void *rt_alloc_mem (void *pool, U32 size) {
     }
   }
 
-  if (p_search->len == 0) {
+  if (p_search->len == 0U) {
     /* No block is allocated, set the Length of the first element */
     p_search->len = size;
     p = (MEMP *)(((U32)p_search) + sizeof(MEMP));
@@ -109,13 +109,13 @@ void *rt_alloc_mem (void *pool, U32 size) {
 //     mem:     Pointer to memory to free
 //   Return:    0 - OK, 1 - Error
 
-int rt_free_mem (void *pool, void *mem) {
+U32 rt_free_mem (void *pool, void *mem) {
   MEMP *p_search, *p_prev, *p_return;
 
-  if ((pool == NULL) || (mem == NULL)) return (1);
+  if ((pool == NULL) || (mem == NULL)) { return (1U); }
 
   p_return = (MEMP *)((U32)mem - sizeof(MEMP));
-
+  
   /* Set list header */
   p_prev = NULL;
   p_search = (MEMP *)pool;
@@ -124,17 +124,17 @@ int rt_free_mem (void *pool, void *mem) {
     p_search = p_search->next;
     if (p_search == NULL) {
       /* Valid Memory block not found */
-      return (1);
+      return (1U);
     }
   }
 
   if (p_prev == NULL) {
     /* First block to be released, only set length to 0 */
-    p_search->len = 0;
+    p_search->len = 0U;
   } else {
     /* Discard block from chain list */
     p_prev->next = p_search->next;
   }
 
-  return (0);
+  return (0U);
 }

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Memory.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Memory.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MEMORY.C
  *      Purpose: Interface functions for Dynamic Memory Management System
- *      Rev.:    V4.79
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -44,17 +44,17 @@
 //     size:    Size of memory pool in bytes
 //   Return:    0 - OK, 1 - Error
 
-U32 rt_init_mem (void *pool, U32 size) {
+int rt_init_mem (void *pool, U32 size) {
   MEMP *ptr;
 
-  if ((pool == NULL) || (size < sizeof(MEMP))) { return (1U); }
+  if ((pool == NULL) || (size < sizeof(MEMP))) return (1);
 
   ptr = (MEMP *)pool;
   ptr->next = (MEMP *)((U32)pool + size - sizeof(MEMP *));
   ptr->next->next = NULL;
-  ptr->len = 0U; 
+  ptr->len = 0;
 
-  return (0U);
+  return (0);
 }
 
 // Allocate Memory from Memory pool
@@ -67,19 +67,19 @@ void *rt_alloc_mem (void *pool, U32 size) {
   MEMP *p, *p_search, *p_new;
   U32   hole_size;
 
-  if ((pool == NULL) || (size == 0U)) { return NULL; }
+  if ((pool == NULL) || (size == 0)) return NULL;
 
   /* Add header offset to 'size' */
   size += sizeof(MEMP);
   /* Make sure that block is 4-byte aligned  */
-  size = (size + 3U) & ~(U32)3U;
+  size = (size + 3) & ~3;
 
   p_search = (MEMP *)pool;
   while (1) {
     hole_size  = (U32)p_search->next - (U32)p_search;
     hole_size -= p_search->len;
     /* Check if hole size is big enough */
-    if (hole_size >= size) { break; }
+    if (hole_size >= size) break;
     p_search = p_search->next;
     if (p_search->next == NULL) {
       /* Failed, we are at the end of the list */
@@ -87,7 +87,7 @@ void *rt_alloc_mem (void *pool, U32 size) {
     }
   }
 
-  if (p_search->len == 0U) {
+  if (p_search->len == 0) {
     /* No block is allocated, set the Length of the first element */
     p_search->len = size;
     p = (MEMP *)(((U32)p_search) + sizeof(MEMP));
@@ -109,13 +109,13 @@ void *rt_alloc_mem (void *pool, U32 size) {
 //     mem:     Pointer to memory to free
 //   Return:    0 - OK, 1 - Error
 
-U32 rt_free_mem (void *pool, void *mem) {
+int rt_free_mem (void *pool, void *mem) {
   MEMP *p_search, *p_prev, *p_return;
 
-  if ((pool == NULL) || (mem == NULL)) { return (1U); }
+  if ((pool == NULL) || (mem == NULL)) return (1);
 
   p_return = (MEMP *)((U32)mem - sizeof(MEMP));
-  
+
   /* Set list header */
   p_prev = NULL;
   p_search = (MEMP *)pool;
@@ -124,17 +124,17 @@ U32 rt_free_mem (void *pool, void *mem) {
     p_search = p_search->next;
     if (p_search == NULL) {
       /* Valid Memory block not found */
-      return (1U);
+      return (1);
     }
   }
 
   if (p_prev == NULL) {
     /* First block to be released, only set length to 0 */
-    p_search->len = 0U;
+    p_search->len = 0;
   } else {
     /* Discard block from chain list */
     p_prev->next = p_search->next;
   }
 
-  return (0U);
+  return (0);
 }

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Memory.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Memory.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MEMORY.H
  *      Purpose: Interface functions for Dynamic Memory Management System
- *      Rev.:    V4.70
+ *      Rev.:    V4.79
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -39,6 +39,6 @@ typedef struct mem {              /* << Memory Pool management struct >>     */
 } MEMP;
 
 /* Functions */
-extern int   rt_init_mem  (void *pool, U32  size);
+extern U32   rt_init_mem  (void *pool, U32  size);
 extern void *rt_alloc_mem (void *pool, U32  size);
-extern int   rt_free_mem  (void *pool, void *mem);
+extern U32   rt_free_mem  (void *pool, void *mem);

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Memory.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Memory.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MEMORY.H
  *      Purpose: Interface functions for Dynamic Memory Management System
- *      Rev.:    V4.79
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -39,6 +39,6 @@ typedef struct mem {              /* << Memory Pool management struct >>     */
 } MEMP;
 
 /* Functions */
-extern U32   rt_init_mem  (void *pool, U32  size);
+extern int   rt_init_mem  (void *pool, U32  size);
 extern void *rt_alloc_mem (void *pool, U32  size);
-extern U32   rt_free_mem  (void *pool, void *mem);
+extern int   rt_free_mem  (void *pool, void *mem);

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Mutex.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Mutex.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MUTEX.C
  *      Purpose: Implements mutex synchronization objects
- *      Rev.:    V4.73
+ *      Rev.:    V4.79 plus changes for RTX-Ax
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH, 2012-2016 ARM Limited
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -56,7 +56,7 @@ void rt_mut_init (OS_ID mutex) {
   P_MUCB p_MCB = mutex;
 
   p_MCB->cb_type = MUCB;
-  p_MCB->level   = 0;
+  p_MCB->level   = 0U;
   p_MCB->p_lnk   = NULL;
   p_MCB->owner   = NULL;
   p_MCB->p_mlnk  = NULL;
@@ -75,7 +75,7 @@ OS_RESULT rt_mut_delete (OS_ID mutex) {
 
   __DMB();
   /* Restore owner task's priority. */
-  if (p_MCB->level != 0) {
+  if (p_MCB->level != 0U) {
 
     p_TCB = p_MCB->owner;
 
@@ -98,7 +98,7 @@ OS_RESULT rt_mut_delete (OS_ID mutex) {
     prio = p_TCB->prio_base;
     p_mlnk = p_TCB->p_mlnk;
     while (p_mlnk) {
-      if (p_mlnk->p_lnk && (p_mlnk->p_lnk->prio > prio)) {
+      if ((p_mlnk->p_lnk != NULL) && (p_mlnk->p_lnk->prio > prio)) {
         /* A task with higher priority is waiting for mutex. */
         prio = p_mlnk->p_lnk->prio;
       }
@@ -108,28 +108,28 @@ OS_RESULT rt_mut_delete (OS_ID mutex) {
       p_TCB->prio = prio;
       if (p_TCB != os_tsk.run) {
         rt_resort_prio (p_TCB);
+      }
     }
-  }
 
   }
 
   while (p_MCB->p_lnk != NULL) {
     /* A task is waiting for mutex. */
     p_TCB = rt_get_first ((P_XCB)p_MCB);
-    rt_ret_val(p_TCB, 0/*osOK*/);
+    rt_ret_val(p_TCB, 0U/*osOK*/);
     rt_rmv_dly(p_TCB);
     p_TCB->state = READY;
     rt_put_prio (&os_rdy, p_TCB);
   }
 
-  if (os_rdy.p_lnk && (os_rdy.p_lnk->prio > os_tsk.run->prio)) {
+  if ((os_rdy.p_lnk != NULL) && (os_rdy.p_lnk->prio > os_tsk.run->prio)) {
     /* preempt running task */
     rt_put_prio (&os_rdy, os_tsk.run);
     os_tsk.run->state = READY;
     rt_dispatch (NULL);
   }
 
-  p_MCB->cb_type = 0;
+  p_MCB->cb_type = 0U;
 
   return (OS_R_OK);
 }
@@ -145,12 +145,12 @@ OS_RESULT rt_mut_release (OS_ID mutex) {
   P_MUCB p_mlnk;
   U8     prio;
 
-  if (p_MCB->level == 0 || p_MCB->owner != os_tsk.run) {
+  if ((p_MCB->level == 0U) || (p_MCB->owner != os_tsk.run)) {
     /* Unbalanced mutex release or task is not the owner */
     return (OS_R_NOK);
   }
   __DMB();
-  if (--p_MCB->level != 0) {
+  if (--p_MCB->level != 0U) {
     return (OS_R_OK);
   }
 
@@ -173,7 +173,7 @@ OS_RESULT rt_mut_release (OS_ID mutex) {
   prio = os_tsk.run->prio_base;
   p_mlnk = os_tsk.run->p_mlnk;
   while (p_mlnk) {
-    if (p_mlnk->p_lnk && (p_mlnk->p_lnk->prio > prio)) {
+    if ((p_mlnk->p_lnk != NULL) && (p_mlnk->p_lnk->prio > prio)) {
       /* A task with higher priority is waiting for mutex. */
       prio = p_mlnk->p_lnk->prio;
     }
@@ -185,14 +185,14 @@ OS_RESULT rt_mut_release (OS_ID mutex) {
     /* A task is waiting for mutex. */
     p_TCB = rt_get_first ((P_XCB)p_MCB);
 #ifdef __CMSIS_RTOS
-    rt_ret_val(p_TCB, 0/*osOK*/);
+    rt_ret_val(p_TCB, 0U/*osOK*/);
 #else
-    rt_ret_val(p_TCB, OS_R_MUT);
+    rt_ret_val(p_TCB, OS_R_MUT); 
 #endif
     rt_rmv_dly (p_TCB);
     /* A waiting task becomes the owner of this mutex. */
-    p_MCB->level     = 1;
-    p_MCB->owner     = p_TCB;
+    p_MCB->level  = 1U;
+    p_MCB->owner  = p_TCB;
     p_MCB->p_mlnk = p_TCB->p_mlnk;
     p_TCB->p_mlnk = p_MCB; 
     /* Priority inversion, check which task continues. */
@@ -226,8 +226,8 @@ OS_RESULT rt_mut_wait (OS_ID mutex, U16 timeout) {
   /* Wait for a mutex, continue when mutex is free. */
   P_MUCB p_MCB = mutex;
 
-  if (p_MCB->level == 0) {
-    p_MCB->owner = os_tsk.run;
+  if (p_MCB->level == 0U) {
+    p_MCB->owner  = os_tsk.run;
     p_MCB->p_mlnk = os_tsk.run->p_mlnk;
     os_tsk.run->p_mlnk = p_MCB; 
     goto inc;
@@ -239,7 +239,7 @@ inc:p_MCB->level++;
     return (OS_R_OK);
   }
   /* Mutex owned by another task, wait until released. */
-  if (timeout == 0) {
+  if (timeout == 0U) {
     return (OS_R_TMO);
   }
   /* Raise the owner task priority if lower than current priority. */
@@ -260,8 +260,6 @@ inc:p_MCB->level++;
   return (OS_R_TMO);
 }
 
-
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Mutex.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Mutex.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MUTEX.C
  *      Purpose: Implements mutex synchronization objects
- *      Rev.:    V4.79 plus changes for RTX-Ax
+ *      Rev.:    V4.73
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH, 2012-2016 ARM Limited
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -56,7 +56,7 @@ void rt_mut_init (OS_ID mutex) {
   P_MUCB p_MCB = mutex;
 
   p_MCB->cb_type = MUCB;
-  p_MCB->level   = 0U;
+  p_MCB->level   = 0;
   p_MCB->p_lnk   = NULL;
   p_MCB->owner   = NULL;
   p_MCB->p_mlnk  = NULL;
@@ -75,7 +75,7 @@ OS_RESULT rt_mut_delete (OS_ID mutex) {
 
   __DMB();
   /* Restore owner task's priority. */
-  if (p_MCB->level != 0U) {
+  if (p_MCB->level != 0) {
 
     p_TCB = p_MCB->owner;
 
@@ -98,7 +98,7 @@ OS_RESULT rt_mut_delete (OS_ID mutex) {
     prio = p_TCB->prio_base;
     p_mlnk = p_TCB->p_mlnk;
     while (p_mlnk) {
-      if ((p_mlnk->p_lnk != NULL) && (p_mlnk->p_lnk->prio > prio)) {
+      if (p_mlnk->p_lnk && (p_mlnk->p_lnk->prio > prio)) {
         /* A task with higher priority is waiting for mutex. */
         prio = p_mlnk->p_lnk->prio;
       }
@@ -108,28 +108,28 @@ OS_RESULT rt_mut_delete (OS_ID mutex) {
       p_TCB->prio = prio;
       if (p_TCB != os_tsk.run) {
         rt_resort_prio (p_TCB);
-      }
     }
+  }
 
   }
 
   while (p_MCB->p_lnk != NULL) {
     /* A task is waiting for mutex. */
     p_TCB = rt_get_first ((P_XCB)p_MCB);
-    rt_ret_val(p_TCB, 0U/*osOK*/);
+    rt_ret_val(p_TCB, 0/*osOK*/);
     rt_rmv_dly(p_TCB);
     p_TCB->state = READY;
     rt_put_prio (&os_rdy, p_TCB);
   }
 
-  if ((os_rdy.p_lnk != NULL) && (os_rdy.p_lnk->prio > os_tsk.run->prio)) {
+  if (os_rdy.p_lnk && (os_rdy.p_lnk->prio > os_tsk.run->prio)) {
     /* preempt running task */
     rt_put_prio (&os_rdy, os_tsk.run);
     os_tsk.run->state = READY;
     rt_dispatch (NULL);
   }
 
-  p_MCB->cb_type = 0U;
+  p_MCB->cb_type = 0;
 
   return (OS_R_OK);
 }
@@ -145,12 +145,12 @@ OS_RESULT rt_mut_release (OS_ID mutex) {
   P_MUCB p_mlnk;
   U8     prio;
 
-  if ((p_MCB->level == 0U) || (p_MCB->owner != os_tsk.run)) {
+  if (p_MCB->level == 0 || p_MCB->owner != os_tsk.run) {
     /* Unbalanced mutex release or task is not the owner */
     return (OS_R_NOK);
   }
   __DMB();
-  if (--p_MCB->level != 0U) {
+  if (--p_MCB->level != 0) {
     return (OS_R_OK);
   }
 
@@ -173,7 +173,7 @@ OS_RESULT rt_mut_release (OS_ID mutex) {
   prio = os_tsk.run->prio_base;
   p_mlnk = os_tsk.run->p_mlnk;
   while (p_mlnk) {
-    if ((p_mlnk->p_lnk != NULL) && (p_mlnk->p_lnk->prio > prio)) {
+    if (p_mlnk->p_lnk && (p_mlnk->p_lnk->prio > prio)) {
       /* A task with higher priority is waiting for mutex. */
       prio = p_mlnk->p_lnk->prio;
     }
@@ -185,14 +185,14 @@ OS_RESULT rt_mut_release (OS_ID mutex) {
     /* A task is waiting for mutex. */
     p_TCB = rt_get_first ((P_XCB)p_MCB);
 #ifdef __CMSIS_RTOS
-    rt_ret_val(p_TCB, 0U/*osOK*/);
+    rt_ret_val(p_TCB, 0/*osOK*/);
 #else
-    rt_ret_val(p_TCB, OS_R_MUT); 
+    rt_ret_val(p_TCB, OS_R_MUT);
 #endif
     rt_rmv_dly (p_TCB);
     /* A waiting task becomes the owner of this mutex. */
-    p_MCB->level  = 1U;
-    p_MCB->owner  = p_TCB;
+    p_MCB->level     = 1;
+    p_MCB->owner     = p_TCB;
     p_MCB->p_mlnk = p_TCB->p_mlnk;
     p_TCB->p_mlnk = p_MCB; 
     /* Priority inversion, check which task continues. */
@@ -226,8 +226,8 @@ OS_RESULT rt_mut_wait (OS_ID mutex, U16 timeout) {
   /* Wait for a mutex, continue when mutex is free. */
   P_MUCB p_MCB = mutex;
 
-  if (p_MCB->level == 0U) {
-    p_MCB->owner  = os_tsk.run;
+  if (p_MCB->level == 0) {
+    p_MCB->owner = os_tsk.run;
     p_MCB->p_mlnk = os_tsk.run->p_mlnk;
     os_tsk.run->p_mlnk = p_MCB; 
     goto inc;
@@ -239,7 +239,7 @@ inc:p_MCB->level++;
     return (OS_R_OK);
   }
   /* Mutex owned by another task, wait until released. */
-  if (timeout == 0U) {
+  if (timeout == 0) {
     return (OS_R_TMO);
   }
   /* Raise the owner task priority if lower than current priority. */
@@ -260,6 +260,8 @@ inc:p_MCB->level++;
   return (OS_R_TMO);
 }
 
+
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Mutex.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Mutex.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MUTEX.H
  *      Purpose: Implements mutex synchronization objects
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -41,4 +41,3 @@ extern OS_RESULT rt_mut_wait    (OS_ID mutex, U16 timeout);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Mutex.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Mutex.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_MUTEX.H
  *      Purpose: Implements mutex synchronization objects
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -41,3 +41,4 @@ extern OS_RESULT rt_mut_wait    (OS_ID mutex, U16 timeout);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Robin.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Robin.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_ROBIN.C
  *      Purpose: Round Robin Task switching
- *      Rev.:    V4.70
+ *      Rev.:    V4.79
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -72,7 +72,7 @@ __weak void rt_chk_robin (void) {
   if (os_robin.task != os_rdy.p_lnk) {
     /* New task was suspended, reset Round Robin timeout. */
     os_robin.task = os_rdy.p_lnk;
-    os_robin.time = (U16)os_time + os_robin.tout - 1;
+    os_robin.time = (U16)os_time + os_robin.tout - 1U;
   }
   if (os_robin.time == (U16)os_time) {
     /* Round Robin timeout has expired, swap Robin tasks. */
@@ -85,4 +85,3 @@ __weak void rt_chk_robin (void) {
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Robin.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Robin.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_ROBIN.C
  *      Purpose: Round Robin Task switching
- *      Rev.:    V4.79
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -72,7 +72,7 @@ __weak void rt_chk_robin (void) {
   if (os_robin.task != os_rdy.p_lnk) {
     /* New task was suspended, reset Round Robin timeout. */
     os_robin.task = os_rdy.p_lnk;
-    os_robin.time = (U16)os_time + os_robin.tout - 1U;
+    os_robin.time = (U16)os_time + os_robin.tout - 1;
   }
   if (os_robin.time == (U16)os_time) {
     /* Round Robin timeout has expired, swap Robin tasks. */
@@ -85,3 +85,4 @@ __weak void rt_chk_robin (void) {
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Robin.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Robin.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_ROBIN.H
  *      Purpose: Round Robin Task switching definitions
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -42,4 +42,3 @@ extern void rt_chk_robin  (void);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Robin.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Robin.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_ROBIN.H
  *      Purpose: Round Robin Task switching definitions
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -42,3 +42,4 @@ extern void rt_chk_robin  (void);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Semaphore.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Semaphore.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_SEMAPHORE.C
  *      Purpose: Implements binary and counting semaphores
- *      Rev.:    V4.70
+ *      Rev.:    V4.79 plus changes for RTX-Ax
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH, 2012-2016 ARM Limited
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -74,20 +74,20 @@ OS_RESULT rt_sem_delete (OS_ID semaphore) {
   while (p_SCB->p_lnk != NULL) {
     /* A task is waiting for token */
     p_TCB = rt_get_first ((P_XCB)p_SCB);
-    rt_ret_val(p_TCB, 0);
+    rt_ret_val(p_TCB, 0U);
     rt_rmv_dly(p_TCB);
     p_TCB->state = READY;
     rt_put_prio (&os_rdy, p_TCB);
   }
 
-  if (os_rdy.p_lnk && (os_rdy.p_lnk->prio > os_tsk.run->prio)) {
+  if ((os_rdy.p_lnk != NULL) && (os_rdy.p_lnk->prio > os_tsk.run->prio)) {
     /* preempt running task */
     rt_put_prio (&os_rdy, os_tsk.run);
     os_tsk.run->state = READY;
     rt_dispatch (NULL);
   }
 
-  p_SCB->cb_type = 0;
+  p_SCB->cb_type = 0U;
 
   return (OS_R_OK);
 }
@@ -106,7 +106,7 @@ OS_RESULT rt_sem_send (OS_ID semaphore) {
     /* A task is waiting for token */
     p_TCB = rt_get_first ((P_XCB)p_SCB);
 #ifdef __CMSIS_RTOS
-    rt_ret_val(p_TCB, 1);
+    rt_ret_val(p_TCB, 1U);
 #else
     rt_ret_val(p_TCB, OS_R_SEM);
 #endif
@@ -133,7 +133,7 @@ OS_RESULT rt_sem_wait (OS_ID semaphore, U16 timeout) {
     return (OS_R_OK);
   }
   /* No token available: wait for one */
-  if (timeout == 0) {
+  if (timeout == 0U) {
     return (OS_R_TMO);
   }
   if (p_SCB->p_lnk != NULL) {
@@ -155,7 +155,7 @@ void isr_sem_send (OS_ID semaphore) {
   /* Same function as "os_sem_send", but to be called by ISRs */
   P_SCB p_SCB = semaphore;
 
-  rt_psq_enq (p_SCB, 0);
+  rt_psq_enq (p_SCB, 0U);
   rt_psh_req ();
 }
 
@@ -173,7 +173,7 @@ void rt_sem_psh (P_SCB p_CB) {
     rt_rmv_dly (p_TCB);
     p_TCB->state   = READY;
 #ifdef __CMSIS_RTOS
-    rt_ret_val(p_TCB, 1);
+    rt_ret_val(p_TCB, 1U);
 #else
     rt_ret_val(p_TCB, OS_R_SEM);
 #endif
@@ -188,4 +188,3 @@ void rt_sem_psh (P_SCB p_CB) {
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Semaphore.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Semaphore.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_SEMAPHORE.C
  *      Purpose: Implements binary and counting semaphores
- *      Rev.:    V4.79 plus changes for RTX-Ax
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH, 2012-2016 ARM Limited
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -74,20 +74,20 @@ OS_RESULT rt_sem_delete (OS_ID semaphore) {
   while (p_SCB->p_lnk != NULL) {
     /* A task is waiting for token */
     p_TCB = rt_get_first ((P_XCB)p_SCB);
-    rt_ret_val(p_TCB, 0U);
+    rt_ret_val(p_TCB, 0);
     rt_rmv_dly(p_TCB);
     p_TCB->state = READY;
     rt_put_prio (&os_rdy, p_TCB);
   }
 
-  if ((os_rdy.p_lnk != NULL) && (os_rdy.p_lnk->prio > os_tsk.run->prio)) {
+  if (os_rdy.p_lnk && (os_rdy.p_lnk->prio > os_tsk.run->prio)) {
     /* preempt running task */
     rt_put_prio (&os_rdy, os_tsk.run);
     os_tsk.run->state = READY;
     rt_dispatch (NULL);
   }
 
-  p_SCB->cb_type = 0U;
+  p_SCB->cb_type = 0;
 
   return (OS_R_OK);
 }
@@ -106,7 +106,7 @@ OS_RESULT rt_sem_send (OS_ID semaphore) {
     /* A task is waiting for token */
     p_TCB = rt_get_first ((P_XCB)p_SCB);
 #ifdef __CMSIS_RTOS
-    rt_ret_val(p_TCB, 1U);
+    rt_ret_val(p_TCB, 1);
 #else
     rt_ret_val(p_TCB, OS_R_SEM);
 #endif
@@ -133,7 +133,7 @@ OS_RESULT rt_sem_wait (OS_ID semaphore, U16 timeout) {
     return (OS_R_OK);
   }
   /* No token available: wait for one */
-  if (timeout == 0U) {
+  if (timeout == 0) {
     return (OS_R_TMO);
   }
   if (p_SCB->p_lnk != NULL) {
@@ -155,7 +155,7 @@ void isr_sem_send (OS_ID semaphore) {
   /* Same function as "os_sem_send", but to be called by ISRs */
   P_SCB p_SCB = semaphore;
 
-  rt_psq_enq (p_SCB, 0U);
+  rt_psq_enq (p_SCB, 0);
   rt_psh_req ();
 }
 
@@ -173,7 +173,7 @@ void rt_sem_psh (P_SCB p_CB) {
     rt_rmv_dly (p_TCB);
     p_TCB->state   = READY;
 #ifdef __CMSIS_RTOS
-    rt_ret_val(p_TCB, 1U);
+    rt_ret_val(p_TCB, 1);
 #else
     rt_ret_val(p_TCB, OS_R_SEM);
 #endif
@@ -188,3 +188,4 @@ void rt_sem_psh (P_SCB p_CB) {
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Semaphore.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Semaphore.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_SEMAPHORE.H
  *      Purpose: Implements binary and counting semaphores
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -43,4 +43,3 @@ extern void      rt_sem_psh (P_SCB p_CB);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Semaphore.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Semaphore.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_SEMAPHORE.H
  *      Purpose: Implements binary and counting semaphores
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -43,3 +43,4 @@ extern void      rt_sem_psh (P_SCB p_CB);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_System.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_System.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_SYSTEM.C
  *      Purpose: System Task Manager
- *      Rev.:    8 April 2015
+ *      Rev.:    V4.80 plus changes for RTX-Ax
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH, 2012-2016 ARM Limited
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -53,7 +53,7 @@
  *      Global Variables
  *---------------------------------------------------------------------------*/
 
-int os_tick_irqn;
+S32 os_tick_irqn;
 U8  scheduler_suspended = 0;    // flag set by rt_suspend, cleared by rt_resume, read by SVC_Handler
 
 /*----------------------------------------------------------------------------
@@ -69,7 +69,7 @@ static          U8  pend_flags;
  *      Global Functions
  *---------------------------------------------------------------------------*/
 
-#define RL_RTX_VER      0x473
+#define RL_RTX_VER      0x480
 
 #if defined (__CC_ARM)
 __asm void $$RTX$$version (void) {
@@ -88,20 +88,20 @@ extern U32 sysUserTimerWakeupTime(void);
 
 U32 rt_suspend (void) {
   /* Suspend OS scheduler */
-  U32 delta = 0xFFFF;
+  U32 delta = 0xFFFFU;
 #ifdef __CMSIS_RTOS
   U32 sleep;
 #endif
 
   rt_tsk_lock();
   scheduler_suspended = 1;
-
+  
   if (os_dly.p_dlnk) {
     delta = os_dly.delta_time;
   }
 #ifdef __CMSIS_RTOS
   sleep = sysUserTimerWakeupTime();
-  if (sleep < delta) delta = sleep;
+  if (sleep < delta) { delta = sleep; }
 #else
   if (os_tmr.next) {
     if (os_tmr.tcnt < delta) delta = os_tmr.tcnt;
@@ -132,16 +132,16 @@ void rt_resume (U32 sleep_time) {
     if (delta >= os_dly.delta_time) {
       delta   -= os_dly.delta_time;
       os_time += os_dly.delta_time;
-      os_dly.delta_time = 1;
+      os_dly.delta_time = 1U;
       while (os_dly.p_dlnk) {
         rt_dec_dly();
-        if (delta == 0) break;
+        if (delta == 0U) { break; }
         delta--;
         os_time++;
       }
     } else {
-      os_time           += delta;
-      os_dly.delta_time -= delta;
+      os_time           +=      delta;
+      os_dly.delta_time -= (U16)delta;
     }
   } else {
     os_time += sleep_time;
@@ -155,10 +155,10 @@ void rt_resume (U32 sleep_time) {
     delta = sleep_time;
     if (delta >= os_tmr.tcnt) {
       delta   -= os_tmr.tcnt;
-      os_tmr.tcnt = 1;
+      os_tmr.tcnt = 1U;
       while (os_tmr.next) {
         rt_tmr_tick();
-        if (delta == 0) break;
+        if (delta == 0U) { break; }
         delta--;
       }
     } else {
@@ -186,11 +186,11 @@ void rt_tsk_lock (void) {
   if (os_tick_irqn < 0) {
     OS_LOCK();
     os_lock = __TRUE;
-    OS_UNPEND (&pend_flags);
+    OS_UNPEND(pend_flags);
   } else {
-    OS_X_LOCK(os_tick_irqn);
+    OS_X_LOCK((U32)os_tick_irqn);
     os_lock = __TRUE;
-    OS_X_UNPEND (&pend_flags);
+    OS_X_UNPEND(pend_flags);
   }
 }
 
@@ -202,12 +202,12 @@ void rt_tsk_unlock (void) {
   if (os_tick_irqn < 0) {
     OS_UNLOCK();
     os_lock = __FALSE;
-    OS_PEND (pend_flags, os_psh_flag);
+    OS_PEND(pend_flags, os_psh_flag);
     os_psh_flag = __FALSE;
   } else {
-    OS_X_UNLOCK(os_tick_irqn);
+    OS_X_UNLOCK((U32)os_tick_irqn);
     os_lock = __FALSE;
-    OS_X_PEND (pend_flags, os_psh_flag);
+    OS_X_PEND(pend_flags, os_psh_flag);
     os_psh_flag = __FALSE;
   }
 }
@@ -218,7 +218,7 @@ void rt_tsk_unlock (void) {
 void rt_psh_req (void) {
   /* Initiate a post service handling request if required. */
   if (os_lock == __FALSE) {
-    OS_PEND_IRQ ();
+    OS_PEND_IRQ();
   }
   else {
     os_psh_flag = __TRUE;
@@ -252,10 +252,10 @@ void rt_pop_req (void) {
       /* Must be of SCB type */
       rt_sem_psh ((P_SCB)p_CB);
     }
-    if (++idx == os_psq->size) idx = 0;
+    if (++idx == os_psq->size) { idx = 0U; }
     rt_dec (&os_psq->count);
   }
-  os_psq->last = idx;
+  os_psq->last = (U8)idx;
 
   next = rt_get_first (&os_rdy);
   rt_switch_req (next);
@@ -264,9 +264,9 @@ void rt_pop_req (void) {
 
 /*--------------------------- os_tick_init ----------------------------------*/
 
-__weak int os_tick_init (void) {
+__weak S32 os_tick_init (void) {
   /* Initialize SysTick timer as system tick timer. */
-  rt_systick_init ();
+  rt_systick_init();
   return (-1);  /* Return IRQ number of SysTick timer */
 }
 
@@ -325,7 +325,7 @@ void rt_systick (void) {
 
 __weak void rt_stk_check (void) {
   /* Check for stack overflow. */
-  if ((os_tsk.run->tsk_stack < (U32)os_tsk.run->stack) ||
+  if ((os_tsk.run->tsk_stack < (U32)os_tsk.run->stack) || 
       (os_tsk.run->stack[0] != MAGIC_WORD)) {
     os_error (OS_ERR_STK_OVF);
   }
@@ -334,4 +334,3 @@ __weak void rt_stk_check (void) {
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_System.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_System.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_SYSTEM.C
  *      Purpose: System Task Manager
- *      Rev.:    V4.80 plus changes for RTX-Ax
+ *      Rev.:    8 April 2015
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH, 2012-2016 ARM Limited
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -53,7 +53,7 @@
  *      Global Variables
  *---------------------------------------------------------------------------*/
 
-S32 os_tick_irqn;
+int os_tick_irqn;
 U8  scheduler_suspended = 0;    // flag set by rt_suspend, cleared by rt_resume, read by SVC_Handler
 
 /*----------------------------------------------------------------------------
@@ -69,7 +69,7 @@ static          U8  pend_flags;
  *      Global Functions
  *---------------------------------------------------------------------------*/
 
-#define RL_RTX_VER      0x480
+#define RL_RTX_VER      0x473
 
 #if defined (__CC_ARM)
 __asm void $$RTX$$version (void) {
@@ -88,20 +88,20 @@ extern U32 sysUserTimerWakeupTime(void);
 
 U32 rt_suspend (void) {
   /* Suspend OS scheduler */
-  U32 delta = 0xFFFFU;
+  U32 delta = 0xFFFF;
 #ifdef __CMSIS_RTOS
   U32 sleep;
 #endif
 
   rt_tsk_lock();
   scheduler_suspended = 1;
-  
+
   if (os_dly.p_dlnk) {
     delta = os_dly.delta_time;
   }
 #ifdef __CMSIS_RTOS
   sleep = sysUserTimerWakeupTime();
-  if (sleep < delta) { delta = sleep; }
+  if (sleep < delta) delta = sleep;
 #else
   if (os_tmr.next) {
     if (os_tmr.tcnt < delta) delta = os_tmr.tcnt;
@@ -132,16 +132,16 @@ void rt_resume (U32 sleep_time) {
     if (delta >= os_dly.delta_time) {
       delta   -= os_dly.delta_time;
       os_time += os_dly.delta_time;
-      os_dly.delta_time = 1U;
+      os_dly.delta_time = 1;
       while (os_dly.p_dlnk) {
         rt_dec_dly();
-        if (delta == 0U) { break; }
+        if (delta == 0) break;
         delta--;
         os_time++;
       }
     } else {
-      os_time           +=      delta;
-      os_dly.delta_time -= (U16)delta;
+      os_time           += delta;
+      os_dly.delta_time -= delta;
     }
   } else {
     os_time += sleep_time;
@@ -155,10 +155,10 @@ void rt_resume (U32 sleep_time) {
     delta = sleep_time;
     if (delta >= os_tmr.tcnt) {
       delta   -= os_tmr.tcnt;
-      os_tmr.tcnt = 1U;
+      os_tmr.tcnt = 1;
       while (os_tmr.next) {
         rt_tmr_tick();
-        if (delta == 0U) { break; }
+        if (delta == 0) break;
         delta--;
       }
     } else {
@@ -186,11 +186,11 @@ void rt_tsk_lock (void) {
   if (os_tick_irqn < 0) {
     OS_LOCK();
     os_lock = __TRUE;
-    OS_UNPEND(pend_flags);
+    OS_UNPEND (&pend_flags);
   } else {
-    OS_X_LOCK((U32)os_tick_irqn);
+    OS_X_LOCK(os_tick_irqn);
     os_lock = __TRUE;
-    OS_X_UNPEND(pend_flags);
+    OS_X_UNPEND (&pend_flags);
   }
 }
 
@@ -202,12 +202,12 @@ void rt_tsk_unlock (void) {
   if (os_tick_irqn < 0) {
     OS_UNLOCK();
     os_lock = __FALSE;
-    OS_PEND(pend_flags, os_psh_flag);
+    OS_PEND (pend_flags, os_psh_flag);
     os_psh_flag = __FALSE;
   } else {
-    OS_X_UNLOCK((U32)os_tick_irqn);
+    OS_X_UNLOCK(os_tick_irqn);
     os_lock = __FALSE;
-    OS_X_PEND(pend_flags, os_psh_flag);
+    OS_X_PEND (pend_flags, os_psh_flag);
     os_psh_flag = __FALSE;
   }
 }
@@ -218,7 +218,7 @@ void rt_tsk_unlock (void) {
 void rt_psh_req (void) {
   /* Initiate a post service handling request if required. */
   if (os_lock == __FALSE) {
-    OS_PEND_IRQ();
+    OS_PEND_IRQ ();
   }
   else {
     os_psh_flag = __TRUE;
@@ -252,10 +252,10 @@ void rt_pop_req (void) {
       /* Must be of SCB type */
       rt_sem_psh ((P_SCB)p_CB);
     }
-    if (++idx == os_psq->size) { idx = 0U; }
+    if (++idx == os_psq->size) idx = 0;
     rt_dec (&os_psq->count);
   }
-  os_psq->last = (U8)idx;
+  os_psq->last = idx;
 
   next = rt_get_first (&os_rdy);
   rt_switch_req (next);
@@ -264,9 +264,9 @@ void rt_pop_req (void) {
 
 /*--------------------------- os_tick_init ----------------------------------*/
 
-__weak S32 os_tick_init (void) {
+__weak int os_tick_init (void) {
   /* Initialize SysTick timer as system tick timer. */
-  rt_systick_init();
+  rt_systick_init ();
   return (-1);  /* Return IRQ number of SysTick timer */
 }
 
@@ -325,7 +325,7 @@ void rt_systick (void) {
 
 __weak void rt_stk_check (void) {
   /* Check for stack overflow. */
-  if ((os_tsk.run->tsk_stack < (U32)os_tsk.run->stack) || 
+  if ((os_tsk.run->tsk_stack < (U32)os_tsk.run->stack) ||
       (os_tsk.run->stack[0] != MAGIC_WORD)) {
     os_error (OS_ERR_STK_OVF);
   }
@@ -334,3 +334,4 @@ __weak void rt_stk_check (void) {
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_System.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_System.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_SYSTEM.H
  *      Purpose: System Task Manager definitions
- *      Rev.:    V4.70
+ *      Rev.:    V4.79
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,26 +15,26 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
 
 /* Variables */
 #define os_psq  ((P_PSQ)&os_fifo)
-extern int os_tick_irqn;
+extern S32 os_tick_irqn;
 
 /* Functions */
 extern U32  rt_suspend    (void);
@@ -49,4 +49,3 @@ extern void rt_stk_check  (void);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_System.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_System.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_SYSTEM.H
  *      Purpose: System Task Manager definitions
- *      Rev.:    V4.79
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,26 +15,26 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
 
 /* Variables */
 #define os_psq  ((P_PSQ)&os_fifo)
-extern S32 os_tick_irqn;
+extern int os_tick_irqn;
 
 /* Functions */
 extern U32  rt_suspend    (void);
@@ -49,3 +49,4 @@ extern void rt_stk_check  (void);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Task.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Task.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_TASK.C
  *      Purpose: Task functions and system start up.
- *      Rev.:    V4.73
+ *      Rev.:    V4.80 plus changes for RTX-Ax
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH, 2012-2016 ARM Limited
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -63,12 +63,12 @@ struct OS_TCB os_idle_TCB;
 static OS_TID rt_get_TID (void) {
   U32 tid;
 
-  for (tid = 1; tid <= os_maxtaskrun; tid++) {
-    if (os_active_TCB[tid-1] == NULL) {
+  for (tid = 1U; tid <= os_maxtaskrun; tid++) {
+    if (os_active_TCB[tid-1U] == NULL) {
       return ((OS_TID)tid);
     }
   }
-  return (0);
+  return (0U);
 }
 
 
@@ -76,22 +76,22 @@ static OS_TID rt_get_TID (void) {
 
 static void rt_init_context (P_TCB p_TCB, U8 priority, FUNCP task_body) {
   /* Initialize general part of the Task Control Block. */
-  p_TCB->cb_type = TCB;
-  p_TCB->state   = READY;
-  p_TCB->prio    = priority;
+  p_TCB->cb_type   = TCB;
+  p_TCB->state     = READY;
+  p_TCB->prio      = priority;
   p_TCB->prio_base = priority;
-  p_TCB->p_lnk   = NULL;
-  p_TCB->p_rlnk  = NULL;
-  p_TCB->p_dlnk  = NULL;
-  p_TCB->p_blnk  = NULL;
+  p_TCB->p_lnk     = NULL;
+  p_TCB->p_rlnk    = NULL;
+  p_TCB->p_dlnk    = NULL;
+  p_TCB->p_blnk    = NULL;
   p_TCB->p_mlnk    = NULL;
-  p_TCB->delta_time    = 0;
-  p_TCB->interval_time = 0;
-  p_TCB->events  = 0;
-  p_TCB->waits   = 0;
-  p_TCB->stack_frame = 0;
+  p_TCB->delta_time    = 0U;
+  p_TCB->interval_time = 0U;
+  p_TCB->events  = 0U;
+  p_TCB->waits   = 0U;
+  p_TCB->stack_frame = 0U;
 
-  if (p_TCB->priv_stack == 0) {
+  if (p_TCB->priv_stack == 0U) {
     /* Allocate the memory space for the stack. */
     p_TCB->stack = rt_alloc_box (mp_stk);
   }
@@ -145,7 +145,7 @@ void rt_block (U16 timeout, U8 block_state) {
   P_TCB next_TCB;
 
   if (timeout) {
-    if (timeout < 0xffff) {
+    if (timeout < 0xFFFFU) {
       rt_put_dly (os_tsk.run, timeout);
     }
     os_tsk.run->state = block_state;
@@ -175,9 +175,9 @@ void rt_tsk_pass (void) {
 OS_TID rt_tsk_self (void) {
   /* Return own task identifier value. */
   if (os_tsk.run == NULL) {
-    return (0);
+    return (0U);
   }
-  return (os_tsk.run->task_id);
+  return ((OS_TID)os_tsk.run->task_id);
 }
 
 
@@ -187,9 +187,9 @@ OS_RESULT rt_tsk_prio (OS_TID task_id, U8 new_prio) {
   /* Change execution priority of a task to "new_prio". */
   P_TCB p_task;
 
-  if (task_id == 0) {
+  if (task_id == 0U) {
     /* Change execution priority of calling task. */
-    os_tsk.run->prio = new_prio;
+    os_tsk.run->prio      = new_prio;
     os_tsk.run->prio_base = new_prio;
 run:if (rt_rdy_prio() > new_prio) {
       rt_put_prio (&os_rdy, os_tsk.run);
@@ -200,12 +200,12 @@ run:if (rt_rdy_prio() > new_prio) {
   }
 
   /* Find the task in the "os_active_TCB" array. */
-  if (task_id > os_maxtaskrun || os_active_TCB[task_id-1] == NULL) {
+  if ((task_id > os_maxtaskrun) || (os_active_TCB[task_id-1U] == NULL)) {
     /* Task with "task_id" not found or not started. */
     return (OS_R_NOK);
   }
-  p_task = os_active_TCB[task_id-1];
-  p_task->prio = new_prio;
+  p_task = os_active_TCB[task_id-1U];
+  p_task->prio      = new_prio;
   p_task->prio_base = new_prio;
   if (p_task == os_tsk.run) {
     goto run;
@@ -228,25 +228,30 @@ OS_TID rt_tsk_create (FUNCP task, U32 prio_stksz, void *stk, void *argv) {
   U32 i;
 
   /* Priority 0 is reserved for idle task! */
-  if ((prio_stksz & 0xFF) == 0) {
-    prio_stksz += 1;
+  if ((prio_stksz & 0xFFU) == 0U) {
+    prio_stksz += 1U;
   }
   task_context = rt_alloc_box (mp_tcb);
   if (task_context == NULL) {
-    return (0);
+    return (0U);
   }
   /* If "size != 0" use a private user provided stack. */
   task_context->stack      = stk;
-  task_context->priv_stack = prio_stksz >> 8;
-  /* Pass parameter 'argv' to 'rt_init_context' */
-  task_context->msg = argv;
-  /* For 'size == 0' system allocates the user stack from the memory pool. */
-  rt_init_context (task_context, prio_stksz & 0xFF, task);
+  task_context->priv_stack = (U16)(prio_stksz >> 8);
 
   /* Find a free entry in 'os_active_TCB' table. */
   i = rt_get_TID ();
-  os_active_TCB[i-1] = task_context;
-  task_context->task_id = i;
+  if (i == 0U) {
+    return (0U);
+  }
+  task_context->task_id = (U8)i;
+  /* Pass parameter 'argv' to 'rt_init_context' */
+  task_context->msg = argv;
+  task_context->argv = argv;
+  /* For 'size == 0' system allocates the user stack from the memory pool. */
+  rt_init_context (task_context, (U8)(prio_stksz & 0xFFU), task);
+
+  os_active_TCB[i-1U] = task_context;
   DBG_TASK_NOTIFY(task_context, __TRUE);
   rt_dispatch (task_context);
   return ((OS_TID)i);
@@ -257,11 +262,11 @@ OS_TID rt_tsk_create (FUNCP task, U32 prio_stksz, void *stk, void *argv) {
 
 OS_RESULT rt_tsk_delete (OS_TID task_id) {
   /* Terminate the task identified with "task_id". */
-  P_TCB task_context;
+  P_TCB  task_context;
   P_TCB  p_TCB;
   P_MUCB p_MCB, p_MCB0;
 
-  if (task_id == 0 || task_id == os_tsk.run->task_id) {
+  if ((task_id == 0U) || (task_id == os_tsk.run->task_id)) {
     /* Terminate itself. */
     os_tsk.run->state     = INACTIVE;
     os_tsk.run->tsk_stack = rt_get_PSP ();
@@ -273,26 +278,30 @@ OS_RESULT rt_tsk_delete (OS_TID task_id) {
         /* A task is waiting for mutex. */
         p_TCB = rt_get_first ((P_XCB)p_MCB);
 #ifdef __CMSIS_RTOS
-        rt_ret_val(p_TCB, 0/*osOK*/);
+        rt_ret_val (p_TCB, 0U/*osOK*/);
 #else
-        rt_ret_val(p_TCB, OS_R_MUT); 
+        rt_ret_val (p_TCB, OS_R_MUT); 
 #endif
         rt_rmv_dly (p_TCB);
         p_TCB->state = READY;
         rt_put_prio (&os_rdy, p_TCB);
         /* A waiting task becomes the owner of this mutex. */
-        p_MCB0 = p_MCB;
-        p_MCB->level  = 1;
+        p_MCB0 = p_MCB->p_mlnk;
+        p_MCB->level  = 1U;
         p_MCB->owner  = p_TCB;
         p_MCB->p_mlnk = p_TCB->p_mlnk;
         p_TCB->p_mlnk = p_MCB; 
-        p_MCB = p_MCB0->p_mlnk;
+        p_MCB = p_MCB0;
       }
       else {
-        p_MCB = p_MCB->p_mlnk;
+        p_MCB0 = p_MCB->p_mlnk;
+        p_MCB->level  = 0U;
+        p_MCB->owner  = NULL;
+        p_MCB->p_mlnk = NULL;
+        p_MCB = p_MCB0;
       }
     }
-    os_active_TCB[os_tsk.run->task_id-1] = NULL;
+    os_active_TCB[os_tsk.run->task_id-1U] = NULL;
     rt_free_box (mp_stk, os_tsk.run->stack);
     os_tsk.run->stack = NULL;
     DBG_TASK_NOTIFY(os_tsk.run, __FALSE);
@@ -303,11 +312,11 @@ OS_RESULT rt_tsk_delete (OS_TID task_id) {
   }
   else {
     /* Find the task in the "os_active_TCB" array. */
-    if (task_id > os_maxtaskrun || os_active_TCB[task_id-1] == NULL) {
+    if ((task_id > os_maxtaskrun) || (os_active_TCB[task_id-1U] == NULL)) {
       /* Task with "task_id" not found or not started. */
       return (OS_R_NOK);
     }
-    task_context = os_active_TCB[task_id-1];
+    task_context = os_active_TCB[task_id-1U];
     rt_rmv_list (task_context);
     rt_rmv_dly (task_context);
     p_MCB = task_context->p_mlnk;
@@ -317,26 +326,30 @@ OS_RESULT rt_tsk_delete (OS_TID task_id) {
         /* A task is waiting for mutex. */
         p_TCB = rt_get_first ((P_XCB)p_MCB);
 #ifdef __CMSIS_RTOS
-        rt_ret_val(p_TCB, 0/*osOK*/);
+        rt_ret_val (p_TCB, 0U/*osOK*/);
 #else
-        rt_ret_val(p_TCB, OS_R_MUT); 
+        rt_ret_val (p_TCB, OS_R_MUT); 
 #endif
         rt_rmv_dly (p_TCB);
         p_TCB->state = READY;
         rt_put_prio (&os_rdy, p_TCB);
         /* A waiting task becomes the owner of this mutex. */
-        p_MCB0 = p_MCB;
-        p_MCB->level  = 1;
+        p_MCB0 = p_MCB->p_mlnk;
+        p_MCB->level  = 1U;
         p_MCB->owner  = p_TCB;
         p_MCB->p_mlnk = p_TCB->p_mlnk;
         p_TCB->p_mlnk = p_MCB; 
-        p_MCB = p_MCB0->p_mlnk;
+        p_MCB = p_MCB0;
       }
       else {
-        p_MCB = p_MCB->p_mlnk;
+        p_MCB0 = p_MCB->p_mlnk;
+        p_MCB->level  = 0U;
+        p_MCB->owner  = NULL;
+        p_MCB->p_mlnk = NULL;
+        p_MCB = p_MCB0;
       }
     }
-    os_active_TCB[task_id-1] = NULL;
+    os_active_TCB[task_id-1U] = NULL;
     rt_free_box (mp_stk, task_context->stack);
     task_context->stack = NULL;
     DBG_TASK_NOTIFY(task_context, __FALSE);
@@ -365,17 +378,17 @@ void rt_sys_init (FUNCP first_task, U32 prio_stksz, void *stk) {
   DBG_INIT();
 
   /* Initialize dynamic memory and task TCB pointers to NULL. */
-  for (i = 0; i < os_maxtaskrun; i++) {
+  for (i = 0U; i < os_maxtaskrun; i++) {
     os_active_TCB[i] = NULL;
   }
-  rt_init_box (&mp_tcb, mp_tcb_size, sizeof(struct OS_TCB));
-  rt_init_box (&mp_stk, mp_stk_size, BOX_ALIGN_8 | (U16)(os_stackinfo));
-  rt_init_box ((U32 *)m_tmr, mp_tmr_size, sizeof(struct OS_TMR));
+  rt_init_box (mp_tcb, (U32)mp_tcb_size, sizeof(struct OS_TCB));
+  rt_init_box (mp_stk, mp_stk_size, BOX_ALIGN_8 | (U16)(os_stackinfo));
+  rt_init_box ((U32 *)m_tmr, (U32)mp_tmr_size, sizeof(struct OS_TMR));
 
   /* Set up TCB of idle demon */
-  os_idle_TCB.task_id    = 255;
-  os_idle_TCB.priv_stack = 0;
-  rt_init_context (&os_idle_TCB, 0, os_idle_demon);
+  os_idle_TCB.task_id    = 255U;
+  os_idle_TCB.priv_stack = 0U;
+  rt_init_context (&os_idle_TCB, 0U, os_idle_demon);
 
   /* Set up ready list: initially empty */
   os_rdy.cb_type = HCB;
@@ -384,31 +397,31 @@ void rt_sys_init (FUNCP first_task, U32 prio_stksz, void *stk) {
   os_dly.cb_type = HCB;
   os_dly.p_dlnk  = NULL;
   os_dly.p_blnk  = NULL;
-  os_dly.delta_time = 0;
+  os_dly.delta_time = 0U;
 
-  /* Fix SP and system variables to assume idle task is running  */
+  /* Fix SP and system variables to assume idle task is running */
   /* Transform main program into idle task by assuming idle TCB */
 #ifndef __CMSIS_RTOS
-  rt_set_PSP (os_idle_TCB.tsk_stack+32);
+  rt_set_PSP (os_idle_TCB.tsk_stack+32U);
 #endif
   os_tsk.run = &os_idle_TCB;
   os_tsk.run->state = RUNNING;
 
   /* Initialize ps queue */
-  os_psq->first = 0;
-  os_psq->last  = 0;
+  os_psq->first = 0U;
+  os_psq->last  = 0U;
   os_psq->size  = os_fifo_size;
 
   rt_init_robin ();
 
+#ifndef __CMSIS_RTOS
   /* Initialize SVC and PendSV */
   rt_svc_init ();
 
-#ifndef __CMSIS_RTOS
   /* Initialize and start system clock timer */
   os_tick_irqn = os_tick_init ();
   if (os_tick_irqn >= 0) {
-    OS_X_INIT(os_tick_irqn);
+    OS_X_INIT((U32)os_tick_irqn);
   }
 
   /* Start up first user task before entering the endless loop */
@@ -423,10 +436,13 @@ void rt_sys_init (FUNCP first_task, U32 prio_stksz, void *stk) {
 void rt_sys_start (void) {
   /* Start system */
 
+  /* Initialize SVC and PendSV */
+  rt_svc_init ();
+
   /* Initialize and start system clock timer */
   os_tick_irqn = os_tick_init ();
   if (os_tick_irqn >= 0) {
-    OS_X_INIT(os_tick_irqn);
+    OS_X_INIT((U32)os_tick_irqn);
   }
 }
 #endif

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Task.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Task.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_TASK.C
  *      Purpose: Task functions and system start up.
- *      Rev.:    V4.80 plus changes for RTX-Ax
+ *      Rev.:    V4.73
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH, 2012-2016 ARM Limited
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -63,12 +63,12 @@ struct OS_TCB os_idle_TCB;
 static OS_TID rt_get_TID (void) {
   U32 tid;
 
-  for (tid = 1U; tid <= os_maxtaskrun; tid++) {
-    if (os_active_TCB[tid-1U] == NULL) {
+  for (tid = 1; tid <= os_maxtaskrun; tid++) {
+    if (os_active_TCB[tid-1] == NULL) {
       return ((OS_TID)tid);
     }
   }
-  return (0U);
+  return (0);
 }
 
 
@@ -76,22 +76,22 @@ static OS_TID rt_get_TID (void) {
 
 static void rt_init_context (P_TCB p_TCB, U8 priority, FUNCP task_body) {
   /* Initialize general part of the Task Control Block. */
-  p_TCB->cb_type   = TCB;
-  p_TCB->state     = READY;
-  p_TCB->prio      = priority;
+  p_TCB->cb_type = TCB;
+  p_TCB->state   = READY;
+  p_TCB->prio    = priority;
   p_TCB->prio_base = priority;
-  p_TCB->p_lnk     = NULL;
-  p_TCB->p_rlnk    = NULL;
-  p_TCB->p_dlnk    = NULL;
-  p_TCB->p_blnk    = NULL;
+  p_TCB->p_lnk   = NULL;
+  p_TCB->p_rlnk  = NULL;
+  p_TCB->p_dlnk  = NULL;
+  p_TCB->p_blnk  = NULL;
   p_TCB->p_mlnk    = NULL;
-  p_TCB->delta_time    = 0U;
-  p_TCB->interval_time = 0U;
-  p_TCB->events  = 0U;
-  p_TCB->waits   = 0U;
-  p_TCB->stack_frame = 0U;
+  p_TCB->delta_time    = 0;
+  p_TCB->interval_time = 0;
+  p_TCB->events  = 0;
+  p_TCB->waits   = 0;
+  p_TCB->stack_frame = 0;
 
-  if (p_TCB->priv_stack == 0U) {
+  if (p_TCB->priv_stack == 0) {
     /* Allocate the memory space for the stack. */
     p_TCB->stack = rt_alloc_box (mp_stk);
   }
@@ -145,7 +145,7 @@ void rt_block (U16 timeout, U8 block_state) {
   P_TCB next_TCB;
 
   if (timeout) {
-    if (timeout < 0xFFFFU) {
+    if (timeout < 0xffff) {
       rt_put_dly (os_tsk.run, timeout);
     }
     os_tsk.run->state = block_state;
@@ -175,9 +175,9 @@ void rt_tsk_pass (void) {
 OS_TID rt_tsk_self (void) {
   /* Return own task identifier value. */
   if (os_tsk.run == NULL) {
-    return (0U);
+    return (0);
   }
-  return ((OS_TID)os_tsk.run->task_id);
+  return (os_tsk.run->task_id);
 }
 
 
@@ -187,9 +187,9 @@ OS_RESULT rt_tsk_prio (OS_TID task_id, U8 new_prio) {
   /* Change execution priority of a task to "new_prio". */
   P_TCB p_task;
 
-  if (task_id == 0U) {
+  if (task_id == 0) {
     /* Change execution priority of calling task. */
-    os_tsk.run->prio      = new_prio;
+    os_tsk.run->prio = new_prio;
     os_tsk.run->prio_base = new_prio;
 run:if (rt_rdy_prio() > new_prio) {
       rt_put_prio (&os_rdy, os_tsk.run);
@@ -200,12 +200,12 @@ run:if (rt_rdy_prio() > new_prio) {
   }
 
   /* Find the task in the "os_active_TCB" array. */
-  if ((task_id > os_maxtaskrun) || (os_active_TCB[task_id-1U] == NULL)) {
+  if (task_id > os_maxtaskrun || os_active_TCB[task_id-1] == NULL) {
     /* Task with "task_id" not found or not started. */
     return (OS_R_NOK);
   }
-  p_task = os_active_TCB[task_id-1U];
-  p_task->prio      = new_prio;
+  p_task = os_active_TCB[task_id-1];
+  p_task->prio = new_prio;
   p_task->prio_base = new_prio;
   if (p_task == os_tsk.run) {
     goto run;
@@ -228,30 +228,25 @@ OS_TID rt_tsk_create (FUNCP task, U32 prio_stksz, void *stk, void *argv) {
   U32 i;
 
   /* Priority 0 is reserved for idle task! */
-  if ((prio_stksz & 0xFFU) == 0U) {
-    prio_stksz += 1U;
+  if ((prio_stksz & 0xFF) == 0) {
+    prio_stksz += 1;
   }
   task_context = rt_alloc_box (mp_tcb);
   if (task_context == NULL) {
-    return (0U);
+    return (0);
   }
   /* If "size != 0" use a private user provided stack. */
   task_context->stack      = stk;
-  task_context->priv_stack = (U16)(prio_stksz >> 8);
+  task_context->priv_stack = prio_stksz >> 8;
+  /* Pass parameter 'argv' to 'rt_init_context' */
+  task_context->msg = argv;
+  /* For 'size == 0' system allocates the user stack from the memory pool. */
+  rt_init_context (task_context, prio_stksz & 0xFF, task);
 
   /* Find a free entry in 'os_active_TCB' table. */
   i = rt_get_TID ();
-  if (i == 0U) {
-    return (0U);
-  }
-  task_context->task_id = (U8)i;
-  /* Pass parameter 'argv' to 'rt_init_context' */
-  task_context->msg = argv;
-  task_context->argv = argv;
-  /* For 'size == 0' system allocates the user stack from the memory pool. */
-  rt_init_context (task_context, (U8)(prio_stksz & 0xFFU), task);
-
-  os_active_TCB[i-1U] = task_context;
+  os_active_TCB[i-1] = task_context;
+  task_context->task_id = i;
   DBG_TASK_NOTIFY(task_context, __TRUE);
   rt_dispatch (task_context);
   return ((OS_TID)i);
@@ -262,11 +257,11 @@ OS_TID rt_tsk_create (FUNCP task, U32 prio_stksz, void *stk, void *argv) {
 
 OS_RESULT rt_tsk_delete (OS_TID task_id) {
   /* Terminate the task identified with "task_id". */
-  P_TCB  task_context;
+  P_TCB task_context;
   P_TCB  p_TCB;
   P_MUCB p_MCB, p_MCB0;
 
-  if ((task_id == 0U) || (task_id == os_tsk.run->task_id)) {
+  if (task_id == 0 || task_id == os_tsk.run->task_id) {
     /* Terminate itself. */
     os_tsk.run->state     = INACTIVE;
     os_tsk.run->tsk_stack = rt_get_PSP ();
@@ -278,30 +273,26 @@ OS_RESULT rt_tsk_delete (OS_TID task_id) {
         /* A task is waiting for mutex. */
         p_TCB = rt_get_first ((P_XCB)p_MCB);
 #ifdef __CMSIS_RTOS
-        rt_ret_val (p_TCB, 0U/*osOK*/);
+        rt_ret_val(p_TCB, 0/*osOK*/);
 #else
-        rt_ret_val (p_TCB, OS_R_MUT); 
+        rt_ret_val(p_TCB, OS_R_MUT); 
 #endif
         rt_rmv_dly (p_TCB);
         p_TCB->state = READY;
         rt_put_prio (&os_rdy, p_TCB);
         /* A waiting task becomes the owner of this mutex. */
-        p_MCB0 = p_MCB->p_mlnk;
-        p_MCB->level  = 1U;
+        p_MCB0 = p_MCB;
+        p_MCB->level  = 1;
         p_MCB->owner  = p_TCB;
         p_MCB->p_mlnk = p_TCB->p_mlnk;
         p_TCB->p_mlnk = p_MCB; 
-        p_MCB = p_MCB0;
+        p_MCB = p_MCB0->p_mlnk;
       }
       else {
-        p_MCB0 = p_MCB->p_mlnk;
-        p_MCB->level  = 0U;
-        p_MCB->owner  = NULL;
-        p_MCB->p_mlnk = NULL;
-        p_MCB = p_MCB0;
+        p_MCB = p_MCB->p_mlnk;
       }
     }
-    os_active_TCB[os_tsk.run->task_id-1U] = NULL;
+    os_active_TCB[os_tsk.run->task_id-1] = NULL;
     rt_free_box (mp_stk, os_tsk.run->stack);
     os_tsk.run->stack = NULL;
     DBG_TASK_NOTIFY(os_tsk.run, __FALSE);
@@ -312,11 +303,11 @@ OS_RESULT rt_tsk_delete (OS_TID task_id) {
   }
   else {
     /* Find the task in the "os_active_TCB" array. */
-    if ((task_id > os_maxtaskrun) || (os_active_TCB[task_id-1U] == NULL)) {
+    if (task_id > os_maxtaskrun || os_active_TCB[task_id-1] == NULL) {
       /* Task with "task_id" not found or not started. */
       return (OS_R_NOK);
     }
-    task_context = os_active_TCB[task_id-1U];
+    task_context = os_active_TCB[task_id-1];
     rt_rmv_list (task_context);
     rt_rmv_dly (task_context);
     p_MCB = task_context->p_mlnk;
@@ -326,30 +317,26 @@ OS_RESULT rt_tsk_delete (OS_TID task_id) {
         /* A task is waiting for mutex. */
         p_TCB = rt_get_first ((P_XCB)p_MCB);
 #ifdef __CMSIS_RTOS
-        rt_ret_val (p_TCB, 0U/*osOK*/);
+        rt_ret_val(p_TCB, 0/*osOK*/);
 #else
-        rt_ret_val (p_TCB, OS_R_MUT); 
+        rt_ret_val(p_TCB, OS_R_MUT); 
 #endif
         rt_rmv_dly (p_TCB);
         p_TCB->state = READY;
         rt_put_prio (&os_rdy, p_TCB);
         /* A waiting task becomes the owner of this mutex. */
-        p_MCB0 = p_MCB->p_mlnk;
-        p_MCB->level  = 1U;
+        p_MCB0 = p_MCB;
+        p_MCB->level  = 1;
         p_MCB->owner  = p_TCB;
         p_MCB->p_mlnk = p_TCB->p_mlnk;
         p_TCB->p_mlnk = p_MCB; 
-        p_MCB = p_MCB0;
+        p_MCB = p_MCB0->p_mlnk;
       }
       else {
-        p_MCB0 = p_MCB->p_mlnk;
-        p_MCB->level  = 0U;
-        p_MCB->owner  = NULL;
-        p_MCB->p_mlnk = NULL;
-        p_MCB = p_MCB0;
+        p_MCB = p_MCB->p_mlnk;
       }
     }
-    os_active_TCB[task_id-1U] = NULL;
+    os_active_TCB[task_id-1] = NULL;
     rt_free_box (mp_stk, task_context->stack);
     task_context->stack = NULL;
     DBG_TASK_NOTIFY(task_context, __FALSE);
@@ -378,17 +365,17 @@ void rt_sys_init (FUNCP first_task, U32 prio_stksz, void *stk) {
   DBG_INIT();
 
   /* Initialize dynamic memory and task TCB pointers to NULL. */
-  for (i = 0U; i < os_maxtaskrun; i++) {
+  for (i = 0; i < os_maxtaskrun; i++) {
     os_active_TCB[i] = NULL;
   }
-  rt_init_box (mp_tcb, (U32)mp_tcb_size, sizeof(struct OS_TCB));
-  rt_init_box (mp_stk, mp_stk_size, BOX_ALIGN_8 | (U16)(os_stackinfo));
-  rt_init_box ((U32 *)m_tmr, (U32)mp_tmr_size, sizeof(struct OS_TMR));
+  rt_init_box (&mp_tcb, mp_tcb_size, sizeof(struct OS_TCB));
+  rt_init_box (&mp_stk, mp_stk_size, BOX_ALIGN_8 | (U16)(os_stackinfo));
+  rt_init_box ((U32 *)m_tmr, mp_tmr_size, sizeof(struct OS_TMR));
 
   /* Set up TCB of idle demon */
-  os_idle_TCB.task_id    = 255U;
-  os_idle_TCB.priv_stack = 0U;
-  rt_init_context (&os_idle_TCB, 0U, os_idle_demon);
+  os_idle_TCB.task_id    = 255;
+  os_idle_TCB.priv_stack = 0;
+  rt_init_context (&os_idle_TCB, 0, os_idle_demon);
 
   /* Set up ready list: initially empty */
   os_rdy.cb_type = HCB;
@@ -397,31 +384,31 @@ void rt_sys_init (FUNCP first_task, U32 prio_stksz, void *stk) {
   os_dly.cb_type = HCB;
   os_dly.p_dlnk  = NULL;
   os_dly.p_blnk  = NULL;
-  os_dly.delta_time = 0U;
+  os_dly.delta_time = 0;
 
-  /* Fix SP and system variables to assume idle task is running */
+  /* Fix SP and system variables to assume idle task is running  */
   /* Transform main program into idle task by assuming idle TCB */
 #ifndef __CMSIS_RTOS
-  rt_set_PSP (os_idle_TCB.tsk_stack+32U);
+  rt_set_PSP (os_idle_TCB.tsk_stack+32);
 #endif
   os_tsk.run = &os_idle_TCB;
   os_tsk.run->state = RUNNING;
 
   /* Initialize ps queue */
-  os_psq->first = 0U;
-  os_psq->last  = 0U;
+  os_psq->first = 0;
+  os_psq->last  = 0;
   os_psq->size  = os_fifo_size;
 
   rt_init_robin ();
 
-#ifndef __CMSIS_RTOS
   /* Initialize SVC and PendSV */
   rt_svc_init ();
 
+#ifndef __CMSIS_RTOS
   /* Initialize and start system clock timer */
   os_tick_irqn = os_tick_init ();
   if (os_tick_irqn >= 0) {
-    OS_X_INIT((U32)os_tick_irqn);
+    OS_X_INIT(os_tick_irqn);
   }
 
   /* Start up first user task before entering the endless loop */
@@ -436,13 +423,10 @@ void rt_sys_init (FUNCP first_task, U32 prio_stksz, void *stk) {
 void rt_sys_start (void) {
   /* Start system */
 
-  /* Initialize SVC and PendSV */
-  rt_svc_init ();
-
   /* Initialize and start system clock timer */
   os_tick_irqn = os_tick_init ();
   if (os_tick_irqn >= 0) {
-    OS_X_INIT((U32)os_tick_irqn);
+    OS_X_INIT(os_tick_irqn);
   }
 }
 #endif

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Task.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Task.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_TASK.H
  *      Purpose: Task functions and system start up.
- *      Rev.:    V4.70
+ *      Rev.:    V4.79
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -35,26 +35,26 @@
 /* Definitions */
 
 /* Values for 'state'   */
-#define INACTIVE        0
-#define READY           1
-#define RUNNING         2
-#define WAIT_DLY        3
-#define WAIT_ITV        4
-#define WAIT_OR         5
-#define WAIT_AND        6
-#define WAIT_SEM        7
-#define WAIT_MBX        8
-#define WAIT_MUT        9
+#define INACTIVE        0U
+#define READY           1U
+#define RUNNING         2U
+#define WAIT_DLY        3U
+#define WAIT_ITV        4U
+#define WAIT_OR         5U
+#define WAIT_AND        6U
+#define WAIT_SEM        7U
+#define WAIT_MBX        8U
+#define WAIT_MUT        9U
 
 /* Return codes */
-#define OS_R_TMO        0x01
-#define OS_R_EVT        0x02
-#define OS_R_SEM        0x03
-#define OS_R_MBX        0x04
-#define OS_R_MUT        0x05
+#define OS_R_TMO        0x01U
+#define OS_R_EVT        0x02U
+#define OS_R_SEM        0x03U
+#define OS_R_MBX        0x04U
+#define OS_R_MUT        0x05U
 
-#define OS_R_OK         0x00
-#define OS_R_NOK        0xff
+#define OS_R_OK         0x00U
+#define OS_R_NOK        0xFFU
 
 /* Variables */
 extern struct OS_TSK os_tsk;
@@ -79,9 +79,3 @@ extern void      rt_sys_init   (FUNCP first_task, U32 prio_stksz, void *stk);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-
-
-
-
-
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Task.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Task.h
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_TASK.H
  *      Purpose: Task functions and system start up.
- *      Rev.:    V4.79
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -35,26 +35,26 @@
 /* Definitions */
 
 /* Values for 'state'   */
-#define INACTIVE        0U
-#define READY           1U
-#define RUNNING         2U
-#define WAIT_DLY        3U
-#define WAIT_ITV        4U
-#define WAIT_OR         5U
-#define WAIT_AND        6U
-#define WAIT_SEM        7U
-#define WAIT_MBX        8U
-#define WAIT_MUT        9U
+#define INACTIVE        0
+#define READY           1
+#define RUNNING         2
+#define WAIT_DLY        3
+#define WAIT_ITV        4
+#define WAIT_OR         5
+#define WAIT_AND        6
+#define WAIT_SEM        7
+#define WAIT_MBX        8
+#define WAIT_MUT        9
 
 /* Return codes */
-#define OS_R_TMO        0x01U
-#define OS_R_EVT        0x02U
-#define OS_R_SEM        0x03U
-#define OS_R_MBX        0x04U
-#define OS_R_MUT        0x05U
+#define OS_R_TMO        0x01
+#define OS_R_EVT        0x02
+#define OS_R_SEM        0x03
+#define OS_R_MBX        0x04
+#define OS_R_MUT        0x05
 
-#define OS_R_OK         0x00U
-#define OS_R_NOK        0xFFU
+#define OS_R_OK         0x00
+#define OS_R_NOK        0xff
 
 /* Variables */
 extern struct OS_TSK os_tsk;
@@ -79,3 +79,9 @@ extern void      rt_sys_init   (FUNCP first_task, U32 prio_stksz, void *stk);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+
+
+
+
+
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Time.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Time.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_TIME.C
  *      Purpose: Delay and interval wait functions
- *      Rev.:    V4.70
+ *      Rev.:    V4.79
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -83,7 +83,7 @@ void rt_itv_wait (void) {
 
   delta = os_tsk.run->delta_time - (U16)os_time;
   os_tsk.run->delta_time += os_tsk.run->interval_time;
-  if ((delta & 0x8000) == 0) {
+  if ((delta & 0x8000U) == 0U) {
     rt_block (delta, WAIT_ITV);
   }
 }
@@ -91,4 +91,3 @@ void rt_itv_wait (void) {
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Time.c
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Time.c
@@ -1,12 +1,12 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_TIME.C
  *      Purpose: Delay and interval wait functions
- *      Rev.:    V4.79
+ *      Rev.:    V4.70
  *----------------------------------------------------------------------------
  *
- * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * Copyright (c) 1999-2009 KEIL, 2009-2013 ARM Germany GmbH
  * All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -83,7 +83,7 @@ void rt_itv_wait (void) {
 
   delta = os_tsk.run->delta_time - (U16)os_time;
   os_tsk.run->delta_time += os_tsk.run->interval_time;
-  if ((delta & 0x8000U) == 0U) {
+  if ((delta & 0x8000) == 0) {
     rt_block (delta, WAIT_ITV);
   }
 }
@@ -91,3 +91,4 @@ void rt_itv_wait (void) {
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Time.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Time.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_TIME.H
  *      Purpose: Delay and interval wait functions definitions
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -44,4 +44,3 @@ extern void rt_itv_wait (void);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Time.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Time.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_TIME.H
  *      Purpose: Delay and interval wait functions definitions
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -44,3 +44,4 @@ extern void rt_itv_wait (void);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Timer.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Timer.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_TIMER.H
  *      Purpose: User timer functions
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -43,4 +43,3 @@ extern OS_ID rt_tmr_kill   (OS_ID timer);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_Timer.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_Timer.h
@@ -1,5 +1,5 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_TIMER.H
  *      Purpose: User timer functions
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -43,3 +43,4 @@ extern OS_ID rt_tmr_kill   (OS_ID timer);
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+

--- a/rtos/rtx/TARGET_CORTEX_A/rt_TypeDef.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_TypeDef.h
@@ -1,9 +1,9 @@
 /*----------------------------------------------------------------------------
- *      RL-ARM - RTX
+ *      CMSIS-RTOS  -  RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_TYPEDEF.H
  *      Purpose: Type Definitions
- *      Rev.:    V4.73 (plus large stack)
+ *      Rev.:    V4.79 (plus large stack)
  *----------------------------------------------------------------------------
  *
  * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without
+ *  - Neither the name of ARM  nor the names of its contributors may be used 
+ *    to endorse or promote products derived from this software without 
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -177,11 +177,10 @@ typedef struct OS_BM {
 } *P_BM;
 
 /* Definitions */
-#define __TRUE          1
-#define __FALSE         0
+#define __TRUE          1U
+#define __FALSE         0U
 #define NULL            ((void *) 0)
 
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
-

--- a/rtos/rtx/TARGET_CORTEX_A/rt_TypeDef.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_TypeDef.h
@@ -1,9 +1,9 @@
 /*----------------------------------------------------------------------------
- *      CMSIS-RTOS  -  RTX
+ *      RL-ARM - RTX
  *----------------------------------------------------------------------------
  *      Name:    RT_TYPEDEF.H
  *      Purpose: Type Definitions
- *      Rev.:    V4.79 (plus large stack)
+ *      Rev.:    V4.73 (plus large stack)
  *----------------------------------------------------------------------------
  *
  * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
@@ -15,19 +15,19 @@
  *  - Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- *  - Neither the name of ARM  nor the names of its contributors may be used 
- *    to endorse or promote products derived from this software without 
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
  *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *---------------------------------------------------------------------------*/
@@ -177,10 +177,11 @@ typedef struct OS_BM {
 } *P_BM;
 
 /* Definitions */
-#define __TRUE          1U
-#define __FALSE         0U
+#define __TRUE          1
+#define __FALSE         0
 #define NULL            ((void *) 0)
 
 /*----------------------------------------------------------------------------
  * end of file
  *---------------------------------------------------------------------------*/
+


### PR DESCRIPTION
PR to update RTX to v4.80 for Cortex-A.
In the latest CI test, three tests result in an error. The cause is mainly three points
- Unsupport RTX v4.80 for Cortex-A
- Insufficient stack size of thread defined in test
- A few Lack of Malloc API in GCC
Therefore, I supported to these. For the stack size for test, @c1728p9 already supported in PR #3362.

Reference for issue of test error is here.
https://github.com/ARMmbed/mbed-os/issues/3273

Reference for PR to update RTX for Cortex-M.
https://github.com/ARMmbed/mbed-os/pull/1702
