### PR TITLE
Allow configuration of artifact name in app config

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -481,8 +481,8 @@ def build_project(src_paths, build_path, target, toolchain_name,
         build_profile=build_profile)
 
     # The first path will give the name to the library
-    if name is None:
-        name = basename(normpath(abspath(src_paths[0])))
+    name = (name or toolchain.config.name or
+            basename(normpath(abspath(src_paths[0]))))
     toolchain.info("Building project %s (%s, %s)" %
                    (name, toolchain.target.name, toolchain_name))
 

--- a/tools/config.py
+++ b/tools/config.py
@@ -355,7 +355,8 @@ class Config(object):
         "library": {"name": str, "config": dict, "target_overrides": dict,
                     "macros": list, "__config_path": str},
         "application": {"config": dict, "target_overrides": dict,
-                        "macros": list, "__config_path": str}
+                        "macros": list, "__config_path": str,
+                        "artifact_name": str}
     }
 
     __unused_overrides = set(["target.bootloader_img", "target.restrict_size"])
@@ -796,6 +797,13 @@ class Config(object):
             raise self.config_errors[0]
         return True
 
+
+    @property
+    def name(self):
+        if "artifact_name" in self.app_config_data:
+            return self.app_config_data["artifact_name"]
+        else:
+            return None
 
     def load_resources(self, resources):
         """ Load configuration data from a Resources instance and expand it

--- a/tools/test/build_api/build_api_test.py
+++ b/tools/test/build_api/build_api_test.py
@@ -84,10 +84,8 @@ class BuildApiTests(unittest.TestCase):
         mock_target = namedtuple("Target",
                                  "init_hooks name features core")(lambda _, __ : None,
                                                                   "Junk", [], "Cortex-M3")
-        mock_config_init.return_value = namedtuple("Config",
-                                                   "target has_regions")(
-                                                       mock_target,
-                                                       False)
+        mock_config_init.return_value = namedtuple(
+            "Config", "target has_regions name")(mock_target, False, None)
 
         prepare_toolchain(self.src_paths, None, self.target, self.toolchain_name,
                           app_config=app_config)
@@ -106,10 +104,8 @@ class BuildApiTests(unittest.TestCase):
         mock_target = namedtuple("Target",
                                  "init_hooks name features core")(lambda _, __ : None,
                                                                   "Junk", [], "Cortex-M3")
-        mock_config_init.return_value = namedtuple("Config",
-                                                   "target has_regions")(
-                                                       mock_target,
-                                                       False)
+        mock_config_init.return_value = namedtuple(
+            "Config", "target has_regions name")(mock_target, False, None)
 
         prepare_toolchain(self.src_paths, None, self.target, self.toolchain_name)
 
@@ -133,7 +129,8 @@ class BuildApiTests(unittest.TestCase):
         app_config = "app_config"
         mock_exists.return_value = False
         mock_prepare_toolchain().link_program.return_value = 1, 2
-        mock_prepare_toolchain().config = namedtuple("Config", "has_regions")(None)
+        mock_prepare_toolchain().config = namedtuple(
+            "Config", "has_regions name")(None, None)
 
         build_project(self.src_paths, self.build_path, self.target,
                       self.toolchain_name, app_config=app_config)
@@ -161,7 +158,8 @@ class BuildApiTests(unittest.TestCase):
         mock_exists.return_value = False
         # Needed for the unpacking of the returned value
         mock_prepare_toolchain().link_program.return_value = 1, 2
-        mock_prepare_toolchain().config = namedtuple("Config", "has_regions")(None)
+        mock_prepare_toolchain().config = namedtuple(
+            "Config", "has_regions name")(None, None)
 
         build_project(self.src_paths, self.build_path, self.target,
                       self.toolchain_name)


### PR DESCRIPTION
This patch allows a user to configure the artifact name through the 
`mbed_app.json` file.

Suggested by @andrewleech in #4103

## Example
```json
{
    "artifact_name" : "FooBar"
}
```
This will rename the executable in your application from `<dirname(app-dir)>.bin` to `FooBar.bin`

The precedence is (fall through if not specified):
 1. Command line argument.
 2. `mbed_app.json` `artifact_name` key
 3. Name of the directory that contains the project.