### PR TITLE
Set mbed minor and patch version to 0 for master

### DIFF
--- a/mbed.h
+++ b/mbed.h
@@ -16,13 +16,17 @@
 #ifndef MBED_H
 #define MBED_H
 
-#define MBED_LIBRARY_VERSION 123
+
+/* mbed minor and patch versions for both mbed 2 and mbed OS 5 are 0 on master branch. They are set
+   to meaningful values for releases and release branches.
+ */
+#define MBED_LIBRARY_VERSION 0
 
 #if MBED_CONF_RTOS_PRESENT
 // RTOS present, this is valid only for mbed OS 5
 #define MBED_MAJOR_VERSION 5
-#define MBED_MINOR_VERSION 2
-#define MBED_PATCH_VERSION 1
+#define MBED_MINOR_VERSION 0
+#define MBED_PATCH_VERSION 0
 
 #else
 // mbed 2

--- a/rtos/rtos.h
+++ b/rtos/rtos.h
@@ -40,10 +40,6 @@ using namespace rtos;
 */
 #include "mbed.h"
 
-#if (MBED_LIBRARY_VERSION < 122)
-#error "This version of RTOS requires mbed library version > 121"
-#endif
-
 #endif
 
 /** @}*/


### PR DESCRIPTION
Currently the MBED_VERSION on master is set to 5.2.1 and 5.0.123 which is confusing. I can see two ways of fixit that:
- After we make a release we make a change on master to reflect the last released mbed version
- We set it to 0 to avoid cofusion and set it to release version for release branch. @adbridge favors this solution.

One possible issue with second approach is if someone will get an idea of disabling/enabling features basing on MBED_VERSION macro in their app, not that it would work now very well, so maybe it's not a problem after all.
