### PR TITLE
STM32s Serial: Correct handling of parity bits

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2014, STMicroelectronics
+ * Copyright (c) 2015, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,63 +29,33 @@
  */
 #include "mbed_assert.h"
 #include "serial_api.h"
+#include "serial_api_hal.h"
 
 #if DEVICE_SERIAL
 
 #include "cmsis.h"
 #include "pinmap.h"
-#include "mbed_error.h"
 #include <string.h>
 #include "PeripheralPins.h"
+#include "mbed_error.h"
 
-#define UART_NUM (3)
+#if defined (TARGET_STM32F091RC)
+    #define UART_NUM (8)
+#elif defined (TARGET_STM32F030R8) || defined (TARGET_STM32F051R8) || defined (TARGET_STM32F042K6)
+    #define UART_NUM (2)
+#elif defined (TARGET_STM32F031K6)
+    #define UART_NUM (1)
+#else
+    #define UART_NUM (4)
+#endif
 
 static uint32_t serial_irq_ids[UART_NUM] = {0};
-static UART_HandleTypeDef uart_handlers[UART_NUM];
+UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
 
 int stdio_uart_inited = 0;
 serial_t stdio_uart;
-
-#if DEVICE_SERIAL_ASYNCH
-    #define SERIAL_S(obj) (&((obj)->serial))
-#else
-    #define SERIAL_S(obj) (obj)
-#endif
-
-static void init_uart(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    huart->Instance = (USART_TypeDef *)(obj_s->uart);
-
-    huart->Init.BaudRate     = obj_s->baudrate;
-    huart->Init.WordLength   = obj_s->databits;
-    huart->Init.StopBits     = obj_s->stopbits;
-    huart->Init.Parity       = obj_s->parity;
-#if DEVICE_SERIAL_FC
-    huart->Init.HwFlowCtl    = obj_s->hw_flow_ctl;
-#else
-    huart->Init.HwFlowCtl    = UART_HWCONTROL_NONE;
-#endif
-    huart->TxXferCount       = 0;
-    huart->TxXferSize        = 0;
-    huart->RxXferCount       = 0;
-    huart->RxXferSize        = 0;
-
-    if (obj_s->pin_rx == NC) {
-        huart->Init.Mode = UART_MODE_TX;
-    } else if (obj_s->pin_tx == NC) {
-        huart->Init.Mode = UART_MODE_RX;
-    } else {
-        huart->Init.Mode = UART_MODE_TX_RX;
-    }
-
-    if (HAL_UART_Init(huart) != HAL_OK) {
-        error("Cannot initialize UART\n");
-    }
-}
 
 void serial_init(serial_t *obj, PinName tx, PinName rx)
 {
@@ -106,20 +76,71 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_USART1_CLK_ENABLE();
         obj_s->index = 0;
     }
+
+#if defined USART2_BASE
     if (obj_s->uart == UART_2) {
         __HAL_RCC_USART2_FORCE_RESET();
         __HAL_RCC_USART2_RELEASE_RESET();
         __HAL_RCC_USART2_CLK_ENABLE();
         obj_s->index = 1;
     }
+#endif
+
+#if defined USART3_BASE
     if (obj_s->uart == UART_3) {
         __HAL_RCC_USART3_FORCE_RESET();
         __HAL_RCC_USART3_RELEASE_RESET();
         __HAL_RCC_USART3_CLK_ENABLE();
         obj_s->index = 2;
     }
+#endif
 
-    // Configure UART pins
+#if defined USART4_BASE
+    if (obj_s->uart == UART_4) {
+        __HAL_RCC_USART4_FORCE_RESET();
+        __HAL_RCC_USART4_RELEASE_RESET();
+        __HAL_RCC_USART4_CLK_ENABLE();
+        obj_s->index = 3;
+    }
+#endif
+
+#if defined USART5_BASE
+    if (obj_s->uart == UART_5) {
+        __HAL_RCC_USART5_FORCE_RESET();
+        __HAL_RCC_USART5_RELEASE_RESET();
+        __HAL_RCC_USART5_CLK_ENABLE();
+        obj_s->index = 4;
+    }
+#endif
+
+#if defined USART6_BASE
+    if (obj_s->uart == UART_6) {
+        __HAL_RCC_USART6_FORCE_RESET();
+        __HAL_RCC_USART6_RELEASE_RESET();
+        __HAL_RCC_USART6_CLK_ENABLE();
+        obj_s->index = 5;
+    }
+#endif
+
+#if defined USART7_BASE
+    if (obj_s->uart == UART_7) {
+        __HAL_RCC_USART7_FORCE_RESET();
+        __HAL_RCC_USART7_RELEASE_RESET();
+        __HAL_RCC_USART7_CLK_ENABLE();
+        obj_s->index = 6;
+    }
+#endif
+
+#if defined USART8_BASE
+    if (obj_s->uart == UART_8) {
+        __HAL_RCC_USART8_FORCE_RESET();
+        __HAL_RCC_USART8_RELEASE_RESET();
+        __HAL_RCC_USART8_CLK_ENABLE();
+        obj_s->index = 7;
+    }
+#endif
+
+    // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
     
@@ -162,16 +183,62 @@ void serial_free(serial_t *obj)
         __HAL_RCC_USART1_RELEASE_RESET();
         __HAL_RCC_USART1_CLK_DISABLE();
     }
+
+#if defined(USART2_BASE)
     if (obj_s->uart == UART_2) {
-        __HAL_RCC_USART2_FORCE_RESET();
-        __HAL_RCC_USART2_RELEASE_RESET();
-        __HAL_RCC_USART2_CLK_DISABLE();
+         __HAL_RCC_USART2_FORCE_RESET();
+         __HAL_RCC_USART2_RELEASE_RESET();
+         __HAL_RCC_USART2_CLK_DISABLE();
     }
+#endif
+
+#if defined USART3_BASE
     if (obj_s->uart == UART_3) {
         __HAL_RCC_USART3_FORCE_RESET();
         __HAL_RCC_USART3_RELEASE_RESET();
         __HAL_RCC_USART3_CLK_DISABLE();
     }
+#endif
+
+#if defined USART4_BASE
+    if (obj_s->uart == UART_4) {
+        __HAL_RCC_USART4_FORCE_RESET();
+        __HAL_RCC_USART4_RELEASE_RESET();
+        __HAL_RCC_USART4_CLK_DISABLE();
+    }
+#endif
+
+#if defined USART5_BASE
+    if (obj_s->uart == UART_5) {
+        __HAL_RCC_USART5_FORCE_RESET();
+        __HAL_RCC_USART5_RELEASE_RESET();
+        __HAL_RCC_USART5_CLK_DISABLE();
+    }
+#endif
+
+#if defined USART6_BASE
+    if (obj_s->uart == UART_6) {
+        __HAL_RCC_USART6_FORCE_RESET();
+        __HAL_RCC_USART6_RELEASE_RESET();
+        __HAL_RCC_USART6_CLK_DISABLE();
+    }
+#endif
+
+#if defined USART7_BASE
+    if (obj_s->uart == UART_7) {
+        __HAL_RCC_USART7_FORCE_RESET();
+        __HAL_RCC_USART7_RELEASE_RESET();
+        __HAL_RCC_USART7_CLK_DISABLE();
+    }
+#endif
+
+#if defined USART8_BASE
+    if (obj_s->uart == UART_8) {
+        __HAL_RCC_USART8_FORCE_RESET();
+        __HAL_RCC_USART8_RELEASE_RESET();
+        __HAL_RCC_USART8_CLK_DISABLE();
+    }
+#endif
 
     // Configure GPIOs
     pin_function(obj_s->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
@@ -188,39 +255,6 @@ void serial_baud(serial_t *obj, int baudrate)
     init_uart(obj);
 }
 
