### PR TITLE
Have objects depend on their respective compiler invocations

### DIFF
--- a/tools/test/build_api/build_api_test.py
+++ b/tools/test/build_api/build_api_test.py
@@ -55,6 +55,7 @@ class BuildApiTests(unittest.TestCase):
            side_effect=[i % 2 for i in range(3000)])
     @patch('os.mkdir')
     @patch('tools.toolchains.exists', return_value=True)
+    @patch('tools.toolchains.mbedToolchain.dump_build_profile')
     @patch('tools.utils.run_cmd', return_value=("", "", 0))
     def test_always_complete_build(self, *_):
         with MagicMock() as notify:


### PR DESCRIPTION
# Description

Each of C, C++, ASM and linker now depend on their command line invocations.
For example, adding `-DFoo` to the mbed CLI invocation (`mbed compile -DFoo`)
would force a complete recompile. Further, switching build profiles will force
all C and C++ to recompile. The assembler flags are the same ¯\\\_(ツ)\_/¯.

Resolves #2412 

# TODO

- [x] manual verification that modifying each part of a build profile causes
  the appropriate rebuild
- [x] /morph test