### PR TITLE
NUCLEO_F439ZI/mbedtls: add SHA1 hw_acceleration

### DIFF
--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/mbedtls_device.h
@@ -23,5 +23,4 @@
 #define MBEDTLS_AES_ALT
 #define MBEDTLS_SHA1_ALT
 
-#define MBEDTLS_SHA1_C
 #endif /* MBEDTLS_DEVICE_H */

--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F439ZI/mbedtls_device.h
@@ -21,6 +21,7 @@
 #define MBEDTLS_DEVICE_H
 
 #define MBEDTLS_AES_ALT
+#define MBEDTLS_SHA1_ALT
 
-
+#define MBEDTLS_SHA1_C
 #endif /* MBEDTLS_DEVICE_H */

--- a/features/mbedtls/targets/TARGET_STM/sha1_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/sha1_alt.c
@@ -40,7 +40,7 @@ void mbedtls_sha1_free( mbedtls_sha1_context *ctx )
     if( ctx == NULL )
         return;
 
-	/* Force the HASH Periheral Clock Reset */
+    /* Force the HASH Periheral Clock Reset */
     __HAL_RCC_HASH_FORCE_RESET();
 
     /* Release the HASH Periheral Clock Reset */

--- a/features/mbedtls/targets/TARGET_STM/sha1_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/sha1_alt.c
@@ -18,8 +18,8 @@
  *
  */
 #include "mbedtls/sha1.h"
-
 #if defined(MBEDTLS_SHA1_ALT)
+#include "mbedtls/platform.h"
 
 /* Implementation that should never be optimized out by the compiler */
 static void mbedtls_zeroize( void *v, size_t n ) {
@@ -40,7 +40,7 @@ void mbedtls_sha1_free( mbedtls_sha1_context *ctx )
 {
     if( ctx == NULL )
         return;
-	
+
 	/* Force the HASH Periheral Clock Reset */
     __HAL_RCC_HASH_FORCE_RESET();
 
@@ -66,7 +66,7 @@ void mbedtls_sha1_starts( mbedtls_sha1_context *ctx )
         // error found to be returned
         return;
     }
-    
+
     /* HASH Configuration */
     ctx->hhash_sha1.Init.DataType = HASH_DATATYPE_8B;
     if (HAL_HASH_Init(&ctx->hhash_sha1) == HAL_ERROR) {
@@ -126,7 +126,7 @@ void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input,
                 ctx->flag=0;
             }
         }
