### PR TITLE
Add NS_DUMMY_DEFINITIONS_OK

### DIFF
--- a/features/FEATURE_COMMON_PAL/nanostack-libservice/mbed-client-libservice/ns_types.h
+++ b/features/FEATURE_COMMON_PAL/nanostack-libservice/mbed-client-libservice/ns_types.h
@@ -256,6 +256,25 @@ typedef int_fast32_t int_fast24_t;
 #define NS_FUNNY_COMPARE_RESTORE
 #endif
 
+/** \brief Pragma to suppress warnings arising from dummy definitions.
+ *
+ * Useful when you have function-like macros that returning constants
+ * in cut-down builds. Can be fairly cavalier about disabling as we
+ * do not expect every build to use this macro. Generic builds of
+ * components should ensure this is not included by only using it in
+ * a ifdef blocks providing dummy definitions.
+ */
+#ifdef __CC_ARM
+// statement is unreachable(111),  controlling expression is constant(236), expression has no effect(174),
+// function was declared but never referenced(177), variable was set but never used(550)
+#define NS_DUMMY_DEFINITIONS_OK _Pragma("diag_suppress=111,236,174,177,550")
+#elif defined __IAR_SYSTEMS_ICC__
+// controlling expression is constant
+#define NS_DUMMY_DEFINITIONS_OK _Pragma("diag_suppress=Pe236")
+#else
+#define NS_DUMMY_DEFINITIONS_OK
+#endif
+
 /** \brief Convert pointer to member to pointer to containing structure */
 #define NS_CONTAINER_OF(ptr, type, member) \
     ((type *) ((char *) (ptr) - offsetof(type, member)))


### PR DESCRIPTION
Add definition from master repository.
This fixes compilation of coap_service.c on non-secure platforms.

## Description
Currently, any application requiring `FEATURE_NANOSTACK` and `FEATURE_COMMON_PAL` fails to build.
Apparently when Coap-service was updated, it pulls in a code that uses macro `NS_DUMMY_DEFINITIONS_OK` that is in the master repository of libservice, but not on the version in mbed-OS tree.

## Status
**READY**


## Steps to test or reproduce
1. Clone `mbed-os-example-blinky`
1. Set target without HW entropy, like `NUCLEO_F401RE`
1. Add features `NANOSTACK` and `COMMON_PAL` into `mbed_app.json`
Fails to compile.
