### PR TITLE
Add support for redirection of main

### DIFF
--- a/platform/mbed_sdk_boot.c
+++ b/platform/mbed_sdk_boot.c
@@ -69,12 +69,18 @@ void mbed_copy_nvic(void)
 
 #if defined (__CC_ARM)
 
-int $Super$$main(void);
+#if defined(CUSTOM_ENTRY_POINT)
+    #define mbed_real_main      mbed_entry_point
+#else
+    #define mbed_real_main      $Super$$main
+#endif
+
+int mbed_real_main(void);
 
 int $Sub$$main(void) 
 {
     mbed_main();
-    return $Super$$main();
+    return mbed_real_main();
 }
 
 void _platform_post_stackheap_init(void) 
@@ -85,7 +91,13 @@ void _platform_post_stackheap_init(void)
 
 #elif defined (__GNUC__) 
 
-extern int __real_main(void);
+#if defined(CUSTOM_ENTRY_POINT)
+    #define mbed_real_main      mbed_entry_point
+#else
+    #define mbed_real_main      __real_main
+#endif
+
+extern int mbed_real_main(void);
 
 void software_init_hook(void)
 {
@@ -98,7 +110,7 @@ void software_init_hook(void)
 int __wrap_main(void) 
 {
     mbed_main();
-    return __real_main();
+    return mbed_real_main();
 }
 
 #elif defined (__ICCARM__)

--- a/rtos/mbed_boot.c
+++ b/rtos/mbed_boot.c
@@ -328,11 +328,17 @@ void mbed_start_main(void)
 
 #if defined (__CC_ARM)
 
+#if defined(CUSTOM_ENTRY_POINT)
+    #define mbed_real_main      mbed_entry_point
+#else
+    #define mbed_real_main      $Super$$main
+#endif
+
 /* Common for both ARMC and MICROLIB */
-int $Super$$main(void);
+int mbed_real_main(void);
 int $Sub$$main(void) {
     mbed_main();
-    return $Super$$main();
+    return mbed_real_main();
 }
 
 #if defined (__MICROLIB)  /******************** MICROLIB ********************/
@@ -416,9 +422,15 @@ void __rt_entry (void) {
 #endif /* ARMC */
 #elif defined (__GNUC__) /******************** GCC ********************/
 
+#if defined(CUSTOM_ENTRY_POINT)
+    #define mbed_real_main      mbed_entry_point
+#else
+    #define mbed_real_main      __real_main
+#endif
+
 extern int main(int argc, char* argv[]);
 extern void __libc_init_array (void);
-extern int __real_main(void);
+extern int mbed_real_main(void);
 
 osMutexId_t               malloc_mutex_id;
 mbed_rtos_storage_mutex_t malloc_mutex_obj;
@@ -434,7 +446,7 @@ osMutexAttr_t             env_mutex_attr;
 
 int __wrap_main(void) {
     mbed_main();
-    return __real_main();
+    return mbed_real_main();
 }
 
 void pre_main(void)

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -1501,6 +1501,24 @@ class mbedToolchain:
         """
         raise NotImplemented
 
+    @staticmethod
+    @abstractmethod
+    def redirect_main(dest, build_dir):
+        """Redirect the main function
+
+        Positional arguments:
+        dest -- the new main function to link against
+        build_dir -- the directory to put "response files" if needed by the toolchain
+
+        Side Effects:
+        Possibly create a file in the build directory
+
+        Return:
+        The linker flag to redirect main as a string
+        """
+        raise NotImplemented
+
+
     # Return the list of macros geenrated by the build system
     def get_config_macros(self):
         return Config.config_to_macros(self.config_data) if self.config_data else []

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -244,6 +244,15 @@ class ARM(mbedToolchain):
         write(handle, "RESOLVE %s AS %s\n" % (source, sync))
         return "--edit=%s" % filename
 
+    @staticmethod
+    def redirect_main(dest, build_dir):
+        if dest == 'main':
+            return ARM.redirect_symbol("mbed_entry_point",
+                                       "$Super$$main", build_dir)
+        else:
+            return ARM.redirect_symbol("mbed_entry_point",
+                                       ARM.name_mangle(dest), build_dir)
+
 
 class ARM_STD(ARM):
     pass

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -285,6 +285,15 @@ class GCC(mbedToolchain):
         return "-Wl,--defsym=%s=%s" % (source, sync)
 
     @staticmethod
+    def redirect_main(dest, build_dir):
+        if dest == 'main':
+            return GCC.redirect_symbol("mbed_entry_point",
+                                       "__real_main", build_dir)
+        else:
+            return GCC.redirect_symbol("mbed_entry_point",
+                                       GCC.name_mangle(dest), build_dir)
+
+    @staticmethod
     def check_executable():
         """Returns True if the executable (arm-none-eabi-gcc) location
         specified by the user exists OR the executable can be found on the PATH.

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -248,3 +248,10 @@ class IAR(mbedToolchain):
     @staticmethod
     def redirect_symbol(source, sync, build_dir):
         return "--redirect %s=%s" % (source, sync)
+
+    @staticmethod
+    def redirect_main(dest, build_dir):
+        if dest != 'main':
+            return IAR.redirect_symbol("main", IAR.name_mangle(dest), build_dir)
+        else:
+            return None


### PR DESCRIPTION
When the define CUSTOM_ENTRY_POINT is set allow the main entry point to be redirected. Redirect your function to mbed_entry_point to have it take the place of main.

The code was used for initially in bootloader development, but is no longer needed. This PR has been created so those changes aren't lost, as they could still be useful for testing or future enhancements.