### PR TITLE
Filesystem: Add mbed namespace to FATFileSystem and BlockDevice classes

### DIFF
--- a/features/filesystem/bd/BlockDevice.cpp
+++ b/features/filesystem/bd/BlockDevice.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "BlockDevice.h"
+#include "mbed.h"
 
 
 // Writes by default perform an erase + program

--- a/features/filesystem/bd/BlockDevice.h
+++ b/features/filesystem/bd/BlockDevice.h
@@ -19,6 +19,10 @@
 
 #include <stdint.h>
 
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
+
 
 /** Enum of standard error codes
  *
@@ -182,5 +186,8 @@ public:
     bool is_valid_erase(bd_addr_t addr, bd_size_t size);
 };
 
+
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/ChainingBlockDevice.cpp
+++ b/features/filesystem/bd/ChainingBlockDevice.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "ChainingBlockDevice.h"
+#include "mbed.h"
 
 
 ChainingBlockDevice::ChainingBlockDevice(BlockDevice **bds, size_t bd_count)

--- a/features/filesystem/bd/ChainingBlockDevice.h
+++ b/features/filesystem/bd/ChainingBlockDevice.h
@@ -25,6 +25,10 @@
 #include "BlockDevice.h"
 #include "mbed.h"
 
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
+
 
 /** Block device for chaining multiple block devices
  *  with the similar block sizes at sequential addresses
@@ -149,5 +153,8 @@ protected:
     bd_size_t _size;
 };
 
+
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/HeapBlockDevice.cpp
+++ b/features/filesystem/bd/HeapBlockDevice.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "HeapBlockDevice.h"
+#include "mbed.h"
 
 
 HeapBlockDevice::HeapBlockDevice(bd_size_t size, bd_size_t block)

--- a/features/filesystem/bd/HeapBlockDevice.h
+++ b/features/filesystem/bd/HeapBlockDevice.h
@@ -25,6 +25,10 @@
 #include "BlockDevice.h"
 #include "mbed.h"
 
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
+
 
 /** Lazily allocated heap-backed block device
  *
@@ -128,5 +132,8 @@ private:
     uint8_t **_blocks;
 };
 
+
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/SlicingBlockDevice.cpp
+++ b/features/filesystem/bd/SlicingBlockDevice.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "SlicingBlockDevice.h"
+#include "mbed.h"
 
 
 SlicingBlockDevice::SlicingBlockDevice(BlockDevice *bd, bd_addr_t start)

--- a/features/filesystem/bd/SlicingBlockDevice.h
+++ b/features/filesystem/bd/SlicingBlockDevice.h
@@ -25,6 +25,10 @@
 #include "BlockDevice.h"
 #include "mbed.h"
 
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
+
 
 /** Block device for mapping to a slice of another block device
  *
@@ -147,5 +151,8 @@ protected:
     bd_size_t _stop;
 };
 
+
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/fat/FATDirHandle.cpp
+++ b/features/filesystem/fat/FATDirHandle.cpp
@@ -23,8 +23,8 @@
 #include "ff.h"
 #include "FATDirHandle.h"
 #include "FATMisc.h"
+#include "mbed.h"
 
-using namespace mbed;
 
 FATDirHandle::FATDirHandle(const FATFS_DIR &the_dir, PlatformMutex * mutex): _mutex(mutex) {
     dir = the_dir;

--- a/features/filesystem/fat/FATDirHandle.h
+++ b/features/filesystem/fat/FATDirHandle.h
@@ -25,7 +25,10 @@
 #include "DirHandle.h"
 #include "PlatformMutex.h"
 
-using namespace mbed;
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
+
 
 class FATDirHandle : public DirHandle {
 
@@ -49,5 +52,9 @@ class FATDirHandle : public DirHandle {
     struct dirent cur_entry;
 
 };
+
+
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/fat/FATFileHandle.cpp
+++ b/features/filesystem/fat/FATFileHandle.cpp
@@ -25,6 +25,7 @@
 
 #include "FATFileHandle.h"
 #include "FATMisc.h"
+#include "mbed.h"
 
 FATFileHandle::FATFileHandle(FIL fh, PlatformMutex * mutex): _mutex(mutex) {
     _fh = fh;

--- a/features/filesystem/fat/FATFileHandle.h
+++ b/features/filesystem/fat/FATFileHandle.h
@@ -25,7 +25,10 @@
 #include "FileHandle.h"
 #include "PlatformMutex.h"
 
-using namespace mbed;
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
+
 
 class FATFileHandle : public FileHandle {
 public:
@@ -48,5 +51,9 @@ protected:
     PlatformMutex * _mutex;
 
 };
+
+
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -30,6 +30,7 @@
 #include "FATDirHandle.h"
 #include "critical.h"
 #include "FATMisc.h"
+#include "mbed.h"
 
 
 // Global access to block device from FAT driver

--- a/features/filesystem/fat/FATFileSystem.h
+++ b/features/filesystem/fat/FATFileSystem.h
@@ -29,7 +29,10 @@
 #include <stdint.h>
 #include "PlatformMutex.h"
 
-using namespace mbed;
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
+
 
 /**
  * FATFileSystem based on ChaN's Fat Filesystem library v0.8 
@@ -115,5 +118,9 @@ protected:
     virtual void lock();
     virtual void unlock();
 };
+
+
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/fat/FATMisc.cpp
+++ b/features/filesystem/fat/FATMisc.cpp
@@ -21,6 +21,8 @@
 #include <errno.h>
 #include "platform/retarget.h"
 
+namespace mbed {
+
 
 /* @brief   Set errno based on the error code returned from underlying filesystem
  *
@@ -80,3 +82,5 @@ void fat_filesystem_set_errno(FRESULT res)
     return;
 }
 
+
+}

--- a/features/filesystem/fat/FATMisc.h
+++ b/features/filesystem/fat/FATMisc.h
@@ -22,6 +22,15 @@
 
 #include "ff.h"
 
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
+
+
 void fat_filesystem_set_errno(FRESULT res);
+
+
+/** @}*/
+} // namespace mbed
 
 #endif /* FILESYSTEM_FAT_MISC_H */


### PR DESCRIPTION
mbed classes should be in the mbed namespace, no technical reason these weren't, we just hadn't gotten to them yet.

cc @simonqhughes
@theotherjimmy (let me know if I did the doxygen group wrong)