### PR TITLE
Add TRNG support for KW41Z

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/trng_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/trng_api.c
@@ -1,0 +1,60 @@
+/*
+ *  Hardware entropy collector for the K64F, using Freescale's RNGA
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * Reference: "K64 Sub-Family Reference Manual, Rev. 2", chapter 34
+ */
+
+#if defined(DEVICE_TRNG)
+
+#include "fsl_trng.h"
+#include "trng_api.h"
+
+void trng_init(trng_t *obj)
+{
+    trng_config_t trngConfig;
+
+    TRNG_GetDefaultConfig(&trngConfig);
+    /* Set sample mode of the TRNG ring oscillator to Von Neumann, for better random data.*/
+    trngConfig.sampleMode = kTRNG_SampleModeVonNeumann;
+    /* Initialize TRNG */
+    TRNG_Init(TRNG0, &trngConfig);
+}
+
+void trng_free(trng_t *obj)
+{
+    TRNG_Deinit(TRNG0);
+}
+
+int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_length)
+{
+    status_t result;
+
+    result = TRNG_GetRandomData(TRNG0, output, length);
+
+    if (result == kStatus_Success) {
+        *output_length = length;
+        return 0;
+    } else {
+        return -1;
+    }
+}
+
+#endif

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -567,7 +567,7 @@
         "macros": ["CPU_MKW41Z512VHT4", "FSL_RTOS_MBED"],
         "inherits": ["Target"],
         "detect_code": ["0201"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "TRNG", "STDIO_MESSAGES"],
         "release_versions": ["2", "5"],
         "device_name": "MKW41Z512xxx4"
     },


### PR DESCRIPTION
Add support to use the TRNG module for entropy generation.

## Status
**READY

- [x] Tests
Passed mbed compliance tests.