### PR TITLE
Allow generic core exports to UVision

### DIFF
--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -121,7 +121,7 @@ class Uvision(Exporter):
     TOOLCHAIN = 'ARM'
     TARGETS = []
     for target, obj in TARGET_MAP.iteritems():
-        if not ("ARM" in obj.supported_toolchains and hasattr(obj, "device_name")):
+        if "ARM" not in obj.supported_toolchains:
             continue
         if not DeviceCMSIS.check_supported(target):
             continue


### PR DESCRIPTION
# Description

There was a bug in the supported check for uvision that disabled all generic
core based exports. This PR fixes that bug


# Todos
- [ ] /morph export-build