### PR TITLE
Enhance memap, and configure depth level

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -446,7 +446,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
                   macros=None, inc_dirs=None, jobs=1, silent=False,
                   report=None, properties=None, project_id=None,
                   project_description=None, extra_verbose=False, config=None,
-                  app_config=None, build_profile=None):
+                  app_config=None, build_profile=None, stats_depth=None):
     """ Build a project. A project may be a test or a user program.
 
     Positional arguments:
@@ -475,6 +475,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
     config - a Config object to use instead of creating one
     app_config - location of a chosen mbed_app.json file
     build_profile - a dict of flags that will be passed to the compiler
+    stats_depth - depth level for memap to display file/dirs
     """
 
     # Convert src_path to a list if needed
@@ -553,18 +554,18 @@ def build_project(src_paths, build_path, target, toolchain_name,
         memap_table = ''
         if memap_instance:
             # Write output to stdout in text (pretty table) format
-            memap_table = memap_instance.generate_output('table')
+            memap_table = memap_instance.generate_output('table', stats_depth)
 
             if not silent:
                 print memap_table
 
             # Write output to file in JSON format
             map_out = join(build_path, name + "_map.json")
-            memap_instance.generate_output('json', map_out)
+            memap_instance.generate_output('json', stats_depth, map_out)
 
             # Write output to file in CSV format for the CI
             map_csv = join(build_path, name + "_map.csv")
-            memap_instance.generate_output('csv-ci', map_csv)
+            memap_instance.generate_output('csv-ci', stats_depth, map_csv)
 
         resources.detect_duplicates(toolchain)
 
@@ -1163,7 +1164,7 @@ def mcu_toolchain_list(release_version='5'):
 
 
 def mcu_target_list(release_version='5'):
-    """  Shows target list 
+    """  Shows target list
 
     """
 

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -574,7 +574,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
             cur_result["elapsed_time"] = end - start
             cur_result["output"] = toolchain.get_output() + memap_table
             cur_result["result"] = "OK"
-            cur_result["memory_usage"] = toolchain.map_outputs
+            cur_result["memory_usage"] = memap_instance.mem_report
             cur_result["bin"] = res
             cur_result["elf"] = splitext(res)[0] + ".elf"
             cur_result.update(toolchain.report)
@@ -1324,7 +1324,7 @@ def print_build_memory_usage(report):
     """
     from prettytable import PrettyTable
     columns_text = ['name', 'target', 'toolchain']
-    columns_int = ['static_ram', 'stack', 'heap', 'total_ram', 'total_flash']
+    columns_int = ['static_ram', 'total_flash']
     table = PrettyTable(columns_text + columns_int)
 
     for col in columns_text:
@@ -1351,10 +1351,6 @@ def print_build_memory_usage(report):
                                 record['toolchain_name'],
                                 record['memory_usage'][-1]['summary'][
                                     'static_ram'],
-                                record['memory_usage'][-1]['summary']['stack'],
-                                record['memory_usage'][-1]['summary']['heap'],
-                                record['memory_usage'][-1]['summary'][
-                                    'total_ram'],
                                 record['memory_usage'][-1]['summary'][
                                     'total_flash'],
                             ]

--- a/tools/make.py
+++ b/tools/make.py
@@ -58,51 +58,66 @@ if __name__ == '__main__':
     # Parse Options
     parser = get_default_options_parser(add_app_config=True)
     group = parser.add_mutually_exclusive_group(required=False)
-    group.add_argument("-p",
-                      type=argparse_many(test_known),
-                      dest="program",
-                      help="The index of the desired test program: [0-%d]" % (len(TESTS)-1))
+    group.add_argument(
+        "-p",
+        type=argparse_many(test_known),
+        dest="program",
+        help="The index of the desired test program: [0-%d]" % (len(TESTS)-1))
 
-    group.add_argument("-n",
-                       type=argparse_many(test_name_known),
-                      dest="program",
-                      help="The name of the desired test program")
+    group.add_argument(
+        "-n",
+        type=argparse_many(test_name_known),
+        dest="program",
+        help="The name of the desired test program")
 
