### PR TITLE
Enable target-specific toolchain options hook

### DIFF
--- a/tools/hooks.py
+++ b/tools/hooks.py
@@ -65,7 +65,9 @@ class Hook(object):
         _HOOKS.clear()
         self._cmdline_hooks = {}
         self.toolchain = toolchain
-        target.init_hooks(self, toolchain.__class__.__name__)
+        for hook_step in _HOOK_STEPS:
+            for hook_type in _HOOK_TYPES:
+                target.init_hooks(self, hook_step, hook_type, toolchain.__class__.__name__)
 
     # Hook various functions directly
     @staticmethod
@@ -84,7 +86,7 @@ class Hook(object):
         _HOOKS[hook_type][hook_step] = function
         return True
 
-    def hook_add_compiler(self, hook_step, function):
+    def hook_add_compile(self, hook_step, function):
         """Add a hook to the compiler
 
         Positional Arguments:
@@ -93,7 +95,7 @@ class Hook(object):
         """
         return self._hook_add("compile", hook_step, function)
 
-    def hook_add_linker(self, hook_step, function):
+    def hook_add_link(self, hook_step, function):
         """Add a hook to the linker
 
         Positional Arguments:
@@ -102,7 +104,7 @@ class Hook(object):
         """
         return self._hook_add("link", hook_step, function)
 
-    def hook_add_assembler(self, hook_step, function):
+    def hook_add_assemble(self, hook_step, function):
         """Add a hook to the assemble
 
         Positional Arguments:
@@ -133,7 +135,7 @@ class Hook(object):
         self._cmdline_hooks[hook_type] = function
         return True
 
-    def hook_cmdline_compiler(self, function):
+    def hook_cmdline_compile(self, function):
         """Add a hook to the compiler command line
 
         Positional arguments:
@@ -141,7 +143,7 @@ class Hook(object):
         """
         return self._hook_cmdline("compile", function)
 
-    def hook_cmdline_linker(self, function):
+    def hook_cmdline_link(self, function):
         """Add a hook to the linker command line
 
         Positional arguments:
@@ -149,7 +151,7 @@ class Hook(object):
         """
         return self._hook_cmdline("link", function)
 
-    def hook_cmdline_assembler(self, function):
+    def hook_cmdline_assemble(self, function):
         """Add a hook to the assembler command line
 
         Positional arguments:
@@ -178,7 +180,7 @@ class Hook(object):
                 self.toolchain.__class__.__name__, cmdline)
         return cmdline
 
-    def get_cmdline_compiler(self, cmdline):
+    def get_cmdline_compile(self, cmdline):
         """Get the compiler command line after running all hooks
 
         Positional arguments:
@@ -186,7 +188,7 @@ class Hook(object):
         """
         return self._get_cmdline("compile", cmdline)
 
-    def get_cmdline_linker(self, cmdline):
+    def get_cmdline_link(self, cmdline):
         """Get the linker command line after running all hooks
 
         Positional arguments:
@@ -194,7 +196,7 @@ class Hook(object):
         """
         return self._get_cmdline("link", cmdline)
 
-    def get_cmdline_assembler(self, cmdline):
+    def get_cmdline_assemble(self, cmdline):
         """Get the assmebler command line after running all hooks
 
         Positional arguments:

--- a/tools/hooks.py
+++ b/tools/hooks.py
@@ -12,7 +12,7 @@ _HOOKS = {}
 _RUNNING_HOOKS = {}
 
 # Available hook types
-_HOOK_TYPES = ["binary", "compile", "link", "assemble"]
+_HOOK_TYPES = ["target", "binary", "compile", "link", "assemble"]
 
 # Available hook steps
 _HOOK_STEPS = ["pre", "replace", "post"]
@@ -85,6 +85,16 @@ class Hook(object):
             _HOOKS[hook_type] = {}
         _HOOKS[hook_type][hook_step] = function
         return True
+
+    def hook_add_target(self, hook_step, function):
+        """Add a hook to the init option
+
+        Positional Arguments:
+        hook_step - target hook is limited to 'post'
+        function - the function to add to the list of hooks
+        """
+        hook_step = 'post'
+        return self._hook_add("target", hook_step, function)
 
     def hook_add_compile(self, hook_step, function):
         """Add a hook to the compiler
@@ -166,6 +176,17 @@ class Hook(object):
         function - the function to call
         """
         return self._hook_cmdline("binary", function)
+
+    def post_target_hook(self, t_self):
+        """Run the post init target-specific hook
+
+        Positional arguments:
+        t_self - the toolchain object
+        """
+        try:
+            _HOOKS['target']['post'](t_self)
+        except:
+            return
 
     # Return the command line after applying the hook
     def _get_cmdline(self, hook_type, cmdline):

--- a/tools/targets.py
+++ b/tools/targets.py
@@ -287,17 +287,16 @@ class Target(namedtuple("Target", "name json_data resolution_order resolution_or
             labels.append("UVISOR_UNSUPPORTED")
         return labels
 
-    def init_hooks(self, hook, toolchain_name):
-        """Initialize the post-build hooks for a toolchain. For now, this
-        function only allows "post binary" hooks (hooks that are executed
-        after the binary image is extracted from the executable file)
+    def init_hooks(self, hook, hook_step, hook_type, toolchain_name):
+        """Initialize hooks for a toolchain.
         """
 
         # If there's no hook, simply return
         try:
-            hook_data = self.post_binary_hook
+            hook_data = getattr(self, hook_step + '_' + hook_type + '_hook')
         except AttributeError:
             return
