### PR TITLE
Adjust Thread interface connect timeout

### DIFF
--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/ThreadInterface.cpp
@@ -39,7 +39,11 @@ int ThreadInterface::connect()
     // Release mutex before blocking
     nanostack_unlock();
 
-    int32_t count = connect_semaphore.wait(30000);
+    // In Thread wait connection for ever:
+    // -routers will create new network and get local connectivity
+    // -end devices will get connectivity once attached to existing network
+    // -devices without network settings gets connectivity once commissioned and attached to network
+    int32_t count = connect_semaphore.wait(osWaitForever);
 
     if (count <= 0) {
         return NSAPI_ERROR_DHCP_FAILURE; // sort of...


### PR DESCRIPTION
## Description
Thread device needs to wait for connectivity:
* routers will create new network and get local connectivity
* end device will get connectivity once attached to existing network
* devices without network settings gets connectivity once commissioned and attached to network

This PR removes connection timeout from Thread interface connect method. Then end devices and devices without network configuration settings will try connection for ever. This change does not affect to routers as they will get local connectivity.


## Status
**READY**

## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

 NO


## Related PRs

## Todos
- [x] Tests
- [x] Documentation

## Steps to test or reproduce
* Set flag thread-use-static-link-config to false to get uncommissioned device
* Once device is started the ThreadInterface connect method does not return until device is commissioned and attached to the Thread network
