### PR TITLE
Add the FPU field to the <Cpu> tag in Keil

### DIFF
--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -178,6 +178,16 @@ class Uvision(Exporter):
                                     key=lambda (_, __, name): name.lower())
         return grouped
 
+    @staticmethod
+    def format_fpu(core):
+        """Generate a core's FPU string"""
+        if core.endswith("FD"):
+            return "FPU3(DFPU)"
+        elif core.endswith("F"):
+            return "FPU2"
+        else:
+            return ""
+
     def generate(self):
         """Generate the .uvproj file"""
         cache = Cache(True, False)
@@ -197,10 +207,11 @@ class Uvision(Exporter):
             'include_paths': '; '.join(self.resources.inc_dirs).encode('utf-8'),
             'device': DeviceUvision(self.target),
         }
-        ctx['cputype'] = ctx['device'].core.rstrip("FD")
+        core = ctx['device'].core
+        ctx['cputype'] = core.rstrip("FD")
         # Turn on FPU optimizations if the core has an FPU
-        ctx['fpu_setting'] = 1 if 'f' not in ctx['device'].core.lower() \
-                                  or 'd' in ctx['device'].core.lower() else 2
+        ctx['fpu_setting'] = 1 if 'F' not in core or 'D' in core else 2
+        ctx['fputype'] = self.format_fpu(core)
         ctx.update(self.format_flags())
         self.gen_file('uvision/uvision.tmpl', ctx, self.project_name+".uvprojx")
         self.gen_file('uvision/uvision_debug.tmpl', ctx, self.project_name + ".uvoptx")

--- a/tools/export/uvision/uvision.tmpl
+++ b/tools/export/uvision/uvision.tmpl
@@ -16,7 +16,7 @@
           <Vendor>{{device.dvendor}}</Vendor>
           <PackID>{{device.pack_id}}</PackID>
           <PackURL>{{device.pack_url}}</PackURL>
-          <Cpu>CPUTYPE("{{cputype}}")</Cpu>
+          <Cpu>CPUTYPE("{{cputype}}") {{fputype}}</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll>{{device.flash_dll}}</FlashDriverDll>


### PR DESCRIPTION
Recently Keil released version 5.23 of their IDE. This version requires
the FPU to be set as part of the <Cpu> tag in the .uvprojx (XML project
file). This patch adds the appropriate FPU settings based on the
trailing F (FPU enabled) or FD (Double precesion FPU enabled) string of
the core.

## Related issues:
  - Resolves #3807 
  - Resolves https://github.com/ARMmbed/mbed-os-example-wifi/issues/19
  - Resolves https://github.com/ARMmbed/mbed-os-example-ble/issues/56
  - Resolves https://github.com/ARMmbed/mbed-os-example-sockets/issues/16
  - Resolves https://github.com/ARMmbed/mbed-os-example-blinky/issues/47