### PR TITLE
Ignore FuzzyWuzzy warnings

### DIFF
--- a/tools/arm_pack_manager/__init__.py
+++ b/tools/arm_pack_manager/__init__.py
@@ -7,12 +7,16 @@ from threading import Thread
 from Queue import Queue
 from re import compile, sub
 from sys import stderr, stdout
-from fuzzywuzzy import process
 from itertools import takewhile
 import argparse
 from json import dump, load
 from zipfile import ZipFile
 from tempfile import gettempdir
+import warnings
+
+warnings.filterwarnings("ignore")
+
+from fuzzywuzzy import process
 
 RootPackURL = "http://www.keil.com/pack/index.idx"
 


### PR DESCRIPTION
This patch will prevent the `UserWarning: Using slow pure-python
SequenceMatcher. Install python-Levenshtein to remove this warning` from
appearing in your terminal every compile. This seems like the right
thing to do (tm) because it can be very difficult to install
`python-levenshtein` in many environments.

## TODO
 - [x] Manually check that it's ignored correctly in travis