### PR TITLE
cmsis5: fixing not portable way to allocate statically control blocks to rtos objects

### DIFF
--- a/rtos/MemoryPool.h
+++ b/rtos/MemoryPool.h
@@ -26,7 +26,7 @@
 #include <string.h>
 
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
+#include "cmsis_os2_storage.h"
 
 namespace rtos {
 /** \addtogroup rtos */

--- a/rtos/Mutex.h
+++ b/rtos/Mutex.h
@@ -24,7 +24,7 @@
 
 #include <stdint.h>
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
+#include "cmsis_os2_storage.h"
 
 namespace rtos {
 /** \addtogroup rtos */

--- a/rtos/Queue.h
+++ b/rtos/Queue.h
@@ -26,7 +26,7 @@
 #include <string.h>
 
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
+#include "cmsis_os2_storage.h"
 #include "platform/mbed_error.h"
 
 namespace rtos {

--- a/rtos/Semaphore.h
+++ b/rtos/Semaphore.h
@@ -24,7 +24,7 @@
 
 #include <stdint.h>
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
+#include "cmsis_os2_storage.h"
 
 namespace rtos {
 /** \addtogroup rtos */

--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -24,7 +24,7 @@
 
 #include <stdint.h>
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
+#include "cmsis_os2_storage.h"
 #include "mbed_rtx_conf.h"
 #include "platform/Callback.h"
 #include "platform/mbed_toolchain.h"

--- a/rtos/mbed_boot.c
+++ b/rtos/mbed_boot.c
@@ -162,7 +162,7 @@
 
 #include "cmsis.h"
 #include "mbed_rtx.h"
-#include "rtx_lib.h"
+#include "cmsis_os2_storage.h"
 #include "cmsis_os2.h"
 #include "mbed_toolchain.h"
 #include "mbed_error.h"

--- a/rtos/rtx2/TARGET_CORTEX_M/cmsis_os2_storage.h
+++ b/rtos/rtx2/TARGET_CORTEX_M/cmsis_os2_storage.h
@@ -1,0 +1,27 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CMSIS_OS_STORAGE_H
+#define CMSIS_OS_STORAGE_H
+
+
+#include "rtx_lib.h"
+
+
+#endif
+
+
+


### PR DESCRIPTION
followed @kjbracey-arm  advice.

related issues:

#3986 
#4011 

## Status
**READY**


