### PR TITLE
Add a template for C++ class headers

### DIFF
--- a/tools/templates/ClassHeader.tmpl
+++ b/tools/templates/ClassHeader.tmpl
@@ -1,0 +1,79 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_{{name|upper}}_H
+#define MBED_{{name|upper}}_H
+
+namespace mbed {
+
+/**
+ * @class {{name}}
+ {% if group is defined -%}
+ * @addtogroup {{group}}
+ {% endif -%}
+ */
+class {{name}} {
+public:
+        {% for name, decl in public.iteritems() -%}
+        {% if decl is mapping -%}
+        {% for returntype, args in decl.iteritems() -%}
+        /**
+         {% for arg in args -%}
+         * @param[in] {{arg[1]}}
+         {% endfor -%}
+         * @return
+         */
+        {% set comma = joiner(", ") -%}
+        {{returntype}} {{name}}({%- for arg in args -%}
+                {{comma()}}{{arg[0]}}
+                {%- if arg[0][-1] != "*" %} {% endif -%}
+                {{arg[1]}}
+                {%- if arg[2] %}={{arg[2]}}{% endif -%}
+                {%- endfor -%});
+
+        {% endfor -%}
+        {% else -%}
+        {{decl}} {{name}};
+        {% endif -%}
+        {% endfor %}
+private:
+        {% for name, decl in private.iteritems() -%}
+        {% if decl is mapping %}
+        {% for returntype, args in decl.iteritems() -%}
+        /**
+         {% for arg in args -%}
+         * @param[in] {{arg[1]}}
+         {% endfor -%}
+         * @return
+         */
+        {% set comma = joiner(", ") -%}
+        {{returntype}} {{name}}({%- for arg in args -%}
+                {{comma()}}{{arg[0]}}
+                {%- if arg[0][-1] != "*" %} {% endif -%}
+                {{arg[1]}}
+                {%- if arg[2] %}={{arg[2]}}{% endif -%}
+                {%- endfor -%});
+
+        {% endfor -%}
+        {% else %}
+        {{decl}} {{name}};
+        {% endif -%}
+        {% endfor %}
+}
+
+} //namespace mbed
+
+#endif /* MBED_{{name|upper}}_H


### PR DESCRIPTION
# Description

Add a simple template that can be used with jinja2-cli for generating a blank
C++ class header. To use this template, install jinja2-cli and create a yaml,
json or toml file following this format:

```yaml
name: MyClass
group: platform
public:
  foo:
    const char *:
      - [const char *, bar]
      - [uint32_t, baz, "0"]
  bar:
    int: 
      - [int, foo]
      - [uint8_t, baz]
  baz: int
private:
  bar:
    const char *:
      - [const char *, bar]
      - [uint32_t, baz, "0"]
  baz:
    int: 
      - [int, foo]
      - [uint8_t, baz]
  foo: int
```

Then pass it to the template (using jinja2-cli):
```bash
jinja2 tools/templates/ClassHeader.tmpl input.yaml > MyClass.h
```

This command produces a new class header file on standard output. The header 
contains:

```C++
/* mbed Microcontroller Library
 * Copyright (c) 2006-2017 ARM Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

#ifndef MBED_MYCLASS_H
#define MBED_MYCLASS_H

namespace mbed {

/**
 * @class MyClass
 * @addtogroup platform
 */
class MyClass {
public:
        /**
         * @param[in] foo
         * @param[in] baz
         * @return
         */
        int bar(int foo, uint8_t baz);

        /**
         * @param[in] bar
         * @param[in] baz
         * @return
         */
        const char * foo(const char *bar, uint32_t baz=0);

        int baz;
        
private:
        
        /**
         * @param[in] bar
         * @param[in] baz
         * @return
         */
        const char * bar(const char *bar, uint32_t baz=0);

        
        int foo;
        
        /**
         * @param[in] foo
         * @param[in] baz
         * @return
         */
        int baz(int foo, uint8_t baz);

        
}

} //namespace mbed

#endif /* MBED_MYCLASS_H
```

Ready to fill in with documentation.

# Tests
 - Travis will do