### PR TITLE
Update Nanostack drivers to CMSIS2/RTX5

### DIFF
--- a/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_interrupt.c
+++ b/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_interrupt.c
@@ -5,15 +5,24 @@
 #include "arm_hal_interrupt.h"
 #include "arm_hal_interrupt_private.h"
 #include "cmsis_os2.h"
-
+#include "rtx_lib.h"
+#include <mbed_assert.h>
 
 static uint8_t sys_irq_disable_counter;
 
+static os_mutex_t critical_mutex;
+static const osMutexAttr_t critical_mutex_attr = {
+  .name = "critical_mutex",
+  .attr_bits = osMutexRecursive,
+  .cb_mem = &critical_mutex,
+  .cb_size = sizeof critical_mutex,
+};
 static osMutexId_t critical_mutex_id;
 
 void platform_critical_init(void)
 {
-    critical_mutex_id = osMutexNew(NULL);
+    critical_mutex_id = osMutexNew(&critical_mutex_attr);
+    MBED_ASSERT(critical_mutex_id);
 }
 
 void platform_enter_critical(void)

--- a/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_timer.cpp
+++ b/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_timer.cpp
@@ -4,24 +4,27 @@
 
 // Include before mbed.h to properly get UINT*_C()
 #include "ns_types.h"
-
-#include "cmsis_os2.h"
 #include "mbed.h"
-
+#include "cmsis_os2.h"
+#include "rtx_os.h"
 #include "platform/arm_hal_timer.h"
 #include "platform/arm_hal_interrupt.h"
+#include <mbed_assert.h>
 
 static osThreadId_t timer_thread_id;
+static uint64_t timer_thread_stk[2048];
+static osRtxThread_t timer_thread_tcb;
 
 static Timer timer;
 static Timeout timeout;
 static uint32_t due;
 static void (*arm_hal_callback)(void);
 
-static void timer_thread(const void *)
+static void timer_thread(void *arg)
 {
+    (void)arg;
     for (;;) {
-        osThreadFlagsWait(1, 0, osWaitForever);
+        osThreadFlagsWait(1, osFlagsWaitAny, osWaitForever);
         // !!! We don't do our own enter/exit critical - we rely on callback
         // doing it (ns_timer_interrupt_handler does)
         //platform_enter_critical();
@@ -33,10 +36,14 @@ static void timer_thread(const void *)
 // Called once at boot
 void platform_timer_enable(void)
 {
-    static osThreadAttr_t timer_thread_attr;
-    timer_thread_attr.stack_size = 2 * 1024;
+    static osThreadAttr_t timer_thread_attr = {0};
+    timer_thread_attr.stack_mem  = &timer_thread_stk[0];
+    timer_thread_attr.cb_mem  = &timer_thread_tcb;
+    timer_thread_attr.stack_size = sizeof(timer_thread_stk);
+    timer_thread_attr.cb_size = sizeof(timer_thread_tcb);
     timer_thread_attr.priority = osPriorityRealtime;
     timer_thread_id = osThreadNew(timer_thread, NULL, &timer_thread_attr);
+    MBED_ASSERT(timer_thread_id != NULL);
     timer.start();
 }
 
@@ -56,7 +63,6 @@ static void timer_callback(void)
 {
     due = 0;
     osThreadFlagsSet(timer_thread_id, 1);
-    //callback();
 }
 
 // This is called from inside platform_enter_critical - IRQs can't happen

--- a/features/nanostack/FEATURE_NANOSTACK/targets/TARGET_NCS36510/NanostackRfPhyNcs36510.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/targets/TARGET_NCS36510/NanostackRfPhyNcs36510.cpp
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
+#include "mbed.h"
 #include "ns_types.h"
 #include <string.h>
 #include "common_functions.h"
@@ -29,17 +29,12 @@ extern "C" {
 #include "TARGET_NCS36510/rfAna.h"
 }
 
-#include "cmsis_os2.h"
-
 #define RF_THREAD_STACK_SIZE 1024
 
 #define SIGNAL_COUNT_RADIO 1
 
-static void rf_thread_loop(const void *arg);
-
-static osThreadDef(rf_thread_loop, osPriorityRealtime, /*1,*/ RF_THREAD_STACK_SIZE);
-
-static osThreadId rf_thread_id;
+static void rf_thread_loop();
+Thread rf_thread(osPriorityRealtime, RF_THREAD_STACK_SIZE);
 
 #define PHY_MTU_SIZE     127
 #define CRC_LENGTH 0
@@ -159,15 +154,13 @@ static phy_device_driver_s device_driver = {
     NULL
 };
 
-static void rf_thread_loop(const void *arg)
+static void rf_thread_loop()
 {
     for (;;) {
-        osEvent event = osSignalWait(0, osWaitForever);
-        if (event.status != osEventSignal) {
-            continue;
-        }
+        int32_t event = rf_thread.signal_wait(0);
+
         platform_enter_critical();
-        if (event.value.signals & SIGNAL_COUNT_RADIO) {
+        if (event & SIGNAL_COUNT_RADIO) {
             handle_IRQ_events();
         }
         platform_exit_critical();
@@ -458,7 +451,8 @@ static void rf_mac_hw_init(void) {
     for (lutIndex=0;lutIndex<96;lutIndex++) {
       *(pMatchReg + lutIndex) = 0xFF;
     }
-    rf_thread_id = osThreadCreate(osThread(rf_thread_loop), NULL);
+    osStatus_t status = rf_thread.start(mbed::callback(rf_thread_loop));
+    MBED_ASSERT(status == osOK);
 
     /** Clear and enable MAC IRQ at task level, when scheduler is on. */
     NVIC_ClearPendingIRQ(MacHw_IRQn);
@@ -809,7 +803,7 @@ static void rf_mac_tx_interrupt(void)
 extern "C" void fIrqMacHwHandler(void)
 {
     NVIC_DisableIRQ(MacHw_IRQn);
-    osSignalSet(rf_thread_id, SIGNAL_COUNT_RADIO);
+    rf_thread.signal_set(SIGNAL_COUNT_RADIO);
 }
 
 static void handle_IRQ_events(void)


### PR DESCRIPTION
* Use statically allocated blocks for mutexes
* Use statically allocated blocks for threads.

**NOTE:** For statically allocated blocks, we are forced to use RTX types and headers, so we are not anymore directly compatible with CMSIS-RTOS2.
But this is how the example documentation does it anyway.

## Status
**READY**

**TODO:**

