### PR TITLE
Add --build-data switch to mbed compile and test

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -18,6 +18,7 @@ limitations under the License.
 import re
 import tempfile
 import datetime
+import uuid
 from types import ListType
 from shutil import rmtree
 from os.path import join, exists, dirname, basename, abspath, normpath, splitext
@@ -106,6 +107,7 @@ def add_result_to_report(report, result):
     result - the result to append
     """
     result["date"] = datetime.datetime.utcnow().isoformat()
+    result["uuid"] = str(uuid.uuid1())
     target = result["target_name"]
     toolchain = result["toolchain_name"]
     id_name = result['id']

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -105,7 +105,7 @@ def add_result_to_report(report, result):
     report - the report to append to
     result - the result to append
     """
-    result["date"] = str(datetime.datetime.now())
+    result["date"] = datetime.datetime.utcnow().isoformat()
     target = result["target_name"]
     toolchain = result["toolchain_name"]
     id_name = result['id']

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -658,6 +658,7 @@ def build_library(src_paths, build_path, target, toolchain_name,
         prep_report(report, toolchain.target.name, toolchain_name, id_name)
         cur_result = create_result(toolchain.target.name, toolchain_name,
                                    id_name, description)
+        cur_result['type'] = 'library'
         if properties != None:
             prep_properties(properties, toolchain.target.name, toolchain_name,
                             vendor_label)
@@ -1369,7 +1370,7 @@ def write_build_report(build_report, template_filename, filename):
             passing_builds=build_report_passing))
 
 
-def merge_build_data(filename, toolchain_report):
+def merge_build_data(filename, toolchain_report, app_type):
     path_to_file = dirname(abspath(filename))
     try:
         build_data = load(open(filename))
@@ -1384,5 +1385,7 @@ def merge_build_data(filename, toolchain_report):
                         build[0]['bin'] = relpath(build[0]['bin'], path_to_file)
                     except KeyError:
                         pass
+                    if 'type' not in build[0]:
+                        build[0]['type'] = app_type
                     build_data['builds'].append(build[0])
     dump(build_data, open(filename, "wb"), indent=4, separators=(',', ': '))

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -17,6 +17,7 @@ limitations under the License.
 
 import re
 import tempfile
+import datetime
 from types import ListType
 from shutil import rmtree
 from os.path import join, exists, dirname, basename, abspath, normpath, splitext
