### PR TITLE
bd: Fix missing const attributes on functions

### DIFF
--- a/features/filesystem/bd/BlockDevice.h
+++ b/features/filesystem/bd/BlockDevice.h
@@ -117,7 +117,7 @@ public:
      *
      *  @return         Size of the underlying device in bytes
      */
-    virtual bd_size_t size() = 0;
+    virtual bd_size_t size() const = 0;
 
     /** Convenience function for checking block read validity
      *
@@ -125,7 +125,7 @@ public:
      *  @param size     Size to read in bytes
      *  @return         True if read is valid for underlying block device
      */
-    bool is_valid_read(bd_addr_t addr, bd_size_t size)
+    bool is_valid_read(bd_addr_t addr, bd_size_t size) const
     {
         return (
             addr % get_read_size() == 0 &&
@@ -139,7 +139,7 @@ public:
      *  @param size     Size to write in bytes
      *  @return         True if program is valid for underlying block device
      */
-    bool is_valid_program(bd_addr_t addr, bd_size_t size)
+    bool is_valid_program(bd_addr_t addr, bd_size_t size) const
     {
         return (
             addr % get_program_size() == 0 &&
@@ -153,7 +153,7 @@ public:
      *  @param size     Size to erase in bytes
      *  @return         True if erase is valid for underlying block device
      */
-    bool is_valid_erase(bd_addr_t addr, bd_size_t size)
+    bool is_valid_erase(bd_addr_t addr, bd_size_t size) const
     {
         return (
             addr % get_erase_size() == 0 &&

--- a/features/filesystem/bd/ChainingBlockDevice.cpp
+++ b/features/filesystem/bd/ChainingBlockDevice.cpp
@@ -190,7 +190,7 @@ bd_size_t ChainingBlockDevice::get_erase_size() const
     return _erase_size;
 }
 
-bd_size_t ChainingBlockDevice::size()
+bd_size_t ChainingBlockDevice::size() const
 {
     return _size;
 }

--- a/features/filesystem/bd/ChainingBlockDevice.h
+++ b/features/filesystem/bd/ChainingBlockDevice.h
@@ -140,7 +140,7 @@ public:
      *
      *  @return         Size of the underlying device in bytes
      */
-    virtual bd_size_t size();
+    virtual bd_size_t size() const;
 
 protected:
     BlockDevice **_bds;

--- a/features/filesystem/bd/HeapBlockDevice.cpp
+++ b/features/filesystem/bd/HeapBlockDevice.cpp
@@ -77,7 +77,7 @@ bd_size_t HeapBlockDevice::get_erase_size() const
     return _erase_size;
 }
 
-bd_size_t HeapBlockDevice::size()
+bd_size_t HeapBlockDevice::size() const
 {
     return _count * _erase_size;
 }

--- a/features/filesystem/bd/HeapBlockDevice.h
+++ b/features/filesystem/bd/HeapBlockDevice.h
@@ -119,7 +119,7 @@ public:
      *
      *  @return         Size of the underlying device in bytes
      */
-    virtual bd_size_t size();
+    virtual bd_size_t size() const;
 
 private:
     bd_size_t _read_size;

--- a/features/filesystem/bd/SlicingBlockDevice.cpp
+++ b/features/filesystem/bd/SlicingBlockDevice.cpp
@@ -108,7 +108,7 @@ bd_size_t SlicingBlockDevice::get_erase_size() const
     return _bd->get_erase_size();
 }
 
-bd_size_t SlicingBlockDevice::size()
+bd_size_t SlicingBlockDevice::size() const
 {
     return _stop - _start;
 }

--- a/features/filesystem/bd/SlicingBlockDevice.h
+++ b/features/filesystem/bd/SlicingBlockDevice.h
@@ -138,7 +138,7 @@ public:
      *
      *  @return         Size of the underlying device in bytes
      */
-    virtual bd_size_t size();
+    virtual bd_size_t size() const;
 
 protected:
     BlockDevice *_bd;


### PR DESCRIPTION
From review for https://github.com/ARMmbed/mbed-os/pull/3762, several of the "getter" functions in the block device had the const attribute added. However, we forgot a few, which is especially annoying if they depend on each other.

cc @simonqhughes, @0xc0170 