### PR TITLE
mbed sdk boot: copy vectors addition

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -1061,7 +1061,7 @@ def build_mbed_libs(target, toolchain_name, verbose=False,
         #                       weak SDK functions
         #   - mbed_main.o: this contains main redirection
         separate_names, separate_objects = ['mbed_retarget.o', 'mbed_board.o',
-                                            'mbed_overrides.o', 'mbed_main.o'], []
+                                            'mbed_overrides.o', 'mbed_main.o', 'mbed_sdk_boot.o'], []
 
         for obj in objects:
             for name in separate_names:


### PR DESCRIPTION
This was a breakage from the latest cmsis5 boot process unification. However, this PR does not completely fixes it. It fixes for non cortex-m0. We will need to address removal of this functionality for cortex-m0.

Without this patch, ticker test would end up in the hard fault..

With this patch, interrupts are properly running.

Note: if anyone test only this patch with debug profile and with ARM toolchain, there is another problem at least with ticker test. This test invokes ``fflush`` from ISR and we now define MBED_TRAP_ERRORS_ENABLED, thus this ends calling exit() via error() function :/  Not saying this is correct - https://github.com/ARMmbed/mbed-os/blob/master/features/unsupported/tests/mbed/ticker/main.cpp#L7 :-) Just that I did not realized fflush is related to this changeset (adding trap errors!). 

cc @LMESTM @bcostm This should help to pass some tests for mbed 2. Please read the note, there might be more problems like this in our tests !

I added here also mbed_sdk_boot object file that should be there (I sent PR to cmsis5 to have it fixed, seems like one of the rebased we did  removed this).

copy nvic function is a duplication with mbed 5 - no it is not, uvisor is involved first, then we might do some other things there, therefore I created own in the mbed 2 boot process. I expect this won't change in mbed 2 , but might change in mbed 5.

@c1728p9 Please review, and lets discuss how to fix cortex-m0 targets