### PR TITLE
[DELTA_DFBM_NQ620] Add RC calibration setting and revise mbed_overrides.c

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TARGET_DELTA_DFBM_NQ620/mbed_overrides.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TARGET_DELTA_DFBM_NQ620/mbed_overrides.c
@@ -16,6 +16,7 @@
 
 void mbed_sdk_init()
 {
-	printf("", __TIME__, __DATE__);	
-	
+    char* debug_date = __DATE__;
+    char* debug_time = __TIME__;	
+
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2545,6 +2545,16 @@
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
         "release_versions": ["2", "5"],
         "overrides": {"lf_clock_src": "NRF_LF_SRC_RC"},
+        "config": {
+            "lf_clock_rc_calib_timer_interval": {
+                "value": 16,
+                "macro_name": "MBED_CONF_NORDIC_NRF_LF_CLOCK_CALIB_TIMER_INTERVAL"
+            },
+            "lf_clock_rc_calib_mode_config": {
+                "value": 0,
+                "macro_name": "MBED_CONF_NORDIC_NRF_LF_CLOCK_CALIB_MODE_CONFIG"
+            }
+        },
         "device_name": "nRF52832_xxAA"
     },
     "BLUEPILL_F103C8": {


### PR DESCRIPTION
In targets.json, add lf_clock_rc_calib_timer_interval and
lf_clock_rc_calib_mode_config setting which are essential when using BLE
In mbed_overrides.c, create valuables instead of doing printf, those
valuables are intended to be used for debugging in runtime.

Please kindly review this PR