### PR TITLE
tests: race test - add not supported for single threaded env

### DIFF
--- a/TESTS/mbed_drivers/race_test/main.cpp
+++ b/TESTS/mbed_drivers/race_test/main.cpp
@@ -22,6 +22,10 @@
 #include "SingletonPtr.h"
 #include <stdio.h>
 
+#ifndef MBED_RTOS_SINGLE_THREAD
+  #error [NOT_SUPPORTED] test not supported for single threaded enviroment
+#endif
+
 using namespace utest::v1;
 
 #define TEST_STACK_SIZE     1024


### PR DESCRIPTION
Fixes #4196. As someone might not be aware that settting default_lib to small has
some implications regarding thread safety, therefore we print an error.
