### PR TITLE
Fix typo that used 16kB for stack.

### DIFF
--- a/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_timer.cpp
+++ b/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_timer.cpp
@@ -12,7 +12,7 @@
 #include <mbed_assert.h>
 
 static osThreadId_t timer_thread_id;
-static uint64_t timer_thread_stk[2048];
+static uint64_t timer_thread_stk[2048/sizeof(uint64_t)];
 static osRtxThread_t timer_thread_tcb;
 
 static Timer timer;


### PR DESCRIPTION
Intent is to use 2kB for stack, not 16kB, but the divide operand
has been forgotten here.


## Description
During a CMSIS2/RTX2 work this typo has appeared in our timer. Caused RAM usage to jump 14kB up.


## Status
**READY**

Should be included in 5.5 RC2