### PR TITLE
- The post_binary_hook is not necessary in MCU_LPC4088 section. It is…

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -335,9 +335,6 @@
         "extra_labels": ["NXP", "LPC408X"],
         "is_disk_virtual": true,
         "supported_toolchains": ["ARM", "GCC_CR", "GCC_ARM", "IAR"],
-        "post_binary_hook": {
-            "function": "LPC4088Code.binary_hook"
-        },
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "features": ["LWIP"],
         "device_name": "LPC4088FBD144"


### PR DESCRIPTION
Remove unused "post_binary_hook" in the MCU_LPC4088 section.

## Description
The post_binary_hook is not necessary in the MCU_LPC4088 section. It is already defined in the "LPCTarget" section. Worse still, it prevents us from exporting the project for eclipse gcc.


