### PR TITLE
fix in mbed_error_vfprintf

### DIFF
--- a/platform/mbed_board.c
+++ b/platform/mbed_board.c
@@ -75,16 +75,31 @@ void mbed_error_printf(const char* format, ...) {
 
 void mbed_error_vfprintf(const char * format, va_list arg) {
 #if DEVICE_SERIAL
+
+#if MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES
+    char stdio_out_prev;
+#endif
+
     core_util_critical_section_enter();
     char buffer[128];
     int size = vsprintf(buffer, format, arg);
     if (size > 0) {
         if (!stdio_uart_inited) {
-        serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
+            serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
         }
-        for (int i = 0; i < size; i++) {
+#if MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES
+        for (unsigned int i = 0; i < size; i++) {
+            if (buffer[i] == '\n' && stdio_out_prev != '\r') {
+                 serial_putc(&stdio_uart, '\r');
+            }
+            serial_putc(&stdio_uart, buffer[i]);
+            stdio_out_prev = buffer[i];
+        }
+#else
+        for (unsigned int i = 0; i < size; i++) {
             serial_putc(&stdio_uart, buffer[i]);
         }
+#endif
     }
     core_util_critical_section_exit();
 #endif


### PR DESCRIPTION

## Description
MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES was not used in mbed_error_vfprintf causing wrong behavior when the option was selected (no new line is some terminals like putty).


## Status
READY


mbed user: yariv colbeci





