### PR TITLE
DISCO_L053C8: Add support of USB Device

### DIFF
--- a/features/unsupported/USBDevice/USBDevice/USBEndpoints.h
+++ b/features/unsupported/USBDevice/USBDevice/USBEndpoints.h
@@ -45,7 +45,7 @@ typedef enum {
 #include "USBEndpoints_KL25Z.h"
 #elif !defined(USB_STM_HAL) && defined(TARGET_STM32F4)
 #include "USBEndpoints_STM32F4.h"
-#elif defined (TARGET_STM32F4) || defined (TARGET_STM32F2) || defined (TARGET_STM32F7) || defined (TARGET_STM32F3) || defined(TARGET_STM32L4) || defined(TARGET_STM32F1)
+#elif defined (TARGET_STM32F4) || defined (TARGET_STM32F2) || defined (TARGET_STM32F7) || defined (TARGET_STM32F3) || defined(TARGET_STM32L0) || defined(TARGET_STM32L4) || defined(TARGET_STM32F1)
 #include "USBEndpoints_STM32.h"
 #elif defined (TARGET_RZ_A1H) || defined (TARGET_VK_RZ_A1H)
 #include "USBEndpoints_RZ_A1H.h"

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/USBHAL_STM32L053C8.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/USBHAL_STM32L053C8.h
@@ -53,12 +53,14 @@ uint32_t HAL_PCDEx_GetTxFiFo(PCD_HandleTypeDef *hpcd, uint8_t fifo)
         return 1024;
 }
 
