### PR TITLE
Added support for the Target Blue Pill F103C8

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -357,7 +357,7 @@ extern void pre_main (void);
 #if defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832) || defined (TARGET_STM32F334R8) ||\
     defined(TARGET_STM32F070RB) || defined(TARGET_STM32F072RB) || \
     defined(TARGET_STM32F302R8) || defined(TARGET_STM32F303K8) || defined (TARGET_STM32F334C8) ||\
-    defined(TARGET_STM32F103RB)
+    defined(TARGET_STM32F103RB) || defined(TARGET_STM32F103C8)
 static uint32_t thread_stack_main[DEFAULT_STACK_SIZE / sizeof(uint32_t)];
 #elif defined(TARGET_XDOT_L151CC)
 static uint32_t thread_stack_main[DEFAULT_STACK_SIZE * 6 / sizeof(uint32_t)];

--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -122,6 +122,21 @@
 #define OS_CLOCK                72000000
 #endif
 
+#elif defined(TARGET_STM32F103C8)
+
+#ifndef INITIAL_SP
+#define INITIAL_SP              (0x20005000UL)
+#endif
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                72000000
+#endif
+
 #elif defined(TARGET_STM32F207ZG)
 
 #ifndef INITIAL_SP

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2724,9 +2724,11 @@
         "core": "Cortex-M3",
         "default_toolchain": "GCC_ARM",
         "extra_labels": ["STM", "STM32F1", "STM32F103C8"],
-        "supported_toolchains": ["GCC_ARM"],
+        "supported_toolchains": ["ARM","GCC_ARM","IAR"],
         "inherits": ["Target"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"]
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
+        "release_versions": ["2", "5"],
+        "device_name": "STM32F103C8"
     },
     "NUMAKER_PFM_NUC472": {
         "core": "Cortex-M4F",


### PR DESCRIPTION
Notes:
* I agree to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).

## Description
The STM32F103RB and STM32F10C8 are identical mcu and only differ in flash size, so the support of mbed os for one and not the other is not reasonable.
The mbed-os is currently kind of if deffing the F103C8 out of the compilation, so I parsed all of the OS and added the flag support for STM32F10C8 where needed to declare things such as OS_TASKCNT,...

## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [x] Tests
- [ ] Documentation


## Deploy notes
Notes regarding the deployment of this PR. These should note any
required changes in the build environment, tools, compilers, etc.


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
