### PR TITLE
rtx2: mbed boot iar - stack and heap init fix

### DIFF
--- a/rtos/mbed_boot.c
+++ b/rtos/mbed_boot.c
@@ -105,10 +105,10 @@
  *         -> __iar_init_core
  *         -> __iar_init_core
  *         -> __iar_init_vfp
- *         -> mbed_set_stack_heap (MBED: rtos/mbed_boot.c)
  *         -> __low_level_init
  *         -> __iar_data_init3
  *         -> mbed_sdk_init (TARGET)
+ *         -> mbed_set_stack_heap (MBED: rtos/mbed_boot.c)
  *         -> osKernelInitialize (RTX)
  *         -> mbed_start_main (MBED: rtos/mbed_boot.c)
  *             -> mbed_cpy_nvic (MBED: rtos/mbed_boot.c)
@@ -529,8 +529,6 @@ void __iar_program_start( void )
   __iar_init_core();
   __iar_init_vfp();
 
-  mbed_set_stack_heap();
-
   uint8_t low_level_init_needed_local;
 
   low_level_init_needed_local = __low_level_init();
@@ -538,6 +536,9 @@ void __iar_program_start( void )
     __iar_data_init3();
     mbed_sdk_init();
   }
+
+  mbed_set_stack_heap();
+
   /* Store in a global variable after RAM has been initialized */
   low_level_init_needed = low_level_init_needed_local;
 


### PR DESCRIPTION
mbed heap and stack initialized too early, thus we postpone after IAR does data init function. Thus they were 0, and test discovered that !! 🍾 

Before this patch:

```
+----------+---------------+-------------------------------------------------------+--------+--------------------+-------------+
| target   | platform_name | test suite                                            | result | elapsed_time (sec) | copy_method |
+----------+---------------+-------------------------------------------------------+--------+--------------------+-------------+
| K64F-IAR | K64F          | rtos-rtx2-target_cortex_m-tests-memory-heap_and_stack | FAIL   | 9.5                | shell       |
+----------+---------------+-------------------------------------------------------+--------+--------------------+-------------+
```


After this patch:

```
+----------+---------------+-------------------------------------------------------+--------+--------------------+-------------+
| target   | platform_name | test suite                                            | result | elapsed_time (sec) | copy_method |
+----------+---------------+-------------------------------------------------------+--------+--------------------+-------------+
| K64F-IAR | K64F          | rtos-rtx2-target_cortex_m-tests-memory-heap_and_stack | OK     | 9.3                | shell       |
+----------+---------------+-------------------------------------------------------+--------+--------------------+-------------+
```