### PR TITLE
STM32 Fixed warning related to __packed redefinition

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/device/stm32f0xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/device/stm32f0xx_hal_def.h
@@ -124,7 +124,7 @@ typedef enum
                                     }while (0)
 #endif /* USE_RTOS */
 
-#if  defined ( __GNUC__ )
+#if  defined ( __GNUC__ ) && !defined ( __CC_ARM )
   #ifndef __weak
     #define __weak   __attribute__((weak))
   #endif /* __weak */

--- a/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_def.h
@@ -124,7 +124,7 @@ typedef enum
                                     }while (0)
 #endif /* USE_RTOS */
 
-#if  defined ( __GNUC__ )
+#if  defined ( __GNUC__ ) && !defined ( __CC_ARM )
   #ifndef __weak
     #define __weak   __attribute__((weak))
   #endif /* __weak */

--- a/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_def.h
@@ -145,7 +145,7 @@ static inline  void atomic_clr_u32(volatile uint32_t *ptr, uint32_t mask)
 	} while (__STREXW(newValue,(volatile unsigned long*) ptr));
 }
 
-#if  defined ( __GNUC__ )
+#if  defined ( __GNUC__ ) && !defined ( __CC_ARM )
   #ifndef __weak
     #define __weak   __attribute__((weak))
   #endif /* __weak */

--- a/targets/TARGET_STM/TARGET_STM32F3/device/stm32f3xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/device/stm32f3xx_hal_def.h
@@ -144,7 +144,7 @@ static inline  void atomic_clr_u32(volatile uint32_t *ptr, uint32_t mask)
 	} while (__STREXW(newValue,(volatile unsigned long*) ptr));
 }
 
-#if  defined ( __GNUC__ )
+#if  defined ( __GNUC__ ) && !defined ( __CC_ARM )
   #ifndef __weak
     #define __weak   __attribute__((weak))
   #endif /* __weak */

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_def.h
@@ -146,7 +146,7 @@ static inline  void atomic_clr_u32(volatile uint32_t *ptr, uint32_t mask)
 
 #endif /* USE_RTOS */
 
-#if  defined ( __GNUC__ )
+#if  defined ( __GNUC__ ) && !defined ( __CC_ARM )
   #ifndef __weak
     #define __weak   __attribute__((weak))
   #endif /* __weak */

--- a/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_def.h
@@ -145,7 +145,7 @@ static inline  void atomic_clr_u32(volatile uint32_t *ptr, uint32_t mask)
 	} while (__STREXW(newValue,(volatile unsigned long*) ptr));
 }
 
-#if  defined ( __GNUC__ )
+#if  defined ( __GNUC__ ) && !defined ( __CC_ARM )
   #ifndef __weak
     #define __weak   __attribute__((weak))
   #endif /* __weak */

--- a/targets/TARGET_STM/TARGET_STM32L0/device/stm32l0xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/device/stm32l0xx_hal_def.h
@@ -127,7 +127,7 @@ typedef enum
                                     }while (0)
 #endif /* USE_RTOS */
 
-#if  defined ( __GNUC__ )
+#if  defined ( __GNUC__ ) && !defined ( __CC_ARM )
   #ifndef __weak
     #define __weak   __attribute__((weak))
   #endif /* __weak */

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_def.h
@@ -124,7 +124,7 @@ typedef enum
                                     }while (0)
 #endif /* USE_RTOS */
 
-#if  defined ( __GNUC__ )
+#if  defined ( __GNUC__ ) && !defined ( __CC_ARM )
   #ifndef __weak
     #define __weak   __attribute__((weak))
   #endif /* __weak */

--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_def.h
@@ -147,7 +147,7 @@ static inline  void atomic_clr_u32(volatile uint32_t *ptr, uint32_t mask)
 	} while (__STREXW(newValue,(volatile unsigned long*) ptr));
 }
 
-#if  defined ( __GNUC__ )
+#if  defined ( __GNUC__ ) && !defined ( __CC_ARM )
   #ifndef __weak
     #define __weak   __attribute__((weak))
   #endif /* __weak */


### PR DESCRIPTION
## Description

This PR solves #3932

Before this patch, many warnings like below were generated
during compilation with ArmCC
[Warning] lwip_ethernet.h@57,0:  3135-D: attribute does not apply to any entity

This happens here as ``--gnu`` option of ArmCC is being used, which
enables the GNU compiler extensions that the ARM compiler supports.

This is solved by adding a extra check on __CCARM .

## Status
**READY**

## Tests results
All STM32 based boards compile OK
The patch was also tested with F429ZI Ethernet tests

![image](https://cloud.githubusercontent.com/assets/17590297/25488019/2c1e734a-2b66-11e7-8b64-6f0305b504d6.png)
