### PR TITLE
[NUC472/M453] Fix serial error with sync/async calls interlaced

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M451/TARGET_NUMAKER_PFM_M453/objects.h
+++ b/targets/TARGET_NUVOTON/TARGET_M451/TARGET_NUMAKER_PFM_M453/objects.h
@@ -61,6 +61,7 @@ struct serial_s {
     void        (*vec)(void);
     uint32_t    irq_handler;
     uint32_t    irq_id;
+    uint32_t    irq_en;
     uint32_t    inten_msk;
     
     // Async transfer related fields

--- a/targets/TARGET_NUVOTON/TARGET_M451/pwmout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/pwmout_api.c
@@ -99,11 +99,9 @@ void pwmout_init(pwmout_t* obj, PinName pin)
     
     ((struct nu_pwm_var *) modinit->var)->en_msk |= 1 << chn;
     
-    if (((struct nu_pwm_var *) modinit->var)->en_msk) {
-        // Mark this module to be inited.
-        int i = modinit - pwm_modinit_tab;
-        pwm_modinit_mask |= 1 << i;
-    }
+    // Mark this module to be inited.
+    int i = modinit - pwm_modinit_tab;
+    pwm_modinit_mask |= 1 << i;
 }
 
 void pwmout_free(pwmout_t* obj)
@@ -122,11 +120,9 @@ void pwmout_free(pwmout_t* obj)
         CLK_DisableModuleClock(modinit->clkidx);
     }
     
-    if (((struct nu_pwm_var *) modinit->var)->en_msk == 0) {
-        // Mark this module to be deinited.
-        int i = modinit - pwm_modinit_tab;
-        pwm_modinit_mask &= ~(1 << i);
-    }
+    // Mark this module to be deinited.
+    int i = modinit - pwm_modinit_tab;
+    pwm_modinit_mask &= ~(1 << i);
 }
 
 void pwmout_write(pwmout_t* obj, float value)

--- a/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
@@ -24,6 +24,7 @@
 #include "PeripheralPins.h"
 #include "nu_modutil.h"
 #include "nu_bitutil.h"
+#include <string.h>
 
 #if DEVICE_SERIAL_ASYNCH
 #include "dma_api.h"
@@ -61,6 +62,8 @@ static void uart_dma_handler_rx(uint32_t id, uint32_t event);
 
 static void serial_tx_enable_interrupt(serial_t *obj, uint32_t address, uint8_t enable);
 static void serial_rx_enable_interrupt(serial_t *obj, uint32_t address, uint8_t enable);
+static void serial_enable_interrupt(serial_t *obj, SerialIrq irq, uint32_t enable);
+static void serial_rollback_interrupt(serial_t *obj, SerialIrq irq);
 static int serial_write_async(serial_t *obj);
 static int serial_read_async(serial_t *obj);
 
@@ -159,7 +162,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
-    MBED_ASSERT(modinit->modname == obj->serial.uart);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
     struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
     
@@ -186,6 +189,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     serial_format(obj, 8, ParityNone, 1);
     
     obj->serial.vec = var->vec;
+    obj->serial.irq_en = 0;
     
 #if DEVICE_SERIAL_ASYNCH
     obj->serial.dma_usage_tx = DMA_USAGE_NEVER;
