### PR TITLE
NCS36510: I2C idle delay of 1us

### DIFF
--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/i2c.h
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/i2c.h
@@ -83,13 +83,17 @@
 #define I2C_APB_CLK_DIVIDER_VAL_MASK    0x1FE0
 
 /* Error check */
-#define I2C_UFL_CHECK         (d->membase->STATUS.WORD & 0x80)
-#define FIFO_OFL_CHECK        (d->membase->STATUS.WORD & 0x10)
-#define I2C_BUS_ERR_CHECK     (d->membase->STATUS.WORD & 0x04)
-#define RD_DATA_READY         (d->membase->STATUS.WORD & 0x02)
+#define I2C_UFL_CHECK         (obj->membase->STATUS.WORD & 0x80)
+#define I2C_FIFO_FULL         (obj->membase->STATUS.WORD & 0x20)
+#define FIFO_OFL_CHECK        (obj->membase->STATUS.WORD & 0x10)
+#define I2C_BUS_ERR_CHECK     (obj->membase->STATUS.WORD & 0x04)
+#define RD_DATA_READY         (obj->membase->STATUS.WORD & 0x02)
+#define I2C_FIFO_EMPTY        (obj->membase->STATUS.WORD & 0x01)
 
 #define I2C_API_STATUS_SUCCESS    0
 #define PAD_REG_ADRS_BYTE_SIZE    4
+
+#define SEND_COMMAND(cmd)  while(!I2C_FIFO_EMPTY); wait_us(1); obj->membase->CMD_REG = cmd;
 
 /** Init I2C device.
  * @details

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/i2c_api.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/i2c_api.c
@@ -31,6 +31,7 @@
 
 #include "i2c.h"
 #include "i2c_api.h"
+#include "wait_api.h"
 
 #define I2C_READ_WRITE_BIT_MASK    0xFE
 
@@ -151,10 +152,10 @@ int i2c_byte_read(i2c_t *obj, int last) /* TODO return size can be uint8_t */
     }
     if(last) {
         /* ACK */
-        obj->membase->CMD_REG = I2C_CMD_WDAT0;
+        SEND_COMMAND(I2C_CMD_WDAT0);
     } else {
         /* No ACK */
-        obj->membase->CMD_REG = I2C_CMD_WDAT1;
+        SEND_COMMAND(I2C_CMD_WDAT1);
     }
     return data;
 }
@@ -167,8 +168,6 @@ int i2c_byte_write(i2c_t *obj, int data)
     if(Count != 1) {
         return Count;
     }
-
-    obj->membase->CMD_REG = I2C_CMD_VRFY_ACK; /* Verify ACK */
 
     while(obj->membase->STATUS.WORD & I2C_STATUS_CMD_FIFO_OFL_BIT); /* Wait till command overflow ends */
 


### PR DESCRIPTION
It is added between I2C commands as I2C_COMMAND_FIFO is too fast to push commands out.

This is a replacement for #3722 (rebased on top of latest master, squashed to one commit).

cc @pradeep-gr 