### PR TITLE
[UBLOX_C030] create target hierarchy for the specific versions of the C030 board

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1342,11 +1342,19 @@
         "extra_labels": ["STM", "STM32F4", "STM32F437", "STM32F437VG", "STM32F437xx", "STM32F437xG"],
         "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2", "RTC_LSI=1", "HSE_VALUE=12000000"],
         "inherits": ["Target"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "RTC", "SPI", "SPISLAVE","STDIO_MESSAGES", "TRNG"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "RTC", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG"],
         "features": ["LWIP"],
-        "release_versions": ["5"],
+        "public": false,
         "device_name": "STM32F437VG"
-        },
+    },
+    "UBLOX_C030_U201": {
+        "inherits": ["UBLOX_C030"],
+        "release_versions": ["5"]
+    },
+    "UBLOX_C030_N211": {
+        "inherits": ["UBLOX_C030"],
+        "release_versions": ["5"]
+    },
     "NZ32_SC151": {
         "inherits": ["Target"],
         "core": "Cortex-M3",


### PR DESCRIPTION
The `UBLOX_C030` board comes in a number of versions, each of which has its own board ID.  This change makes `UBLOX_C030` a private target that the specific board versions can inherit.  The two board IDs allocated at the moment are `UBLOX_C030_U201` (for the Sara-U201 2G/3G module) and `UBLOX_C030_N211` (for the NBIoT module), hence these are the two new targets.  The targets are identical right now; they will diverge once the mbed Cellular API comes along.

Note that this change is built on top of the change from @philwareublox in pull request #4133.

The `UBLOX_C030` boards are not on the market yet, hence this change cannot cause any customer surprises.