### PR TITLE
Improve error messages for bootloader build errors

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -479,7 +479,15 @@ class Config(object):
         """Generate a list of regions from the config"""
         if not self.target.bootloader_supported:
             raise ConfigException("Bootloader not supported on this target.")
-        cmsis_part = Cache(False, False).index[self.target.device_name]
+        if not hasattr(self.target, "device_name"):
+            raise ConfigException("Bootloader not supported on this target: "
+                                  "targets.json `device_name` not specified.")
+        cache = Cache(False, False)
+        if self.target.device_name not in cache.index:
+            raise ConfigException("Bootloader not supported on this target: "
+                                  "targets.json `device_name` not found in "
+                                  "arm_pack_manager index.")
+        cmsis_part = cache.index[self.target.device_name]
         start = 0
         target_overrides = self.app_config_data['target_overrides'].get(
             self.target.name, {})


### PR DESCRIPTION
The error messages related to missing or broken device names in the
targets.json file were bad/just python tracebacks. This PR changes that
behavior, by having the Config object raise ConfigExceptions for those
mis-configurations.

Resolves #4057

## Testing
 - [x] Normal /morph test
 - [x] Manual exercise of each corner case and verification that the
 messages seen are good.

### Manual testing
 - `mbed_app.json`
```
{
    "target_overrides":{
        "NCS36510":{
            "target.restrict_size": "0x40000"
        }
    }
}
```
- `mbed compile -m NCS36510`
```
[ERROR] Bootloader not supported on this target.
```
- add `"bootloader_supported": true` to `targets.json`
- `mbed compile -m NCS36510`
```
[ERROR] Bootloader not supported on this target: targets.json `device_name` not specified.
```
- add `"device_name": "NCS36510"` to `targets.json`
- `mbed compile -m NCS36510`
```
[ERROR] Bootloader not supported on this target: targets.json `device_name` not found in arm_pack_manager index.
```