### PR TITLE
EFM32: Fixed `pwmout_all_inactive` being inversed

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/pwmout_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/pwmout_api.c
@@ -131,7 +131,7 @@ bool pwmout_all_inactive(void) {
         return true;
     }
 #else
-    if(PWM_TIMER->ROUTE & (TIMER_ROUTE_CC0PEN | TIMER_ROUTE_CC1PEN | TIMER_ROUTE_CC2PEN)) {
+    if (!(PWM_TIMER->ROUTE & (TIMER_ROUTE_CC0PEN | TIMER_ROUTE_CC1PEN | TIMER_ROUTE_CC2PEN))) {
         return true;
     }
 #endif
@@ -210,10 +210,11 @@ void pwmout_init(pwmout_t *obj, PinName pin)
 #else
     // On P1, the route location is statically defined for the entire timer.
     PWM_TIMER->ROUTE &= ~_TIMER_ROUTE_LOCATION_MASK;
-if(pwmout_all_inactive()) {
+    // Make sure the route location is not overwritten
+    if(pwmout_all_inactive()) {
         PWM_TIMER->ROUTE |= pinmap_find_function(pin,PinMap_PWM) << _TIMER_ROUTE_LOCATION_SHIFT;
     } else {
-        MBED_ASSERT((pinmap_find_function(pin,PinMap_PWM) << _TIMER_ROUTE_LOCATION_SHIFT) == (PWM_TIMER->ROUTE & _TIMER_ROUTE_LOCATION_MASK));
+        MBED_ASSERT(PWM_TIMER->ROUTE & _TIMER_ROUTE_LOCATION_MASK == pinmap_find_function(pin,PinMap_PWM) << _TIMER_ROUTE_LOCATION_SHIFT);
     }
 #endif
 


### PR DESCRIPTION
## Description

Fixes a bug causing the `pwmout_all_inactive` function to return the inverse of the actual state. If one of the CC channel pins is enabled it means a channel is active so it should return `true`.

The bug seems to have been introduced in mbed 3 (a81fdc461d). Before `pwmout_all_inactive` just checked if the route was enabled (which doesn't really work...)

This PR also contains some cleanup in `pwm_init`.

## Status
**READY**

## Steps to test or reproduce
Note: I only tested this on the EFM32 Happy Gecko MCU (EFM32HG_STK3400 target).

Since `pwm_free` is not called in `~PWMOut` (see #3106), this bug currently does not cause any problems. However, when enabling this functionality, e.g by adding the folowing destructor to PWMOut:
```cpp
~PwmOut() {
        core_util_critical_section_enter();
        pwmout_free(&_pwm);
        core_util_critical_section_exit();
}
```
this bug causes the PWM timer to be disabled when a PWMOut object is destroyed, even if other PWMOut objects are still being used. This causes the other PWMOut object to end up in an invalid state (I'm not sure why).

An excerpt of the code I used to test this:

```cpp
#include "mbed.h"

InterruptIn activate_button(PC10);
AnalogIn in(PD6);
PwmOut *motor_forward;
PwmOut *motor_reverse;
volatile bool reverse = false;

static void activate_button_pressed() {
    reverse = ! reverse;
}

int main() {
    activate_button.rise(activate_button_pressed);

    while(true) {
        while (activate_button == 1) {
            if (motor_forward == NULL) {
                motor_forward = new PwmOut(PA0);
                motor_forward->period_us(25);
            }
            if (motor_reverse == NULL) {
                motor_reverse = new PwmOut(PA1);
                motor_reverse->period_us(25);
            }
            if (reverse) {
                motor_reverse->write(in.read());
                motor_forward->write(0);
            } else {
                motor_forward->write(in.read());
                motor_reverse->write(0);
            }
        }
        motor_reverse->write(0);
        motor_forward->write(0);
        if (motor_forward != NULL) {
            delete motor_forward;
            motor_forward = NULL;
        }
        if (motor_reverse != NULL) {
            delete motor_reverse;
            motor_reverse = NULL;
        }
        sleep();
    }
}
```

Without the fix of this PR, `motor_reverse` stops working after it gets destructed (even when it is initialized again).