### PR TITLE
tests: Fix error on MacOS for udp_dtls_handshake test

### DIFF
--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/host_tests/udp_shotgun.py
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/host_tests/udp_shotgun.py
@@ -65,7 +65,10 @@ class UDPEchoClientTest(BaseHostTest):
         :return:
         """
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect((target_ip, 0)) # Target IP, Any port
+        try:
+            s.connect((target_ip, 0)) # Target IP, any port
+        except socket.error:
+            s.connect((target_ip, 8000)) # Target IP, 'random' port
         ip = s.getsockname()[0]
         s.close()
         return ip


### PR DESCRIPTION

## Description
MacOS doesn't like the `s.connect((target_ip, 0))` any port construct and the tests are failing. Fix doesn't change the default behavior but provides a fallback.

## Status
**READY**

@bridadan @geky 