-    parser.add_argument("-j", "--jobs",
-                      type=int,
-                      dest="jobs",
-                      default=0,
-                      help="Number of concurrent jobs. Default: 0/auto (based on host machine's number of CPUs)")
+    parser.add_argument(
+        "-j", "--jobs",
+        type=int,
+        dest="jobs",
+        default=0,
+        help="Number of concurrent jobs. Default: 0/auto (based on host machine's number of CPUs)")
 
-    parser.add_argument("-v", "--verbose",
-                      action="store_true",
-                      dest="verbose",
-                      default=False,
-                      help="Verbose diagnostic output")
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        dest="verbose",
+        default=False,
+        help="Verbose diagnostic output")
 
-    parser.add_argument("--silent",
-                      action="store_true",
-                      dest="silent",
-                      default=False,
-                      help="Silent diagnostic output (no copy, compile notification)")
+    parser.add_argument(
+        "--silent",
+        action="store_true",
+        dest="silent",
+        default=False,
+        help="Silent diagnostic output (no copy, compile notification)")
 
-    parser.add_argument("-D",
-                      action="append",
-                      dest="macros",
-                      help="Add a macro definition")
+    parser.add_argument(
+        "-D",
+        action="append",
+        dest="macros",
+        help="Add a macro definition")
 
-    group.add_argument("-S", "--supported-toolchains",
-                      dest="supported_toolchains",
-                      default=False,
-                      const="matrix",
-                      choices=["matrix", "toolchains", "targets"],
-                      nargs="?",
-                      help="Displays supported matrix of MCUs and toolchains")
+    group.add_argument(
+        "-S", "--supported-toolchains",
+        dest="supported_toolchains",
+        default=False,
+        const="matrix",
+        choices=["matrix", "toolchains", "targets"],
+        nargs="?",
+        help="Displays supported matrix of MCUs and toolchains")
 
-    parser.add_argument('-f', '--filter',
-                      dest='general_filter_regex',
-                      default=None,
-                      help='For some commands you can use filter to filter out results')
+    parser.add_argument(
+        '-f', '--filter',
+        dest='general_filter_regex',
+        default=None,
+        help='For some commands you can use filter to filter out results')
+
+    parser.add_argument(
+        "--stats-depth",
+        type=int,
+        dest="stats_depth",
+        default=2,
+        help="Depth level for static memory report")
 
     # Local run
     parser.add_argument("--automated", action="store_true", dest="automated",
@@ -277,7 +292,8 @@ if __name__ == '__main__':
                                      inc_dirs=[dirname(MBED_LIBRARIES)],
                                      build_profile=extract_profile(parser,
                                                                    options,
-                                                                   toolchain))
+                                                                   toolchain),
+                                     stats_depth=options.stats_depth)
             print 'Image: %s'% bin_file
 
             if options.disk:
@@ -322,7 +338,7 @@ if __name__ == '__main__':
                 traceback.print_exc(file=sys.stdout)
             else:
                 print "[ERROR] %s" % str(e)
-            
+
             sys.exit(1)
     if options.build_data:
         merge_build_data(options.build_data, build_data_blob, "application")

--- a/tools/test.py
+++ b/tools/test.py
@@ -44,12 +44,12 @@ if __name__ == '__main__':
     try:
         # Parse Options
         parser = get_default_options_parser(add_app_config=True)
-        
+
         parser.add_argument("-D",
                           action="append",
                           dest="macros",
                           help="Add a macro definition")
