### PR TITLE
lpc1768: Remove invalid use of IP_SOF_BROADCAST_RECV option

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NXP/lpc17_emac.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NXP/lpc17_emac.c
@@ -861,11 +861,7 @@ static err_t low_level_init(struct netif *netif)
 		return ERR_BUF;
 
 	/* Enable packet reception */
-#if IP_SOF_BROADCAST_RECV
 	LPC_EMAC->RxFilterCtrl = EMAC_RFC_PERFECT_EN | EMAC_RFC_BCAST_EN | EMAC_RFC_MCAST_EN;
-#else
-	LPC_EMAC->RxFilterCtrl = EMAC_RFC_PERFECT_EN;
-#endif
 
 	/* Clear and enable rx/tx interrupts */
 	LPC_EMAC->IntClear = 0xFFFF;


### PR DESCRIPTION
From opt.h:
> IP_SOF_BROADCAST_RECV (requires IP_SOF_BROADCAST=1) enable the broadcast filter on recv operations.

The IP_SOF_BROADCAST_RECV option does not enable or disable recieving broadcast packets, it only enables a software filter. The lpc1768 was using the IP_SOF_BROADCAST_RECV to disable recieving broadcasts entirely.

This resulted in an issue for certain DHCP servers, which apparently can respond to discover packets via broadcast.

Tested locally with with dump provided by @chrissnow

related: https://github.com/ARMmbed/mbed-os/issues/4018, https://github.com/ARMmbed/mbed-os-example-sockets/issues/17
cause: https://github.com/ARMmbed/mbed-os/pull/3482
cc: @chrissnow, @toyowata, @kjbracey-arm 

