### PR TITLE
Fix C++11 build error w/ u-blox EVK-ODIN-W2

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/sdk/wifi_emac/wifi_emac_api.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/sdk/wifi_emac/wifi_emac_api.cpp
@@ -328,9 +328,11 @@ static void wifi_set_link_state_cb(emac_interface_t *emac, emac_link_state_chang
 emac_interface_t* wifi_emac_get_interface()
 {
     if (_intf == NULL) {
-        _intf = new emac_interface_t();
-        _intf->hw = NULL;
-        memcpy((void*)&_intf->ops, &wifi_emac_interface, sizeof(wifi_emac_interface));
+        _intf = (emac_interface_t*)malloc(sizeof(emac_interface_t));
+        if (_intf) {
+            _intf->hw = NULL;
+            memcpy((void*)&_intf->ops, &wifi_emac_interface, sizeof(wifi_emac_interface));
+        }
     }
    return _intf;
 }


### PR DESCRIPTION
When attempting to perform a test build of various mbed-os targets with
GCC configured to build -std=gnu++11, all of the targets built
successfully except for this one. It gave errors like this:
```
    ../mbed-os/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/sdk/wifi_emac/wifi_emac_api.cpp: In function 'emac_interface_t* wifi_emac_get_interface()':
    ../mbed-os/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/sdk/wifi_emac/wifi_emac_api.cpp:331:38: error: use of deleted function 'emac_interface::emac_interface()'
             _intf = new emac_interface_t();
                                          ^
    In file included from ../mbed-os/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/sdk/wifi_emac/wifi_emac_api.cpp:9:0:
    ../mbed-os/hal/emac_api.h:150:16: note: 'emac_interface::emac_interface()' is implicitly deleted because the default definition would be ill-formed:
     typedef struct emac_interface {
                    ^
    ../mbed-os/hal/emac_api.h:150:16: error: uninitialized const member in 'struct emac_interface'
    ../mbed-os/hal/emac_api.h:151:32: note: 'const emac_interface_ops_t emac_interface::ops' should be initialized
         const emac_interface_ops_t ops;
```
This commit contains a proposed change which fixes this issue by not
using the new operator to allocate the emac_interface_t structure but
instead using the malloc() function since the construction is being
handled explicitly in the subsequent lines of the
wifi_emac_get_interface() function anyway.

I also added code which only completes the initialization of the _intf
object if its allocation succeeds and just returns NULL otherwise.

I see no deallocation of the _intf object occurring so no change from
delete to free() needed to be made.
