### PR TITLE
STM32L476xG: set APB2 clock to 80MHz (instead of 40MHz)

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/system_stm32l4xx.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/system_stm32l4xx.c
@@ -569,7 +569,7 @@ uint8_t SetSysClock_PLL_MSI(void)
   RCC_ClkInitStruct.SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK; /* 80 MHz */
   RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;         /* 80 MHz */
   RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;           /* 80 MHz */
-  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV2;           /* 40 MHz */
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;           /* 80 MHz */
   if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4) != HAL_OK)
   {
     return 0; // FAIL

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_NUCLEO_L476RG/system_stm32l4xx.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_NUCLEO_L476RG/system_stm32l4xx.c
@@ -569,7 +569,7 @@ uint8_t SetSysClock_PLL_MSI(void)
   RCC_ClkInitStruct.SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK; /* 80 MHz */
   RCC_ClkInitStruct.AHBCLKDivider  = RCC_SYSCLK_DIV1;         /* 80 MHz */
   RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;           /* 80 MHz */
-  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV2;           /* 40 MHz */
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;           /* 80 MHz */
   if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4) != HAL_OK)
   {
     return 0; // FAIL


### PR DESCRIPTION
## Description
The APB2 clock was not set to the maximum possible value (80 MHz). The SPI clock can now go up to 40 MHz.

Discussion started in Issue #3735.

## Status
READY

## Migrations
NO