### PR TITLE
Platform support for new CellularInterface in UBLOX_C027 and UBLOX_C030_U201.

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/ublox_low_level_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/ublox_low_level_api.c
@@ -46,6 +46,12 @@ void ublox_mdm_init(void)
     while ((us_ticker_read() - start) < 50000);
 }
 
+// For forwards compatibility
+void ublox_mdm_power_on(int usb)
+{
+    ublox_mdm_powerOn(usb);
+}
+
 void ublox_mdm_powerOn(int usb)
 {
     gpio_t gpio;
@@ -59,6 +65,12 @@ void ublox_mdm_powerOn(int usb)
         if (gpsOn)
             gpio_init_out_ex(&gpio, MDMILVLOE, 1); // ILVLEN: 1=enabled (i2c)
     }
+}
+
+// For forwards compatibility
+void ublox_mdm_power_off()
+{
+    ublox_mdm_powerOff();
 }
 
 void ublox_mdm_powerOff(void)

--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/ublox_low_level_api.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/ublox_low_level_api.h
@@ -22,8 +22,10 @@ extern "C" {
 
 void ublox_mdm_init(void);
 
+void ublox_mdm_power_on(int usb);
 void ublox_mdm_powerOn(int usb);
 
+void ublox_mdm_power_off(void);
 void ublox_mdm_powerOff(void);
 
 void ublox_gps_powerOn(void);

--- a/targets/TARGET_NXP/TARGET_LPC176X/objects.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/objects.h
@@ -71,10 +71,6 @@ struct spi_s {
     LPC_SSP_TypeDef *spi;
 };
 
-struct modem_s {
-    uint32_t state;
-};
-
 #ifdef __cplusplus
 }
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/PeripheralPins.c
@@ -101,6 +101,18 @@ const PinMap PinMap_UART_RX[] = {
     {NC,    NC,     0}
 };
 
