### PR TITLE
[NUC472/M453] Support unique locally administered MAC address and other driver updates

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NUVOTON/TARGET_NUC472/nuc472_netif.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NUVOTON/TARGET_NUC472/nuc472_netif.c
@@ -117,9 +117,9 @@ void mbed_mac_address(char *mac)
         SYS_UnlockReg();
         FMC_Open();
         // = FMC_ReadUID(0);
-         uID1 = FMC_ReadUID(1);
-         word1 = (uID1 & 0x003FFFFF) | ((uID1 & 0x030000) << 6) >> 8;
-         word0 = ((FMC_ReadUID(0) >> 4) << 20) | ((uID1 & 0xFF)<<12) | (FMC_ReadUID(2) & 0xFFF);
+        uID1 = FMC_ReadUID(1);
+        word1 = (uID1 & 0x003FFFFF) | ((uID1 & 0x030000) << 6) >> 8;
+        word0 = ((FMC_ReadUID(0) >> 4) << 20) | ((uID1 & 0xFF)<<12) | (FMC_ReadUID(2) & 0xFFF);
         /* Disable FMC ISP function */
         FMC_Close();
         /* Lock protected registers */
@@ -135,7 +135,8 @@ void mbed_mac_address(char *mac)
     mac[3] = (word0 & 0x00ff0000) >> 16;
     mac[4] = (word0 & 0x0000ff00) >> 8;
     mac[5] = (word0 & 0x000000ff);
-//    printf("mac address %02x-%02x-%02x-%02x-%02x-%02x \r\n", mac[0], mac[1],mac[2],mac[3],mac[4],mac[5]);
+    
+    LWIP_DEBUGF(LWIP_DBG_LEVEL_WARNING|LWIP_DBG_ON, ("mac address %02x-%02x-%02x-%02x-%02x-%02x \r\n", mac[0], mac[1],mac[2],mac[3],mac[4],mac[5]));
 }
 
 /**
@@ -356,7 +357,7 @@ ethernetif_loopback_input(struct pbuf *p)           // TODO: make sure packet no
 {
     /* pass all packets to ethernet_input, which decides what packets it supports */
     if (netif->input(p, netif) != ERR_OK) {
-        LWIP_DEBUGF(NETIF_DEBUG, ("k64f_enetif_input: input error\n"));
+        LWIP_DEBUGF(NETIF_DEBUG, ("netif_input: input error\n"));
         /* Free buffer */
         pbuf_free(p);
     }

