### PR TITLE
Disabled lwip ethernet ipv6 multicast filter for STM boards

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_STM/TARGET_STM32F2/stm32f2_eth_conf.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_STM/TARGET_STM32F2/stm32f2_eth_conf.c
@@ -1,0 +1,61 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "stm32f2xx_hal.h"
+
+void _eth_config_mac(ETH_HandleTypeDef *heth)
+{
+    ETH_MACInitTypeDef macconf =
+        {
+        .Watchdog = ETH_WATCHDOG_ENABLE,
+        .Jabber = ETH_JABBER_ENABLE,
+        .InterFrameGap = ETH_INTERFRAMEGAP_96BIT,
+        .CarrierSense = ETH_CARRIERSENCE_ENABLE,
+        .ReceiveOwn = ETH_RECEIVEOWN_ENABLE,
+        .LoopbackMode = ETH_LOOPBACKMODE_DISABLE,
+        .ChecksumOffload = ETH_CHECKSUMOFFLAOD_ENABLE,
+        .RetryTransmission = ETH_RETRYTRANSMISSION_DISABLE,
+        .AutomaticPadCRCStrip = ETH_AUTOMATICPADCRCSTRIP_DISABLE,
+        .BackOffLimit = ETH_BACKOFFLIMIT_10,
+        .DeferralCheck = ETH_DEFFERRALCHECK_DISABLE,
+        .ReceiveAll = ETH_RECEIVEAll_DISABLE,
+        .SourceAddrFilter = ETH_SOURCEADDRFILTER_DISABLE,
+        .PassControlFrames = ETH_PASSCONTROLFRAMES_BLOCKALL,
+        .BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE,
+        .DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL,
+        .PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE,
+        .MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_NONE, // Disable multicast filter
+        .UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT,
+        .HashTableHigh = 0x0U,
+        .HashTableLow = 0x0U,
+        .PauseTime = 0x0U,
+        .ZeroQuantaPause = ETH_ZEROQUANTAPAUSE_DISABLE,
+        .PauseLowThreshold = ETH_PAUSELOWTHRESHOLD_MINUS4,
+        .UnicastPauseFrameDetect = ETH_UNICASTPAUSEFRAMEDETECT_DISABLE,
+        .ReceiveFlowControl = ETH_RECEIVEFLOWCONTROL_DISABLE,
+        .TransmitFlowControl = ETH_TRANSMITFLOWCONTROL_DISABLE,
+        .VLANTagComparison = ETH_VLANTAGCOMPARISON_16BIT,
+        .VLANTagIdentifier = 0x0U
+        };
+
+    if (heth->Init.ChecksumMode == ETH_CHECKSUM_BY_HARDWARE) {
+        macconf.ChecksumOffload = ETH_CHECKSUMOFFLAOD_ENABLE;
+    } else {
+        macconf.ChecksumOffload = ETH_CHECKSUMOFFLAOD_DISABLE;
+    }
+
+    (void) HAL_ETH_ConfigMAC(heth, &macconf);
+}

--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_STM/TARGET_STM32F4/stm32f4_eth_conf.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_STM/TARGET_STM32F4/stm32f4_eth_conf.c
@@ -1,0 +1,61 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "stm32f4xx_hal.h"
+
+void _eth_config_mac(ETH_HandleTypeDef *heth)
+{
+    ETH_MACInitTypeDef macconf =
+        {
+        .Watchdog = ETH_WATCHDOG_ENABLE,
+        .Jabber = ETH_JABBER_ENABLE,
+        .InterFrameGap = ETH_INTERFRAMEGAP_96BIT,
+        .CarrierSense = ETH_CARRIERSENCE_ENABLE,
+        .ReceiveOwn = ETH_RECEIVEOWN_ENABLE,
+        .LoopbackMode = ETH_LOOPBACKMODE_DISABLE,
+        .ChecksumOffload = ETH_CHECKSUMOFFLAOD_ENABLE,
+        .RetryTransmission = ETH_RETRYTRANSMISSION_DISABLE,
+        .AutomaticPadCRCStrip = ETH_AUTOMATICPADCRCSTRIP_DISABLE,
+        .BackOffLimit = ETH_BACKOFFLIMIT_10,
+        .DeferralCheck = ETH_DEFFERRALCHECK_DISABLE,
+        .ReceiveAll = ETH_RECEIVEAll_DISABLE,
+        .SourceAddrFilter = ETH_SOURCEADDRFILTER_DISABLE,
+        .PassControlFrames = ETH_PASSCONTROLFRAMES_BLOCKALL,
+        .BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE,
+        .DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL,
+        .PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE,
+        .MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_NONE, // Disable multicast filter
+        .UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT,
+        .HashTableHigh = 0x0U,
+        .HashTableLow = 0x0U,
+        .PauseTime = 0x0U,
+        .ZeroQuantaPause = ETH_ZEROQUANTAPAUSE_DISABLE,
+        .PauseLowThreshold = ETH_PAUSELOWTHRESHOLD_MINUS4,
+        .UnicastPauseFrameDetect = ETH_UNICASTPAUSEFRAMEDETECT_DISABLE,
+        .ReceiveFlowControl = ETH_RECEIVEFLOWCONTROL_DISABLE,
+        .TransmitFlowControl = ETH_TRANSMITFLOWCONTROL_DISABLE,
+        .VLANTagComparison = ETH_VLANTAGCOMPARISON_16BIT,
+        .VLANTagIdentifier = 0x0U,
+        };
+
+    if (heth->Init.ChecksumMode == ETH_CHECKSUM_BY_HARDWARE) {
+        macconf.ChecksumOffload = ETH_CHECKSUMOFFLAOD_ENABLE;
+    } else {
+        macconf.ChecksumOffload = ETH_CHECKSUMOFFLAOD_DISABLE;
+    }
+
+    (void) HAL_ETH_ConfigMAC(heth, &macconf);
+}

