### PR TITLE
Fixes linking errors when building with debug profile

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/i2c_device.h
@@ -61,7 +61,7 @@ extern "C" {
 #define I2CAPI_I2C1_CLKSRC RCC_I2C1CLKSOURCE_SYSCLK
 
 /*  Provide the suitable timing depending on requested frequencie */
-inline uint32_t get_i2c_timing(int hz)
+static inline uint32_t get_i2c_timing(int hz)
 {
     uint32_t tim = 0;
 

--- a/targets/TARGET_STM/TARGET_STM32F3/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/i2c_device.h
@@ -48,7 +48,7 @@ extern "C" {
 #define I2CAPI_I2C3_CLKSRC RCC_I2C3CLKSOURCE_SYSCLK
 
 /*  Provide the suitable timing depending on requested frequencie */
-inline uint32_t get_i2c_timing(int hz)
+static inline uint32_t get_i2c_timing(int hz)
 {
     uint32_t tim = 0;
     /*

--- a/targets/TARGET_STM/TARGET_STM32F7/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/i2c_device.h
@@ -49,7 +49,7 @@ extern "C" {
 #define I2CAPI_I2C4_CLKSRC RCC_I2C4CLKSOURCE_PCLK1
 
 /*  Provide the suitable timing depending on requested frequencie */
-inline uint32_t get_i2c_timing(int hz)
+static inline uint32_t get_i2c_timing(int hz)
 {
     uint32_t tim = 0;
     /*

--- a/targets/TARGET_STM/TARGET_STM32L0/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/i2c_device.h
@@ -61,7 +61,7 @@ extern "C" {
 #define I2CAPI_I2C4_CLKSRC RCC_I2C4CLKSOURCE_SYSCLK
 
 /*  Provide the suitable timing depending on requested frequencie */
-inline uint32_t get_i2c_timing(int hz)
+static inline uint32_t get_i2c_timing(int hz)
 {
     uint32_t tim = 0;
 

--- a/targets/TARGET_STM/TARGET_STM32L4/i2c_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/i2c_device.h
@@ -49,7 +49,7 @@ extern "C" {
 #define I2CAPI_I2C4_CLKSRC RCC_I2C4CLKSOURCE_SYSCLK
 
 /*  Provide the suitable timing depending on requested frequencie */
-inline uint32_t get_i2c_timing(int hz)
+static inline uint32_t get_i2c_timing(int hz)
 {
     uint32_t tim = 0;
     if (SystemCoreClock == 80000000) {


### PR DESCRIPTION
## Description
When building with the debug profile, certain ST plaforms error with
'get_i2c_timing' not being defined. This is because the function is not
defined as 'static inline', but just 'inline'.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Related PRs
Should fix the current export-build CI failure on #3534 


## Todos
- [ ] Tests


## Notes to Reviewers
@LMESTM Would you double check this change since you were working on I2C for ST platforms?
@geky Would you please check this since you're a wizard at all things C/C++? :smile: 