-    }    
+    }
 }
 
 /*
@@ -140,7 +140,7 @@ void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] )
     }
 
     __HAL_HASH_START_DIGEST();
-        
+
     if (HAL_HASH_SHA1_Finish(&ctx->hhash_sha1, output, 10)){
         // error code to be returned
     }

--- a/features/mbedtls/targets/TARGET_STM/sha1_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/sha1_alt.c
@@ -1,0 +1,149 @@
+/*
+ *  sha1_alt.c for SHA1 HASH
+ *******************************************************************************
+ * Copyright (c) 2017, STMicroelectronics
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+#include "mbedtls/sha1.h"
+
+#if defined(MBEDTLS_SHA1_ALT)
+
+/* Implementation that should never be optimized out by the compiler */
+static void mbedtls_zeroize( void *v, size_t n ) {
+    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
+}
+
+void mbedtls_sha1_init( mbedtls_sha1_context *ctx )
+{
+    memset( ctx, 0, sizeof( mbedtls_sha1_context ) );	
+
+    /* Enable HASH clock */
+    __HAL_RCC_HASH_CLK_ENABLE();
+
+    ctx->flag=0;
+}
+
+void mbedtls_sha1_free( mbedtls_sha1_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+	
+	/* Force the HASH Periheral Clock Reset */
+    __HAL_RCC_HASH_FORCE_RESET();
+
+    /* Release the HASH Periheral Clock Reset */
+    __HAL_RCC_HASH_RELEASE_RESET();
+
+    mbedtls_zeroize( ctx, sizeof( mbedtls_sha1_context ) );
+}
+
+void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
+                         const mbedtls_sha1_context *src )
+{
+    *dst = *src;
+}
+
+/*
+ * SHA-1 context setup
+ */
+void mbedtls_sha1_starts( mbedtls_sha1_context *ctx )
+{
+    /* Deinitializes the HASH peripheral */
+    if (HAL_HASH_DeInit(&ctx->hhash_sha1) == HAL_ERROR) {
+        // error found to be returned
+        return;
+    }
+    
+    /* HASH Configuration */
+    ctx->hhash_sha1.Init.DataType = HASH_DATATYPE_8B;
+    if (HAL_HASH_Init(&ctx->hhash_sha1) == HAL_ERROR) {
+        // error found to be returned
+        return;
+    }
+
+    ctx->flag=0;
+}
+
+void mbedtls_sha1_process( mbedtls_sha1_context *ctx, const unsigned char data[64] )
+{
+	HAL_HASH_SHA1_Accumulate(&ctx->hhash_sha1, (uint8_t *) data, 64);
+}
+
+/*
+ * SHA-1 process buffer
+ */
+void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input, size_t ilen )
+{
+    unsigned char *intermediate_buf=NULL;
+    unsigned char modulus=0;
+    unsigned char buf_len=0;
+
+    // Accumulate cannot be called for a size <4 unless it is the last call
+
+    modulus = ilen % 4;
+
+    if (ilen <4)
+    {
+        ctx->sbuf=malloc(ilen);
+        memcpy(ctx->sbuf, input, ilen);
+        ctx->flag = 1;
+        ctx->sbuf_len=ilen;
+    }
+    else
+    {
+        if (modulus !=0)
+        {
+            buf_len = ilen - modulus;
+            HAL_HASH_SHA1_Accumulate(&ctx->hhash_sha1, (uint8_t *)input, buf_len);
+            ctx->sbuf_len=modulus;
+            ctx->sbuf=malloc(ctx->sbuf_len);
+            memcpy(ctx->sbuf, input+buf_len, modulus);
+            ctx->flag = 1;
+        }
+        else
+        {
+            if (ctx->flag==0)
+                HAL_HASH_SHA1_Accumulate(&ctx->hhash_sha1, (uint8_t *)input, ilen);
+            else
+            {
+                intermediate_buf=malloc(ilen+ctx->sbuf_len);
+                memcpy(intermediate_buf, ctx->sbuf, ctx->sbuf_len);
+                memcpy(intermediate_buf+ctx->sbuf_len, input, ilen);
+                HAL_HASH_SHA1_Accumulate(&ctx->hhash_sha1, intermediate_buf, ilen+ctx->sbuf_len);
+                ctx->flag=0;
+            }
+        }
+    }    
+}
+
+/*
+ * SHA-1 final digest
+ */
+void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] )
+{
+    if (ctx->flag == 1) {
+        HAL_HASH_SHA1_Accumulate(&ctx->hhash_sha1, ctx->sbuf, ctx->sbuf_len);
+        ctx->flag=0;
+    }
+
+    __HAL_HASH_START_DIGEST();
+        
+    if (HAL_HASH_SHA1_Finish(&ctx->hhash_sha1, output, 10)){
+        // error code to be returned
+    }
+}
+
+#endif /*MBEDTLS_SHA1_ALT*/

