### PR TITLE
Honor OS_MAINSTKSIZE setting

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -354,15 +354,21 @@ __attribute__((used)) void _mutex_release (OS_ID *mutex) {
 /* Main Thread definition */
 extern void pre_main (void);
 
+#ifdef OS_MAINSTKSIZE
+#    define MAIN_STACK_SIZE   (OS_MAINSTKSIZE * 4)
+#else
+#    define MAIN_STACK_SIZE   (DEFAULT_STACK_SIZE)
+#endif
+
 #if defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832) || defined (TARGET_STM32F334R8) ||\
     defined(TARGET_STM32F070RB) || defined(TARGET_STM32F072RB) || \
     defined(TARGET_STM32F302R8) || defined(TARGET_STM32F303K8) || defined (TARGET_STM32F334C8) ||\
     defined(TARGET_STM32F103RB)
-static uint32_t thread_stack_main[DEFAULT_STACK_SIZE / sizeof(uint32_t)];
+static uint32_t thread_stack_main[MAIN_STACK_SIZE / sizeof(uint32_t)];
 #elif defined(TARGET_XDOT_L151CC)
-static uint32_t thread_stack_main[DEFAULT_STACK_SIZE * 6 / sizeof(uint32_t)];
+static uint32_t thread_stack_main[MAIN_STACK_SIZE * 6 / sizeof(uint32_t)];
 #else
-static uint32_t thread_stack_main[DEFAULT_STACK_SIZE * 2 / sizeof(uint32_t)];
+static uint32_t thread_stack_main[MAIN_STACK_SIZE * 2 / sizeof(uint32_t)];
 #endif
 osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1U, sizeof(thread_stack_main), thread_stack_main};
 


### PR DESCRIPTION
I'm using the NRF52832, and ran into a problem with mbedTLS using more than 2K of stack memory, which causes a stack overflow with the default main thread configuration. 

Changing `OS_MAINSTKSIZE` didn't fix the problem, and I needed to understand why.

The bug hunt is documented here:
https://vilimpoc.org/blog/2017/02/01/stack-heap-and-thread-crash-hunting-in-mbed-os/

## OS_MAINSTKSIZE isn't being honored

**RTX_CM_lib.h**

Here is the definition of the main thread's stack memory area:

```c
#if defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832) || defined (TARGET_STM32F334R8) ||\
    defined(TARGET_STM32F070RB) || defined(TARGET_STM32F072RB) || \
    defined(TARGET_STM32F302R8) || defined(TARGET_STM32F303K8) || defined (TARGET_STM32F334C8) ||\
    defined(TARGET_STM32F103RB)
static uint32_t thread_stack_main[DEFAULT_STACK_SIZE / sizeof(uint32_t)];
#elif defined(TARGET_XDOT_L151CC)
static uint32_t thread_stack_main[DEFAULT_STACK_SIZE * 6 / sizeof(uint32_t)];
#else
static uint32_t thread_stack_main[DEFAULT_STACK_SIZE * 2 / sizeof(uint32_t)];
#endif
osThreadDef_t os_thread_def_main = {(os_pthread)pre_main, osPriorityNormal, 1U, sizeof(thread_stack_main), thread_stack_main};
```

Following `DEFAULT_STACK_SIZE` leads to **cmsis_os.h**:

```c
#if defined(TARGET_XDOT_L151CC)
#define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE/2)
#else
#define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE*4)
#endif
```

which leads to (also **cmsis_os.h**):

```c
// The stack space occupied is mainly dependent on the underling C standard library
#if defined(TOOLCHAIN_GCC) || defined(TOOLCHAIN_ARM_STD) || defined(TOOLCHAIN_IAR)
#    define WORDS_STACK_SIZE   512
#elif defined(TOOLCHAIN_ARM_MICRO)
#    define WORDS_STACK_SIZE   128
#endif
```

So setting `OS_MAINSTKSIZE = 512` in `mbed_rtx.h` (`targets/TARGET_NORDIC/mbed_rtx.h`) does nothing.

This change pulls `OS_MAINSTKSIZE` into `RTX_CM_lib.h` if it is defined.

**Note**

One negative aspect of this is that if the user has not defined `ISR_STACK_SIZE` somewhere, then changing `OS_MAINSTKSIZE` also changes that derived parameter (so doubling it doubles the ISR/OS scheduler stack size):

```c
/* Define stack sizes if they haven't been set already */
#if !defined(ISR_STACK_SIZE)
    #define ISR_STACK_SIZE ((uint32_t)OS_MAINSTKSIZE * 4)
#endif
```