### PR TITLE
Use the C Pre-Processor on GCC Linker scripts

### DIFF
--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -67,6 +67,9 @@ CC      = {{cc_cmd}}
 CPP     = {{cppc_cmd}}
 LD      = {{ld_cmd}}
 ELF2BIN = {{elf2bin_cmd}}
+{% if pp_cmd -%}
+PREPROC = {{pp_cmd}}
+{%- endif %}
 {% if hex_files %}
 SREC_CAT = srec_cat
 {%- endif %}
@@ -119,8 +122,13 @@ all: $(PROJECT).bin $(PROJECT).hex size
 	+@echo "Compile: $(notdir $<)"
 	@$(CPP) $(CXX_FLAGS) $(INCLUDE_PATHS) -o $@ $<
 
+{% if pp_cmd %}
+$(PROJECT).link_script{{link_script_ext}}: $(LINKER_SCRIPT)
+	@$(PREPROC) $< -o $@
+{% endif %}
+
 {% block target_project_elf %}
-$(PROJECT).elf: $(OBJECTS) $(SYS_OBJECTS) $(LINKER_SCRIPT)
+$(PROJECT).elf: $(OBJECTS) $(SYS_OBJECTS) {% if pp_cmd -%} $(PROJECT).link_script{{link_script_ext}} {% else%} $(LINKER_SCRIPT) {% endif %}
 	+@echo "link: $(notdir $@)"
 	@$(LD) $(LD_FLAGS) {{link_script_option}} $(filter %{{link_script_ext}}, $^) $(LIBRARY_PATHS) --output $@ $(filter %.o, $^) $(LIBRARIES) $(LD_SYS_LIBS)
 {% endblock %}

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -87,6 +87,14 @@ class Makefile(Exporter):
             'user_library_flag': self.USER_LIBRARY_FLAG,
         }
 
+        if hasattr(self.toolchain, "preproc"):
+            ctx['pp_cmd'] = " ".join(["\'" + part + "\'" for part
+                                      in ([basename(self.toolchain.preproc[0])] +
+                                          self.toolchain.preproc[1:] + 
+                                          self.toolchain.ld[1:])])
+        else:
+            ctx['pp_cmd'] = None
+
         for key in ['include_paths', 'library_paths', 'linker_script',
                     'hex_files']:
             if isinstance(ctx[key], list):


### PR DESCRIPTION
This allows us to define parts of the linker script outside of the linker script itself. In particular, we are interested in restricting ROM to a subsection.

