### PR TITLE
Usb host msd block device

### DIFF
--- a/features/unsupported/USBHost/USBHostMSD/USBHostMSD.cpp
+++ b/features/unsupported/USBHost/USBHostMSD/USBHostMSD.cpp
@@ -74,6 +74,11 @@ bool USBHostMSD::connect()
                 break;
 
             if (msd_device_found) {
+                /* As this is done in a specific thread
+                 * this lock is taken to avoid to process a disconnection in
+                 * usb process during the device registering */
+                USBHost::Lock  Lock(host);
+
                 bulk_in = dev->getEndpoint(msd_intf, BULK_ENDPOINT, IN);
                 bulk_out = dev->getEndpoint(msd_intf, BULK_ENDPOINT, OUT);
 

--- a/features/unsupported/USBHost/USBHostMSD/USBHostMSD.h
+++ b/features/unsupported/USBHost/USBHostMSD/USBHostMSD.h
@@ -23,24 +23,26 @@
 
 #include "USBHost.h"
 #include "FATFileSystem.h"
+#include "BlockDevice.h"
 
 /**
  * A class to communicate a USB flash disk
  */
-class USBHostMSD : public IUSBEnumerator, public FATFileSystem {
+class USBHostMSD : public IUSBEnumerator, public BlockDevice
+{
 public:
     /**
-    * Constructor
-    *
-    * @param rootdir mount name
-    */
-    USBHostMSD(const char * rootdir);
+     * Constructor
+     *
+     * @param rootdir mount name
+     */
+    USBHostMSD();
 
     /**
-    * Check if a MSD device is connected
-    *
-    * @return true if a MSD device is connected
-    */
+     * Check if a MSD device is connected
+     *
+     * @return true if a MSD device is connected
+     */
     bool connected();
 
     /**
@@ -49,6 +51,20 @@ public:
      * @return true if connection was successful
      */
     bool connect();
+    virtual int init();
+    virtual int deinit()
+    {
+        return BD_ERROR_OK;
+    };
+    virtual int read(void *buffer, bd_addr_t addr, bd_size_t size);
+    virtual int program(const void *buffer, bd_addr_t addr, bd_size_t size);
+    virtual int erase(bd_addr_t addr, bd_size_t size);
+    virtual bd_size_t get_read_size() const;
+    virtual bd_size_t get_program_size() const;
+    virtual bd_size_t get_erase_size() const;
+    virtual bd_size_t size() const;
+
+
 
 protected:
     //From IUSBEnumerator
@@ -56,13 +72,6 @@ protected:
     virtual bool parseInterface(uint8_t intf_nb, uint8_t intf_class, uint8_t intf_subclass, uint8_t intf_protocol); //Must return true if the interface should be parsed
     virtual bool useEndpoint(uint8_t intf_nb, ENDPOINT_TYPE type, ENDPOINT_DIRECTION dir); //Must return true if the endpoint will be used
 
-    // From FATFileSystem
-    virtual int disk_initialize();
-    virtual int disk_status() {return 0;};
-    virtual int disk_read(uint8_t* buffer, uint32_t sector, uint32_t count);
-    virtual int disk_write(const uint8_t* buffer, uint32_t sector, uint32_t count);
-    virtual int disk_sync() {return 0;};
-    virtual uint32_t disk_sectors();
 
 private:
     USBHost * host;
@@ -110,7 +119,7 @@ private:
     bool msd_device_found;
     bool disk_init;
 
-    void init();
+    void init_usb();
 
 };
 

--- a/features/unsupported/tests/usb/host/mass_storage/main.cpp
+++ b/features/unsupported/tests/usb/host/mass_storage/main.cpp
@@ -1,42 +1,68 @@
 #include "mbed.h"
 #include "USBHostMSD.h"
 DigitalOut led(LED1);
-void msd_task(void const *) {
-	printf("init msd\n");
-	USBHostMSD msd("usb");
-	int i = 0;
-	printf("wait for usb memory stick insertion\n");
-	while(1) {
+#include "FATFileSystem.h"
+#include <stdlib.h>
 
-		// try to connect a MSD device
-		while(!msd.connect()) {
-			Thread::wait(500);
-		}
 
-		// in a loop, append a file
-		// if the device is disconnected, we try to connect it again
+void msd_task(void const *)
+{
 
-		// append a file
-		FILE * fp = fopen("/usb/test1.txt", "a");
+    USBHostMSD msd;
+    int i = 0;
+    FATFileSystem fs("usb");
+    int err;
+    printf("wait for usb memory stick insertion\n");
+    while(1) {
 
-		if (fp != NULL) {
-			fprintf(fp, "Hello fun SD Card World: %d!\r\n", i++);
-			printf("Goodbye World!\r\n");
-			fclose(fp);
-		} else {
-			printf("FILE == NULL\r\n");
-		}
-		Thread::wait(500);
-		printf("again\n");
-		// if device disconnected, try to connect again
-		while (msd.connected()) {
-			Thread::wait(500);
-		}
-	}
+        // try to connect a MSD device
+        while(!msd.connect()) {
+            Thread::wait(500);
+        }
+        if (fs.mount(&msd) != 0) {
+            continue;
+        } else {
+            printf("file system mounted\n");
+        }
+
+        if  (!msd.connect()) {
+            continue;
+        }
+
+        // in a loop, append a file
+        // if the device is disconnected, we try to connect it again
+
+        // append a file
+        File file;
+        err = file.open(&fs, "test1.txt", O_WRONLY | O_CREAT |O_APPEND);
+
+        if (err == 0) {
+            char tmp[100];
+            sprintf(tmp,"Hello fun USB stick  World: %d!\r\n", i++);
+            file.write(tmp,strlen(tmp));
+            sprintf(tmp,"Goodbye World!\r\n");
+            file.write(tmp,strlen(tmp));
+            file.close();
+        } else {
+            printf("FILE == NULL\r\n");
+        }
+        Thread::wait(500);
+        printf("again\n");
+        // if device disconnected, try to connect again
+        while (msd.connected()) {
+            Thread::wait(500);
+        }
+        while (fs.unmount() < 0) {
+            Thread::wait(500);
+            printf("unmount\n");
+        }
+    }
 }
 
-int main() {
+int main()
+{
     Thread msdTask(msd_task, NULL, osPriorityNormal, 1024 * 4);
+
     while(1) {
         led=!led;
         Thread::wait(500);


### PR DESCRIPTION
## Description
Since BlockDevice has been introduced USBHostMSD is no more supported.
With this patch USBhostMSD inherits from BlockDevice , and can be used with  FATFileSystem class.
## Migration
As USBHostMSD does not inherit from FATFilesystem any more, the code using the class has to be modified.  
## Status
READY


