### PR TITLE
Add static to NRF5 SDK11 macro definition

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_SDK11/libraries/experimental_section_vars/section_vars.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_SDK11/libraries/experimental_section_vars/section_vars.h
@@ -242,7 +242,7 @@
 #elif defined(__ICCARM__)
 
 #define NRF_SECTION_VARS_ADD(section_name, type_def) \
-    __root type_def @ #section_name
+    static __root type_def @ #section_name
 
 #endif
 


### PR DESCRIPTION
# This is blocking CI
## Description
After https://github.com/ARMmbed/mbed-os-example-ble/pull/80 was merged, the Austin Example build CI correctly started failing for NRF51_DK and NRF52_DK with IAR with a mulitple symbol definition:

```
Error[Li006]: duplicate definitions for "fs_config"; in "Z:\home\jimbri01\src\a
          rmmbed\mbed-os-example-ble\BLE_EddystoneService\BUILD\NRF51_DK\iar\mb
          ed-os\targets\TARGET_NORDIC\TARGET_NRF5\TARGET_SDK11\libraries\fds\fd
          s.o"
          , and "Z:\home\jimbri01\src\armmbed\mbed-os-example-ble\BLE_Eddystone
          Service\BUILD\NRF51_DK\iar\source\PersistentStorageHelper\nrfPersiste
          ntStorageHelper\nrfConfigParamsPersistence.o"
[ERROR] Error[Li006]: duplicate definitions for "fs_config"; in "Z:\home\jimbri01\src\a
          rmmbed\mbed-os-example-ble\BLE_EddystoneService\BUILD\NRF51_DK\iar\mb
          ed-os\targets\TARGET_NORDIC\TARGET_NRF5\TARGET_SDK11\libraries\fds\fd
          s.o"
          , and "Z:\home\jimbri01\src\armmbed\mbed-os-example-ble\BLE_Eddystone
          Service\BUILD\NRF51_DK\iar\source\PersistentStorageHelper\nrfPersiste
          ntStorageHelper\nrfConfigParamsPersistence.o"
```

This PR adds static to the NRF_SECTION_VARS_ADD macro for IAR because it's present on the other 2 compilers.

 
## Status
**READY**


## Todos
- [ ] @pan- 
- [ ] /morph test

## Steps to test or reproduce
Try building the BLE_EddystoneService with the latest mbed-os master.