-void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-
-    if (data_bits == 9) {
-        obj_s->databits = UART_WORDLENGTH_9B;
-    } else {
-        obj_s->databits = UART_WORDLENGTH_8B;
-    }
-
-    switch (parity) {
-        case ParityOdd:
-            obj_s->parity = UART_PARITY_ODD;
-            break;
-        case ParityEven:
-            obj_s->parity = UART_PARITY_EVEN;
-            break;
-        default: // ParityNone
-        case ParityForced0: // unsupported!
-        case ParityForced1: // unsupported!
-            obj_s->parity = UART_PARITY_NONE;
-            break;
-    }
-
-    if (stop_bits == 2) {
-        obj_s->stopbits = UART_STOPBITS_2;
-    } else {
-        obj_s->stopbits = UART_STOPBITS_1;
-    }
-
-    init_uart(obj);
-}
-
 /******************************************************************************
  * INTERRUPTS HANDLING
  ******************************************************************************/
@@ -233,18 +267,19 @@ static void uart_irq(int id)
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TC) != RESET) {
                 irq_handler(serial_irq_ids[id], TxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
+                __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET) {
                 irq_handler(serial_irq_ids[id], RxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
+                volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE flag
+                UNUSED(tmpval);
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET) {
-                volatile uint32_t tmpval = huart->Instance->DR; // Clear ORE flag
+            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ORE) != RESET) {
+                __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
             }
         }
     }
@@ -255,15 +290,54 @@ static void uart1_irq(void)
     uart_irq(0);
 }
 
+#if defined(USART2_BASE)
 static void uart2_irq(void)
 {
     uart_irq(1);
 }
+#endif
 
+#if defined USART3_BASE
 static void uart3_irq(void)
 {
     uart_irq(2);
 }
+#endif
+
+#if defined USART4_BASE
+static void uart4_irq(void)
+{
+    uart_irq(3);
+}
+#endif
+
+#if defined USART5_BASE
+static void uart5_irq(void)
+{
+    uart_irq(4);
+}
+#endif
+
+#if defined USART6_BASE
+static void uart6_irq(void)
+{
+    uart_irq(5);
+}
+#endif
+
+#if defined USART7_BASE
+static void uart7_irq(void)
+{
+    uart_irq(6);
+}
+#endif
+
+#if defined USART8_BASE
+static void uart8_irq(void)
+{
+    uart_irq(7);
+}
+#endif
 
 void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
 {
@@ -285,15 +359,61 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         vector = (uint32_t)&uart1_irq;
     }
 
+#if defined(USART2_BASE)
     if (obj_s->uart == UART_2) {
         irq_n = USART2_IRQn;
         vector = (uint32_t)&uart2_irq;
     }
+#endif
 
+#if defined (TARGET_STM32F091RC)
     if (obj_s->uart == UART_3) {
-        irq_n = USART3_IRQn;
+        irq_n = USART3_8_IRQn;
         vector = (uint32_t)&uart3_irq;
     }
+
+    if (obj_s->uart == UART_4) {
+        irq_n = USART3_8_IRQn;
+        vector = (uint32_t)&uart4_irq;
+    }
+
+    if (obj_s->uart == UART_5) {
+        irq_n = USART3_8_IRQn;
+        vector = (uint32_t)&uart5_irq;
+    }
+
+    if (obj_s->uart == UART_6) {
+        irq_n = USART3_8_IRQn;
+        vector = (uint32_t)&uart6_irq;
+    }
+
+    if (obj_s->uart == UART_7) {
+        irq_n = USART3_8_IRQn;
+        vector = (uint32_t)&uart7_irq;
+    }
+
+    if (obj_s->uart == UART_8) {
+        irq_n = USART3_8_IRQn;
+        vector = (uint32_t)&uart8_irq;
+    }
+
+#elif defined (TARGET_STM32F030R8) || defined (TARGET_STM32F051R8)
+
+#else
+#if defined(USART3_BASE)
+    if (obj_s->uart == UART_3) {
+        irq_n = USART3_4_IRQn;
+        vector = (uint32_t)&uart3_irq;
+    }
+#endif
+
+#if defined(USART4_BASE)
+    if (obj_s->uart == UART_4) {
+        irq_n = USART3_4_IRQn;
+        vector = (uint32_t)&uart4_irq;
+    }
+#endif
+#endif
 
     if (enable) {
         if (irq == RxIrq) {
@@ -321,7 +441,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         }
 
         if (all_disabled) {
-            NVIC_DisableIRQ(irq_n);
+          NVIC_DisableIRQ(irq_n);
         }
     }
 }
@@ -336,11 +456,7 @@ int serial_getc(serial_t *obj)
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
 
     while (!serial_readable(obj));
-    if (obj_s->databits == UART_WORDLENGTH_8B) {
-        return (int)(huart->Instance->DR & (uint8_t)0xFF);
-    } else {
-        return (int)(huart->Instance->DR & (uint16_t)0x1FF);
-    }
+    return (int)(huart->Instance->RDR & (uint16_t)0xFF);
 }
 
 void serial_putc(serial_t *obj, int c)
@@ -349,11 +465,7 @@ void serial_putc(serial_t *obj, int c)
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
 
     while (!serial_writable(obj));
-    if (obj_s->databits == UART_WORDLENGTH_8B) {
-        huart->Instance->DR = (uint8_t)(c & (uint8_t)0xFF);
-    } else {
-        huart->Instance->DR = (uint16_t)(c & (uint16_t)0x1FF);
-    }
+    huart->Instance->TDR = (uint32_t)(c & (uint16_t)0xFF);
 }
 
 int serial_readable(serial_t *obj)
@@ -393,7 +505,7 @@ void serial_break_set(serial_t *obj)
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
     
-    HAL_LIN_SendBreak(huart);
+    //HAL_LIN_SendBreak(huart);
 }
 
 void serial_break_clear(serial_t *obj)
@@ -481,24 +593,38 @@ static IRQn_Type serial_get_irq_n(serial_t *obj)
     IRQn_Type irq_n;
 
     switch (obj_s->index) {
+#if defined(USART1_BASE)
         case 0:
             irq_n = USART1_IRQn;
             break;
-
+#endif
+#if defined(USART2_BASE)
         case 1:
             irq_n = USART2_IRQn;
             break;
-
+#endif
+#if defined (TARGET_STM32F091RC)
         case 2:
-            irq_n = USART3_IRQn;
+        case 3:
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+            irq_n = USART3_8_IRQn;
             break;
-
+#elif !defined (TARGET_STM32F030R8) && !defined (TARGET_STM32F051R8)
+        case 2:
+        case 3:
+            irq_n = USART3_4_IRQn;
+            break;
+#endif
         default:
             irq_n = (IRQn_Type)0;
     }
     
     return irq_n;
 }
