### PR TITLE
STM32L486RG/mbedtls: add aes hw acceleration

### DIFF
--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L486RG/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L486RG/mbedtls_device.h
@@ -22,9 +22,4 @@
 
 #define MBEDTLS_AES_ALT
 
-//the following defines are provided to maintain compatibility between STM32 families
-#define __HAL_RCC_CRYP_CLK_ENABLE    __HAL_RCC_AES_CLK_ENABLE
-#define __HAL_RCC_CRYP_FORCE_RESET   __HAL_RCC_AES_FORCE_RESET
-#define __HAL_RCC_CRYP_RELEASE_RESET __HAL_RCC_AES_RELEASE_RESET
-#define CRYP                         AES
 #endif /* MBEDTLS_DEVICE_H */

--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L486RG/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L486RG/mbedtls_device.h
@@ -1,0 +1,30 @@
+/*
+ *  mbedtls_device.h 
+ *******************************************************************************
+ * Copyright (c) 2017, STMicroelectronics
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+#ifndef MBEDTLS_DEVICE_H
+#define MBEDTLS_DEVICE_H
+
+#define MBEDTLS_AES_ALT
+
+//the following defines are provided to maintain compatibility between STM32 families
+#define __HAL_RCC_CRYP_CLK_ENABLE    __HAL_RCC_AES_CLK_ENABLE
+#define __HAL_RCC_CRYP_FORCE_RESET   __HAL_RCC_AES_FORCE_RESET
+#define __HAL_RCC_CRYP_RELEASE_RESET __HAL_RCC_AES_RELEASE_RESET
+#define CRYP                         AES
+#endif /* MBEDTLS_DEVICE_H */

--- a/features/mbedtls/targets/TARGET_STM/aes_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/aes_alt.c
@@ -23,10 +23,17 @@
 
 #if defined(MBEDTLS_AES_ALT)
 
