### PR TITLE
[Silicon Labs] Bugfix for bootloader on Pearl and Mighty Gecko

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG/device/TARGET_256K/TOOLCHAIN_GCC_ARM/efm32pg1b.ld
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG/device/TARGET_256K/TOOLCHAIN_GCC_ARM/efm32pg1b.ld
@@ -219,5 +219,5 @@ SECTIONS
   ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
 
   /* Check if FLASH usage exceeds FLASH size */
-  ASSERT( LENGTH(FLASH) >= (__etext + SIZEOF(.data)), "FLASH memory overflowed !")
+  ASSERT(ORIGIN(FLASH) + LENGTH(FLASH) >= (__etext + SIZEOF(.data)), "FLASH memory overflowed !")
 }

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/device/TOOLCHAIN_GCC_ARM/efm32pg12b.ld
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/device/TOOLCHAIN_GCC_ARM/efm32pg12b.ld
@@ -219,5 +219,5 @@ SECTIONS
   ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
 
   /* Check if FLASH usage exceeds FLASH size */
-  ASSERT( LENGTH(FLASH) >= (__etext + SIZEOF(.data)), "FLASH memory overflowed !")
+  ASSERT(ORIGIN(FLASH) + LENGTH(FLASH) >= (__etext + SIZEOF(.data)), "FLASH memory overflowed !")
 }

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/device/TOOLCHAIN_GCC_ARM/efr32mg1p.ld
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/device/TOOLCHAIN_GCC_ARM/efr32mg1p.ld
@@ -219,5 +219,5 @@ SECTIONS
   ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
 
   /* Check if FLASH usage exceeds FLASH size */
-  ASSERT( LENGTH(FLASH) >= (__etext + SIZEOF(.data)), "FLASH memory overflowed !")
+  ASSERT( ORIGIN(FLASH) + LENGTH(FLASH) >= (__etext + SIZEOF(.data)), "FLASH memory overflowed !")
 }

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/device/TOOLCHAIN_GCC_ARM/efr32mg12p.ld
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/device/TOOLCHAIN_GCC_ARM/efr32mg12p.ld
@@ -219,5 +219,5 @@ SECTIONS
   ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
 
   /* Check if FLASH usage exceeds FLASH size */
-  ASSERT( LENGTH(FLASH) >= (__etext + SIZEOF(.data)), "FLASH memory overflowed !")
+  ASSERT(ORIGIN(FLASH) + LENGTH(FLASH) >= (__etext + SIZEOF(.data)), "FLASH memory overflowed !")
 }

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/common/mbed_overrides.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/common/mbed_overrides.c
@@ -38,19 +38,20 @@ void mbed_sdk_init()
 {
     CHIP_Init();
 
-#if defined(_SILICON_LABS_32B_PLATFORM_2)
+#if defined(_SILICON_LABS_32B_SERIES_1)
     EMU_DCDCInit_TypeDef dcdcInit = EMU_DCDCINIT_DEFAULT;
     EMU_DCDCInit(&dcdcInit);
     
+#if (CORE_CLOCK_SOURCE == HFXO)
+    // Only init HFXO if not already done (e.g. by bootloader)
+    if (CMU_ClockSelectGet(cmuClock_HF) != cmuSelect_HFXO) {
 #if defined(_EFR_DEVICE)
-    CMU_HFXOInit_TypeDef hfxoInit = CMU_HFXOINIT_WSTK_DEFAULT;
-    // Initialize the HFXO using the settings from the WSTK bspconfig.h
-    // Note: This configures things like the capacitive tuning CTUNE variable
-    //   which can vary based on your hardware design.
-    CMU_HFXOInit(&hfxoInit);
+        CMU_HFXOInit_TypeDef hfxoInit = CMU_HFXOINIT_WSTK_DEFAULT;
 #else
-    CMU_HFXOInit_TypeDef hfxoInit = CMU_HFXOINIT_STK_DEFAULT;
-    CMU_HFXOInit(&hfxoInit);
+        CMU_HFXOInit_TypeDef hfxoInit = CMU_HFXOINIT_STK_DEFAULT;
+#endif
+        CMU_HFXOInit(&hfxoInit);
+    }
 #endif
 #endif
 


### PR DESCRIPTION
Linker assert should take main app flash offset into account. Also, HFXO should not be re-initialized when bootloader has already initialized it (and core is already running from it).