### PR TITLE
K66F: Move bss section to m_data_2 Section

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_GCC_ARM/MK66FN2M0xxx18.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_GCC_ARM/MK66FN2M0xxx18.ld
@@ -223,7 +223,7 @@ SECTIONS
     . = ALIGN(4);
     __bss_end__ = .;
     __END_BSS = .;
-  } > m_data
+  } > m_data_2
 
   .heap :
   {


### PR DESCRIPTION
Move bss section to m_data_2 Section. This should fix below issue:
https://github.com/ARMmbed/mbed-os/issues/3978

## Status
**READY

- [x] Tests
Passed the mbed K66F test suite
