### PR TITLE
RTX2: Fix nrf52 crash

### DIFF
--- a/rtos/rtx2/mbed_rtx_conf.h
+++ b/rtos/rtx2/mbed_rtx_conf.h
@@ -34,6 +34,8 @@
 
 #define OS_TIMER_THREAD_STACK_SIZE 768
 
+#define OS_IDLE_THREAD_STACK_SIZE   256
+
 #define OS_DYNAMIC_MEM_SIZE         0
 
 #if defined(__CC_ARM)


### PR DESCRIPTION
Various tests, such as tests-mbedmicro-rtos-mbed-basic, fail on the nrf52. This is because the background thread is overflowing on this target - the stack size is 200 bytes while the stack usage is 224 bytes or more. This patch increases the background stack size to 256 bytes to fix this overflow.