### PR TITLE
NSAPI - Don't send trailing garbage in DNS queries

### DIFF
--- a/features/netsocket/nsapi_dns.cpp
+++ b/features/netsocket/nsapi_dns.cpp
@@ -227,7 +227,7 @@ static nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const
         uint8_t *question = packet;
         dns_append_question(&question, host, version);
 
-        err = socket.sendto(SocketAddress(dns_servers[i], 53), packet, DNS_BUFFER_SIZE);
+        err = socket.sendto(SocketAddress(dns_servers[i], 53), packet, question - packet);
         // send may fail for various reasons, including wrong address type - move on
         if (err < 0) {
             continue;


### PR DESCRIPTION
Observed during investigation of
https://github.com/ARMmbed/mbed-os/issues/4246 - DNS queries sent
the entire buffer, not just the bit filled in.

Inefficient, especially for 6LoWPAN, and a security hole - the trailing
data could be previously-used heap.

