### PR TITLE
ARM - pass linker flags along to the linker

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -179,6 +179,8 @@ class ARM(mbedToolchain):
         else:
             args = ["-o", output, "--info=totals", "--map", "--list=%s" % map_file]
 
+        args.extend(self.flags['ld'])
+
         if mem_map:
             args.extend(["--scatter", mem_map])
 


### PR DESCRIPTION
On the ARM toolchain linker flags specified in the build profile do not get passed to armlink. This patch adds these flags to the arguments sent to armlink.
