### PR TITLE
Check for correct library naming in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,17 @@ python:
   - "2.7"
 
 script:
-  - mkdir BUILD && doxygen doxyfile_options
+  - mkdir BUILD
 # Assert that the Doxygen build produced no warnings.
 # The strange command below asserts that the Doxygen command had an
 # output of zero length
   - |
-    [ -z "`doxygen doxyfile_options 2>&1`" ]
-  - find -name "*.a" -and -not -name "lib*.a"
+    doxygen doxyfile_options 2>&1 | tee BUILD/doxygen.out && [ ! -s BUILD/doxygen.out ]
 # Assert that all binary libraries are named correctly
 # The strange command below asserts that there are exactly 0 libraries that do
 # not start with lib
   - |
-    [ -z '`find -name "*.a" -and -not -name "lib*.a"`' ]
+    find -name "*.a" -and -not -name "lib*" | tee BUILD/badlibs && [ ! -s BUILD/badlibs ]
   - make -C events/equeue test clean
   - PYTHONPATH=. python tools/test/config_test/config_test.py
   - PYTHONPATH=. python tools/test/build_api/build_api_test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ script:
   - mkdir BUILD && doxygen doxyfile_options
   - |
     [ -z "`doxygen doxyfile_options 2>&1`" ]
+  - find -name "*.a" -and -not -name "lib*.a"
+  - |
+    [ -z '`find -name "*.a" -and -not -name "lib*.a"`' ]
   - make -C events/equeue test clean
   - PYTHONPATH=. python tools/test/config_test/config_test.py
   - PYTHONPATH=. python tools/test/build_api/build_api_test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,15 @@ python:
 
 script:
   - mkdir BUILD && doxygen doxyfile_options
+# Assert that the Doxygen build produced no warnings.
+# The strange command below asserts that the Doxygen command had an
+# output of zero length
   - |
     [ -z "`doxygen doxyfile_options 2>&1`" ]
   - find -name "*.a" -and -not -name "lib*.a"
+# Assert that all binary libraries are named correctly
+# The strange command below asserts that there are exactly 0 libraries that do
+# not start with lib
   - |
     [ -z '`find -name "*.a" -and -not -name "lib*.a"`' ]
   - make -C events/equeue test clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 # The strange command below asserts that there are exactly 0 libraries that do
 # not start with lib
   - |
-    find -name "*.a" -and -not -name "lib*" | tee BUILD/badlibs && [ ! -s BUILD/badlibs ]
+    find -name "*.a" -and -not -name "lib*" | tee BUILD/badlibs | sed -e "s/^/Bad library name found: /" && [ ! -s BUILD/badlibs ]
   - make -C events/equeue test clean
   - PYTHONPATH=. python tools/test/config_test/config_test.py
   - PYTHONPATH=. python tools/test/build_api/build_api_test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 # The strange command below asserts that there are exactly 0 libraries that do
 # not start with lib
   - |
-    find -name "*.a" -and -not -name "lib*" | tee BUILD/badlibs | sed -e "s/^/Bad library name found: /" && [ ! -s BUILD/badlibs ]
+    find "(" -name "*.a" -or -name "*.ar" ")" -and -not -name "lib*" | tee BUILD/badlibs | sed -e "s/^/Bad library name found: /" && [ ! -s BUILD/badlibs ]
   - make -C events/equeue test clean
   - PYTHONPATH=. python tools/test/config_test/config_test.py
   - PYTHONPATH=. python tools/test/build_api/build_api_test.py


### PR DESCRIPTION
# Description

Preventative maintenance for exporters. The build tools are able to handle 
incorrectly named libraries, but the exporters can't. This PR adds a CI check
in Travis CI that will prevent incorrectly named libraries from coming in.


# Status
**ready**

# Testing
 - Just Travis CI is fine