### PR TITLE
Updated CAN to new Callback API

### DIFF
--- a/drivers/CAN.cpp
+++ b/drivers/CAN.cpp
@@ -27,7 +27,7 @@ CAN::CAN(PinName rd, PinName td) : _can(), _irq() {
     // No lock needed in constructor
 
     for (int i = 0; i < sizeof _irq / sizeof _irq[0]; i++) {
-        _irq[i].attach(donothing);
+        _irq[i] = callback(donothing);
     }
 
     can_init(&_can, rd, td);
@@ -104,10 +104,10 @@ int CAN::filter(unsigned int id, unsigned int mask, CANFormat format, int handle
 void CAN::attach(Callback<void()> func, IrqType type) {
     lock();
     if (func) {
-        _irq[(CanIrqType)type].attach(func);
+        _irq[(CanIrqType)type] = func;
         can_irq_set(&_can, (CanIrqType)type, 1);
     } else {
-        _irq[(CanIrqType)type].attach(donothing);
+        _irq[(CanIrqType)type] = callback(donothing);
         can_irq_set(&_can, (CanIrqType)type, 0);
     }
     unlock();


### PR DESCRIPTION
Updated `CAN` to use new `Callback` assignment API in order to fix compiler warnings.