### PR TITLE
Fix  mistake register setting in serial_format()

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1H/serial_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1H/serial_api.c
@@ -398,10 +398,11 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
         break;
     }
 
-    obj->serial.uart->SCSMR = data_bits   << 6
-                       | parity_enable    << 5
-                       | parity_select    << 4
-                       | stop_bits        << 3;
+    obj->serial.uart->SCSMR = (obj->serial.uart->SCSMR & ~0x0078)
+                       | (data_bits       << 6)
+                       | (parity_enable   << 5)
+                       | (parity_select   << 4)
+                       | (stop_bits       << 3);
 }
 
 /******************************************************************************


### PR DESCRIPTION
Currently, there is the issue in register setting into serial_format().
The issue is that parameter for baudrate setting is initialed zero in this function.
In baudrate  is less 9600bps, the issue occurs. In baudrate  is over 9600, not occurs. When call serial_baud() before serial_format(), baudrate override and set with an incorrect value.

Therefore, I fixed register setting not to set the parameter of baudrate setting in serial_format().