### PR TITLE
CMSIS5: Encapsulate usage of private RTX structures to one header file

### DIFF
--- a/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_interrupt.c
+++ b/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_interrupt.c
@@ -5,12 +5,12 @@
 #include "arm_hal_interrupt.h"
 #include "arm_hal_interrupt_private.h"
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
+#include "mbed_rtos_storage.h"
 #include <mbed_assert.h>
 
 static uint8_t sys_irq_disable_counter;
 
-static os_mutex_t critical_mutex;
+static mbed_rtos_storage_mutex_t critical_mutex;
 static const osMutexAttr_t critical_mutex_attr = {
   .name = "critical_mutex",
   .attr_bits = osMutexRecursive,

--- a/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/ns_event_loop.c
+++ b/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/ns_event_loop.c
@@ -5,7 +5,7 @@
 #include <mbed_assert.h>
 #include "cmsis.h"
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
+#include "mbed_rtos_storage.h"
 #include "ns_trace.h"
 
 #include "eventOS_scheduler.h"
@@ -17,7 +17,7 @@
 static void event_loop_thread(void *arg);
 
 static uint64_t event_thread_stk[MBED_CONF_NANOSTACK_HAL_EVENT_LOOP_THREAD_STACK_SIZE/8];
-static osRtxThread_t event_thread_tcb;
+static mbed_rtos_storage_thread_t event_thread_tcb;
 static const osThreadAttr_t event_thread_attr = {
     .priority = osPriorityNormal,
     .stack_mem = &event_thread_stk[0],
@@ -26,7 +26,7 @@ static const osThreadAttr_t event_thread_attr = {
     .cb_size = sizeof event_thread_tcb,
 };
 static osThreadId_t event_thread_id;
-static os_mutex_t event_mutex;
+static mbed_rtos_storage_mutex_t event_mutex;
 static const osMutexAttr_t event_mutex_attr = {
   .name = "event_mutex",
   .attr_bits = osMutexRecursive,

--- a/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/lwip_sys_arch.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/lwip_sys_arch.c
@@ -21,6 +21,7 @@
 #include "mbed_error.h"
 #include "mbed_interface.h"
 #include "us_ticker_api.h"
+#include "mbed_rtos_storage.h"
 
 /* lwIP includes. */
 #include "lwip/opt.h"
@@ -412,7 +413,7 @@ void sys_mutex_free(sys_mutex_t *mutex) {}
  *---------------------------------------------------------------------------*/
 osMutexId_t lwip_sys_mutex;
 osMutexAttr_t lwip_sys_mutex_attr;
-os_mutex_t lwip_sys_mutex_data;
+mbed_rtos_storage_mutex_t lwip_sys_mutex_data;
 
 void sys_init(void) {
     us_ticker_read(); // Init sys tick

--- a/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/sys_arch.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/sys_arch.h
@@ -19,7 +19,7 @@
 #define __ARCH_SYS_ARCH_H__
 
 #include "lwip/opt.h"
-#include "rtx_lib.h"
+#include "mbed_rtos_storage.h"
 
 extern u8_t lwip_ram_heap[];
 
@@ -28,9 +28,9 @@ extern u8_t lwip_ram_heap[];
 
 // === SEMAPHORE ===
 typedef struct {
-    osSemaphoreId_t   id;
-    osSemaphoreAttr_t attr;
-    os_semaphore_t    data;
+    osSemaphoreId_t               id;
+    osSemaphoreAttr_t             attr;
+    mbed_rtos_storage_semaphore_t data;
 } sys_sem_t;
 
 #define sys_sem_valid(x)        (((*x).id == NULL) ? 0 : 1)
@@ -38,18 +38,18 @@ typedef struct {
 
 // === MUTEX ===
 typedef struct {
-    osMutexId_t   id;
-    osMutexAttr_t attr;
-    os_mutex_t    data;
+    osMutexId_t               id;
+    osMutexAttr_t             attr;
+    mbed_rtos_storage_mutex_t data;
 } sys_mutex_t;
 
 // === MAIL BOX ===
 #define MB_SIZE      8
 
 typedef struct {
-    osEventFlagsId_t   id;
-    osEventFlagsAttr_t attr;
-    os_event_flags_t   data;
+    osEventFlagsId_t                id;
+    osEventFlagsAttr_t              attr;
+    mbed_rtos_storage_event_flags_t data;
 
     uint8_t     post_idx;
     uint8_t     fetch_idx;
@@ -73,9 +73,9 @@ typedef struct {
 
 // === THREAD ===
 typedef struct {
-    osThreadId_t   id;
-    osThreadAttr_t attr;
-    os_thread_t    data;
+    osThreadId_t               id;
+    osThreadAttr_t             attr;
+    mbed_rtos_storage_thread_t data;
 } sys_thread_data_t;
 typedef sys_thread_data_t* sys_thread_t;
 

--- a/features/FEATURE_UVISOR/source/rtx/secure_allocator.c
+++ b/features/FEATURE_UVISOR/source/rtx/secure_allocator.c
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "rtx_lib.h"
+#include "mbed_rtos_storage.h"
 
 /* uVisor uses rtx_memory instead of implementing its own dynamic,
  * non-fixed-size memory allocator. To do this, uVisor creates multiple

--- a/features/FEATURE_UVISOR/source/rtx/uvisor_semaphore.c
+++ b/features/FEATURE_UVISOR/source/rtx/uvisor_semaphore.c
@@ -2,13 +2,13 @@
 #include "api/inc/uvisor_exports.h"
 #include "api/inc/halt_exports.h"
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
+#include "mbed_rtos_storage.h"
 #include <string.h>
 
 typedef struct uvisor_semaphore_internal {
-    osSemaphoreId_t   id;
-    osSemaphoreAttr_t attr;
-    osRtxSemaphore_t data;
+    osSemaphoreId_t               id;
+    osSemaphoreAttr_t             attr;
+    mbed_rtos_storage_semaphore_t data;
 } UVISOR_ALIGN(4) uvisor_semaphore_internal_t;
 
 UVISOR_STATIC_ASSERT(UVISOR_SEMAPHORE_INTERNAL_SIZE >= sizeof(UvisorSemaphore), semaphore_size_too_small);

--- a/rtos/MemoryPool.h
+++ b/rtos/MemoryPool.h
@@ -26,8 +26,8 @@
 #include <string.h>
 
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
 #include "mbed_rtos1_types.h"
+#include "mbed_rtos_storage.h"
 
 namespace rtos {
 /** \addtogroup rtos */
@@ -83,10 +83,10 @@ public:
     }
 
 private:
-    osMemoryPoolId_t   _id;
-    osMemoryPoolAttr_t _attr;
-    char               _pool_mem[sizeof(T) * pool_sz];
-    os_memory_pool_t   _obj_mem;
+    osMemoryPoolId_t             _id;
+    osMemoryPoolAttr_t           _attr;
+    char                         _pool_mem[sizeof(T) * pool_sz];
+    mbed_rtos_storage_mem_pool_t _obj_mem;
 };
 
 }

--- a/rtos/Mutex.h
+++ b/rtos/Mutex.h
@@ -24,8 +24,8 @@
 
 #include <stdint.h>
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
 #include "mbed_rtos1_types.h"
+#include "mbed_rtos_storage.h"
 
 namespace rtos {
 /** \addtogroup rtos */
@@ -62,9 +62,9 @@ public:
     ~Mutex();
 
 private:
-    osMutexId_t   _id;
-    osMutexAttr_t _attr;
-    os_mutex_t    _obj_mem;
+    osMutexId_t               _id;
+    osMutexAttr_t             _attr;
+    mbed_rtos_storage_mutex_t _obj_mem;
 };
 
 }

--- a/rtos/Queue.h
+++ b/rtos/Queue.h
@@ -26,7 +26,7 @@
 #include <string.h>
 
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
+#include "mbed_rtos_storage.h"
 #include "platform/mbed_error.h"
 #include "mbed_rtos1_types.h"
 
@@ -100,10 +100,10 @@ public:
     }
 
 private:
-    osMessageQueueId_t   _id;
-    osMessageQueueAttr_t _attr;
-    char                 _queue_mem[queue_sz * (sizeof(T*) + sizeof(os_message_t))];
-    os_message_queue_t   _obj_mem;
+    osMessageQueueId_t            _id;
+    osMessageQueueAttr_t          _attr;
+    char                          _queue_mem[queue_sz * (sizeof(T*) + sizeof(mbed_rtos_storage_message_t))];
+    mbed_rtos_storage_msg_queue_t _obj_mem;
 };
 
 }

