### PR TITLE
Use PATH env variable when gcc found in PATH

### DIFF
--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -15,7 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import re
-from os.path import join, basename, splitext, dirname
+from os.path import join, basename, splitext, dirname, exists
+from distutils.spawn import find_executable
 
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool
@@ -285,7 +286,15 @@ class GCC(mbedToolchain):
         """Returns True if the executable (arm-none-eabi-gcc) location
         specified by the user exists OR the executable can be found on the PATH.
         Returns False otherwise."""
-        return mbedToolchain.generic_check_executable("GCC_ARM", 'arm-none-eabi-gcc', 1)
+        if not TOOLCHAIN_PATHS['GCC_ARM'] or not exists(TOOLCHAIN_PATHS['GCC_ARM']):
+            if find_executable('arm-none-eabi-gcc'):
+                TOOLCHAIN_PATHS['GCC_ARM'] = ''
+                return True
+            else:
+                return False
+        else:
+            exec_name = join(TOOLCHAIN_PATHS['GCC_ARM'], 'arm-none-eabi-gcc')
+            return exists(exec_name) or exists(exec_name + '.exe')
 
 class GCC_ARM(GCC):
     pass


### PR DESCRIPTION
Resolves the github issue #3790: Blinky fails to build (on Mac) after
addition of linker script preprocessing feature. Paraphrasing, this
issue is that Homebrew on mac does not install `arm-none-eabi-gcc` in
the same location as `arm-none-eabi-cpp`, the C Pre-Processor. The tools
prior to this commit, and after turning on the pre-processing of the
linker-script will fail on any Mac homebrew installed toolchains.

This commit resolves the above issue by allowing the toolchain's path to
the executable to remain empty after a call to `check_executable`. When
this path is empty, the tools will search the PATH environment variable
for the executable.

## TODO

- [x] Unit test to verify that this problem can never happen again.