### PR TITLE
Add TARGET_LPC11U35_501 for Xadow M0 device

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -148,15 +148,7 @@
         "device_name": "LPC11U35FHI33/501"
     },
     "XADOW_M0": {
-        "inherits": ["LPCTarget"],
-        "core": "Cortex-M0",
-        "default_toolchain": "uARM",
-        "extra_labels": ["NXP", "LPC11UXX", "MCU_LPC11U35_501"],
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
-        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "default_lib": "small",
-        "release_versions": ["2"],
-        "device_name": "LPC11U35FHI33/501"
+        "inherits": ["LPC11U35_501"],
     },
     "LPC11U35_Y5_MBUG": {
         "inherits": ["LPCTarget"],


### PR DESCRIPTION
targets/targets.json already added MCU_LPC11U35_501 as an extra label
but it didn't have LPC11U35_501 (without the MCU_ prefix). Both of
these target names are used as folder names to organize files
specific to this device. For example the LPC11U35.ld linker script used
by GCC_ARM for this target is located in a TARGET_LPC11U35_501 folder.
