### PR TITLE
STORAGE: Pr 3705 fix for fat_file_system test missing symbols

### DIFF
--- a/drivers/DirHandle.h
+++ b/drivers/DirHandle.h
@@ -16,6 +16,8 @@
 #ifndef MBED_DIRHANDLE_H
 #define MBED_DIRHANDLE_H
 
+#include <stdint.h>
+
 #if defined(__ARMCC_VERSION) || defined(__ICCARM__)
 #   define NAME_MAX 255
 typedef int mode_t;
@@ -28,6 +30,18 @@ typedef int mode_t;
 
 struct dirent {
     char d_name[NAME_MAX+1];
+    uint8_t d_type;
+};
+
+enum {
+    DT_UNKNOWN, // The file type could not be determined.
+    DT_FIFO,    // This is a named pipe (FIFO).
+    DT_CHR,     // This is a character device.
+    DT_DIR,     // This is a directory.
+    DT_BLK,     // This is a block device.
+    DT_REG,     // This is a regular file.
+    DT_LNK,     // This is a symbolic link.
+    DT_SOCK,    // This is a UNIX domain socket.
 };
 
 namespace mbed {

--- a/features/TESTS/filesystem/fat_file_system/main.cpp
+++ b/features/TESTS/filesystem/fat_file_system/main.cpp
@@ -21,6 +21,7 @@
 #include "HeapBlockDevice.h"
 #include "FATFileSystem.h"
 #include <stdlib.h>
+#include "retarget.h"
 
 using namespace utest::v1;
 

--- a/features/filesystem/fat/FATDirHandle.cpp
+++ b/features/filesystem/fat/FATDirHandle.cpp
@@ -50,6 +50,7 @@ struct dirent *FATDirHandle::readdir() {
 
     FRESULT res = f_readdir(&dir, &finfo);
     fat_filesystem_set_errno(res);
+    cur_entry.d_type = (finfo.fattrib & AM_DIR) ? DT_DIR : DT_REG;
 
 #if _USE_LFN
     if(res != 0 || finfo.fname[0]==0) {


### PR DESCRIPTION
This PR is a 1 line fix for #3705 and submitted to check whether there are any other CI breakages cause by commit:

```
Added d_type member of dirent struct to readdir 
```