+
 
 /******************************************************************************
  * MBED API FUNCTIONS
@@ -636,19 +762,22 @@ uint8_t serial_rx_active(serial_t *obj)
 
 void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-        __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
     }
 }
 
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart) {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear PE flag
-    } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear FE flag
-    } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_NE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear NE flag
-    } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear ORE flag
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_PEF);
+    }
+    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_FEF);
+    }
+    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_NE) != RESET) {
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_NEF);
+    }
+    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
     }
 }
 
@@ -682,8 +811,8 @@ int serial_irq_handler_asynch(serial_t *obj)
         if (__HAL_UART_GET_IT_SOURCE(huart, USART_IT_ERR) != RESET) {
             return_event |= (SERIAL_EVENT_RX_PARITY_ERROR & obj_s->events);
         }
-}
-
+    }
+    
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
         if (__HAL_UART_GET_IT_SOURCE(huart, USART_IT_ERR) != RESET) {
             return_event |= (SERIAL_EVENT_RX_FRAMING_ERROR & obj_s->events);
@@ -745,7 +874,7 @@ void serial_tx_abort_asynch(serial_t *obj)
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
     
     // clear flags
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
+    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
     
     // reset states
     huart->TxXferCount = 0;
@@ -774,8 +903,9 @@ void serial_rx_abort_asynch(serial_t *obj)
     __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
     
     // clear flags
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
-    volatile uint32_t tmpval = huart->Instance->DR; // Clear errors flag
+    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_OREF);
+    volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE flag
+    UNUSED(tmpval);
     
     // reset states
     huart->RxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2014, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,9 +27,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************
  */
-
 #include "mbed_assert.h"
 #include "serial_api.h"
+#include "serial_api_hal.h"
 
 #if DEVICE_SERIAL
 
@@ -39,60 +39,20 @@
 #include "PeripheralPins.h"
 #include "mbed_error.h"
 
-#define UART_NUM (8)
-static uint32_t serial_irq_ids[UART_NUM] = {0};
-static UART_HandleTypeDef uart_handlers[UART_NUM];
+#define UART_NUM (5)
 
-static uart_irq_handler irq_handler;
+static uint32_t serial_irq_ids[UART_NUM] = {0};
+UART_HandleTypeDef uart_handlers[UART_NUM];
+
+uart_irq_handler irq_handler;
 
 int stdio_uart_inited = 0;
 serial_t stdio_uart;
 
-#if DEVICE_SERIAL_ASYNCH
-    #define SERIAL_S(obj) (&((obj)->serial))
-#else
-    #define SERIAL_S(obj) (obj)
-#endif
-
-
-static void init_uart(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    huart->Instance = (USART_TypeDef *)(obj_s->uart);
-
-    huart->Init.BaudRate     = obj_s->baudrate;
-    huart->Init.WordLength   = obj_s->databits;
-    huart->Init.StopBits     = obj_s->stopbits;
-    huart->Init.Parity       = obj_s->parity;
-#if DEVICE_SERIAL_FC
-    huart->Init.HwFlowCtl    = obj_s->hw_flow_ctl;
-#else
-    huart->Init.HwFlowCtl    = UART_HWCONTROL_NONE;
-#endif
-    huart->Init.OverSampling = UART_OVERSAMPLING_16;
-    huart->TxXferCount       = 0;
-    huart->TxXferSize        = 0;
-    huart->RxXferCount       = 0;
-    huart->RxXferSize        = 0;
-
-    if (obj_s->pin_rx == NC) {
-        huart->Init.Mode = UART_MODE_TX;
-    } else if (obj_s->pin_tx == NC) {
-        huart->Init.Mode = UART_MODE_RX;
-    } else {
-        huart->Init.Mode = UART_MODE_TX_RX;
-    }
-
-    if (HAL_UART_Init(huart) != HAL_OK) {
-        error("Cannot initialize UART\n");
-    }
-}
-
 void serial_init(serial_t *obj, PinName tx, PinName rx)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
-  
+    
     // Determine the UART to use (UART_1, UART_2, ...)
     UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
     UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
@@ -101,70 +61,60 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     obj_s->uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
     MBED_ASSERT(obj_s->uart != (UARTName)NC);
 
