### PR TITLE
Filesystem: Include '.' and '..' in directory iteration

### DIFF
--- a/features/TESTS/filesystem/fat_filesystem/main.cpp
+++ b/features/TESTS/filesystem/fat_filesystem/main.cpp
@@ -116,7 +116,13 @@ void test_read_dir() {
     while ((de = readdir(&dir))) {
         printf("d_name: %.32s, d_type: %x\n", de->d_name, de->d_type);
 
-        if (strcmp(de->d_name, "test_dir") == 0) {
+        if (strcmp(de->d_name, ".") == 0) {
+            test_dir_found = true;
+            TEST_ASSERT_EQUAL(DT_DIR, de->d_type);
+        } else if (strcmp(de->d_name, "..") == 0) {
+            test_dir_found = true;
+            TEST_ASSERT_EQUAL(DT_DIR, de->d_type);
+        } else if (strcmp(de->d_name, "test_dir") == 0) {
             test_dir_found = true;
             TEST_ASSERT_EQUAL(DT_DIR, de->d_type);
         } else if (strcmp(de->d_name, "test_file") == 0) {

--- a/features/filesystem/fat/ChaN/ffconf.h
+++ b/features/filesystem/fat/ChaN/ffconf.h
@@ -126,7 +126,7 @@
 /  When _LFN_UNICODE is 0, this option has no effect. */
 
 
-#define _FS_RPATH	0
+#define _FS_RPATH	1
 /* This option configures relative path feature.
 /
 /   0: Disable relative path feature and remove related functions.


### PR DESCRIPTION
The standard is intentionally vague on if filesystems must have '.' and '..' entries, allowing filesystems to omit this concept completely. However, if '.' and '..' entries are present, they **must** appear during directory iteration:
http://pubs.opengroup.org/onlinepubs/9699919799/functions/readdir.html

The '.' and '..' entries are common on FAT filesystems and in most other filesystems. Not providing '.' and '..' entries deviates from convention in a way that may cause user's code to not work when ported to a different filesystem.

This enables '.' and '..' entries in the FAT filesystem.

Note: After this patch, '.' and '..' entries will show up during directory iteration. **This is a breaking change**, but needed to match conventions on host PCs.

I also need to check if the sd-driver tests need updating, but wanted to get this up there for review.

cc @simonqhughes, @theotherjimmy 