--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_STM/TARGET_STM32F7/stm32f7_eth_conf.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_STM/TARGET_STM32F7/stm32f7_eth_conf.c
@@ -1,0 +1,61 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "stm32f7xx_hal.h"
+
+void _eth_config_mac(ETH_HandleTypeDef *heth)
+{
+    ETH_MACInitTypeDef macconf =
+        {
+        .Watchdog = ETH_WATCHDOG_ENABLE,
+        .Jabber = ETH_JABBER_ENABLE,
+        .InterFrameGap = ETH_INTERFRAMEGAP_96BIT,
+        .CarrierSense = ETH_CARRIERSENCE_ENABLE,
+        .ReceiveOwn = ETH_RECEIVEOWN_ENABLE,
+        .LoopbackMode = ETH_LOOPBACKMODE_DISABLE,
+        .ChecksumOffload = ETH_CHECKSUMOFFLAOD_ENABLE,
+        .RetryTransmission = ETH_RETRYTRANSMISSION_DISABLE,
+        .AutomaticPadCRCStrip = ETH_AUTOMATICPADCRCSTRIP_DISABLE,
+        .BackOffLimit = ETH_BACKOFFLIMIT_10,
+        .DeferralCheck = ETH_DEFFERRALCHECK_DISABLE,
+        .ReceiveAll = ETH_RECEIVEAll_DISABLE,
+        .SourceAddrFilter = ETH_SOURCEADDRFILTER_DISABLE,
+        .PassControlFrames = ETH_PASSCONTROLFRAMES_BLOCKALL,
+        .BroadcastFramesReception = ETH_BROADCASTFRAMESRECEPTION_ENABLE,
+        .DestinationAddrFilter = ETH_DESTINATIONADDRFILTER_NORMAL,
+        .PromiscuousMode = ETH_PROMISCUOUS_MODE_DISABLE,
+        .MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_NONE, // Disable multicast filter
+        .UnicastFramesFilter = ETH_UNICASTFRAMESFILTER_PERFECT,
+        .HashTableHigh = 0x0,
+        .HashTableLow = 0x0,
+        .PauseTime = 0x0,
+        .ZeroQuantaPause = ETH_ZEROQUANTAPAUSE_DISABLE,
+        .PauseLowThreshold = ETH_PAUSELOWTHRESHOLD_MINUS4,
+        .UnicastPauseFrameDetect = ETH_UNICASTPAUSEFRAMEDETECT_DISABLE,
+        .ReceiveFlowControl = ETH_RECEIVEFLOWCONTROL_DISABLE,
+        .TransmitFlowControl = ETH_TRANSMITFLOWCONTROL_DISABLE,
+        .VLANTagComparison = ETH_VLANTAGCOMPARISON_16BIT,
+        .VLANTagIdentifier = 0x0
+        };
+
+    if (heth->Init.ChecksumMode == ETH_CHECKSUM_BY_HARDWARE) {
+        macconf.ChecksumOffload = ETH_CHECKSUMOFFLAOD_ENABLE;
+    } else {
+        macconf.ChecksumOffload = ETH_CHECKSUMOFFLAOD_DISABLE;
+    }
+
+    (void) HAL_ETH_ConfigMAC(heth, &macconf);
+}

--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_STM/stm32xx_emac.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_STM/stm32xx_emac.c
@@ -59,6 +59,8 @@ static struct pbuf * _eth_arch_low_level_input(struct netif *netif);
 __weak uint8_t mbed_otp_mac_address(char *mac);
 void mbed_default_mac_address(char *mac);
 
+void _eth_config_mac(ETH_HandleTypeDef *heth);
+
 /**
  * Ethernet Rx Transfer completed callback
  *
@@ -143,6 +145,9 @@ static void _eth_arch_low_level_init(struct netif *netif)
     /* device capabilities */
     /* don't set NETIF_FLAG_ETHARP if this device is not an ethernet one */
     netif->flags |= NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP;
+
+    /* Configure MAC */
+    _eth_config_mac(&EthHandle);
 
     /* Enable MAC and DMA transmission and reception */
     HAL_ETH_Start(&EthHandle);


### PR DESCRIPTION
## Description
Disabled lwip ethernet ipv6 multicast filter for STM boards.

This is correction to https://github.com/ARMmbed/mbed-os/issues/4432

## Status
READY


## Migrations
NO


## Related PRs
None


## Todos
- [ ] Tests
- [ ] Documentation


## Deploy notes
None


## Steps to test or reproduce
None
