### PR TITLE
Fix Stack stats by running the test command with "-DMBED_HEAP_STATS_ENABLED=1"

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_A/RTX_Conf_CA.c
+++ b/rtos/rtx/TARGET_CORTEX_A/RTX_Conf_CA.c
@@ -107,7 +107,11 @@
 //   <i> Initialize thread stack with watermark pattern for analyzing stack usage (current/maximum) in System and Thread Viewer.
 //   <i> Enabling this option increases significantly the execution time of osThreadCreate.
 #ifndef OS_STKINIT
-#define OS_STKINIT      0
+  #if (defined(MBED_STACK_STATS_ENABLED) && MBED_STACK_STATS_ENABLED)
+   #define OS_STKINIT   1
+  #else
+   #define OS_STKINIT   0
+  #endif
 #endif
 
 //   <o>Processor mode for thread execution


### PR DESCRIPTION
In CI, I receive an mbed assert of stack stats by running the following commands. Its assert is TIMEOUT.
```
mbed test -m RZ_A1H -t GCC_ARM -DMBED_STACK_STATS_ENABLED=1 --clean --compile
mbed test -m RZ_A1H -t GCC_ARM --run -n tests-mbed_drivers-stl_features -v
```

So, I fixed the process of related to stack stats (`osThreadInfoStackMax`).The Detail contents is here.
https://github.com/ARMmbed/mbed-os/issues/3273#issuecomment-268407191
