### PR TITLE
RTX2: _mutex_* functions to be strongly-linked

### DIFF
--- a/rtos/rtx2/TARGET_CORTEX_M/rtx_config.h
+++ b/rtos/rtx2/TARGET_CORTEX_M/rtx_config.h
@@ -531,7 +531,7 @@ void *__user_perthread_libspace (void) {
 typedef void *mutex;
 
 // Initialize mutex
-int _mutex_initialize(mutex *m);
+__USED int _mutex_initialize(mutex *m);
 int _mutex_initialize(mutex *m) {
   *m = osMutexNew(NULL);
   if (*m == NULL) {
@@ -542,7 +542,7 @@ int _mutex_initialize(mutex *m) {
 }
 
 // Acquire mutex
-void _mutex_acquire(mutex *m);
+__USED void _mutex_acquire(mutex *m);
 void _mutex_acquire(mutex *m) {
   if (os_kernel_is_active()) {
     osMutexAcquire(*m, osWaitForever);
@@ -550,7 +550,7 @@ void _mutex_acquire(mutex *m) {
 }
 
 // Release mutex
-void _mutex_release(mutex *m);
+__USED void _mutex_release(mutex *m);
 void _mutex_release(mutex *m) {
   if (os_kernel_is_active()) {
     osMutexRelease(*m);
@@ -558,7 +558,7 @@ void _mutex_release(mutex *m) {
 }
 
 // Free mutex
-void _mutex_free(mutex *m);
+__USED void _mutex_free(mutex *m);
 void _mutex_free(mutex *m) {
   osMutexDelete(*m);
 }


### PR DESCRIPTION
This patch is for feature_cmsis5 branch. 

Test tests-mbedmicro-rtos-mbed-malloc for ARMCC passing with this patch. ARMCC guide
says that these functions are weakly linked. This attribute used to be
in RTX for _mutex_* functions (therefore this test passes on master). Only _mutex_initialize is strongly linked thus no change there. Reference: http://www.keil.com/forum/16315/

The issue is created at CMSIS_5 repo for proper fix that we can propagate later.

Before this patch:
```
+----------+---------------+----------------------------------+----------------------------------+--------+--------+--------+--------------------+
| target   | platform_name | test suite                       | test case                        | passed | failed | result | elapsed_time (sec) |
+----------+---------------+----------------------------------+----------------------------------+--------+--------+--------+--------------------+
| K64F-ARM | K64F          | tests-mbedmicro-rtos-mbed-malloc | tests-mbedmicro-rtos-mbed-malloc | 0      | 1      | FAIL   | 25.19
     |
+----------+---------------+----------------------------------+----------------------------------+--------+--------+--------+--------------------+
```

After this patch:
```
mbedgt: test case report:
+----------+---------------+----------------------------------+----------------------------------+--------+--------+--------+--------------------+
| target   | platform_name | test suite                       | test case                        | passed | failed | result | elapsed_time (sec) |
+----------+---------------+----------------------------------+----------------------------------+--------+--------+--------+--------------------+
| K64F-ARM | K64F          | tests-mbedmicro-rtos-mbed-malloc | tests-mbedmicro-rtos-mbed-malloc | 1      | 0      | OK     | 27.79
     |
+----------+---------------+----------------------------------+----------------------------------+--------+--------+--------+--------------------+
```

cc @bulislaw @c1728p9 