### PR TITLE
Bug fix of initial value of interrupt edge in "gpio_irq_init" again

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1H/gpio_irq_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1H/gpio_irq_api.c
@@ -166,7 +166,6 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     InterruptHandlerRegister((IRQn_Type)(nIRQn_h+obj->ch), (void (*)(uint32_t))irq_tbl[obj->ch]);
     INTCICR1 &= ~(0x3 << shift);
     GIC_SetPriority((IRQn_Type)(nIRQn_h+obj->ch), 5);
-    GIC_EnableIRQ((IRQn_Type)(nIRQn_h+obj->ch));
     obj->int_enable = 1;
     __enable_irq();
 


### PR DESCRIPTION
I modified the bug in PR #3289. But It seems not enough the changes.
For the reason, It occured the following issue.
https://github.com/ARMmbed/mbed-os/issues/3694
So I reviewed and re-modified about the setting of initial value of interrupt edge in "gpio_irq_init".