-    // Enable USART clock
-    switch (obj_s->uart) {
-        case UART_1:
-            __HAL_RCC_USART1_FORCE_RESET();
-            __HAL_RCC_USART1_RELEASE_RESET();
-            __HAL_RCC_USART1_CLK_ENABLE();
-            obj_s->index = 0;
-            break;
-            
-        case UART_2:
-            __HAL_RCC_USART2_FORCE_RESET();
-            __HAL_RCC_USART2_RELEASE_RESET();
-            __HAL_RCC_USART2_CLK_ENABLE();
-            obj_s->index = 1;
-            break;
+    // Enable USART clock + switch to SystemClock
+    if (obj_s->uart == UART_1) {
+        __USART1_FORCE_RESET();
+        __USART1_RELEASE_RESET();
+        __USART1_CLK_ENABLE();
+#if defined(RCC_USART1CLKSOURCE_SYSCLK) 
+        __HAL_RCC_USART1_CONFIG(RCC_USART1CLKSOURCE_SYSCLK);
+#endif
+        obj_s->index = 0;
+    }
+#if defined(USART2_BASE)
+    if (obj_s->uart == UART_2) {
+        __USART2_FORCE_RESET();
+        __USART2_RELEASE_RESET();
+        __USART2_CLK_ENABLE();
+#if defined(RCC_USART2CLKSOURCE_SYSCLK)
+        __HAL_RCC_USART2_CONFIG(RCC_USART2CLKSOURCE_SYSCLK);
+#endif
+        obj_s->index = 1;
+    }
+#endif
 #if defined(USART3_BASE)
-        case UART_3:
-            __HAL_RCC_USART3_FORCE_RESET();
-            __HAL_RCC_USART3_RELEASE_RESET();
-            __HAL_RCC_USART3_CLK_ENABLE();
-            obj_s->index = 2;
-            break;
+    if (obj_s->uart == UART_3) {
+        __USART3_FORCE_RESET();
+        __USART3_RELEASE_RESET();
+        __USART3_CLK_ENABLE();
+#if defined(RCC_USART3CLKSOURCE_SYSCLK)
+        __HAL_RCC_USART3_CONFIG(RCC_USART3CLKSOURCE_SYSCLK);
+#endif
+        obj_s->index = 2;
+    }
 #endif
 #if defined(UART4_BASE)
-        case UART_4:
-            __HAL_RCC_UART4_FORCE_RESET();
-            __HAL_RCC_UART4_RELEASE_RESET();
-            __HAL_RCC_UART4_CLK_ENABLE();
-            obj_s->index = 3;
-            break;
+    if (obj_s->uart == UART_4) {
+        __UART4_FORCE_RESET();
+        __UART4_RELEASE_RESET();
+        __UART4_CLK_ENABLE();
+#if defined(RCC_UART4CLKSOURCE_SYSCLK)
+        __HAL_RCC_UART4_CONFIG(RCC_UART4CLKSOURCE_SYSCLK);
+#endif
+        obj_s->index = 3;
+    }
 #endif
 #if defined(UART5_BASE)
-        case UART_5:
-            __HAL_RCC_UART5_FORCE_RESET();
-            __HAL_RCC_UART5_RELEASE_RESET();
-            __HAL_RCC_UART5_CLK_ENABLE();
-            obj_s->index = 4;
-            break;
+    if (obj_s->uart == UART_5) {
+        __HAL_RCC_UART5_FORCE_RESET();
+        __HAL_RCC_UART5_RELEASE_RESET();
+        __UART5_CLK_ENABLE();
+#if defined(RCC_UART5CLKSOURCE_SYSCLK)
+        __HAL_RCC_UART5_CONFIG(RCC_UART5CLKSOURCE_SYSCLK);
 #endif
-#if defined(USART6_BASE)
-        case UART_6:
-            __HAL_RCC_USART6_FORCE_RESET();
-            __HAL_RCC_USART6_RELEASE_RESET();
-            __HAL_RCC_USART6_CLK_ENABLE();
-            obj_s->index = 5;
-            break;
-#endif
-#if defined(UART7_BASE)
-        case UART_7:
-            __HAL_RCC_UART7_FORCE_RESET();
-            __HAL_RCC_UART7_RELEASE_RESET();
-            __HAL_RCC_UART7_CLK_ENABLE();
-            obj_s->index = 6;
-            break;
-#endif
-#if defined(UART8_BASE)
-        case UART_8:
-            __HAL_RCC_UART8_FORCE_RESET();
-            __HAL_RCC_UART8_RELEASE_RESET();
-            __HAL_RCC_UART8_CLK_ENABLE();
-            obj_s->index = 7;
-            break;
-#endif
+        obj_s->index = 4;
     }
+#endif
 
     // Configure the UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
@@ -182,7 +132,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     obj_s->databits = UART_WORDLENGTH_8B;
     obj_s->stopbits = UART_STOPBITS_1;
     obj_s->parity   = UART_PARITY_NONE;
-    
+
 #if DEVICE_SERIAL_FC
     obj_s->hw_flow_ctl = UART_HWCONTROL_NONE;
 #endif
@@ -202,63 +152,40 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 void serial_free(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
-    
+      
     // Reset UART and disable clock
-    switch (obj_s->index) {
-        case 0:
-            __HAL_RCC_USART1_FORCE_RESET();
-            __HAL_RCC_USART1_RELEASE_RESET();
-            __HAL_RCC_USART1_CLK_DISABLE();
-            break;
-        case 1:
-            __HAL_RCC_USART2_FORCE_RESET();
-            __HAL_RCC_USART2_RELEASE_RESET();
-            __HAL_RCC_USART2_CLK_DISABLE();
-            break;
+    if (obj_s->uart == UART_1) {
+        __USART1_FORCE_RESET();
+        __USART1_RELEASE_RESET();
+        __USART1_CLK_DISABLE();
+    }
+    if (obj_s->uart == UART_2) {
+        __USART2_FORCE_RESET();
+        __USART2_RELEASE_RESET();
+        __USART2_CLK_DISABLE();
+    }
 #if defined(USART3_BASE)
-        case 2:
-            __HAL_RCC_USART3_FORCE_RESET();
-            __HAL_RCC_USART3_RELEASE_RESET();
-            __HAL_RCC_USART3_CLK_DISABLE();
-            break;
+    if (obj_s->uart == UART_3) {
+        __USART3_FORCE_RESET();
+        __USART3_RELEASE_RESET();
+        __USART3_CLK_DISABLE();
+    }
 #endif
 #if defined(UART4_BASE)
-        case 3:
-            __HAL_RCC_UART4_FORCE_RESET();
-            __HAL_RCC_UART4_RELEASE_RESET();
-            __HAL_RCC_UART4_CLK_DISABLE();
-            break;
+    if (obj_s->uart == UART_4) {
+        __UART4_FORCE_RESET();
+        __UART4_RELEASE_RESET();
+        __UART4_CLK_DISABLE();
+    }
 #endif
 #if defined(UART5_BASE)
-        case 4:
-            __HAL_RCC_UART5_FORCE_RESET();
-            __HAL_RCC_UART5_RELEASE_RESET();
-            __HAL_RCC_UART5_CLK_DISABLE();
-            break;
-#endif
-#if defined(USART6_BASE)
-        case 5:
-            __HAL_RCC_USART6_FORCE_RESET();
-            __HAL_RCC_USART6_RELEASE_RESET();
-            __HAL_RCC_USART6_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART7_BASE)
-        case 6:
-            __HAL_RCC_UART7_FORCE_RESET();
-            __HAL_RCC_UART7_RELEASE_RESET();
-            __HAL_RCC_UART7_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART8_BASE)
-        case 7:
-            __HAL_RCC_UART8_FORCE_RESET();
-            __HAL_RCC_UART8_RELEASE_RESET();
-            __HAL_RCC_UART8_CLK_DISABLE();
-            break;
-#endif
+    if (obj_s->uart == UART_5) {
+        __UART5_FORCE_RESET();
+        __UART5_RELEASE_RESET();
+        __UART5_CLK_DISABLE();
     }
-    
+#endif
+
     // Configure GPIOs
     pin_function(obj_s->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
     pin_function(obj_s->pin_rx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
@@ -269,41 +196,8 @@ void serial_free(serial_t *obj)
 void serial_baud(serial_t *obj, int baudrate)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
-  
+
     obj_s->baudrate = baudrate;
-    init_uart(obj);
-}
-
-void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-  
-    if (data_bits == 9) {
-        obj_s->databits = UART_WORDLENGTH_9B;
-    } else {
-        obj_s->databits = UART_WORDLENGTH_8B;
-    }
-
-    switch (parity) {
-        case ParityOdd:
-            obj_s->parity = UART_PARITY_ODD;
-            break;
-        case ParityEven:
-            obj_s->parity = UART_PARITY_EVEN;
-            break;
-        default: // ParityNone
-        case ParityForced0: // unsupported!
-        case ParityForced1: // unsupported!
-            obj_s->parity = UART_PARITY_NONE;
-            break;
-    }
-
-    if (stop_bits == 2) {
-        obj_s->stopbits = UART_STOPBITS_2;
-    } else {
-        obj_s->stopbits = UART_STOPBITS_1;
-    }
-
     init_uart(obj);
 }
 
@@ -318,19 +212,20 @@ static void uart_irq(int id)
     if (serial_irq_ids[id] != 0) {
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TC) != RESET) {
-                irq_handler(serial_irq_ids[id], TxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
-            }
+            irq_handler(serial_irq_ids[id], TxIrq);
+                __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
+        }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET) {
-                irq_handler(serial_irq_ids[id], RxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
+            irq_handler(serial_irq_ids[id], RxIrq);
+                volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE flag
+                UNUSED(tmpval);
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, USART_IT_ERR) != RESET) {
-                volatile uint32_t tmpval = huart->Instance->DR; // Clear ORE flag
+            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ORE) != RESET) {
+                __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
             }
         }
     }
@@ -367,27 +262,6 @@ static void uart5_irq(void)
 }
 #endif
 
-#if defined(USART6_BASE)
-static void uart6_irq(void)
-{
-    uart_irq(5);
-}
-#endif
-
-#if defined(UART7_BASE)
-static void uart7_irq(void)
-{
-    uart_irq(6);
-}
-#endif
-
-#if defined(UART8_BASE)
-static void uart8_irq(void)
-{
-    uart_irq(7);
-}
-#endif
-
 void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
@@ -403,53 +277,36 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
     IRQn_Type irq_n = (IRQn_Type)0;
     uint32_t vector = 0;
 
