### PR TITLE
Doxygen HAL updates to not produce warnings and errors [DOC Changes Only]

### DIFF
--- a/doxyfile_options
+++ b/doxyfile_options
@@ -843,7 +843,6 @@ EXCLUDE_PATTERNS       = */tools/* \
                          */events/* \
                          */rtos/* \
                          */cmsis/* \
-                         */hal/* \
                          */FEATURE_* \
                          */features/mbedtls/* \
                          */features/storage/* \

--- a/doxygen_options.json
+++ b/doxygen_options.json
@@ -8,5 +8,5 @@
     "PREDEFINED": "DOXYGEN_ONLY \"MBED_DEPRECATED_SINCE(f, g)=\" \"MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, M)=\"",
     "EXPAND_AS_DEFINED": "", 
     "SKIP_FUNCTION_MACROS": "NO",
-    "EXCLUDE_PATTERNS": "*/tools/* */TESTS/* */targets/* */FEATURE_*/* */features/mbedtls/* */features/storage/* */features/unsupported/* */features/frameworks/* */features/filesystem/* */BUILD/* */rtos/* */events/* */cmsis/* */hal/* */features/FEATURES_*"
+    "EXCLUDE_PATTERNS": "*/tools/* */TESTS/* */targets/* */FEATURE_*/* */features/mbedtls/* */features/storage/* */features/unsupported/* */features/frameworks/* */features/filesystem/* */BUILD/* */rtos/* */events/* */cmsis/* */features/FEATURES_*"
 }

--- a/hal/gpio_api.h
+++ b/hal/gpio_api.h
@@ -83,30 +83,30 @@ int gpio_read(gpio_t *obj);
 
 /** Init the input pin and set mode to PullDefault
  *
- * @param obj The GPIO object
- * @param pin The pin name
+ * @param gpio The GPIO object
+ * @param pin  The pin name
  */
 void gpio_init_in(gpio_t* gpio, PinName pin);
 
 /** Init the input pin and set the mode
  *
- * @param obj  The GPIO object
- * @param pin  The pin name
- * @param mode The pin mode to be set
+ * @param gpio  The GPIO object
+ * @param pin   The pin name
+ * @param mode  The pin mode to be set
  */
 void gpio_init_in_ex(gpio_t* gpio, PinName pin, PinMode mode);
 
 /** Init the output pin as an output, with predefined output value 0
  *
- * @param obj The GPIO object
- * @param pin The pin name
- * @return An integer value 1 or 0
+ * @param gpio The GPIO object
+ * @param pin  The pin name
+ * @return     An integer value 1 or 0
  */
 void gpio_init_out(gpio_t* gpio, PinName pin);
 
 /** Init the pin as an output and set the output value
  *
- * @param obj   The GPIO object
+ * @param gpio  The GPIO object
  * @param pin   The pin name
  * @param value The value to be set
  */
@@ -114,7 +114,7 @@ void gpio_init_out_ex(gpio_t* gpio, PinName pin, int value);
 
 /** Init the pin to be in/out
  *
- * @param obj       The GPIO object
+ * @param gpio      The GPIO object
  * @param pin       The pin name
  * @param direction The pin direction to be set
  * @param mode      The pin mode to be set

--- a/hal/storage_abstraction/Driver_Storage.h
+++ b/hal/storage_abstraction/Driver_Storage.h
@@ -615,9 +615,9 @@ typedef struct _ARM_DRIVER_STORAGE {
    *
    * This optional function erases the complete device. If the device does not
    *    support global erase then the function returns the error value \ref
-   *    ARM_DRIVER_ERROR_UNSUPPORTED. The data field \em 'erase_all' =
-   *    \token{1} of the structure \ref ARM_STORAGE_CAPABILITIES encodes that
-   *    \ref ARM_STORAGE_EraseAll is supported.
+   *    ARM_DRIVER_ERROR_UNSUPPORTED. The data field \em 'erase_all' = 1
+   *    of the structure \ref ARM_STORAGE_CAPABILITIES encodes that
+   *    ARM_STORAGE_EraseAll is supported.
    *
    * @note This API may execute asynchronously if
    *     ARM_STORAGE_CAPABILITIES::asynchronous_ops is set. Asynchronous

--- a/hal/ticker_api.h
+++ b/hal/ticker_api.h
@@ -163,7 +163,8 @@ us_timestamp_t ticker_read_us(const ticker_data_t *const ticker);
 
 /** Read the next event's timestamp
  *
- * @param ticker The ticker object.
+ * @param ticker        The ticker object.
+ * @param timestamp     The timestamp object.
  * @return 1 if timestamp is pending event, 0 if there's no event pending
  */
 int ticker_get_next_timestamp(const ticker_data_t *const ticker, timestamp_t *timestamp);


### PR DESCRIPTION
**NOTE** The commit history is not cleaned up and pulls in a lot of duplicate changes from @sg-'s pull request linked below. Putting this review up to get eyes on the doxygen changes as the structure changed a decent amount for how I documented the overloaded functions. This also pulls in Jimmy's CI changes so I can get a CI run in.  

**Commit history will be cleaned up prior to merging.**
**Note to reviewers:** In particular *ticker_api.h*, *Driver_Storage.h*, and *gpio_api.h* are the modified files that are unique to this PR. See (ignore Makefile, will squash when rebasing): https://github.com/kegilbert/mbed-os/compare/kg-doxygen-template...kg-doxygen-hal 

_______________________________________________________________________________________________________
Documentation changes to Doxygen descriptions for the HAL module to allow Doxygen to build without errors/warnings. 

## Related PRs
https://github.com/ARMmbed/mbed-os/pull/4425
https://github.com/ARMmbed/mbed-os/pull/4434

## Todos
- [x] Tests/CI
- [x] Review

