### PR TITLE
NSAPI/lwIP: Free held netbuf on close

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -648,6 +648,7 @@ static int mbed_lwip_socket_close(nsapi_stack_t *stack, nsapi_socket_t handle)
 {
     struct lwip_socket *s = (struct lwip_socket *)handle;
 
+    netbuf_delete(s->buf);
     err_t err = netconn_delete(s->conn);
     mbed_lwip_arena_dealloc(s);
     return mbed_lwip_err_remap(err);


### PR DESCRIPTION
mbed_lwip_socket_recv() takes one netbuf at a time from the netconn API,
and it holds a partially-read netbuf if necessary in order to present as
a stream for TCP.

This held netbuf was not being freed when the socket was closed.

Fixes issue #3974.