### PR TITLE
DISCO_F469NI: allow the use of CAN2 instance when CAN1 is not activated

### DIFF
--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -43,6 +43,7 @@ void can_init(can_t *obj, PinName rd, PinName td)
     }
 #if defined(CAN2_BASE) && (CAN_NUM == 2)
     else if (obj->can == CAN_2) {
+        __HAL_RCC_CAN1_CLK_ENABLE(); // needed to set filters
         __HAL_RCC_CAN2_CLK_ENABLE();
         obj->index = 1;
     }


### PR DESCRIPTION
## Description
On STM32F4 family, the CAN2 hw instance is using CAN1's filters.
HAL_CAN1_CLOCK_ENABLE must be activated.
This modification is not impacting other STM32 families behavior

## Status
**READY**

## Migrations
NO

## Steps to test or reproduce
Use the can autoloop test with only CAN2 activated on DISCO_F469NI
(test name **MBED_A27**, with `CAN can1(PB_5, PB_13);` instead of `CAN can1(PB_8, PB_9);`)
Without the patch, the` can.read `does not work (only write works) and MBED_A27 test is failed
With the patch, can.read works and MBED_A27 test is a success

