### PR TITLE
fixed missing device_name for xDot and removed progen

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1291,10 +1291,10 @@
         "default_toolchain": "ARM",
         "extra_labels": ["STM", "STM32L1", "STM32L151CC"],
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
-        "progen": {"target": "xdot-l151cc"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "default_lib": "std",
-        "release_versions": ["5"]
+        "release_versions": ["5"],
+        "device_name": "STM32L151CC"
     },
     "MOTE_L152RC": {
         "inherits": ["Target"],


### PR DESCRIPTION
## Description
xDot targets has device_name missing so uvision will not export.

## Status
**READY**


Resolves #4221 