### PR TITLE
Elide adding regions to profile when empty

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -283,6 +283,8 @@ def add_regions_to_profile(profile, config, toolchain_class):
     config - the configuration object that owns the region
     toolchain_class - the class of the toolchain being used
     """
+    if not profile:
+        return
     regions = list(config.regions)
     for region in regions:
         for define in [(region.name.upper() + "_ADDR", region.start),


### PR DESCRIPTION
Resolves #4055

The add_regions_to_profile function assumed that there would always be a
profile to add regions to. If the profile is not specified, we would get
a traceback. Instead of bombing horribly, we should just elide adding
the region list to the profile when it does not exist.

# Testing
- [x] manual verification that the issue in #4055 no longer happens

# CC
@0xc0170 
@tkaman