### PR TITLE
[Silicon Labs] Fix compile warnings and ticker test failure

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/common/objects.h
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/common/objects.h
@@ -37,9 +37,9 @@ extern "C" {
 #endif
 
 typedef struct {
-    PinName pin:8;
-    PinMode mode:6;
-    PinDirection dir:2;
+    PinName pin;
+    PinMode mode;
+    PinDirection dir;
 } gpio_t;
 
 #if DEVICE_ANALOGIN
@@ -84,9 +84,9 @@ struct pwmout_s {
 
 #if DEVICE_INTERRUPTIN
 struct gpio_irq_s {
-    PinName pin:8; // Pin number 4 least significant bits, port number 4 most significant bits
-    uint32_t risingEdge:1;
-    uint32_t fallingEdge:1;
+    PinName pin;
+    uint8_t risingEdge;
+    uint8_t fallingEdge;
 };
 #endif
 

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/lp_ticker.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/lp_ticker.c
@@ -95,7 +95,6 @@ void lp_ticker_set_interrupt(timestamp_t timestamp)
 inline void lp_ticker_disable_interrupt()
 {
     RTC_IntDisable(RTC_IF_COMP0);
-    lp_ticker_free();
 }
 
 inline void lp_ticker_clear_interrupt()
@@ -164,7 +163,6 @@ void lp_ticker_set_interrupt(timestamp_t timestamp)
 inline void lp_ticker_disable_interrupt()
 {
     RTCC_IntDisable(RTCC_IF_CC0);
-    lp_ticker_free();
 }
 
 inline void lp_ticker_clear_interrupt()


### PR DESCRIPTION
* Using PinName as bitfield doesn't work without warnings, since NC
  needs all 32 bits to be represented.
* lp_ticker should not be freed when interrupt is disabled, since this
  will kill the timebase. This change makes the lp_ticker related tests pass.