### PR TITLE
spi: Add SPI block-write to C++ and HAL for performance

### DIFF
--- a/drivers/SPI.cpp
+++ b/drivers/SPI.cpp
@@ -79,20 +79,11 @@ int SPI::write(int value) {
 }
 
 int SPI::write(const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
-    int total = (tx_length > rx_length) ? tx_length : rx_length;
-
     lock();
     aquire();
-    for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
-        char in = spi_master_write(&_spi, out);
-        if (i < rx_length) {
-            rx_buffer[i] = in;
-        }
-    }
+    int ret = spi_master_block_write(&_spi, tx_buffer, tx_length, rx_buffer, rx_length);
     unlock();
-
-    return total;
+    return ret;
 }
 
 void SPI::lock() {

--- a/drivers/SPI.cpp
+++ b/drivers/SPI.cpp
@@ -78,6 +78,23 @@ int SPI::write(int value) {
     return ret;
 }
 
+int SPI::write(const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    lock();
+    aquire();
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(&_spi, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+    unlock();
+
+    return total;
+}
+
 void SPI::lock() {
     _mutex->lock();
 }

--- a/drivers/SPI.h
+++ b/drivers/SPI.h
@@ -115,8 +115,24 @@ public:
      *
      *  @returns
      *    Response from the SPI slave
-    */
+     */
     virtual int write(int value);
+
+    /** Write to the SPI Slave and obtain the response
+     *
+     *  The total number of bytes sent and recieved will be the maximum of
+     *  tx_length and rx_length. The bytes written will be padded with the
+     *  value 0xff.
+     *
+     *  @param tx_buffer Pointer to the byte-array of data to write to the device
+     *  @param tx_length Number of bytes to write, may be zero
+     *  @param rx_buffer Pointer to the byte-array of data to read from the device
+     *  @param rx_length Number of bytes to read, may be zero
+     *  @returns
+     *      The number of bytes written and read from the device. This is
+     *      maximum of tx_length and rx_length.
+     */
+    virtual int write(const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length);
 
     /** Acquire exclusive access to this SPI bus
      */

--- a/hal/spi_api.h
+++ b/hal/spi_api.h
@@ -116,6 +116,23 @@ void spi_frequency(spi_t *obj, int hz);
  */
 int  spi_master_write(spi_t *obj, int value);
 
+/** Write a block out in master mode and receive a value
+ *
+ *  The total number of bytes sent and recieved will be the maximum of
+ *  tx_length and rx_length. The bytes written will be padded with the
+ *  value 0xff.
+ *
+ * @param[in] obj       The SPI peripheral to use for sending
+ * @param[in] tx_buffer Pointer to the byte-array of data to write to the device
+ * @param[in] tx_length Number of bytes to write, may be zero
+ * @param[in] rx_buffer Pointer to the byte-array of data to read from the device
+ * @param[in] rx_length Number of bytes to read, may be zero
+ * @returns
+ *      The number of bytes written and read from the device. This is
+ *      maximum of tx_length and rx_length.
+ */
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length);
+
 /** Check if a value is available to read
  *
  * @param[in] obj The SPI peripheral to check

--- a/targets/TARGET_ARM_SSG/TARGET_BEETLE/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_BEETLE/spi_api.c
@@ -262,6 +262,20 @@ int spi_master_write(spi_t *obj, int value) {
     return data;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 uint8_t spi_get_module(spi_t *obj) {
     return obj->spi->MID;
 }

--- a/targets/TARGET_ARM_SSG/TARGET_IOTSS/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_IOTSS/spi_api.c
@@ -268,6 +268,20 @@ int spi_master_write(spi_t *obj, int value) {
     return (ssp_read(obj));
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/spi_api.c
@@ -268,6 +268,20 @@ int spi_master_write(spi_t *obj, int value) {
     return (ssp_read(obj));
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/spi_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/spi_api.c
@@ -555,6 +555,20 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 /** Check if a value is available to read
  *
  * @param[in] obj The SPI peripheral to check

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM4/spi_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM4/spi_api.c
@@ -296,6 +296,20 @@ int  spi_master_write(spi_t *obj, int value)
     return 0;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 /** Check if a value is available to read
  *
  * @param[in] obj The SPI peripheral to check

--- a/targets/TARGET_Freescale/TARGET_K20XX/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/spi_api.c
@@ -140,6 +140,20 @@ int spi_master_write(spi_t *obj, int value) {
     return obj->spi->POPR;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return spi_readable(obj);
 }

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/spi_api.c
@@ -141,6 +141,20 @@ int spi_master_write(spi_t *obj, int value) {
     return obj->spi->D & 0xff;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return spi_readable(obj);
 }

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/spi_api.c
@@ -120,6 +120,20 @@ int spi_master_write(spi_t *obj, int value) {
     return obj->spi->D & 0xff;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return spi_readable(obj);
 }

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/spi_api.c
@@ -199,6 +199,20 @@ int spi_master_write(spi_t *obj, int value) {
     return ret;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return spi_readable(obj);
 }

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/spi_api.c
@@ -199,6 +199,20 @@ int spi_master_write(spi_t *obj, int value) {
     return ret;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return spi_readable(obj);
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/spi_api.c
@@ -118,6 +118,20 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj)
 {
     return spi_readable(obj);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/spi_api.c
@@ -118,6 +118,20 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj)
 {
     return spi_readable(obj);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/spi_api.c
@@ -115,6 +115,20 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj)
 {
     return spi_readable(obj);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/spi_api.c
@@ -115,6 +115,20 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj)
 {
     return spi_readable(obj);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/spi_api.c
@@ -117,6 +117,20 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj)
 {
     return spi_readable(obj);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/spi_api.c
@@ -117,6 +117,20 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj)
 {
     return spi_readable(obj);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/spi_api.c
@@ -117,6 +117,20 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj)
 {
     return spi_readable(obj);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/spi_api.c
@@ -117,6 +117,20 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj)
 {
     return spi_readable(obj);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/spi_api.c
@@ -127,6 +127,20 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj)
 {
     return spi_readable(obj);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
@@ -127,6 +127,20 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj)
 {
     return spi_readable(obj);

--- a/targets/TARGET_Maxim/TARGET_MAX32600/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32600/spi_api.c
@@ -179,6 +179,20 @@ int spi_master_write(spi_t *obj, int value)
     return result;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 //******************************************************************************
 int spi_busy(spi_t *obj)
 {

--- a/targets/TARGET_Maxim/TARGET_MAX32610/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32610/spi_api.c
@@ -179,6 +179,20 @@ int spi_master_write(spi_t *obj, int value)
     return result;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 //******************************************************************************
 int spi_busy(spi_t *obj)
 {

--- a/targets/TARGET_Maxim/TARGET_MAX32620/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620/spi_api.c
@@ -231,6 +231,20 @@ int spi_master_write(spi_t *obj, int value)
     return spi_master_transaction(obj, value, MXC_S_SPI_FIFO_DIR_BOTH);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 //******************************************************************************
 int spi_master_read(spi_t *obj)
 {

--- a/targets/TARGET_Maxim/TARGET_MAX32625/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/spi_api.c
@@ -167,6 +167,20 @@ int spi_master_write(spi_t *obj, int value)
     return *req.rx_data;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 //******************************************************************************
 int spi_busy(spi_t *obj)
 {

--- a/targets/TARGET_Maxim/TARGET_MAX32630/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/spi_api.c
@@ -167,6 +167,20 @@ int spi_master_write(spi_t *obj, int value)
     return *req.rx_data;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 //******************************************************************************
 int spi_busy(spi_t *obj)
 {

--- a/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/spi_api.c
@@ -263,6 +263,20 @@ int spi_master_write(spi_t *obj, int value)
     return spi_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 //static inline int spis_writeable(spi_t *obj) {
 //    return (obj->spis->EVENTS_ACQUIRED==1);
 //}

--- a/targets/TARGET_NORDIC/TARGET_NRF5/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/spi_api.c
@@ -485,6 +485,20 @@ int spi_master_write(spi_t *obj, int value)
     return p_spi_info->rx_buf;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj)
 {
     spi_info_t *p_spi_info = SPI_INFO(obj);

--- a/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
@@ -241,6 +241,20 @@ int spi_master_write(spi_t *obj, int value)
     return value2;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 #if DEVICE_SPISLAVE
 int spi_slave_receive(spi_t *obj)
 {

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
@@ -244,6 +244,20 @@ int spi_master_write(spi_t *obj, int value)
     return value2;
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 #if DEVICE_SPISLAVE
 int spi_slave_receive(spi_t *obj)
 {

--- a/targets/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
@@ -190,6 +190,20 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
@@ -156,6 +156,20 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }

--- a/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
@@ -192,6 +192,20 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return ssp_readable(obj) ? (1) : (0);
 }

--- a/targets/TARGET_NXP/TARGET_LPC13XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC13XX/spi_api.c
@@ -184,6 +184,20 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }

--- a/targets/TARGET_NXP/TARGET_LPC15XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC15XX/spi_api.c
@@ -248,6 +248,20 @@ int spi_master_write(spi_t *obj, int value)
     return spi_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj)
 {
     return (spi_readable(obj) && !spi_busy(obj)) ? (1) : (0);

--- a/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
@@ -190,6 +190,20 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
@@ -197,6 +197,20 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/spi_api.c
@@ -177,6 +177,20 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }

--- a/targets/TARGET_NXP/TARGET_LPC43XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/spi_api.c
@@ -196,6 +196,20 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }

--- a/targets/TARGET_NXP/TARGET_LPC81X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC81X/spi_api.c
@@ -178,6 +178,20 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }

--- a/targets/TARGET_NXP/TARGET_LPC82X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC82X/spi_api.c
@@ -174,6 +174,20 @@ int spi_master_write(spi_t *obj, int value)
     return spi_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_busy(spi_t *obj)
 {
     // checking RXOV(Receiver Overrun interrupt flag)

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/spi_api.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/spi_api.c
@@ -83,6 +83,20 @@ int  spi_master_write(spi_t *obj, int value)
     return(fSpiWriteB(obj, value));
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int  spi_busy(spi_t *obj)
 {
     return(obj->membase->STATUS.BITS.XFER_IP);

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1H/spi_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1H/spi_api.c
@@ -260,6 +260,20 @@ int spi_master_write(spi_t *obj, int value) {
     return spi_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return (spi_readable(obj) && !spi_busy(obj)) ? (1) : (0);
 }

--- a/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/spi_api.c
+++ b/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/spi_api.c
@@ -311,6 +311,20 @@ int spi_master_write(spi_t *obj, int value) {
     return spi_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return (spi_readable(obj) && !spi_busy(obj)) ? (1) : (0);
 }

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -367,6 +367,21 @@ int spi_master_write(spi_t *obj, int value)
     }
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length)
+{
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj)
 {
     return ((ssp_readable(obj) && !ssp_busy(obj)) ? 1 : 0);

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
@@ -390,6 +390,20 @@ int spi_master_write(spi_t *obj, int value)
     return spi_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 inline uint8_t spi_master_tx_ready(spi_t *obj)
 {
     return (obj->spi.spi->STATUS & USART_STATUS_TXBL) ? true : false;

--- a/targets/TARGET_WIZNET/TARGET_W7500x/spi_api.c
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/spi_api.c
@@ -183,6 +183,20 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+    int total = (tx_length > rx_length) ? tx_length : rx_length;
+
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
+
+    return total;
+}
+
 int spi_slave_receive(spi_t *obj) {
     return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
 }


### PR DESCRIPTION
This is based on previous work done by @simonqhughes to speed up the SD card implementation, it has a wider impact than just the SD card, so I'm making this pr against the current SPI implementation.

Replaced with assertion on current mutex owner. This requires locking in the caller, but without external locking the current behaviour is still at risk of contention for transactions > 1 byte.

Tested with sd-driver basic tests:

|                                   |  1MHz SPI | 40 MHz SPI |
|-------------|----|----|
| with byte-locking      | 32.911s | 25.386s |
| without byte-locking | 25.386s | 15.977s |

**Note:** This does create the concern that single-byte writes are no longer thread-safe when used across multiple threads. However, there is very few use cases where single-byte SPI transactions are used, and most transactions already have external locking.

cc @c1728p9, @sg- 

---

EDIT:

Sorry about the delay, got dragged into some other issues.

I have more data for you all, there's still quite a few patches I need to put up places but I have a better test that measure block writes vs block reads vs spi traffic (this is all with the SD card). I was also tinkering with the K64F's ~dma~ dspi api and put together a block_write like the one @kjbracey-arm was suggesting that takes advantage of the K64F's ~dma~ dspi api (this was before the talk of using the async api).

Anyways here's what I found with GCC_ARM and K64F at 40MHz:

|    |   SD write speed   |   SD read speed |    SPI speed  |
|---|-----------------------|----------------------|---|
| with byte-writes      | 463.263Kbps      |      792.419Kbps|         913.783Kbps |
| with block-writes    |   757.669Kbps      |      2.338Mbps       |     3.997Mbps |
| with hal block-writes |  878.342Kbps      |      4.239Mbps        |    17.809Mbps |

There is definitely motivation for block writes at the hal level in terms of raw SPI throughput.

As for why we don't see a proportional increase in throughput on the SD card, well I think this image sums it up quite nicely:
![image](https://cloud.githubusercontent.com/assets/1075160/26221504/624a3568-3bdc-11e7-8bc9-53aecc682151.png)

---

EDIT: EDIT:

I've gone ahead and updated this pr with the hal-level block writes, a default implementation in all of the target's spi implementations, and the example block write implementation using ~DMA~ the DSPI API in the k64f (33e9129) that I used for evaluation.

I've gone ahead and updated the PR description and title to reflect this.