### PR TITLE
events: Add support for infering event type from Callback objects

### DIFF
--- a/TESTS/events/queue/main.cpp
+++ b/TESTS/events/queue/main.cpp
@@ -210,7 +210,7 @@ void event_class_helper_test() {
 
 void event_inference_test() {
     counter = 0;
-    EventQueue queue (2048);
+    EventQueue queue(2048);
 
     queue.event(count5, 1, 1, 1, 1, 1).post();
     queue.event(count5, 1, 1, 1, 1).post(1);
@@ -219,9 +219,16 @@ void event_inference_test() {
     queue.event(count5, 1).post(1, 1, 1, 1);
     queue.event(count5).post(1, 1, 1, 1, 1);
 
+    queue.event(callback(count5), 1, 1, 1, 1, 1).post();
+    queue.event(callback(count5), 1, 1, 1, 1).post(1);
+    queue.event(callback(count5), 1, 1, 1).post(1, 1);
+    queue.event(callback(count5), 1, 1).post(1, 1, 1);
+    queue.event(callback(count5), 1).post(1, 1, 1, 1);
+    queue.event(callback(count5)).post(1, 1, 1, 1, 1);
+
     queue.dispatch(0);
 
-    TEST_ASSERT_EQUAL(counter, 30);
+    TEST_ASSERT_EQUAL(counter, 60);
 }
 
 

--- a/events/Event.h
+++ b/events/Event.h
@@ -2417,6 +2417,11 @@ Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)() const vo
     return Event<void()>(this, mbed::callback(obj, method));
 }
 
+template <typename R>
+Event<void()> EventQueue::event(mbed::Callback<R()> cb) {
+    return Event<void()>(this, cb);
+}
+
 template <typename R, typename B0, typename C0>
 Event<void()> EventQueue::event(R (*func)(B0), C0 c0) {
     return Event<void()>(this, func, c0);
@@ -2440,6 +2445,11 @@ Event<void()> EventQueue::event(volatile T *obj, R (T::*method)(B0) volatile, C0
 template <typename T, typename R, typename B0, typename C0>
 Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(B0) const volatile, C0 c0) {
     return Event<void()>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename R, typename B0, typename C0>
+Event<void()> EventQueue::event(mbed::Callback<R(B0)> cb, C0 c0) {
+    return Event<void()>(this, cb, c0);
 }
 
 template <typename R, typename B0, typename B1, typename C0, typename C1>
@@ -2467,6 +2477,11 @@ Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1) co
     return Event<void()>(this, mbed::callback(obj, method), c0, c1);
 }
 
+template <typename R, typename B0, typename B1, typename C0, typename C1>
+Event<void()> EventQueue::event(mbed::Callback<R(B0, B1)> cb, C0 c0, C1 c1) {
+    return Event<void()>(this, cb, c0, c1);
+}
+
 template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
 Event<void()> EventQueue::event(R (*func)(B0, B1, B2), C0 c0, C1 c1, C2 c2) {
     return Event<void()>(this, func, c0, c1, c2);
@@ -2490,6 +2505,11 @@ Event<void()> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2) vola
 template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
 Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2) const volatile, C0 c0, C1 c1, C2 c2) {
     return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+Event<void()> EventQueue::event(mbed::Callback<R(B0, B1, B2)> cb, C0 c0, C1 c1, C2 c2) {
+    return Event<void()>(this, cb, c0, c1, c2);
 }
 
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
@@ -2517,6 +2537,11 @@ Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2
     return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2, c3);
 }
 
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+Event<void()> EventQueue::event(mbed::Callback<R(B0, B1, B2, B3)> cb, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void()>(this, cb, c0, c1, c2, c3);
+}
+
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
 Event<void()> EventQueue::event(R (*func)(B0, B1, B2, B3, B4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
     return Event<void()>(this, func, c0, c1, c2, c3, c4);
@@ -2540,6 +2565,11 @@ Event<void()> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, 
 template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
 Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
     return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+Event<void()> EventQueue::event(mbed::Callback<R(B0, B1, B2, B3, B4)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void()>(this, cb, c0, c1, c2, c3, c4);
 }
 
 template <typename R, typename A0>
@@ -2567,6 +2597,11 @@ Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(A0) cons
     return Event<void(A0)>(this, mbed::callback(obj, method));
 }
 
+template <typename R, typename A0>
+Event<void(A0)> EventQueue::event(mbed::Callback<R(A0)> cb) {
+    return Event<void(A0)>(this, cb);
+}
+
 template <typename R, typename B0, typename C0, typename A0>
 Event<void(A0)> EventQueue::event(R (*func)(B0, A0), C0 c0) {
     return Event<void(A0)>(this, func, c0);
@@ -2590,6 +2625,11 @@ Event<void(A0)> EventQueue::event(volatile T *obj, R (T::*method)(B0, A0) volati
 template <typename T, typename R, typename B0, typename C0, typename A0>
 Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, A0) const volatile, C0 c0) {
     return Event<void(A0)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename R, typename B0, typename C0, typename A0>
+Event<void(A0)> EventQueue::event(mbed::Callback<R(B0, A0)> cb, C0 c0) {
+    return Event<void(A0)>(this, cb, c0);
 }
 
 template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
@@ -2617,6 +2657,11 @@ Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, 
     return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1);
 }
 