--- a/features/mbedtls/targets/TARGET_STM/sha1_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/sha1_alt.c
@@ -28,7 +28,7 @@ static void mbedtls_zeroize( void *v, size_t n ) {
 
 void mbedtls_sha1_init( mbedtls_sha1_context *ctx )
 {
-    memset( ctx, 0, sizeof( mbedtls_sha1_context ) );	
+    mbedtls_zeroize( ctx, sizeof( mbedtls_sha1_context ) );
 
     /* Enable HASH clock */
     __HAL_RCC_HASH_CLK_ENABLE();

--- a/features/mbedtls/targets/TARGET_STM/sha1_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/sha1_alt.h
@@ -22,7 +22,7 @@
 #ifndef MBEDTLS_SHA1_ALT_H
 #define MBEDTLS_SHA1_ALT_H
 
-#if defined MBEDTLS_SHA1_ALT
+#if defined (MBEDTLS_SHA1_ALT)
 
 
 #include "cmsis.h"
@@ -32,19 +32,22 @@
 extern "C" {
 #endif
 
-#define MBEDTLS_SHA1_BLOCK_SIZE   (64) // must be a multiple of 4
+#define ST_SHA1_BLOCK_SIZE   (64) // HW handles 512 bits, ie 64 bytes
 /**
  * \brief    SHA-1 context structure
- * \note     HAL_HASH_SHA1_Accumulate cannot handle less than 4 bytes, unless it is the last call to the  function
- *           A MBEDTLS_SHA1_BLOCK_SIZE bytes buffer is used to save values and handle the processing
- *           MBEDTLS_SHA1_BLOCK_SIZE bytes per MBEDTLS_SHA1_BLOCK_SIZE bytes
+ * \note     HAL_HASH_SHA1_Accumulate will accumulate 512 bits packets, unless it is the last call to the  function
+ *           A ST_SHA1_BLOCK_SIZE bytes buffer is used to save values and handle the processing
+ *           multiples of ST_SHA1_BLOCK_SIZE bytes
  *           If SHA1_finish is called and sbuf_len>0, the remaining bytes are accumulated prior to the call to HAL_HASH_SHA1_Finish
  */
 typedef struct
 {
-    unsigned char sbuf[MBEDTLS_SHA1_BLOCK_SIZE]; /*!< MBEDTLS_SHA1_BLOCK_SIZE buffer to store values so that algorithm is caled once the buffer is filled */
+    unsigned char sbuf[ST_SHA1_BLOCK_SIZE]; /*!< MBEDTLS_SHA1_BLOCK_SIZE buffer to store values so that algorithm is caled once the buffer is filled */
     unsigned char sbuf_len; /*!< number of bytes remaining in sbuf to be processed */
     HASH_HandleTypeDef hhash_sha1; /*!< ST HAL HASH struct */
+    uint32_t ctx_save_cr;
+    uint32_t ctx_save_str;
+    uint32_t ctx_save_csr[38];
 }
 mbedtls_sha1_context;
 
@@ -96,7 +99,7 @@ void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input,
 void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] );
 
 /* Internal use */
-void mbedtls_sha1_process( mbedtls_sha1_context *ctx, const unsigned char data[MBEDTLS_SHA1_BLOCK_SIZE] );
+void mbedtls_sha1_process( mbedtls_sha1_context *ctx, const unsigned char data[ST_SHA1_BLOCK_SIZE] );
 
 #ifdef __cplusplus
 }

