### PR TITLE
Eclipse debug fixes (build w/ DEBUG=1 and load symbols)

### DIFF
--- a/tools/export/cdt/pyocd_settings.tmpl
+++ b/tools/export/cdt/pyocd_settings.tmpl
@@ -35,7 +35,7 @@
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU ARM PyOCD"/>
 <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="{{load_exe}}"/>
-<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="{{load_exe}}"/>
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
 <intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
 <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>


### PR DESCRIPTION
1. Pass the `DEBUG=1` flag to `make` for projects exported to Eclipse. Together with #3530 this enables builds with debug symbols from Eclipse again.
2. Enable symbol loading when starting a debug session.

@theotherjimmy 