### PR TITLE
Feature CMSIS5: stats: cast thread_id fix

### DIFF
--- a/platform/mbed_stats.c
+++ b/platform/mbed_stats.c
@@ -54,7 +54,7 @@ size_t mbed_stats_stack_get_each(mbed_stats_stack_t *stats, size_t count)
         uint32_t stack_size = osThreadGetStackSize(threads[i]);
         stats[i].max_size = stack_size - osThreadGetStackSpace(threads[i]);
         stats[i].reserved_size = stack_size;
-        stats[i].thread_id = threads[i];
+        stats[i].thread_id = (uint32_t)threads[i];
         stats[i].stack_cnt = 1;
     }
     osKernelUnlock();


### PR DESCRIPTION
It's the same on master (this threadid is represented as uint32_t value). This resolves the error we saw with IAR:

```
[Error] mbed_stats.c@57,0: [Pe513]: a value of type "void *" cannot be assigned to an entity of type "uint32_t"
[ERROR]
          stats[i].thread_id = threads[i];
```

@bulislaw 