### PR TITLE
Fix mbed-cli issue #468. Add LPCTargetCode.lpc_patch to POST_BINARY_WHITELIST

### DIFF
--- a/tools/export/embitz/__init__.py
+++ b/tools/export/embitz/__init__.py
@@ -20,7 +20,8 @@ from tools.export.exporters import Exporter, filter_supported
 
 
 POST_BINARY_WHITELIST = set([
-    "TEENSY3_1Code.binary_hook"
+    "TEENSY3_1Code.binary_hook",
+    "LPCTargetCode.lpc_patch"
 ])
 
 

--- a/tools/export/gnuarmeclipse/__init__.py
+++ b/tools/export/gnuarmeclipse/__init__.py
@@ -61,6 +61,7 @@ u = UID()
 POST_BINARY_WHITELIST = set([
     "TEENSY3_1Code.binary_hook",
     "MCU_NRF51Code.binary_hook",
+    "LPCTargetCode.lpc_patch"
 ])
 
 class GNUARMEclipse(Exporter):

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -37,7 +37,8 @@ class Makefile(Exporter):
 
     POST_BINARY_WHITELIST = set([
         "MCU_NRF51Code.binary_hook",
-        "TEENSY3_1Code.binary_hook"
+        "TEENSY3_1Code.binary_hook",
+        "LPCTargetCode.lpc_patch"
     ])
 
     def generate(self):


### PR DESCRIPTION
Notes:
* Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
* This is just a template, so feel free to use/remove the unnecessary things

## Description
Although the post_binary_hooks are not used by the exporters at this time, the exporters do set up a POST_BINARY_WHITELIST and reject anything with a post_binary_hook not in the whitelist. This prevents LPCTargets from working with exporters. This patch adds the LPCTarget to the whitelist of all exporters.


## Status
**READY**
Resolves ARMmbed/mbed-cli#468

## Todos
- [x] Tests - /morph export-build