### PR TITLE
Increase stm32 timeout for spi transfers

### DIFF
--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -357,7 +357,7 @@ int spi_master_write(spi_t *obj, int value)
     size = (handle->Init.DataSize == SPI_DATASIZE_16BIT) ? 2 : 1;
 
     /*  Use 10ms timeout */
-    ret = HAL_SPI_TransmitReceive(handle,(uint8_t*)&value,(uint8_t*)&Rx,size,10);
+    ret = HAL_SPI_TransmitReceive(handle,(uint8_t*)&value,(uint8_t*)&Rx,size,HAL_MAX_DELAY);
 
     if(ret == HAL_OK) {
         return Rx;


### PR DESCRIPTION
## Description

Default timeout of 10ms was reported in #4300

There seems to be conditions or use cases where the system is loaded with
higher priority tasks so that SPI transfer would be delayed more than 10ms.

## Status
This PR is sent because of request for a quick fix and this should unblock the situation, nevertheless I am not sure that the problem is entirely understood.

## Steps to test or reproduce
How to reproduce the issue was not explained in the ticket.
The patch was not tested and needs to be tested by reporters of the issue #4300 
