### PR TITLE
EFM32GG: Fix GCC_ARM linker script

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/device/TARGET_1024K/TOOLCHAIN_GCC_ARM/efm32gg.ld
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/device/TARGET_1024K/TOOLCHAIN_GCC_ARM/efm32gg.ld
@@ -152,7 +152,7 @@ SECTIONS
   /* Note: The uVisor expects this section at a fixed location, as specified
            by the porting process configuration parameter: SRAM_OFFSET. */
   __UVISOR_SRAM_OFFSET = 0x0;
-  __UVISOR_SRAM_START = ORIGIN(m_data) + __UVISOR_SRAM_OFFSET;
+  __UVISOR_SRAM_START = ORIGIN(RAM) + __UVISOR_SRAM_OFFSET;
   .uvisor.bss __UVISOR_SRAM_START (NOLOAD):
   {
     . = ALIGN(32);


### PR DESCRIPTION
A copy paste error snuck into the uVisor related updates to the EFM32GG
linker script. Fix the error by replacing "m_data" with "RAM".

Fixes: 89641bc7e0ce "uVisor: Update K64F and EFM32GG linker scripts"


## Status
**READY**

@AlessandroA @0xc0170 
