### PR TITLE
[RZ/A1H]Fix TTB setting of RO_DATA area

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1H/device/mmu_Renesas_RZ_A1.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1H/device/mmu_Renesas_RZ_A1.c
@@ -198,13 +198,13 @@ void create_translation_table(void)
 
 #if defined( __ICCARM__ )
     //Define Image
-    __TTSection (&Image$$TTB$$ZI$$Base, (uint32_t)Image$$RO_DATA$$Base, RO_DATA_SIZE, Sect_Normal_RO);
+    __TTSection (&Image$$TTB$$ZI$$Base, (uint32_t)Image$$RO_DATA$$Base, RO_DATA_SIZE, Sect_Normal_Cod);
     __TTSection (&Image$$TTB$$ZI$$Base, (uint32_t)Image$$VECTORS$$Base, VECTORS_SIZE, Sect_Normal_Cod);
     __TTSection (&Image$$TTB$$ZI$$Base, (uint32_t)Image$$RW_DATA$$Base, RW_DATA_SIZE, Sect_Normal_RW);
     __TTSection (&Image$$TTB$$ZI$$Base, (uint32_t)Image$$ZI_DATA$$Base, ZI_DATA_SIZE, Sect_Normal_RW);
 #else
     //Define Image
-    __TTSection (&Image$$TTB$$ZI$$Base, (uint32_t)&Image$$RO_DATA$$Base, RO_DATA_SIZE, Sect_Normal_RO);
+    __TTSection (&Image$$TTB$$ZI$$Base, (uint32_t)&Image$$RO_DATA$$Base, RO_DATA_SIZE, Sect_Normal_Cod);
     __TTSection (&Image$$TTB$$ZI$$Base, (uint32_t)&Image$$VECTORS$$Base, VECTORS_SIZE, Sect_Normal_Cod);
     __TTSection (&Image$$TTB$$ZI$$Base, (uint32_t)&Image$$RW_DATA$$Base, RW_DATA_SIZE, Sect_Normal_RW);
     __TTSection (&Image$$TTB$$ZI$$Base, (uint32_t)&Image$$ZI_DATA$$Base, ZI_DATA_SIZE, Sect_Normal_RW);


### PR DESCRIPTION
I modified the TTB setting of RO_DATA area.
The current setting of this area is "not executable".
Therefore, when trying to execute a program placed in this area, a prefetch abort will occur.
So I changed from "Sect_Normal_RO" to "Sect_Normal_Cod".