--- a/rtos/Semaphore.h
+++ b/rtos/Semaphore.h
@@ -24,8 +24,8 @@
 
 #include <stdint.h>
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
 #include "mbed_rtos1_types.h"
+#include "mbed_rtos_storage.h"
 
 namespace rtos {
 /** \addtogroup rtos */
@@ -59,9 +59,9 @@ public:
     ~Semaphore();
 
 private:
-    osSemaphoreId_t   _id;
-    osSemaphoreAttr_t _attr;
-    os_semaphore_t    _obj_mem;
+    osSemaphoreId_t               _id;
+    osSemaphoreAttr_t             _attr;
+    mbed_rtos_storage_semaphore_t _obj_mem;
 };
 
 }

--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -24,8 +24,8 @@
 
 #include <stdint.h>
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
 #include "mbed_rtos1_types.h"
+#include "mbed_rtos_storage.h"
 #include "mbed_rtx_conf.h"
 #include "platform/Callback.h"
 #include "platform/mbed_toolchain.h"
@@ -368,14 +368,14 @@ private:
                      const char *name=NULL);
     static void _thunk(void * thread_ptr);
 
-    mbed::Callback<void()> _task;
-    osThreadId_t           _tid;
-    osThreadAttr_t         _attr;
-    bool                   _dynamic_stack;
-    Semaphore              _join_sem;
-    Mutex                  _mutex;
-    os_thread_t            _obj_mem;
-    bool                   _finished;
+    mbed::Callback<void()>     _task;
+    osThreadId_t               _tid;
+    osThreadAttr_t             _attr;
+    bool                       _dynamic_stack;
+    Semaphore                  _join_sem;
+    Mutex                      _mutex;
+    mbed_rtos_storage_thread_t _obj_mem;
+    bool                       _finished;
 };
 
 }