--- a/features/mbedtls/targets/TARGET_STM/sha1_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/sha1_alt.h
@@ -1,6 +1,8 @@
 /*
- *  sha1_alt.h SHA-1 hash
- *******************************************************************************
+ * \file sha1_alt.h
+ *
+ * \brief SHA1 hw acceleration (hash function)
+ *
  *  Copyright (C) 2017, STMicroelectronics
  *  SPDX-License-Identifier: Apache-2.0
  *
@@ -30,16 +32,17 @@
 extern "C" {
 #endif
 
-#define MBEDTLS_SHA1_BLOCK_SIZE   (64)
+#define MBEDTLS_SHA1_BLOCK_SIZE   (64) // must be a multiple of 4
 /**
  * \brief    SHA-1 context structure
  * \note     HAL_HASH_SHA1_Accumulate cannot handle less than 4 bytes, unless it is the last call to the  function
- *           A 64 bytes buffer is used to save values and handle the processing 64 bytes per 64 bytes
- *           If SHA1_finish is called and sbuf_len>0, the remaining bytes are accumulated before the call to HAL_HASH_SHA1_Finish
+ *           A MBEDTLS_SHA1_BLOCK_SIZE bytes buffer is used to save values and handle the processing
+ *           MBEDTLS_SHA1_BLOCK_SIZE bytes per MBEDTLS_SHA1_BLOCK_SIZE bytes
+ *           If SHA1_finish is called and sbuf_len>0, the remaining bytes are accumulated prior to the call to HAL_HASH_SHA1_Finish
  */
 typedef struct
 {
-    unsigned char sbuf[MBEDTLS_SHA1_BLOCK_SIZE]; /*!< 64 buffer to store values so that algorithm is caled once the buffer is filled */
+    unsigned char sbuf[MBEDTLS_SHA1_BLOCK_SIZE]; /*!< MBEDTLS_SHA1_BLOCK_SIZE buffer to store values so that algorithm is caled once the buffer is filled */
     unsigned char sbuf_len; /*!< number of bytes remaining in sbuf to be processed */
     HASH_HandleTypeDef hhash_sha1; /*!< ST HAL HASH struct */
 }
@@ -94,14 +97,6 @@ void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] );
 
 /* Internal use */
 void mbedtls_sha1_process( mbedtls_sha1_context *ctx, const unsigned char data[64] );
-
-#ifdef __cplusplus
-}
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #ifdef __cplusplus
 }

--- a/features/mbedtls/targets/TARGET_STM/sha1_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/sha1_alt.h
@@ -22,8 +22,6 @@
 
 #if defined MBEDTLS_SHA1_ALT
 
-#include "mbedtls/platform.h"
-#include "mbedtls/config.h"
 
 #include "cmsis.h"
 #include <string.h>
@@ -106,22 +104,6 @@ void mbedtls_sha1_process( mbedtls_sha1_context *ctx, const unsigned char data[6
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * \brief          Output = SHA-1( input buffer )
- *
- * \param input    buffer holding the  data
- * \param ilen     length of the input data
- * \param output   SHA-1 checksum result
- */
-void mbedtls_sha1( const unsigned char *input, size_t ilen, unsigned char output[20] );
-
-/**
- * \brief          Checkup routine
- *
- * \return         0 if successful, or 1 if the test failed
- */
-int mbedtls_sha1_self_test( int verbose );
 
 #ifdef __cplusplus
 }

--- a/features/mbedtls/targets/TARGET_STM/sha1_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/sha1_alt.h
@@ -33,14 +33,19 @@ extern "C" {
 #endif
 
 /**
- * \brief          SHA-1 context structure
+ * \brief    SHA-1 context structure
+ * \note     HAL_HASH_SHA1_Accumulate cannot handle less than 4 bytes, unless it is the last call to the  function
+ *           In case of buffer size < 4, flag is set to 1, remaining bytes are copied in a temp buffer.
+ *           The pointer and the length are saved in sbuf and sbuf_len.
+ *           At the next accumulation, the saved values are taken into account, and flag is set to 0
+ *           If SHA1_finish is called and flag=1, the remaining bytes are accumulated before the call to HAL_HASH_SHA1_Finish
  */
 typedef struct
 {
-    unsigned char *sbuf;
-    unsigned char sbuf_len;
-    HASH_HandleTypeDef hhash_sha1;
-    int flag;  /* flag to manage buffer constraint of crypto Hw */
+    unsigned char *sbuf; /*!< pointer to the remaining buffer to be processed */
+    unsigned char sbuf_len; /*!< number of bytes remaining in sbuf to be processed */
+    HASH_HandleTypeDef hhash_sha1; /*!< ST HAL HASH struct */
+    int flag;  /*!< 1 : there are sbuf_len bytes to be processed in sbuf, 0 : every data have been processed. */
 }
 mbedtls_sha1_context;
 

--- a/features/mbedtls/targets/TARGET_STM/sha1_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/sha1_alt.h
@@ -96,7 +96,7 @@ void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input,
 void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] );
 
 /* Internal use */
