### PR TITLE
Prevent underflow in heap size calculation

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -478,7 +478,7 @@ void set_stack_heap(void) {
     mbed_stack_isr_start = ISR_STACK_START;
 #else
     /* Interrupt stack -  reserve space at the end of the free block */
-    mbed_stack_isr_size = ISR_STACK_SIZE;
+    mbed_stack_isr_size = ISR_STACK_SIZE < free_size ? ISR_STACK_SIZE : free_size;
     mbed_stack_isr_start = free_start + free_size - mbed_stack_isr_size;
     free_size -= mbed_stack_isr_size;
 #endif


### PR DESCRIPTION
If the free memory on a device is small enough then the calculation to determine heap size could underflow to a large value. If this happens then malloc will never return failure and instead will cause a crash on allocation. This patch prevents the underflow so malloc works as expected even with low amounts of free memory.

This resolves #3210