### PR TITLE
DISCO_L072CZ_LRWAN1: PC_13 definition missing in PinNames.h fix

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L072CZ_LRWAN1/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L072CZ_LRWAN1/PinNames.h
@@ -87,6 +87,7 @@ typedef enum {
     PC_0  = 0x20,
     PC_1  = 0x21,
     PC_2  = 0x22,
+    PC_13 = 0x2D,
 
     PH_0  = 0x70,
     PH_1  = 0x71,


### PR DESCRIPTION
Pull request to fix issue #4404