### PR TITLE
cmsis5 iar: system/file mutex to be recursive

### DIFF
--- a/rtos/mbed_boot.c
+++ b/rtos/mbed_boot.c
@@ -181,7 +181,8 @@ osThreadAttr_t _main_thread_attr;
 /* The main stack size is hardcoded on purpose, so it's less tempting to change it per platform. As usually it's not
  * the correct solution to the problem and it makes mbed OS behave differently on different targets.
  */
-char _main_stack[4096] __ALIGNED(8);
+MBED_ALIGN(8) char _main_stack[4096];
+
 char _main_obj[sizeof(os_thread_t)];
 
 osMutexId_t   singleton_mutex_id;
@@ -319,7 +320,10 @@ void mbed_start_main(void)
     _main_thread_attr.cb_mem = _main_obj;
     _main_thread_attr.priority = osPriorityNormal;
     _main_thread_attr.name = "MAIN";
-    osThreadNew((osThreadFunc_t)pre_main, NULL, &_main_thread_attr);
+    osThreadId_t result = osThreadNew((osThreadFunc_t)pre_main, NULL, &_main_thread_attr);
+    if ((void *)result == NULL) {
+        error("Pre main thread not created");
+    }
 
     osKernelStart();
 }

--- a/rtos/mbed_boot.c
+++ b/rtos/mbed_boot.c
@@ -571,6 +571,7 @@ void __iar_system_Mtxinit(__iar_Rmtx *mutex) /* Initialize a system lock */
     if (0 == std_mutex_id_sys[index]) {
       attr.cb_mem = &std_mutex_sys[index];
       attr.cb_size = sizeof(std_mutex_sys[index]);
+      attr.attr_bits = osMutexRecursive;
       std_mutex_id_sys[index] = osMutexNew(&attr);
       *mutex = (__iar_Rmtx*)&std_mutex_id_sys[index];
       return;
@@ -605,6 +606,7 @@ void __iar_file_Mtxinit(__iar_Rmtx *mutex) /* Initialize a file lock */
       if (0 == std_mutex_id_file[index]) {
         attr.cb_mem = &std_mutex_file[index];
         attr.cb_size = sizeof(std_mutex_file[index]);
+        attr.attr_bits = osMutexRecursive;
         std_mutex_id_file[index] = osMutexNew(&attr);
         *mutex = (__iar_Rmtx*)&std_mutex_id_file[index];
         return;


### PR DESCRIPTION
Based on top of #4164 (that one should get in first), to allow me to bug-hunt the last bug in there!

How does this fixes the last 2 issues (those tests that use printf). They use printf with a new line. printf with just fflush(stdout) worked, but with newline it failed (hey, we got a deadlock in here). From the DLIB specifications for IAR threaded support: http://supp.iar.com/FilesPublic/UPDINFO/005691/arm/doc/infocenter/DLIBThreadSupport.html 

``The lock and unlock implementation must survive nested calls.``. 
This was the case here, printf() invokes multiple times the lock on the same file in some cases (the last one that caused wait forever was flushone IAR internal function). 

To reproduce the problem easily ``printf("\n"); in the main()`` , this call would never return.

Test results:

```
+----------+---------------+-------------------------------------+--------+--------------------+-------------+
| target   | platform_name | test suite                          | result | elapsed_time (sec) | copy_method |
+----------+---------------+-------------------------------------+--------+--------------------+-------------+
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-basic     | OK     | 21.87              | shell       |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-isr       | OK     | 15.91              | shell       |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-malloc    | OK     | 25.91              | shell       |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-mutex     | OK     | 24.15              | shell       |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-queue     | OK     | 12.61              | shell       |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-semaphore | OK     | 18.55              | shell       |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-signals   | OK     | 15.92              | shell       |
| K64F-IAR | K64F          | tests-mbedmicro-rtos-mbed-threads   | OK     | 17.61              | shell       |
+----------+---------------+-------------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 8 OK
```

All tests green for K64F IAR !

🙌 🎆 🍾 