### PR TITLE
STM32: gpio SPEED - always set High Speed by default

### DIFF
--- a/targets/TARGET_STM/pinmap.c
+++ b/targets/TARGET_STM/pinmap.c
@@ -71,6 +71,16 @@ void pin_function(PinName pin, int data)
     // Enable GPIO clock
     GPIO_TypeDef *gpio = Set_GPIO_Clock(port);
 
+    /*  Set default speed to high.
+     *  This is done before other settings on purpose:
+     *  For most families there are dedicated registers so it is
+     *  not so important, register can be set at any time.
+     *  But for families like F1, speed only applies to output. so we set
+     *  it here, and then if input is selected, this setting might be
+     *  overriden by the input one.
+     */
+    LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_HIGH);
+
     switch (mode) {
         case STM_PIN_INPUT:
             ll_mode = LL_GPIO_MODE_INPUT;
@@ -103,7 +113,6 @@ void pin_function(PinName pin, int data)
 
     /*  For now by default use Speed HIGH for output or alt modes */
     if ((mode == STM_PIN_OUTPUT) ||(mode == STM_PIN_ALTERNATE)) {
-        LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_HIGH);
     if (STM_PIN_OD(data)) {
             LL_GPIO_SetPinOutputType(gpio, ll_pin, LL_GPIO_OUTPUT_OPENDRAIN);
     } else {


### PR DESCRIPTION
## Description

Up to now, speed was set for outputs and alternate, but this is
also valid for input configuration.

By default, let's configure high speed.

This is done first, because speed for some families like F1 is mixed
with Input/Output mode settings, so can be later over-ridden if needed.

A few sentences describing the overall goals of the pull request's commits.

## Status
**READY**

## Related PRs
This is actually a missing piece in GPIO rework done here: #3665 