-       
+
         parser.add_argument("-j", "--jobs",
                           type=int,
                           dest="jobs",
@@ -76,29 +76,35 @@ if __name__ == '__main__':
         parser.add_argument("-f", "--format", dest="format",
                             type=argparse_lowercase_type(format_choices, "format"),
                             default=format_default_choice, help=format_help)
-        
+
         parser.add_argument("--continue-on-build-fail", action="store_true", dest="continue_on_build_fail",
                           default=None, help="Continue trying to build all tests if a build failure occurs")
 
         #TODO validate the names instead of just passing through str
         parser.add_argument("-n", "--names", dest="names", type=argparse_many(str),
                           default=None, help="Limit the tests to a comma separated list of names")
-                          
+
         parser.add_argument("--test-spec", dest="test_spec",
                           default=None, help="Destination path for a test spec file that can be used by the Greentea automated test tool")
-        
+
         parser.add_argument("--build-report-junit", dest="build_report_junit",
                           default=None, help="Destination path for a build report in the JUnit xml format")
         parser.add_argument("--build-data",
                             dest="build_data",
                             default=None,
                             help="Dump build_data to this file")
-        
+
         parser.add_argument("-v", "--verbose",
                           action="store_true",
                           dest="verbose",
                           default=False,
                           help="Verbose diagnostic output")
+
+        parser.add_argument("--stats-depth",
+                            type=int,
+                            dest="stats_depth",
+                            default=2,
+                            help="Depth level for static memory report")
 
         options = parser.parse_args()
 
@@ -129,7 +135,7 @@ if __name__ == '__main__':
 
         # Find all tests in the relevant paths
         for path in all_paths:
-            all_tests.update(find_tests(path, mcu, toolchain, 
+            all_tests.update(find_tests(path, mcu, toolchain,
                                         app_config=options.app_config))
 
         # Filter tests by name if specified
@@ -172,7 +178,7 @@ if __name__ == '__main__':
             # Default base source path is the current directory
             if not base_source_paths:
                 base_source_paths = ['.']
-            
+
             build_report = {}
             build_properties = {}
 
@@ -214,8 +220,9 @@ if __name__ == '__main__':
                         notify=notify,
                         jobs=options.jobs,
                         continue_on_build_fail=options.continue_on_build_fail,
-                                                             app_config=options.app_config,
-                                                             build_profile=profile)
+                        app_config=options.app_config,
+                        build_profile=profile,
+                        stats_depth=options.stats_depth)
 
                 # If a path to a test spec is provided, write it to a file
                 if options.test_spec:

--- a/tools/test/memap/memap_test.py
+++ b/tools/test/memap/memap_test.py
@@ -16,6 +16,7 @@ limitations under the License.
 """
 import sys
 import os
+import json
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 sys.path.insert(0, ROOT)
@@ -40,57 +41,105 @@ class MemapParserTests(unittest.TestCase):
         :return:
         """
         self.memap_parser = MemapParser()
-        
+
         self.memap_parser.modules = {
-            "Misc": {
-                "unknown": 0,
-                ".ARM": 8,
-                ".ARM.extab": 0,
-                ".init": 12,
-                "OUTPUT": 0,
-                ".stack": 0,
-                ".eh_frame": 0,
-                ".fini_array": 4,
+            "mbed-os/targets/TARGET/TARGET_MCUS/api/pinmap.o": {
+                ".text": 1,
+                ".data": 2,
+                ".bss": 3,
                 ".heap": 0,
-                ".stabstr": 0,
-                ".interrupts_ram": 0,
-                ".init_array": 0,
-                ".stab": 0,
-                ".ARM.attributes": 7347,
-                ".bss": 8517,
-                ".flash_config": 16,
-                ".interrupts": 1024,
-                ".data": 2325,
-                ".ARM.exidx": 0,
-                ".text": 59906,
-                ".jcr": 0
-            },
-            "Fill": {
-                "unknown": 12,
-                ".ARM": 0,
-                ".ARM.extab": 0,
-                ".init": 0,
-                "OUTPUT": 0,
                 ".stack": 0,
-                ".eh_frame": 0,
-                ".fini_array": 0,
-                ".heap": 65536,
-                ".stabstr": 0,
-                ".interrupts_ram": 1024,
-                ".init_array": 0,
-                ".stab": 0,
-                ".ARM.attributes": 0,
-                ".bss": 2235,
-                ".flash_config": 0,
-                ".interrupts": 0,
-                ".data": 3,
-                ".ARM.exidx": 0,
-                ".text": 136,
-                ".jcr": 0
-            }
+                ".interrupts_ram":0,
+                ".init":0,
+                ".ARM.extab":0,
+                ".ARM.exidx":0,
+                ".ARM.attributes":0,
+                ".eh_frame":0,
+                ".init_array":0,
+                ".fini_array":0,
+                ".jcr":0,
+                ".stab":0,
+                ".stabstr":0,
+                ".ARM.exidx":0,
+                ".ARM":0,
+                ".interrupts":0,
+                ".flash_config":0,
+                "unknown":0,
+                "OUTPUT":0,
+                },
+            "[lib]/libc.a/lib_a-printf.o": {
+                ".text": 4,
+                ".data": 5,
+                ".bss": 6,
+                ".heap": 0,
+                ".stack": 0,
+                ".interrupts_ram":0,
+                ".init":0,
+                ".ARM.extab":0,
+                ".ARM.exidx":0,
+                ".ARM.attributes":0,
+                ".eh_frame":0,
+                ".init_array":0,
+                ".fini_array":0,
+                ".jcr":0,
+                ".stab":0,
+                ".stabstr":0,
+                ".ARM.exidx":0,
+                ".ARM":0,
+                ".interrupts":0,
+                ".flash_config":0,
+                "unknown":0,
+                "OUTPUT":0,
+                },
+            "main.o": {
+                ".text": 7,
+                ".data": 8,
+                ".bss": 0,
+                ".heap": 0,
+                ".stack": 0,
+                ".interrupts_ram":0,
+                ".init":0,
+                ".ARM.extab":0,
+                ".ARM.exidx":0,
+                ".ARM.attributes":0,
+                ".eh_frame":0,
+                ".init_array":0,
+                ".fini_array":0,
+                ".jcr":0,
+                ".stab":0,
+                ".stabstr":0,
+                ".ARM.exidx":0,
+                ".ARM":0,
+                ".interrupts":0,
+                ".flash_config":0,
+                "unknown":0,
+                "OUTPUT":0,
+                },
+            "test.o": {
+                ".text": 0,
+                ".data": 0,
+                ".bss": 0,
+                ".heap": 0,
+                ".stack": 0,
+                ".interrupts_ram":0,
+                ".init":0,
+                ".ARM.extab":0,
+                ".ARM.exidx":0,
+                ".ARM.attributes":0,
+                ".eh_frame":0,
+                ".init_array":0,
+                ".fini_array":0,
+                ".jcr":0,
+                ".stab":0,
+                ".stabstr":0,
+                ".ARM.exidx":0,
+                ".ARM":0,
+                ".interrupts":0,
+                ".flash_config":0,
+                "unknown":0,
+                "OUTPUT":0,
+                },
         }
-        
-        self.memap_parser.compute_report()
 
     def tearDown(self):
         """
@@ -99,70 +148,71 @@ class MemapParserTests(unittest.TestCase):
         :return:
         """
         pass
-    
-    def generate_test_helper(self, output_type, file_output=None):
+
+    def generate_test_helper(self, output_type, depth, file_output=None):
         """
-        Helper that ensures that the member variables "modules", "mem_report",
-        and "mem_summary" are unchanged after calling "generate_output"
-        
+        Helper that ensures that the member variables "modules" is
+        unchanged after calling "generate_output"
+
         :param output_type: type string that is passed to "generate_output"
-        :param file_output: path to output file that is passed to "generate_output"      
+        :param file_output: path to output file that is passed to "generate_output"
         :return:
         """
-        
+
         old_modules = deepcopy(self.memap_parser.modules)
-        old_report = deepcopy(self.memap_parser.mem_report)
-        old_summary = deepcopy(self.memap_parser.mem_summary)
-        self.memap_parser.generate_output(output_type, file_output)
+
+        self.memap_parser.generate_output(output_type, depth, file_output)
+
         self.assertEqual(self.memap_parser.modules, old_modules,
-                         "generate_output modified the 'modules' property")
-        self.assertEqual(self.memap_parser.mem_report, old_report,
-                         "generate_output modified the 'mem_report' property")
-        self.assertEqual(self.memap_parser.mem_summary, old_summary,
-                         "generate_output modified the 'mem_summary' property")
+                        "generate_output modified the 'modules' property")
+
 
     def test_report_computed(self):
         """
         Test ensures the report and summary are computed
-        
+
         :return:
         """
