### PR TITLE
Add extra_targets.json support to build tools

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -32,6 +32,7 @@ from tools.toolchains import mbedToolchain
 from tools.targets import TARGET_NAMES, TARGET_MAP
 from tools.options import get_default_options_parser
 from tools.options import extract_profile
+from tools.options import extract_mcus
 from tools.build_api import build_library, build_mbed_libs, build_lib
 from tools.build_api import mcu_toolchain_matrix
 from tools.build_api import print_build_results
@@ -134,7 +135,7 @@ if __name__ == '__main__':
 
 
     # Get target list
-    targets = options.mcu if options.mcu else TARGET_NAMES
+    targets = extract_mcus(parser, options) if options.mcu else TARGET_NAMES
 
     # Get toolchains list
     toolchains = options.tool if options.tool else TOOLCHAINS

--- a/tools/get_config.py
+++ b/tools/get_config.py
@@ -26,6 +26,7 @@ sys.path.insert(0, ROOT)
 
 from tools.utils import args_error
 from tools.options import get_default_options_parser
+from tools.options import extract_mcus
 from tools.build_api import get_config
 from config import Config
 from utils import argparse_filestring_type
@@ -49,7 +50,7 @@ if __name__ == '__main__':
     # Target
     if options.mcu is None :
         args_error(parser, "argument -m/--mcu is required")
-    target = options.mcu[0]
+    target = extract_mcus(parser, options)[0]
 
     # Toolchain
     if options.tool is None:

--- a/tools/make.py
+++ b/tools/make.py
@@ -42,6 +42,7 @@ from tools.tests import test_known, test_name_known
 from tools.targets import TARGET_MAP
 from tools.options import get_default_options_parser
 from tools.options import extract_profile
+from tools.options import extract_mcus
 from tools.build_api import build_project
 from tools.build_api import mcu_toolchain_matrix
 from tools.build_api import mcu_toolchain_list
@@ -200,7 +201,7 @@ if __name__ == '__main__':
     # Target
     if options.mcu is None :
         args_error(parser, "argument -m/--mcu is required")
-    mcu = options.mcu[0]
+    mcu = extract_mcus(parser, options)[0]
 
     # Toolchain
     if options.tool is None:

--- a/tools/options.py
+++ b/tools/options.py
@@ -130,9 +130,8 @@ def mcu_is_enabled(parser, mcu):
     
 def extract_mcus(parser, options):
     try:
-        extra_targets = [join(src, "custom_targets.json") for src in options.source_dir]
-        for filename in extra_targets:
-            Target.add_extra_targets(filename)
+        for source_dir in options.source_dir:
+            Target.add_extra_targets(source_dir)
         update_target_data()
     except KeyError:
         pass

--- a/tools/options.py
+++ b/tools/options.py
@@ -130,9 +130,10 @@ def mcu_is_enabled(parser, mcu):
     
 def extract_mcus(parser, options):
     try:
-        for source_dir in options.source_dir:
-            Target.add_extra_targets(source_dir)
-        update_target_data()
+        if options.source_dir:
+            for source_dir in options.source_dir:
+                Target.add_extra_targets(source_dir)
+            update_target_data()
     except KeyError:
         pass
     targetnames = TARGET_NAMES

--- a/tools/project.py
+++ b/tools/project.py
@@ -20,7 +20,7 @@ from tools.utils import argparse_filestring_type, argparse_profile_filestring_ty
 from tools.utils import argparse_force_lowercase_type
 from tools.utils import argparse_force_uppercase_type
 from tools.utils import print_large_string
