### PR TITLE
[NRF51822] Fix reference to sleep in hal_patch override

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/hal_patch/sleep.c
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/hal_patch/sleep.c
@@ -66,6 +66,6 @@ void hal_sleep(void)
 
 void hal_deepsleep(void)
 {
-    sleep();
+    hal_sleep();
     //   NRF_POWER->SYSTEMOFF=1;
 }


### PR DESCRIPTION
## Description

The `sleep` function as been changed into `hal_sleep` by #3607.
Unfortunately the call to `sleep` in the hal_patch for the NRF51822 has not been
updated to `hal_sleep`. The result was a link time error for targets based on
NRF51822_LEGACY compiling with the mbed OS 5 tree.

## Status
**READY**

## Migrations
NO



