### PR TITLE
Remove default -m and -i options for project.py

### DIFF
--- a/tools/project.py
+++ b/tools/project.py
@@ -106,14 +106,12 @@ def main():
 
     parser.add_argument("-m", "--mcu",
                         metavar="MCU",
-                        default='LPC1768',
                         type=argparse_force_uppercase_type(targetnames, "MCU"),
                         help="generate project for the given MCU ({})".format(
                             ', '.join(targetnames)))
 
     parser.add_argument("-i",
                         dest="ide",
-                        default='uvision',
                         type=argparse_force_lowercase_type(
                             toolchainlist, "toolchain"),
                         help="The target IDE: %s"% str(toolchainlist))
@@ -215,14 +213,6 @@ def main():
         cache = Cache(True, True)
         cache.cache_descriptors()
 
-    # Clean Export Directory
-    if options.clean:
-        if exists(EXPORT_DIR):
-            rmtree(EXPORT_DIR)
-
-    for mcu in options.mcu:
-        zip_proj = not bool(options.source_dir)
-
     # Target
     if not options.mcu:
         args_error(parser, "argument -m/--mcu is required")
@@ -230,6 +220,14 @@ def main():
     # Toolchain
     if not options.ide:
         args_error(parser, "argument -i is required")
+
+    # Clean Export Directory
+    if options.clean:
+        if exists(EXPORT_DIR):
+            rmtree(EXPORT_DIR)
+
+    for mcu in options.mcu:
+        zip_proj = not bool(options.source_dir)
 
     if (options.program is None) and (not options.source_dir):
         args_error(parser, "one of -p, -n, or --source is required")


### PR DESCRIPTION
## Description
This was spurred by https://github.com/ARMmbed/mbed-cli/issues/410.

Having a default target and ide in the `project.py` script is inconsistent with the rest of the tools. This PR removes them and makes `-m` and `-i` required arguments.

## Status
**READY**

## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

YES - Though I doubt it will affect anyone. There is now no longer a default value for the target and the IDE. It will now error if neither of them are provided.

## Todos
- [ ] Exporter tests

## Reviewer Notes
@theotherjimmy - Could you please make sure I haven't done anything with argparse settings?
@0xc0170 and/or @sarahmarshy - Will removing the default target and IDE cause any issues to your knowledge?
