### PR TITLE
Define GPIO_IP_WITHOUT_BRR for xDot platform

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/objects.h
@@ -65,6 +65,7 @@ struct dac_s {
     PinName pin;
 };
 
+#define GPIO_IP_WITHOUT_BRR
 #include "common_objects.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Description
Define GPIO_IP_WITHOUT_BRR for xDot platform. Apparently the L151CC doesn't have GPIOx->BRR even though documentation says it does. GPIOx->BSRR must be used instead when setting output pin value to 0. This resolves #3823.


## Status
**READY**
