### PR TITLE
[Silicon Labs] Enable dynamic heap with ARMCC

### DIFF
--- a/targets/TARGET_Silicon_Labs/mbed_rtx.h
+++ b/targets/TARGET_Silicon_Labs/mbed_rtx.h
@@ -20,20 +20,6 @@
 #include <stdint.h>
 #include "clocking.h"
 
-#if defined(__CC_ARM)
-extern uint32_t HEAP$$Base;
-extern uint32_t HEAP$$Limit;
-extern uint32_t STACK$$Limit;
-extern uint32_t STACK$$Base;
-#ifndef INITIAL_SP
-#define INITIAL_SP            ((uint32_t)&STACK$$Limit)
-#endif
-#define ISR_STACK_START       ((uint32_t)&STACK$$Base)
-#define ISR_STACK_SIZE        ((uint32_t) ((uint32_t)&STACK$$Limit - (uint32_t)&STACK$$Base))
-#define HEAP_START            ((unsigned char*) ((uint32_t)&HEAP$$Base))
-#define HEAP_SIZE             ((uint32_t) ((uint32_t)&HEAP$$Limit - (uint32_t)&HEAP$$Base))
-#endif
-
 #if defined(TARGET_EFM32GG_STK3700)
 
 #ifndef INITIAL_SP


### PR DESCRIPTION
Moving PR #4041 to master:


When using ARM Compiler 5, the RTX config hard-coded the heap and stack
sizes to specific values. This prevented the RTX HAL from dynamically
allocating unused memory as heap space.

Specifically, the HEAP_START define prevents this logic in RTX_CM_lib.h
from activating. The rest of the defines are also set in that header,
and should be removed from here.

CC @akselsm