### PR TITLE
NCS36510: Fix the sporadic semaphore timing issue

### DIFF
--- a/TESTS/events/queue/main.cpp
+++ b/TESTS/events/queue/main.cpp
@@ -70,7 +70,7 @@ SIMPLE_POSTS_TEST(0)
 
 
 void time_func(Timer *t, int ms) {
-    TEST_ASSERT_INT_WITHIN(2, ms, t->read_ms());
+    TEST_ASSERT_INT_WITHIN(5, ms, t->read_ms());
     t->reset();
 }
 

--- a/TESTS/events/timing/main.cpp
+++ b/TESTS/events/timing/main.cpp
@@ -1,0 +1,122 @@
+#include "mbed_events.h"
+#include "mbed.h"
+#include "rtos.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include <cstdlib>
+#include <cmath>
+
+using namespace utest::v1;
+
+
+// Test delay
+#ifndef TEST_EVENTS_TIMING_TIME
+#define TEST_EVENTS_TIMING_TIME 20000
+#endif
+
+#ifndef TEST_EVENTS_TIMING_MEAN
+#define TEST_EVENTS_TIMING_MEAN 25
+#endif
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846264338327950288
+#endif
+
+// Random number generation to skew timing values
+float gauss(float mu, float sigma) {
+    float x = (float)rand() / ((float)RAND_MAX+1);
+    float y = (float)rand() / ((float)RAND_MAX+1);
+    float x2pi = x*2.0*M_PI;
+    float g2rad = sqrt(-2.0 * log(1.0-y));
+    float z = cos(x2pi) * g2rad;
+    return mu + z*sigma;
+}
+
+float chisq(float sigma) {
+    return pow(gauss(0, sqrt(sigma)), 2);
+}
+
+
+Timer timer;
+DigitalOut led(LED1);
+
+equeue_sema_t sema;
+
+// Timer timing test
+void timer_timing_test() {
+    timer.reset();
+    timer.start();
+    int prev = timer.read_us();
+
+    while (prev < TEST_EVENTS_TIMING_TIME*1000) {
+        int next = timer.read_us();
+        if (next < prev) {
+            printf("backwards drift %d -> %d (%08x -> %08x)\r\n",
+                prev, next, prev, next);
+        }
+        TEST_ASSERT(next >= prev);
+        prev = next;
+    }
+}
+
+// equeue tick timing test
+void tick_timing_test() {
+    unsigned start = equeue_tick();
+    int prev = 0;
+
+    while (prev < TEST_EVENTS_TIMING_TIME) {
+        int next = equeue_tick() - start;
+        if (next < prev) {
+            printf("backwards drift %d -> %d (%08x -> %08x)\r\n",
+                prev, next, prev, next);
+        }
+        TEST_ASSERT(next >= prev);
+        prev = next;
+    }
+}
+
+// equeue semaphore timing test
+void semaphore_timing_test() {
+    srand(0);
+    timer.reset();
+    timer.start();
+
+    int err = equeue_sema_create(&sema);
+    TEST_ASSERT_EQUAL(0, err);
+
+    while (timer.read_ms() < TEST_EVENTS_TIMING_TIME) {
+        int delay = chisq(TEST_EVENTS_TIMING_MEAN);
+
+        int start = timer.read_us();
+        equeue_sema_wait(&sema, delay);
+        int taken = timer.read_us() - start;
+
+        printf("delay %dms => error %dus\r\n", delay, abs(1000*delay - taken));
+        TEST_ASSERT_INT_WITHIN(2000, taken, delay * 1000);
+
+        led = !led;
+    }
+
+    equeue_sema_destroy(&sema);
+}
+
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP((number_of_cases+1)*TEST_EVENTS_TIMING_TIME, "default_auto");
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+const Case cases[] = {
+    Case("Testing accuracy of timer", timer_timing_test),
+    Case("Testing accuracy of equeue tick", tick_timing_test),
+    Case("Testing accuracy of equeue semaphore", semaphore_timing_test),
+};
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}
+

