### PR TITLE
events: Fix zero wait condition in non-rtos semaphore

### DIFF
--- a/events/equeue/equeue_mbed.cpp
+++ b/events/equeue/equeue_mbed.cpp
@@ -131,7 +131,9 @@ static void equeue_sema_timeout(equeue_sema_t *s) {
 bool equeue_sema_wait(equeue_sema_t *s, int ms) {
     int signal = 0;
     Timeout timeout;
-    if (ms > 0) {
+    if (ms == 0) {
+        return false;
+    } else if (ms > 0) {
         timeout.attach_us(callback(equeue_sema_timeout, s), ms*1000);
     }
 

--- a/events/equeue/equeue_platform.h
+++ b/events/equeue/equeue_platform.h
@@ -129,7 +129,8 @@ typedef volatile int equeue_sema_t;
 // The equeue_sema_wait waits for a semaphore to be signalled or returns
 // immediately if equeue_sema_signal had been called since the last
 // equeue_sema_wait. The equeue_sema_wait returns true if it detected that
-// equeue_sema_signal had been called.
+// equeue_sema_signal had been called. If ms is negative, equeue_sema_wait
+// will wait for a signal indefinitely.
 int equeue_sema_create(equeue_sema_t *sema);
 void equeue_sema_destroy(equeue_sema_t *sema);
 void equeue_sema_signal(equeue_sema_t *sema);


### PR DESCRIPTION
Before, if the semaphore recieved a wait of zero, the semaphore would erronously drop the ticker event to wake up the device, causing the device to go to sleep without any mechanism to wake itself up.

During a dispatch operation, the event queue dispatches all events that have expired, so the call to equeue_sema_wait very rarely has a wait of zero. But this can happen when an event is posted just after a dispatch has occured.

The rtos version handles this correctly:
https://github.com/ARMmbed/mbed-os/blob/master/events/equeue/equeue_mbed.cpp#L105

related issue https://github.com/ARMmbed/mbed-os/issues/3857
cc @pan-, @tbondar, @nvlsianpu 