### PR TITLE
Remove non-portable code from FlashIAP

### DIFF
--- a/drivers/FlashIAP.cpp
+++ b/drivers/FlashIAP.cpp
@@ -103,19 +103,6 @@ int FlashIAP::program(const void *buffer, uint32_t addr, uint32_t size)
     return ret;
 }
 
-int FlashIAP::write(const void *buffer, uint32_t addr, uint32_t size)
-{
-    int ret = 0;
-    // erase will lock
-    if (erase(addr, size) != 0) {
-        return -1;
-    }
-    _mutex->lock();
-    ret = program(buffer, addr, size);
-    _mutex->unlock();
-    return ret;
-}
-
 bool FlashIAP::is_aligned_to_sector(uint32_t addr, uint32_t size)
 {
     uint32_t current_sector_size = flash_get_sector_size(&_flash, addr);

--- a/drivers/FlashIAP.h
+++ b/drivers/FlashIAP.h
@@ -66,17 +66,6 @@ public:
      */
     int read(void *buffer, uint32_t addr, uint32_t size);
 
-    /** Write data at defined flash address
-     *
-     *  A write is equivalent to an erase followed by a program. 
-     *
-     *  @param buffer Buffer of data to be written
-     *  @param addr   Address of a page to begin writing to
-     *  @param size   Size to write in bytes, must be a multiple of program and sector sizes
-     *  @return       0 on success, negative error code on failure
-     */
-    int write(const void *buffer, uint32_t addr, uint32_t size);
-
     /** Program data to pages
      *
      *  The sectors must have been erased prior to being programmed


### PR DESCRIPTION
Remove write function since this is not portable across targets and fix tests.