### PR TITLE
Adding case insensitive 'error' detection

### DIFF
--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -25,7 +25,7 @@ class GCC(mbedToolchain):
     LIBRARY_EXT = '.a'
 
     STD_LIB_NAME = "lib%s.a"
-    DIAGNOSTIC_PATTERN = re.compile('((?P<file>[^:]+):(?P<line>\d+):)(\d+:)? (?P<severity>warning|error|fatal error): (?P<message>.+)')
+    DIAGNOSTIC_PATTERN = re.compile('((?P<file>[^:]+):(?P<line>\d+):)(\d+:)? (?P<severity>warning|[eE]rror|fatal error): (?P<message>.+)')
     INDEX_PATTERN  = re.compile('(?P<col>\s*)\^')
 
     def __init__(self, target,  notify=None, macros=None,


### PR DESCRIPTION
## Description
GCC Assembler errors were being missed because it prints 'error' with a captial 'E'. This change allows the 'e' to be either lower case or upper case.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Related PRs
This may conflict with https://github.com/ARMmbed/mbed-os/pull/3653


## Todos
- [x] Tests


## Notes
Before, the tools would miss errors like the following when it was printed from the assembler:

```
/tmp/ccXLitIR.s: Assembler messages:
/tmp/ccXLitIR.s:677: Error: cannot honor width suffix -- `mov r1,#0'
/tmp/ccXLitIR.s:679: Error: cannot honor width suffix -- `mov r0,#0'
/tmp/ccXLitIR.s:727: Error: cannot honor width suffix -- `mov r1,#4'
/tmp/ccXLitIR.s:729: Error: cannot honor width suffix -- `neg r1,r1'
/tmp/ccXLitIR.s:731: Error: cannot honor width suffix -- `mov r5,#4'
/tmp/ccXLitIR.s:737: Error: cannot honor width suffix -- `mov r1,#3'
/tmp/ccXLitIR.s:739: Error: cannot honor width suffix -- `neg r1,r1'
/tmp/ccXLitIR.s:741: Error: cannot honor width suffix -- `mov r5,#3'
/tmp/ccXLitIR.s:743: Error: cannot honor width suffix -- `neg r5,r5'
/tmp/ccXLitIR.s:754: Error: cannot honor width suffix -- `orr r5,r2'
/tmp/ccXLitIR.s:904: Error: cannot honor width suffix -- `mov r1,#4'
/tmp/ccXLitIR.s:906: Error: cannot honor width suffix -- `neg r1,r1'
/tmp/ccXLitIR.s:908: Error: cannot honor width suffix -- `mov r0,#4'
/tmp/ccXLitIR.s:915: Error: cannot honor width suffix -- `mov r1,#3'
/tmp/ccXLitIR.s:916: Error: cannot honor width suffix -- `neg r1,r1'
/tmp/ccXLitIR.s:919: Error: cannot honor width suffix -- `mov r0,#3'
/tmp/ccXLitIR.s:921: Error: cannot honor width suffix -- `neg r0,r0'
/tmp/ccXLitIR.s:926: Error: lo register required -- `add r0,r0,#12'
/tmp/ccXLitIR.s:982: Error: cannot honor width suffix -- `mov r1,#6'
/tmp/ccXLitIR.s:984: Error: cannot honor width suffix -- `neg r1,r1'
/tmp/ccXLitIR.s:986: Error: cannot honor width suffix -- `mov r0,#6'
/tmp/ccXLitIR.s:987: Error: cannot honor width suffix -- `neg r0,r0'
```

Now it should list every one of the errors.