### PR TITLE
arm-pack-manager - fix tracebacks

### DIFF
--- a/tools/arm_pack_manager/__init__.py
+++ b/tools/arm_pack_manager/__init__.py
@@ -251,8 +251,9 @@ class Cache () :
         :return: A file-like object that, when read, is the ELF file that describes the flashing algorithm
         :rtype: ZipExtFile
         """
-        pack = self.pack_from_cache(self.index[device_name])
-        return pack.open(device['algorithm']['file'])
+        device = self.index[device_name]
+        pack = self.pack_from_cache(device)
+        return pack.open(device['algorithm'].keys()[0])
 
     def get_svd_file(self, device_name) :
         """Retrieve the flash algorithm file for a particular part.
@@ -264,7 +265,8 @@ class Cache () :
         :return: A file-like object that, when read, is the ELF file that describes the flashing algorithm
         :rtype: ZipExtFile
         """
-        pack = self.pack_from_cache(self.index[device_name])
+        device = self.index[device_name]
+        pack = self.pack_from_cache(device)
         return pack.open(device['debug'])
 
     def generate_index(self) :
@@ -407,7 +409,7 @@ class Cache () :
         with open(dest, "r") as fd :
             return BeautifulSoup(fd, "html.parser")
 
-    def pack_from_cache(self, url) :
+    def pack_from_cache(self, device) :
         """Low level inteface for extracting a PACK file from the cache.
 
         Assumes that the file specified is a PACK file and is in the cache.

--- a/tools/arm_pack_manager/__init__.py
+++ b/tools/arm_pack_manager/__init__.py
@@ -26,7 +26,8 @@ def strip_protocol(url) :
     return protocol_matcher.sub("", str(url))
 
 def largest_version(content) :
-    return sorted([t['version'] for t in content.package.releases('release')], reverse=True)[0]
+    return sorted([t['version'] for t in content.package.releases('release')],
+                  reverse=True, key=lambda v: map(int, v.split(".")))[0]
 
 def do_queue(Class, function, interable) :
     q = Queue()


### PR DESCRIPTION
Fix tracebacks from trying to read dictionary values that don't exist and from incorrect variable names.