### PR TITLE
Fix gcc [-Wsign-compare] warning

### DIFF
--- a/platform/mbed_board.c
+++ b/platform/mbed_board.c
@@ -75,19 +75,16 @@ void mbed_error_printf(const char* format, ...) {
 
 void mbed_error_vfprintf(const char * format, va_list arg) {
 #if DEVICE_SERIAL
-
-#if MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES
-    char stdio_out_prev;
-#endif
-
+#define ERROR_BUF_SIZE      (128)
     core_util_critical_section_enter();
-    char buffer[128];
-    int size = vsprintf(buffer, format, arg);
+    char buffer[ERROR_BUF_SIZE];
+    int size = vsnprintf(buffer, ERROR_BUF_SIZE, format, arg);
     if (size > 0) {
         if (!stdio_uart_inited) {
             serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
         }
 #if MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES
+        char stdio_out_prev = '\0';
         for (int i = 0; i < size; i++) {
             if (buffer[i] == '\n' && stdio_out_prev != '\r') {
                  serial_putc(&stdio_uart, '\r');


### PR DESCRIPTION
## Description
[Warning] mbed_board.c@99,36: comparison between signed and unsigned
integer expressions [-Wsign-compare] is seen during compilation.
Fix the warning and small improvements.

1. Change type of loop variable "i" to the same type as "size".
   Size is > 0 checked by the if statement and the for loop stops at i == size
   so none can be negative. However size still needs to be signed
   to detect error codes from vsnprintf.
2. Reduced scope of stdio_out_prev and make sure it's initialized.
3. Define a name for the error buffer size and use vsnprintf instead
   of vsprintf to avoid writing outside of the array.
   NOTE: the `if(size > 0)` statement doesn't need to change. If
   the message to write is larger than the buffer size vsnprintf
   truncates it automatically but still returns a positive value.

## Status
READY

## Steps to test or reproduce
1. mbed import mbed-os-example-blinky
2. cd mbed-os-example-blinky
3. mbed compile -m NUCLEO_F401RE

