### PR TITLE
Reduce test overhead in preperation for CMSIS 5

### DIFF
--- a/TESTS/events/queue/main.cpp
+++ b/TESTS/events/queue/main.cpp
@@ -7,6 +7,7 @@
 
 using namespace utest::v1;
 
+#define TEST_EQUEUE_SIZE 1024
 
 // flag for called
 volatile bool touched = false;
@@ -43,7 +44,7 @@ void func0() {
 
 #define SIMPLE_POSTS_TEST(i, ...)                           \
 void simple_posts_test##i() {                               \
-    EventQueue queue;                                       \
+    EventQueue queue(TEST_EQUEUE_SIZE);                     \
                                                             \
     touched = false;                                        \
     queue.call(func##i,##__VA_ARGS__);                      \
@@ -78,7 +79,7 @@ template <int N>
 void call_in_test() {
     Timer tickers[N];
 
-    EventQueue queue;
+    EventQueue queue(TEST_EQUEUE_SIZE);
 
     for (int i = 0; i < N; i++) {
         tickers[i].start();
@@ -92,7 +93,7 @@ template <int N>
 void call_every_test() {
     Timer tickers[N];
 
-    EventQueue queue;
+    EventQueue queue(TEST_EQUEUE_SIZE);
 
     for (int i = 0; i < N; i++) {
         tickers[i].start();
@@ -103,7 +104,7 @@ void call_every_test() {
 }
 
 void allocate_failure_test() {
-    EventQueue queue;
+    EventQueue queue(TEST_EQUEUE_SIZE);
     int id;
 
     for (int i = 0; i < 100; i++) {
@@ -119,7 +120,7 @@ void no() {
 
 template <int N>
 void cancel_test1() {
-    EventQueue queue;
+    EventQueue queue(TEST_EQUEUE_SIZE);
 
     int ids[N];
 
@@ -164,7 +165,7 @@ void count0() {
 
 void event_class_test() {
     counter = 0;
-    EventQueue queue(2048);
+    EventQueue queue(TEST_EQUEUE_SIZE);
 
     Event<void(int, int, int, int, int)> e5(&queue, count5);
     Event<void(int, int, int, int)> e4(&queue, count5, 1);
@@ -187,7 +188,7 @@ void event_class_test() {
 
 void event_class_helper_test() {
     counter = 0;
-    EventQueue queue(2048);
+    EventQueue queue(TEST_EQUEUE_SIZE);
 
     Event<void()> e5 = queue.event(count5, 1, 1, 1, 1, 1);
     Event<void()> e4 = queue.event(count4, 1, 1, 1, 1);
@@ -210,7 +211,7 @@ void event_class_helper_test() {
 
 void event_inference_test() {
     counter = 0;
-    EventQueue queue(2048);
+    EventQueue queue(TEST_EQUEUE_SIZE);
 
     queue.event(count5, 1, 1, 1, 1, 1).post();
     queue.event(count5, 1, 1, 1, 1).post(1);

--- a/TESTS/mbed_drivers/race_test/main.cpp
+++ b/TESTS/mbed_drivers/race_test/main.cpp
@@ -28,20 +28,18 @@
 
 using namespace utest::v1;
 
-#define TEST_STACK_SIZE     1024
+#define TEST_STACK_SIZE     512
 static uint32_t instance_count = 0;
 
 class TestClass {
 public:
     TestClass() {
-        printf("TestClass ctor start\r\n");
         Thread::wait(500);
         instance_count++;
-        printf("TestClass ctor end\r\n");
     }
 
     void do_something() {
-        printf("Do something called\r\n");
+        Thread::wait(100);
     }
 
     ~TestClass() {
@@ -69,7 +67,6 @@ static void main_class_race()
 
 void test_case_func_race()
 {
-    printf("Running function race test\r\n");
     Callback<void()> cb(main_func_race);
     Thread *t1 = new Thread(osPriorityNormal, TEST_STACK_SIZE);
     Thread *t2 = new Thread(osPriorityNormal, TEST_STACK_SIZE);
@@ -95,7 +92,6 @@ void test_case_func_race()
 
 void test_case_class_race()
 {
-    printf("Running class race test\r\n");
     Callback<void()> cb(main_class_race);
     Thread *t1 = new Thread(osPriorityNormal, TEST_STACK_SIZE);
     Thread *t2 = new Thread(osPriorityNormal, TEST_STACK_SIZE);

--- a/TESTS/mbed_drivers/stats/main.cpp
+++ b/TESTS/mbed_drivers/stats/main.cpp
@@ -30,7 +30,7 @@ using namespace utest::v1;
 
 #define ALLOCATION_SIZE_DEFAULT 564
 #define ALLOCATION_SIZE_SMALL   124
-#define ALLOCATION_SIZE_LARGE   790
+#define ALLOCATION_SIZE_LARGE   700
 #define ALLOCATION_SIZE_FAIL   (1024 * 1024 *1024)
 
 typedef void* (*malloc_cb_t) (uint32_t size);
@@ -49,7 +49,6 @@ malloc_cb_t malloc_thunk_array[] = {
 
 void test_case_malloc_free_size()
 {
-    printf("Initial print to setup stdio buffers\n");
     mbed_stats_heap_t stats_start;
     mbed_stats_heap_t stats_current;
     void *data;
@@ -127,26 +126,22 @@ void test_case_allocate_fail()
 
 static void* thunk_malloc(uint32_t size)
 {
-    printf("Malloc thunk\n");
     return malloc(size);
 }
 
 static void* thunk_calloc_1(uint32_t size)
 {
-    printf("Calloc thunk 1 byte\n");
     return calloc(size / 1, 1);
 }
 
 static void* thunk_calloc_4(uint32_t size)
 {
-    printf("Calloc thunk 4 bytes\n");
     return calloc(size / 4, 4);
 }
 
 
 static void* thunk_realloc(uint32_t size)
 {
-    printf("Realloc thunk\n");
     return realloc(NULL, size);
 }
 

--- a/TESTS/mbed_drivers/stl_features/main.cpp
+++ b/TESTS/mbed_drivers/stl_features/main.cpp
@@ -32,15 +32,10 @@ using namespace utest::v1;
 #define TABLE_SIZE(TAB) (sizeof(TAB) / sizeof(TAB[0]))
 
 #define NEGATIVE_INTEGERS -32768,-3214,-999,-100,-1,0,1,4231,999,4123,32760,99999
-#define POSITIVE_INTEGERS 32768,3214,999,100,1,0,1,4231,999,4123,32760,99999
 #define FLOATS  0.002,0.92430,15.91320,791.77368,6208.2,25719.4952,426815.982588,6429271.046,42468024.93,212006462.910
 #define FLOATS_STR  "0.002","0.92430","15.91320","791.77368","6208.2","25719.4952","426815.982588","6429271.046","42468024.93","212006462.910"
 
-
 namespace {
-int p_integers[] = {POSITIVE_INTEGERS};
-int n_integers[] = {NEGATIVE_INTEGERS};
-float floats[] = {FLOATS};
 
 template <class T, class F>
 void BubbleSort(T& _array, size_t array_size, F functor) {
@@ -59,18 +54,6 @@ void BubbleSort(T& _array, size_t array_size, F functor) {
     }
 }
 
-struct printInt {
-    void operator()(int i) { printf("%d ", i); }
-};
-
-struct printFloat {
-    void operator()(float f) { printf("%f ", f); }
-};
-
-struct printString {
-    void operator()(const char* s) { printf("%s ", s); }
-};
-
 struct greaterAbs {
     bool operator()(int a, int b) { return abs(a) > abs(b); }
 };
@@ -78,42 +61,41 @@ struct greaterAbs {
 }   // namespace
 
 void test_case_stl_equal() {
-    std::vector<int> v_pints(p_integers, p_integers + TABLE_SIZE(p_integers));
-    TEST_ASSERT_TRUE(std::equal(v_pints.begin(), v_pints.end(), p_integers));
+    const int n_integers[] = {NEGATIVE_INTEGERS};
+    std::vector<int> v_pints(n_integers, n_integers + TABLE_SIZE(n_integers));
+    TEST_ASSERT_TRUE(std::equal(v_pints.begin(), v_pints.end(), n_integers));
 }
 
 void test_case_stl_transform() {
+    const float floats[] = {FLOATS};
     const char* floats_str[] = {FLOATS_STR};
     float floats_transform[TABLE_SIZE(floats_str)] = {0.0};
     std::transform(floats_str, floats_str + TABLE_SIZE(floats_str), floats_transform, atof);
-    //printf("stl_transform::floats_str: ");
-    //std::for_each(floats_str, floats_str + TABLE_SIZE(floats_str), printString());
-    //printf("stl_transform::floats_transform: ");
-    //std::for_each(floats_transform, floats_transform + TABLE_SIZE(floats_transform), printFloat());
-    //printf("\n");
 
     TEST_ASSERT_TRUE(std::equal(floats_transform, floats_transform + TABLE_SIZE(floats_transform), floats));
 }
 
 void test_case_stl_sort_greater() {
-    std::vector<int> v_nints_1(n_integers, n_integers + TABLE_SIZE(n_integers));
-    std::vector<int> v_nints_2(n_integers, n_integers + TABLE_SIZE(n_integers));
+    int n_integers[] = {NEGATIVE_INTEGERS};
+    int n_integers2[] = {NEGATIVE_INTEGERS};
 
-    BubbleSort(v_nints_1, v_nints_1.size(), std::greater<int>());
-    std::sort(v_nints_2.begin(), v_nints_2.end(), std::greater<int>());
+    BubbleSort(n_integers, TABLE_SIZE(n_integers), std::greater<int>());
+    std::sort(n_integers2, n_integers2 + TABLE_SIZE(n_integers2), std::greater<int>());
 
-    TEST_ASSERT_TRUE(std::equal(v_nints_1.begin(), v_nints_1.end(), v_nints_2.begin()));
+    TEST_ASSERT_TRUE(std::equal(n_integers2, n_integers2 + TABLE_SIZE(n_integers2), n_integers));
 }
+
 
 void test_case_stl_sort_abs() {
-    std::vector<int> v_nints_1(n_integers, n_integers + TABLE_SIZE(n_integers));
-    std::vector<int> v_nints_2(n_integers, n_integers + TABLE_SIZE(n_integers));
+    int n_integers[] = {NEGATIVE_INTEGERS};
+    int n_integers2[] = {NEGATIVE_INTEGERS};
 
-    BubbleSort(v_nints_1, v_nints_1.size(), greaterAbs());
-    std::sort(v_nints_2.begin(), v_nints_2.end(), greaterAbs());
+    BubbleSort(n_integers, TABLE_SIZE(n_integers), greaterAbs());
+    std::sort(n_integers2, n_integers2 + TABLE_SIZE(n_integers2), greaterAbs());
 
-    TEST_ASSERT_TRUE(std::equal(v_nints_1.begin(), v_nints_1.end(), v_nints_2.begin()));
+    TEST_ASSERT_TRUE(std::equal(n_integers2, n_integers2 + TABLE_SIZE(n_integers2), n_integers));
 }
+
 
 utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason) {
     greentea_case_failure_abort_handler(source, reason);

--- a/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
@@ -6,26 +6,7 @@
   #error [NOT_SUPPORTED] test not supported
 #endif
 
-/*
- * The stack size is defined in cmsis_os.h mainly dependent on the underlying toolchain and
- * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
- * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
- */
-#if defined(TARGET_STM32F070RB) && defined(TOOLCHAIN_GCC)
-#define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
-#define STACK_SIZE 512
-#elif (defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32PG_STK3401)) && !defined(TOOLCHAIN_ARM_MICRO)
-#define STACK_SIZE 768
-#elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
-#define STACK_SIZE 1536
-#elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
-#define STACK_SIZE 768
-#elif defined(TARGET_XDOT_L151CC)
-#define STACK_SIZE 1024
-#else
-#define STACK_SIZE DEFAULT_STACK_SIZE
-#endif
+#define TEST_STACK_SIZE 768
 
 #define SIGNAL_PRINT_TICK 0x01
 
@@ -43,15 +24,15 @@ void print_tick_thread() {
 
 int main() {
     GREENTEA_SETUP(total_ticks + 5, "timing_drift_auto");
-    
-    Thread tick_thread(osPriorityNormal, STACK_SIZE);
+
+    Thread tick_thread(osPriorityNormal, TEST_STACK_SIZE);
     tick_thread.start(print_tick_thread);
-    
+
     for (int i = 0; i <= total_ticks; i++) {
         Thread::wait(1000);
         tick_thread.signal_set(SIGNAL_PRINT_TICK);
     }
-    
+
     tick_thread.join();
     GREENTEA_TESTSUITE_RESULT(1);
 }

--- a/TESTS/mbedmicro-rtos-mbed/isr/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/isr/main.cpp
@@ -11,24 +11,7 @@
 #define QUEUE_PUT_ISR_VALUE     128
 #define QUEUE_PUT_THREAD_VALUE  127
 
-/*
- * The stack size is defined in cmsis_os.h mainly dependent on the underlying toolchain and
- * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
- * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
- */
-#if (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 512
-#elif (defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32PG_STK3401)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 768
-#elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 1536
-#elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
-    #define STACK_SIZE 768
-#elif defined(TARGET_XDOT_L151CC)
-    #define STACK_SIZE 1024
-#else
-    #define STACK_SIZE DEFAULT_STACK_SIZE
-#endif
+#define TEST_STACK_SIZE 512
 
 Queue<uint32_t, QUEUE_SIZE> queue;
 
@@ -50,7 +33,7 @@ void queue_thread() {
 int main (void) {
     GREENTEA_SETUP(20, "default_auto");
 
-    Thread thread(osPriorityNormal, STACK_SIZE);
+    Thread thread(osPriorityNormal, TEST_STACK_SIZE);
     thread.start(queue_thread);
     Ticker ticker;
     ticker.attach(queue_isr, 1.0);
@@ -60,7 +43,7 @@ int main (void) {
     while (true) {
         osEvent evt = queue.get();
         if (evt.status != osEventMessage) {
-            printf("QUEUE_GET: Status(0x%02X) ... [FAIL]\r\n", evt.status);
+            printf("QUEUE_GET: FAIL\r\n");
             result = false;
             break;
         } else {

--- a/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
@@ -21,7 +21,7 @@ typedef struct {
 
 Mail<mail_t, QUEUE_SIZE> mail_box;
 
-void send_thread (void const *argument) {
+void send_thread () {
     static uint32_t i = 10;
     while (true) {
         i++; // fake data update
@@ -37,7 +37,8 @@ void send_thread (void const *argument) {
 int main (void) {
     GREENTEA_SETUP(20, "default_auto");
 
-    Thread thread(send_thread, NULL, osPriorityNormal, STACK_SIZE);
+    Thread thread(osPriorityNormal, STACK_SIZE);
+    thread.start(send_thread);
     bool result = true;
     int result_counter = 0;
 

--- a/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
@@ -17,28 +17,11 @@ typedef struct {
 #define QUEUE_SIZE       16
 #define QUEUE_PUT_DELAY  100
 
-/*
- * The stack size is defined in cmsis_os.h mainly dependent on the underlying toolchain and
- * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
- * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
- */
-#if (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 512
-#elif (defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32PG_STK3401)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 768
-#elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 1536
-#elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
-    #define STACK_SIZE 768
-#elif defined(TARGET_XDOT_L151CC)
-    #define STACK_SIZE 1024
-#else
-    #define STACK_SIZE DEFAULT_STACK_SIZE
-#endif
+#define STACK_SIZE 1024
 
 Mail<mail_t, QUEUE_SIZE> mail_box;
 
-void send_thread () {
+void send_thread (void const *argument) {
     static uint32_t i = 10;
     while (true) {
         i++; // fake data update
@@ -54,8 +37,7 @@ void send_thread () {
 int main (void) {
     GREENTEA_SETUP(20, "default_auto");
 
-    Thread thread(osPriorityNormal, STACK_SIZE);
-    thread.start(send_thread);
+    Thread thread(send_thread, NULL, osPriorityNormal, STACK_SIZE);
     bool result = true;
     int result_counter = 0;
 

--- a/TESTS/mbedmicro-rtos-mbed/malloc/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/malloc/main.cpp
@@ -7,6 +7,7 @@
 #endif
 
 #define NUM_THREADS         5
+
 #if defined(__CORTEX_A9)
 #define THREAD_STACK_SIZE   DEFAULT_STACK_SIZE
 #else

--- a/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
@@ -10,11 +10,6 @@
 
 using namespace utest::v1;
 
-/*
- * The stack size is defined in cmsis_os.h mainly dependent on the underlying toolchain and
- * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
- * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
- */
 #define TEST_STACK_SIZE 512
 
 #define TEST_ONE_SEC_MS  (1000)
@@ -106,7 +101,7 @@ template <void (*F)(Mutex *)>
 void test_dual_thread_nolock(void)
 {
     Mutex mutex;
-    Thread thread;
+    Thread thread(osPriorityNormal, TEST_STACK_SIZE);
 
     thread.start(callback(F, &mutex));
 

--- a/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
@@ -17,24 +17,7 @@ typedef struct {
 #define QUEUE_SIZE       16
 #define QUEUE_PUT_DELAY  100
 
-/*
- * The stack size is defined in cmsis_os.h mainly dependent on the underlying toolchain and
- * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
- * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
- */
-#if (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 512
-#elif (defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32PG_STK3401)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 768
-#elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 1536
-#elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
-    #define STACK_SIZE 768
-#elif defined(TARGET_XDOT_L151CC)
-    #define STACK_SIZE 1024
-#else
-    #define STACK_SIZE DEFAULT_STACK_SIZE
-#endif
+#define TEST_STACK_SIZE 512
 
 MemoryPool<message_t, QUEUE_SIZE> mpool;
 Queue<message_t, QUEUE_SIZE> queue;
@@ -56,7 +39,7 @@ void send_thread () {
 int main (void) {
     GREENTEA_SETUP(20, "default_auto");
 
-    Thread thread(osPriorityNormal, STACK_SIZE);
+    Thread thread(osPriorityNormal, TEST_STACK_SIZE);
     thread.start(send_thread);
     bool result = true;
     int result_counter = 0;

--- a/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
@@ -10,45 +10,7 @@
 #define SEMAPHORE_SLOTS  2
 #define SEM_CHANGES      100
 
-/*
- * The stack size is defined in cmsis_os.h mainly dependent on the underlying toolchain and
- * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
- * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
- */
-#if defined(TARGET_STM32F334R8) && (defined(TOOLCHAIN_GCC) || defined(TOOLCHAIN_IAR))
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif defined(TARGET_STM32F103RB)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif defined(TARGET_STM32F070RB)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2	
-#elif defined(TARGET_STM32F072RB)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2	
-#elif defined(TARGET_STM32F302R8) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2		
-#elif defined(TARGET_STM32L073RZ)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/2
-#elif defined(TARGET_STM32F303K8) && defined(TOOLCHAIN_IAR)
-    #define STACK_SIZE DEFAULT_STACK_SIZE/4
-#elif (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 512
-#elif (defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32PG_STK3401)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 768
-#elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 1536
-#elif (defined(TARGET_EFR32)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 768
-#elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
-    #define STACK_SIZE 768
-#elif defined(TARGET_XDOT_L151CC)
-    #define STACK_SIZE 1024
-#else
-    #define STACK_SIZE DEFAULT_STACK_SIZE
-#endif
-
-void print_char(char c = '*') {
-    printf("%c", c);
-    fflush(stdout);
-}
+#define THREAD_STACK_SIZE 512
 
 Semaphore two_slots(SEMAPHORE_SLOTS);
 
@@ -62,13 +24,10 @@ void test_thread(int const *delay) {
         two_slots.wait();
         sem_counter++;
         const bool sem_lock_failed = sem_counter > SEMAPHORE_SLOTS;
-        const char msg = sem_lock_failed ? 'e' : sem_counter + '0';
-        print_char(msg);
         if (sem_lock_failed) {
             sem_defect = true;
         }
         Thread::wait(thread_delay);
-        print_char('.');
         sem_counter--;
         change_counter++;
         two_slots.release();
@@ -81,9 +40,10 @@ int main (void) {
     const int t1_delay = THREAD_DELAY * 1;
     const int t2_delay = THREAD_DELAY * 2;
     const int t3_delay = THREAD_DELAY * 3;
-    Thread t1(osPriorityNormal, STACK_SIZE);
-    Thread t2(osPriorityNormal, STACK_SIZE);
-    Thread t3(osPriorityNormal, STACK_SIZE);
+
+    Thread t1(osPriorityNormal, THREAD_STACK_SIZE);
+    Thread t2(osPriorityNormal, THREAD_STACK_SIZE);
+    Thread t3(osPriorityNormal, THREAD_STACK_SIZE);
 
     t1.start(callback(test_thread, &t1_delay));
     t2.start(callback(test_thread, &t2_delay));
@@ -98,7 +58,6 @@ int main (void) {
         }
     }
 
-    fflush(stdout);
     GREENTEA_TESTSUITE_RESULT(!sem_defect);
     return 0;
 }

--- a/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
@@ -6,28 +6,11 @@
   #error [NOT_SUPPORTED] test not supported
 #endif
 
+#define TEST_STACK_SIZE 512
+
 #define SIGNAL_SET_VALUE    0x01
 const int SIGNALS_TO_EMIT = 100;
 const int SIGNAL_HANDLE_DELEY = 25;
-
-/*
- * The stack size is defined in cmsis_os.h mainly dependent on the underlying toolchain and
- * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes
- * and for ARM_MICRO 512. Because of reduce RAM size some targets need a reduced stacksize.
- */
-#if (defined(TARGET_EFM32HG_STK3400)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 512
-#elif (defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32WG_STK3800) || defined(TARGET_EFM32PG_STK3401)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 768
-#elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
-    #define STACK_SIZE 1536
-#elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
-    #define STACK_SIZE 768
-#elif defined(TARGET_XDOT_L151CC)
-    #define STACK_SIZE 1024
-#else
-    #define STACK_SIZE DEFAULT_STACK_SIZE
-#endif
 
 DigitalOut led(LED1);
 int signal_counter = 0;
@@ -44,8 +27,9 @@ void led_thread() {
 int main (void) {
     GREENTEA_SETUP(20, "default_auto");
 
-    Thread thread(osPriorityNormal, STACK_SIZE);
+    Thread thread(osPriorityNormal, TEST_STACK_SIZE);
     thread.start(led_thread);
+
     bool result = false;
 
     printf("Handling %d signals...\r\n", SIGNALS_TO_EMIT);

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/tcp_echo_parallel/main.cpp
@@ -84,11 +84,10 @@ public:
     }
 };
 
-Echo echoers[MBED_CFG_TCP_CLIENT_ECHO_THREADS];
-
-
 int main() {
     GREENTEA_SETUP(60, "tcp_echo");
+
+    Echo echoers[MBED_CFG_TCP_CLIENT_ECHO_THREADS];
 
     int err = net.connect();
     TEST_ASSERT_EQUAL(0, err);

--- a/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
+++ b/features/FEATURE_LWIP/TESTS/mbedmicro-net/udp_echo_parallel/main.cpp
@@ -95,11 +95,10 @@ public:
     }
 };
 
-Echo echoers[MBED_CFG_UDP_CLIENT_ECHO_THREADS];
-
-
 int main() {
     GREENTEA_SETUP(60, "udp_echo");
+
+    Echo echoers[MBED_CFG_UDP_CLIENT_ECHO_THREADS];
 
     int err = net.connect();
     TEST_ASSERT_EQUAL(0, err);

--- a/features/TESTS/filesystem/heap_block_device/main.cpp
+++ b/features/TESTS/filesystem/heap_block_device/main.cpp
@@ -24,8 +24,8 @@
 using namespace utest::v1;
 
 #define TEST_BLOCK_SIZE 512
-#define TEST_BLOCK_DEVICE_SIZE 16*TEST_BLOCK_SIZE
 #define TEST_BLOCK_COUNT 10
+#define TEST_BLOCK_DEVICE_SIZE 16*TEST_BLOCK_SIZE
 #define TEST_ERROR_MASK 16
 
 const struct {
@@ -47,12 +47,9 @@ void test_read_write() {
     TEST_ASSERT_EQUAL(0, err);
 
     for (unsigned a = 0; a < sizeof(ATTRS)/sizeof(ATTRS[0]); a++) {
-        static const char *prefixes[] = {"", "k", "M", "G"};
         for (int i = 3; i >= 0; i--) {
             bd_size_t size = (bd.*ATTRS[a].method)();
             if (size >= (1ULL << 10*i)) {
-                printf("%s: %llu%sbytes (%llubytes)\n",
-                    ATTRS[a].name, size >> 10*i, prefixes[i], size);
                 break;
             }
         }
@@ -62,7 +59,6 @@ void test_read_write() {
     uint8_t *write_block = new uint8_t[block_size];
     uint8_t *read_block = new uint8_t[block_size];
     uint8_t *error_mask = new uint8_t[TEST_ERROR_MASK];
-    unsigned addrwidth = ceil(log(float(bd.size()-1)) / log(float(16)))+1;
 
     for (int b = 0; b < TEST_BLOCK_COUNT; b++) {
         // Find a random block
@@ -78,29 +74,14 @@ void test_read_write() {
             write_block[i] = 0xff & rand();
         }
 
-        // erase, program, and read the block
-        printf("test  %0*llx:%llu...\n", addrwidth, block, block_size);
-
         err = bd.erase(block, block_size);
         TEST_ASSERT_EQUAL(0, err);
 
         err = bd.program(write_block, block, block_size);
         TEST_ASSERT_EQUAL(0, err);
 
-        printf("write %0*llx:%llu ", addrwidth, block, block_size);
-        for (int i = 0; i < 16; i++) {
-            printf("%02x", write_block[i]);
-        }
-        printf("...\n");
-
         err = bd.read(read_block, block, block_size);
         TEST_ASSERT_EQUAL(0, err);
-
-        printf("read  %0*llx:%llu ", addrwidth, block, block_size);
-        for (int i = 0; i < 16; i++) {
-            printf("%02x", read_block[i]);
-        }
-        printf("...\n");
 
         // Find error mask for debugging
         memset(error_mask, 0, TEST_ERROR_MASK);
@@ -114,12 +95,6 @@ void test_read_write() {
                 }
             }
         }
-
-        printf("error %0*llx:%llu ", addrwidth, block, block_size);
-        for (int i = 0; i < 16; i++) {
-            printf("%02x", error_mask[i]);
-        }
-        printf("\n");
 
         // Check that the data was unmodified
         srand(seed);

--- a/features/TESTS/filesystem/heap_block_device/main.cpp
+++ b/features/TESTS/filesystem/heap_block_device/main.cpp
@@ -24,8 +24,12 @@
 using namespace utest::v1;
 
 #define TEST_BLOCK_SIZE 512
+#if MBED_SMALL_TARGET
+#    define TEST_BLOCK_DEVICE_SIZE 8*TEST_BLOCK_SIZE
+#else
+#    define TEST_BLOCK_DEVICE_SIZE 16*TEST_BLOCK_SIZE
+#endif
 #define TEST_BLOCK_COUNT 10
-#define TEST_BLOCK_DEVICE_SIZE 16*TEST_BLOCK_SIZE
 #define TEST_ERROR_MASK 16
 
 const struct {
@@ -47,9 +51,12 @@ void test_read_write() {
     TEST_ASSERT_EQUAL(0, err);
 
     for (unsigned a = 0; a < sizeof(ATTRS)/sizeof(ATTRS[0]); a++) {
+        static const char *prefixes[] = {"", "k", "M", "G"};
         for (int i = 3; i >= 0; i--) {
             bd_size_t size = (bd.*ATTRS[a].method)();
             if (size >= (1ULL << 10*i)) {
+                printf("%s: %llu%sbytes (%llubytes)\n",
+                    ATTRS[a].name, size >> 10*i, prefixes[i], size);
                 break;
             }
         }
@@ -59,6 +66,7 @@ void test_read_write() {
     uint8_t *write_block = new uint8_t[block_size];
     uint8_t *read_block = new uint8_t[block_size];
     uint8_t *error_mask = new uint8_t[TEST_ERROR_MASK];
+    unsigned addrwidth = ceil(log(float(bd.size()-1)) / log(float(16)))+1;
 
     for (int b = 0; b < TEST_BLOCK_COUNT; b++) {
         // Find a random block
@@ -74,14 +82,29 @@ void test_read_write() {
             write_block[i] = 0xff & rand();
         }
 
+        // erase, program, and read the block
+        printf("test  %0*llx:%llu...\n", addrwidth, block, block_size);
+
         err = bd.erase(block, block_size);
         TEST_ASSERT_EQUAL(0, err);
 
         err = bd.program(write_block, block, block_size);
         TEST_ASSERT_EQUAL(0, err);
 
+        printf("write %0*llx:%llu ", addrwidth, block, block_size);
+        for (int i = 0; i < 16; i++) {
+            printf("%02x", write_block[i]);
+        }
+        printf("...\n");
+
         err = bd.read(read_block, block, block_size);
         TEST_ASSERT_EQUAL(0, err);
+
+        printf("read  %0*llx:%llu ", addrwidth, block, block_size);
+        for (int i = 0; i < 16; i++) {
+            printf("%02x", read_block[i]);
+        }
+        printf("...\n");
 
         // Find error mask for debugging
         memset(error_mask, 0, TEST_ERROR_MASK);
@@ -95,6 +118,12 @@ void test_read_write() {
                 }
             }
         }
+
+        printf("error %0*llx:%llu ", addrwidth, block, block_size);
+        for (int i = 0; i < 16; i++) {
+            printf("%02x", error_mask[i]);
+        }
+        printf("\n");
 
         // Check that the data was unmodified
         srand(seed);

--- a/targets/TARGET_ARM_SSG/mbed_rtx.h
+++ b/targets/TARGET_ARM_SSG/mbed_rtx.h
@@ -23,7 +23,7 @@
 #define INITIAL_SP              (0x20020000UL)
 #endif
 #ifndef OS_TASKCNT
-#define OS_TASKCNT              6
+#define OS_TASKCNT              7
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          112

--- a/targets/TARGET_NORDIC/mbed_rtx.h
+++ b/targets/TARGET_NORDIC/mbed_rtx.h
@@ -28,7 +28,7 @@
 #endif
 
 #ifndef OS_TASKCNT
-#define OS_TASKCNT              6
+#define OS_TASKCNT              7
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          512
@@ -46,7 +46,7 @@
 #define INITIAL_SP              (0x20010000UL)
 #endif
 #ifndef OS_TASKCNT
-#define OS_TASKCNT              6
+#define OS_TASKCNT              7
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          512


### PR DESCRIPTION
Reduce RAM consumption so all tests can still be built when using CMSIS/RTX5. Also reduce clutter by removing the per target stack size defines in the tests.