+#if defined(TARGET_STM32L486xG)
+//the following defines are provided to maintain compatibility between STM32 families
+#define __HAL_RCC_CRYP_CLK_ENABLE    __HAL_RCC_AES_CLK_ENABLE
+#define __HAL_RCC_CRYP_FORCE_RESET   __HAL_RCC_AES_FORCE_RESET
+#define __HAL_RCC_CRYP_RELEASE_RESET __HAL_RCC_AES_RELEASE_RESET
+#define CRYP                         AES
+#endif
+
 static int aes_set_key( mbedtls_aes_context *ctx, const unsigned char *key, unsigned int keybits )
 {
-    switch( keybits )
-    {
+    switch( keybits ) {
         case 128:
             ctx->hcryp_aes.Init.KeySize = CRYP_KEYSIZE_128B;
             memcpy(ctx->aes_key, key, 16);
@@ -70,7 +77,8 @@ static int aes_set_key( mbedtls_aes_context *ctx, const unsigned char *key, unsi
 }
 
 /* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
+static void mbedtls_zeroize( void *v, size_t n )
+{
     volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
 }
 
@@ -122,14 +130,11 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
     /* allow multi-instance of CRYP use: restore context for CRYP hw module */
     ctx->hcryp_aes.Instance->CR = ctx->ctx_save_cr;
 
-    if(mode == MBEDTLS_AES_DECRYPT) /* AES decryption */
-    {
+    if(mode == MBEDTLS_AES_DECRYPT) { /* AES decryption */
         ctx->hcryp_aes.Init.DataType = CRYP_DATATYPE_8B;
         ctx->hcryp_aes.Init.pKey = ctx->aes_key;
         mbedtls_aes_decrypt( ctx, input, output );
-    }
-    else /* AES encryption */
-    {
+    } else { /* AES encryption */
         ctx->hcryp_aes.Init.DataType = CRYP_DATATYPE_8B;
         ctx->hcryp_aes.Init.pKey = ctx->aes_key;
         mbedtls_aes_encrypt( ctx, input, output );
@@ -141,6 +146,31 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
 }
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
+#if defined (TARGET_STM32L486xG)
+static int st_hal_cryp_cbc( mbedtls_aes_context *ctx, uint32_t opmode, size_t length, 
+                            unsigned char iv[16], uint8_t *input, uint8_t *output) 
+{
+    int status = 0;
+    ctx->hcryp_aes.Init.pInitVect = &iv[0]; // used in process, not in the init
+    if ((ctx->hcryp_aes.Init.OperatingMode != opmode) || \
+         (ctx->hcryp_aes.Init.ChainingMode != CRYP_CHAINMODE_AES_CBC) || \
+         (ctx->hcryp_aes.Init.KeyWriteFlag != CRYP_KEY_WRITE_ENABLE)) {
+
+        /* Re-initialize AES IP with proper parameters */
+        if (HAL_CRYP_DeInit(&ctx->hcryp_aes) != HAL_OK)
+            return HAL_ERROR;
+        ctx->hcryp_aes.Init.OperatingMode = opmode;
+        ctx->hcryp_aes.Init.ChainingMode = CRYP_CHAINMODE_AES_CBC;
+        ctx->hcryp_aes.Init.KeyWriteFlag = CRYP_KEY_WRITE_ENABLE;
+        if (HAL_CRYP_Init(&ctx->hcryp_aes) != HAL_OK)
+            return HAL_ERROR;
+    }
+
+    status =  HAL_CRYPEx_AES(&ctx->hcryp_aes, input, length, output, 10);
+
+    return status;
+}
+#endif /* TARGET_STM32L486xG */
 
 int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
                     int mode,
@@ -149,54 +179,24 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
                     const unsigned char *input,
                     unsigned char *output )
 {
-    int status=0;
+    int status = 0;
     if( length % 16 )
         return( MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH );
-
-    if( mode == MBEDTLS_AES_DECRYPT )
-    {
-        ctx->hcryp_aes.Init.pInitVect = &iv[0]; // used in process, not in the init 
 #if defined (TARGET_STM32L486xG)
-        if ((ctx->hcryp_aes.Init.OperatingMode != CRYP_ALGOMODE_KEYDERIVATION_DECRYPT) || \
-             (ctx->hcryp_aes.Init.ChainingMode != CRYP_CHAINMODE_AES_CBC) || \
-             (ctx->hcryp_aes.Init.KeyWriteFlag != CRYP_KEY_WRITE_ENABLE)) {
-            /* Re-initialize AES IP with proper parameters */
-            if (HAL_CRYP_DeInit(&ctx->hcryp_aes) != HAL_OK) 
-                return HAL_ERROR;
-            ctx->hcryp_aes.Init.OperatingMode = CRYP_ALGOMODE_KEYDERIVATION_DECRYPT;
-            ctx->hcryp_aes.Init.ChainingMode = CRYP_CHAINMODE_AES_CBC;
-            ctx->hcryp_aes.Init.KeyWriteFlag = CRYP_KEY_WRITE_ENABLE;
-            if (HAL_CRYP_Init(&ctx->hcryp_aes) != HAL_OK)
-                return HAL_ERROR;
-        }
-      
-        status =  HAL_CRYPEx_AES(&ctx->hcryp_aes, (uint8_t *)input, length, (uint8_t *)output, 10);
+    if( mode == MBEDTLS_AES_DECRYPT ) {
+        status = st_hal_cryp_cbc(ctx, CRYP_ALGOMODE_KEYDERIVATION_DECRYPT, length, iv, (uint8_t *)input, (uint8_t *)output);
+    } else {
+        status = st_hal_cryp_cbc(ctx, CRYP_ALGOMODE_ENCRYPT, length, iv, (uint8_t *)input, (uint8_t *)output);
+    }
 #else
+    ctx->hcryp_aes.Init.pInitVect = &iv[0];
+    
+    if( mode == MBEDTLS_AES_DECRYPT ) {
         status = HAL_CRYP_AESCBC_Decrypt(&ctx->hcryp_aes, (uint8_t *)input, length, (uint8_t *)output, 10);
-#endif
-    }
-    else
-    {
-        ctx->hcryp_aes.Init.pInitVect = &iv[0]; // used in process, not in the init 
-#if defined (TARGET_STM32L486xG)
-        if ((ctx->hcryp_aes.Init.OperatingMode != CRYP_ALGOMODE_ENCRYPT) || \
-             (ctx->hcryp_aes.Init.ChainingMode != CRYP_CHAINMODE_AES_CBC) || \
-             (ctx->hcryp_aes.Init.KeyWriteFlag != CRYP_KEY_WRITE_ENABLE)) {
-            /* Re-initialize AES IP with proper parameters */
-            if (HAL_CRYP_DeInit(&ctx->hcryp_aes) != HAL_OK) 
-                return HAL_ERROR;
-            ctx->hcryp_aes.Init.OperatingMode = CRYP_ALGOMODE_ENCRYPT;
-            ctx->hcryp_aes.Init.ChainingMode = CRYP_CHAINMODE_AES_CBC;
-            ctx->hcryp_aes.Init.KeyWriteFlag = CRYP_KEY_WRITE_ENABLE;
-            if (HAL_CRYP_Init(&ctx->hcryp_aes) != HAL_OK)
-                return HAL_ERROR;
-        }
-      
-        status =  HAL_CRYPEx_AES(&ctx->hcryp_aes, (uint8_t *)input, length, (uint8_t *)output, 10);
-#else
+    } else {
         status = HAL_CRYP_AESCBC_Encrypt(&ctx->hcryp_aes, (uint8_t *)input, length, (uint8_t *)output, 10);
-#endif
     }
+#endif
     return( status );
 }
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
@@ -213,10 +213,8 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
     int c;
     size_t n = *iv_off;
 
-    if( mode == MBEDTLS_AES_DECRYPT )
-    {
-        while( length-- )
-        {
+    if( mode == MBEDTLS_AES_DECRYPT ) {
+        while( length-- ) {
             if( n == 0 )
                 mbedtls_aes_crypt_ecb( ctx, MBEDTLS_AES_ENCRYPT, iv, iv );
 
@@ -226,11 +224,8 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
 
             n = ( n + 1 ) & 0x0F;
         }
-    }
-    else
-    {
-        while( length-- )
-        {
+    } else {
+        while( length-- ) {
             if( n == 0 )
                 mbedtls_aes_crypt_ecb( ctx, MBEDTLS_AES_ENCRYPT, iv, iv );
 
@@ -256,8 +251,7 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
     unsigned char c;
     unsigned char ov[17];
 
-    while( length-- )
-    {
+    while( length-- ) {
         memcpy( ov, iv, 16 );
         mbedtls_aes_crypt_ecb( ctx, MBEDTLS_AES_ENCRYPT, iv, iv );
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1109,7 +1109,7 @@
         "core": "Cortex-M4F",
         "extra_labels_add": ["STM32L4", "STM32L486RG", "STM32L486xG"],
         "detect_code": ["0827"],
-        "macros_add": ["USBHOST_OTHER"],
+        "macros_add": ["USBHOST_OTHER", "MBEDTLS_CONFIG_HW_SUPPORT"],
         "device_has_add": ["ANALOGOUT", "CAN", "LOWPOWERTIMER", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L486RG"


### PR DESCRIPTION
## Description

Add hw acceleration for mbedTLS/aes on NUCLEO_L486RG
Please be aware that this device does not support 192bit key size.
The aes selftest and gcm selftest shall be modified not to run this key size. As it is located in the official mbedtls stack, I did not touch it.
is #3962
## Status

~~DO NOT MERGE~~

## Steps to test or reproduce

Run aes seltest from TESTS/mbedtls/selftest/main.cpp

```
+-------------------+---------------+------------------------+-----------------------------+--------+--------+--------+--------------------+
| target            | platform_name | test suite             | test case                   | passed | failed | result | elapsed_time (sec) |
+-------------------+---------------+------------------------+-----------------------------+--------+--------+--------+--------------------+
| NUCLEO_L486RG-IAR | NUCLEO_L486RG | tests-mbedtls-selftest | mbedtls_aes_self_test       | 1      | 0      | OK     | 0.9                |
| NUCLEO_L486RG-IAR | NUCLEO_L486RG | tests-mbedtls-selftest | mbedtls_base64_self_test    | 1      | 0      | OK     | 0.11               |
| NUCLEO_L486RG-IAR | NUCLEO_L486RG | tests-mbedtls-selftest | mbedtls_ccm_self_test       | 1      | 0      | OK     | 0.12               |
| NUCLEO_L486RG-IAR | NUCLEO_L486RG | tests-mbedtls-selftest | mbedtls_ctr_drbg_self_test  | 1      | 0      | OK     | 0.13               |
| NUCLEO_L486RG-IAR | NUCLEO_L486RG | tests-mbedtls-selftest | mbedtls_ecp_self_test       | 1      | 0      | OK     | 6.56               |
| NUCLEO_L486RG-IAR | NUCLEO_L486RG | tests-mbedtls-selftest | mbedtls_entropy_self_test   | 1      | 0      | OK     | 0.1                |
| NUCLEO_L486RG-IAR | NUCLEO_L486RG | tests-mbedtls-selftest | mbedtls_gcm_self_test       | 1      | 0      | OK     | 1.75               |
| NUCLEO_L486RG-IAR | NUCLEO_L486RG | tests-mbedtls-selftest | mbedtls_hmac_drbg_self_test | 1      | 0      | OK     | 0.06               |
| NUCLEO_L486RG-IAR | NUCLEO_L486RG | tests-mbedtls-selftest | mbedtls_mpi_self_test       | 1      | 0      | OK     | 0.31               |
| NUCLEO_L486RG-IAR | NUCLEO_L486RG | tests-mbedtls-selftest | mbedtls_rsa_self_test       | 1      | 0      | OK     | 0.53               |
| NUCLEO_L486RG-IAR | NUCLEO_L486RG | tests-mbedtls-selftest | mbedtls_sha256_self_test    | 1      | 0      | OK     | 1.66               |
| NUCLEO_L486RG-IAR | NUCLEO_L486RG | tests-mbedtls-selftest | mbedtls_sha512_self_test    | 1      | 0      | OK     | 4.51               |
+-------------------+---------------+------------------------+-----------------------------+--------+--------+--------+--------------------+
```