### PR TITLE
Fix IAR compilation for cortex-m0

### DIFF
--- a/rtos/rtx2/TARGET_CORTEX_M/core_cm.h
+++ b/rtos/rtx2/TARGET_CORTEX_M/core_cm.h
@@ -31,6 +31,7 @@
 #include <stdint.h>
 #include "cmsis.h"
 #include "cmsis_compiler.h"
+#include "arm_math.h"
 
 #ifndef __ARM_ARCH_6M__
 #define __ARM_ARCH_6M__         0U


### PR DESCRIPTION
Include arm_math.h so __CLZ is defined for cortex-m0 when compiling for IAR. This fixes "__cmsis_iar_clz" is undefined errors.
