### PR TITLE
uVisor: Fix copy of quick-start doc in exporter script

### DIFF
--- a/features/FEATURE_UVISOR/importer/Makefile
+++ b/features/FEATURE_UVISOR/importer/Makefile
@@ -84,7 +84,7 @@ rsync:
 	cp $(UVISOR_DIR)/core/cmsis/inc/core_cmSecureAccess.h $(MBED_OS_CMSIS)/
 	#
 	# Copying the documentation...
-	cp $(UVISOR_DIR)/docs/api/QUICKSTART.md $(TARGET_PREFIX)/README.md
+	cp $(UVISOR_DIR)/docs/*/QUICKSTART.md $(TARGET_PREFIX)/README.md
 	#
 	# Copying licenses
 	cp $(UVISOR_DIR)/LICENSE* $(TARGET_SUPPORTED)


### PR DESCRIPTION
## Description

This is a quick PR to update the uVisor exporter script. It has no effect on mbed OS.

## Status

Ready

## Migrations

NO


## Related PRs

This PR blocks a uVisor PR: https://github.com/ARMmbed/uvisor/pull/422

@0xc0170 