### PR TITLE
Proposal to allow changing of default stack size

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
@@ -68,11 +68,15 @@
 #define __CMSIS_RTOS
 #endif
 
-// The stack space occupied is mainly dependent on the underling C standard library
-#if defined(TOOLCHAIN_GCC) || defined(TOOLCHAIN_ARM_STD) || defined(TOOLCHAIN_IAR)
-#    define WORDS_STACK_SIZE   512
-#elif defined(TOOLCHAIN_ARM_MICRO)
-#    define WORDS_STACK_SIZE   128
+// The stack space occupied is mainly dependent on the underlining C standard library
+#if defined(MBED_RTOS_WORDS_STACK_SIZE)
+#   define WORDS_STACK_SIZE MBED_RTOS_WORDS_STACK_SIZE
+#else
+#   if defined(TOOLCHAIN_GCC) || defined(TOOLCHAIN_ARM_STD) || defined(TOOLCHAIN_IAR)
+#       define WORDS_STACK_SIZE   512
+#   elif defined(TOOLCHAIN_ARM_MICRO)
+#       define WORDS_STACK_SIZE   128
+#endif
 #endif
 
 #ifdef __MBED_CMSIS_RTOS_CM


### PR DESCRIPTION
I noticed on the LPC1768 platform, that 4k of RAM was reserved for the
main thread stack. While a developer can customize the size of the
stacks used for their other threads, the main thread's stack size is
currently fixed. It would be nice to allow the developer a way easier
than modifying the RTOS code directly to customize the default
stack size. I can see reasons when a developer would want to make this
stack smaller to make more RAM available to other threads or the heap.
There might also be times when the main thread needs a larger stack to
accomodate some more stack hungry functions that only get called from
main.

This commit contains a proposed change to allow the developer to
customize the default stack size. It allows the developer to set the
MBED_RTOS_WORDS_STACK_SIZE macro to override the setting of
WORDS_STACK_SIZE that would normally be made in cmsis_os.h based on
the TOOLCHAIN setting. I chose this name and methodology based on the
existing MBED_RTOS_SINGLE_THREAD macro usage in the same header file.
