### PR TITLE
Fix deprecated Thread ctor usage in RTOS tests

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/isr/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/isr/main.cpp
@@ -40,7 +40,7 @@ void queue_isr() {
     myled = !myled;
 }
 
-void queue_thread(void const *argument) {
+void queue_thread() {
     while (true) {
         queue.put((uint32_t*)QUEUE_PUT_THREAD_VALUE);
         Thread::wait(THREAD_DELAY);
@@ -50,7 +50,8 @@ void queue_thread(void const *argument) {
 int main (void) {
     GREENTEA_SETUP(20, "default_auto");
 
-    Thread thread(queue_thread, NULL, osPriorityNormal, STACK_SIZE);
+    Thread thread(osPriorityNormal, STACK_SIZE);
+    thread.start(queue_thread);
     Ticker ticker;
     ticker.attach(queue_isr, 1.0);
     int isr_puts_counter = 0;

--- a/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
@@ -38,7 +38,7 @@ typedef struct {
 
 Mail<mail_t, QUEUE_SIZE> mail_box;
 
-void send_thread (void const *argument) {
+void send_thread () {
     static uint32_t i = 10;
     while (true) {
         i++; // fake data update
@@ -54,7 +54,8 @@ void send_thread (void const *argument) {
 int main (void) {
     GREENTEA_SETUP(20, "default_auto");
 
-    Thread thread(send_thread, NULL, osPriorityNormal, STACK_SIZE);
+    Thread thread(osPriorityNormal, STACK_SIZE);
+    thread.start(send_thread);
     bool result = true;
     int result_counter = 0;
 

--- a/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
@@ -77,10 +77,9 @@ bool manipulate_protected_zone(const int thread_delay) {
     return result;
 }
 
-void test_thread(void const *args) {
-    const int thread_delay = int(args);
+void test_thread(int const *thread_delay) {
     while (true) {
-        manipulate_protected_zone(thread_delay);
+        manipulate_protected_zone(*thread_delay);
     }
 }
 
@@ -90,8 +89,11 @@ int main() {
     const int t1_delay = THREAD_DELAY * 1;
     const int t2_delay = THREAD_DELAY * 2;
     const int t3_delay = THREAD_DELAY * 3;
-    Thread t2(test_thread, (void *)t2_delay, osPriorityNormal, STACK_SIZE);
-    Thread t3(test_thread, (void *)t3_delay, osPriorityNormal, STACK_SIZE);
+    Thread t2(osPriorityNormal, STACK_SIZE);
+    Thread t3(osPriorityNormal, STACK_SIZE);
+
+    t2.start(callback(test_thread, &t2_delay));
+    t3.start(callback(test_thread, &t3_delay));
 
     while (true) {
         // Thread 1 action

--- a/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
@@ -40,7 +40,7 @@ MemoryPool<message_t, QUEUE_SIZE> mpool;
 Queue<message_t, QUEUE_SIZE> queue;
 
 /* Send Thread */
-void send_thread (void const *argument) {
+void send_thread () {
     static uint32_t i = 10;
     while (true) {
         i++; // Fake data update
@@ -56,7 +56,8 @@ void send_thread (void const *argument) {
 int main (void) {
     GREENTEA_SETUP(20, "default_auto");
 
-    Thread thread(send_thread, NULL, osPriorityNormal, STACK_SIZE);
+    Thread thread(osPriorityNormal, STACK_SIZE);
+    thread.start(send_thread);
     bool result = true;
     int result_counter = 0;
 

--- a/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
@@ -56,8 +56,8 @@ volatile int change_counter = 0;
 volatile int sem_counter = 0;
 volatile bool sem_defect = false;
 
-void test_thread(void const *delay) {
-    const int thread_delay = int(delay);
+void test_thread(int const *delay) {
+    const int thread_delay = *delay;
     while (true) {
         two_slots.wait();
         sem_counter++;
@@ -81,9 +81,13 @@ int main (void) {
     const int t1_delay = THREAD_DELAY * 1;
     const int t2_delay = THREAD_DELAY * 2;
     const int t3_delay = THREAD_DELAY * 3;
-    Thread t1(test_thread, (void *)t1_delay, osPriorityNormal, STACK_SIZE);
-    Thread t2(test_thread, (void *)t2_delay, osPriorityNormal, STACK_SIZE);
-    Thread t3(test_thread, (void *)t3_delay, osPriorityNormal, STACK_SIZE);
+    Thread t1(osPriorityNormal, STACK_SIZE);
+    Thread t2(osPriorityNormal, STACK_SIZE);
+    Thread t3(osPriorityNormal, STACK_SIZE);
+
+    t1.start(callback(test_thread, &t1_delay));
+    t2.start(callback(test_thread, &t2_delay));
+    t3.start(callback(test_thread, &t3_delay));
 
     while (true) {
         if (change_counter >= SEM_CHANGES or sem_defect == true) {

--- a/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
@@ -32,7 +32,7 @@ const int SIGNAL_HANDLE_DELEY = 25;
 DigitalOut led(LED1);
 int signal_counter = 0;
 
-void led_thread(void const *argument) {
+void led_thread() {
     while (true) {
         // Signal flags that are reported as event are automatically cleared.
         Thread::signal_wait(SIGNAL_SET_VALUE);
@@ -44,7 +44,8 @@ void led_thread(void const *argument) {
 int main (void) {
     GREENTEA_SETUP(20, "default_auto");
 
-    Thread thread(led_thread, NULL, osPriorityNormal, STACK_SIZE);
+    Thread thread(osPriorityNormal, STACK_SIZE);
+    thread.start(led_thread);
     bool result = false;
 
     printf("Handling %d signals...\r\n", SIGNALS_TO_EMIT);


### PR DESCRIPTION
Thread spawning constructors are deprecated, start function should be
used instead.

## Status
**READY**