### PR TITLE
Removing old filesystem test

### DIFF
--- a/tools/tests.py
+++ b/tools/tests.py
@@ -1042,11 +1042,6 @@ TESTS = [
         "automated": True,
         #"host_test" : "dev_null_auto",
     },
-    {
-        "id": "EXAMPLE_2", "description": "FS + RTOS",
-        "source_dir": join(TEST_DIR, "mbed", "fs"),
-        "dependencies": [MBED_LIBRARIES, RTOS_LIBRARIES, TEST_MBED_LIB],
-    },
 
     # CPPUTEST Library provides Unit testing Framework
     #


### PR DESCRIPTION
## Description
This should solve #4114. This PR removes an old Filesystem mbed 2 test. The source directory for the test doesn't exist anymore, so we should probably remove the test listing!


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO

## Todos
- [x] mbed 2 test

FYI @pranavshandilya, @geky 