### PR TITLE
lwip: Added delay to dtls handshake test to compensate for local network

### DIFF
--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/host_tests/udp_shotgun.py
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/host_tests/udp_shotgun.py
@@ -20,6 +20,7 @@ import socket
 import json
 import random
 import itertools
+import time
 from sys import stdout
 from threading import Thread
 from SocketServer import BaseRequestHandler, UDPServer
@@ -41,6 +42,9 @@ class UDPEchoClientHandler(BaseRequestHandler):
             data.append(reduce(lambda a,b: a^b, data))
             data = ''.join(map(chr, data))
             sock.sendto(data, self.client_address)
+
+            # Sleep a tiny bit to compensate for local network
+            time.sleep(0.01)
 
 
 class UDPEchoClientTest(BaseHostTest):


### PR DESCRIPTION
The speed of packets on the local network exceeds even the speed of the ethernet hardware on some of the less powerful devices. Adding a small delay which can be expected from a real DTLS handshake prevents this condition from occuring.

Let me know if there is still problems with this test as this delay may need to be refined.

cc @bridadan, @MarceloSalazar 
should resolve https://github.com/ARMmbed/mbed-os/issues/3549