### PR TITLE
cmsis5: fix warnings for ARMCC and IAR - aligned, compiler macro and arm_math

### DIFF
--- a/cmsis/TARGET_CORTEX_M/cmsis_compiler.h
+++ b/cmsis/TARGET_CORTEX_M/cmsis_compiler.h
@@ -73,6 +73,11 @@
 
   #include <cmsis_iar.h>
 
+  // IAR version 7.8.1 and earlier do not include __ALIGNED
+  #ifndef __ALIGNED
+  #define __ALIGNED(x) __attribute__((aligned(x)))
+  #endif
+
   #ifndef   __NO_RETURN
     #define __NO_RETURN                            __noreturn
   #endif

--- a/cmsis/TARGET_CORTEX_M/cmsis_compiler.h
+++ b/cmsis/TARGET_CORTEX_M/cmsis_compiler.h
@@ -53,14 +53,6 @@
  */
 #elif defined ( __ICCARM__ )
 
-#if (__CORE__ == __ARM6M__) || (__CORE__ == __ARM6SM__)
-#define __ARM_ARCH_6M__ 1
-#elif (__CORE__ == __ARM7M__)
-#define __ARM_ARCH_7M__ 1
-#elif (__CORE__ == __ARM7EM__)
-#define __ARM_ARCH_7EM__ 1
-#endif
-
   #ifndef   __ASM
     #define __ASM                                  __asm
   #endif
@@ -72,6 +64,21 @@
   #endif
 
   #include <cmsis_iar.h>
+
+  /* CMSIS compiler control architecture macros */
+  #if (__CORE__ == __ARM6M__) || (__CORE__ == __ARM6SM__)
+    #ifndef __ARM_ARCH_6M__
+      #define __ARM_ARCH_6M__                      1
+    #endif
+  #elif (__CORE__ == __ARM7M__)
+    #ifndef __ARM_ARCH_7M__
+      #define __ARM_ARCH_7M__                      1
+    #endif
+  #elif (__CORE__ == __ARM7EM__)
+    #ifndef __ARM_ARCH_7EM__
+      #define __ARM_ARCH_7EM__                     1
+    #endif
+  #endif
 
   // IAR version 7.8.1 and earlier do not include __ALIGNED
   #ifndef __ALIGNED

--- a/cmsis/arm_math.h
+++ b/cmsis/arm_math.h
@@ -293,13 +293,29 @@
 #ifndef _ARM_MATH_H
 #define _ARM_MATH_H
 
-/* ignore some GCC warnings */
-#if defined ( __GNUC__ )
+/* Compiler specific diagnostic adjustment */
+#if   defined ( __CC_ARM )
+
+#elif defined ( __ARMCC_VERSION ) && ( __ARMCC_VERSION >= 6010050 )
+
+#elif defined ( __GNUC__ )
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+
+#elif defined ( __ICCARM__ )
+
+#elif defined ( __TI_ARM__ )
+
+#elif defined ( __CSMC__ )
+
+#elif defined ( __TASKING__ )
+
+#else
+  #error Unknown compiler
 #endif
+
 
 #define __CMSIS_GENERIC         /* disable NVIC and Systick functions */
 
@@ -7213,9 +7229,24 @@ void arm_rfft_fast_f32(
 }
 #endif
 
+/* Compiler specific diagnostic adjustment */
+#if   defined ( __CC_ARM )
 
-#if defined ( __GNUC__ )
+#elif defined ( __ARMCC_VERSION ) && ( __ARMCC_VERSION >= 6010050 )
+
+#elif defined ( __GNUC__ )
 #pragma GCC diagnostic pop
+
+#elif defined ( __ICCARM__ )
+
+#elif defined ( __TI_ARM__ )
+
+#elif defined ( __CSMC__ )
+
+#elif defined ( __TASKING__ )
+
+#else
+  #error Unknown compiler
 #endif
 
 #endif /* _ARM_MATH_H */

--- a/docs/cmsis_rtx.md
+++ b/docs/cmsis_rtx.md
@@ -32,7 +32,7 @@ Due to different use cases between mbed OS and CMSIS, we had to do some modifica
 
 Filename | Description |
 ---------|-------------|
-cmsis_compiler.h | Added IAR architecture macros |
+cmsis_compiler.h | Added IAR missing __ALIGNED attribute for earlier (less than 7.8.4) versions |
 arm_math.h | Rename `PI` to `_PI` to avoid name clash with a register name in mcr20a-rf-driver |
 
 ### RTX


### PR DESCRIPTION
Cherry-picking some work I have done here https://github.com/ARMmbed/mbed-os/pull/4223 (so that one stays smaller with only relevant mbed 2 backward compatible changes).

This PR includes 3 commits that are also upstream (as noted in the commits) - aligned is not there, noted in the our docs.