### PR TITLE
NXP KL43Z/KL27Z: fix spi format bits check

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/spi_api.c
@@ -65,7 +65,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
     spi_master_config_t master_config;
     spi_slave_config_t slave_config;
 
-    if ((bits != 8) || (bits != 16)) {
+    if ((bits != 8) && (bits != 16)) {
         error("Only 8bits and 16bits SPI supported");
         return;
     }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/spi_api.c
@@ -65,7 +65,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
     spi_master_config_t master_config;
     spi_slave_config_t slave_config;
 
-    if ((bits != 8) || (bits != 16)) {
+    if ((bits != 8) && (bits != 16)) {
         error("Only 8bits and 16bits SPI supported");
         return;
     }


### PR DESCRIPTION
It was always true for valid values (if its not 8 neither 16 bits, fail).

Fixes #2989. Logical error. Tested - compile tests for these 2 platforms.