### PR TITLE
MCUXpresso: Update ARM linker files to eliminate reserving RAM for stack & heap

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
@@ -47,10 +47,6 @@
 */
 #define __ram_vector_table__            1
 
-/* Heap 1/4 of ram and stack 1/8 */
-#define __stack_size__       0x8000
-#define __heap_size__        0x10000
-
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x00000400
 #else

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/device/TOOLCHAIN_ARM_STD/MK82FN256xxx15.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/device/TOOLCHAIN_ARM_STD/MK82FN256xxx15.sct
@@ -49,10 +49,6 @@
 */
 
 #define __ram_vector_table__            1
-  		  
-/* Heap 1/4 of ram and stack 1/8 */
-#define __stack_size__       0x8000
-#define __heap_size__        0x10000
 
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x000003C0

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/device/TOOLCHAIN_ARM_STD/MKL27Z64xxx4.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/device/TOOLCHAIN_ARM_STD/MKL27Z64xxx4.sct
@@ -50,10 +50,6 @@
 */
 #define __ram_vector_table__            1
 
-/* Heap 1/4 of ram and stack 1/8 */
-#define __stack_size__       0x800
-#define __heap_size__        0x1000
-
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x00000200
 #else

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/device/TOOLCHAIN_ARM_STD/MKL43Z256xxx4.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/device/TOOLCHAIN_ARM_STD/MKL43Z256xxx4.sct
@@ -47,10 +47,6 @@
 */
 #define __ram_vector_table__            1
 
-/* Heap 1/4 of ram and stack 1/8 */
-#define __stack_size__       0x1000
-#define __heap_size__        0x2800
-
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x00000200
 #else

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/device/TOOLCHAIN_ARM_STD/MKL82Z128xxx7.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/device/TOOLCHAIN_ARM_STD/MKL82Z128xxx7.sct
@@ -50,10 +50,6 @@
 */
 #define __ram_vector_table__            1
 
-/* Heap 1/4 of ram and stack 1/8 */
-#define __stack_size__       0x3000
-#define __heap_size__        0x6000
-
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x00000140
 #else

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/device/TOOLCHAIN_ARM_STD/MKW24D512xxx5.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/device/TOOLCHAIN_ARM_STD/MKW24D512xxx5.sct
@@ -45,10 +45,6 @@
 */
 #define __ram_vector_table__            1
 
-/* Heap 1/4 of ram and stack 1/8 */
-#define __stack_size__       0x2000
-#define __heap_size__        0x4000
-
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x00000400
 #else

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/device/TOOLCHAIN_ARM_STD/MKW41Z512xxx4.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/device/TOOLCHAIN_ARM_STD/MKW41Z512xxx4.sct
@@ -45,10 +45,6 @@
 */
 #define __ram_vector_table__            1
 
-/* Heap 1/4 of ram and stack 1/8 */
-#define __stack_size__       0x4000
-#define __heap_size__        0x8000
-
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x00000200
 #else

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/device/TOOLCHAIN_ARM_STD/MK22FN512xxx12.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/device/TOOLCHAIN_ARM_STD/MK22FN512xxx12.sct
@@ -51,10 +51,6 @@
 */
 #define __ram_vector_table__            1
 
-/* Heap 1/4 of ram and stack 1/8 */
-#define __stack_size__       0x4000
-#define __heap_size__        0x8000
-
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x00000400
 #else

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
@@ -50,10 +50,6 @@
 */
 #define __ram_vector_table__            1
 
-/* Heap 1/4 of ram and stack 1/8 */
-#define __stack_size__       0x8000
-#define __heap_size__        0x10000
-
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x00000400
 #else


### PR DESCRIPTION
## Description
Update ARM linker files to eliminate reserving RAM for stack & heap. Heap and stack size is determined via the RTOS. This should fix the below issue:
https://github.com/ARMmbed/mbed-os/issues/3763

## Status
**READY

- [ ] Tests
Ran & passed mbed-os tests.