### PR TITLE
stm32f4xx: Consider all DMA ready/busy states in conditionals

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_dma.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_dma.c
@@ -762,9 +762,6 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
       
       /* Update error code */
       hdma->ErrorCode |= HAL_DMA_ERROR_TE;
-
-      /* Change the DMA state */
-      hdma->State = HAL_DMA_STATE_ERROR; // FIX
     }
   }
   /* FIFO Error Interrupt management ******************************************/
@@ -777,9 +774,6 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
 
       /* Update error code */
       hdma->ErrorCode |= HAL_DMA_ERROR_FE;
-
-      /* Change the DMA state */
-      hdma->State = HAL_DMA_STATE_ERROR; // FIX
     }
   }
   /* Direct Mode Error Interrupt management ***********************************/
@@ -792,9 +786,6 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
 
       /* Update error code */
       hdma->ErrorCode |= HAL_DMA_ERROR_DME;
-
-      /* Change the DMA state */
-      hdma->State = HAL_DMA_STATE_ERROR; // FIX
     }
   }
   /* Half Transfer Complete Interrupt management ******************************/
@@ -811,9 +802,6 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
         /* Current memory buffer used is Memory 0 */
         if((hdma->Instance->CR & DMA_SxCR_CT) == RESET)
         {
-          /* Change DMA peripheral state */
-          hdma->State = HAL_DMA_STATE_READY_HALF_MEM0; // FIX
-
           if(hdma->XferHalfCpltCallback != NULL)
           {
             /* Half transfer callback */
@@ -823,9 +811,6 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
         /* Current memory buffer used is Memory 1 */
         else
         {
-          /* Change DMA peripheral state */
-          hdma->State = HAL_DMA_STATE_READY_HALF_MEM1; // FIX
-
           if(hdma->XferM1HalfCpltCallback != NULL)
           {
             /* Half transfer callback */
@@ -842,9 +827,6 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
           hdma->Instance->CR  &= ~(DMA_IT_HT);
         }
         
-        /* Change DMA peripheral state */
-        hdma->State = HAL_DMA_STATE_READY_HALF_MEM0; // FIX
-
         if(hdma->XferHalfCpltCallback != NULL)
         {
           /* Half transfer callback */
@@ -893,9 +875,6 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
         /* Current memory buffer used is Memory 0 */
         if((hdma->Instance->CR & DMA_SxCR_CT) == RESET)
         {
-          /* Change DMA peripheral state */
-          hdma->State = HAL_DMA_STATE_READY_MEM1; // FIX
-     
           if(hdma->XferM1CpltCallback != NULL)
           {
             /* Transfer complete Callback for memory1 */
@@ -905,9 +884,6 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
         /* Current memory buffer used is Memory 1 */
         else
         {
-          /* Change DMA peripheral state */
-          hdma->State = HAL_DMA_STATE_READY_MEM0; // FIX
-     
           if(hdma->XferCpltCallback != NULL)
           {
             /* Transfer complete Callback for memory0 */
@@ -918,9 +894,6 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
       /* Disable the transfer complete interrupt if the DMA mode is not CIRCULAR */
       else
       {
-    	/* Change DMA peripheral state */
-    	hdma->State = HAL_DMA_STATE_READY_MEM0; // FIX
-     
         if((hdma->Instance->CR & DMA_SxCR_CIRC) == RESET)
         {
           /* Disable the transfer complete interrupt */

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_dma.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_dma.h
@@ -122,13 +122,7 @@ typedef enum
 {
   HAL_DMA_STATE_RESET             = 0x00U,  /*!< DMA not yet initialized or disabled */
   HAL_DMA_STATE_READY             = 0x01U,  /*!< DMA initialized and ready for use   */
-  HAL_DMA_STATE_READY_MEM0        = 0x11U,  /*!< DMA Mem0 process success            */ // FIX
-  HAL_DMA_STATE_READY_MEM1        = 0x21U,  /*!< DMA Mem1 process success            */ // FIX
-  HAL_DMA_STATE_READY_HALF_MEM0   = 0x31U,  /*!< DMA Mem0 Half process success       */ // FIX
-  HAL_DMA_STATE_READY_HALF_MEM1   = 0x41U,  /*!< DMA Mem1 Half process success       */ // FIX
   HAL_DMA_STATE_BUSY              = 0x02U,  /*!< DMA process is ongoing              */
-  HAL_DMA_STATE_BUSY_MEM0         = 0x12U,  /*!< DMA Mem0 process is ongoing         */ // FIX
-  HAL_DMA_STATE_BUSY_MEM1         = 0x22U,  /*!< DMA Mem1 process is ongoing         */ // FIX
   HAL_DMA_STATE_TIMEOUT           = 0x03U,  /*!< DMA timeout state                   */
   HAL_DMA_STATE_ERROR             = 0x04U,  /*!< DMA error state                     */
   HAL_DMA_STATE_ABORT             = 0x05U,  /*!< DMA Abort state                     */


### PR DESCRIPTION
Fix for #4262 

This fixes potential corner case issues relating to
stopping, starting, init/deinit, and setting callbacks.

The issue is only found with the stm32f4xx targets.
