### PR TITLE
Export: fix issue #3865 - cmsis-dap swd

### DIFF
--- a/tools/export/iar/ewd.tmpl
+++ b/tools/export/iar/ewd.tmpl
@@ -348,7 +348,7 @@
         </option>
         <option>
           <name>CMSISDAPInterfaceRadio</name>
-          <state>0</state>
+          <state>1</state>
         </option>
         <option>
           <name>CMSISDAPInterfaceCmdLine</name>


### PR DESCRIPTION
From JTAG to SWD by default. This was causing flashing error.

Tested with IAR 7.80, CMSIS-DAP shows now SWD and I was able to flash. prior this patch, flashing would stop due to an error as reported in the issue referenced.

@theotherjimmy  @senthilr