-        self.assertTrue(self.memap_parser.mem_report)
+
+        self.memap_parser.generate_output('table', 2)
+
+        # Report is created after generating output
         self.assertTrue(self.memap_parser.mem_summary)
-        self.assertEqual(self.memap_parser.mem_report[-1]['summary'],
-                         self.memap_parser.mem_summary,
-                         "mem_report did not contain a correct copy of mem_summary")
-    
+        self.assertTrue(self.memap_parser.mem_report)
+
     def test_generate_output_table(self):
         """
         Test ensures that an output of type "table" can be generated correctly
-        
+
         :return:
         """
-        self.generate_test_helper('table')
-    
+        depth = 2
+        self.generate_test_helper('table', depth)
+
     def test_generate_output_json(self):
         """
         Test ensures that an output of type "json" can be generated correctly
-        
+
         :return:
         """
         file_name = '.json_test_output.json'
-        self.generate_test_helper('json', file_output=file_name)
+        depth = 2
+        self.generate_test_helper('json', depth, file_output=file_name)
         self.assertTrue(os.path.exists(file_name), "Failed to create json file")
         os.remove(file_name)
-    
+
     def test_generate_output_csv_ci(self):
         """
         Test ensures that an output of type "csv-ci" can be generated correctly
-        
+
         :return:
         """
         file_name = '.csv_ci_test_output.csv'
