### PR TITLE
lwip: Adopt lightweight mbox implementation based on event flags

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/sys_arch.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/sys_arch.h
@@ -47,15 +47,21 @@ typedef struct {
 #define MB_SIZE      8
 
 typedef struct {
-    osMessageQueueId_t   id;
-    osMessageQueueAttr_t attr;
-    char                 queue[MB_SIZE * (sizeof(void*) + sizeof(os_message_t))];
-    os_message_queue_t   data;
+    osEventFlagsId_t   id;
+    osEventFlagsAttr_t attr;
+    os_event_flags_t   data;
+
+    uint8_t     post_idx;
+    uint8_t     fetch_idx;
+    void*       queue[MB_SIZE];
 } sys_mbox_t;
 
+#define SYS_MBOX_FETCH_EVENT 0x1
+#define SYS_MBOX_POST_EVENT  0x2
+
 #define SYS_MBOX_NULL               ((uint32_t) NULL)
-#define sys_mbox_valid(x)           (((*x).id == NULL) ? 0 : 1 )
-#define sys_mbox_set_invalid(x)     ( (*x).id = NULL )
+#define sys_mbox_valid(x)           (((*x).id == NULL) ? 0 : 1)
+#define sys_mbox_set_invalid(x)     ( (*x).id = NULL)
 
 #if ((DEFAULT_RAW_RECVMBOX_SIZE) > (MB_SIZE)) || \
     ((DEFAULT_UDP_RECVMBOX_SIZE) > (MB_SIZE)) || \


### PR DESCRIPTION
Reduces the size of an mbox object from 180 bytes (45w) to 72 bytes (18w). Since the mbox is used in many places in lwip as a lightweight message buffer, this saves roughly 1kB of ram.

Memory comparison of the tcp_echo_parallel test:
```
+---------+----------+-----------+------------+-------+------+-----------+-------------+
|         | target   | toolchain | static_ram | stack | heap | total_ram | total_flash |
+---------+----------+-----------+------------+-------+------+-----------+-------------+
| master  | ARCH_PRO | GCC_ARM   |      20396 |  3072 | 2048 |     25516 |      109397 |
+---------+----------+-----------+------------+-------+------+-----------+-------------+
| rtx5    | ARCH_PRO | GCC_ARM   |      21464 |  3072 | 2048 |     26584 |      112145 |
+---------+----------+-----------+------------+-------+------+-----------+-------------+
| this pr | ARCH_PRO | GCC_ARM   |      20240 |  3072 | 2048 |     25360 |      113713 |
+---------+----------+-----------+------------+-------+------+-----------+-------------+
```

This is necessary to fit in the memory constraints of IAR as a result of IAR's lack of dynamic heap sizing (https://github.com/ARMmbed/mbed-os/issues/3466).

Tested locally with ARCH_PRO+GCC_ARM.

cc @bulislaw, @studavekar