### PR TITLE
Fix semaphore usage on lpc1768 emac

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NXP/lpc17_emac.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NXP/lpc17_emac.c
@@ -604,10 +604,13 @@ static err_t lpc_low_level_output(struct netif *netif, struct pbuf *p)
 
 	/* Wait until enough descriptors are available for the transfer. */
 	/* THIS WILL BLOCK UNTIL THERE ARE ENOUGH DESCRIPTORS AVAILABLE */
-	while (dn > lpc_tx_ready(netif))
 #if NO_SYS == 0
+	for (idx = 0; idx < dn; idx++) {
 	    osSemaphoreAcquire(lpc_enetif->xTXDCountSem.id, osWaitForever);
+	}
+	MBED_ASSERT(dn <= lpc_tx_ready(netif));
 #else
+	while (dn > lpc_tx_ready(netif))
 		osDelay(1);
 #endif
 


### PR DESCRIPTION
The semaphore xTXDCountSem had the count to match the number of resources available, but was being used as a binary semaphore in a loop to listen for events. This patch updates the logic to make use of the resource count.

With RTX5 the OS traps with an error if the a semaphore is released more times than its count with an error similar to "Semaphore 10000e6c error -17". Because xTXDCountSem is being used as a binary semaphore it triggered this trap. With this patch the semaphore is no longer used as a binary semaphore and no longer traps.
