### PR TITLE
STM32 GPIO: Typo correction. Update comment (GPIO_IP_WITHOUT_BRR)

### DIFF
--- a/targets/TARGET_STM/gpio_object.h
+++ b/targets/TARGET_STM/gpio_object.h
@@ -43,7 +43,7 @@ extern "C" {
 /*
  * Note: reg_clr might actually be same as reg_set.
  * Depends on family whether BRR is available on top of BSRR
- * if BRR does not exist, family shall define GPIO_DOES_NOT_HAVE_BRR
+ * if BRR does not exist, family shall define GPIO_IP_WITHOUT_BRR
  */
 typedef struct {
     uint32_t mask;


### PR DESCRIPTION
## Description
Typo correction to avoid any error for future platforms.

## Status
READY

## Migrations
NO
