### PR TITLE
Ticker - kl25z bugfix for handling events in the past

### DIFF
--- a/hal/mbed_ticker_api.c
+++ b/hal/mbed_ticker_api.c
@@ -74,6 +74,10 @@ void ticker_insert_event(const ticker_data_t *const data, ticker_event_t *obj, t
         prev = p;
         p = p->next;
     }
+    
+    /* if we're at the end p will be NULL, which is correct */
+    obj->next = p;
+
     /* if prev is NULL we're at the head */
     if (prev == NULL) {
         data->queue->head = obj;
@@ -81,8 +85,6 @@ void ticker_insert_event(const ticker_data_t *const data, ticker_event_t *obj, t
     } else {
         prev->next = obj;
     }
-    /* if we're at the end p will be NULL, which is correct */
-    obj->next = p;
 
     core_util_critical_section_exit();
 }

--- a/targets/TARGET_Freescale/TARGET_KLXX/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/us_ticker.c
@@ -185,12 +185,11 @@ static void lptmr_isr(void) {
 }
 
 void us_ticker_set_interrupt(timestamp_t timestamp) {
-    uint32_t tcur = us_ticker_read();
-    int delta = (int)((uint32_t)timestamp - tcur);
+    int delta = (int)((uint32_t)timestamp - us_ticker_read());
     if (delta <= 0) {
         // This event was in the past.  Force it into the very near
 	// future instead.
-	timestamp = tcur + 2;
+	delta = 1;
     } 
 	
     us_ticker_int_counter   = (uint32_t)(delta >> 16);

--- a/targets/TARGET_Freescale/TARGET_KLXX/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/us_ticker.c
@@ -185,13 +185,14 @@ static void lptmr_isr(void) {
 }
 
 void us_ticker_set_interrupt(timestamp_t timestamp) {
-    int delta = (int)((uint32_t)timestamp - us_ticker_read());
+    uint32_t tcur = us_ticker_read();
+    int delta = (int)((uint32_t)timestamp - tcur);
     if (delta <= 0) {
-        // This event was in the past:
-        us_ticker_irq_handler();
-        return;
-    }
-    
+        // This event was in the past.  Force it into the very near
+	// future instead.
+	timestamp = tcur + 2;
+    } 
+	
     us_ticker_int_counter   = (uint32_t)(delta >> 16);
     us_ticker_int_remainder = (uint16_t)(0xFFFF & delta);
     if (us_ticker_int_counter > 0) {


### PR DESCRIPTION
## Description

Ticker can cause a crash if you disable interrupts for longer than the Ticker object's interval, if you have at least one other timed event in the system.

This problem has two causes.

1.  ticker_insert_event() leaves the event linked list in an inconsistent state before calling set_interrupt(), which can recurse back into ticker_insert_event(), which will again modify the list.  This can cause crashes in different ways depending on the particular path through the code, but with the Ticker setup described above, it will usually create a cycle in the list (head->A->B->A->B...) that causes an infinite loop the next time someone tries to traverse the list.

The fix is to complete all manipulations to the list pointers BEFORE calling set_interrupt().

2.  TARGET_KLXX/us_ticker.c has a separate problem that isn't quite as much an outright error, but is still problematic.  In us_ticker_set_interrupt(), the routine calls the interrupt handler recursively if the event is in the past.  This is the actual thing that triggered problem #1 above - ticker_insert_event() calls us_ticker_set_interrupt() to set the interrupt, and for an event in the past, that calls the handler, which for a Ticker schedules the next instance of the event by calling ticker_insert_event().  But the recursion is a separate problem if you have a Ticker that gets behind real-time.  The problem is that the whole backlog of past calls gets piled on the stack through recursive calls, so if you have more than a few, it can blow the stack.  A separate potential problem is that the interrupt handler might be written to assume that it's running in interrupt context, so it might not properly protect statics when running from thread context.  

The fix here is to force a past timestamp slightly (1us) into the future.  This makes the routine handle past and future events uniformly; in both cases, we schedule an interrupt and call the handler on the interrupt.  This resolves any recurring event backlogs iteratively rather than recursively, eliminating the risk of unbounded stack usage.  It also calls the callback uniformly in ISR context.  The runtime timing is about the same as the original.

## Migrations
No API changes

## Related PRs
No other changes required

## Todos
No to-do items

## Deploy notes
It's just an internal bug fix; no deployment changes required

## Steps to test or reproduce
On KL25Z:
- Create a couple of Ticker objects, one with a 1ms interval
- Disable interrupts (__disable_irq())
- Spin for about 5ms
- Re-enable interrupts (__enable_irq())
- Program will crash by way of an infinite loop in ticker_insert_event()