-        self.generate_test_helper('csv-ci', file_output=file_name)
+        depth = 2
+        self.generate_test_helper('csv-ci', depth, file_output=file_name)
         self.assertTrue(os.path.exists(file_name), "Failed to create csv-ci file")
         os.remove(file_name)
-    
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -496,7 +496,8 @@ class SingleTestRunner(object):
                                      properties=build_properties,
                                      project_id=test_id,
                                      project_description=test.get_description(),
-                                     build_profile=profile)
+                                     build_profile=profile,
+                                     stats_depth=stats_depth)
 
                 except Exception, e:
                     project_name_str = project_name if project_name is not None else test_id
@@ -2038,7 +2039,7 @@ def find_tests(base_dir, target_name, toolchain_name, app_config=None):
                 if path_depth == 2:
                     test_group_directory_path, test_case_directory = os.path.split(d)
                     test_group_directory = os.path.basename(test_group_directory_path)
-                    
+
                     # Check to make sure discoverd folder is not in a host test directory
                     if test_case_directory != 'host_tests' and test_group_directory != 'host_tests':
                         test_name = test_path_to_name(d, base_dir)
@@ -2122,7 +2123,7 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
                 clean=False, notify=None, verbose=False, jobs=1, macros=None,
                 silent=False, report=None, properties=None,
                 continue_on_build_fail=False, app_config=None,
-                build_profile=None):
+                build_profile=None, stats_depth=None):
     """Given the data structure from 'find_tests' and the typical build parameters,
     build all the tests
 
@@ -2158,7 +2159,7 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
         src_path = base_source_paths + [test_path]
         bin_file = None
         test_case_folder_name = os.path.basename(test_path)
-        
+
         args = (src_path, test_build_path, target, toolchain_name)
         kwargs = {
             'jobs': 1,
@@ -2172,9 +2173,10 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
             'app_config': app_config,
             'build_profile': build_profile,
             'silent': True,
-            'toolchain_paths': TOOLCHAIN_PATHS
+            'toolchain_paths': TOOLCHAIN_PATHS,
+            'stats_depth': stats_depth
         }
-        
+
         results.append(p.apply_async(build_test_worker, args, kwargs))
 
     p.close()
@@ -2199,7 +2201,7 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
                         report_entry = worker_result['kwargs']['report'][target_name][toolchain_name]
                         for test_key in report_entry.keys():
                             report[target_name][toolchain_name][test_key] = report_entry[test_key]
-                        
+
                         # Set the overall result to a failure if a build failure occurred
                         if ('reason' in worker_result and
                             not worker_result['reason'] and

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -416,7 +416,6 @@ class mbedToolchain:
 
         # Print output buffer
         self.output = str()
-        self.map_outputs = list()   # Place to store memmap scan results in JSON like data structures
 
         # uVisor spepcific rules
         if 'UVISOR' in self.target.features and 'UVISOR_SUPPORTED' in self.target.extra_labels:
@@ -585,13 +584,13 @@ class mbedToolchain:
             # information about the library paths. Safe option: assume an update
             if not d or not exists(d):
                 return True
-            
+
             if not self.stat_cache.has_key(d):
                 self.stat_cache[d] = stat(d).st_mtime
 
             if self.stat_cache[d] >= target_mod_time:
                 return True
-        
+
         return False
 
     def is_ignored(self, file_path):
@@ -852,7 +851,7 @@ class mbedToolchain:
             string = " ".join(cmd_list)
             f.write(string)
         return link_file
- 
+
     # Generate response file for all objects when archiving.
     # ARM, GCC, IAR cross compatible
     def get_arch_file(self, objects):
@@ -1128,7 +1127,8 @@ class mbedToolchain:
             self.progress("elf2bin", name)
             self.binary(r, elf, bin)
 
-        self.map_outputs = self.mem_stats(map)
+        # Initialize memap and process map file. This doesn't generate output.
+        self.mem_stats(map)
 
         self.var("compile_succeded", True)
         self.var("binary", filename)
@@ -1193,8 +1193,7 @@ class mbedToolchain:
     def mem_stats(self, map):
         """! Creates parser object
         @param map Path to linker map file to parse and decode
