### PR TITLE
Wrong linker symbol for Silicon Labs VT relocation on CMSIS5 & GCC

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/common/cmsis_nvic.h
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/common/cmsis_nvic.h
@@ -10,7 +10,7 @@
 /* For GCC, use dynamic vector table placement since otherwise we run into an alignment conflict */
 #if (defined (__GNUC__) && (!defined(__CC_ARM)))
 extern uint32_t __start_vector_table__;       // Dynamic vector positioning in GCC
-#define NVIC_RAM_VECTOR_ADDRESS (__start_vector_table__)
+#define NVIC_RAM_VECTOR_ADDRESS (&__start_vector_table__)
 #else
 #define NVIC_RAM_VECTOR_ADDRESS 0x20000000    // Vectors positioned at start of RAM
 #endif


### PR DESCRIPTION
Linker magic was supplying the address of the vector table address into the pound define used in mbed_boot.c for relocating the vector table. mbed_cpy_nvic() expects the plain address to be loaded in the define.

This PR fixes the bug filed in #3903 
CC @bulislaw 