+const PinMap PinMap_UART_RTS[] = {
+    {PA_12, UART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART1)},
+    {PD_4,  UART_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART2)},
+    {NC,    NC,     0}
+};
+
+const PinMap PinMap_UART_CTS[] = {
+    {PA_11, UART_1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART1)},
+    {PD_3,  UART_2, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, GPIO_AF7_USART2)},
+    {NC,    NC,     0}
+};
+
 //*** SPI ***
 
 const PinMap PinMap_SPI_MOSI[] = {

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/PinNames.h
@@ -69,29 +69,34 @@ typedef enum {
     // Not connected
     NC = -1,
 
+    // Power
+    PWR3V3 = PE_0,       // 3.3V rail for the Arduino interface,
+                         // user LEDs and GNSS power, should be
+                         // set to open drain output
+    
+    // GNSS
+    GNSSEN  = PA_15,     // VCC_IO to GNSS, should be set to push-pull, no pull-up, output
     GNSSTXD = PC_6,
     GNSSRXD = PC_7,
-    // Control
-    GNSSRST = PC_10, // Reset (input to GPS, active low)
-    GNSSPWR = PE_0,  // 2.8V rail, should be set to open drain output
-    GNSSEN = PA_15,  // VCC_IO to GNSS, should be set to push-pull, no pull-up, output
-    // u-blox LISA/SARA cellular modem
-    // http://www.u-blox.com/wireless-modules.html
-    // -----------------------------------------------------------
-    // UART (LISA/SARA = DCE)
-    MDMTXD = PD_5, // Transmit Data
-    MDMRXD = PD_6, // Receive Data
-    MDMCTS = PD_3, // Clear to Send
-    MDMRTS = PD_4, // Request to Send (set high or use handshake)
-    MDMDCD = NC,   // DCD line not connecetd
     
-    // USB
-    // Control 
-    MDMEN     = PC_2,  // Supply Control (high = enabled)
-    MDMPWRON  = PE_14,  // 
-    MDMGPIO2  = PD_1,  // 
-    MDMGPIO3  = PB_4,  //
-    MDMRST    = PB_5,  // Reset (active low, set as open drain!)
+    // Cellular modem (a DCE)
+    MDMPWRON  = PE_14,   // Power (active high)
+    MDMRST    = PB_5,    // Reset (active low)
+    MDMTXD    = PD_5,    // Transmit Data
+    MDMRXD    = PD_6,    // Receive Data
+    MDMCTS    = PD_3,    // Clear to Send
+    MDMRTS    = PD_4,    // Request to Send
+    MDMDCD    = NC,      // DCD line not connected
+    MDMDSR    = NC,      // DSR line not connected
+    MDMDTR    = NC,      // DTR line not connected
+    MDMRI     = NC,      // RI line not connected
+    MDMGPIO2  = PD_1,    // 
+    MDMGPIO3  = PB_4,    //
+    MDMCURRENTSENSE = PC_2,
+
+    // SD card
+    SDPWRON     = PE_10, // Set to high to power on the SD card
+    SDCSEL      = PD_7,  // SPI chip select for on-board SD card
 
     // Board Pins
     // A0-A5
@@ -126,6 +131,20 @@ typedef enum {
     LED_RED = LED1,
     SW0     = PC_13,  // Switch-0
 
+    // Arduino header I2C
+    I2C_SDA = D14,
+    I2C_SCL = D15,
+
+    // On-board I2C
+    I2C_SDA_B = PC_9,
+    I2C_SCL_B = PA_8,
+
+    // SPI
+    SPI_MOSI    = D11,
+    SPI_MISO    = D12,
+    SPI_CLK     = D13,
+    SPI_NSS     = D10,
+
     // ST-Link
     USBRX   = PA_10,
     USBTX   = PA_9,
@@ -134,8 +153,13 @@ typedef enum {
     NTRST   = PB_4,  
 } PinName;
 
-#define GNSSBAUD    9600    // Default GNSS Baud Rate
-#define MDMBAUD     115200  // Default Modem Baud Rate
+#define ACTIVE_HIGH_POLARITY    1
+#define ACTIVE_LOW_POLARITY     0
+
+#define MDM_PIN_POLARITY            ACTIVE_LOW_POLARITY
+
+// The default GNSS baud rate is set in targets.json
+// The default modem baud rate is set in the mbed_lib.json file under features/cellular/TARGET_UBLOX_MODEM_GENERIC/ubox_modem_driver
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/onboard_modem_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/onboard_modem_api.c
@@ -1,0 +1,67 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if MBED_CONF_NSAPI_PRESENT
+
+#include "onboard_modem_api.h"
+#include "gpio_api.h"
+#include "platform/mbed_wait_api.h"
+#include "PinNames.h"
+
+#if MODEM_ON_BOARD
+
+// Note microseconds not milliseconds
+static void press_power_button(int time_us)
+{
+    gpio_t gpio;
+
+    gpio_init_out_ex(&gpio, MDMPWRON, 0);
+    wait_us(time_us);
+    gpio_write(&gpio, 1);
+}
+
+void onboard_modem_init()
+{
+    gpio_t gpio;
+
+    // Take us out of reset
+    gpio_init_out_ex(&gpio, MDMRST,    1);
+}
+
+void onboard_modem_deinit()
+{
+    gpio_t gpio;
+
+    // Back into reset
+    gpio_init_out_ex(&gpio, MDMRST, 0);
+}
+
+void onboard_modem_power_up()
+{
+    /* keep the power line low for 50 microseconds */
+    press_power_button(50);
+    /* give modem a little time to respond */
+    wait_ms(100);
+}
+
+void onboard_modem_power_down()
+{
+    /* keep the power line low for 1 second */
+    press_power_button(1000000);
+}
+
+#endif //MODEM_ON_BOARD
+#endif //MBED_CONF_NSAPI_PRESENT

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/system_stm32f4xx.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/system_stm32f4xx.c
@@ -78,6 +78,7 @@
   */
 
 
+#include "ublox_low_level_api.h"
 #include "stm32f4xx.h"
 
 #if !defined  (HSE_VALUE) 
@@ -220,6 +221,7 @@ void SystemInit(void)
   SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
 #endif
 
+  ublox_board_init();
 }
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/ublox_low_level_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/ublox_low_level_api.c
@@ -1,0 +1,46 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "ublox_low_level_api.h"
+
+#include <stdbool.h>
+#include "gpio_api.h"
+
+void ublox_board_init(void) {
+    gpio_t gpio;
+
+    // Enable power to 3V3
+    gpio_init_inout(&gpio, PWR3V3, PIN_OUTPUT, OpenDrain, 1);
+    
+    // start with modem disabled 
+    gpio_init_out_ex(&gpio, MDMRST,    0);
+    gpio_init_out_ex(&gpio, MDMPWRON,  0);
+    gpio_init_out_ex(&gpio, MDMRTS,    0);
+    gpio_init_in_ex(&gpio,  MDMCURRENTSENSE, PullNone);
+
+    // start with GNSS disabled
+    gpio_init_inout(&gpio,  GNSSEN,  PIN_OUTPUT, PushPullNoPull, 0);
+
+    // power on SD card
+    gpio_init_out_ex(&gpio, SDPWRON,   1);
+
+    // led should be off
+    gpio_init_out_ex(&gpio, LED1,      1);
+    gpio_init_out_ex(&gpio, LED2,      1);
+    gpio_init_out_ex(&gpio, LED3,      1);
+    gpio_init_out_ex(&gpio, LED4,      1);
+}
+
+// End Of File

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/ublox_low_level_api.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/ublox_low_level_api.h
@@ -1,0 +1,14 @@
+#ifndef UBLOX_LOW_LEVEL_API_H
+#define UBLOX_LOW_LEVEL_API_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ublox_board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // UBLOX_LOW_LEVEL_H

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -259,7 +259,7 @@
         "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M3",
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
-        "extra_labels": ["NXP", "LPC176X", "FLASH_CMSIS_ALGO", "UBLOX_MODEM_GENERIC"],
+        "extra_labels": ["NXP", "LPC176X", "FLASH_CMSIS_ALGO"],
         "config": {
             "modem_is_on_board": {
                 "help": "Value: Tells the build system that the modem is on-board as oppose to a plug-in shield/module.",
@@ -1439,9 +1439,21 @@
         "default_toolchain": "ARM",
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
         "extra_labels": ["STM", "STM32F4", "STM32F437", "STM32F437VG", "STM32F437xx", "STM32F437xG"],
-        "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2", "RTC_LSI=1", "HSE_VALUE=12000000"],
+        "config": {
+            "modem_is_on_board": {
+                "help": "Value: Tells the build system that the modem is on-board as oppose to a plug-in shield/module.",
+                "value": 1,
+                "macro_name": "MODEM_ON_BOARD" 
+            },
+            "modem_data_connection_type": {
+                "help": "Value: Defines how the modem is wired up to the MCU, e.g., data connection can be a UART or USB and so forth.",
+                "value": 1,
+                "macro_name": "MODEM_ON_BOARD_UART" 
+            }
+        },
+        "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2", "RTC_LSI=1", "HSE_VALUE=12000000", "GNSSBAUD=9600"],
         "inherits": ["Target"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "RTC", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "RTC", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG"],
         "features": ["LWIP"],
         "public": false,
         "device_name": "STM32F437VG"


### PR DESCRIPTION
This change implements the platform support which allows both the mbed-os OnboardModem and the u-blox PPP and AT data drivers to be used with both the u-blox C027 and u-blox C030 platforms.