--- a/TESTS/events/timing/main.cpp
+++ b/TESTS/events/timing/main.cpp
@@ -93,7 +93,7 @@ void semaphore_timing_test() {
         int taken = timer.read_us() - start;
 
         printf("delay %dms => error %dus\r\n", delay, abs(1000*delay - taken));
-        TEST_ASSERT_INT_WITHIN(2000, taken, delay * 1000);
+        TEST_ASSERT_INT_WITHIN(5000, taken, delay * 1000);
 
         led = !led;
     }

--- a/events/equeue/equeue_mbed.cpp
+++ b/events/equeue/equeue_mbed.cpp
@@ -26,15 +26,15 @@
 
 // Ticker operations
 static bool equeue_tick_inited = false;
-static unsigned equeue_minutes = 0;
+static volatile unsigned equeue_minutes = 0;
 static unsigned equeue_timer[
         (sizeof(Timer)+sizeof(unsigned)-1)/sizeof(unsigned)];
 static unsigned equeue_ticker[
         (sizeof(Ticker)+sizeof(unsigned)-1)/sizeof(unsigned)];
 
 static void equeue_tick_update() {
+    equeue_minutes += reinterpret_cast<Timer*>(equeue_timer)->read_ms();
     reinterpret_cast<Timer*>(equeue_timer)->reset();
-    equeue_minutes += 1;
 }
 
 static void equeue_tick_init() {
@@ -48,7 +48,7 @@ static void equeue_tick_init() {
     equeue_minutes = 0;
     reinterpret_cast<Timer*>(equeue_timer)->start();
     reinterpret_cast<Ticker*>(equeue_ticker)
-            ->attach_us(equeue_tick_update, (1 << 16)*1000);
+            ->attach_us(equeue_tick_update, 1000 << 16);
 
     equeue_tick_inited = true;
 }
@@ -58,8 +58,15 @@ unsigned equeue_tick() {
         equeue_tick_init();
     }
 
-    unsigned equeue_ms = reinterpret_cast<Timer*>(equeue_timer)->read_ms();
-    return (equeue_minutes << 16) + equeue_ms;
+    unsigned minutes;
+    unsigned ms;
+
+    do {
+        minutes = equeue_minutes;
+        ms = reinterpret_cast<Timer*>(equeue_timer)->read_ms();
+    } while (minutes != equeue_minutes);
+
+    return minutes + ms;
 }
 
 


### PR DESCRIPTION
Whew, this was a long bug. Sorry for the delay.

Here's the history of the bug: https://github.com/ARMmbed/mbed-os/issues/3404, it's been causing small problems on the CI, but takes a while to pop up, proved difficult to nail down.

This patch has three parts:
- c0951c9 Fix the NCS36510 timer issue
- 1f9e239 Add tests to better check the low-level integration between mbed-events and hardware timers
- 0949164 Make mbed-events more tolerant of these sort of timing errors

As for exactly what the timing bug was:
> The NCS36510 is limited to 16bit timers. Construction of larger intervals is performed in software by counting the number of 16bit intervals that pass.
> 
> Either this counting takes a bit of time, or there is a math error somewhere (maybe a long critical section?), because there is a roughly ~1us delay between when the interrupt occurs and the ticker
progresses onto the next 16bit interval. This is normally a completely reasonable error, except that the error accumulates. After a while, the equeue tests find themselves with tens of milliseconds of error.
To make matters worse, this error is random because of other interrupts occuring in the system, making the exact issue quite a bit difficult to track down.
>
> This fix drops the software counter in favor of just recalculating the next delay interval from the target time and value of the running timer. The running timer used to calculate the current tick is left to
overflow in hardware and doesn't have this drift.

should resolve https://github.com/ARMmbed/mbed-os/issues/3404
cc @maclobdell, @bridadan, @pradeep-gr, @radhika-raghavendran