### PR TITLE
Removed superfluous space

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -35,7 +35,7 @@
     },
     "IAR": {
         "common": [
-            "--no_wrap_diagnostics",  "-e",
+            "--no_wrap_diagnostics", "-e",
             "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-On", "-r"],
         "asm": [],
         "c": ["--vla"],


### PR DESCRIPTION
The extra space between "--no_wrap_diagnostics" and "-e" is inconsistent with the development and release targets.

It bugs people (like me) that have little OCD tics 😉.