### PR TITLE
change iar debugger default option for CMSIS DAP from JTAG to SWD

### DIFF
--- a/tools/export/iar/ewd.tmpl
+++ b/tools/export/iar/ewd.tmpl
@@ -348,7 +348,7 @@
         </option>
         <option>
           <name>CMSISDAPInterfaceRadio</name>
-          <state>0</state>
+          <state>1</state>
         </option>
         <option>
           <name>CMSISDAPInterfaceCmdLine</name>


### PR DESCRIPTION
## Description

Found out during mbed os 5.4 OOB exercise that IAR debugger exporter template sets JTAG as default interface for CMSIS DAP. This causes the debugger Download/Debug operation to error out and requires the interface to be correctly set to SWD for proper operation.

This patch contains the one line change to set default interface option to SWD

## Status

READY

## Related issue:

Resolves [#3865](https://github.com/ARMmbed/mbed-os/issues/3865)