-    switch (obj_s->index) {
-        case 0:
-            irq_n = USART1_IRQn;
-            vector = (uint32_t)&uart1_irq;
-            break;
-
-        case 1:
-            irq_n = USART2_IRQn;
-            vector = (uint32_t)&uart2_irq;
-            break;
-#if defined(USART3_BASE)
-        case 2:
-            irq_n = USART3_IRQn;
-            vector = (uint32_t)&uart3_irq;
-            break;
-#endif
-#if defined(UART4_BASE)
-        case 3:
-            irq_n = UART4_IRQn;
-            vector = (uint32_t)&uart4_irq;
-            break;
-#endif
-#if defined(UART5_BASE)
-        case 4:
-            irq_n = UART5_IRQn;
-            vector = (uint32_t)&uart5_irq;
-            break;
-#endif
-#if defined(USART6_BASE)
-        case 5:
-            irq_n = USART6_IRQn;
-            vector = (uint32_t)&uart6_irq;
-            break;
-#endif
-#if defined(UART7_BASE)
-        case 6:
-            irq_n = UART7_IRQn;
-            vector = (uint32_t)&uart7_irq;
-            break;
-#endif
-#if defined(UART8_BASE)
-        case 7:
-            irq_n = UART8_IRQn;
-            vector = (uint32_t)&uart8_irq;
-            break;
-#endif
+    if (obj_s->uart == UART_1) {
+        irq_n = USART1_IRQn;
+        vector = (uint32_t)&uart1_irq;
     }
+
+    if (obj_s->uart == UART_2) {
+        irq_n = USART2_IRQn;
+        vector = (uint32_t)&uart2_irq;
+    }
+
+#if defined(USART3_BASE)
+    if (obj_s->uart == UART_3) {
+        irq_n = USART3_IRQn;
+        vector = (uint32_t)&uart3_irq;
+    }
+#endif
+
+#if defined(UART4_BASE)
+    if (obj_s->uart == UART_4) {
+        irq_n = UART4_IRQn;
+        vector = (uint32_t)&uart4_irq;
+    }
+#endif
+
+#if defined(UART5_BASE)
+    if (obj_s->uart == UART_5) {
+        irq_n = UART5_IRQn;
+        vector = (uint32_t)&uart5_irq;
+    }
+#endif
 
     if (enable) {
         if (irq == RxIrq) {
@@ -457,8 +314,8 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         } else { // TxIrq
             __HAL_UART_ENABLE_IT(huart, UART_IT_TC);
         }
-            NVIC_SetVector(irq_n, vector);
-            NVIC_EnableIRQ(irq_n);
+        NVIC_SetVector(irq_n, vector);
+        NVIC_EnableIRQ(irq_n);
 
     } else { // disable
         int all_disabled = 0;
@@ -477,7 +334,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         }
 
         if (all_disabled) {
-          NVIC_DisableIRQ(irq_n);
+            NVIC_DisableIRQ(irq_n);
         }
     }
 }
@@ -490,18 +347,26 @@ int serial_getc(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+
     while (!serial_readable(obj));
-    return (int)(huart->Instance->DR & 0x1FF);
+    if (obj_s->databits == UART_WORDLENGTH_8B) {
+        return (int)(huart->Instance->RDR & (uint8_t)0xFF);
+    } else {
+        return (int)(huart->Instance->RDR & (uint16_t)0x1FF);
+    }
 }
 
 void serial_putc(serial_t *obj, int c)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+
     while (!serial_writable(obj));
-    huart->Instance->DR = (uint32_t)(c & 0x1FF);
+    if (obj_s->databits == UART_WORDLENGTH_8B) {
+        huart->Instance->TDR = (uint8_t)(c & (uint8_t)0xFF);
+    } else {
+        huart->Instance->TDR = (uint16_t)(c & (uint16_t)0x1FF);
+    }
 }
 
 int serial_readable(serial_t *obj)
@@ -526,9 +391,9 @@ void serial_clear(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    huart->TxXferCount = 0;
-    huart->RxXferCount = 0;
+
+    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
+    __HAL_UART_SEND_REQ(huart, UART_RXDATA_FLUSH_REQUEST);
 }
 
 void serial_pinout_tx(PinName tx)
@@ -629,16 +494,14 @@ static IRQn_Type serial_get_irq_n(serial_t *obj)
     IRQn_Type irq_n;
 
     switch (obj_s->index) {
-#if defined(USART1_BASE)
         case 0:
             irq_n = USART1_IRQn;
             break;
-#endif
-#if defined(USART2_BASE)
+
         case 1:
             irq_n = USART2_IRQn;
             break;
-#endif
+
 #if defined(USART3_BASE)
         case 2:
             irq_n = USART3_IRQn;
@@ -649,24 +512,9 @@ static IRQn_Type serial_get_irq_n(serial_t *obj)
             irq_n = UART4_IRQn;
             break;
 #endif
-#if defined(USART5_BASE)
+#if defined(UART5_BASE)
         case 4:
             irq_n = UART5_IRQn;
-            break;
-#endif
-#if defined(USART6_BASE)
-        case 5:
-            irq_n = USART6_IRQn;
-            break;
-#endif
-#if defined(UART7_BASE)
-        case 6:
-            irq_n = UART7_IRQn;
-            break;
-#endif
-#if defined(UART8_BASE)
-        case 7:
-            irq_n = UART8_IRQn;
             break;
 #endif
         default:
@@ -675,6 +523,7 @@ static IRQn_Type serial_get_irq_n(serial_t *obj)
     
     return irq_n;
 }
+
 
 /******************************************************************************
  * MBED API FUNCTIONS
@@ -812,19 +661,22 @@ uint8_t serial_rx_active(serial_t *obj)
 
 void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-        __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
     }
 }
 
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart) {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear PE flag
-    } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear FE flag
-    } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_NE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear NE flag
-    } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear ORE flag
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_PEF);
+    }
+    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_FEF);
+    }
+    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_NE) != RESET) {
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_NEF);
+    }
+    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
     }
 }
 
@@ -921,8 +773,8 @@ void serial_tx_abort_asynch(serial_t *obj)
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
     
     // clear flags
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
-
+    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
+    
     // reset states
     huart->TxXferCount = 0;
     // update handle state
@@ -950,8 +802,9 @@ void serial_rx_abort_asynch(serial_t *obj)
     __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
     
     // clear flags
-    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
-    volatile uint32_t tmpval = huart->Instance->DR; // Clear errors flag
+    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_OREF);
+    volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE flag
+    UNUSED(tmpval);
     
     // reset states
     huart->RxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2014, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,69 +29,30 @@
  */
 #include "mbed_assert.h"
 #include "serial_api.h"
+#include "serial_api_hal.h"
 
 #if DEVICE_SERIAL
 
 #include "cmsis.h"
 #include "pinmap.h"
+#include "mbed_error.h"
 #include <string.h>
 #include "PeripheralPins.h"
-#include "mbed_error.h"
 
-#define UART_NUM (8)
+#define UART_NUM (5)
+
 static uint32_t serial_irq_ids[UART_NUM] = {0};
-static UART_HandleTypeDef uart_handlers[UART_NUM];
+UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
 
 int stdio_uart_inited = 0;
 serial_t stdio_uart;
 
-#if DEVICE_SERIAL_ASYNCH
-    #define SERIAL_S(obj) (&((obj)->serial))
-#else
-    #define SERIAL_S(obj) (obj)
-#endif
-
-
-static void init_uart(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    huart->Instance = (USART_TypeDef *)(obj_s->uart);
-
-    huart->Init.BaudRate     = obj_s->baudrate;
-    huart->Init.WordLength   = obj_s->databits;
-    huart->Init.StopBits     = obj_s->stopbits;
-    huart->Init.Parity       = obj_s->parity;
-#if DEVICE_SERIAL_FC
-    huart->Init.HwFlowCtl    = obj_s->hw_flow_ctl;
-#else
-    huart->Init.HwFlowCtl    = UART_HWCONTROL_NONE;
-#endif
-    huart->Init.OverSampling = UART_OVERSAMPLING_16;
-    huart->TxXferCount       = 0;
-    huart->TxXferSize        = 0;
-    huart->RxXferCount       = 0;
-    huart->RxXferSize        = 0;
-
-    if (obj_s->pin_rx == NC) {
-        huart->Init.Mode = UART_MODE_TX;
-    } else if (obj_s->pin_tx == NC) {
-        huart->Init.Mode = UART_MODE_RX;
-    } else {
-        huart->Init.Mode = UART_MODE_TX_RX;
-    }
-
-    if (HAL_UART_Init(huart) != HAL_OK) {
-        error("Cannot initialize UART\n");
-    }
-}
-
 void serial_init(serial_t *obj, PinName tx, PinName rx)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