-from tools.options import extract_profile, list_profiles
+from tools.options import extract_profile, list_profiles, extract_mcus
 
 def setup_project(ide, target, program=None, source_dir=None, build=None, export_path=None):
     """Generate a name, if not provided, and find dependencies
@@ -247,7 +247,8 @@ def main():
     profile = extract_profile(parser, options, toolchain_name, fallback="debug")
     if options.clean:
         rmtree(BUILD_DIR)
-    export(options.mcu, options.ide, build=options.build,
+    mcu = extract_mcus(parser, options)[0]
+    export(mcu, options.ide, build=options.build,
            src=options.source_dir, macros=options.macros,
            project_id=options.program, zip_proj=zip_proj,
            build_profile=profile, app_config=options.app_config)

--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -169,6 +169,7 @@ class Target(namedtuple("Target", "name json_data resolution_order resolution_or
         """Set the location of the targets.json file"""
         Target.__targets_json_location = (location or
                                           Target.__targets_json_location_default)
+        Target.__extra_target_json_files = []
         # Invalidate caches, since the location of the JSON file changed
         CACHES.clear()
 

--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -129,23 +129,6 @@ class Target(namedtuple("Target", "name json_data resolution_order resolution_or
     __extra_target_json_files = []
 
     @staticmethod
-    def _merge_dict(dct, merge_dct):
-        """ Recursive dict merge. Inspired by `dict.update()` however instead of
-        updating only top-level keys, dict_merge recurses down into dicts nested
-        to an arbitrary depth, updating keys. 
-        The provided  ``merge_dct`` is merged into ``dct`` in place.
-        :param dct: dict onto which the merge is executed
-        :param merge_dct: dct merged into dct
-        :return: None
-        """
-        for k, v in merge_dct.iteritems():
-            if (k in dct and isinstance(dct[k], dict)
-                    and isinstance(merge_dct[k], Mapping)):
-                Target._merge_dict(dct[k], merge_dct[k])
-            else:
-                dct[k] = merge_dct[k]
-
-    @staticmethod
     @cached
     def get_json_target_data():
         """Load the description of JSON target data"""
@@ -153,7 +136,11 @@ class Target(namedtuple("Target", "name json_data resolution_order resolution_or
                                     Target.__targets_json_location_default)
 
         for extra_target in Target.__extra_target_json_files:
-            Target._merge_dict(targets, json_file_to_dict(extra_target))
+            for k, v in json_file_to_dict(extra_target).iteritems():
+                if k in targets:
+                    print 'WARNING: Custom target "%s" cannot replace existing target.' % k
+                else:
+                    targets[k] = v
 
         return targets
 

--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -127,34 +127,34 @@ class Target(namedtuple("Target", "name json_data resolution_order resolution_or
 
     @staticmethod
     def _merge_dict(dct, merge_dct):
-    """ Recursive dict merge. Inspired by `dict.update()` however instead of
-    updating only top-level keys, dict_merge recurses down into dicts nested
-    to an arbitrary depth, updating keys. 
-    The provided  ``merge_dct`` is merged into ``dct`` in place.
-    :param dct: dict onto which the merge is executed
-    :param merge_dct: dct merged into dct
-    :return: None
-    """
-    for k, v in merge_dct.iteritems():
-        if (k in dct and isinstance(dct[k], dict)
-                and isinstance(merge_dct[k], Mapping)):
-            Target._merge_dict(dct[k], merge_dct[k])
-        else:
-            dct[k] = merge_dct[k]
+        """ Recursive dict merge. Inspired by `dict.update()` however instead of
+        updating only top-level keys, dict_merge recurses down into dicts nested
+        to an arbitrary depth, updating keys. 
+        The provided  ``merge_dct`` is merged into ``dct`` in place.
+        :param dct: dict onto which the merge is executed
+        :param merge_dct: dct merged into dct
+        :return: None
+        """
+        for k, v in merge_dct.iteritems():
+            if (k in dct and isinstance(dct[k], dict)
+                    and isinstance(merge_dct[k], Mapping)):
+                Target._merge_dict(dct[k], merge_dct[k])
+            else:
+                dct[k] = merge_dct[k]
 
     @staticmethod
     @cached
     def get_json_target_data():
         """Load the description of JSON target data"""
         targets = json_file_to_dict(Target.__targets_json_location or
-                                     Target.__targets_json_location_default)
+                                    Target.__targets_json_location_default)
+        return targets
 
-        # If extra_targets.json exists in working directory load it over the top
-        extra = os.path.join('.', 'extra_targets.json')
+    @staticmethod
+    @cached
+    def add_extra_targets(extra):
         if os.path.exists(extra):
             Target._merge_dict(targets, json_file_to_dict(extra))
-
-        return targets
 
     @staticmethod
     def set_targets_json_location(location=None):
@@ -561,6 +561,9 @@ def set_targets_json_location(location=None):
     # re-initialization does not create new variables, it keeps the old ones
     # instead. This ensures compatibility with code that does
     # "from tools.targets import TARGET_NAMES"
+    update_target_data()
+
+def update_target_data():
     TARGETS[:] = [Target.get_target(tgt) for tgt, obj
                   in Target.get_json_target_data().items()
                   if obj.get("public", True)]

--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -125,6 +125,9 @@ class Target(namedtuple("Target", "name json_data resolution_order resolution_or
     # Current/new location of the 'targets.json' file
     __targets_json_location = None
 
+    # Extra custom targets files
+    __extra_target_json_files = []
+
     @staticmethod
     def _merge_dict(dct, merge_dct):
         """ Recursive dict merge. Inspired by `dict.update()` however instead of