-void mbedtls_sha1_process( mbedtls_sha1_context *ctx, const unsigned char data[64] );
+void mbedtls_sha1_process( mbedtls_sha1_context *ctx, const unsigned char data[MBEDTLS_SHA1_BLOCK_SIZE] );
 
 #ifdef __cplusplus
 }

--- a/features/mbedtls/targets/TARGET_STM/sha1_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/sha1_alt.h
@@ -30,20 +30,18 @@
 extern "C" {
 #endif
 
+#define MBEDTLS_SHA1_BLOCK_SIZE   (64)
 /**
  * \brief    SHA-1 context structure
  * \note     HAL_HASH_SHA1_Accumulate cannot handle less than 4 bytes, unless it is the last call to the  function
- *           In case of buffer size < 4, flag is set to 1, remaining bytes are copied in a temp buffer.
- *           The pointer and the length are saved in sbuf and sbuf_len.
- *           At the next accumulation, the saved values are taken into account, and flag is set to 0
- *           If SHA1_finish is called and flag=1, the remaining bytes are accumulated before the call to HAL_HASH_SHA1_Finish
+ *           A 64 bytes buffer is used to save values and handle the processing 64 bytes per 64 bytes
+ *           If SHA1_finish is called and sbuf_len>0, the remaining bytes are accumulated before the call to HAL_HASH_SHA1_Finish
  */
 typedef struct
 {
-    unsigned char *sbuf; /*!< pointer to the remaining buffer to be processed */
+    unsigned char sbuf[MBEDTLS_SHA1_BLOCK_SIZE]; /*!< 64 buffer to store values so that algorithm is caled once the buffer is filled */
     unsigned char sbuf_len; /*!< number of bytes remaining in sbuf to be processed */
     HASH_HandleTypeDef hhash_sha1; /*!< ST HAL HASH struct */
-    int flag;  /*!< 1 : there are sbuf_len bytes to be processed in sbuf, 0 : every data have been processed. */
 }
 mbedtls_sha1_context;
 

--- a/features/mbedtls/targets/TARGET_STM/sha1_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/sha1_alt.h
@@ -32,7 +32,8 @@
 extern "C" {
 #endif
 
-#define ST_SHA1_BLOCK_SIZE   (64) // HW handles 512 bits, ie 64 bytes
+#define ST_SHA1_BLOCK_SIZE   ((size_t) 64) // HW handles 512 bits, ie 64 bytes
+#define ST_SHA1_TIMEOUT      ((uint32_t) 3)
 /**
  * \brief    SHA-1 context structure
  * \note     HAL_HASH_SHA1_Accumulate will accumulate 512 bits packets, unless it is the last call to the  function

--- a/features/mbedtls/targets/TARGET_STM/sha1_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/sha1_alt.h
@@ -1,0 +1,127 @@
+/*
+ *  sha1_alt.h SHA-1 hash
+ *******************************************************************************
+ *  Copyright (C) 2017, STMicroelectronics
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+#ifndef MBEDTLS_SHA1_ALT_H
+#define MBEDTLS_SHA1_ALT_H
+
+#if defined MBEDTLS_SHA1_ALT
+
+#include "mbedtls/platform.h"
+#include "mbedtls/config.h"
+
+#include "cmsis.h"
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief          SHA-1 context structure
+ */
+typedef struct
+{
+    unsigned char *sbuf;
+    unsigned char sbuf_len;
+    HASH_HandleTypeDef hhash_sha1;
+    int flag;  /* flag to manage buffer constraint of crypto Hw */
+}
+mbedtls_sha1_context;
+
+/**
+ * \brief          Initialize SHA-1 context
+ *
+ * \param ctx      SHA-1 context to be initialized
+ */
+void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
+
+/**
+ * \brief          Clear SHA-1 context
+ *
+ * \param ctx      SHA-1 context to be cleared
+ */
+void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
+
+/**
+ * \brief          Clone (the state of) a SHA-1 context
+ *
+ * \param dst      The destination context
+ * \param src      The context to be cloned
+ */
+void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
+                         const mbedtls_sha1_context *src );
+
+/**
+ * \brief          SHA-1 context setup
+ *
+ * \param ctx      context to be initialized
+ */
+void mbedtls_sha1_starts( mbedtls_sha1_context *ctx );
+
+/**
+ * \brief          SHA-1 process buffer
+ *
+ * \param ctx      SHA-1 context
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ */
+void mbedtls_sha1_update( mbedtls_sha1_context *ctx, const unsigned char *input, size_t ilen );
+
+/**
+ * \brief          SHA-1 final digest
+ *
+ * \param ctx      SHA-1 context
+ * \param output   SHA-1 checksum result
+ */
+void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] );
+
+/* Internal use */
+void mbedtls_sha1_process( mbedtls_sha1_context *ctx, const unsigned char data[64] );
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief          Output = SHA-1( input buffer )
+ *
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ * \param output   SHA-1 checksum result
+ */
+void mbedtls_sha1( const unsigned char *input, size_t ilen, unsigned char output[20] );
+
+/**
+ * \brief          Checkup routine
+ *
+ * \return         0 if successful, or 1 if the test failed
+ */
+int mbedtls_sha1_self_test( int verbose );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_SHA1_ALT */
+
+#endif /* sha1_alt.h */

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -955,7 +955,7 @@
         "extra_labels": ["STM", "STM32F4", "STM32F439", "STM32F439ZI", "STM32F439xx", "STM32F439xI", "FLASH_CMSIS_ALGO"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "progen": {"target": "nucleo-f439zi"},
-        "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2", "MBEDTLS_CONFIG_HW_SUPPORT", "USB_STM_HAL", "USBHOST_OTHER", "MBEDTLS_SHA1_C"],
+        "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2", "MBEDTLS_CONFIG_HW_SUPPORT", "USB_STM_HAL", "USBHOST_OTHER"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "TRNG", "FLASH"],
         "detect_code": ["0797"],
         "features": ["LWIP"],

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -955,7 +955,7 @@
         "extra_labels": ["STM", "STM32F4", "STM32F439", "STM32F439ZI", "STM32F439xx", "STM32F439xI", "FLASH_CMSIS_ALGO"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "progen": {"target": "nucleo-f439zi"},
-        "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2", "MBEDTLS_CONFIG_HW_SUPPORT", "USB_STM_HAL", "USBHOST_OTHER"],
+        "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2", "MBEDTLS_CONFIG_HW_SUPPORT", "USB_STM_HAL", "USBHOST_OTHER", "MBEDTLS_SHA1_C"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "TRNG", "FLASH"],
         "detect_code": ["0797"],
         "features": ["LWIP"],


### PR DESCRIPTION
## Description

Enable SHA1 for STM32F439ZI
Enable HW acceleration for SHA1 algorithm on STM32F439ZI
is PR #3947 on another branch

## Status

READY


## Steps to test or reproduce

To test this feature, you have to modify TESTS/mbedtls/selfttest/main.cpp in order to call sha1 self test:
add:
`#include "mbedtls/sha1.h"`
then

```
#if defined(MBEDTLS_SHA1_C)
MBEDTLS_SELF_TEST_TEST_CASE(mbedtls_sha1_self_test)
#endif
```
then

```
#if defined(MBEDTLS_SHA1_C)
    Case("mbedtls_sha1_self_test", mbedtls_sha1_self_test_test_case),
#endif
```