### PR TITLE
STM32 increase IAR heap size for big RAM targets

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/device/TOOLCHAIN_IAR/stm32f412xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/device/TOOLCHAIN_IAR/stm32f412xx.icf
@@ -15,7 +15,6 @@ define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__]
 define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 
 /* Stack and Heap */
-/*Heap 1/4 of ram and stack 1/8*/
 define symbol __size_cstack__ = 0x8000;
 define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/device/TOOLCHAIN_IAR/stm32f469xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/device/TOOLCHAIN_IAR/stm32f469xx.icf
@@ -15,9 +15,8 @@ define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__]
 define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 
 /* Stack and Heap */
-/*Heap 1/4 of ram and stack 1/8*/
 define symbol __size_cstack__ = 0x4000;
-define symbol __size_heap__   = 0x8000;
+define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/TOOLCHAIN_IAR/stm32f756xg.icf
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/TOOLCHAIN_IAR/stm32f756xg.icf
@@ -19,9 +19,8 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define region ITCMRAM_region = mem:[from __region_ITCMRAM_start__ to __region_ITCMRAM_end__];
 
 /* Stack and Heap */
-/*Heap 1/4 of ram and stack 1/8*/
 define symbol __size_cstack__ = 0x4000;
-define symbol __size_heap__   = 0x8000;
+define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_IAR/stm32f767xi.icf
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_IAR/stm32f767xi.icf
@@ -19,9 +19,8 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define region ITCMRAM_region = mem:[from __region_ITCMRAM_start__ to __region_ITCMRAM_end__];
 
 /* Stack and Heap */
-/*Heap 1/4 of ram and stack 1/8*/
 define symbol __size_cstack__ = 0x8000;
-define symbol __size_heap__   = 0x8000;
+define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/TOOLCHAIN_IAR/stm32f769xi.icf
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/TOOLCHAIN_IAR/stm32f769xi.icf
@@ -19,9 +19,8 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define region ITCMRAM_region = mem:[from __region_ITCMRAM_start__ to __region_ITCMRAM_end__];
 
 /* Stack and Heap */
-/*Heap 1/4 of ram and stack 1/8*/
 define symbol __size_cstack__ = 0x8000;
-define symbol __size_heap__   = 0x8000;
+define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };


### PR DESCRIPTION
## Description
Following https://github.com/ARMmbed/mbed-os/pull/3920
I have updated the heap size for all targets with 192K RAM and more

## Status
READY

## Tests
OS5 results are coming.
OS2 tests:
![image](https://cloud.githubusercontent.com/assets/12710147/24346595/497ee39c-12d5-11e7-9918-26e43400c3ee.png)

