### PR TITLE
Fix mbed_board.c compiler warning

### DIFF
--- a/platform/mbed_board.c
+++ b/platform/mbed_board.c
@@ -88,7 +88,7 @@ void mbed_error_vfprintf(const char * format, va_list arg) {
             serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
         }
 #if MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES
-        for (unsigned int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             if (buffer[i] == '\n' && stdio_out_prev != '\r') {
                  serial_putc(&stdio_uart, '\r');
             }
@@ -96,7 +96,7 @@ void mbed_error_vfprintf(const char * format, va_list arg) {
             stdio_out_prev = buffer[i];
         }
 #else
-        for (unsigned int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             serial_putc(&stdio_uart, buffer[i]);
         }
 #endif


### PR DESCRIPTION
## Description
Fix the following compiler warning.

Compile [ 63.7%]: mbed_board.c
[Warning] mbed_board.c@99,36: comparison between signed and unsigned integer expressions [-Wsign-compare]

## Status
READY

## Migrations
NO

## Related PRs
NONE

## Todos
NONE

## Deploy notes
NONE

## Steps to test or reproduce
NONE