### PR TITLE
STM32: serial: clear Overrun flag if it is set when checking if readable

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
@@ -472,7 +472,12 @@ int serial_readable(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+    /*  To avoid a target blocking case, let's check for
+     *  possible OVERRUN error and discard it
+     */
+    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
+        __HAL_UART_CLEAR_OREFLAG(huart);
+    }
     // Check if data is received
     return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
 }

--- a/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
@@ -468,54 +468,21 @@ void serial_putc(serial_t *obj, int c)
     huart->Instance->TDR = (uint32_t)(c & (uint16_t)0xFF);
 }
 
-int serial_readable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    /*  To avoid a target blocking case, let's check for
-     *  possible OVERRUN error and discard it
-     */
-    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
-        __HAL_UART_CLEAR_OREFLAG(huart);
-    }
-    // Check if data is received
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
-}
-
-int serial_writable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    // Check if data is transmitted
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) ? 1 : 0;
-}
-
 void serial_clear(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+
     huart->TxXferCount = 0;
     huart->RxXferCount = 0;
-}
-
-void serial_pinout_tx(PinName tx)
-{
-    pinmap_pinout(tx, PinMap_UART_TX);
 }
 
 void serial_break_set(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    //HAL_LIN_SendBreak(huart);
-}
 
-void serial_break_clear(serial_t *obj)
-{
-    (void)obj;
+    //HAL_LIN_SendBreak(huart);
 }
 
 #if DEVICE_SERIAL_ASYNCH

--- a/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
@@ -289,7 +289,12 @@ int serial_readable(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+    /*  To avoid a target blocking case, let's check for
+     *  possible OVERRUN error and discard it
+     */
+    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
+        __HAL_UART_CLEAR_OREFLAG(huart);
+    }
     // Check if data is received
     return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
 }

--- a/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
@@ -285,54 +285,21 @@ void serial_putc(serial_t *obj, int c)
     }
 }
 
-int serial_readable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    /*  To avoid a target blocking case, let's check for
-     *  possible OVERRUN error and discard it
-     */
-    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
-        __HAL_UART_CLEAR_OREFLAG(huart);
-    }
-    // Check if data is received
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
-}
-
-int serial_writable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    // Check if data is transmitted
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) ? 1 : 0;
-}
-
 void serial_clear(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+
     huart->TxXferCount = 0;
     huart->RxXferCount = 0;
-}
-
-void serial_pinout_tx(PinName tx)
-{
-    pinmap_pinout(tx, PinMap_UART_TX);
 }
 
 void serial_break_set(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    HAL_LIN_SendBreak(huart);
-}
 
-void serial_break_clear(serial_t *obj)
-{
-    (void)obj;
+    HAL_LIN_SendBreak(huart);
 }
 
 #if DEVICE_SERIAL_ASYNCH

--- a/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
@@ -434,54 +434,21 @@ void serial_putc(serial_t *obj, int c)
     huart->Instance->DR = (uint32_t)(c & (uint16_t)0x1FF);
 }
 
-int serial_readable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    /*  To avoid a target blocking case, let's check for
-     *  possible OVERRUN error and discard it
-     */
-    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
-        __HAL_UART_CLEAR_OREFLAG(huart);
-    }
-    // Check if data is received
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
-}
-
-int serial_writable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    // Check if data is transmitted
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) ? 1 : 0;
-}
-
 void serial_clear(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+
     huart->TxXferCount = 0;
     huart->RxXferCount = 0;
-}
-
-void serial_pinout_tx(PinName tx)
-{
-    pinmap_pinout(tx, PinMap_UART_TX);
 }
 
 void serial_break_set(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    HAL_LIN_SendBreak(huart);
-}
 
-void serial_break_clear(serial_t *obj)
-{
-    (void)obj;
+    HAL_LIN_SendBreak(huart);
 }
 
 #if DEVICE_SERIAL_ASYNCH

--- a/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
@@ -438,7 +438,12 @@ int serial_readable(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+    /*  To avoid a target blocking case, let's check for
+     *  possible OVERRUN error and discard it
+     */
+    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
+        __HAL_UART_CLEAR_OREFLAG(huart);
+    }
     // Check if data is received
     return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
 }

--- a/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
@@ -369,29 +369,6 @@ void serial_putc(serial_t *obj, int c)
     }
 }
 
