### PR TITLE
Allow to redefine nRF's PSTORAGE_NUM_OF_PAGES outside of the mbed-os

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/sdk/source/drivers_nrf/pstorage/config/pstorage_platform.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/sdk/source/drivers_nrf/pstorage/config/pstorage_platform.h
@@ -66,7 +66,10 @@ static __INLINE uint32_t pstorage_flash_page_end()
 
 #define PSTORAGE_FLASH_PAGE_END     pstorage_flash_page_end()
 
+#ifndef PSTORAGE_NUM_OF_PAGES
 #define PSTORAGE_NUM_OF_PAGES       1                                                           /**< Number of flash pages allocated for the pstorage module excluding the swap page, configurable based on system requirements. */
+#endif
+
 #define PSTORAGE_MIN_BLOCK_SIZE     0x0010                                                      /**< Minimum size of block that can be registered with the module. Should be configured based on system requirements, recommendation is not have this value to be at least size of word. */
 
 #define PSTORAGE_DATA_START_ADDR    ((PSTORAGE_FLASH_PAGE_END - PSTORAGE_NUM_OF_PAGES - 1) \

--- a/targets/TARGET_NORDIC/TARGET_NRF5/sdk/drivers_nrf/pstorage/config/pstorage_platform.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/sdk/drivers_nrf/pstorage/config/pstorage_platform.h
@@ -67,7 +67,10 @@ static __INLINE uint32_t pstorage_flash_page_end()
 
 #define PSTORAGE_FLASH_PAGE_END     pstorage_flash_page_end()
 
+#ifndef PSTORAGE_NUM_OF_PAGES
 #define PSTORAGE_NUM_OF_PAGES       1                                                           /**< Number of flash pages allocated for the pstorage module excluding the swap page, configurable based on system requirements. */
+#endif
+
 #define PSTORAGE_MIN_BLOCK_SIZE     0x0010                                                      /**< Minimum size of block that can be registered with the module. Should be configured based on system requirements, recommendation is not have this value to be at least size of word. */
 
 #define PSTORAGE_DATA_START_ADDR    ((PSTORAGE_FLASH_PAGE_END - PSTORAGE_NUM_OF_PAGES - 1) \


### PR DESCRIPTION
## Description
By default the number of pstorage pages is set 1 and all addresses are calculated in the pstorage module accordingly. Nordic recommends changing this macro to whatever number is suitable for the app ([see this answer from Petter Myhre](https://devzone.nordicsemi.com/question/53066/what-will-be-the-starting-address-of-pstorage-page-how-we-can-change-it/?answer=53085#post-id-53085)) which is not quite elegant given that pstorage_platform.h is part of the mbed-os repo. With this modification you can e.g. define PSTORAGE_NUM_OF_PAGES on the command line, however note that you should rebuild mbed-os with this setting as it affects pstorage_platform.c.

This patch modifies the source for both nRF51 and nRF52 families.