### PR TITLE
Fix for #3863: STM Check can sync error

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/can_device.h
@@ -17,6 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
+#include "stm32f0xx_hal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32F1/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/can_device.h
@@ -17,6 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
+#include "stm32f1xx_hal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32F2/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/can_device.h
@@ -17,6 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
+#include "stm32f2xx_hal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32F3/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/can_device.h
@@ -17,6 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
+#include "stm32f3xx_hal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32F4/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/can_device.h
@@ -17,6 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
+#include "stm32f4xx_hal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32F7/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/can_device.h
@@ -17,6 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
+#include "stm32f7xx_hal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32L4/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/can_device.h
@@ -17,6 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
+#include "stm32l4xx_hal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -198,7 +198,7 @@ int can_frequency(can_t *obj, int f)
     int btr = can_speed(pclk, (unsigned int)f, 1);
     CAN_TypeDef *can = (CAN_TypeDef *)(obj->can);
     uint32_t tickstart = 0;
-    int status = 0;
+    int status = 1;
 
     if (btr > 0) {
         can->MCR |= CAN_MCR_INRQ ;
@@ -211,15 +211,12 @@ int can_frequency(can_t *obj, int f)
         while ((can->MSR & CAN_MSR_INAK) == CAN_MSR_INAK) {
             if((HAL_GetTick() - tickstart ) > 2)
             {
-                status = HAL_CAN_STATE_TIMEOUT;
+                status = 0;
                 break;
             }
         }
-        if (status !=0) {
+        if (status ==0) {
             error("can ESR  0x%04x.%04x + timeout status %d", (can->ESR&0XFFFF0000)>>16, (can->ESR&0XFFFF), status);
-            status=0;
-        } else {
-            status=1; //mbed OK value
         }
     } else {
         status=0;

--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -88,7 +88,7 @@ void can_init_freq (can_t *obj, PinName rd, PinName td, int hz)
     // Set initial CAN frequency to 100 kb/s
     if (can_frequency(obj, 100000) != 1) {
         error("Can frequency could not be set\n");
-    };
+    }
 
     uint32_t filter_number = (obj->can == CAN_1) ? 0 : 14;
     can_filter(obj, 0, 0, CANStandard, filter_number);
@@ -205,8 +205,7 @@ int can_frequency(can_t *obj, int f)
         /* Get tick */
         tickstart = HAL_GetTick();
         while ((can->MSR & CAN_MSR_INAK) != CAN_MSR_INAK) {
-            if((HAL_GetTick() - tickstart ) > 2)
-            {
+            if ((HAL_GetTick() - tickstart ) > 2) {
                 status = 0;
                 break;
             }
@@ -217,20 +216,19 @@ int can_frequency(can_t *obj, int f)
             /* Get tick */
             tickstart = HAL_GetTick();
             while ((can->MSR & CAN_MSR_INAK) == CAN_MSR_INAK) {
-                if((HAL_GetTick() - tickstart ) > 2)
-                {
+                if ((HAL_GetTick() - tickstart ) > 2) {
                     status = 0;
                     break;
                 }
             }
-            if (status ==0) {
-                error("can ESR  0x%04x.%04x + timeout status %d", (can->ESR&0XFFFF0000)>>16, (can->ESR&0XFFFF), status);
+            if (status == 0) {
+                error("can ESR  0x%04x.%04x + timeout status %d", (can->ESR & 0xFFFF0000) >> 16, (can->ESR & 0xFFFF), status);
             }
         } else {
             error("can init request timeout\n");
         }
     } else {
-        status=0;
+        status = 0;
     }
     return status;
 }

--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -205,7 +205,7 @@ int can_frequency(can_t *obj, int f)
         /* Get tick */
         tickstart = HAL_GetTick();
         while ((can->MSR & CAN_MSR_INAK) != CAN_MSR_INAK) {
-            if ((HAL_GetTick() - tickstart ) > 2) {
+            if ((HAL_GetTick() - tickstart) > 2) {
                 status = 0;
                 break;
             }
@@ -216,7 +216,7 @@ int can_frequency(can_t *obj, int f)
             /* Get tick */
             tickstart = HAL_GetTick();
             while ((can->MSR & CAN_MSR_INAK) == CAN_MSR_INAK) {
-                if ((HAL_GetTick() - tickstart ) > 2) {
+                if ((HAL_GetTick() - tickstart) > 2) {
                     status = 0;
                     break;
                 }


### PR DESCRIPTION
## Description
Can init function needs 11 bits at the same level to synchronize to the CAN bus. 
In some cases this cannot occur (refer to #3863 where the object is initialized at a lower frequency than the bus and the bus is very busy). We thus need a timeout mechanism to exit the init function.
in TARGET_STM/can_api.c: 
```
        /* Get tick */
        tickstart = HAL_GetTick();
        can->BTR = btr;
        can->MCR &= ~(uint32_t)CAN_MCR_INRQ;
        while ((can->MSR & CAN_MSR_INAK) == CAN_MSR_INAK) {
            if((HAL_GetTick() - tickstart ) > 2)
            {
                status = 0;
                break;
            }
        }
        if (status ==0) {
            error("can ESR  0x%04x.%04x + timeout status %d", (can->ESR&0XFFFF0000)>>16, (can->ESR&0XFFFF), status);
        }
```


## Status
**READY**

## Migrations
NO

## Steps to test or reproduce
refer to #3863 : need a 1st device that overloads the CAN bus with a high frequency. Then try to initialize the 2nd device with a low frequency (or the default one at 100kHz).
The CAN object of the 2nd device will not output of the init function because the HW synchronization cannot occur
With this PR, you will be notified that the initialization could not occur.

cc @bperry730 @ohagendorf 
