### PR TITLE
STM32L4 : Fix GPIO G port compatibility

### DIFF
--- a/targets/TARGET_STM/gpio_api.c
+++ b/targets/TARGET_STM/gpio_api.c
@@ -73,7 +73,7 @@ GPIO_TypeDef *Set_GPIO_Clock(uint32_t port_idx) {
 #endif
 #if defined GPIOG_BASE
         case PortG:
-#if defined STM32L4
+#if defined TARGET_STM32L4
             __HAL_RCC_PWR_CLK_ENABLE();
             HAL_PWREx_EnableVddIO2();
 #endif

--- a/targets/TARGET_STM/gpio_api.c
+++ b/targets/TARGET_STM/gpio_api.c
@@ -73,6 +73,10 @@ GPIO_TypeDef *Set_GPIO_Clock(uint32_t port_idx) {
 #endif
 #if defined GPIOG_BASE
         case PortG:
+#if defined STM32L4
+            __HAL_RCC_PWR_CLK_ENABLE();
+            HAL_PWREx_EnableVddIO2();
+#endif
             gpio_add = GPIOG_BASE;
             __GPIOG_CLK_ENABLE();
             break;


### PR DESCRIPTION
## Description
Fix #3771 by adding functions to enable GPIOF and GPIOG clocks for STM32L4 targets.
For GPIOG the VDDIO2 external VDD is also activated as it is the one who supply pins PG2 to PG15
