### PR TITLE
STM32: Fix 32-bit us ticker interrupt scheduling

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f0xx.h"
+#include "stm32f0xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST         TIM1

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f0xx.h"
+#include "stm32f0xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST         TIM1

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/device/hal_tick.h
@@ -40,6 +40,7 @@ extern "C" {
 #endif
 
 #include "stm32f0xx.h"
+#include "stm32f0xx_ll_tim.h"
 #include "cmsis_nvic.h"
 
 #define TIM_MST      TIM2

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/device/hal_tick.h
@@ -40,6 +40,7 @@ extern "C" {
 #endif
 
 #include "stm32f0xx.h"
+#include "stm32f0xx_ll_tim.h":
 #include "cmsis_nvic.h"
 
 #define TIM_MST      TIM2

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f0xx.h"
+#include "stm32f0xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST         TIM1

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f0xx.h"
+#include "stm32f0xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM2

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f0xx.h"
+#include "stm32f0xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM2

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f1xx.h"
+#include "stm32f1xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM4

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f1xx.h"
+#include "stm32f1xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM4

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f1xx.h"
+#include "stm32f1xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM4

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/hal_tick.h
@@ -40,6 +40,7 @@ extern "C" {
 #endif
 
 #include "stm32f2xx.h"
+#include "stm32f2xx_ll_tim.h"
 #include "cmsis_nvic.h"
 
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f3xx.h"
+#include "stm32f3xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM2

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f3xx.h"
+#include "stm32f3xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM2

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f3xx.h"
+#include "stm32f3xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM2

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f3xx.h"
+#include "stm32f3xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM2

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f3xx.h"
+#include "stm32f3xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM2

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xC/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xC/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM2

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_EVK_ODIN_W2/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f4xx.h"
+#include "stm32f4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f7xx.h"
+#include "stm32f7xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f7xx.h"
+#include "stm32f7xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f7xx.h"
+#include "stm32f7xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32f7xx.h"
+#include "stm32f7xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32l0xx.h"
+#include "stm32l0xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM21

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L072CZ_LRWAN1/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L072CZ_LRWAN1/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32l0xx.h"
+#include "stm32l0xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM21

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32l0xx.h"
+#include "stm32l0xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM21

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32l0xx.h"
+#include "stm32l0xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM21

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32l0xx.h"
+#include "stm32l0xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM21

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32l0xx.h"
+#include "stm32l0xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM21

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32l1xx.h"
+#include "stm32l1xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32l1xx.h"
+#include "stm32l1xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32l1xx.h"
+#include "stm32l1xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32l1xx.h"
+#include "stm32l1xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32l4xx.h"
+#include "stm32l4xx_ll_tim.h"
 #include "cmsis_nvic.h"
 
 #define TIM_MST      TIM2

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32l4xx.h"
+#include "stm32l4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/hal_tick.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/hal_tick.h
@@ -40,6 +40,7 @@
 #endif
 
 #include "stm32l4xx.h"
+#include "stm32l4xx_ll_tim.h"
 #include "cmsis_nvic.h"
    
 #define TIM_MST      TIM5

--- a/targets/TARGET_STM/us_ticker_32b.c
+++ b/targets/TARGET_STM/us_ticker_32b.c
@@ -48,6 +48,10 @@ void us_ticker_set_interrupt(timestamp_t timestamp)
     __HAL_TIM_SET_COMPARE(&TimMasterHandle, TIM_CHANNEL_1, (uint32_t)timestamp);
     // Enable IT
     __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC1);
+    // Check if timestamp has already passed, and if so, set the event immediately
+    if ((int32_t)(timestamp - TIM_MST->CNT) <= 0) {
+        LL_TIM_GenerateEvent_CC1(TimMasterHandle.Instance);
+    }
 }
 
 void us_ticker_disable_interrupt(void)


### PR DESCRIPTION
## Description
For STM32 targets using a 32-bit timer for the microsecond ticker, the driver did not properly handle timestamps that are in the past.  It would just blindly set the compare register to the requested timestamp, resulting in the interrupt being serviced up to 4295 seconds late (i.e. after the 32-bit timer counts all the way around to hit the timestamp again).

Now, after the compare register has been set, the timestamp is checked against the current time to see if the timestamp is in the past, and if so, the IRQ handler is immediately called.

NOTE: By checking if the timestamp is in the past after configuring the capture register, we ensure proper handling in the case where the timer updates past the timestamp while setting the capture register.

## Status
READY

## Migrations
NO

## Related PRs
None

## Todos
None

## Deploy notes
None

## Steps to test or reproduce
This problem can easily be reproduced by creating a Timeout object then calling the timeout's attach_us() member function to attach a callback with a timeout of 0 us.  The callback will not get called for over 2147 seconds, and possibly up to 4295 seconds late if no other microsecond ticker events are getting scheduled in the meantime.