@@ -212,7 +216,7 @@ void serial_free(serial_t *obj)
 {
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
-    MBED_ASSERT(modinit->modname == obj->serial.uart);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
     struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
     
@@ -329,7 +333,7 @@ void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
     
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
-    MBED_ASSERT(modinit->modname == obj->serial.uart);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
     obj->serial.irq_handler = (uint32_t) handler;
     obj->serial.irq_id = id;
@@ -340,51 +344,18 @@ void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
 
 void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
 {
-    if (enable) {
-        const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
-        MBED_ASSERT(modinit != NULL);
-        MBED_ASSERT(modinit->modname == obj->serial.uart);
-    
-        NVIC_SetVector(modinit->irq_n, (uint32_t) obj->serial.vec);
-        NVIC_EnableIRQ(modinit->irq_n);
-        
-        struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
-        // Multiple serial S/W objects for single UART H/W module possibly.
-        // Bind serial S/W object to UART H/W module as interrupt is enabled.
-        var->obj = obj;
-        
-        switch (irq) {
-            // NOTE: Setting inten_msk first to avoid race condition
-            case RxIrq:
-                obj->serial.inten_msk = obj->serial.inten_msk | (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk);
-                UART_ENABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk));
-                break;
-            case TxIrq:
-                obj->serial.inten_msk = obj->serial.inten_msk | UART_INTEN_THREIEN_Msk;
-                UART_ENABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), UART_INTEN_THREIEN_Msk);
-                break;
-        }
-    } else { // disable
-        switch (irq) {
-            case RxIrq:
-                UART_DISABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk));
-                obj->serial.inten_msk = obj->serial.inten_msk & ~(UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk);
-                break;
-            case TxIrq:
-                UART_DISABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), UART_INTEN_THREIEN_Msk);
-                obj->serial.inten_msk = obj->serial.inten_msk & ~UART_INTEN_THREIEN_Msk;
-                break;
-        }
-    }
+    obj->serial.irq_en = enable;
+    serial_enable_interrupt(obj, irq, enable);
 }
 
 int serial_getc(serial_t *obj)
 {
-    // TODO: Fix every byte access requires accompaniness of one interrupt. This degrades performance much.    
+    // TODO: Fix every byte access requires accompaniment of one interrupt. This has side effect of performance degradation.
     while (! serial_readable(obj));
     int c = UART_READ(((UART_T *) NU_MODBASE(obj->serial.uart)));
     
-    // Simulate clear of the interrupt flag
+    // NOTE: On Nuvoton targets, no H/W IRQ to match TxIrq/RxIrq.
+    //       Simulation of TxIrq/RxIrq requires the call to Serial::putc()/Serial::getc() respectively. 
     if (obj->serial.inten_msk & (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk)) {
         UART_ENABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk));
     }
@@ -394,11 +365,12 @@ int serial_getc(serial_t *obj)
 
 void serial_putc(serial_t *obj, int c)
 {
-    // TODO: Fix every byte access requires accompaniness of one interrupt. This degrades performance much.
+    // TODO: Fix every byte access requires accompaniment of one interrupt. This has side effect of performance degradation.
     while (! serial_writable(obj));
     UART_WRITE(((UART_T *) NU_MODBASE(obj->serial.uart)), c);
     
-    // Simulate clear of the interrupt flag
+    // NOTE: On Nuvoton targets, no H/W IRQ to match TxIrq/RxIrq.
+    //       Simulation of TxIrq/RxIrq requires the call to Serial::putc()/Serial::getc() respectively. 
     if (obj->serial.inten_msk & UART_INTEN_THREIEN_Msk) {
         UART_ENABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), UART_INTEN_THREIEN_Msk);
     }
@@ -500,7 +472,7 @@ int serial_tx_asynch(serial_t *obj, const void *tx, size_t tx_length, uint8_t tx
         // DMA way
         const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
         MBED_ASSERT(modinit != NULL);
-        MBED_ASSERT(modinit->modname == obj->serial.uart);
+        MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
         PDMA_T *pdma_base = dma_modbase();
         
@@ -563,7 +535,7 @@ void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_widt
         // DMA way
         const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
         MBED_ASSERT(modinit != NULL);
-        MBED_ASSERT(modinit->modname == obj->serial.uart);
+        MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
         PDMA_T *pdma_base = dma_modbase();
         
@@ -612,10 +584,8 @@ void serial_tx_abort_asynch(serial_t *obj)
     }
     
     // Necessary for both interrupt way and DMA way
-    serial_irq_set(obj, TxIrq, 0);
-    // FIXME: more complete abort operation
-    //UART_HAL_DisableTransmitter(obj->serial.serial.address);
-    //UART_HAL_FlushTxFifo(obj->serial.serial.address);
+    serial_enable_interrupt(obj, TxIrq, 0);
+    serial_rollback_interrupt(obj, TxIrq);
 }
 
 void serial_rx_abort_asynch(serial_t *obj)
@@ -633,20 +603,30 @@ void serial_rx_abort_asynch(serial_t *obj)
     }
     
     // Necessary for both interrupt way and DMA way
-    serial_irq_set(obj, RxIrq, 0);
-    // FIXME: more complete abort operation
-    //UART_HAL_DisableReceiver(obj->serial.serial.address);
-    //UART_HAL_FlushRxFifo(obj->serial.serial.address);
+    serial_enable_interrupt(obj, RxIrq, 0);
+    serial_rollback_interrupt(obj, RxIrq);
 }
 
 uint8_t serial_tx_active(serial_t *obj)
 {
-    return serial_is_irq_en(obj, TxIrq);
+    // NOTE: Judge by serial_is_irq_en(obj, TxIrq) doesn't work with sync/async modes interleaved. Change with TX FIFO empty flag.
+    const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
+    MBED_ASSERT(modinit != NULL);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
+    
+    struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;    
+    return (obj->serial.vec == var->vec_async);
 }
 
 uint8_t serial_rx_active(serial_t *obj)
 {
-    return serial_is_irq_en(obj, RxIrq);
+    // NOTE: Judge by serial_is_irq_en(obj, RxIrq) doesn't work with sync/async modes interleaved. Change with RX FIFO empty flag.
+    const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
+    MBED_ASSERT(modinit != NULL);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
+    
+    struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;    
+    return (obj->serial.vec == var->vec_async);
 }
 
 int serial_irq_handler_asynch(serial_t *obj)
