### PR TITLE
Add support for Unmanaged Bootloader

### DIFF
--- a/tools/test/toolchains/api.py
+++ b/tools/test/toolchains/api.py
@@ -42,6 +42,7 @@ def test_toolchain_profile_c(profile, source_file):
             toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile)
             toolchain.inc_md5 = ""
             toolchain.build_dir = ""
+            toolchain.config = MagicMock(app_config_locaiton=None)
             compile_command = toolchain.compile_command(to_compile,
                                                         to_compile + ".o", [])
             for parameter in profile['c'] + profile['common']:
@@ -67,6 +68,7 @@ def test_toolchain_profile_cpp(profile, source_file):
             toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile)
             toolchain.inc_md5 = ""
             toolchain.build_dir = ""
+            toolchain.config = MagicMock(app_config_locaiton=None)
             compile_command = toolchain.compile_command(to_compile,
                                                         to_compile + ".o", [])
             for parameter in profile['cxx'] + profile['common']:

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -1008,7 +1008,10 @@ class mbedToolchain:
         map = join(tmp_path, name + '.map')
 
         r.objects = sorted(set(r.objects))
-        if self.need_update(elf, r.objects + r.libraries + [r.linker_script]):
+        config_file = ([self.config.app_config_location]
+                       if self.config.app_config_location else [])
+        if self.need_update(elf, r.objects + r.libraries + [r.linker_script] +
+                            config_file):
             needed_update = True
             self.progress("link", name)
             self.link(elf, r.objects, r.libraries, r.lib_dirs, r.linker_script)

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -909,7 +909,9 @@ class mbedToolchain:
                 deps = self.parse_dependencies(dep_path) if (exists(dep_path)) else []
             except IOError, IndexError:
                 deps = []
-            if len(deps) == 0 or self.need_update(object, deps):
+            config_file = ([self.config.app_config_location]
+                           if self.config.app_config_location else [])
+            if len(deps) == 0 or self.need_update(object, deps + config_file):
                 if ext == '.cpp' or self.COMPILE_C_AS_CPP:
                     return self.compile_cpp(source, object, includes)
                 else:


### PR DESCRIPTION
# Description

This allows a user to build a completely customized bootloader configuration.

The new configuration options are:
 - `target.mbed_app_start`: The start address of the application
 - `target.mbed_app_size`: The size of the application
 
When elided, the defaults are:
 - `target.mbed_app_start` defaults to the start of ROM
 - `target.mbed_app_size` defaults to the remaining ROM from the start of the application
 
Checks are performed to verify that:
 - `target.mbed_app_start` is a location in ROM
 - `target.mbed_app_size` + `target.mbed_app_start` is also a location in ROM or 1 byte past the end of ROM


# Tests
 - [x] Manual verification that boot loader still works
 - [x] Manual verification that `mbed_app_start` and `mbed_app_size` change the apps start 
       and size, respectively
 - [x] Manually verify that boot loader and` mbed_app_*` are mutually exclusive
 - [x] /morph test
 - [x] Documentation