### PR TITLE
LPC4088: add "LPC4088Code.binary_hook" to the white list of the embit…

### DIFF
--- a/tools/export/embitz/__init__.py
+++ b/tools/export/embitz/__init__.py
@@ -21,7 +21,8 @@ from tools.export.exporters import Exporter, filter_supported
 
 POST_BINARY_WHITELIST = set([
     "TEENSY3_1Code.binary_hook",
-    "LPCTargetCode.lpc_patch"
+    "LPCTargetCode.lpc_patch",
+    "LPC4088Code.binary_hook"
 ])
 
 

--- a/tools/export/gnuarmeclipse/__init__.py
+++ b/tools/export/gnuarmeclipse/__init__.py
@@ -61,7 +61,8 @@ u = UID()
 POST_BINARY_WHITELIST = set([
     "TEENSY3_1Code.binary_hook",
     "MCU_NRF51Code.binary_hook",
-    "LPCTargetCode.lpc_patch"
+    "LPCTargetCode.lpc_patch",
+    "LPC4088Code.binary_hook"
 ])
 
 class GNUARMEclipse(Exporter):

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -38,7 +38,8 @@ class Makefile(Exporter):
     POST_BINARY_WHITELIST = set([
         "MCU_NRF51Code.binary_hook",
         "TEENSY3_1Code.binary_hook",
-        "LPCTargetCode.lpc_patch"
+        "LPCTargetCode.lpc_patch",
+        "LPC4088Code.binary_hook"
     ])
 
     def generate(self):


### PR DESCRIPTION
Add "LPCTargetCode.lpc_patch" to the white list of the embitz, gnuarmeclipse and makefile exporter.

## Description
With this changes it is possible to export the programs for LPC4088 as embitz, gnuarmeclipse or makefile project.
