### PR TITLE
[HAL] Add support for 64 bit us timestamp

### DIFF
--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -28,8 +28,8 @@
 
 using namespace utest::v1;
 
-volatile static bool complete;
-volatile static timestamp_t complete_timestamp;
+static volatile bool complete;
+static volatile timestamp_t complete_timestamp;
 static ticker_event_t delay_event;
 static const ticker_data_t *lp_ticker_data = get_lp_ticker_data();
 
@@ -39,8 +39,13 @@ static const ticker_data_t *lp_ticker_data = get_lp_ticker_data();
 #define SHORT_TIMEOUT (600)
 
 void cb_done(uint32_t id) {
-    complete = true;
     complete_timestamp = us_ticker_read();
+    complete = true;
+}
+
+void cb_done_deepsleep(uint32_t id) {
+    complete_timestamp = lp_ticker_read();
+    complete = true;
 }
 
 void lp_ticker_delay_us(uint32_t delay_us, uint32_t tolerance)
@@ -77,7 +82,7 @@ void lp_ticker_1s_deepsleep()
      */
     wait_ms(10);
 
-    ticker_set_handler(lp_ticker_data, cb_done);
+    ticker_set_handler(lp_ticker_data, cb_done_deepsleep);
     ticker_remove_event(lp_ticker_data, &delay_event);
     delay_ts = lp_ticker_read() + 1000000;
 

--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -29,6 +29,7 @@
 using namespace utest::v1;
 
 volatile static bool complete;
+volatile static timestamp_t complete_timestamp;
 static ticker_event_t delay_event;
 static const ticker_data_t *lp_ticker_data = get_lp_ticker_data();
 
@@ -39,6 +40,7 @@ static const ticker_data_t *lp_ticker_data = get_lp_ticker_data();
 
 void cb_done(uint32_t id) {
     complete = true;
+    complete_timestamp = us_ticker_read();
 }
 
 void lp_ticker_delay_us(uint32_t delay_us, uint32_t tolerance)
@@ -53,7 +55,7 @@ void lp_ticker_delay_us(uint32_t delay_us, uint32_t tolerance)
     timestamp_t start = us_ticker_read();
     ticker_insert_event(lp_ticker_data, &delay_event, delay_ts, (uint32_t)&delay_event);
     while (!complete);
-    timestamp_t end = us_ticker_read();
+    timestamp_t end = complete_timestamp;
 
     TEST_ASSERT_UINT32_WITHIN(tolerance, delay_us, end - start);
     TEST_ASSERT_TRUE(complete);
@@ -87,7 +89,7 @@ void lp_ticker_1s_deepsleep()
     ticker_insert_event(lp_ticker_data, &delay_event, delay_ts, (uint32_t)&delay_event);
     deepsleep();
     while (!complete);
-    timestamp_t end = lp_ticker_read();
+    timestamp_t end = complete_timestamp;
 
     TEST_ASSERT_UINT32_WITHIN(LONG_TIMEOUT, 1000000, end - start);
     TEST_ASSERT_TRUE(complete);
@@ -106,7 +108,7 @@ void lp_ticker_1s_sleep()
     ticker_insert_event(lp_ticker_data, &delay_event, delay_ts, (uint32_t)&delay_event);
     sleep();
     while (!complete);
-    timestamp_t end = us_ticker_read();
+    timestamp_t end = complete_timestamp;
 
     TEST_ASSERT_UINT32_WITHIN(LONG_TIMEOUT, 1000000, end - start);
     TEST_ASSERT_TRUE(complete);

