### PR TITLE
Fix invalid assert in exporters

### DIFF
--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -132,7 +132,7 @@ class Exporter(object):
         """
         rel_path = relpath(src, self.resources.file_basepath[src])
         path_list = os.path.normpath(rel_path).split(os.sep)
-        assert path_list >= 1
+        assert len(path_list) >= 1
         if len(path_list) == 1:
             key = self.project_name
         else:


### PR DESCRIPTION
Assert that the length is greater than one rather than the value itself. This bug was introduced in the commit:
329be06ad02b82e045c1aadc799f88005276400a -
"exporters - group by directories in prj root"
