### PR TITLE
st rtc api: remove usage of mktime/localtime in favor of dedicated functions

### DIFF
--- a/targets/TARGET_STM/TESTS/hal/rtc/main.cpp
+++ b/targets/TARGET_STM/TESTS/hal/rtc/main.cpp
@@ -111,10 +111,10 @@ void test_mk_time_out_of_range() {
         8
     );
 
-    TEST_ASSERT_EQUAL_INT(-1, st_rtc_mktime(&invalid_lower_bound));
-    TEST_ASSERT_EQUAL_INT(0, st_rtc_mktime(&valid_lower_bound));
-    TEST_ASSERT_EQUAL_INT(INT_MAX, st_rtc_mktime(&valid_upper_bound));
-    TEST_ASSERT_EQUAL_INT(-1, st_rtc_mktime(&invalid_upper_bound));
+    TEST_ASSERT_EQUAL_INT(((time_t) -1), st_rtc_mktime(&invalid_lower_bound));
+    TEST_ASSERT_EQUAL_INT(((time_t) 0), st_rtc_mktime(&valid_lower_bound));
+    TEST_ASSERT_EQUAL_INT(((time_t) INT_MAX), st_rtc_mktime(&valid_upper_bound));
+    TEST_ASSERT_EQUAL_INT(((time_t) -1), st_rtc_mktime(&invalid_upper_bound));
 }
 
 /* 

--- a/targets/TARGET_STM/TESTS/hal/rtc/main.cpp
+++ b/targets/TARGET_STM/TESTS/hal/rtc/main.cpp
@@ -1,0 +1,247 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+
+#include "mbed.h"
+
+using namespace utest::v1;
+
+extern "C" { 
+bool st_rtc_is_leap_year(int year);
+time_t st_rtc_mktime(const struct tm* time);
+bool st_rtc_localtime(time_t timestamp, struct tm* time_info);
+}
+
+/* 
+ * regular is_leap_year, see rtc_api.c for the optimized version
+ */
+bool is_leap_year(int year) {
+    year = 1900 + year;
+    if (year % 4) {
+        return false;
+    } else if (year % 100) {
+        return true;
+    } else if (year % 400) {
+        return false;
+    }
+    return true;
+}
+
+/*
+ * Test the optimized version of st_rtc_is_leap_year against the generic version.
+ */
+void test_is_leap_year() { 
+    for (int i = 70; i < 138; ++i) { 
+        bool expected = is_leap_year(i);
+        bool actual_value = is_leap_year(i);
+
+        if (expected != actual_value) { 
+            printf ("leap year failed with i = %d\r\n", i);
+        }
+        TEST_ASSERT_EQUAL(expected, actual_value);
+    }
+}
+
+struct tm make_time_info(int year, int month, int day, int hours, int minutes, int seconds) { 
+    struct tm timeinfo;
+    timeinfo.tm_year = year;
+    timeinfo.tm_mon  = month;
+    timeinfo.tm_mday = day;
+    timeinfo.tm_hour = hours;
+    timeinfo.tm_min  = minutes;
+    timeinfo.tm_sec  = seconds;
+    return timeinfo;
+}
+
+/*
+ * test out of range values for st_rtc_mktime. 
+ * The function operates from the 1st of january 1970 at 00:00:00 to the 19th 
+ * of january 2038 at 03:14:07.
+ */
+void test_mk_time_out_of_range() { 
+    tm invalid_lower_bound = make_time_info(
+        69,
+        11,
+        31,
+        23,
+        59,
+        59
+    );    
+
+    tm valid_lower_bound = make_time_info(
+        70,
+        0,
+        1,
+        0,
+        0,
+        0
+    );
+
+    tm valid_upper_bound = make_time_info(
+        138,
+        0,
+        19,
+        3,
+        14,
+        7
+    );
+
+    tm invalid_upper_bound = make_time_info(
+        138,
+        0,
+        19,
+        3,
+        14,
+        8
+    );
+
+    TEST_ASSERT_EQUAL_INT(-1, st_rtc_mktime(&invalid_lower_bound));
+    TEST_ASSERT_EQUAL_INT(0, st_rtc_mktime(&valid_lower_bound));
+    TEST_ASSERT_EQUAL_INT(INT_MAX, st_rtc_mktime(&valid_upper_bound));
+    TEST_ASSERT_EQUAL_INT(-1, st_rtc_mktime(&invalid_upper_bound));
+}
+
+/* 
+ * test mktime over a large set of values 
+ */
+void test_mk_time() { 
+    for (size_t year = 70; year < 137; ++year) { 
+        for (size_t month = 0; month < 12; ++month) { 
+            for (size_t day = 1; day < 32; ++day) {
+                if (month == 1 && is_leap_year(year) && day == 29) { 
+                    break;
+                } else if(month == 1 && !is_leap_year(year) && day == 28) {
+                    break;
+                } else if (
+                    day == 31 && 
+                    (month == 3 || month == 5 || month == 8 || month == 10)
+                ) {
+                    break;
+                }
+
+                for (size_t hour = 0; hour < 24; ++hour) {  
+                    tm time_info = make_time_info(
+                        year,
+                        month,
+                        day,
+                        hour,
+                        hour % 2 ? 59 : 0,
+                        hour % 2 ? 59 : 0
+                    );
+
+                    time_t expected = mktime(&time_info);
+                    time_t actual_value = st_rtc_mktime(&time_info);
+
+                    char msg[128] = "";
+                    if (expected != actual_value) { 
+                        snprintf(
+                            msg, sizeof(msg), 
+                            "year = %d, month = %d, day = %d, diff = %ld", 
+                            year, month, day, expected - actual_value
+                        );
+                    }
+
+                    TEST_ASSERT_EQUAL_UINT32_MESSAGE(expected, actual_value, msg);
+                }
+            }
+        }
+    }
+}
+
+/* 
+ * test value out of range for localtime
+ */
+void test_local_time_limit() {
+    struct tm dummy_value; 
+    TEST_ASSERT_FALSE(st_rtc_localtime((time_t) -1, &dummy_value));
+    TEST_ASSERT_FALSE(st_rtc_localtime((time_t) INT_MIN, &dummy_value));
+}
+
+/* 
+ * test st_rtc_localtime over a large set of values.
+ */
+void test_local_time() { 
+    for (uint32_t i = 0; i < INT_MAX; i += 3451) {  
+        time_t copy = (time_t) i;
+        struct tm* expected = localtime(&copy);
+        struct tm actual_value; 
+        bool result = st_rtc_localtime((time_t) i, &actual_value);
+
+        if (
+            expected->tm_sec != actual_value.tm_sec || 
+            expected->tm_min != actual_value.tm_min ||
+            expected->tm_hour != actual_value.tm_hour || 
+            expected->tm_mday != actual_value.tm_mday ||
+            expected->tm_mon != actual_value.tm_mon || 
+            expected->tm_year != actual_value.tm_year || 
+            result == false
+        ) { 
+            printf("error: i = %lu\r\n", i);
+        }
+
+        TEST_ASSERT_TRUE(result);
+        TEST_ASSERT_EQUAL_UINT32_MESSAGE(
+            expected->tm_sec, actual_value.tm_sec, "invalid seconds"
+        );
+        TEST_ASSERT_EQUAL_UINT32_MESSAGE(
+            expected->tm_min, actual_value.tm_min, "invalid minutes"
+        );
+        TEST_ASSERT_EQUAL_UINT32_MESSAGE(
+            expected->tm_hour, actual_value.tm_hour, "invalid hours"
+        );
+        TEST_ASSERT_EQUAL_UINT32_MESSAGE(
+            expected->tm_mday, actual_value.tm_mday, "invalid day"
+        );
+        TEST_ASSERT_EQUAL_UINT32_MESSAGE(
+            expected->tm_mon, actual_value.tm_mon, "invalid month"
+        );
+        TEST_ASSERT_EQUAL_UINT32_MESSAGE(
+            expected->tm_year, actual_value.tm_year, "invalid year"
+        );
+    }
+}
+
+utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason) {
+    greentea_case_failure_abort_handler(source, reason);
+    return STATUS_CONTINUE;
+}
+
+Case cases[] = {
+    Case("test is leap year", test_is_leap_year, greentea_failure_handler),
+    Case("test mk time out of range values", test_mk_time_out_of_range, greentea_failure_handler),
+    Case("mk time", test_mk_time, greentea_failure_handler),
+    Case("test local time", test_local_time, greentea_failure_handler),
+    Case("test local time limits", test_local_time_limit, greentea_failure_handler),
+};
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(1200, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+
+extern "C" { 
+    time_t rtc_read(void);
+    void rtc_init(void);
+}
+
+int main() {
+    return Harness::run(specification);
+}

--- a/targets/TARGET_STM/TESTS/hal/rtc/main.cpp
+++ b/targets/TARGET_STM/TESTS/hal/rtc/main.cpp
@@ -190,6 +190,7 @@ void test_local_time() {
             expected->tm_mday != actual_value.tm_mday ||
             expected->tm_mon != actual_value.tm_mon || 
             expected->tm_year != actual_value.tm_year || 
+            expected->tm_wday != actual_value.tm_wday || 
             result == false
         ) { 
             printf("error: i = %lu\r\n", i);
@@ -213,6 +214,9 @@ void test_local_time() {
         );
         TEST_ASSERT_EQUAL_UINT32_MESSAGE(
             expected->tm_year, actual_value.tm_year, "invalid year"
+        );
+        TEST_ASSERT_EQUAL_UINT32_MESSAGE(
+            expected->tm_wday, actual_value.tm_wday, "invalid weekday"
         );
     }
 }

