### PR TITLE
feature_cmsis5: Fix mbedmicro-rtos-threads test for gcc 5.4.

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/malloc/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/malloc/main.cpp
@@ -10,7 +10,7 @@
 #if defined(__CORTEX_A9)
 #define THREAD_STACK_SIZE   DEFAULT_STACK_SIZE
 #else
-#define THREAD_STACK_SIZE   256
+#define THREAD_STACK_SIZE   512
 #endif
 
 DigitalOut led1(LED1);
@@ -44,11 +44,12 @@ int main()
 
     // Allocate threads for the test
     for (int i = 0; i < NUM_THREADS; i++) {
-        thread_list[i] = new Thread(osPriorityNormal, THREAD_STACK_SIZE);
+        thread_list[i] = new (std::nothrow) Thread(osPriorityNormal, THREAD_STACK_SIZE);
         if (NULL == thread_list[i]) {
             allocation_failure = true;
+        } else {
+            thread_list[i]->start(task_using_malloc);
         }
-        thread_list[i]->start(task_using_malloc);
     }
 
     // Give the test time to run


### PR DESCRIPTION
## Description
For gcc 5.4 each task created into this test consumes 0x128 B of stack. for gcc 4.9 consumption was 0xA0 B. Increase the THREAD_STACK_SIZE fixed the problem.

## Status
**READY**

## Related to Issue
https://github.com/ARMmbed/mbed-os/issues/3690