### PR TITLE
STM32F4 set HSE timeout value to 100ms

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_conf.h
@@ -108,7 +108,7 @@
 #endif /* HSE_VALUE */
 
 #if !defined  (HSE_STARTUP_TIMEOUT)
-  #define HSE_STARTUP_TIMEOUT    ((uint32_t)5000U)   /*!< Time out for HSE start up, in ms */
+  #define HSE_STARTUP_TIMEOUT    100U      /*!< Time out for HSE start up, in ms */
 #endif /* HSE_STARTUP_TIMEOUT */
 
 /**


### PR DESCRIPTION
## Description
HSE timeout value is set to 100ms
This is aligned with official ST cube since v1.11.0

This fix #1096 


## Status
READY
