### PR TITLE
Fix typo in LPCExpresso exporter template

### DIFF
--- a/tools/export/lpcxpresso/lpc1549_project.tmpl
+++ b/tools/export/lpcxpresso/lpc1549_project.tmpl
@@ -1,1 +1,1 @@
-{% extends "lpcxprosso/project_common.tmpl" %}
+{% extends "lpcxpresso/project_common.tmpl" %}


### PR DESCRIPTION
# How to reproduce
Export for LPCXpresso and LPC1549

```python-traceback
Traceback (most recent call last):
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/project.py", line 247, in <module>
    main()
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/project.py", line 243, in main
    build_profile=profile)
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/project.py", line 93, in export
    build_profile=build_profile, silent=silent)
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/export/__init__.py", line 329, in export_project
    macros=macros)
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/export/__init__.py", line 196, in generate_project_files
    exporter.generate()
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/export/lpcxpresso/__init__.py", line 59, in generate
    self.gen_file('lpcxpresso/%s_project.tmpl' % self.target.lower(), ctx, '.project')
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/export/exporters.py", line 122, in gen_file
    target_text = template.render(data)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/local/lib/python2.7/dist-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/export/lpcxpresso/lpc1549_project.tmpl", line 1, in top-level template code
    {% extends "lpcxprosso/project_common.tmpl" %}
  File "/usr/local/lib/python2.7/dist-packages/jinja2/loaders.py", line 187, in get_source
    raise TemplateNotFound(template)
jinja2.exceptions.TemplateNotFound: lpcxprosso/project_common.tmpl
```

That should not happen

# New behavior

Export works.