### PR TITLE
Limit ISR stack to 4k on NUCLEO_F429ZI

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_IAR/stm32f429xx_flash.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_IAR/stm32f429xx_flash.icf
@@ -15,8 +15,8 @@ define symbol __ICFEDIT_region_RAM_end__      = 0x2002FFFF;
 define symbol __ICFEDIT_region_CCMRAM_start__ = 0x10000000;
 define symbol __ICFEDIT_region_CCMRAM_end__   = 0x1000FFFF;
 /*-Sizes-*/
-/*Heap 64K and stack 24K */
-define symbol __ICFEDIT_size_cstack__ = 0x6000;
+/*Heap 64K and stack 4K */
+define symbol __ICFEDIT_size_cstack__ = 0x1000;
 define symbol __ICFEDIT_size_heap__   = 0x10000;
 /**** End of ICF editor section. ###ICF###*/
 


### PR DESCRIPTION
Decrease the interrupt stack size of the NUCLEO_F429ZI to save space when building for IAR.

This is a cherry pick of 78d28ffaffe9e0eaa50b19ece36de5df49c824cf from the CMSIS_5 branch.