### PR TITLE
Error when bootloader is specified but does not exist

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -145,6 +145,8 @@ def get_config(src_paths, target, toolchain_name):
 
         prev_features = features
     toolchain.config.validate_config()
+    if toolchain.config.has_regions:
+        _ = list(toolchain.config.regions)
 
     cfg, macros = toolchain.config.get_config_data()
     features = toolchain.config.get_features()

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -17,7 +17,7 @@ limitations under the License.
 
 from copy import deepcopy
 import os
-from os.path import dirname, abspath
+from os.path import dirname, abspath, exists
 import sys
 from collections import namedtuple
 from os.path import splitext
@@ -506,6 +506,8 @@ class Config(object):
                                   "build a bootloader project")
         if 'target.bootloader_img' in target_overrides:
             filename = target_overrides['target.bootloader_img']
+            if not exists(filename):
+                raise ConfigException("Bootloader %s not found" % filename)
             part = intelhex_offset(filename, offset=rom_start)
             if part.minaddr() != rom_start:
                 raise ConfigException("bootloader executable does not "

--- a/tools/test/config_test/test29/mbed_app.json
+++ b/tools/test/config_test/test29/mbed_app.json
@@ -1,0 +1,7 @@
+{
+    "target_overrides": {
+        "K64F": {
+            "target.bootloader_img": "does_not_exists.bin"
+        }
+    }
+}

--- a/tools/test/config_test/test29/test_data.py
+++ b/tools/test/config_test/test29/test_data.py
@@ -1,0 +1,6 @@
+expected_results = {
+    "K64F": {
+        "desc": "error when bootloader not found",
+        "exception_msg": "not found"
+    }
+}


### PR DESCRIPTION
# Descritpion

This patch changes the behavior when a bootloader is specified, but not
present. It is now considered a Bad Config™.

# How to reproduce

Take the mbed-os-example-bootloader-blinky example and delete the 
`bootloader` directory. You will now see a ~nice~awful IOError.

# New behavior

Do the steps to reproduce, but with this branch as mbed-os. The error 
message that you will get it a ConfigException: 
"Bootloader <your-filename> not found".


# TODO
 - [x] Write unit test that tests this behavior
 - [x] Ensure that the unit test runs as part of Travis CI