### PR TITLE
Debug build flag + change to sleep behavior in debug mode

### DIFF
--- a/platform/mbed_sleep.h
+++ b/platform/mbed_sleep.h
@@ -28,7 +28,7 @@ extern "C" {
 /** Send the microcontroller to sleep
  *
  * @note This function can be a noop if not implemented by the platform.
- * @note This function will only put device to sleep in release mode (small profile or when NDEBUG is defined).
+ * @note This function will be a noop in debug mode (debug build profile when MBED_DEBUG is defined)
  *
  * The processor is setup ready for sleep, and sent to sleep using __WFI(). In this mode, the
  * system clock to the core is stopped until a reset or an interrupt occurs. This eliminates
@@ -44,17 +44,17 @@ extern "C" {
  */
 __INLINE static void sleep(void)
 {
-#ifdef NDEBUG
+#ifndef MBED_DEBUG
 #if DEVICE_SLEEP
     hal_sleep();
 #endif /* DEVICE_SLEEP */
-#endif /* NDEBUG */
+#endif /* MBED_DEBUG */
 }
 
 /** Send the microcontroller to deep sleep
  *
  * @note This function can be a noop if not implemented by the platform.
- * @note This function will only put device to sleep in release mode (small profile or when NDEBUG is defined).
+ * @note This function will be a noop in debug mode (debug build profile when MBED_DEBUG is defined)
  *
  * This processor is setup ready for deep sleep, and sent to sleep using __WFI(). This mode
  * has the same sleep features as sleep plus it powers down peripherals and clocks. All state
@@ -69,11 +69,11 @@ __INLINE static void sleep(void)
  */
 __INLINE static void deepsleep(void)
 {
-#ifdef NDEBUG
+#ifndef MBED_DEBUG
 #if DEVICE_SLEEP
     hal_deepsleep();
 #endif /* DEVICE_SLEEP */
-#endif /* NDEBUG */
+#endif /* MBED_DEBUG */
 }
 
 #ifdef __cplusplus

--- a/platform/mbed_sleep.h
+++ b/platform/mbed_sleep.h
@@ -28,7 +28,8 @@ extern "C" {
 /** Send the microcontroller to sleep
  *
  * @note This function can be a noop if not implemented by the platform.
- * @note This function will be a noop in debug mode (debug build profile when MBED_DEBUG is defined)
+ * @note This function will be a noop in debug mode (debug build profile when MBED_DEBUG is defined).
+ * @note This function will be a noop while uVisor is in use.
  *
  * The processor is setup ready for sleep, and sent to sleep using __WFI(). In this mode, the
  * system clock to the core is stopped until a reset or an interrupt occurs. This eliminates
@@ -44,17 +45,20 @@ extern "C" {
  */
 __INLINE static void sleep(void)
 {
+#if !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED))
 #ifndef MBED_DEBUG
 #if DEVICE_SLEEP
     hal_sleep();
 #endif /* DEVICE_SLEEP */
 #endif /* MBED_DEBUG */
+#endif /* !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED)) */
 }
 
 /** Send the microcontroller to deep sleep
  *
  * @note This function can be a noop if not implemented by the platform.
  * @note This function will be a noop in debug mode (debug build profile when MBED_DEBUG is defined)
+ * @note This function will be a noop while uVisor is in use.
  *
  * This processor is setup ready for deep sleep, and sent to sleep using __WFI(). This mode
  * has the same sleep features as sleep plus it powers down peripherals and clocks. All state
@@ -69,11 +73,13 @@ __INLINE static void sleep(void)
  */
 __INLINE static void deepsleep(void)
 {
+#if !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED))
 #ifndef MBED_DEBUG
 #if DEVICE_SLEEP
     hal_deepsleep();
 #endif /* DEVICE_SLEEP */
 #endif /* MBED_DEBUG */
+#endif /* !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED)) */
 }
 
 #ifdef __cplusplus

--- a/targets/TARGET_Maxim/TARGET_MAX32630/sleep.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/sleep.c
@@ -34,13 +34,13 @@
 #include "sleep_api.h"
 #include "lp.h"
 
-void sleep(void)
+void hal_sleep(void)
 {
     LP_EnterLP2();
 }
 
 // Low-power stop mode
-void deepsleep(void)
+void hal_deepsleep(void)
 {
-    sleep();
+    hal_sleep();
 }

--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -5,7 +5,7 @@
                    "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
                    "-MMD", "-fno-delete-null-pointer-checks",
-                   "-fomit-frame-pointer", "-O0", "-g3"],
+                   "-fomit-frame-pointer", "-O0", "-g3", "-DMBED_DEBUG"],
         "asm": ["-x", "assembler-with-cpp"],
         "c": ["-std=gnu99"],
         "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],
@@ -17,7 +17,7 @@
     "ARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
-                   "--multibyte_chars", "-O0", "-g"],
+                   "--multibyte_chars", "-O0", "-g", "-DMBED_DEBUG"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
@@ -27,7 +27,7 @@
         "common": ["-c", "--gnu", "-Otime", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
                    "--multibyte_chars", "-O0", "-D__MICROLIB", "-g",
-                   "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD"],
+                   "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD", "-DMBED_DEBUG"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
@@ -35,8 +35,8 @@
     },
     "IAR": {
         "common": [
-            "--no_wrap_diagnostics", "-e",
-            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-On", "-r"],
+            "--no_wrap_diagnostics",  "-e",
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-On", "-r", "-DMBED_DEBUG"],
         "asm": [],
         "c": ["--vla"],
         "cxx": ["--guard_calls", "--no_static_destruction"],


### PR DESCRIPTION
## Description
- Introduce new macro `MBED_DEBUG` that's only defined for debug profile. Right now NDEBUG is defined only for release profile, which makes it impossible to separate develop and debug builds features.
- Profile used by online IDE is develop, we probably don't want disable sleep for profile which people actually may use in 'production'. This PR makes sleep a noop only for the debug builds.

## Status
**READY**


CC: @theotherjimmy @0xc0170 