### PR TITLE
Stack watermark enable for mbed

### DIFF
--- a/rtos/rtx2/mbed_rtx_conf.h
+++ b/rtos/rtx2/mbed_rtx_conf.h
@@ -35,4 +35,8 @@
 #define OS_MUTEX_NUM                6
 #endif
 
+#if !defined(OS_STACK_WATERMARK) && (defined(MBED_STACK_STATS_ENABLED) && MBED_STACK_STATS_ENABLED)
+#define OS_STACK_WATERMARK          1
+#endif
+
 #endif /* MBED_RTX_CONF_H */


### PR DESCRIPTION
Please review, this PR is against feature branch. Stack stats are part of the RTX API, however they have to be enabled otherwise 0 is returned.

An example:

```
uint32_t stack_size = osThreadGetStackSize(current_id);

uint32_t stack_space = osThreadGetStackSpace(current_id);
```

Tested with k64f, and -DMBED_STACK_STATS_ENABLED to get stack sizes via the API provided above

@bulislaw @c1728p9 