### PR TITLE
Feature lwip broadcast

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -858,6 +858,18 @@ static nsapi_error_t mbed_lwip_setsockopt(nsapi_stack_t *stack, nsapi_socket_t h
             }
             return 0;
 
+        case NSAPI_BROADCAST:
+            if (optlen != sizeof(int) || (s->conn->type != NETCONN_UDP && s->conn->type != NETCONN_RAW)) {
+                return NSAPI_ERROR_UNSUPPORTED;
+            }
+
+            if (*(int *)optval) {
+                s->conn->pcb.udp->so_options |= SOF_BROADCAST;
+            } else {
+                s->conn->pcb.udp->so_options &= SOF_BROADCAST;
+            }
+            return 0;
+
         default:
             return NSAPI_ERROR_UNSUPPORTED;
     }

--- a/features/netsocket/UDPSocket.cpp
+++ b/features/netsocket/UDPSocket.cpp
@@ -121,6 +121,12 @@ nsapi_size_or_error_t UDPSocket::recvfrom(SocketAddress *address, void *buffer, 
     return ret;
 }
 
+nsapi_error_t UDPSocket::set_broadcast(bool broadcast)
+{
+    int _broadcast = broadcast ? 1 : 0;
+    return setsockopt(NSAPI_SOCKET, NSAPI_BROADCAST, &_broadcast, sizeof(int));
+}
+
 void UDPSocket::event()
 {
     int32_t wcount = _write_sem.wait(0);

--- a/features/netsocket/UDPSocket.h
+++ b/features/netsocket/UDPSocket.h
@@ -112,6 +112,17 @@ public:
     nsapi_size_or_error_t recvfrom(SocketAddress *address,
             void *data, nsapi_size_t size);
 
+    /** Set broadcast packet behaviour
+     *
+     *  Initially all sockets ignore broadcast packets.
+     *  Setting broadcast to true enable the reception of broadcast packets.
+     *
+     *  @param broadcast    true to enable or false to disable broadcast
+     *                      packets reception
+     *  @return             nsapi_error_t on error or 0 if sucessfull
+     */
+    nsapi_error_t set_broadcast(bool broadcast);
+
 protected:
     virtual nsapi_protocol_t get_proto();
     virtual void event();

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -184,6 +184,7 @@ typedef enum nsapi_option {
     NSAPI_LINGER,    /*!< Keeps close from returning until queues empty */
     NSAPI_SNDBUF,    /*!< Sets send buffer size */
     NSAPI_RCVBUF,    /*!< Sets recv buffer size */
+    NSAPI_BROADCAST, /*!< Receive broadcast packets */
 } nsapi_option_t;
 
 /** nsapi_wifi_ap structure


### PR DESCRIPTION
## Description
Implement to SO_BROADCAST socket option and provide a UDPSocket::set_broadcast(bool) method.

```cpp
sock.set_broadcast(true); // Enable reception of broadcast packets
```

Fix  #3395.

## Status
**READY**