-        @return Memory summary structure with memory usage statistics
-                None if map file can't be opened and processed
+        @return None
         """
         toolchain = self.__class__.__name__
 
@@ -1209,10 +1208,10 @@ class mbedToolchain:
         # Store the memap instance for later use
         self.memap_instance = memap
 
-        # Here we return memory statistics structure (constructed after
-        # call to generate_output) which contains raw data in bytes
-        # about sections + summary
-        return memap.mem_report
+        # Note: memory statistics are not returned.
+        # Need call to generate_output later (depends on depth & output format)
+
+        return None
 
     # Set the configuration data
     def set_config_data(self, config_data):


### PR DESCRIPTION
Generates a detailed report by analysing static memory information from the map file.

The information from the map file is combined with the information from the BUILD directory (compiled objects and path to these objects), including the main application and user libraries.

In addition, it's now possible to visualise compiler libraries and identify other miscellaneous objects introduced by the toolchain. 

By default, memap generates a report with depth=2, but it's possible to specify a different depth level, and even to enable a full report (depth=0).

It has been tested with the three major toolchains: GCC, ARM and IAR compiler.

## Status
**READY**

## Migrations
NO

## Todos
- [x] Review usability of stats report 
- [x] Add corresponding hooks to select depth level from mbed CLI
- [x] Tests
- [x] Documentation (https://github.com/ARMmbed/Handbook/pull/167)

@sg- @theotherjimmy @screamerbg please review

## Usage
```
$ mbed compile -t <toolchain> -m <target>    # displays memap info with depth=2 (default)
$ python mbed-os/tools/memap.py BUILD/<TARGET>/<TOOLCHAIN>/<memap-file.map> -t <TOOLCHAIN> -d <DEPTH_LEVEL>
```

## Examples

```
$ python mbed-os/tools/memap.py BUILD/K64F/GCC_ARM/example.map -t GCC_ARM -d 1
+-----------+-------+-------+-------+
| Module    | .text | .data |  .bss |
+-----------+-------+-------+-------+
| [fill]    |    62 |     4 |  2513 |
| [lib]     | 26514 |  2212 |    84 |
| main.o    |    56 |     0 |     4 |
| mbed-os   | 17487 |    40 |  7719 |
| Subtotals | 44119 |  2256 | 10320 |
+-----------+-------+-------+-------+
Allocated Heap: 24576 bytes
Allocated Stack: unknown
Total Static RAM memory (data + bss): 12576 bytes
Total RAM memory (data + bss + heap + stack): 37152 bytes
Total Flash memory (text + data + misc): 47415 bytes

$ python mbed-os/tools/memap.py BUILD/K64F/GCC_ARM/example.map -t GCC_ARM -d 2
+------------------+-------+-------+-------+
| Module           | .text | .data |  .bss |
+------------------+-------+-------+-------+
| [fill]           |    62 |     4 |  2513 |
| [lib]/libc.a     | 22434 |  2204 |    56 |
| [lib]/libgcc.a   |  3728 |     0 |     0 |
| [lib]/libm.a     |    88 |     0 |     0 |
| [lib]/libnosys.a |    32 |     0 |     0 |
| [lib]/misc       |   232 |     8 |    28 |
| main.o           |    56 |     0 |     4 |
| mbed-os/features |    42 |     0 |   184 |
| mbed-os/hal      |   450 |     0 |     8 |
| mbed-os/platform |  1252 |     4 |   269 |
| mbed-os/rtos     |  5955 |    24 |  6874 |
| mbed-os/targets  |  9788 |    12 |   384 |
| Subtotals        | 44119 |  2256 | 10320 |
+------------------+-------+-------+-------+
Allocated Heap: 24576 bytes
Allocated Stack: unknown
Total Static RAM memory (data + bss): 12576 bytes
Total RAM memory (data + bss + heap + stack): 37152 bytes
Total Flash memory (text + data + misc): 47415 bytes

$ python mbed-os/tools/memap.py BUILD/K64F/GCC_ARM/example.map -t GCC_ARM -d 3
+----------------------------------------+-------+-------+-------+
| Module                                 | .text | .data |  .bss |
+----------------------------------------+-------+-------+-------+
| [fill]                                 |    62 |     4 |  2513 |
| [lib]/libc.a/lib_a-abort.o             |    16 |     0 |     0 |
| [lib]/libc.a/lib_a-assert.o            |   123 |     0 |     0 |
| [lib]/libc.a/lib_a-callocr.o           |    96 |     0 |     0 |
| [lib]/libc.a/lib_a-closer.o            |    36 |     0 |     0 |
| [lib]/libc.a/lib_a-dtoa.o              |  4044 |     0 |     0 |
| [lib]/libc.a/lib_a-errno.o             |    12 |     0 |     0 |
| [lib]/libc.a/lib_a-fclose.o            |   132 |     0 |     0 |
| [lib]/libc.a/lib_a-fflush.o            |   420 |     0 |     0 |
| [lib]/libc.a/lib_a-findfp.o            |   272 |     0 |     0 |
| [lib]/libc.a/lib_a-fiprintf.o          |    40 |     0 |     0 |
| [lib]/libc.a/lib_a-fputwc.o            |   212 |     0 |     0 |
| [lib]/libc.a/lib_a-freer.o             |   588 |     0 |     0 |
| [lib]/libc.a/lib_a-fstatr.o            |    40 |     0 |     0 |
| [lib]/libc.a/lib_a-fvwrite.o           |   792 |     0 |     0 |
| [lib]/libc.a/lib_a-fwalk.o             |    84 |     0 |     0 |
| [lib]/libc.a/lib_a-impure.o            |     6 |  1068 |     0 |
| [lib]/libc.a/lib_a-init.o              |    80 |     0 |     0 |
| [lib]/libc.a/lib_a-isattyr.o           |    36 |     0 |     0 |
| [lib]/libc.a/lib_a-locale.o            |    40 |    92 |     0 |
| [lib]/libc.a/lib_a-lseekr.o            |    40 |     0 |     0 |
| [lib]/libc.a/lib_a-makebuf.o           |   224 |     0 |     0 |
| [lib]/libc.a/lib_a-mallocr.o           |  1316 |  1040 |    52 |
| [lib]/libc.a/lib_a-memchr.o            |   148 |     0 |     0 |
| [lib]/libc.a/lib_a-memcpy.o            |   308 |     0 |     0 |
| [lib]/libc.a/lib_a-memmove.o           |   200 |     0 |     0 |
| [lib]/libc.a/lib_a-memset.o            |   156 |     0 |     0 |
| [lib]/libc.a/lib_a-mprec.o             |  1764 |     0 |     0 |
| [lib]/libc.a/lib_a-readr.o             |    40 |     0 |     0 |
| [lib]/libc.a/lib_a-reallocr.o          |  1004 |     0 |     0 |
| [lib]/libc.a/lib_a-reent.o             |     0 |     0 |     4 |
| [lib]/libc.a/lib_a-sbrkr.o             |    36 |     0 |     0 |
| [lib]/libc.a/lib_a-signal.o            |   104 |     0 |     0 |
| [lib]/libc.a/lib_a-signalr.o           |    44 |     0 |     0 |
| [lib]/libc.a/lib_a-stdio.o             |   132 |     0 |     0 |
| [lib]/libc.a/lib_a-strlen.o            |    92 |     0 |     0 |
| [lib]/libc.a/lib_a-svfiprintf.o        |   260 |     0 |     0 |
| [lib]/libc.a/lib_a-svfprintf.o         |  5426 |     0 |     0 |
| [lib]/libc.a/lib_a-vfiprintf.o         |  3407 |     0 |     0 |
| [lib]/libc.a/lib_a-vsnprintf.o         |   148 |     0 |     0 |
| [lib]/libc.a/lib_a-wbuf.o              |   168 |     0 |     0 |
| [lib]/libc.a/lib_a-wcrtomb.o           |    84 |     0 |     0 |
| [lib]/libc.a/lib_a-wctomb_r.o          |    28 |     4 |     0 |
| [lib]/libc.a/lib_a-writer.o            |    40 |     0 |     0 |
| [lib]/libc.a/lib_a-wsetup.o            |   196 |     0 |     0 |
| [lib]/libgcc.a/_aeabi_uldivmod.o       |    48 |     0 |     0 |
| [lib]/libgcc.a/_arm_addsubdf3.o        |   880 |     0 |     0 |
| [lib]/libgcc.a/_arm_cmpdf2.o           |   272 |     0 |     0 |
| [lib]/libgcc.a/_arm_fixdfsi.o          |    80 |     0 |     0 |
| [lib]/libgcc.a/_arm_muldivdf3.o        |  1060 |     0 |     0 |
| [lib]/libgcc.a/_divdi3.o               |   668 |     0 |     0 |
| [lib]/libgcc.a/_dvmd_tls.o             |     4 |     0 |     0 |
| [lib]/libgcc.a/_udivdi3.o              |   620 |     0 |     0 |
| [lib]/libgcc.a/bpabi.o                 |    96 |     0 |     0 |
| [lib]/libm.a/lib_a-s_fpclassify.o      |    88 |     0 |     0 |
| [lib]/libnosys.a/getpid.o              |    16 |     0 |     0 |
| [lib]/libnosys.a/kill.o                |    16 |     0 |     0 |
| [lib]/misc/crt0.o                      |   116 |     0 |     0 |
| [lib]/misc/crtbegin.o                  |    92 |     4 |    28 |
| [lib]/misc/crtend.o                    |     0 |     4 |     0 |
| [lib]/misc/crti.o                      |     8 |     0 |     0 |
| [lib]/misc/crtn.o                      |    16 |     0 |     0 |
| main.o                                 |    56 |     0 |     4 |
| mbed-os/features/storage               |    42 |     0 |   184 |
| mbed-os/hal/mbed_gpio.o                |    96 |     0 |     0 |
| mbed-os/hal/mbed_pinmap_common.o       |   242 |     0 |     0 |
| mbed-os/hal/mbed_ticker_api.o          |    72 |     0 |     0 |
| mbed-os/hal/mbed_us_ticker_api.o       |    40 |     0 |     8 |
| mbed-os/platform/mbed_alloc_wrappers.o |    16 |     0 |     0 |
| mbed-os/platform/mbed_assert.o         |    85 |     0 |     0 |
| mbed-os/platform/mbed_board.o          |   156 |     0 |     0 |
| mbed-os/platform/mbed_critical.o       |   251 |     0 |     5 |
| mbed-os/platform/mbed_error.o          |    22 |     0 |     0 |
| mbed-os/platform/mbed_retarget.o       |   636 |     4 |   264 |
| mbed-os/platform/mbed_wait_api_rtos.o  |    86 |     0 |     0 |
| mbed-os/rtos/Thread.o                  |    20 |     0 |     4 |
| mbed-os/rtos/rtos_idle.o               |    20 |     4 |     0 |
| mbed-os/rtos/rtx                       |  5915 |    20 |  6870 |
| mbed-os/targets/TARGET_Freescale       |  9788 |    12 |   384 |
| Subtotals                              | 44119 |  2256 | 10320 |
+----------------------------------------+-------+-------+-------+
Allocated Heap: 24576 bytes
Allocated Stack: unknown
Total Static RAM memory (data + bss): 12576 bytes
Total RAM memory (data + bss + heap + stack): 37152 bytes
Total Flash memory (text + data + misc): 47415 bytes
```
