### PR TITLE
mbedtls/F439ZI: add md5 HASH feature

### DIFF
--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/mbedtls_device.h
@@ -22,5 +22,7 @@
 
 #define MBEDTLS_AES_ALT
 
+#define MBEDTLS_MD5_ALT
 
+#define MBEDTLS_MD5_C
 #endif /* MBEDTLS_DEVICE_H */

--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/mbedtls_device.h
@@ -1,5 +1,5 @@
 /*
- *  mbedtls_device.h 
+ *  mbedtls_device.h
  *******************************************************************************
  * Copyright (c) 2017, STMicroelectronics
  *  SPDX-License-Identifier: Apache-2.0
@@ -24,5 +24,4 @@
 
 #define MBEDTLS_MD5_ALT
 
-#define MBEDTLS_MD5_C
 #endif /* MBEDTLS_DEVICE_H */

--- a/features/mbedtls/targets/TARGET_STM/md5_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/md5_alt.c
@@ -1,0 +1,94 @@
+/*
+ *  MD5 hw acceleration
+ *******************************************************************************
+ * Copyright (c) 2017, STMicroelectronics
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "mbedtls/md5.h"
+
+#if defined(MBEDTLS_MD5_ALT)
+
+/* Implementation that should never be optimized out by the compiler */
+static void mbedtls_zeroize( void *v, size_t n ) {
+    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+}
+
+void mbedtls_md5_init( mbedtls_md5_context *ctx )
+{
+    memset( ctx, 0, sizeof( mbedtls_md5_context ) );
+
+    /* Enable HASH clock */
+    __HAL_RCC_HASH_CLK_ENABLE();
+}
+
+void mbedtls_md5_free( mbedtls_md5_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+
+    /* Force the HASH Periheral Clock Reset */
+    __HAL_RCC_HASH_FORCE_RESET();
+
+    /* Release the HASH Periheral Clock Reset */
+    __HAL_RCC_HASH_RELEASE_RESET();
+
+    mbedtls_zeroize( ctx, sizeof( mbedtls_md5_context ) );
+}
+
+void mbedtls_md5_clone( mbedtls_md5_context *dst,
+                        const mbedtls_md5_context *src )
+{
+    *dst = *src;
+}
+
+/*
+ * MD5 context setup
+ */
+void mbedtls_md5_starts( mbedtls_md5_context *ctx )
+{
+    /* HASH IP initialization */
+    HAL_HASH_DeInit(&ctx->hhash_md5);
+    
+    /* HASH Configuration */
+    ctx->hhash_md5.Init.DataType = HASH_DATATYPE_8B;
+    HAL_HASH_Init(&ctx->hhash_md5);
+}
+
+void mbedtls_md5_process( mbedtls_md5_context *ctx, const unsigned char data[64] )
+{
+    HAL_HASH_MD5_Accumulate(&ctx->hhash_md5, (uint8_t *)data, 64);
+}
+
+/*
+ * MD5 process buffer
+ */
+void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, size_t ilen )
+{
+    HAL_HASH_MD5_Accumulate(&ctx->hhash_md5, (uint8_t *)input, ilen);
+}
+
+/*
+ * MD5 final digest
+ */
+void mbedtls_md5_finish( mbedtls_md5_context *ctx, unsigned char output[16] )
+{
+    __HAL_HASH_START_DIGEST();
+        
+    HAL_HASH_MD5_Finish(&ctx->hhash_md5, output, 10);
+}
+
+#endif /* MBEDTLS_MD5_ALT */

