### PR TITLE
tools: add new examples

### DIFF
--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -146,6 +146,34 @@
       "compile" : true,
       "export": true,
       "auto-update" : false
+    },
+    {
+      "name": "mbed-os-example-bootloader",
+      "github":"https://github.com/ARMmbed/mbed-os-example-bootloader",
+      "mbed": [
+          "https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-bootloader"
+      ],
+      "features" : [],
+      "targets" : ["K64F", "NUCLEO_F429ZI", "UBLOX_EVK_ODIN_W2"],
+      "toolchains" : [],
+      "exporters": [],
+      "compile" : true,
+      "export": true,
+      "auto-update" : true
+    },
+    {
+      "name": "mbed-os-example-fat-filesystem",
+      "github":"https://github.com/ARMmbed/mbed-os-example-fat-filesystem",
+      "mbed": [
+          "https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-fat-filesystem"
+      ],
+      "features" : [],
+      "targets" : ["K64F"],
+      "toolchains" : [],
+      "exporters": [],
+      "compile" : true,
+      "export": true,
+      "auto-update" : true
     }
   ]
 }


### PR DESCRIPTION
Bootloader, bootloader blinky and fat filesystem examples added.

Up for review, to bring examples json file up to date.

@c1728p9 @simonqhughes @adbridge - please review. check if the example supports the configuration that is in here. Let me know, I'll add it based on your inputs