@@ -886,7 +866,7 @@ static int serial_write_async(serial_t *obj)
 {   
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
-    MBED_ASSERT(modinit->modname == obj->serial.uart);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
     UART_T *uart_base = (UART_T *) NU_MODBASE(obj->serial.uart);
     
@@ -938,7 +918,7 @@ static int serial_read_async(serial_t *obj)
 {
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
-    MBED_ASSERT(modinit->modname == obj->serial.uart);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
     uint32_t rx_fifo_busy = (((UART_T *) NU_MODBASE(obj->serial.uart))->FIFOSTS & UART_FIFOSTS_RXPTR_Msk) >> UART_FIFOSTS_RXPTR_Pos;
     //uint32_t rx_fifo_free = ((struct nu_uart_var *) modinit->var)->fifo_size_rx - rx_fifo_busy;
@@ -1013,28 +993,81 @@ static void serial_tx_enable_interrupt(serial_t *obj, uint32_t handler, uint8_t 
 {
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
-    MBED_ASSERT(modinit->modname == obj->serial.uart);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
     // Necessary for both interrupt way and DMA way
     struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
     // With our own async vector, tx/rx handlers can be different.
     obj->serial.vec = var->vec_async;
     obj->serial.irq_handler_tx_async = (void (*)(void)) handler;
-    serial_irq_set(obj, TxIrq, enable);
+    serial_enable_interrupt(obj, TxIrq, enable);
 }
 
 static void serial_rx_enable_interrupt(serial_t *obj, uint32_t handler, uint8_t enable)
 {
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
-    MBED_ASSERT(modinit->modname == obj->serial.uart);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
     // Necessary for both interrupt way and DMA way
     struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
     // With our own async vector, tx/rx handlers can be different.
     obj->serial.vec = var->vec_async;
     obj->serial.irq_handler_rx_async = (void (*) (void)) handler;
-    serial_irq_set(obj, RxIrq, enable);
+    serial_enable_interrupt(obj, RxIrq, enable);
+}
+
+static void serial_enable_interrupt(serial_t *obj, SerialIrq irq, uint32_t enable)
+{
+    if (enable) {
+        const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
+        MBED_ASSERT(modinit != NULL);
+        MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
+    
+        NVIC_SetVector(modinit->irq_n, (uint32_t) obj->serial.vec);
+        NVIC_EnableIRQ(modinit->irq_n);
+        
+        struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
+        // Multiple serial S/W objects for single UART H/W module possibly.
+        // Bind serial S/W object to UART H/W module as interrupt is enabled.
+        var->obj = obj;
+        
+        switch (irq) {
+            // NOTE: Setting inten_msk first to avoid race condition
+            case RxIrq:
+                obj->serial.inten_msk = obj->serial.inten_msk | (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk);
+                UART_ENABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk));
+                break;
+            case TxIrq:
+                obj->serial.inten_msk = obj->serial.inten_msk | UART_INTEN_THREIEN_Msk;
+                UART_ENABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), UART_INTEN_THREIEN_Msk);
+                break;
+        }
+    }
+    else { // disable
+        switch (irq) {
+            case RxIrq:
+                UART_DISABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk));
+                obj->serial.inten_msk = obj->serial.inten_msk & ~(UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk);
+                break;
+            case TxIrq:
+                UART_DISABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), UART_INTEN_THREIEN_Msk);
+                obj->serial.inten_msk = obj->serial.inten_msk & ~UART_INTEN_THREIEN_Msk;
+                break;
+        }
+    }
+}
+
+static void serial_rollback_interrupt(serial_t *obj, SerialIrq irq)
+{
+    const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
+    MBED_ASSERT(modinit != NULL);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
+    
+    struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
+    
+    obj->serial.vec = var->vec;
+    serial_enable_interrupt(obj, irq, obj->serial.irq_en);
 }
 
 static void serial_check_dma_usage(DMAUsage *dma_usage, int *dma_ch)

--- a/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/serial_api.c
@@ -350,7 +350,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
 
 int serial_getc(serial_t *obj)
 {
-    // TODO: Fix every byte access requires accompaniment of one interrupt. This has side effect of performance degradation.
+    // NOTE: Every byte access requires accompaniment of one interrupt. This has side effect of performance degradation.
     while (! serial_readable(obj));
     int c = UART_READ(((UART_T *) NU_MODBASE(obj->serial.uart)));
     
@@ -365,7 +365,7 @@ int serial_getc(serial_t *obj)
 
 void serial_putc(serial_t *obj, int c)
 {
-    // TODO: Fix every byte access requires accompaniment of one interrupt. This has side effect of performance degradation.
+    // NOTE: Every byte access requires accompaniment of one interrupt. This has side effect of performance degradation.
     while (! serial_writable(obj));
     UART_WRITE(((UART_T *) NU_MODBASE(obj->serial.uart)), c);
     

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/objects.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/objects.h
@@ -61,6 +61,7 @@ struct serial_s {
     void        (*vec)(void);
     uint32_t    irq_handler;
     uint32_t    irq_id;
+    uint32_t    irq_en;
     uint32_t    inten_msk;
     
     // Async transfer related fields

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/dma_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/dma_api.c
@@ -23,6 +23,10 @@
 #include "nu_bitutil.h"
 #include "dma.h"
 
+#define NU_PDMA_CH_MAX      PDMA_CH_MAX     /* Specify maximum channels of PDMA */
+#define NU_PDMA_CH_Pos      0               /* Specify first channel number of PDMA */
+#define NU_PDMA_CH_Msk      (((1 << NU_PDMA_CH_MAX) - 1) << NU_PDMA_CH_Pos)
+
 struct nu_dma_chn_s {
     void        (*handler)(uint32_t, uint32_t);
     uint32_t    id;
@@ -31,7 +35,7 @@ struct nu_dma_chn_s {
 
 static int dma_inited = 0;
 static uint32_t dma_chn_mask = 0;
-static struct nu_dma_chn_s dma_chn_arr[PDMA_CH_MAX];
+static struct nu_dma_chn_s dma_chn_arr[NU_PDMA_CH_MAX];
 
 static void pdma_vec(void);
 static const struct nu_modinit_s dma_modinit = {DMA_0, PDMA_MODULE, 0, 0, PDMA_RST, PDMA_IRQn, (void *) pdma_vec};
@@ -44,7 +48,7 @@ void dma_init(void)
     }
     
     dma_inited = 1;
-    dma_chn_mask = 0;
+    dma_chn_mask = ~NU_PDMA_CH_Msk;
     memset(dma_chn_arr, 0x00, sizeof (dma_chn_arr));
     
     // Reset this module
@@ -65,25 +69,12 @@ int dma_channel_allocate(uint32_t capabilities)
         dma_init();
     }
     
-#if 1
     int i = nu_cto(dma_chn_mask);
     if (i != 32) {
          dma_chn_mask |= 1 << i;
-         memset(dma_chn_arr + i, 0x00, sizeof (struct nu_dma_chn_s));
+         memset(dma_chn_arr + i - NU_PDMA_CH_Pos, 0x00, sizeof (struct nu_dma_chn_s));
          return i;
     }
-#else
-    int i;
-    
-    for (i = 0; i < PDMA_CH_MAX; i ++) {
-        if ((dma_chn_mask & (1 << i)) == 0) {
-            // Channel available
-            dma_chn_mask |= 1 << i;
-            memset(dma_chn_arr + i, 0x00, sizeof (struct nu_dma_chn_s));
-            return i;
-        }
-    }
-#endif
 
     // No channel available
     return DMA_ERROR_OUT_OF_CHANNELS;
@@ -102,9 +93,9 @@ void dma_set_handler(int channelid, uint32_t handler, uint32_t id, uint32_t even
 {
     MBED_ASSERT(dma_chn_mask & (1 << channelid));
     
-    dma_chn_arr[channelid].handler = (void (*)(uint32_t, uint32_t)) handler;
-    dma_chn_arr[channelid].id = id;
-    dma_chn_arr[channelid].event = event;
+    dma_chn_arr[channelid - NU_PDMA_CH_Pos].handler = (void (*)(uint32_t, uint32_t)) handler;
+    dma_chn_arr[channelid - NU_PDMA_CH_Pos].id = id;
+    dma_chn_arr[channelid - NU_PDMA_CH_Pos].event = event;
     
     // Set interrupt vector if someone has removed it.
     NVIC_SetVector(dma_modinit.irq_n, (uint32_t) dma_modinit.var);
@@ -127,14 +118,14 @@ static void pdma_vec(void)
         PDMA_CLR_ABORT_FLAG(abtsts);
         
         while (abtsts) {
-            int chn_id = nu_ctz(abtsts);
+            int chn_id = nu_ctz(abtsts) - PDMA_ABTSTS_ABTIF_Pos + NU_PDMA_CH_Pos;
             if (dma_chn_mask & (1 << chn_id)) {
-                struct nu_dma_chn_s *dma_chn = dma_chn_arr + chn_id;
+                struct nu_dma_chn_s *dma_chn = dma_chn_arr + chn_id - NU_PDMA_CH_Pos;
                 if (dma_chn->handler && (dma_chn->event & DMA_EVENT_ABORT)) {
                     dma_chn->handler(dma_chn->id, DMA_EVENT_ABORT);
                 }
             }
-            abtsts &= ~(1 << chn_id);
+            abtsts &= ~(1 << (chn_id - NU_PDMA_CH_Pos + PDMA_ABTSTS_ABTIF_Pos));
         }
     }
     
@@ -145,14 +136,14 @@ static void pdma_vec(void)
         PDMA_CLR_TD_FLAG(tdsts);
         
         while (tdsts) {
-            int chn_id = nu_ctz(tdsts);
+            int chn_id = nu_ctz(tdsts) - PDMA_TDSTS_TDIF_Pos + NU_PDMA_CH_Pos;
             if (dma_chn_mask & (1 << chn_id)) {
-                struct nu_dma_chn_s *dma_chn = dma_chn_arr + chn_id;
+                struct nu_dma_chn_s *dma_chn = dma_chn_arr + chn_id - NU_PDMA_CH_Pos;
                 if (dma_chn->handler && (dma_chn->event & DMA_EVENT_TRANSFER_DONE)) {
                     dma_chn->handler(dma_chn->id, DMA_EVENT_TRANSFER_DONE);
                 }
             }
-            tdsts &= ~(1 << chn_id);
+            tdsts &= ~(1 << (chn_id - NU_PDMA_CH_Pos + PDMA_TDSTS_TDIF_Pos));
         }
     }
     
@@ -170,14 +161,14 @@ static void pdma_vec(void)
         PDMA->INTSTS = reqto;
         
         while (reqto) {
-            int chn_id = nu_ctz(reqto) - PDMA_INTSTS_REQTOFX_Pos;
+            int chn_id = nu_ctz(reqto) - PDMA_INTSTS_REQTOFX_Pos + NU_PDMA_CH_Pos;
             if (dma_chn_mask & (1 << chn_id)) {
-                struct nu_dma_chn_s *dma_chn = dma_chn_arr + chn_id;
+                struct nu_dma_chn_s *dma_chn = dma_chn_arr + chn_id - NU_PDMA_CH_Pos;
                 if (dma_chn->handler && (dma_chn->event & DMA_EVENT_TIMEOUT)) {
                     dma_chn->handler(dma_chn->id, DMA_EVENT_TIMEOUT);
                 }
             }
-            reqto &= ~(1 << (chn_id + PDMA_INTSTS_REQTOFX_Pos));
+            reqto &= ~(1 << (chn_id - NU_PDMA_CH_Pos + PDMA_INTSTS_REQTOFX_Pos));
         }
     }
 }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/pwmout_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/pwmout_api.c
@@ -105,11 +105,9 @@ void pwmout_init(pwmout_t* obj, PinName pin)
     
     ((struct nu_pwm_var *) modinit->var)->en_msk |= 1 << chn;
     
-    if (((struct nu_pwm_var *) modinit->var)->en_msk) {
-        // Mark this module to be inited.
-        int i = modinit - pwm_modinit_tab;
-        pwm_modinit_mask |= 1 << i;
-    }
+    // Mark this module to be inited.
+    int i = modinit - pwm_modinit_tab;
+    pwm_modinit_mask |= 1 << i;
 }
 
 void pwmout_free(pwmout_t* obj)
@@ -145,11 +143,9 @@ void pwmout_free(pwmout_t* obj)
         }
     }
     
-    if (((struct nu_pwm_var *) modinit->var)->en_msk == 0) {
-        // Mark this module to be deinited.
-        int i = modinit - pwm_modinit_tab;
-        pwm_modinit_mask &= ~(1 << i);
-    }
+    // Mark this module to be deinited.
+    int i = modinit - pwm_modinit_tab;
+    pwm_modinit_mask &= ~(1 << i);
 }
 
 void pwmout_write(pwmout_t* obj, float value)

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
@@ -24,6 +24,7 @@
 #include "PeripheralPins.h"
 #include "nu_modutil.h"
 #include "nu_bitutil.h"
+#include <string.h>
 
 #if DEVICE_SERIAL_ASYNCH
 #include "dma_api.h"
@@ -65,6 +66,8 @@ static void uart_dma_handler_rx(uint32_t id, uint32_t event);
 
 static void serial_tx_enable_interrupt(serial_t *obj, uint32_t address, uint8_t enable);
 static void serial_rx_enable_interrupt(serial_t *obj, uint32_t address, uint8_t enable);
+static void serial_enable_interrupt(serial_t *obj, SerialIrq irq, uint32_t enable);
+static void serial_rollback_interrupt(serial_t *obj, SerialIrq irq);
 static int serial_write_async(serial_t *obj);
 static int serial_read_async(serial_t *obj);
 
@@ -189,7 +192,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
-    MBED_ASSERT(modinit->modname == obj->serial.uart);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
     struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
     
@@ -216,6 +219,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     serial_format(obj, 8, ParityNone, 1);
     
     obj->serial.vec = var->vec;
+    obj->serial.irq_en = 0;
     
 #if DEVICE_SERIAL_ASYNCH
     obj->serial.dma_usage_tx = DMA_USAGE_NEVER;
@@ -242,7 +246,7 @@ void serial_free(serial_t *obj)
 {
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
-    MBED_ASSERT(modinit->modname == obj->serial.uart);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
     struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
     
@@ -361,7 +365,7 @@ void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
     
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
-    MBED_ASSERT(modinit->modname == obj->serial.uart);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
     obj->serial.irq_handler = (uint32_t) handler;
     obj->serial.irq_id = id;
@@ -372,51 +376,18 @@ void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
 
 void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
 {
-    if (enable) {
-        const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
-        MBED_ASSERT(modinit != NULL);
-        MBED_ASSERT(modinit->modname == obj->serial.uart);
-    
-        NVIC_SetVector(modinit->irq_n, (uint32_t) obj->serial.vec);
-        NVIC_EnableIRQ(modinit->irq_n);
-        
-        struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
-        // Multiple serial S/W objects for single UART H/W module possibly.
-        // Bind serial S/W object to UART H/W module as interrupt is enabled.
-        var->obj = obj;
-        
-        switch (irq) {
-            // NOTE: Setting inten_msk first to avoid race condition
-            case RxIrq:
-                obj->serial.inten_msk = obj->serial.inten_msk | (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk);
-                UART_ENABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk));
-                break;
-            case TxIrq:
-                obj->serial.inten_msk = obj->serial.inten_msk | UART_INTEN_THREIEN_Msk;
-                UART_ENABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), UART_INTEN_THREIEN_Msk);
-                break;
-        }
-    } else { // disable
-        switch (irq) {
-            case RxIrq:
-                UART_DISABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk));
-                obj->serial.inten_msk = obj->serial.inten_msk & ~(UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk);
-                break;
-            case TxIrq:
-                UART_DISABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), UART_INTEN_THREIEN_Msk);
-                obj->serial.inten_msk = obj->serial.inten_msk & ~UART_INTEN_THREIEN_Msk;
-                break;
-        }
-    }
+    obj->serial.irq_en = enable;
+    serial_enable_interrupt(obj, irq, enable);
 }
 
 int serial_getc(serial_t *obj)
 {
-    // TODO: Fix every byte access requires accompaniness of one interrupt. This degrades performance much.    
+    // TODO: Fix every byte access requires accompaniment of one interrupt. This has side effect of performance degradation.
     while (! serial_readable(obj));
     int c = UART_READ(((UART_T *) NU_MODBASE(obj->serial.uart)));
     
-    // Simulate clear of the interrupt flag
+    // NOTE: On Nuvoton targets, no H/W IRQ to match TxIrq/RxIrq.
+    //       Simulation of TxIrq/RxIrq requires the call to Serial::putc()/Serial::getc() respectively. 
     if (obj->serial.inten_msk & (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk)) {
         UART_ENABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk));
     }
@@ -426,11 +397,12 @@ int serial_getc(serial_t *obj)
 
 void serial_putc(serial_t *obj, int c)
 {
-    // TODO: Fix every byte access requires accompaniness of one interrupt. This degrades performance much.
+    // TODO: Fix every byte access requires accompaniment of one interrupt. This has side effect of performance degradation.
     while (! serial_writable(obj));
     UART_WRITE(((UART_T *) NU_MODBASE(obj->serial.uart)), c);
     
-    // Simulate clear of the interrupt flag
+    // NOTE: On Nuvoton targets, no H/W IRQ to match TxIrq/RxIrq.
+    //       Simulation of TxIrq/RxIrq requires the call to Serial::putc()/Serial::getc() respectively. 
     if (obj->serial.inten_msk & UART_INTEN_THREIEN_Msk) {
         UART_ENABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), UART_INTEN_THREIEN_Msk);
     }
@@ -542,7 +514,7 @@ int serial_tx_asynch(serial_t *obj, const void *tx, size_t tx_length, uint8_t tx
         // DMA way
         const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
         MBED_ASSERT(modinit != NULL);
-        MBED_ASSERT(modinit->modname == obj->serial.uart);
+        MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
         PDMA_T *pdma_base = dma_modbase();
         
@@ -603,7 +575,7 @@ void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_widt
         // DMA way
         const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
         MBED_ASSERT(modinit != NULL);
-        MBED_ASSERT(modinit->modname == obj->serial.uart);
+        MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
         PDMA_T *pdma_base = dma_modbase();
         
@@ -650,10 +622,8 @@ void serial_tx_abort_asynch(serial_t *obj)
     }
     
     // Necessary for both interrupt way and DMA way
-    serial_irq_set(obj, TxIrq, 0);
-    // FIXME: more complete abort operation
-    //UART_HAL_DisableTransmitter(obj->serial.serial.address);
-    //UART_HAL_FlushTxFifo(obj->serial.serial.address);
+    serial_enable_interrupt(obj, TxIrq, 0);
+    serial_rollback_interrupt(obj, TxIrq);
 }
 
 void serial_rx_abort_asynch(serial_t *obj)
@@ -671,20 +641,30 @@ void serial_rx_abort_asynch(serial_t *obj)
     }
     
     // Necessary for both interrupt way and DMA way
-    serial_irq_set(obj, RxIrq, 0);
-    // FIXME: more complete abort operation
-    //UART_HAL_DisableReceiver(obj->serial.serial.address);
-    //UART_HAL_FlushRxFifo(obj->serial.serial.address);
+    serial_enable_interrupt(obj, RxIrq, 0);
+    serial_rollback_interrupt(obj, RxIrq);
 }
 
 uint8_t serial_tx_active(serial_t *obj)
 {
-    return serial_is_irq_en(obj, TxIrq);
+    // NOTE: Judge by serial_is_irq_en(obj, TxIrq) doesn't work with sync/async modes interleaved. Change with TX FIFO empty flag.
+    const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
+    MBED_ASSERT(modinit != NULL);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
+    
+    struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;    
+    return (obj->serial.vec == var->vec_async);
 }
 
 uint8_t serial_rx_active(serial_t *obj)
 {
-    return serial_is_irq_en(obj, RxIrq);
+    // NOTE: Judge by serial_is_irq_en(obj, RxIrq) doesn't work with sync/async modes interleaved. Change with RX FIFO empty flag.
+    const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
+    MBED_ASSERT(modinit != NULL);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
+    
+    struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;    
+    return (obj->serial.vec == var->vec_async);
 }
 
 int serial_irq_handler_asynch(serial_t *obj)
@@ -934,7 +914,7 @@ static int serial_write_async(serial_t *obj)
 {   
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
-    MBED_ASSERT(modinit->modname == obj->serial.uart);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
     UART_T *uart_base = (UART_T *) NU_MODBASE(obj->serial.uart);
     
@@ -986,7 +966,7 @@ static int serial_read_async(serial_t *obj)
 {
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
-    MBED_ASSERT(modinit->modname == obj->serial.uart);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
     uint32_t rx_fifo_busy = (((UART_T *) NU_MODBASE(obj->serial.uart))->FIFOSTS & UART_FIFOSTS_RXPTR_Msk) >> UART_FIFOSTS_RXPTR_Pos;
     //uint32_t rx_fifo_free = ((struct nu_uart_var *) modinit->var)->fifo_size_rx - rx_fifo_busy;
@@ -1061,28 +1041,81 @@ static void serial_tx_enable_interrupt(serial_t *obj, uint32_t handler, uint8_t 
 {
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
-    MBED_ASSERT(modinit->modname == obj->serial.uart);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
     // Necessary for both interrupt way and DMA way
     struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
     // With our own async vector, tx/rx handlers can be different.
     obj->serial.vec = var->vec_async;
     obj->serial.irq_handler_tx_async = (void (*)(void)) handler;
-    serial_irq_set(obj, TxIrq, enable);
+    serial_enable_interrupt(obj, TxIrq, enable);
 }
 
 static void serial_rx_enable_interrupt(serial_t *obj, uint32_t handler, uint8_t enable)
 {
     const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
     MBED_ASSERT(modinit != NULL);
-    MBED_ASSERT(modinit->modname == obj->serial.uart);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
     
     // Necessary for both interrupt way and DMA way
     struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
     // With our own async vector, tx/rx handlers can be different.
     obj->serial.vec = var->vec_async;
     obj->serial.irq_handler_rx_async = (void (*) (void)) handler;
-    serial_irq_set(obj, RxIrq, enable);
+    serial_enable_interrupt(obj, RxIrq, enable);
+}
+
+static void serial_enable_interrupt(serial_t *obj, SerialIrq irq, uint32_t enable)
+{
+    if (enable) {
+        const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
+        MBED_ASSERT(modinit != NULL);
+        MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
+    
+        NVIC_SetVector(modinit->irq_n, (uint32_t) obj->serial.vec);
+        NVIC_EnableIRQ(modinit->irq_n);
+        
+        struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
+        // Multiple serial S/W objects for single UART H/W module possibly.
+        // Bind serial S/W object to UART H/W module as interrupt is enabled.
+        var->obj = obj;
+        
+        switch (irq) {
+            // NOTE: Setting inten_msk first to avoid race condition
+            case RxIrq:
+                obj->serial.inten_msk = obj->serial.inten_msk | (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk);
+                UART_ENABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk));
+                break;
+            case TxIrq:
+                obj->serial.inten_msk = obj->serial.inten_msk | UART_INTEN_THREIEN_Msk;
+                UART_ENABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), UART_INTEN_THREIEN_Msk);
+                break;
+        }
+    }
+    else { // disable
+        switch (irq) {
+            case RxIrq:
+                UART_DISABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), (UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk));
+                obj->serial.inten_msk = obj->serial.inten_msk & ~(UART_INTEN_RDAIEN_Msk | UART_INTEN_RXTOIEN_Msk);
+                break;
+            case TxIrq:
+                UART_DISABLE_INT(((UART_T *) NU_MODBASE(obj->serial.uart)), UART_INTEN_THREIEN_Msk);
+                obj->serial.inten_msk = obj->serial.inten_msk & ~UART_INTEN_THREIEN_Msk;
+                break;
+        }
+    }
+}
+
+static void serial_rollback_interrupt(serial_t *obj, SerialIrq irq)
+{
+    const struct nu_modinit_s *modinit = get_modinit(obj->serial.uart, uart_modinit_tab);
+    MBED_ASSERT(modinit != NULL);
+    MBED_ASSERT(modinit->modname == (int) obj->serial.uart);
+    
+    struct nu_uart_var *var = (struct nu_uart_var *) modinit->var;
+    
+    obj->serial.vec = var->vec;
+    serial_enable_interrupt(obj, irq, obj->serial.irq_en);
 }
 
 static void serial_check_dma_usage(DMAUsage *dma_usage, int *dma_ch)

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/serial_api.c
@@ -382,7 +382,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
 
 int serial_getc(serial_t *obj)
 {
-    // TODO: Fix every byte access requires accompaniment of one interrupt. This has side effect of performance degradation.
+    // NOTE: Every byte access requires accompaniment of one interrupt. This has side effect of performance degradation.
     while (! serial_readable(obj));
     int c = UART_READ(((UART_T *) NU_MODBASE(obj->serial.uart)));
     
@@ -397,7 +397,7 @@ int serial_getc(serial_t *obj)
 
 void serial_putc(serial_t *obj, int c)
 {
-    // TODO: Fix every byte access requires accompaniment of one interrupt. This has side effect of performance degradation.
+    // NOTE: Every byte access requires accompaniment of one interrupt. This has side effect of performance degradation.
     while (! serial_writable(obj));
     UART_WRITE(((UART_T *) NU_MODBASE(obj->serial.uart)), c);
     


### PR DESCRIPTION
## Description
This PR includes the following bugfixes for NUMAKER_PFM_NUC472/NUMAKER_PFM_M453 targets.
1. Fix serial error with sync/async calls interlaced.
1. Remove unreleased register setting from flash algorithm.
1. Other minor bugfixes