--- a/features/mbedtls/targets/TARGET_STM/md5_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/md5_alt.h
@@ -1,0 +1,128 @@
+/**
+ * \file md5_alt.h
+ *
+ * \brief MD5 hw acceleration (hash function)
+ *
+ * Copyright (c) 2017, STMicroelectronics
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+#ifndef MBEDTLS_MD5_ALT_H
+#define MBEDTLS_MD5_ALT_H
+
+#if defined(MBEDTLS_MD5_ALT)
+#include "mbedtls/platform.h"
+#include "mbedtls/config.h"
+
+#include "cmsis.h"
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief          MD5 context structure
+ */
+typedef struct
+{
+    uint32_t total[2];          /*!< number of bytes processed  */
+    uint32_t state[4];          /*!< intermediate digest state  */
+    unsigned char buffer[64];   /*!< data block being processed */
+    HASH_HandleTypeDef hhash_md5;
+}
+mbedtls_md5_context;
+
+/**
+ * \brief          Initialize MD5 context
+ *
+ * \param ctx      MD5 context to be initialized
+ */
+void mbedtls_md5_init( mbedtls_md5_context *ctx );
+
+/**
+ * \brief          Clear MD5 context
+ *
+ * \param ctx      MD5 context to be cleared
+ */
+void mbedtls_md5_free( mbedtls_md5_context *ctx );
+
+/**
+ * \brief          Clone (the state of) an MD5 context
+ *
+ * \param dst      The destination context
+ * \param src      The context to be cloned
+ */
+void mbedtls_md5_clone( mbedtls_md5_context *dst,
+                        const mbedtls_md5_context *src );
+
+/**
+ * \brief          MD5 context setup
+ *
+ * \param ctx      context to be initialized
+ */
+void mbedtls_md5_starts( mbedtls_md5_context *ctx );
+
+/**
+ * \brief          MD5 process buffer
+ *
+ * \param ctx      MD5 context
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ */
+void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, size_t ilen );
+
+/**
+ * \brief          MD5 final digest
+ *
+ * \param ctx      MD5 context
+ * \param output   MD5 checksum result
+ */
+void mbedtls_md5_finish( mbedtls_md5_context *ctx, unsigned char output[16] );
+
+/* Internal use */
+void mbedtls_md5_process( mbedtls_md5_context *ctx, const unsigned char data[64] );
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief          Output = MD5( input buffer )
+ *
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ * \param output   MD5 checksum result
+ */
+void mbedtls_md5( const unsigned char *input, size_t ilen, unsigned char output[16] );
+
+/**
+ * \brief          Checkup routine
+ *
+ * \return         0 if successful, or 1 if the test failed
+ */
+int mbedtls_md5_self_test( int verbose );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_MD5_ALT */
+
+#endif /* md5_alt.h */

--- a/features/mbedtls/targets/TARGET_STM/md5_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/md5_alt.h
@@ -23,8 +23,6 @@
 #define MBEDTLS_MD5_ALT_H
 
 #if defined(MBEDTLS_MD5_ALT)
-#include "mbedtls/platform.h"
-#include "mbedtls/config.h"
 
 #include "cmsis.h"
 #include <string.h>

--- a/features/mbedtls/targets/TARGET_STM/md5_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/md5_alt.h
@@ -103,22 +103,6 @@ void mbedtls_md5_process( mbedtls_md5_context *ctx, const unsigned char data[64]
 extern "C" {
 #endif
 
-/**
- * \brief          Output = MD5( input buffer )
- *
- * \param input    buffer holding the  data
- * \param ilen     length of the input data
- * \param output   MD5 checksum result
- */
-void mbedtls_md5( const unsigned char *input, size_t ilen, unsigned char output[16] );
-
-/**
- * \brief          Checkup routine
- *
- * \return         0 if successful, or 1 if the test failed
- */
-int mbedtls_md5_self_test( int verbose );
-
 #ifdef __cplusplus
 }
 #endif

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -903,7 +903,7 @@
         "extra_labels": ["STM", "STM32F4", "STM32F439", "STM32F439ZI", "STM32F439xx", "STM32F439xI", "FLASH_CMSIS_ALGO"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "progen": {"target": "nucleo-f439zi"},
-        "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2", "MBEDTLS_CONFIG_HW_SUPPORT", "USB_STM_HAL", "USBHOST_OTHER"],
+        "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2", "MBEDTLS_CONFIG_HW_SUPPORT", "USB_STM_HAL", "USBHOST_OTHER", "MBEDTLS_MD5_C"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "TRNG", "FLASH"],
         "detect_code": ["0797"],
         "features": ["LWIP"],


### PR DESCRIPTION
## Description
Enable MD5 for STM32F439ZI
Add HW acceleratoin for MD5 on STM32F439ZI

## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

YES | NO

## Steps to test or reproduce
To test this feature, you have to modify TESTS/mbedtls/selfttest/main.cpp in order to call md5 self test:
add:
`#include "mbedtls/md5.h"`
then
```
#if defined(MBEDTLS_MD5_C)
MBEDTLS_SELF_TEST_TEST_CASE(mbedtls_md5_self_test)
#endif
```
then

```
#if defined(MBEDTLS_MD5_C)
    Case("mbedtls_md5_self_test", mbedtls_md5_self_test_test_case),
#endif
```