### PR TITLE
STM32 - Remove the call to HAL_InitTick() in HAL_Init()

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/device/stm32f0xx_hal.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/device/stm32f0xx_hal.c
@@ -163,7 +163,7 @@ HAL_StatusTypeDef HAL_Init(void)
 
   /* Use systick as time base source and configure 1ms tick (default clock after Reset is HSI) */
 
-  HAL_InitTick(TICK_INT_PRIORITY);
+  //HAL_InitTick(TICK_INT_PRIORITY); // Removed to fix Issue 3683
 
   /* Init the low level hardware */
   HAL_MspInit();

--- a/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal.c
@@ -172,7 +172,7 @@ HAL_StatusTypeDef HAL_Init(void)
   HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
 
   /* Use systick as time base source and configure 1ms tick (default clock after Reset is MSI) */
-  HAL_InitTick(TICK_INT_PRIORITY);
+  //HAL_InitTick(TICK_INT_PRIORITY); // Removed to fix Issue 3683
 
   /* Init the low level hardware */
   HAL_MspInit();

--- a/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal.c
@@ -183,7 +183,7 @@ HAL_StatusTypeDef HAL_Init(void)
   HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
 
   /* Use systick as time base source and configure 1ms tick (default clock after Reset is HSI) */
-  HAL_InitTick(TICK_INT_PRIORITY);
+  //HAL_InitTick(TICK_INT_PRIORITY); // Removed to fix Issue 3683
   
   /* Init the low level hardware */
   HAL_MspInit();

--- a/targets/TARGET_STM/TARGET_STM32F3/device/stm32f3xx_hal.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/device/stm32f3xx_hal.c
@@ -162,7 +162,7 @@ HAL_StatusTypeDef HAL_Init(void)
   HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
 
   /* Enable systick and configure 1ms tick (default clock after Reset is HSI) */
-  HAL_InitTick(TICK_INT_PRIORITY);
+  //HAL_InitTick(TICK_INT_PRIORITY); // Removed to fix Issue 3683
 
   /* Init the low level hardware */
   HAL_MspInit();

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal.c
@@ -180,7 +180,7 @@ HAL_StatusTypeDef HAL_Init(void)
 #endif /* PREFETCH_ENABLE */
 
   /* Use systick as time base source and configure 1ms tick (default clock after Reset is HSI) */
-  HAL_InitTick(TICK_INT_PRIORITY);
+  //HAL_InitTick(TICK_INT_PRIORITY); // Removed to fix Issue 3683
   
   /* Init the low level hardware */
   HAL_MspInit();

--- a/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal.c
@@ -162,7 +162,7 @@ HAL_StatusTypeDef HAL_Init(void)
   HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
 
   /* Use systick as time base source and configure 1ms tick (default clock after Reset is HSI) */
-  HAL_InitTick(TICK_INT_PRIORITY);
+  //HAL_InitTick(TICK_INT_PRIORITY); // Removed to fix Issue 3683
   
   /* Init the low level hardware */
   HAL_MspInit();

--- a/targets/TARGET_STM/TARGET_STM32L0/device/stm32l0xx_hal.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/device/stm32l0xx_hal.c
@@ -181,7 +181,7 @@ HAL_StatusTypeDef HAL_Init(void)
 
   /* Use systick as time base source and configure 1ms tick (default clock after Reset is MSI) */
 
-  HAL_InitTick(TICK_INT_PRIORITY);
+  //HAL_InitTick(TICK_INT_PRIORITY); // Removed to fix Issue 3683
 
   /* Init the low level hardware */
   HAL_MspInit();

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal.c
@@ -165,7 +165,7 @@ HAL_StatusTypeDef HAL_Init(void)
   HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
 
   /* Use systick as time base source and configure 1ms tick (default clock after Reset is MSI) */
-  HAL_InitTick(TICK_INT_PRIORITY);
+  //HAL_InitTick(TICK_INT_PRIORITY); // Removed to fix Issue 3683
 
   /* Init the low level hardware */
   HAL_MspInit();

--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal.c
@@ -179,7 +179,7 @@ HAL_StatusTypeDef HAL_Init(void)
   HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
 
   /* Use SysTick as time base source and configure 1ms tick (default clock after Reset is MSI) */
-  HAL_InitTick(TICK_INT_PRIORITY);
+  //HAL_InitTick(TICK_INT_PRIORITY); // Removed to fix Issue 3683
 
   /* Init the low level hardware */
   HAL_MspInit();


### PR DESCRIPTION
## Description
This is a proposal to fix Issue #3683.

## Status
Tested OK on different boards with ARM, GCC, IAR toolchains on `ARMmbed/master` and `ARMmbed/feature_cmsis5` branches.

Do not merge yet.

## Migrations
NO

## Todos
- [ ] Tests on ARMmbed/feature_cmsis5 branch
