### PR TITLE
Turn on debugging by default when exporting. Remove optimizations for IAR and Uvision

### DIFF
--- a/tools/export/iar/__init__.py
+++ b/tools/export/iar/__init__.py
@@ -89,16 +89,15 @@ class IAR(Exporter):
                self.resources.c_sources + self.resources.cpp_sources + \
                self.resources.objects + self.resources.libraries
         flags = self.flags
-        flags['c_flags'] = list(set(flags['common_flags']
+        c_flags = list(set(flags['common_flags']
                                     + flags['c_flags']
                                     + flags['cxx_flags']))
-        if '--vla' in flags['c_flags']:
-            flags['c_flags'].remove('--vla')
-        if '--no_static_destruction' in flags['c_flags']:
-            flags['c_flags'].remove('--no_static_destruction')
-        #Optimizations
-        if '-Oh' in flags['c_flags']:
-            flags['c_flags'].remove('-Oh')
+        # Flags set in template to be set by user in IDE
+        template = ["--vla", "--no_static_destruction"]
+        # Flag invalid if set in template
+        # Optimizations are also set in template
+        invalid_flag = lambda x: x in template or re.match("-O(\d|time|n)", x)
+        flags['c_flags'] = [flag for flag in c_flags if not invalid_flag(flag)]
 
         try:
             debugger = DeviceCMSIS(self.target).debug.replace('-','').upper()

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -155,27 +155,19 @@ class Uvision(Exporter):
     def format_flags(self):
         """Format toolchain flags for Uvision"""
         flags = copy.deepcopy(self.flags)
+        # to be preprocessed with armcc
         asm_flag_string = '--cpreproc --cpreproc_opts=-D__ASSERT_MSG,' + \
                           ",".join(flags['asm_flags'])
-        # asm flags only, common are not valid within uvision project,
-        # they are armcc specific
         flags['asm_flags'] = asm_flag_string
-        # cxx flags included, as uvision have them all in one tab
-        flags['c_flags'] = list(set(['-D__ASSERT_MSG']
-                                        + flags['common_flags']
-                                        + flags['c_flags']
-                                        + flags['cxx_flags']))
-        # not compatible with c99 flag set in the template
-        try: flags['c_flags'].remove("--c99")
-        except ValueError: pass
-        # cpp is not required as it's implicit for cpp files
-        try: flags['c_flags'].remove("--cpp")
-        except ValueError: pass
-        # we want no-vla for only cxx, but it's also applied for C in IDE,
-        #  thus we remove it
-        try: flags['c_flags'].remove("--no_vla")
-        except ValueError: pass
-        flags['c_flags'] =" ".join(flags['c_flags'])
+        # All non-asm flags are in one template field
+        c_flags = list(set(flags['c_flags'] + flags['cxx_flags'] +flags['common_flags']))
+        # These flags are in template to be set by user i n IDE
+        template = ["--no_vla", "--cpp", "--c99"]
+        # Flag is invalid if set in template
+        # Optimizations are also set in the template
+        invalid_flag = lambda x: x in template or re.match("-O(\d|time)", x) 
+        flags['c_flags'] = [flag for flag in c_flags if not invalid_flag(flag)]
+        flags['c_flags'] = " ".join(flags['c_flags'])
         return flags
 
     def format_src(self, srcs):

--- a/tools/export/uvision/uvision.tmpl
+++ b/tools/export/uvision/uvision.tmpl
@@ -351,7 +351,7 @@
           </ArmAdsMisc>
           <Cads>
             <interw>0</interw>
-            <Optim>2</Optim>
+            <Optim>1</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
             <OneElfS>0</OneElfS>

--- a/tools/options.py
+++ b/tools/options.py
@@ -100,7 +100,7 @@ def list_profiles():
     """
     return [fn.replace(".json", "") for fn in listdir(join(dirname(__file__), "profiles")) if fn.endswith(".json")]
 
-def extract_profile(parser, options, toolchain):
+def extract_profile(parser, options, toolchain, fallback="default"):
     """Extract a Toolchain profile from parsed options
 
     Positional arguments:
@@ -110,7 +110,7 @@ def extract_profile(parser, options, toolchain):
     """
     profile = {'c': [], 'cxx': [], 'ld': [], 'common': [], 'asm': []}
     filenames = options.profile or [join(dirname(__file__), "profiles",
-                                         "default.json")]
+                                         fallback + ".json")]
     for filename in filenames:
         contents = load(open(filename))
         try:

--- a/tools/project.py
+++ b/tools/project.py
@@ -237,7 +237,7 @@ def main():
     exporter, toolchain_name = get_exporter_toolchain(options.ide)
     if options.mcu not in exporter.TARGETS:
         args_error(parser, "%s not supported by %s"%(options.mcu,options.ide))
-    profile = extract_profile(parser, options, toolchain_name)
+    profile = extract_profile(parser, options, toolchain_name, fallback="debug")
     if options.clean:
         rmtree(BUILD_DIR)
     export(options.mcu, options.ide, build=options.build,


### PR DESCRIPTION
## Description
This PR will turn on flags for debug symbols for all exporters. 

It also removes optimization flags from the compiler flags, as those are set in the IDE by the user. If they exist as a hard-coded flag, the user will not be able to use the IDE to turn them off, and instead will have to manually search through the considerably long compiler flags to turn them off (if they realize they their IDE setting did nothing). Not a big deal in some exporters, but uvision makes them into a single text box in the GUI, so you just have to arrow over. 

@janjongboom @theotherjimmy 

## Status
**READY**


## Migrations
Now, if users *do not* want debug flags when exporting, they should use:
`mbed export --profile default`

Related: #3532 
This is a more generalized version for *all* the exporters. 

## Todos
- [ ] Tests
- [ ] Reviewers