### PR TITLE
NUCLEO_F439ZI/mbedtls: add SHA256 hw_acceleration

### DIFF
--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/mbedtls_device.h
@@ -22,5 +22,6 @@
 
 #define MBEDTLS_AES_ALT
 
+#define MBEDTLS_SHA256_ALT
 
 #endif /* MBEDTLS_DEVICE_H */

--- a/features/mbedtls/targets/TARGET_STM/sha256_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/sha256_alt.c
@@ -1,0 +1,104 @@
+/*
+ *  sha256_alt.c for SHA256 HASH
+ *******************************************************************************
+ * Copyright (c) 2017, STMicroelectronics
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+#include "mbedtls/sha256.h"
+
+#if defined(MBEDTLS_SHA256_ALT)
+
+/* Implementation that should never be optimized out by the compiler */
+static void mbedtls_zeroize( void *v, size_t n ) {
+    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+}
+
+void mbedtls_sha256_init( mbedtls_sha256_context *ctx )
+{
+    memset( ctx, 0, sizeof( mbedtls_sha256_context ) );	
+
+    /* Enable HASH clock */
+    __HAL_RCC_HASH_CLK_ENABLE();
+}
+
+void mbedtls_sha256_free( mbedtls_sha256_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+	
+	/* Force the HASH Periheral Clock Reset */
+    __HAL_RCC_HASH_FORCE_RESET();
+
+    /* Release the HASH Periheral Clock Reset */
+    __HAL_RCC_HASH_RELEASE_RESET();
+
+    mbedtls_zeroize( ctx, sizeof( mbedtls_sha256_context ) );
+}
+
+void mbedtls_sha256_clone( mbedtls_sha256_context *dst,
+                         const mbedtls_sha256_context *src )
+{
+    *dst = *src;
+}
+
+/*
+ * SHA-256 context setup
+ */
+void mbedtls_sha256_starts( mbedtls_sha256_context *ctx, int is224 )
+{
+    /* HASH IP initialization */
+    HAL_HASH_DeInit(&ctx->hhash_sha256);
+    
+    /* HASH Configuration */
+    ctx->hhash_sha256.Init.DataType = HASH_DATATYPE_8B;
+    HAL_HASH_Init(&ctx->hhash_sha256);
+
+    ctx->is224 = is224;
+}
+
+void mbedtls_sha256_process( mbedtls_sha256_context *ctx, const unsigned char data[64] )
+{
+    if (ctx->is224 == 0)
+        HAL_HASHEx_SHA256_Accumulate(&ctx->hhash_sha256, (uint8_t *) data, 64);
+    else
+        HAL_HASHEx_SHA224_Accumulate(&ctx->hhash_sha256, (uint8_t *) data, 64);
+}
+
+/*
+ * SHA-256 process buffer
+ */
+void mbedtls_sha256_update( mbedtls_sha256_context *ctx, const unsigned char *input, size_t ilen )
+{
+    if (ctx->is224 == 0)
+        HAL_HASHEx_SHA256_Accumulate(&ctx->hhash_sha256, (uint8_t *)input, ilen);
+    else
+        HAL_HASHEx_SHA224_Accumulate(&ctx->hhash_sha256, (uint8_t *)input, ilen);
+}
+
+/*
+ * SHA-256 final digest
+ */
+void mbedtls_sha256_finish( mbedtls_sha256_context *ctx, unsigned char output[32] )
+{
+    __HAL_HASH_START_DIGEST();
+        
+    if (ctx->is224 == 0)
+        HAL_HASHEx_SHA256_Finish(&ctx->hhash_sha256, output, 10);
+    else
+        HAL_HASHEx_SHA224_Finish(&ctx->hhash_sha256, output, 10);
+}
+
+#endif /*MBEDTLS_SHA256_ALT*/

--- a/features/mbedtls/targets/TARGET_STM/sha256_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/sha256_alt.h
@@ -1,0 +1,127 @@
+/*
+ *  sha256_alt.h SHA-256 hash
+ *******************************************************************************
+ *  Copyright (C) 2017, STMicroelectronics
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+#ifndef MBEDTLS_SHA256_ALT_H
+#define MBEDTLS_SHA256_ALT_H
+
+#if defined (MBEDTLS_SHA256_ALT)
+#include "mbedtls/platform.h"
+#include "mbedtls/config.h"
+
+#include "cmsis.h"
+#include <string.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief          SHA-256 context structure
+ */
+typedef struct
+{
+    int is224;                  /*!< 0 => SHA-256, else SHA-224 */  
+    HASH_HandleTypeDef hhash_sha256;  
+}
+mbedtls_sha256_context;
+
+/**
+ * \brief          Initialize SHA-256 context
+ *
+ * \param ctx      SHA-256 context to be initialized
+ */
+void mbedtls_sha256_init( mbedtls_sha256_context *ctx );
+
+/**
+ * \brief          Clear SHA-256 context
+ *
+ * \param ctx      SHA-256 context to be cleared
+ */
+void mbedtls_sha256_free( mbedtls_sha256_context *ctx );
+
+/**
+ * \brief          Clone (the state of) a SHA-256 context
+ *
+ * \param dst      The destination context
+ * \param src      The context to be cloned
+ */
+void mbedtls_sha256_clone( mbedtls_sha256_context *dst,
+                           const mbedtls_sha256_context *src );
+
+/**
+ * \brief          SHA-256 context setup
+ *
+ * \param ctx      context to be initialized
+ * \param is224    0 = use SHA256, 1 = use SHA224
+ */
+void mbedtls_sha256_starts( mbedtls_sha256_context *ctx, int is224 );
+
+/**
+ * \brief          SHA-256 process buffer
+ *
+ * \param ctx      SHA-256 context
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ */
+void mbedtls_sha256_update( mbedtls_sha256_context *ctx, const unsigned char *input,
+                    size_t ilen );
+
+/**
+ * \brief          SHA-256 final digest
+ *
+ * \param ctx      SHA-256 context
+ * \param output   SHA-224/256 checksum result
+ */
+void mbedtls_sha256_finish( mbedtls_sha256_context *ctx, unsigned char output[32] );
+
+/* Internal use */
+void mbedtls_sha256_process( mbedtls_sha256_context *ctx, const unsigned char data[64] );
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief          Output = SHA-256( input buffer )
+ *
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ * \param output   SHA-224/256 checksum result
+ * \param is224    0 = use SHA256, 1 = use SHA224
+ */
+void mbedtls_sha256( const unsigned char *input, size_t ilen,
+           unsigned char output[32], int is224 );
+
+/**
+ * \brief          Checkup routine
+ *
+ * \return         0 if successful, or 1 if the test failed
+ */
+int mbedtls_sha256_self_test( int verbose );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_SHA256_ALT */
+
+#endif /* sha1_alt.h */


### PR DESCRIPTION
### Description

Enable HW acceleration for SHA256 algorithm on STM32F439ZI

### Status

READY

### Migrations

If this PR changes any APIs or behaviors, give a short description of what API users should do when this PR is merged.

YES | NO

### Steps to test or reproduce

To test this feature, you have to modify TESTS/mbedtls/selfttest/main.cpp in order to call sha256 self test:
add:
`#include "mbedtls/sha256.h"`
then

```
#if defined(MBEDTLS_SHA256_C)
MBEDTLS_SELF_TEST_TEST_CASE(mbedtls_sha256_self_test)
#endif
```
then

```
#if defined(MBEDTLS_SHA256_C)
    Case("mbedtls_sha256_self_test", mbedtls_sha256_self_test_test_case),
#endif
```