### PR TITLE
Fix access before variable defined bug in test_api

### DIFF
--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2201,12 +2201,16 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
                             report[target_name][toolchain_name][test_key] = report_entry[test_key]
                         
                         # Set the overall result to a failure if a build failure occurred
-                        if not worker_result['result'] and not isinstance(worker_result['reason'], NotSupportedException):
+                        if ('reason' in worker_result and
+                            not worker_result['reason'] and
+                            not isinstance(worker_result['reason'], NotSupportedException)):
                             result = False
                             break
 
                         # Adding binary path to test build result
-                        if worker_result['result'] and 'bin_file' in worker_result:
+                        if ('result' in worker_result and
+                            worker_result['result'] and
+                            'bin_file' in worker_result):
                             bin_file = norm_relative_path(worker_result['bin_file'], execution_directory)
 
                             test_build['tests'][worker_result['kwargs']['project_id']] = {


### PR DESCRIPTION
The worker_result variable was not guaranteed to have a `'result'` or `'reason'` key and accessing them before testing for them could result in an error when they are not provided. This patch changes the checks to prevent check for their existence before accessing them.

Moved this commit from #3706