### PR TITLE
tools - turn off page alignment of sections

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -11,7 +11,8 @@
         "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
                "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r",
-               "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit"]
+               "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
+               "-Wl,-n"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -11,7 +11,8 @@
         "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
                "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r",
-               "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit"]
+               "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
+               "-Wl,-n"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -11,7 +11,8 @@
         "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
                "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r",
-               "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit"]
+               "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
+               "-Wl,-n"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",


### PR DESCRIPTION
## Description

By default, ld sets page alignment of sections to 0x8000, which bloats
up elf file size. This behavior is unnecessary for MCU.

Example:

1. page alignment on

mbed.elf file size 144936

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x008000 0x00000000 0x00000000 0x00400 0x00400 R   0x8000
  LOAD           0x008400 0x00000400 0x00000400 0x00010 0x00010 R   0x8000
  LOAD           0x008410 0x00000410 0x00000410 0x0ab3c 0x0ab3c RWE 0x8000
  LOAD           0x018000 0x20000000 0x0000af4c 0x008d0 0x008d0 RW  0x8000
  LOAD           0x01b81c 0x0000b81c 0x0000b81c 0x00000 0x00004 RW  0x8000
  LOAD           0x020000 0x1fff0000 0x1fff0000 0x00000 0x00400 RW  0x8000
  LOAD           0x0188d0 0x200008d0 0x200008d0 0x00000 0x08860 RW  0x8000

2. page alignment off

mbed.elf file size 91792

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x000114 0x00000000 0x00000000 0x00400 0x00400 R   0x4
  LOAD           0x000514 0x00000400 0x00000400 0x00010 0x00010 R   0x1
  LOAD           0x000528 0x00000410 0x00000410 0x0ab3c 0x0ab3c RWE 0x8
  LOAD           0x00b068 0x20000000 0x0000af4c 0x008d0 0x008d0 RW  0x8
  LOAD           0x00b938 0x0000b81c 0x0000b81c 0x00000 0x00004 RW  0x1
  LOAD           0x00b938 0x1fff0000 0x1fff0000 0x00000 0x00400 RW  0x1
  LOAD           0x00b938 0x200008d0 0x200008d0 0x00000 0x08860 RW  0x8

## Status
READY

## Migrations
NO

## Related PRs
NONE

## Todos
NONE

## Deploy notes
NONE

## Steps to test or reproduce
NONE