### PR TITLE
Generate GNU ARM Eclipse .mbedignore file with jinja2

### DIFF
--- a/tools/export/gnuarmeclipse/__init__.py
+++ b/tools/export/gnuarmeclipse/__init__.py
@@ -273,22 +273,13 @@ class GNUARMEclipse(Exporter):
             'u': u,
         }
 
-        # TODO: it would be good to have jinja stop if one of the
-        # expected context values is not defined.
         self.gen_file('gnuarmeclipse/.project.tmpl', jinja_ctx,
                       '.project', trim_blocks=True, lstrip_blocks=True)
         self.gen_file('gnuarmeclipse/.cproject.tmpl', jinja_ctx,
                       '.cproject', trim_blocks=True, lstrip_blocks=True)
         self.gen_file('gnuarmeclipse/makefile.targets.tmpl', jinja_ctx,
                       'makefile.targets', trim_blocks=True, lstrip_blocks=True)
-
-        if not exists('.mbedignore'):
-            print
-            print 'Create .mbedignore'
-            with open('.mbedignore', 'w') as f:
-                for bf in build_folders:
-                    print bf + '/'
-                    f.write(bf + '/\n')
+        self.gen_file('gnuarmeclipse/mbedignore.tmpl', jinja_ctx, '.mbedignore')
 
         print
         print 'Done. Import the \'{0}\' project in Eclipse.'.format(self.project_name)

--- a/tools/export/gnuarmeclipse/mbedignore.tmpl
+++ b/tools/export/gnuarmeclipse/mbedignore.tmpl
@@ -1,0 +1,3 @@
+{%- for config in options.values() -%}
+{{config.name}}/*
+{% endfor -%}


### PR DESCRIPTION
# Descritpion

There are subtleties about where the exporters generate files when using
the online exporers-as-a-service. Simply calling open does not do the 
correct thing in this environment. The `self.gen_file` method can be used
instead to account for these differences.

I saw an exception generated by the online build system recently.
This was the traceback:
```python-traceback
IOError: [Errno 13] Permission denied: '.mbedignore'
  File "django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "django/views/decorators/vary.py", line 21, in inner_func
    response = func(*args, **kwargs)
  File "piston/resource.py", line 190, in __call__
    result = self.error_handler(e, request, meth, em_format)
  File "piston/resource.py", line 188, in __call__
    result = meth(request, *args, **kwargs)
  File "mbed/api/api_misc.py", line 262, in create
    inc_repos=request.POST.get('inc_repos'))
  File "mbed_compiler/export.py", line 149, in export
    notify=notify
  File "tools/project_api.py", line 222, in export_project
    macros=macros)
  File "tools/project_api.py", line 89, in generate_project_files
    exporter.generate()
  File "tools/export/gnuarmeclipse/__init__.py", line 281, in generate
    with open('.mbedignore', 'w') as f:
```

# How to reproduce

Export a project to gnuarmeclipse on the online exporters-as-a-service.

# New behavior

It should be resolved with this change, and export correctly

# Testing
 - [x] /morph export-build