### PR TITLE
Fix a bug in the dispatch function

### DIFF
--- a/events/equeue/equeue.c
+++ b/events/equeue/equeue.c
@@ -431,7 +431,14 @@ void equeue_dispatch(equeue_t *q, int ms) {
             }
         }
         equeue_mutex_unlock(&q->queuelock);
-
+        
+        // in any case 'deadline' must be <= than 'ms'
+        // Unrecognized bug on some platform (deadline == 511999)
+        if(ms >= o && deadline > ms) {
+            deadline = ms;
+            if(ms == 0)
+                return;
+        }
         // wait for events
         equeue_sema_wait(&q->eventsema, deadline);
 

--- a/events/equeue/equeue.c
+++ b/events/equeue/equeue.c
@@ -434,7 +434,7 @@ void equeue_dispatch(equeue_t *q, int ms) {
         
         // in any case 'deadline' must be <= than 'ms'
         // Unrecognized bug on some platform (deadline == 511999)
-        if(ms >= o && deadline > ms) {
+        if(ms >= 0 && deadline > ms) {
             deadline = ms;
             if(ms == 0)
                 return;


### PR DESCRIPTION
On Mbed os 5.4, NRF52-DK, no RTOS, no active SoftDevice after long time (timer/counter overflow?) 'deadline' == 511999.
In my case timeout (parameters ms) == ZERO and dispatch(0) run "forever".
This modification is only simply safeguard. I dont know where is real problem (Mbed, Nordic drivers, ...)