### PR TITLE
K64F UART Asynch API: Fix synchronization issue

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/serial_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/serial_api.c
@@ -518,9 +518,10 @@ int serial_tx_asynch(serial_t *obj, const void *tx, size_t tx_length, uint8_t tx
         }
     }
 
+    obj->serial.txstate = kUART_TxBusy;
+
     /* Start the transfer */
     serial_send_asynch(obj);
-    obj->serial.txstate = kUART_TxBusy;
 
     return 0;
 }
@@ -583,9 +584,10 @@ void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_widt
         }
     }
 
+    obj->serial.rxstate = kUART_RxBusy;
+
     /* Start the transfer */
     serial_receive_asynch(obj);
-    obj->serial.rxstate = kUART_RxBusy;
 }
 
 uint8_t serial_tx_active(serial_t *obj)


### PR DESCRIPTION
## Description
This PR fixes the issues highlighted in the below issue:
https://github.com/ARMmbed/mbed-os/issues/3535

## Status
**READY

- [ ] Tests
Ran the test that was included in the PR, below is the output:
Hello and welcome to serial DMA fun!
_________________________________
-------- dma_serial_write_async_without_dma -------Howdy


Congratulations! You've made it through the gauntlet!


        Sorry, looks like we hung.
________________________________

The last line is printed even for a pass as it is the result of a 2 second timer that is activated in the test
