### PR TITLE
Feature cmsis5: Fixes for IAR

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NXP/lpc17_emac.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NXP/lpc17_emac.c
@@ -947,10 +947,10 @@ err_t lpc_etharp_output_ipv6(struct netif *netif, struct pbuf *q,
 
 #if NO_SYS == 0
 /* periodic PHY status update */
-void phy_update(void const *nif) {
+void phy_update(void *nif) {
     lpc_phy_sts_sm((struct netif*)nif);
 }
-osTimerDef(phy_update, phy_update);
+
 #endif
 
 /**

--- a/rtos/mbed_boot.c
+++ b/rtos/mbed_boot.c
@@ -206,7 +206,9 @@ osMutexAttr_t singleton_mutex_attr;
     #error "HEAP_START must be defined if HEAP_SIZE is defined"
 #endif
 
-#if !defined(INITIAL_SP) && !defined(HEAP_START)
+/* IAR - INITIAL_SP and HEAP_START ignored as described in Memory layout notes above
+ */
+#if !defined(__ICCARM__) && !defined(INITIAL_SP) && !defined(HEAP_START)
     #error "no target defined"
 #endif
 

--- a/targets/TARGET_Maxim/TARGET_MAX32630/gpio_irq_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/gpio_irq_api.c
@@ -100,15 +100,15 @@ int gpio_irq_init(gpio_irq_t *obj, PinName name, gpio_irq_handler handler, uint3
 
     /* register handlers */
     irq_handler = handler;
-    NVIC_SetVector(GPIO_P0_IRQn, gpio_irq_0);
-    NVIC_SetVector(GPIO_P1_IRQn, gpio_irq_1);
-    NVIC_SetVector(GPIO_P2_IRQn, gpio_irq_2);
-    NVIC_SetVector(GPIO_P3_IRQn, gpio_irq_3);
-    NVIC_SetVector(GPIO_P4_IRQn, gpio_irq_4);
-    NVIC_SetVector(GPIO_P5_IRQn, gpio_irq_5);
-    NVIC_SetVector(GPIO_P6_IRQn, gpio_irq_6);
-    NVIC_SetVector(GPIO_P7_IRQn, gpio_irq_7);
-    NVIC_SetVector(GPIO_P8_IRQn, gpio_irq_8);
+    NVIC_SetVector(GPIO_P0_IRQn, (uint32_t)gpio_irq_0);
+    NVIC_SetVector(GPIO_P1_IRQn, (uint32_t)gpio_irq_1);
+    NVIC_SetVector(GPIO_P2_IRQn, (uint32_t)gpio_irq_2);
+    NVIC_SetVector(GPIO_P3_IRQn, (uint32_t)gpio_irq_3);
+    NVIC_SetVector(GPIO_P4_IRQn, (uint32_t)gpio_irq_4);
+    NVIC_SetVector(GPIO_P5_IRQn, (uint32_t)gpio_irq_5);
+    NVIC_SetVector(GPIO_P6_IRQn, (uint32_t)gpio_irq_6);
+    NVIC_SetVector(GPIO_P7_IRQn, (uint32_t)gpio_irq_7);
+    NVIC_SetVector(GPIO_P8_IRQn, (uint32_t)gpio_irq_8);
 
     /* disable the interrupt locally */
     MXC_GPIO->int_mode[port] &= ~(0xF << (pin*4));

--- a/targets/TARGET_Maxim/TARGET_MAX32630/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/rtc_api.c
@@ -71,9 +71,9 @@ void rtc_init(void)
     CLKMAN_SetClkScale(CLKMAN_CLK_SYNC, CLKMAN_SCALE_DIV_1);
 
     // Prepare interrupt handlers
-    NVIC_SetVector(RTC0_IRQn, lp_ticker_irq_handler);
+    NVIC_SetVector(RTC0_IRQn, (uint32_t)lp_ticker_irq_handler);
     NVIC_EnableIRQ(RTC0_IRQn);
-    NVIC_SetVector(RTC3_IRQn, overflow_handler);
+    NVIC_SetVector(RTC3_IRQn, (uint32_t)overflow_handler);
     NVIC_EnableIRQ(RTC3_IRQn);
 
     // Enable wakeup on RTC rollover

--- a/targets/TARGET_Maxim/TARGET_MAX32630/serial_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/serial_api.c
@@ -202,19 +202,19 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
 {
     switch (obj->index) {
         case 0:
-            NVIC_SetVector(UART0_IRQn, uart0_handler);
+            NVIC_SetVector(UART0_IRQn, (uint32_t)uart0_handler);
             NVIC_EnableIRQ(UART0_IRQn);
             break;
         case 1:
-            NVIC_SetVector(UART1_IRQn, uart1_handler);
+            NVIC_SetVector(UART1_IRQn, (uint32_t)uart1_handler);
             NVIC_EnableIRQ(UART1_IRQn);
             break;
         case 2:
-            NVIC_SetVector(UART2_IRQn, uart2_handler);
+            NVIC_SetVector(UART2_IRQn, (uint32_t)uart2_handler);
             NVIC_EnableIRQ(UART2_IRQn);
             break;
         case 3:
-            NVIC_SetVector(UART3_IRQn, uart3_handler);
+            NVIC_SetVector(UART3_IRQn, (uint32_t)uart3_handler);
             NVIC_EnableIRQ(UART3_IRQn);
             break;
         default:

--- a/targets/TARGET_Maxim/TARGET_MAX32630/us_ticker.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/us_ticker.c
@@ -140,7 +140,7 @@ void us_ticker_init(void)
     cfg.compareCount = 0xFFFFFFFF;
     TMR32_Config(US_TIMER, &cfg);
 
-    NVIC_SetVector(US_TIMER_IRQn, tmr_handler);
+    NVIC_SetVector(US_TIMER_IRQn, (uint32_t)tmr_handler);
     NVIC_EnableIRQ(US_TIMER_IRQn);
     TMR32_EnableINT(US_TIMER);
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5/us_ticker.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/us_ticker.c
@@ -77,9 +77,6 @@ void COMMON_RTC_IRQ_HANDLER(void)
     }
 }
 
-#if (defined (__ICCARM__)) && defined(TARGET_MCU_NRF51822)//IAR
-__stackless __task 
-#endif
 void RTC1_IRQHandler(void);
 
 void common_rtc_init(void)


### PR DESCRIPTION
Remove unused osTimerDef. This should fix any lpc17xx board in our code base (ARCH PRO, LPC1768). they should be green now

@bulislaw 