### PR TITLE
Doxygen EventQueue updates to not produce warnings and errors [DOC Changes Only]

### DIFF
--- a/doxyfile_options
+++ b/doxyfile_options
@@ -840,7 +840,6 @@ EXCLUDE_PATTERNS       = */tools/* \
                          */TESTS/* \
                          */targets/* \
                          */BUILD/* \
-                         */events/* \
                          */rtos/* \
                          */cmsis/* \
                          */hal/* \

--- a/doxygen_options.json
+++ b/doxygen_options.json
@@ -8,5 +8,5 @@
     "PREDEFINED": "DOXYGEN_ONLY \"MBED_DEPRECATED_SINCE(f, g)=\" \"MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, M)=\"",
     "EXPAND_AS_DEFINED": "", 
     "SKIP_FUNCTION_MACROS": "NO",
-    "EXCLUDE_PATTERNS": "*/tools/* */TESTS/* */targets/* */FEATURE_*/* */features/mbedtls/* */features/storage/* */features/unsupported/* */features/frameworks/* */features/filesystem/* */BUILD/* */rtos/* */events/* */cmsis/* */hal/* */features/FEATURES_*"
+    "EXCLUDE_PATTERNS": "*/tools/* */TESTS/* */targets/* */FEATURE_*/* */features/mbedtls/* */features/storage/* */features/unsupported/* */features/frameworks/* */features/filesystem/* */BUILD/* */rtos/* */cmsis/* */hal/* */features/FEATURES_*"
 }

--- a/events/Event.h
+++ b/events/Event.h
@@ -44,12 +44,8 @@ public:
      *  callback acts as the target for the event and is executed in the
      *  context of the event queue's dispatch loop once posted.
      *
