### PR TITLE
STM32F3: Remove dependence upon a specific flash vector table location

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/device/cmsis_nvic.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/device/cmsis_nvic.c
@@ -31,14 +31,13 @@
 #include "cmsis_nvic.h"
 
 #define NVIC_RAM_VECTOR_ADDRESS   (0x20000000)  // Vectors positioned at start of RAM
-#define NVIC_FLASH_VECTOR_ADDRESS (0x08000000)  // Initial vector position in flash
 
 void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     uint32_t *vectors = (uint32_t *)SCB->VTOR;
     uint32_t i;
 
     // Copy and switch to dynamic vectors if the first time called
-    if (SCB->VTOR == NVIC_FLASH_VECTOR_ADDRESS) {
+    if (SCB->VTOR != NVIC_RAM_VECTOR_ADDRESS) {
         uint32_t *old_vectors = vectors;
         vectors = (uint32_t*)NVIC_RAM_VECTOR_ADDRESS;
         for (i=0; i<NVIC_NUM_VECTORS; i++) {

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/device/cmsis_nvic.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/device/cmsis_nvic.c
@@ -31,14 +31,13 @@
 #include "cmsis_nvic.h"
 
 #define NVIC_RAM_VECTOR_ADDRESS   (0x20000000)  // Vectors positioned at start of RAM
-#define NVIC_FLASH_VECTOR_ADDRESS (0x08000000)  // Initial vector position in flash
 
 void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     uint32_t *vectors = (uint32_t *)SCB->VTOR;
     uint32_t i;
 
     // Copy and switch to dynamic vectors if the first time called
-    if (SCB->VTOR == NVIC_FLASH_VECTOR_ADDRESS) {
+    if (SCB->VTOR != NVIC_RAM_VECTOR_ADDRESS) {
         uint32_t *old_vectors = vectors;
         vectors = (uint32_t*)NVIC_RAM_VECTOR_ADDRESS;
         for (i=0; i<NVIC_NUM_VECTORS; i++) {

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/device/cmsis_nvic.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/device/cmsis_nvic.c
@@ -31,14 +31,13 @@
 #include "cmsis_nvic.h"
 
 #define NVIC_RAM_VECTOR_ADDRESS   (0x20000000)  // Vectors positioned at start of RAM
-#define NVIC_FLASH_VECTOR_ADDRESS (0x08000000)  // Initial vector position in flash
 
 void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     uint32_t *vectors = (uint32_t *)SCB->VTOR;
     uint32_t i;
 
     // Copy and switch to dynamic vectors if the first time called
-    if (SCB->VTOR == NVIC_FLASH_VECTOR_ADDRESS) {
+    if (SCB->VTOR != NVIC_RAM_VECTOR_ADDRESS) {
         uint32_t *old_vectors = vectors;
         vectors = (uint32_t*)NVIC_RAM_VECTOR_ADDRESS;
         for (i=0; i<NVIC_NUM_VECTORS; i++) {

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/cmsis_nvic.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/cmsis_nvic.c
@@ -31,14 +31,13 @@
 #include "cmsis_nvic.h"
 
 #define NVIC_RAM_VECTOR_ADDRESS   (0x20000000)  // Vectors positioned at start of RAM
-#define NVIC_FLASH_VECTOR_ADDRESS (0x08000000)  // Initial vector position in flash
 
 void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     uint32_t *vectors = (uint32_t *)SCB->VTOR;
     uint32_t i;
 
     // Copy and switch to dynamic vectors if the first time called
-    if (SCB->VTOR == NVIC_FLASH_VECTOR_ADDRESS) {
+    if (SCB->VTOR != NVIC_RAM_VECTOR_ADDRESS) {
         uint32_t *old_vectors = vectors;
         vectors = (uint32_t*)NVIC_RAM_VECTOR_ADDRESS;
         for (i=0; i<NVIC_NUM_VECTORS; i++) {

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/device/cmsis_nvic.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/device/cmsis_nvic.c
@@ -31,14 +31,13 @@
 #include "cmsis_nvic.h"
 
 #define NVIC_RAM_VECTOR_ADDRESS   (0x20000000)  // Vectors positioned at start of RAM
-#define NVIC_FLASH_VECTOR_ADDRESS (0x08000000)  // Initial vector position in flash
 
 void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     uint32_t *vectors = (uint32_t *)SCB->VTOR;
     uint32_t i;
 
     // Copy and switch to dynamic vectors if the first time called
-    if (SCB->VTOR == NVIC_FLASH_VECTOR_ADDRESS) {
+    if (SCB->VTOR != NVIC_RAM_VECTOR_ADDRESS) {
         uint32_t *old_vectors = vectors;
         vectors = (uint32_t*)NVIC_RAM_VECTOR_ADDRESS;
         for (i=0; i<NVIC_NUM_VECTORS; i++) {


### PR DESCRIPTION
## Description
The STM32F3 cmsis_nvic code is currently checking for a specific flash address when determining if the vector table is in flash or RAM.  By changing the test to instead see if the vector table base is NOT set to
the RAM address, it simplifies the code, and removes the dependency on the flash vectors being located at a specific address.  This becomes important when adding a custom boot loader, which requires that the flash vector table location in the mbed project be at a different address.

## Status
READY

## Migrations
NO

## Related PRs
None

## Todos
None

## Deploy notes
None

## Steps to test or reproduce
Create an STM32F3 based project but with the flash vector table moved to a different location (requires modifying the VECT_TAB_OFFSET setting in your target's system_stm32f3xx.cpp file, and moving the KEEP(*(.isr_vector)) line from your target's ld file (e.g. STM32F303XC.ld) to a different location ; be sure to align it to a multiple of 0x200).  Without the changes from this commit, any attempt to set an interrupt handler will fail because the cmsis_nvic code will think the ISR vectors are already in RAM, since they are not at the expected flash address.  With the changes, setting interrupt handlers properly results in the copy of the flash ISR vectors into RAM before modification.
