### PR TITLE
KL27Z: Update IAR linker file with new stack and heap sizes

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/device/TOOLCHAIN_IAR/MKL27Z64xxx4.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/device/TOOLCHAIN_IAR/MKL27Z64xxx4.icf
@@ -49,9 +49,9 @@
 */
 define symbol __ram_vector_table__ = 1;
 
-/* Heap 1/4 of ram and stack 1/8 */
-define symbol __stack_size__=0x800;
-define symbol __heap_size__=0x1000;
+/* Heap and stack sizes */
+define symbol __stack_size__=0x180;
+define symbol __heap_size__=0x1900;
 
 define symbol __ram_vector_table_size__ =  isdefinedsymbol(__ram_vector_table__) ? 0x00000200 : 0;
 define symbol __ram_vector_table_offset__ =  isdefinedsymbol(__ram_vector_table__) ? 0x000001FF : 0;


### PR DESCRIPTION
## Description
Increase the heap size and reduce stack size to pass all mbed-os and mbed 2.0 tests under IAR

## Status
**READY

- [ ] Tests
Passed mbed-os and mbed 2.0 tests on KL27Z when compiled with IAR toolchain