### PR TITLE
Add up OS_MUTEX_NUM for ARMCC compiler

### DIFF
--- a/rtos/rtx5/mbed_rtx_conf.h
+++ b/rtos/rtx5/mbed_rtx_conf.h
@@ -38,7 +38,7 @@
 
 #if defined(__CC_ARM)
 #define OS_MUTEX_OBJ_MEM            1
-#define OS_MUTEX_NUM                6
+#define OS_MUTEX_NUM                7
 #endif
 
 #if !defined(OS_STACK_WATERMARK) && (defined(MBED_STACK_STATS_ENABLED) && MBED_STACK_STATS_ENABLED)


### PR DESCRIPTION
CI shield test (SPI test) may need 7 mutexes

DEPENDENT ON #4294 
Once that officially lands on Master, this PR should be rebased and then retargeted to Master.
