### PR TITLE
storage: Add the I2C EEPROM block device

### DIFF
--- a/features/filesystem/i2cee/I2CEEBlockDevice.cpp
+++ b/features/filesystem/i2cee/I2CEEBlockDevice.cpp
@@ -1,0 +1,135 @@
+/* Simple access class for I2C EEPROM chips like Microchip 24LC
+ * Copyright (c) 2015 Robin Hourahane
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "I2CEEBlockDevice.h"
+
+#define I2CEE_TIMEOUT 10000
+ 
+
+I2CEEBlockDevice::I2CEEBlockDevice(
+        PinName sda, PinName scl, uint8_t addr,
+        bd_size_t size, bd_size_t block, int freq)
+    : _i2c(sda, scl), _i2c_addr(addr), _size(size), _block(block)
+{
+    _i2c.frequency(freq);
+}
+
+bd_error_t I2CEEBlockDevice::init()
+{
+    return _sync();
+}
+
+bd_error_t I2CEEBlockDevice::deinit()
+{
+    return 0;
+}
+
+bd_error_t I2CEEBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
+{
+    // Check the address and size fit onto the chip.
+    if (!is_valid_read(addr, size)) {
+        return BD_ERROR_PARAMETER;
+    }
+
+    _i2c.start();
+    if (!_i2c.write(_i2c_addr | 0) ||
+        !_i2c.write((char)(addr >> 8)) ||
+        !_i2c.write((char)(addr & 0xff))) {
+        return BD_ERROR_DEVICE_ERROR;
+    }
+    _i2c.stop();
+
+    if (_i2c.read(_i2c_addr, static_cast<char*>(buffer), size) < 0) {
+        return BD_ERROR_DEVICE_ERROR;
+    }
+
+    return 0;
+}
+ 
+bd_error_t I2CEEBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size)
+{
+    // Check the addr and size fit onto the chip.
+    if (!is_valid_program(addr, size)) {
+        return BD_ERROR_PARAMETER;
+    }
+        
+    // While we have some more data to write.
+    while (size > 0) {
+        _i2c.start();
+        if (!_i2c.write(_i2c_addr | 0) ||
+            !_i2c.write((char)(addr >> 8)) ||
+            !_i2c.write((char)(addr & 0xff))) {
+            return BD_ERROR_DEVICE_ERROR;
+        }
+
+        for (unsigned i = 0; i < _block; i++) {
+            _i2c.write(static_cast<const char*>(buffer)[i]);
+        }
+        _i2c.stop();
+
+        bd_error_t err = _sync();
+        if (err) {
+            return err;
+        }
+
+        addr += _block;
+        size -= _block;
+        buffer = static_cast<const char*>(buffer) + _block;
+    }
+
+    return 0;
+}
+
+bd_error_t I2CEEBlockDevice::erase(bd_addr_t addr, bd_size_t size)
+{
+    // No erase needed
+    return 0;
+}
+
+bd_error_t I2CEEBlockDevice::_sync()
+{
+    // The chip doesn't ACK while writing to the actual EEPROM
+    // so loop trying to do a zero byte write until it is ACKed
+    // by the chip.
+    for (int i = 0; i < I2CEE_TIMEOUT; i++) {
+        if (_i2c.write(_i2c_addr | 0, 0, 0) < 1) {
+            return 0;
+        }
+
+        wait_ms(1);
+    }
+
+    return BD_ERROR_DEVICE_ERROR;
+}
+ 
+bd_size_t I2CEEBlockDevice::get_read_size()
+{
+    return 1;
+}
+
+bd_size_t I2CEEBlockDevice::get_program_size()
+{
+    return _block;
+}
+
+bd_size_t I2CEEBlockDevice::get_erase_size()
+{
+    return _block;
+}
+
+bd_size_t I2CEEBlockDevice::size()
+{
+    return _size;
+}

--- a/features/filesystem/i2cee/I2CEEBlockDevice.h
+++ b/features/filesystem/i2cee/I2CEEBlockDevice.h
@@ -1,0 +1,149 @@
+/* Simple access class for I2C EEPROM chips like Microchip 24LC
+ * Copyright (c) 2015 Robin Hourahane
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_I2CEEPROM_BLOCK_DEVICE_H
+#define MBED_I2CEEPROM_BLOCK_DEVICE_H
+
+/* If the target has no I2C support then I2CEEPROM is not supported */
+#ifdef DEVICE_I2C
+ 
+#include <mbed.h>
+#include "BlockDevice.h"
+
+ 
+/** BlockDevice for I2C based flash device such as
+ *  Microchip's 24LC or ATMEL's AT24C ranges
+ *
+ *  @code
+ *  #include "mbed.h"
+ *  #include "I2CEEBlockDevice.h"
+ *
+ *  // Create 24LC device with 32Kbytes of memory 
+ *  I2CEEBlockDevice flash(D14, D15, 0xa0, 32*1024);
+ *
+ *  int main() {
+ *      printf("flash test\n");
+ *      mx52r.init();
+ *      printf("flash size: %llu\n", flash.size());
+ *      printf("flash read size: %llu\n", flash.get_read_size());
+ *      printf("flash program size: %llu\n", flash.get_program_size());
+ *      printf("flash erase size: %llu\n", flash.get_erase_size());
+ *
+ *      uint8_t *buffer = malloc(flash.get_erase_size());
+ *      sprintf(buffer, "Hello World!\n");
+ *      flash.erase(0, flash.get_erase_size());
+ *      flash.write(buffer, 0, flash.get_erase_size());
+ *      flash.read(buffer, 0, flash.get_erase_size());
+ *      printf("%s", buffer);
+ *
+ *      flash.deinit();
+ *  }
+ */
+class I2CEEBlockDevice : public BlockDevice {
+public:
+    /** Constructor to create an I2CEEBlockDevice on I2C pins
+     *
+     *  @param sda      The pin name for the sda line of the I2C bus.
+     *  @param scl      The pin name for the scl line of the I2C bus.
+     *  @param addr     The 8bit I2C address of the chip, common range 0xa0 - 0xae.
+     *  @param size     The size of the device in bytes
+     *  @param block    The block size of the device in bytes, defaults to 32bytes
+     *  @param freq     The frequency of the I2C bus, defaults to 400K.
+     */
+    I2CEEBlockDevice(
+            PinName sda, PinName scl, uint8_t address,
+            bd_size_t size, bd_size_t block=32,
+            int bus_speed=400000);
+
+    /** Initialize a block device
+     *
+     *  @return         0 on success or a negative error code on failure
+     */
+    virtual bd_error_t init();
+
+    /** Deinitialize a block device
+     *
+     *  @return         0 on success or a negative error code on failure
+     */
+    virtual bd_error_t deinit();
+
+    /** Read blocks from a block device
+     *
+     *  @param buffer   Buffer to write blocks to
+     *  @param addr     Address of block to begin reading from
+     *  @param size     Size to read in bytes, must be a multiple of read block size
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual bd_error_t read(void *buffer, bd_addr_t addr, bd_size_t size);
+
+    /** Program blocks to a block device
+     *
+     *  The blocks must have been erased prior to being programmed
+     *
+     *  @param buffer   Buffer of data to write to blocks
+     *  @param addr     Address of block to begin writing to
+     *  @param size     Size to write in bytes, must be a multiple of program block size
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual bd_error_t program(const void *buffer, bd_addr_t addr, bd_size_t size);
+
+    /** Erase blocks on a block device
+     *
+     *  The state of an erased block is undefined until it has been programmed
+     *
+     *  @param addr     Address of block to begin erasing
+     *  @param size     Size to erase in bytes, must be a multiple of erase block size
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual bd_error_t erase(bd_addr_t addr, bd_size_t size);
+
+    /** Get the size of a readable block
+     *
+     *  @return         Size of a readable block in bytes
+     */
+    virtual bd_size_t get_read_size();
+
+    /** Get the size of a programable block
+     *
+     *  @return         Size of a programable block in bytes
+     *  @note Must be a multiple of the read size
+     */
+    virtual bd_size_t get_program_size();
+
+    /** Get the size of a eraseable block
+     *
+     *  @return         Size of a eraseable block in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual bd_size_t get_erase_size();
+
+    /** Get the total size of the underlying device
+     *
+     *  @return         Size of the underlying device in bytes
+     */
+    virtual bd_size_t size();
+    
+private:
+    I2C _i2c;
+    uint8_t _i2c_addr;
+    uint32_t _size;
+    uint32_t _block;
+
+    bd_error_t _sync();
+};
+ 
+#endif  /* DEVICE_SPI */
+
+#endif  /* MBED_SD_BLOCK_DEVICE_H */

