### PR TITLE
Clean up dead classes in retarget layer

### DIFF
--- a/platform/FileSystemLike.h
+++ b/platform/FileSystemLike.h
@@ -44,7 +44,6 @@ public:
 
     // Inherited functions with name conflicts
     using FileSystemHandle::open;
-    using FileSystemHandle::open;
 
     /** Open a file on the filesystem
      *

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -164,25 +164,6 @@ static inline int openmode_to_posix(int openmode) {
     return posix;
 }
 
-// Internally used file objects with managed memory on close
-class ManagedFile : public FileHandle {
-public:
-    virtual int close() {
-        int err = FileHandle::close();
-        delete this;
-        return err;
-    }
-};
-
-class ManagedDir : public DirHandle {
-public:
-     virtual int close() {
-        int err = DirHandle::close();
-        delete this;
-        return err;
-    }
-};
-
 /* @brief 	standard c library fopen() retargeting function.
  *
  * This function is invoked by the standard c library retargeting to handle fopen()


### PR DESCRIPTION
Exactly what is says on the tin. There were quite a few prs that came in at once related to the retarget layer. Unfortunately they conflicted during merge and had to be rebased by a few different people. End result is a few odds and ends that are dead.

cc @sg- 