### PR TITLE
IAR exporter: extended debugger settings template with modifiable options needed for Nordic targets

### DIFF
--- a/tools/export/iar/__init__.py
+++ b/tools/export/iar/__init__.py
@@ -78,6 +78,9 @@ class IAR(Exporter):
             "FPU2": 0,
             "NrRegs": 0,
             "NEON": '',
+            "CExtraOptionsCheck": 0,
+            "CExtraOptions": "",
+            "CMSISDAPJtagSpeedList": 0,
         }
 
         iar_defaults.update(device_info)

--- a/tools/export/iar/ewd.tmpl
+++ b/tools/export/iar/ewd.tmpl
@@ -57,11 +57,11 @@
         </option>
         <option>
           <name>CExtraOptionsCheck</name>
-          <state>0</state>
+          <state>{{device.CExtraOptionsCheck}}</state>
         </option>
         <option>
           <name>CExtraOptions</name>
-          <state></state>
+          <state>{{device.CExtraOptions}}</state>
         </option>
         <option>
           <name>CFpuProcessor</name>
@@ -365,7 +365,7 @@
         <option>
           <name>CMSISDAPJtagSpeedList</name>
           <version>0</version>
-          <state>0</state>
+          <state>{{device.CMSISDAPJtagSpeedList}}</state>
         </option>
         <option>
           <name>CMSISDAPBreakpointRadio</name>

--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -42,7 +42,10 @@
         "OGChipSelectEditMenu": "STM32F072RB\tST STM32F072RB"
     },
     "nRF51822_xxAA": {
-        "OGChipSelectEditMenu": "nRF51822-QFAA\tNordicSemi nRF51822-QFAA"
+        "OGChipSelectEditMenu": "nRF51822-QFAA\tNordicSemi nRF51822-QFAA",
+        "CExtraOptionsCheck": 1,
+        "CExtraOptions": "--drv_vector_table_base=0x0",
+        "CMSISDAPJtagSpeedList": 10
     },
     "EFM32GG990F1024": {
         "OGChipSelectEditMenu": "EFM32GG990F1024\tSiliconLaboratories EFM32GG990F1024"
@@ -163,7 +166,10 @@
         "OGChipSelectEditMenu": "STM32F407VG\tST STM32F407VG"
     },
     "nRF52832_xxAA":{
-        "OGChipSelectEditMenu": "nRF52832-xxAA\tNordicSemi nRF52832-xxAA"
+        "OGChipSelectEditMenu": "nRF52832-xxAA\tNordicSemi nRF52832-xxAA",
+        "CExtraOptionsCheck": 1,
+        "CExtraOptions": "--drv_vector_table_base=0x0",
+        "CMSISDAPJtagSpeedList": 10
     },
     "NCS36510":{
         "OGChipSelectEditMenu": "NCS36510\tONSemiconductor NCS36510"


### PR DESCRIPTION
## Description
The default CMSIS-DAP interface speed (Auto) is causing troubles in debug communication (at least on Nordic's DKs). It was changed to 2 MHz for Nordic targets. An extra option "--drv_vector_table_base=0x0" was also added for these, so the debug session is not started with a jump to the application's reset handler, but to the SoftDevice's one instead.

## Status
**READY**

## Migrations
NO

## TODO
 - [x] /morph export-bulid