--- a/features/filesystem/i2cee/TESTS/block_device/i2cee/main.cpp
+++ b/features/filesystem/i2cee/TESTS/block_device/i2cee/main.cpp
@@ -1,0 +1,139 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+
+#include "I2CEEBlockDevice.h"
+#include <stdlib.h>
+
+using namespace utest::v1;
+
+//#if !I2CEE_INSTALLED
+//#error [NOT_SUPPORTED] I2CEE Required
+//#endif
+
+#define TEST_PINS D14, D15
+#define TEST_ADDR 0xa0
+#define TEST_SIZE 32*1024
+#define TEST_BLOCK_SIZE 64
+#define TEST_FREQ 400000
+#define TEST_BLOCK_COUNT 10
+#define TEST_ERROR_MASK 16
+
+const struct {
+    const char *name;
+    bd_size_t (BlockDevice::*method)();
+} ATTRS[] = {
+    {"read size",    &BlockDevice::get_read_size},
+    {"program size", &BlockDevice::get_program_size},
+    {"erase size",   &BlockDevice::get_erase_size},
+    {"total size",   &BlockDevice::size},
+};
+
+
+void test_read_write() {
+    I2CEEBlockDevice bd(TEST_PINS, TEST_ADDR,
+        TEST_SIZE, TEST_BLOCK_SIZE, TEST_FREQ);
+
+    int err = bd.init();
+    TEST_ASSERT_EQUAL(0, err);
+
+    for (unsigned a = 0; a < sizeof(ATTRS)/sizeof(ATTRS[0]); a++) {
+        static const char *prefixes[] = {"", "k", "M", "G"};
+        for (int i = 3; i >= 0; i--) {
+            bd_size_t size = (bd.*ATTRS[a].method)();
+            if (size >= (1ULL << 10*i)) {
+                printf("%s: %llu%sbytes (%llubytes)\n",
+                    ATTRS[a].name, size >> 10*i, prefixes[i], size);
+                break;
+            }
+        }
+    }
+
+    bd_size_t block_size = bd.get_erase_size();
+    uint8_t *write_block = new uint8_t[block_size];
+    uint8_t *read_block = new uint8_t[block_size];
+    uint8_t *error_mask = new uint8_t[TEST_ERROR_MASK];
+    unsigned addrwidth = ceil(log(bd.size()-1) / log(16))+1;
+
+    for (int b = 0; b < TEST_BLOCK_COUNT; b++) {
+        // Find a random block
+        bd_addr_t block = (rand()*block_size) % bd.size();
+
+        // Use next random number as temporary seed to keep
+        // the address progressing in the pseudorandom sequence
+        unsigned seed = rand();
+
+        // Fill with random sequence
+        srand(seed);
+        for (bd_size_t i = 0; i < block_size; i++) {
+            write_block[i] = 0xff & rand();
+        }
+
+        // Write, sync, and read the block
+        printf("test  %0*llx:%llu...\n", addrwidth, block, block_size);
+
+        err = bd.write(write_block, block, block_size);
+        TEST_ASSERT_EQUAL(0, err);
+
+        printf("write %0*llx:%llu ", addrwidth, block, block_size);
+        for (int i = 0; i < 16; i++) {
+            printf("%02x", write_block[i]);
+        }
+        printf("...\n");
+
+        err = bd.read(read_block, block, block_size);
+        TEST_ASSERT_EQUAL(0, err);
+
+        printf("read  %0*llx:%llu ", addrwidth, block, block_size);
+        for (int i = 0; i < 16; i++) {
+            printf("%02x", read_block[i]);
+        }
+        printf("...\n");
+
+        // Find error mask for debugging
+        memset(error_mask, 0, TEST_ERROR_MASK);
+        bd_size_t error_scale = block_size / (TEST_ERROR_MASK*8);
+
+        srand(seed);
+        for (bd_size_t i = 0; i < TEST_ERROR_MASK*8; i++) {
+            for (bd_size_t j = 0; j < error_scale; j++) {
+                if ((0xff & rand()) != read_block[i*error_scale + j]) {
+                    error_mask[i/8] |= 1 << (i%8);
+                }
+            }
+        }
+
+        printf("error %0*llx:%llu ", addrwidth, block, block_size);
+        for (int i = 0; i < 16; i++) {
+            printf("%02x", error_mask[i]);
+        }
+        printf("\n");
+
+        // Check that the data was unmodified
+        srand(seed);
+        for (bd_size_t i = 0; i < block_size; i++) {
+            TEST_ASSERT_EQUAL(0xff & rand(), read_block[i]);
+        }
+    }
+    
+    err = bd.deinit();
+    TEST_ASSERT_EQUAL(0, err);
+}
+
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(30, "default_auto");
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("Testing read write random blocks", test_read_write),
+};
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}


### PR DESCRIPTION
Adds support for I2CEepromBlockDevice, a block device driver to support I2C EEPROMs like Microchip's 24LC range and AMTELS AT24C range.

This is a fork of the I2CEeprom driver by Robin Hourahane on the developer site:
https://developer.mbed.org/users/rhourahane/code/I2CEeprom/

This provides support for small I2C EEPROM devices around the 32k byte range. Note, these chips may be too small to support the FATFileSystem which requires a minimum of 64k bytes.

This driver should follow the life-cycle of the SDCardBlockDevice, and move into its own repo before this feature-branch is merged.

dependent on https://github.com/ARMmbed/mbed-os/pull/3671
relevant commit range https://github.com/ARMmbed/mbed-os/compare/3440cd7...geky:bd-i2ceeprom
cc @simonqhughes, @c1728p9, @theotherjimmy 

