### PR TITLE
Revome duplicate optimization flags in IAR export

### DIFF
--- a/tools/export/iar/__init__.py
+++ b/tools/export/iar/__init__.py
@@ -114,7 +114,7 @@ class IAR(Exporter):
         template = ["--vla", "--no_static_destruction"]
         # Flag invalid if set in template
         # Optimizations are also set in template
-        invalid_flag = lambda x: x in template or re.match("-O(\d|time|n)", x)
+        invalid_flag = lambda x: x in template or re.match("-O(\d|time|n|hz?)", x)
         flags['c_flags'] = [flag for flag in c_flags if not invalid_flag(flag)]
 
         try:


### PR DESCRIPTION
# Description

Compiling with some IAR exports would result in a warning/error message saying
```
[Su004]: Option -O can only occur once
```

This is a Bad Thing^TM.

Resolves  https://github.com/ARMmbed/mbed-cli/issues/487

## Why did this happen?

We had an incomplete filter for optimization options that would be put in the 
miscellaneous options section of the IAR project XML. It did not filter out 
some options, like `-Oh` and `-Ohz`

## Why this patch?

This patch fixes this bug by filtering out a wider range of optimization options
from the miscellaneous flags section.

# TODO
- [x] /morph export-build