### PR TITLE
Preventing app_config from clobbering CLI macros

### DIFF
--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2133,7 +2133,7 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
     base_path = norm_relative_path(build_path, execution_directory)
 
     target_name = target if isinstance(target, str) else target.name
-    cfg, macros, features = get_config(base_source_paths, target_name, toolchain_name)
+    cfg, _, _ = get_config(base_source_paths, target_name, toolchain_name)
 
     baud_rate = 9600
     if 'platform.stdio-baud-rate' in cfg:


### PR DESCRIPTION
## Description
This fixes #3516. If an `mbed_app.json` file is used when compiling tests, the tools were incorrectly ignoring macros that were supplied on the command line. This PR fixes this so the macros propagate correctly.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [ ] Tests


## Steps to test or reproduce
Edit any test with the following code:

```c++
#ifdef MY_SILLY_MACRO
printf("MY_SILLY_MACRO is set!\r\n");
#else
printf("MY_SILLY_MACRO is NOT set!\r\n");
#endif
```

If run the following commands, you should see `MY_SILLY_MACRO is set!` printed in the test report:

```
mbed test -DMY_SILLY_MACRO --compile --clean
mbed test --run -v
```

However, if you add an `mbed_app.json` file with the following contents:
```json
{
    "macros": ["MY_DUMMY_MACRO"]
}
```

Then do a clean compile and run step again, you will see `MY_SILLY_MACRO is NOT set!` printed in the test report.