### PR TITLE
U-BLOX_C030: Default XTAL is now 12MHz onboard. Option to use Debug 8MHz

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/system_stm32f4xx.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/system_stm32f4xx.c
@@ -21,20 +21,20 @@
   *                                 during program execution.
   *
   * This file configures the system clock as follows:
-  *--------------------------------------------------------------------------------------
-  * System clock source                | PLL_HSE_XTAL           | PLL_HSE_XTAL           
-  *                                    | (external 8 MHz clock) | (external 8 MHz clock) 
-  *--------------------------------------------------------------------------------------
-  * SYSCLK(MHz)                        | 168                    | 84                    
-  *--------------------------------------------------------------------------------------
-  * AHBCLK (MHz)                       | 168                    | 84                   
-  *--------------------------------------------------------------------------------------
-  * APB1CLK (MHz)                      | 42                     | 42                     
-  *--------------------------------------------------------------------------------------
-  * APB2CLK (MHz)                      | 84                     | 84                     
-  *--------------------------------------------------------------------------------------
-  * USB capable (48 MHz precise clock) | YES                    | YES                     
-  *--------------------------------------------------------------------------------------
+  *----------------------------------------------------------------------------------------------------------------------------------------
+  * System clock source                | PLL_HSE_XTAL           | PLL_HSE_XTAL           | PLL_HSE_XTAL           | PLL_HSE_XTAL
+  *                                    | (external 8 MHz clock) | (external 8 MHz clock) | (external 12 MHz clock)| (external 12 MHz clock)
+  *----------------------------------------------------------------------------------------------------------------------------------------
+  * SYSCLK(MHz)                        | 168                    | 84                     | 168                    | 84
+  *----------------------------------------------------------------------------------------------------------------------------------------
+  * AHBCLK (MHz)                       | 168                    | 84                     | 168                    | 84
+  *----------------------------------------------------------------------------------------------------------------------------------------
+  * APB1CLK (MHz)                      | 42                     | 42                     | 42                     | 42
+  *----------------------------------------------------------------------------------------------------------------------------------------
+  * APB2CLK (MHz)                      | 84                     | 84                     | 84                     | 84
+  *----------------------------------------------------------------------------------------------------------------------------------------
+  * USB capable (48 MHz precise clock) | YES                    | YES                    | YES                    | YES
+  *----------------------------------------------------------------------------------------------------------------------------------------
   ******************************************************************************
   * @attention
   *
@@ -136,8 +136,8 @@
   */
 
 /* Select the SYSCLOCK  to start with (0=OFF, 1=ON) */
-#define USE_SYSCLOCK_168 (1) /* Use external 8MHz xtal and sets SYSCLK to 168MHz */
-#define USE_SYSCLOCK_84 (0) /* Use external 8MHz xtal and sets SYSCLK to 84MHz */
+#define USE_SYSCLOCK_168 (1) /* Use external 8MHz or 12 MHz xtal and sets SYSCLK to 168MHz */
+#define USE_SYSCLOCK_84 (0) /* Use external 8MHz or 12 MHz xtal and sets SYSCLK to 84MHz */
 
 /**
   * @}
@@ -801,7 +801,11 @@ void SetSysClock(void)
   RCC_OscInitStruct.HSEState = RCC_HSE_ON;
   RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
   RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+#ifdef USE_DEBUG_8MHz_XTAL
   RCC_OscInitStruct.PLL.PLLM = 8;
+#else
+  RCC_OscInitStruct.PLL.PLLM = 12;
+#endif
   RCC_OscInitStruct.PLL.PLLN = 336;
   RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
   RCC_OscInitStruct.PLL.PLLQ = 7;
@@ -838,7 +842,11 @@ void SetSysClock(void)
   RCC_OscInitStruct.HSEState = RCC_HSE_ON;
   RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
   RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+#ifdef USE_DEBUG_8MHz_XTAL
   RCC_OscInitStruct.PLL.PLLM = 8;
+#else
+  RCC_OscInitStruct.PLL.PLLM = 12;
+#endif
   RCC_OscInitStruct.PLL.PLLN = 336;
   RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV4;
   RCC_OscInitStruct.PLL.PLLQ = 7;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1340,10 +1340,10 @@
         "default_toolchain": "ARM",
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
         "extra_labels": ["STM", "STM32F4", "STM32F437", "STM32F437VG", "STM32F437xx", "STM32F437xG"],
-        "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2", "RTC_LSI=1"],
+        "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2", "RTC_LSI=1", "HSE_VALUE=12000000"],
         "inherits": ["Target"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "RTC", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG"],
-        "features": ["LWIP"],        
+        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "RTC", "SPI", "SPISLAVE","STDIO_MESSAGES", "TRNG"],
+        "features": ["LWIP"],
         "release_versions": ["5"],
         "device_name": "STM32F437VG"
         },


### PR DESCRIPTION
XTAL by using Macro USE_DEBUG_8MHz_XTAL

HSE is now set to 12MHz and the PLL default is 12MHz. This is because all hardware will work from local crystal and not the 8MHz debug chip clock. 

Created a new Macro USE_DEBUG_8MHz_XTAL to switch back to the 8MHz debug chip clock if the user wishes.