### PR TITLE
Enable boot-loader builds

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -10,7 +10,8 @@
         "features": [],
         "detect_code": [],
         "public": false,
-        "default_lib": "std"
+        "default_lib": "std",
+        "bootloader_supported": false
     },
     "Super_Target": {
         "inherits": ["Target"],
@@ -455,7 +456,8 @@
         "detect_code": ["0220"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "release_versions": ["2", "5"],
-        "device_name": "MKL46Z256xxx4"
+        "device_name": "MKL46Z256xxx4",
+        "bootloader_supported": true
     },
     "K20D50M": {
         "inherits": ["Target"],
@@ -581,7 +583,8 @@
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE", "STDIO_MESSAGES", "STORAGE", "TRNG"],
         "features": ["LWIP", "STORAGE"],
         "release_versions": ["2", "5"],
-        "device_name": "MK64FN1M0xxx12"
+        "device_name": "MK64FN1M0xxx12",
+        "bootloader_supported": true
     },
     "MTS_GAMBIT": {
         "inherits": ["Target"],
@@ -889,7 +892,8 @@
         "detect_code": ["0796"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
-        "device_name" : "STM32F429ZI"
+        "device_name" : "STM32F429ZI",
+        "bootloader_supported": true
     },
     "NUCLEO_F439ZI": {
         "supported_form_factors": ["ARDUINO"],
@@ -1327,7 +1331,8 @@
         "device_has": ["ANALOGIN", "CAN", "EMAC", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG"],
         "features": ["LWIP"],
         "release_versions": ["5"],
-        "device_name": "STM32F439ZI"
+        "device_name": "STM32F439ZI",
+        "bootloader_supported": true
     },
     "NZ32_SC151": {
         "inherits": ["Target"],

--- a/tools/config.py
+++ b/tools/config.py
@@ -477,6 +477,8 @@ class Config(object):
     @property
     def regions(self):
         """Generate a list of regions from the config"""
+        if not self.target.bootloader_supported:
+            raise ConfigException("Bootloader not supported on this target.")
         cmsis_part = Cache(False, False).index[self.target.device_name]
         start = 0
         target_overrides = self.app_config_data['target_overrides'].get(

--- a/tools/config.py
+++ b/tools/config.py
@@ -18,8 +18,12 @@ limitations under the License.
 from copy import deepcopy
 import os
 import sys
+from collections import namedtuple
+from os.path import splitext
+from intelhex import IntelHex
 # Implementation of mbed configuration mechanism
-from tools.utils import json_file_to_dict
+from tools.utils import json_file_to_dict, intelhex_offset
+from tools.arm_pack_manager import Cache
 from tools.targets import CUMULATIVE_ATTRIBUTES, TARGET_MAP, \
     generate_py_target, get_resolution_order
 
@@ -328,6 +332,8 @@ def _process_macros(mlist, macros, unit_name, unit_kind):
         macros[macro.macro_name] = macro
 
 
+Region = namedtuple("Region", "name start size active filename")
+
 class Config(object):
     """'Config' implements the mbed configuration mechanism"""
 
@@ -345,6 +351,8 @@ class Config(object):
         "application": set(["config", "target_overrides",
                             "macros", "__config_path"])
     }
+
+    __unused_overrides = set(["target.bootloader_img", "target.restrict_size"])
 
     # Allowed features in configurations
     __allowed_features = [
@@ -455,6 +463,52 @@ class Config(object):
                        self.lib_config_data[cfg["name"]]["__config_path"]))
             self.lib_config_data[cfg["name"]] = cfg
 
+    @property
+    def has_regions(self):
+        """Does this config have regions defined?"""
+        if 'target_overrides' in self.app_config_data:
+            target_overrides = self.app_config_data['target_overrides'].get(
+                self.target.name, {})
+            return ('target.bootloader_img' in target_overrides or
+                    'target.restrict_size' in target_overrides)
+        else:
+            return False
+
+    @property
+    def regions(self):
+        """Generate a list of regions from the config"""
+        cmsis_part = Cache(False, False).index[self.target.device_name]
+        start = 0
+        target_overrides = self.app_config_data['target_overrides'].get(
+            self.target.name, {})
+        try:
+            rom_size = int(cmsis_part['memory']['IROM1']['size'], 0)
+            rom_start = int(cmsis_part['memory']['IROM1']['start'], 0)
+        except KeyError:
+            raise ConfigException("Not enough information in CMSIS packs to "
+                                  "build a bootloader project")
+        if 'target.bootloader_img' in target_overrides:
+            filename = target_overrides['target.bootloader_img']
+            part = intelhex_offset(filename, offset=rom_start)
+            if part.minaddr() != rom_start:
+                raise ConfigException("bootloader executable does not "
+                                      "start at 0x%x" % rom_start)
+            part_size = (part.maxaddr() - part.minaddr()) + 1
+            yield Region("bootloader", rom_start + start, part_size, False,
+                         filename)
+            start += part_size
+        if 'target.restrict_size' in target_overrides:
+            new_size = int(target_overrides['target.restrict_size'], 0)
+            yield Region("application", rom_start + start, new_size, True, None)
+            start += new_size
+            yield Region("post_application", rom_start +start, rom_size - start,
+                         False, None)
+        else:
+            yield Region("application", rom_start + start, rom_size - start,
+                         True, None)
+        if start > rom_size:
+            raise ConfigException("Not enough memory on device to fit all "
+                                  "application regions")
 
     def _process_config_and_overrides(self, data, params, unit_name, unit_kind):
         """Process "config_parameters" and "target_config_overrides" into a
@@ -508,6 +562,8 @@ class Config(object):
                     if full_name in params:
                         params[full_name].set_value(val, unit_name, unit_kind,
                                                     label)
+                    elif name in self.__unused_overrides:
+                        pass
                     else:
                         self.config_errors.append(
                             ConfigException(
@@ -560,6 +616,8 @@ class Config(object):
                 rel_names = [tgt for tgt, _ in
                              get_resolution_order(self.target.json_data, tname,
                                                   [])]
+                if full_name in self.__unused_overrides:
+                    continue
                 if (full_name not in params) or \
                    (params[full_name].defined_by[7:] not in rel_names):
                     raise ConfigException(

--- a/tools/test/build_api/build_api_test.py
+++ b/tools/test/build_api/build_api_test.py
@@ -68,6 +68,7 @@ class BuildApiTests(unittest.TestCase):
             toolchain.config_file = "junk"
             toolchain.compile_sources(res, self.build_path)
 
+            print notify.mock_calls
             assert any('percent' in msg[0] and msg[0]['percent'] == 100.0
                        for _, msg, _ in notify.mock_calls if msg)
 
@@ -81,10 +82,13 @@ class BuildApiTests(unittest.TestCase):
         :return:
         """
         app_config = "app_config"
-        mock_config_init.return_value = namedtuple("Config", "target")(
-            namedtuple("Target",
-                       "init_hooks name features core")(lambda _, __ : None,
-                                                        "Junk", [], "Cortex-M3"))
+        mock_target = namedtuple("Target",
+                                 "init_hooks name features core")(lambda _, __ : None,
+                                                                  "Junk", [], "Cortex-M3")
+        mock_config_init.return_value = namedtuple("Config",
+                                                   "target has_regions")(
+                                                       mock_target,
+                                                       False)
 
         prepare_toolchain(self.src_paths, self.target, self.toolchain_name,
                           app_config=app_config)
@@ -100,10 +104,13 @@ class BuildApiTests(unittest.TestCase):
         :param mock_config_init: mock of Config __init__
         :return:
         """
-        mock_config_init.return_value = namedtuple("Config", "target")(
-            namedtuple("Target",
-                       "init_hooks name features core")(lambda _, __ : None,
-                                                        "Junk", [], "Cortex-M3"))
+        mock_target = namedtuple("Target",
+                                 "init_hooks name features core")(lambda _, __ : None,
+                                                                  "Junk", [], "Cortex-M3")
+        mock_config_init.return_value = namedtuple("Config",
+                                                   "target has_regions")(
+                                                       mock_target,
+                                                       False)
 
         prepare_toolchain(self.src_paths, self.target, self.toolchain_name)
 
@@ -127,6 +134,7 @@ class BuildApiTests(unittest.TestCase):
         app_config = "app_config"
         mock_exists.return_value = False
         mock_prepare_toolchain().link_program.return_value = 1, 2
+        mock_prepare_toolchain().config = namedtuple("Config", "has_regions")(None)
 
         build_project(self.src_paths, self.build_path, self.target,
                       self.toolchain_name, app_config=app_config)
@@ -154,6 +162,7 @@ class BuildApiTests(unittest.TestCase):
         mock_exists.return_value = False
         # Needed for the unpacking of the returned value
         mock_prepare_toolchain().link_program.return_value = 1, 2
+        mock_prepare_toolchain().config = namedtuple("Config", "has_regions")(None)
 
         build_project(self.src_paths, self.build_path, self.target,
                       self.toolchain_name)

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -28,6 +28,7 @@ from math import ceil
 import json
 from collections import OrderedDict
 import logging
+from intelhex import IntelHex
 
 def remove_if_in(lst, thing):
     if thing in lst:
@@ -514,3 +515,16 @@ def print_large_string(large_string):
         else:
             end_index = ((string_part + 1) * string_limit) - 1
             print large_string[start_index:end_index],
+
+def intelhex_offset(filename, offset):
+    """Load a hex or bin file at a particular offset"""
+    _, inteltype = splitext(filename)
+    ih = IntelHex()
+    if inteltype == ".bin":
+        ih.loadbin(filename, offset=offset)
+    elif inteltype == ".hex":
+        ih.loadhex(filename)
+    else:
+        raise ToolException("File %s does not have a known binary file type"
+                            % filename)
+    return ih


### PR DESCRIPTION
To enable a boot-loader style application, overrides
"targets.bootloader_exec" or "targets.restrict_size" on a particular
target. These parameters are a bin or hex file and an integer, in bytes,
respectively. If either override is present, then an application region
is created after the boot-loader region, when "targets.bootloader_exec"
is present, and before post-application, when "targets.restric_size" is
present. The size of the boot-loader region is read from the file
provided in the configuration.

## Status
**READY**

## Todos
- [ ] Tests - standard stuff