-int serial_readable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    /*  To avoid a target blocking case, let's check for
-     *  possible OVERRUN error and discard it
-     */
-    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
-        __HAL_UART_CLEAR_OREFLAG(huart);
-    }
-    // Check if data is received
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
-}
-
-int serial_writable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    // Check if data is transmitted
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) ? 1 : 0;
-}
-
 void serial_clear(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
@@ -401,22 +378,12 @@ void serial_clear(serial_t *obj)
     __HAL_UART_SEND_REQ(huart, UART_RXDATA_FLUSH_REQUEST);
 }
 
-void serial_pinout_tx(PinName tx)
-{
-    pinmap_pinout(tx, PinMap_UART_TX);
-}
-
 void serial_break_set(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    HAL_LIN_SendBreak(huart);
-}
 
-void serial_break_clear(serial_t *obj)
-{
-    (void)obj;
+    HAL_LIN_SendBreak(huart);
 }
 
 #if DEVICE_SERIAL_ASYNCH

--- a/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
@@ -373,7 +373,12 @@ int serial_readable(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+    /*  To avoid a target blocking case, let's check for
+     *  possible OVERRUN error and discard it
+     */
+    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
+        __HAL_UART_CLEAR_OREFLAG(huart);
+    }
     // Check if data is received
     return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -431,29 +431,6 @@ void serial_putc(serial_t *obj, int c)
     huart->Instance->DR = (uint32_t)(c & 0x1FF);
 }
 
-int serial_readable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    /*  To avoid a target blocking case, let's check for
-     *  possible OVERRUN error and discard it
-     */
-    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
-        __HAL_UART_CLEAR_OREFLAG(huart);
-    }
-    // Check if data is received
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
-}
-
-int serial_writable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    // Check if data is transmitted
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) ? 1 : 0;
-}
-
 void serial_clear(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
@@ -463,22 +440,12 @@ void serial_clear(serial_t *obj)
     huart->RxXferCount = 0;
 }
 
-void serial_pinout_tx(PinName tx)
-{
-    pinmap_pinout(tx, PinMap_UART_TX);
-}
-
 void serial_break_set(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
     
     HAL_LIN_SendBreak(huart);
-}
-
-void serial_break_clear(serial_t *obj)
-{
-    (void)obj;
 }
 
 #if DEVICE_SERIAL_ASYNCH

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -435,7 +435,12 @@ int serial_readable(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+    /*  To avoid a target blocking case, let's check for
+     *  possible OVERRUN error and discard it
+     */
+    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
+        __HAL_UART_CLEAR_OREFLAG(huart);
+    }
     // Check if data is received
     return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
 }

--- a/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
@@ -426,7 +426,12 @@ int serial_readable(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+    /*  To avoid a target blocking case, let's check for
+     *  possible OVERRUN error and discard it
+     */
+    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
+        __HAL_UART_CLEAR_OREFLAG(huart);
+    }
     // Check if data is received
     return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
 }

--- a/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
@@ -408,7 +408,7 @@ int serial_getc(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+
     while (!serial_readable(obj));
     return (int)(huart->Instance->RDR & 0x1FF);
 }
@@ -417,32 +417,9 @@ void serial_putc(serial_t *obj, int c)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+
     while (!serial_writable(obj));
     huart->Instance->TDR = (uint32_t)(c & 0x1FF);
-}
-
-int serial_readable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    /*  To avoid a target blocking case, let's check for
-     *  possible OVERRUN error and discard it
-     */
-    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
-        __HAL_UART_CLEAR_OREFLAG(huart);
-    }
-    // Check if data is received
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
-}
-
-int serial_writable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    // Check if data is transmitted
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) ? 1 : 0;
 }
 
 void serial_clear(serial_t *obj)
@@ -454,22 +431,12 @@ void serial_clear(serial_t *obj)
     __HAL_UART_CLEAR_IT(huart, UART_FLAG_RXNE);
 }
 
-void serial_pinout_tx(PinName tx)
-{
-    pinmap_pinout(tx, PinMap_UART_TX);
-}
-
 void serial_break_set(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    HAL_LIN_SendBreak(huart);
-}
 
-void serial_break_clear(serial_t *obj)
-{
-    (void)obj;
+    HAL_LIN_SendBreak(huart);
 }
 
 #if DEVICE_SERIAL_ASYNCH

