### PR TITLE
Platform: Add sleep/deepsleep user facing functions

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/hal_patch/sleep.c
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/hal_patch/sleep.c
@@ -23,7 +23,7 @@
 // In this case, bits which are equal to 0 are the bits reserved in this register
 #define SCB_ICSR_RESERVED_BITS_MASK     0x9E43F03F
 
-void sleep(void)
+void hal_sleep(void)
 {
     // ensure debug is disconnected if semihost is enabled....
 
@@ -64,7 +64,7 @@ void sleep(void)
     }
 }
 
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     sleep();
     //   NRF_POWER->SYSTEMOFF=1;

--- a/mbed.h
+++ b/mbed.h
@@ -92,6 +92,7 @@
 #include "drivers/InterruptIn.h"
 #include "platform/wait_api.h"
 #include "hal/sleep_api.h"
+#include "platform/sleep.h"
 #include "platform/rtc_time.h"
 
 // mbed Non-hardware components

--- a/platform/sleep.h
+++ b/platform/sleep.h
@@ -1,8 +1,8 @@
 
-/** \addtogroup hal */
+/** \addtogroup platform */
 /** @{*/
 /* mbed Microcontroller Library
- * Copyright (c) 2006-2013 ARM Limited
+ * Copyright (c) 2006-2017 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef MBED_SLEEP_API_H
-#define MBED_SLEEP_API_H
+#ifndef MBED_SLEEP_H
+#define MBED_SLEEP_H
 
-#include "device.h"
+#include "sleep_api.h"
 
-#if DEVICE_SLEEP
+#if !DEVICE_SLEEP
+#warning Sleep is not supported on this platform.
+#else /* DEVICE_SLEEP */
+#ifndef NDEBUG
+#warning Sleep is disabled for debug builds.
+#endif /* NDEBUG */
+#endif /* DEVICE_SLEEP */
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /** Send the microcontroller to sleep
+ *
+ * @note This function can be a noop if not implemented by the platform.
+ * @note This function will only put device to sleep in release mode (small profile or when NDEBUG is defined).
  *
  * The processor is setup ready for sleep, and sent to sleep using __WFI(). In this mode, the
  * system clock to the core is stopped until a reset or an interrupt occurs. This eliminates
@@ -41,9 +50,19 @@ extern "C" {
  * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
  * able to access the LocalFileSystem
  */
-void hal_sleep(void);
+__INLINE void sleep(void)
+{
+#ifdef NDEBUG
+#if DEVICE_SLEEP
+    hal_sleep();
+#endif /* DEVICE_SLEEP */
+#endif /* NDEBUG */
+}
 
 /** Send the microcontroller to deep sleep
+ *
+ * @note This function can be a noop if not implemented by the platform.
+ * @note This function will only put device to sleep in release mode (small profile or when NDEBUG is defined).
  *
  * This processor is setup ready for deep sleep, and sent to sleep using __WFI(). This mode
  * has the same sleep features as sleep plus it powers down peripherals and clocks. All state
@@ -56,12 +75,17 @@ void hal_sleep(void);
  * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
  * able to access the LocalFileSystem
  */
-void hal_deepsleep(void);
+__INLINE void deepsleep(void)
+{
+#ifdef NDEBUG
+#if DEVICE_SLEEP
+    hal_deepsleep();
+#endif /* DEVICE_SLEEP */
+#endif /* NDEBUG */
+}
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif
 
 #endif

--- a/platform/sleep.h
+++ b/platform/sleep.h
@@ -21,14 +21,6 @@
 
 #include "sleep_api.h"
 