-  
+    
     // Determine the UART to use (UART_1, UART_2, ...)
     UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
     UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
@@ -101,69 +62,42 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     MBED_ASSERT(obj_s->uart != (UARTName)NC);
 
     // Enable USART clock
-    switch (obj_s->uart) {
-        case UART_1:
-            __HAL_RCC_USART1_FORCE_RESET();
-            __HAL_RCC_USART1_RELEASE_RESET();
-            __HAL_RCC_USART1_CLK_ENABLE();
-            obj_s->index = 0;
-            break;
-            
-        case UART_2:
-            __HAL_RCC_USART2_FORCE_RESET();
-            __HAL_RCC_USART2_RELEASE_RESET();
-            __HAL_RCC_USART2_CLK_ENABLE();
-            obj_s->index = 1;
-            break;
-#if defined(USART3_BASE)
-        case UART_3:
-            __HAL_RCC_USART3_FORCE_RESET();
-            __HAL_RCC_USART3_RELEASE_RESET();
-            __HAL_RCC_USART3_CLK_ENABLE();
-            obj_s->index = 2;
-            break;
-#endif
+    if (obj_s->uart == UART_1) {
+        __HAL_RCC_USART1_FORCE_RESET();
+        __HAL_RCC_USART1_RELEASE_RESET();
+        __HAL_RCC_USART1_CLK_ENABLE();
+        obj_s->index = 0;
+    }
+    if (obj_s->uart == UART_2) {
+        __HAL_RCC_USART2_FORCE_RESET();
+        __HAL_RCC_USART2_RELEASE_RESET();
+        __HAL_RCC_USART2_CLK_ENABLE();
+        obj_s->index = 1;
+    }
+    if (obj_s->uart == UART_3) {
+        __HAL_RCC_USART3_FORCE_RESET();
+        __HAL_RCC_USART3_RELEASE_RESET();
+        __HAL_RCC_USART3_CLK_ENABLE();
+        obj_s->index = 2;
+    }
 #if defined(UART4_BASE)
-        case UART_4:
-            __HAL_RCC_UART4_FORCE_RESET();
-            __HAL_RCC_UART4_RELEASE_RESET();
-            __HAL_RCC_UART4_CLK_ENABLE();
-            obj_s->index = 3;
-            break;
+    if (obj_s->uart == UART_4) {
+        __HAL_RCC_UART4_FORCE_RESET();
+        __HAL_RCC_UART4_RELEASE_RESET();
+        __HAL_RCC_UART4_CLK_ENABLE();
+        obj_s->index = 3;
+    }
 #endif
 #if defined(UART5_BASE)
-        case UART_5:
-            __HAL_RCC_UART5_FORCE_RESET();
-            __HAL_RCC_UART5_RELEASE_RESET();
-            __HAL_RCC_UART5_CLK_ENABLE();
-            obj_s->index = 4;
-            break;
-#endif
-        case UART_6:
-            __HAL_RCC_USART6_FORCE_RESET();
-            __HAL_RCC_USART6_RELEASE_RESET();
-            __HAL_RCC_USART6_CLK_ENABLE();
-            obj_s->index = 5;
-            break;
-#if defined(UART7_BASE)
-        case UART_7:
-            __HAL_RCC_UART7_FORCE_RESET();
-            __HAL_RCC_UART7_RELEASE_RESET();
-            __HAL_RCC_UART7_CLK_ENABLE();
-            obj_s->index = 6;
-            break;
-#endif
-#if defined(UART8_BASE)
-        case UART_8:
-            __HAL_RCC_UART8_FORCE_RESET();
-            __HAL_RCC_UART8_RELEASE_RESET();
-            __HAL_RCC_UART8_CLK_ENABLE();
-            obj_s->index = 7;
-            break;
-#endif
+    if (obj_s->uart == UART_5) {
+        __HAL_RCC_UART5_FORCE_RESET();
+        __HAL_RCC_UART5_RELEASE_RESET();
+        __HAL_RCC_UART5_CLK_ENABLE();
+        obj_s->index = 4;
     }
+#endif
 
-    // Configure the UART pins
+    // Configure UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
     pinmap_pinout(rx, PinMap_UART_RX);
     
@@ -199,61 +133,39 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 void serial_free(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
-    
+      
     // Reset UART and disable clock
-    switch (obj_s->uart) {
-        case UART_1:
-            __USART1_FORCE_RESET();
-            __USART1_RELEASE_RESET();
-            __USART1_CLK_DISABLE();
-            break;
-        case UART_2:
-            __USART2_FORCE_RESET();
-            __USART2_RELEASE_RESET();
-            __USART2_CLK_DISABLE();
-            break;
-#if defined(USART3_BASE)
-        case UART_3:
-            __USART3_FORCE_RESET();
-            __USART3_RELEASE_RESET();
-            __USART3_CLK_DISABLE();
-            break;
-#endif
+    if (obj_s->uart == UART_1) {
+        __USART1_FORCE_RESET();
+        __USART1_RELEASE_RESET();
+        __USART1_CLK_DISABLE();
+    }
+    if (obj_s->uart == UART_2) {
+        __USART2_FORCE_RESET();
+        __USART2_RELEASE_RESET();
+        __USART2_CLK_DISABLE();
+    }
+    if (obj_s->uart == UART_3) {
+        __USART3_FORCE_RESET();
+        __USART3_RELEASE_RESET();
+        __USART3_CLK_DISABLE();
+    }
+
 #if defined(UART4_BASE)
-        case UART_4:
-            __UART4_FORCE_RESET();
-            __UART4_RELEASE_RESET();
-            __UART4_CLK_DISABLE();
-            break;
+    if (obj_s->uart == UART_4) {
+        __UART4_FORCE_RESET();
+        __UART4_RELEASE_RESET();
+        __UART4_CLK_DISABLE();
+    }
 #endif
 #if defined(UART5_BASE)
-        case UART_5:
-            __UART5_FORCE_RESET();
-            __UART5_RELEASE_RESET();
-            __UART5_CLK_DISABLE();
-            break;
-#endif
-        case UART_6:
-            __USART6_FORCE_RESET();
-            __USART6_RELEASE_RESET();
-            __USART6_CLK_DISABLE();
-            break;
-#if defined(UART7_BASE)
-        case UART_7:
-            __UART7_FORCE_RESET();
-            __UART7_RELEASE_RESET();
-            __UART7_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART8_BASE)
-        case UART_8:
-            __UART8_FORCE_RESET();
-            __UART8_RELEASE_RESET();
-            __UART8_CLK_DISABLE();
-            break;
-#endif
+    if (obj_s->uart == UART_5) {
+        __UART5_FORCE_RESET();
+        __UART5_RELEASE_RESET();
+        __UART5_CLK_DISABLE();
     }
-    
+#endif
+
     // Configure GPIOs
     pin_function(obj_s->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
     pin_function(obj_s->pin_rx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
@@ -264,41 +176,8 @@ void serial_free(serial_t *obj)
 void serial_baud(serial_t *obj, int baudrate)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
-  
+
     obj_s->baudrate = baudrate;
-    init_uart(obj);
-}
-
-void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-  
-    if (data_bits == 9) {
-        obj_s->databits = UART_WORDLENGTH_9B;
-    } else {
-        obj_s->databits = UART_WORDLENGTH_8B;
-    }
-
-    switch (parity) {
-        case ParityOdd:
-            obj_s->parity = UART_PARITY_ODD;
-            break;
-        case ParityEven:
-            obj_s->parity = UART_PARITY_EVEN;
-            break;
-        default: // ParityNone
-        case ParityForced0: // unsupported!
-        case ParityForced1: // unsupported!
-            obj_s->parity = UART_PARITY_NONE;
-            break;
-    }
-
-    if (stop_bits == 2) {
-        obj_s->stopbits = UART_STOPBITS_2;
-    } else {
-        obj_s->stopbits = UART_STOPBITS_1;
-    }
-
     init_uart(obj);
 }
 
@@ -314,18 +193,18 @@ static void uart_irq(int id)
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TC) != RESET) {
                 irq_handler(serial_irq_ids[id], TxIrq);
-                __HAL_UART_CLEAR_IT(huart, UART_CLEAR_TCF);
+                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET) {
                 irq_handler(serial_irq_ids[id], RxIrq);
-                volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE
+                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ORE) != RESET) {
-                __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
+            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET) {
+                volatile uint32_t tmpval = huart->Instance->DR; // Clear ORE flag
             }
         }
     }
