### PR TITLE
Fix include paths for Windows builds

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -612,6 +612,7 @@ class mbedToolchain:
                             break
 
             # Add root to include paths
+            root = root.rstrip("/")
             resources.inc_dirs.append(root)
             resources.file_basepath[root] = base_path
 


### PR DESCRIPTION
# Descritpion

Resolves #3940

# How to reproduce
The issue mentioned above can me sumarized as:

This does not work:
```bash
mbed compile --source ./
```

This works:
```bash
mbed compile --source .
```

Both should work.

## Why does this fail?

The include directories passed to `--source` are added as-is to the list
of include directories. GCC, and possibly other compilers, on Windows 
does not like the path `./` and will ignore it when searching for header
files.

# New behavior

Remove trailing `/`s before appending include paths to when scanning 
resources.

# Testing
 - [x] /morph test