### PR TITLE
LPC4088: Enable LWIP feature

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -347,6 +347,7 @@
             "function": "LPC4088Code.binary_hook"
         },
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "features": ["LWIP"],
         "device_name": "LPC4088FBD144"
     },
     "LPC4088": {


### PR DESCRIPTION
## Description
This patch enable the LWIP feature for the LPC4088 and LPC4088_DM boards.
The lwIP stack support already this hardware.
See: ./features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NXP/lpc17_emac.c

