### PR TITLE
USB: Added support for the logo key to the keyboard

### DIFF
--- a/features/unsupported/USBDevice/USBHID/USBKeyboard.h
+++ b/features/unsupported/USBDevice/USBHID/USBKeyboard.h
@@ -22,11 +22,16 @@
 #include "USBHID.h"
 #include "Stream.h"
 
-/* Modifiers */
+/* Modifiers, left keys then right keys. */
 enum MODIFIER_KEY {
-    KEY_CTRL = 1,
-    KEY_SHIFT = 2,
-    KEY_ALT = 4,
+    KEY_CTRL = 0x01,
+    KEY_SHIFT = 0x02,
+    KEY_ALT = 0x04,
+    KEY_LOGO = 0x08,
+    KEY_RCTRL = 0x10,
+    KEY_RSHIFT = 0x20,
+    KEY_RALT = 0x40,
+    KEY_RLOGO = 0x80,
 };
 
 


### PR DESCRIPTION
Minor change - List of key modifiers updated to include the
logo/GUI/windows key. Also added the options to specify the right hand
versions of the keys rather than just the left if for some reason
someone wants to do this.

Changes are limited to the keyboard header file and are backwards
compatible.

The new modifier values are in line with the table given on page 56 of
this document http://www.usb.org/developers/hidpage/HID1_11.pdf