--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NUVOTON/TARGET_NUC472/nuc472_netif.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NUVOTON/TARGET_NUC472/nuc472_netif.c
@@ -100,6 +100,7 @@ struct ethernetif {
 // Override mbed_mac_address of mbed_interface.c to provide ethernet devices with a semi-unique MAC address
 void mbed_mac_address(char *mac)
 {
+    uint32_t uID1;
     // Fetch word 0
     uint32_t word0 = *(uint32_t *)0x7F804; // 2KB Data Flash at 0x7F800
     // Fetch word 1
@@ -116,8 +117,9 @@ void mbed_mac_address(char *mac)
         SYS_UnlockReg();
         FMC_Open();
         // = FMC_ReadUID(0);
-         word1 = FMC_ReadUID(1) >> 8; 
-         word0 = ((FMC_ReadUID(0) >> 4) << 20) | (FMC_ReadUID(2) & 0xFFFFF);
+         uID1 = FMC_ReadUID(1);
+         word1 = (uID1 & 0x003FFFFF) | ((uID1 & 0x030000) << 6) >> 8;
+         word0 = ((FMC_ReadUID(0) >> 4) << 20) | ((uID1 & 0xFF)<<12) | (FMC_ReadUID(2) & 0xFFF);
         /* Disable FMC ISP function */
         FMC_Close();
         /* Lock protected registers */

--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NUVOTON/TARGET_NUC472/nuc472_netif.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NUVOTON/TARGET_NUC472/nuc472_netif.c
@@ -100,36 +100,40 @@ struct ethernetif {
 // Override mbed_mac_address of mbed_interface.c to provide ethernet devices with a semi-unique MAC address
 void mbed_mac_address(char *mac)
 {
-	unsigned char my_mac_addr[6] = {0x02, 0x00, 0xac, 0x55, 0x66, 0x77};		// default mac adderss
     // Fetch word 0
-    uint32_t word0 = *(uint32_t *)0x7FFFC;
+    uint32_t word0 = *(uint32_t *)0x7F804; // 2KB Data Flash at 0x7F800
     // Fetch word 1
     // we only want bottom 16 bits of word1 (MAC bits 32-47)
     // and bit 9 forced to 1, bit 8 forced to 0
     // Locally administered MAC, reduced conflicts
     // http://en.wikipedia.org/wiki/MAC_address
-    uint32_t word1 = *(uint32_t *)0x7FFF8;
-	if( word0 == 0xFFFFFFFF )		// Not burn any mac address at the last 2 words of flash
+    uint32_t word1 = *(uint32_t *)0x7F800; // 2KB Data Flash at 0x7F800
+
+	if( word0 == 0xFFFFFFFF )		// Not burn any mac address at 1st 2 words of Data Flash
 	{
-		mac[0] = my_mac_addr[0];
-		mac[1] = my_mac_addr[1];
-		mac[2] = my_mac_addr[2];
-		mac[3] = my_mac_addr[3];
-		mac[4] = my_mac_addr[4];
-		mac[5] = my_mac_addr[5];	
-		return;
+        // with a semi-unique MAC address from the UUID
+        /* Enable FMC ISP function */
+        SYS_UnlockReg();
+        FMC_Open();
+        // = FMC_ReadUID(0);
+         word1 = FMC_ReadUID(1) >> 8; 
+         word0 = ((FMC_ReadUID(0) >> 4) << 20) | (FMC_ReadUID(2) & 0xFFFFF);
+        /* Disable FMC ISP function */
+        FMC_Close();
+        /* Lock protected registers */
+        SYS_LockReg();
 	}
 
     word1 |= 0x00000200;
     word1 &= 0x0000FEFF;
-    
-    mac[0] = (word1 & 0x000000ff);
-    mac[1] = (word1 & 0x0000ff00) >> 8;
+
+    mac[0] = (word1 & 0x0000ff00) >> 8;    
+    mac[1] = (word1 & 0x000000ff);
     mac[2] = (word0 & 0xff000000) >> 24;
     mac[3] = (word0 & 0x00ff0000) >> 16;
     mac[4] = (word0 & 0x0000ff00) >> 8;
     mac[5] = (word0 & 0x000000ff);
-
+//    printf("mac address %02x-%02x-%02x-%02x-%02x-%02x \r\n", mac[0], mac[1],mac[2],mac[3],mac[4],mac[5]);
 }
 
 /**

--- a/targets/TARGET_NUVOTON/TARGET_M451/TARGET_NUMAKER_PFM_M453/PeripheralNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M451/TARGET_NUMAKER_PFM_M453/PeripheralNames.h
@@ -23,95 +23,101 @@
 extern "C" {
 #endif
 
-// NOTE: TIMER0_BASE=(APBPERIPH_BASE + 0x10000)
-//       TIMER1_BASE=(APBPERIPH_BASE + 0x10020)
-#define NU_MODNAME(MODBASE, SUBINDEX)   ((MODBASE) | (SUBINDEX))
-#define NU_MODBASE(MODNAME)             ((MODNAME) & 0xFFFFFFE0)
-#define NU_MODSUBINDEX(MODNAME)         ((MODNAME) & 0x0000001F)
+// NOTE: Check all module base addresses (XXX_BASE in BSP) for free bit fields to define module name 
+//       which encodes module base address and module index/subindex.
+#define NU_MODSUBINDEX_Pos              0
+#define NU_MODSUBINDEX_Msk              (0x1Ful << NU_MODSUBINDEX_Pos)
+#define NU_MODINDEX_Pos                 20
+#define NU_MODINDEX_Msk                 (0xFul << NU_MODINDEX_Pos)
+
+#define NU_MODNAME(MODBASE, INDEX, SUBINDEX)    ((MODBASE) | ((INDEX) << NU_MODINDEX_Pos) | ((SUBINDEX) << NU_MODSUBINDEX_Pos))
+#define NU_MODBASE(MODNAME)                     ((MODNAME) & ~(NU_MODINDEX_Msk | NU_MODSUBINDEX_Msk))
+#define NU_MODINDEX(MODNAME)                    (((MODNAME) & NU_MODINDEX_Msk) >> NU_MODINDEX_Pos)
+#define NU_MODSUBINDEX(MODNAME)                 (((MODNAME) & NU_MODSUBINDEX_Msk) >> NU_MODSUBINDEX_Pos)
 
 #if 0
 typedef enum {
-    GPIO_A = (int) NU_MODNAME(GPIOA_BASE, 0),
-    GPIO_B = (int) NU_MODNAME(GPIOB_BASE, 0),
-    GPIO_C = (int) NU_MODNAME(GPIOC_BASE, 0),
-    GPIO_D = (int) NU_MODNAME(GPIOD_BASE, 0),
-    GPIO_E = (int) NU_MODNAME(GPIOE_BASE, 0),
-    GPIO_F = (int) NU_MODNAME(GPIOF_BASE, 0)
+    GPIO_A = (int) NU_MODNAME(GPIOA_BASE, 0, 0),
+    GPIO_B = (int) NU_MODNAME(GPIOB_BASE, 1, 0),
+    GPIO_C = (int) NU_MODNAME(GPIOC_BASE, 2, 0),
+    GPIO_D = (int) NU_MODNAME(GPIOD_BASE, 3, 0),
+    GPIO_E = (int) NU_MODNAME(GPIOE_BASE, 4, 0),
+    GPIO_F = (int) NU_MODNAME(GPIOF_BASE, 5, 0)
 } GPIOName;
 #endif
 
 typedef enum {
-    ADC_0_0 = (int) NU_MODNAME(EADC0_BASE, 0),
-    ADC_0_1 = (int) NU_MODNAME(EADC0_BASE, 1),
-    ADC_0_2 = (int) NU_MODNAME(EADC0_BASE, 2),
-    ADC_0_3 = (int) NU_MODNAME(EADC0_BASE, 3),
-    ADC_0_4 = (int) NU_MODNAME(EADC0_BASE, 4),
-    ADC_0_5 = (int) NU_MODNAME(EADC0_BASE, 5),
-    ADC_0_6 = (int) NU_MODNAME(EADC0_BASE, 6),
-    ADC_0_7 = (int) NU_MODNAME(EADC0_BASE, 7),
-    ADC_0_8 = (int) NU_MODNAME(EADC0_BASE, 8),
-    ADC_0_9 = (int) NU_MODNAME(EADC0_BASE, 9),
-    ADC_0_10 = (int) NU_MODNAME(EADC0_BASE, 10),
-    ADC_0_11 = (int) NU_MODNAME(EADC0_BASE, 11),
-    ADC_0_12 = (int) NU_MODNAME(EADC0_BASE, 12),
-    ADC_0_13 = (int) NU_MODNAME(EADC0_BASE, 13),
-    ADC_0_14 = (int) NU_MODNAME(EADC0_BASE, 14),
-    ADC_0_15 = (int) NU_MODNAME(EADC0_BASE, 15)
+    ADC_0_0 = (int) NU_MODNAME(EADC0_BASE, 0, 0),
+    ADC_0_1 = (int) NU_MODNAME(EADC0_BASE, 0, 1),
+    ADC_0_2 = (int) NU_MODNAME(EADC0_BASE, 0, 2),
+    ADC_0_3 = (int) NU_MODNAME(EADC0_BASE, 0, 3),
+    ADC_0_4 = (int) NU_MODNAME(EADC0_BASE, 0, 4),
+    ADC_0_5 = (int) NU_MODNAME(EADC0_BASE, 0, 5),
+    ADC_0_6 = (int) NU_MODNAME(EADC0_BASE, 0, 6),
+    ADC_0_7 = (int) NU_MODNAME(EADC0_BASE, 0, 7),
+    ADC_0_8 = (int) NU_MODNAME(EADC0_BASE, 0, 8),
+    ADC_0_9 = (int) NU_MODNAME(EADC0_BASE, 0, 9),
+    ADC_0_10 = (int) NU_MODNAME(EADC0_BASE, 0, 10),
+    ADC_0_11 = (int) NU_MODNAME(EADC0_BASE, 0, 11),
+    ADC_0_12 = (int) NU_MODNAME(EADC0_BASE, 0, 12),
+    ADC_0_13 = (int) NU_MODNAME(EADC0_BASE, 0, 13),
+    ADC_0_14 = (int) NU_MODNAME(EADC0_BASE, 0, 14),
+    ADC_0_15 = (int) NU_MODNAME(EADC0_BASE, 0, 15)
 } ADCName;
 
 typedef enum {
-    UART_0 = (int) NU_MODNAME(UART0_BASE, 0),
-    UART_1 = (int) NU_MODNAME(UART1_BASE, 0),
-    UART_2 = (int) NU_MODNAME(UART2_BASE, 0),
-    UART_3 = (int) NU_MODNAME(UART3_BASE, 0),
+    UART_0 = (int) NU_MODNAME(UART0_BASE, 0, 0),
+    UART_1 = (int) NU_MODNAME(UART1_BASE, 1, 0),
+    UART_2 = (int) NU_MODNAME(UART2_BASE, 2, 0),
+    UART_3 = (int) NU_MODNAME(UART3_BASE, 3, 0),
     // FIXME: board-specific
     STDIO_UART  = UART_3
 } UARTName;
 
 typedef enum {
-    SPI_0 = (int) NU_MODNAME(SPI0_BASE, 0),
-    SPI_1 = (int) NU_MODNAME(SPI1_BASE, 0),
-    SPI_2 = (int) NU_MODNAME(SPI2_BASE, 0)
+    SPI_0 = (int) NU_MODNAME(SPI0_BASE, 0, 0),
+    SPI_1 = (int) NU_MODNAME(SPI1_BASE, 1, 0),
+    SPI_2 = (int) NU_MODNAME(SPI2_BASE, 2, 0)
 } SPIName;
 
 typedef enum {
-    I2C_0 = (int) NU_MODNAME(I2C0_BASE, 0),
-    I2C_1 = (int) NU_MODNAME(I2C1_BASE, 0)
+    I2C_0 = (int) NU_MODNAME(I2C0_BASE, 0, 0),
+    I2C_1 = (int) NU_MODNAME(I2C1_BASE, 1, 0)
 } I2CName;
 
 typedef enum {
-    PWM_0_0 = (int) NU_MODNAME(PWM0_BASE, 0),
-    PWM_0_1 = (int) NU_MODNAME(PWM0_BASE, 1),
-    PWM_0_2 = (int) NU_MODNAME(PWM0_BASE, 2),
-    PWM_0_3 = (int) NU_MODNAME(PWM0_BASE, 3),
-    PWM_0_4 = (int) NU_MODNAME(PWM0_BASE, 4),
-    PWM_0_5 = (int) NU_MODNAME(PWM0_BASE, 5),
+    PWM_0_0 = (int) NU_MODNAME(PWM0_BASE, 0, 0),
+    PWM_0_1 = (int) NU_MODNAME(PWM0_BASE, 0, 1),
+    PWM_0_2 = (int) NU_MODNAME(PWM0_BASE, 0, 2),
+    PWM_0_3 = (int) NU_MODNAME(PWM0_BASE, 0, 3),
+    PWM_0_4 = (int) NU_MODNAME(PWM0_BASE, 0, 4),
+    PWM_0_5 = (int) NU_MODNAME(PWM0_BASE, 0, 5),
     
-    PWM_1_0 = (int) NU_MODNAME(PWM1_BASE, 0),
-    PWM_1_1 = (int) NU_MODNAME(PWM1_BASE, 1),
-    PWM_1_2 = (int) NU_MODNAME(PWM1_BASE, 2),
-    PWM_1_3 = (int) NU_MODNAME(PWM1_BASE, 3),
-    PWM_1_4 = (int) NU_MODNAME(PWM1_BASE, 4),
-    PWM_1_5 = (int) NU_MODNAME(PWM1_BASE, 5)
+    PWM_1_0 = (int) NU_MODNAME(PWM1_BASE, 1, 0),
+    PWM_1_1 = (int) NU_MODNAME(PWM1_BASE, 1, 1),
+    PWM_1_2 = (int) NU_MODNAME(PWM1_BASE, 1, 2),
+    PWM_1_3 = (int) NU_MODNAME(PWM1_BASE, 1, 3),
+    PWM_1_4 = (int) NU_MODNAME(PWM1_BASE, 1, 4),
+    PWM_1_5 = (int) NU_MODNAME(PWM1_BASE, 1, 5)
 } PWMName;
 
 typedef enum {
-    TIMER_0  = (int) NU_MODNAME(TMR01_BASE, 0),
-    TIMER_1  = (int) NU_MODNAME(TMR01_BASE + 0x20, 0),
-    TIMER_2  = (int) NU_MODNAME(TMR23_BASE, 0),
-    TIMER_3  = (int) NU_MODNAME(TMR23_BASE + 0x20, 0),
+    TIMER_0  = (int) NU_MODNAME(TMR01_BASE, 0, 0),
+    TIMER_1  = (int) NU_MODNAME(TMR01_BASE + 0x20, 1, 0),
+    TIMER_2  = (int) NU_MODNAME(TMR23_BASE, 2, 0),
+    TIMER_3  = (int) NU_MODNAME(TMR23_BASE + 0x20, 3, 0),
 } TIMERName;
 
 typedef enum {
-    RTC_0 = (int) NU_MODNAME(RTC_BASE, 0)
+    RTC_0 = (int) NU_MODNAME(RTC_BASE, 0, 0)
 } RTCName;
 
 typedef enum {
-    DMA_0 = (int) NU_MODNAME(PDMA_BASE, 0)
+    DMA_0 = (int) NU_MODNAME(PDMA_BASE, 0, 0)
 } DMAName;
 
 typedef enum {
-    CAN_0 = (int) NU_MODNAME(CAN0_BASE, 0)
+    CAN_0 = (int) NU_MODNAME(CAN0_BASE, 0, 0)
 } CANName;
 
 #ifdef __cplusplus

--- a/targets/TARGET_NUVOTON/TARGET_M451/TARGET_NUMAKER_PFM_M453/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M451/TARGET_NUMAKER_PFM_M453/PinNames.h
@@ -22,13 +22,32 @@
 extern "C" {
 #endif
 
-#define NU_PORT_SHIFT  12
-#define NU_PINNAME_TO_PORT(name)            ((unsigned int)(name) >> NU_PORT_SHIFT)
-#define NU_PINNAME_TO_PIN(name)             ((unsigned int)(name) & ~(0xFFFFFFFF << NU_PORT_SHIFT))
-#define NU_PORT_N_PIN_TO_PINNAME(port, pin) ((((unsigned int) (port)) << (NU_PORT_SHIFT)) | ((unsigned int) (pin)))
-#define NU_PORT_BASE(port)                  ((GPIO_T *)(((uint32_t) GPIOA_BASE) + 0x40 * port))
-#define NU_MFP_POS(pin)                     ((pin % 8) * 4)
-#define NU_MFP_MSK(pin)                     (0xful << NU_MFP_POS(pin))
+#define NU_PININDEX_Pos                             0
+#define NU_PININDEX_Msk                             (0xFFul << NU_PININDEX_Pos)
+#define NU_PINPORT_Pos                              8
+#define NU_PINPORT_Msk                              (0xFul << NU_PINPORT_Pos)
+#define NU_PIN_MODINDEX_Pos                         12
+#define NU_PIN_MODINDEX_Msk                         (0xFul << NU_PIN_MODINDEX_Pos)
+#define NU_PIN_BIND_Pos                             16
+#define NU_PIN_BIND_Msk                             (0x1ul << NU_PIN_BIND_Pos)
+
+#define NU_PININDEX(PINNAME)                        (((unsigned int)(PINNAME) & NU_PININDEX_Msk) >> NU_PININDEX_Pos)
+#define NU_PINPORT(PINNAME)                         (((unsigned int)(PINNAME) & NU_PINPORT_Msk) >> NU_PINPORT_Pos)
+#define NU_PIN_BIND(PINNAME)                        (((unsigned int)(PINNAME) & NU_PIN_BIND_Msk) >> NU_PIN_BIND_Pos)
+#define NU_PIN_MODINDEX(PINNAME)                    (((unsigned int)(PINNAME) & NU_PIN_MODINDEX_Msk) >> NU_PIN_MODINDEX_Pos)
+#define NU_PINNAME(PORT, PIN)                       ((((unsigned int) (PORT)) << (NU_PINPORT_Pos)) | (((unsigned int) (PIN)) << NU_PININDEX_Pos))
+#define NU_PINNAME_BIND(PINNAME, modname)           NU_PINNAME_BIND_(NU_PINPORT(PINNAME), NU_PININDEX(PINNAME), modname)
+#define NU_PINNAME_BIND_(PORT, PIN, modname)        ((((unsigned int)(PORT)) << NU_PINPORT_Pos) | (((unsigned int)(PIN)) << NU_PININDEX_Pos) | (NU_MODINDEX(modname) << NU_PIN_MODINDEX_Pos) | NU_PIN_BIND_Msk)
+
+#define NU_PORT_BASE(port)                          ((GPIO_T *)(((uint32_t) GPIOA_BASE) + 0x40 * port))
+#define NU_MFP_POS(pin)                             ((pin % 8) * 4)
+#define NU_MFP_MSK(pin)                             (0xful << NU_MFP_POS(pin))
+
+// LEGACY
+#define NU_PINNAME_TO_PIN(PINNAME)                  NU_PININDEX(PINNAME)
+#define NU_PINNAME_TO_PORT(PINNAME)                 NU_PINPORT(PINNAME)
+#define NU_PINNAME_TO_MODSUBINDEX(PINNAME)          NU_PIN_MODINDEX(PINNAME)
+#define NU_PORT_N_PIN_TO_PINNAME(PORT, PIN)         NU_PINNAME((PORT), (PIN))
 
 typedef enum {
     PIN_INPUT,

--- a/targets/TARGET_NUVOTON/TARGET_M451/dma.h
+++ b/targets/TARGET_NUVOTON/TARGET_M451/dma.h
@@ -32,6 +32,7 @@ extern "C" {
 #define DMA_EVENT_MASK              DMA_EVENT_ALL
 
 void dma_set_handler(int channelid, uint32_t handler, uint32_t id, uint32_t event);
+PDMA_T *dma_modbase(void);
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_NUVOTON/TARGET_M451/dma_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/dma_api.c
@@ -165,7 +165,7 @@ static void pdma_vec(void)
         PDMA->INTSTS = reqto;
         
         while (reqto) {
-            int chn_id = nu_ctz(reqto) >> PDMA_INTSTS_REQTOFn_Pos;
+            int chn_id = nu_ctz(reqto) - PDMA_INTSTS_REQTOFn_Pos;
             if (dma_chn_mask & (1 << chn_id)) {
                 struct nu_dma_chn_s *dma_chn = dma_chn_arr + chn_id;
                 if (dma_chn->handler && (dma_chn->event & DMA_EVENT_TIMEOUT)) {

--- a/targets/TARGET_NUVOTON/TARGET_M451/dma_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/dma_api.c
@@ -111,6 +111,11 @@ void dma_set_handler(int channelid, uint32_t handler, uint32_t id, uint32_t even
     NVIC_EnableIRQ(dma_modinit.irq_n);
 }
 
+PDMA_T *dma_modbase(void)
+{
+    return (PDMA_T *) NU_MODBASE(dma_modinit.modname);
+}
+
 static void pdma_vec(void)
 {
     uint32_t intsts = PDMA_GET_INT_STATUS();

--- a/targets/TARGET_NUVOTON/TARGET_M451/pwmout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/pwmout_api.c
@@ -99,9 +99,11 @@ void pwmout_init(pwmout_t* obj, PinName pin)
     
     ((struct nu_pwm_var *) modinit->var)->en_msk |= 1 << chn;
     
-    // Mark this module to be inited.
-    int i = modinit - pwm_modinit_tab;
-    pwm_modinit_mask |= 1 << i;
+    if (((struct nu_pwm_var *) modinit->var)->en_msk) {
+        // Mark this module to be inited.
+        int i = modinit - pwm_modinit_tab;
+        pwm_modinit_mask |= 1 << i;
+    }
 }
 
 void pwmout_free(pwmout_t* obj)
@@ -120,9 +122,11 @@ void pwmout_free(pwmout_t* obj)
         CLK_DisableModuleClock(modinit->clkidx);
     }
     
-    // Mark this module to be deinited.
-    int i = modinit - pwm_modinit_tab;
-    pwm_modinit_mask &= ~(1 << i);
+    if (((struct nu_pwm_var *) modinit->var)->en_msk == 0) {
+        // Mark this module to be deinited.
+        int i = modinit - pwm_modinit_tab;
+        pwm_modinit_mask &= ~(1 << i);
+    }
 }
 
 void pwmout_write(pwmout_t* obj, float value)

--- a/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
@@ -255,7 +255,7 @@ void serial_free(serial_t *obj)
 
 void serial_baud(serial_t *obj, int baudrate) {
     // Flush Tx FIFO. Otherwise, output data may get lost on this change.
-    while (! UART_IS_TX_EMPTY(((UART_T *) obj->serial.uart)));
+    while (! UART_IS_TX_EMPTY(((UART_T *) NU_MODBASE(obj->serial.uart))));
     
     obj->serial.baudrate = baudrate;
     UART_Open((UART_T *) NU_MODBASE(obj->serial.uart), baudrate);
@@ -263,7 +263,7 @@ void serial_baud(serial_t *obj, int baudrate) {
 
 void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits) {
     // Flush Tx FIFO. Otherwise, output data may get lost on this change.
-    while (! UART_IS_TX_EMPTY(((UART_T *) obj->serial.uart)));
+    while (! UART_IS_TX_EMPTY(((UART_T *) NU_MODBASE(obj->serial.uart))));
     
     // TODO: Assert for not supported parity and data bits
     obj->serial.databits = data_bits;
@@ -325,7 +325,7 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
 void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
 {
     // Flush Tx FIFO. Otherwise, output data may get lost on this change.
-    while (! UART_IS_TX_EMPTY(((UART_T *) obj->serial.uart)));
+    while (! UART_IS_TX_EMPTY(((UART_T *) NU_MODBASE(obj->serial.uart))));
     
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
@@ -515,7 +515,7 @@ int serial_tx_asynch(serial_t *obj, const void *tx, size_t tx_length, uint8_t tx
                             // NUC472: End of source address
                             // M451: Start of source address
             PDMA_SAR_INC,   // Source address incremental
-            (uint32_t) obj->serial.uart,    // Destination address
+            (uint32_t) NU_MODBASE(obj->serial.uart),    // Destination address
             PDMA_DAR_FIX);  // Destination address fixed
         PDMA_SetBurstType(obj->serial.dma_chn_id_tx, 
             PDMA_REQ_SINGLE,    // Single mode
@@ -572,7 +572,7 @@ void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_widt
             (rx_width == 8) ? PDMA_WIDTH_8 : (rx_width == 16) ? PDMA_WIDTH_16 : PDMA_WIDTH_32, 
             rx_length);
         PDMA_SetTransferAddr(obj->serial.dma_chn_id_rx,
-            (uint32_t) obj->serial.uart,    // Source address
+            (uint32_t) NU_MODBASE(obj->serial.uart),    // Source address
             PDMA_SAR_FIX,   // Source address fixed
             (uint32_t) rx,  // NOTE: 
                             // NUC472: End of destination address
@@ -593,7 +593,7 @@ void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_widt
 void serial_tx_abort_asynch(serial_t *obj)
 {
     // Flush Tx FIFO. Otherwise, output data may get lost on this change.
-    while (! UART_IS_TX_EMPTY(((UART_T *) obj->serial.uart)));
+    while (! UART_IS_TX_EMPTY(((UART_T *) NU_MODBASE(obj->serial.uart))));
     
     if (obj->serial.dma_usage_tx != DMA_USAGE_NEVER) {
         if (obj->serial.dma_chn_id_tx != DMA_ERROR_OUT_OF_CHANNELS) {

--- a/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
@@ -314,8 +314,10 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
         MBED_ASSERT(modinit != NULL);
         MBED_ASSERT(modinit->modname == obj->spi.spi);
     
+        PDMA_T *pdma_base = dma_modbase();
+        
         // Configure tx DMA
-        PDMA->CHCTL |= 1 << obj->spi.dma_chn_id_tx;  // Enable this DMA channel
+        pdma_base->CHCTL |= 1 << obj->spi.dma_chn_id_tx;  // Enable this DMA channel
         PDMA_SetTransferMode(obj->spi.dma_chn_id_tx,
             ((struct nu_spi_var *) modinit->var)->pdma_perp_tx,    // Peripheral connected to this PDMA
             0,  // Scatter-gather disabled
@@ -339,7 +341,7 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
         dma_set_handler(obj->spi.dma_chn_id_tx, (uint32_t) spi_dma_handler_tx, (uint32_t) obj, DMA_EVENT_ALL);
         
         // Configure rx DMA
-        PDMA->CHCTL |= 1 << obj->spi.dma_chn_id_rx;  // Enable this DMA channel
+        pdma_base->CHCTL |= 1 << obj->spi.dma_chn_id_rx;  // Enable this DMA channel
         PDMA_SetTransferMode(obj->spi.dma_chn_id_rx,
             ((struct nu_spi_var *) modinit->var)->pdma_perp_rx,    // Peripheral connected to this PDMA
             0,  // Scatter-gather disabled
@@ -380,6 +382,7 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
 void spi_abort_asynch(spi_t *obj)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
+    PDMA_T *pdma_base = dma_modbase();
     
     if (obj->spi.dma_usage != DMA_USAGE_NEVER) {
         // Receive FIFO Overrun in case of tx length > rx length on DMA way
@@ -388,18 +391,18 @@ void spi_abort_asynch(spi_t *obj)
         }
         
         if (obj->spi.dma_chn_id_tx != DMA_ERROR_OUT_OF_CHANNELS) {
-            PDMA_DisableInt(obj->spi.dma_chn_id_tx, 0);
+            PDMA_DisableInt(obj->spi.dma_chn_id_tx, PDMA_INT_TRANS_DONE);
             // FIXME: On NUC472, next PDMA transfer will fail with PDMA_STOP() called. Cause is unknown.
             //PDMA_STOP(obj->spi.dma_chn_id_tx);
-            PDMA->CHCTL &= ~(1 << obj->spi.dma_chn_id_tx);
+            pdma_base->CHCTL &= ~(1 << obj->spi.dma_chn_id_tx);
         }
         SPI_DISABLE_TX_PDMA(((SPI_T *) NU_MODBASE(obj->spi.spi)));
         
         if (obj->spi.dma_chn_id_rx != DMA_ERROR_OUT_OF_CHANNELS) {
-            PDMA_DisableInt(obj->spi.dma_chn_id_rx, 0);
+            PDMA_DisableInt(obj->spi.dma_chn_id_rx, PDMA_INT_TRANS_DONE);
             // FIXME: On NUC472, next PDMA transfer will fail with PDMA_STOP() called. Cause is unknown.
             //PDMA_STOP(obj->spi.dma_chn_id_rx);
-            PDMA->CHCTL &= ~(1 << obj->spi.dma_chn_id_rx);
+            pdma_base->CHCTL &= ~(1 << obj->spi.dma_chn_id_rx);
         }
         SPI_DISABLE_RX_PDMA(((SPI_T *) NU_MODBASE(obj->spi.spi)));
     }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/PeripheralNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/PeripheralNames.h
@@ -23,111 +23,117 @@
 extern "C" {
 #endif
 
-// NOTE: TIMER0_BASE=(APBPERIPH_BASE + 0x10000)
-//       TIMER1_BASE=(APBPERIPH_BASE + 0x10020)
-#define NU_MODNAME(MODBASE, SUBINDEX)   ((MODBASE) | (SUBINDEX))
-#define NU_MODBASE(MODNAME)             ((MODNAME) & 0xFFFFFFE0)
-#define NU_MODSUBINDEX(MODNAME)         ((MODNAME) & 0x0000001F)
+// NOTE: Check all module base addresses (XXX_BASE in BSP) for free bit fields to define module name 
+//       which encodes module base address and module index/subindex.
+#define NU_MODSUBINDEX_Pos              0
+#define NU_MODSUBINDEX_Msk              (0x1Ful << NU_MODSUBINDEX_Pos)
+#define NU_MODINDEX_Pos                 20
+#define NU_MODINDEX_Msk                 (0xFul << NU_MODINDEX_Pos)
+
+#define NU_MODNAME(MODBASE, INDEX, SUBINDEX)    ((MODBASE) | ((INDEX) << NU_MODINDEX_Pos) | ((SUBINDEX) << NU_MODSUBINDEX_Pos))
+#define NU_MODBASE(MODNAME)                     ((MODNAME) & ~(NU_MODINDEX_Msk | NU_MODSUBINDEX_Msk))
+#define NU_MODINDEX(MODNAME)                    (((MODNAME) & NU_MODINDEX_Msk) >> NU_MODINDEX_Pos)
+#define NU_MODSUBINDEX(MODNAME)                 (((MODNAME) & NU_MODSUBINDEX_Msk) >> NU_MODSUBINDEX_Pos)
 
 #if 0
 typedef enum {
-    GPIO_A = (int) NU_MODNAME(GPIOA_BASE, 0),
-    GPIO_B = (int) NU_MODNAME(GPIOB_BASE, 0),
-    GPIO_C = (int) NU_MODNAME(GPIOC_BASE, 0),
-    GPIO_D = (int) NU_MODNAME(GPIOD_BASE, 0),
-    GPIO_E = (int) NU_MODNAME(GPIOE_BASE, 0),
-    GPIO_F = (int) NU_MODNAME(GPIOF_BASE, 0),
-    GPIO_G = (int) NU_MODNAME(GPIOG_BASE, 0),
-    GPIO_H = (int) NU_MODNAME(GPIOH_BASE, 0),
-    GPIO_I = (int) NU_MODNAME(GPIOI_BASE, 0)
+    GPIO_A = (int) NU_MODNAME(GPIOA_BASE, 0, 0),
+    GPIO_B = (int) NU_MODNAME(GPIOB_BASE, 1, 0),
+    GPIO_C = (int) NU_MODNAME(GPIOC_BASE, 2, 0),
+    GPIO_D = (int) NU_MODNAME(GPIOD_BASE, 3, 0),
+    GPIO_E = (int) NU_MODNAME(GPIOE_BASE, 4, 0),
+    GPIO_F = (int) NU_MODNAME(GPIOF_BASE, 5, 0),
+    GPIO_G = (int) NU_MODNAME(GPIOG_BASE, 6, 0),
+    GPIO_H = (int) NU_MODNAME(GPIOH_BASE, 7, 0),
+    GPIO_I = (int) NU_MODNAME(GPIOI_BASE, 8, 0)
 } GPIOName;
 #endif
 
 typedef enum {
-    ADC_0_0 = (int) NU_MODNAME(EADC_BASE, 0),
-    ADC_0_1 = (int) NU_MODNAME(EADC_BASE, 1),
-    ADC_0_2 = (int) NU_MODNAME(EADC_BASE, 2),
-    ADC_0_3 = (int) NU_MODNAME(EADC_BASE, 3),
-    ADC_0_4 = (int) NU_MODNAME(EADC_BASE, 4),
-    ADC_0_5 = (int) NU_MODNAME(EADC_BASE, 5),
-    ADC_0_6 = (int) NU_MODNAME(EADC_BASE, 6),
-    ADC_0_7 = (int) NU_MODNAME(EADC_BASE, 7),
+    ADC_0_0 = (int) NU_MODNAME(EADC_BASE, 0, 0),
+    ADC_0_1 = (int) NU_MODNAME(EADC_BASE, 0, 1),
+    ADC_0_2 = (int) NU_MODNAME(EADC_BASE, 0, 2),
+    ADC_0_3 = (int) NU_MODNAME(EADC_BASE, 0, 3),
+    ADC_0_4 = (int) NU_MODNAME(EADC_BASE, 0, 4),
+    ADC_0_5 = (int) NU_MODNAME(EADC_BASE, 0, 5),
+    ADC_0_6 = (int) NU_MODNAME(EADC_BASE, 0, 6),
+    ADC_0_7 = (int) NU_MODNAME(EADC_BASE, 0, 7),
     
-    ADC_1_0 = (int) NU_MODNAME(EADC_BASE, 8),
-    ADC_1_1 = (int) NU_MODNAME(EADC_BASE, 9),
-    ADC_1_2 = (int) NU_MODNAME(EADC_BASE, 10),
-    ADC_1_3 = (int) NU_MODNAME(EADC_BASE, 11),
-    ADC_1_4 = (int) NU_MODNAME(EADC_BASE, 12),
-    ADC_1_5 = (int) NU_MODNAME(EADC_BASE, 13),
-    ADC_1_6 = (int) NU_MODNAME(EADC_BASE, 14),
-    ADC_1_7 = (int) NU_MODNAME(EADC_BASE, 15),
+    ADC_1_0 = (int) NU_MODNAME(EADC_BASE, 1, 0),
+    ADC_1_1 = (int) NU_MODNAME(EADC_BASE, 1, 1),
+    ADC_1_2 = (int) NU_MODNAME(EADC_BASE, 1, 2),
+    ADC_1_3 = (int) NU_MODNAME(EADC_BASE, 1, 3),
+    ADC_1_4 = (int) NU_MODNAME(EADC_BASE, 1, 4),
+    ADC_1_5 = (int) NU_MODNAME(EADC_BASE, 1, 5),
+    ADC_1_6 = (int) NU_MODNAME(EADC_BASE, 1, 6),
+    ADC_1_7 = (int) NU_MODNAME(EADC_BASE, 1, 7),
 } ADCName;
 
 typedef enum {
-    UART_0 = (int) NU_MODNAME(UART0_BASE, 0),
-    UART_1 = (int) NU_MODNAME(UART1_BASE, 0),
-    UART_2 = (int) NU_MODNAME(UART2_BASE, 0),
-    UART_3 = (int) NU_MODNAME(UART3_BASE, 0),
-    UART_4 = (int) NU_MODNAME(UART4_BASE, 0),
-    UART_5 = (int) NU_MODNAME(UART5_BASE, 0),
+    UART_0 = (int) NU_MODNAME(UART0_BASE, 0, 0),
+    UART_1 = (int) NU_MODNAME(UART1_BASE, 1, 0),
+    UART_2 = (int) NU_MODNAME(UART2_BASE, 2, 0),
+    UART_3 = (int) NU_MODNAME(UART3_BASE, 3, 0),
+    UART_4 = (int) NU_MODNAME(UART4_BASE, 4, 0),
+    UART_5 = (int) NU_MODNAME(UART5_BASE, 5, 0),
     // FIXME: board-specific
     STDIO_UART  = UART_3
 } UARTName;
 
 typedef enum {
-    SPI_0 = (int) NU_MODNAME(SPI0_BASE, 0),
-    SPI_1 = (int) NU_MODNAME(SPI1_BASE, 0),
-    SPI_2 = (int) NU_MODNAME(SPI2_BASE, 0),
-    SPI_3 = (int) NU_MODNAME(SPI3_BASE, 0)
+    SPI_0 = (int) NU_MODNAME(SPI0_BASE, 0, 0),
+    SPI_1 = (int) NU_MODNAME(SPI1_BASE, 1, 0),
+    SPI_2 = (int) NU_MODNAME(SPI2_BASE, 2, 0),
+    SPI_3 = (int) NU_MODNAME(SPI3_BASE, 3, 0)
 } SPIName;
 
 typedef enum {
-    I2C_0 = (int) NU_MODNAME(I2C0_BASE, 0),
-    I2C_1 = (int) NU_MODNAME(I2C1_BASE, 0),
-    I2C_2 = (int) NU_MODNAME(I2C2_BASE, 0),
-    I2C_3 = (int) NU_MODNAME(I2C3_BASE, 0),
-    I2C_4 = (int) NU_MODNAME(I2C4_BASE, 0)
+    I2C_0 = (int) NU_MODNAME(I2C0_BASE, 0, 0),
+    I2C_1 = (int) NU_MODNAME(I2C1_BASE, 1, 0),
+    I2C_2 = (int) NU_MODNAME(I2C2_BASE, 2, 0),
+    I2C_3 = (int) NU_MODNAME(I2C3_BASE, 3, 0),
+    I2C_4 = (int) NU_MODNAME(I2C4_BASE, 4, 0)
 } I2CName;
 
 typedef enum {
-    PWM_0_0 = (int) NU_MODNAME(PWM0_BASE, 0),
-    PWM_0_1 = (int) NU_MODNAME(PWM0_BASE, 1),
-    PWM_0_2 = (int) NU_MODNAME(PWM0_BASE, 2),
-    PWM_0_3 = (int) NU_MODNAME(PWM0_BASE, 3),
-    PWM_0_4 = (int) NU_MODNAME(PWM0_BASE, 4),
-    PWM_0_5 = (int) NU_MODNAME(PWM0_BASE, 5),
+    PWM_0_0 = (int) NU_MODNAME(PWM0_BASE, 0, 0),
+    PWM_0_1 = (int) NU_MODNAME(PWM0_BASE, 0, 1),
+    PWM_0_2 = (int) NU_MODNAME(PWM0_BASE, 0, 2),
+    PWM_0_3 = (int) NU_MODNAME(PWM0_BASE, 0, 3),
+    PWM_0_4 = (int) NU_MODNAME(PWM0_BASE, 0, 4),
+    PWM_0_5 = (int) NU_MODNAME(PWM0_BASE, 0, 5),
     
-    PWM_1_0 = (int) NU_MODNAME(PWM1_BASE, 0),
-    PWM_1_1 = (int) NU_MODNAME(PWM1_BASE, 1),
-    PWM_1_2 = (int) NU_MODNAME(PWM1_BASE, 2),
-    PWM_1_3 = (int) NU_MODNAME(PWM1_BASE, 3),
-    PWM_1_4 = (int) NU_MODNAME(PWM1_BASE, 4),
-    PWM_1_5 = (int) NU_MODNAME(PWM1_BASE, 5)
+    PWM_1_0 = (int) NU_MODNAME(PWM1_BASE, 1, 0),
+    PWM_1_1 = (int) NU_MODNAME(PWM1_BASE, 1, 1),
+    PWM_1_2 = (int) NU_MODNAME(PWM1_BASE, 1, 2),
+    PWM_1_3 = (int) NU_MODNAME(PWM1_BASE, 1, 3),
+    PWM_1_4 = (int) NU_MODNAME(PWM1_BASE, 1, 4),
+    PWM_1_5 = (int) NU_MODNAME(PWM1_BASE, 1, 5)
 } PWMName;
 
 typedef enum {
-    TIMER_0  = (int) NU_MODNAME(TIMER0_BASE, 0),
-    TIMER_1  = (int) NU_MODNAME(TIMER1_BASE, 0),
-    TIMER_2  = (int) NU_MODNAME(TIMER2_BASE, 0),
-    TIMER_3  = (int) NU_MODNAME(TIMER3_BASE, 0)
+    TIMER_0  = (int) NU_MODNAME(TIMER0_BASE, 0, 0),
+    TIMER_1  = (int) NU_MODNAME(TIMER1_BASE, 1, 0),
+    TIMER_2  = (int) NU_MODNAME(TIMER2_BASE, 2, 0),
+    TIMER_3  = (int) NU_MODNAME(TIMER3_BASE, 3, 0)
 } TIMERName;
 
 typedef enum {
-    RTC_0 = (int) NU_MODNAME(RTC_BASE, 0)
+    RTC_0 = (int) NU_MODNAME(RTC_BASE, 0, 0)
 } RTCName;
 
 typedef enum {
-    DMA_0 = (int) NU_MODNAME(PDMA_BASE, 0)
+    DMA_0 = (int) NU_MODNAME(PDMA_BASE, 0, 0)
 } DMAName;
 
 typedef enum {
-    SD_0_0 = (int) NU_MODNAME(SD_BASE, 0),
-    SD_0_1 = (int) NU_MODNAME(SD_BASE, 1)
+    SD_0_0 = (int) NU_MODNAME(SD_BASE, 0, 0),
+    SD_0_1 = (int) NU_MODNAME(SD_BASE, 0, 1)
 } SDName;
 
 typedef enum {
-    CAN_0 = (int) NU_MODNAME(CAN0_BASE, 0),
-    CAN_1 = (int) NU_MODNAME(CAN1_BASE, 0)
+    CAN_0 = (int) NU_MODNAME(CAN0_BASE, 0, 0),
+    CAN_1 = (int) NU_MODNAME(CAN1_BASE, 1, 0)
 } CANName;
 
 #ifdef __cplusplus

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/PinNames.h
@@ -22,13 +22,32 @@
 extern "C" {
 #endif
 
-#define NU_PORT_SHIFT  12
-#define NU_PINNAME_TO_PORT(name)            ((unsigned int)(name) >> NU_PORT_SHIFT)
-#define NU_PINNAME_TO_PIN(name)             ((unsigned int)(name) & ~(0xFFFFFFFF << NU_PORT_SHIFT))
-#define NU_PORT_N_PIN_TO_PINNAME(port, pin) ((((unsigned int) (port)) << (NU_PORT_SHIFT)) | ((unsigned int) (pin)))
-#define NU_PORT_BASE(port)                  ((GPIO_T *)(((uint32_t) GPIOA_BASE) + 0x40 * port))
-#define NU_MFP_POS(pin)                     ((pin % 8) * 4)
-#define NU_MFP_MSK(pin)                     (0xful << NU_MFP_POS(pin))
+#define NU_PININDEX_Pos                             0
+#define NU_PININDEX_Msk                             (0xFFul << NU_PININDEX_Pos)
+#define NU_PINPORT_Pos                              8
+#define NU_PINPORT_Msk                              (0xFul << NU_PINPORT_Pos)
+#define NU_PIN_MODINDEX_Pos                         12
+#define NU_PIN_MODINDEX_Msk                         (0xFul << NU_PIN_MODINDEX_Pos)
+#define NU_PIN_BIND_Pos                             16
+#define NU_PIN_BIND_Msk                             (0x1ul << NU_PIN_BIND_Pos)
+
+#define NU_PININDEX(PINNAME)                        (((unsigned int)(PINNAME) & NU_PININDEX_Msk) >> NU_PININDEX_Pos)
+#define NU_PINPORT(PINNAME)                         (((unsigned int)(PINNAME) & NU_PINPORT_Msk) >> NU_PINPORT_Pos)
+#define NU_PIN_BIND(PINNAME)                        (((unsigned int)(PINNAME) & NU_PIN_BIND_Msk) >> NU_PIN_BIND_Pos)
+#define NU_PIN_MODINDEX(PINNAME)                    (((unsigned int)(PINNAME) & NU_PIN_MODINDEX_Msk) >> NU_PIN_MODINDEX_Pos)
+#define NU_PINNAME(PORT, PIN)                       ((((unsigned int) (PORT)) << (NU_PINPORT_Pos)) | (((unsigned int) (PIN)) << NU_PININDEX_Pos))
+#define NU_PINNAME_BIND(PINNAME, modname)           NU_PINNAME_BIND_(NU_PINPORT(PINNAME), NU_PININDEX(PINNAME), modname)
+#define NU_PINNAME_BIND_(PORT, PIN, modname)        ((((unsigned int)(PORT)) << NU_PINPORT_Pos) | (((unsigned int)(PIN)) << NU_PININDEX_Pos) | (NU_MODINDEX(modname) << NU_PIN_MODINDEX_Pos) | NU_PIN_BIND_Msk)
+
+#define NU_PORT_BASE(port)                          ((GPIO_T *)(((uint32_t) GPIOA_BASE) + 0x40 * port))
+#define NU_MFP_POS(pin)                             ((pin % 8) * 4)
+#define NU_MFP_MSK(pin)                             (0xful << NU_MFP_POS(pin))
+
+// LEGACY
+#define NU_PINNAME_TO_PIN(PINNAME)                  NU_PININDEX(PINNAME)
+#define NU_PINNAME_TO_PORT(PINNAME)                 NU_PINPORT(PINNAME)
+#define NU_PINNAME_TO_MODSUBINDEX(PINNAME)          NU_PIN_MODINDEX(PINNAME)
+#define NU_PORT_N_PIN_TO_PINNAME(PORT, PIN)         NU_PINNAME((PORT), (PIN))
 
 typedef enum {
     PIN_INPUT,

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/analogin_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/analogin_api.c
@@ -70,25 +70,27 @@ void analogin_init(analogin_t *obj, PinName pin)
         EADC_Open(eadc_base, 0);
     }
     
-    uint32_t chn =  NU_MODSUBINDEX(obj->adc);
+    uint32_t smp_chn =  NU_MODSUBINDEX(obj->adc);
+    uint32_t smp_mod =  NU_MODINDEX(obj->adc) * 8 + smp_chn;
     
     // Wire pinout
     pinmap_pinout(pin, PinMap_ADC);
     
     // Configure the sample module Nmod for analog input channel Nch and software trigger source
-    EADC_ConfigSampleModule(eadc_base, chn, EADC_SOFTWARE_TRIGGER, chn % 8);
+    EADC_ConfigSampleModule(eadc_base, smp_mod, EADC_SOFTWARE_TRIGGER, smp_chn);
     
-    eadc_modinit_mask |= 1 << chn;
+    eadc_modinit_mask |= 1 << smp_mod;
 }
 
 uint16_t analogin_read_u16(analogin_t *obj)
 {
     EADC_T *eadc_base = (EADC_T *) NU_MODBASE(obj->adc);
-    uint32_t chn =  NU_MODSUBINDEX(obj->adc);
+    uint32_t smp_chn =  NU_MODSUBINDEX(obj->adc);
+    uint32_t smp_mod =  NU_MODINDEX(obj->adc) * 8 + smp_chn;
     
-    EADC_START_CONV(eadc_base, 1 << chn);
-    while (EADC_GET_DATA_VALID_FLAG(eadc_base, 1 << chn) != (1 << chn));
-    uint16_t conv_res_12 = EADC_GET_CONV_DATA(eadc_base, chn);
+    EADC_START_CONV(eadc_base, 1 << smp_mod);
+    while (EADC_GET_DATA_VALID_FLAG(eadc_base, 1 << smp_mod) != (1 << smp_mod));
+    uint16_t conv_res_12 = EADC_GET_CONV_DATA(eadc_base, smp_mod);
     // Just 12 bits are effective. Convert to 16 bits.
     // conv_res_12: 0000 b11b10b9b8 b7b6b5b4 b3b2b1b0
     // conv_res_16: b11b10b9b8 b7b6b5b4 b3b2b1b0 b11b10b9b8

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/can_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/can_api.c
@@ -75,7 +75,7 @@
     PA2 = 0x00;
     PA3 = 0x00; 
 
-    CAN_Open((CAN_T *)obj->can, 500000, CAN_NORMAL_MODE);
+    CAN_Open((CAN_T *)NU_MODBASE(obj->can), 500000, CAN_NORMAL_MODE);
     
     can_filter(obj, 0, 0, CANStandard, 0);
  }
@@ -97,9 +97,9 @@ void can_free(can_t *obj)
 
 int can_frequency(can_t *obj, int hz)
 {
-    CAN_SetBaudRate((CAN_T *)obj->can, hz);
+    CAN_SetBaudRate((CAN_T *)NU_MODBASE(obj->can), hz);
     
-    return CAN_GetCANBitRate((CAN_T *)obj->can);
+    return CAN_GetCANBitRate((CAN_T *)NU_MODBASE(obj->can));
 }
 
 static void can_irq(CANName name, int id) 
@@ -188,7 +188,7 @@ void can_irq_init(can_t *obj, can_irq_handler handler, uint32_t id)
 
 void can_irq_free(can_t *obj)
 {
-    CAN_DisableInt((CAN_T *)obj->can, (CAN_CON_IE_Msk|CAN_CON_SIE_Msk|CAN_CON_EIE_Msk));
+    CAN_DisableInt((CAN_T *)NU_MODBASE(obj->can), (CAN_CON_IE_Msk|CAN_CON_SIE_Msk|CAN_CON_EIE_Msk));
     
     can_irq_ids[obj->index] = 0;
     
@@ -202,25 +202,26 @@ void can_irq_free(can_t *obj)
 
 void can_irq_set(can_t *obj, CanIrqType irq, uint32_t enable)
 {
+    CAN_T *can_base = (CAN_T *) NU_MODBASE(obj->can);
     
-    CAN_EnterInitMode((CAN_T*)obj->can);
+    CAN_EnterInitMode((CAN_T*)can_base);
     
-    ((CAN_T *)(obj->can))->CON = (((CAN_T *)(obj->can))->CON ) | ((enable != 0 )? CAN_CON_IE_Msk :0);
+    ((CAN_T *)can_base)->CON = (((CAN_T *)can_base)->CON ) | ((enable != 0 )? CAN_CON_IE_Msk :0);
     
     switch (irq)
     {
         case IRQ_ERROR:
         case IRQ_BUS:
         case IRQ_PASSIVE:
-            ((CAN_T *)(obj->can))->CON = (((CAN_T *)(obj->can))->CON) |CAN_CON_EIE_Msk;
-            ((CAN_T *)(obj->can))->CON = (((CAN_T *)(obj->can))->CON) |CAN_CON_SIE_Msk;
+            can_base->CON = can_base->CON |CAN_CON_EIE_Msk;
+            can_base->CON = can_base->CON |CAN_CON_SIE_Msk;
             break;
         
         case IRQ_RX:
         case IRQ_TX:
         case IRQ_OVERRUN:
         case IRQ_WAKEUP:
-            ((CAN_T *)(obj->can))->CON = (((CAN_T *)(obj->can))->CON) |CAN_CON_SIE_Msk;
+            can_base->CON = can_base->CON |CAN_CON_SIE_Msk;
             break;
         
         default:
@@ -228,7 +229,7 @@ void can_irq_set(can_t *obj, CanIrqType irq, uint32_t enable)
     
     }
 
-    CAN_LeaveInitMode((CAN_T*)obj->can);
+    CAN_LeaveInitMode(can_base);
     
     if(!obj->index)
     {
@@ -253,14 +254,14 @@ int can_write(can_t *obj, CAN_Message msg, int cc)
     CMsg.DLC = msg.len;
     memcpy((void *)&CMsg.Data[0],(const void *)&msg.data[0], (unsigned int)8);
 
-    return CAN_Transmit((CAN_T *)(obj->can), cc, &CMsg);
+    return CAN_Transmit((CAN_T *)NU_MODBASE(obj->can), cc, &CMsg);
 }
 
 int can_read(can_t *obj, CAN_Message *msg, int handle)
 {
     STR_CANMSG_T CMsg;
 
-    if(!CAN_Receive((CAN_T *)(obj->can), handle, &CMsg))
+    if(!CAN_Receive((CAN_T *)NU_MODBASE(obj->can), handle, &CMsg))
     return 0;
         
     msg->format = (CANFormat)CMsg.IdType;
@@ -274,32 +275,34 @@ int can_read(can_t *obj, CAN_Message *msg, int handle)
 
 int can_mode(can_t *obj, CanMode mode)
 {
+    CAN_T *can_base = (CAN_T *) NU_MODBASE(obj->can);
+    
     int success = 0;
     switch (mode)
     {
         case MODE_RESET:
-            CAN_LeaveTestMode((CAN_T*)obj->can);
+            CAN_LeaveTestMode(can_base);
             success = 1;
             break;
         
         case MODE_NORMAL:
-            CAN_EnterTestMode((CAN_T*)(obj->can), CAN_TEST_BASIC_Msk);
+            CAN_EnterTestMode(can_base, CAN_TEST_BASIC_Msk);
             success = 1;
             break;
         
         case MODE_SILENT:
-            CAN_EnterTestMode((CAN_T*)(obj->can), CAN_TEST_SILENT_Msk);
+            CAN_EnterTestMode(can_base, CAN_TEST_SILENT_Msk);
             success = 1;
             break;
         
         case MODE_TEST_LOCAL:
         case MODE_TEST_GLOBAL:
-            CAN_EnterTestMode((CAN_T*)(obj->can), CAN_TEST_LBACK_Msk);
+            CAN_EnterTestMode(can_base, CAN_TEST_LBACK_Msk);
             success = 1;
             break;
         
         case MODE_TEST_SILENT:
-            CAN_EnterTestMode((CAN_T*)(obj->can), CAN_TEST_SILENT_Msk | CAN_TEST_LBACK_Msk);
+            CAN_EnterTestMode(can_base, CAN_TEST_SILENT_Msk | CAN_TEST_LBACK_Msk);
             success = 1;
             break;
         
@@ -315,7 +318,7 @@ int can_mode(can_t *obj, CanMode mode)
 
 int can_filter(can_t *obj, uint32_t id, uint32_t mask, CANFormat format, int32_t handle)
 {
-    return CAN_SetRxMsg((CAN_T *)(obj->can), handle , (uint32_t)format, id);
+    return CAN_SetRxMsg((CAN_T *)NU_MODBASE(obj->can), handle , (uint32_t)format, id);
 }
 
 
@@ -333,19 +336,19 @@ void can_reset(can_t *obj)
 
 unsigned char can_rderror(can_t *obj)
 {
-    CAN_T *can = (CAN_T *)(obj->can); 
+    CAN_T *can = (CAN_T *)NU_MODBASE(obj->can); 
     return ((can->ERR>>8)&0xFF);
 }
 
 unsigned char can_tderror(can_t *obj)
 {
-    CAN_T *can = (CAN_T *)(obj->can);
+    CAN_T *can = (CAN_T *)NU_MODBASE(obj->can);
     return ((can->ERR)&0xFF);
 }
 
 void can_monitor(can_t *obj, int silent)
 {
-    CAN_EnterTestMode((CAN_T *)(obj->can), CAN_TEST_SILENT_Msk);
+    CAN_EnterTestMode((CAN_T *)NU_MODBASE(obj->can), CAN_TEST_SILENT_Msk);
 }
  
 #endif // DEVICE_CAN

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/dma.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/dma.h
@@ -32,6 +32,7 @@ extern "C" {
 #define DMA_EVENT_MASK              DMA_EVENT_ALL
 
 void dma_set_handler(int channelid, uint32_t handler, uint32_t id, uint32_t event);
+PDMA_T *dma_modbase(void);
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/dma_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/dma_api.c
@@ -111,6 +111,11 @@ void dma_set_handler(int channelid, uint32_t handler, uint32_t id, uint32_t even
     NVIC_EnableIRQ(dma_modinit.irq_n);
 }
 
+PDMA_T *dma_modbase(void)
+{
+    return (PDMA_T *) NU_MODBASE(dma_modinit.modname);
+}
+
 static void pdma_vec(void)
 {
     uint32_t intsts = PDMA_GET_INT_STATUS();

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/dma_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/dma_api.c
@@ -165,7 +165,7 @@ static void pdma_vec(void)
         PDMA->INTSTS = reqto;
         
         while (reqto) {
-            int chn_id = nu_ctz(reqto) >> PDMA_INTSTS_REQTOFX_Pos;
+            int chn_id = nu_ctz(reqto) - PDMA_INTSTS_REQTOFX_Pos;
             if (dma_chn_mask & (1 << chn_id)) {
                 struct nu_dma_chn_s *dma_chn = dma_chn_arr + chn_id;
                 if (dma_chn->handler && (dma_chn->event & DMA_EVENT_TIMEOUT)) {

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/pwmout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/pwmout_api.c
@@ -105,9 +105,11 @@ void pwmout_init(pwmout_t* obj, PinName pin)
     
     ((struct nu_pwm_var *) modinit->var)->en_msk |= 1 << chn;
     
-    // Mark this module to be inited.
-    int i = modinit - pwm_modinit_tab;
-    pwm_modinit_mask |= 1 << i;
+    if (((struct nu_pwm_var *) modinit->var)->en_msk) {
+        // Mark this module to be inited.
+        int i = modinit - pwm_modinit_tab;
+        pwm_modinit_mask |= 1 << i;
+    }
 }
 
 void pwmout_free(pwmout_t* obj)
@@ -143,9 +145,11 @@ void pwmout_free(pwmout_t* obj)
         }
     }
     
-    // Mark this module to be deinited.
-    int i = modinit - pwm_modinit_tab;
-    pwm_modinit_mask &= ~(1 << i);
+    if (((struct nu_pwm_var *) modinit->var)->en_msk == 0) {
+        // Mark this module to be deinited.
+        int i = modinit - pwm_modinit_tab;
+        pwm_modinit_mask &= ~(1 << i);
+    }
 }
 
 void pwmout_write(pwmout_t* obj, float value)

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
@@ -285,7 +285,7 @@ void serial_free(serial_t *obj)
 
 void serial_baud(serial_t *obj, int baudrate) {
     // Flush Tx FIFO. Otherwise, output data may get lost on this change.
-    while (! UART_IS_TX_EMPTY(((UART_T *) obj->serial.uart)));
+    while (! UART_IS_TX_EMPTY(((UART_T *) NU_MODBASE(obj->serial.uart))));
     
     obj->serial.baudrate = baudrate;
     UART_Open((UART_T *) NU_MODBASE(obj->serial.uart), baudrate);
@@ -293,7 +293,7 @@ void serial_baud(serial_t *obj, int baudrate) {
 
 void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits) {
     // Flush Tx FIFO. Otherwise, output data may get lost on this change.
-    while (! UART_IS_TX_EMPTY(((UART_T *) obj->serial.uart)));
+    while (! UART_IS_TX_EMPTY(((UART_T *) NU_MODBASE(obj->serial.uart))));
     
     // TODO: Assert for not supported parity and data bits
     obj->serial.databits = data_bits;
@@ -357,7 +357,7 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
 void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
 {
     // Flush Tx FIFO. Otherwise, output data may get lost on this change.
-    while (! UART_IS_TX_EMPTY(((UART_T *) obj->serial.uart)));
+    while (! UART_IS_TX_EMPTY(((UART_T *) NU_MODBASE(obj->serial.uart))));
     
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
@@ -555,7 +555,7 @@ int serial_tx_asynch(serial_t *obj, const void *tx, size_t tx_length, uint8_t tx
         PDMA_SetTransferAddr(obj->serial.dma_chn_id_tx, 
             ((uint32_t) tx) + (tx_width / 8) * tx_length,   // NOTE: End of source address
             PDMA_SAR_INC,   // Source address incremental
-            (uint32_t) obj->serial.uart,    // Destination address
+            (uint32_t) NU_MODBASE(obj->serial.uart),    // Destination address
             PDMA_DAR_FIX);  // Destination address fixed
         PDMA_SetBurstType(obj->serial.dma_chn_id_tx, 
             PDMA_REQ_SINGLE,    // Single mode
@@ -612,7 +612,7 @@ void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_widt
             (rx_width == 8) ? PDMA_WIDTH_8 : (rx_width == 16) ? PDMA_WIDTH_16 : PDMA_WIDTH_32, 
             rx_length);
         PDMA_SetTransferAddr(obj->serial.dma_chn_id_rx,
-            (uint32_t) obj->serial.uart,    // Source address
+            (uint32_t) NU_MODBASE(obj->serial.uart),    // Source address
             PDMA_SAR_FIX,   // Source address fixed
             ((uint32_t) rx) + (rx_width / 8) * rx_length,   // NOTE: End of destination address
             PDMA_DAR_INC);  // Destination address incremental
@@ -631,7 +631,7 @@ void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_widt
 void serial_tx_abort_asynch(serial_t *obj)
 {
     // Flush Tx FIFO. Otherwise, output data may get lost on this change.
-    while (! UART_IS_TX_EMPTY(((UART_T *) obj->serial.uart)));
+    while (! UART_IS_TX_EMPTY(((UART_T *) NU_MODBASE(obj->serial.uart))));
     
     if (obj->serial.dma_usage_tx != DMA_USAGE_NEVER) {
         if (obj->serial.dma_chn_id_tx != DMA_ERROR_OUT_OF_CHANNELS) {

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
@@ -317,8 +317,10 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
         MBED_ASSERT(modinit != NULL);
         MBED_ASSERT(modinit->modname == obj->spi.spi);
     
+        PDMA_T *pdma_base = dma_modbase();
+        
         // Configure tx DMA
-        PDMA->CHCTL |= 1 << obj->spi.dma_chn_id_tx;  // Enable this DMA channel
+        pdma_base->CHCTL |= 1 << obj->spi.dma_chn_id_tx;  // Enable this DMA channel
         PDMA_SetTransferMode(obj->spi.dma_chn_id_tx,
             ((struct nu_spi_var *) modinit->var)->pdma_perp_tx,    // Peripheral connected to this PDMA
             0,  // Scatter-gather disabled
@@ -340,7 +342,7 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
         dma_set_handler(obj->spi.dma_chn_id_tx, (uint32_t) spi_dma_handler_tx, (uint32_t) obj, DMA_EVENT_ALL);
         
         // Configure rx DMA
-        PDMA->CHCTL |= 1 << obj->spi.dma_chn_id_rx;  // Enable this DMA channel
+        pdma_base->CHCTL |= 1 << obj->spi.dma_chn_id_rx;  // Enable this DMA channel
         PDMA_SetTransferMode(obj->spi.dma_chn_id_rx,
             ((struct nu_spi_var *) modinit->var)->pdma_perp_rx,    // Peripheral connected to this PDMA
             0,  // Scatter-gather disabled
@@ -379,6 +381,7 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
 void spi_abort_asynch(spi_t *obj)
 {
     SPI_T *spi_base = (SPI_T *) NU_MODBASE(obj->spi.spi);
+    PDMA_T *pdma_base = dma_modbase();
     
     if (obj->spi.dma_usage != DMA_USAGE_NEVER) {
         // Receive FIFO Overrun in case of tx length > rx length on DMA way
@@ -390,7 +393,7 @@ void spi_abort_asynch(spi_t *obj)
             PDMA_DisableInt(obj->spi.dma_chn_id_tx, 0);
             // FIXME: Next PDMA transfer will fail with PDMA_STOP() called. Cause is unknown.
             //PDMA_STOP(obj->spi.dma_chn_id_tx);
-            PDMA->CHCTL &= ~(1 << obj->spi.dma_chn_id_tx);
+            pdma_base->CHCTL &= ~(1 << obj->spi.dma_chn_id_tx);
         }
         SPI_DISABLE_TX_PDMA(((SPI_T *) NU_MODBASE(obj->spi.spi)));
         
@@ -398,7 +401,7 @@ void spi_abort_asynch(spi_t *obj)
             PDMA_DisableInt(obj->spi.dma_chn_id_rx, 0);
             // FIXME: Next PDMA transfer will fail with PDMA_STOP() called. Cause is unknown.
             //PDMA_STOP(obj->spi.dma_chn_id_rx);
-            PDMA->CHCTL &= ~(1 << obj->spi.dma_chn_id_rx);
+            pdma_base->CHCTL &= ~(1 << obj->spi.dma_chn_id_rx);
         }
         SPI_DISABLE_RX_PDMA(((SPI_T *) NU_MODBASE(obj->spi.spi)));
     }


### PR DESCRIPTION
This PR patches for the targets NuMaker-PFM-NUC472 and NuMaker-PFM-M453 and has the following modifications:

1.  Support unique locally administered MAC address.
2.  Refine serial & SPI PDMA code
3.  Refine pwmout power-down condition
4. Refine pin/peripheral/pin map definitions