### PR TITLE
Disallow building of mbed OS 2 + RTOS, and remove mbed OS 5 support for Cortext-A

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1926,7 +1926,7 @@
         "inherits": ["Target"],
         "device_has": ["ANALOGIN", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "features": ["LWIP"],
-        "release_versions": ["2", "5"]
+        "release_versions": ["2"]
     },
     "VK_RZ_A1H": {
         "inherits": ["Target"],
@@ -1938,7 +1938,7 @@
         "device_has": ["ANALOGIN", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "features": ["LWIP"],
         "default_lib": "std",
-        "release_versions": ["2", "5"]
+        "release_versions": ["2"]
     },
     "MAXWSNENV": {
         "inherits": ["Target"],

--- a/tools/build.py
+++ b/tools/build.py
@@ -32,7 +32,6 @@ from tools.toolchains import mbedToolchain
 from tools.targets import TARGET_NAMES, TARGET_MAP
 from tools.options import get_default_options_parser
 from tools.options import extract_profile
-from tools.options import mcu_is_enabled
 from tools.build_api import build_library, build_mbed_libs, build_lib
 from tools.build_api import mcu_toolchain_matrix
 from tools.build_api import print_build_results
@@ -136,7 +135,6 @@ if __name__ == '__main__':
 
     # Get target list
     targets = options.mcu if options.mcu else TARGET_NAMES
-    assert [mcu_is_enabled(parser, mcu) for mcu in targets]
 
     # Get toolchains list
     toolchains = options.tool if options.tool else TOOLCHAINS

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -478,12 +478,10 @@ def build_project(src_paths, build_path, target, toolchain_name,
         src_paths.extend(libraries_paths)
         inc_dirs.extend(map(dirname, libraries_paths))
 
-    # Build Directory
     if clean and exists(build_path):
         rmtree(build_path)
     mkdir(build_path)
 
-    # Pass all params to the unified prepare_toolchain()
     toolchain = prepare_toolchain(
         src_paths, build_path, target, toolchain_name, macros=macros,
         clean=clean, jobs=jobs, notify=notify, silent=silent, verbose=verbose,
@@ -513,6 +511,10 @@ def build_project(src_paths, build_path, target, toolchain_name,
     try:
         # Call unified scan_resources
         resources = scan_resources(src_paths, toolchain, inc_dirs=inc_dirs)
+        if  (hasattr(toolchain.target, "release_versions") and
+             "5" not in toolchain.target.release_versions and
+             "rtos" in toolchain.config.lib_config_data):
+            raise NotSupportedException("Target does not support mbed OS 5")
 
         # Change linker script if specified
         if linker_script is not None:

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -514,7 +514,14 @@ def build_project(src_paths, build_path, target, toolchain_name,
         if  (hasattr(toolchain.target, "release_versions") and
              "5" not in toolchain.target.release_versions and
              "rtos" in toolchain.config.lib_config_data):
-            raise NotSupportedException("Target does not support mbed OS 5")
+            if "Cortex-A" in toolchain.target.core:
+                raise NotSupportedException(
+                    ("%s Will be supported in mbed OS 5.6. "
+                     "To use the %s, please checkout the mbed OS 5.4 release branch. "
+                     "See https://developer.mbed.org/platforms/Renesas-GR-PEACH/#important-notice "
+                     "for more information") % (toolchain.target.name, toolchain.target.name))
+            else:
+                raise NotSupportedException("Target does not support mbed OS 5")
 
         # Change linker script if specified
         if linker_script is not None:

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -1244,9 +1244,6 @@ def mcu_toolchain_matrix(verbose_html=False, platform_filter=None,
             # FIlter out platforms using regex
             if re.search(platform_filter, target) is None:
                 continue
-        # TODO: Remove this check when Cortex-A is re-enabled
-        if "Cortex-A" in TARGET_MAP[target].core:
-            continue
         target_counter += 1
 
         row = [target]  # First column is platform name

--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -33,7 +33,7 @@ from tools.export import embitz, coide, kds, simplicity, atmelstudio
 from tools.export import sw4stm32, e2studio, zip, cmsis, uvision, cdt, vscode
 from tools.export import gnuarmeclipse
 from tools.export import qtcreator
-from tools.targets import TARGET_NAMES, TARGET_MAP
+from tools.targets import TARGET_NAMES
 
 EXPORTERS = {
     'uvision5': uvision.Uvision,
@@ -100,8 +100,6 @@ def mcu_ide_matrix(verbose_html=False):
 
     perm_counter = 0
     for target in sorted(TARGET_NAMES):
-        if "Cortex-A" in TARGET_MAP[target].core:
-            continue
         row = [target]  # First column is platform name
         for ide in supported_ides:
             text = "-"

--- a/tools/make.py
+++ b/tools/make.py
@@ -42,7 +42,6 @@ from tools.tests import test_known, test_name_known
 from tools.targets import TARGET_MAP
 from tools.options import get_default_options_parser
 from tools.options import extract_profile
-from tools.options import mcu_is_enabled
 from tools.build_api import build_project
 from tools.build_api import mcu_toolchain_matrix
 from tools.build_api import mcu_toolchain_list
@@ -202,7 +201,6 @@ if __name__ == '__main__':
     if options.mcu is None :
         args_error(parser, "argument -m/--mcu is required")
     mcu = options.mcu[0]
-    assert mcu_is_enabled(parser, mcu)
 
     # Toolchain
     if options.tool is None:

--- a/tools/make.py
+++ b/tools/make.py
@@ -313,8 +313,8 @@ if __name__ == '__main__':
 
         except KeyboardInterrupt, e:
             print "\n[CTRL+c] exit"
-        except NotSupportedException, e:
-            print "\nNot supported for selected target"
+        except NotSupportedException as e:
+            print "\nCould not compile for %s: %s" % (mcu, str(e))
         except Exception,e:
             if options.verbose:
                 import traceback

--- a/tools/options.py
+++ b/tools/options.py
@@ -19,7 +19,7 @@ from os.path import join, dirname
 from os import listdir
 from argparse import ArgumentParser
 from tools.toolchains import TOOLCHAINS
-from tools.targets import TARGET_NAMES, TARGET_MAP
+from tools.targets import TARGET_NAMES
 from tools.utils import argparse_force_uppercase_type, \
     argparse_lowercase_hyphen_type, argparse_many, \
     argparse_filestring_type, args_error, argparse_profile_filestring_type,\
@@ -121,13 +121,3 @@ def extract_profile(parser, options, toolchain, fallback="develop"):
                                 " supported by profile {}").format(toolchain,
                                                                    filename))
     return profile
-
-def mcu_is_enabled(parser, mcu):
-    if "Cortex-A" in TARGET_MAP[mcu].core:
-        args_error(
-            parser,
-            ("%s Will be supported in mbed OS 5.6. "
-             "To use the %s, please checkout the mbed OS 5.4 release branch. "
-             "See https://developer.mbed.org/platforms/Renesas-GR-PEACH/#important-notice "
-             "for more information") % (mcu, mcu))
-    return True

--- a/tools/project.py
+++ b/tools/project.py
@@ -20,7 +20,7 @@ from tools.utils import argparse_filestring_type, argparse_profile_filestring_ty
 from tools.utils import argparse_force_lowercase_type
 from tools.utils import argparse_force_uppercase_type
 from tools.utils import print_large_string
-from tools.options import extract_profile, list_profiles, mcu_is_enabled
+from tools.options import extract_profile, list_profiles
 
 def setup_project(ide, target, program=None, source_dir=None, build=None, export_path=None):
     """Generate a name, if not provided, and find dependencies
@@ -221,7 +221,6 @@ def main():
     if not options.mcu:
         args_error(parser, "argument -m/--mcu is required")
 
-    assert mcu_is_enabled(parser, options.mcu)
     # Toolchain
     if not options.ide:
         args_error(parser, "argument -i is required")

--- a/tools/test.py
+++ b/tools/test.py
@@ -39,7 +39,6 @@ from utils import argparse_filestring_type, argparse_lowercase_type, argparse_ma
 from utils import argparse_dir_not_parent
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS, TOOLCHAIN_CLASSES
 from tools.settings import CLI_COLOR_MAP
-from tools.options import mcu_is_enabled
 
 if __name__ == '__main__':
     try:
@@ -116,7 +115,6 @@ if __name__ == '__main__':
         if options.mcu is None :
             args_error(parser, "argument -m/--mcu is required")
         mcu = options.mcu[0]
-        assert mcu_is_enabled(parser, mcu)
 
         # Toolchain
         if options.tool is None:

--- a/tools/test/build_api/build_api_test.py
+++ b/tools/test/build_api/build_api_test.py
@@ -131,7 +131,7 @@ class BuildApiTests(unittest.TestCase):
         mock_exists.return_value = False
         mock_prepare_toolchain().link_program.return_value = 1, 2
         mock_prepare_toolchain().config = namedtuple(
-            "Config", "has_regions name")(None, None)
+            "Config", "has_regions name lib_config_data")(None, None, {})
 
         build_project(self.src_paths, self.build_path, self.target,
                       self.toolchain_name, app_config=app_config)
@@ -160,7 +160,7 @@ class BuildApiTests(unittest.TestCase):
         # Needed for the unpacking of the returned value
         mock_prepare_toolchain().link_program.return_value = 1, 2
         mock_prepare_toolchain().config = namedtuple(
-            "Config", "has_regions name")(None, None)
+            "Config", "has_regions name lib_config_data")(None, None, {})
 
         build_project(self.src_paths, self.build_path, self.target,
                       self.toolchain_name)


### PR DESCRIPTION
# Description

I found my prior implementation of disabling Cortex-A unsatisfactory.
This PR actually fixes a long-standing bug: you can compile mbed OS 5 for mbed OS 2 only targets.


# Todos
- [x] /morph test