### PR TITLE
CMSIS5: RTOS: Add thread name option to wrapper

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
@@ -61,11 +61,13 @@ void self_terminate(Thread *self) {
 // Tests that spawn tasks in different configurations
 template <void (*F)(counter_t *)>
 void test_single_thread() {
+    const char tname[] = "Single Thread";
     counter_t counter(0);
-    Thread thread(osPriorityNormal, THREAD_STACK_SIZE);
+    Thread thread(osPriorityNormal, THREAD_STACK_SIZE, NULL, tname);
     thread.start(callback(F, &counter));
     thread.join();
     TEST_ASSERT_EQUAL(counter, 1);
+    TEST_ASSERT_EQUAL(strcmp(tname, thread.get_name()), 0);
 }
 
 template <int N, void (*F)(counter_t *)>

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -35,18 +35,19 @@ extern "C" void thread_terminate_hook(osThreadId_t id)
 namespace rtos {
 
 void Thread::constructor(osPriority_t priority,
-        uint32_t stack_size, unsigned char *stack_mem) {
+        uint32_t stack_size, unsigned char *stack_mem, const char *name) {
     _tid = 0;
     _dynamic_stack = (stack_mem == NULL);
 
     _attr.priority = priority;
     _attr.stack_size = stack_size;
+    _attr.name = name;
     _attr.stack_mem = (uint32_t*)stack_mem;
 }
 
 void Thread::constructor(Callback<void()> task,
-        osPriority_t priority, uint32_t stack_size, unsigned char *stack_mem) {
-    constructor(priority, stack_size, stack_mem);
+        osPriority_t priority, uint32_t stack_size, unsigned char *stack_mem, const char *name) {
+    constructor(priority, stack_size, stack_mem, name);
 
     switch (start(task)) {
         case osErrorResource:
@@ -227,6 +228,10 @@ uint32_t Thread::max_stack() {
 
     _mutex.unlock();
     return size;
+}
+
+const char *Thread::get_name() {
+    return _attr.name;
 }
 
 int32_t Thread::signal_wait(int32_t flags, uint32_t millisec) {

--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -69,11 +69,12 @@ public:
       @param   priority       initial priority of the thread function. (default: osPriorityNormal).
       @param   stack_size     stack size (in bytes) requirements for the thread function. (default: OS_STACK_SIZE).
       @param   stack_mem      pointer to the stack area to be used by this thread (default: NULL).
+      @param   name           name to be used for this thread. It has to stay allocated for the lifetime of the thread (default: NULL)
     */
     Thread(osPriority_t priority=osPriorityNormal,
            uint32_t stack_size=OS_STACK_SIZE,
-           unsigned char *stack_mem=NULL) {
-        constructor(priority, stack_size, stack_mem);
+           unsigned char *stack_mem=NULL, const char *name=NULL) {
+        constructor(priority, stack_size, stack_mem, name);
     }
 
     /** Create a new thread, and start it executing the specified function.
@@ -276,6 +277,11 @@ public:
     */
     uint32_t max_stack();
 
+    /** Get thread name
+      @return  thread name or NULL if the name was not set.
+     */
+    const char *get_name();
+
     /** Wait for one or more flags to become signaled for the current RUNNING thread.
       @param   flags     wait until all specified flags set or 0 for any single flag.
       @param   millisec  timeout value or 0 in case of no time-out. (default: osWaitForever).
@@ -319,11 +325,13 @@ private:
     // delegated constructors
     void constructor(osPriority_t priority=osPriorityNormal,
                      uint32_t stack_size=OS_STACK_SIZE,
-                     unsigned char *stack_mem=NULL);
+                     unsigned char *stack_mem=NULL,
+                     const char *name=NULL);
     void constructor(mbed::Callback<void()> task,
                      osPriority_t priority=osPriorityNormal,
                      uint32_t stack_size=OS_STACK_SIZE,
-                     unsigned char *stack_mem=NULL);
+                     unsigned char *stack_mem=NULL,
+                     const char *name=NULL);
     static void _thunk(void * thread_ptr);
 
     mbed::Callback<void()> _task;


### PR DESCRIPTION
New RTX supports naming threads, extend our wrapper to support this new functionality, add tests for the feature.

The change is for feature_cmsis5 branch and can be merged with failing CI.