### PR TITLE
Improve error message when exporting for make without a linker script

### DIFF
--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -40,6 +40,9 @@ class Makefile(Exporter):
 
         Note: subclasses should not need to override this method
         """
+        if not self.resources.linker_script:
+            raise NotSupportedException("No linker script found.")
+
         self.resources.win_to_unix()
 
         to_be_compiled = [splitext(src)[0] + ".o" for src in


### PR DESCRIPTION
## Description
The error message is a bit better.


## Status
**READY**

## Todos
- [x] Manual test that not having a linker script causes this error

## Sample output
### Before
```
Scan: basic
Scan: env
Scan: hal
Traceback (most recent call last):
  File "project.py", line 244, in <module>
    main()
  File "project.py", line 240, in main
    zip_proj=zip_proj, build_profile=profile)
  File "project.py", line 93, in export
    build_profile=build_profile, silent=silent)
  File "D:\mbed-os-mbed-os-5.2\tools\project_api.py", line 229, in export_project
    macros=macros)
  File "D:\mbed-os-mbed-os-5.2\tools\project_api.py", line 90, in generate_project_files
    exporter.generate()
  File "D:\mbed-os-mbed-os-5.2\tools\export\cdt\__init__.py", line 14, in generate
    super(Eclipse, self).generate()
  File "D:\mbed-os-mbed-os-5.2\tools\export\makefile\__init__.py", line 82, in generate
    ctx[key] = ctx['vpath'][0] + "/" + ctx[key]
TypeError: cannot concatenate 'str' and 'NoneType' objects
```
### After
```
Scan: basic
Scan: env
Scan: hal
Traceback (most recent call last):
  File "tools/project.py", line 248, in <module>
    main()
  File "tools/project.py", line 244, in main
    zip_proj=zip_proj, build_profile=profile)
  File "tools/project.py", line 94, in export
    build_profile=build_profile, silent=silent)
  File "/home/jimbri01/src/mbedmicro/mbed/tools/project_api.py", line 228, in export_project
    macros=macros)
  File "/home/jimbri01/src/mbedmicro/mbed/tools/project_api.py", line 89, in generate_project_files
    exporter.generate()
  File "/home/jimbri01/src/mbedmicro/mbed/tools/export/makefile/__init__.py", line 44, in generate
    raise NotSupportedException("No linker script found.")
tools.utils.NotSupportedException: No linker script found.
```