### PR TITLE
CMSIS5 rtos: fix main stack alignment for IAR

### DIFF
--- a/rtos/mbed_boot.c
+++ b/rtos/mbed_boot.c
@@ -181,7 +181,8 @@ osThreadAttr_t _main_thread_attr;
 /* The main stack size is hardcoded on purpose, so it's less tempting to change it per platform. As usually it's not
  * the correct solution to the problem and it makes mbed OS behave differently on different targets.
  */
-char _main_stack[4096] __ALIGNED(8);
+MBED_ALIGN(8) char _main_stack[4096];
+
 char _main_obj[sizeof(os_thread_t)];
 
 osMutexId_t   singleton_mutex_id;
@@ -319,7 +320,10 @@ void mbed_start_main(void)
     _main_thread_attr.cb_mem = _main_obj;
     _main_thread_attr.priority = osPriorityNormal;
     _main_thread_attr.name = "MAIN";
-    osThreadNew((osThreadFunc_t)pre_main, NULL, &_main_thread_attr);
+    osThreadId_t result = osThreadNew((osThreadFunc_t)pre_main, NULL, &_main_thread_attr);
+    if ((void *)result == NULL) {
+        error("Pre main thread not created");
+    }
 
     osKernelStart();
 }


### PR DESCRIPTION
CMSIS does not provide ALIGNED for IAR currently (tested with 7.8 IAR), thus we were getting a failure to create a new thread (pre_main thread). MBED_ALIGNED should work for any compiler we support.

As an addition, ThreadNew function returns NULL if it fails (in our case, it was not aligned stack memory), thus we return an error if it fails.

Test results:

```
+----------+---------------+-------------------------------------+----------------------------------------+--------+--------+--------+--------------------+
| target   | platform_name | test suite                          | test case                              | passed | failed | result | elapsed_time (sec) |
+----------+---------------+-------------------------------------+----------------------------------------+--------+--------+--------+--------------------+
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-basic     | tests-mbedmicro-rtos-mbed-basic        | 1      | 0      | OK     | 20.38              |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-isr       | tests-mbedmicro-rtos-mbed-isr          | 0      | 1      | ERROR  | 29.71              |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-malloc    | tests-mbedmicro-rtos-mbed-malloc       | 1      | 0      | OK     | 24.39              |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-mutex     | Test dual thread lock locked           | 1      | 0      | OK     | 0.05               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-mutex     | Test dual thread lock unlock           | 1      | 0      | OK     | 0.05               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-mutex     | Test dual thread second thread lock    | 1      | 0      | OK     | 0.06               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-mutex     | Test dual thread second thread trylock | 1      | 0      | OK     | 0.06               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-mutex     | Test dual thread trylock locked        | 1      | 0      | OK     | 0.06               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-mutex     | Test multiple thread                   | 1      | 0      | OK     | 10.26              |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-mutex     | Test single thread lock                | 1      | 0      | OK     | 0.07               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-mutex     | Test single thread lock recursive      | 1      | 0      | OK     | 0.06               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-mutex     | Test single thread trylock             | 1      | 0      | OK     | 0.05               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-queue     | tests-mbedmicro-rtos-mbed-queue        | 1      | 0      | OK     | 11.24              |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-semaphore | tests-mbedmicro-rtos-mbed-semaphore    | 1      | 0      | OK     | 17.25              |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-signals   | tests-mbedmicro-rtos-mbed-signals      | 0      | 1      | ERROR  | 29.62              |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing parallel threads               | 1      | 0      | OK     | 0.05               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing parallel threads with child    | 1      | 0      | OK     | 0.07               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing parallel threads with murder   | 1      | 0      | OK     | 0.06               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing parallel threads with wait     | 1      | 0      | OK     | 0.14               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing parallel threads with yield    | 1      | 0      | OK     | 0.08               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing serial threads                 | 1      | 0      | OK     | 0.06               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing serial threads with child      | 1      | 0      | OK     | 0.07               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing serial threads with murder     | 1      | 0      | OK     | 0.07               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing serial threads with wait       | 1      | 0      | OK     | 1.05               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing serial threads with yield      | 1      | 0      | OK     | 0.06               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing single thread                  | 1      | 0      | OK     | 0.05               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing single thread with child       | 1      | 0      | OK     | 0.07               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing single thread with murder      | 1      | 0      | OK     | 0.07               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing single thread with wait        | 1      | 0      | OK     | 0.16               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing single thread with yield       | 1      | 0      | OK     | 0.06               |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | Testing thread self terminate          | 1      | 0      | OK     | 0.07               |
+----------+---------------+-------------------------------------+----------------------------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 29 OK / 2 ERROR
```

From 4 errors to 2 !