### PR TITLE
Removed unused variable in TARGET_NXP/lpc17_emac.c

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NXP/lpc17_emac.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NXP/lpc17_emac.c
@@ -402,7 +402,6 @@ static struct pbuf *lpc_low_level_input(struct netif *netif)
  */
 void lpc_enetif_input(struct netif *netif)
 {
-	struct eth_hdr *ethhdr;
 	struct pbuf *p;
 
 	/* move received packet into a new pbuf */


### PR DESCRIPTION
## Description
Unused variable causes compiler warning:
```
/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NXP/lpc17_emac.c: In function 'lpc_enetif_input':
1>[path removed]\features\FEATURE_LWIP\lwip-interface\lwip-eth\arch\TARGET_NXP\lpc17_emac.c(405,18): warning :  unused variable 'ethhdr' [-Wunused-variable]
```


## Status
**READY**


## Migrations
NO


## Todos
none


## Deploy notes
none


## Steps to test or reproduce
turn on compiler flag "-Wunused-variable"