### PR TITLE
Fix to the mbedtls test to resolve namespace conflict when running on Kinetis devices

### DIFF
--- a/TESTS/mbedtls/ecp/main.cpp
+++ b/TESTS/mbedtls/ecp/main.cpp
@@ -20,8 +20,6 @@
 #include "utest.h"
 #include "rtos.h"
 
-using namespace utest::v1;
-
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
 #else
@@ -38,6 +36,8 @@ using namespace utest::v1;
 #include <stdio.h>
 #include <stdlib.h>
 #endif
+
+using namespace utest::v1;
 
 #ifndef PUT_UINT32_BE
 #define PUT_UINT32_BE(n,b,i)                            \

--- a/TESTS/mbedtls/selftest/main.cpp
+++ b/TESTS/mbedtls/selftest/main.cpp
@@ -20,8 +20,6 @@
 #include "utest.h"
 #include "rtos.h"
 
-using namespace utest::v1;
-
 #if !defined(MBEDTLS_CONFIG_FILE)
 #include "mbedtls/config.h"
 #else
@@ -48,6 +46,8 @@ using namespace utest::v1;
 #define MBEDTLS_EXIT_SUCCESS EXIT_SUCCESS
 #define MBEDTLS_EXIT_FAILURE EXIT_FAILURE
 #endif
+
+using namespace utest::v1;
 
 #define MBEDTLS_SELF_TEST_TEST_CASE(self_test_function) \
     void self_test_function ## _test_case() {           \


### PR DESCRIPTION
## Description
Fix to the mbedtls test to resolve namespace conflict when running on Kinetis devices

## Status
**READY