--- a/rtos/mbed_boot.c
+++ b/rtos/mbed_boot.c
@@ -162,7 +162,7 @@
 
 #include "cmsis.h"
 #include "mbed_rtx.h"
-#include "rtx_lib.h"
+#include "mbed_rtos_storage.h"
 #include "cmsis_os2.h"
 #include "mbed_toolchain.h"
 #include "mbed_error.h"
@@ -182,12 +182,11 @@ osThreadAttr_t _main_thread_attr;
  * the correct solution to the problem and it makes mbed OS behave differently on different targets.
  */
 MBED_ALIGN(8) char _main_stack[4096];
+mbed_rtos_storage_thread_t _main_obj;
 
-char _main_obj[sizeof(os_thread_t)];
-
-osMutexId_t   singleton_mutex_id;
-os_mutex_t    singleton_mutex_obj;
-osMutexAttr_t singleton_mutex_attr;
+osMutexId_t               singleton_mutex_id;
+mbed_rtos_storage_mutex_t singleton_mutex_obj;
+osMutexAttr_t             singleton_mutex_attr;
 
 /*
  * Sanity check values
@@ -317,7 +316,7 @@ void mbed_start_main(void)
     _main_thread_attr.stack_mem = _main_stack;
     _main_thread_attr.stack_size = sizeof(_main_stack);
     _main_thread_attr.cb_size = sizeof(_main_obj);
-    _main_thread_attr.cb_mem = _main_obj;
+    _main_thread_attr.cb_mem = &_main_obj;
     _main_thread_attr.priority = osPriorityNormal;
     _main_thread_attr.name = "MAIN";
     osThreadId_t result = osThreadNew((osThreadFunc_t)pre_main, NULL, &_main_thread_attr);
@@ -414,13 +413,13 @@ extern int main(int argc, char* argv[]);
 extern void __libc_init_array (void);
 extern int __real_main(void);
 
-osMutexId_t   malloc_mutex_id;
-os_mutex_t    malloc_mutex_obj;
-osMutexAttr_t malloc_mutex_attr;
+osMutexId_t               malloc_mutex_id;
+mbed_rtos_storage_mutex_t malloc_mutex_obj;
+osMutexAttr_t             malloc_mutex_attr;
 
-osMutexId_t   env_mutex_id;
-os_mutex_t    env_mutex_obj;
-osMutexAttr_t env_mutex_attr;
+osMutexId_t               env_mutex_id;
+mbed_rtos_storage_mutex_t env_mutex_obj;
+osMutexAttr_t             env_mutex_attr;
 
 #ifdef  FEATURE_UVISOR
 #include "uvisor-lib/uvisor-lib.h"
@@ -549,11 +548,11 @@ void __iar_program_start( void )
 }
 
 /* Thread safety */
