### PR TITLE
fix failing RTC initialization for MTS_DRAGONFLY_F411RE

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1269,7 +1269,7 @@
         "core": "Cortex-M4F",
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "extra_labels": ["STM", "STM32F4", "STM32F411RE"],
-        "macros": ["HSE_VALUE=26000000", "VECT_TAB_OFFSET=0x08010000","TRANSACTION_QUEUE_SIZE_SPI=2"],
+        "macros": ["HSE_VALUE=26000000", "VECT_TAB_OFFSET=0x08010000","TRANSACTION_QUEUE_SIZE_SPI=2", "RTC_LSI=1"],
         "post_binary_hook": {
             "function": "MTSCode.combine_bins_mts_dragonfly",
             "toolchains": ["GCC_ARM", "ARM_STD", "ARM_MICRO"]


### PR DESCRIPTION
## Description
Dragonfly was failing RTC unit tests b/c RTC_LSI wasn't explicitly specified in targets.json and LSE is no longer populated by default. This PR sets RTC_LSI macro for Dragonfly builds so RTC is functional.


## Status
**READY**
