### PR TITLE
Fix vscode intellisense engine to 'Tag Parser'

### DIFF
--- a/tools/export/vscode/settings.tmpl
+++ b/tools/export/vscode/settings.tmpl
@@ -1,4 +1,5 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "C_Cpp.addWorkspaceRootToIncludePath": false
+    "C_Cpp.addWorkspaceRootToIncludePath": false,
+    "C_Cpp.intelliSenseEngine": "Tag Parser"
 }


### PR DESCRIPTION
Since the vscode C++ plugin has been upgraded to 0.11 the intellisense engine has changed, and it does not understand the mbed code base.

Quick fix is to set the engine back to the previous engine.

See https://github.com/Microsoft/vscode-cpptools/blob/master/Documentation/LanguageServer/FAQ.md#what-is-the-difference-between-includepath-and-browsepath-in-c_cpp_propertiesjson

Need a proper patch though, created #4380 as a follow up.

@sg- @theotherjimmy 