-#if !DEVICE_SLEEP
-#warning Sleep is not supported on this platform.
-#else /* DEVICE_SLEEP */
-#ifndef NDEBUG
-#warning Sleep is disabled for debug builds.
-#endif /* NDEBUG */
-#endif /* DEVICE_SLEEP */
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/platform/sleep.h
+++ b/platform/sleep.h
@@ -42,7 +42,7 @@ extern "C" {
  * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
  * able to access the LocalFileSystem
  */
-__INLINE void sleep(void)
+__INLINE static void sleep(void)
 {
 #ifdef NDEBUG
 #if DEVICE_SLEEP
@@ -67,7 +67,7 @@ __INLINE void sleep(void)
  * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
  * able to access the LocalFileSystem
  */
-__INLINE void deepsleep(void)
+__INLINE static void deepsleep(void)
 {
 #ifdef NDEBUG
 #if DEVICE_SLEEP

--- a/targets/TARGET_ARM_SSG/TARGET_BEETLE/sleep.c
+++ b/targets/TARGET_ARM_SSG/TARGET_BEETLE/sleep.c
@@ -16,13 +16,13 @@
 #include "sleep_api.h"
 #include "cmsis.h"
 
- void sleep(void)
+ void hal_sleep(void)
  {
     SystemPowerSuspend(POWER_MODE_SLEEP);
     SystemPowerResume(POWER_MODE_SLEEP);
  }
 
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     SystemPowerSuspend(POWER_MODE_DEEP_SLEEP);
     SystemPowerResume(POWER_MODE_DEEP_SLEEP);

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/sleep_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/sleep_api.c
@@ -25,7 +25,7 @@
  * @param[void] void
  * @return      void
  */
-void sleep(void)
+void hal_sleep(void)
 {
 #if (SAMD21) || (SAMR21)
     system_set_sleepmode(SYSTEM_SLEEPMODE_IDLE_2);
@@ -43,7 +43,7 @@ void sleep(void)
  * @param[void] void
  * @return      void
  */
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     system_set_sleepmode(SYSTEM_SLEEPMODE_STANDBY);
     system_sleep();

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM4/sleep_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM4/sleep_api.c
@@ -24,7 +24,7 @@
  * @param[void] void
  * @return      void
  */
-void sleep(void)
+void hal_sleep(void)
 {
     enum sleepmgr_mode sleep_mode;
 
@@ -40,7 +40,7 @@ void sleep(void)
  * @param[void] void
  * @return      void
  */
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     enum sleepmgr_mode sleep_mode;
 

--- a/targets/TARGET_Freescale/TARGET_K20XX/sleep.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/sleep.c
@@ -17,7 +17,7 @@
 #include "cmsis.h"
 
 //Normal wait mode
-void sleep(void)
+void hal_sleep(void)
 {
     SMC->PMPROT = SMC_PMPROT_AVLLS_MASK | SMC_PMPROT_ALLS_MASK | SMC_PMPROT_AVLP_MASK;
 
@@ -27,7 +27,7 @@ void sleep(void)
 }
 
 //Very low-power stop mode
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     //Check if ADC is enabled and HS mode is set, if yes disable it (lowers power consumption by 60uA)
     uint8_t ADC_HSC = 0;

--- a/targets/TARGET_Freescale/TARGET_KLXX/sleep.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/sleep.c
@@ -18,7 +18,7 @@
 #include "PeripheralPins.h"
 
 //Normal wait mode
-void sleep(void)
+void hal_sleep(void)
 {
     SMC->PMPROT = SMC_PMPROT_AVLLS_MASK | SMC_PMPROT_ALLS_MASK | SMC_PMPROT_AVLP_MASK;
 
@@ -28,7 +28,7 @@ void sleep(void)
 }
 
 //Very low-power stop mode
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     //Check if ADC is enabled and HS mode is set, if yes disable it (lowers power consumption by 60uA)
     uint8_t ADC_HSC = 0;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/sleep.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/sleep.c
@@ -18,14 +18,14 @@
 #include "fsl_smc.h"
 #include "fsl_clock_config.h"
 
-void sleep(void)
+void hal_sleep(void)
 {
     SMC_SetPowerModeProtection(SMC, kSMC_AllowPowerModeAll);
 
     SMC_SetPowerModeWait(SMC);
 }
 
-void deepsleep(void)
+void hal_deepsleep(void)
 {
 #if (defined(FSL_FEATURE_SOC_MCG_COUNT) && FSL_FEATURE_SOC_MCG_COUNT)
     mcg_mode_t mode = CLOCK_GetMode();

--- a/targets/TARGET_Maxim/TARGET_MAX32600/sleep.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32600/sleep.c
@@ -41,7 +41,7 @@
 static mxc_uart_regs_t *stdio_uart = (mxc_uart_regs_t*)STDIO_UART;
 
 // Normal wait mode
-void sleep(void)
+void hal_sleep(void)
 {
     // Normal sleep mode for ARM core
     SCB->SCR = 0;
@@ -70,7 +70,7 @@ static void clearAllGPIOWUD(void)
 }
 
 // Low-power stop mode
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     __disable_irq();
 

--- a/targets/TARGET_Maxim/TARGET_MAX32610/sleep.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32610/sleep.c
@@ -41,7 +41,7 @@
 static mxc_uart_regs_t *stdio_uart = (mxc_uart_regs_t*)STDIO_UART;
 
 // Normal wait mode
-void sleep(void)
+void hal_sleep(void)
 {
     // Normal sleep mode for ARM core
     SCB->SCR = 0;
@@ -70,7 +70,7 @@ static void clearAllGPIOWUD(void)
 }
 
 // Low-power stop mode
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     __disable_irq();
 

--- a/targets/TARGET_Maxim/TARGET_MAX32620/sleep.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620/sleep.c
@@ -54,7 +54,7 @@ static mxc_uart_regs_t *stdio_uart = (mxc_uart_regs_t*)STDIO_UART;
 static int restore_usb;
 static usb_state_t usb_state;
 
-void sleep(void)
+void hal_sleep(void)
 {
     // Normal sleep mode for ARM core
     SCB->SCR = 0;
@@ -109,7 +109,7 @@ static void usb_wakeup(void)
 }
 
 // Low-power stop mode
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     unsigned int part_rev = MXC_PWRMAN->mask_id0 & MXC_F_PWRMAN_MASK_ID0_REVISION_ID;
 

--- a/targets/TARGET_Maxim/TARGET_MAX32625/sleep.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/sleep.c
@@ -34,13 +34,13 @@
 #include "sleep_api.h"
 #include "lp.h"
 
-void sleep(void)
+void hal_sleep(void)
 {
     LP_EnterLP2();
 }
 
 // Low-power stop mode
-void deepsleep(void)
+void hal_deepsleep(void)
 {
-    sleep();
+    hal_sleep();
 }

--- a/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/sleep.c
+++ b/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/sleep.c
@@ -18,7 +18,7 @@
 #include "mbed_interface.h"
 #include "toolchain.h"
 
-MBED_WEAK void sleep(void)
+MBED_WEAK void hal_sleep(void)
 {
     // ensure debug is disconnected if semihost is enabled....
     NRF_POWER->TASKS_LOWPWR = 1;
@@ -26,8 +26,8 @@ MBED_WEAK void sleep(void)
     __WFE();
 }
 
-MBED_WEAK void deepsleep(void)
+MBED_WEAK void hal_deepsleep(void)
 {
-    sleep();
+    hal_sleep();
     //   NRF_POWER->SYSTEMOFF=1;
 }

--- a/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/sleep.c
+++ b/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/sleep.c
@@ -18,7 +18,7 @@
 #include "mbed_interface.h"
 #include "toolchain.h"
 
-MBED_WEAK void hal_sleep(void)
+void hal_sleep(void)
 {
     // ensure debug is disconnected if semihost is enabled....
     NRF_POWER->TASKS_LOWPWR = 1;
@@ -26,7 +26,7 @@ MBED_WEAK void hal_sleep(void)
     __WFE();
 }
 
-MBED_WEAK void hal_deepsleep(void)
+void hal_deepsleep(void)
 {
     hal_sleep();
     //   NRF_POWER->SYSTEMOFF=1;

--- a/targets/TARGET_NORDIC/TARGET_NRF5/sleep.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/sleep.c
@@ -25,7 +25,7 @@
 
 #define FPU_EXCEPTION_MASK 0x0000009F
 
-void sleep(void)
+void hal_sleep(void)
 {
     // ensure debug is disconnected if semihost is enabled....
 
@@ -73,8 +73,8 @@ void sleep(void)
     }
 }
 
-void deepsleep(void)
+void hal_deepsleep(void)
 {
-    sleep();
+    hal_sleep();
     //   NRF_POWER->SYSTEMOFF=1;
 }

--- a/targets/TARGET_NUVOTON/TARGET_M451/sleep.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/sleep.c
@@ -38,7 +38,7 @@ int pwmout_allow_powerdown(void);
 /**
  * Enter Idle mode.
  */
-void sleep(void)
+void hal_sleep(void)
 {
     struct sleep_s sleep_obj;
     sleep_obj.powerdown = 0;
@@ -49,7 +49,7 @@ void sleep(void)
 /**
  * Enter Power-down mode while no peripheral is active; otherwise, enter Idle mode.
  */
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     struct sleep_s sleep_obj;
     sleep_obj.powerdown = 1;

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/sleep.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/sleep.c
@@ -38,7 +38,7 @@ int pwmout_allow_powerdown(void);
 /**
  * Enter Idle mode.
  */
-void sleep(void)
+void hal_sleep(void)
 {
     struct sleep_s sleep_obj;
     sleep_obj.powerdown = 0;
@@ -49,7 +49,7 @@ void sleep(void)
 /**
  * Enter Power-down mode while no peripheral is active; otherwise, enter Idle mode.
  */
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     struct sleep_s sleep_obj;
     sleep_obj.powerdown = 1;

--- a/targets/TARGET_NXP/TARGET_LPC11U6X/sleep.c
+++ b/targets/TARGET_NXP/TARGET_LPC11U6X/sleep.c
@@ -19,7 +19,7 @@
 
 #if DEVICE_SLEEP
 
-void sleep(void) {
+void hal_sleep(void) {
 
 #if (DEVICE_SEMIHOST == 1)
     // ensure debug is disconnected
@@ -37,7 +37,7 @@ void sleep(void) {
 }
 
 
-void deepsleep(void) {
+void hal_deepsleep(void) {
 
 #if (DEVICE_SEMIHOST == 1)
     // ensure debug is disconnected

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/sleep.c
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/sleep.c
@@ -17,7 +17,7 @@
 #include "cmsis.h"
 #include "mbed_interface.h"
 
-void sleep(void) {
+void hal_sleep(void) {
     // ensure debug is disconnected
     #if DEVICE_SEMIHOST
     mbed_interface_disconnect();
@@ -59,7 +59,7 @@ void sleep(void) {
 *       We treat a deepsleep() as a normal sleep().
 */
 
-void deepsleep(void) {
+void hal_deepsleep(void) {
     // ensure debug is disconnected
     #if DEVICE_SEMIHOST
     mbed_interface_disconnect();

--- a/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/sleep.c
+++ b/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/sleep.c
@@ -17,7 +17,7 @@
 #include "cmsis.h"
 #include "mbed_interface.h"
 
-void sleep(void) {
+void hal_sleep(void) {
     
     // PCON[DPDEN] set to sleep
     LPC_PMU->PCON = 0x0;
@@ -29,7 +29,7 @@ void sleep(void) {
     __WFI();
 }
 
-void deepsleep(void) {
+void hal_deepsleep(void) {
     
     // PCON[DPDEN] set to deepsleep
     LPC_PMU->PCON = 0;

--- a/targets/TARGET_NXP/TARGET_LPC13XX/sleep.c
+++ b/targets/TARGET_NXP/TARGET_LPC13XX/sleep.c
@@ -17,7 +17,7 @@
 #include "cmsis.h"
 #include "mbed_interface.h"
 
-void sleep(void) {
+void hal_sleep(void) {
     // PCON[PD] set to sleep
     LPC_PMU->PCON = 0x0;
     
@@ -28,7 +28,7 @@ void sleep(void) {
     __WFI();
 }
 
-void deepsleep(void) {
+void hal_deepsleep(void) {
     // PCON[PD] set to deepsleep
     LPC_PMU->PCON = 0x1;
     

--- a/targets/TARGET_NXP/TARGET_LPC176X/sleep.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/sleep.c
@@ -17,7 +17,7 @@
 #include "cmsis.h"
 #include "mbed_interface.h"
 
-void sleep(void) {
+void hal_sleep(void) {
 
 #if (DEVICE_SEMIHOST == 1)
     // ensure debug is disconnected
@@ -60,7 +60,7 @@ void sleep(void) {
 *       We treat a deepsleep() as a normal sleep().
 */
 
-void deepsleep(void) {
+void hal_deepsleep(void) {
 
 #if (DEVICE_SEMIHOST == 1)
     // ensure debug is disconnected
@@ -68,5 +68,5 @@ void deepsleep(void) {
 #endif
     
     // PCON[PD] set to deepsleep
-    sleep();
+    hal_sleep();
 }

--- a/targets/TARGET_NXP/TARGET_LPC408X/sleep.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/sleep.c
@@ -17,7 +17,7 @@
 #include "cmsis.h"
 #include "mbed_interface.h"
 
-void sleep(void) {
+void hal_sleep(void) {
     LPC_SC->PCON = 0x0;
     
     // SRC[SLEEPDEEP] set to 0 = sleep
@@ -52,6 +52,6 @@ void sleep(void) {
 *
 *       We treat a deepsleep() as a normal sleep().
 */
-void deepsleep(void) {
-    sleep();
+void hal_deepsleep(void) {
+    hal_sleep();
 }

--- a/targets/TARGET_NXP/TARGET_LPC43XX/sleep.c
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/sleep.c
@@ -19,7 +19,7 @@
 #include "cmsis.h"
 #include "mbed_interface.h"
 
-void sleep(void) {
+void hal_sleep(void) {
     
     // SRC[SLEEPDEEP] set to 0 = sleep
     SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
@@ -31,6 +31,6 @@ void sleep(void) {
 /*
  *  ToDo: Implement deepsleep()
  */
-void deepsleep(void) {
-    sleep();
+void hal_deepsleep(void) {
+    hal_sleep();
 }

--- a/targets/TARGET_NXP/TARGET_LPC81X/sleep.c
+++ b/targets/TARGET_NXP/TARGET_LPC81X/sleep.c
@@ -20,7 +20,7 @@
 //#define DEEPSLEEP
 #define POWERDOWN
  
-void sleep(void) {  
+void hal_sleep(void) {  
     //Normal sleep mode for PCON:
     LPC_PMU->PCON &= ~0x03;
     
@@ -36,7 +36,7 @@ void sleep(void) {
 //Deepsleep/powerdown modes assume the device is configured to use its internal RC oscillator directly
  
 #ifdef DEEPSLEEP
-void deepsleep(void) {
+void hal_deepsleep(void) {
     //Deep sleep in PCON
     LPC_PMU->PCON &= ~0x03;
     LPC_PMU->PCON |= 0x01;
@@ -59,7 +59,7 @@ void deepsleep(void) {
 #endif
  
 #ifdef POWERDOWN
-void deepsleep(void) {
+void hal_deepsleep(void) {
     //Powerdown in PCON
     LPC_PMU->PCON &= ~0x03;
     LPC_PMU->PCON |= 0x02;

--- a/targets/TARGET_NXP/TARGET_LPC82X/sleep.c
+++ b/targets/TARGET_NXP/TARGET_LPC82X/sleep.c
@@ -20,7 +20,7 @@
 //#define DEEPSLEEP
 #define POWERDOWN
 
-void sleep(void)
+void hal_sleep(void)
 {
     //Normal sleep mode for PCON:
     LPC_PMU->PCON &= ~0x03;
@@ -34,7 +34,7 @@ void sleep(void)
 
 // Deepsleep/powerdown modes assume the device is configured to use its internal RC oscillator directly
  
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     //Deep sleep in PCON
     LPC_PMU->PCON &= ~0x03;

--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -35,7 +35,7 @@
 #include "cmsis.h"
 
 
-void sleep(void)
+void hal_sleep(void)
 {
     // Stop HAL systick
     HAL_SuspendTick();
@@ -45,7 +45,7 @@ void sleep(void)
     HAL_ResumeTick();
 }
 
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     // Stop HAL systick
     HAL_SuspendTick();

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/sleep.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/sleep.c
@@ -35,7 +35,7 @@ uint32_t sleep_block_counter[NUM_SLEEP_MODES] = {0};
  * Sleep mode.
  * Enter the lowest possible sleep mode that is not blocked by ongoing activity.
  */
-void sleep(void)
+void hal_sleep(void)
 {
     if (sleep_block_counter[0] > 0) {
         /* Blocked everything below EM0, so just return */
@@ -64,7 +64,7 @@ void sleep(void)
  * consumption as low as 1.1 μA with RTC enabled. Power-on Reset, Brown-out
  * Detection and full RAM and CPU retention is also included.
  */
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     EMU_EnterEM2(true);
 }

--- a/targets/TARGET_WIZNET/TARGET_W7500x/sleep.c
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/sleep.c
@@ -31,12 +31,12 @@
 #include "cmsis.h"
 #include "mbed_interface.h"
 
-void sleep(void)
+void hal_sleep(void)
 {
     // To Do
 }
 
-void deepsleep(void)
+void hal_deepsleep(void)
 {
     // To Do
 }

--- a/targets/TARGET_ublox/TARGET_HI2110/sleep.c
+++ b/targets/TARGET_ublox/TARGET_HI2110/sleep.c
@@ -40,14 +40,14 @@
  * MBED API CALLS
  * ----------------------------------------------------------------*/
 
-void sleep(void)
+void hal_sleep(void)
 {
     __DSB();
     __WFI();
     __ISB();
 }
 
-void deepsleep()
+void hal_deepsleep()
 {
-    sleep();
+    hal_sleep();
 }


### PR DESCRIPTION
Add sleep/deepsleep functions to platform layer which are replacing HAL
functions with the same name, rename existing symbols in HAL layer
to hal_sleep/hal_deepsleep. This way sleep functions
are always available, even if target doesn't implement them, which makes
the code using sleep clearer. It also enables us to make decision on in
which builds (debug/release) the sleep will be enabled.

## Status
**READY**

## Related PRs
https://github.com/ARMmbed/mbed-os/pull/3566

CC: @0xc0170 @sg- @betzw 