+template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+Event<void(A0)> EventQueue::event(mbed::Callback<R(B0, B1, A0)> cb, C0 c0, C1 c1) {
+    return Event<void(A0)>(this, cb, c0, c1);
+}
+
 template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
 Event<void(A0)> EventQueue::event(R (*func)(B0, B1, B2, A0), C0 c0, C1 c1, C2 c2) {
     return Event<void(A0)>(this, func, c0, c1, c2);
@@ -2640,6 +2685,11 @@ Event<void(A0)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, A0
 template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
 Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0) const volatile, C0 c0, C1 c1, C2 c2) {
     return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+Event<void(A0)> EventQueue::event(mbed::Callback<R(B0, B1, B2, A0)> cb, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0)>(this, cb, c0, c1, c2);
 }
 
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
@@ -2667,6 +2717,11 @@ Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, 
     return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
 }
 
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+Event<void(A0)> EventQueue::event(mbed::Callback<R(B0, B1, B2, B3, A0)> cb, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0)>(this, cb, c0, c1, c2, c3);
+}
+
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
 Event<void(A0)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
     return Event<void(A0)>(this, func, c0, c1, c2, c3, c4);
@@ -2690,6 +2745,11 @@ Event<void(A0)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, B3
 template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
 Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
     return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+Event<void(A0)> EventQueue::event(mbed::Callback<R(B0, B1, B2, B3, B4, A0)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0)>(this, cb, c0, c1, c2, c3, c4);
 }
 
 template <typename R, typename A0, typename A1>
@@ -2717,6 +2777,11 @@ Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(A0, 
     return Event<void(A0, A1)>(this, mbed::callback(obj, method));
 }
 
+template <typename R, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(mbed::Callback<R(A0, A1)> cb) {
+    return Event<void(A0, A1)>(this, cb);
+}
+
 template <typename R, typename B0, typename C0, typename A0, typename A1>
 Event<void(A0, A1)> EventQueue::event(R (*func)(B0, A0, A1), C0 c0) {
     return Event<void(A0, A1)>(this, func, c0);
@@ -2740,6 +2805,11 @@ Event<void(A0, A1)> EventQueue::event(volatile T *obj, R (T::*method)(B0, A0, A1
 template <typename T, typename R, typename B0, typename C0, typename A0, typename A1>
 Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, A0, A1) const volatile, C0 c0) {
     return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename R, typename B0, typename C0, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(mbed::Callback<R(B0, A0, A1)> cb, C0 c0) {
+    return Event<void(A0, A1)>(this, cb, c0);
 }
 
 template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
@@ -2767,6 +2837,11 @@ Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, 
     return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1);
 }
 
+template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(mbed::Callback<R(B0, B1, A0, A1)> cb, C0 c0, C1 c1) {
+    return Event<void(A0, A1)>(this, cb, c0, c1);
+}
+
 template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
 Event<void(A0, A1)> EventQueue::event(R (*func)(B0, B1, B2, A0, A1), C0 c0, C1 c1, C2 c2) {
     return Event<void(A0, A1)>(this, func, c0, c1, c2);
@@ -2790,6 +2865,11 @@ Event<void(A0, A1)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2
 template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
 Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1) const volatile, C0 c0, C1 c1, C2 c2) {
     return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(mbed::Callback<R(B0, B1, B2, A0, A1)> cb, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1)>(this, cb, c0, c1, c2);
 }
 
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
@@ -2817,6 +2897,11 @@ Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, 
     return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
 }
 
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(mbed::Callback<R(B0, B1, B2, B3, A0, A1)> cb, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1)>(this, cb, c0, c1, c2, c3);
+}
+
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
 Event<void(A0, A1)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
     return Event<void(A0, A1)>(this, func, c0, c1, c2, c3, c4);
