### PR TITLE
Improve directory scanning performance

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -63,6 +63,12 @@ class LazyDict(dict):
     def __setitem__(self, key, value):
         self.eager[key] = value
 
+    def __delitem__(self, key):
+        if key in self.eager:
+            del self.eager[key]
+        else:
+            del self.lazy[key]
+
     def __contains__(self, key):
         return key in self.eager or key in self.lazy
 
@@ -71,6 +77,12 @@ class LazyDict(dict):
 
     def __len__(self):
         return len(self.eager) + len(self.lazy)
+
+    def __str__(self):
+        return "Lazy{%s}" % (
+            ", ".join("%r: %r" % (k, v) for k, v in
+                      chain(self.eager.iteritems(), ((k, "not evaluated")
+                                                     for k in self.lazy))))
 
     def update(self, other):
         if isinstance(other, LazyDict):

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -23,6 +23,7 @@ from time import time, sleep
 from types import ListType
 from shutil import copyfile
 from os.path import join, splitext, exists, relpath, dirname, basename, split, abspath, isfile, isdir, normcase
+from itertools import chain
 from inspect import getmro
 from copy import deepcopy
 from tools.config import Config
@@ -48,6 +49,8 @@ class LazyDict(dict):
         self.lazy = {}
 
     def add_lazy(self, key, thunk):
+        if key in self.eager:
+            del self.eager[key]
         self.lazy[key] = thunk
 
     def __getitem__(self, key):
@@ -62,6 +65,12 @@ class LazyDict(dict):
 
     def __contains__(self, key):
         return key in self.eager or key in self.lazy
+
+    def __iter__(self):
+        return chain(iter(self.eager), iter(self.lazy))
+
+    def __len__(self):
+        return len(self.eager) + len(self.lazy)
 
     def update(self, other):
         if isinstance(other, LazyDict):


### PR DESCRIPTION
# Description
Graph of the first commit compared to master in the next comment.

The remaining commits allow us to _correctly_ elide much processing. In particular, if we delay scanning of features until we try access their respective resource objects, we can avoid scanning some resources by never trying to access their resource objects. Turns out that this optimization saves us ~1/2 of the scan resources time!
# Todos
- [ ] /morph test