### PR TITLE
greentea: Add reporting of reserved heap

### DIFF
--- a/features/frameworks/greentea-client/source/greentea_metrics.cpp
+++ b/features/frameworks/greentea-client/source/greentea_metrics.cpp
@@ -72,6 +72,7 @@ static void send_heap_info()
     mbed_stats_heap_t heap_stats;
     mbed_stats_heap_get(&heap_stats);
     greentea_send_kv("max_heap_usage",heap_stats.max_size);
+    greentea_send_kv("reserved_heap",heap_stats.reserved_size);
 }
 
 #if defined(MBED_STACK_STATS_ENABLED) && MBED_STACK_STATS_ENABLED


### PR DESCRIPTION
This exposes the reporting of reserved heap and stack to mbed-greentea when the memory stats are enabled.

Note: Reporting of reserved stack is already performed by the thread layer

related pr https://github.com/ARMmbed/greentea/pull/228
cc @bridadan, @studavekar