+
         # A hook was found. The hook's name is in the format
         # "classname.functionname"
         temp = hook_data["function"].split(".")
@@ -332,7 +331,8 @@ class Target(namedtuple("Target", "name json_data resolution_order resolution_or
            (toolchain_name not in toolchain_restrictions):
             return
         # Finally, hook the requested function
-        hook.hook_add_binary("post", getattr(cls, function_name))
+        hook_func = getattr(hook, 'hook_add_' + hook_type)
+        hook_func(hook_step, getattr(cls, function_name))
 
 ################################################################################
 # Target specific code goes in this section

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -147,8 +147,8 @@ class ARM(mbedToolchain):
         cmd = self.asm + ["-o", object, tempfile]
 
         # Call cmdline hook
-        cmd_pre = self.hook.get_cmdline_assembler(cmd_pre)
-        cmd = self.hook.get_cmdline_assembler(cmd)
+        cmd_pre = self.hook.get_cmdline_assemble(cmd_pre)
+        cmd = self.hook.get_cmdline_assemble(cmd)
        
         # Return command array, don't execute
         return [cmd_pre, cmd]
@@ -163,7 +163,7 @@ class ARM(mbedToolchain):
         cmd.extend(["-o", object, source])
 
         # Call cmdline hook
-        cmd = self.hook.get_cmdline_compiler(cmd)
+        cmd = self.hook.get_cmdline_compile(cmd)
 
         return [cmd]
 
@@ -190,7 +190,7 @@ class ARM(mbedToolchain):
         cmd = self.ld + args + objects + libraries + self.sys_libs
 
         # Call cmdline hook
-        cmd = self.hook.get_cmdline_linker(cmd)
+        cmd = self.hook.get_cmdline_link(cmd)
 
         if self.RESPONSE_FILES:
             # Split link command to linker executable + response file

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -72,6 +72,8 @@ class ARM(mbedToolchain):
         self.ar = join(ARM_BIN, "armar")
         self.elf2bin = join(ARM_BIN, "fromelf")
 
+        self.hook.post_target_hook(self)
+
     def parse_dependencies(self, dep_path):
         dependencies = []
         for line in open(dep_path).readlines():

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -98,6 +98,8 @@ class GCC(mbedToolchain):
         self.ar = join(tool_path, "arm-none-eabi-ar")
         self.elf2bin = join(tool_path, "arm-none-eabi-objcopy")
 
+        self.hook.post_target_hook(self)
+
     def parse_dependencies(self, dep_path):
         dependencies = []
         buff = open(dep_path).readlines()

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -181,7 +181,7 @@ class GCC(mbedToolchain):
         cmd = self.asm + self.get_compile_options(self.get_symbols(True), includes) + ["-o", object, source]
 
         # Call cmdline hook
-        cmd = self.hook.get_cmdline_assembler(cmd)
+        cmd = self.hook.get_cmdline_assemble(cmd)
 
         # Return command array, don't execute
         return [cmd]
@@ -196,7 +196,7 @@ class GCC(mbedToolchain):
         cmd.extend(["-o", object, source])
 
         # Call cmdline hook
-        cmd = self.hook.get_cmdline_compiler(cmd)
+        cmd = self.hook.get_cmdline_compile(cmd)
 
         return [cmd]
 
@@ -234,7 +234,7 @@ class GCC(mbedToolchain):
         cmd.extend(libs)
 
         # Call cmdline hook
-        cmd = self.hook.get_cmdline_linker(cmd)
+        cmd = self.hook.get_cmdline_link(cmd)
 
         if self.RESPONSE_FILES:
             # Split link command to linker executable + response file

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -159,7 +159,7 @@ class IAR(mbedToolchain):
         cmd = self.asm + self.get_compile_options(self.get_symbols(True), includes, True) + ["-o", object, source]
 
         # Call cmdline hook
-        cmd = self.hook.get_cmdline_assembler(cmd)
+        cmd = self.hook.get_cmdline_assemble(cmd)
 
         # Return command array, don't execute
         return [cmd]
@@ -176,7 +176,7 @@ class IAR(mbedToolchain):
         cmd.extend(["-o", object, source])
 
         # Call cmdline hook
-        cmd = self.hook.get_cmdline_compiler(cmd)
+        cmd = self.hook.get_cmdline_compile(cmd)
 
         return [cmd]
 
@@ -196,7 +196,7 @@ class IAR(mbedToolchain):
             cmd.extend(["--config", mem_map])
 
         # Call cmdline hook
-        cmd = self.hook.get_cmdline_linker(cmd)
+        cmd = self.hook.get_cmdline_link(cmd)
 
         if self.RESPONSE_FILES:
             # Split link command to linker executable + response file

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -93,6 +93,8 @@ class IAR(mbedToolchain):
         self.ar = join(IAR_BIN, "iarchive")
         self.elf2bin = join(IAR_BIN, "ielftool")
 
+        self.hook.post_target_hook(self)
+
     def parse_dependencies(self, dep_path):
         return [(self.CHROOT if self.CHROOT else '')+path.strip() for path in open(dep_path).readlines()
                 if (path and not path.isspace())]


### PR DESCRIPTION
## Description
Enable target-specific toolchain options hook

Some target, e.g. REALTEK_RTL8195AM, requires special compiler/linker options. Without target-specific options hook, these options have to be added in global files. This PR includes two commits:

1. Enable all toolchain hooks, make hook naming consistent and scriptable
2. Enable target-specific toolchain hook.

## Status
READY


## Migrations
NO

## Related PRs
#3758 

## Todos
- [ ] Tests
- [ ] Documentation

## Deploy notes
NO

## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
