### PR TITLE
mbed sdk boot: fix IAR note

### DIFF
--- a/platform/mbed_sdk_boot.c
+++ b/platform/mbed_sdk_boot.c
@@ -82,7 +82,7 @@ int __wrap_main(void)
 
 #elif defined (__ICCARM__)
 
-// empty for now
+// cmain.S file implements the mbed SDK boot for IAR
 
 #endif
 


### PR DESCRIPTION
There's already PR (to master) that reintroduces cmain.S to fix IAR nonrtos bootup sequence. Thus we should update this comment to reflect that change