### PR TITLE
Support for dynamic Case array in Specification constructor

### DIFF
--- a/features/frameworks/utest/utest/utest_case.h
+++ b/features/frameworks/utest/utest/utest_case.h
@@ -103,6 +103,12 @@ namespace v1 {
             const case_teardown_handler_t teardown_handler,
             const case_failure_handler_t failure_handler = default_handler);
 
+        Case &operator=(const Case &c) {
+            // workaround for assignment of const members
+            this->~Case();
+            new (this) Case(c);
+            return *this;
+        }
 
         /// @returns the textual description of the test case
         const char* get_description() const;

--- a/features/frameworks/utest/utest/utest_specification.h
+++ b/features/frameworks/utest/utest/utest_specification.h
@@ -48,6 +48,16 @@ namespace v1 {
     class Specification
     {
     public:
+
+        Specification(const test_setup_handler_t setup_handler,
+                      const Case *cases,
+                      size_t N,
+                      const handlers_t defaults = default_handlers) :
+            setup_handler(setup_handler), teardown_handler(default_handler), failure_handler(default_handler),
+            cases(cases), length(N),
+            defaults(defaults)
+        {}
+        
         template< size_t N >
         Specification(const Case (&cases)[N],
                       const handlers_t defaults = default_handlers) :


### PR DESCRIPTION
## Description
This pull request modifies the utest framework to allow for dynamic creation of Case arrays. The previous Specification class had multiple overloaded constructors which required a static pointer to a static array of Case objects. New overloaded constructor now allows for a static pointer to a dynamic array, with modification to the Case = operator for assignment of const member variables.

## Reasoning
New modifications to the CI Test Shield (https://github.com/ARMmbed/ci-test-shield/) will require dynamic testing of available pins.

## Test Results
```
+--------------+---------------+------------------------------------------------------------------------------+--------+--------------------+-------------+
| target       | platform_name | test suite                                                                   | result | elapsed_time (sec) | copy_method |
+--------------+---------------+------------------------------------------------------------------------------+--------+--------------------+-------------+
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-basic_test                        | OK     | 11.97              | shell       |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-basic_test_default                | OK     | 11.97              | shell       |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_async_validate               | OK     | 13.77              | shell       |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_control_async                | OK     | 19.95              | shell       |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_control_repeat               | OK     | 13.98              | shell       |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_selection                    | OK     | 11.84              | shell       |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_setup_failure                | OK     | 12.54              | shell       |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_teardown_failure             | OK     | 12.53              | shell       |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-control_type                      | OK     | 12.93              | shell       |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-minimal_async_scheduler           | OK     | 12.72              | shell       |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-minimal_scheduler                 | OK     | 13.45              | shell       |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-test_assertion_failure_test_setup | OK     | 11.63              | shell       |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-test_setup_case_selection_failure | OK     | 11.72              | shell       |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-test_setup_failure                | OK     | 11.76              | shell       |
+--------------+---------------+------------------------------------------------------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 14 OK
mbedgt: test case report:
+--------------+---------------+------------------------------------------------------------------------------+--------------------------------------------------------+--------+--------+--------+--------------------+
| target       | platform_name | test suite                                                                   | test case                                              | passed | failed | result | elapsed_time (sec) |
+--------------+---------------+------------------------------------------------------------------------------+--------------------------------------------------------+--------+--------+--------+--------------------+
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-basic_test                        | Repeating Test                                         | 2      | 0      | OK     | 0.07               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-basic_test                        | Simple Test                                            | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-basic_test_default                | Repeating Test                                         | 2      | 0      | OK     | 0.07               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-basic_test_default                | Simple Test                                            | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_async_validate               | Validate: Attributed Validation: Cancel Repeat         | 1      | 0      | OK     | 0.17               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_async_validate               | Validate: Attributed Validation: Enable Repeat Handler | 2      | 0      | OK     | 0.18               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_async_validate               | Validate: Multiple Premature Validation                | 1      | 0      | OK     | 0.07               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_async_validate               | Validate: Multiple Validation                          | 1      | 0      | OK     | 0.17               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_async_validate               | Validate: Premature Validation                         | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_async_validate               | Validate: Simple Validation                            | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_control_async                | Control: Await                                         | 1      | 0      | OK     | 1.42               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_control_async                | Control: CaseNext                                      | 1      | 0      | OK     | 0.06               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_control_async                | Control: NoTimeout                                     | 1      | 0      | OK     | 0.04               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_control_async                | Control: RepeatAllOnTimeout                            | 1      | 0      | OK     | 0.1                |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_control_async                | Control: RepeatHandlerOnTimeout                        | 1      | 0      | OK     | 1.64               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_control_async                | Control: Timeout (Failure)                             | 1      | 0      | OK     | 0.22               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_control_async                | Control: Timeout (Success)                             | 1      | 0      | OK     | 0.16               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_control_repeat               | Control: CaseNext                                      | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_control_repeat               | Control: NoRepeat                                      | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_control_repeat               | Control: RepeatAll                                     | 10     | 0      | OK     | 0.06               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_control_repeat               | Control: RepeatHandler                                 | 10     | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_selection                    | Case 1                                                 | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_selection                    | Case 2                                                 | 1      | 0      | OK     | 0.03               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_selection                    | Case 3                                                 | 1      | 0      | OK     | 0.01               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_setup_failure                | Setup handler returns ABORT                            | 1      | 0      | OK     | 0.14               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_setup_failure                | Setup handler returns CONTINUE                         | 1      | 0      | OK     | 0.07               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_setup_failure                | Setup handler returns IGNORE                           | 1      | 0      | OK     | 0.13               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_teardown_failure             | Teardown handler returns ABORT                         | 1      | 0      | OK     | 0.04               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_teardown_failure             | Teardown handler returns ABORT but is IGNORED          | 1      | 0      | OK     | 0.07               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-case_teardown_failure             | Teardown handler returns CONTINUE                      | 1      | 0      | OK     | 0.06               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-control_type                      | Testing combinations of different group                | 1      | 0      | OK     | 0.07               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-control_type                      | Testing combinations of same group                     | 1      | 0      | OK     | 0.07               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-control_type                      | Testing constants                                      | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-control_type                      | Testing constructors                                   | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-minimal_async_scheduler           | Minimal Scheduler: Async Case 4 (Failure)              | 0      | 0      | OK     | 0.35               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-minimal_async_scheduler           | Minimal Scheduler: Case 1                              | 1      | 0      | OK     | 0.04               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-minimal_async_scheduler           | Minimal Scheduler: Case 2                              | 1      | 0      | OK     | 0.06               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-minimal_async_scheduler           | Minimal Scheduler: Case 3                              | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-minimal_scheduler                 | Minimal Scheduler: Case 1                              | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-minimal_scheduler                 | Minimal Scheduler: Case 2                              | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-minimal_scheduler                 | Minimal Scheduler: Case 3                              | 1      | 0      | OK     | 0.04               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-minimal_scheduler                 | Minimal Scheduler: Case 4                              | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-minimal_scheduler                 | Minimal Scheduler: Case 5                              | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-minimal_scheduler                 | Minimal Scheduler: Case 6                              | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-minimal_scheduler                 | Minimal Scheduler: Case 7                              | 1      | 0      | OK     | 0.07               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-minimal_scheduler                 | Minimal Scheduler: Case 8                              | 1      | 0      | OK     | 0.06               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-test_assertion_failure_test_setup | dummy test                                             | 1      | 0      | OK     | 0.03               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-test_setup_case_selection_failure | dummy test                                             | 1      | 0      | OK     | 0.03               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-test_setup_case_selection_failure | dummy test 2                                           | 1      | 0      | OK     | 0.03               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-test_setup_failure                | dummy test                                             | 1      | 0      | OK     | 0.05               |
| K64F-GCC_ARM | K64F          | features-frameworks-utest-tests-unit_tests-test_setup_failure                | dummy test 2                                           | 1      | 0      | OK     | 0.03               |
+--------------+---------------+------------------------------------------------------------------------------+--------------------------------------------------------+--------+--------+--------+--------------------+
```
