### PR TITLE
[Silicon Labs] Add flash HAL API support

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/common/objects.h
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/common/objects.h
@@ -145,6 +145,11 @@ typedef enum {
 } sleepstate_enum;
 #endif
 
+#if DEVICE_FLASH
+struct flash_s {
+    MSC_TypeDef *msc;
+};
+#endif
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/flash_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/flash_api.c
@@ -1,0 +1,138 @@
+/***************************************************************************//**
+ * @file flash_api.c
+ *******************************************************************************
+ * @section License
+ * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#include "device.h"
+#if DEVICE_FLASH
+
+#include "flash_api.h"
+#include "em_msc.h"
+
+/** Initialize the flash peripheral and the flash_t object
+ *
+ * @param obj The flash object
+ * @return 0 for success, -1 for error
+ */
+int32_t flash_init(flash_t *obj)
+{
+    (void)obj;
+    return 0;
+}
+
+/** Uninitialize the flash peripheral and the flash_t object
+ *
+ * @param obj The flash object
+ * @return 0 for success, -1 for error
+ */
+int32_t flash_free(flash_t *obj)
+{
+    (void)obj;
+    return 0;
+}
+
+/** Erase one sector starting at defined address
+ *
+ * The address should be at sector boundary. This function does not do any check for address alignments
+ * @param obj The flash object
+ * @param address The sector starting address
+ * @return 0 for success, -1 for error
+ */
+int32_t flash_erase_sector(flash_t *obj, uint32_t address)
+{
+    (void)obj;
+    MSC_Status_TypeDef mscStatus = MSC_ErasePage((uint32_t *)address);
+
+    return (mscStatus == mscReturnOk) ? 0 : -1;
+}
+
+/** Program one page starting at defined address
+ *
+ * The page should be at page boundary, should not cross multiple sectors.
+ * This function does not do any check for address alignments or if size is aligned to a page size.
+ * @param obj The flash object
+ * @param address The sector starting address
+ * @param data The data buffer to be programmed
+ * @param size The number of bytes to program
+ * @return 0 for success, -1 for error
+ */
+int32_t flash_program_page(flash_t *obj, uint32_t address, const uint8_t *data, uint32_t size)
+{
+    (void)obj;
+    MSC_Status_TypeDef mscStatus = MSC_WriteWord((uint32_t *)address, data, size);
+
+    return (mscStatus == mscReturnOk) ? 0 : -1;
+}
+
+/** Get sector size
+ *
+ * @param obj The flash object
+ * @param address The sector starting address
+ * @return The size of a sector
+ */
+uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address)
+{
+    (void)obj;
+    (void)address;
+
+    if (address < FLASH_BASE || address >= FLASH_BASE + FLASH_SIZE) {
+        // Address outside of flash -- invalid sector
+        return MBED_FLASH_INVALID_SIZE;
+    }
+
+    return FLASH_PAGE_SIZE;
+}
+
+/** Get page size
+ *
+ * @param obj The flash object
+ * @param address The page starting address
+ * @return The size of a page
+ */
+uint32_t flash_get_page_size(const flash_t *obj)
+{
+    (void)obj;
+    return FLASH_PAGE_SIZE;
+}
+
+/** Get start address for the flash region
+ *
+ * @param obj The flash object
+ * @return The start address for the flash region
+ */
+uint32_t flash_get_start_address(const flash_t *obj)
+{
+    (void)obj;
+    return FLASH_BASE;
+}
+
+/** Get the flash region size
+ *
+ * @param obj The flash object
+ * @return The flash region size
+ */
+uint32_t flash_get_size(const flash_t *obj)
+{
+    (void)obj;
+    return FLASH_SIZE;
+}
+
+#endif // DEVICE_FLASH

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1931,7 +1931,7 @@
     "EFM32GG_STK3700": {
         "inherits": ["EFM32GG990F1024"],
         "progen": {"target": "efm32gg-stk"},
-        "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -1983,7 +1983,7 @@
     },
     "EFM32LG_STK3600": {
         "inherits": ["EFM32LG990F256"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "FLASH"],
         "forced_reset_timeout": 2,
         "device_name": "EFM32LG990F256",
         "config": {
@@ -2037,7 +2037,7 @@
     "EFM32WG_STK3800": {
         "inherits": ["EFM32WG990F256"],
         "progen": {"target": "efm32wg-stk"},
-        "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -2197,7 +2197,7 @@
     },
     "EFM32PG_STK3401": {
         "inherits": ["EFM32PG1B100F256GM32"],
-        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -2258,7 +2258,7 @@
     },
     "EFR32MG1_BRD4150": {
         "inherits": ["EFR32MG1P132F256GM48"],
-        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -2301,7 +2301,7 @@
     },
     "THUNDERBOARD_SENSE": {
         "inherits": ["EFR32MG1P233F256GM48"],
-        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "FLASH"],
         "forced_reset_timeout": 5,
         "config": {
             "hf_clock_src": {
@@ -2347,7 +2347,7 @@
     },
     "EFM32PG12_STK3402": {
         "inherits": ["EFM32PG12B500F1024GL125"],
-        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -2398,7 +2398,7 @@
     },
 	"THUNDERBOARD_SENSE_12": {
         "inherits": ["EFR32MG12P332F1024GL125"],
-        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "FLASH"],
         "forced_reset_timeout": 5,
         "config": {
             "hf_clock_src": {


### PR DESCRIPTION
## Description
Implements the flash HAL API for EFM32 and EFR32.

## Status
**READY**

## Migrations
NO

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
Bugfix to flash API test | [#4036](https://github.com/ARMmbed/mbed-os/pull/4036)

## Todos
- [x] Tests

## Steps to test or reproduce
Run the flash HAL and flash IAP tests on any EFM32GG, WG, LG, PG1 or PG12, or EFR32MG1 or MG12 target. They pass if the test bugfix referenced above is applied.