### PR TITLE
Fail IAR exports without linker scirpts with NotSupportedException

### DIFF
--- a/tools/export/iar/__init__.py
+++ b/tools/export/iar/__init__.py
@@ -10,6 +10,7 @@ from tools.targets import TARGET_MAP
 from tools.export.exporters import Exporter, TargetNotSupportedException
 import json
 from tools.export.cmsis import DeviceCMSIS
+from tools.utils import NotSupportedException
 from multiprocessing import cpu_count
 
 class IAR(Exporter):
@@ -100,6 +101,8 @@ class IAR(Exporter):
 
     def generate(self):
         """Generate the .eww, .ewd, and .ewp files"""
+        if not self.resources.linker_script:
+            raise NotSupportedException("No linker script found.")
         srcs = self.resources.headers + self.resources.s_sources + \
                self.resources.c_sources + self.resources.cpp_sources + \
                self.resources.objects + self.resources.libraries


### PR DESCRIPTION
# How to reproduce
Delete a linker script. 
For example:
```bash
 rm mbed-os/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_IAR/MK64FN1M0xxx12.icf 
```

Then try to export that Target to IAR:

```python-traceback
Traceback (most recent call last):
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/project.py", line 247, in <module>
    main()
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/project.py", line 243, in main
    build_profile=profile)
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/project.py", line 93, in export
    build_profile=build_profile, silent=silent)
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/export/__init__.py", line 329, in export_project
    macros=macros)
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/export/__init__.py", line 196, in generate_project_files
    exporter.generate()
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/export/iar/__init__.py", line 125, in generate
    'linker_script': self.format_file(self.resources.linker_script),
  File "/home/jimbri01/src/armmbed/mbed-os-example-fat-filesystem/mbed-os/tools/export/iar/__init__.py", line 92, in format_file
    return join('$PROJ_DIR$',file)
  File "/usr/lib/python2.7/posixpath.py", line 68, in join
    if b.startswith('/'):
AttributeError: 'NoneType' object has no attribute 'startswith'
```

That should not happen

# New behavior

```python-traceback
tools.utils.NotSupportedException: No linker script found.
```

# Testing
 - [ ] /morph export-bulid