### PR TITLE
USBHOST : fix device disconnection from hub during hub port reset

### DIFF
--- a/features/unsupported/USBHost/USBHostHub/USBHostHub.cpp
+++ b/features/unsupported/USBHost/USBHostHub/USBHostHub.cpp
@@ -227,6 +227,9 @@ void USBHostHub::portReset(uint8_t port) {
 #endif
     while(1) {
         status = getPortStatus(port);
+        /*  disconnection since reset request */
+        if (!(status & PORT_CONNECTION))
+            break;
         if (status & (PORT_ENABLE | PORT_RESET))
             break;
         if (status & PORT_OVER_CURRENT) {


### PR DESCRIPTION
## Description
If device is disconnected from hub during the hub port reset request, the reset function keeps waiting for reset done.  
## Status
READY