### PR TITLE
Fix commit 5152c1c7ac5186ac7b797334d51e922259044c4f

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -500,13 +500,13 @@ class mbedToolchain:
             # information about the library paths. Safe option: assume an update
             if not d or not exists(d):
                 return True
-            
+
             if not self.stat_cache.has_key(d):
                 self.stat_cache[d] = stat(d).st_mtime
 
             if self.stat_cache[d] >= target_mod_time:
                 return True
-        
+
         return False
 
     def is_ignored(self, file_path):
@@ -760,7 +760,7 @@ class mbedToolchain:
             string = " ".join(cmd_list)
             f.write(string)
         return link_file
- 
+
     # Generate response file for all objects when archiving.
     # ARM, GCC, IAR cross compatible
     def get_arch_file(self, objects):
@@ -914,7 +914,7 @@ class mbedToolchain:
                 deps = []
             config_file = ([self.config.app_config_location]
                            if self.config.app_config_location else [])
-            deps.append(config_file)
+            deps.extend(config_file)
             if ext == '.cpp' or self.COMPILE_C_AS_CPP:
                 deps.append(join(self.build_dir, self.PROFILE_FILE_NAME + "-cxx"))
             else:


### PR DESCRIPTION
After commit 5152c1c7ac5186ac7b797334d51e922259044c4f, the incremental build was broken and a full build was always performed even if the target was up to date.

The variable [`config_file`](https://github.com/ARMmbed/mbed-os/commit/5152c1c7ac5186ac7b797334d51e922259044c4f#diff-486f048c4c5775670840b518bf8b0ad5R918) is an array and was appended to the list of dependencies. An array is always either False either a non existent file and therefore [`need_update()`](https://github.com/ARMmbed/mbed-os/blob/master/tools/toolchains/__init__.py#L501-L502) always returns True.

*(My apologies for the whitespaces, I should have commited them in a seperate commit)*

Edit: Crap, I did not see PR #4413 before, closing this one.
