### PR TITLE
Add script to lint targets.json

### DIFF
--- a/tools/targets/lint.py
+++ b/tools/targets/lint.py
@@ -77,13 +77,12 @@ def check_inherits(dict):
     if  ("inherits" in dict and len(dict["inherits"]) > 1):
         yield "multiple inheritance is forbidden"
 
-DEVICE_HAS_ALLOWED = ["AACI", "ANALOGIN", "ANALOGOUT", "CAN", "CLCD",
-                      "ERROR_PATTERN", "ETHERNET", "EMAC", "FLASH", "I2C",
-                      "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER",
-                      "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "TRNG",
-                      "TSC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP",
-                      "SPI", "SPI_ASYNCH", "SPISLAVE", "STDIO_MESSAGES",
-                      "STORAGE", "SEMIHOST", "LOCALFILESYSTEM"]
+DEVICE_HAS_ALLOWED = ["ANALOGIN", "ANALOGOUT", "CAN", "ETHERNET", "EMAC",
+                      "FLASH", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN",
+                      "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT",
+                      "PWMOUT", "RTC", "TRNG","SERIAL", "SERIAL_ASYNCH",
+                      "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE",
+                      "STORAGE"]
 def check_device_has(dict):
     for name in dict.get("device_has", []):
         if name not in DEVICE_HAS_ALLOWED:

--- a/tools/targets/lint.py
+++ b/tools/targets/lint.py
@@ -1,0 +1,140 @@
+"""A linting utility for targets.json"""
+
+from os.path import join, abspath, dirname
+if __name__ == "__main__":
+    import sys
+    ROOT = abspath(join(dirname(__file__), "..", ".."))
+    sys.path.insert(0, ROOT)
+from copy import copy
+from yaml import dump
+from tools.targets import Target, set_targets_json_location, TARGET_MAP
+
+def must_have_keys(keys, dict):
+    for key in keys:
+        if key not in dict:
+            yield "%s not found, and is required" % key
+
+def may_have_keys(keys, dict):
+    for key in dict.keys():
+        if key not in keys:
+            yield "%s found, and is not allowed" % key
+
+
+MCU_REQUIRED_KEYS = ["release_versions", "supported_toolchains",
+                     "default_lib", "public", "inherits"]
+MCU_ALLOWED_KEYS = ["device_has", "core", "extra_labels", "features", "bootloader_supported", "device_name", "post_binary_hook", "default_toolchain"] + MCU_REQUIRED_KEYS
+def check_mcu(mcu_json, strict=False):
+    """Generate a list of problems with an mcu"""
+    if strict:
+        for err in must_have_keys(MCU_REQUIRED_KEYS, mcu_json):
+            yield err
+    for err in may_have_keys(MCU_ALLOWED_KEYS, mcu_json):
+        yield err
+    if 'public' in mcu_json and mcu_json['public']:
+        yield "public must be false"
+    if ("release_versions" in mcu_json and
+        "5" in mcu_json["release_versions"] and
+        "supported_toolchains" in mcu_json):
+        for tc in ["GCC_ARM", "ARM", "IAR"]:
+            if tc not in mcu_json["supported_toolchains"]:
+                yield ("%s not found in supported_toolchains, and is "
+                       "required by mbed OS 5" % tc)
+
+BOARD_REQUIRED_KEYS = ["inherits"]
+BOARD_ALLOWED_KEYS = ["supported_form_factors", "is_disk_virtual", "detect_code", "device_name", "extra_labels", "public"] + BOARD_REQUIRED_KEYS
+def check_board(board_json, strict=False):
+    if strict:
+        for err in must_have_keys(BOARD_REQUIRED_KEYS, board_json):
+            yield err
+    for err in may_have_keys(BOARD_ALLOWED_KEYS, board_json):
+        yield err
+
+
+def add_if(dict, key, val):
+    if val:
+        dict[key] = val
+
+def _split_boards(resolution_order, tgt):
+    mcus = []
+    boards = []
+    iterable = iter(resolution_order)
+    for name in iterable:
+        mcu_json = tgt.json_data[name]
+        if  (len(list(check_mcu(mcu_json, True))) >
+             len(list(check_board(mcu_json, True)))):
+            boards.append(name)
+        else:
+            mcus.append(name)
+            break
+    mcus.extend(iterable)
+    mcus.reverse()
+    boards.reverse()
+    return mcus, boards
+
+
+MCU_FORMAT_STRING = {1: "MCU (%s) ->",
+                     2: "Family (%s) -> MCU (%s) ->",
+                     3: "Family (%s) -> SubFamily (%s) -> MCU (%s) ->"}
+BOARD_FORMAT_STRING = {1: "Board (%s)",
+                       2: "Module (%s) -> Board (%s)"}
+def _generate_hierarchy_string(mcus, boards):
+    global_errors = []
+    if len(mcus) < 1:
+        global_errors.append("No MCUS found in heirarchy")
+        mcus_string = "??? ->"
+    elif len(mcus) > 3:
+        global_errors.append("No name for targets: %s" % mcus[3:])
+        mcus_string = MCU_FORMAT_STRING[3] % tuple(mcus[:3])
+        for name in mcus[3:]:
+            mcus_string += " ??? (%s) ->" % name
+    else:
+        mcus_string = MCU_FORMAT_STRING[len(mcus)] % tuple(mcus)
+
+    if len(boards) < 1:
+        global_errors.append("no boards found in heirarchy")
+        boards_string = "???"
+    elif len(boards) > 2:
+        global_errors.append("no name for targets: %s" % boards[2:])
+        boards_string = BOARD_FORMAT_STRING[3] % tuple(boards[:2])
+        for name in boards[2:]:
+            boards_string += " ??? (%s)" % name
+    else:
+        boards_string = BOARD_FORMAT_STRING[len(boards)] % tuple(boards)
+    return mcus_string + " " + boards_string, global_errors
+
+
+def check_hierarchy(tgt):
+    """Atempts to assign labels to the heirarchy"""
+    resolution_order = copy(tgt.resolution_order_names[:-1])
+    mcus, boards = _split_boards(resolution_order, tgt)
+
+    target_errors = {}
+    hierachy_string, hierachy_errors = _generate_hierarchy_string(mcus, boards)
+    to_ret = {"hierarchy": hierachy_string}
+    add_if(to_ret, "hierachy errors", hierachy_errors)
+
+    for name in mcus[:-1]:
+        add_if(target_errors, name, list(check_mcu(tgt.json_data[name])))
+    if len(mcus) >= 1:
+        add_if(target_errors, mcus[-1],
+               list(check_mcu(tgt.json_data[mcus[-1]], True)))
+    for name in boards:
+        add_if(target_errors, name, list(check_board(tgt.json_data[name])))
+    if len(boards) >= 1:
+        add_if(target_errors, boards[-1],
+               list(check_board(tgt.json_data[boards[-1]], True)))
+    add_if(to_ret, "target errors", target_errors)
+    return to_ret
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mcu", choices=TARGET_MAP.keys(), metavar="MCU")
+    options = parser.parse_args()
+    print dump(check_hierarchy(TARGET_MAP[options.mcu]), default_flow_style=False)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/tools/targets/lint.py
+++ b/tools/targets/lint.py
@@ -29,6 +29,7 @@ if __name__ == "__main__":
 from copy import copy
 from yaml import dump_all
 import argparse
