### PR TITLE
test - add nanostack to examples.json file

### DIFF
--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -174,6 +174,18 @@
       "compile" : true,
       "export": true,
       "auto-update" : true
+    },
+    {
+      "name": "nanostack-border-router",
+      "github":"https://github.com/ARMmbed/nanostack-border-router",
+      "mbed": [],
+      "features" : [],
+      "targets" : ["K64F", "K66F", "NUCLEO_F429ZI"],
+      "toolchains" : [],
+      "exporters": [],
+      "compile" : true,
+      "export": true,
+      "auto-update" : false
     }
   ]
 }


### PR DESCRIPTION
## Description

Adding nanostack border router example to the list as requested by @MarceloSalazar 

@MarceloSalazar @SeppoTakalo - what configurations are supported - any toolchain? k64f and k66f and stm32 nucleo f429? Let me know, I can update this