### PR TITLE
Update gnuarmeclipse to preprocess linker scripts

### DIFF
--- a/tools/export/gnuarmeclipse/__init__.py
+++ b/tools/export/gnuarmeclipse/__init__.py
@@ -243,7 +243,9 @@ class GNUARMEclipse(Exporter):
             opts['ld']['object_files'] = objects
             opts['ld']['user_libraries'] = libraries
             opts['ld']['system_libraries'] = self.system_libraries
-            opts['ld']['script'] = self.ld_script
+            opts['ld']['script'] = join(id.capitalize(),
+                                        "linker-script-%s.ld" % id)
+            opts['cpp_cmd'] = " ".join(toolchain.preproc)
 
             # Unique IDs used in multiple places.
             # Those used only once are implemented with {{u.id}}.
@@ -260,6 +262,7 @@ class GNUARMEclipse(Exporter):
 
         jinja_ctx = {
             'name': self.project_name,
+            'ld_script': self.ld_script,
 
             # Compiler & linker command line options
             'options': self.options,

--- a/tools/export/gnuarmeclipse/makefile.targets.tmpl
+++ b/tools/export/gnuarmeclipse/makefile.targets.tmpl
@@ -3,5 +3,11 @@
 mbedclean:
 	$(RM) $(OBJS)
 	$(RM) $(CC_DEPS)$(C++_DEPS)$(C_UPPER_DEPS)$(CXX_DEPS)$(ASM_DEPS)$(S_UPPER_DEPS)$(C_DEPS)$(CPP_DEPS)
-	$(RM) $(SECONDARY_FLASH)$(SECONDARY_SIZE) {{name}}.*
+	$(RM) $(SECONDARY_FLASH)$(SECONDARY_SIZE) {{name}}.* linker-script-*.ld
 	-@echo ' '
+
+{% for config, data in options.iteritems() %}
+linker-script-{{config}}.ld: ../{{ld_script}}
+	{{data.cpp_cmd}} {{data.ld.other}} $< -o $@
+{{name}}.elf: linker-script-{{config}}.ld
+{% endfor %}


### PR DESCRIPTION
PR #3706 changed the behavior of `.ld` files in mbed-os. After that PR, all `.ld` files are passed through the C pre-processor before handing them off to the linker. This PR changes the GNU ARM Eclipse exporter to do that pre-processing as well.

## Todos
- [x] /morph export-build (with gnuarmeclipse enabled please)
- [x] Review by @bridadan 
- [x] Review by @ilg-ul 

## Notes
At the moment, the implementation pre-processes the linker script for all profiles, when it only needs one. This is because I was not able to find a way to get the linker other flags as a make variable. @ilg-ul is it possible to get the linker other flags in a Makefile variable for the `makefile.targets` extension?