+
 from tools.targets import Target, set_targets_json_location, TARGET_MAP
 
 def must_have_keys(keys, dict):

--- a/tools/targets/lint.py
+++ b/tools/targets/lint.py
@@ -61,9 +61,21 @@ def check_inherits(dict):
     if  ("inherits" in dict and len(dict["inherits"]) > 1):
         yield "multiple inheritance is forbidden"
 
+DEVICE_HAS_ALLOWED = ["AACI", "ANALOGIN", "ANALOGOUT", "CAN", "CLCD",
+                      "ERROR_PATTERN", "ETHERNET", "EMAC", "FLASH", "I2C",
+                      "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER",
+                      "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "TRNG",
+                      "TSC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP",
+                      "SPI", "SPI_ASYNCH", "SPISLAVE", "STDIO_MESSAGES",
+                      "STORAGE", "SEMIHOST", "LOCALFILESYSTEM"]
+def check_device_has(dict):
+    for name in dict.get("device_has", []):
+        if name not in DEVICE_HAS_ALLOWED:
+            yield "%s is not allowed in device_has" % name
+
 MCU_REQUIRED_KEYS = ["release_versions", "supported_toolchains",
                      "default_lib", "public", "inherits", "device_has"]
-MCU_ALLOWED_KEYS = ["device_has", "device_has_add", "device_has_remove", "core",
+MCU_ALLOWED_KEYS = ["device_has_add", "device_has_remove", "core",
                     "extra_labels", "features", "features_add",
                     "features_remove", "bootloader_supported", "device_name",
                     "post_binary_hook", "default_toolchain", "config",
@@ -81,6 +93,7 @@ def check_mcu(mcu_json, strict=False):
     errors.extend(check_extra_labels(mcu_json))
     errors.extend(check_release_version(mcu_json))
     errors.extend(check_inherits(mcu_json))
+    errors.extend(check_device_has(mcu_json))
     if 'public' in mcu_json and mcu_json['public']:
         errors.append("public must be false")
     return errors

--- a/tools/targets/lint.py
+++ b/tools/targets/lint.py
@@ -1,10 +1,25 @@
 """A linting utility for targets.json
 
 This linting utility may be called as follows:
-python <path-to>/lint.py TARGET [TARGET ...]
+python <path-to>/lint.py targets TARGET [TARGET ...]
 
 all targets will be linted
 """
+
+# mbed SDK
+# Copyright (c) 2017 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from os.path import join, abspath, dirname
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

The linting script for targets.json (tools/targets/lint.py) is a utility for
avoiding common pit-falls of defining targets, and detecting style 
inconsistencies between targets. 

## Rules Enforced
A target's inheritance must look like one of these:
```
MCU -> Board
MCU -> Module -> Board
Family -> MCU -> Board
Family -> MCU -> Module -> Board
Family -> SubFamily -> MCU -> Board
Family -> SubFamily -> MCU -> Module -> Board
```

For each of these target roles, some rules are in place:
1. For Family, MCU and SubFamily, the following keys are allowed
  - `core`
  - `extra_labels`
  - `features`
  - `bootloader_supported`
  - `device_name`
  - `post_binary_hook`
  - `default_tool chain`
  - `public`
  - `config`
  - `target_overrides`
2. MCU's are required to have, and Families and SubFamilies may have:
  - `release_versions`
  - `supported_toolchains`
  - `default_lib`
  - `device_has`
3. For Module and Board, the following keys are allowed:
  - `supported_form_factors`
  - `is_disk_virtual`
  - `detect_code`
  - `extra_labels`
  - `public`
  - `config`
  - `forced_reset_timeout`
  - `target_overrides`

`macros` is missing from this list. That is intentional: they do not provide any benefit over `config` and `target_overrides` but can be very difficult to use. In practice it is very difficult to override the value of a macro with a value. `config` on the other hand, was designed for this.
- `device_has` may only contain values from the following list:
  - `ANALOGIN`.
  - `ANALOGOUT`.
  - `CAN`.
  - `ETHERNET`.
  - `EMAC`.
  - `FLASH`.
  - `I2C`.
  - `I2CSLAVE`.
  - `I2C_ASYNCH`.
  - `INTERRUPTIN`.
  - `LOWPOWERTIMER`.
  - `PORTIN`.
  - `PORTINOUT`.
  - `PORTOUT`.
  - `PWMOUT`.
  - `RTC`.
  - `TRNG`.
  - `SERIAL`.
  - `SERIAL_ASYNCH`.
  - `SERIAL_FC`.
  - `SLEEP`.
  - `SPI`.
  - `SPI_ASYNCH`.
  - `SPISLAVE`.

`extra_labels` may not contain any target names.

if `release_versions` contains 5, then `supported_toolchains` must contain all 
of `GCC_ARM`, `ARM` and `IAR`.


# Sample output
There are three commands, `targets`, `all-targets` and `orphans`. The `targets` 
and `all-targets` commands both show errors within public inheritance 
hierarchies. The `orphans` command shows all targets that are not reachable from
a public target.

`python tools/targets/lint.py targets EFM32GG_STK3700 EFM32WG_STK3800 LPC11U24_301`

```yaml
hierarchy: Family (EFM32) -> MCU (EFM32GG990F1024) -> Board (EFM32GG_STK3700)
target errors:
  EFM32:
  - EFM32 is not allowed in extra_labels
  EFM32GG990F1024:
  - macros found, and is not allowed
  - default_lib not found, and is required
  - device_has not found, and is required
  EFM32GG_STK3700:
  - progen found, and is not allowed
  - device_has found, and is not allowed
---
hierarchy: Family (EFM32) -> MCU (EFM32WG990F256) -> Board (EFM32WG_STK3800)
target errors:
  EFM32:
  - EFM32 is not allowed in extra_labels
  EFM32WG990F256:
  - macros found, and is not allowed
  - default_lib not found, and is required
  - device_has not found, and is required
  EFM32WG_STK3800:
  - progen found, and is not allowed
  - device_has found, and is not allowed
---
hierarchy: Family (LPCTarget) -> MCU (LPC11U24_301) -> ???
hierarchy errors:
- no boards found in heirarchy
target errors:
  LPC11U24_301:
  - release_versions not found, and is required
  - default_lib not found, and is required
  - public not found, and is required
```

`python tools/targets/lint.py orphans`

```yaml
- CM4_UARM
- CM4_ARM
- CM4F_UARM
- CM4F_ARM
- LPC1800
- EFR32MG1P132F256GM48
- EFR32MG1_BRD4150
```


# TODO

- [x] Documentation