-void HAL_PCDEx_SetConnectionState(PCD_HandleTypeDef *hpcd, uint8_t state){
+void HAL_PCDEx_SetConnectionState(PCD_HandleTypeDef *hpcd, uint8_t state)
+{
     USBHAL_Private_t *priv=((USBHAL_Private_t *)(hpcd->pData));
     gpio_write(&(priv->usb_switch),state);
 }
 
-void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd) {
+void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd)
+{
     USBHAL_Private_t *priv=((USBHAL_Private_t *)(hpcd->pData));
     USBHAL *obj= priv->inst;
     uint32_t sofnum = (hpcd->Instance->FNR) & USB_FNR_FN;
@@ -68,7 +70,8 @@ void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd) {
 
 USBHAL * USBHAL::instance;
 
-USBHAL::USBHAL(void) {
+USBHAL::USBHAL(void)
+{
     /*  init parameter  */
     USBHAL_Private_t *HALPriv = new(USBHAL_Private_t);
     hpcd.Instance = USB;

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/USBHAL_STM32L053C8.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/USBHAL_STM32L053C8.h
@@ -1,0 +1,131 @@
+/* Copyright (c) 2016 mbed.org, MIT License
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+* and associated documentation files (the "Software"), to deal in the Software without
+* restriction, including without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all copies or
+* substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+* BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+#ifndef USBHAL_STM32L053C8_H
+#define USBHAL_STM32L053C8_H
+
+#define USBHAL_IRQn  USB_IRQn
+
+/*  must be multiple of 4 bytes */
+#define NB_ENDPOINT 8
+#define MAXTRANSFER_SIZE  0x200
+#define FIFO_USB_RAM_SIZE (MAXTRANSFER_SIZE+MAX_PACKET_SIZE_EP0+MAX_PACKET_SIZE_EP1+MAX_PACKET_SIZE_EP2+MAX_PACKET_SIZE_EP3)
+#if (FIFO_USB_RAM_SIZE > 0x500)
+#error "FIFO dimensioning incorrect"
+#endif
+
+typedef struct
+{
+	USBHAL *inst;
+	void (USBHAL::*bus_reset)(void);
+	void (USBHAL::*sof)(int frame);
+	void (USBHAL::*connect_change)(unsigned int  connected);
+	void (USBHAL::*suspend_change)(unsigned int suspended);
+	void (USBHAL::*ep0_setup)(void);
+	void (USBHAL::*ep0_in)(void);
+	void (USBHAL::*ep0_out)(void);
+	void (USBHAL::*ep0_read)(void);
+	bool (USBHAL::*ep_realise)(uint8_t endpoint, uint32_t maxPacket, uint32_t flags);
+	bool (USBHAL::*epCallback[6])(void);
+	uint8_t epComplete[2*NB_ENDPOINT];
+	/*  memorize dummy buffer used for reception */
+	uint32_t pBufRx[MAXTRANSFER_SIZE>>2];
+	uint32_t pBufRx0[MAX_PACKET_SIZE_EP0>>2];
+    gpio_t usb_switch;
+}USBHAL_Private_t;
+
+uint32_t HAL_PCDEx_GetTxFiFo(PCD_HandleTypeDef *hpcd, uint8_t fifo)
+{
+        return 1024;
+}
+
+void HAL_PCDEx_SetConnectionState(PCD_HandleTypeDef *hpcd, uint8_t state){
+    USBHAL_Private_t *priv=((USBHAL_Private_t *)(hpcd->pData));
+    gpio_write(&(priv->usb_switch),state);
+}
+
+void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd) {
+    USBHAL_Private_t *priv=((USBHAL_Private_t *)(hpcd->pData));
+    USBHAL *obj= priv->inst;
+    uint32_t sofnum = (hpcd->Instance->FNR) & USB_FNR_FN;
+    void (USBHAL::*func)(int frame) = priv->sof;
+    (obj->*func)(sofnum);
+}
+
+USBHAL * USBHAL::instance;
+
+USBHAL::USBHAL(void) {
+    /*  init parameter  */
+    USBHAL_Private_t *HALPriv = new(USBHAL_Private_t);
+    hpcd.Instance = USB;
+    /*  initialized Init to zero (constructor does not zero initialized the
+     *  area */
+    /*  initialized all field of init including 0 field  */
+    /*  constructor does not fill with zero */
+    memset(&hpcd.Init, 0, sizeof(hpcd.Init));
+    hpcd.Init.dev_endpoints = NB_ENDPOINT;
+    hpcd.Init.ep0_mps =   MAX_PACKET_SIZE_EP0;
+    hpcd.Init.phy_itface = PCD_PHY_EMBEDDED;
+    hpcd.Init.Sof_enable = 1;
+    hpcd.Init.speed = PCD_SPEED_FULL;
+    /*  pass instance for usage inside call back */
+    HALPriv->inst = this;
+    HALPriv->bus_reset = &USBHAL::busReset;
+    HALPriv->suspend_change = &USBHAL::suspendStateChanged;
+    HALPriv->connect_change = &USBHAL::connectStateChanged;
+    HALPriv->sof = &USBHAL::SOF;
+    HALPriv->ep0_setup = &USBHAL::EP0setupCallback;
+    HALPriv->ep_realise = &USBHAL::realiseEndpoint;
+    HALPriv->ep0_in = &USBHAL::EP0in;
+    HALPriv->ep0_out = &USBHAL::EP0out;
+    HALPriv->ep0_read = &USBHAL::EP0read;
+    hpcd.pData = (void*)HALPriv;
+    HALPriv->epCallback[0] = &USBHAL::EP1_OUT_callback;
+    HALPriv->epCallback[1] = &USBHAL::EP1_IN_callback;
+    HALPriv->epCallback[2] = &USBHAL::EP2_OUT_callback;
+    HALPriv->epCallback[3] = &USBHAL::EP2_IN_callback;
+    HALPriv->epCallback[4] = &USBHAL::EP3_OUT_callback;
+    HALPriv->epCallback[5] = &USBHAL::EP3_IN_callback;
+    instance = this;
+    
+    /* Configure USB DM pin. This is optional, and maintained only for user guidance. */
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    pin_function(PA_11, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF2_USB));
+    pin_function(PA_12, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF2_USB));
+    
+    /* Enable USB Clock */
+    __HAL_RCC_USB_CLK_ENABLE();
+    
+    /* Enable SYSCFG Clock */
+    __HAL_RCC_SYSCFG_CLK_ENABLE();
+    hpcd.State = HAL_PCD_STATE_RESET;
+    HAL_PCD_Init(&hpcd);
+    
+    /* hardcoded size of FIFO according definition*/
+    HAL_PCDEx_PMAConfig(&hpcd , 0x00 , PCD_SNG_BUF, 0x30);
+    HAL_PCDEx_PMAConfig(&hpcd , 0x80 , PCD_SNG_BUF, 0x70);
+#if 1
+    HAL_PCDEx_PMAConfig(&hpcd , 0x3, PCD_DBL_BUF, 0x018000b0);
+#else
+    HAL_PCDEx_PMAConfig(&hpcd , 0x3, PCD_SNG_BUF, 0x180);
+#endif
+    HAL_PCDEx_PMAConfig(&hpcd , 0x83, PCD_SNG_BUF, 0xb0);
+    NVIC_SetVector(USBHAL_IRQn,(uint32_t)&_usbisr);
+    NVIC_SetPriority(USBHAL_IRQn, 1);
+    HAL_PCD_Start(&hpcd);
+}
+#endif

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/USBHAL_STM_TARGET.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/USBHAL_STM_TARGET.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2016 mbed.org, MIT License
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+* and associated documentation files (the "Software"), to deal in the Software without
+* restriction, including without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all copies or
+* substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+* BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+#include "USBHAL_STM32L053C8.h"

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/device/system_stm32l0xx.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/device/system_stm32l0xx.c
@@ -377,10 +377,8 @@ uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
     RCC_OscInitStruct.HSEState          = RCC_HSE_BYPASS; /* External 8 MHz clock on OSC_IN */
   }
   RCC_OscInitStruct.HSIState            = RCC_HSI_OFF;
-#if !defined (STM32L031xx) && !defined (STM32L041xx) && !defined(STM32L051xx) && !defined(STM32L061xx) && !defined(STM32L071xx)  && !defined(STM32L081xx) && \
-  !defined (STM32L011xx) && !defined (STM32L021xx)
   RCC_OscInitStruct.HSI48State          = RCC_HSI48_ON; /* For USB and RNG clock */
-#endif
+
   // PLLCLK = (8 MHz * 8)/2 = 32 MHz
   RCC_OscInitStruct.PLL.PLLState        = RCC_PLL_ON;
   RCC_OscInitStruct.PLL.PLLSource       = RCC_PLLSOURCE_HSE;
@@ -390,6 +388,12 @@ uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
   {
     return 0; // FAIL
   }
+
+  /* Select HSI48 as USB clock source */
+  RCC_PeriphCLKInitTypeDef  PeriphClkInitStruct;
+  PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
+  PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
+  HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct);
 
   /* Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2 clocks dividers */
   RCC_ClkInitStruct.ClockType      = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);


### PR DESCRIPTION
## Description
Add the support of USB Device on the DISCO_L053C8 platform.

USB_1 (HID) and USB_4 (Serial) tests are OK.

Fix Issue #4010 

## Status
READY

## Migrations
NO
