### PR TITLE
events: Remove strict-aliasing warning

### DIFF
--- a/events/equeue/equeue_mbed.cpp
+++ b/events/equeue/equeue_mbed.cpp
@@ -42,13 +42,12 @@ static void equeue_tick_init() {
             "The equeue_timer buffer must fit the class Timer");
     MBED_STATIC_ASSERT(sizeof(equeue_ticker) >= sizeof(Ticker),
             "The equeue_ticker buffer must fit the class Ticker");
-    new (equeue_timer) Timer;
-    new (equeue_ticker) Ticker;
+    Timer *timer = new (equeue_timer) Timer;
+    Ticker *ticker = new (equeue_ticker) Ticker;
 
     equeue_minutes = 0;
-    reinterpret_cast<Timer*>(equeue_timer)->start();
-    reinterpret_cast<Ticker*>(equeue_ticker)
-            ->attach_us(equeue_tick_update, 1000 << 16);
+    timer->start();
+    ticker->attach_us(equeue_tick_update, 1000 << 16);
 
     equeue_tick_inited = true;
 }


### PR DESCRIPTION
If you have compiled mbed-os with gcc version 6 you may have seen this warning:
```
Compile [ 10.9%]: equeue_mbed.cpp
[Warning] equeue_mbed.cpp@51,13: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
```

#### Short story:
This pr removes the warning.

#### Long story:
Several opaque buffers are used to to wrap c++ classes to pass to the c layer. The reinterpret cast to c++ classes is fine as long as the underlying buffer is not interpreted as different incompatible types, or else the behaviour is undefined.

In the equeue_tick_init function, placement new is used to initialize the buffers. However, this interprets the buffer as a simple array of bytes, not the actual class type. Later the buffer is casted to the class type. From the point of view of the compiler, these two types are incompatible, and the compiler is free to reorder the operations under the assumption that they can't affect each other.

Reinterpet casting the buffer to a class pointer before using placement new insures that the buffer is only interpreted as a single type. Or simple using the return value from placement new will handle the aliasing appropriately.

cc @pan- 
