### PR TITLE
ncs36510: lp ticker - remove unused header file inclusion (sleep)

### DIFF
--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/ncs36510_lp_ticker_api.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/ncs36510_lp_ticker_api.c
@@ -34,12 +34,10 @@
 #include "device.h"
 #if DEVICE_LOWPOWERTIMER
 
-#include "sleep_api.h"
 #include "cmsis_nvic.h"
 #include "lp_ticker_api.h"
 #include "rtc.h"
 #include "rtc_map.h"
-#include "sleep.h"
 
 /* Initialize the RTC for low power ticker */
 void lp_ticker_init()


### PR DESCRIPTION
Remove unused header files (not needed for lp ticker implementation).

This was found during the release preparation when I noticed that if sleep.h was not in the tree (another bug I discovered), this was causing build failures in lp ticker code file.

@pradeep-gr 