### PR TITLE
Modify semihost_disabledebug() to support more interface FW revs

### DIFF
--- a/platform/mbed_semihost_api.c
+++ b/platform/mbed_semihost_api.c
@@ -152,10 +152,11 @@ int semihost_connected(void) {
 #endif
 
 int semihost_disabledebug(void) {
+    uint32_t args[1];
 #if !(DEVICE_DEBUG_AWARENESS)
     is_debugger_attached = 0;
 #endif
-    return __semihost(USR_DISABLEDEBUG, NULL);
+    return __semihost(USR_DISABLEDEBUG, &args);
 }
 
 #endif


### PR DESCRIPTION
The current implementation of semihost_disabledebug() hangs when used
with mbed interface firwmare revision 21164, the first version which
added support for this semihost call. I encountered this hang when
running a Release build on my mbed-LPC1768 board as the RTOS attempted
to disable the debugger before the idle thread put the CPU to sleep.

The 21164 interface firmware expects that R1 points to a valid argument
block but the current implementation passes in NULL. The fix was to
pass in a dummy block which is ignored by the newer 141212 revision of
the firmware and allows the 21164 version to proceeed without halting
the CPU until a manual reset.

Before this fix semihost_disabledebug() did work with the latest
mbed interface firmware revision 141212 but I rarely use this revision
of the interface firmware due to the instability issues I have
encountered in the past with its CDC and LocalFileSystem functionality.

With this proposed fix, the code now works with both the 21164 and
141212 revisions of the mbed interface firmware on the mbed-LPC1768.