### PR TITLE
[platform] Update doxygen comments

### DIFF
--- a/doxygen_options.json
+++ b/doxygen_options.json
@@ -8,5 +8,5 @@
     "PREDEFINED": "DOXYGEN_ONLY \"MBED_DEPRECATED_SINCE(f, g)=\"",
     "EXPAND_AS_DEFINED": "", 
     "SKIP_FUNCTION_MACROS": "NO",
-    "EXCLUDE_PATTERNS": "*/targets/* */features/FEATURE_*/* */features/mbedtls/* */features/nanostack/* */features/storage/* */features/unsupported/* */features/frameworks/* */features/filesystem/fat/* */BUILD/* */rtos/* */events/* */platform/* */cmsis/* */hal/* */features/*"
+    "EXCLUDE_PATTERNS": "*/targets/* */features/FEATURE_*/* */features/mbedtls/* */features/nanostack/* */features/storage/* */features/unsupported/* */features/frameworks/* */features/filesystem/fat/* */BUILD/* */rtos/* */events/* */cmsis/* */hal/* */features/*"
 }

--- a/doxygen_options.json
+++ b/doxygen_options.json
@@ -5,8 +5,8 @@
     "SEARCH_INCLUDES": "YES",
     "INCLUDE_PATH": "", 
     "INCLUDE_FILE_PATTERNS": "", 
-    "PREDEFINED": "DOXYGEN_ONLY \"MBED_DEPRECATED_SINCE(f, g)=\"",
+    "PREDEFINED": "DOXYGEN_ONLY \"MBED_DEPRECATED_SINCE(f, g)=\" \"MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, M)=\"",
     "EXPAND_AS_DEFINED": "", 
     "SKIP_FUNCTION_MACROS": "NO",
-    "EXCLUDE_PATTERNS": "*/targets/* */features/FEATURE_*/* */features/mbedtls/* */features/nanostack/* */features/storage/* */features/unsupported/* */features/frameworks/* */features/filesystem/fat/* */BUILD/* */rtos/* */events/* */cmsis/* */hal/* */features/*"
+    "EXCLUDE_PATTERNS": "*/tools/* */TESTS/* */targets/* */features/FEATURE_*/* */features/mbedtls/* */features/nanostack/* */features/storage/* */features/unsupported/* */features/frameworks/* */features/filesystem/fat/* */BUILD/* */rtos/* */events/* */cmsis/* */hal/* */features/*"
 }

--- a/platform/CThunk.h
+++ b/platform/CThunk.h
@@ -77,7 +77,7 @@ typedef void (*CThunkEntry)(void);
 /**
  * Class for created a pointer with data bound to it
  *
- * @Note Synchronization level: Not protected
+ * @note Synchronization level: Not protected
  * @ingroup platform
  */
 template<class T>

