### PR TITLE
Heap size adjusted to work for both tls-client and mbed-client

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_IAR/stm32f429xx_flash.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_IAR/stm32f429xx_flash.icf
@@ -15,9 +15,9 @@ define symbol __ICFEDIT_region_RAM_end__      = 0x2002FFFF;
 define symbol __ICFEDIT_region_CCMRAM_start__ = 0x10000000;
 define symbol __ICFEDIT_region_CCMRAM_end__   = 0x1000FFFF;
 /*-Sizes-*/
-/*Heap 1/2 of ram and stack 1/8*/
+/*Heap 64K and stack 24K */
 define symbol __ICFEDIT_size_cstack__ = 0x6000;
-define symbol __ICFEDIT_size_heap__   = 0x18000;
+define symbol __ICFEDIT_size_heap__   = 0x10000;
 /**** End of ICF editor section. ###ICF###*/
 
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/device/TOOLCHAIN_IAR/stm32f439xx_flash.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/device/TOOLCHAIN_IAR/stm32f439xx_flash.icf
@@ -15,9 +15,9 @@ define symbol __ICFEDIT_region_RAM_end__      = 0x2002FFFF;
 define symbol __ICFEDIT_region_CCMRAM_start__ = 0x10000000;
 define symbol __ICFEDIT_region_CCMRAM_end__   = 0x1000FFFF;
 /*-Sizes-*/
-/*Heap 1/2 of ram and stack 1/8*/
+/*Heap 64kB and stack 24kB */
 define symbol __ICFEDIT_size_cstack__ = 0x6000;
-define symbol __ICFEDIT_size_heap__   = 0x18000;
+define symbol __ICFEDIT_size_heap__   = 0x10000;
 /**** End of ICF editor section. ###ICF###*/
 
 


### PR DESCRIPTION
## Description
Targets NUCLEO_F429ZI and UBLOX_EVK_ODIN_W2 have 192K RAM.
Heap size in PR #3871 was increased from 48K to 96K as tls-client
example failed with 48K heap. But this resulted in compilation failures
in mbed-client that requires 71K for global/static data.
Hence this PR reduces heap to 64K that minimum required by tls-client
to work. This also meets mbed-client data segment requirements.



## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

 NO


## Related PRs
https://github.com/ARMmbed/mbed-os/pull/3871

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ ] Documentation


## Deploy notes
Notes regarding the deployment of this PR. These should note any
required changes in the build environment, tools, compilers, etc.


## Steps to test or reproduce
It should fix issue https://github.com/ARMmbed/mbed-os-example-client/issues/194#issuecomment-285347501
and build failure mentioned here https://github.com/ARMmbed/mbed-os-example-client/issues/194#issuecomment-284789471

@0xc0170 @SeppoTakalo 