@@ -148,13 +151,18 @@ class Target(namedtuple("Target", "name json_data resolution_order resolution_or
         """Load the description of JSON target data"""
         targets = json_file_to_dict(Target.__targets_json_location or
                                     Target.__targets_json_location_default)
+
+        for extra_target in Target.__extra_target_json_files:
+            Target._merge_dict(targets, json_file_to_dict(extra_target))
+
         return targets
 
     @staticmethod
-    @cached
-    def add_extra_targets(extra):
-        if os.path.exists(extra):
-            Target._merge_dict(targets, json_file_to_dict(extra))
+    def add_extra_targets(source_dir):
+        extra_targets_file = os.path.join(source_dir, "custom_targets.json")
+        if os.path.exists(extra_targets_file):
+            Target.__extra_target_json_files.append(extra_targets_file)
+            CACHES.clear()
 
     @staticmethod
     def set_targets_json_location(location=None):
@@ -531,14 +539,20 @@ class RTL8195ACode:
 ################################################################################
 
 # Instantiate all public targets
-TARGETS = [Target.get_target(name) for name, value
-           in Target.get_json_target_data().items()
-           if value.get("public", True)]
+def update_target_data():
+    TARGETS[:] = [Target.get_target(tgt) for tgt, obj
+                  in Target.get_json_target_data().items()
+                  if obj.get("public", True)]
+    # Map each target name to its unique instance
+    TARGET_MAP.clear()
+    TARGET_MAP.update(dict([(tgt.name, tgt) for tgt in TARGETS]))
+    TARGET_NAMES[:] = TARGET_MAP.keys()
 
-# Map each target name to its unique instance
-TARGET_MAP = dict([(t.name, t) for t in TARGETS])
+TARGETS = []
+TARGET_MAP = dict()
+TARGET_NAMES = []
 
-TARGET_NAMES = TARGET_MAP.keys()
+update_target_data()
 
 # Some targets with different name have the same exporters
 EXPORT_MAP = {}
@@ -563,10 +577,3 @@ def set_targets_json_location(location=None):
     # "from tools.targets import TARGET_NAMES"
     update_target_data()
 
-def update_target_data():
-    TARGETS[:] = [Target.get_target(tgt) for tgt, obj
-                  in Target.get_json_target_data().items()
-                  if obj.get("public", True)]
-    TARGET_MAP.clear()
-    TARGET_MAP.update(dict([(tgt.name, tgt) for tgt in TARGETS]))
-    TARGET_NAMES[:] = TARGET_MAP.keys()

--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -129,8 +129,15 @@ class Target(namedtuple("Target", "name json_data resolution_order resolution_or
     @cached
     def get_json_target_data():
         """Load the description of JSON target data"""
-        return json_file_to_dict(Target.__targets_json_location or
-                                 Target.__targets_json_location_default)
+        targets = json_file_to_dict(Target.__targets_json_location or
+                                     Target.__targets_json_location_default)
+
+        # If extra_targets.json exists in working directory load it over the top
+        extra = os.path.join('.', 'extra_targets.json')
+        if os.path.exists(extra):
+            targets.update(json_file_to_dict(extra))
+
+        return targets
 
     @staticmethod
     def set_targets_json_location(location=None):

--- a/tools/test.py
+++ b/tools/test.py
@@ -28,7 +28,7 @@ sys.path.insert(0, ROOT)
 
 from tools.config import ConfigException
 from tools.test_api import test_path_to_name, find_tests, print_tests, build_tests, test_spec_from_test_builds
-from tools.options import get_default_options_parser, extract_profile
+from tools.options import get_default_options_parser, extract_profile, extract_mcus
 from tools.build_api import build_project, build_library
 from tools.build_api import print_build_memory_usage
 from tools.build_api import merge_build_data
@@ -114,7 +114,7 @@ if __name__ == '__main__':
         # Target
         if options.mcu is None :
             args_error(parser, "argument -m/--mcu is required")
-        mcu = options.mcu[0]
+        mcu = extract_mcus(parser, options)[0]
 
         # Toolchain
         if options.tool is None:

--- a/tools/test/targets/target_test.py
+++ b/tools/test/targets/target_test.py
@@ -15,17 +15,22 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-
+import os
 import sys
+import shutil
+import tempfile
 from os.path import join, abspath, dirname
+from contextlib import contextmanager
 import unittest
 
 # Be sure that the tools directory is in the search path
+
 ROOT = abspath(join(dirname(__file__), "..", "..", ".."))
 sys.path.insert(0, ROOT)
 
-from tools.targets import TARGETS
+from tools.targets import TARGETS, TARGET_MAP, Target, update_target_data
 from tools.arm_pack_manager import Cache
+
 
 class TestTargets(unittest.TestCase):
 
@@ -38,6 +43,98 @@ class TestTargets(unittest.TestCase):
             self.assertTrue(target.device_name in cache.index,
                             "Target %s contains invalid device_name %s" %
                             (target.name, target.device_name))
+
+    @contextmanager
+    def temp_target_file(self, extra_target, json_filename='custom_targets.json'):
+        """Create an extra targets temp file in a context manager"""
+        tempdir = tempfile.mkdtemp()
+        try:
+            targetfile = os.path.join(tempdir, json_filename)
+            with open(targetfile, 'w') as f:
+                f.write(extra_target)
+            yield tempdir
+        finally:
+            # Reset extra targets
+            Target.set_targets_json_location()
+            # Delete temp files
+            shutil.rmtree(tempdir)
+
+    def test_add_extra_targets(self):
+        """Search for extra targets json in a source folder"""
+        test_target_json = """
+        { 
+            "Test_Target": {
+                "inherits": ["Target"]
+            }
+        }
+        """
+        with self.temp_target_file(test_target_json) as source_dir:
+            Target.add_extra_targets(source_dir=source_dir)
+            update_target_data()
+
+            assert 'Test_Target' in TARGET_MAP
+            assert TARGET_MAP['Test_Target'].core is None, \
+                   "attributes should be inherited from Target"
+
+    def test_modify_default_target(self):
+        """Set default targets file, then override base Target definition"""
+        initial_target_json = """
+        {
+            "Target": {
+                "core": null,
+                "default_toolchain": "ARM",
+                "supported_toolchains": null,
+                "extra_labels": [],
+                "is_disk_virtual": false,
+                "macros": [],
+                "device_has": [],
+                "features": [],
+                "detect_code": [],
+                "public": false,
+                "default_lib": "std",
+                "bootloader_supported": false
+            },
+            "Test_Target": {
+                "inherits": ["Target"],
+                "core": "Cortex-M4",
+                "supported_toolchains": ["ARM"]
+            }
+        }"""
+
+        test_target_json = """
+        { 
+            "Target": {
+                "core": "Cortex-M0",
+                "default_toolchain": "GCC_ARM",
+                "supported_toolchains": null,
+                "extra_labels": [],
+                "is_disk_virtual": false,
+                "macros": [],
+                "device_has": [],
+                "features": [],
+                "detect_code": [],
+                "public": false,
+                "default_lib": "std",
+                "bootloader_supported": true
+            }
+        }
+        """
+
+        with self.temp_target_file(initial_target_json, json_filename="targets.json") as targets_dir:
+            Target.set_targets_json_location(os.path.join(targets_dir, "targets.json"))
+            update_target_data()
+            assert TARGET_MAP["Test_Target"].core == "Cortex-M4"
+            assert TARGET_MAP["Test_Target"].default_toolchain == 'ARM'
+            assert TARGET_MAP["Test_Target"].bootloader_supported == False
+
+            with self.temp_target_file(test_target_json) as source_dir:
+                Target.add_extra_targets(source_dir=source_dir)
+                update_target_data()
+
+                assert TARGET_MAP["Test_Target"].core == "Cortex-M4"
+                assert TARGET_MAP["Test_Target"].default_toolchain == 'GCC_ARM'
+                assert TARGET_MAP["Test_Target"].bootloader_supported == True
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/test/targets/target_test.py
+++ b/tools/test/targets/target_test.py
@@ -76,7 +76,7 @@ class TestTargets(unittest.TestCase):
             assert TARGET_MAP['Test_Target'].core is None, \
                    "attributes should be inherited from Target"
 
-    def test_modify_default_target(self):
+    def test_modify_existing_target(self):
         """Set default targets file, then override base Target definition"""
         initial_target_json = """
         {
@@ -132,8 +132,9 @@ class TestTargets(unittest.TestCase):
                 update_target_data()
 
                 assert TARGET_MAP["Test_Target"].core == "Cortex-M4"
-                assert TARGET_MAP["Test_Target"].default_toolchain == 'GCC_ARM'
-                assert TARGET_MAP["Test_Target"].bootloader_supported == True
+                # The existing target should not be modified by custom targets
+                assert TARGET_MAP["Test_Target"].default_toolchain != 'GCC_ARM'
+                assert TARGET_MAP["Test_Target"].bootloader_supported != True
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
Enhancement to provide simple method of adding or overriding target definitions without modifying mbed-os library.

If the file extra_targets.json exists in the working directory load it over the top of the built in targets.json for defining new and overriding built in mbed target definitions.

This is currently just a suggestion for replacing functionality removed in PR #2691 below.

## Status
**IN DEVELOPMENT**
Not ready for merging, open for discussion of direction before considering writing docs/tests

## Related PRs

branch | PR
------ | ------
no_custom_targets | [Removed custom targets from config system]( https://github.com/ARMmbed/mbed-os/pull/2691 )


## Todos
- [x] Tests
- [x] Documentation

