### PR TITLE
Fix a scoping typo in toolchains

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -474,7 +474,7 @@ class mbedToolchain:
             # This is a policy decision and it should /really/ be in the config system
             # ATM it's here for backward compatibility
             if ((("-g" in self.flags['common'] or "-g3" in self.flags['common']) and
-                 "-O0") in self.flags['common'] or
+                 "-O0" in self.flags['common']) or
                 ("-r" in self.flags['common'] and
                  "-On" in self.flags['common'])):
                 self.labels['TARGET'].append("DEBUG")


### PR DESCRIPTION
I don't know what this affected, or even if it affected anything.

# Testing
 - [x] /morph test.