### PR TITLE
Reduce thread stack size for parallel network tests

### DIFF
--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
@@ -42,6 +42,10 @@ private:
     Thread thread;
 
 public:
+    // Limiting stack size to 1k
+    Echo(): thread(osPriorityNormal, 1024) {
+    }
+
     void start() {
         osStatus status = thread.start(callback(this, &Echo::echo));
         TEST_ASSERT_EQUAL(osOK, status);

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
@@ -46,6 +46,10 @@ private:
     Thread thread;
 
 public:
+    // Limiting stack size to 1k
+    Echo(): thread(osPriorityNormal, 1024) {
+    }
+
     void start() {
         osStatus status = thread.start(callback(this, &Echo::echo));
         TEST_ASSERT_EQUAL(osOK, status);


### PR DESCRIPTION
## Description
This commit reduces the thread stack from 2k to 1k for each thread in
the parallel network tests. This allows the tests to run on more
constrained devices (like the LPC1768).


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [x] Nightly test run