### PR TITLE
Doxygen features/Frameworks updates to not produce warnings and errors [DOC Changes Only]

### DIFF
--- a/doxyfile_options
+++ b/doxyfile_options
@@ -848,7 +848,6 @@ EXCLUDE_PATTERNS       = */tools/* \
                          */features/mbedtls/* \
                          */features/storage/* \
                          */features/unsupported/* \
-                         */features/frameworks/* \
                          */features/filesystem/* \
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names

--- a/doxygen_options.json
+++ b/doxygen_options.json
@@ -8,5 +8,5 @@
     "PREDEFINED": "DOXYGEN_ONLY \"MBED_DEPRECATED_SINCE(f, g)=\" \"MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, M)=\"",
     "EXPAND_AS_DEFINED": "", 
     "SKIP_FUNCTION_MACROS": "NO",
-    "EXCLUDE_PATTERNS": "*/tools/* */TESTS/* */targets/* */FEATURE_*/* */features/mbedtls/* */features/storage/* */features/unsupported/* */features/frameworks/* */features/filesystem/* */BUILD/* */rtos/* */events/* */cmsis/* */hal/* */features/FEATURES_*"
+    "EXCLUDE_PATTERNS": "*/tools/* */TESTS/* */targets/* */FEATURE_*/* */features/mbedtls/* */features/storage/* */features/unsupported/* */features/filesystem/* */BUILD/* */rtos/* */events/* */cmsis/* */hal/* */features/FEATURES_*"
 }

--- a/features/frameworks/utest/utest/utest_default_handlers.h
+++ b/features/frameworks/utest/utest/utest_default_handlers.h
@@ -38,6 +38,9 @@ namespace v1 {
      */
     static const struct
     {
+        ///@cond IGNORE
+        // Doxygen can't parse these implicit conversion operators properly, remove from
+        // doc build
         operator test_setup_handler_t()    const { return test_setup_handler_t(1); }
         operator test_teardown_handler_t() const { return test_teardown_handler_t(1); }
         operator test_failure_handler_t()  const { return test_failure_handler_t(1); }
@@ -45,6 +48,7 @@ namespace v1 {
         operator case_setup_handler_t()    const { return case_setup_handler_t(1); }
         operator case_teardown_handler_t() const { return case_teardown_handler_t(1); }
         operator case_failure_handler_t()  const { return case_failure_handler_t(1); }
+        ///@endcond
     } default_handler;
 
     /** Ignore handler hint.
@@ -55,6 +59,9 @@ namespace v1 {
      */
     static const struct
     {
+        ///@cond IGNORE
+        // Doxygen can't parse these implicit conversion operators properly, remove from
+        // doc build
         operator case_handler_t()            const { return case_handler_t(NULL); }
         operator case_control_handler_t()    const { return case_control_handler_t(NULL); }
         operator case_call_count_handler_t() const { return case_call_count_handler_t(NULL); }
@@ -66,6 +73,7 @@ namespace v1 {
         operator case_setup_handler_t()    const { return case_setup_handler_t(NULL); }
         operator case_teardown_handler_t() const { return case_teardown_handler_t(NULL); }
         operator case_failure_handler_t()  const { return case_failure_handler_t(NULL); }
+        ///@endcond
     } ignore_handler;
 
     /** A table of handlers.

--- a/features/frameworks/utest/utest/utest_types.h
+++ b/features/frameworks/utest/utest/utest_types.h
@@ -30,6 +30,7 @@ namespace utest {
 /** @{*/
 namespace v1 {
 
+    /// repeat_t
     enum repeat_t {
         REPEAT_UNDECLR = 0,
         REPEAT_NONE    = 1,       ///< continue with the next test case
@@ -47,12 +48,14 @@ namespace v1 {
         REPEAT_HANDLER = REPEAT_CASE_ONLY | REPEAT_ON_VALIDATE              ///< repeat only the handler
     };
 
+    /// status_t
     enum status_t {
         STATUS_CONTINUE = -1,   ///< continues testing
         STATUS_IGNORE = -2,     ///< ignores failure and continues testing
         STATUS_ABORT = -3       ///< stops testing
     };
 
+    /// failure_reason_t
     enum failure_reason_t {
         REASON_NONE          = 0,           ///< No failure occurred
 
@@ -74,6 +77,7 @@ namespace v1 {
         REASON_IGNORE        = 0x8000       ///< The failure may be ignored
     };
 
+    /// location_t
     enum location_t {
         LOCATION_NONE = 0,      ///< No location information
         LOCATION_TEST_SETUP,    ///< A failure occurred in the test setup


### PR DESCRIPTION
**NOTE** The commit history is not cleaned up and pulls in a lot of duplicate changes from @sg-'s pull request linked below. Putting this review up to get eyes on the doxygen changes as the structure changed a decent amount for how I documented the overloaded functions. This also pulls in Jimmy's CI changes so I can get a CI run in.  

**Rebased to remove references to Makefile I accidentally added in my template branch.**
**Note to reviewers:** In particular look at the following diff to see what files to review:
https://github.com/kegilbert/mbed-os/compare/kg-doxygen-template...kegilbert:kg-doxygen-framework2?expand=1

_______________________________________________________________________________________________________
Documentation changes to Doxygen descriptions for the features/Frameworks module to allow Doxygen to build without errors/warnings. 

## Related PRs
https://github.com/ARMmbed/mbed-os/pull/4425
https://github.com/ARMmbed/mbed-os/pull/4434
https://github.com/ARMmbed/mbed-os/pull/4435

## Todos
- [x] Tests/CI
- [x] Review

