### PR TITLE
Extending CAN mode to include FIFO

### DIFF
--- a/drivers/CAN.h
+++ b/drivers/CAN.h
@@ -162,7 +162,8 @@ public:
         Silent,
         LocalTest,
         GlobalTest,
-        SilentTest
+        SilentTest,
+        FIFO            // Tx message order preserved
     };
 
     /** Change CAN operation to the specified mode

--- a/hal/can_api.h
+++ b/hal/can_api.h
@@ -50,7 +50,8 @@ typedef enum {
     MODE_SILENT,
     MODE_TEST_LOCAL,
     MODE_TEST_GLOBAL,
-    MODE_TEST_SILENT
+    MODE_TEST_SILENT,
+    MODE_FIFO
 } CanMode;
 
 typedef void (*can_irq_handler)(uint32_t id, CanIrqType type);

--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -342,6 +342,8 @@ int can_mode(can_t *obj, CanMode mode)
     }
 
     switch (mode) {
+        case MODE_FIFO:
+            can->MCR |= CAN_MCR_TXFP;
         case MODE_NORMAL:
             can->BTR &= ~(CAN_BTR_SILM | CAN_BTR_LBKM);
             success = 1;
@@ -592,4 +594,5 @@ void can_irq_set(can_t *obj, CanIrqType type, uint32_t enable)
 }
 
 #endif // DEVICE_CAN
+
 

--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -344,8 +344,11 @@ int can_mode(can_t *obj, CanMode mode)
     switch (mode) {
         case MODE_FIFO:
             can->MCR |= CAN_MCR_TXFP;
-        case MODE_NORMAL:
             can->BTR &= ~(CAN_BTR_SILM | CAN_BTR_LBKM);
+            success = 1;
+            break;
+        case MODE_NORMAL:
+            can->BTR &= ~(CAN_BTR_SILM | CAN_BTR_LBKM | CAN_MCR_TXFP);
             success = 1;
             break;
         case MODE_SILENT:


### PR DESCRIPTION
Allows optional configuration of CAN controller to transmit messages in
FIFO order (chronologically) independent of their priority.


## Description
This pull request is a continuation of #4121 using a clean copy of the MBED lib.  The goal is to allow an ability for application to assure CAN message order it retained.  In the conversations of #4121 it was suggested to extend the ::MODE() API to include a FIFO option.

This pull request does that for the STM32.. CPUs featuring a built in CAN controller. 


## Status
READY


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

YES -- ::MODE now has a new option: FIFO.  If the controller as drivers have been modified to support FIFO mode 1 will be returned.  It the controller is not able to assure message order, 0 (failure) will be returned.
, 



## Related PRs
#4090, #4121 

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ x] Documentation


## Deploy notes
Notes regarding the deployment of this PR. These should note any
required changes in the build environment, tools, compilers, etc.


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
