### PR TITLE
Networking test fixes

### DIFF
--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/connectivity/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/connectivity/main.cpp
@@ -52,7 +52,7 @@ void test_bring_up_down() {
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases) {
     char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(60, "default_auto", uuid, 48);
+    GREENTEA_SETUP_UUID(120, "default_auto", uuid, 48);
     mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
     return verbose_test_setup_handler(number_of_cases);
 }

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/connectivity/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/connectivity/main.cpp
@@ -52,8 +52,15 @@ void test_bring_up_down() {
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases) {
     char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(120, "default_auto", uuid, 48);
-    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
+    GREENTEA_SETUP_UUID(120, "default_auto", uuid, sizeof(uuid));
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
+
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/connectivity/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/connectivity/main.cpp
@@ -65,8 +65,8 @@ utest::v1::status_t test_setup(const size_t number_of_cases) {
 }
 
 Case cases[] = {
-    Case("Testing bringing the network up and down", test_bring_up_down<1>),
-    Case("Testing bringing the network up and down twice", test_bring_up_down<2>),
+    Case("Bringing the network up and down", test_bring_up_down<1>),
+    Case("Bringing the network up and down twice", test_bring_up_down<2>),
 };
 
 Specification specification(test_setup, cases);

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/connectivity/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/connectivity/main.cpp
@@ -51,7 +51,9 @@ void test_bring_up_down() {
 
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases) {
-    GREENTEA_SETUP(60, "default_auto");
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(60, "default_auto", uuid, 48);
+    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/gethostbyname/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/gethostbyname/main.cpp
@@ -106,10 +106,10 @@ utest::v1::status_t test_setup(const size_t number_of_cases) {
 }
 
 Case cases[] = {
-    Case("Testing DNS query",               test_dns_query),
-    Case("Testing DNS preference query",    test_dns_query_pref),
-    Case("Testing DNS literal",             test_dns_literal),
-    Case("Testing DNS preference literal",  test_dns_literal_pref),
+    Case("DNS query",               test_dns_query),
+    Case("DNS preference query",    test_dns_query_pref),
+    Case("DNS literal",             test_dns_literal),
+    Case("DNS preference literal",  test_dns_literal_pref),
 };
 
 Specification specification(test_setup, cases);

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/gethostbyname/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/gethostbyname/main.cpp
@@ -93,8 +93,15 @@ void test_dns_literal_pref() {
 utest::v1::status_t test_setup(const size_t number_of_cases) {
     char uuid[48] = {0};
     GREENTEA_SETUP_UUID(120, "default_auto", uuid, 48);
-    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
     net_bringup();
+
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/gethostbyname/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/gethostbyname/main.cpp
@@ -92,7 +92,7 @@ void test_dns_literal_pref() {
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases) {
     char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(60, "default_auto", uuid, 48);
+    GREENTEA_SETUP_UUID(120, "default_auto", uuid, 48);
     mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
     net_bringup();
     return verbose_test_setup_handler(number_of_cases);

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/gethostbyname/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/gethostbyname/main.cpp
@@ -91,7 +91,9 @@ void test_dns_literal_pref() {
 
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases) {
-    GREENTEA_SETUP(60, "default_auto");
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(60, "default_auto", uuid, 48);
+    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
     net_bringup();
     return verbose_test_setup_handler(number_of_cases);
 }

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo/main.cpp
@@ -30,9 +30,13 @@ void prep_buffer(char *tx_buffer, size_t tx_size) {
 
 int main() {
     GREENTEA_SETUP(60, "tcp_echo");
-
     EthernetInterface eth;
-    eth.connect();
+    int err = eth.connect();
+
+    if (err) {
+        printf("MBED: failed to connect with an error of %d\r\n", err);
+        GREENTEA_TESTSUITE_RESULT(false);
+    }
 
     printf("MBED: TCPClient IP address is '%s'\n", eth.get_ip_address());
     printf("MBED: TCPClient waiting for server IP and port...\n");
@@ -64,12 +68,12 @@ int main() {
 
         prep_buffer(tx_buffer, sizeof(tx_buffer));
         sock.send(tx_buffer, sizeof(tx_buffer));
-
+        printf("MBED: Finished sending\r\n");
         // Server will respond with HTTP GET's success code
         const int ret = sock.recv(rx_buffer, sizeof(rx_buffer));
-        
+        printf("MBED: Finished receiving\r\n");
+
         result = !memcmp(tx_buffer, rx_buffer, sizeof(tx_buffer));
-        
         TEST_ASSERT_EQUAL(ret, sizeof(rx_buffer));
         TEST_ASSERT_EQUAL(true, result);
     }

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo/main.cpp
@@ -31,7 +31,14 @@ void prep_buffer(char *tx_buffer, size_t tx_size) {
 int main() {
     char uuid[48] = {0};
     GREENTEA_SETUP_UUID(120, "tcp_echo", uuid, 48);
-    mbed_set_mac_address(uuid, /*coerce control bits TRUE */ 1); 
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
+
     EthernetInterface eth;
     int err = eth.connect();
 

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo/main.cpp
@@ -30,7 +30,7 @@ void prep_buffer(char *tx_buffer, size_t tx_size) {
 
 int main() {
     char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(60, "tcp_echo", uuid, 48);
+    GREENTEA_SETUP_UUID(120, "tcp_echo", uuid, 48);
     mbed_set_mac_address(uuid, /*coerce control bits TRUE */ 1); 
     EthernetInterface eth;
     int err = eth.connect();

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo/main.cpp
@@ -29,7 +29,9 @@ void prep_buffer(char *tx_buffer, size_t tx_size) {
 }
 
 int main() {
-    GREENTEA_SETUP(60, "tcp_echo");
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(60, "tcp_echo", uuid, 48);
+    mbed_set_mac_address(uuid, /*coerce control bits TRUE */ 1); 
     EthernetInterface eth;
     int err = eth.connect();
 

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
@@ -64,7 +64,7 @@ public:
         TEST_ASSERT_EQUAL(0, err);
 
         iomutex.lock();
-        printf("HTTP: Connected to %s:%d\r\n", 
+        printf("HTTP: Connected to %s:%d\r\n",
                 tcp_addr.get_ip_address(), tcp_addr.get_port());
         printf("tx_buffer buffer size: %u\r\n", sizeof(tx_buffer));
         printf("rx_buffer buffer size: %u\r\n", sizeof(rx_buffer));
@@ -89,7 +89,7 @@ Echo echoers[MBED_CFG_TCP_CLIENT_ECHO_THREADS];
 
 int main() {
     char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(60, "default_auto", uuid, 48);
+    GREENTEA_SETUP_UUID(60, "tcp_echo", uuid, 48);
     mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
 
     int err = net.connect();

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
@@ -88,7 +88,9 @@ Echo echoers[MBED_CFG_TCP_CLIENT_ECHO_THREADS];
 
 
 int main() {
-    GREENTEA_SETUP(60, "tcp_echo");
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(60, "default_auto", uuid, 48);
+    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
 
     int err = net.connect();
     TEST_ASSERT_EQUAL(0, err);

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
@@ -90,7 +90,13 @@ Echo echoers[MBED_CFG_TCP_CLIENT_ECHO_THREADS];
 int main() {
     char uuid[48] = {0};
     GREENTEA_SETUP_UUID(120, "tcp_echo", uuid, 48);
-    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
 
     int err = net.connect();
     TEST_ASSERT_EQUAL(0, err);

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
@@ -87,7 +87,7 @@ public:
     }
 };
 
-Echo echoers[MBED_CFG_TCP_CLIENT_ECHO_THREADS];
+Echo *echoers[MBED_CFG_TCP_CLIENT_ECHO_THREADS];
 
 
 void test_tcp_echo_parallel() {
@@ -117,11 +117,13 @@ void test_tcp_echo_parallel() {
 
     // Startup echo threads in parallel
     for (int i = 0; i < MBED_CFG_TCP_CLIENT_ECHO_THREADS; i++) {
-        echoers[i].start();
+        echoers[i] = new Echo;
+        echoers[i]->start();
     }
 
     for (int i = 0; i < MBED_CFG_TCP_CLIENT_ECHO_THREADS; i++) {
-        echoers[i].join();
+        echoers[i]->join();
+        delete echoers[i];
     }
 
     net.disconnect();

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
@@ -89,7 +89,7 @@ Echo echoers[MBED_CFG_TCP_CLIENT_ECHO_THREADS];
 
 int main() {
     char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(60, "tcp_echo", uuid, 48);
+    GREENTEA_SETUP_UUID(120, "tcp_echo", uuid, 48);
     mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
 
     int err = net.connect();

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_hello_world/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_hello_world/main.cpp
@@ -11,6 +11,10 @@
 #include "TCPSocket.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
+#include "utest.h"
+
+using namespace utest::v1;
+
 
 namespace {
     // Test connection information
@@ -35,17 +39,7 @@ bool find_substring(const char *first, const char *last, const char *s_first, co
     return (f != last);
 }
 
-int main() {
-    char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(120, "default_auto", uuid, 48);
-
-    // create mac address based on uuid
-    uint64_t mac = 0;
-    for (int i = 0; i < sizeof(uuid); i++) {
-        mac += uuid[i];
-    }
-    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
-
+void test_tcp_hello_world() {
     bool result = false;
     EthernetInterface eth;
     eth.connect();
@@ -90,5 +84,32 @@ int main() {
     }
 
     eth.disconnect();
-    GREENTEA_TESTSUITE_RESULT(result);
+    TEST_ASSERT_EQUAL(true, result);
 }
+
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(120, "default_auto", uuid, 48);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
+
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("TCP hello world", test_tcp_hello_world),
+};
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}
+

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_hello_world/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_hello_world/main.cpp
@@ -37,7 +37,7 @@ bool find_substring(const char *first, const char *last, const char *s_first, co
 
 int main() {
     char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(60, "default_auto", uuid, 48);
+    GREENTEA_SETUP_UUID(120, "default_auto", uuid, 48);
     mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
 
     bool result = false;

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_hello_world/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_hello_world/main.cpp
@@ -38,11 +38,16 @@ bool find_substring(const char *first, const char *last, const char *s_first, co
 int main() {
     char uuid[48] = {0};
     GREENTEA_SETUP_UUID(120, "default_auto", uuid, 48);
-    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
 
     bool result = false;
     EthernetInterface eth;
-    //eth.init(); //Use DHCP
     eth.connect();
     printf("TCP client IP Address is %s\r\n", eth.get_ip_address());
 

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_hello_world/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_hello_world/main.cpp
@@ -36,7 +36,9 @@ bool find_substring(const char *first, const char *last, const char *s_first, co
 }
 
 int main() {
-    GREENTEA_SETUP(60, "default_auto");
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(60, "default_auto", uuid, 48);
+    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
 
     bool result = false;
     EthernetInterface eth;

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure/main.cpp
@@ -108,7 +108,10 @@ void generate_buffer(uint8_t **buffer, size_t *size, size_t min, size_t max) {
 
 
 int main() {
-    GREENTEA_SETUP(60, "tcp_echo");
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(60, "tcp_echo", uuid, 48);
+    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
+
     generate_buffer(&buffer, &buffer_size,
         MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN,
         MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MAX);

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure/main.cpp
@@ -110,7 +110,13 @@ void generate_buffer(uint8_t **buffer, size_t *size, size_t min, size_t max) {
 int main() {
     char uuid[48] = {0};
     GREENTEA_SETUP_UUID(120, "tcp_echo", uuid, 48);
-    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
 
     generate_buffer(&buffer, &buffer_size,
         MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN,

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure/main.cpp
@@ -109,7 +109,7 @@ void generate_buffer(uint8_t **buffer, size_t *size, size_t min, size_t max) {
 
 int main() {
     char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(60, "tcp_echo", uuid, 48);
+    GREENTEA_SETUP_UUID(120, "tcp_echo", uuid, 48);
     mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
 
     generate_buffer(&buffer, &buffer_size,

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure/main.cpp
@@ -13,6 +13,9 @@
 #include "TCPSocket.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
+#include "utest.h"
+
+using namespace utest::v1;
 
 
 #ifndef MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN
@@ -107,17 +110,7 @@ void generate_buffer(uint8_t **buffer, size_t *size, size_t min, size_t max) {
 }
 
 
-int main() {
-    char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(120, "tcp_echo", uuid, 48);
-
-    // create mac address based on uuid
-    uint64_t mac = 0;
-    for (int i = 0; i < sizeof(uuid); i++) {
-        mac += uuid[i];
-    }
-    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
-
+void test_tcp_packet_pressure() {
     generate_buffer(&buffer, &buffer_size,
         MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN,
         MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MAX);
@@ -131,8 +124,6 @@ int main() {
     printf("MBED: TCPClient waiting for server IP and port...\n");
 
     greentea_send_kv("target_ip", eth.get_ip_address());
-
-    bool result = true;
 
     char recv_key[] = "host_port";
     char ipbuf[60] = {0};
@@ -232,5 +223,31 @@ int main() {
             MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN) / (1000*timer.read()));
 
     eth.disconnect();
-    GREENTEA_TESTSUITE_RESULT(result);
 }
+
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(120, "tcp_echo", uuid, 48);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
+
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("TCP packet pressure", test_tcp_packet_pressure),
+};
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}
+

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure_parallel/main.cpp
@@ -227,7 +227,13 @@ PressureTest *pressure_tests[MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_THREADS];
 int main() {
     char uuid[48] = {0};
     GREENTEA_SETUP_UUID(120, "tcp_echo", uuid, 48);
-    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
 
     uint8_t *buffer;
     size_t buffer_size;

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure_parallel/main.cpp
@@ -225,7 +225,9 @@ PressureTest *pressure_tests[MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_THREADS];
 
 
 int main() {
-    GREENTEA_SETUP(2*60, "tcp_echo");
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(60, "tcp_echo", uuid, 48);
+    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
 
     uint8_t *buffer;
     size_t buffer_size;

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure_parallel/main.cpp
@@ -226,7 +226,7 @@ PressureTest *pressure_tests[MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_THREADS];
 
 int main() {
     char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(60, "tcp_echo", uuid, 48);
+    GREENTEA_SETUP_UUID(120, "tcp_echo", uuid, 48);
     mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
 
     uint8_t *buffer;

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_packet_pressure_parallel/main.cpp
@@ -13,6 +13,9 @@
 #include "TCPSocket.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
+#include "utest.h"
+
+using namespace utest::v1;
 
 
 #ifndef MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN
@@ -224,17 +227,7 @@ public:
 PressureTest *pressure_tests[MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_THREADS];
 
 
-int main() {
-    char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(120, "tcp_echo", uuid, 48);
-
-    // create mac address based on uuid
-    uint64_t mac = 0;
-    for (int i = 0; i < sizeof(uuid); i++) {
-        mac += uuid[i];
-    }
-    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
-
+void test_tcp_packet_pressure_parallel() {
     uint8_t *buffer;
     size_t buffer_size;
     generate_buffer(&buffer, &buffer_size,
@@ -254,8 +247,6 @@ int main() {
     printf("MBED: TCPClient waiting for server IP and port...\n");
 
     greentea_send_kv("target_ip", net.get_ip_address());
-
-    bool result = true;
 
     char recv_key[] = "host_port";
     char ipbuf[60] = {0};
@@ -294,5 +285,31 @@ int main() {
             MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN) / (1000*timer.read()));
 
     net.disconnect();
-    GREENTEA_TESTSUITE_RESULT(result);
 }
+
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(120, "tcp_echo", uuid, 48);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
+
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("TCP packet pressure parallel", test_tcp_packet_pressure_parallel),
+};
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}
+

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_dtls_handshake/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_dtls_handshake/main.cpp
@@ -71,6 +71,8 @@ int main() {
 
     UDPSocket sock;
     SocketAddress udp_addr(ipbuf, port);
+    sock.set_blocking(true);
+    sock.set_timeout(1500);
 
     for (int attempt = 0; attempt < MBED_CFG_UDP_DTLS_HANDSHAKE_RETRIES; attempt++) {
         err = sock.open(&eth);

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_dtls_handshake/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_dtls_handshake/main.cpp
@@ -10,6 +10,10 @@
 #include "UDPSocket.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
+#include "utest.h"
+
+using namespace utest::v1;
+
 
 #ifndef MBED_CFG_UDP_DTLS_HANDSHAKE_BUFFER_SIZE
 #define MBED_CFG_UDP_DTLS_HANDSHAKE_BUFFER_SIZE 512
@@ -31,17 +35,7 @@ uint8_t buffer[MBED_CFG_UDP_DTLS_HANDSHAKE_BUFFER_SIZE] = {0};
 int udp_dtls_handshake_pattern[] = {MBED_CFG_UDP_DTLS_HANDSHAKE_PATTERN};
 const int udp_dtls_handshake_count = sizeof(udp_dtls_handshake_pattern) / sizeof(int);
 
-int main() {
-    char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(120, "udp_shotgun", uuid, 48);
-
-    // create mac address based on uuid
-    uint64_t mac = 0;
-    for (int i = 0; i < sizeof(uuid); i++) {
-        mac += uuid[i];
-    }
-    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
-
+void test_udp_dtls_handshake() {
     EthernetInterface eth;
     int err = eth.connect();
     TEST_ASSERT_EQUAL(0, err);
@@ -135,5 +129,32 @@ int main() {
     }
 
     eth.disconnect();
-    GREENTEA_TESTSUITE_RESULT(result);
+    TEST_ASSERT_EQUAL(true, result);
 }
+
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(120, "udp_shotgun", uuid, 48);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
+
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("UDP DTLS handshake", test_udp_dtls_handshake),
+};
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}
+

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_dtls_handshake/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_dtls_handshake/main.cpp
@@ -29,7 +29,7 @@ const int udp_dtls_handshake_count = sizeof(udp_dtls_handshake_pattern) / sizeof
 
 int main() {
     char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(60, "udp_shotgun", uuid, 48);
+    GREENTEA_SETUP_UUID(120, "udp_shotgun", uuid, 48);
     mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
 
     EthernetInterface eth;

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_dtls_handshake/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_dtls_handshake/main.cpp
@@ -34,7 +34,13 @@ const int udp_dtls_handshake_count = sizeof(udp_dtls_handshake_pattern) / sizeof
 int main() {
     char uuid[48] = {0};
     GREENTEA_SETUP_UUID(120, "udp_shotgun", uuid, 48);
-    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
 
     EthernetInterface eth;
     int err = eth.connect();

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_dtls_handshake/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_dtls_handshake/main.cpp
@@ -23,6 +23,10 @@
 #define MBED_CFG_UDP_DTLS_HANDSHAKE_PATTERN 112, 384, 200, 219, 25
 #endif
 
+#ifndef MBED_CFG_UDP_DTLS_HANDSHAKE_TIMEOUT
+#define MBED_CFG_UDP_DTLS_HANDSHAKE_TIMEOUT 1500
+#endif
+
 uint8_t buffer[MBED_CFG_UDP_DTLS_HANDSHAKE_BUFFER_SIZE] = {0};
 int udp_dtls_handshake_pattern[] = {MBED_CFG_UDP_DTLS_HANDSHAKE_PATTERN};
 const int udp_dtls_handshake_count = sizeof(udp_dtls_handshake_pattern) / sizeof(int);
@@ -73,8 +77,7 @@ int main() {
 
     UDPSocket sock;
     SocketAddress udp_addr(ipbuf, port);
-    sock.set_blocking(true);
-    sock.set_timeout(1500);
+    sock.set_timeout(MBED_CFG_UDP_DTLS_HANDSHAKE_TIMEOUT);
 
     for (int attempt = 0; attempt < MBED_CFG_UDP_DTLS_HANDSHAKE_RETRIES; attempt++) {
         err = sock.open(&eth);

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_dtls_handshake/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_dtls_handshake/main.cpp
@@ -28,7 +28,9 @@ int udp_dtls_handshake_pattern[] = {MBED_CFG_UDP_DTLS_HANDSHAKE_PATTERN};
 const int udp_dtls_handshake_count = sizeof(udp_dtls_handshake_pattern) / sizeof(int);
 
 int main() {
-    GREENTEA_SETUP(60, "udp_shotgun");
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(60, "udp_shotgun", uuid, 48);
+    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
 
     EthernetInterface eth;
     int err = eth.connect();

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo/main.cpp
@@ -43,7 +43,7 @@ void prep_buffer(char *uuid_buffer, size_t uuid_len, char *tx_buffer, size_t tx_
 
 int main() {
     char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(60, "udp_echo", uuid, 48);
+    GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
     printf("Got a uuid of %s\r\n", uuid);
     size_t uuid_len = strlen(uuid);
     EthernetInterface eth;

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo/main.cpp
@@ -83,10 +83,23 @@ int main() {
         while (success < ECHO_LOOPS) {
             prep_buffer(uuid, uuid_len, tx_buffer, sizeof(tx_buffer));
             const int ret = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
-            printf("[%02d] sent %d Bytes - %.*s  \n", i, ret, MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE, tx_buffer);
+            if (ret >= 0) {
+                printf("[%02d] sent %d Bytes - %.*s  \n", i, ret, ret, tx_buffer);
+            } else {
+                printf("[%02d] Network error %d\n", i, ret);
+                i++;
+                continue;
+            }
+
             SocketAddress temp_addr;
             const int n = sock.recvfrom(&temp_addr, rx_buffer, sizeof(rx_buffer));
-            printf("[%02d] recv %d Bytes - %.*s  \n", i, ret, MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE, rx_buffer);
+            if (n >= 0) {
+                printf("[%02d] receive %d Bytes - %.*s  \n", i, n, n, tx_buffer);
+            } else {
+                printf("[%02d] Network error %d\n", i, n);
+                i++;
+                continue;
+            }
 
             if ((temp_addr == udp_addr &&
                  n == sizeof(tx_buffer) &&

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo/main.cpp
@@ -47,53 +47,61 @@ int main() {
     printf("Got a uuid of %s\r\n", uuid);
     size_t uuid_len = strlen(uuid);
     EthernetInterface eth;
-    eth.connect();
-    printf("UDP client IP Address is %s\n", eth.get_ip_address());
 
-    greentea_send_kv("target_ip", eth.get_ip_address());
+    int err = eth.connect();
+    TEST_ASSERT_EQUAL(0, err);
 
-    char recv_key[] = "host_port";
-    char ipbuf[60] = {0};
-    char portbuf[16] = {0};
-    unsigned int port = 0;
+    if (err) {
+        printf("MBED: failed to connect with an error of %d\r\n", err);
+        GREENTEA_TESTSUITE_RESULT(false);
+    } else {
+        printf("UDP client IP Address is %s\n", eth.get_ip_address());
 
-    UDPSocket sock;
-    sock.open(&eth);
-    sock.set_timeout(MBED_CFG_UDP_CLIENT_ECHO_TIMEOUT);
+        greentea_send_kv("target_ip", eth.get_ip_address());
 
-    greentea_send_kv("host_ip", " ");
-    greentea_parse_kv(recv_key, ipbuf, sizeof(recv_key), sizeof(ipbuf));
+        char recv_key[] = "host_port";
+        char ipbuf[60] = {0};
+        char portbuf[16] = {0};
+        unsigned int port = 0;
 
-    greentea_send_kv("host_port", " ");
-    greentea_parse_kv(recv_key, portbuf, sizeof(recv_key), sizeof(ipbuf));
-    sscanf(portbuf, "%u", &port);
+        UDPSocket sock;
+        sock.open(&eth);
+        sock.set_timeout(MBED_CFG_UDP_CLIENT_ECHO_TIMEOUT);
 
-    printf("MBED: UDP Server IP address received: %s:%d \n", ipbuf, port);
-    SocketAddress udp_addr(ipbuf, port);
+        greentea_send_kv("host_ip", " ");
+        greentea_parse_kv(recv_key, ipbuf, sizeof(recv_key), sizeof(ipbuf));
 
-    int success = 0;
-    int i = 0;
-    while (success < ECHO_LOOPS) {
-        prep_buffer(uuid, uuid_len, tx_buffer, sizeof(tx_buffer));
-        const int ret = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
-        printf("[%02d] sent %d Bytes - %.*s  \n", i, ret, MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE, tx_buffer);
-        SocketAddress temp_addr;
-        const int n = sock.recvfrom(&temp_addr, rx_buffer, sizeof(rx_buffer));
-        printf("[%02d] recv %d Bytes - %.*s  \n", i, ret, MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE, rx_buffer);
+        greentea_send_kv("host_port", " ");
+        greentea_parse_kv(recv_key, portbuf, sizeof(recv_key), sizeof(ipbuf));
+        sscanf(portbuf, "%u", &port);
 
-        if ((temp_addr == udp_addr &&
-             n == sizeof(tx_buffer) &&
-             memcmp(rx_buffer, tx_buffer, sizeof(rx_buffer)) == 0)) {
-            success += 1;
+        printf("MBED: UDP Server IP address received: %s:%d \n", ipbuf, port);
+        SocketAddress udp_addr(ipbuf, port);
 
-            printf("[%02d] success #%d\n", i, success);
+        int success = 0;
+        int i = 0;
+        while (success < ECHO_LOOPS) {
+            prep_buffer(uuid, uuid_len, tx_buffer, sizeof(tx_buffer));
+            const int ret = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
+            printf("[%02d] sent %d Bytes - %.*s  \n", i, ret, MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE, tx_buffer);
+            SocketAddress temp_addr;
+            const int n = sock.recvfrom(&temp_addr, rx_buffer, sizeof(rx_buffer));
+            printf("[%02d] recv %d Bytes - %.*s  \n", i, ret, MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE, rx_buffer);
+
+            if ((temp_addr == udp_addr &&
+                 n == sizeof(tx_buffer) &&
+                 memcmp(rx_buffer, tx_buffer, sizeof(rx_buffer)) == 0)) {
+                success += 1;
+
+                printf("[%02d] success #%d\n", i, success);
+            }
+            i++;
         }
-        i++;
+
+        bool result = success == ECHO_LOOPS;
+
+        sock.close();
+        eth.disconnect();
+        GREENTEA_TESTSUITE_RESULT(result);
     }
-
-    bool result = success == ECHO_LOOPS;
-
-    sock.close();
-    eth.disconnect();
-    GREENTEA_TESTSUITE_RESULT(result);
 }

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo/main.cpp
@@ -46,6 +46,14 @@ int main() {
     GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
     printf("Got a uuid of %s\r\n", uuid);
     size_t uuid_len = strlen(uuid);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
+
     EthernetInterface eth;
 
     int err = eth.connect();

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo/main.cpp
@@ -89,15 +89,13 @@ int main() {
     SocketAddress udp_addr(ipbuf, port);
 
     int success = 0;
-    int i = 0;
-    while (success < ECHO_LOOPS) {
         prep_buffer(uuid, uuid_len, tx_buffer, sizeof(tx_buffer));
+    for (int i = 0; success < ECHO_LOOPS; i++) {
         const int ret = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
         if (ret >= 0) {
             printf("[%02d] sent %d bytes - %.*s  \n", i, ret, ret, tx_buffer);
         } else {
             printf("[%02d] Network error %d\n", i, ret);
-            i++;
             continue;
         }
 
@@ -107,7 +105,6 @@ int main() {
             printf("[%02d] recv %d bytes - %.*s  \n", i, n, n, tx_buffer);
         } else {
             printf("[%02d] Network error %d\n", i, n);
-            i++;
             continue;
         }
 
@@ -117,7 +114,6 @@ int main() {
             success += 1;
 
             printf("[%02d] success #%d\n", i, success);
-            i++;
             continue;
         }
 

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo/main.cpp
@@ -10,6 +10,10 @@
 #include "UDPSocket.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
+#include "utest.h"
+
+using namespace utest::v1;
+
 
 #ifndef MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE
 #define MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE 64
@@ -25,14 +29,14 @@ namespace {
     char rx_buffer[MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE] = {0};
     const char ASCII_MAX = '~' - ' ';
     const int ECHO_LOOPS = 16;
+    char uuid[48] = {0};
 }
 
-void prep_buffer(char *uuid_buffer, size_t uuid_len, char *tx_buffer, size_t tx_size) {
+void prep_buffer(char *uuid, char *tx_buffer, size_t tx_size) {
     size_t i = 0;
 
-    for (; i<uuid_len; ++i) {
-        tx_buffer[i] = uuid_buffer[i];
-    }
+    memcpy(tx_buffer, uuid, strlen(uuid));
+    i += strlen(uuid);
 
     tx_buffer[i++] = ' ';
 
@@ -41,19 +45,7 @@ void prep_buffer(char *uuid_buffer, size_t uuid_len, char *tx_buffer, size_t tx_
     }
 }
 
-int main() {
-    char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
-    printf("Got a uuid of %s\r\n", uuid);
-    size_t uuid_len = strlen(uuid);
-
-    // create mac address based on uuid
-    uint64_t mac = 0;
-    for (int i = 0; i < sizeof(uuid); i++) {
-        mac += uuid[i];
-    }
-    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
-
+void test_udp_echo() {
     EthernetInterface eth;
 
     int err = eth.connect();
@@ -61,8 +53,7 @@ int main() {
 
     if (err) {
         printf("MBED: failed to connect with an error of %d\r\n", err);
-        GREENTEA_TESTSUITE_RESULT(false);
-        return 0;
+        TEST_ASSERT_EQUAL(0, err);
     }
 
     printf("UDP client IP Address is %s\n", eth.get_ip_address());
@@ -89,8 +80,8 @@ int main() {
     SocketAddress udp_addr(ipbuf, port);
 
     int success = 0;
-        prep_buffer(uuid, uuid_len, tx_buffer, sizeof(tx_buffer));
     for (int i = 0; success < ECHO_LOOPS; i++) {
+        prep_buffer(uuid, tx_buffer, sizeof(tx_buffer));
         const int ret = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
         if (ret >= 0) {
             printf("[%02d] sent %d bytes - %.*s  \n", i, ret, ret, tx_buffer);
@@ -128,9 +119,33 @@ int main() {
         sock.set_timeout(MBED_CFG_UDP_CLIENT_ECHO_TIMEOUT);
     }
 
-    bool result = success == ECHO_LOOPS;
-
     sock.close();
     eth.disconnect();
-    GREENTEA_TESTSUITE_RESULT(result);
+    TEST_ASSERT_EQUAL(ECHO_LOOPS, success);
 }
+
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
+
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("UDP echo", test_udp_echo),
+};
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}
+

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
@@ -90,15 +90,31 @@ public:
         while(success < ECHO_LOOPS) {
             prep_buffer(id, uuid_buffer, uuid_len, tx_buffer, sizeof(tx_buffer));
             const int ret = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
-            iomutex.lock();
-            printf("[ID:%01d][%02d] sent %d Bytes - %.*s\n", id, i, ret, MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE, tx_buffer);
-            iomutex.unlock();
+            if (ret >= 0) {
+                iomutex.lock();
+                printf("[ID:%01d][%02d] sent %d Bytes - %.*s  \n", id, i, ret, ret, tx_buffer);
+                iomutex.unlock();
+            } else {
+                iomutex.lock();
+                printf("[ID:%01d][%02d] Network error %d\n", id, i, ret);
+                iomutex.unlock();
+                i++;
+                continue;
+            }
 
             SocketAddress temp_addr;
             const int n = sock.recvfrom(&temp_addr, rx_buffer, sizeof(rx_buffer));
-            iomutex.lock();
-            printf("[ID:%01d][%02d] recv %d Bytes - %.*s\n", id, i, ret, MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE, rx_buffer);
-            iomutex.unlock();
+            if (n >= 0) {
+                iomutex.lock();
+                printf("[ID:%01d][%02d] receive %d Bytes - %.*s  \n", id, i, n, n, tx_buffer);
+                iomutex.unlock();
+            } else {
+                iomutex.lock();
+                printf("[ID:%01d][%02d] Network error %d\n", id, i, n);
+                iomutex.unlock();
+                i++;
+                continue;
+            }
 
             if ((temp_addr == udp_addr &&
                  n == sizeof(tx_buffer) &&

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
@@ -86,9 +86,8 @@ public:
 
         sock.set_timeout(MBED_CFG_UDP_CLIENT_ECHO_TIMEOUT);
 
-        int i = 0;
-        while (success < ECHO_LOOPS) {
             prep_buffer(id, uuid_buffer, uuid_len, tx_buffer, sizeof(tx_buffer));
+        for (int i = 0; success < ECHO_LOOPS; i++) {
             const int ret = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
             if (ret >= 0) {
                 iomutex.lock();
@@ -98,7 +97,6 @@ public:
                 iomutex.lock();
                 printf("[ID:%01d][%02d] Network error %d\n", id, i, ret);
                 iomutex.unlock();
-                i++;
                 continue;
             }
 
@@ -112,7 +110,6 @@ public:
                 iomutex.lock();
                 printf("[ID:%01d][%02d] Network error %d\n", id, i, n);
                 iomutex.unlock();
-                i++;
                 continue;
             }
 
@@ -123,8 +120,6 @@ public:
                 iomutex.lock();
                 printf("[ID:%01d][%02d] success #%d\n", id, i, success);
                 iomutex.unlock();
-
-                i++;
                 continue;
             }
 

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
@@ -133,6 +133,8 @@ int main() {
     char uuid[48] = {0};
     GREENTEA_SETUP_UUID(60, "udp_echo", uuid, 48);
     printf("Got a uuid of %s\r\n", uuid);
+    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
+
     size_t uuid_len = strlen(uuid);
 
     int err = net.connect();

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
@@ -147,7 +147,7 @@ Echo echoers[MBED_CFG_UDP_CLIENT_ECHO_THREADS];
 
 int main() {
     char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(60, "udp_echo", uuid, 48);
+    GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
     printf("Got a uuid of %s\r\n", uuid);
     mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
 

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
@@ -160,9 +160,14 @@ int main() {
     char uuid[48] = {0};
     GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
     printf("Got a uuid of %s\r\n", uuid);
-    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
-
     size_t uuid_len = strlen(uuid);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
 
     int err = net.connect();
     TEST_ASSERT_EQUAL(0, err);

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
@@ -150,7 +150,7 @@ public:
     }
 };
 
-Echo echoers[MBED_CFG_UDP_CLIENT_ECHO_THREADS];
+Echo *echoers[MBED_CFG_UDP_CLIENT_ECHO_THREADS];
 
 
 void test_udp_echo_parallel() {
@@ -183,14 +183,16 @@ void test_udp_echo_parallel() {
 
         // Startup echo threads in parallel
         for (int i = 0; i < MBED_CFG_UDP_CLIENT_ECHO_THREADS; i++) {
-            echoers[i].start(i, uuid);
+            echoers[i] = new Echo;
+            echoers[i]->start(i, uuid);
         }
 
         bool result = true;
 
         for (int i = 0; i < MBED_CFG_UDP_CLIENT_ECHO_THREADS; i++) {
-            echoers[i].join();
-            result = result && echoers[i].get_result();
+            echoers[i]->join();
+            result = result && echoers[i]->get_result();
+            delete echoers[i];
         }
 
         net.disconnect();

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
@@ -29,8 +29,20 @@ EthernetInterface net;
 SocketAddress udp_addr;
 Mutex iomutex;
 
-void prep_buffer(char *tx_buffer, size_t tx_size) {
-    for (size_t i=0; i<tx_size; ++i) {
+// NOTE: assuming that "id" stays in the single digits
+void prep_buffer(int id, char *uuid_buffer, size_t uuid_len, char *tx_buffer, size_t tx_size) {
+    size_t i = 2;
+
+    tx_buffer[0] = '0' + id;
+    tx_buffer[1] = ' ';
+
+    for (; i<uuid_len + 2; ++i) {
+        tx_buffer[i] = uuid_buffer[i - 2];
+    }
+
+    tx_buffer[i++] = ' ';
+
+    for (; i<tx_size; ++i) {
         tx_buffer[i] = (rand() % 10) + '0';
     }
 }
@@ -44,15 +56,21 @@ private:
 
     UDPSocket sock;
     Thread thread;
+    bool result;
+    int id;
+    char *uuid_buffer;
+    size_t uuid_len;
 
 public:
     // Limiting stack size to 1k
-    Echo(): thread(osPriorityNormal, 1024) {
+    Echo(): thread(osPriorityNormal, 1024), result(false) {
     }
 
-    void start() {
+    void start(int id, char *uuid_buffer, size_t uuid_len) {
+        this->id = id;
+        this->uuid_buffer = uuid_buffer;
+        this->uuid_len = uuid_len;
         osStatus status = thread.start(callback(this, &Echo::echo));
-        TEST_ASSERT_EQUAL(osOK, status);
     }
 
     void join() {
@@ -68,30 +86,43 @@ public:
 
         sock.set_timeout(MBED_CFG_UDP_CLIENT_ECHO_TIMEOUT);
 
-        for (int i = 0; i < ECHO_LOOPS; i++) {
-            prep_buffer(tx_buffer, sizeof(tx_buffer));
+        int i = 0;
+        while(success < ECHO_LOOPS) {
+            prep_buffer(id, uuid_buffer, uuid_len, tx_buffer, sizeof(tx_buffer));
             const int ret = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
             iomutex.lock();
-            printf("[%02d] sent...%d Bytes \n", i, ret);
+            printf("[ID:%01d][%02d] sent %d Bytes - %.*s\n", id, i, ret, MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE, tx_buffer);
             iomutex.unlock();
 
             SocketAddress temp_addr;
             const int n = sock.recvfrom(&temp_addr, rx_buffer, sizeof(rx_buffer));
             iomutex.lock();
-            printf("[%02d] recv...%d Bytes \n", i, n);
+            printf("[ID:%01d][%02d] recv %d Bytes - %.*s\n", id, i, ret, MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE, rx_buffer);
             iomutex.unlock();
 
             if ((temp_addr == udp_addr &&
                  n == sizeof(tx_buffer) &&
                  memcmp(rx_buffer, tx_buffer, sizeof(rx_buffer)) == 0)) {
                 success += 1;
+                iomutex.lock();
+                printf("[ID:%01d][%02d] success #%d\n", id, i, success);
+                iomutex.unlock();
             }
+
+            i++;
         }
+
+        result = success == ECHO_LOOPS;
 
         err = sock.close();
         TEST_ASSERT_EQUAL(0, err);
+        if (err) {
+            result = false;
+        }
+    }
 
-        TEST_ASSERT(success > 3*ECHO_LOOPS/4);
+    bool get_result() {
+        return result;
     }
 };
 
@@ -99,39 +130,51 @@ Echo echoers[MBED_CFG_UDP_CLIENT_ECHO_THREADS];
 
 
 int main() {
-    GREENTEA_SETUP(60, "udp_echo");
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(60, "udp_echo", uuid, 48);
+    printf("Got a uuid of %s\r\n", uuid);
+    size_t uuid_len = strlen(uuid);
 
     int err = net.connect();
     TEST_ASSERT_EQUAL(0, err);
-    printf("UDP client IP Address is %s\n", net.get_ip_address());
 
-    greentea_send_kv("target_ip", net.get_ip_address());
+    if (err) {
+        printf("MBED: failed to connect with an error of %d\r\n", err);
+        GREENTEA_TESTSUITE_RESULT(false);
+    } else {
+        printf("UDP client IP Address is %s\n", net.get_ip_address());
 
-    char recv_key[] = "host_port";
-    char ipbuf[60] = {0};
-    char portbuf[16] = {0};
-    unsigned int port = 0;
+        greentea_send_kv("target_ip", net.get_ip_address());
 
-    greentea_send_kv("host_ip", " ");
-    greentea_parse_kv(recv_key, ipbuf, sizeof(recv_key), sizeof(ipbuf));
+        char recv_key[] = "host_port";
+        char ipbuf[60] = {0};
+        char portbuf[16] = {0};
+        unsigned int port = 0;
 
-    greentea_send_kv("host_port", " ");
-    greentea_parse_kv(recv_key, portbuf, sizeof(recv_key), sizeof(ipbuf));
-    sscanf(portbuf, "%u", &port);
+        greentea_send_kv("host_ip", " ");
+        greentea_parse_kv(recv_key, ipbuf, sizeof(recv_key), sizeof(ipbuf));
 
-    printf("MBED: UDP Server IP address received: %s:%d \n", ipbuf, port);
-    udp_addr.set_ip_address(ipbuf);
-    udp_addr.set_port(port);
+        greentea_send_kv("host_port", " ");
+        greentea_parse_kv(recv_key, portbuf, sizeof(recv_key), sizeof(ipbuf));
+        sscanf(portbuf, "%u", &port);
 
-    // Startup echo threads in parallel
-    for (int i = 0; i < MBED_CFG_UDP_CLIENT_ECHO_THREADS; i++) {
-        echoers[i].start();
+        printf("MBED: UDP Server IP address received: %s:%d \n", ipbuf, port);
+        udp_addr.set_ip_address(ipbuf);
+        udp_addr.set_port(port);
+
+        // Startup echo threads in parallel
+        for (int i = 0; i < MBED_CFG_UDP_CLIENT_ECHO_THREADS; i++) {
+            echoers[i].start(i, uuid, uuid_len);
+        }
+
+        bool result = true;
+
+        for (int i = 0; i < MBED_CFG_UDP_CLIENT_ECHO_THREADS; i++) {
+            echoers[i].join();
+            result = result && echoers[i].get_result();
+        }
+
+        net.disconnect();
+        GREENTEA_TESTSUITE_RESULT(result);
     }
-
-    for (int i = 0; i < MBED_CFG_UDP_CLIENT_ECHO_THREADS; i++) {
-        echoers[i].join();
-    }
-
-    net.disconnect();
-    GREENTEA_TESTSUITE_RESULT(true);
 }

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
@@ -10,6 +10,10 @@
 #include "UDPSocket.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
+#include "utest.h"
+
+using namespace utest::v1;
+
 
 #ifndef MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE
 #define MBED_CFG_UDP_CLIENT_ECHO_BUFFER_SIZE 64
@@ -28,17 +32,17 @@ const int ECHO_LOOPS = 16;
 EthernetInterface net;
 SocketAddress udp_addr;
 Mutex iomutex;
+char uuid[48] = {0};
 
 // NOTE: assuming that "id" stays in the single digits
-void prep_buffer(int id, char *uuid_buffer, size_t uuid_len, char *tx_buffer, size_t tx_size) {
-    size_t i = 2;
+void prep_buffer(int id, char *uuid, char *tx_buffer, size_t tx_size) {
+    size_t i = 0;
 
-    tx_buffer[0] = '0' + id;
-    tx_buffer[1] = ' ';
+    tx_buffer[i++] = '0' + id;
+    tx_buffer[i++] = ' ';
 
-    for (; i<uuid_len + 2; ++i) {
-        tx_buffer[i] = uuid_buffer[i - 2];
-    }
+    memcpy(tx_buffer+i, uuid, strlen(uuid));
+    i += strlen(uuid);
 
     tx_buffer[i++] = ' ';
 
@@ -58,18 +62,16 @@ private:
     Thread thread;
     bool result;
     int id;
-    char *uuid_buffer;
-    size_t uuid_len;
+    char *uuid;
 
 public:
     // Limiting stack size to 1k
     Echo(): thread(osPriorityNormal, 1024), result(false) {
     }
 
-    void start(int id, char *uuid_buffer, size_t uuid_len) {
+    void start(int id, char *uuid) {
         this->id = id;
-        this->uuid_buffer = uuid_buffer;
-        this->uuid_len = uuid_len;
+        this->uuid = uuid;
         osStatus status = thread.start(callback(this, &Echo::echo));
     }
 
@@ -86,8 +88,8 @@ public:
 
         sock.set_timeout(MBED_CFG_UDP_CLIENT_ECHO_TIMEOUT);
 
-            prep_buffer(id, uuid_buffer, uuid_len, tx_buffer, sizeof(tx_buffer));
         for (int i = 0; success < ECHO_LOOPS; i++) {
+            prep_buffer(id, uuid, tx_buffer, sizeof(tx_buffer));
             const int ret = sock.sendto(udp_addr, tx_buffer, sizeof(tx_buffer));
             if (ret >= 0) {
                 iomutex.lock();
@@ -151,19 +153,7 @@ public:
 Echo echoers[MBED_CFG_UDP_CLIENT_ECHO_THREADS];
 
 
-int main() {
-    char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
-    printf("Got a uuid of %s\r\n", uuid);
-    size_t uuid_len = strlen(uuid);
-
-    // create mac address based on uuid
-    uint64_t mac = 0;
-    for (int i = 0; i < sizeof(uuid); i++) {
-        mac += uuid[i];
-    }
-    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
-
+void test_udp_echo_parallel() {
     int err = net.connect();
     TEST_ASSERT_EQUAL(0, err);
 
@@ -193,7 +183,7 @@ int main() {
 
         // Startup echo threads in parallel
         for (int i = 0; i < MBED_CFG_UDP_CLIENT_ECHO_THREADS; i++) {
-            echoers[i].start(i, uuid, uuid_len);
+            echoers[i].start(i, uuid);
         }
 
         bool result = true;
@@ -204,6 +194,32 @@ int main() {
         }
 
         net.disconnect();
-        GREENTEA_TESTSUITE_RESULT(result);
+        TEST_ASSERT_EQUAL(true, result);
     }
 }
+
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
+
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("UDP echo parallel", test_udp_echo_parallel),
+};
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}
+

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure/main.cpp
@@ -112,7 +112,7 @@ void generate_buffer(uint8_t **buffer, size_t *size, size_t min, size_t max) {
 
 int main() {
     char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(60, "udp_echo", uuid, 48);
+    GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
     mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
 
     generate_buffer(&buffer, &buffer_size,

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure/main.cpp
@@ -13,6 +13,9 @@
 #include "UDPSocket.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
+#include "utest.h"
+
+using namespace utest::v1;
 
 
 #ifndef MBED_CFG_UDP_CLIENT_PACKET_PRESSURE_MIN
@@ -110,17 +113,7 @@ void generate_buffer(uint8_t **buffer, size_t *size, size_t min, size_t max) {
     TEST_ASSERT(buffer);
 }
 
-int main() {
-    char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
-
-    // create mac address based on uuid
-    uint64_t mac = 0;
-    for (int i = 0; i < sizeof(uuid); i++) {
-        mac += uuid[i];
-    }
-    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
-
+void test_udp_packet_pressure() {
     generate_buffer(&buffer, &buffer_size,
         MBED_CFG_UDP_CLIENT_PACKET_PRESSURE_MIN,
         MBED_CFG_UDP_CLIENT_PACKET_PRESSURE_MAX);
@@ -134,8 +127,6 @@ int main() {
     printf("MBED: UDPClient waiting for server IP and port...\n");
 
     greentea_send_kv("target_ip", eth.get_ip_address());
-
-    bool result = true;
 
     char recv_key[] = "host_port";
     char ipbuf[60] = {0};
@@ -255,5 +246,31 @@ int main() {
             MBED_CFG_UDP_CLIENT_PACKET_PRESSURE_MIN) / (1000*timer.read()));
 
     eth.disconnect();
-    GREENTEA_TESTSUITE_RESULT(result);
 }
+
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
+
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("UDP packet pressure", test_udp_packet_pressure),
+};
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}
+

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure/main.cpp
@@ -113,7 +113,13 @@ void generate_buffer(uint8_t **buffer, size_t *size, size_t min, size_t max) {
 int main() {
     char uuid[48] = {0};
     GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
-    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
 
     generate_buffer(&buffer, &buffer_size,
         MBED_CFG_UDP_CLIENT_PACKET_PRESSURE_MIN,

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure/main.cpp
@@ -111,7 +111,10 @@ void generate_buffer(uint8_t **buffer, size_t *size, size_t min, size_t max) {
 }
 
 int main() {
-    GREENTEA_SETUP(60, "udp_echo");
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(60, "udp_echo", uuid, 48);
+    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
+
     generate_buffer(&buffer, &buffer_size,
         MBED_CFG_UDP_CLIENT_PACKET_PRESSURE_MIN,
         MBED_CFG_UDP_CLIENT_PACKET_PRESSURE_MAX);

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure_parallel/main.cpp
@@ -250,7 +250,9 @@ PressureTest *pressure_tests[MBED_CFG_UDP_CLIENT_PACKET_PRESSURE_THREADS];
 
 
 int main() {
-    GREENTEA_SETUP(2*60, "udp_echo");
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(2*60, "udp_echo", uuid, 48);
+    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
 
     uint8_t *buffer;
     size_t buffer_size;

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure_parallel/main.cpp
@@ -13,6 +13,9 @@
 #include "UDPSocket.h"
 #include "greentea-client/test_env.h"
 #include "unity/unity.h"
+#include "utest.h"
+
+using namespace utest::v1;
 
 
 #ifndef MBED_CFG_UDP_CLIENT_PACKET_PRESSURE_MIN
@@ -249,17 +252,7 @@ public:
 PressureTest *pressure_tests[MBED_CFG_UDP_CLIENT_PACKET_PRESSURE_THREADS];
 
 
-int main() {
-    char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
-
-    // create mac address based on uuid
-    uint64_t mac = 0;
-    for (int i = 0; i < sizeof(uuid); i++) {
-        mac += uuid[i];
-    }
-    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
-
+void test_udp_packet_pressure_parallel() {
     uint8_t *buffer;
     size_t buffer_size;
     generate_buffer(&buffer, &buffer_size,
@@ -279,8 +272,6 @@ int main() {
     printf("MBED: UDPClient waiting for server IP and port...\n");
 
     greentea_send_kv("target_ip", net.get_ip_address());
-
-    bool result = true;
 
     char recv_key[] = "host_port";
     char ipbuf[60] = {0};
@@ -319,5 +310,32 @@ int main() {
             MBED_CFG_UDP_CLIENT_PACKET_PRESSURE_MIN) / (1000*timer.read()));
 
     net.disconnect();
-    GREENTEA_TESTSUITE_RESULT(result);
 }
+
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    char uuid[48] = {0};
+    GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
+
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("UDP packet pressure parallel", test_udp_packet_pressure_parallel),
+};
+
+Specification specification(test_setup, cases);
+
+int main() {
+    return !Harness::run(specification);
+}
+
+

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure_parallel/main.cpp
@@ -252,7 +252,13 @@ PressureTest *pressure_tests[MBED_CFG_UDP_CLIENT_PACKET_PRESSURE_THREADS];
 int main() {
     char uuid[48] = {0};
     GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
-    mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
+
+    // create mac address based on uuid
+    uint64_t mac = 0;
+    for (int i = 0; i < sizeof(uuid); i++) {
+        mac += uuid[i];
+    }
+    mbed_set_mac_address((const char*)mac, /*coerce control bits*/ 1);
 
     uint8_t *buffer;
     size_t buffer_size;

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_packet_pressure_parallel/main.cpp
@@ -251,7 +251,7 @@ PressureTest *pressure_tests[MBED_CFG_UDP_CLIENT_PACKET_PRESSURE_THREADS];
 
 int main() {
     char uuid[48] = {0};
-    GREENTEA_SETUP_UUID(2*60, "udp_echo", uuid, 48);
+    GREENTEA_SETUP_UUID(120, "udp_echo", uuid, 48);
     mbed_set_mac_address(uuid, /*coerce control bits*/ 1);
 
     uint8_t *buffer;

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -41,8 +41,6 @@
     #define MBED_NETIF_INIT_FN eth_arch_enetif_init
 #endif
 
-#define DHCP_TIMEOUT 15000
-
 /* Static arena of sockets */
 static struct lwip_socket {
     bool in_use;
@@ -463,7 +461,7 @@ nsapi_error_t mbed_lwip_bringup(bool dhcp, const char *ip, const char *netmask, 
     u32_t ret;
 
     if (!netif_is_link_up(&lwip_netif)) {
-        ret = sys_arch_sem_wait(&lwip_netif_linked, 15000);
+        ret = sys_arch_sem_wait(&lwip_netif_linked, DHCP_TIMEOUT * 1000);
 
         if (ret == SYS_ARCH_TIMEOUT) {
             return NSAPI_ERROR_NO_CONNECTION;
@@ -502,7 +500,7 @@ nsapi_error_t mbed_lwip_bringup(bool dhcp, const char *ip, const char *netmask, 
 
     // If doesn't have address
     if (!mbed_lwip_get_ip_addr(true, &lwip_netif)) {
-        ret = sys_arch_sem_wait(&lwip_netif_has_addr, 15000);
+        ret = sys_arch_sem_wait(&lwip_netif_has_addr, DHCP_TIMEOUT * 1000);
         if (ret == SYS_ARCH_TIMEOUT) {
             return NSAPI_ERROR_DHCP_FAILURE;
         }

--- a/features/FEATURE_LWIP/lwip-interface/lwipopts.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwipopts.h
@@ -52,6 +52,8 @@
 #define ADDR_TIMEOUT                0
 #endif
 
+#define DHCP_TIMEOUT                60
+
 #define PREF_IPV4                   1
 #define PREF_IPV6                   2
 

--- a/features/frameworks/greentea-client/greentea-client/test_env.h
+++ b/features/frameworks/greentea-client/greentea-client/test_env.h
@@ -77,6 +77,7 @@ extern const char* GREENTEA_TEST_ENV_LCOV_START;
  *  Greentea-client related API for communication with host side
  */
 void GREENTEA_SETUP(const int, const char *);
+void GREENTEA_SETUP_UUID(const int timeout, const char *host_test_name, char *buffer, size_t size);
 void GREENTEA_TESTSUITE_RESULT(const int);
 void GREENTEA_TESTCASE_START(const char *test_case_name);
 void GREENTEA_TESTCASE_FINISH(const char *test_case_name, const size_t passes, const size_t failed);

--- a/features/frameworks/greentea-client/source/greentea_test_env.cpp
+++ b/features/frameworks/greentea-client/source/greentea_test_env.cpp
@@ -60,25 +60,21 @@ static void greentea_notify_completion(const int);
 static void greentea_notify_version();
 static void greentea_write_string(const char *str);
 
-/** \brief Handshake with host and send setup data (timeout and host test name)
- *  \details This function will send preamble to master.
- *           After host test name is received master will invoke host test script
- *           and add hos test's callback handlers to main event loop
- *           This function is blocking.
- */
-void GREENTEA_SETUP(const int timeout, const char *host_test_name) {
+
+void _GREENTEA_SETUP_COMMON(const int timeout, const char *host_test_name, char *buffer, size_t size) {
     greentea_metrics_setup();
     // Key-value protocol handshake function. Waits for {{__sync;...}} message
     // Sync preamble: "{{__sync;0dad4a9d-59a3-4aec-810d-d5fb09d852c1}}"
     // Example value of sync_uuid == "0dad4a9d-59a3-4aec-810d-d5fb09d852c1"
-	char _key[8] = {0};
-	char _value[48] = {0};
-	while (1) {
-        greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+
+    char _key[8] = {0};
+
+    while (1) {
+        greentea_parse_kv(_key, buffer, sizeof(_key), size);
         greentea_write_string("mbedmbedmbedmbedmbedmbedmbedmbed\r\n");
         if (strcmp(_key, GREENTEA_TEST_ENV_SYNC) == 0) {
             // Found correct __sunc message
-            greentea_send_kv(_key, _value);
+            greentea_send_kv(_key, buffer);
             break;
         }
     }
@@ -86,6 +82,27 @@ void GREENTEA_SETUP(const int timeout, const char *host_test_name) {
     greentea_notify_version();
     greentea_notify_timeout(timeout);
     greentea_notify_hosttest(host_test_name);
+}
+
+/** \brief Handshake with host and send setup data (timeout and host test name)
+ *  \details This function will send preamble to master.
+ *           After host test name is received master will invoke host test script
+ *           and add hos test's callback handlers to main event loop
+ *           This function is blocking.
+ */
+void GREENTEA_SETUP(const int timeout, const char *host_test_name) {
+    char _value[48] = {0};
+    _GREENTEA_SETUP_COMMON(timeout, host_test_name, _value, 48);
+}
+
+/** \brief Handshake with host and send setup data (timeout and host test name)
+ *  \details This function will send preamble to master.
+ *           After host test name is received master will invoke host test script
+ *           and add hos test's callback handlers to main event loop
+ *           This function is blocking.
+ */
+void GREENTEA_SETUP_UUID(const int timeout, const char *host_test_name, char *buffer, size_t size) {
+    _GREENTEA_SETUP_COMMON(timeout, host_test_name, buffer, size);
 }
 
 /** \brief Notify host (__exit message) side that test suite execution was complete
@@ -194,7 +211,7 @@ inline void greentea_write_preamble()
     greentea_serial->putc('{');
     greentea_serial->putc('{');
 }
- 
+
 /**
  * \brief Write the postamble characters to the serial port
  *
@@ -202,7 +219,7 @@ inline void greentea_write_preamble()
  *        for key-value comunication between the target and the host.
  *        This uses a Rawserial object, greentea_serial, which provides
  *        a direct interface to the USBTX and USBRX serial pins and allows
- *        the direct writing of characters using the putc() method. 
+ *        the direct writing of characters using the putc() method.
  *        This suite of functions are provided to allow for serial communication
  *        to the host from within a thread/ISR.
  *
@@ -238,8 +255,8 @@ inline void greentea_write_string(const char *str)
  * \brief Write an int to the serial port
  *
  *        This function writes an integer value from the target
- *        to the host. The integer value is converted to a string and 
- *        and then written character by character directly to the serial 
+ *        to the host. The integer value is converted to a string and
+ *        and then written character by character directly to the serial
  *        port using the greentea_serial, Rawserial object.
  *        sprintf() is used to convert the int to a string. Sprintf if
  *        inherently thread safe so can be used.
@@ -302,7 +319,7 @@ void greentea_send_kv(const char *key, const int val) {
         greentea_write_postamble();
     }
 }
- 
+
 /**
  * \brief Encapsulate and send key-value-value message from DUT to host
  *
@@ -367,10 +384,10 @@ void greentea_send_kv(const char *key, const char *val, const int passes, const 
 /**
  * \brief Encapsulate and send key-value-value message from DUT to host
  *
- *        This function uses underlying functions to write directly 
- *        to the serial port, (USBTX). This allows key-value-value to be used 
+ *        This function uses underlying functions to write directly
+ *        to the serial port, (USBTX). This allows key-value-value to be used
  *        from within interrupt context.
- *        Both values are integers to avoid integer to string conversion 
+ *        Both values are integers to avoid integer to string conversion
  *        made by the user.
  *
  *        Names of the parameters: this function is used to send number

--- a/platform/mbed_interface.c
+++ b/platform/mbed_interface.c
@@ -81,6 +81,14 @@ WEAK int mbed_uid(char *uid) {
 }
 #endif
 
+static uint8_t manual_mac_address_set = 0;
+static char manual_mac_address[6];
+
+void mbed_set_mac_address(const char *mac) {
+    memcpy(manual_mac_address, mac, 6);
+    manual_mac_address_set = 1;
+}
+
 WEAK void mbed_mac_address(char *mac) {
 #if DEVICE_SEMIHOST
     char uid[DEVICE_ID_LENGTH + 1];
@@ -101,12 +109,16 @@ WEAK void mbed_mac_address(char *mac) {
         mac[0] &= ~0x01;    // reset the IG bit in the address; see IEE 802.3-2002, Section 3.2.3(b)
     } else {  // else return a default MAC
 #endif
+    if(manual_mac_address_set) {
+        memcpy(mac, manual_mac_address, 6);
+    } else {
         mac[0] = 0x00;
         mac[1] = 0x02;
         mac[2] = 0xF7;
         mac[3] = 0xF0;
         mac[4] = 0x00;
         mac[5] = 0x00;
+    }
 #if DEVICE_SEMIHOST
     }
 #endif

--- a/platform/mbed_interface.c
+++ b/platform/mbed_interface.c
@@ -84,9 +84,13 @@ WEAK int mbed_uid(char *uid) {
 static uint8_t manual_mac_address_set = 0;
 static char manual_mac_address[6];
 
-void mbed_set_mac_address(const char *mac) {
+void mbed_set_mac_address(const char *mac, uint8_t coerce_mac_control_bits) {
     memcpy(manual_mac_address, mac, 6);
     manual_mac_address_set = 1;
+    if(coerce_mac_control_bits) {
+        manual_mac_address[0] |= 0x02; // force bit 1 to a "1" = "Locally Administered"
+        manual_mac_address[0] &= 0xFE; // force bit 0 to a "0" = Unicast
+    }
 }
 
 WEAK void mbed_mac_address(char *mac) {

--- a/platform/mbed_interface.h
+++ b/platform/mbed_interface.h
@@ -98,6 +98,15 @@ int mbed_interface_uid(char *uid);
 
 #endif
 
+/** This provides a generic function to set a unique 6-byte MAC address based on the passed
+ *  parameter character array. Provides no MAC address validity checking
+ *  
+ *  mbed_mac_address() will readback this configured value
+ *
+ *  @param mac A 6-byte array containing the desired MAC address to be set
+ */
+void mbed_set_mac_address(const char *mac);
+
 /** This returns a unique 6-byte MAC address, based on the interface UID
  * If the interface is not present, it returns a default fixed MAC address (00:02:F7:F0:00:00)
  *

--- a/platform/mbed_interface.h
+++ b/platform/mbed_interface.h
@@ -104,8 +104,11 @@ int mbed_interface_uid(char *uid);
  *  mbed_mac_address() will readback this configured value
  *
  *  @param mac A 6-byte array containing the desired MAC address to be set
+ *  @param coerce_mac_control_bits An 8-bit int that is used as a boolean flag to either coerce
+ *         the provided MAC address to be Locally Administered and Unicast or to use the
+ *         provided MAC address unmodified
  */
-void mbed_set_mac_address(const char *mac);
+void mbed_set_mac_address(const char *mac, uint8_t coerce_mac_control_bits);
 
 /** This returns a unique 6-byte MAC address, based on the interface UID
  * If the interface is not present, it returns a default fixed MAC address (00:02:F7:F0:00:00)


### PR DESCRIPTION
## Description
This PR attempts to fix a number of issues that have cropped up with the networking tests lately. This pr is still in development.


## Status
**IN DEVELOPMENT**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [x] Transition all Greentea tests that use `TEST_ASSERT` statements to utest-style tests
- [x] Generate MAC addresses from the Greentea UUID to help prevent MAC conflicts (should help with DHCP failures)
- [ ] Get the nightly passing, maybe run additional stress testing