### PR TITLE
NUCLEO_F302R8: Add missing PB_8/PB_9 CAN pins

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/TARGET_NUCLEO_F302R8/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/TARGET_NUCLEO_F302R8/PeripheralPins.c
@@ -226,13 +226,13 @@ const PinMap PinMap_SPI_SSEL[] = {
 };
 
 const PinMap PinMap_CAN_RD[] = {
-//  {PB_8 , CAN_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF9_CAN)}, // Not available in 32 pins package
+    {PB_8 , CAN_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF9_CAN)},
     {PA_11, CAN_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF9_CAN)},
     {NC,    NC,    0}
 };
 
 const PinMap PinMap_CAN_TD[] = {
-//  {PB_9 ,  CAN_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF9_CAN)}, // Not available in 32 pins package
+    {PB_9 ,  CAN_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF9_CAN)},
     {PA_12,  CAN_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF9_CAN)},
     {NC,    NC,    0}
 };


### PR DESCRIPTION
## Description
Add missing PB_8/PB_9 CAN pins. These pins were commented by mistake.

## Status
READY

## Migrations
NO
