### PR TITLE
Move config system into it's own folder and refactor header generation

### DIFF
--- a/tools/config/header.tmpl
+++ b/tools/config/header.tmpl
@@ -1,0 +1,26 @@
+// Automatically generated configuration file.
+// DO NOT EDIT, content will be overwritten.
+
+#ifndef __MBED_CONFIG_DATA__
+#define __MBED_CONFIG_DATA__
+
+{% if cfg_params -%}
+// Configuration parameters
+{% for name, value, set_by in cfg_params -%}
+{% if value is not none -%}
+#define {{name.ljust(name_len)}} {{value.ljust(val_len)}} // set by {{set_by}}
+{%- endif %}
+{% endfor %}
+{%- endif -%}
+
+{%- if macros -%}
+// Macros
+{% for name, value, set_by in macros -%}
+{% if value is not none -%}
+#define {{name.ljust(name_len)}} {{value.ljust(val_len)}} // defined by {{set_by}}
+{%- else -%}
+#define {{name.ljust(name_len + val_len + 1)}} // defined by {{set_by}}
+{%- endif %}
+{% endfor %}
+{%- endif %}
+#endif

--- a/tools/config/header.tmpl
+++ b/tools/config/header.tmpl
@@ -1,3 +1,20 @@
+/*
+ * mbed SDK
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Automatically generated configuration file.
 // DO NOT EDIT, content will be overwritten.
 


### PR DESCRIPTION
# Descritpion

The config system is a huge file, and seems to be growing to support 
things such as bootloader. This implies that the Config class may grow
to beyond the size of this one file.

Furthermore, I saw an error generated by the online build system recently.
This was the traceback:
```python-traceback
ValueError: max() arg is an empty sequence
  File "mbed/build_tasks/tasks.py", line 33, in perform_build
    result = _perform_build(build_params)
  File "mbed/build_tasks/tasks.py", line 139, in _perform_build
    result = build(build_params=build_params)
  File "mbed_compiler/build.py", line 223, in build
    mbed_compiler.build_api.build_program(build_params=build_params, notify=notify)
  File "mbed_compiler/build_api.py", line 227, in build_program
    resources.objects = toolchain.compile_sources(resources, build_params['chrooted_build']) + resources.objects
  File "tools/toolchains/__init__.py", line 802, in compile_sources
    self.get_config_header()
  File "tools/toolchains/__init__.py", line 1134, in get_config_header
    crt_data = Config.config_to_header(self.config_data) if self.config_data else None
  File "tools/config.py", line 823, in config_to_header
    if params else 0)
```

# How to reproduce

Simply create an `mbed_app.json` that removes all macros. This will 
cause the macros array to be empty without causing a `ConfigException`.
When the macros array is empty,  `max()` becomes very confused, as it
is asked to take the maximum of an empty array.

# New behavior

We just add a `[0]` to the end to prevent that silly traceback.