### PR TITLE
Remove deprecated clean argument

### DIFF
--- a/tools/test/export/build_test.py
+++ b/tools/test/export/build_test.py
@@ -167,10 +167,10 @@ class ExportBuildTest(object):
             return
         profile = extract_profile(self.parser, self.options, toolchain)
         exporter = export(test_case.mcu, test_case.ide,
-                              project_id=test_case.id, zip_proj=None,
-                              clean=True, src=test_case.src,
-                              export_path=join(EXPORT_DIR,name_str),
-                              silent=True, build_profile=profile)
+                          project_id=test_case.id, zip_proj=None,
+                          src=test_case.src,
+                          export_path=join(EXPORT_DIR, name_str),
+                          silent=True, build_profile=profile)
         exporter.generated_files.append(join(EXPORT_DIR,name_str,test_case.log))
         self.build_queue.put((exporter,test_case))
             # Check if the specified name is in all_os_tests


### PR DESCRIPTION
## Description
#3486 removed the clean argument, but forgot to update the build_test 

## Status
**READY**

## Related PRs
https://github.com/ARMmbed/mbed-os/pull/3486

## Todos
- [ ] Tests (export-bulid)

/morph export-build
