### PR TITLE
Put quotes around include files

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -740,7 +740,7 @@ class mbedToolchain:
                         c = c.replace("\\", "/")
                         if self.CHROOT:
                             c = c.replace(self.CHROOT, '')
-                        cmd_list.append('-I%s' % c)
+                        cmd_list.append('"-I%s"' % c)
                 string = " ".join(cmd_list)
                 f.write(string)
         return include_file


### PR DESCRIPTION
This fixes a problem when the path to include files have spaces.
See https://github.com/ARMmbed/mbed-os-example-uvisor/issues/31 for an
example of this problem.

Signed-off-by: Mo Chen <mo.chen@arm.com>
