### PR TITLE
Allow target attribute overrides in app config and pick toolchain with default_toolchain

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -331,7 +331,7 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
     extra_verbose - even more output!
     config - a Config object to use instead of creating one
     app_config - location of a chosen mbed_app.json file
-    build_profile - a dict of flags that will be passed to the compiler
+    build_profile - a list of mergeable build profiles
     """
 
     # We need to remove all paths which are repeated to avoid
@@ -345,12 +345,17 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
         cur_tc = TOOLCHAIN_CLASSES[toolchain_name]
     except KeyError:
         raise KeyError("Toolchain %s not supported" % toolchain_name)
-    if config.has_regions:
-        add_regions_to_profile(build_profile, config, cur_tc)
 
-    # Toolchain instance
+    profile = {'c': [], 'cxx': [], 'common': [], 'asm': [], 'ld': []}
+    for contents in build_profile or []:
+        for key in profile:
+            profile[key].extend(contents[toolchain_name][key])
+
+    if config.has_regions:
+        add_regions_to_profile(profile, config, cur_tc)
+
     toolchain = cur_tc(target, notify, macros, silent, build_dir=build_dir,
-                       extra_verbose=extra_verbose, build_profile=build_profile)
+                       extra_verbose=extra_verbose, build_profile=profile)
 
     toolchain.config = config
     toolchain.jobs = jobs

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -644,6 +644,10 @@ class Config(object):
                                                     label)
                     elif name in self.__unused_overrides:
                         pass
+                    elif (name.startswith("target.") and
+                          unit_kind is "application"):
+                        _, attribute = name.split(".")
+                        setattr(self.target, attribute, val)
                     else:
                         self.config_errors.append(
                             ConfigException(

--- a/tools/options.py
+++ b/tools/options.py
@@ -108,16 +108,25 @@ def extract_profile(parser, options, toolchain, fallback="develop"):
     options - The parsed command line arguments
     toolchain - the toolchain that the profile should be extracted for
     """
-    profile = {'c': [], 'cxx': [], 'ld': [], 'common': [], 'asm': []}
+    profiles = []
     filenames = options.profile or [join(dirname(__file__), "profiles",
                                          fallback + ".json")]
     for filename in filenames:
         contents = load(open(filename))
-        try:
-            for key in profile.iterkeys():
-                profile[key] += contents[toolchain][key]
-        except KeyError:
+        if toolchain not in contents:
             args_error(parser, ("argument --profile: toolchain {} is not"
                                 " supported by profile {}").format(toolchain,
                                                                    filename))
-    return profile
+        profiles.append(contents)
+
+    return profiles
+
+def mcu_is_enabled(parser, mcu):
+    if "Cortex-A" in TARGET_MAP[mcu].core:
+        args_error(
+            parser,
+            ("%s Will be supported in mbed OS 5.6. "
+             "To use the %s, please checkout the mbed OS 5.4 release branch. "
+             "See https://developer.mbed.org/platforms/Renesas-GR-PEACH/#important-notice "
+             "for more information") % (mcu, mcu))
+    return True


### PR DESCRIPTION
# Description

The two commits in this PR do independent things:

## First
We currently do not allow a user to override noncumulative attributes in the app
config. Attempting to override `target.core`, `target.default_lib` or
`target.default_toolchain` will error out with "Atempted to override undefined 
parameter". 

Instead, lets allow user to do this.

## Second
This commit  delays evaluation of the build profiles until after the app config has had a chance to override things.

# TODO
- [x] /morph test
- [x] Write documentation for the first commit and submit the PR to the handbook