### PR TITLE
[NRF52840]: enabled SdBlockDevice capability

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/TARGET_MCU_NRF52840/sdk/sdk_config.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/TARGET_MCU_NRF52840/sdk/sdk_config.h
@@ -1566,7 +1566,7 @@
 // <e> RTC_ENABLED - nrf_drv_rtc - RTC peripheral driver
 //==========================================================
 #ifndef RTC_ENABLED
-#define RTC_ENABLED 0
+#define RTC_ENABLED 1
 #endif
 #if  RTC_ENABLED
 // <o> RTC_DEFAULT_CONFIG_FREQUENCY - Frequency  <16-32768> 

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/TARGET_MCU_NRF52840/sdk/sdk_config.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/TARGET_MCU_NRF52840/sdk/sdk_config.h
@@ -1566,7 +1566,7 @@
 // <e> RTC_ENABLED - nrf_drv_rtc - RTC peripheral driver
 //==========================================================
 #ifndef RTC_ENABLED
-#define RTC_ENABLED 1
+#define RTC_ENABLED 0
 #endif
 #if  RTC_ENABLED
 // <o> RTC_DEFAULT_CONFIG_FREQUENCY - Frequency  <16-32768> 
@@ -1962,7 +1962,7 @@
  
 
 #ifndef SPI0_USE_EASY_DMA
-#define SPI0_USE_EASY_DMA 1
+#define SPI0_USE_EASY_DMA 0
 #endif
 
 // <o> SPI0_DEFAULT_FREQUENCY  - SPI frequency
@@ -1992,7 +1992,7 @@
  
 
 #ifndef SPI1_USE_EASY_DMA
-#define SPI1_USE_EASY_DMA 1
+#define SPI1_USE_EASY_DMA 0
 #endif
 
 // <o> SPI1_DEFAULT_FREQUENCY  - SPI frequency
@@ -2022,7 +2022,7 @@
  
 
 #ifndef SPI2_USE_EASY_DMA
-#define SPI2_USE_EASY_DMA 1
+#define SPI2_USE_EASY_DMA 0
 #endif
 
 // <q> SPI2_DEFAULT_FREQUENCY  - Use EasyDMA

--- a/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5_SDK13/spi_api.c
@@ -144,12 +144,14 @@ static void master_event_handler(uint8_t spi_idx,
     if (p_event->type == NRF_DRV_SPI_EVENT_DONE)
     {
         p_spi_info->flag.busy = false;
+#if DEVICE_SPI_ASYNCH
         if (p_spi_info->handler)
         {
             void (*handler)(void) = (void (*)(void))p_spi_info->handler;
             p_spi_info->handler = 0;
             handler();
         }
+#endif // if DEVICE_SPI_ASYNCH
     }
 }
 #define MASTER_EVENT_HANDLER(idx) \

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2696,7 +2696,7 @@
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF52840"],
         "macros_add": ["BOARD_PCA10056", "CONFIG_GPIO_AS_PINRESET", "SWI_DISABLE0", "NRF52_ERRATA_20"],
-        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
+        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE"],
         "release_versions": ["2", "5"],
         "device_name": "nRF52840_xxAA"
     },


### PR DESCRIPTION
## Description
Fix capability by using SPI instead of SPIM peripheral and resign from SPI_ASNCHRONUS capability.
SPIM peripheral has the bug which imposed on one-byte transfer.

tests-api-spi is also fixed by this PR.

## Status
**READY**

##Test result:

```{{__version;1.3.0}}
                                                           
{{__timeout;40}}
                                                              
{{__host_test_name;default_auto}}
                                             
>>> Running 6 test cases...
                                                    
{{__testcase_name;SPI - Object Definable}}
                                    
{{__testcase_name;SPI - SD card exists}}
                                      
{{__testcase_name;SPI - SD Write}}
                                            
{{__testcase_name;SPI - SD Read}}
                                             
{{__testcase_name;SPI - SD 2nd Write}}
                                        
{{__testcase_name;SPI - SD 2nd Read}}
                                         

                                                                               
>>> Running case #1: 'SPI - Object Definable'...
                               
{{__testcase_start;SPI - Object Definable}}
                                   
{{__testcase_finish;SPI - Object Definable;1;0}}
                              
>>> 'SPI - Object Definable': 1 passed, 0 failed
                               

                                                                               
>>> Running case #2: 'SPI - SD card exists'...
                                 
{{__testcase_start;SPI - SD card exists}}
                                     
{{__testcase_finish;SPI - SD card exists;1;0}}
                                
>>> 'SPI - SD card exists': 1 passed, 0 failed
                                 

                                                                               
>>> Running case #3: 'SPI - SD Write'...
                                       
{{__testcase_start;SPI - SD Write}}
                                           
{{__testcase_finish;SPI - SD Write;1;0}}
                                      
>>> 'SPI - SD Write': 1 passed, 0 failed
                                       

                                                                               
>>> Running case #4: 'SPI - SD Read'...
                                        
{{__testcase_start;SPI - SD Read}}
                                            
{{__testcase_finish;SPI - SD Read;1;0}}
                                       
>>> 'SPI - SD Read': 1 passed, 0 failed
                                        

                                                                               
>>> Running case #5: 'SPI - SD 2nd Write'...
                                   
{{__testcase_start;SPI - SD 2nd Write}}
                                       
{{__testcase_finish;SPI - SD 2nd Write;1;0}}
                                  
>>> 'SPI - SD 2nd Write': 1 passed, 0 failed
                                   

                                                                               
>>> Running case #6: 'SPI - SD 2nd Read'...
                                    
{{__testcase_start;SPI - SD 2nd Read}}
                                        
{{__testcase_finish;SPI - SD 2nd Read;1;0}}
                                   
>>> 'SPI - SD 2nd Read': 1 passed, 0 failed
                                    

                                                                               
>>> Test cases: 6 passed, 0 failed
                                             
{{__testcase_summary;6;0}}
                                                    
{{max_heap_usage;0}}
                                                          
{{end;success}}
                                                               
{{__exit;0}}
   
```
