### PR TITLE
lwip - power up emac before reading its settings

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/emac_lwip.c
+++ b/features/FEATURE_LWIP/lwip-interface/emac_lwip.c
@@ -63,10 +63,13 @@ err_t emac_lwip_if_init(struct netif *netif)
     mac->ops.set_link_input_cb(mac, emac_lwip_input, netif);
     mac->ops.set_link_state_cb(mac, emac_lwip_state_change, netif);
 
-    netif->hwaddr_len = mac->ops.get_hwaddr_size(mac);
-    mac->ops.get_hwaddr(mac, netif->hwaddr);
+    if (!mac->ops.power_up(mac)) {
+        err = ERR_IF;
+    }
 
     netif->mtu = mac->ops.get_mtu_size(mac);
+    netif->hwaddr_len = mac->ops.get_hwaddr_size(mac);
+    mac->ops.get_hwaddr(mac, netif->hwaddr);
 
     /* Interface capabilities */
     netif->flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP | NETIF_FLAG_ETHERNET | NETIF_FLAG_IGMP;
@@ -78,10 +81,6 @@ err_t emac_lwip_if_init(struct netif *netif)
 #endif /* LWIP_IPV4 */
 
     netif->linkoutput = emac_lwip_low_level_output;
-
-    if (!mac->ops.power_up(mac)) {
-        err = ERR_IF;
-    }
 
     return err;
 }

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -393,8 +393,6 @@ nsapi_error_t mbed_lwip_init(emac_interface_t *emac)
     // Check if we've already brought up lwip
     if (!mbed_lwip_get_mac_address()) {
         // Set up network
-        mbed_lwip_set_mac_address();
-
         sys_sem_new(&lwip_tcpip_inited, 0);
         sys_sem_new(&lwip_netif_linked, 0);
         sys_sem_new(&lwip_netif_has_addr, 0);
@@ -411,6 +409,7 @@ nsapi_error_t mbed_lwip_init(emac_interface_t *emac)
             return NSAPI_ERROR_DEVICE_ERROR;
         }
 
+        mbed_lwip_set_mac_address();
         netif_set_default(&lwip_netif);
 
         netif_set_link_callback(&lwip_netif, mbed_lwip_netif_link_irq);


### PR DESCRIPTION
## Description

Power up emac before reading its settings, such as mac address, for some emac settings are only available after device is powered up.

## Status
READY

## Migrations
NO

## Related PRs
#3758 

## Todos
NONE

## Deploy notes
NONE

## Steps to test or reproduce
NONE