### PR TITLE
lwip: Increase timeout on network tests with python projects

### DIFF
--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/gethostbyname/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/gethostbyname/main.cpp
@@ -91,7 +91,7 @@ void test_dns_literal_pref() {
 
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases) {
-    GREENTEA_SETUP(20, "default_auto");
+    GREENTEA_SETUP(60, "default_auto");
     net_bringup();
     return verbose_test_setup_handler(number_of_cases);
 }

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo/main.cpp
@@ -29,7 +29,7 @@ void prep_buffer(char *tx_buffer, size_t tx_size) {
 }
 
 int main() {
-    GREENTEA_SETUP(20, "tcp_echo");
+    GREENTEA_SETUP(60, "tcp_echo");
 
     EthernetInterface eth;
     eth.connect();

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
@@ -88,7 +88,7 @@ Echo echoers[MBED_CFG_TCP_CLIENT_ECHO_THREADS];
 
 
 int main() {
-    GREENTEA_SETUP(20, "tcp_echo");
+    GREENTEA_SETUP(60, "tcp_echo");
 
     int err = net.connect();
     TEST_ASSERT_EQUAL(0, err);

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_hello_world/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_hello_world/main.cpp
@@ -36,7 +36,7 @@ bool find_substring(const char *first, const char *last, const char *s_first, co
 }
 
 int main() {
-    GREENTEA_SETUP(20, "default_auto");
+    GREENTEA_SETUP(60, "default_auto");
 
     bool result = false;
     EthernetInterface eth;

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_dtls_handshake/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_dtls_handshake/main.cpp
@@ -28,7 +28,7 @@ int udp_dtls_handshake_pattern[] = {MBED_CFG_UDP_DTLS_HANDSHAKE_PATTERN};
 const int udp_dtls_handshake_count = sizeof(udp_dtls_handshake_pattern) / sizeof(int);
 
 int main() {
-    GREENTEA_SETUP(20, "udp_shotgun");
+    GREENTEA_SETUP(60, "udp_shotgun");
 
     EthernetInterface eth;
     int err = eth.connect();

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo/main.cpp
@@ -34,7 +34,7 @@ void prep_buffer(char *tx_buffer, size_t tx_size) {
 }
 
 int main() {
-    GREENTEA_SETUP(20, "udp_echo");
+    GREENTEA_SETUP(60, "udp_echo");
 
     EthernetInterface eth;
     eth.connect();

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
@@ -99,7 +99,7 @@ Echo echoers[MBED_CFG_UDP_CLIENT_ECHO_THREADS];
 
 
 int main() {
-    GREENTEA_SETUP(20, "udp_echo");
+    GREENTEA_SETUP(60, "udp_echo");
 
     int err = net.connect();
     TEST_ASSERT_EQUAL(0, err);


### PR DESCRIPTION
Sometimes when under heavy load, the CI machines can take a significant amount of time to bring up a python process (~10s). The timeouts for the network tests were chosen without much thought, and didn't leave much room for this sort of delay.

This patch brings up timeouts for ntetwork tests 20s -> 60s

cc @bridadan 
