### PR TITLE
avoid 03/05 intel-hex records for nordic devices

### DIFF
--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -490,7 +490,7 @@ class MCU_NRF51Code(object):
             binh.merge(blh)
 
         with open(binf.replace(".bin", ".hex"), "w") as fileout:
-            binh.tofile(fileout, format='hex')
+            binh.write_hex_file(fileout, write_start_addr=False)
 
 class NCS36510TargetCode:
     @staticmethod


### PR DESCRIPTION
Use Intelhex::write_hex_file instead of IntelHex::tofile do the work.
Mentioned records types has no sense for nordic devices.
Sucha a record comes from *.hex file from the mbed-os sources build.

This PR solves https://github.com/ARMmbed/mbed-os/issues/4237