### PR TITLE
Adding fatal error detection to toolchains

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -26,7 +26,7 @@ class ARM(mbedToolchain):
     LIBRARY_EXT = '.ar'
 
     STD_LIB_NAME = "%s.ar"
-    DIAGNOSTIC_PATTERN  = re.compile('"(?P<file>[^"]+)", line (?P<line>\d+)( \(column (?P<column>\d+)\)|): (?P<severity>Warning|Error): (?P<message>.+)')
+    DIAGNOSTIC_PATTERN  = re.compile('"(?P<file>[^"]+)", line (?P<line>\d+)( \(column (?P<column>\d+)\)|): (?P<severity>Warning|Error|Fatal error): (?P<message>.+)')
     INDEX_PATTERN  = re.compile('(?P<col>\s*)\^')
     DEP_PATTERN = re.compile('\S+:\s(?P<file>.+)\n')
 

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -25,7 +25,7 @@ class GCC(mbedToolchain):
     LIBRARY_EXT = '.a'
 
     STD_LIB_NAME = "lib%s.a"
-    DIAGNOSTIC_PATTERN = re.compile('((?P<file>[^:]+):(?P<line>\d+):)(\d+:)? (?P<severity>warning|error): (?P<message>.+)')
+    DIAGNOSTIC_PATTERN = re.compile('((?P<file>[^:]+):(?P<line>\d+):)(\d+:)? (?P<severity>warning|error|fatal error): (?P<message>.+)')
     INDEX_PATTERN  = re.compile('(?P<col>\s*)\^')
 
     def __init__(self, target,  notify=None, macros=None,

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -26,7 +26,7 @@ class IAR(mbedToolchain):
     LINKER_EXT = '.icf'
     STD_LIB_NAME = "%s.a"
 
-    DIAGNOSTIC_PATTERN = re.compile('"(?P<file>[^"]+)",(?P<line>[\d]+)\s+(?P<severity>Warning|Error)(?P<message>.+)')
+    DIAGNOSTIC_PATTERN = re.compile('"(?P<file>[^"]+)",(?P<line>[\d]+)\s+(?P<severity>Warning|Error|Fatal error)(?P<message>.+)')
     INDEX_PATTERN  = re.compile('(?P<col>\s*)\^')
 
     @staticmethod


### PR DESCRIPTION
## Description

Before the toolchains would ignore error messages that contained the
string "Fatal error". This would lead to a silent failure unless the
compile command was ran with verbose options. This is now fixed.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [x] Tests
