### PR TITLE
nsapi: Rename attach -> sigio to decrease confusion on its behaviour

### DIFF
--- a/features/netsocket/Socket.cpp
+++ b/features/netsocket/Socket.cpp
@@ -149,11 +149,14 @@ nsapi_error_t Socket::getsockopt(int level, int optname, void *optval, unsigned 
 
 }
 
-void Socket::attach(Callback<void()> callback)
+void Socket::sigio(Callback<void()> callback)
 {
     _lock.lock();
-
     _callback = callback;
-
     _lock.unlock();
+}
+
+void Socket::attach(Callback<void()> callback)
+{
+    sigio(callback);
 }

--- a/features/netsocket/Socket.h
+++ b/features/netsocket/Socket.h
@@ -163,22 +163,30 @@ public:
      *  The callback may be called in an interrupt context and should not
      *  perform expensive operations such as recv/send calls.
      *
+     *  Note! This is not intended as a replacement for a poll or attach-like
+     *  asynchronous api, but rather as a building block for constructing
+     *  such functionality. The exact timing of when the registered function
+     *  is called is not guaranteed and susceptible to change.
+     *
      *  @param func     Function to call on state change
      */
+    void sigio(mbed::Callback<void()> func);
+
+    /** Register a callback on state change of the socket
+     *
+     *  @see Socket::sigio
+     *  @deprecated
+     *      The behaviour of Socket::attach differs from other attach functions in
+     *      mbed OS and has been known to cause confusion. Replaced by Socket::sigio.
+     */
+    MBED_DEPRECATED_SINCE("mbed-os-5.4",
+        "The behaviour of Socket::attach differs from other attach functions in "
+        "mbed OS and has been known to cause confusion. Replaced by Socket::sigio.")
     void attach(mbed::Callback<void()> func);
 
     /** Register a callback on state change of the socket
      *
-     *  The specified callback will be called on state changes such as when
-     *  the socket can recv/send/accept successfully and on when an error
-     *  occurs. The callback may also be called spuriously without reason.
-     *
-     *  The callback may be called in an interrupt context and should not
-     *  perform expensive operations such as recv/send calls.
-     *
-     *  @param obj      Pointer to object to call method on
-     *  @param method   Method to call on state change
-     *
+     *  @see Socket::sigio
      *  @deprecated
      *      The attach function does not support cv-qualifiers. Replaced by
      *      attach(callback(obj, method)).


### PR DESCRIPTION
Currently the Socket::attach function behaves differently than other attach functions in the mbed codebase.

There is quite a bit of discussion on the future of asynch socket apis (related issue https://github.com/ARMmbed/mbed-os/issues/3620), and given the current focus of mbed OS, I think it will take some time before we see a full-featured async user api mainlined.

In the meantime, I would like to change the name of the function to hopefully **1:** reduce some of the confusion around it and **2:** free up the attach name to potentially be used for a full-fledge async api in the future:

``` cpp
/** Register a callback on state change of the socket
 *
 *  The specified callback will be called on state changes such as when
 *  the socket can recv/send/accept successfully and on when an error
 *  occurs. The callback may also be called spuriously without reason.
 *
 *  The callback may be called in an interrupt context and should not
 *  perform expensive operations such as recv/send calls.
 *
 *  Note! This is not intended as a replacement for a poll or attach-like
 *  asynchronous api, but rather as a building block for constructing
 *  such functionality. The exact timing of when the registered function
 *  is called is not garunteed and susceptible to change.
 *
 *  @param func     Function to call on state change
 */
void sigio(mbed::Callback<void()> func);
```

cc @kjbracey-arm, @hasnainvirk, @marcuschangarm, @bogdanm 