### PR TITLE
DRAFT: Enable MBEDTLS_FS_IO when this feature can be used

### DIFF
--- a/features/mbedtls/importer/adjust-config.sh
+++ b/features/mbedtls/importer/adjust-config.sh
@@ -37,28 +37,33 @@ add_code() {
 
 # add an #ifndef to include config-no-entropy.h when the target does not have
 # an entropy source we can use.
-add_code                                                                                  \
-    "#ifndef MBEDTLS_CONFIG_H\n"                                                          \
-    "\n"                                                                                  \
-    "#include \"platform\/inc\/platform_mbed.h\"\n"                                       \
-    "\n"                                                                                  \
-    "\/*\n"                                                                               \
-    " * Only use features that do not require an entropy source when\n"                   \
-    " * DEVICE_ENTROPY_SOURCE is not defined in mbed OS.\n"                               \
-    " *\/\n"                                                                              \
-    "#if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT) && !defined(MBEDTLS_TEST_NULL_ENTROPY)\n" \
-    "#include \"mbedtls\/config-no-entropy.h\"\n"                                         \
-    "\n"                                                                                  \
-    "#if defined(MBEDTLS_USER_CONFIG_FILE)\n"                                             \
-    "#include MBEDTLS_USER_CONFIG_FILE\n"                                                 \
-    "#endif\n"                                                                            \
-    "\n"                                                                                  \
+add_code                                                                \
+    "#ifndef MBEDTLS_CONFIG_H\n"                                        \
+    "\n"                                                                \
+    "#include \"platform\/inc\/platform_mbed.h\"\n"                     \
+    "\n"                                                                \
+    "\/*\n"                                                             \
+    " * Only use features that do not require an entropy source when\n" \
+    " * this is not available in Mbed OS. For more information on\n"    \
+    " * Mbed TLS entropy options please refer to entropy.h\n"           \
+    " *\/\n"                                                            \
+    "#if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT) && \\\\\n"              \
+    "    !defined(MBEDTLS_TEST_NULL_ENTROPY) && \\\\\n"                 \
+    "    !defined(MBEDTLS_ENTROPY_NV_SEED)\n"                           \
+    "#include \"mbedtls\/config-no-entropy.h\"\n"                       \
+    "\n"                                                                \
+    "#if defined(MBEDTLS_USER_CONFIG_FILE)\n"                           \
+    "#include MBEDTLS_USER_CONFIG_FILE\n"                               \
+    "#endif\n"                                                          \
+    "\n"                                                                \
     "#else\n"
 
 add_code                                                                              \
     "#include \"check_config.h\"\n"                                                   \
     "\n"                                                                              \
-    "#endif \/* !MBEDTLS_ENTROPY_HARDWARE_ALT && !MBEDTLS_TEST_NULL_ENTROPY *\/\n"    \
+    "#endif \/* !MBEDTLS_ENTROPY_HARDWARE_ALT &&\n"                                   \
+    "        * !MBEDTLS_TEST_NULL_ENTROPY &&\n"                                       \
+    "        * !MBEDTLS_ENTROPY_NV_SEED *\/\n"                                        \
     "\n"                                                                              \
     "#if defined(MBEDTLS_TEST_NULL_ENTROPY)\n"                                        \
     "#warning \"MBEDTLS_TEST_NULL_ENTROPY has been enabled. This \" \\\\\n"           \
@@ -66,7 +71,8 @@ add_code                                                                        
     "#endif\n"                                                                        \
     "\n"                                                                              \
     "#if defined(MBEDTLS_SSL_TLS_C) && !defined(MBEDTLS_TEST_NULL_ENTROPY) && \\\\\n" \
-    "    !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)\n"                                    \
+    "    !defined(MBEDTLS_ENTROPY_HARDWARE_ALT) && \\\\\n"                            \
+    "    !defined(MBEDTLS_ENTROPY_NV_SEED)\n"                                         \
     "#error \"No entropy source was found at build time, so TLS \" \\\\\n"            \
     "    \"functionality is not available\"\n"                                        \
     "#endif\n"

--- a/features/mbedtls/inc/mbedtls/config.h
+++ b/features/mbedtls/inc/mbedtls/config.h
@@ -31,9 +31,12 @@
 
 /*
  * Only use features that do not require an entropy source when
- * DEVICE_ENTROPY_SOURCE is not defined in mbed OS.
+ * this is not available in Mbed OS. For more information on
+ * Mbed TLS entropy options please refer to entropy.h
  */
-#if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT) && !defined(MBEDTLS_TEST_NULL_ENTROPY)
+#if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT) && \
+    !defined(MBEDTLS_TEST_NULL_ENTROPY) && \
+    !defined(MBEDTLS_ENTROPY_NV_SEED)
 #include "mbedtls/config-no-entropy.h"
 
 #if defined(MBEDTLS_USER_CONFIG_FILE)
@@ -2731,7 +2734,9 @@
 
 #include "check_config.h"
 
-#endif /* !MBEDTLS_ENTROPY_HARDWARE_ALT && !MBEDTLS_TEST_NULL_ENTROPY */
+#endif /* !MBEDTLS_ENTROPY_HARDWARE_ALT &&
+        * !MBEDTLS_TEST_NULL_ENTROPY &&
+        * !MBEDTLS_ENTROPY_NV_SEED */
 
 #if defined(MBEDTLS_TEST_NULL_ENTROPY)
 #warning "MBEDTLS_TEST_NULL_ENTROPY has been enabled. This " \
@@ -2739,7 +2744,8 @@
 #endif
 
 #if defined(MBEDTLS_SSL_TLS_C) && !defined(MBEDTLS_TEST_NULL_ENTROPY) && \
-    !defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+    !defined(MBEDTLS_ENTROPY_HARDWARE_ALT) && \
+    !defined(MBEDTLS_ENTROPY_NV_SEED)
 #error "No entropy source was found at build time, so TLS " \
     "functionality is not available"
 #endif

--- a/features/mbedtls/platform/inc/platform_mbed.h
+++ b/features/mbedtls/platform/inc/platform_mbed.h
@@ -21,6 +21,10 @@
 #define MBEDTLS_ENTROPY_HARDWARE_ALT
 #endif
 
+#if defined(MBED_CONF_FILESYSTEM_PRESENT)
+#define MBEDTLS_FS_IO
+#endif
+
 #if defined(MBEDTLS_CONFIG_HW_SUPPORT)
 #include "mbedtls_device.h"
 #endif


### PR DESCRIPTION
## Description
This patch is the first step towards integrating the mbed TLS NV Seed feature with mbed OS. The change enables the macro `MBEDTLS_FS_IO` when filesystem support is present in mbed OS. To use NV Seed, users will need to define the macros `MBEDTLS_ENTROPY_NV_SEED` and `MBEDTLS_PLATFORM_STD_NV_SEED_FILE` either through the user config file or the `mbed_app.json`.

**NOTE:** The entropy seed file will be stored unencrypted in the non-volatile storage.

@RonEld @sbutcher-arm @yanesca: Please review.

## Status
**IN DEVELOPMENT**

## Migrations
NO

## Related PRs
List related PRs against other branches:
* https://github.com/ARMmbed/mbed-os/pull/3949: The PR enables the dir access functions to be callable from C so that mbed TLS code can use them. This change must be merged after PR https://github.com/ARMmbed/mbed-os/pull/3949.

## Todos
- [X] Tests