### PR TITLE
Nucleo-F070RB It doesn't work when use internal clock

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/system_stm32f0xx.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/system_stm32f0xx.c
@@ -450,7 +450,7 @@ uint8_t SetSysClock_PLL_HSI(void)
   RCC_OscInitStruct.LSIState                = RCC_LSI_OFF;
   RCC_OscInitStruct.PLL.PLLState            = RCC_PLL_ON;
   RCC_OscInitStruct.PLL.PLLSource           = RCC_PLLSOURCE_HSI; // HSI div 2
-  RCC_OscInitStruct.PLL.PREDIV              = RCC_PREDIV_DIV1;
+  RCC_OscInitStruct.PLL.PREDIV              = RCC_PREDIV_DIV2;
   RCC_OscInitStruct.PLL.PLLMUL              = RCC_PLL_MUL12;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
       return 0; // FAIL

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/system_stm32f0xx.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/system_stm32f0xx.c
@@ -449,8 +449,8 @@ uint8_t SetSysClock_PLL_HSI(void)
   RCC_OscInitStruct.HSI48State              = RCC_HSI_ON;
   RCC_OscInitStruct.LSIState                = RCC_LSI_OFF;
   RCC_OscInitStruct.PLL.PLLState            = RCC_PLL_ON;
-  RCC_OscInitStruct.PLL.PLLSource           = RCC_PLLSOURCE_HSI; // HSI div 2
-  RCC_OscInitStruct.PLL.PREDIV              = RCC_PREDIV_DIV2;
+  RCC_OscInitStruct.PLL.PLLSource           = RCC_PLLSOURCE_HSI;
+  RCC_OscInitStruct.PLL.PREDIV              = RCC_PREDIV_DIV2; // HSI div 2
   RCC_OscInitStruct.PLL.PLLMUL              = RCC_PLL_MUL12;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
       return 0; // FAIL


### PR DESCRIPTION
## Description
Nucleo-F070RB have a wrong divisor when it initial the clock.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

**NO**


## Steps to test or reproduce
Run display message to UART

Fixes #4361