### PR TITLE
Exporters: make jinja engine strict

### DIFF
--- a/tools/export/cmsis/cpdsc.tmpl
+++ b/tools/export/cmsis/cpdsc.tmpl
@@ -12,7 +12,7 @@
     <project name="{{name}}" documentation="">
       <target Dendian="{{device.dendian}}" Dfpu="{{device.dfpu}}" Dname="{{device.dname}}" Dvendor="{{device.dvendor}}">
         <output debug="1" name="{{name}}" type="exe"/>
-        <debugProbe name="{{device.debug_interface}}" protocol="jtag"/>
+        <debugProbe name="{{device.debug}}" protocol="jtag"/>
       </target>
       {{project_files}}
     </project>

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -111,11 +111,12 @@ class Exporter(object):
             source_files.extend(getattr(self.resources, key))
         return list(set([os.path.dirname(src) for src in source_files]))
 
-    def gen_file(self, template_file, data, target_file):
+    def gen_file(self, template_file, data, target_file, **kwargs):
         """Generates a project file from a template using jinja"""
         jinja_loader = FileSystemLoader(
             os.path.dirname(os.path.abspath(__file__)))
-        jinja_environment = Environment(loader=jinja_loader, undefined=StrictUndefined, trim_blocks=True, lstrip_blocks=True)
+        jinja_environment = Environment(loader=jinja_loader,
+                                        undefined=StrictUndefined, **kwargs)
 
         template = jinja_environment.get_template(template_file)
         target_text = template.render(data)

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -4,7 +4,7 @@ from abc import abstractmethod, ABCMeta
 import logging
 from os.path import join, dirname, relpath, basename, realpath, normpath
 from itertools import groupby
-from jinja2 import FileSystemLoader
+from jinja2 import FileSystemLoader, StrictUndefined
 from jinja2.environment import Environment
 import copy
 
@@ -115,7 +115,7 @@ class Exporter(object):
         """Generates a project file from a template using jinja"""
         jinja_loader = FileSystemLoader(
             os.path.dirname(os.path.abspath(__file__)))
-        jinja_environment = Environment(loader=jinja_loader)
+        jinja_environment = Environment(loader=jinja_loader, undefined=StrictUndefined, trim_blocks=True, lstrip_blocks=True)
 
         template = jinja_environment.get_template(template_file)
         target_text = template.render(data)

--- a/tools/export/iar/__init__.py
+++ b/tools/export/iar/__init__.py
@@ -64,8 +64,10 @@ class IAR(Exporter):
             "GFPUCoreSlave": '',
             "GFPUCoreSlave2": 40,
             "GBECoreSlave": 35,
+            "GBECoreSlave2": '',
             "FPU2": 0,
             "NrRegs": 0,
+            "NEON": '',
         }
 
         iar_defaults.update(device_info)

--- a/tools/export/iar/ewp.tmpl
+++ b/tools/export/iar/ewp.tmpl
@@ -131,7 +131,7 @@
         <option>
           <name>GBECoreSlave</name>
           <version>24</version>
-          <state>{{GBECoreSlave}}</state>
+          <state>{{device.GBECoreSlave}}</state>
         </option>
         <option>
           <name>OGUseCmsis</name>


### PR DESCRIPTION
- configure the jinja Environment to raise exception when substitution
variables are not defined
- trim spaces and lines, to avoid empty lines in generated files