### PR TITLE
Allow user overrides of LINKER_SCRIPT Make variable

### DIFF
--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -55,9 +55,6 @@ PROJECT := {{name}}
 {% endfor %}
 LIBRARY_PATHS :={% for p in library_paths %} {{user_library_flag}}{{p}} {% endfor %}
 LIBRARIES :={% for lib in libraries %} {{lib}} {% endfor %}
-
-# Allow user overrides of LINKER_SCRIPT from the command line, useful
-# if user wants to reserve specific flash areas for production config data
 LINKER_SCRIPT ?= {{linker_script}}
 {%- block additional_variables -%}{% endblock %}
 

--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -58,9 +58,7 @@ LIBRARIES :={% for lib in libraries %} {{lib}} {% endfor %}
 
 # Allow user overrides of LINKER_SCRIPT from the command line, useful
 # if user wants to reserve specific flash areas for production config data
-ifndef $(LINKER_SCRIPT)
-LINKER_SCRIPT := {{linker_script}}
-endif
+LINKER_SCRIPT ?= {{linker_script}}
 {%- block additional_variables -%}{% endblock %}
 
 # Objects and Paths

--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -55,7 +55,12 @@ PROJECT := {{name}}
 {% endfor %}
 LIBRARY_PATHS :={% for p in library_paths %} {{user_library_flag}}{{p}} {% endfor %}
 LIBRARIES :={% for lib in libraries %} {{lib}} {% endfor %}
+
+# Allow user overrides of LINKER_SCRIPT from the command line, useful
+# if user wants to reserve specific flash areas for production config data
+ifndef $(LINKER_SCRIPT)
 LINKER_SCRIPT := {{linker_script}}
+endif
 {%- block additional_variables -%}{% endblock %}
 
 # Objects and Paths


### PR DESCRIPTION
## Description
Allow `LINKER_SCRIPT` overrides via:

> `make LINKER_SCRIPT=something.ld -f Makefile`

The user can then set aside a block of flash memory for production config data by customizing the linker script like so: https://vilimpoc.org/blog/2016/12/25/flash-based-configuration-data-using-the-ld-linker/