### PR TITLE
Trap earlier when a Thread instance is re-used

### DIFF
--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -179,11 +179,15 @@ int32_t Thread::signal_clr(int32_t signals) {
 Thread::State Thread::get_state() {
 #if !defined(__MBED_CMSIS_RTOS_CA9) && !defined(__MBED_CMSIS_RTOS_CM)
 #ifdef CMSIS_OS_RTX
-    State status = Deleted;
+    State status;
     _mutex.lock();
 
     if (_tid != NULL) {
         status = (State)_thread_def.tcb.state;
+    } else if (_finished) {
+        status = Deleted;
+    } else {
+        status = Inactive;
     }
 
     _mutex.unlock();

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -44,6 +44,7 @@ namespace rtos {
 void Thread::constructor(osPriority priority,
         uint32_t stack_size, unsigned char *stack_pointer) {
     _tid = 0;
+    _finished = false;
     _dynamic_stack = (stack_pointer == NULL);
 
 #if defined(__MBED_CMSIS_RTOS_CA9) || defined(__MBED_CMSIS_RTOS_CM)
@@ -74,7 +75,7 @@ void Thread::constructor(Callback<void()> task,
 osStatus Thread::start(Callback<void()> task) {
     _mutex.lock();
 
-    if (_tid != 0) {
+    if ((_tid != 0) || _finished) {
         _mutex.unlock();
         return osErrorParameter;
     }
@@ -117,6 +118,7 @@ osStatus Thread::terminate() {
     osThreadId local_id = _tid;
     _join_sem.release();
     _tid = (osThreadId)NULL;
+    _finished = true;
 
     ret = osThreadTerminate(local_id);
 
@@ -367,6 +369,7 @@ void Thread::_thunk(const void * thread_ptr)
     t->_task();
     t->_mutex.lock();
     t->_tid = (osThreadId)NULL;
+    t->_finished = true;
     t->_join_sem.release();
     // rtos will release the mutex automatically
 }

--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -331,6 +331,10 @@ public:
     virtual ~Thread();
 
 private:
+    /* disallow copy constructor and assignment operators */
+    Thread(const Thread&);
+    Thread& operator=(const Thread&);
+
     // Required to share definitions without
     // delegated constructors
     void constructor(osPriority priority=osPriorityNormal,

--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -197,6 +197,7 @@ public:
     /** Starts a thread executing the specified function.
       @param   task           function to be executed by this thread.
       @return  status code that indicates the execution status of the function.
+      @note a thread can only be started once
     */
     osStatus start(mbed::Callback<void()> task);
 
@@ -344,9 +345,10 @@ private:
     mbed::Callback<void()> _task;
     osThreadId _tid;
     osThreadDef_t _thread_def;
-    bool _dynamic_stack;
     Semaphore _join_sem;
     Mutex _mutex;
+    bool _dynamic_stack;
+    bool _finished;
 };
 
 }

--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -252,7 +252,7 @@ public:
 
     /** State of the Thread */
     enum State {
-        Inactive,           /**< Not created or terminated */
+        Inactive,           /**< Not created */
         Ready,              /**< Ready to run */
         Running,            /**< Running */
         WaitingDelay,       /**< Waiting for a delay to occur */


### PR DESCRIPTION
Calling Thread::start multiple times leads to undefined behavior since the Thread class was not designed to handle this.  Add an assert to trap immediately if Thread::start is called a second time to prevent this behavior.