### PR TITLE
Removing default toolchain paths

### DIFF
--- a/tools/settings.py
+++ b/tools/settings.py
@@ -28,19 +28,19 @@ ROOT = abspath(join(dirname(__file__), ".."))
 BUILD_DIR = abspath(join(ROOT, "BUILD"))
 
 # ARM Compiler 5
-ARM_PATH = "C:/Keil_v5/ARM/ARMCC"
+ARM_PATH = ""
 
 # GCC ARM
 GCC_ARM_PATH = ""
 
 # GCC CodeRed
-GCC_CR_PATH = "C:/code_red/RedSuite_4.2.0_349/redsuite/Tools/bin"
+GCC_CR_PATH = ""
 
 # IAR
-IAR_PATH = "C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.3/arm"
+IAR_PATH = ""
 
 # Goanna static analyser. Please overload it in mbed_settings.py
-GOANNA_PATH = "c:/Program Files (x86)/RedLizards/Goanna Central 3.2.3/bin"
+GOANNA_PATH = ""
 
 # cppcheck path (command) and output message format
 CPPCHECK_CMD = ["cppcheck", "--enable=all"]


### PR DESCRIPTION
## Description
This change was spurred by a confusing error. I attempted to compile for the RZ_A1H (a Cortex-A device), and I had the standalone ARM compiler in my system path, which supports Cortex-A. However, the default path for the ARM compiler in settings.py uses a Keil installation, which only supports Cortex-M. It found my Keil installation and used that instead, **causing a compiler error**. This change proposes to remove this default behavior and instead **requires the user to explicitly set the intended compiler path**, either by a settings file, mbed CLI, environment variables, or by placing the compiler in your PATH.


## Status
**READY**


## Migrations
**YES**

This will now require that a user sets the compiler paths via mbed CLI, environment variables, settings files, or by placing them in the system PATH.

I realize this could be a breaking change for some developers, so perhaps we should wait a release before doing this? We could detect that the default path in settings.py is being used and warn the users to set the compiler path explicitly. **Open to suggestions here!**

## Todos
- [ ] Tests
- [ ] Documentation


## Notes to Maintainers
I requested a lot of reviewers on this PR since this is changing some legacy behavior that we've had for quite some time now. It'd be good to get input from everyone since this may affect many different parts of the mbed ecosystem.
