### PR TITLE
resolve lwip init twice issue

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -469,6 +469,7 @@ nsapi_error_t mbed_lwip_emac_init(emac_interface_t *emac)
     eth_arch_enable_interrupts();
 #endif
 
+	netif_inited = true;
     return NSAPI_ERROR_OK;
 #else
     return NSAPI_ERROR_UNSUPPORTED;

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -469,7 +469,6 @@ nsapi_error_t mbed_lwip_emac_init(emac_interface_t *emac)
     eth_arch_enable_interrupts();
 #endif
 
-    netif_inited = true;
     return NSAPI_ERROR_OK;
 #else
     return NSAPI_ERROR_UNSUPPORTED;
@@ -479,8 +478,13 @@ nsapi_error_t mbed_lwip_emac_init(emac_interface_t *emac)
 // Backwards compatibility with people using DEVICE_EMAC
 nsapi_error_t mbed_lwip_init(emac_interface_t *emac)
 {
+    nsapi_error_t ret;
     mbed_lwip_core_init();
-    return mbed_lwip_emac_init(emac);
+    ret = mbed_lwip_emac_init(emac);
+    if (ret == NSAPI_ERROR_OK) {
+        netif_inited = true;
+    }
+    return ret;
 }
 
 // Backwards compatibility with people using DEVICE_EMAC

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -469,7 +469,7 @@ nsapi_error_t mbed_lwip_emac_init(emac_interface_t *emac)
     eth_arch_enable_interrupts();
 #endif
 
-	netif_inited = true;
+    netif_inited = true;
     return NSAPI_ERROR_OK;
 #else
     return NSAPI_ERROR_UNSUPPORTED;


### PR DESCRIPTION
resolve wifi example test fail before lwip is init
We find for REALTEK_RTL8195AM target, the wifi example will hang at mbed_lwip_bringup(). 