### PR TITLE
Fix vector table bug when using bootloader on ST

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_NUCLEO_F429ZI/system_stm32f4xx.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_NUCLEO_F429ZI/system_stm32f4xx.c
@@ -80,6 +80,7 @@
 
 #include "stm32f4xx.h"
 #include "hal_tick.h"
+#include "nvic_addr.h"
 
 #if !defined  (HSE_VALUE) 
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Default value of the External oscillator in Hz */
@@ -218,7 +219,7 @@ void SystemInit(void)
 #ifdef VECT_TAB_SRAM
   SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+  SCB->VTOR = NVIC_FLASH_VECTOR_ADDRESS; /* Vector Table Relocation in Internal FLASH */
 #endif
 
   /* Configure the Cube driver */

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/cmsis_nvic.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/cmsis_nvic.c
@@ -29,9 +29,9 @@
  *******************************************************************************
  */ 
 #include "cmsis_nvic.h"
+#include "nvic_addr.h"
 
 #define NVIC_RAM_VECTOR_ADDRESS   (0x20000000)  // Vectors positioned at start of RAM
-#define NVIC_FLASH_VECTOR_ADDRESS (0x08000000)  // Initial vector position in flash
 
 void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     uint32_t *vectors = (uint32_t *)SCB->VTOR;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/nvic_addr.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/nvic_addr.h
@@ -1,0 +1,40 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017-2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NVIC_ADDR_H
+#define NVIC_ADDR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__ICCARM__)
+    #pragma section=".intvec"
+    #define NVIC_FLASH_VECTOR_ADDRESS   ((uint32_t)__section_begin(".intvec"))
+#elif defined(__CC_ARM)
+    extern uint32_t Load$$LR$$LR_IROM1$$Base[];
+    #define NVIC_FLASH_VECTOR_ADDRESS   ((uint32_t)Load$$LR$$LR_IROM1$$Base)
+#elif defined(__GNUC__)
+    extern uint32_t g_pfnVectors[];
+    #define NVIC_FLASH_VECTOR_ADDRESS   ((uint32_t)g_pfnVectors)
+#else
+    #error "Flash vector address not set for this toolchain"
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/system_init_pre.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/system_init_pre.c
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include "stm32f4xx.h"
+#include "nvic_addr.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -37,6 +38,6 @@ void SystemInitPre(void)
 #ifdef VECT_TAB_SRAM
     SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-    SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+  SCB->VTOR = NVIC_FLASH_VECTOR_ADDRESS; /* Vector Table Relocation in Internal FLASH */
 #endif
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_NUCLEO_F439ZI/system_stm32f4xx.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_NUCLEO_F439ZI/system_stm32f4xx.c
@@ -80,6 +80,7 @@
 
 #include "stm32f4xx.h"
 #include "hal_tick.h"
+#include "nvic_addr.h"
 
 #if !defined  (HSE_VALUE) 
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Default value of the External oscillator in Hz */
@@ -218,7 +219,7 @@ void SystemInit(void)
 #ifdef VECT_TAB_SRAM
   SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+  SCB->VTOR = NVIC_FLASH_VECTOR_ADDRESS; /* Vector Table Relocation in Internal FLASH */
 #endif
 
   /* Configure the Cube driver */

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/cmsis_nvic.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/cmsis_nvic.c
@@ -29,9 +29,9 @@
  *******************************************************************************
  */ 
 #include "cmsis_nvic.h"
+#include "nvic_addr.h"
 
 #define NVIC_RAM_VECTOR_ADDRESS   (0x20000000)  // Vectors positioned at start of RAM
-#define NVIC_FLASH_VECTOR_ADDRESS (0x08000000)  // Initial vector position in flash
 
 void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     uint32_t *vectors = (uint32_t *)SCB->VTOR;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/nvic_addr.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/nvic_addr.h
@@ -1,0 +1,40 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017-2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NVIC_ADDR_H
+#define NVIC_ADDR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__ICCARM__)
+    #pragma section=".intvec"
+    #define NVIC_FLASH_VECTOR_ADDRESS   ((uint32_t)__section_begin(".intvec"))
+#elif defined(__CC_ARM)
+    extern uint32_t Load$$LR$$LR_IROM1$$Base[];
+    #define NVIC_FLASH_VECTOR_ADDRESS   ((uint32_t)Load$$LR$$LR_IROM1$$Base)
+#elif defined(__GNUC__)
+    extern uint32_t g_pfnVectors[];
+    #define NVIC_FLASH_VECTOR_ADDRESS   ((uint32_t)g_pfnVectors)
+#else
+    #error "Flash vector address not set for this toolchain"
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/device/cmsis_nvic.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/device/cmsis_nvic.c
@@ -29,9 +29,9 @@
  *******************************************************************************
  */ 
 #include "cmsis_nvic.h"
+#include "nvic_addr.h"
 
 #define NVIC_RAM_VECTOR_ADDRESS   (0x20000000)  // Vectors positioned at start of RAM
-#define NVIC_FLASH_VECTOR_ADDRESS (0x08000000)  // Initial vector position in flash
 
 void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     uint32_t *vectors = (uint32_t *)SCB->VTOR;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/device/nvic_addr.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/device/nvic_addr.h
@@ -1,0 +1,40 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017-2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NVIC_ADDR_H
+#define NVIC_ADDR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__ICCARM__)
+    #pragma section=".intvec"
+    #define NVIC_FLASH_VECTOR_ADDRESS   ((uint32_t)__section_begin(".intvec"))
+#elif defined(__CC_ARM)
+    extern uint32_t Load$$LR$$LR_IROM1$$Base[];
+    #define NVIC_FLASH_VECTOR_ADDRESS   ((uint32_t)Load$$LR$$LR_IROM1$$Base)
+#elif defined(__GNUC__)
+    extern uint32_t g_pfnVectors[];
+    #define NVIC_FLASH_VECTOR_ADDRESS   ((uint32_t)g_pfnVectors)
+#else
+    #error "Flash vector address not set for this toolchain"
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/device/system_stm32f4xx.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/device/system_stm32f4xx.c
@@ -80,6 +80,7 @@
 
 #include "stm32f4xx.h"
 #include "hal_tick.h"
+#include "nvic_addr.h"
 
 #if !defined  (HSE_VALUE) 
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Default value of the External oscillator in Hz */
@@ -218,7 +219,7 @@ void SystemInit(void)
 #ifdef VECT_TAB_SRAM
   SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+  SCB->VTOR = NVIC_FLASH_VECTOR_ADDRESS; /* Vector Table Relocation in Internal FLASH */
 #endif
 
   /* Configure the Cube driver */


### PR DESCRIPTION
The address of the vector table is hardcoded to the start of flash in many, if not all, ST targets. This causes a crash in applications that are using a bootloader.  This patch updates the boards STM32F429xI,
STM32F439xI and Odin so they properly handle updating the VTOR with a bootloader.
