### PR TITLE
STM32: Correct I2C master error handling

### DIFF
--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -904,7 +904,10 @@ void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c){
 
 #if DEVICE_I2CSLAVE
     /*  restore slave address */
-    i2c_slave_address(obj, 0, address, 0);
+    if (address != 0) {
+        obj_s->slave = 1;
+        i2c_slave_address(obj, 0, address, 0);
+    }
 #endif
 
     /* Keep Set event flag */


### PR DESCRIPTION
## Description
If I2C slave support is included, then the I2C error handler would always reset the I2C address, resulting in incorrectly changing the I2C state to listen for a controller configured as I2C master.  This change conditionalizes the address setting to only occur if the controller was in slave mode when the error occurred.

## Status
READY

## Migrations
NO

## Related PRs
None

## Todos
None

## Deploy notes
None

## Steps to test or reproduce
Create a build for an STM32 based board with DEVICE_I2CSLAVE and DEVICE_I2C_ASYNCH enabled (current default).  Create an I2C master and issue a .transfer() call to a non-existent I2C device address, so that the transfer will be NACKed.  HAL_I2C_ErrorCallback() will be called on the NACK and call i2c_slave_address(), resulting in the state being set to LISTEN.  Subsequent I2C transfer attempts to any address will then immediately fail because i2c_active() returns 1 (true) for any state other than READY.