@@ -341,12 +220,10 @@ static void uart2_irq(void)
     uart_irq(1);
 }
 
-#if defined(USART3_BASE)
 static void uart3_irq(void)
 {
     uart_irq(2);
 }
-#endif
 
 #if defined(UART4_BASE)
 static void uart4_irq(void)
@@ -354,30 +231,10 @@ static void uart4_irq(void)
     uart_irq(3);
 }
 #endif
-
 #if defined(UART5_BASE)
 static void uart5_irq(void)
 {
     uart_irq(4);
-}
-#endif
-
-static void uart6_irq(void)
-{
-    uart_irq(5);
-}
-
-#if defined(UART7_BASE)
-static void uart7_irq(void)
-{
-    uart_irq(6);
-}
-#endif
-
-#if defined(UART8_BASE)
-static void uart8_irq(void)
-{
-    uart_irq(7);
 }
 #endif
 
@@ -396,51 +253,32 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
     IRQn_Type irq_n = (IRQn_Type)0;
     uint32_t vector = 0;
 
-    switch (obj_s->uart) {
-        case UART_1:
-            irq_n = USART1_IRQn;
-            vector = (uint32_t)&uart1_irq;
-            break;
+    if (obj_s->uart == UART_1) {
+        irq_n = USART1_IRQn;
+        vector = (uint32_t)&uart1_irq;
+    }
 
-        case UART_2:
-            irq_n = USART2_IRQn;
-            vector = (uint32_t)&uart2_irq;
-            break;
-#if defined(USART3_BASE)
-        case UART_3:
-            irq_n = USART3_IRQn;
-            vector = (uint32_t)&uart3_irq;
-            break;
-#endif
+    if (obj_s->uart == UART_2) {
+        irq_n = USART2_IRQn;
+        vector = (uint32_t)&uart2_irq;
+    }
+
+    if (obj_s->uart == UART_3) {
+        irq_n = USART3_IRQn;
+        vector = (uint32_t)&uart3_irq;
+    }
 #if defined(UART4_BASE)
-        case UART_4:
-            irq_n = UART4_IRQn;
-            vector = (uint32_t)&uart4_irq;
-            break;
+    if (obj_s->uart == UART_4) {
+        irq_n = UART4_IRQn;
+        vector = (uint32_t)&uart4_irq;
+    }
 #endif
 #if defined(UART5_BASE)
-        case UART_5:
-            irq_n = UART5_IRQn;
-            vector = (uint32_t)&uart5_irq;
-            break;
-#endif
-        case UART_6:
-            irq_n = USART6_IRQn;
-            vector = (uint32_t)&uart6_irq;
-            break;
-#if defined(UART7_BASE)
-        case UART_7:
-            irq_n = UART7_IRQn;
-            vector = (uint32_t)&uart7_irq;
-            break;
-#endif
-#if defined(UART8_BASE)
-        case UART_8:
-            irq_n = UART8_IRQn;
-            vector = (uint32_t)&uart8_irq;
-            break;
-#endif
+    if (obj_s->uart == UART_5) {
+        irq_n = UART5_IRQn;
+        vector = (uint32_t)&uart5_irq;
     }
+#endif
 
     if (enable) {
         if (irq == RxIrq) {
@@ -481,18 +319,26 @@ int serial_getc(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+
     while (!serial_readable(obj));
-    return (int)(huart->Instance->RDR & 0x1FF);
+    if (obj_s->databits == UART_WORDLENGTH_8B) {
+        return (int)(huart->Instance->DR & (uint8_t)0xFF);
+    } else {
+        return (int)(huart->Instance->DR & (uint16_t)0x1FF);
+    }
 }
 
 void serial_putc(serial_t *obj, int c)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+
     while (!serial_writable(obj));
-    huart->Instance->TDR = (uint32_t)(c & 0x1FF);
+    if (obj_s->databits == UART_WORDLENGTH_8B) {
+        huart->Instance->DR = (uint8_t)(c & (uint8_t)0xFF);
+    } else {
+        huart->Instance->DR = (uint16_t)(c & (uint16_t)0x1FF);
+    }
 }
 
 int serial_readable(serial_t *obj)
@@ -517,9 +363,9 @@ void serial_clear(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-
-    __HAL_UART_CLEAR_IT(huart, UART_FLAG_TXE);
-    __HAL_UART_CLEAR_IT(huart, UART_FLAG_RXNE);
+    
+    huart->TxXferCount = 0;
+    huart->RxXferCount = 0;
 }
 
 void serial_pinout_tx(PinName tx)
@@ -620,7 +466,6 @@ static IRQn_Type serial_get_irq_n(serial_t *obj)
     IRQn_Type irq_n;
 
     switch (obj_s->index) {
-
         case 0:
             irq_n = USART1_IRQn;
             break;
@@ -628,11 +473,10 @@ static IRQn_Type serial_get_irq_n(serial_t *obj)
         case 1:
             irq_n = USART2_IRQn;
             break;
-#if defined(USART3_BASE)
+
         case 2:
             irq_n = USART3_IRQn;
             break;
-#endif
 #if defined(UART4_BASE)
         case 3:
             irq_n = UART4_IRQn;
@@ -641,19 +485,6 @@ static IRQn_Type serial_get_irq_n(serial_t *obj)
 #if defined(UART5_BASE)
         case 4:
             irq_n = UART5_IRQn;
-            break;
-#endif
-        case 5:
-            irq_n = USART6_IRQn;
-            break;
-#if defined(UART7_BASE)
-        case 6:
-            irq_n = UART7_IRQn;
-            break;
-#endif
-#if defined(UART8_BASE)
-        case 7:
-            irq_n = UART8_IRQn;
             break;
 #endif
         default:
@@ -695,7 +526,7 @@ int serial_tx_asynch(serial_t *obj, const void *tx, size_t tx_length, uint8_t tx
     if (tx_length == 0) {
         return 0;
     }
-
+  
     // Set up buffer
     serial_tx_buffer_set(obj, (void *)tx, tx_length, tx_width);
   
@@ -799,22 +630,19 @@ uint8_t serial_rx_active(serial_t *obj)
 
 void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-        __HAL_UART_CLEAR_IT(huart, UART_CLEAR_TCF);
+        __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
     }
 }
 
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart) {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
-        __HAL_UART_CLEAR_IT(huart, UART_CLEAR_PEF);
-    }
-    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
-        __HAL_UART_CLEAR_IT(huart, UART_CLEAR_FEF);
-    }
-    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_NE) != RESET) {
-        __HAL_UART_CLEAR_IT(huart, UART_CLEAR_NEF);
-    }
-    if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-        __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
+        volatile uint32_t tmpval = huart->Instance->DR; // Clear PE flag
+    } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
+        volatile uint32_t tmpval = huart->Instance->DR; // Clear FE flag
+    } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_NE) != RESET) {
+        volatile uint32_t tmpval = huart->Instance->DR; // Clear NE flag
+    } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
+        volatile uint32_t tmpval = huart->Instance->DR; // Clear ORE flag
     }
 }
 
