### PR TITLE
Don't set the build_dir to anything on export

### DIFF
--- a/tools/export/gnuarmeclipse/__init__.py
+++ b/tools/export/gnuarmeclipse/__init__.py
@@ -207,7 +207,7 @@ class GNUARMEclipse(Exporter):
             src_paths = ['']
             target_name = self.toolchain.target.name
             toolchain = prepare_toolchain(
-                src_paths, target_name, self.TOOLCHAIN, build_profile=profile_toolchain)
+                src_paths, "", target_name, self.TOOLCHAIN, build_profile=profile_toolchain)
 
             # Hack to fill in build_dir
             toolchain.build_dir = self.toolchain.build_dir

--- a/tools/project_api.py
+++ b/tools/project_api.py
@@ -187,7 +187,7 @@ def export_project(src_paths, export_path, target, ide, libraries_paths=None,
 
     # Pass all params to the unified prepare_resources()
     toolchain = prepare_toolchain(
-        paths, export_path, target, toolchain_name, macros=macros, jobs=jobs,
+        paths, "", target, toolchain_name, macros=macros, jobs=jobs,
         notify=notify, silent=silent, verbose=verbose,
         extra_verbose=extra_verbose, config=config, build_profile=build_profile)
     # The first path will give the name to the library


### PR DESCRIPTION
When constructing a toolchain for export, we currently set the
`build_dir` to the `export_dir`. When exporting offline, the
`export_dir` is always set to the root of the project. The toolchains
ignore their `build_dir` when scanning for sorces, so when the exporters
use the toolchains to scan for their resources, they get nothing.

In this patch we set the `build_dir` of the toolchain that the exports
use to nothing. A path of nothing should not match anything, and will
therefore not ignore everything when scanning for resources.

# TODO
- [x]  /morph export-build