### PR TITLE
Disable lwIP checksum-on-copy

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwipopts.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwipopts.h
@@ -249,7 +249,8 @@
 
 #define LWIP_BROADCAST_PING         1
 
-#define LWIP_CHECKSUM_ON_COPY       1
+// Checksum-on-copy disabled due to https://savannah.nongnu.org/bugs/?50914
+#define LWIP_CHECKSUM_ON_COPY       0
 
 #define LWIP_NETIF_HOSTNAME         1
 #define LWIP_NETIF_STATUS_CALLBACK  1


### PR DESCRIPTION
Current version of lwIP has a bug in its checksum-on-copy code - see

#4140 and https://savannah.nongnu.org/bugs/?50914

Pending a fix from lwIP, set LWIP_CHECKSUM_ON_COPY to 0 to work around.
Will impact performance.

@mikaleppanen , @geky - if there's not a patch for the bug in the next few days, I think we should do this.