### PR TITLE
Allow examples to specify which repo source to use for testing

### DIFF
--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -6,6 +6,7 @@
       "mbed": [
           "https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-blinky"
       ],
+      "test-repo-source": "github",
       "features" : [],
       "targets" : [],
       "toolchains" : [],
@@ -23,6 +24,7 @@
           "https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-tls-hashing",
           "https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-tls-authcrypt"
       ],
+      "test-repo-source": "mbed",
       "features" : [],
       "targets" : ["K64F", "NUCLEO_F429ZI"],
       "toolchains" : ["GCC_ARM", "ARM"],
@@ -37,6 +39,7 @@
       "mbed": [
           "https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-mesh-minimal"
       ],
+      "test-repo-source": "github",
       "features" : [],
       "targets" : ["DISCO_F469NI", "DISCO_F746NG", "K64F", "K66F",
                    "NUCLEO_F429ZI", "NUCLEO_F439ZI", "NUCLEO_F746ZG",
@@ -63,6 +66,7 @@
           "https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-ble-Button",
           "https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-ble-BatteryLevel"
       ],
+      "test-repo-source": "mbed",
       "features" : ["BLE"],
       "targets" : ["NRF51_DK", "NRF52_DK", "K64F", "NUCLEO_F401RE"],
       "toolchains" : [],
@@ -77,6 +81,7 @@
       "mbed": [
           "https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-client"
       ],
+      "test-repo-source": "github",
       "features" : ["LWIP"],
       "targets" : [],
       "toolchains" : [],
@@ -90,6 +95,7 @@
       "github":"https://github.com/ARMmbed/mbed-os-example-sockets",
       "mbed": [
       ],
+      "test-repo-source": "github",
       "features" : ["LWIP"],
       "targets" : [],
       "toolchains" : [],
@@ -103,6 +109,7 @@
       "github":"https://github.com/ARMmbed/mbed-os-example-wifi",
       "mbed": [
       ],
+      "test-repo-source": "github",
       "features" : [],
       "targets" : [],
       "toolchains" : [],
@@ -115,6 +122,7 @@
       "name": "mbed-os-example-uvisor",
       "github":"https://github.com/ARMmbed/mbed-os-example-uvisor",
       "mbed": [],
+      "test-repo-source": "github",
       "features" : [],
       "targets" : ["K64F"],
       "toolchains" : ["GCC_ARM"],
@@ -127,6 +135,7 @@
       "name": "mbed-os-example-uvisor-thread",
       "github":"https://github.com/ARMmbed/mbed-os-example-uvisor-thread",
       "mbed": [],
+      "test-repo-source": "github",
       "features" : [],
       "targets" : ["K64F"],
       "toolchains" : ["GCC_ARM"],
@@ -139,6 +148,7 @@
       "name": "mbed-os-example-uvisor-number-store",
       "github":"https://github.com/ARMmbed/mbed-os-example-uvisor-number-store",
       "mbed": [],
+      "test-repo-source": "github",
       "features" : [],
       "targets" : ["K64F"],
       "toolchains" : ["GCC_ARM"],
@@ -153,6 +163,7 @@
       "mbed": [
           "https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-bootloader"
       ],
+      "test-repo-source": "github",
       "features" : [],
       "targets" : ["K64F", "NUCLEO_F429ZI", "UBLOX_EVK_ODIN_W2"],
       "toolchains" : [],
@@ -167,6 +178,7 @@
       "mbed": [
           "https://developer.mbed.org/teams/mbed-os-examples/code/mbed-os-example-fat-filesystem"
       ],
+      "test-repo-source": "github",
       "features" : [],
       "targets" : ["K64F"],
       "toolchains" : [],
@@ -179,6 +191,7 @@
       "name": "nanostack-border-router",
       "github":"https://github.com/ARMmbed/nanostack-border-router",
       "mbed": [],
+      "test-repo-source": "github",
       "features" : [],
       "targets" : ["K64F", "K66F", "NUCLEO_F429ZI"],
       "toolchains" : [],

--- a/tools/test/examples/examples_lib.py
+++ b/tools/test/examples/examples_lib.py
@@ -1,8 +1,8 @@
 """ Import and bulid a bunch of example programs
 
-    This library includes functions that are shared between the examples.py and 
+    This library includes functions that are shared between the examples.py and
     the update.py modules.
-    
+
  """
 import os
 from os.path import dirname, abspath, basename
@@ -123,20 +123,19 @@ def target_cross_ide(allowed_targets, allowed_ides, features=[], toolchains=[]):
 
 
 def get_repo_list(example):
