### PR TITLE
Fix Traceback in CMSIS export.

### DIFF
--- a/tools/export/cmsis/__init__.py
+++ b/tools/export/cmsis/__init__.py
@@ -121,7 +121,7 @@ class CMSIS(Exporter):
             new_srcs = []
             for f in list(files):
                 spl = f.name.split(sep)
-                if len(spl)==2:
+                if len(spl) <= 2:
                     file_element = Element('file',
                                            attrib={
                                                'category':f.type,
@@ -148,8 +148,4 @@ class CMSIS(Exporter):
             'device': DeviceCMSIS(self.target),
             'date': ''
         }
-        # TODO: find how to keep prettyxml from adding xml version to this blob
-        #dom = parseString(ctx['project_files'])
-        #ctx['project_files'] = dom.toprettyxml(indent="\t")
-
         self.gen_file('cmsis/cpdsc.tmpl', ctx, 'project.cpdsc')


### PR DESCRIPTION
# How to reproduce

Then try to export any project online to cmsis. You will get this 
trackback (unbeknownst to you):

```python-traceback
TypeError: join() takes at least 1 argument (0 given)
  File "django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "django/contrib/auth/decorators.py", line 22, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "mbed/repositories/views.py", line 1601, in web_export
    name=repo.slug)
  File "mbed_compiler/export.py", line 149, in export
    notify=notify
  File "tools/project_api.py", line 222, in export_project
    macros=macros)
  File "tools/project_api.py", line 89, in generate_project_files
    exporter.generate()
  File "tools/export/cmsis/__init__.py", line 147, in generate
    'project_files': tostring(self.group_project_files(srcs, Element('files'))),
  File "tools/export/cmsis/__init__.py", line 131, in group_project_files
    f.name = os.path.join(*spl[1:])
```

That should not happen

# New behavior

Export works.


# Testing

¯\\\_(ツ)\_/¯