### PR TITLE
Add fourth PWM module support for nRF52840 target

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/sdk/sdk_config.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/sdk/sdk_config.h
@@ -1311,6 +1311,8 @@
 #endif //PWM_CONFIG_LOG_ENABLED
 // </e>
 
+#define PWM_COUNT (PWM0_ENABLED + PWM1_ENABLED + PWM2_ENABLED + PWM3_ENABLED)
+
 #endif //PWM_ENABLED
 // </e>
 
@@ -2883,7 +2885,7 @@
 // <e> APP_TIMER_ENABLED - app_timer - Application timer functionality
 //==========================================================
 #ifndef APP_TIMER_ENABLED
-#define APP_TIMER_ENABLED 0
+#define APP_TIMER_ENABLED 1
 #endif
 #if  APP_TIMER_ENABLED
 // <q> APP_TIMER_WITH_PROFILER  - Enable app_timer profiling

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_NRF52_COMMON/pwmout_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_NRF52_COMMON/pwmout_api.c
@@ -69,7 +69,10 @@ static const nrf_drv_pwm_t m_pwm_driver[PWM_INSTANCE_COUNT] =
     NRF_DRV_PWM_INSTANCE(1),
 #endif
 #if PWM2_ENABLED
-    NRF_DRV_PWM_INSTANCE(2)
+    NRF_DRV_PWM_INSTANCE(2),
+#endif
+#if PWM3_ENABLED
+    NRF_DRV_PWM_INSTANCE(3)
 #endif
 };
 
@@ -96,6 +99,9 @@ static pwm_t m_pwm[PWM_INSTANCE_COUNT] =
     {.p_pwm_driver = NULL},
 #endif
 #if PWM2_ENABLED
+    {.p_pwm_driver = NULL},
+#endif
+#if PWM3_ENABLED
     {.p_pwm_driver = NULL}
 #endif
 };  /// Array of internal PWM instances.
@@ -114,6 +120,7 @@ static void internal_pwmout_exe(pwmout_t *obj, bool new_period, bool initializat
 void PWM0_IRQHandler(void);
 void PWM1_IRQHandler(void);
 void PWM2_IRQHandler(void);
+void PWM3_IRQHandler(void);
 
 static const peripheral_handler_desc_t pwm_handlers[PWM_INSTANCE_COUNT] =
 {
@@ -128,6 +135,10 @@ static const peripheral_handler_desc_t pwm_handlers[PWM_INSTANCE_COUNT] =
     {
         PWM2_IRQn,
         (uint32_t)PWM2_IRQHandler
+    },
+    {
+        PWM3_IRQn,
+        (uint32_t)PWM3_IRQHandler
     }
 };
  


### PR DESCRIPTION
## Description
The nRF52840 target implementation has only 3 PWM modules, but the chip contains 4. Based on the existing implementation, this PR will add the missing PWM module.


## Status
READY


## Migrations
NO
