### PR TITLE
Doxygen RTOS updates to not produce warnings and errors [DOC Changes Only]

### DIFF
--- a/doxyfile_options
+++ b/doxyfile_options
@@ -840,6 +840,7 @@ EXCLUDE_PATTERNS       = */tools/* \
                          */TESTS/* \
                          */targets/* \
                          */BUILD/* \
+                         */rtos/rtx* \
                          */events/* \
                          */cmsis/* \
                          */hal/* \

--- a/doxyfile_options
+++ b/doxyfile_options
@@ -841,7 +841,6 @@ EXCLUDE_PATTERNS       = */tools/* \
                          */targets/* \
                          */BUILD/* \
                          */events/* \
-                         */rtos/* \
                          */cmsis/* \
                          */hal/* \
                          */FEATURE_* \

--- a/doxygen_options.json
+++ b/doxygen_options.json
@@ -8,5 +8,5 @@
     "PREDEFINED": "DOXYGEN_ONLY \"MBED_DEPRECATED_SINCE(f, g)=\" \"MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, M)=\"",
     "EXPAND_AS_DEFINED": "", 
     "SKIP_FUNCTION_MACROS": "NO",
-    "EXCLUDE_PATTERNS": "*/tools/* */TESTS/* */targets/* */FEATURE_*/* */features/mbedtls/* */features/storage/* */features/unsupported/* */features/frameworks/* */features/filesystem/* */BUILD/* */rtos/* */events/* */cmsis/* */hal/* */features/FEATURES_*"
+    "EXCLUDE_PATTERNS": "*/tools/* */TESTS/* */targets/* */FEATURE_*/* */features/mbedtls/* */features/storage/* */features/unsupported/* */features/frameworks/* */features/filesystem/* */BUILD/* */events/* */rtos/rtx*/* */cmsis/* */hal/* */features/FEATURES_*"
 }

--- a/rtos/MemoryPool.h
+++ b/rtos/MemoryPool.h
@@ -76,8 +76,8 @@ public:
     }
 
     /** Free a memory block.
-      @param   address of the allocated memory block to be freed.
-      @return  status code that indicates the execution status of the function.
+      @param   block  address of the allocated memory block to be freed.
+      @return         status code that indicates the execution status of the function.
     */
     osStatus free(T *block) {
         return osMemoryPoolFree(_id, (void*)block);

--- a/rtos/Semaphore.h
+++ b/rtos/Semaphore.h
@@ -40,7 +40,7 @@ namespace rtos {
 class Semaphore {
 public:
     /** Create and Initialize a Semaphore object used for managing resources.
-      @param number of available resources; maximum index value is (count-1). (default: 0).
+      @param count      number of available resources; maximum index value is (count-1). (default: 0).
     */
     Semaphore(int32_t count=0);
 

--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -85,7 +85,6 @@ public:
 
     /** Create a new thread, and start it executing the specified function.
       @param   task           function to be executed by this thread.
-      @param   argument       pointer that is passed to the thread function as start argument. (default: NULL).
       @param   priority       initial priority of the thread function. (default: osPriorityNormal).
       @param   stack_size     stack size (in bytes) requirements for the thread function. (default: OS_STACK_SIZE).
       @param   stack_mem      pointer to the stack area to be used by this thread (default: NULL).
@@ -112,9 +111,8 @@ public:
     }
 
     /** Create a new thread, and start it executing the specified function.
-      @param   obj            argument to task.
-      @param   method         function to be executed by this thread.
       @param   argument       pointer that is passed to the thread function as start argument. (default: NULL).
+      @param   task           argument to task.
       @param   priority       initial priority of the thread function. (default: osPriorityNormal).
       @param   stack_size     stack size (in bytes) requirements for the thread function. (default: OS_STACK_SIZE).
       @param   stack_mem      pointer to the stack area to be used by this thread (default: NULL).
@@ -143,9 +141,8 @@ public:
     }
 
     /** Create a new thread, and start it executing the specified function.
-      @param   obj            argument to task.
-      @param   method         function to be executed by this thread.
       @param   argument       pointer that is passed to the thread function as start argument. (default: NULL).
+      @param   task           argument to task.
       @param   priority       initial priority of the thread function. (default: osPriorityNormal).
       @param   stack_size     stack size (in bytes) requirements for the thread function. (default: OS_STACK_SIZE).
       @param   stack_mem      pointer to the stack area to be used by this thread (default: NULL).


### PR DESCRIPTION
**NOTE** The commit history is not cleaned up and pulls in a lot of duplicate changes from @sg-'s pull request linked below. Putting this review up to get eyes on the doxygen changes as the structure changed a decent amount for how I documented the overloaded functions. This also pulls in Jimmy's CI changes so I can get a CI run in.  

**Rebased to remove references to Makefile I accidentally added in my template branch.**
**Note to reviewers:** In particular look at the last two commits to see what changed separate from sg-'s changes.

_______________________________________________________________________________________________________
Documentation changes to Doxygen descriptions for the RTOS module (mbed components only, exclude CMSIS/RTX doc) to allow Doxygen to build without errors/warnings. 

## Related PRs
https://github.com/ARMmbed/mbed-os/pull/4425
https://github.com/ARMmbed/mbed-os/pull/4434
https://github.com/ARMmbed/mbed-os/pull/4435
https://github.com/ARMmbed/mbed-os/pull/4452

## Todos
- [ ] Tests/CI
- [ ] Review

