### PR TITLE
Pass linker flags to the linker only once

### DIFF
--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -78,9 +78,7 @@ class Makefile(Exporter):
             'asm_cmd': " ".join(["\'" + part + "\'" for part
                                 in ([basename(self.toolchain.asm[0])] +
                                     self.toolchain.asm[1:])]),
-            'ld_cmd': " ".join(["\'" + part + "\'" for part
-                                in ([basename(self.toolchain.ld[0])] +
-                                    self.toolchain.ld[1:])]),
+            'ld_cmd': "\'" + basename(self.toolchain.ld[0]) + "\'",
             'elf2bin_cmd': "\'" + basename(self.toolchain.elf2bin) + "\'",
             'link_script_ext': self.toolchain.LINKER_EXT,
             'link_script_option': self.LINK_SCRIPT_OPTION,


### PR DESCRIPTION
Before, `make_gcc_arm` would export a makefile with both linker flags in
the `$(LD)` make variable and the `$(LD_FLAGS)` make variable. This only
affected GCC based makefiles, as the `$(LD)` make variable would only
contain the linker for both ARMC5 and IAR. This patch enforces the
`$(LD)` behavior of ARMC5 and IAR on all of the compilers by truncating
`$(LD)` to just the command.

Resolves #3744

## TODO
- [x] /morph export-build