### PR TITLE
[STM32L0] reduce IAR heap and stack size for small targets

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/device/TOOLCHAIN_IAR/stm32l053xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/device/TOOLCHAIN_IAR/stm32l053xx.icf
@@ -15,8 +15,8 @@ define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__]
 define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 
 /* Stack and Heap */
-define symbol __size_cstack__ = 0x500;
-define symbol __size_heap__   = 0x1000;
+define symbol __size_cstack__ = 0x400;
+define symbol __size_heap__   = 0x800;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/device/TOOLCHAIN_IAR/stm32l031xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/device/TOOLCHAIN_IAR/stm32l031xx.icf
@@ -15,8 +15,8 @@ define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__]
 define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 
 /* Stack and Heap */
-define symbol __size_cstack__ = 0x500;
-define symbol __size_heap__   = 0x1000;
+define symbol __size_cstack__ = 0x400;
+define symbol __size_heap__   = 0x800;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/device/TOOLCHAIN_IAR/stm32l053xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/device/TOOLCHAIN_IAR/stm32l053xx.icf
@@ -15,8 +15,8 @@ define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__]
 define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 
 /* Stack and Heap */
-define symbol __size_cstack__ = 0x500;
-define symbol __size_heap__   = 0x1000;
+define symbol __size_cstack__ = 0x400;
+define symbol __size_heap__   = 0x800;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };


### PR DESCRIPTION
## Description
I decreased heap and stack size for some "small" OS2 targets:
- DISCO_L053C8
- NUCLEO_L053R8
- NUCLEO_L031K6

## Status
READY


## Tests
![image](https://cloud.githubusercontent.com/assets/12710147/24345812/1f57f4da-12d2-11e7-93bb-41172a2a1905.png)


