### PR TITLE
Fix i2c communication with pcf8574 on stm32 targets of f1, f2, f4 and l1 families 

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_i2c.c
@@ -2,8 +2,8 @@
   ******************************************************************************
   * @file    stm32f1xx_hal_i2c.c
   * @author  MCD Application Team
-  * @version V1.1.0
-  * @date    14-April-2017
+  * @version V1.1.1
+  * @date    12-May-2017
   * @brief   I2C HAL module driver.
   *          This file provides firmware functions to manage the following
   *          functionalities of the Inter Integrated Circuit (I2C) peripheral:
@@ -1462,7 +1462,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Transmit_IT(I2C_HandleTypeDef *hi2c,
         /* Generate Start */
         hi2c->Instance->CR1 |= I2C_CR1_START;
       }
-      else if(Prev_State == I2C_STATE_MASTER_BUSY_RX)
+      else
       {
         /* Generate ReStart */
         hi2c->Instance->CR1 |= I2C_CR1_START;
@@ -1564,7 +1564,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Receive_IT(I2C_HandleTypeDef *hi2c, 
         /* Generate Start */
         hi2c->Instance->CR1 |= I2C_CR1_START;
       }
-      else if(hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX)
+      else
       {
         /* Enable Acknowledge */
         hi2c->Instance->CR1 |= I2C_CR1_ACK;
@@ -2198,8 +2198,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t D
 HAL_StatusTypeDef HAL_I2C_Master_Abort_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 {
   /* Prevent unused argument(s) compilation warning */
-  UNUSED(DevAddress); 
-  
+  UNUSED(DevAddress);
+
   /* Abort Master transfer during Receive or Transmit process    */
   if(hi2c->Mode == HAL_I2C_MODE_MASTER)
   {
@@ -3132,11 +3132,10 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
 HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
 {
   uint32_t tickstart = 0x00U;
+  __IO uint32_t count = 0U;
 
   /* Init tickstart for timeout management*/
   tickstart = HAL_GetTick();
-
-  __IO uint32_t count = 0U;
 
   /* Check the parameters */
   assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
@@ -3983,7 +3982,6 @@ static HAL_StatusTypeDef I2C_MasterTransmit_BTF(I2C_HandleTypeDef *hi2c)
   return HAL_OK;
 }
 
-
 /**
   * @brief  Handle RXNE flag for Master
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
@@ -3992,7 +3990,6 @@ static HAL_StatusTypeDef I2C_MasterTransmit_BTF(I2C_HandleTypeDef *hi2c)
   */
 static HAL_StatusTypeDef I2C_MasterReceive_RXNE(I2C_HandleTypeDef *hi2c)
 {
-
   if(hi2c->State == HAL_I2C_STATE_BUSY_RX)
   {
     uint32_t tmp = 0U;
@@ -4033,9 +4030,8 @@ static HAL_StatusTypeDef I2C_MasterReceive_RXNE(I2C_HandleTypeDef *hi2c)
       (*hi2c->pBuffPtr++) = hi2c->Instance->DR;
       hi2c->XferCount--;
 
-      tmp = (uint32_t)(hi2c->State) & I2C_STATE_MSK;
-      hi2c->PreviousState = tmp | (uint32_t)(hi2c->Mode);
       hi2c->State = HAL_I2C_STATE_READY;
+      hi2c->PreviousState = I2C_STATE_NONE;
 
       if(hi2c->Mode == HAL_I2C_MODE_MEM)
       {
@@ -4061,7 +4057,6 @@ static HAL_StatusTypeDef I2C_MasterReceive_RXNE(I2C_HandleTypeDef *hi2c)
 static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
 {
   /* Declaration of temporary variables to prevent undefined behavior of volatile usage */
-  uint32_t tmp;
   uint32_t CurrentXferOptions = hi2c->XferOptions;
 
   if(hi2c->XferCount == 3U)
@@ -4083,19 +4078,9 @@ static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
     {
       /* Disable Acknowledge */
       hi2c->Instance->CR1 &= ~I2C_CR1_ACK;
-
-      if((CurrentXferOptions == I2C_NEXT_FRAME) || (CurrentXferOptions == I2C_FIRST_FRAME))
-      {
-        /* Generate Start */
-        hi2c->Instance->CR1 |= I2C_CR1_START;
-      }
-      tmp = (uint32_t)(hi2c->State) & I2C_STATE_MSK;
-      hi2c->PreviousState = tmp | (uint32_t)(hi2c->Mode);
     }
     else
     {
-      hi2c->PreviousState = I2C_STATE_MASTER_BUSY_RX;
-
       /* Generate Stop */
       hi2c->Instance->CR1 |= I2C_CR1_STOP;
     }
@@ -4135,7 +4120,6 @@ static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
   }
   return HAL_OK;
 }
-
 
 /**
   * @brief  Handle SB flag for Master
@@ -5568,3 +5552,4 @@ static HAL_StatusTypeDef I2C_IsAcknowledgeFailed(I2C_HandleTypeDef *hi2c)
   */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_i2c.c
@@ -1413,17 +1413,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Transmit_IT(I2C_HandleTypeDef *hi2c,
     /* Generate Start */    
     if((Prev_State == I2C_STATE_MASTER_BUSY_RX) || (Prev_State == I2C_STATE_NONE))
     {
-      /* Generate Start condition if first transfer */
-      if((XferOptions == I2C_FIRST_AND_LAST_FRAME) || (XferOptions == I2C_FIRST_FRAME))
-      {
-        /* Generate Start */
+        /* Generate Start or ReStart */
         hi2c->Instance->CR1 |= I2C_CR1_START;
-      }
-      else
-      {
-        /* Generate ReStart */
-        hi2c->Instance->CR1 |= I2C_CR1_START;
-      }
     }
 
     /* Process Unlocked */
@@ -1512,23 +1503,10 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Receive_IT(I2C_HandleTypeDef *hi2c, 
     
     if((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX) || (hi2c->PreviousState == I2C_STATE_NONE))
     {
-      /* Generate Start condition if first transfer */
-      if((XferOptions == I2C_FIRST_AND_LAST_FRAME) || (XferOptions == I2C_FIRST_FRAME)  || (XferOptions == I2C_NO_OPTION_FRAME))
-      {
         /* Enable Acknowledge */
         hi2c->Instance->CR1 |= I2C_CR1_ACK;
-        
-        /* Generate Start */
+        /* Generate Start or ReStart */
         hi2c->Instance->CR1 |= I2C_CR1_START;
-      }
-      else if(hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX)
-      {
-        /* Enable Acknowledge */
-        hi2c->Instance->CR1 |= I2C_CR1_ACK;
-        
-        /* Generate ReStart */
-        hi2c->Instance->CR1 |= I2C_CR1_START;
-      }
     }
 
     /* Process Unlocked */
@@ -4015,12 +3993,6 @@ static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
     {
       /* Disable Acknowledge */
       hi2c->Instance->CR1 &= ~I2C_CR1_ACK;
-
-      if((CurrentXferOptions == I2C_NEXT_FRAME) || (CurrentXferOptions == I2C_FIRST_FRAME))
-      {
-        /* Enable Acknowledge */
-        hi2c->Instance->CR1 |= I2C_CR1_START;
-      }
     }
     else
     {

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_i2c.c
@@ -1428,17 +1428,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Transmit_IT(I2C_HandleTypeDef *hi2c,
     /* Generate Start */
     if((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_RX) || (hi2c->PreviousState == I2C_STATE_NONE))
     {
-      /* Generate Start condition if first transfer */
-      if((XferOptions == I2C_FIRST_AND_LAST_FRAME) || (XferOptions == I2C_FIRST_FRAME))
-      {
-        /* Generate Start */
+        /* Generate Start or ReStart */
         SET_BIT(hi2c->Instance->CR1, I2C_CR1_START);
-      }
-      else if(hi2c->PreviousState == I2C_STATE_MASTER_BUSY_RX)
-      {
-        /* Generate ReStart */
-        SET_BIT(hi2c->Instance->CR1, I2C_CR1_START);
-      }
     }
 
     /* Process Unlocked */
@@ -1527,23 +1518,10 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Receive_IT(I2C_HandleTypeDef *hi2c, 
 
     if((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX) || (hi2c->PreviousState == I2C_STATE_NONE))
     {
-      /* Generate Start condition if first transfer */
-      if((XferOptions == I2C_FIRST_AND_LAST_FRAME) || (XferOptions == I2C_FIRST_FRAME)  || (XferOptions == I2C_NO_OPTION_FRAME))
-      {
         /* Enable Acknowledge */
         SET_BIT(hi2c->Instance->CR1, I2C_CR1_ACK);
-        
-        /* Generate Start */
+        /* Generate Start or ReStart */
         SET_BIT(hi2c->Instance->CR1, I2C_CR1_START);
-      }
-      else if(hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX)
-      {
-        /* Enable Acknowledge */
-        SET_BIT(hi2c->Instance->CR1, I2C_CR1_ACK);
-        
-        /* Generate ReStart */
-        SET_BIT(hi2c->Instance->CR1, I2C_CR1_START);
-      }
     }
 
     /* Process Unlocked */
@@ -3840,9 +3818,8 @@ static HAL_StatusTypeDef I2C_MasterReceive_RXNE(I2C_HandleTypeDef *hi2c)
       (*hi2c->pBuffPtr++) = hi2c->Instance->DR;
       hi2c->XferCount--;
 
-      tmp = (uint32_t)(hi2c->State) & I2C_STATE_MSK;
-      hi2c->PreviousState = tmp | (uint32_t)(hi2c->Mode);
       hi2c->State = HAL_I2C_STATE_READY;
+      hi2c->PreviousState = I2C_STATE_NONE;
 
       if(hi2c->Mode == HAL_I2C_MODE_MEM)
       {
@@ -3868,7 +3845,6 @@ static HAL_StatusTypeDef I2C_MasterReceive_RXNE(I2C_HandleTypeDef *hi2c)
 static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
 {
   /* Declaration of temporary variables to prevent undefined behavior of volatile usage */
-  uint32_t tmp;
   uint32_t CurrentXferOptions = hi2c->XferOptions;
 
   if(hi2c->XferCount == 3U)
@@ -3890,14 +3866,6 @@ static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
     {
       /* Disable Acknowledge */
       hi2c->Instance->CR1 &= ~I2C_CR1_ACK;
-
-      if((CurrentXferOptions == I2C_NEXT_FRAME) || (CurrentXferOptions == I2C_FIRST_FRAME))
-      {
-        /* Generate Start */
-        hi2c->Instance->CR1 |= I2C_CR1_START;
-      }
-      tmp = (uint32_t)(hi2c->State) & I2C_STATE_MSK;
-      hi2c->PreviousState = tmp | (uint32_t)(hi2c->Mode);
     }
     else
     {

--- a/targets/TARGET_STM/pinmap.c
+++ b/targets/TARGET_STM/pinmap.c
@@ -72,14 +72,17 @@ void pin_function(PinName pin, int data)
     GPIO_TypeDef *gpio = Set_GPIO_Clock(port);
 
     /*  Set default speed to high.
-     *  This is done before other settings on purpose:
      *  For most families there are dedicated registers so it is
      *  not so important, register can be set at any time.
-     *  But for families like F1, speed only applies to output. so we set
-     *  it here, and then if input is selected, this setting might be
-     *  overriden by the input one.
+     *  But for families like F1, speed only applies to output.
      */
+#if defined (TARGET_STM32F1)
+if (mode == STM_PIN_OUTPUT) {
+#endif
     LL_GPIO_SetPinSpeed(gpio, ll_pin, LL_GPIO_SPEED_FREQ_HIGH);
+#if defined (TARGET_STM32F1)
+}
+#endif
 
     switch (mode) {
         case STM_PIN_INPUT:


### PR DESCRIPTION
## Description
This PR fixes issue reported in #4214 
This requires an update in HAL but also a fix in the GPIO management of F1 family targets

## Status
**READY**


## Tests 
Test reported in #4214 is passed ok with the fix.
CI test cases passed ok as well on all 4 families where fix applies:

+-------------------+---------------+---------------+--------+--------------------+-------------+
| target            | platform_name | test suite    | result | elapsed_time (sec) | copy_method |
+-------------------+---------------+---------------+--------+--------------------+-------------+
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | tests-api-i2c | OK     | 59.24              | shell       |
| NUCLEO_F103RB-ARM | NUCLEO_F103RB | tests-api-i2c | OK     | 73.24              | shell       |
| NUCLEO_F207ZG-ARM | NUCLEO_F207ZG | tests-api-i2c | OK     | 58.66              | shell       |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-api-i2c | OK     | 61.36              | shell       |
| NUCLEO_F446RE-ARM | NUCLEO_F446RE | tests-api-i2c | OK     | 59.19              | shell       |
| NUCLEO_F767ZI-ARM | NUCLEO_F767ZI | tests-api-i2c | OK     | 59.74              | shell       |
| NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | tests-api-i2c | OK     | 63.78              | shell       |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-api-i2c | OK     | 59.62              | shell       |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-api-i2c | OK     | 58.96              | shell       |
+-------------------+---------------+---------------+--------+--------------------+-------------+

