### PR TITLE
rtc_time: Fix incorrect return value when the calendar is not available.

### DIFF
--- a/platform/mbed_rtc_time.cpp
+++ b/platform/mbed_rtc_time.cpp
@@ -53,7 +53,7 @@ time_t time(time_t *timer)
         }
     }
     
-    time_t t = 0;
+    time_t t = -1;
     if (_rtc_read != NULL) {
         t = _rtc_read();
     }


### PR DESCRIPTION
## Description
According to the C99 specification "The value (time_t)(-1) is returned if the
calendar time is not available". Before this patch, in such case the function
was returning 0 instead of -1.


## Status
**READY**


## Migrations
NO


