### PR TITLE
Add new target in mbedtls importer Makefile for mbedtls tests

### DIFF
--- a/features/mbedtls/importer/Makefile
+++ b/features/mbedtls/importer/Makefile
@@ -33,6 +33,7 @@ MBED_TLS_RELEASE ?= mbedtls-2.5.0
 TARGET_PREFIX:=../
 TARGET_SRC:=$(TARGET_PREFIX)src
 TARGET_INC:=$(TARGET_PREFIX)inc
+TARGET_TESTS:=$(TARGET_PREFIX)TESTS
 
 # mbed TLS source directory - hidden from mbed via TARGET_IGNORE
 MBED_TLS_URL:=https://github.com/ARMmbed/mbedtls-restricted.git
@@ -69,6 +70,15 @@ deploy: rsync
 	#
 	# Copy the trimmed config that does not require entropy source
 	cp $(MBED_TLS_DIR)/configs/config-no-entropy.h $(TARGET_INC)/mbedtls/.
+
+deploy-tests: deploy
+	#
+	# Copying mbed TLS tests...
+	rm -rf $(TARGET_TESTS)
+	mkdir -p $(TARGET_TESTS)
+	rsync -a --delete $(MBED_TLS_DIR)/tests/TESTS/ $(TARGET_TESTS)
+	mkdir -p $(TARGET_TESTS)/host_tests
+	cp $(MBED_TLS_DIR)/tests/scripts/mbedtls_test.py $(TARGET_TESTS)/host_tests/
 
 update: $(MBED_TLS_GIT_CFG)  $(MBED_TLS_HA_GIT_CFG)
 	#

--- a/features/mbedtls/importer/Makefile
+++ b/features/mbedtls/importer/Makefile
@@ -41,7 +41,7 @@ MBED_TLS_DIR:=TARGET_IGNORE/mbedtls
 MBED_TLS_API:=$(MBED_TLS_DIR)/include/mbedtls
 MBED_TLS_GIT_CFG=$(MBED_TLS_DIR)/.git/config
 
-.PHONY: all deploy rsync mbedtls clean update
+.PHONY: all deploy deploy-tests rsync mbedtls clean update
 
 all: mbedtls
 


### PR DESCRIPTION

## Description
A new target is added to deploy mbedtls tests along with source code in mbed-os. Separate target is added to prevent changes in current deployment process. For some time it would only be used in staging CI to observer test stability. Also it gives the ability to only import tests for testing mbedtls with mbed-os i.e. only deploy tests for testing purpose.


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

YES | NO


## Related PRs
List related PRs against other branches:
Does not depend but will be used with mbedtls PR https://github.com/ARMmbed/mbedtls/pull/930

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ ] Documentation


## Deploy notes
- Check out mbedtls inside ```mbed-os/features/mbedtls/importer/TARGET_IGNORE/```
- ```cd mbed-os/features/mbedtls/importer/TARGET_IGNORE/mbedtls/tests/```
- ```make gen-embedded-tests```
- ```cd ../../../``` at importer level
- ```make deploy-tests```
- ```cd ../../../``` at mbed-os level
- Build with mbed-cli
- Run with Greentea


## Steps to test or reproduce
See deploy steps.
