### PR TITLE
Fix a small bug in subtract_basepath

### DIFF
--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -138,7 +138,7 @@ def rewrite_basepath(file_name, resources, export_path, loc):
     export_path - the final destination of the file after export
     """
     new_f = join(loc, relpath(file_name, resources.file_basepath[file_name]))
-    resources.file_basepath[join(export_path, new_f)] = export_path
+    resources.file_basepath[new_f] = export_path
     return new_f
 
 
@@ -309,10 +309,10 @@ def export_project(src_paths, export_path, target, ide, libraries_paths=None,
     resources.file_basepath[config_header] = dirname(config_header)
 
     if zip_proj:
-        subtract_basepath(resources, export_path)
+        subtract_basepath(resources, ".")
         for loc, res in resource_dict.iteritems():
             temp = copy.deepcopy(res)
-            subtract_basepath(temp, export_path, loc)
+            subtract_basepath(temp, ".", loc)
             resources.add(temp)
     else:
         for _, res in resource_dict.iteritems():


### PR DESCRIPTION
It was causing tracebacks on the website. The make_key function of the
export object would use the basepath of every file and would not prefix
it with the export path. I don't know why we added the prefix in the
first place, so I removed it. Further, using any path other than "."
would result in ".." being the only group. that's definitely strange
behavior, but easy to work around: just pass in "."

## TESTS
 - [x] /morph export-build