### PR TITLE
Decode STDERR from compiler

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -958,7 +958,7 @@ class mbedToolchain:
 
     def compile_output(self, output=[]):
         _rc = output[0]
-        _stderr = output[1]
+        _stderr = output[1].decode("utf-8")
         command = output[2]
 
         # Parse output for Warnings and Errors


### PR DESCRIPTION
## Description
Strangely, python does not seem to treat streams as unicode by default. 
Therefore, we need to manually decode the STDERR stream from the compiler before
we use it as it might contain not-ascii characters.

Resolves #4318

cc @teetak01

## TODO
 - [ ] @teetak01 verifies that this has resolved his issue