### PR TITLE
nsapi: Changed initial state of sockets to allow events

### DIFF
--- a/features/netsocket/TCPServer.cpp
+++ b/features/netsocket/TCPServer.cpp
@@ -18,7 +18,7 @@
 #include "mbed.h"
 
 TCPServer::TCPServer()
-    : _pending(1), _accept_sem(0)
+    : _pending(0), _accept_sem(0)
 {
 }
 

--- a/features/netsocket/TCPServer.h
+++ b/features/netsocket/TCPServer.h
@@ -46,7 +46,7 @@ public:
      */
     template <typename S>
     TCPServer(S *stack)
-        : _pending(1), _accept_sem(0)
+        : _pending(0), _accept_sem(0)
     {
         open(stack);
     }

--- a/features/netsocket/TCPSocket.cpp
+++ b/features/netsocket/TCPSocket.cpp
@@ -19,7 +19,7 @@
 #include "mbed_assert.h"
 
 TCPSocket::TCPSocket()
-    : _pending(1), _read_sem(0), _write_sem(0),
+    : _pending(0), _read_sem(0), _write_sem(0),
       _read_in_progress(false), _write_in_progress(false)
 {
 }

--- a/features/netsocket/TCPSocket.h
+++ b/features/netsocket/TCPSocket.h
@@ -45,7 +45,7 @@ public:
      */
     template <typename S>
     TCPSocket(S *stack)
-        : _pending(1), _read_sem(0), _write_sem(0),
+        : _pending(0), _read_sem(0), _write_sem(0),
           _read_in_progress(false), _write_in_progress(false)
     {
         open(stack);

--- a/features/netsocket/UDPSocket.cpp
+++ b/features/netsocket/UDPSocket.cpp
@@ -19,7 +19,7 @@
 #include "mbed_assert.h"
 
 UDPSocket::UDPSocket()
-    : _pending(1), _read_sem(0), _write_sem(0)
+    : _pending(0), _read_sem(0), _write_sem(0)
 {
 }
 

--- a/features/netsocket/UDPSocket.h
+++ b/features/netsocket/UDPSocket.h
@@ -45,7 +45,7 @@ public:
      */
     template <typename S>
     UDPSocket(S *stack)
-        : _pending(1), _read_sem(0), _write_sem(0)
+        : _pending(0), _read_sem(0), _write_sem(0)
     {
         open(stack);
     }


### PR DESCRIPTION
As pointed out by @kjbracey-arm, the previous behaviour was broken for sockets that started out listening.

Note, the registered callback is still disabled by a call to socket_attach. This will avoid being called after the socket is closed unless close is called from the attached callback, which is in irq context.

This effectively reverts https://github.com/ARMmbed/mbed-os/pull/3374, which contains a discussion on the expected behaviour.

cc @kjbracey-arm, @0xc0170 