### PR TITLE
Support default_toolchain override in mbed_app.json

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -287,7 +287,8 @@ class ConfigCumulativeOverride(object):
                 list((set(getattr(target, self.name, []))
                       | self.additions) - self.removals))
         else:
-            setattr(target, self.name, self.override)
+            if( self.override != None ):            
+                setattr(target, self.name, self.override)
 
 def _process_config_parameters(data, params, unit_name, unit_kind):
     """Process a "config_parameters" section in either a target, a library,
@@ -665,6 +666,8 @@ class Config(object):
                                                                      label)))))
 
         for cumulatives in self.cumulative_overrides.itervalues():
+            if( type(getattr(self.target, cumulatives.name)) != type(list()) ):
+                cumulatives.isList = False
             cumulatives.update_target(self.target)
 
         return params

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -615,7 +615,7 @@ class Config(object):
                 for attr, cumulatives in self.cumulative_overrides.iteritems():
                     if 'target.'+attr in overrides:
                         key = 'target.' + attr
-                        if( type(getattr(self.target, attr)) != type(list()) ):
+                        if( type(getattr(self.target, attr, [])) != type(list()) ):
                             cumulatives.isList = False                        
                         if (cumulatives.isList == True) and (not isinstance(overrides[key], list)):
                             raise ConfigException(
@@ -666,7 +666,7 @@ class Config(object):
                                                                      label)))))
 
         for cumulatives in self.cumulative_overrides.itervalues():
-            if( type(getattr(self.target, cumulatives.name)) != type(list()) ):
+            if( type(getattr(self.target, cumulatives.name, [])) != type(list()) ):
                 cumulatives.isList = False
             cumulatives.update_target(self.target)
 

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -232,6 +232,9 @@ class ConfigCumulativeOverride(object):
             self.removals = set()
         self.strict = strict
 
+        self.isList = True
+        self.override = None
+        
     def remove_cumulative_overrides(self, overrides):
         """Extend the list of override removals.
 
@@ -260,8 +263,10 @@ class ConfigCumulativeOverride(object):
                 raise ConfigException(
                     "Configuration conflict. The %s %s both added and removed."
                     % (self.name[:-1], override))
-
-        self.additions |= set(overrides)
+        if( self.isList == True ):
+            self.additions |= set(overrides)
+        else:
+            self.override = overrides
 
     def strict_cumulative_overrides(self, overrides):
         """Remove all overrides that are not the specified ones
@@ -276,10 +281,13 @@ class ConfigCumulativeOverride(object):
 
     def update_target(self, target):
         """Update the attributes of a target based on this override"""
-        setattr(target, self.name,
+
+        if( self.isList == True ):
+            setattr(target, self.name,
                 list((set(getattr(target, self.name, []))
                       | self.additions) - self.removals))
-
+        else:
+            setattr(target, self.name, self.override)
 
 def _process_config_parameters(data, params, unit_name, unit_kind):
     """Process a "config_parameters" section in either a target, a library,
@@ -606,7 +614,9 @@ class Config(object):
                 for attr, cumulatives in self.cumulative_overrides.iteritems():
                     if 'target.'+attr in overrides:
                         key = 'target.' + attr
-                        if not isinstance(overrides[key], list):
+                        if( type(getattr(self.target, attr)) != type(list()) ):
+                            cumulatives.isList = False                        
+                        if (cumulatives.isList == True) and (not isinstance(overrides[key], list)):
                             raise ConfigException(
                                 "The value of %s.%s is not of type %s" %
                                 (unit_name, "target_overrides." + key,

--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -68,7 +68,7 @@ def cached(func):
 
 # Cumulative attributes can have values appended to them, so they
 # need to be computed differently than regular attributes
-CUMULATIVE_ATTRIBUTES = ['extra_labels', 'macros', 'device_has', 'features']
+CUMULATIVE_ATTRIBUTES = ['extra_labels', 'macros', 'device_has', 'features', 'default_toolchain']
 
 
 def get_resolution_order(json_data, target_name, order, level=0):


### PR DESCRIPTION
@sg- 
## Description
On-line IDE compiler will build the code by the `default_toolchain` in `target.json`. 
For some purpose, some application will prefer to use another one in `supported_toolchains`.
So, to override the default tool chain by` mbed_app.josn` is a better way.

## Status
**READY**


## Migrations
This PR is to add one more item `default_toolchain` in` CUMULATIVE_ATTRIBUTES`.
Also to modify config python file for non-list type of overrides.

## Steps to test or reproduce
1. Prepare mbed_app.json like as:
```
    "target_overrides": {
        "*": {
            "target.default_toolchain": "uARM",
            "platform.stdio-flush-at-exit": false
        }
```
2. $ mbed compile -m NUMAKER_PFM_NUC472
3. Got debug log as:
```
Before: ConfigCumulativeOverride: update_target default_toolchain --> Attr: ARM
After: ConfigCumulativeOverride: update_target default_toolchain --> Attr: uARM
```
