### PR TITLE
Fix timeout units in events timing test

### DIFF
--- a/TESTS/events/timing/main.cpp
+++ b/TESTS/events/timing/main.cpp
@@ -104,7 +104,7 @@ void semaphore_timing_test() {
 
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases) {
-    GREENTEA_SETUP((number_of_cases+1)*TEST_EVENTS_TIMING_TIME, "default_auto");
+    GREENTEA_SETUP((number_of_cases+1)*TEST_EVENTS_TIMING_TIME/1000, "default_auto");
     return verbose_test_setup_handler(number_of_cases);
 }
 


### PR DESCRIPTION
A units mistake led to passing 20000 seconds instead of 20000 milliseconds to greentea. The would cause the test to spin for 6 hours if it got stuck anywhere.

@bridadan noticed this popping up during testing of the feature_cmsis5 branch
cc @bulislaw 