--- a/platform/CallChain.h
+++ b/platform/CallChain.h
@@ -27,7 +27,7 @@ namespace mbed {
  * sequence using CallChain::call(). Used mostly by the interrupt chaining code,
  * but can be used for other purposes.
  *
- * @Note Synchronization level: Not protected
+ * @note Synchronization level: Not protected
  *
  * Example:
  * @code

--- a/platform/CallChain.h
+++ b/platform/CallChain.h
@@ -114,8 +114,8 @@ public:
 
     /** Add a function at the beginning of the chain
      *
-     *  @param tptr pointer to the object to call the member function on
-     *  @param mptr pointer to the member function to be called
+     *  @param obj pointer to the object to call the member function on
+     *  @param method pointer to the member function to be called
      *
      *  @returns
      *  The function object created for 'tptr' and 'mptr'

--- a/platform/Callback.h
+++ b/platform/Callback.h
@@ -160,7 +160,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -172,7 +172,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -184,7 +184,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -196,7 +196,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -404,7 +404,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f     Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -421,7 +421,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f     Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -438,7 +438,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -455,7 +455,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -571,6 +571,8 @@ public:
 
     /** Static thunk for passing as C-style function
      *  @param func Callback to call passed as void pointer
+     *  @return the value as determined by func which is of 
+     *      type and determined by the signiture of func
      */
     static R thunk(void *func) {
         return static_cast<Callback*>(func)->call();
@@ -756,7 +758,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -768,7 +770,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -780,7 +782,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -792,7 +794,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -1000,7 +1002,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -1017,7 +1019,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -1034,7 +1036,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -1051,7 +1053,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -1167,6 +1169,9 @@ public:
 
     /** Static thunk for passing as C-style function
      *  @param func Callback to call passed as void pointer
+     *  @param a0 An argument to be called with function func
+     *  @return the value as determined by func which is of 
+     *      type and determined by the signiture of func
      */
     static R thunk(void *func, A0 a0) {
         return static_cast<Callback*>(func)->call(a0);
@@ -1352,7 +1357,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -1364,7 +1369,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -1376,7 +1381,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -1388,7 +1393,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -1596,7 +1601,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -1613,7 +1618,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -1630,7 +1635,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -1647,7 +1652,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -1763,6 +1768,10 @@ public:
 
     /** Static thunk for passing as C-style function
      *  @param func Callback to call passed as void pointer
+     *  @param a0 An argument to be called with function func
+     *  @param a1 An argument to be called with function func
+     *  @return the value as determined by func which is of 
+     *      type and determined by the signiture of func
      */
     static R thunk(void *func, A0 a0, A1 a1) {
         return static_cast<Callback*>(func)->call(a0, a1);
@@ -1948,7 +1957,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -1960,7 +1969,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -1972,7 +1981,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -1984,7 +1993,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -2192,7 +2201,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -2209,7 +2218,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -2226,7 +2235,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -2243,7 +2252,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -2359,6 +2368,11 @@ public:
 
     /** Static thunk for passing as C-style function
      *  @param func Callback to call passed as void pointer
+     *  @param a0 An argument to be called with function func
+     *  @param a1 An argument to be called with function func
+     *  @param a2 An argument to be called with function func
+     *  @return the value as determined by func which is of 
+     *      type and determined by the signiture of func
      */
     static R thunk(void *func, A0 a0, A1 a1, A2 a2) {
         return static_cast<Callback*>(func)->call(a0, a1, a2);
@@ -2544,7 +2558,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -2556,7 +2570,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -2568,7 +2582,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -2580,7 +2594,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -2788,7 +2802,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -2805,7 +2819,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -2822,7 +2836,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -2839,7 +2853,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -2955,6 +2969,12 @@ public:
 
     /** Static thunk for passing as C-style function
      *  @param func Callback to call passed as void pointer
+     *  @param a0 An argument to be called with function func
+     *  @param a1 An argument to be called with function func
+     *  @param a2 An argument to be called with function func
+     *  @param a3 An argument to be called with function func
+     *  @return the value as determined by func which is of 
+     *      type and determined by the signiture of func
      */
     static R thunk(void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
         return static_cast<Callback*>(func)->call(a0, a1, a2, a3);
@@ -3140,7 +3160,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -3152,7 +3172,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -3164,7 +3184,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -3176,7 +3196,7 @@ public:
     }
 
     /** Create a Callback with a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
@@ -3384,7 +3404,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -3401,7 +3421,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -3418,7 +3438,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -3435,7 +3455,7 @@ public:
     }
 
     /** Attach a function object
-     *  @param func     Function object to attach
+     *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -3551,6 +3571,13 @@ public:
 
     /** Static thunk for passing as C-style function
      *  @param func Callback to call passed as void pointer
+     *  @param a0 An argument to be called with function func
+     *  @param a1 An argument to be called with function func
+     *  @param a2 An argument to be called with function func
+     *  @param a3 An argument to be called with function func
+     *  @param a4 An argument to be called with function func
+     *  @return the value as determined by func which is of 
+     *      type and determined by the signiture of func
      */
     static R thunk(void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
         return static_cast<Callback*>(func)->call(a0, a1, a2, a3, a4);

--- a/platform/Callback.h
+++ b/platform/Callback.h
@@ -58,6 +58,12 @@ namespace detail {
     };
 }
 
+#define MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, M)                            \
+    typename detail::enable_if<                                             \
+            detail::is_type<M, &F::operator()>::value &&                    \
+            sizeof(F) <= sizeof(uintptr_t)                                  \
+        >::type = detail::nil()
+
 /** Callback class based on template specialization
  *
  * @note Synchronization level: Not protected
@@ -164,10 +170,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)())) {
         generate(f);
     }
 
@@ -176,10 +179,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)() const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)() const)) {
         generate(f);
     }
 
@@ -188,10 +188,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)() volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)() volatile)) {
         generate(f);
     }
 
@@ -200,10 +197,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)() const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)() const volatile)) {
         generate(f);
     }
 
@@ -412,10 +406,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)())) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -429,10 +420,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)() const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)() const)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -446,10 +434,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)() volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)() volatile)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -463,10 +448,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)() const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)() const volatile)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -762,10 +744,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0))) {
         generate(f);
     }
 
@@ -774,10 +753,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0) const)) {
         generate(f);
     }
 
@@ -786,10 +762,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0) volatile)) {
         generate(f);
     }
 
@@ -798,10 +771,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0) const volatile)) {
         generate(f);
     }
 
@@ -1010,10 +980,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0))) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -1027,10 +994,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0) const)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -1044,10 +1008,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0) volatile)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -1061,10 +1022,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0) const volatile)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -1361,10 +1319,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1))) {
         generate(f);
     }
 
@@ -1373,10 +1328,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1) const)) {
         generate(f);
     }
 
@@ -1385,10 +1337,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1) volatile)) {
         generate(f);
     }
 
@@ -1397,10 +1346,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1) const volatile)) {
         generate(f);
     }
 
@@ -1609,10 +1555,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1))) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -1626,10 +1569,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1) const)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -1643,10 +1583,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1) volatile)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -1660,10 +1597,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1) const volatile)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -1961,10 +1895,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2))) {
         generate(f);
     }
 
@@ -1973,10 +1904,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2) const)) {
         generate(f);
     }
 
@@ -1985,10 +1913,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2) volatile)) {
         generate(f);
     }
 
@@ -1997,10 +1922,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2) const volatile)) {
         generate(f);
     }
 
@@ -2209,10 +2131,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2))) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -2226,10 +2145,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2) const)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -2243,10 +2159,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2) volatile)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -2260,10 +2173,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2) const volatile)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -2562,10 +2472,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3))) {
         generate(f);
     }
 
@@ -2574,10 +2481,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3) const)) {
         generate(f);
     }
 
@@ -2586,10 +2490,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3) volatile)) {
         generate(f);
     }
 
@@ -2598,10 +2499,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3) const volatile)) {
         generate(f);
     }
 
@@ -2810,10 +2708,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3))) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -2827,10 +2722,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3) const)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -2844,10 +2736,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3) volatile)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -2861,10 +2750,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3) const volatile)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -3164,10 +3050,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3, A4))) {
         generate(f);
     }
 
@@ -3176,10 +3059,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3, A4) const)) {
         generate(f);
     }
 
@@ -3188,10 +3068,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3, A4) volatile)) {
         generate(f);
     }
 
@@ -3200,10 +3077,7 @@ public:
      *  @note The function object is limited to a single word of storage
      */
     template <typename F>
-    Callback(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    Callback(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3, A4) const volatile)) {
         generate(f);
     }
 
@@ -3412,10 +3286,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4), &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3, A4))) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -3429,10 +3300,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(const F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) const, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(const F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3, A4) const)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -3446,10 +3314,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3, A4) volatile)) {
         this->~Callback();
         new (this) Callback(f);
     }
