### PR TITLE
Restore mbed OS 5.4 mbed_lwip_ function prototypes

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/EthernetInterface.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/EthernetInterface.cpp
@@ -46,7 +46,7 @@ nsapi_error_t EthernetInterface::set_dhcp(bool dhcp)
 
 nsapi_error_t EthernetInterface::connect()
 {
-    return mbed_lwip_bringup(_dhcp, false,
+    return mbed_lwip_bringup_2(_dhcp, false,
             _ip_address[0] ? _ip_address : 0,
             _netmask[0] ? _netmask : 0,
             _gateway[0] ? _gateway : 0);
@@ -54,7 +54,7 @@ nsapi_error_t EthernetInterface::connect()
 
 nsapi_error_t EthernetInterface::disconnect()
 {
-    return mbed_lwip_bringdown(false);
+    return mbed_lwip_bringdown_2(false);
 }
 
 const char *EthernetInterface::get_mac_address()

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <string.h>
+#include "lwip_stack.h"
 
 #include "eth_arch.h"
 #include "lwip/opt.h"
@@ -391,7 +392,7 @@ char *mbed_lwip_get_ip_address(char *buf, nsapi_size_t buflen)
 #endif
 }
 
-const char *mbed_lwip_get_netmask(char *buf, nsapi_size_t buflen)
+char *mbed_lwip_get_netmask(char *buf, nsapi_size_t buflen)
 {
 #if LWIP_IPV4
     const ip4_addr_t *addr = netif_ip4_netmask(&lwip_netif);

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -482,7 +482,13 @@ nsapi_error_t mbed_lwip_init(emac_interface_t *emac)
     return mbed_lwip_emac_init(emac);
 }
 
-nsapi_error_t mbed_lwip_bringup(bool dhcp, bool ppp, const char *ip, const char *netmask, const char *gw)
+// Backwards compatibility with people using DEVICE_EMAC
+nsapi_error_t mbed_lwip_bringup(bool dhcp, const char *ip, const char *netmask, const char *gw)
+{
+    return mbed_lwip_bringup_2(dhcp, false, ip, netmask, gw);
+}
+
+nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const char *netmask, const char *gw)
 {
     // Check if we've already connected
     if (lwip_connected) {
@@ -625,7 +631,13 @@ void mbed_lwip_clear_ipv6_addresses(struct netif *lwip_netif)
 }
 #endif
 
-nsapi_error_t mbed_lwip_bringdown(bool ppp)
+// Backwards compatibility with people using DEVICE_EMAC
+nsapi_error_t mbed_lwip_bringdown(void)
+{
+    return mbed_lwip_bringdown_2(false);
+}
+
+nsapi_error_t mbed_lwip_bringdown_2(bool ppp)
 {
     // Check if we've connected
     if (!lwip_connected) {

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
@@ -24,11 +24,14 @@
 extern "C" {
 #endif
 
-// Access to lwip through the nsapi
+// Access to lwip through the nsapi - be wary of API changes as external 1st-generation EMAC
+// drivers attach through these.
 nsapi_error_t mbed_lwip_init(emac_interface_t *emac);
 nsapi_error_t mbed_lwip_emac_init(emac_interface_t *emac);
-nsapi_error_t mbed_lwip_bringup(bool dhcp, bool ppp, const char *ip, const char *netmask, const char *gw);
-nsapi_error_t mbed_lwip_bringdown(bool ppp);
+nsapi_error_t mbed_lwip_bringup(bool dhcp, const char *ip, const char *netmask, const char *gw);
+nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const char *netmask, const char *gw);
+nsapi_error_t mbed_lwip_bringdown(void);
+nsapi_error_t mbed_lwip_bringdown_2(bool ppp);
 
 const char *mbed_lwip_get_mac_address(void);
 char *mbed_lwip_get_ip_address(char *buf, nsapi_size_t buflen);

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
@@ -31,9 +31,9 @@ nsapi_error_t mbed_lwip_bringup(bool dhcp, bool ppp, const char *ip, const char 
 nsapi_error_t mbed_lwip_bringdown(bool ppp);
 
 const char *mbed_lwip_get_mac_address(void);
-char *mbed_lwip_get_ip_address(char *buf, int buflen);
-char *mbed_lwip_get_netmask(char *buf, int buflen);
-char *mbed_lwip_get_gateway(char *buf, int buflen);
+char *mbed_lwip_get_ip_address(char *buf, nsapi_size_t buflen);
+char *mbed_lwip_get_netmask(char *buf, nsapi_size_t buflen);
+char *mbed_lwip_get_gateway(char *buf, nsapi_size_t buflen);
 
 extern nsapi_stack_t lwip_stack;
 

--- a/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
@@ -354,7 +354,7 @@ nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(nsapi_error_t)
 
     // mustn't start calling input until after connect -
     // attach deferred until ppp_lwip_connect, called from mbed_lwip_bringup
-    nsapi_error_t retcode = mbed_lwip_bringup(false, true, NULL, NULL, NULL);
+    nsapi_error_t retcode = mbed_lwip_bringup_2(false, true, NULL, NULL, NULL);
 
     if (retcode != NSAPI_ERROR_OK && connect_error_code != NSAPI_ERROR_OK) {
         return connect_error_code;
@@ -365,7 +365,7 @@ nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(nsapi_error_t)
 
 nsapi_error_t nsapi_ppp_disconnect(FileHandle *stream)
 {
-    return mbed_lwip_bringdown(true);
+    return mbed_lwip_bringdown_2(true);
 }
 
 NetworkStack *nsapi_ppp_get_stack()


### PR DESCRIPTION
External EMAC drivers are currently directly attaching to lwip_stack.c
via mbed_lwip_bringup et al. Restore the original prototypes changed in #4119 to avoid
compatibility breakage.

Fix some other type mismatches between lwip_stack.c and lwip_stack.h.

Ultimately #4079 should give a better way of EMAC drivers attaching.