@@ -2840,6 +2925,11 @@ Event<void(A0, A1)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2
 template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
 Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
     return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(mbed::Callback<R(B0, B1, B2, B3, B4, A0, A1)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1)>(this, cb, c0, c1, c2, c3, c4);
 }
 
 template <typename R, typename A0, typename A1, typename A2>
@@ -2867,6 +2957,11 @@ Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(
     return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method));
 }
 
+template <typename R, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(mbed::Callback<R(A0, A1, A2)> cb) {
+    return Event<void(A0, A1, A2)>(this, cb);
+}
+
 template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
 Event<void(A0, A1, A2)> EventQueue::event(R (*func)(B0, A0, A1, A2), C0 c0) {
     return Event<void(A0, A1, A2)>(this, func, c0);
@@ -2890,6 +2985,11 @@ Event<void(A0, A1, A2)> EventQueue::event(volatile T *obj, R (T::*method)(B0, A0
 template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
 Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2) const volatile, C0 c0) {
     return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(mbed::Callback<R(B0, A0, A1, A2)> cb, C0 c0) {
+    return Event<void(A0, A1, A2)>(this, cb, c0);
 }
 
 template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
@@ -2917,6 +3017,11 @@ Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(
     return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1);
 }
 
+template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(mbed::Callback<R(B0, B1, A0, A1, A2)> cb, C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2)>(this, cb, c0, c1);
+}
+
 template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
 Event<void(A0, A1, A2)> EventQueue::event(R (*func)(B0, B1, B2, A0, A1, A2), C0 c0, C1 c1, C2 c2) {
     return Event<void(A0, A1, A2)>(this, func, c0, c1, c2);
@@ -2940,6 +3045,11 @@ Event<void(A0, A1, A2)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1
 template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
 Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2) const volatile, C0 c0, C1 c1, C2 c2) {
     return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(mbed::Callback<R(B0, B1, B2, A0, A1, A2)> cb, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2)>(this, cb, c0, c1, c2);
 }
 
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
@@ -2967,6 +3077,11 @@ Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(
     return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
 }
 
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(mbed::Callback<R(B0, B1, B2, B3, A0, A1, A2)> cb, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2)>(this, cb, c0, c1, c2, c3);
+}
+
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
 Event<void(A0, A1, A2)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
     return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3, c4);
@@ -2990,6 +3105,11 @@ Event<void(A0, A1, A2)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1
 template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
 Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
     return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(mbed::Callback<R(B0, B1, B2, B3, B4, A0, A1, A2)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2)>(this, cb, c0, c1, c2, c3, c4);
 }
 
 template <typename R, typename A0, typename A1, typename A2, typename A3>
@@ -3017,6 +3137,11 @@ Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*meth
     return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method));
 }
 
+template <typename R, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(mbed::Callback<R(A0, A1, A2, A3)> cb) {
+    return Event<void(A0, A1, A2, A3)>(this, cb);
+}
+
 template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
 Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(B0, A0, A1, A2, A3), C0 c0) {
     return Event<void(A0, A1, A2, A3)>(this, func, c0);
@@ -3040,6 +3165,11 @@ Event<void(A0, A1, A2, A3)> EventQueue::event(volatile T *obj, R (T::*method)(B0
 template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
 Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3) const volatile, C0 c0) {
     return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(mbed::Callback<R(B0, A0, A1, A2, A3)> cb, C0 c0) {
+    return Event<void(A0, A1, A2, A3)>(this, cb, c0);
 }
 
 template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
@@ -3067,6 +3197,11 @@ Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*meth
     return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1);
 }
 
+template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(mbed::Callback<R(B0, B1, A0, A1, A2, A3)> cb, C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2, A3)>(this, cb, c0, c1);
+}
+
 template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
 Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(B0, B1, B2, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2) {
     return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2);
