### PR TITLE
LPC4088 - Fix vector checksum

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -343,8 +343,7 @@
         "is_disk_virtual": true,
         "supported_toolchains": ["ARM", "GCC_CR", "GCC_ARM", "IAR"],
         "post_binary_hook": {
-            "function": "LPC4088Code.binary_hook",
-            "toolchains": ["ARM_STD", "ARM_MICRO"]
+            "function": "LPC4088Code.binary_hook"
         },
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "release_versions": ["2", "5"],


### PR DESCRIPTION
Turn on the vector checksum on all LPC4088 variants. This checksum is required for an application to boot.