--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -183,6 +183,7 @@ time_t st_rtc_mktime(const struct tm* time) {
  *   - tm_mday
  *   - tm_mon
  *   - tm_year
+ *   - tm_wday
  * The time in input shall be in the range [0, INT32_MAX] otherwise the function 
  * will return false and the structure time_info in input will remain untouch.
  */
@@ -197,6 +198,11 @@ bool st_rtc_localtime(time_t timestamp, struct tm* time_info) {
     timestamp = timestamp / 60;  // timestamp in hours
     time_info->tm_hour = timestamp % 24;
     timestamp = timestamp / 24;  // timestamp in days;
+
+    // compute the weekday
+    // The 1st of January 1970 was a Thursday which is equal to 4 in the weekday
+    // representation ranging from [0:6]
+    time_info->tm_wday = (timestamp + 4) % 7;
 
     // years start at 70
     time_info->tm_year = 70;

--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -29,6 +29,8 @@
  */
 #if DEVICE_RTC
 
+#include <stdbool.h>
+
 #include "rtc_api.h"
 #include "rtc_api_hal.h"
 #include "mbed_error.h"
@@ -53,6 +55,182 @@ static RTC_HandleTypeDef RtcHandle;
 static void (*irq_handler)(void);
 static void RTC_IRQHandler(void);
 #endif
+
+/*
+ * time constants 
+ */
+#define SECONDS_BY_MINUTES 60
+#define MINUTES_BY_HOUR 60
+#define SECONDS_BY_HOUR (SECONDS_BY_MINUTES * MINUTES_BY_HOUR)
+#define HOURS_BY_DAY 24 
+#define SECONDS_BY_DAY (SECONDS_BY_HOUR * HOURS_BY_DAY)
+
+/*
+ * 2 dimensional array containing the number of seconds elapsed before a given 
+ * month.
+ * The second index map to the month while the first map to the type of year:
+ *   - 0: non leap year 
+ *   - 1: leap year
+ */
+static const uint32_t seconds_before_month[2][12] = {
+    {
+        0,
+        31 * SECONDS_BY_DAY,
+        (31 + 28) * SECONDS_BY_DAY,
+        (31 + 28 + 31) * SECONDS_BY_DAY,
+        (31 + 28 + 31 + 30) * SECONDS_BY_DAY,
+        (31 + 28 + 31 + 30 + 31) * SECONDS_BY_DAY,
+        (31 + 28 + 31 + 30 + 31 + 30) * SECONDS_BY_DAY,
+        (31 + 28 + 31 + 30 + 31 + 30 + 31) * SECONDS_BY_DAY,
+        (31 + 28 + 31 + 30 + 31 + 30 + 31 + 31) * SECONDS_BY_DAY,
+        (31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30) * SECONDS_BY_DAY,
+        (31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31) * SECONDS_BY_DAY,
+        (31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30) * SECONDS_BY_DAY,
+    },
+    {
+        0,
+        31 * SECONDS_BY_DAY,
+        (31 + 29) * SECONDS_BY_DAY,
+        (31 + 29 + 31) * SECONDS_BY_DAY,
+        (31 + 29 + 31 + 30) * SECONDS_BY_DAY,
+        (31 + 29 + 31 + 30 + 31) * SECONDS_BY_DAY,
+        (31 + 29 + 31 + 30 + 31 + 30) * SECONDS_BY_DAY,
+        (31 + 29 + 31 + 30 + 31 + 30 + 31) * SECONDS_BY_DAY,
+        (31 + 29 + 31 + 30 + 31 + 30 + 31 + 31) * SECONDS_BY_DAY,
+        (31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 + 30) * SECONDS_BY_DAY,
+        (31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31) * SECONDS_BY_DAY,
+        (31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30) * SECONDS_BY_DAY,
+    }
+};
+
+/*
+ * Compute if a year is a leap year or not. 
+ * year 0 is translated into year 1900 CE.
+ */
+bool st_rtc_is_leap_year(int year) {
+    /* 
+     * since in practice, the value manipulated by this algorithm lie in the 
+     * range [70 : 138], the algorith can be reduced to: year % 4.
+     * The algorithm valid over the full range of value is: 
+
+        year = 1900 + year;
+        if (year % 4) {
+            return false;
+        } else if (year % 100) {
+            return true;
+        } else if (year % 400) {
+            return false;
+        }
+        return true;
+
+     */ 
+    return (year) % 4 ? false : true;
+}
+
+/*
+ * Thread safe (partial) replacement for mktime. 
+ * This function is tailored around ST RTC specification and is not a full 
+ * replacement for mktime. 
+ * The fields from tm used are:
+ *   - tm_sec
+ *   - tm_min
+ *   - tm_hour
+ *   - tm_mday
+ *   - tm_mon
+ *   - tm_year
+ * Other fields are ignored and won't be normalized by the call.
+ * If the time in input is less than UNIX epoch (1st january of 1970 at 00:00:00),
+ * then this function consider the input as invalid and will return time_t(-1).
+ * Values in output range from 0 to INT_MAX.
+ * Leap seconds are not supported.
+ */  
+time_t st_rtc_mktime(const struct tm* time) {
+    // partial check for the upper bound of the range
+    // normalization might happen at the end of the function 
+    // this solution is faster than checking if the input is after the 19th of 
+    // january 2038 at 03:14:07.  
+    if ((time->tm_year < 70) || (time->tm_year > 138)) { 
+        return ((time_t) -1);
+    }
+
+    uint32_t result = time->tm_sec;
+    result += time->tm_min * SECONDS_BY_MINUTES;
+    result += time->tm_hour * SECONDS_BY_HOUR;
+    result += (time->tm_mday - 1) * SECONDS_BY_DAY;
+    result += seconds_before_month[st_rtc_is_leap_year(time->tm_year)][time->tm_mon];
+
+    if (time->tm_year > 70) { 
+        // valid in the range [70:138] 
+        uint32_t count_of_leap_days = ((time->tm_year - 1) / 4) - (70 / 4);
+        result += (((time->tm_year - 70) * 365) + count_of_leap_days) * SECONDS_BY_DAY;
+    }
+
+    if (result > INT32_MAX) { 
+        return -1;
+    }
+
+    return result;
+}
+
+/* 
+ * Thread safe (partial) replacement for localtime. 
+ * This function is tailored around ST RTC specification and is not a full 
+ * replacement for localtime.
+ * The tm fields filled by this function are:
+ *   - tm_sec
+ *   - tm_min
+ *   - tm_hour
+ *   - tm_mday
+ *   - tm_mon
+ *   - tm_year
+ * The time in input shall be in the range [0, INT32_MAX] otherwise the function 
+ * will return false and the structure time_info in input will remain untouch.
+ */
+bool st_rtc_localtime(time_t timestamp, struct tm* time_info) {
+    if (((int32_t) timestamp) < 0) { 
+        return false;
+    } 
+
+    time_info->tm_sec = timestamp % 60;
+    timestamp = timestamp / 60;   // timestamp in minutes
+    time_info->tm_min = timestamp % 60;
+    timestamp = timestamp / 60;  // timestamp in hours
+    time_info->tm_hour = timestamp % 24;
+    timestamp = timestamp / 24;  // timestamp in days;
+
+    // years start at 70
+    time_info->tm_year = 70;
+    while (true) { 
+        if (st_rtc_is_leap_year(time_info->tm_year) && timestamp >= 366) { 
+            ++time_info->tm_year;
+            timestamp -= 366;
+        } else if (!st_rtc_is_leap_year(time_info->tm_year) && timestamp >= 365) { 
+            ++time_info->tm_year;
+            timestamp -= 365;
+        } else {
+            // the remaining days are less than a years
+            break;
+        }
+    }
+
+    // convert days into seconds and find the current month
+    timestamp *= SECONDS_BY_DAY;
+    time_info->tm_mon = 11;
+    bool leap = st_rtc_is_leap_year(time_info->tm_year);
+    for (uint32_t i = 0; i < 12; ++i) {
+        if ((uint32_t) timestamp < seconds_before_month[leap][i]) {
+            time_info->tm_mon = i - 1;
+            break;
+        }
+    }
+
+    // remove month from timestamp and compute the number of days.
+    // note: unlike other fields, days are not 0 indexed.
+    timestamp -= seconds_before_month[leap][time_info->tm_mon];
+    time_info->tm_mday = (timestamp / SECONDS_BY_DAY) + 1;
+
+    return true;
+}
 
 void rtc_init(void)
 {
@@ -239,7 +417,7 @@ time_t rtc_read(void)
     timeinfo.tm_isdst  = -1;
 
     // Convert to timestamp
-    time_t t = mktime(&timeinfo);
+    time_t t = st_rtc_mktime(&timeinfo);
 
     return t;
 }
@@ -252,20 +430,23 @@ void rtc_write(time_t t)
     RtcHandle.Instance = RTC;
 
     // Convert the time into a tm
-    struct tm *timeinfo = localtime(&t);
+    struct tm timeinfo;
+    if (st_rtc_localtime(t, &timeinfo) == false) { 
+        return;
+    }
 
     // Fill RTC structures
-    if (timeinfo->tm_wday == 0) {
+    if (timeinfo.tm_wday == 0) {
         dateStruct.WeekDay    = 7;
     } else {
-        dateStruct.WeekDay    = timeinfo->tm_wday;
+        dateStruct.WeekDay    = timeinfo.tm_wday;
     }
-    dateStruct.Month          = timeinfo->tm_mon + 1;
-    dateStruct.Date           = timeinfo->tm_mday;
-    dateStruct.Year           = timeinfo->tm_year - 68;
-    timeStruct.Hours          = timeinfo->tm_hour;
-    timeStruct.Minutes        = timeinfo->tm_min;
-    timeStruct.Seconds        = timeinfo->tm_sec;
+    dateStruct.Month          = timeinfo.tm_mon + 1;
+    dateStruct.Date           = timeinfo.tm_mday;
+    dateStruct.Year           = timeinfo.tm_year - 68;
+    timeStruct.Hours          = timeinfo.tm_hour;
+    timeStruct.Minutes        = timeinfo.tm_min;
+    timeStruct.Seconds        = timeinfo.tm_sec;
 
 #if !(TARGET_STM32F1)
     timeStruct.TimeFormat     = RTC_HOURFORMAT_24;


### PR DESCRIPTION
## Description
The use of mktime was causing a fault when called in interrupt handler because on GCC it lock the mutex protecting the environment, To overcome this issue, this patch add dedicated routine to convert a time_t into a tm and vice versa.
In the process mktime has been optimized and is now an order of magnitude faster than the routines present in the C library. It should increase the accuracy of the low power timer.



## Status
**READY**


## Migrations
NO


## Related PRs
partially solve #4369 