--- a/TESTS/mbed_hal/ticker/main.cpp
+++ b/TESTS/mbed_hal/ticker/main.cpp
@@ -46,31 +46,37 @@ struct ticker_interface_stub_t {
 
 static ticker_interface_stub_t interface_stub = { 0 };
 
-static void ticker_interface_stub_init() { 
+static void ticker_interface_stub_init()
+{
     ++interface_stub.init_call;
     interface_stub.initialized = true;
 }
 
-static uint32_t ticker_interface_stub_read() { 
+static uint32_t ticker_interface_stub_read()
+{
     ++interface_stub.read_call;
     return interface_stub.timestamp;
 } 
 
-static void ticker_interface_stub_disable_interrupt() { 
+static void ticker_interface_stub_disable_interrupt()
+{ 
     ++interface_stub.disable_interrupt_call;
 }
 
-static void ticker_interface_stub_clear_interrupt() { 
+static void ticker_interface_stub_clear_interrupt()
+{
     ++interface_stub.clear_interrupt_call;
     interface_stub.interrupt_flag = false;
 }
 
-static void ticker_interface_stub_set_interrupt(timestamp_t timestamp) { 
+static void ticker_interface_stub_set_interrupt(timestamp_t timestamp)
+{
     ++interface_stub.set_interrupt_call;
     interface_stub.interrupt_timestamp = timestamp; 
 }
 
-static void reset_ticker_interface_stub() { 
+static void reset_ticker_interface_stub()
+{
     interface_stub.interface.init = ticker_interface_stub_init;
     interface_stub.interface.read = ticker_interface_stub_read;
     interface_stub.interface.disable_interrupt = 
@@ -90,14 +96,15 @@ static void reset_ticker_interface_stub() {
 }
 
 // stub of the event queue 
-static ticker_event_queue_t queue_stub = { 
+static ticker_event_queue_t queue_stub = {
     /* event handler */ NULL,
     /* head */ NULL,
     /* timestamp */ 0,
     /* initialized */ false
 };
 
-static void reset_queue_stub() { 
+static void reset_queue_stub()
+{
     queue_stub.event_handler = NULL;
     queue_stub.head = NULL,
     queue_stub.present_time = 0;
@@ -105,12 +112,13 @@ static void reset_queue_stub() {
 }
 
 // stub of the ticker
-static ticker_data_t ticker_stub = { 
+static ticker_data_t ticker_stub = {
     /* interface */ &interface_stub.interface,
     /* queue */ &queue_stub
 };
 
-static void reset_ticker_stub() { 
+static void reset_ticker_stub()
+{
     reset_queue_stub();
     reset_ticker_interface_stub();
 }
@@ -142,7 +150,8 @@ static utest::v1::status_t greentea_failure_handler(
     return status;
 }
 
-static Case make_test_case(const char *description, const case_handler_t handler) { 
+static Case make_test_case(const char *description, const case_handler_t handler)
+{
     return Case(
         description, 
         case_setup_handler, 
@@ -164,7 +173,8 @@ static Case make_test_case(const char *description, const case_handler_t handler
  *     TIMESTAMP_MAX_DELTA
  *   - The queue should not contains any event
  */
-static void test_ticker_initialization() { 
+static void test_ticker_initialization()
+{
     ticker_event_handler dummy_handler = (ticker_event_handler)0xDEADBEEF;
 
     // setup of the stub 
@@ -192,7 +202,8 @@ static void test_ticker_initialization() {
  *   - The queue handler should be set to the new handler.
  *   - The events in the queue should remains the same.
  */
-static void test_ticker_re_initialization() { 
+static void test_ticker_re_initialization()
+{
     ticker_event_handler dummy_handler = (ticker_event_handler) 0xDEADBEEF;
     ticker_event_handler expected_handler = (ticker_event_handler) 0xFEEDDEAF;
     
@@ -226,7 +237,8 @@ static void test_ticker_re_initialization() {
  * When the ticker is read 
  * Then it should return the value present in the ticker interface
  */
-static void test_ticker_read() { 
+static void test_ticker_read()
+{
     ticker_set_handler(&ticker_stub, NULL);
 
     timestamp_t timestamps[] = { 
@@ -260,7 +272,8 @@ static void test_ticker_read() {
  *     + upper 8 bytes should be equal to the previous value of upper 8 bytes
  *       plus one.
  */
-static void test_ticker_read_overflow() { 
+static void test_ticker_read_overflow()
+{
     const timestamp_t timestamps[] = { 
         0xAAAAAAAA,
         0xAAAAAAA,
@@ -299,7 +312,8 @@ static void test_ticker_read_overflow() {
  *   - The timestamp of the event should reflect the timestamp requested. 
  *   - The id of the event should be equal to the id passed in parameter. 
  */
-static void test_legacy_insert_event_outside_overflow_range() { 
+static void test_legacy_insert_event_outside_overflow_range()
+{
     ticker_set_handler(&ticker_stub, NULL);
     interface_stub.set_interrupt_call = 0;
 
@@ -359,7 +373,8 @@ static void test_legacy_insert_event_outside_overflow_range() {
  *   - The timestamp of the event should reflect the timestamp requested. 
  *   - The id of the event should be equal to the id passed in parameter. 
  */
-static void test_legacy_insert_event_in_overflow_range() { 
+static void test_legacy_insert_event_in_overflow_range()
+{
     ticker_set_handler(&ticker_stub, NULL);
     interface_stub.set_interrupt_call = 0;
 
@@ -424,7 +439,7 @@ static void test_legacy_insert_event_in_overflow_range() {
  *       timestamp state stored in the queue plus one.
  *   - The id of the event should be equal to the id passed in parameter. 
  */
-static void test_legacy_insert_event_overflow() { 
+static void test_legacy_insert_event_overflow(){
     ticker_set_handler(&ticker_stub, NULL);
     interface_stub.set_interrupt_call = 0;
 
@@ -470,7 +485,8 @@ static void test_legacy_insert_event_overflow() {
  *   - The id of the event should be equal to the id passed in parameter. 
  *   - Events in the queue should remained ordered by timestamp.
  */
-static void test_legacy_insert_event_head() { 
+static void test_legacy_insert_event_head()
+{
     ticker_set_handler(&ticker_stub, NULL);
     interface_stub.set_interrupt_call = 0;
 
@@ -538,7 +554,8 @@ static void test_legacy_insert_event_head() {
  *   - The id of the event should be equal to the id passed in parameter. 
  *   - Events in the queue should remained ordered by timestamp.
  */
-static void test_legacy_insert_event_tail() { 
+static void test_legacy_insert_event_tail()
+{
     ticker_set_handler(&ticker_stub, NULL);
     interface_stub.set_interrupt_call = 0;
 
@@ -597,7 +614,8 @@ static void test_legacy_insert_event_tail() {
  *   - The id of the event should be equal to the id passed in parameter. 
  *   - Events in the queue should remained ordered by timestamp.
  */
-static void test_legacy_insert_event_multiple_overflow() { 
+static void test_legacy_insert_event_multiple_overflow()
+{
     ticker_set_handler(&ticker_stub, NULL);
     interface_stub.set_interrupt_call = 0;
 
@@ -670,7 +688,8 @@ static void test_legacy_insert_event_multiple_overflow() {
  *   - The id of the event should be equal to the id passed in parameter. 
  *   - Events in the queue should remained ordered by timestamp.
  */
-static void test_legacy_insert_event_multiple_random() { 
+static void test_legacy_insert_event_multiple_random()
+{
     ticker_set_handler(&ticker_stub, NULL);
     interface_stub.set_interrupt_call = 0;
 
@@ -788,7 +807,8 @@ static void test_legacy_insert_event_multiple_random() {
  *   - The timestamp of the event should be equal to the timestamp requested. 
  *   - The id of the event should be equal to the id passed in parameter. 
  */
-static void test_insert_event_us_outside_overflow_range() { 
+static void test_insert_event_us_outside_overflow_range()
+{
     ticker_set_handler(&ticker_stub, NULL);
     interface_stub.set_interrupt_call = 0;
     interface_stub.timestamp = 0xAAAAAAAA;
@@ -848,7 +868,8 @@ static void test_insert_event_us_outside_overflow_range() {
  *   - The timestamp of the event should be equal to the timestamp in parameter. 
  *   - The id of the event should be equal to the id passed in parameter. 
  */
-static void test_insert_event_us_in_overflow_range() { 
+static void test_insert_event_us_in_overflow_range()
+{
     ticker_set_handler(&ticker_stub, NULL);
     interface_stub.set_interrupt_call = 0;
     interface_stub.timestamp = 0xAAAAAAAA;
@@ -909,7 +930,8 @@ static void test_insert_event_us_in_overflow_range() {
  *   - The interrupt timestamp should be set to interface_stub.timestamp so it
  *     is scheduled immediately.
  */
-static void test_insert_event_us_underflow() { 
+static void test_insert_event_us_underflow()
+{
     ticker_set_handler(&ticker_stub, NULL);
     interface_stub.set_interrupt_call = 0;
 
@@ -948,7 +970,8 @@ static void test_insert_event_us_underflow() {
  *   - The id of the event should be equal to the id passed in parameter. 
  *   - Events in the queue should remained ordered by timestamp.
  */
-static void test_insert_event_us_head() { 
+static void test_insert_event_us_head()
+{
     ticker_set_handler(&ticker_stub, NULL);
     interface_stub.set_interrupt_call = 0;
     interface_stub.timestamp = 0xAAAAAAAA;
@@ -1015,7 +1038,8 @@ static void test_insert_event_us_head() {
  *   - The id of the event should be equal to the id passed in parameter. 
  *   - Events in the queue should remained ordered by timestamp.
  */
-static void test_insert_event_us_tail() { 
+static void test_insert_event_us_tail()
+{
     ticker_set_handler(&ticker_stub, NULL);
     interface_stub.set_interrupt_call = 0;
 
@@ -1073,7 +1097,8 @@ static void test_insert_event_us_tail() {
  *   - The id of the event should be equal to the id passed in parameter. 
  *   - Events in the queue should remained ordered by timestamp.
  */
-static void test_insert_event_us_multiple_random() { 
+static void test_insert_event_us_multiple_random()
+{
     ticker_set_handler(&ticker_stub, NULL);
     interface_stub.set_interrupt_call = 0;
 
@@ -1168,7 +1193,8 @@ static void test_insert_event_us_multiple_random() {
  *    - The events in the queue should remain ordered
  *    - The interrupt timestamp should be unchanged. 
  */
-static void test_remove_event_tail() { 
+static void test_remove_event_tail()
+{
     ticker_set_handler(&ticker_stub, NULL);
     const us_timestamp_t timestamps[] = { 
         0xA,
@@ -1232,7 +1258,8 @@ static void test_remove_event_tail() {
  *      of the head event or TIMESTAMP_MAX_DELTA if the 
  *      timestamp is in the overflow range.
  */
-static void test_remove_event_head() { 
+static void test_remove_event_head()
+{
     ticker_set_handler(&ticker_stub, NULL);
     const us_timestamp_t timestamps[] = { 
         TIMESTAMP_MAX_DELTA / 8,
@@ -1293,7 +1320,8 @@ static void test_remove_event_head() {
  * When an event not in the queue is attempted to be removed.
  * Then the queue should remains identical as before.
  */
-static void test_remove_event_invalid() { 
+static void test_remove_event_invalid()
+{
     ticker_set_handler(&ticker_stub, NULL);
     const us_timestamp_t timestamps[] = { 
         TIMESTAMP_MAX_DELTA / 8,
@@ -1339,7 +1367,8 @@ static void test_remove_event_invalid() {
  *     TIMESTAMP_MAX_DELTA depending on the distance between the current time 
  *     ans the timestamp of the event at the head of the queue.
  */
-static void test_remove_random() { 
+static void test_remove_random()
+{
     ticker_set_handler(&ticker_stub, NULL);
     interface_stub.set_interrupt_call = 0;
 
@@ -1452,7 +1481,8 @@ static void test_remove_random() {
  *     interface plus TIMESTAMP_MAX_DELTA. 
  *   - The irq handler registered should not be called.
  */
-static void test_overflow_event_update() { 
+static void test_overflow_event_update()
+{
     static uint32_t handler_call = 0;
     struct irq_handler_stub_t { 
         static void event_handler(uint32_t id) { 
@@ -1493,7 +1523,8 @@ static void test_overflow_event_update() {
  *     interface plus TIMESTAMP_MAX_DELTA. 
  *   - The irq handler registered should not be called.
  */
-static void test_overflow_event_update_when_spurious_interrupt() { 
+static void test_overflow_event_update_when_spurious_interrupt()
+{
     static uint32_t handler_call = 0;
     struct irq_handler_stub_t { 
         static void event_handler(uint32_t id) { 
@@ -1536,7 +1567,8 @@ static void test_overflow_event_update_when_spurious_interrupt() {
  *   - The interrupt timestamp in the ticker interface should be set to the 
  *     value of the interface timestamp + TIMESTAMP_MAX_DELTA  
  */
-static void test_irq_handler_single_event() { 
+static void test_irq_handler_single_event()
+{
     const timestamp_t event_timestamp = 0xAAAAAAAA;
     static const timestamp_t interface_timestamp_after_irq = event_timestamp + 100;
     static const uint32_t event_id = 0xFFAAFFAA;
@@ -1585,7 +1617,8 @@ static void test_irq_handler_single_event() {
  *   - The interrupt timestamp in the ticker interface should be set to the 
  *     value of the event timestamp  
  */
-static void test_irq_handler_single_event_spurious() { 
+static void test_irq_handler_single_event_spurious()
+{
     struct irq_handler_stub_t { 
         static void event_handler(uint32_t id) { 
             TEST_FAIL();
@@ -1636,7 +1669,8 @@ static void test_irq_handler_single_event_spurious() {
  *   - The interrupt timestamp in the ticker interface should be scheduled in
  *     TIMESTAMP_MAX_DELTAs
  */
-static void test_irq_handler_multiple_event_multiple_dequeue() { 
+static void test_irq_handler_multiple_event_multiple_dequeue()
+{
     const us_timestamp_t timestamps [] = {
         10, 
         10 + TIMESTAMP_MAX_DELTA - 1,
@@ -1698,7 +1732,8 @@ static void test_irq_handler_multiple_event_multiple_dequeue() {
  *   - The interrupt timestamp in the ticker interface should be scheduled in
  *     TIMESTAMP_MAX_DELTA.
  */
-static void test_irq_handler_multiple_event_single_dequeue_overflow() { 
+static void test_irq_handler_multiple_event_single_dequeue_overflow()
+{
     const us_timestamp_t timestamps [] = {
         10, 
         10 + TIMESTAMP_MAX_DELTA + 1
@@ -1753,7 +1788,8 @@ static void test_irq_handler_multiple_event_single_dequeue_overflow() {
  *   - The interrupt timestamp in the ticker interface should be equal to the 
  *     timestamp of the second event.
  */
-static void test_irq_handler_multiple_event_single_dequeue() { 
+static void test_irq_handler_multiple_event_single_dequeue()
+{
     const us_timestamp_t timestamps [] = {
         10, 
         10 + TIMESTAMP_MAX_DELTA - 1
@@ -1810,7 +1846,8 @@ static void test_irq_handler_multiple_event_single_dequeue() {
  *   - The interrupt timestamp in the ticker interface should be equal to 
  *     timestamp of the head event.
  */
-static void test_irq_handler_insert_immediate_in_irq() { 
+static void test_irq_handler_insert_immediate_in_irq()
+{
     const us_timestamp_t timestamps [] = {
         10, 
         10 + TIMESTAMP_MAX_DELTA - 1
@@ -1885,7 +1922,8 @@ static void test_irq_handler_insert_immediate_in_irq() {
  *   - The interrupt timestamp in the ticker interface should be equal to 
  *     timestamp of the head event.
  */
-static void test_irq_handler_insert_non_immediate_in_irq() { 
+static void test_irq_handler_insert_non_immediate_in_irq()
+{
     const us_timestamp_t timestamps [] = {
         10, 
         10 + TIMESTAMP_MAX_DELTA - 1
@@ -2036,13 +2074,15 @@ static const Case cases[] = {
     )
 };
 
-static utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
+static utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
+{
     GREENTEA_SETUP(30, "default_auto");
     return verbose_test_setup_handler(number_of_cases);
 }
 
 static Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
 
-int main() {
+int main()
+{
     return !Harness::run(specification);
 }

--- a/TESTS/mbed_hal/ticker/main.cpp
+++ b/TESTS/mbed_hal/ticker/main.cpp
@@ -1,0 +1,2047 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define __STDC_LIMIT_MACROS
+#include <stdint.h>
+#include <algorithm>
+
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+
+#include "mbed.h"
+#include "ticker_api.h"
+
+using namespace utest::v1;
+
+#define MBED_ARRAY_SIZE(array) (sizeof(array)/sizeof(array[0]))
+
+#define TIMESTAMP_MAX_DELTA MBED_TICKER_INTERRUPT_TIMESTAMP_MAX_DELTA
+
+struct ticker_interface_stub_t { 
+    ticker_interface_t interface;
+    bool initialized; 
+    bool interrupt_flag;
+    timestamp_t timestamp ;
+    timestamp_t interrupt_timestamp; 
+    unsigned int init_call;
+    unsigned int read_call;
+    unsigned int disable_interrupt_call;
+    unsigned int clear_interrupt_call;
+    unsigned int set_interrupt_call;
+};
+
+static ticker_interface_stub_t interface_stub = { 0 };
+
+static void ticker_interface_stub_init() { 
+    ++interface_stub.init_call;
+    interface_stub.initialized = true;
+}
+
+static uint32_t ticker_interface_stub_read() { 
+    ++interface_stub.read_call;
+    return interface_stub.timestamp;
+} 
+
+static void ticker_interface_stub_disable_interrupt() { 
+    ++interface_stub.disable_interrupt_call;
+}
+
+static void ticker_interface_stub_clear_interrupt() { 
+    ++interface_stub.clear_interrupt_call;
+    interface_stub.interrupt_flag = false;
+}
+
+static void ticker_interface_stub_set_interrupt(timestamp_t timestamp) { 
+    ++interface_stub.set_interrupt_call;
+    interface_stub.interrupt_timestamp = timestamp; 
+}
+
+static void reset_ticker_interface_stub() { 
+    interface_stub.interface.init = ticker_interface_stub_init;
+    interface_stub.interface.read = ticker_interface_stub_read;
+    interface_stub.interface.disable_interrupt = 
+        ticker_interface_stub_disable_interrupt;
+    interface_stub.interface.clear_interrupt = 
+        ticker_interface_stub_clear_interrupt;
+    interface_stub.interface.set_interrupt =ticker_interface_stub_set_interrupt;
+    interface_stub.initialized = false;
+    interface_stub.interrupt_flag = false;
+    interface_stub.timestamp = 0;
+    interface_stub.interrupt_timestamp = 0;
+    interface_stub.init_call = 0;
+    interface_stub.read_call = 0;
+    interface_stub.disable_interrupt_call = 0;
+    interface_stub.clear_interrupt_call = 0;
+    interface_stub.set_interrupt_call = 0;
+}
+
+// stub of the event queue 
+static ticker_event_queue_t queue_stub = { 
+    /* event handler */ NULL,
+    /* head */ NULL,
+    /* timestamp */ 0,
+    /* initialized */ false
+};
+
+static void reset_queue_stub() { 
+    queue_stub.event_handler = NULL;
+    queue_stub.head = NULL,
+    queue_stub.timestamp = 0;
+    queue_stub.initialized = false;
+}
+
+// stub of the ticker
+static ticker_data_t ticker_stub = { 
+    /* interface */ &interface_stub.interface,
+    /* queue */ &queue_stub
+};
+
+static void reset_ticker_stub() { 
+    reset_queue_stub();
+    reset_ticker_interface_stub();
+}
+
+static utest::v1::status_t case_setup_handler(
+    const Case *const source, const size_t index_of_case
+) { 
+    utest::v1::status_t status = greentea_case_setup_handler(source, index_of_case);
+    reset_ticker_stub();
+    return status;
+}
+
+static utest::v1::status_t case_teardown_handler(
+    const Case *const source, const size_t passed, const size_t failed, const failure_t reason
+) { 
+    reset_ticker_stub();
+    utest::v1::status_t status = greentea_case_teardown_handler(
+        source, passed, failed, reason
+    );
+    return status;
+}
+
+static utest::v1::status_t greentea_failure_handler(
+    const Case *const source, const failure_t reason
+) {
+    utest::v1::status_t status = greentea_case_failure_abort_handler(
+        source, reason
+    );
+    return status;
+}
+
+static Case make_test_case(const char *description, const case_handler_t handler) { 
+    return Case(
+        description, 
+        case_setup_handler, 
+        handler,
+        case_teardown_handler,
+        greentea_failure_handler
+    );
+}
+
+/**
+ * Given an unitialized ticker_data instance. 
+ * When the ticker is initialized 
+ * Then: 
+ *   - The ticker interface should be initialized 
+ *   - The queue handler should be set to the handler provided in parameter
+ *   - The internal ticker timestamp should be synced with the counter in the 
+ *     interface counter.
+ *   - interrupt should be scheduled in current timestamp + 
+ *     TIMESTAMP_MAX_DELTA
+ *   - The queue should not contains any event
+ */
+static void test_ticker_initialization() { 
+    ticker_event_handler dummy_handler = (ticker_event_handler)0xDEADBEEF;
+
+    // setup of the stub 
+    interface_stub.timestamp = 0xFEEDBABE;
+
+    ticker_set_handler(&ticker_stub, dummy_handler);
+
+    TEST_ASSERT_TRUE(interface_stub.initialized);
+    TEST_ASSERT_EQUAL_PTR(dummy_handler, queue_stub.event_handler);
+    TEST_ASSERT_EQUAL_UINT64(interface_stub.timestamp, queue_stub.timestamp);
+    TEST_ASSERT_EQUAL(1, interface_stub.set_interrupt_call);
+    TEST_ASSERT_EQUAL_UINT32(
+        interface_stub.timestamp + TIMESTAMP_MAX_DELTA,
+        interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_PTR(NULL, queue_stub.head);
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker_data instance. 
+ * When the ticker handler is set to a new value    
+ * Then: 
+ *   - The ticker interface initialization function should not be called.
+ *   - The queue handler should be set to the new handler.
+ *   - The events in the queue should remains the same.
+ */
+static void test_ticker_re_initialization() { 
+    ticker_event_handler dummy_handler = (ticker_event_handler) 0xDEADBEEF;
+    ticker_event_handler expected_handler = (ticker_event_handler) 0xFEEDDEAF;
+    
+    ticker_event_t first_event = { 0 }; 
+    ticker_event_t second_event  = { 0 }; 
+    ticker_event_t third_event  = { 0 }; 
+
+    first_event.next = &second_event;
+    second_event.next = &third_event;
+
+    // initialize the ticker and put few events in the queue.
+    ticker_set_handler(&ticker_stub, dummy_handler);
+    // simulate insertion, it shouldn't affect the queue behaviour for this test
+    queue_stub.head = &first_event;
+    interface_stub.init_call = 0;
+
+    ticker_set_handler(&ticker_stub, expected_handler);
+
+    TEST_ASSERT_TRUE(interface_stub.initialized);
+    TEST_ASSERT_EQUAL(0, interface_stub.init_call);
+    TEST_ASSERT_EQUAL(expected_handler, queue_stub.event_handler);
+    TEST_ASSERT_EQUAL(&first_event, queue_stub.head);
+    TEST_ASSERT_EQUAL(&second_event, queue_stub.head->next);
+    TEST_ASSERT_EQUAL(&third_event, queue_stub.head->next->next);
+    TEST_ASSERT_EQUAL(NULL, queue_stub.head->next->next->next);
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker_data instance. 
+ * When the ticker is read 
+ * Then it should return the value present in the ticker interface
+ */
+static void test_ticker_read() { 
+    ticker_set_handler(&ticker_stub, NULL);
+
+    timestamp_t timestamps[] = { 
+        0xA,
+        0xAA,
+        0xAAA,
+        0xAAAA,
+        0xAAAAA,
+        0xAAAAAA,
+        0xAAAAAAA,
+        0xAAAAAAAA
+    };
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(timestamps); ++i) {
+        interface_stub.timestamp = timestamps[i];
+        TEST_ASSERT_EQUAL_UINT32(timestamps[i], ticker_read(&ticker_stub));
+        TEST_ASSERT_EQUAL_UINT64(timestamps[i], ticker_read_us(&ticker_stub));
+    }
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker_data instance. 
+ * When the ticker is read and the value read is less than the previous 
+ * value read.
+ * Then:
+ *   - ticker_read should return the value read in the ticker interface 
+ *   - ticker_read_us should return a value where: 
+ *     + lower 8 bytes should be equal to the value in the ticker interface
+ *     + upper 8 bytes should be equal to the previous value of upper 8 bytes
+ *       plus one.
+ */
+static void test_ticker_read_overflow() { 
+    const timestamp_t timestamps[] = { 
+        0xAAAAAAAA,
+        0xAAAAAAA,
+        0xAAAAAA,
+        0xAAAAA,
+        0xAAAA,
+        0xAAA,
+        0xAA,
+        0xA
+    };
+
+    ticker_set_handler(&ticker_stub, NULL);
+
+    uint32_t upper_bytes_begin = ticker_read_us(&ticker_stub) >> 32;
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(timestamps); ++i) {
+        interface_stub.timestamp = timestamps[i];
+        TEST_ASSERT_EQUAL_UINT32(timestamps[i], ticker_read(&ticker_stub));
+        TEST_ASSERT_EQUAL_UINT32(timestamps[i], ticker_read_us(&ticker_stub));
+        TEST_ASSERT_EQUAL_UINT64(
+            upper_bytes_begin + i, ticker_read_us(&ticker_stub) >> 32
+        );
+    }
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker without user registered events.  
+ * When an event is inserted with ticker_insert_event and the timestamp passed 
+ * in parameter is in range [ticker_timestamp : ticker_timestamp + 
+ * TIMESTAMP_MAX_DELTA[.
+ * Then 
+ *   - The event should be in the queue
+ *   - The interrupt timestamp should be equal to the timestamp of the event 
+ *   - The timestamp of the event should reflect the timestamp requested. 
+ *   - The id of the event should be equal to the id passed in parameter. 
+ */
+static void test_legacy_insert_event_outside_overflow_range() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    interface_stub.set_interrupt_call = 0;
+
+    // test the end of the range
+    ticker_event_t last_event = { 0 };
+    const timestamp_t timestamp_last_event = 
+        interface_stub.timestamp + TIMESTAMP_MAX_DELTA; 
+    const uint32_t id_last_event = 0xDEADDEAF;
+
+    ticker_insert_event(
+        &ticker_stub, 
+        &last_event, timestamp_last_event, id_last_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&last_event, queue_stub.head);
+    TEST_ASSERT_EQUAL(1, interface_stub.set_interrupt_call);    
+    TEST_ASSERT_EQUAL_UINT32(
+        timestamp_last_event, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_PTR(NULL, queue_stub.head->next);
+    TEST_ASSERT_EQUAL_UINT32(timestamp_last_event, last_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT32(id_last_event, last_event.id);
+
+    // test the beginning of the range
+    ticker_event_t first_event = { 0 };
+    const timestamp_t timestamp_first_event = interface_stub.timestamp + 1; 
+    const uint32_t id_first_event = 0xAAAAAAAA;
+
+    ticker_insert_event(
+        &ticker_stub, 
+        &first_event, timestamp_first_event, id_first_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&first_event, queue_stub.head);
+    TEST_ASSERT_EQUAL(2, interface_stub.set_interrupt_call);    
+    TEST_ASSERT_EQUAL_UINT32(
+        timestamp_first_event, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_PTR(&last_event, queue_stub.head->next);
+    TEST_ASSERT_EQUAL_UINT32(
+        timestamp_first_event, first_event.timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT32(id_first_event, first_event.id);
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}  
+
+/**
+ * Given an initialized ticker without user registered events.  
+ * When an event is inserted with ticker_insert_event and a timestamp in the 
+ * range [ticker_timestamp + TIMESTAMP_MAX_DELTA + 1 : 
+ * ticker_timestamp + UINT32MAX [
+ * Then 
+ *   - The event should be in the queue
+ *   - The interrupt timestamp should be equal to 
+ *     TIMESTAMP_MAX_DELTA 
+ *   - The timestamp of the event should reflect the timestamp requested. 
+ *   - The id of the event should be equal to the id passed in parameter. 
+ */
+static void test_legacy_insert_event_in_overflow_range() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    interface_stub.set_interrupt_call = 0;
+
+    // test the end of the range
+    ticker_event_t last_event = { 0 };
+    const timestamp_t timestamp_last_event = 
+        interface_stub.timestamp + UINT32_MAX; 
+    const uint32_t id_last_event = 0xDEADDEAF;
+
+    ticker_insert_event(
+        &ticker_stub, 
+        &last_event, timestamp_last_event, id_last_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&last_event, queue_stub.head);
+    TEST_ASSERT_EQUAL(1, interface_stub.set_interrupt_call);    
+    TEST_ASSERT_EQUAL_UINT32(
+        interface_stub.timestamp + TIMESTAMP_MAX_DELTA, 
+        interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_PTR(NULL, queue_stub.head->next);
+    TEST_ASSERT_EQUAL_UINT32(timestamp_last_event, last_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT32(id_last_event, last_event.id);
+
+    // test the beginning of the range
+    ++interface_stub.timestamp;
+
+    ticker_event_t first_event = { 0 };
+    const timestamp_t timestamp_first_event = 
+        interface_stub.timestamp + TIMESTAMP_MAX_DELTA + 1; 
+    const uint32_t id_first_event = 0xAAAAAAAA;
+
+    ticker_insert_event(
+        &ticker_stub, 
+        &first_event, timestamp_first_event, id_first_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&first_event, queue_stub.head);
+    TEST_ASSERT_EQUAL(2, interface_stub.set_interrupt_call);    
+    TEST_ASSERT_EQUAL_UINT32(
+        interface_stub.timestamp + TIMESTAMP_MAX_DELTA, 
+        interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_PTR(&last_event, queue_stub.head->next);
+    TEST_ASSERT_EQUAL_UINT32(
+        timestamp_first_event, first_event.timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT32(id_first_event, first_event.id);
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}  
+
+/**
+ * Given an initialized ticker without user registered events.  
+ * When an event is inserted with ticker_insert_event and the timestamp in 
+ * parameter is less than the current timestamp value.
+ * Then 
+ *   - The event should be in the queue
+ *   - The timestamp of the event should reflect the timestamp requested:
+ *     + lower 8 bytes should be equal to the timestamp in input. 
+ *     + upper 8 bytes should be equal to the upper of the upper 8 bytes of the
+ *       timestamp state stored in the queue plus one.
+ *   - The id of the event should be equal to the id passed in parameter. 
+ */
+static void test_legacy_insert_event_overflow() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    interface_stub.set_interrupt_call = 0;
+
+    interface_stub.timestamp = 0x20000000;
+    ticker_read(&ticker_stub);
+
+    ticker_event_t event = { 0 };
+    const timestamp_t expected_timestamp = 
+        interface_stub.timestamp + 
+        TIMESTAMP_MAX_DELTA + 
+        1; 
+    const us_timestamp_t expected_us_timestamp = 
+        (((queue_stub.timestamp >> 32) + 1) << 32) | expected_timestamp; 
+    const uint32_t expected_id = 0xDEADDEAF;
+
+    ticker_insert_event(
+        &ticker_stub, 
+        &event, expected_timestamp, expected_id
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&event, queue_stub.head);
+    TEST_ASSERT_EQUAL(1, interface_stub.set_interrupt_call);    
+    TEST_ASSERT_EQUAL_UINT32(
+        interface_stub.timestamp + TIMESTAMP_MAX_DELTA, 
+        interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_PTR(NULL, queue_stub.head->next);
+    TEST_ASSERT_EQUAL_UINT32(expected_us_timestamp, event.timestamp);
+    TEST_ASSERT_EQUAL_UINT32(expected_id, event.id);
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}  
+
+/**
+ * Given an initialized ticker.
+ * When an event is inserted with ticker_insert_event and a timestamp less than 
+ * the one for the next scheduled timestamp.
+ * Then 
+ *   - The event inserted should be the first in the queue
+ *   - The interrupt timestamp should be equal to the timestamp of the event or 
+ *     TIMESTAMP_MAX_DELTA if in the overflow range.
+ *   - The timestamp of the event should reflect the timestamp requested.
+ *   - The id of the event should be equal to the id passed in parameter. 
+ *   - Events in the queue should remained ordered by timestamp.
+ */
+static void test_legacy_insert_event_head() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    interface_stub.set_interrupt_call = 0;
+
+    const timestamp_t timestamps[] = { 
+        UINT32_MAX,
+        TIMESTAMP_MAX_DELTA + 1,
+        TIMESTAMP_MAX_DELTA,
+        TIMESTAMP_MAX_DELTA / 2,
+        TIMESTAMP_MAX_DELTA / 4,
+        TIMESTAMP_MAX_DELTA / 8,
+        TIMESTAMP_MAX_DELTA / 16,
+    };
+    ticker_event_t events[MBED_ARRAY_SIZE(timestamps)] = { 0 };
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_insert_event(
+            &ticker_stub, 
+            &events[i], timestamps[i], i
+        );
+
+        TEST_ASSERT_EQUAL_PTR(&events[i], queue_stub.head);
+        TEST_ASSERT_EQUAL(i + 1, interface_stub.set_interrupt_call);  
+        if (timestamps[i] < TIMESTAMP_MAX_DELTA) { 
+            TEST_ASSERT_EQUAL_UINT32(
+                timestamps[i], 
+                interface_stub.interrupt_timestamp
+            );
+        } else { 
+            TEST_ASSERT_EQUAL_UINT32(
+                TIMESTAMP_MAX_DELTA, 
+                interface_stub.interrupt_timestamp
+            );
+        }
+
+        TEST_ASSERT_EQUAL_UINT32(
+            timestamps[i], events[i].timestamp
+        );
+        TEST_ASSERT_EQUAL_UINT32(i, events[i].id);
+
+        ticker_event_t* e = &events[i];
+        while (e) { 
+            TEST_ASSERT_EQUAL_UINT32(timestamps[e->id], e->timestamp);
+            if (e->next) { 
+                TEST_ASSERT_TRUE(e->id > e->next->id);
+                TEST_ASSERT_TRUE(e->timestamp < e->next->timestamp);
+            } else { 
+                TEST_ASSERT_EQUAL_UINT32(0, e->id);
+            }
+            e = e->next;
+        }
+    }
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}  
+
+/** 
+ * Given an initialized ticker.
+ * When an event is inserted with ticker_insert_event and its timestamp is bigger 
+ * than the one of the last event in the queue.
+ * Then 
+ *   - The event inserted should be the last in the queue
+ *   - The interrupt timestamp should remains equal to the interrupt timestamp 
+ *     of the head event .
+ *   - The timestamp of the event should reflect the timestamp requested.
+ *   - The id of the event should be equal to the id passed in parameter. 
+ *   - Events in the queue should remained ordered by timestamp.
+ */
+static void test_legacy_insert_event_tail() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    interface_stub.set_interrupt_call = 0;
+
+    const timestamp_t timestamps[] = { 
+        0xA,
+        0xAA,
+        0xAAA,
+        0xAAAA,
+        0xAAAAA,
+        0xAAAAAA,
+        0xAAAAAAA,
+        0xAAAAAAAA,
+    };
+    ticker_event_t events[MBED_ARRAY_SIZE(timestamps)] = { 0 };
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_insert_event(
+            &ticker_stub, 
+            &events[i], timestamps[i], i
+        );
+
+        TEST_ASSERT_EQUAL_PTR(&events[0], queue_stub.head);
+        TEST_ASSERT_EQUAL_UINT32(
+            timestamps[0], interface_stub.interrupt_timestamp
+        );
+
+        TEST_ASSERT_EQUAL_UINT32(timestamps[i], events[i].timestamp);
+        TEST_ASSERT_EQUAL_UINT32(i, events[i].id);
+
+        ticker_event_t* e = queue_stub.head;
+        while (e) { 
+            TEST_ASSERT_EQUAL_UINT32(timestamps[e->id], e->timestamp);
+            if (e->next) { 
+                TEST_ASSERT_TRUE(e->id < e->next->id);
+                TEST_ASSERT_TRUE(e->timestamp < e->next->timestamp);
+            } else { 
+                TEST_ASSERT_EQUAL_UINT32(&events[i], e);
+            }
+            e = e->next;
+        }
+    }
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+} 
+
+/**
+ * Given an initialized ticker.
+ * When an event is inserted with ticker_insert_event and a timestamp less 
+ * than the current timestamp in the interface and less than the relative 
+ * timestamp of the next event to execute.
+ * Then 
+ *   - The event inserted should be after the head
+ *   - The interrupt timestamp should remains equal to the interrupt timestamp 
+ *     of the head event .
+ *   - The timestamp of the event should reflect the timestamp requested (overflow)
+ *   - The id of the event should be equal to the id passed in parameter. 
+ *   - Events in the queue should remained ordered by timestamp.
+ */
+static void test_legacy_insert_event_multiple_overflow() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    interface_stub.set_interrupt_call = 0;
+
+    const timestamp_t timestamps[] = { 
+        0xA,
+        0xAA,
+        0xAAA,
+        0xAAAA,
+        0xAAAAA,
+        0xAAAAAA,
+        0xAAAAAAA,
+        0xAAAAAAAA
+    };
+    ticker_event_t events[MBED_ARRAY_SIZE(timestamps)] = { 0 };
+
+    ticker_event_t ref_event;
+    timestamp_t ref_event_timestamp = 0xCCCCCCCC;
+    ticker_insert_event(
+        &ticker_stub, 
+        &ref_event, ref_event_timestamp, 0xDEADBEEF
+    );
+
+    timestamp_t last_timestamp_to_insert = 
+        timestamps[MBED_ARRAY_SIZE(timestamps) - 1];
+    interface_stub.timestamp = 
+        last_timestamp_to_insert + 
+        ((ref_event_timestamp - last_timestamp_to_insert) / 2);
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_insert_event(
+            &ticker_stub, 
+            &events[i], timestamps[i], i
+        );
+
+        TEST_ASSERT_EQUAL_PTR(&ref_event, queue_stub.head);
+        TEST_ASSERT_EQUAL_PTR(&events[0], queue_stub.head->next);
+        TEST_ASSERT_EQUAL_UINT32(
+            ref_event_timestamp, interface_stub.interrupt_timestamp
+        );
+
+        TEST_ASSERT_EQUAL_UINT32(timestamps[i], events[i].timestamp);
+        TEST_ASSERT_EQUAL_UINT32(i, events[i].id);
+
+        ticker_event_t* e = queue_stub.head->next;
+        while (e) { 
+            TEST_ASSERT_EQUAL_UINT32(timestamps[e->id], e->timestamp);
+            if (e->next) { 
+                TEST_ASSERT_TRUE(e->id < e->next->id);
+                TEST_ASSERT_TRUE(e->timestamp < e->next->timestamp);
+            } else { 
+                TEST_ASSERT_EQUAL_UINT32(&events[i], e);
+            }
+            e = e->next;
+        }
+    }
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker.
+ * When an event is inserted with ticker_insert_event.
+ * Then 
+ *   - The event inserted should be at the correct position in the queue
+ *   - The event queue should remain ordered by timestamp
+ *   - The interrupt timestamp should be equal to the interrupt timestamp 
+ *     of the head event or TIMESTAMP_MAX_DELTA if the 
+ *     timestamp is in the overflow range.
+ *   - The timestamp of the event should reflect the timestamp requested (overflow)
+ *   - The id of the event should be equal to the id passed in parameter. 
+ *   - Events in the queue should remained ordered by timestamp.
+ */
+static void test_legacy_insert_event_multiple_random() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    interface_stub.set_interrupt_call = 0;
+
+    const timestamp_t ref_timestamp = UINT32_MAX / 2;
+    interface_stub.timestamp = ref_timestamp;
+
+    // insert first event at the head of the queue 
+    ticker_event_t first_event;
+    const timestamp_t first_event_timestamp = 
+        ref_timestamp + TIMESTAMP_MAX_DELTA + 100;
+
+    ticker_insert_event(
+        &ticker_stub,
+        &first_event, first_event_timestamp, (uint32_t) &first_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&first_event, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(NULL, first_event.next);
+    TEST_ASSERT_EQUAL_UINT32(
+        ref_timestamp + TIMESTAMP_MAX_DELTA, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT32(first_event_timestamp, first_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT64(
+        first_event.timestamp,
+        first_event_timestamp + 
+        ((first_event_timestamp < ref_timestamp) ? (1ULL << 32) : 0)
+    );
+    TEST_ASSERT_EQUAL_UINT32((uint32_t) &first_event, first_event.id);
+
+    // insert second event at the tail of the queue
+    ticker_event_t second_event;
+    const timestamp_t second_event_timestamp = first_event_timestamp + 1;
+
+    ticker_insert_event(
+        &ticker_stub,
+        &second_event, second_event_timestamp, (uint32_t) &second_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&first_event, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(&second_event, first_event.next);
+    TEST_ASSERT_EQUAL_PTR(NULL, second_event.next);
+    TEST_ASSERT_EQUAL_UINT32(
+        ref_timestamp + TIMESTAMP_MAX_DELTA, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT32(second_event_timestamp, second_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT64(
+        second_event.timestamp,
+        second_event_timestamp + 
+        ((second_event_timestamp < ref_timestamp) ? (1ULL << 32) : 0)
+    );
+    TEST_ASSERT_EQUAL_UINT32((uint32_t) &second_event, second_event.id);
+
+
+    // insert third event at the head of the queue out the overflow zone
+    ticker_event_t third_event;
+    const timestamp_t third_event_timestamp = 
+        ref_timestamp + TIMESTAMP_MAX_DELTA - 100;
+
+    ticker_insert_event(
+        &ticker_stub,
+        &third_event, third_event_timestamp, (uint32_t) &third_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&third_event, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(&first_event, third_event.next);
+    TEST_ASSERT_EQUAL_PTR(&second_event, first_event.next);
+    TEST_ASSERT_EQUAL_PTR(NULL, second_event.next);
+    TEST_ASSERT_EQUAL_UINT32(
+        third_event_timestamp, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT32(third_event_timestamp, third_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT64(
+        third_event.timestamp,
+        third_event_timestamp + 
+        ((third_event_timestamp < ref_timestamp) ? (1ULL << 32) : 0)
+    );
+    TEST_ASSERT_EQUAL_UINT32((uint32_t) &third_event, third_event.id);
+
+    // insert fourth event right after the third event
+    ticker_event_t fourth_event;
+    const timestamp_t fourth_event_timestamp = third_event_timestamp + 50;
+
+    ticker_insert_event(
+        &ticker_stub,
+        &fourth_event, fourth_event_timestamp, (uint32_t) &fourth_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&third_event, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(&fourth_event, third_event.next);
+    TEST_ASSERT_EQUAL_PTR(&first_event, fourth_event.next);
+    TEST_ASSERT_EQUAL_PTR(&second_event, first_event.next);
+    TEST_ASSERT_EQUAL_PTR(NULL, second_event.next);
+    TEST_ASSERT_EQUAL_UINT32(
+        third_event_timestamp, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT32(fourth_event_timestamp, fourth_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT64(
+        fourth_event.timestamp,
+        fourth_event_timestamp + 
+        ((fourth_event_timestamp < ref_timestamp) ? (1ULL << 32) : 0)
+    );
+    TEST_ASSERT_EQUAL_UINT32((uint32_t) &fourth_event, fourth_event.id);
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker without user registered events.  
+ * When an event is inserted with ticker_insert_event_us and the timestamp passed 
+ * in parameter is in range [ticker_timestamp : ticker_timestamp + 
+ * TIMESTAMP_MAX_DELTA[.
+ * Then 
+ *   - The event should be in the queue
+ *   - The interrupt timestamp should be equal to the lower 8 bytes of the event. 
+ *   - The timestamp of the event should be equal to the timestamp requested. 
+ *   - The id of the event should be equal to the id passed in parameter. 
+ */
+static void test_insert_event_us_outside_overflow_range() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    interface_stub.set_interrupt_call = 0;
+    interface_stub.timestamp = 0xAAAAAAAA;
+    queue_stub.timestamp = 10ULL << 32 | interface_stub.timestamp;
+
+    // test the end of the range
+    ticker_event_t last_event = { 0 };
+    const us_timestamp_t timestamp_last_event = 
+        queue_stub.timestamp + TIMESTAMP_MAX_DELTA; 
+    const uint32_t id_last_event = 0xDEADDEAF;
+
+    ticker_insert_event_us(
+        &ticker_stub, 
+        &last_event, timestamp_last_event, id_last_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&last_event, queue_stub.head);
+    TEST_ASSERT_EQUAL(1, interface_stub.set_interrupt_call);    
+    TEST_ASSERT_EQUAL_UINT32(
+        timestamp_last_event, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_PTR(NULL, queue_stub.head->next);
+    TEST_ASSERT_EQUAL_UINT64(timestamp_last_event, last_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT32(id_last_event, last_event.id);
+
+    // test the beginning of the range
+    ticker_event_t first_event = { 0 };
+    const us_timestamp_t timestamp_first_event = queue_stub.timestamp + 1; 
+    const uint32_t id_first_event = 0xAAAAAAAA;
+
+    ticker_insert_event_us(
+        &ticker_stub, 
+        &first_event, timestamp_first_event, id_first_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&first_event, queue_stub.head);
+    TEST_ASSERT_EQUAL(2, interface_stub.set_interrupt_call);    
+    TEST_ASSERT_EQUAL_UINT32(
+        timestamp_first_event, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_PTR(&last_event, queue_stub.head->next);
+    TEST_ASSERT_EQUAL_UINT64(
+        timestamp_first_event, first_event.timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT32(id_first_event, first_event.id);
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}  
+
+/**
+ * Given an initialized ticker without user registered events.  
+ * When an event is inserted with ticker_insert_event_us and a timestamp in the 
+ * range [ticker_timestamp + TIMESTAMP_MAX_DELTA + 1 : UINT64_MAX [ 
+ * Then 
+ *   - The event should be in the queue
+ *   - The interrupt timestamp should be equal to TIMESTAMP_MAX_DELTA 
+ *   - The timestamp of the event should be equal to the timestamp in parameter. 
+ *   - The id of the event should be equal to the id passed in parameter. 
+ */
+static void test_insert_event_us_in_overflow_range() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    interface_stub.set_interrupt_call = 0;
+    interface_stub.timestamp = 0xAAAAAAAA;
+    queue_stub.timestamp = 10ULL << 32 | interface_stub.timestamp;
+
+    // test the end of the range
+    ticker_event_t last_event = { 0 };
+    const us_timestamp_t timestamp_last_event = UINT64_MAX; 
+    const uint32_t id_last_event = 0xDEADDEAF;
+
+    ticker_insert_event_us(
+        &ticker_stub, 
+        &last_event, timestamp_last_event, id_last_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&last_event, queue_stub.head);
+    TEST_ASSERT_EQUAL(1, interface_stub.set_interrupt_call);    
+    TEST_ASSERT_EQUAL_UINT32(
+        interface_stub.timestamp + TIMESTAMP_MAX_DELTA, 
+        interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_PTR(NULL, queue_stub.head->next);
+    TEST_ASSERT_EQUAL_UINT64(timestamp_last_event, last_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT32(id_last_event, last_event.id);
+
+    // test the beginning of the range
+    ++interface_stub.timestamp;
+    ++queue_stub.timestamp;
+
+    ticker_event_t first_event = { 0 };
+    const us_timestamp_t timestamp_first_event = 
+        queue_stub.timestamp + TIMESTAMP_MAX_DELTA + 1; 
+    uint32_t id_first_event = 0xAAAAAAAA;
+
+    ticker_insert_event_us(&ticker_stub, 
+        &first_event, timestamp_first_event, id_first_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&first_event, queue_stub.head);
+    TEST_ASSERT_EQUAL(2, interface_stub.set_interrupt_call);    
+    TEST_ASSERT_EQUAL_UINT32(
+        interface_stub.timestamp + TIMESTAMP_MAX_DELTA, 
+        interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_PTR(&last_event, queue_stub.head->next);
+    TEST_ASSERT_EQUAL_UINT64(timestamp_first_event, first_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT32(id_first_event, first_event.id);
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+} 
+
+/**
+ * Given an initialized ticker without user registered events.  
+ * When an event is inserted with ticker_insert_event_us and a timestamp less 
+ * than timestamp value in the ticker interface.
+ * Then 
+ *   - The event should not be in the queue
+ *   - The interrupt timestamp should be set to 
+ *     interface_stub.timestamp + TIMESTAMP_MAX_DELTA.
+ */
+static void test_insert_event_us_underflow() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    interface_stub.set_interrupt_call = 0;
+
+    interface_stub.timestamp = 0xAAAAAAAA;
+    queue_stub.timestamp = 10ULL << 32 | interface_stub.timestamp;
+
+    // test the end of the range
+    ticker_event_t event = { 0 };
+    const timestamp_t expected_timestamp = queue_stub.timestamp - 1; 
+    const uint32_t expected_id = 0xDEADDEAF;
+
+    ticker_insert_event_us(
+        &ticker_stub, 
+        &event, expected_timestamp, expected_id
+    );
+
+    TEST_ASSERT_EQUAL_PTR(NULL, queue_stub.head);
+    TEST_ASSERT_EQUAL_UINT32(
+        interface_stub.timestamp + TIMESTAMP_MAX_DELTA, 
+        interface_stub.interrupt_timestamp
+    );
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}  
+
+/**
+ * Given an initialized ticker.
+ * When an event is inserted with ticker_insert_event_us and a timestamp less 
+ * than the one for the next scheduled timestamp.
+ * Then 
+ *   - The event inserted should be the first in the queue
+ *   - The interrupt timestamp should be equal to the timestamp of the event or 
+ *     TIMESTAMP_MAX_DELTA if in the overflow range.
+ *   - The timestamp of the event should be equal to the timestamp in parameter. 
+ *   - The id of the event should be equal to the id passed in parameter. 
+ *   - Events in the queue should remained ordered by timestamp.
+ */
+static void test_insert_event_us_head() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    interface_stub.set_interrupt_call = 0;
+    interface_stub.timestamp = 0xAAAAAAAA;
+    queue_stub.timestamp = 10ULL << 32 | interface_stub.timestamp;
+
+    const us_timestamp_t timestamps[] = { 
+        UINT64_MAX,
+        queue_stub.timestamp + TIMESTAMP_MAX_DELTA + 1,
+        queue_stub.timestamp + TIMESTAMP_MAX_DELTA,
+        queue_stub.timestamp + (TIMESTAMP_MAX_DELTA / 2),
+        queue_stub.timestamp + (TIMESTAMP_MAX_DELTA / 4),
+        queue_stub.timestamp + (TIMESTAMP_MAX_DELTA / 8),
+        queue_stub.timestamp + (TIMESTAMP_MAX_DELTA / 16),
+    };
+    ticker_event_t events[MBED_ARRAY_SIZE(timestamps)] = { 0 };
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_insert_event_us(
+            &ticker_stub, 
+            &events[i], timestamps[i], i
+        );
+
+        TEST_ASSERT_EQUAL_PTR(&events[i], queue_stub.head);
+        if ((timestamps[i] - queue_stub.timestamp) < TIMESTAMP_MAX_DELTA) { 
+            TEST_ASSERT_EQUAL_UINT32(
+                timestamps[i], 
+                interface_stub.interrupt_timestamp
+            );
+        } else { 
+            TEST_ASSERT_EQUAL_UINT32(
+                queue_stub.timestamp + TIMESTAMP_MAX_DELTA, 
+                interface_stub.interrupt_timestamp
+            );
+        }
+
+        TEST_ASSERT_EQUAL_UINT64(timestamps[i], events[i].timestamp);
+        TEST_ASSERT_EQUAL_UINT32(i, events[i].id);
+
+        ticker_event_t* e = &events[i];
+        while (e) { 
+            TEST_ASSERT_EQUAL_UINT32(timestamps[e->id], e->timestamp);
+            if (e->next) { 
+                TEST_ASSERT_TRUE(e->id > e->next->id);
+                TEST_ASSERT_TRUE(e->timestamp < e->next->timestamp);
+            } else { 
+                TEST_ASSERT_EQUAL_UINT32(0, e->id);
+            }
+            e = e->next;
+        }
+    }
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}  
+
+/** 
+ * Given an initialized ticker.
+ * When an event is inserted with ticker_insert_event_us and its timestamp is 
+ * bigger than the one of the last event in the queue.
+ * Then 
+ *   - The event inserted should be the last in the queue
+ *   - The interrupt timestamp should remains equal to the interrupt timestamp 
+ *     of the head event .
+ *   - The timestamp of the event should reflect the timestamp requested.
+ *   - The id of the event should be equal to the id passed in parameter. 
+ *   - Events in the queue should remained ordered by timestamp.
+ */
+static void test_insert_event_us_tail() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    interface_stub.set_interrupt_call = 0;
+
+    const us_timestamp_t timestamps[] = { 
+        0xA,
+        (1ULL << 32),
+        (2ULL << 32),
+        (4ULL << 32),
+        (8ULL << 32),
+        (16ULL << 32),
+        (32ULL << 32),
+        (64ULL << 32),
+    };
+    ticker_event_t events[MBED_ARRAY_SIZE(timestamps)] = { 0 };
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_insert_event_us(
+            &ticker_stub, 
+            &events[i], timestamps[i], i
+        );
+
+        TEST_ASSERT_EQUAL_PTR(&events[0], queue_stub.head); 
+        TEST_ASSERT_EQUAL_UINT32(
+            timestamps[0], interface_stub.interrupt_timestamp
+        );
+        TEST_ASSERT_EQUAL_UINT64(timestamps[i], events[i].timestamp);
+        TEST_ASSERT_EQUAL_UINT32(i, events[i].id);
+
+        ticker_event_t* e = queue_stub.head;
+        while (e) { 
+            TEST_ASSERT_EQUAL_UINT32(timestamps[e->id], e->timestamp);
+            if (e->next) { 
+                TEST_ASSERT_TRUE(e->id < e->next->id);
+                TEST_ASSERT_TRUE(e->timestamp < e->next->timestamp);
+            } else { 
+                TEST_ASSERT_EQUAL_UINT32(&events[i], e);
+            }
+            e = e->next;
+        }
+    }
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+} 
+
+/**
+ * Given an initialized ticker.
+ * When an event is inserted with ticker_insert_event_us.
+ * Then 
+ *   - The event inserted should be at the correct position in the queue
+ *   - The event queue should remain ordered by timestamp
+ *   - The interrupt timestamp should be equal to the interrupt timestamp 
+ *     of the head event or TIMESTAMP_MAX_DELTA if the 
+ *     timestamp is in the overflow range.
+ *   - The timestamp of the event should be equal to the timestamp parameter.
+ *   - The id of the event should be equal to the id passed in parameter. 
+ *   - Events in the queue should remained ordered by timestamp.
+ */
+static void test_insert_event_us_multiple_random() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    interface_stub.set_interrupt_call = 0;
+
+    const timestamp_t ref_timestamp = UINT32_MAX / 2;
+    interface_stub.timestamp = ref_timestamp;
+
+    // insert first event at the head of the queue 
+    ticker_event_t first_event;
+    const us_timestamp_t first_event_timestamp = 
+        ref_timestamp + TIMESTAMP_MAX_DELTA + 100;
+
+    ticker_insert_event_us(
+        &ticker_stub,
+        &first_event, first_event_timestamp, (uint32_t) &first_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&first_event, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(NULL, first_event.next);
+    TEST_ASSERT_EQUAL_UINT32(
+        ref_timestamp + TIMESTAMP_MAX_DELTA, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT64(first_event.timestamp, first_event_timestamp);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t) &first_event, first_event.id);
+
+    // insert second event at the tail of the queue
+    ticker_event_t second_event;
+    const us_timestamp_t second_event_timestamp = first_event_timestamp + 1;
+
+    ticker_insert_event_us(
+        &ticker_stub,
+        &second_event, second_event_timestamp, (uint32_t) &second_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&first_event, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(&second_event, first_event.next);
+    TEST_ASSERT_EQUAL_PTR(NULL, second_event.next);
+    TEST_ASSERT_EQUAL_UINT32(
+        ref_timestamp + TIMESTAMP_MAX_DELTA, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT64(second_event_timestamp, second_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t) &second_event, second_event.id);
+
+
+    // insert third event at the head of the queue out the overflow zone
+    ticker_event_t third_event;
+    const us_timestamp_t third_event_timestamp = 
+        ref_timestamp + TIMESTAMP_MAX_DELTA - 100;
+
+    ticker_insert_event_us(
+        &ticker_stub,
+        &third_event, third_event_timestamp, (uint32_t) &third_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&third_event, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(&first_event, third_event.next);
+    TEST_ASSERT_EQUAL_PTR(&second_event, first_event.next);
+    TEST_ASSERT_EQUAL_PTR(NULL, second_event.next);
+    TEST_ASSERT_EQUAL_UINT32(
+        third_event_timestamp, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT64(third_event_timestamp, third_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t) &third_event, third_event.id);
+
+    // insert fourth event right after the third event
+    ticker_event_t fourth_event;
+    const us_timestamp_t fourth_event_timestamp = third_event_timestamp + 50;
+
+    ticker_insert_event_us(
+        &ticker_stub,
+        &fourth_event, fourth_event_timestamp, (uint32_t) &fourth_event
+    );
+
+    TEST_ASSERT_EQUAL_PTR(&third_event, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(&fourth_event, third_event.next);
+    TEST_ASSERT_EQUAL_PTR(&first_event, fourth_event.next);
+    TEST_ASSERT_EQUAL_PTR(&second_event, first_event.next);
+    TEST_ASSERT_EQUAL_PTR(NULL, second_event.next);
+    TEST_ASSERT_EQUAL_UINT32(
+        third_event_timestamp, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT64(fourth_event_timestamp, fourth_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t) &fourth_event, fourth_event.id);
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker with multiple events registered. 
+ * When the event at the tail of the queue is removed from the queue.
+ * Then: 
+ *    - The event should not be in the queue.
+ *    - The events in the queue should remain ordered
+ *    - The interrupt timestamp should be unchanged. 
+ */
+static void test_remove_event_tail() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    const us_timestamp_t timestamps[] = { 
+        0xA,
+        (1ULL << 32),
+        (2ULL << 32),
+        (4ULL << 32),
+        (8ULL << 32),
+        (16ULL << 32),
+        (32ULL << 32),
+        (64ULL << 32),
+    };
+    ticker_event_t events[MBED_ARRAY_SIZE(timestamps)] = { 0 };
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_insert_event_us(
+            &ticker_stub, 
+            &events[i], timestamps[i], i
+        );
+    }
+
+    for (ssize_t i = MBED_ARRAY_SIZE(events) - 1; i >= 0; --i) { 
+        ticker_remove_event(&ticker_stub, &events[i]);
+
+        ticker_event_t* e = queue_stub.head;
+        size_t event_count = 0;
+        while (e) { 
+            TEST_ASSERT_NOT_EQUAL(e, &events[i]);
+            if (e->next) { 
+                TEST_ASSERT_TRUE(e->timestamp <= e->next->timestamp);
+            }
+            e = e->next;
+            ++event_count;
+        }
+
+        TEST_ASSERT_EQUAL(i, event_count);
+
+        if (i != 0 ) { 
+            TEST_ASSERT_EQUAL(
+                timestamps[0],
+                interface_stub.interrupt_timestamp
+            );
+        } else { 
+            TEST_ASSERT_EQUAL(
+                interface_stub.timestamp + TIMESTAMP_MAX_DELTA,
+                interface_stub.interrupt_timestamp
+            );
+        }
+    }
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker with multiple events registered. 
+ * When the event at the head of the queue is removed from the queue.
+ * Then: 
+ *    - The event should not be in the queue.
+ *    - The event at the head of the queue should be the equal to the one 
+ *      after the event removed.
+ *    - The interrupt timestamp should be equal to the interrupt timestamp 
+ *      of the head event or TIMESTAMP_MAX_DELTA if the 
+ *      timestamp is in the overflow range.
+ */
+static void test_remove_event_head() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    const us_timestamp_t timestamps[] = { 
+        TIMESTAMP_MAX_DELTA / 8,
+        TIMESTAMP_MAX_DELTA / 4,
+        TIMESTAMP_MAX_DELTA / 2,
+        TIMESTAMP_MAX_DELTA - 1,
+        TIMESTAMP_MAX_DELTA,
+        TIMESTAMP_MAX_DELTA + 1,
+        (1ULL << 32) | TIMESTAMP_MAX_DELTA,
+        UINT64_MAX
+    };
+    ticker_event_t events[MBED_ARRAY_SIZE(timestamps)] = { 0 };
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_insert_event_us(&ticker_stub, 
+            &events[i], timestamps[i], i
+        );
+    }
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_remove_event(&ticker_stub, &events[i]);
+
+        ticker_event_t* e = queue_stub.head;
+        size_t event_count = 0;
+        while (e) { 
+            TEST_ASSERT_NOT_EQUAL(e, &events[i]);
+            if (e->next) { 
+                TEST_ASSERT_TRUE(e->timestamp <= e->next->timestamp);
+            }
+            e = e->next;
+            ++event_count;
+        }
+
+        TEST_ASSERT_EQUAL(MBED_ARRAY_SIZE(events) - i - 1, event_count);
+
+        if (event_count) { 
+            TEST_ASSERT_EQUAL(
+                std::min(
+                    timestamps[i + 1], 
+                    interface_stub.timestamp + TIMESTAMP_MAX_DELTA
+                ),
+                interface_stub.interrupt_timestamp
+            );
+        } else { 
+            TEST_ASSERT_EQUAL(
+                interface_stub.timestamp + TIMESTAMP_MAX_DELTA,
+                interface_stub.interrupt_timestamp
+            );
+        }
+
+    }
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker with multiple events registered. 
+ * When an event not in the queue is attempted to be removed.
+ * Then the queue should remains identical as before.
+ */
+static void test_remove_event_invalid() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    const us_timestamp_t timestamps[] = { 
+        TIMESTAMP_MAX_DELTA / 8,
+        TIMESTAMP_MAX_DELTA / 4,
+        TIMESTAMP_MAX_DELTA / 2,
+        TIMESTAMP_MAX_DELTA - 1,
+        TIMESTAMP_MAX_DELTA,
+        TIMESTAMP_MAX_DELTA + 1,
+        (1ULL << 32) | TIMESTAMP_MAX_DELTA,
+        UINT64_MAX
+    };
+    ticker_event_t events[MBED_ARRAY_SIZE(timestamps)] = { 0 };
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_insert_event_us(
+            &ticker_stub, 
+            &events[i], timestamps[i], i
+        );
+    }
+
+    ticker_event_t invalid_event;
+    ticker_remove_event(&ticker_stub, &invalid_event);
+
+    TEST_ASSERT_EQUAL(&events[0], queue_stub.head);
+
+    ticker_event_t* e = queue_stub.head;
+    size_t event_count = 0;
+    while (e) { 
+        TEST_ASSERT_EQUAL(e, &events[event_count]);
+        e = e->next;
+        ++event_count;
+    }
+    TEST_ASSERT_EQUAL(MBED_ARRAY_SIZE(events), event_count);
+}
+
+/**
+ * Given an initialized ticker with multiple events inserted.
+ * When an event is remoced
+ * Then:
+ *   - the event should not be in the queue
+ *   - the queue should remain ordered
+ *   - the interrupt timestamp should be set to either head->timestamp or 
+ *     TIMESTAMP_MAX_DELTA depending on the distance between the current time 
+ *     ans the timestamp of the event at the head of the queue.
+ */
+static void test_remove_random() { 
+    ticker_set_handler(&ticker_stub, NULL);
+    interface_stub.set_interrupt_call = 0;
+
+    const timestamp_t ref_timestamp = UINT32_MAX / 2;
+    interface_stub.timestamp = ref_timestamp;
+
+    // insert all events 
+    ticker_event_t first_event;
+    const us_timestamp_t first_event_timestamp = 
+        ref_timestamp + TIMESTAMP_MAX_DELTA + 100;
+
+    ticker_insert_event_us(
+        &ticker_stub,
+        &first_event, first_event_timestamp, (uint32_t) &first_event
+    );
+
+
+    ticker_event_t second_event;
+    const us_timestamp_t second_event_timestamp = first_event_timestamp + 1;
+
+    ticker_insert_event_us(
+        &ticker_stub,
+        &second_event, second_event_timestamp, (uint32_t) &second_event
+    );
+
+    ticker_event_t third_event;
+    const us_timestamp_t third_event_timestamp = 
+        ref_timestamp + TIMESTAMP_MAX_DELTA - 100;
+
+    ticker_insert_event_us(
+        &ticker_stub,
+        &third_event, third_event_timestamp, (uint32_t) &third_event
+    );
+
+    ticker_event_t fourth_event;
+    const us_timestamp_t fourth_event_timestamp = third_event_timestamp + 50;
+
+    ticker_insert_event_us(
+        &ticker_stub,
+        &fourth_event, fourth_event_timestamp, (uint32_t) &fourth_event
+    );
+
+    // test that the queue is in the correct state 
+    TEST_ASSERT_EQUAL_PTR(&third_event, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(&fourth_event, third_event.next);
+    TEST_ASSERT_EQUAL_PTR(&first_event, fourth_event.next);
+    TEST_ASSERT_EQUAL_PTR(&second_event, first_event.next);
+    TEST_ASSERT_EQUAL_PTR(NULL, second_event.next);
+    TEST_ASSERT_EQUAL_UINT32(
+        third_event_timestamp, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT64(fourth_event_timestamp, fourth_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t) &fourth_event, fourth_event.id);
+
+    // remove fourth event 
+    ticker_remove_event(&ticker_stub, &fourth_event);
+
+    TEST_ASSERT_EQUAL_PTR(&third_event, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(&first_event, third_event.next);
+    TEST_ASSERT_EQUAL_PTR(&second_event, first_event.next);
+    TEST_ASSERT_EQUAL_PTR(NULL, second_event.next);
+    TEST_ASSERT_EQUAL_UINT32(
+        third_event_timestamp, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT64(third_event_timestamp, third_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t) &third_event, third_event.id);
+
+    // remove third event 
+    ticker_remove_event(&ticker_stub, &third_event);
+
+    TEST_ASSERT_EQUAL_PTR(&first_event, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(&second_event, first_event.next);
+    TEST_ASSERT_EQUAL_PTR(NULL, second_event.next);
+    TEST_ASSERT_EQUAL_UINT32(
+        ref_timestamp + TIMESTAMP_MAX_DELTA, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT64(second_event_timestamp, second_event.timestamp);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t) &second_event, second_event.id);
+
+    // remove second event 
+    ticker_remove_event(&ticker_stub, &second_event);
+
+    TEST_ASSERT_EQUAL_PTR(&first_event, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(NULL, first_event.next);
+    TEST_ASSERT_EQUAL_UINT32(
+        ref_timestamp + TIMESTAMP_MAX_DELTA, interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_UINT64(first_event.timestamp, first_event_timestamp);
+    TEST_ASSERT_EQUAL_UINT32((uint32_t) &first_event, first_event.id);
+
+    // remove first event 
+    ticker_remove_event(&ticker_stub, &first_event);
+
+    TEST_ASSERT_EQUAL_PTR(NULL, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(NULL, first_event.next);
+    TEST_ASSERT_EQUAL_UINT32(
+        ref_timestamp + TIMESTAMP_MAX_DELTA, interface_stub.interrupt_timestamp
+    );
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/** 
+ * Given an initialized ticker without user registered events and a ticker 
+ * interface timestamp equal or bigger than the one registered by the overflow 
+ * event.
+ * When the interrupt handler is called.
+ * Then:
+ *   - The interrupt timestamp should be updated to the timestamp of the ticker 
+ *     interface plus TIMESTAMP_MAX_DELTA. 
+ *   - The irq handler registered should not be called.
+ */
+static void test_overflow_event_update() { 
+    static uint32_t handler_call = 0;
+    struct irq_handler_stub_t { 
+        static void event_handler(uint32_t id) { 
+            ++handler_call;
+        }
+    };
+    handler_call = 0;
+
+    ticker_set_handler(&ticker_stub, irq_handler_stub_t::event_handler);
+    interface_stub.set_interrupt_call = 0;
+
+    for (size_t i = 0; i < 8; ++i) {
+        us_timestamp_t previous_timestamp = queue_stub.timestamp;
+        timestamp_t interface_timestamp = 
+            previous_timestamp + (TIMESTAMP_MAX_DELTA + i * 100);
+        interface_stub.timestamp = interface_timestamp;
+            
+        ticker_irq_handler(&ticker_stub);
+        TEST_ASSERT_EQUAL(i + 1, interface_stub.clear_interrupt_call);
+
+        TEST_ASSERT_EQUAL(i + 1, interface_stub.set_interrupt_call);
+        TEST_ASSERT_EQUAL_UINT32(
+            interface_timestamp + TIMESTAMP_MAX_DELTA,
+            interface_stub.interrupt_timestamp
+        );
+        TEST_ASSERT_EQUAL(0, handler_call);
+    }
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}  
+
+/** 
+ * Given an initialized ticker without user registered events and a ticker 
+ * interface timestamp less than the one registered to handle overflow.
+ * When the interrupt handler is called.
+ * Then:
+ *   - The interrupt timestamp should be updated to the timestamp of the ticker 
+ *     interface plus TIMESTAMP_MAX_DELTA. 
+ *   - The irq handler registered should not be called.
+ */
+static void test_overflow_event_update_when_spurious_interrupt() { 
+    static uint32_t handler_call = 0;
+    struct irq_handler_stub_t { 
+        static void event_handler(uint32_t id) { 
+            ++handler_call;
+        }
+    };
+    handler_call = 0;
+
+    ticker_set_handler(&ticker_stub, irq_handler_stub_t::event_handler);
+    interface_stub.set_interrupt_call = 0;
+
+    for (size_t i = 0; i < 8; ++i) {
+        us_timestamp_t previous_timestamp = queue_stub.timestamp;
+        timestamp_t interface_timestamp = 
+            previous_timestamp + (TIMESTAMP_MAX_DELTA / (2 + i));
+        interface_stub.timestamp = interface_timestamp;
+            
+        ticker_irq_handler(&ticker_stub);
+
+        TEST_ASSERT_EQUAL(i + 1, interface_stub.clear_interrupt_call);
+        TEST_ASSERT_EQUAL(i + 1, interface_stub.set_interrupt_call);
+        TEST_ASSERT_EQUAL_UINT32(
+            interface_timestamp + TIMESTAMP_MAX_DELTA,
+            interface_stub.interrupt_timestamp
+        );
+        TEST_ASSERT_EQUAL(0, handler_call);
+    }
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}  
+
+/**
+ * Given an initialized ticker with a single ticker event inserted and a ticker 
+ * interface timestamp bigger than the one set for interrupt. 
+ * When ticker_irq_handler is called.
+ * Then: 
+ *   - The IRQ handler should be called with the id of the event at the head of 
+ *     the queue.
+ *   - The event at the head of the queue should be replaced by the next event.
+ *   - The interrupt timestamp in the ticker interface should be set to the 
+ *     value of the interface timestamp + TIMESTAMP_MAX_DELTA  
+ */
+static void test_irq_handler_single_event() { 
+    const timestamp_t event_timestamp = 0xAAAAAAAA;
+    static const timestamp_t interface_timestamp_after_irq = event_timestamp + 100;
+    static const uint32_t event_id = 0xFFAAFFAA;
+
+    static uint32_t handler_call = 0;
+    struct irq_handler_stub_t { 
+        static void event_handler(uint32_t id) { 
+            ++handler_call;
+            interface_stub.timestamp = interface_timestamp_after_irq;
+            TEST_ASSERT_EQUAL_UINT32(event_id, id);
+        }
+    };
+    handler_call = 0;
+
+    ticker_set_handler(&ticker_stub, irq_handler_stub_t::event_handler);
+    interface_stub.set_interrupt_call = 0;
+
+    ticker_event_t e; 
+    ticker_insert_event(&ticker_stub, &e, event_timestamp, event_id);
+
+    interface_stub.timestamp = event_timestamp;
+    interface_stub.set_interrupt_call = 0;
+
+    ticker_irq_handler(&ticker_stub);
+
+    TEST_ASSERT_EQUAL(1, interface_stub.clear_interrupt_call);
+    TEST_ASSERT_EQUAL(1, interface_stub.set_interrupt_call);
+    TEST_ASSERT_EQUAL(1, handler_call);
+    TEST_ASSERT_EQUAL_UINT32(
+        interface_timestamp_after_irq + TIMESTAMP_MAX_DELTA,
+        interface_stub.interrupt_timestamp
+    );
+
+    TEST_ASSERT_NULL(queue_stub.head);
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker with at least a ticker event inserted and a ticker 
+ * interface timestamp less than the one set for interrupt. 
+ * When ticker_irq_handler is called.
+ * Then: 
+ *   - The IRQ handler should not be called.
+ *   - The event at the head of the queue should remains the same.
+ *   - The interrupt timestamp in the ticker interface should be set to the 
+ *     value of the event timestamp  
+ */
+static void test_irq_handler_single_event_spurious() { 
+    struct irq_handler_stub_t { 
+        static void event_handler(uint32_t id) { 
+            TEST_FAIL();
+        }
+    };
+
+    ticker_set_handler(&ticker_stub, irq_handler_stub_t::event_handler);
+    interface_stub.set_interrupt_call = 0;
+
+    const us_timestamp_t timestamps [] = {
+        UINT32_MAX, 
+        TIMESTAMP_MAX_DELTA + 1, 
+        TIMESTAMP_MAX_DELTA,
+        TIMESTAMP_MAX_DELTA - 1
+    };
+
+    static ticker_event_t events[MBED_ARRAY_SIZE(timestamps)] = { 0 };
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_insert_event_us(
+            &ticker_stub, 
+            &events[i], timestamps[i], timestamps[i]
+        );
+        interface_stub.set_interrupt_call = 0;
+        interface_stub.clear_interrupt_call = 0;
+
+        ticker_irq_handler(&ticker_stub);
+
+        TEST_ASSERT_EQUAL(1, interface_stub.clear_interrupt_call);
+        TEST_ASSERT_EQUAL(1, interface_stub.set_interrupt_call);
+        TEST_ASSERT_EQUAL_UINT32(
+            std::min(timestamps[i], TIMESTAMP_MAX_DELTA),
+            interface_stub.interrupt_timestamp
+        );
+    }
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker with multiple ticker event inserted, its 
+ * interface timestamp at greater than the timestamp of the next schedule event 
+ * and all event execution time taking at least the time befor ethe next event.
+ * When ticker_irq_handler is called.
+ * Then: 
+ *   - The IRQ handler should have been called for every event.
+ *   - The head of the queue should be set to NULL.
+ *   - The interrupt timestamp in the ticker interface should be scheduled in
+ *     TIMESTAMP_MAX_DELTAs
+ */
+static void test_irq_handler_multiple_event_multiple_dequeue() { 
+    const us_timestamp_t timestamps [] = {
+        10, 
+        10 + TIMESTAMP_MAX_DELTA - 1,
+        10 + TIMESTAMP_MAX_DELTA,
+        10 + TIMESTAMP_MAX_DELTA + 1, 
+        UINT32_MAX
+    };
+
+    static size_t handler_called = 0;
+    struct irq_handler_stub_t { 
+        static void event_handler(uint32_t id) { 
+            ++handler_called;
+            ticker_event_t* e = (ticker_event_t*) id;
+            if (e->next) { 
+                interface_stub.timestamp = e->next->timestamp;
+            }
+        }
+    };
+    handler_called = 0;
+
+    ticker_set_handler(&ticker_stub, irq_handler_stub_t::event_handler);
+    interface_stub.set_interrupt_call = 0;
+
+    ticker_event_t events[MBED_ARRAY_SIZE(timestamps)] = { 0 };
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_insert_event_us(
+            &ticker_stub, 
+            &events[i], timestamps[i], (uint32_t) &events[i]
+        );
+    }
+
+    interface_stub.set_interrupt_call = 0;
+    interface_stub.clear_interrupt_call = 0;
+    interface_stub.timestamp = timestamps[0];
+    
+    ticker_irq_handler(&ticker_stub);
+
+    TEST_ASSERT_EQUAL(1, interface_stub.clear_interrupt_call);
+    TEST_ASSERT_EQUAL(1, interface_stub.set_interrupt_call);
+    TEST_ASSERT_EQUAL_UINT32(MBED_ARRAY_SIZE(timestamps), handler_called);
+    TEST_ASSERT_EQUAL_UINT32(
+        timestamps[MBED_ARRAY_SIZE(timestamps) - 1] + TIMESTAMP_MAX_DELTA,
+        interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_NULL(queue_stub.head);
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker with two ticker event inserted scheduled from more 
+ * than TIMESTAMP_MAX_DELTA from one another. The interface 
+ * timestamp is equal to the timestamp of the first event. 
+ * When ticker_irq_handler is called.
+ * Then: 
+ *   - The IRQ handler should have been called for the first event.
+ *   - The head of the queue should be set to the event after the first event.
+ *   - The interrupt timestamp in the ticker interface should be scheduled in
+ *     TIMESTAMP_MAX_DELTA.
+ */
+static void test_irq_handler_multiple_event_single_dequeue_overflow() { 
+    const us_timestamp_t timestamps [] = {
+        10, 
+        10 + TIMESTAMP_MAX_DELTA + 1
+    };
+
+    static size_t handler_called = 0;
+    struct irq_handler_stub_t { 
+        static void event_handler(uint32_t id) { 
+            ++handler_called;
+        }
+    };
+    handler_called = 0;
+
+    ticker_set_handler(&ticker_stub, irq_handler_stub_t::event_handler);
+    interface_stub.set_interrupt_call = 0;
+
+    ticker_event_t events[MBED_ARRAY_SIZE(timestamps)] = { 0 };
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_insert_event_us(
+            &ticker_stub, 
+            &events[i], timestamps[i], (uint32_t) &events[i]
+        );
+    }
+
+    interface_stub.set_interrupt_call = 0;
+    interface_stub.clear_interrupt_call = 0;
+    interface_stub.timestamp = timestamps[0];
+    
+    ticker_irq_handler(&ticker_stub);
+
+    TEST_ASSERT_EQUAL(1, interface_stub.clear_interrupt_call);
+    TEST_ASSERT_EQUAL(1, interface_stub.set_interrupt_call);
+    TEST_ASSERT_EQUAL_UINT32(1, handler_called);
+    TEST_ASSERT_EQUAL_UINT32(
+        timestamps[0] + TIMESTAMP_MAX_DELTA,
+        interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_PTR(&events[1], queue_stub.head);
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker with two ticker event inserted scheduled from less 
+ * than TIMESTAMP_MAX_DELTA from one another. The interface 
+ * timestamp is equal to the timestamp of the first event. 
+ * When ticker_irq_handler is called.
+ * Then: 
+ *   - The IRQ handler should have been called for the first event.
+ *   - The head of the queue should be set to second event.
+ *   - The interrupt timestamp in the ticker interface should be equal to the 
+ *     timestamp of the second event.
+ */
+static void test_irq_handler_multiple_event_single_dequeue() { 
+    const us_timestamp_t timestamps [] = {
+        10, 
+        10 + TIMESTAMP_MAX_DELTA - 1
+    };
+
+    static size_t handler_called = 0;
+    struct irq_handler_stub_t { 
+        static void event_handler(uint32_t id) { 
+            ++handler_called;
+        }
+    };
+    handler_called = 0;
+
+    ticker_set_handler(&ticker_stub, irq_handler_stub_t::event_handler);
+    interface_stub.set_interrupt_call = 0;
+
+    ticker_event_t events[MBED_ARRAY_SIZE(timestamps)] = { 0 };
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_insert_event_us(
+            &ticker_stub, 
+            &events[i], timestamps[i], (uint32_t) &events[i]
+        );
+    }
+
+    interface_stub.set_interrupt_call = 0;
+    interface_stub.clear_interrupt_call = 0;
+    interface_stub.timestamp = timestamps[0];
+    
+    ticker_irq_handler(&ticker_stub);
+
+    TEST_ASSERT_EQUAL(1, interface_stub.clear_interrupt_call);
+    TEST_ASSERT_EQUAL(1, interface_stub.set_interrupt_call);
+    TEST_ASSERT_EQUAL_UINT32(1, handler_called);
+    TEST_ASSERT_EQUAL_UINT32(
+        timestamps[1],
+        interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_PTR(&events[1], queue_stub.head);
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker with multiple ticker event inserted and the 
+ * interface timestamp is equal to the timestamp of the first event. The first
+ * event to execute will insert an events in the ticker which have to be executed 
+ * immediately.
+ * When ticker_irq_handler is called.
+ * Then: 
+ *   - The IRQ handler should have been called for the first event and the event 
+ *     inserted during irq.
+ *   - The head of the queue should be set correctly.
+ *   - The interrupt timestamp in the ticker interface should be equal to 
+ *     timestamp of the head event.
+ */
+static void test_irq_handler_insert_immediate_in_irq() { 
+    const us_timestamp_t timestamps [] = {
+        10, 
+        10 + TIMESTAMP_MAX_DELTA - 1
+    };
+
+    static const us_timestamp_t expected_timestamp = 
+        ((timestamps[1] - timestamps[0]) / 2) + timestamps[0];
+
+    struct ctrl_block_t { 
+        bool irq_event_called;
+        ticker_event_t immediate_event; 
+        size_t handler_called;
+    };
+
+    static ctrl_block_t ctrl_block = { 0 };
+
+    struct irq_handler_stub_t { 
+        static void event_handler(uint32_t id) { 
+            ctrl_block_t*  ctrl_block = (ctrl_block_t*) id;
+
+            if (ctrl_block->handler_called == 0) {
+                ticker_insert_event(
+                    &ticker_stub, 
+                    &ctrl_block->immediate_event, expected_timestamp, id
+                );
+                interface_stub.timestamp = expected_timestamp;
+            } else if (ctrl_block->handler_called > 1) { 
+                TEST_FAIL();
+            }
+            ++ctrl_block->handler_called;
+        }
+    };
+
+    ticker_set_handler(&ticker_stub, irq_handler_stub_t::event_handler);
+    interface_stub.set_interrupt_call = 0;
+
+    ticker_event_t events[MBED_ARRAY_SIZE(timestamps)] = { 0 };
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_insert_event_us(
+            &ticker_stub, 
+            &events[i], timestamps[i], (uint32_t) &ctrl_block
+        );
+    }
+
+    interface_stub.set_interrupt_call = 0;
+    interface_stub.clear_interrupt_call = 0;
+    interface_stub.timestamp = timestamps[0];
+    
+    ticker_irq_handler(&ticker_stub);
+
+    TEST_ASSERT_EQUAL(1, interface_stub.clear_interrupt_call);
+    TEST_ASSERT_EQUAL_UINT32(2, ctrl_block.handler_called);
+    TEST_ASSERT_EQUAL_UINT32(
+        timestamps[1],
+        interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_PTR(&events[1], queue_stub.head);
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+/**
+ * Given an initialized ticker with multiple ticker event inserted and the 
+ * interface timestamp is equal to the timestamp of the first event. The first
+ * event to execute will insert an events in the ticker which does not have to 
+ * be executed  immediately.
+ * When ticker_irq_handler is called.
+ * Then: 
+ *   - The IRQ handler should have been called for the first event.
+ *   - The head of the queue should be set to the event inserted in IRQ.
+ *   - The interrupt timestamp in the ticker interface should be equal to 
+ *     timestamp of the head event.
+ */
+static void test_irq_handler_insert_non_immediate_in_irq() { 
+    const us_timestamp_t timestamps [] = {
+        10, 
+        10 + TIMESTAMP_MAX_DELTA - 1
+    };
+
+    static const us_timestamp_t expected_timestamp = 
+        ((timestamps[1] - timestamps[0]) / 2) + timestamps[0];
+
+    struct ctrl_block_t { 
+        bool irq_event_called;
+        ticker_event_t non_immediate_event; 
+        size_t handler_called;
+    };
+
+    static ctrl_block_t ctrl_block = { 0 };
+
+    struct irq_handler_stub_t { 
+        static void event_handler(uint32_t id) { 
+            ctrl_block_t*  ctrl_block = (ctrl_block_t*) id;
+
+            if (ctrl_block->handler_called == 0) {
+                ticker_insert_event(
+                    &ticker_stub, 
+                    &ctrl_block->non_immediate_event, expected_timestamp, id
+                );
+            } else { 
+                TEST_FAIL();
+            }
+            ++ctrl_block->handler_called;
+        }
+    };
+
+
+    ticker_set_handler(&ticker_stub, irq_handler_stub_t::event_handler);
+    interface_stub.set_interrupt_call = 0;
+
+    ticker_event_t events[MBED_ARRAY_SIZE(timestamps)] = { 0 };
+
+    for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
+        ticker_insert_event_us(
+            &ticker_stub, 
+            &events[i], timestamps[i], (uint32_t) &ctrl_block
+        );
+    }
+
+    interface_stub.set_interrupt_call = 0;
+    interface_stub.clear_interrupt_call = 0;
+    interface_stub.timestamp = timestamps[0];
+    
+    ticker_irq_handler(&ticker_stub);
+
+    TEST_ASSERT_EQUAL(1, interface_stub.clear_interrupt_call);
+    TEST_ASSERT_EQUAL_UINT32(1, ctrl_block.handler_called);
+    TEST_ASSERT_EQUAL_UINT32(
+        expected_timestamp,
+        interface_stub.interrupt_timestamp
+    );
+    TEST_ASSERT_EQUAL_PTR(&ctrl_block.non_immediate_event, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(&events[1], queue_stub.head->next);
+
+    TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
+}
+
+static const Case cases[] = {
+    make_test_case("ticker initialization", test_ticker_initialization),
+    make_test_case(
+        "ticker multiple initialization",  test_ticker_re_initialization
+    ),
+    make_test_case("ticker read", test_ticker_read),
+    make_test_case("ticker read overflow", test_ticker_read_overflow),
+    make_test_case(
+        "legacy insert event outside overflow range", 
+        test_legacy_insert_event_outside_overflow_range
+    ),
+    make_test_case(
+        "legacy insert event in overflow range", 
+        test_legacy_insert_event_in_overflow_range
+    ),
+    make_test_case(
+        "legacy insert event overflow", test_legacy_insert_event_overflow
+    ),
+    make_test_case(
+        "legacy insert event head", test_legacy_insert_event_head
+    ),
+    make_test_case(
+        "legacy insert event tail", test_legacy_insert_event_tail
+    ),
+    make_test_case(
+        "legacy insert event multiple overflow", 
+        test_legacy_insert_event_multiple_overflow
+    ),
+    make_test_case(
+        "test_legacy_insert_event_multiple_random", 
+        test_legacy_insert_event_multiple_random
+    ),
+    make_test_case(
+        "test_insert_event_us_outside_overflow_range", 
+        test_insert_event_us_outside_overflow_range
+    ),
+    make_test_case(
+        "test_insert_event_us_in_overflow_range", 
+        test_insert_event_us_in_overflow_range
+    ),
+    make_test_case(
+        "test_insert_event_us_underflow", test_insert_event_us_underflow
+    ),
+    make_test_case("test_insert_event_us_head", test_insert_event_us_head),
+    make_test_case("test_insert_event_us_tail", test_insert_event_us_tail),
+    make_test_case(
+        "test_insert_event_us_multiple_random", 
+        test_insert_event_us_multiple_random
+    ),
+    make_test_case("test_remove_event_tail", test_remove_event_tail),
+    make_test_case("test_remove_event_head", test_remove_event_head),
+    make_test_case("test_remove_event_invalid", test_remove_event_invalid),
+    make_test_case("test_remove_random", test_remove_random),
+    make_test_case("update overflow guard", test_overflow_event_update),
+    make_test_case(
+        "update overflow guard in case of spurious interrupt", 
+        test_overflow_event_update_when_spurious_interrupt
+    ),
+    make_test_case(
+        "test_irq_handler_single_event", test_irq_handler_single_event
+    ),
+    make_test_case(
+        "test_irq_handler_single_event_spurious", 
+        test_irq_handler_single_event_spurious
+    ),
+    make_test_case(
+        "test_irq_handler_multiple_event_multiple_dequeue", 
+        test_irq_handler_multiple_event_multiple_dequeue
+    ),
+    make_test_case(
+        "test_irq_handler_multiple_event_single_dequeue_overflow", 
+        test_irq_handler_multiple_event_single_dequeue_overflow
+    ),
+    make_test_case(
+        "test_irq_handler_multiple_event_single_dequeue", 
+        test_irq_handler_multiple_event_single_dequeue
+    ),
+    make_test_case(
+        "test_irq_handler_insert_immediate_in_irq", 
+        test_irq_handler_insert_immediate_in_irq
+    ),
+    make_test_case(
+        "test_irq_handler_insert_non_immediate_in_irq", 
+        test_irq_handler_insert_non_immediate_in_irq
+    )
+};
+
+static utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(30, "default_auto");
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+static Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+
+int main() {
+    return !Harness::run(specification);
+}

--- a/TESTS/mbed_hal/ticker/main.cpp
+++ b/TESTS/mbed_hal/ticker/main.cpp
@@ -905,9 +905,9 @@ static void test_insert_event_us_in_overflow_range() {
  * When an event is inserted with ticker_insert_event_us and a timestamp less 
  * than timestamp value in the ticker interface.
  * Then 
- *   - The event should not be in the queue
- *   - The interrupt timestamp should be set to 
- *     interface_stub.timestamp + TIMESTAMP_MAX_DELTA.
+ *   - The event should be in the queue
+ *   - The interrupt timestamp should be set to interface_stub.timestamp so it
+ *     is scheduled immediately.
  */
 static void test_insert_event_us_underflow() { 
     ticker_set_handler(&ticker_stub, NULL);
@@ -922,15 +922,16 @@ static void test_insert_event_us_underflow() {
     const uint32_t expected_id = 0xDEADDEAF;
 
     ticker_insert_event_us(
-        &ticker_stub, 
+        &ticker_stub,
         &event, expected_timestamp, expected_id
     );
 
-    TEST_ASSERT_EQUAL_PTR(NULL, queue_stub.head);
+    TEST_ASSERT_EQUAL_PTR(&event, queue_stub.head);
     TEST_ASSERT_EQUAL_UINT32(
-        interface_stub.timestamp + TIMESTAMP_MAX_DELTA, 
+        interface_stub.timestamp, 
         interface_stub.interrupt_timestamp
     );
+    TEST_ASSERT_EQUAL(1, interface_stub.set_interrupt_call);
 
     TEST_ASSERT_EQUAL(0, interface_stub.disable_interrupt_call);
 }  

--- a/TESTS/mbed_hal/ticker/main.cpp
+++ b/TESTS/mbed_hal/ticker/main.cpp
@@ -1569,8 +1569,8 @@ static void test_overflow_event_update_when_spurious_interrupt()
  */
 static void test_irq_handler_single_event()
 {
-    const timestamp_t event_timestamp = 0xAAAAAAAA;
-    const timestamp_t interface_timestamp_after_irq = event_timestamp + 100;
+    static const timestamp_t event_timestamp = 0xAAAAAAAA;
+    static const timestamp_t interface_timestamp_after_irq = event_timestamp + 100;
 
     uint32_t handler_call = 0;
     struct irq_handler_stub_t { 

--- a/drivers/Ticker.cpp
+++ b/drivers/Ticker.cpp
@@ -29,16 +29,16 @@ void Ticker::detach() {
     core_util_critical_section_exit();
 }
 
-void Ticker::setup(timestamp_t t) {
+void Ticker::setup(us_timestamp_t t) {
     core_util_critical_section_enter();
     remove();
     _delay = t;
-    insert(_delay + ticker_read(_ticker_data));
+    insert_absolute(_delay + ticker_read_us(_ticker_data));
     core_util_critical_section_exit();
 }
 
 void Ticker::handler() {
-    insert(event.timestamp + _delay);
+    insert_absolute(event.timestamp + _delay);
     _function();
 }
 

--- a/drivers/Ticker.h
+++ b/drivers/Ticker.h
@@ -100,7 +100,7 @@ public:
      *  @param func pointer to the function to be called
      *  @param t the time between calls in micro-seconds
      */
-    void attach_us(Callback<void()> func, timestamp_t t) {
+    void attach_us(Callback<void()> func, us_timestamp_t t) {
         _function = func;
         setup(t);
     }
@@ -118,7 +118,7 @@ public:
     MBED_DEPRECATED_SINCE("mbed-os-5.1",
         "The attach_us function does not support cv-qualifiers. Replaced by "
         "attach_us(callback(obj, method), t).")
-    void attach_us(T *obj, M method, timestamp_t t) {
+    void attach_us(T *obj, M method, us_timestamp_t t) {
         attach_us(Callback<void()>(obj, method), t);
     }
 
@@ -131,12 +131,12 @@ public:
     void detach();
 
 protected:
-    void setup(timestamp_t t);
+    void setup(us_timestamp_t t);
     virtual void handler();
 
 protected:
-    timestamp_t         _delay;     /* Time delay (in microseconds) for re-setting the multi-shot callback. */
-    Callback<void()>    _function;  /* Callback. */
+    us_timestamp_t         _delay;  /**< Time delay (in microseconds) for re-setting the multi-shot callback. */
+    Callback<void()>    _function;  /**< Callback. */
 };
 
 } // namespace mbed

--- a/drivers/Timer.cpp
+++ b/drivers/Timer.cpp
@@ -31,7 +31,7 @@ Timer::Timer(const ticker_data_t *data) : _running(), _start(), _time(), _ticker
 void Timer::start() {
     core_util_critical_section_enter();
     if (!_running) {
-        _start = ticker_read(_ticker_data);
+        _start = ticker_read_us(_ticker_data);
         _running = 1;
     }
     core_util_critical_section_exit();
@@ -46,24 +46,31 @@ void Timer::stop() {
 
 int Timer::read_us() {
     core_util_critical_section_enter();
-    int time = _time + slicetime();
+    us_timestamp_t time = _time + slicetime();
     core_util_critical_section_exit();
     return time;
 }
 
 float Timer::read() {
-    return (float)read_us() / 1000000.0f;
+    core_util_critical_section_enter();
+    us_timestamp_t time = _time + slicetime();
+    core_util_critical_section_exit();
+    time = time / 1000;
+    return (float)read_ms() / 1000.0f;
 }
 
 int Timer::read_ms() {
-    return read_us() / 1000;
+    core_util_critical_section_enter();
+    us_timestamp_t time = _time + slicetime();
+    core_util_critical_section_exit();
+    return time / 1000;    
 }
 
-int Timer::slicetime() {
+us_timestamp_t Timer::slicetime() {
     core_util_critical_section_enter();
-    int ret = 0;
+    us_timestamp_t ret = 0;
     if (_running) {
-        ret = ticker_read(_ticker_data) - _start;
+        ret = ticker_read_us(_ticker_data) - _start;
     }
     core_util_critical_section_exit();
     return ret;
@@ -71,7 +78,7 @@ int Timer::slicetime() {
 
 void Timer::reset() {
     core_util_critical_section_enter();
-    _start = ticker_read(_ticker_data);
+    _start = ticker_read_us(_ticker_data);
     _time = 0;
     core_util_critical_section_exit();
 }

--- a/drivers/Timer.cpp
+++ b/drivers/Timer.cpp
@@ -45,30 +45,27 @@ void Timer::stop() {
 }
 
 int Timer::read_us() {
+    return read_high_resolution_us();
+}
+
+float Timer::read() {
+    return (float)read_us() / 1000000.0f;
+}
+
+int Timer::read_ms() {
+    return read_high_resolution_us() / 1000;
+}
+
+us_timestamp_t Timer::read_high_resolution_us() {
     core_util_critical_section_enter();
     us_timestamp_t time = _time + slicetime();
     core_util_critical_section_exit();
     return time;
 }
 
-float Timer::read() {
-    core_util_critical_section_enter();
-    us_timestamp_t time = _time + slicetime();
-    core_util_critical_section_exit();
-    time = time / 1000;
-    return (float)read_ms() / 1000.0f;
-}
-
-int Timer::read_ms() {
-    core_util_critical_section_enter();
-    us_timestamp_t time = _time + slicetime();
-    core_util_critical_section_exit();
-    return time / 1000;    
-}
-
 us_timestamp_t Timer::slicetime() {
-    core_util_critical_section_enter();
     us_timestamp_t ret = 0;
+    core_util_critical_section_enter();
     if (_running) {
         ret = ticker_read_us(_ticker_data) - _start;
     }

--- a/drivers/Timer.h
+++ b/drivers/Timer.h
@@ -82,6 +82,10 @@ public:
      */
     operator float();
 
+    /** Get in a high resolution type the time passed in micro-seconds.
+     */
+    us_timestamp_t read_high_resolution_us();
+
 protected:
     us_timestamp_t slicetime();
     int _running;            // whether the timer is running

--- a/drivers/Timer.h
+++ b/drivers/Timer.h
@@ -83,10 +83,10 @@ public:
     operator float();
 
 protected:
-    int slicetime();
-    int _running;          // whether the timer is running
-    unsigned int _start;   // the start time of the latest slice
-    int _time;             // any accumulated time from previous slices
+    us_timestamp_t slicetime();
+    int _running;            // whether the timer is running
+    us_timestamp_t _start;   // the start time of the latest slice
+    us_timestamp_t _time;    // any accumulated time from previous slices
     const ticker_data_t *_ticker_data;
 };
 

--- a/drivers/TimerEvent.cpp
+++ b/drivers/TimerEvent.cpp
@@ -44,6 +44,10 @@ void TimerEvent::insert(timestamp_t timestamp) {
     ticker_insert_event(_ticker_data, &event, timestamp, (uint32_t)this);
 }
 
+void TimerEvent::insert_absolute(us_timestamp_t timestamp) {
+    ticker_insert_event(_ticker_data, &event, timestamp, (uint32_t)this);
+}
+
 void TimerEvent::remove() {
     ticker_remove_event(_ticker_data, &event);
 }

--- a/drivers/TimerEvent.cpp
+++ b/drivers/TimerEvent.cpp
@@ -45,7 +45,7 @@ void TimerEvent::insert(timestamp_t timestamp) {
 }
 
 void TimerEvent::insert_absolute(us_timestamp_t timestamp) {
-    ticker_insert_event(_ticker_data, &event, timestamp, (uint32_t)this);
+    ticker_insert_event_us(_ticker_data, &event, timestamp, (uint32_t)this);
 }
 
 void TimerEvent::remove() {

--- a/drivers/TimerEvent.h
+++ b/drivers/TimerEvent.h
@@ -44,8 +44,11 @@ protected:
     // The handler called to service the timer event of the derived class
     virtual void handler() = 0;
 
-    // insert in to linked list
+    // insert relative timestamp in to linked list
     void insert(timestamp_t timestamp);
+
+    // insert absolute timestamp into linked list
+    void insert_absolute(us_timestamp_t timestamp);
 
     // remove from linked list, if in it
     void remove();

--- a/hal/mbed_lp_ticker_api.c
+++ b/hal/mbed_lp_ticker_api.c
@@ -17,7 +17,7 @@
 
 #if DEVICE_LOWPOWERTIMER
 
-static ticker_event_queue_t events;
+static ticker_event_queue_t events = { 0 };
 
 static const ticker_interface_t lp_interface = {
     .init = lp_ticker_init,

--- a/hal/mbed_ticker_api.c
+++ b/hal/mbed_ticker_api.c
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- #include <stdio.h>
+#include <stdio.h>
 #include <stddef.h>
 #include "hal/ticker_api.h"
 #include "platform/mbed_critical.h"
@@ -26,7 +26,8 @@ static void update_current_timestamp(const ticker_data_t *const ticker);
 /*
  * Initialize a ticker instance.  
  */
-static void initialize(const ticker_data_t *ticker) { 
+static void initialize(const ticker_data_t *ticker)
+{
     // return if the queue has already been initialized, in that case the 
     // interface used by the queue is already initialized.
     if (ticker->queue->initialized) { 
@@ -47,7 +48,8 @@ static void initialize(const ticker_data_t *ticker) {
 /**
  * Set the event handler function of a ticker instance. 
  */
-static void set_handler(const ticker_data_t *const ticker, ticker_event_handler handler) { 
+static void set_handler(const ticker_data_t *const ticker, ticker_event_handler handler)
+{
     ticker->queue->event_handler = handler;
 }
 
@@ -63,7 +65,8 @@ static void set_handler(const ticker_data_t *const ticker, ticker_event_handler 
  * @param ref: The timestamp of reference. 
  * @param relative_timestamp: The timestamp to convert. 
  */
-static us_timestamp_t convert_relative_timestamp(us_timestamp_t ref, timestamp_t relative_timestamp) { 
+static us_timestamp_t convert_relative_timestamp(us_timestamp_t ref, timestamp_t relative_timestamp)
+{
      bool overflow = relative_timestamp < ((timestamp_t) ref) ? true : false;
 
     us_timestamp_t result = (ref & ~((us_timestamp_t)UINT32_MAX)) | relative_timestamp;
@@ -77,7 +80,8 @@ static us_timestamp_t convert_relative_timestamp(us_timestamp_t ref, timestamp_t
 /**
  * update the current timestamp value of a ticker.
  */
-static void update_current_timestamp(const ticker_data_t *const ticker) { 
+static void update_current_timestamp(const ticker_data_t *const ticker)
+{ 
     ticker->queue->timestamp = convert_relative_timestamp(
         ticker->queue->timestamp, 
         ticker->interface->read()
@@ -91,7 +95,8 @@ static void update_current_timestamp(const ticker_data_t *const ticker) {
  * interrupt will be set to MBED_TICKER_INTERRUPT_TIMESTAMP_MAX_DELTA us from now. 
  * Otherwise the interrupt will be set to head->timestamp - queue->timestamp us.
  */
-static void update_interrupt(const ticker_data_t *const ticker) { 
+static void update_interrupt(const ticker_data_t *const ticker)
+{
     update_current_timestamp(ticker);
     uint32_t diff = MBED_TICKER_INTERRUPT_TIMESTAMP_MAX_DELTA;
 
@@ -107,12 +112,14 @@ static void update_interrupt(const ticker_data_t *const ticker) {
     );
 }
 
-void ticker_set_handler(const ticker_data_t *const ticker, ticker_event_handler handler) {
+void ticker_set_handler(const ticker_data_t *const ticker, ticker_event_handler handler)
+{
     initialize(ticker);
     set_handler(ticker, handler);
 }
 
-void ticker_irq_handler(const ticker_data_t *const ticker) {
+void ticker_irq_handler(const ticker_data_t *const ticker)
+{
     ticker->interface->clear_interrupt();
 
     /* Go through all the pending TimerEvents */
@@ -142,7 +149,8 @@ void ticker_irq_handler(const ticker_data_t *const ticker) {
     update_interrupt(ticker);
 }
 
-void ticker_insert_event(const ticker_data_t *const ticker, ticker_event_t *obj, timestamp_t timestamp, uint32_t id) {
+void ticker_insert_event(const ticker_data_t *const ticker, ticker_event_t *obj, timestamp_t timestamp, uint32_t id)
+{
     /* disable interrupts for the duration of the function */
     core_util_critical_section_enter();
 
@@ -161,7 +169,8 @@ void ticker_insert_event(const ticker_data_t *const ticker, ticker_event_t *obj,
     );
 }
 
-void ticker_insert_event_us(const ticker_data_t *const ticker, ticker_event_t *obj, us_timestamp_t timestamp, uint32_t id) { 
+void ticker_insert_event_us(const ticker_data_t *const ticker, ticker_event_t *obj, us_timestamp_t timestamp, uint32_t id)
+{
     /* disable interrupts for the duration of the function */
     core_util_critical_section_enter();
 
@@ -207,7 +216,8 @@ void ticker_insert_event_us(const ticker_data_t *const ticker, ticker_event_t *o
     core_util_critical_section_exit();
 }
 
-void ticker_remove_event(const ticker_data_t *const ticker, ticker_event_t *obj) {
+void ticker_remove_event(const ticker_data_t *const ticker, ticker_event_t *obj)
+{
     core_util_critical_section_enter();
 
     // remove this object from the list
@@ -230,11 +240,13 @@ void ticker_remove_event(const ticker_data_t *const ticker, ticker_event_t *obj)
     core_util_critical_section_exit();
 }
 
-timestamp_t ticker_read(const ticker_data_t *const ticker) {
+timestamp_t ticker_read(const ticker_data_t *const ticker)
+{
     return ticker_read_us(ticker);
 }
 
-us_timestamp_t ticker_read_us(const ticker_data_t *const ticker) {
+us_timestamp_t ticker_read_us(const ticker_data_t *const ticker)
+{
     update_current_timestamp(ticker);
     return ticker->queue->timestamp;
 }

--- a/hal/mbed_ticker_api.c
+++ b/hal/mbed_ticker_api.c
@@ -13,49 +13,166 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+ #include <stdio.h>
 #include <stddef.h>
 #include "hal/ticker_api.h"
 #include "platform/mbed_critical.h"
 
-void ticker_set_handler(const ticker_data_t *const data, ticker_event_handler handler) {
-    data->interface->init();
+#define MBED_MIN(x,y) (((x)<(y))?(x):(y))
 
-    data->queue->event_handler = handler;
+static void update_interrupt(const ticker_data_t *const ticker);
+static void update_current_timestamp(const ticker_data_t *const ticker);
+
+/*
+ * Initialize a ticker instance.  
+ */
+static void initialize(const ticker_data_t *ticker) { 
+    // return if the queue has already been initialized, in that case the 
+    // interface used by the queue is already initialized.
+    if (ticker->queue->initialized) { 
+        return;
+    }
+
+    ticker->interface->init();
+    
+    ticker->queue->event_handler = NULL;
+    ticker->queue->head = NULL;
+    ticker->queue->timestamp = 0;
+    ticker->queue->initialized = true;
+    
+    update_current_timestamp(ticker);
+    update_interrupt(ticker);
 }
 
-void ticker_irq_handler(const ticker_data_t *const data) {
-    data->interface->clear_interrupt();
+/**
+ * Set the event handler function of a ticker instance. 
+ */
+static void set_handler(const ticker_data_t *const ticker, ticker_event_handler handler) { 
+    ticker->queue->event_handler = handler;
+}
+
+/*
+ * Convert a low res timestamp to a high res timestamp. An high resolution 
+ * timestamp is used as the reference point to convert the low res timestamp 
+ * into an high res one. 
+ * 
+ * It is important to note that the result will **never** be in the past. If the 
+ * value of the low res timetamp is less than the low res part of the reference 
+ * timestamp then an overflow is 
+ * 
+ * @param ref: The timestamp of reference. 
+ * @param relative_timestamp: The timestamp to convert. 
+ */
+static us_timestamp_t convert_relative_timestamp(us_timestamp_t ref, timestamp_t relative_timestamp) { 
+     bool overflow = relative_timestamp < ((timestamp_t) ref) ? true : false;
+
+    us_timestamp_t result = (ref & ~((us_timestamp_t)UINT32_MAX)) | relative_timestamp;
+    if (overflow) { 
+        result += (1ULL<<32);
+    }
+
+    return result;
+}
+
+/**
+ * update the current timestamp value of a ticker.
+ */
+static void update_current_timestamp(const ticker_data_t *const ticker) { 
+    ticker->queue->timestamp = convert_relative_timestamp(
+        ticker->queue->timestamp, 
+        ticker->interface->read()
+    );
+}
+
+/**
+ * update the interrupt with the appropriate timestamp. 
+ * if there is no interrupt scheduled or the next event to execute is in more 
+ * than MBED_TICKER_INTERRUPT_TIMESTAMP_MAX_DELTA us from now then the 
+ * interrupt will be set to MBED_TICKER_INTERRUPT_TIMESTAMP_MAX_DELTA us from now. 
+ * Otherwise the interrupt will be set to head->timestamp - queue->timestamp us.
+ */
+static void update_interrupt(const ticker_data_t *const ticker) { 
+    update_current_timestamp(ticker);
+    uint32_t diff = MBED_TICKER_INTERRUPT_TIMESTAMP_MAX_DELTA;
+
+    if (ticker->queue->head) { 
+        diff = MBED_MIN(
+            (ticker->queue->head->timestamp - ticker->queue->timestamp), 
+            MBED_TICKER_INTERRUPT_TIMESTAMP_MAX_DELTA
+        );
+    } 
+
+    ticker->interface->set_interrupt(
+        ticker->queue->timestamp + diff
+    );
+}
+
+void ticker_set_handler(const ticker_data_t *const ticker, ticker_event_handler handler) {
+    initialize(ticker);
+    set_handler(ticker, handler);
+}
+
+void ticker_irq_handler(const ticker_data_t *const ticker) {
+    ticker->interface->clear_interrupt();
 
     /* Go through all the pending TimerEvents */
     while (1) {
-        if (data->queue->head == NULL) {
-            // There are no more TimerEvents left, so disable matches.
-            data->interface->disable_interrupt();
-            return;
+        if (ticker->queue->head == NULL) {
+            break;
         }
 
-        if ((int)(data->queue->head->timestamp - data->interface->read()) <= 0) {
+        // update the current timestamp used by the queue 
+        update_current_timestamp(ticker);
+
+        if (ticker->queue->head->timestamp <= ticker->queue->timestamp) { 
             // This event was in the past:
             //      point to the following one and execute its handler
-            ticker_event_t *p = data->queue->head;
-            data->queue->head = data->queue->head->next;
-            if (data->queue->event_handler != NULL) {
-                (*data->queue->event_handler)(p->id); // NOTE: the handler can set new events
+            ticker_event_t *p = ticker->queue->head;
+            ticker->queue->head = ticker->queue->head->next;
+            if (ticker->queue->event_handler != NULL) {
+                (*ticker->queue->event_handler)(p->id); // NOTE: the handler can set new events
             }
             /* Note: We continue back to examining the head because calling the
              * event handler may have altered the chain of pending events. */
         } else {
-            // This event and the following ones in the list are in the future:
-            //      set it as next interrupt and return
-            data->interface->set_interrupt(data->queue->head->timestamp);
-            return;
-        }
+            break;
+        } 
     }
+
+    update_interrupt(ticker);
 }
 
-void ticker_insert_event(const ticker_data_t *const data, ticker_event_t *obj, timestamp_t timestamp, uint32_t id) {
+void ticker_insert_event(const ticker_data_t *const ticker, ticker_event_t *obj, timestamp_t timestamp, uint32_t id) {
     /* disable interrupts for the duration of the function */
     core_util_critical_section_enter();
+
+    // update the current timestamp
+    update_current_timestamp(ticker);
+    us_timestamp_t absolute_timestamp = convert_relative_timestamp(
+        ticker->queue->timestamp, 
+        timestamp
+    );
+    core_util_critical_section_exit();
+
+    // defer to ticker_insert_event_us
+    ticker_insert_event_us(
+        ticker, 
+        obj, absolute_timestamp, id
+    );
+}
+
+void ticker_insert_event_us(const ticker_data_t *const ticker, ticker_event_t *obj, us_timestamp_t timestamp, uint32_t id) { 
+    /* disable interrupts for the duration of the function */
+    core_util_critical_section_enter();
+
+    // update the current timestamp
+    update_current_timestamp(ticker);
+
+    // filter out timestamp in the past 
+    if (timestamp < ticker->queue->timestamp) { 
+        update_interrupt(ticker);
+        return;
+    }
 
     // initialise our data
     obj->timestamp = timestamp;
@@ -64,10 +181,10 @@ void ticker_insert_event(const ticker_data_t *const data, ticker_event_t *obj, t
     /* Go through the list until we either reach the end, or find
        an element this should come before (which is possibly the
        head). */
-    ticker_event_t *prev = NULL, *p = data->queue->head;
+    ticker_event_t *prev = NULL, *p = ticker->queue->head;
     while (p != NULL) {
         /* check if we come before p */
-        if ((int)(timestamp - p->timestamp) < 0) {
+        if (timestamp < p->timestamp) {
             break;
         }
         /* go to the next element */
@@ -80,30 +197,27 @@ void ticker_insert_event(const ticker_data_t *const data, ticker_event_t *obj, t
 
     /* if prev is NULL we're at the head */
     if (prev == NULL) {
-        data->queue->head = obj;
-        data->interface->set_interrupt(timestamp);
+        ticker->queue->head = obj;
     } else {
         prev->next = obj;
     }
 
+    update_interrupt(ticker);
+
     core_util_critical_section_exit();
 }
 
-void ticker_remove_event(const ticker_data_t *const data, ticker_event_t *obj) {
+void ticker_remove_event(const ticker_data_t *const ticker, ticker_event_t *obj) {
     core_util_critical_section_enter();
 
     // remove this object from the list
-    if (data->queue->head == obj) {
+    if (ticker->queue->head == obj) {
         // first in the list, so just drop me
-        data->queue->head = obj->next;
-        if (data->queue->head == NULL) {
-            data->interface->disable_interrupt();
-        } else {
-            data->interface->set_interrupt(data->queue->head->timestamp);
-        }
+        ticker->queue->head = obj->next;
+        update_interrupt(ticker);
     } else {
         // find the object before me, then drop me
-        ticker_event_t* p = data->queue->head;
+        ticker_event_t* p = ticker->queue->head;
         while (p != NULL) {
             if (p->next == obj) {
                 p->next = obj->next;
@@ -116,9 +230,13 @@ void ticker_remove_event(const ticker_data_t *const data, ticker_event_t *obj) {
     core_util_critical_section_exit();
 }
 
-timestamp_t ticker_read(const ticker_data_t *const data)
-{
-    return data->interface->read();
+timestamp_t ticker_read(const ticker_data_t *const ticker) {
+    return ticker_read_us(ticker);
+}
+
+us_timestamp_t ticker_read_us(const ticker_data_t *const ticker) {
+    update_current_timestamp(ticker);
+    return ticker->queue->timestamp;
 }
 
 int ticker_get_next_timestamp(const ticker_data_t *const data, timestamp_t *timestamp)

--- a/hal/mbed_us_ticker_api.c
+++ b/hal/mbed_us_ticker_api.c
@@ -15,7 +15,7 @@
  */
 #include "hal/us_ticker_api.h"
 
-static ticker_event_queue_t events;
+static ticker_event_queue_t events = { 0 };
 
 static const ticker_interface_t us_interface = {
     .init = us_ticker_init,
@@ -27,7 +27,7 @@ static const ticker_interface_t us_interface = {
 
 static const ticker_data_t us_data = {
     .interface = &us_interface,
-    .queue = &events,
+    .queue = &events
 };
 
 const ticker_data_t* get_us_ticker_data(void)

--- a/hal/ticker_api.h
+++ b/hal/ticker_api.h
@@ -67,7 +67,7 @@ typedef struct {
 typedef struct {
     ticker_event_handler event_handler; /**< Event handler */
     ticker_event_t *head;               /**< A pointer to head */
-    us_timestamp_t timestamp;           /**< Store the last timestamp used */
+    us_timestamp_t present_time;        /**< Store the timestamp used for present time */
     bool initialized;                   /**< Indicate if the instance is initialized */
 } ticker_event_queue_t;
 
@@ -89,20 +89,20 @@ extern "C" {
 
 /** Initialize a ticker and set the event handler
  *
- * @param data    The ticker's data
+ * @param ticker The ticker object.
  * @param handler A handler to be set
  */
 void ticker_set_handler(const ticker_data_t *const ticker, ticker_event_handler handler);
 
 /** IRQ handler that goes through the events to trigger overdue events.
  *
- * @param data    The ticker's data
+ * @param ticker The ticker object.
  */
 void ticker_irq_handler(const ticker_data_t *const ticker);
 
 /** Remove an event from the queue
  *
- * @param data The ticker's data
+ * @param ticker The ticker object.
  * @param obj  The event object to be removed from the queue
  */
 void ticker_remove_event(const ticker_data_t *const ticker, ticker_event_t *obj);
@@ -120,7 +120,7 @@ void ticker_remove_event(const ticker_data_t *const ticker, ticker_event_t *obj)
  * @note prefer the use of ticker_insert_event_us which allows registration of
  * absolute timestamp.
  *
- * @param data      The ticker's data
+ * @param ticker    The ticker object.
  * @param obj       The event object to be inserted to the queue
  * @param timestamp The event's timestamp
  * @param id        The event object
@@ -134,7 +134,7 @@ void ticker_insert_event(const ticker_data_t *const ticker, ticker_event_t *obj,
  * @warning If an event is inserted with a timestamp less than the current
  * timestamp then the event will **not** be inserted.
  *
- * @param data      The ticker's data
+ * @param ticker    The ticker object.
  * @param obj       The event object to be inserted to the queue
  * @param timestamp The event's timestamp
  * @param id        The event object
@@ -146,7 +146,7 @@ void ticker_insert_event_us(const ticker_data_t *const ticker, ticker_event_t *o
  * @warning Return a relative timestamp because the counter wrap every 4294
  * seconds.
  *
- * @param data The ticker's data
+ * @param ticker The ticker object.
  * @return The current timestamp
  */
 timestamp_t ticker_read(const ticker_data_t *const ticker);
@@ -156,14 +156,14 @@ timestamp_t ticker_read(const ticker_data_t *const ticker);
  * @warning Return an absolute timestamp counting from the initialization of the
  * ticker.
  *
- * @param data The ticker's data
+ * @param ticker The ticker object.
  * @return The current timestamp
  */
 us_timestamp_t ticker_read_us(const ticker_data_t *const ticker);
 
 /** Read the next event's timestamp
  *
- * @param data The ticker's data
+ * @param ticker The ticker object.
  * @return 1 if timestamp is pending event, 0 if there's no event pending
  */
 int ticker_get_next_timestamp(const ticker_data_t *const ticker, timestamp_t *timestamp);

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/rtc.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/rtc.c
@@ -45,8 +45,25 @@
 #include "mbed_assert.h"
 #include "lp_ticker_api.h"
 
-static uint16_t SubSecond;
-static uint64_t LastRtcTimeus;
+static volatile uint64_t last_time_read;
+
+/**
+ * Convert sub seconds ticks to micro seconds.
+ * The clock running at 32kHz, a tick is 1/32768 of a second.
+ */
+static inline uint32_t ticks_to_us(uint16_t ticks) {
+	return (((uint64_t)ticks * RTC_SEC_TO_US) / RTC_CLOCK_HZ);
+}
+
+/**
+ * Convert us into sub seconds ticks.
+ * @note result might be troncated to be in the range [0 - RTC_SUB_SEC_MASK].
+ */
+static inline uint16_t us_to_ticks(uint32_t us) {
+	return (((uint64_t) us * RTC_CLOCK_HZ) / RTC_SEC_TO_US) & RTC_SUB_SEC_MASK;
+}
+
+#define RTC_TICK_THRESHOLD 5 
 
 /* See rtc.h for details */
 void fRtcInit(void)
@@ -55,115 +72,131 @@ void fRtcInit(void)
     CLOCKREG->CCR.BITS.RTCEN = True;     /* Enable RTC clock 32K */
 
     /* Reset RTC control register */
-    RTCREG->CONTROL.WORD     = False;
+    RTCREG->CONTROL.WORD = 0;
 
     /* Initialize all counters */
-    RTCREG->SECOND_COUNTER       = False;
-    RTCREG->SUB_SECOND_COUNTER   = False;
-    RTCREG->SECOND_ALARM         = False;
-    RTCREG->SUB_SECOND_ALARM     = False;
-    LastRtcTimeus = 0;
+    RTCREG->SECOND_COUNTER = 0;
+    RTCREG->SUB_SECOND_COUNTER = 0;
+    RTCREG->SECOND_ALARM = 0;
+    RTCREG->SUB_SECOND_ALARM = 0;
+    last_time_read = 0;
 
     /* Reset RTC Status register */
-    RTCREG->STATUS.WORD      = False;
+    RTCREG->STATUS.WORD = 0;
 
     /* Clear interrupt status */
-    RTCREG->INT_CLEAR.WORD   = False;
+    RTCREG->INT_CLEAR.WORD = (
+        (1 << RTC_INT_CLR_SUB_SEC_BIT_POS) | 
+        (1 << RTC_INT_CLR_SEC_BIT_POS)
+    );
 
+    /* Wait previous write to complete */
+    while(RTCREG->STATUS.BITS.BSY_CTRL_REG_WRT == True);
     /* Start sec & sub_sec counter */
-    while(RTCREG->STATUS.BITS.BSY_CTRL_REG_WRT == True);/* Wait previous write to complete */
-    RTCREG->CONTROL.WORD |= ((True << RTC_CONTROL_SUBSEC_CNT_START_BIT_POS) |
-                             (True << RTC_CONTROL_SEC_CNT_START_BIT_POS));
+    RTCREG->CONTROL.WORD |= (
+        (True << RTC_CONTROL_SUBSEC_CNT_START_BIT_POS) |
+        (True << RTC_CONTROL_SEC_CNT_START_BIT_POS)
+    );
 
     /* enable interruption associated with the rtc at NVIC level */
-    NVIC_SetVector(Rtc_IRQn,(uint32_t)fRtcHandler); /* TODO define lp_ticker_isr */
+    NVIC_SetVector(Rtc_IRQn,(uint32_t) fRtcHandler); /* TODO define lp_ticker_isr */
     NVIC_ClearPendingIRQ(Rtc_IRQn);
     NVIC_EnableIRQ(Rtc_IRQn);
 
-    while(RTCREG->STATUS.BITS.BSY_CTRL_REG_WRT == True); /* Wait for RTC to finish writing register - RTC operates on 32K clock as compared to 32M core*/
-
-    return;
+    /* Wait for RTC to finish writing register */
+    while(RTCREG->STATUS.BITS.BSY_CTRL_REG_WRT == True);
 }
 
 /* See rtc.h for details */
 void fRtcFree(void)
 {
-    /* Reset RTC control register */
-    RTCREG->CONTROL.WORD = False;
+    /* Disable interrupts and counter */
+    RTCREG->CONTROL.WORD = 0;
 
     /* disable interruption associated with the rtc */
     NVIC_DisableIRQ(Rtc_IRQn);
 
-    while(RTCREG->STATUS.BITS.BSY_CTRL_REG_WRT == True); /* Wait for RTC to finish writing register - RTC operates on 32K clock as compared to 32M core*/
+    /* Wait for RTC to finish writing register */
+    while(RTCREG->STATUS.BITS.BSY_CTRL_REG_WRT == True);
 }
 
 /* See rtc.h for details */
 void fRtcSetInterrupt(uint32_t timestamp)
 {
-    SubSecond             = False;
-    uint32_t Second = False, EnableInterrupt = False;
-    uint8_t DividerAdjust = 1;
+	uint64_t current_time = fRtcRead();
 
-    if(timestamp) {
-        if(timestamp >= RTC_SEC_TO_US) {
-            /* TimeStamp is big enough to set second alarm */
-            Second =  ((timestamp / RTC_SEC_TO_US) & RTC_SEC_MASK); /* Convert micro second to second */
-            RTCREG->SECOND_ALARM = Second; /* Write to alarm register */
+	/* compute delta between current time and timestamp.
+	 * Note: the current time used to compute the delta is relative (truncated 
+     * to 32 bits).
+	 */
+	int32_t delta = timestamp - (uint32_t) current_time;
+	if (delta <= 0) {
+		// event considered in the past, set the interrupt as pending.
+		NVIC_SetPendingIRQ(Rtc_IRQn);
+		return;
+	}
 
-            /* Enable second interrupt */
-              EnableInterrupt = True << RTC_CONTROL_SEC_CNT_INT_BIT_POS;
-        }
-        timestamp = timestamp - Second * RTC_SEC_TO_US; /* Take out micro second for sub second alarm */
-        if(timestamp > False) {
-            /* We have some thing for sub second */
+	uint64_t full_timestamp = (current_time & ~UINT32_MAX) | timestamp;
+	if ( (uint32_t)current_time > timestamp) {
+		full_timestamp += ((uint64_t) UINT32_MAX) + 1;
+	}
 
-            /* Convert micro second to sub_seconds(each count = 30.5 us) */
-            if(timestamp > 131000) {
-                DividerAdjust = 100;
-            }
+	uint32_t target_seconds = full_timestamp / RTC_SEC_TO_US;
+	uint16_t target_ticks = us_to_ticks(full_timestamp);
 
-            volatile uint64_t Temp = (timestamp / DividerAdjust * RTC_CLOCK_HZ);
-            Temp = (uint64_t)(Temp / RTC_SEC_TO_US * DividerAdjust);
-            SubSecond = Temp & RTC_SUB_SEC_MASK;
+	/*
+	 * If the interrupt is in more than one second from now then use the
+	 * second alarm, otherwise use the subsecond alarm.
+	 * In case of the second alarm is used, there is no need to preserve the
+	 * remaining subsecond because the irq handler should manage spurious
+	 * interrupts (like when the timestamp is in the past). In such case, irq
+	 * handler will schedule a new interrupt with the remaining us.
+	 */
+	NVIC_DisableIRQ(Rtc_IRQn);
+	if (target_seconds != RTCREG->SECOND_COUNTER) {
+		RTCREG->SECOND_ALARM = target_seconds;
 
-            if(SubSecond <= 5) {
-                SubSecond = 0;
-            }
+		uint32_t rtc_control = RTCREG->CONTROL.WORD;
+		rtc_control |= (1 << RTC_CONTROL_SEC_CNT_INT_BIT_POS); // enable seconds interrupt
+		rtc_control &= ~(1 << RTC_CONTROL_SUBSEC_CNT_INT_BIT_POS); // disable sub sec interrupt
+		RTCREG->CONTROL.WORD = rtc_control;
+	} else {
+		uint16_t current_ticks = RTCREG->SUB_SECOND_COUNTER;
+		if (current_ticks == target_ticks ||
+			((target_ticks > current_ticks) && ((target_ticks - current_ticks) < RTC_TICK_THRESHOLD)) ||
+			((target_ticks < current_ticks) && ((RTC_SUB_SEC_MASK - (current_ticks - target_ticks)) < RTC_TICK_THRESHOLD))) {
+			// target ticks too close; schedule the interrupt immediately
+			NVIC_SetPendingIRQ(Rtc_IRQn);
+		} else {
+			RTCREG->SUB_SECOND_ALARM = target_ticks;
 
-            if(SubSecond > False) {
-                /* Second interrupt not enabled */
+			uint32_t rtc_control = RTCREG->CONTROL.WORD;
+			rtc_control &= ~(1 << RTC_CONTROL_SEC_CNT_INT_BIT_POS); // disable seconds interrupt
+			rtc_control |= (1 << RTC_CONTROL_SUBSEC_CNT_INT_BIT_POS); // enable sub sec interrupt
+			RTCREG->CONTROL.WORD = rtc_control;
+		}
+	}
+	 NVIC_EnableIRQ(Rtc_IRQn);
 
-                /* Set SUB SEC_ALARM */
-                RTCREG->SUB_SECOND_ALARM = SubSecond;    /* Write to sub second alarm */
-
-                /* Enable sub second interrupt */
-                EnableInterrupt |= (True << RTC_CONTROL_SUBSEC_CNT_INT_BIT_POS);
-            }
-        }
-        
-        RTCREG->CONTROL.WORD |= EnableInterrupt;
-        /* Enable RTC interrupt */
-        NVIC_EnableIRQ(Rtc_IRQn);
-        
-        /* Wait for RTC to finish writing register - RTC operates on 32K clock as compared to 32M core*/
-        while((RTCREG->STATUS.WORD & ((True << RTC_STATUS_SUB_SEC_ALARM_WRT_BIT_POS) |
-                                      (True << RTC_STATUS_SEC_ALARM_WRT_BIT_POS) |
-                                      (True << RTC_STATUS_CONTROL_WRT_BIT_POS)))); 
-    }
-    return;
+     /* Wait for RTC to finish writing register - RTC operates on 32K clock as compared to 32M core*/
+     while(RTCREG->STATUS.WORD &
+        (
+        	(True << RTC_STATUS_SUB_SEC_ALARM_WRT_BIT_POS) |
+			(True << RTC_STATUS_SEC_ALARM_WRT_BIT_POS) |
+			(True << RTC_STATUS_CONTROL_WRT_BIT_POS)
+		)
+	);
 }
 
 /* See rtc.h for details */
 void fRtcDisableInterrupt(void)
 {
-    /* Disable RTC interrupt */
     NVIC_DisableIRQ(Rtc_IRQn);
 }
 
 /* See rtc.h for details */
 void fRtcEnableInterrupt(void)
 {
-    /* Enable RTC interrupt */
     NVIC_EnableIRQ(Rtc_IRQn);
 }
 
@@ -182,33 +215,30 @@ void fRtcClearInterrupt(void)
 /* See rtc.h for details */
 uint64_t fRtcRead(void)
 {
-    uint32_t Second;
-    uint16_t SubSecond;
-
     /* Hardware Bug fix: The rollover of the sub-second counter initiates the increment of the second counter.
      * That means there is one cycle where the sub-second has rolled back to zero and the second counter has not incremented
      * and a read during that cycle will be incorrect.  That will occur for one RTC cycle and that is about 31us of exposure.
      * If you read a zero in the sub-second counter then increment the second counter by 1.
      * Alternatively, subtract 1 from the Sub-seconds counter to align the Second and Sub-Second rollover.
      */
+	uint32_t seconds = RTCREG->SECOND_COUNTER;
+    uint16_t ticks = (RTCREG->SUB_SECOND_COUNTER - 1) & SUB_SEC_MASK;
 
-    /* Read the Second and Sub-second counters, then read the Second counter again.
-     * If it changed, then the Second rolled over while reading Sub-seconds, so go back and read them both again.
+    /*
+     * If seconds has changed while reading ticks, read them both again.
      */
+    while (seconds != RTCREG->SECOND_COUNTER) {
+        seconds = RTCREG->SECOND_COUNTER;
+        ticks = (RTCREG->SUB_SECOND_COUNTER - 1) & SUB_SEC_MASK;
+    }
 
-    do {
-        Second    = RTCREG->SECOND_COUNTER;                            /* Get SEC_COUNTER reg value */
-        SubSecond = (RTCREG->SUB_SECOND_COUNTER - 1) & SUB_SEC_MASK;   /* Get SUB_SEC_COUNTER reg value */
-    } while (Second != RTCREG->SECOND_COUNTER);                        /* Repeat if the second has changed */
-
-    //note: casting to float removed to avoid reduction in resolution
-    uint64_t RtcTimeus = ((uint64_t)SubSecond * RTC_SEC_TO_US / RTC_CLOCK_HZ) + ((uint64_t)Second * RTC_SEC_TO_US);
+    uint64_t current_time = ((uint64_t) seconds *  RTC_SEC_TO_US) + ticks_to_us(ticks);
 
     /*check that the time did not go backwards */
-    MBED_ASSERT(RtcTimeus >= LastRtcTimeus);
-    LastRtcTimeus = RtcTimeus;
+	MBED_ASSERT(current_time >= last_time_read);
+    last_time_read = current_time;
 
-    return RtcTimeus;
+    return current_time;
 }
 
 /* See rtc.h for details */
@@ -244,43 +274,31 @@ void fRtcWrite(uint64_t RtcTimeus)
 /* See rtc.h for details */
 void fRtcHandler(void)
 {
-    /* SUB_SECOND/SECOND interrupt occured */
-    volatile uint32_t TempStatus = RTCREG->STATUS.WORD;
-
     /* Disable RTC interrupt */
     NVIC_DisableIRQ(Rtc_IRQn);
 
     /* Clear sec & sub_sec interrupts */
-    RTCREG->INT_CLEAR.WORD = ((True << RTC_INT_CLR_SUB_SEC_BIT_POS) |
-                              (True << RTC_INT_CLR_SEC_BIT_POS));
+    RTCREG->INT_CLEAR.WORD = (
+    	(True << RTC_INT_CLR_SUB_SEC_BIT_POS) |
+        (True << RTC_INT_CLR_SEC_BIT_POS)
+	);
 
-    /* TODO  ANDing SUB_SEC & SEC interrupt - work around for RTC issue - will be resolved in REV G */
-    if(TempStatus & RTC_SEC_INT_STATUS_MASK) {
-        /* Second interrupt occured */
-        if(SubSecond > False) {
-            /* Set SUB SEC_ALARM */
-            RTCREG->SUB_SECOND_ALARM = SubSecond + RTCREG->SUB_SECOND_COUNTER;
-            /* Enable sub second interrupt */
-            RTCREG->CONTROL.WORD |= (True << RTC_CONTROL_SUBSEC_CNT_INT_BIT_POS);
-        } else {
-            /* We reach here after second interrupt is occured */
-            RTCREG->CONTROL.WORD &= ~(True << RTC_CONTROL_SUBSEC_CNT_INT_BIT_POS) |
-                                    (True << RTC_CONTROL_SEC_CNT_INT_BIT_POS);
-        }
-    } else {
-        /* We reach here after sub_second or (Sub second + second) interrupt occured */
-		/* Disable Second and sub_second interrupt */
-        RTCREG->CONTROL.WORD &= ~(True << RTC_CONTROL_SUBSEC_CNT_INT_BIT_POS) |
-                                (True << RTC_CONTROL_SEC_CNT_INT_BIT_POS);
-    }
+    /* Disable sub seconds and seconds interrupts */
+    RTCREG->CONTROL.WORD &= ~(
+    	(True << RTC_CONTROL_SUBSEC_CNT_INT_BIT_POS) |
+        (True << RTC_CONTROL_SEC_CNT_INT_BIT_POS)
+	);
 
 	NVIC_EnableIRQ(Rtc_IRQn);
 	
-    /* Wait for RTC to finish writing register - RTC operates on 32K clock as compared to 32M core*/
-    while((RTCREG->STATUS.WORD & ((True << RTC_STATUS_SUB_SEC_ALARM_WRT_BIT_POS) |
-                                  (True << RTC_STATUS_CONTROL_WRT_BIT_POS) |
-                                  (True << RTC_STATUS_SUB_SEC_INT_CLR_WRT_BIT_POS) |
-                                  (True << RTC_STATUS_SEC_INT_CLR_WRT_BIT_POS))));  
+    /* Wait for RTC to finish writing registers */
+    while(RTCREG->STATUS.WORD &
+    	(
+    		(True << RTC_STATUS_CONTROL_WRT_BIT_POS) |
+			(True << RTC_STATUS_SUB_SEC_INT_CLR_WRT_BIT_POS) |
+            (True << RTC_STATUS_SEC_INT_CLR_WRT_BIT_POS)
+		)
+	);
 	
 	lp_ticker_irq_handler();
 }

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/rtc.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/rtc.c
@@ -7,11 +7,11 @@
  * $Rev: 3525 $
  * $Date: 2015-07-20 15:24:25 +0530 (Mon, 20 Jul 2015) $
  ******************************************************************************
- * Copyright 2016 Semiconductor Components Industries LLC (d/b/a “ON Semiconductor”).
+ * Copyright 2016 Semiconductor Components Industries LLC (d/b/a ï¿½ON Semiconductorï¿½).
  * All rights reserved.  This software and/or documentation is licensed by ON Semiconductor
  * under limited terms and conditions.  The terms and conditions pertaining to the software
  * and/or documentation are available at http://www.onsemi.com/site/pdf/ONSEMI_T&C.pdf
- * (“ON Semiconductor Standard Terms and Conditions of Sale, Section 8 Software”) and
+ * (ï¿½ON Semiconductor Standard Terms and Conditions of Sale, Section 8 Softwareï¿½) and
  * if applicable the software license agreement.  Do not use this software and/or
  * documentation unless you have carefully read and you agree to the limited terms and
  * conditions.  By using this software and/or documentation, you agree to the limited
@@ -148,7 +148,7 @@ void fRtcSetInterrupt(uint32_t timestamp)
         /* Wait for RTC to finish writing register - RTC operates on 32K clock as compared to 32M core*/
         while((RTCREG->STATUS.WORD & ((True << RTC_STATUS_SUB_SEC_ALARM_WRT_BIT_POS) |
                                       (True << RTC_STATUS_SEC_ALARM_WRT_BIT_POS) |
-                                      (True << RTC_STATUS_CONTROL_WRT_BIT_POS))) == True); 
+                                      (True << RTC_STATUS_CONTROL_WRT_BIT_POS)))); 
     }
     return;
 }
@@ -176,7 +176,7 @@ void fRtcClearInterrupt(void)
                               (True << RTC_INT_CLR_SEC_BIT_POS));
     
     while((RTCREG->STATUS.WORD & ((True << RTC_STATUS_SUB_SEC_INT_CLR_WRT_BIT_POS) |
-                                  (True << RTC_STATUS_SEC_INT_CLR_WRT_BIT_POS))) == True);  /* Wait for RTC to finish writing register - RTC operates on 32K clock as compared to 32M core*/
+                                  (True << RTC_STATUS_SEC_INT_CLR_WRT_BIT_POS))));  /* Wait for RTC to finish writing register - RTC operates on 32K clock as compared to 32M core*/
 }
 
 /* See rtc.h for details */
@@ -280,7 +280,7 @@ void fRtcHandler(void)
     while((RTCREG->STATUS.WORD & ((True << RTC_STATUS_SUB_SEC_ALARM_WRT_BIT_POS) |
                                   (True << RTC_STATUS_CONTROL_WRT_BIT_POS) |
                                   (True << RTC_STATUS_SUB_SEC_INT_CLR_WRT_BIT_POS) |
-                                  (True << RTC_STATUS_SEC_INT_CLR_WRT_BIT_POS))) == True);  
+                                  (True << RTC_STATUS_SEC_INT_CLR_WRT_BIT_POS))));  
 	
 	lp_ticker_irq_handler();
 }


### PR DESCRIPTION
## Description
This patch add support of 64 bit us timestamp in the HAL ticker API. 
As a result it is possible to schedule events in more than 2147 seconds as it was previously the case. 
The class Ticker, Timer and Timeout takes advantage of this new possibility. 

## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO