### PR TITLE
Config: config header file should contain new line

### DIFF
--- a/tools/config/header.tmpl
+++ b/tools/config/header.tmpl
@@ -41,3 +41,4 @@
 {% endfor %}
 {%- endif %}
 #endif
+


### PR DESCRIPTION
Tested with ARM

Before this patch
```
Compile [  5.3%]: analogout_api.c
[Warning] mbed_config.h@30,0:  #1-D: last line of file ends without a newline
Compile [ 10.5%]: analogin_api.c
[Warning] mbed_config.h@30,0:  #1-D: last line of file ends without a newline
Compile [ 15.8%]: startup_LPC17xx.S
[Warning] mbed_config.h@30,0:  #1-D: last line of file ends without a newline
Compile [ 21.1%]: can_api.c
[Warning] mbed_config.h@30,0:  #1-D: last line of file ends without a newline
```

After this patch:
```
Compile [  2.2%]: AnalogIn.cpp
Compile [  4.4%]: BusIn.cpp
Compile [  6.7%]: BusOut.cpp
Compile [  8.9%]: BusInOut.cpp
Compile [ 11.1%]: FlashIAP.cpp
Compile [ 13.3%]: Ethernet.cpp
Compile [ 15.6%]: I2C.cpp
Compile [ 17.8%]: CAN.cpp
Compile [ 20.0%]: I2CSlave.cpp
Compile [ 22.2%]: InterruptIn.cpp
Compile [ 24.4%]: SPI.cpp
```

We shall be careful with warnings (not adding more to the codebase that we already have :-) )

@theotherjimmy 