### PR TITLE
Fix typo in test code

### DIFF
--- a/tools/test/toolchains/api.py
+++ b/tools/test/toolchains/api.py
@@ -42,7 +42,7 @@ def test_toolchain_profile_c(profile, source_file):
             toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile)
             toolchain.inc_md5 = ""
             toolchain.build_dir = ""
-            toolchain.config = MagicMock(app_config_locaiton=None)
+            toolchain.config = MagicMock(app_config_location=None)
             compile_command = toolchain.compile_command(to_compile,
                                                         to_compile + ".o", [])
             for parameter in profile['c'] + profile['common']:
@@ -68,7 +68,7 @@ def test_toolchain_profile_cpp(profile, source_file):
             toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile)
             toolchain.inc_md5 = ""
             toolchain.build_dir = ""
-            toolchain.config = MagicMock(app_config_locaiton=None)
+            toolchain.config = MagicMock(app_config_location=None)
             compile_command = toolchain.compile_command(to_compile,
                                                         to_compile + ".o", [])
             for parameter in profile['cxx'] + profile['common']:


### PR DESCRIPTION
I swapped two letters in "location". my bad.

Testing is covered by travis, so this is good to go when that finishes