-     *  @param q        Event queue to dispatch on
-     *  @param f        Function to execute when the event is dispatched
-     *  @param c0..c4   Arguments to bind to the callback, these arguments are
-     *                  allocated on an irq-safe allocator from the event queue's
-     *                  memory pool. Must be type-compatible with b0..b4, the
-     *                  arguments to the underlying callback.
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
      */
     template <typename F>
     Event(EventQueue *q, F f) {
@@ -132,7 +128,6 @@ public:
      *  The post function is irq safe and can act as a mechanism for moving
      *  events out of irq contexts.
      *
-     *  @param a0..a4   Arguments to pass to the event
      *  @return         A unique id that represents the posted event and can
      *                  be passed to EventQueue::cancel, or an id of 0 if
      *                  there is not enough memory to allocate the event.
@@ -148,7 +143,6 @@ public:
 
     /** Posts an event onto the underlying event queue, returning void
      *
-     *  @param a0..a4   Arguments to pass to the event
      */
     void call() const {
         MBED_UNUSED int id = post();
@@ -157,7 +151,6 @@ public:
 
     /** Posts an event onto the underlying event queue, returning void
      *
-     *  @param a0..a4   Arguments to pass to the event
      */
     void operator()() const {
         return call();
@@ -166,7 +159,6 @@ public:
     /** Static thunk for passing as C-style function
      *
      *  @param func     Event to call passed as a void pointer
-     *  @param a0..a4   Arguments to pass to the event
      */
     static void thunk(void *func) {
         return static_cast<Event*>(func)->call();
@@ -227,7 +219,12 @@ private:
 
 public:
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0               Argument to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0>
     Event(EventQueue *q, F f, C0 c0) {
@@ -235,7 +232,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1            Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b1, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1>
     Event(EventQueue *q, F f, C0 c0, C1 c1) {
@@ -243,7 +245,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2         Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b2, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2) {
@@ -251,7 +258,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2,c3      Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b3, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2, typename C3>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3) {
@@ -259,7 +271,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2,c3,c4   Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b4, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
@@ -443,10 +460,6 @@ public:
      *
      *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
-     *  @param c0..c4   Arguments to bind to the callback, these arguments are
-     *                  allocated on an irq-safe allocator from the event queue's
-     *                  memory pool. Must be type-compatible with b0..b4, the
-     *                  arguments to the underlying callback.
      */
     template <typename F>
     Event(EventQueue *q, F f) {
@@ -529,7 +542,7 @@ public:
      *  The post function is irq safe and can act as a mechanism for moving
      *  events out of irq contexts.
      *
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param a0       Argument to pass to the event
      *  @return         A unique id that represents the posted event and can
      *                  be passed to EventQueue::cancel, or an id of 0 if
      *                  there is not enough memory to allocate the event.
@@ -545,7 +558,7 @@ public:
 
     /** Posts an event onto the underlying event queue, returning void
      *
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param a0       Argument to pass to the event
      */
     void call(A0 a0) const {
         MBED_UNUSED int id = post(a0);
@@ -554,7 +567,7 @@ public:
 
     /** Posts an event onto the underlying event queue, returning void
      *
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param a0      Argument to pass to the event
      */
     void operator()(A0 a0) const {
         return call(a0);
@@ -563,7 +576,7 @@ public:
     /** Static thunk for passing as C-style function
      *
      *  @param func     Event to call passed as a void pointer
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param a0       Argument to pass to the event
      */
     static void thunk(void *func, A0 a0) {
         return static_cast<Event*>(func)->call(a0);
@@ -624,7 +637,12 @@ private:
 
 public:
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0               Argument to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0>
     Event(EventQueue *q, F f, C0 c0) {
@@ -632,7 +650,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1            Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b1, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1>
     Event(EventQueue *q, F f, C0 c0, C1 c1) {
@@ -640,7 +663,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2         Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b2, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2) {
@@ -648,7 +676,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2,c3      Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b3, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2, typename C3>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3) {
@@ -656,7 +689,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2,c3,c4   Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b4, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
@@ -840,10 +878,6 @@ public:
      *
      *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
-     *  @param c0..c4   Arguments to bind to the callback, these arguments are
-     *                  allocated on an irq-safe allocator from the event queue's
-     *                  memory pool. Must be type-compatible with b0..b4, the
-     *                  arguments to the underlying callback.
      */
     template <typename F>
     Event(EventQueue *q, F f) {
@@ -926,7 +960,7 @@ public:
      *  The post function is irq safe and can act as a mechanism for moving
      *  events out of irq contexts.
      *
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param a0,a1    Arguments to pass to the event
      *  @return         A unique id that represents the posted event and can
      *                  be passed to EventQueue::cancel, or an id of 0 if
      *                  there is not enough memory to allocate the event.
@@ -942,7 +976,7 @@ public:
 
     /** Posts an event onto the underlying event queue, returning void
      *
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param a0,a1    Arguments to pass to the event
      */
     void call(A0 a0, A1 a1) const {
         MBED_UNUSED int id = post(a0, a1);
@@ -951,7 +985,7 @@ public:
 
     /** Posts an event onto the underlying event queue, returning void
      *
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param a0,a1    Arguments to pass to the event
      */
     void operator()(A0 a0, A1 a1) const {
         return call(a0, a1);
@@ -960,7 +994,7 @@ public:
     /** Static thunk for passing as C-style function
      *
      *  @param func     Event to call passed as a void pointer
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param a0,a1    Arguments to pass to the event
      */
     static void thunk(void *func, A0 a0, A1 a1) {
         return static_cast<Event*>(func)->call(a0, a1);
@@ -1021,7 +1055,12 @@ private:
 
 public:
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0               Argument to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0>
     Event(EventQueue *q, F f, C0 c0) {
@@ -1029,7 +1068,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1            Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b1, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1>
     Event(EventQueue *q, F f, C0 c0, C1 c1) {
@@ -1037,7 +1081,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2         Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b2, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2) {
@@ -1045,7 +1094,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2,c3      Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b3, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2, typename C3>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3) {
@@ -1053,7 +1107,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2,c3,c4   Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b4, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
@@ -1237,10 +1296,6 @@ public:
      *
      *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
-     *  @param c0..c4   Arguments to bind to the callback, these arguments are
-     *                  allocated on an irq-safe allocator from the event queue's
-     *                  memory pool. Must be type-compatible with b0..b4, the
-     *                  arguments to the underlying callback.
      */
     template <typename F>
     Event(EventQueue *q, F f) {
@@ -1323,10 +1378,10 @@ public:
      *  The post function is irq safe and can act as a mechanism for moving
      *  events out of irq contexts.
      *
-     *  @param a0..a4   Arguments to pass to the event
-     *  @return         A unique id that represents the posted event and can
-     *                  be passed to EventQueue::cancel, or an id of 0 if
-     *                  there is not enough memory to allocate the event.
+     *  @param a0,a1,a2     Arguments to pass to the event
+     *  @return             A unique id that represents the posted event and can
+     *                      be passed to EventQueue::cancel, or an id of 0 if
+     *                      there is not enough memory to allocate the event.
      */
     int post(A0 a0, A1 a1, A2 a2) const {
         if (!_event) {
@@ -1339,7 +1394,7 @@ public:
 
     /** Posts an event onto the underlying event queue, returning void
      *
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param a0,a1,a2     Arguments to pass to the event
      */
     void call(A0 a0, A1 a1, A2 a2) const {
         MBED_UNUSED int id = post(a0, a1, a2);
@@ -1348,7 +1403,7 @@ public:
 
     /** Posts an event onto the underlying event queue, returning void
      *
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param a0,a1,a2     Arguments to pass to the event
      */
     void operator()(A0 a0, A1 a1, A2 a2) const {
         return call(a0, a1, a2);
@@ -1356,8 +1411,8 @@ public:
 
     /** Static thunk for passing as C-style function
      *
-     *  @param func     Event to call passed as a void pointer
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param func         Event to call passed as a void pointer
+     *  @param a0,a1,a2     Arguments to pass to the event
      */
     static void thunk(void *func, A0 a0, A1 a1, A2 a2) {
         return static_cast<Event*>(func)->call(a0, a1, a2);
@@ -1418,7 +1473,12 @@ private:
 
 public:
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0               Argument to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0>
     Event(EventQueue *q, F f, C0 c0) {
@@ -1426,7 +1486,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1            Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b1, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1>
     Event(EventQueue *q, F f, C0 c0, C1 c1) {
@@ -1434,7 +1499,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2         Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b2, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2) {
@@ -1442,7 +1512,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2,c3      Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b3, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2, typename C3>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3) {
@@ -1450,7 +1525,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2,c3,c4   Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b4, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
@@ -1634,10 +1714,6 @@ public:
      *
      *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
-     *  @param c0..c4   Arguments to bind to the callback, these arguments are
-     *                  allocated on an irq-safe allocator from the event queue's
-     *                  memory pool. Must be type-compatible with b0..b4, the
-     *                  arguments to the underlying callback.
      */
     template <typename F>
     Event(EventQueue *q, F f) {
@@ -1720,10 +1796,10 @@ public:
      *  The post function is irq safe and can act as a mechanism for moving
      *  events out of irq contexts.
      *
-     *  @param a0..a4   Arguments to pass to the event
-     *  @return         A unique id that represents the posted event and can
-     *                  be passed to EventQueue::cancel, or an id of 0 if
-     *                  there is not enough memory to allocate the event.
+     *  @param a0,a1,a2,a3   Arguments to pass to the event
+     *  @return              A unique id that represents the posted event and can
+     *                       be passed to EventQueue::cancel, or an id of 0 if
+     *                       there is not enough memory to allocate the event.
      */
     int post(A0 a0, A1 a1, A2 a2, A3 a3) const {
         if (!_event) {
@@ -1736,7 +1812,7 @@ public:
 
     /** Posts an event onto the underlying event queue, returning void
      *
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param a0,a1,a2,a3   Arguments to pass to the event
      */
     void call(A0 a0, A1 a1, A2 a2, A3 a3) const {
         MBED_UNUSED int id = post(a0, a1, a2, a3);
@@ -1745,7 +1821,7 @@ public:
 
     /** Posts an event onto the underlying event queue, returning void
      *
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param a0,a1,a2,a3   Arguments to pass to the event
      */
     void operator()(A0 a0, A1 a1, A2 a2, A3 a3) const {
         return call(a0, a1, a2, a3);
@@ -1753,8 +1829,8 @@ public:
 
     /** Static thunk for passing as C-style function
      *
-     *  @param func     Event to call passed as a void pointer
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param func          Event to call passed as a void pointer
+     *  @param a0,a1,a2,a3   Arguments to pass to the event
      */
     static void thunk(void *func, A0 a0, A1 a1, A2 a2, A3 a3) {
         return static_cast<Event*>(func)->call(a0, a1, a2, a3);
@@ -1815,7 +1891,12 @@ private:
 
 public:
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0               Argument to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0>
     Event(EventQueue *q, F f, C0 c0) {
@@ -1823,7 +1904,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1            Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b1, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1>
     Event(EventQueue *q, F f, C0 c0, C1 c1) {
@@ -1831,7 +1917,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2         Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b2, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2) {
@@ -1839,7 +1930,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2,c3      Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b3, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2, typename C3>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3) {
@@ -1847,7 +1943,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2,c3,c4   Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b4, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
@@ -2031,10 +2132,6 @@ public:
      *
      *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
-     *  @param c0..c4   Arguments to bind to the callback, these arguments are
-     *                  allocated on an irq-safe allocator from the event queue's
-     *                  memory pool. Must be type-compatible with b0..b4, the
-     *                  arguments to the underlying callback.
      */
     template <typename F>
     Event(EventQueue *q, F f) {
@@ -2117,10 +2214,10 @@ public:
      *  The post function is irq safe and can act as a mechanism for moving
      *  events out of irq contexts.
      *
-     *  @param a0..a4   Arguments to pass to the event
-     *  @return         A unique id that represents the posted event and can
-     *                  be passed to EventQueue::cancel, or an id of 0 if
-     *                  there is not enough memory to allocate the event.
+     *  @param a0,a1,a2,a3,a4   Arguments to pass to the event
+     *  @return                 A unique id that represents the posted event and can
+     *                          be passed to EventQueue::cancel, or an id of 0 if
+     *                          there is not enough memory to allocate the event.
      */
     int post(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) const {
         if (!_event) {
@@ -2133,7 +2230,7 @@ public:
 
     /** Posts an event onto the underlying event queue, returning void
      *
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param a0,a1,a2,a3,a4   Arguments to pass to the event
      */
     void call(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) const {
         MBED_UNUSED int id = post(a0, a1, a2, a3, a4);
@@ -2142,7 +2239,7 @@ public:
 
     /** Posts an event onto the underlying event queue, returning void
      *
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param a0,a1,a2,a3,a4   Arguments to pass to the event
      */
     void operator()(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) const {
         return call(a0, a1, a2, a3, a4);
@@ -2150,8 +2247,8 @@ public:
 
     /** Static thunk for passing as C-style function
      *
-     *  @param func     Event to call passed as a void pointer
-     *  @param a0..a4   Arguments to pass to the event
+     *  @param func             Event to call passed as a void pointer
+     *  @param a0,a1,a2,a3,a4   Arguments to pass to the event
      */
     static void thunk(void *func, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
         return static_cast<Event*>(func)->call(a0, a1, a2, a3, a4);
@@ -2212,7 +2309,12 @@ private:
 
 public:
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0               Argument to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0>
     Event(EventQueue *q, F f, C0 c0) {
@@ -2220,7 +2322,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1            Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b1, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1>
     Event(EventQueue *q, F f, C0 c0, C1 c1) {
@@ -2228,7 +2335,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2         Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b2, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2) {
@@ -2236,7 +2348,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2,c3      Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b3, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2, typename C3>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3) {
@@ -2244,7 +2361,12 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param f                Function to execute when the event is dispatched
+     *  @param c0,c1,c2,c3,c4   Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b4, the
+     *                          arguments to the underlying callback.
      */
     template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {

--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -167,7 +167,6 @@ public:
      *  events out of irq contexts.
      *
      *  @param f        Function to execute in the context of the dispatch loop
-     *  @param a0..a4   Arguments to pass to the callback
      *  @return         A unique id that represents the posted event and can
      *                  be passed to cancel, or an id of 0 if there is not
      *                  enough memory to allocate the event.
@@ -185,7 +184,9 @@ public:
     }
 
     /** Calls an event on the queue
-     *  @see EventQueue::call
+     *  @see                    EventQueue::call
+     *  @param f                Function to execute in the context of the dispatch loop
+     *  @param a0               Argument to pass to the callback
      */
     template <typename F, typename A0>
     int call(F f, A0 a0) {
@@ -193,7 +194,9 @@ public:
     }
 
     /** Calls an event on the queue
-     *  @see EventQueue::call
+     *  @see                    EventQueue::call
+     *  @param f                Function to execute in the context of the dispatch loop
+     *  @param a0,a1            Arguments to pass to the callback
      */
     template <typename F, typename A0, typename A1>
     int call(F f, A0 a0, A1 a1) {
@@ -201,7 +204,9 @@ public:
     }
 
     /** Calls an event on the queue
-     *  @see EventQueue::call
+     *  @see                    EventQueue::call
+     *  @param f                Function to execute in the context of the dispatch loop
+     *  @param a0,a1,a2         Arguments to pass to the callback
      */
     template <typename F, typename A0, typename A1, typename A2>
     int call(F f, A0 a0, A1 a1, A2 a2) {
@@ -209,7 +214,9 @@ public:
     }
 
     /** Calls an event on the queue
-     *  @see EventQueue::call
+     *  @see                     EventQueue::call
+     *  @param f                 Function to execute in the context of the dispatch loop
+     *  @param a0,a1,a2,a3       Arguments to pass to the callback
      */
     template <typename F, typename A0, typename A1, typename A2, typename A3>
     int call(F f, A0 a0, A1 a1, A2 a2, A3 a3) {
@@ -217,7 +224,9 @@ public:
     }
 
     /** Calls an event on the queue
-     *  @see EventQueue::call
+     *  @see                    EventQueue::call
+     *  @param f                Function to execute in the context of the dispatch loop
+     *  @param a0,a1,a2,a3,a4   Arguments to pass to the callback
      */
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
@@ -425,7 +434,6 @@ public:
      *  events out of irq contexts.
      *
      *  @param f        Function to execute in the context of the dispatch loop
-     *  @param a0..a4   Arguments to pass to the callback
      *  @param ms       Time to delay in milliseconds
      *  @return         A unique id that represents the posted event and can
      *                  be passed to cancel, or an id of 0 if there is not
@@ -445,7 +453,10 @@ public:
     }
 
     /** Calls an event on the queue after a specified delay
-     *  @see EventQueue::call_in
+     *  @see                        EventQueue::call_in
+     *  @param ms                   Time to delay in milliseconds
+     *  @param f                    Function to execute in the context of the dispatch loop
+     *  @param a0                   Argument to pass to the callback
      */
     template <typename F, typename A0>
     int call_in(int ms, F f, A0 a0) {
@@ -453,7 +464,10 @@ public:
     }
 
     /** Calls an event on the queue after a specified delay
-     *  @see EventQueue::call_in
+     *  @see                        EventQueue::call_in
+     *  @param ms                   Time to delay in milliseconds
+     *  @param f                    Function to execute in the context of the dispatch loop
+     *  @param a0,a1                Arguments to pass to the callback
      */
     template <typename F, typename A0, typename A1>
     int call_in(int ms, F f, A0 a0, A1 a1) {
@@ -461,7 +475,10 @@ public:
     }
 
     /** Calls an event on the queue after a specified delay
-     *  @see EventQueue::call_in
+     *  @see                        EventQueue::call_in
+     *  @param ms                   Time to delay in milliseconds
+     *  @param f                    Function to execute in the context of the dispatch loop
+     *  @param a0,a1,a2             Arguments to pass to the callback
      */
     template <typename F, typename A0, typename A1, typename A2>
     int call_in(int ms, F f, A0 a0, A1 a1, A2 a2) {
@@ -469,7 +486,10 @@ public:
     }
 
     /** Calls an event on the queue after a specified delay
-     *  @see EventQueue::call_in
+     *  @see                        EventQueue::call_in
+     *  @param ms                   Time to delay in milliseconds
+     *  @param f                    Function to execute in the context of the dispatch loop
+     *  @param a0,a1,a2,a3          Arguments to pass to the callback
      */
     template <typename F, typename A0, typename A1, typename A2, typename A3>
     int call_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
@@ -477,7 +497,10 @@ public:
     }
 
     /** Calls an event on the queue after a specified delay
-     *  @see EventQueue::call_in
+     *  @see                        EventQueue::call_in
+     *  @param ms                   Time to delay in milliseconds
+     *  @param f                    Function to execute in the context of the dispatch loop
+     *  @param a0,a1,a2,a3,a4       Arguments to pass to the callback
      */
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
@@ -685,7 +708,6 @@ public:
      *  moving events out of irq contexts.
      *
      *  @param f        Function to execute in the context of the dispatch loop
-     *  @param a0..a4   Arguments to pass to the callback
      *  @param ms       Period of the event in milliseconds
      *  @return         A unique id that represents the posted event and can
      *                  be passed to cancel, or an id of 0 if there is not
@@ -706,7 +728,10 @@ public:
     }
 
     /** Calls an event on the queue periodically
-     *  @see EventQueue::call_every
+     *  @see                    EventQueue::call_every
+     *  @param f                Function to execute in the context of the dispatch loop
+     *  @param a0               Argument to pass to the callback
+     *  @param ms               Period of the event in milliseconds
      */
     template <typename F, typename A0>
     int call_every(int ms, F f, A0 a0) {
@@ -714,7 +739,10 @@ public:
     }
 
     /** Calls an event on the queue periodically
-     *  @see EventQueue::call_every
+     *  @see                    EventQueue::call_every
+     *  @param f                Function to execute in the context of the dispatch loop
+     *  @param a0,a1            Arguments to pass to the callback
+     *  @param ms               Period of the event in milliseconds
      */
     template <typename F, typename A0, typename A1>
     int call_every(int ms, F f, A0 a0, A1 a1) {
@@ -722,7 +750,10 @@ public:
     }
 
     /** Calls an event on the queue periodically
-     *  @see EventQueue::call_every
+     *  @see                    EventQueue::call_every
+     *  @param f                Function to execute in the context of the dispatch loop
+     *  @param a0,a1,a2         Arguments to pass to the callback
+     *  @param ms               Period of the event in milliseconds
      */
     template <typename F, typename A0, typename A1, typename A2>
     int call_every(int ms, F f, A0 a0, A1 a1, A2 a2) {
@@ -730,7 +761,10 @@ public:
     }
 
     /** Calls an event on the queue periodically
-     *  @see EventQueue::call_every
+     *  @see                    EventQueue::call_every
+     *  @param f                Function to execute in the context of the dispatch loop
+     *  @param a0,a1,a2,a3      Arguments to pass to the callback
+     *  @param ms               Period of the event in milliseconds
      */
     template <typename F, typename A0, typename A1, typename A2, typename A3>
     int call_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
@@ -738,7 +772,10 @@ public:
     }
 
     /** Calls an event on the queue periodically
-     *  @see EventQueue::call_every
+     *  @see                    EventQueue::call_every
+     *  @param f                Function to execute in the context of the dispatch loop
+     *  @param a0,a1,a2,a3,a4   Arguments to pass to the callback
+     *  @param ms               Period of the event in milliseconds
      */
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
@@ -943,12 +980,8 @@ public:
      *  callback acts as the target for the event and is executed in the
      *  context of the event queue's dispatch loop once posted.
      *
-     *  @param f        Function to execute when the event is dispatched
-     *  @param c0..c4   Arguments to bind to the callback, these arguments are
-     *                  allocated on an irq-safe allocator from the event queue's
-     *                  memory pool. Must be type-compatible with b0..b4, the
-     *                  arguments to the underlying callback.
-     *  @return         Event that will dispatch on the specific queue
+     *  @param func        Function to execute when the event is dispatched
+     *  @return            Event that will dispatch on the specific queue
      */
     template <typename R>
     Event<void()> event(R (*func)());


### PR DESCRIPTION
**NOTE** The commit history is not cleaned up and pulls in a lot of duplicate changes from @sg-'s pull request linked below. Putting this review up to get eyes on the doxygen changes as the structure changed a decent amount for how I documented the overloaded functions. This also pulls in Jimmy's CI changes so I can get a CI run in.  

**Commit history will be cleaned up prior to merging.**
**Note to reviewers:** In particular *Event.h* and *EventQueue.h* are the modified files that are unique to this PR.

_______________________________________________________________________________________________________
Documentation changes to Doxygen descriptions for the Event module to allow Doxygen to build without errors/warnings. 

All overloaded functions had refereed to the base function with the base function containing all parameter descriptions for all variations (the overloaded functions largely just added more callback arguments and shared most parameters).  This caused a ton of warnings from Doxygen so I moved the documentation blocks to each overloaded function to match that particular implementation. This is a pretty messy method, but I wasn't able to find a better way to handle it with Doxygen.

Please let me know if you're not a fan of the new setup and would like it done a different way.

## Related PRs
https://github.com/ARMmbed/mbed-os/pull/4425

## Todos
- [x] Tests/CI
- [ ] Review
- [ ] Rebase onto #4425

