### PR TITLE
[toolchains] Refactor sys libs

### DIFF
--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -80,7 +80,7 @@ SREC_CAT = srec_cat
 {% endfor %}
 
 LD_FLAGS :={%- block ld_flags -%} {{ld_flags|join(" ")}} {% endblock %}
-{% block sys_libs -%}{%- endblock %}
+LD_SYS_LIBS :={%- block sys_libs -%} {{ld_sys_libs|join(" ")}} {% endblock %}
 
 # Tools and Flags
 ###############################################################################

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -52,6 +52,8 @@ class Makefile(Exporter):
 
         libraries = [self.prepare_lib(basename(lib)) for lib
                      in self.resources.libraries]
+        sys_libs = [self.prepare_sys_lib(lib) for lib
+                    in self.toolchain.sys_libs]
 
         ctx = {
             'name': self.project_name,
@@ -61,6 +63,7 @@ class Makefile(Exporter):
             'library_paths': self.resources.lib_dirs,
             'linker_script': self.resources.linker_script,
             'libraries': libraries,
+            'ld_sys_libs': sys_libs,
             'hex_files': self.resources.hex_files,
             'vpath': (["../../.."]
                       if (basename(dirname(dirname(self.export_dir)))
@@ -171,6 +174,10 @@ class GccArm(Makefile):
     def prepare_lib(libname):
         return "-l:" + libname
 
+    @staticmethod
+    def prepare_sys_lib(libname):
+        return "-l" + libname
+
 
 class Armc5(Makefile):
     """ARM Compiler 5 specific makefile target"""
@@ -186,6 +193,10 @@ class Armc5(Makefile):
     def prepare_lib(libname):
         return libname
 
+    @staticmethod
+    def prepare_sys_lib(libname):
+        return libname
+
 
 class IAR(Makefile):
     """IAR specific makefile target"""
@@ -199,6 +210,12 @@ class IAR(Makefile):
 
     @staticmethod
     def prepare_lib(libname):
+        if "lib" == libname[:3]:
+            libname = libname[3:]
+        return "-l" + splitext(libname)[0]
+
+    @staticmethod
+    def prepare_sys_lib(libname):
         if "lib" == libname[:3]:
             libname = libname[3:]
         return "-l" + splitext(libname)[0]

--- a/tools/export/makefile/make-gcc-arm.tmpl
+++ b/tools/export/makefile/make-gcc-arm.tmpl
@@ -1,10 +1,6 @@
 {% extends "makefile/Makefile.tmpl" %}
 
-{% block sys_libs %}
-{% for lib in ["-lstdc++", "-lsupc++", "-lm", "-lc", "-lgcc", "-lnosys"] -%}
-LD_SYS_LIBS += {{lib}}
-{% endfor %}
-{%- endblock %}
+{%- block sys_libs -%} -Wl,--start-group {{ld_sys_libs|join(" ")}} -Wl,--end-group {%- endblock -%}
 
 {% block elf2bin %}
 	$(ELF2BIN) -O binary $< $@

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -266,6 +266,9 @@ class mbedToolchain:
         # Toolchain flags
         self.flags = deepcopy(build_profile or self.profile_template)
 
+        # System libraries provided by the toolchain
+        self.sys_libs = []
+
         # User-defined macros
         self.macros = macros or []
 

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -66,7 +66,6 @@ class ARM(mbedToolchain):
         self.cppc = [main_cc] + self.flags['common'] + self.flags['c'] + self.flags['cxx']
 
         self.ld = [join(ARM_BIN, "armlink")]
-        self.sys_libs = []
 
         self.ar = join(ARM_BIN, "armar")
         self.elf2bin = join(ARM_BIN, "fromelf")


### PR DESCRIPTION
Refactor toolchains to use a common sys_libs variable. This allows the exporters to rely on that information.

## Status
**READY**


##Todos
- [x] Tests - /morph export-build