--- a/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
@@ -355,7 +355,12 @@ int serial_readable(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+    /*  To avoid a target blocking case, let's check for
+     *  possible OVERRUN error and discard it
+     */
+    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
+        __HAL_UART_CLEAR_OREFLAG(huart);
+    }
     // Check if data is received
     return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
 }

--- a/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
@@ -351,41 +351,13 @@ void serial_putc(serial_t *obj, int c)
     huart->Instance->TDR = (uint32_t)(c & (uint16_t)0xFF);
 }
 
-int serial_readable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    /*  To avoid a target blocking case, let's check for
-     *  possible OVERRUN error and discard it
-     */
-    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
-        __HAL_UART_CLEAR_OREFLAG(huart);
-    }
-    // Check if data is received
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
-}
-
-int serial_writable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    // Check if data is transmitted
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) ? 1 : 0;
-}
-
 void serial_clear(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+
     huart->TxXferCount = 0;
     huart->RxXferCount = 0;
-}
-
-void serial_pinout_tx(PinName tx)
-{
-    pinmap_pinout(tx, PinMap_UART_TX);
 }
 
 void serial_break_set(serial_t *obj)
@@ -394,11 +366,6 @@ void serial_break_set(serial_t *obj)
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
 
     __HAL_UART_SEND_REQ(huart, UART_SENDBREAK_REQUEST);
-}
-
-void serial_break_clear(serial_t *obj)
-{
-    (void)obj;
 }
 
 #if DEVICE_SERIAL_ASYNCH

--- a/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
@@ -345,7 +345,12 @@ int serial_readable(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+    /*  To avoid a target blocking case, let's check for
+     *  possible OVERRUN error and discard it
+     */
+    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
+        __HAL_UART_CLEAR_OREFLAG(huart);
+    }
     // Check if data is received
     return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
 }

--- a/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
@@ -341,54 +341,21 @@ void serial_putc(serial_t *obj, int c)
     }
 }
 
-int serial_readable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    /*  To avoid a target blocking case, let's check for
-     *  possible OVERRUN error and discard it
-     */
-    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
-        __HAL_UART_CLEAR_OREFLAG(huart);
-    }
-    // Check if data is received
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
-}
-
-int serial_writable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    // Check if data is transmitted
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) ? 1 : 0;
-}
-
 void serial_clear(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+
     huart->TxXferCount = 0;
     huart->RxXferCount = 0;
-}
-
-void serial_pinout_tx(PinName tx)
-{
-    pinmap_pinout(tx, PinMap_UART_TX);
 }
 
 void serial_break_set(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    HAL_LIN_SendBreak(huart);
-}
 
-void serial_break_clear(serial_t *obj)
-{
-    (void)obj;
+    HAL_LIN_SendBreak(huart);
 }
 
 #if DEVICE_SERIAL_ASYNCH

--- a/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
@@ -387,54 +387,21 @@ void serial_putc(serial_t *obj, int c)
     }
 }
 
-int serial_readable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    /*  To avoid a target blocking case, let's check for
-     *  possible OVERRUN error and discard it
-     */
-    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
-        __HAL_UART_CLEAR_OREFLAG(huart);
-    }
-    // Check if data is received
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
-}
-
-int serial_writable(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    // Check if data is transmitted
-    return (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) ? 1 : 0;
-}
-
 void serial_clear(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+
     huart->TxXferCount = 0;
     huart->RxXferCount = 0;
-}
-
-void serial_pinout_tx(PinName tx)
-{
-    pinmap_pinout(tx, PinMap_UART_TX);
 }
 
 void serial_break_set(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
-    HAL_LIN_SendBreak(huart);
-}
 
-void serial_break_clear(serial_t *obj)
-{
-    (void)obj;
+    HAL_LIN_SendBreak(huart);
 }
 
 #if DEVICE_SERIAL_ASYNCH

--- a/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
@@ -391,7 +391,12 @@ int serial_readable(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+    /*  To avoid a target blocking case, let's check for
+     *  possible OVERRUN error and discard it
+     */
+    if(__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE)) {
+        __HAL_UART_CLEAR_OREFLAG(huart);
+    }
     // Check if data is received
     return (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) ? 1 : 0;
 }


### PR DESCRIPTION
## Description
This PR is the answer to request in #899 
In case of OVERRUN on a serial interface when using the polling method, the OVERRUN flag is reset so
that next characters can be received.  

## Status
**READY**

## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.