@@ -3463,10 +3328,7 @@ public:
     template <typename F>
     MBED_DEPRECATED_SINCE("mbed-os-5.4",
         "Replaced by simple assignment 'Callback cb = func")
-    void attach(const volatile F f, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) const volatile, &F::operator()>::value &&
-                sizeof(F) <= sizeof(uintptr_t)
-            >::type = detail::nil()) {
+    void attach(const volatile F f, MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, R (F::*)(A0, A1, A2, A3, A4) const volatile)) {
         this->~Callback();
         new (this) Callback(f);
     }

--- a/platform/CircularBuffer.h
+++ b/platform/CircularBuffer.h
@@ -23,7 +23,7 @@ namespace mbed {
 
 /** Templated Circular buffer class
  *
- *  @Note Synchronization level: Interrupt safe
+ *  @note Synchronization level: Interrupt safe
  *  @ingroup platform
  */
 template<typename T, uint32_t BufferSize, typename CounterType = uint32_t>

--- a/platform/DirHandle.h
+++ b/platform/DirHandle.h
@@ -38,7 +38,7 @@ namespace mbed {
  *  reflect this.
  *
  *  @note to create a directory, @see Dir
- *  @Note Synchronization level: Set by subclass
+ *  @note Synchronization level: Set by subclass
  *  @ingroup platform
  */
 class DirHandle {

--- a/platform/DirHandle.h
+++ b/platform/DirHandle.h
@@ -47,7 +47,6 @@ public:
 
     /** Read the next directory entry
      *
-     *  @param path     The buffer to read the null terminated path name in to
      *  @param ent      The directory entry to fill out
      *  @return         1 on reading a filename, 0 at end of directory, negative error on failure
      */

--- a/platform/FileLike.h
+++ b/platform/FileLike.h
@@ -28,7 +28,7 @@ namespace mbed {
  *  A file-like object is one that can be opened with fopen by
  *  fopen("/name", mode).
  *
- *  @Note Synchronization level: Set by subclass
+ *  @note Synchronization level: Set by subclass
  *  @ingroup platform
  */
 class FileLike : public FileHandle, public FileBase {

--- a/platform/FileSystemLike.h
+++ b/platform/FileSystemLike.h
@@ -31,7 +31,7 @@ namespace mbed {
  *  Implementations must define at least open (the default definitions
  *  of the rest of the functions just return error values).
  *
- * @Note Synchronization level: Set by subclass
+ * @note Synchronization level: Set by subclass
  * @ingroup platform
  */
 class FileSystemLike : public FileBase {

--- a/platform/FileSystemLike.h
+++ b/platform/FileSystemLike.h
@@ -69,7 +69,7 @@ public:
     /** Remove a file from the filesystem.
      *
      *  @param filename the name of the file to remove.
-     *  @param returns 0 on success, -1 on failure.
+     *  @returns 0 on success, -1 on failure.
      */
     virtual int remove(const char *filename) { (void) filename; return -1; };
 

--- a/platform/LocalFileSystem.h
+++ b/platform/LocalFileSystem.h
@@ -67,7 +67,7 @@ protected:
  *  mbed Microcontroller. Once created, the standard C file access functions are used to open,
  *  read and write files.
  *
- * @Note Synchronization level: Thread safe
+ * @note Synchronization level: Thread safe
  *
  * Example:
  * @code

--- a/platform/SingletonPtr.h
+++ b/platform/SingletonPtr.h
@@ -59,13 +59,13 @@ inline static void singleton_unlock(void)
 
 /** Utility class for creating an using a singleton
  *
- * @Note Synchronization level: Thread safe
+ * @note Synchronization level: Thread safe
  *
- * @Note: This class must only be used in a static context -
+ * @note: This class must only be used in a static context -
  * this class must never be allocated or created on the
  * stack.
  *
- * @Note: This class is lazily initialized on first use.
+ * @note: This class is lazily initialized on first use.
  * This class is a POD type so if it is not used it will
  * be garbage collected.
  * @ingroup platform

--- a/platform/Stream.h
+++ b/platform/Stream.h
@@ -32,7 +32,7 @@ extern char* mbed_gets(char *s, int size, FILE *_file);
 
 /** File stream
  *
- * @Note Synchronization level: Set by subclass
+ * @note Synchronization level: Set by subclass
  * @ingroup platform
  */
 class Stream : public FileLike {

--- a/platform/Transaction.h
+++ b/platform/Transaction.h
@@ -37,7 +37,7 @@ typedef struct {
 
 /** Transaction class defines a transaction.
  *
- * @Note Synchronization level: Not protected
+ * @note Synchronization level: Not protected
  * @ingroup platform
  */
 template<typename Class>

--- a/platform/mbed_application.h
+++ b/platform/mbed_application.h
@@ -21,7 +21,7 @@
 
 #include<stdint.h>
 
-#define MBED_APPLICATION_SUPPORT (defined(__CORTEX_M3) || defined(__CORTEX_M4) || defined(__CORTEX_M7))
+#define MBED_APPLICATION_SUPPORT defined(__CORTEX_M3) || defined(__CORTEX_M4) || defined(__CORTEX_M7)
 #if MBED_APPLICATION_SUPPORT
 #ifdef __cplusplus
 extern "C" {

--- a/platform/mbed_critical.h
+++ b/platform/mbed_critical.h
@@ -33,7 +33,7 @@ extern "C" {
 /** Determine the current interrupts enabled state
   *
   * This function can be called to determine whether or not interrupts are currently enabled.
-  * \note
+  * @note
   * NOTE:
   * This function works for both cortex-A and cortex-M, although the underlyng implementation
   * differs.
@@ -44,7 +44,7 @@ bool core_util_are_interrupts_enabled(void);
 /** Mark the start of a critical section
   *
   * This function should be called to mark the start of a critical section of code.
-  * \note
+  * @note
   * NOTES:
   * 1) The use of this style of critical section is targetted at C based implementations.
   * 2) These critical sections can be nested.
@@ -57,7 +57,7 @@ void core_util_critical_section_enter(void);
 /** Mark the end of a critical section
   *
   * This function should be called to mark the end of a critical section of code.
-  * \note
+  * @note
   * NOTES:
   * 1) The use of this style of critical section is targetted at C based implementations.
   * 2) These critical sections can be nested.
@@ -82,7 +82,7 @@ void core_util_critical_section_exit(void);
  * @param[in,out] expectedCurrentValue A pointer to some location holding the
  *                              expected current value of the data being set atomically.
  *                              The computed 'desiredValue' should be a function of this current value.
- *                              @Note: This is an in-out parameter. In the
+ *                              @note: This is an in-out parameter. In the
  *                              failure case of atomic_cas (where the
  *                              destination isn't set), the pointee of expectedCurrentValue is
  *                              updated with the current value.
@@ -105,7 +105,7 @@ void core_util_critical_section_exit(void);
  *     return true
  * }
  *
- * @Note: In the failure case (where the destination isn't set), the value
+ * @note: In the failure case (where the destination isn't set), the value
  * pointed to by expectedCurrentValue is still updated with the current value.
  * This property helps writing concise code for the following incr:
  *
@@ -135,7 +135,7 @@ bool core_util_atomic_cas_u8(uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_
  * @param[in,out] expectedCurrentValue A pointer to some location holding the
  *                              expected current value of the data being set atomically.
  *                              The computed 'desiredValue' should be a function of this current value.
- *                              @Note: This is an in-out parameter. In the
+ *                              @note: This is an in-out parameter. In the
  *                              failure case of atomic_cas (where the
  *                              destination isn't set), the pointee of expectedCurrentValue is
  *                              updated with the current value.
@@ -158,7 +158,7 @@ bool core_util_atomic_cas_u8(uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_
  *     return true
  * }
  *
- * @Note: In the failure case (where the destination isn't set), the value
+ * @note: In the failure case (where the destination isn't set), the value
  * pointed to by expectedCurrentValue is still updated with the current value.
  * This property helps writing concise code for the following incr:
  *
@@ -188,7 +188,7 @@ bool core_util_atomic_cas_u16(uint16_t *ptr, uint16_t *expectedCurrentValue, uin
  * @param[in,out] expectedCurrentValue A pointer to some location holding the
  *                              expected current value of the data being set atomically.
  *                              The computed 'desiredValue' should be a function of this current value.
- *                              @Note: This is an in-out parameter. In the
+ *                              @note: This is an in-out parameter. In the
  *                              failure case of atomic_cas (where the
  *                              destination isn't set), the pointee of expectedCurrentValue is
  *                              updated with the current value.
@@ -211,7 +211,7 @@ bool core_util_atomic_cas_u16(uint16_t *ptr, uint16_t *expectedCurrentValue, uin
  *     return true
  * }
  *
- * @Note: In the failure case (where the destination isn't set), the value
+ * @note: In the failure case (where the destination isn't set), the value
  * pointed to by expectedCurrentValue is still updated with the current value.
  * This property helps writing concise code for the following incr:
  *
@@ -241,7 +241,7 @@ bool core_util_atomic_cas_u32(uint32_t *ptr, uint32_t *expectedCurrentValue, uin
  * @param[in,out] expectedCurrentValue A pointer to some location holding the
  *                              expected current value of the data being set atomically.
  *                              The computed 'desiredValue' should be a function of this current value.
- *                              @Note: This is an in-out parameter. In the
+ *                              @note: This is an in-out parameter. In the
  *                              failure case of atomic_cas (where the
  *                              destination isn't set), the pointee of expectedCurrentValue is
  *                              updated with the current value.
@@ -264,7 +264,7 @@ bool core_util_atomic_cas_u32(uint32_t *ptr, uint32_t *expectedCurrentValue, uin
  *     return true
  * }
  *
- * @Note: In the failure case (where the destination isn't set), the value
+ * @note: In the failure case (where the destination isn't set), the value
  * pointed to by expectedCurrentValue is still updated with the current value.
  * This property helps writing concise code for the following incr:
  *

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -53,7 +53,7 @@
  * if(x >= 5) {
  *     error("expected x to be less than 5, but got %d", x);
  * }
- * #endcode
+ * @endcode
  */
 
 #ifdef __cplusplus

--- a/platform/mbed_interface.h
+++ b/platform/mbed_interface.h
@@ -115,14 +115,14 @@ void mbed_die(void);
 /** Print out an error message.  This is typically called when
  * hanlding a crash.
  *
- * @Note Synchronization level: Interrupt safe
+ * @note Synchronization level: Interrupt safe
  */
 void mbed_error_printf(const char* format, ...);
 
 /** Print out an error message.  Similar to mbed_error_printf
  * but uses a va_list.
  *
- * @Note Synchronization level: Interrupt safe
+ * @note Synchronization level: Interrupt safe
  */
 void mbed_error_vfprintf(const char * format, va_list arg);
 

--- a/platform/mbed_mem_trace.h
+++ b/platform/mbed_mem_trace.h
@@ -80,7 +80,7 @@ void *mbed_mem_trace_malloc(void *res, size_t size, void *caller);
  * @param res the result of running 'realloc'.
  * @param ptr the 'ptr' argument given to 'realloc'.
  * @param size the 'size' argument given to 'realloc'.
- *
+ * @param caller the caller of the memory operation.
  * @return 'res' (the first argument).
  */
 void *mbed_mem_trace_realloc(void *res, void *ptr, size_t size, void *caller);
@@ -88,7 +88,7 @@ void *mbed_mem_trace_realloc(void *res, void *ptr, size_t size, void *caller);
 /**
  * Trace a call to 'calloc'.
  * @param res the result of running 'calloc'.
- * @param nmemb the 'nmemb' argument given to 'calloc'.
+ * @param num the 'nmemb' argument given to 'calloc'.
  * @param size the 'size' argument given to 'calloc'.
  * @param caller the caller of the memory operation.
  * @return 'res' (the first argument).
@@ -108,13 +108,13 @@ void mbed_mem_trace_free(void *ptr, void *caller);
  *
  * The default callback outputs trace data using 'printf', in a format that's
  * easily parsable by an external tool. For each memory operation, the callback
- * outputs a line that begins with '#<op>:<0xresult>;<0xcaller>-':
+ * outputs a line that begins with "#<op>:<0xresult>;<0xcaller>-":
  *
  * - 'op' identifies the memory operation ('m' for 'malloc', 'r' for 'realloc',
  *   'c' for 'calloc' and 'f' for 'free').
  * - 'result' (base 16) is the result of the memor operation. This is always NULL
  *   for 'free', since 'free' doesn't return anything.
- * -'caller' (base 16) is the caller of the memory operation. Note that the value
+ * - 'caller' (base 16) is the caller of the memory operation. Note that the value
  *   of 'caller' might be unreliable.
  *
  * The rest of the output depends on the operation being traced:
@@ -126,9 +126,9 @@ void mbed_mem_trace_free(void *ptr, void *caller);
  *
  * Examples:
  *
- * - '#m:0x20003240;0x600d-50' encodes a 'malloc' that returned 0x20003240, was called
+ * - "#m:0x20003240;0x600d-50" encodes a 'malloc' that returned 0x20003240, was called
  *   by the instruction at 0x600D with a the 'size' argument equal to 50.
- * - '#f:0x0;0x602f-0x20003240' encodes a 'free' that was called by the instruction at
+ * - "#f:0x0;0x602f-0x20003240" encodes a 'free' that was called by the instruction at
  *   0x602f with the 'ptr' argument equal to 0x20003240.
  */
 void mbed_mem_trace_default_callback(uint8_t op, void *res, void *caller, ...);

--- a/platform/mbed_mem_trace.h
+++ b/platform/mbed_mem_trace.h
@@ -91,7 +91,7 @@ void *mbed_mem_trace_realloc(void *res, void *ptr, size_t size, void *caller);
  * @param nmemb the 'nmemb' argument given to 'calloc'.
  * @param size the 'size' argument given to 'calloc'.
  * @param caller the caller of the memory operation.
- * @Return 'res' (the first argument).
+ * @return 'res' (the first argument).
  */
 void *mbed_mem_trace_calloc(void *res, size_t num, size_t size, void *caller);
 

--- a/platform/mbed_rtc_time.h
+++ b/platform/mbed_rtc_time.h
@@ -61,7 +61,7 @@ extern "C" {
  *
  * @param t Number of seconds since January 1, 1970 (the UNIX timestamp)
  *
- * @Note Synchronization level: Thread safe
+ * @note Synchronization level: Thread safe
  *
  * Example:
  * @code
@@ -76,7 +76,7 @@ void set_time(time_t t);
 
 /** Attach an external RTC to be used for the C time functions
  *
- * @Note Synchronization level: Thread safe
+ * @note Synchronization level: Thread safe
  *
  * @param read_rtc pointer to function which returns current UNIX timestamp
  * @param write_rtc pointer to function which sets current UNIX timestamp, can be NULL

--- a/platform/mbed_wait_api.h
+++ b/platform/mbed_wait_api.h
@@ -41,6 +41,7 @@ extern "C" {
  *         wait(0.5);
  *     }
  * }
+ * @endcode
  */
 
 /** Waits for a number of seconds, with microsecond resolution (within

--- a/platform/toolchain.h
+++ b/platform/toolchain.h
@@ -24,3 +24,5 @@
 #include "platform/mbed_toolchain.h"
 
 #endif
+
+/** @}*/


### PR DESCRIPTION
# Description
Fix warnings and errors when building API docs in the mbed-os/platform directory using doxygen. Still a rouge warning that I haven't yet gotten to the bottom of but other eyes are welcome. Doxyfile attached that is used to build this (matches the developer site settings)

[doxyfile-developer.txt](https://github.com/ARMmbed/mbed-os/files/960056/doxyfile-developer.txt)

```
C:\dev\mbed-os>doxygen doxyfile-developer
deprecated:11: warning: explicit link request to 'type' could not be resolved
deprecated:14: warning: explicit link request to 'type' could not be resolved
deprecated:17: warning: explicit link request to 'type' could not be resolved
deprecated:53: warning: explicit link request to 'type' could not be resolved
deprecated:83: warning: explicit link request to 'type' could not be resolved
deprecated:86: warning: explicit link request to 'type' could not be resolved
deprecated:89: warning: explicit link request to 'type' could not be resolved
deprecated:92: warning: explicit link request to 'type' could not be resolved
deprecated:173: warning: explicit link request to 'type' could not be resolved
deprecated:176: warning: explicit link request to 'type' could not be resolved
deprecated:179: warning: explicit link request to 'type' could not be resolved
deprecated:182: warning: explicit link request to 'type' could not be resolved
deprecated:227: warning: explicit link request to 'type' could not be resolved
deprecated:230: warning: explicit link request to 'type' could not be resolved
deprecated:233: warning: explicit link request to 'type' could not be resolved
deprecated:251: warning: explicit link request to 'type' could not be resolved
deprecated:305: warning: explicit link request to 'type' could not be resolved
deprecated:311: warning: explicit link request to 'type' could not be resolved
deprecated:314: warning: explicit link request to 'type' could not be resolved
deprecated:317: warning: explicit link request to 'type' could not be resolved
deprecated:338: warning: explicit link request to 'type' could not be resolved
deprecated:362: warning: explicit link request to 'type' could not be resolved
deprecated:380: warning: explicit link request to 'type' could not be resolved
deprecated:383: warning: explicit link request to 'type' could not be resolved

C:\dev\mbed-os>
```
## Status
**IN DEVELOPMENT**