### PR TITLE
uVisor: Fix 'publish' and core libs dependencies

### DIFF
--- a/features/FEATURE_UVISOR/importer/Makefile
+++ b/features/FEATURE_UVISOR/importer/Makefile
@@ -89,12 +89,13 @@ rsync:
 	# Copying licenses
 	cp $(UVISOR_DIR)/LICENSE* $(TARGET_SUPPORTED)
 
-TARGET_M%: $(TARGET_SUPPORTED)/*/*/*_cortex_m%*.a
+TARGET_M%: TARGET_LIBS_FIND=$(wildcard $(TARGET_SUPPORTED)/*/*/*_cortex_m$(subst TARGET_M,,$@)*.a)
+TARGET_M%: rsync
 	@printf "#\n# Copying $@ files...\n"
-	mkdir $(foreach file,$^,$(dir $(file))$@)
-	$(foreach file,$^,mv $(file) $(dir $(file))$@/lib$(notdir $(file));)
+	mkdir $(foreach file,$(TARGET_LIBS_FIND),$(dir $(file))$@)
+	$(foreach file,$(TARGET_LIBS_FIND),mv $(file) $(dir $(file))$@/lib$(notdir $(file));)
 
-publish: rsync TARGET_M3 TARGET_M4
+publish: TARGET_M3 TARGET_M4
 	#
 	# Rename release directorires to TARGET_RELEASE filters...
 	$(foreach dir, $(TARGET_LIST_RELEASE),mv $(dir) $(dir $(dir))TARGET_RELEASE;)


### PR DESCRIPTION
## Description
Fix `uvisor` build issues observed with GNU Make 4.2.1, caused by missing dependencies and wildcard patterns in core libs targets' pre-requisites.

Fixes issue #3905.

Tested successfully for building `uvisor` and `mbed-os` with GNU Make versions 4.2.1 and 3.81, with GCC_ARM toolchain version 6.3.0.

## Status
**READY**

## Migrations
NO

## Related PRs
None

## Todos
- [x] Tests

## Deploy notes
None

## Steps to test or reproduce
Refer to issue #3905.