@@ -102,6 +103,7 @@ def add_result_to_report(report, result):
     report - the report to append to
     result - the result to append
     """
+    result["date"] = str(datetime.datetime.now())
     target = result["target_name"]
     toolchain = result["toolchain_name"]
     id_name = result['id']
@@ -550,6 +552,9 @@ def build_project(src_paths, build_path, target, toolchain_name,
             cur_result["output"] = toolchain.get_output() + memap_table
             cur_result["result"] = "OK"
             cur_result["memory_usage"] = toolchain.map_outputs
+            cur_result["bin"] = res
+            cur_result["elf"] = splitext(res)[0] + ".elf"
+            cur_result.update(toolchain.report)
 
             add_result_to_report(report, cur_result)
 

--- a/tools/make.py
+++ b/tools/make.py
@@ -55,17 +55,17 @@ from utils import argparse_dir_not_parent
 from tools.toolchains import mbedToolchain, TOOLCHAIN_CLASSES, TOOLCHAIN_PATHS
 from tools.settings import CLI_COLOR_MAP
 
-def merge_metadata(filename, toolchain_report):
+def merge_build_data(filename, toolchain_report):
     try:
-        metadata = load(open(filename))
+        build_data = load(open(filename))
     except (IOError, ValueError):
-        metadata = {'builds': []}
+        build_data = {'builds': []}
     for tgt in toolchain_report.values():
         for tc in tgt.values():
             for project in tc.values():
                 for build in project:
-                    metadata['builds'].append(build[0])
-    dump(metadata, open(filename, "wb"), indent=4, separators=(',', ': '))
+                    build_data['builds'].append(build[0])
+    dump(build_data, open(filename, "wb"), indent=4, separators=(',', ': '))
 
 if __name__ == '__main__':
     # Parse Options
@@ -190,10 +190,10 @@ if __name__ == '__main__':
                       default=False,
                       help="Link with mbed test library")
 
-    parser.add_argument("--metadata",
-                        dest="metadata",
+    parser.add_argument("--build-data",
+                        dest="build_data",
                         default=None,
-                        help="Dump metadata to this file")
+                        help="Dump build_data to this file")
 
     # Specify a different linker script
     parser.add_argument("-l", "--linker", dest="linker_script",
@@ -267,7 +267,7 @@ if __name__ == '__main__':
                            %(toolchain,search_path))
 
     # Test
-    metadata_blob = {} if options.metadata else None
+    build_data_blob = {} if options.build_data else None
     for test_no in p:
         test = Test(test_no)
         if options.automated is not None:    test.automated = options.automated
@@ -306,7 +306,7 @@ if __name__ == '__main__':
                                      clean=options.clean,
                                      verbose=options.verbose,
                                      notify=notify,
-                                     report=metadata_blob,
+                                     report=build_data_blob,
                                      silent=options.silent,
                                      macros=options.macros,
                                      jobs=options.jobs,
@@ -362,5 +362,5 @@ if __name__ == '__main__':
                 print "[ERROR] %s" % str(e)
             
             sys.exit(1)
-    if options.metadata:
-        merge_metadata(options.metadata, metadata_blob)
+    if options.build_data:
+        merge_build_data(options.build_data, build_data_blob)

--- a/tools/make.py
+++ b/tools/make.py
@@ -352,4 +352,4 @@ if __name__ == '__main__':
             
             sys.exit(1)
     if options.build_data:
-        merge_build_data(options.build_data, build_data_blob)
+        merge_build_data(options.build_data, build_data_blob, "application")

--- a/tools/make.py
+++ b/tools/make.py
@@ -49,23 +49,12 @@ from tools.build_api import build_project
 from tools.build_api import mcu_toolchain_matrix
 from tools.build_api import mcu_toolchain_list
 from tools.build_api import mcu_target_list
+from tools.build_api import merge_build_data
 from utils import argparse_filestring_type
 from utils import argparse_many
 from utils import argparse_dir_not_parent
 from tools.toolchains import mbedToolchain, TOOLCHAIN_CLASSES, TOOLCHAIN_PATHS
 from tools.settings import CLI_COLOR_MAP
-
-def merge_build_data(filename, toolchain_report):
-    try:
-        build_data = load(open(filename))
-    except (IOError, ValueError):
-        build_data = {'builds': []}
-    for tgt in toolchain_report.values():
-        for tc in tgt.values():
-            for project in tc.values():
-                for build in project:
-                    build_data['builds'].append(build[0])
-    dump(build_data, open(filename, "wb"), indent=4, separators=(',', ': '))
 
 if __name__ == '__main__':
     # Parse Options

--- a/tools/test.py
+++ b/tools/test.py
@@ -31,6 +31,7 @@ from tools.test_api import test_path_to_name, find_tests, print_tests, build_tes
 from tools.options import get_default_options_parser, extract_profile
 from tools.build_api import build_project, build_library
 from tools.build_api import print_build_memory_usage
+from tools.build_api import merge_build_data
 from tools.targets import TARGET_MAP
 from tools.utils import mkdir, ToolException, NotSupportedException, args_error
 from tools.test_exporters import ReportExporter, ResultExporterType
@@ -88,6 +89,10 @@ if __name__ == '__main__':
         
         parser.add_argument("--build-report-junit", dest="build_report_junit",
                           default=None, help="Destination path for a build report in the JUnit xml format")
+        parser.add_argument("--build-data",
+                            dest="build_data",
+                            default=None,
+                            help="Dump build_data to this file")
         
         parser.add_argument("-v", "--verbose",
                           action="store_true",
@@ -175,17 +180,13 @@ if __name__ == '__main__':
             profile = extract_profile(parser, options, toolchain)
             try:
                 # Build sources
-                build_library(base_source_paths, options.build_dir, mcu, toolchain,
-                                                jobs=options.jobs,
-                                                clean=options.clean,
-                                                report=build_report,
-                                                properties=build_properties,
-                                                name="mbed-build",
-                                                macros=options.macros,
-                                                verbose=options.verbose,
-                                                notify=notify,
-                                                archive=False,
-                                                app_config=options.app_config,
+                build_library(base_source_paths, options.build_dir, mcu,
+                              toolchain, jobs=options.jobs,
+                              clean=options.clean, report=build_report,
+                              properties=build_properties, name="mbed-build",
+                              macros=options.macros, verbose=options.verbose,
+                              notify=notify, archive=False,
+                              app_config=options.app_config,
                               build_profile=profile)
 
                 library_build_success = True
@@ -245,6 +246,8 @@ if __name__ == '__main__':
 
             print_report_exporter = ReportExporter(ResultExporterType.PRINT, package="build")
             status = print_report_exporter.report(build_report)
+            if options.build_data:
+                merge_build_data(options.build_data, build_report)
 
             if status:
                 sys.exit(0)

--- a/tools/test.py
+++ b/tools/test.py
@@ -247,7 +247,7 @@ if __name__ == '__main__':
             print_report_exporter = ReportExporter(ResultExporterType.PRINT, package="build")
             status = print_report_exporter.report(build_report)
             if options.build_data:
-                merge_build_data(options.build_data, build_report)
+                merge_build_data(options.build_data, build_report, "test")
 
             if status:
                 sys.exit(0)

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -1393,6 +1393,19 @@ class mbedToolchain:
     def get_config_macros(self):
         return Config.config_to_macros(self.config_data) if self.config_data else []
 
+    @property
+    def report(self):
+        to_ret = {}
+        to_ret['c_compiler'] = {'flags': copy(self.flags['c']),
+                                'symbols': self.get_symbols()}
+        to_ret['cxx_compiler'] = {'flags': copy(self.flags['cxx']),
+                                  'symbols': self.get_symbols()}
+        to_ret['assembler'] = {'flags': copy(self.flags['asm']),
+                               'symbols': self.get_symbols(True)}
+        to_ret['linker'] = {'flags': copy(self.flags['ld'])}
+        to_ret.update(self.config.report)
+        return to_ret
+
 from tools.settings import ARM_PATH
 from tools.settings import GCC_ARM_PATH
 from tools.settings import IAR_PATH


### PR DESCRIPTION
The `--build-data` switch is used to specify a file that will be filled
with build metadata.

Testing
 - [x] /morph test
 - [ ] mbed 2 tests