### PR TITLE
mbed: version macros are not defined on master

### DIFF
--- a/mbed.h
+++ b/mbed.h
@@ -16,29 +16,6 @@
 #ifndef MBED_H
 #define MBED_H
 
-
-/* mbed minor and patch versions for both mbed 2 and mbed OS 5 are 0 on master branch. They are set
-   to meaningful values for releases and release branches.
- */
-#define MBED_LIBRARY_VERSION 0
-
-#if MBED_CONF_RTOS_PRESENT
-// RTOS present, this is valid only for mbed OS 5
-#define MBED_MAJOR_VERSION 5
-#define MBED_MINOR_VERSION 0
-#define MBED_PATCH_VERSION 0
-
-#else
-// mbed 2
-#define MBED_MAJOR_VERSION 2
-#define MBED_MINOR_VERSION 0
-#define MBED_PATCH_VERSION MBED_LIBRARY_VERSION
-#endif
-
-#define MBED_ENCODE_VERSION(major, minor, patch) ((major)*10000 + (minor)*100 + (patch))
-
-#define MBED_VERSION MBED_ENCODE_VERSION(MBED_MAJOR_VERSION, MBED_MINOR_VERSION, MBED_PATCH_VERSION)
-
 #if MBED_CONF_RTOS_PRESENT
 #include "rtos/rtos.h"
 #endif


### PR DESCRIPTION
This PR is trying to address issues with using latest master. The version macros that we have currently on master brings confusion as they are set to values that are valid - the releases that are out there, thus do not indicate that this is development version and might bring confusion.

If we remove them, then any sw that is on bleeding edge, can easily use these as follows:

```
#ifndef MBED_VERSION
// bleeding edge, be aware you are using moving target

#else

// some compatiblity layers
#if defined(MBED_VERSION == x.x.x)
// do something special for x.x.x version
#endif

#endif
```

We considered using specific version for devel (like patch set to -1), this however does not protect sw anyhow. Removing these macros should be more clear than it is now (using really old values that are valid however), and still more clear than any specific devel numbers like -1. What do you think?

Some more info in the commit message.

@JanneKiiskila @avolinski @sg- @adbridge @c1728p9 @theotherjimmy @geky