### PR TITLE
NUCLEO_F756ZG/mbedtls: Add hw acceleration for SHA256

### DIFF
--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F756ZG/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F756ZG/mbedtls_device.h
@@ -24,5 +24,6 @@
 #define MBEDTLS_SHA1_ALT
 
 
+#define MBEDTLS_SHA256_ALT
 
 #endif /* MBEDTLS_DEVICE_H */


### PR DESCRIPTION
## Description

Enable HW acceleration for SHA256 algorithm on STM32F756ZG
is #3961
## Status

READY

## Related PRs

# This PR needs #4159 + #4161 (formerly #3954) to be merged first

## Steps to test or reproduce

To test this feature, you have to modify TESTS/mbedtls/selfttest/main.cpp in order to call sha256 self test:
add:
`#include "mbedtls/sha256.h"`
then

```
#if defined(MBEDTLS_SHA256_C)
MBEDTLS_SELF_TEST_TEST_CASE(mbedtls_sha256_self_test)
#endif
```
then

```
#if defined(MBEDTLS_SHA256_C)
    Case("mbedtls_sha256_self_test", mbedtls_sha256_self_test_test_case),
#endif
```