### PR TITLE
NCS36510: SPISLAVE enabled (Conflict resolved)

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2595,7 +2595,7 @@
         "post_binary_hook": {"function": "NCS36510TargetCode.ncs36510_addfib"},
         "macros": ["CM3", "CPU_NCS36510", "TARGET_NCS36510", "LOAD_ADDRESS=0x3000"],
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
-        "device_has": ["ANALOGIN", "SERIAL", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "LOWPOWERTIMER", "TRNG"],
+        "device_has": ["ANALOGIN", "SERIAL", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "LOWPOWERTIMER", "TRNG", "SPISLAVE"],
         "release_versions": ["2", "5"]
     },
     "NUMAKER_PFM_M453": {


### PR DESCRIPTION
## Description
SPISLAVE enabled. 
Conflict resolved


## Status
**READY**


## Migrations
SPI slave features can be used.

## Related PRs
This PR is one of the feature(SPISLAVE) from #3611. So PR #3611 will be invalid and can be closed.
This PR replaces #3724. Please close #3724




## Todos
- [ ] Tests


## Deploy notes
No changes required


## Steps to test or reproduce
Can be tested with SPISLAVE ci-test-shield tests
