### PR TITLE
Use OUTPUT_EXT to pick binary type

### DIFF
--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -386,12 +386,9 @@ class TEENSY3_1Code(object):
     @staticmethod
     def binary_hook(t_self, resources, elf, binf):
         """Hook that is run after elf is generated"""
-        from intelhex import IntelHex
-        binh = IntelHex()
-        binh.loadbin(binf, offset=0)
-
-        with open(binf.replace(".bin", ".hex"), "w") as file_desc:
-            binh.tofile(file_desc, format='hex')
+        # This function is referenced by old versions of targets.json and should
+        # be kept for backwards compatibility.
+        pass
 
 class MTSCode(object):
     """Generic MTS code"""
@@ -475,7 +472,11 @@ class MCU_NRF51Code(object):
         # Merge user code with softdevice
         from intelhex import IntelHex
         binh = IntelHex()
-        binh.loadbin(binf, offset=softdevice_and_offset_entry['offset'])
+        _, ext = os.path.splitext(binf)
+        if ext == ".hex":
+            binh.loadhex(binf)
+        elif ext == ".bin":
+            binh.loadbin(binf, softdevice_and_offset_entry['offset'])
 
         if t_self.target.MERGE_SOFT_DEVICE is True:
             t_self.debug("Merge SoftDevice file %s"

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -1003,7 +1003,7 @@ class mbedToolchain:
 
         filename = name+'.'+ext
         elf = join(tmp_path, name + '.elf')
-        bin = join(tmp_path, filename)
+        bin = None if ext is 'elf' else join(tmp_path, filename)
         map = join(tmp_path, name + '.map')
 
         r.objects = sorted(set(r.objects))
@@ -1012,7 +1012,7 @@ class mbedToolchain:
             self.progress("link", name)
             self.link(elf, r.objects, r.libraries, r.lib_dirs, r.linker_script)
 
-        if self.need_update(bin, [elf]):
+        if bin and self.need_update(bin, [elf]):
             needed_update = True
             self.progress("elf2bin", name)
             self.binary(r, elf, bin)

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -216,8 +216,10 @@ class ARM(mbedToolchain):
 
     @hook_tool
     def binary(self, resources, elf, bin):
+        _, fmt = splitext(bin)
+        bin_arg = {".bin": "--bin", ".hex": "--i32"}[fmt]
         # Build binary command
-        cmd = [self.elf2bin, '--bin', '-o', bin, elf]
+        cmd = [self.elf2bin, bin_arg, '-o', bin, elf]
 
         # Call cmdline hook
         cmd = self.hook.get_cmdline_binary(cmd)

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -261,7 +261,9 @@ class GCC(mbedToolchain):
     @hook_tool
     def binary(self, resources, elf, bin):
         # Build binary command
-        cmd = [self.elf2bin, "-O", "binary", elf, bin]
+        _, fmt = splitext(bin)
+        bin_arg = {'.bin': 'binary', '.hex': 'ihex'}[fmt]
+        cmd = [self.elf2bin, "-O", bin_arg, elf, bin]
 
         # Call cmdline hook
         cmd = self.hook.get_cmdline_binary(cmd)

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -224,8 +224,10 @@ class IAR(mbedToolchain):
 
     @hook_tool
     def binary(self, resources, elf, bin):
+        _, fmt = splitext(bin)
+        bin_arg = {".bin": "--bin", ".hex": "--ihex"}[fmt]
         # Build binary command
-        cmd = [self.elf2bin, "--bin", elf, bin]
+        cmd = [self.elf2bin, bin_arg, elf, bin]
 
         # Call cmdline hook
         cmd = self.hook.get_cmdline_binary(cmd)


### PR DESCRIPTION
The tools now use the extension provided by `OUTPUT_EXT` to determine the file
type of the output executable.

Resolves https://github.com/ARMmbed/mbed-os/issues/3973

## Testing
 - [x] /morph test