### PR TITLE
Fix RAM vector table for NCS36510

### DIFF
--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_ARM/NCS36510.sct
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_ARM/NCS36510.sct
@@ -9,7 +9,7 @@ LR_IROM1 0x00003000 0x0004F000  {    ; load region size_region
 
   ; no uvisor support at this time
 
-  RW_IRAM1 0x3FFF4000 {
+  RW_IRAM1 0x3FFF4000 + 0x90 { ; 8_byte_aligned(35 vectors * 4 bytes each) = 0x90
     .ANY(+RW +ZI)
   }
   ARM_LIB_HEAP AlignExpr(+0, 8) ALIGN 8 EMPTY (0x3FFF4000 + 0xC000 - AlignExpr(ImageLimit(RW_IRAM1),8) ) {}

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_GCC_ARM/NCS36510.ld
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_GCC_ARM/NCS36510.ld
@@ -5,7 +5,7 @@
 MEMORY {
     VECTORS (rx)          : ORIGIN = 0x00003000, LENGTH = 0x00000090
         FLASH (rx)            : ORIGIN = 0x00003090, LENGTH = 320K - 4K - 0x90
-        RAM (rwx)             : ORIGIN = 0x3FFF4000, LENGTH = 48K
+        RAM (rwx)             : ORIGIN = 0x3FFF4090, LENGTH = 48K - 0x90 /* 8_byte_aligned(35 vectors * 4 bytes each) = 0x90 */
     }
 
     /* Linker script to place sections and symbol values. Should be used together

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_IAR/NCS36510.icf
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_IAR/NCS36510.icf
@@ -8,8 +8,8 @@ define region FLASHB = Mem:[from 0x00100000 size 0x50000];
 define region RAMA = Mem:[from 0x3FFFC000 size 0x4000];
 define region RAMB = Mem:[from 0x3FFF8000 size 0x4000];
 /* G2H ZPRO requires RAMC to be enabled */
-define region RAMC = Mem:[from 0x3FFF4000 size 0x4000];
-define region RAM_ALL = Mem:[from 0x3FFF4000 size 0xC000];
+define region RAMC = Mem:[from 0x3FFF4000 + 0x90 size 0x4000 - 0x90]; /* 8_byte_aligned(35 vectors * 4 bytes each) = 0x90 */
+define region RAM_ALL = Mem:[from 0x3FFF4000 + 0x90 size 0xC000 - 0x90]; /* 8_byte_aligned(35 vectors * 4 bytes each) = 0x90 */
 
 /* Create a stack */
 define block CSTACK with size = 0x200, alignment = 8 { };

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/device/cmsis_nvic.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/device/cmsis_nvic.c
@@ -31,7 +31,7 @@
 
 #include <cmsis_nvic.h>
 
-#define NVIC_RAM_VECTOR_ADDRESS   (0x20000000)  // Vectors positioned at start of RAM
+#define NVIC_RAM_VECTOR_ADDRESS   (0x3FFF4000)  // Vectors positioned at start of RAM
 #define NVIC_FLASH_VECTOR_ADDRESS (0x00000000)  // Initial vector position in flash
 
 


### PR DESCRIPTION
Fix the ram address of the vector table on the NCS36510. Also reserve space for it in the linker scripts.

This is based on  94a0256cad2485b23638bde3072641b45ce8b554 from the CMSIS_5 branch.
