### PR TITLE
Added filter to send minus events to lwip adaptation

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -87,6 +87,11 @@ static void mbed_lwip_arena_dealloc(struct lwip_socket *s)
 
 static void mbed_lwip_socket_callback(struct netconn *nc, enum netconn_evt eh, u16_t len)
 {
+    // Filter send minus events
+    if (eh == NETCONN_EVT_SENDMINUS && nc->state == NETCONN_WRITE) {
+        return;
+    }
+
     sys_prot_t prot = sys_arch_protect();
 
     for (int i = 0; i < MEMP_NUM_NETCONN; i++) {


### PR DESCRIPTION
## Description
Added filtering to send minus event to lwip adaptation layer. Send minus events should not be conveyed to upper layers since they indicate that socket send would block on next call. Also in case of would block on sending, minus events can generate sending loop, where send minus event triggers new send in application.


## Status
READY


## Migrations
NO


## Related PRs
None


## Todos
- [x] Tests
- [x] Documentation


## Deploy notes
None


## Steps to test or reproduce
None