### PR TITLE
Fixing toolchain executable not found error for build.py

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -211,15 +211,17 @@ if __name__ == '__main__':
     successes = []
     skipped = []
 
-    # CPPCHECK code validation
-    if options.cppcheck_validation:
-        for toolchain in toolchains:
-            if not TOOLCHAIN_CLASSES[toolchain].check_executable():
-                search_path = TOOLCHAIN_PATHS[toolchain] or "No path set"
-                args_error(parser, "Could not find executable for %s.\n"
-                                   "Currently set search path: %s"
-                           % (toolchain, search_path))
-            for target in targets:
+    for toolchain in toolchains:
+        if not TOOLCHAIN_CLASSES[toolchain].check_executable():
+            search_path = TOOLCHAIN_PATHS[toolchain] or "No path set"
+            args_error(parser, "Could not find executable for %s.\n"
+                               "Currently set search path: %s"
+                       % (toolchain, search_path))
+
+    for toolchain in toolchains:
+        for target in targets:
+            # CPPCHECK code validation
+            if options.cppcheck_validation:
                 try:
                     mcu = TARGET_MAP[target]
                     # CMSIS and MBED libs analysis
@@ -244,10 +246,8 @@ if __name__ == '__main__':
                         traceback.print_exc(file=sys.stdout)
                         sys.exit(1)
                     print e
-    else:
-        # Build
-        for toolchain in toolchains:
-            for target in targets:
+            else:
+                # Build
                 tt_id = "%s::%s" % (toolchain, target)
                 if toolchain not in TARGET_MAP[target].supported_toolchains:
                     # Log this later
@@ -298,6 +298,7 @@ if __name__ == '__main__':
                             sys.exit(1)
                         failures.append(tt_id)
                         print e
+
 
     # Write summary of the builds
     print


### PR DESCRIPTION
## Description
Commit 19d56fd40fc3130b970e03fd530ab340d4a65465 removed the default file
paths for the toolchains. This was done under the assumption that the
top-level compile scripts were properly checking that the toolchain
executable was availble. The build.py script was doing this in the wrong
place. This commit rearranges the script a bit so the check is performed
properly.

Should fix #3581.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [ ] Tests


## Notes to reviewers
@toyowata - Could you please confirm that I've fixed your issue?
@theotherjimmy - General code review please!
