### PR TITLE
Fix mbed 2 builds

### DIFF
--- a/drivers/FileSystemLike.h
+++ b/drivers/FileSystemLike.h
@@ -114,7 +114,7 @@ public:
      *    0 on success or un-needed,
      *   -1 on error
      */
-    virtual int stat(const char *name, struct stat *st) = 0;
+    virtual int stat(const char *name, struct stat *st) { return -1; };
 };
 
 } // namespace mbed

--- a/features/unsupported/tests/mbed/file/main.cpp
+++ b/features/unsupported/tests/mbed/file/main.cpp
@@ -1,0 +1,78 @@
+#include "test_env.h"
+#include "mbed_semihost_api.h"
+
+Serial pc(USBTX, USBRX);
+
+#define FILENAME      "/local/out.txt"
+#define TEST_STRING   "Hello World!"
+
+FILE *test_open(const char *mode) {
+    FILE *f = fopen(FILENAME, mode);
+    if (f == NULL) {
+        printf("Error opening file"NL);
+        notify_completion(false);
+    }
+    return f;
+}
+
+void test_write(FILE *f, char *str, int str_len) {
+    int n = fprintf(f, str);
+
+    if (n != str_len) {
+        printf("Error writing file"NL);
+        notify_completion(false);
+    }
+}
+
+void test_read(FILE *f, char *str, int str_len) {
+    int n = fread(str, sizeof(unsigned char), str_len, f);
+
+    if (n != str_len) {
+        printf("Error reading file"NL);
+        notify_completion(false);
+    }
+}
+
+void test_close(FILE *f) {
+    int rc = fclose(f);
+
+    if (rc != 0) {
+        printf("Error closing file"NL);
+        notify_completion(false);
+    }
+}
+
+int main() {
+    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_SELECT(default_auto);
+    MBED_HOSTTEST_DESCRIPTION(Semihost file system);
+    MBED_HOSTTEST_START("MBED_A2");
+
+    pc.printf("Test the Stream class\n");
+
+    printf("connected: %s\n", (semihost_connected()) ? ("Yes") : ("No"));
+
+    char mac[16];
+    mbed_mac_address(mac);
+    printf("mac address: %02x,%02x,%02x,%02x,%02x,%02x\n", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+
+    LocalFileSystem local("local");
+
+    FILE *f;
+    char *str = TEST_STRING;
+    char *buffer = (char *)malloc(sizeof(unsigned char) * strlen(TEST_STRING));
+    int str_len = strlen(TEST_STRING);
+
+    // Write
+    f = test_open("w");
+    test_write(f, str, str_len);
+    test_close(f);
+
+    // Read
+    f = test_open("r");
+    test_read(f, buffer, str_len);
+    test_close(f);
+
+    // Check the two strings are equal
+    MBED_HOSTTEST_RESULT((strncmp(buffer, str, str_len) == 0));
+}

--- a/platform/mbed_retarget.h
+++ b/platform/mbed_retarget.h
@@ -20,6 +20,7 @@
 #define RETARGET_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 /* We can get the following standard types from sys/types for gcc, but we
  * need to define the types ourselves for the other compilers that normally

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -732,7 +732,8 @@ def build_library(src_paths, build_path, target, toolchain_name,
 ######################
 
 def mbed2_obj_path(target_name, toolchain_name):
-    return join("TARGET_" + target_name, "TOOLCHAIN_" + toolchain_name)
+    real_tc_name = TOOLCHAIN_CLASSES[toolchain_name].__name__
+    return join("TARGET_" + target_name, "TOOLCHAIN_" + real_tc_name)
 
 def build_lib(lib_id, target, toolchain_name, verbose=False,
               clean=False, macros=None, notify=None, jobs=1, silent=False,
@@ -955,7 +956,7 @@ def build_mbed_libs(target, toolchain_name, verbose=False,
     try:
         # Source and Build Paths
         build_target = join(MBED_LIBRARIES, "TARGET_" + target.name)
-        build_toolchain = join(build_target, "TOOLCHAIN_" + toolchain_name)
+        build_toolchain = join(MBED_LIBRARIES, mbed2_obj_path(target.name, toolchain_name))
         mkdir(build_toolchain)
 
         # Toolchain


### PR DESCRIPTION
Some file must have been indirectly including something that brought in `size_t`, since this type is notably missing from the mbed 2 builds. Fixed by including `stddef.h` which includes this definitions.

cc @bridadan 