### PR TITLE
STM32: change spi error to debug warning

### DIFF
--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -308,7 +308,7 @@ void spi_frequency(spi_t *obj, int hz) {
 
     /*  In case maximum pre-scaler still gives too high freq, raise an error */
     if (spi_hz > hz) {
-        error("Couldn't set suitable spi freq: request:%d, lowest:%d\r\n", hz, spi_hz);
+        DEBUG_PRINTF("WARNING: lowest SPI freq (%d)  higher than requested (%d)\r\n", spi_hz, hz);
     }
 
     DEBUG_PRINTF("spi_frequency, request:%d, select:%d\r\n", hz, spi_hz);


### PR DESCRIPTION
This is the proposed fix to issue #3849 

## Description

In case the selected frequency is higher than the requested one, it is
better to send a debug warning rather than an blocking error.

In case of such warning, user may need to redefine the clock tree setting
at higher level (reducing peripheral's input clocks during init phase).


This will avoid to block basic operations that would work anyway with a frequency higher than the requested one.