@@ -848,8 +676,8 @@ int serial_irq_handler_asynch(serial_t *obj)
         if (__HAL_UART_GET_IT_SOURCE(huart, USART_IT_ERR) != RESET) {
             return_event |= (SERIAL_EVENT_RX_PARITY_ERROR & obj_s->events);
         }
-    }
-    
+}
+
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
         if (__HAL_UART_GET_IT_SOURCE(huart, USART_IT_ERR) != RESET) {
             return_event |= (SERIAL_EVENT_RX_FRAMING_ERROR & obj_s->events);
@@ -891,8 +719,8 @@ int serial_irq_handler_asynch(serial_t *obj)
                 }
             }
         }
-    }
-    
+}
+
     return return_event;  
 }
 
@@ -911,15 +739,15 @@ void serial_tx_abort_asynch(serial_t *obj)
     __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
     
     // clear flags
-    __HAL_UART_CLEAR_IT(huart, UART_FLAG_TC);
-
+    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
+    
     // reset states
     huart->TxXferCount = 0;
     // update handle state
-    if(huart->gState == HAL_UART_STATE_BUSY_TX_RX) {
-        huart->gState = HAL_UART_STATE_BUSY_RX;
+    if(huart->State == HAL_UART_STATE_BUSY_TX_RX) {
+        huart->State = HAL_UART_STATE_BUSY_RX;
     } else {
-        huart->gState = HAL_UART_STATE_READY;
+        huart->State = HAL_UART_STATE_READY;
     }
 }
 
@@ -940,19 +768,16 @@ void serial_rx_abort_asynch(serial_t *obj)
     __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
     
     // clear flags
-    volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE
-    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_PEF);
-    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_FEF);
-    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_NEF);
-    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
+    __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
+    volatile uint32_t tmpval = huart->Instance->DR; // Clear errors flag
     
     // reset states
     huart->RxXferCount = 0;
     // update handle state
-    if(huart->RxState == HAL_UART_STATE_BUSY_TX_RX) {
-        huart->RxState = HAL_UART_STATE_BUSY_TX;
+    if(huart->State == HAL_UART_STATE_BUSY_TX_RX) {
+        huart->State = HAL_UART_STATE_BUSY_TX;
     } else {
-        huart->RxState = HAL_UART_STATE_READY;
+        huart->State = HAL_UART_STATE_READY;
     }
 }
 

--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -1,0 +1,122 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2015, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include "mbed_assert.h"
+#include "mbed_error.h"
+#include "serial_api.h"
+#include "serial_api_hal.h"
+
+#if DEVICE_SERIAL
+
+void init_uart(serial_t *obj)
+{
+    struct serial_s *obj_s = SERIAL_S(obj);
+    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
+    huart->Instance = (USART_TypeDef *)(obj_s->uart);
+
+    huart->Init.BaudRate     = obj_s->baudrate;
+    huart->Init.WordLength   = obj_s->databits;
+    huart->Init.StopBits     = obj_s->stopbits;
+    huart->Init.Parity       = obj_s->parity;
+#if DEVICE_SERIAL_FC
+    huart->Init.HwFlowCtl    = obj_s->hw_flow_ctl;
+#else
+    huart->Init.HwFlowCtl    = UART_HWCONTROL_NONE;
+#endif
+    huart->Init.OverSampling = UART_OVERSAMPLING_16;
+    huart->TxXferCount       = 0;
+    huart->TxXferSize        = 0;
+    huart->RxXferCount       = 0;
+    huart->RxXferSize        = 0;
+
+    if (obj_s->pin_rx == NC) {
+        huart->Init.Mode = UART_MODE_TX;
+    } else if (obj_s->pin_tx == NC) {
+        huart->Init.Mode = UART_MODE_RX;
+    } else {
+        huart->Init.Mode = UART_MODE_TX_RX;
+    }
+
+    if (HAL_UART_Init(huart) != HAL_OK) {
+        error("Cannot initialize UART\n");
+    }
+}
+
+void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits)
+{
+    struct serial_s *obj_s = SERIAL_S(obj);
+
+    switch (parity) {
+        case ParityOdd:
+            obj_s->parity = UART_PARITY_ODD;
+            break;
+        case ParityEven:
+            obj_s->parity = UART_PARITY_EVEN;
+            break;
+        default: // ParityNone
+        case ParityForced0: // unsupported!
+        case ParityForced1: // unsupported!
+            obj_s->parity = UART_PARITY_NONE;
+            break;
+    }
+
+    switch (data_bits) {
+        case 9:
+            MBED_ASSERT(parity == UART_PARITY_NONE);
+            obj_s->databits = UART_WORDLENGTH_9B;
+            break;
+        default:
+        case 8:
+            if (parity != UART_PARITY_NONE) {
+                obj_s->databits = UART_WORDLENGTH_9B;
+            } else {
+                obj_s->databits = UART_WORDLENGTH_8B;
+            }
+            break;
+#if defined UART_WORDLENGTH_7B
+        case 7:
+            if (parity != UART_PARITY_NONE) {
+                obj_s->databits = UART_WORDLENGTH_8B;
+            } else {
+                obj_s->databits = UART_WORDLENGTH_7B;
+            }
+            break;
+#endif
+    }
+
+    if (stop_bits == 2) {
+        obj_s->stopbits = UART_STOPBITS_2;
+    } else {
+        obj_s->stopbits = UART_STOPBITS_1;
+    }
+
+    init_uart(obj);
+}
+
+#endif /* DEVICE_SERIAL */

--- a/targets/TARGET_STM/serial_api_hal.h
+++ b/targets/TARGET_STM/serial_api_hal.h
@@ -1,0 +1,63 @@
+/* mbed Microcontroller Library
+*******************************************************************************
+* Copyright (c) 2016, STMicroelectronics
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+* 3. Neither the name of STMicroelectronics nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************
+*/
+
+#ifndef MBED_SERIAL_API_HAL_H
+#define MBED_SERIAL_API_HAL_H
+
+#include "serial_api.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Extend serial_api.h
+ */
+
+#if DEVICE_SERIAL_ASYNCH
+    #define SERIAL_S(obj) (&((obj)->serial))
+#else
+    #define SERIAL_S(obj) (obj)
+#endif
+
+extern UART_HandleTypeDef uart_handlers[];
+
+
+/** Initialize and configure the UART peripheral
+ *
+ * @param obj       The serial object containing the configuration
+ */
+void init_uart(serial_t *obj);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
## Description
Reworked the serial_format() function for STM32F0x devices to take the format in the form:
`data_bits - parity - stop_bits`
(E.g. 8 - N - 1) where data_bits exclude the parity bit.
Added a case for 7 bits data as at least STM32F0x1/STM32F0x2/STM32F0x8 support 7 bits data.
Consolidated serial_format() and uart_init() functions into a general TARGET_STM serial_api.c file since the functions are common to all STM targets.

## Status
DONE

## Migrations
YES
After this is merged, behaviour for STM32s will be consistent with the API behaviour for other manufacturers. Users won't be able to specify 9bits data + (parity != none). Users will have to review their applications to ensure the way they specify their format takes into account that the parity bit is no longer included in the data_bits count.

Fixes #4189