### PR TITLE
Add error check in Stream constructor

### DIFF
--- a/platform/Stream.cpp
+++ b/platform/Stream.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #include "platform/Stream.h"
+#include "platform/mbed_error.h"
+#include <errno.h>
 
 namespace mbed {
 
@@ -23,7 +25,11 @@ Stream::Stream(const char *name) : FileLike(name), _file(NULL) {
     char buf[12]; /* :0x12345678 + null byte */
     std::sprintf(buf, ":%p", this);
     _file = std::fopen(buf, "w+");
-    mbed_set_unbuffered_stream(_file);
+    if (_file) {
+        mbed_set_unbuffered_stream(_file);
+    } else {
+        error("Stream obj failure, errno=%d\r\n", errno);
+    }
 }
 
 Stream::~Stream() {


### PR DESCRIPTION
Proposal following discussion on #687 

## Description
On small targets there might be memory issues that lead to failing on file allocaiton / opening during Stream creation.

The consequence was application continues running, but any printf
to the Serial object whose Stream was not properly created
would not show any error (and characters would not show either)

Let's add a check to be properly inform user of the error.


## Status
**READY**