@@ -3090,6 +3225,11 @@ Event<void(A0, A1, A2, A3)> EventQueue::event(volatile T *obj, R (T::*method)(B0
 template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
 Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3) const volatile, C0 c0, C1 c1, C2 c2) {
     return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(mbed::Callback<R(B0, B1, B2, A0, A1, A2, A3)> cb, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2, A3)>(this, cb, c0, c1, c2);
 }
 
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
@@ -3117,6 +3257,11 @@ Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*meth
     return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
 }
 
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(mbed::Callback<R(B0, B1, B2, B3, A0, A1, A2, A3)> cb, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2, A3)>(this, cb, c0, c1, c2, c3);
+}
+
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
 Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
     return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3, c4);
@@ -3140,6 +3285,11 @@ Event<void(A0, A1, A2, A3)> EventQueue::event(volatile T *obj, R (T::*method)(B0
 template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
 Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
     return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(mbed::Callback<R(B0, B1, B2, B3, B4, A0, A1, A2, A3)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2, A3)>(this, cb, c0, c1, c2, c3, c4);
 }
 
 template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
@@ -3167,6 +3317,11 @@ Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*
     return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method));
 }
 
+template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(mbed::Callback<R(A0, A1, A2, A3, A4)> cb) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, cb);
+}
+
 template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
 Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(B0, A0, A1, A2, A3, A4), C0 c0) {
     return Event<void(A0, A1, A2, A3, A4)>(this, func, c0);
@@ -3190,6 +3345,11 @@ Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile T *obj, R (T::*method
 template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
 Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3, A4) const volatile, C0 c0) {
     return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(mbed::Callback<R(B0, A0, A1, A2, A3, A4)> cb, C0 c0) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, cb, c0);
 }
 
 template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
@@ -3217,6 +3377,11 @@ Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*
     return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1);
 }
 
+template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(mbed::Callback<R(B0, B1, A0, A1, A2, A3, A4)> cb, C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, cb, c0, c1);
+}
+
 template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
 Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(B0, B1, B2, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2) {
     return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2);
@@ -3240,6 +3405,11 @@ Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile T *obj, R (T::*method
 template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
 Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1, C2 c2) {
     return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(mbed::Callback<R(B0, B1, B2, A0, A1, A2, A3, A4)> cb, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, cb, c0, c1, c2);
 }
 
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
@@ -3267,6 +3437,11 @@ Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*
     return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
 }
 
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(mbed::Callback<R(B0, B1, B2, B3, A0, A1, A2, A3, A4)> cb, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, cb, c0, c1, c2, c3);
+}
+
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
 Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
     return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3, c4);
@@ -3290,6 +3465,11 @@ Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile T *obj, R (T::*method
 template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
 Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
     return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(mbed::Callback<R(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, cb, c0, c1, c2, c3, c4);
 }
 
 }

--- a/events/Event.h
+++ b/events/Event.h
@@ -45,7 +45,10 @@ public:
      *
      *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
