### PR TITLE
Fix crash with events in the past

### DIFF
--- a/hal/mbed_ticker_api.c
+++ b/hal/mbed_ticker_api.c
@@ -74,6 +74,10 @@ void ticker_insert_event(const ticker_data_t *const data, ticker_event_t *obj, t
         prev = p;
         p = p->next;
     }
+    
+    /* if we're at the end p will be NULL, which is correct */
+    obj->next = p;
+
     /* if prev is NULL we're at the head */
     if (prev == NULL) {
         data->queue->head = obj;
@@ -81,8 +85,6 @@ void ticker_insert_event(const ticker_data_t *const data, ticker_event_t *obj, t
     } else {
         prev->next = obj;
     }
-    /* if we're at the end p will be NULL, which is correct */
-    obj->next = p;
 
     core_util_critical_section_exit();
 }


### PR DESCRIPTION
ticker_insert_event() can crash on KLXX (and probably other platforms) if an event is inserted with a timestamp before the current real time.  

The problem is easy to trigger:  you just need to set up a Ticker object, and then disable interrupts for slightly longer than the Ticker object's interval.  It's generally bad practice to disable interrupts for too long, but there are some cases where it's unavoidable, and anyway it would be better for the core library function not to crash.  The case where I had an unavoidably long interrupts-off interval was writing flash with the FTFA.  The FTFA hardware prohibits flash reads while an FTFA command is in progress, so interrupts must be disabled for the whole duration of each command to ensure that there are no instruction fetches from flash-resident ISRs in the course of the execution.  An FTFA "erase sector" command takes a fairly long time (milliseconds), and I have a fairly high frequency Ticker (1ms).

The problem and the fix are pretty straightforward.  ticker_insert_event() searches the linked list to figure out where to insert the new event, looking for a spot earlier than any event currently queued.  If the event is in the past, it'll usually end up at the head of the list.  When the routine sees that the new event belongs at the head of the list, it calls data->interface->set_interrupt() to schedule the interrupt for the event, since it's the new soonest event.  The KLXX version of us_ticker_set_interrupt() then looks to see if the event is in the past, which we've stipulated that it is, so rather than actually setting the interrupt, it simply calls the handler directly.  The first thing the Ticker interrupt handler does is re-schedule itself, so we re-enter ticker_insert_event() at this point.  This is where the problem comes in:  we didn't finish updating the linked list before we called set_interrupt() and thus before we recursed back into ticker_insert_event().  We set the head of the list to the new event but we didn't set the new event's 'next' pointer.

The fix is simply to finish updating the list before we call set_interrupt(), which we can do by moving the obj->next initialization ahead of the head pointer update.

Notes:
* Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
* This is just a template, so feel free to use/remove the unnecessary things

## Description
Fix the crash bug in ticker_insert_event() as described above

## Migrations
No API changes

## Related PRs
No other changes required

## Todos
No to-do items

## Deploy notes
It's just an internal bug fix; no deployment changes required

## Steps to test or reproduce
On KL25Z
Create a couple of Ticker objects, at least one with a 1ms interval
Disable interrupts (__disable_irq()) for about 2ms
Re-enable interrupts (__enable_irq())
Crash results (might be sporadic, since the root cause is the un-updated 'next' pointer in the linked list entry; in some cases the old link value might happen to be correct, avoiding the crash, while in other cases the old value will cause an infinite loop, access to freed memory, etc)
