### PR TITLE
Missing IRQ pin fix for platform VK_RZ_A1H

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/gpio_irq_api.c
+++ b/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/gpio_irq_api.c
@@ -71,6 +71,7 @@ static const PinMap PinMap_IRQ[] = {
 #else
 static const PinMap PinMap_IRQ[] = {
     {P9_1,  IRQ0, 4},
+    {P7_8,  IRQ1, 8},
     {P1_2,  IRQ2, 4}, {P1_8,  IRQ2, 3}, {P3_0,  IRQ2, 3}, {P5_9,  IRQ2, 4},
     {P1_3,  IRQ3, 4}, {P1_9,  IRQ3, 3},
     {P1_4,  IRQ4, 4}, {P1_10, IRQ4, 3},


### PR DESCRIPTION
Notes:
* missed external IRQ interrupt pin added!

## Description
This IRQ is used for signalling 'new data ready' from the touch controller of the VKLCD70RT (which is a companion board for VK_RZ_A1H).

## Related PRs
#3632