### PR TITLE
Fixed a problem that the STOP2 was falling back to STOP1

### DIFF
--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -55,17 +55,21 @@ void hal_deepsleep(void)
     int pwrClockEnabled = __HAL_RCC_PWR_IS_CLK_ENABLED();
     int lowPowerModeEnabled = PWR->CR1 & PWR_CR1_LPR;
     
-    if (!pwrClockEnabled)
+    if (!pwrClockEnabled) {
         __HAL_RCC_PWR_CLK_ENABLE();
-    if (lowPowerModeEnabled)
+    }
+    if (lowPowerModeEnabled) {
         HAL_PWREx_DisableLowPowerRunMode();
+    }
     
     HAL_PWREx_EnterSTOP2Mode(PWR_STOPENTRY_WFI);
     
-    if (lowPowerModeEnabled)
+    if (lowPowerModeEnabled) {
         HAL_PWREx_EnableLowPowerRunMode();
-    if (!pwrClockEnabled)
+    }
+    if (!pwrClockEnabled) {
         __HAL_RCC_PWR_CLK_DISABLE();
+    }
 #else /* TARGET_STM32L4 */
     HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
 #endif /* TARGET_STM32L4 */

--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -52,17 +52,20 @@ void hal_deepsleep(void)
 
     // Request to enter STOP mode with regulator in low power mode
 #if TARGET_STM32L4
-    if (__HAL_RCC_PWR_IS_CLK_ENABLED()) {
-        HAL_PWREx_EnableLowPowerRunMode();
-        HAL_PWREx_EnterSTOP2Mode(PWR_STOPENTRY_WFI);
-        HAL_PWREx_DisableLowPowerRunMode();
-    } else {
+    int pwrClockEnabled = __HAL_RCC_PWR_IS_CLK_ENABLED();
+    int lowPowerModeEnabled = PWR->CR1 & PWR_CR1_LPR;
+    
+    if (!pwrClockEnabled)
         __HAL_RCC_PWR_CLK_ENABLE();
-        HAL_PWREx_EnableLowPowerRunMode();
-        HAL_PWREx_EnterSTOP2Mode(PWR_STOPENTRY_WFI);
+    if (lowPowerModeEnabled)
         HAL_PWREx_DisableLowPowerRunMode();
+    
+    HAL_PWREx_EnterSTOP2Mode(PWR_STOPENTRY_WFI);
+    
+    if (lowPowerModeEnabled)
+        HAL_PWREx_EnableLowPowerRunMode();
+    if (!pwrClockEnabled)
         __HAL_RCC_PWR_CLK_DISABLE();
-    }
 #else /* TARGET_STM32L4 */
     HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
 #endif /* TARGET_STM32L4 */


### PR DESCRIPTION
The LPR was not turned on when entering into STOP2. Now the deepsleep mode on the STM32L4 Nucleo board needs only 1.6uA instead of 10uA.

This is described in the STM RM0351 Reference manual, Section PWR registers BIT-14
Note: Stop 2 mode cannot be entered when LPR bit is set. Stop 1 is entered instead.

I am pretty happy that I figured this out.

Regards Helmut