### PR TITLE
NRF51822: HAL: Restore WEAK declaration for hal_(deep)sleep

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/sleep.c
+++ b/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/sleep.c
@@ -18,7 +18,7 @@
 #include "mbed_interface.h"
 #include "toolchain.h"
 
-void hal_sleep(void)
+MBED_WEAK void hal_sleep(void)
 {
     // ensure debug is disconnected if semihost is enabled....
     NRF_POWER->TASKS_LOWPWR = 1;
@@ -26,7 +26,7 @@ void hal_sleep(void)
     __WFE();
 }
 
-void hal_deepsleep(void)
+MBED_WEAK void hal_deepsleep(void)
 {
     hal_sleep();
     //   NRF_POWER->SYSTEMOFF=1;


### PR DESCRIPTION
Fixes a conflict between NRF51822 and DELTA_DFCM_NNN40.

Fix https://github.com/ARMmbed/mbed-os/issues/3672

@0xc0170 @sarahmarshy 