### PR TITLE
Include mbed_debug.h in mbed.h

### DIFF
--- a/mbed.h
+++ b/mbed.h
@@ -63,6 +63,7 @@
 #include "platform/mbed_error.h"
 #include "platform/mbed_interface.h"
 #include "platform/mbed_assert.h"
+#include "platform/mbed_debug.h"
 
 // mbed Peripheral components
 #include "drivers/DigitalIn.h"


### PR DESCRIPTION
## Description
Allows access to mbed debug printing when including `mbed.h`

## Steps to test or reproduce
Currently, you must include `mbed_debug.h` in addition to `mbed.h` if you want to use the debug print function. 
