### PR TITLE
Fix #3756 for 64 bytes transfers

### DIFF
--- a/features/unsupported/USBDevice/USBDevice/TARGET_STM/USBHAL_STM32F769NI.h
+++ b/features/unsupported/USBDevice/USBDevice/TARGET_STM/USBHAL_STM32F769NI.h
@@ -135,7 +135,7 @@ USBHAL::USBHAL(void) {
     /*  bulk/int 64 bytes in FS  */
     HAL_PCDEx_SetTxFiFo(&hpcd, 0, (MAX_PACKET_SIZE_EP0/4)+1);
     /*  bulk/int bytes in FS */
-    HAL_PCDEx_SetTxFiFo(&hpcd, 1, (MAX_PACKET_SIZE_EP1/4));
+    HAL_PCDEx_SetTxFiFo(&hpcd, 1, (MAX_PACKET_SIZE_EP1/4)+1);
     HAL_PCDEx_SetTxFiFo(&hpcd, 2, (MAX_PACKET_SIZE_EP2/4));
     /* ISOchronous */
     HAL_PCDEx_SetTxFiFo(&hpcd, 3, (MAX_PACKET_SIZE_EP3/4));

--- a/features/unsupported/USBDevice/USBDevice/TARGET_STM/USBHAL_STM32L476VG.h
+++ b/features/unsupported/USBDevice/USBDevice/TARGET_STM/USBHAL_STM32L476VG.h
@@ -131,7 +131,7 @@ USBHAL::USBHAL(void) {
     /*  bulk/int 64 bytes in FS  */
     HAL_PCDEx_SetTxFiFo(&hpcd, 0, (MAX_PACKET_SIZE_EP0/4)+1);
     /*  bulk/int bytes in FS */
-    HAL_PCDEx_SetTxFiFo(&hpcd, 1, (MAX_PACKET_SIZE_EP1/4));
+    HAL_PCDEx_SetTxFiFo(&hpcd, 1, (MAX_PACKET_SIZE_EP1/4)+1);
     HAL_PCDEx_SetTxFiFo(&hpcd, 2, (MAX_PACKET_SIZE_EP2/4));
     /* ISOchronous */
     HAL_PCDEx_SetTxFiFo(&hpcd, 3, (MAX_PACKET_SIZE_EP3/4));

--- a/features/unsupported/USBDevice/USBDevice/TARGET_STM/USBHAL_STM_144_64pins.h
+++ b/features/unsupported/USBDevice/USBDevice/TARGET_STM/USBHAL_STM_144_64pins.h
@@ -121,7 +121,7 @@ USBHAL::USBHAL(void) {
     /*  bulk/int 64 bytes in FS  */
     HAL_PCDEx_SetTxFiFo(&hpcd, 0, (MAX_PACKET_SIZE_EP0/4)+1);
     /*  bulk/int bytes in FS */
-    HAL_PCDEx_SetTxFiFo(&hpcd, 1, (MAX_PACKET_SIZE_EP1/4));
+    HAL_PCDEx_SetTxFiFo(&hpcd, 1, (MAX_PACKET_SIZE_EP1/4)+1);
     HAL_PCDEx_SetTxFiFo(&hpcd, 2, (MAX_PACKET_SIZE_EP2/4));
     /* ISOchronous */
     HAL_PCDEx_SetTxFiFo(&hpcd, 3, (MAX_PACKET_SIZE_EP3/4));


### PR DESCRIPTION
## Description
Refer to issue #3756 
USB TX fifo is missing 1 for parameter length transmission

## Status
**READY**

## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Steps to test or reproduce
copy/paste the main example provided in the issue inside : features/unsupported/tests/usb/device/raw_hid/main.cpp

python tools/build.py --usb --rtos -m NUCLEO_F446ZE  -t GCC_ARM
python tools/make.py -m NUCLEO_F446ZE -t GCC_ARM --profile=debug -n USB_5
drag and drop the binary