-    """ Returns a list of all the repos associated with the specific example in the json
-        config file.
-        If there are repos listed under the mbed section then these will be returned as a 
-        list. If not then the github single repo with be returned. 
-        NOTE: This does not currently deal with multiple examples underneath a github 
+    """ Returns a list of all the repos and their types associated with the
+        specific example in the json config file.
+        If the key 'test-repo-source' is set to 'mbed', then it will return the
+        mbed section as a list. Otherwise, it will return the single github repo.
+        NOTE: This does not currently deal with multiple examples underneath a github
         sourced exampe repo.
 
     Args:
     example - Example for which the repo list is requested
-    repos - The list of repos and types contained within that example in the json file
 
     """
     repos = []
-    if len(example['mbed']) > 0:
+    if example['test-repo-source'] == 'mbed':
         for repo in example['mbed']:
             repos.append({
                 'repo': repo,
@@ -156,7 +155,7 @@ def source_repos(config, examples):
         there is already a clone of the repo then it will first be removed to
         ensure a clean, up to date cloning.
     Args:
-    config - the json object imported from the file. 
+    config - the json object imported from the file.
 
     """
     print("\nImporting example repos....\n")
@@ -214,7 +213,7 @@ def get_num_failures(results, export=False):
     Args:
     results - results summary of the compilation stage. See compile_repos() for
               details of the format.
-    num_failures 
+    num_failures
 
     """
     num_failures = 0
@@ -314,23 +313,23 @@ def export_repos(config, ides, targets, examples):
 
 def compile_repos(config, toolchains, targets, examples):
     """Compiles combinations of example programs, targets and compile chains.
-       
+
        The results are returned in a [key: value] dictionary format:
        Where key = The example name from the json config file
              value = a list containing: pass_status, successes, and failures
-             
+
              where pass_status = The overall pass status for the compilation of the full
                                  set of example programs comprising the example suite.
                                  True if all examples pass, false otherwise
-                   successes = list of passing examples. 
+                   successes = list of passing examples.
                    failures = list of failing examples.
-                   
+
                    Both successes and failures contain the example name, target and compile chain
 
     Args:
-    config - the json object imported from the file. 
+    config - the json object imported from the file.
     toolchains - List of toolchains to compile for.
-    results - results of the compilation stage. 
+    results - results of the compilation stage.
 
     """
     results = {}
@@ -349,8 +348,8 @@ def compile_repos(config, toolchains, targets, examples):
             for repo_info in get_repo_list(example):
                 name = basename(repo_info['repo'])
                 os.chdir(name)
-                
-                # Check that the target, toolchain and features combinations are valid and return a 
+
+                # Check that the target, toolchain and features combinations are valid and return a
                 # list of valid combinations to work through
                 for target, toolchain in target_cross_toolchain(valid_choices(example['targets'], targets),
                                                                 valid_choices(example['toolchains'], toolchains),
@@ -365,7 +364,7 @@ def compile_repos(config, toolchains, targets, examples):
                     else:
                         successes.append(example_summary)
                 os.chdir("..")
-            
+
             # If there are any compilation failures for the example 'set' then the overall status is fail.
             if len(failures) > 0:
                 pass_status = False
@@ -378,14 +377,14 @@ def compile_repos(config, toolchains, targets, examples):
 
 
 def update_mbedos_version(config, tag, examples):
-    """ For each example repo identified in the config json object, update the version of 
+    """ For each example repo identified in the config json object, update the version of
         mbed-os to that specified by the supplied GitHub tag. This function assumes that each
         example repo has already been cloned.
-        
+
     Args:
-    config - the json object imported from the file. 
+    config - the json object imported from the file.
     tag - GitHub tag corresponding to a version of mbed-os to upgrade to.
-    
+
     """
     print("Updating mbed-os in examples to version %s\n" % tag)
     for example in config['examples']:
@@ -397,4 +396,3 @@ def update_mbedos_version(config, tag, examples):
             os.chdir(update_dir)
             subprocess.call(["mbed-cli", "update", tag, "--clean"])
             os.chdir("../..")
-


### PR DESCRIPTION
## Description
Currently the CI is aware of the GitHub repository and the mbed developer site mercurial repo mirror when it is building and testing mbed OS example applications. It will pick the mbed developer site repo if it is defined in the `examples.json` file in the test folder: https://github.com/ARMmbed/mbed-os/blob/master/tools/test/examples/examples.json#L20

This is not always the desirable behavior, as GitHub is often used as the staging point for changes.

This PR adds an explicit flag to the `examples.json` file that allows you to specify which repo source to use during testing.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Related PRs
Currently blocking https://github.com/ARMmbed/mbed-os/pull/4294

## Todos
- [ ] morph test