### PR TITLE
race tests: fix conditional check for MBED_RTOS_SINGLE_THREAD being defined

### DIFF
--- a/TESTS/mbed_drivers/race_test/main.cpp
+++ b/TESTS/mbed_drivers/race_test/main.cpp
@@ -22,7 +22,7 @@
 #include "SingletonPtr.h"
 #include <stdio.h>
 
-#ifndef MBED_RTOS_SINGLE_THREAD
+#ifdef MBED_RTOS_SINGLE_THREAD
   #error [NOT_SUPPORTED] test not supported for single threaded enviroment
 #endif
 


### PR DESCRIPTION
Simple fix, this condition was added recently and the logic was unfortunately inverted.

cc @jeromecoutant 