### PR TITLE
STM: SPI: Initialize Rx in spi_master_write

### DIFF
--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -344,7 +344,8 @@ static inline int ssp_busy(spi_t *obj)
 
 int spi_master_write(spi_t *obj, int value)
 {
-    uint16_t size, Rx, ret;
+    uint16_t size, ret;
+    int Rx = 0;
     struct spi_s *spiobj = SPI_S(obj);
     SPI_HandleTypeDef *handle = &(spiobj->handle);
 


### PR DESCRIPTION
Fixes an SPI issue as reported here:  #3501
Also applicable to other NUCLEO boards tested on -ci-test-shield

Note:
To have the test completely PASS on NUCLEO_L476RG, this PR on ci-test-shield repo is also needed  https://github.com/ARMmbed/ci-test-shield/pull/21
Otherwise the test would fail at the "SPI - Object Definable" step.


## Description
In case Rx is not initialized its content might be random from stack.
This is causing problem in case of 8 bits read only as the left-side 8 bits
of the returned int value may contain this random byte data. This was for
instance detected when using SDFileSystem Lib.

## Status
READY

## Tests results

+-----------------------+---------------+---------------+------------------------+--------+--------+--------+--------------------+
| target                | platform_name | test suite    | test case              | passed | failed | result | elapsed_time (sec) |
+-----------------------+---------------+---------------+------------------------+--------+--------+--------+--------------------+
| NUCLEO_L476RG-GCC_ARM | NUCLEO_L476RG | tests-api-spi | SPI - Object Definable | 1      | 0      | OK     | 0.05               |
| NUCLEO_L476RG-GCC_ARM | NUCLEO_L476RG | tests-api-spi | SPI - SD Read          | 1      | 0      | OK     | 0.25               |
| NUCLEO_L476RG-GCC_ARM | NUCLEO_L476RG | tests-api-spi | SPI - SD Write         | 1      | 0      | OK     | 0.51               |
| NUCLEO_L476RG-GCC_ARM | NUCLEO_L476RG | tests-api-spi | SPI - SD card exists   | 1      | 0      | OK     | 0.44               |
+-----------------------+---------------+---------------+------------------------+--------+--------+--------+--------------------+

+-----------------------+---------------+---------------+------------------------+--------+--------+--------+--------------------+
| target                | platform_name | test suite    | test case              | passed | failed | result | elapsed_time (sec) |
+-----------------------+---------------+---------------+------------------------+--------+--------+--------+--------------------+
| NUCLEO_F410RB-GCC_ARM | NUCLEO_F410RB | tests-api-spi | SPI - Object Definable | 1      | 0      | OK     | 0.05               |
| NUCLEO_F410RB-GCC_ARM | NUCLEO_F410RB | tests-api-spi | SPI - SD Read          | 1      | 0      | OK     | 0.21               |
| NUCLEO_F410RB-GCC_ARM | NUCLEO_F410RB | tests-api-spi | SPI - SD Write         | 1      | 0      | OK     | 0.42               |
| NUCLEO_F410RB-GCC_ARM | NUCLEO_F410RB | tests-api-spi | SPI - SD card exists   | 1      | 0      | OK     | 0.71               |
+-----------------------+---------------+---------------+------------------------+--------+--------+--------+--------------------+