-static osMutexId_t std_mutex_id_sys[_MAX_LOCK] = {0};
-static os_mutex_t  std_mutex_sys[_MAX_LOCK] = {0};
+static osMutexId_t               std_mutex_id_sys[_MAX_LOCK] = {0};
+static mbed_rtos_storage_mutex_t std_mutex_sys[_MAX_LOCK] = {0};
 #define _FOPEN_MAX 10
-static osMutexId_t std_mutex_id_file[_FOPEN_MAX] = {0};
-static os_mutex_t  std_mutex_file[_FOPEN_MAX] = {0};
+static osMutexId_t               std_mutex_id_file[_FOPEN_MAX] = {0};
+static mbed_rtos_storage_mutex_t std_mutex_file[_FOPEN_MAX] = {0};
 
 void __iar_system_Mtxinit(__iar_Rmtx *mutex) /* Initialize a system lock */
 {

--- a/rtos/mbed_rtos_storage.h
+++ b/rtos/mbed_rtos_storage.h
@@ -1,8 +1,5 @@
-
-/** \addtogroup rtos */
-/** @{*/
 /* mbed Microcontroller Library
- * Copyright (c) 2006-2012 ARM Limited
+ * Copyright (c) 2006-2017 ARM Limited
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,30 +19,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef RTOS_H
-#define RTOS_H
+#ifndef MBED_RTOS_STORAGE_H
+#define MBED_RTOS_STORAGE_H
 
-#include "mbed_rtx.h"
-#include "mbed_rtx_conf.h"
-#include "mbed_rtos_storage.h"
-#include "rtos/Thread.h"
-#include "rtos/Mutex.h"
-#include "rtos/RtosTimer.h"
-#include "rtos/Semaphore.h"
-#include "rtos/Mail.h"
-#include "rtos/MemoryPool.h"
-#include "rtos/Queue.h"
+/** \addtogroup rtos */
+/** @{*/
 
-using namespace rtos;
+/** @brief RTOS primitives storage types for RTX
 
-/* Get mbed lib version number, as RTOS depends on mbed lib features
-   like mbed_error, Callback and others.
-*/
-#include "mbed.h"
+ Types defined in this file should be utilized, when the direct RTOS C API usage is required, to provide backing memory
+ for internal RTX data. Allocated object should be wrapped in attribute struct and passed to os*New call, for details
+ see CMSIS-RTOS2 documentation.
 
-#if (MBED_LIBRARY_VERSION < 122)
-#error "This version of RTOS requires mbed library version > 121"
-#endif
+ @note
+ This file breaks abstraction layers and uses RTX internal types, but it limits the contamination to single, RTOS
+ implementation specific, header file, therefore limiting scope of possible changes.
+ */
+
+#include "rtx_lib.h"
+
+typedef os_mutex_t mbed_rtos_storage_mutex_t;
+typedef os_semaphore_t mbed_rtos_storage_semaphore_t;
+typedef os_thread_t mbed_rtos_storage_thread_t;
+typedef os_memory_pool_t mbed_rtos_storage_mem_pool_t;
+typedef os_message_queue_t mbed_rtos_storage_msg_queue_t;
+typedef os_event_flags_t mbed_rtos_storage_event_flags_t;
+typedef os_message_t mbed_rtos_storage_message_t;
 
 #endif
 


### PR DESCRIPTION
mbed OS requires access to internal RTX structures, to use them as RTOS
object's backing storage. To avoid contaminating multiple places across
mbed sources, all required types are typedefed in one header file.

@0xc0170 