### PR TITLE
Fix #3463 CAN read() return value

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/can_api.c
@@ -267,10 +267,10 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
     /* Release the FIFO */
     if (handle == CAN_FIFO0) {
         /* Release FIFO0 */
-        can->RF0R = CAN_RF0R_RFOM0;
+        can->RF0R |= CAN_RF0R_RFOM0;
     } else { /* FIFONumber == CAN_FIFO1 */
       /* Release FIFO1 */
-      can->RF1R = CAN_RF1R_RFOM1;
+      can->RF1R |= CAN_RF1R_RFOM1;
     }
 
     return 1;

--- a/targets/TARGET_STM/TARGET_STM32F0/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/can_api.c
@@ -235,6 +235,12 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
 
     CAN_TypeDef *can = (CAN_TypeDef *)(obj->can);    
     
+    // check FPM0 which holds the pending message count in FIFO 0
+    // if no message is pending, return 0
+    if ((can->RF0R & CAN_RF0R_FMP0) == 0) {
+        return 0;
+    }
+
     /* Get the Id */
     msg->format = (CANFormat)((uint8_t)0x04 & can->sFIFOMailBox[handle].RIR);
     if (!msg->format) {

--- a/targets/TARGET_STM/TARGET_STM32F1/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/can_api.c
@@ -238,6 +238,12 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
 
     CAN_TypeDef *can = (CAN_TypeDef *)(obj->can);    
     
+    // check FPM0 which holds the pending message count in FIFO 0
+    // if no message is pending, return 0
+    if ((can->RF0R & CAN_RF0R_FMP0) == 0) {
+        return 0;
+    }
+
     /* Get the Id */
     msg->format = (CANFormat)((uint8_t)0x04 & can->sFIFOMailBox[handle].RIR);
     if (!msg->format) {

--- a/targets/TARGET_STM/TARGET_STM32F1/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/can_api.c
@@ -270,10 +270,10 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
     /* Release the FIFO */
     if(handle == CAN_FIFO0) {
         /* Release FIFO0 */
-        can->RF0R = CAN_RF0R_RFOM0;
+        can->RF0R |= CAN_RF0R_RFOM0;
     } else { /* FIFONumber == CAN_FIFO1 */
       /* Release FIFO1 */
-      can->RF1R = CAN_RF1R_RFOM1;
+      can->RF1R |= CAN_RF1R_RFOM1;
     }
 
     return 1;

--- a/targets/TARGET_STM/TARGET_STM32F2/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/can_api.c
@@ -280,10 +280,10 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
     /* Release the FIFO */
     if (handle == CAN_FIFO0) {
         /* Release FIFO0 */
-        can->RF0R = CAN_RF0R_RFOM0;
+        can->RF0R |= CAN_RF0R_RFOM0;
     } else { /* FIFONumber == CAN_FIFO1 */
         /* Release FIFO1 */
-        can->RF1R = CAN_RF1R_RFOM1;
+        can->RF1R |= CAN_RF1R_RFOM1;
     }
 
     return 1;

--- a/targets/TARGET_STM/TARGET_STM32F2/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/can_api.c
@@ -248,6 +248,12 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
 
     CAN_TypeDef *can = (CAN_TypeDef *)(obj->can);
 
+    // check FPM0 which holds the pending message count in FIFO 0
+    // if no message is pending, return 0
+    if ((can->RF0R & CAN_RF0R_FMP0) == 0) {
+        return 0;
+    }
+
     /* Get the Id */
     msg->format = (CANFormat)((uint8_t)0x04 & can->sFIFOMailBox[handle].RIR);
     if (!msg->format) {

--- a/targets/TARGET_STM/TARGET_STM32F3/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/can_api.c
@@ -238,6 +238,12 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
 
     CAN_TypeDef *can = (CAN_TypeDef *)(obj->can);    
     
+    // check FPM0 which holds the pending message count in FIFO 0
+    // if no message is pending, return 0
+    if ((can->RF0R & CAN_RF0R_FMP0) == 0) {
+        return 0;
+    }
+
     /* Get the Id */
     msg->format = (CANFormat)((uint8_t)0x04 & can->sFIFOMailBox[handle].RIR);
     if (!msg->format) {

--- a/targets/TARGET_STM/TARGET_STM32F3/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/can_api.c
@@ -270,10 +270,10 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
     /* Release the FIFO */
     if(handle == CAN_FIFO0) {
         /* Release FIFO0 */
-        can->RF0R = CAN_RF0R_RFOM0;
+        can->RF0R |= CAN_RF0R_RFOM0;
     } else { /* FIFONumber == CAN_FIFO1 */
       /* Release FIFO1 */
-      can->RF1R = CAN_RF1R_RFOM1;
+      can->RF1R |= CAN_RF1R_RFOM1;
     }
 
     return 1;

--- a/targets/TARGET_STM/TARGET_STM32F4/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/can_api.c
@@ -251,6 +251,12 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
 
     CAN_TypeDef *can = (CAN_TypeDef *)(obj->can);    
     
+    // check FPM0 which holds the pending message count in FIFO 0
+    // if no message is pending, return 0
+    if ((can->RF0R & CAN_RF0R_FMP0) == 0) {
+        return 0;
+    }
+
     /* Get the Id */
     msg->format = (CANFormat)((uint8_t)0x04 & can->sFIFOMailBox[handle].RIR);
     if (!msg->format) {

--- a/targets/TARGET_STM/TARGET_STM32F4/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/can_api.c
@@ -283,10 +283,10 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
     /* Release the FIFO */
     if(handle == CAN_FIFO0) {
         /* Release FIFO0 */
-        can->RF0R = CAN_RF0R_RFOM0;
+        can->RF0R |= CAN_RF0R_RFOM0;
     } else { /* FIFONumber == CAN_FIFO1 */
       /* Release FIFO1 */
-      can->RF1R = CAN_RF1R_RFOM1;
+      can->RF1R |= CAN_RF1R_RFOM1;
     }
 
     return 1;

--- a/targets/TARGET_STM/TARGET_STM32F7/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/can_api.c
@@ -251,6 +251,12 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
 
     CAN_TypeDef *can = (CAN_TypeDef *)(obj->can);    
     
+    // check FPM0 which holds the pending message count in FIFO 0
+    // if no message is pending, return 0
+    if ((can->RF0R & CAN_RF0R_FMP0) == 0) {
+        return 0;
+    }
+
     /* Get the Id */
     msg->format = (CANFormat)((uint8_t)0x04 & can->sFIFOMailBox[handle].RIR);
     if (!msg->format) {

--- a/targets/TARGET_STM/TARGET_STM32F7/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/can_api.c
@@ -283,10 +283,10 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
     /* Release the FIFO */
     if(handle == CAN_FIFO0) {
         /* Release FIFO0 */
-        can->RF0R = CAN_RF0R_RFOM0;
+        can->RF0R |= CAN_RF0R_RFOM0;
     } else { /* FIFONumber == CAN_FIFO1 */
       /* Release FIFO1 */
-      can->RF1R = CAN_RF1R_RFOM1;
+      can->RF1R |= CAN_RF1R_RFOM1;
     }
 
     return 1;

--- a/targets/TARGET_STM/TARGET_STM32L4/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/can_api.c
@@ -238,6 +238,12 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
 
     CAN_TypeDef *can = (CAN_TypeDef *)(obj->can);    
     
+    // check FPM0 which holds the pending message count in FIFO 0
+    // if no message is pending, return 0
+    if ((can->RF0R & CAN_RF0R_FMP0) == 0) {
+        return 0;
+    }
+
     /* Get the Id */
     msg->format = (CANFormat)((uint8_t)0x04 & can->sFIFOMailBox[handle].RIR);
     if (!msg->format) {

--- a/targets/TARGET_STM/TARGET_STM32L4/can_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/can_api.c
@@ -270,10 +270,10 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
     /* Release the FIFO */
     if(handle == CAN_FIFO0) {
         /* Release FIFO0 */
-        can->RF0R = CAN_RF0R_RFOM0;
+        can->RF0R |= CAN_RF0R_RFOM0;
     } else { /* FIFONumber == CAN_FIFO1 */
       /* Release FIFO1 */
-      can->RF1R = CAN_RF1R_RFOM1;
+      can->RF1R |= CAN_RF1R_RFOM1;
     }
 
     return 1;


### PR DESCRIPTION
## Description

This PR includes two commits which fix two things both related to the CAN read() method, but if you prefer two separate PRs, I can do it without any problem.

### 1 - CAN read() return value

The first commit fixes bug #3463 (CAN read() return value).

*Disclaimer: Although this PR as only been tested on nucleo F303K8 and L476RG, I expect others series to work too.*

* STM32F0: checked registers with the reference manual of the F0 serie
* STM32F1: checked registers with the reference manual of the F1 serie
* STM32F2: has a cortex m3, this is assumed to be working as a F3
* STM32F3: successfully tested with a nucleo F303K8
* STM32F4: checked registers with the reference manual of the F4 serie
* STM32F7: wild guessed
* STM32L4: successfully tested with a nucleo L476RG

### 2 - bit set vs. register reset

The second commit prevent the reset of the whole `RF0R` register. I am not sure what is the impact, since at first my PR seemed to be working without, but I think that at least it does no harm.




