### PR TITLE
Remove explicit include of flash_data.h in flash api test

### DIFF
--- a/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -24,7 +24,6 @@
 
 #include "mbed.h"
 #include "flash_api.h"
-#include "flash_data.h"
 
 using namespace utest::v1;
 


### PR DESCRIPTION
## Description
The header is already included inside of flash_api.h if the target
uses CMSIS flash algos. If it doesn't, the file shouldn't be included,
since it doesn't exist.

## Status
**READY**

## Migrations
NO

## Steps to test or reproduce
Run the flash tests on a device that implements the flash API using the HAL functions directly, without using the CMSIS flash algorithms. On current master, the test will fail to compile, because flash_data.h doesn't exist.