### PR TITLE
NRF52840: enabled SdBlockDevice capability

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/sdk/sdk_config.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/sdk/sdk_config.h
@@ -1962,7 +1962,7 @@
  
 
 #ifndef SPI0_USE_EASY_DMA
-#define SPI0_USE_EASY_DMA 1
+#define SPI0_USE_EASY_DMA 0
 #endif
 
 // <o> SPI0_DEFAULT_FREQUENCY  - SPI frequency
@@ -1992,7 +1992,7 @@
  
 
 #ifndef SPI1_USE_EASY_DMA
-#define SPI1_USE_EASY_DMA 1
+#define SPI1_USE_EASY_DMA 0
 #endif
 
 // <o> SPI1_DEFAULT_FREQUENCY  - SPI frequency
@@ -2022,7 +2022,7 @@
  
 
 #ifndef SPI2_USE_EASY_DMA
-#define SPI2_USE_EASY_DMA 1
+#define SPI2_USE_EASY_DMA 0
 #endif
 
 // <q> SPI2_DEFAULT_FREQUENCY  - Use EasyDMA

--- a/targets/TARGET_NORDIC/TARGET_NRF5/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/spi_api.c
@@ -141,11 +141,13 @@ static void master_event_handler(uint8_t spi_idx,
 
     if (p_event->type == NRF_DRV_SPI_EVENT_DONE) {
         p_spi_info->flag.busy = false;
+#if DEVICE_SPI_ASYNCH
         if (p_spi_info->handler) {
             void (*handler)(void) = (void (*)(void))p_spi_info->handler;
             p_spi_info->handler = 0;
             handler();
         }
+#endif
     }
 }
 #define MASTER_EVENT_HANDLER(idx) \

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2806,7 +2806,7 @@
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF52840"],
         "macros_add": ["BOARD_PCA10056", "CONFIG_GPIO_AS_PINRESET", "SWI_DISABLE0", "NRF52_ERRATA_20"],
-        "device_has": ["FLASH", "ANALOGIN", "ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE", "TRNG"],
+        "device_has": ["FLASH", "ANALOGIN", "ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "TRNG"],
         "release_versions": ["2", "5"],
         "device_name": "nRF52840_xxAA"
     },


### PR DESCRIPTION
**NOTE** This is a duplicate PR of #4478. There was a merge conflict after some recent changes were pushed up to master. I used the GitHub fix conflicts shiny button which created a merge commit. I wasn't able to undo it in a clean way, so I moved the rebase to this branch.
_______________________________________________________________________________________________
Rebase against master for: #4088 

Smaller chunk of the Workshop branch additions: #4412

Feel free to add in however else should be a reviewer @c1728p9

Changes from the original commit to targets/TARGET_NORDIC/TARGET_NRF5_SDK13/spi_api.c have been removed as the following commit removed those files as orphans: 
https://github.com/ARMmbed/mbed-os/commit/708dd4703d969bb85043cf09009e7e5607d1f3b1