### PR TITLE
Fixed OBOE in async serial tx for NRF52 target, fixes #4002

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/serial_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/serial_api.c
@@ -199,12 +199,13 @@ void UART_IRQ_HANDLER(void)
 
     #if DEVICE_SERIAL_ASYNCH
         if (UART_CB.tx_active) {
-            if (++UART_CB.tx_pos <= UART_CB.tx_length) {
+            if (UART_CB.tx_pos < UART_CB.tx_length) {
                 // When there is still something to send, clear the TXDRDY event
                 // and put next byte to transmitter.
                 nrf_uart_event_clear(UART_INSTANCE, NRF_UART_EVENT_TXDRDY);
                 nrf_uart_txd_set(UART_INSTANCE,
                     UART_CB.tx_buffer[UART_CB.tx_pos]);
+                UART_CB.tx_pos++;
             }
             else {
                 // When the TXDRDY event is set after the last byte to be sent


### PR DESCRIPTION
## Description

This fixes an off-by-one error in the async serial write code for the NRF5 target.

## Status

**READY**

## Migrations

User should make sure to remove any workarounds they might have added to circumvent this issue.

## Steps to test or reproduce

See #4002.

