### PR TITLE
Disable Cortex-A in tooling for better error messages

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1906,6 +1906,29 @@
         "features": ["BLE"],
         "release_versions": ["2", "5"]
     },
+    "RZ_A1H": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-A9",
+        "program_cycle_s": 2,
+        "extra_labels": ["RENESAS", "MBRZA1H"],
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "inherits": ["Target"],
+        "device_has": ["ANALOGIN", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "features": ["LWIP"],
+        "release_versions": ["2", "5"]
+    },
+    "VK_RZ_A1H": {
+        "inherits": ["Target"],
+        "core": "Cortex-A9",
+        "extra_labels": ["RENESAS", "VKRZA1H"],
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "default_toolchain": "ARM",
+        "program_cycle_s": 2,
+        "device_has": ["ANALOGIN", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "features": ["LWIP"],
+        "default_lib": "std",
+        "release_versions": ["2", "5"]
+    },
     "MAXWSNENV": {
         "inherits": ["Target"],
         "core": "Cortex-M3",

--- a/tools/build.py
+++ b/tools/build.py
@@ -32,6 +32,7 @@ from tools.toolchains import mbedToolchain
 from tools.targets import TARGET_NAMES, TARGET_MAP
 from tools.options import get_default_options_parser
 from tools.options import extract_profile
+from tools.options import mcu_is_enabled
 from tools.build_api import build_library, build_mbed_libs, build_lib
 from tools.build_api import mcu_toolchain_matrix
 from tools.build_api import print_build_results
@@ -135,6 +136,7 @@ if __name__ == '__main__':
 
     # Get target list
     targets = options.mcu if options.mcu else TARGET_NAMES
+    assert [mcu_is_enabled(parser, mcu) for mcu in targets]
 
     # Get toolchains list
     toolchains = options.tool if options.tool else TOOLCHAINS

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -1244,6 +1244,9 @@ def mcu_toolchain_matrix(verbose_html=False, platform_filter=None,
             # FIlter out platforms using regex
             if re.search(platform_filter, target) is None:
                 continue
+        # TODO: Remove this check when Cortex-A is re-enabled
+        if "Cortex-A" in TARGET_MAP[target].core:
+            continue
         target_counter += 1
 
         row = [target]  # First column is platform name

--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -33,7 +33,7 @@ from tools.export import embitz, coide, kds, simplicity, atmelstudio
 from tools.export import sw4stm32, e2studio, zip, cmsis, uvision, cdt, vscode
 from tools.export import gnuarmeclipse
 from tools.export import qtcreator
-from tools.targets import TARGET_NAMES
+from tools.targets import TARGET_NAMES, TARGET_MAP
 
 EXPORTERS = {
     'uvision5': uvision.Uvision,
@@ -100,6 +100,8 @@ def mcu_ide_matrix(verbose_html=False):
 
     perm_counter = 0
     for target in sorted(TARGET_NAMES):
+        if "Cortex-A" in TARGET_MAP[target].core:
+            continue
         row = [target]  # First column is platform name
         for ide in supported_ides:
             text = "-"

--- a/tools/make.py
+++ b/tools/make.py
@@ -42,6 +42,7 @@ from tools.tests import test_known, test_name_known
 from tools.targets import TARGET_MAP
 from tools.options import get_default_options_parser
 from tools.options import extract_profile
+from tools.options import mcu_is_enabled
 from tools.build_api import build_project
 from tools.build_api import mcu_toolchain_matrix
 from tools.build_api import mcu_toolchain_list
@@ -201,6 +202,7 @@ if __name__ == '__main__':
     if options.mcu is None :
         args_error(parser, "argument -m/--mcu is required")
     mcu = options.mcu[0]
+    assert mcu_is_enabled(parser, mcu)
 
     # Toolchain
     if options.tool is None:

--- a/tools/options.py
+++ b/tools/options.py
@@ -19,7 +19,7 @@ from os.path import join, dirname
 from os import listdir
 from argparse import ArgumentParser
 from tools.toolchains import TOOLCHAINS
-from tools.targets import TARGET_NAMES
+from tools.targets import TARGET_NAMES, TARGET_MAP
 from tools.utils import argparse_force_uppercase_type, \
     argparse_lowercase_hyphen_type, argparse_many, \
     argparse_filestring_type, args_error, argparse_profile_filestring_type,\
@@ -121,3 +121,13 @@ def extract_profile(parser, options, toolchain, fallback="develop"):
                                 " supported by profile {}").format(toolchain,
                                                                    filename))
     return profile
+
+def mcu_is_enabled(parser, mcu):
+    if "Cortex-A" in TARGET_MAP[mcu].core:
+        args_error(
+            parser,
+            ("%s Will be supported in mbed OS 5.6. "
+             "To use the %s, please checkout the mbed OS 5.4 release branch. "
+             "See https://developer.mbed.org/platforms/Renesas-GR-PEACH/#important-notice "
+             "for more information") % (mcu, mcu))
+    return True

--- a/tools/project.py
+++ b/tools/project.py
@@ -20,7 +20,7 @@ from tools.utils import argparse_filestring_type, argparse_profile_filestring_ty
 from tools.utils import argparse_force_lowercase_type
 from tools.utils import argparse_force_uppercase_type
 from tools.utils import print_large_string
-from tools.options import extract_profile, list_profiles
+from tools.options import extract_profile, list_profiles, mcu_is_enabled
 
 def setup_project(ide, target, program=None, source_dir=None, build=None, export_path=None):
     """Generate a name, if not provided, and find dependencies
@@ -221,6 +221,7 @@ def main():
     if not options.mcu:
         args_error(parser, "argument -m/--mcu is required")
 
+    assert mcu_is_enabled(parser, options.mcu)
     # Toolchain
     if not options.ide:
         args_error(parser, "argument -i is required")

--- a/tools/test.py
+++ b/tools/test.py
@@ -39,6 +39,7 @@ from utils import argparse_filestring_type, argparse_lowercase_type, argparse_ma
 from utils import argparse_dir_not_parent
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS, TOOLCHAIN_CLASSES
 from tools.settings import CLI_COLOR_MAP
+from tools.options import mcu_is_enabled
 
 if __name__ == '__main__':
     try:
@@ -115,6 +116,7 @@ if __name__ == '__main__':
         if options.mcu is None :
             args_error(parser, "argument -m/--mcu is required")
         mcu = options.mcu[0]
+        assert mcu_is_enabled(parser, mcu)
 
         # Toolchain
         if options.tool is None:


### PR DESCRIPTION
# Description

This PR will disable building of Cortex-A targets for the mean time. The tools 
bits that disable Cortex-A are (currently) in a single commit that can be 
reverted to re-enable Cortex-A support.

# Tests
 - [x] /morph test (ensure that Cortex-A is not building)
 - [x] /morph export-build (ensure that Cortex-A is not building)