### PR TITLE
Fix NVIC_SetVector type in HAL for MAX32630FTHR

### DIFF
--- a/targets/TARGET_Maxim/TARGET_MAX32630/gpio_irq_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/gpio_irq_api.c
@@ -100,15 +100,15 @@ int gpio_irq_init(gpio_irq_t *obj, PinName name, gpio_irq_handler handler, uint3
 
     /* register handlers */
     irq_handler = handler;
-    NVIC_SetVector(GPIO_P0_IRQn, gpio_irq_0);
-    NVIC_SetVector(GPIO_P1_IRQn, gpio_irq_1);
-    NVIC_SetVector(GPIO_P2_IRQn, gpio_irq_2);
-    NVIC_SetVector(GPIO_P3_IRQn, gpio_irq_3);
-    NVIC_SetVector(GPIO_P4_IRQn, gpio_irq_4);
-    NVIC_SetVector(GPIO_P5_IRQn, gpio_irq_5);
-    NVIC_SetVector(GPIO_P6_IRQn, gpio_irq_6);
-    NVIC_SetVector(GPIO_P7_IRQn, gpio_irq_7);
-    NVIC_SetVector(GPIO_P8_IRQn, gpio_irq_8);
+    NVIC_SetVector(GPIO_P0_IRQn, (uint32_t)gpio_irq_0);
+    NVIC_SetVector(GPIO_P1_IRQn, (uint32_t)gpio_irq_1);
+    NVIC_SetVector(GPIO_P2_IRQn, (uint32_t)gpio_irq_2);
+    NVIC_SetVector(GPIO_P3_IRQn, (uint32_t)gpio_irq_3);
+    NVIC_SetVector(GPIO_P4_IRQn, (uint32_t)gpio_irq_4);
+    NVIC_SetVector(GPIO_P5_IRQn, (uint32_t)gpio_irq_5);
+    NVIC_SetVector(GPIO_P6_IRQn, (uint32_t)gpio_irq_6);
+    NVIC_SetVector(GPIO_P7_IRQn, (uint32_t)gpio_irq_7);
+    NVIC_SetVector(GPIO_P8_IRQn, (uint32_t)gpio_irq_8);
 
     /* disable the interrupt locally */
     MXC_GPIO->int_mode[port] &= ~(0xF << (pin*4));

--- a/targets/TARGET_Maxim/TARGET_MAX32630/mxc/nvic_table.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/mxc/nvic_table.c
@@ -76,7 +76,7 @@ void NVIC_SetRAM(void)
 }
 
 /* ************************************************************************* */
-int NVIC_SetVector(IRQn_Type irqn, void(*irq_handler)(void))
+int NVIC_SetVector(IRQn_Type irqn, uint32_t irq_handler)
 {
     int index = irqn + 16;  /* offset for externals */
 
@@ -85,7 +85,7 @@ int NVIC_SetVector(IRQn_Type irqn, void(*irq_handler)(void))
         NVIC_SetRAM();
     }
 
-    ramVectorTable[index] = irq_handler;
+    ramVectorTable[index] = (void(*)(void))irq_handler;
     NVIC_EnableIRQ(irqn);
 
     return 0;

--- a/targets/TARGET_Maxim/TARGET_MAX32630/mxc/nvic_table.h
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/mxc/nvic_table.h
@@ -71,7 +71,7 @@ typedef void (*irq_fn)(void);
  * @param      irqn         ARM external IRQ number, see #IRQn_Type
  * @param      irq_handler  Function to be called at IRQ context
  */
-int NVIC_SetVector(IRQn_Type irqn, irq_fn irq_handler);
+int NVIC_SetVector(IRQn_Type irqn, uint32_t irq_handler);
 
 /**
  * @brief Copy NVIC vector table to RAM and set NVIC to RAM based table.

--- a/targets/TARGET_Maxim/TARGET_MAX32630/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/rtc_api.c
@@ -71,9 +71,9 @@ void rtc_init(void)
     CLKMAN_SetClkScale(CLKMAN_CLK_SYNC, CLKMAN_SCALE_DIV_1);
 
     // Prepare interrupt handlers
-    NVIC_SetVector(RTC0_IRQn, lp_ticker_irq_handler);
+    NVIC_SetVector(RTC0_IRQn, (uint32_t)lp_ticker_irq_handler);
     NVIC_EnableIRQ(RTC0_IRQn);
-    NVIC_SetVector(RTC3_IRQn, overflow_handler);
+    NVIC_SetVector(RTC3_IRQn, (uint32_t)overflow_handler);
     NVIC_EnableIRQ(RTC3_IRQn);
 
     // Enable wakeup on RTC rollover

--- a/targets/TARGET_Maxim/TARGET_MAX32630/serial_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/serial_api.c
@@ -202,19 +202,19 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
 {
     switch (obj->index) {
         case 0:
-            NVIC_SetVector(UART0_IRQn, uart0_handler);
+            NVIC_SetVector(UART0_IRQn, (uint32_t)uart0_handler);
             NVIC_EnableIRQ(UART0_IRQn);
             break;
         case 1:
-            NVIC_SetVector(UART1_IRQn, uart1_handler);
+            NVIC_SetVector(UART1_IRQn, (uint32_t)uart1_handler);
             NVIC_EnableIRQ(UART1_IRQn);
             break;
         case 2:
-            NVIC_SetVector(UART2_IRQn, uart2_handler);
+            NVIC_SetVector(UART2_IRQn, (uint32_t)uart2_handler);
             NVIC_EnableIRQ(UART2_IRQn);
             break;
         case 3:
-            NVIC_SetVector(UART3_IRQn, uart3_handler);
+            NVIC_SetVector(UART3_IRQn, (uint32_t)uart3_handler);
             NVIC_EnableIRQ(UART3_IRQn);
             break;
         default:

--- a/targets/TARGET_Maxim/TARGET_MAX32630/us_ticker.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/us_ticker.c
@@ -140,7 +140,7 @@ void us_ticker_init(void)
     cfg.compareCount = 0xFFFFFFFF;
     TMR32_Config(US_TIMER, &cfg);
 
-    NVIC_SetVector(US_TIMER_IRQn, tmr_handler);
+    NVIC_SetVector(US_TIMER_IRQn, (uint32_t)tmr_handler);
     NVIC_EnableIRQ(US_TIMER_IRQn);
     TMR32_EnableINT(US_TIMER);
 


### PR DESCRIPTION
Change the irq_handler parameter of NVIC_SetVector from a function
pointer to a uin32_t so it matches the cmsis specification. This
prevents the following problem from occurring in RTX5 when building
for IAR:
The error: Error[Pe167]: argument of type "void (*)(void)" is incompatible
with parameter of type "uint32_t".

Based on b5db96090c8066f9a4195b974ccb9ff07ec7b1f0 from the CMSIS_5 branch.
