### PR TITLE
[NCS36510] Reduce default heap size allocated by IAR to 1/4 of RAM

### DIFF
--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_IAR/NCS36510.icf
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_IAR/NCS36510.icf
@@ -15,7 +15,7 @@ define region RAM_ALL = Mem:[from 0x3FFF4000 size 0xC000];
 define block CSTACK with size = 0x200, alignment = 8 { };
 
 /* No Heap is created for C library, all memory management should be handled by the application */
- define block HEAP with alignment = 8, size = 0x4000    { }; 
+ define block HEAP with alignment = 8, size = 0x3000    { }; 
 
 /* Handle initialization */
 do not initialize { section .noinit };


### PR DESCRIPTION
## Description
The IAR linker file allocates the heap size by default to 0x4000, which for this target is causing the mbed-os-example-mesh-minimal application not to be able to fit into the RAM.  It has been changed to 0x3000 (12K, which is 1/4 of the total 48K RAM).  This change both passes all mbed OS tests and allows the mesh minimal example to compile with IAR and run.

helps fix https://github.com/ARMmbed/mbed-os-example-mesh-minimal/issues/63

cc: @pradeep-gr @radhika-raghavendran @danclement @jacobjohnson-ON 
please review and confirm this looks good to you.

## Status
**READY**

## Migrations
 NO

## Related PRs
None

branch | PR
------ | ------
n/a

## Todos
none

## Deploy notes
none

## Steps to test or reproduce
n/a