-     *  @param a0..a4   Arguments to pass to the callback
+     *  @param c0..c4   Arguments to bind to the callback, these arguments are
+     *                  allocated on an irq-safe allocator from the event queue's
+     *                  memory pool. Must be type-compatible with b0..b4, the
+     *                  arguments to the underlying callback.
      */
     template <typename F>
     Event(EventQueue *q, F f) {
@@ -438,7 +441,10 @@ public:
      *
      *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
-     *  @param a0..a4   Arguments to pass to the callback
+     *  @param c0..c4   Arguments to bind to the callback, these arguments are
+     *                  allocated on an irq-safe allocator from the event queue's
+     *                  memory pool. Must be type-compatible with b0..b4, the
+     *                  arguments to the underlying callback.
      */
     template <typename F>
     Event(EventQueue *q, F f) {
@@ -831,7 +837,10 @@ public:
      *
      *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
-     *  @param a0..a4   Arguments to pass to the callback
+     *  @param c0..c4   Arguments to bind to the callback, these arguments are
+     *                  allocated on an irq-safe allocator from the event queue's
+     *                  memory pool. Must be type-compatible with b0..b4, the
+     *                  arguments to the underlying callback.
      */
     template <typename F>
     Event(EventQueue *q, F f) {
@@ -1224,7 +1233,10 @@ public:
      *
      *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
-     *  @param a0..a4   Arguments to pass to the callback
+     *  @param c0..c4   Arguments to bind to the callback, these arguments are
+     *                  allocated on an irq-safe allocator from the event queue's
+     *                  memory pool. Must be type-compatible with b0..b4, the
+     *                  arguments to the underlying callback.
      */
     template <typename F>
     Event(EventQueue *q, F f) {
@@ -1617,7 +1629,10 @@ public:
      *
      *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
-     *  @param a0..a4   Arguments to pass to the callback
+     *  @param c0..c4   Arguments to bind to the callback, these arguments are
+     *                  allocated on an irq-safe allocator from the event queue's
+     *                  memory pool. Must be type-compatible with b0..b4, the
+     *                  arguments to the underlying callback.
      */
     template <typename F>
     Event(EventQueue *q, F f) {
@@ -2010,7 +2025,10 @@ public:
      *
      *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
-     *  @param a0..a4   Arguments to pass to the callback
+     *  @param c0..c4   Arguments to bind to the callback, these arguments are
+     *                  allocated on an irq-safe allocator from the event queue's
+     *                  memory pool. Must be type-compatible with b0..b4, the
+     *                  arguments to the underlying callback.
      */
     template <typename F>
     Event(EventQueue *q, F f) {

--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -977,6 +977,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R>
+    Event<void()> event(mbed::Callback<R()> cb);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename C0>
     Event<void()> event(R (*func)(B0), C0 c0);
 
@@ -1003,6 +1009,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename C0>
     Event<void()> event(const volatile T *obj, R (T::*method)(B0) const volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename C0>
+    Event<void()> event(mbed::Callback<R(B0)> cb, C0 c0);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1037,6 +1049,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename B0, typename B1, typename C0, typename C1>
+    Event<void()> event(mbed::Callback<R(B0, B1)> cb, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
     Event<void()> event(R (*func)(B0, B1, B2), C0 c0, C1 c1, C2 c2);
 
@@ -1063,6 +1081,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
     Event<void()> event(const volatile T *obj, R (T::*method)(B0, B1, B2) const volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+    Event<void()> event(mbed::Callback<R(B0, B1, B2)> cb, C0 c0, C1 c1, C2 c2);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1097,6 +1121,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+    Event<void()> event(mbed::Callback<R(B0, B1, B2, B3)> cb, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event<void()> event(R (*func)(B0, B1, B2, B3, B4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
@@ -1123,6 +1153,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event<void()> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event<void()> event(mbed::Callback<R(B0, B1, B2, B3, B4)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1157,6 +1193,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename A0>
+    Event<void(A0)> event(mbed::Callback<R(A0)> cb);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename C0, typename A0>
     Event<void(A0)> event(R (*func)(B0, A0), C0 c0);
 
@@ -1183,6 +1225,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename C0, typename A0>
     Event<void(A0)> event(const volatile T *obj, R (T::*method)(B0, A0) const volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename C0, typename A0>
+    Event<void(A0)> event(mbed::Callback<R(B0, A0)> cb, C0 c0);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1217,6 +1265,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+    Event<void(A0)> event(mbed::Callback<R(B0, B1, A0)> cb, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
     Event<void(A0)> event(R (*func)(B0, B1, B2, A0), C0 c0, C1 c1, C2 c2);
 
@@ -1243,6 +1297,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
     Event<void(A0)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0) const volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+    Event<void(A0)> event(mbed::Callback<R(B0, B1, B2, A0)> cb, C0 c0, C1 c1, C2 c2);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1277,6 +1337,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+    Event<void(A0)> event(mbed::Callback<R(B0, B1, B2, B3, A0)> cb, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
     Event<void(A0)> event(R (*func)(B0, B1, B2, B3, B4, A0), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
@@ -1303,6 +1369,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
     Event<void(A0)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+    Event<void(A0)> event(mbed::Callback<R(B0, B1, B2, B3, B4, A0)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1337,6 +1409,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename A0, typename A1>
+    Event<void(A0, A1)> event(mbed::Callback<R(A0, A1)> cb);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename C0, typename A0, typename A1>
     Event<void(A0, A1)> event(R (*func)(B0, A0, A1), C0 c0);
 
@@ -1363,6 +1441,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1>
     Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(B0, A0, A1) const volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename C0, typename A0, typename A1>
+    Event<void(A0, A1)> event(mbed::Callback<R(B0, A0, A1)> cb, C0 c0);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1397,6 +1481,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+    Event<void(A0, A1)> event(mbed::Callback<R(B0, B1, A0, A1)> cb, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
     Event<void(A0, A1)> event(R (*func)(B0, B1, B2, A0, A1), C0 c0, C1 c1, C2 c2);
 
@@ -1423,6 +1513,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
     Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1) const volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+    Event<void(A0, A1)> event(mbed::Callback<R(B0, B1, B2, A0, A1)> cb, C0 c0, C1 c1, C2 c2);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1457,6 +1553,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+    Event<void(A0, A1)> event(mbed::Callback<R(B0, B1, B2, B3, A0, A1)> cb, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
     Event<void(A0, A1)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
@@ -1483,6 +1585,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
     Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+    Event<void(A0, A1)> event(mbed::Callback<R(B0, B1, B2, B3, B4, A0, A1)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1517,6 +1625,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(mbed::Callback<R(A0, A1, A2)> cb);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(R (*func)(B0, A0, A1, A2), C0 c0);
 
@@ -1543,6 +1657,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2) const volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(mbed::Callback<R(B0, A0, A1, A2)> cb, C0 c0);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1577,6 +1697,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(mbed::Callback<R(B0, B1, A0, A1, A2)> cb, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(R (*func)(B0, B1, B2, A0, A1, A2), C0 c0, C1 c1, C2 c2);
 
@@ -1603,6 +1729,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2) const volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(mbed::Callback<R(B0, B1, B2, A0, A1, A2)> cb, C0 c0, C1 c1, C2 c2);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1637,6 +1769,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(mbed::Callback<R(B0, B1, B2, B3, A0, A1, A2)> cb, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
@@ -1663,6 +1801,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(mbed::Callback<R(B0, B1, B2, B3, B4, A0, A1, A2)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1697,6 +1841,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(mbed::Callback<R(A0, A1, A2, A3)> cb);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(R (*func)(B0, A0, A1, A2, A3), C0 c0);
 
@@ -1723,6 +1873,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3) const volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(mbed::Callback<R(B0, A0, A1, A2, A3)> cb, C0 c0);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1757,6 +1913,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(mbed::Callback<R(B0, B1, A0, A1, A2, A3)> cb, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(R (*func)(B0, B1, B2, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2);
 
@@ -1783,6 +1945,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3) const volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(mbed::Callback<R(B0, B1, B2, A0, A1, A2, A3)> cb, C0 c0, C1 c1, C2 c2);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1817,6 +1985,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(mbed::Callback<R(B0, B1, B2, B3, A0, A1, A2, A3)> cb, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
@@ -1843,6 +2017,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(mbed::Callback<R(B0, B1, B2, B3, B4, A0, A1, A2, A3)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1877,6 +2057,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(mbed::Callback<R(A0, A1, A2, A3, A4)> cb);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, A0, A1, A2, A3, A4), C0 c0);
 
@@ -1903,6 +2089,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3, A4) const volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(mbed::Callback<R(B0, A0, A1, A2, A3, A4)> cb, C0 c0);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1937,6 +2129,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(mbed::Callback<R(B0, B1, A0, A1, A2, A3, A4)> cb, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, B1, B2, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2);
 
@@ -1963,6 +2161,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(mbed::Callback<R(B0, B1, B2, A0, A1, A2, A3, A4)> cb, C0 c0, C1 c1, C2 c2);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1997,6 +2201,12 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(mbed::Callback<R(B0, B1, B2, B3, A0, A1, A2, A3, A4)> cb, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
@@ -2023,6 +2233,12 @@ public:
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(mbed::Callback<R(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
 protected:
     template <typename F>

--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -944,7 +944,10 @@ public:
      *  context of the event queue's dispatch loop once posted.
      *
      *  @param f        Function to execute when the event is dispatched
-     *  @param a0..a4   Arguments to pass to the callback
+     *  @param c0..c4   Arguments to bind to the callback, these arguments are
+     *                  allocated on an irq-safe allocator from the event queue's
+     *                  memory pool. Must be type-compatible with b0..b4, the
+     *                  arguments to the underlying callback.
      *  @return         Event that will dispatch on the specific queue
      */
     template <typename R>


### PR DESCRIPTION
While limitations in type inference prevent the event helper from infering the type of generic function objects, there is nothing technical preventing inference from the Callback class, where the function type is encoded in the template parameters.

With adoption of the Callback class as the standard function representation, it makes sense to support events created from callback objects.

This use case came up in client code that used a separate type for function pointers.
cc @pan- (I'm ccing you on anything with this much template stuff)