### PR TITLE
Add SCL and SDA defs for I2C[0-2]; redefine I2C_[SCL,SDA] to I2C2

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_MBED_LPC1768/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_MBED_LPC1768/PinNames.h
@@ -106,11 +106,17 @@ typedef enum {
     A4 = P1_30,
     A5 = P1_31,
 
-    I2C_SCL = D15,
-    I2C_SDA = D14,
-
     // Not connected
-    NC = (int)0xFFFFFFFF
+    NC = (int)0xFFFFFFFF,
+
+    I2C_SCL0 = NC,
+    I2C_SDA0 = NC,
+    I2C_SCL1 = p10,
+    I2C_SDA1 = p9,
+    I2C_SCL2 = p27, // pin used by application board
+    I2C_SDA2 = p28, // pin used by application board
+    I2C_SCL = I2C_SCL2,
+    I2C_SDA = I2C_SDA2,
 } PinName;
 
 typedef enum {


### PR DESCRIPTION
## Description
See discussion in issue #4099. I've only tested this by compiling an I2C app with an LPC1768 target and then running the result. I have yet to be able to successfully run 'mbed test' in my environment (against stable, head, etc.), so I'm not able to demonstrate the results of that.


## Status
**READY/IN DEVELOPMENT/HOLD**


## Todos
- [x] Tests