### PR TITLE
Check Ethernet before including lwipopts_conf.h

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwipopts.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwipopts.h
@@ -19,7 +19,9 @@
 #ifndef LWIPOPTS_H
 #define LWIPOPTS_H
 
+#if MBED_CONF_LWIP_ETHERNET_ENABLED
 #include "lwipopts_conf.h"
+#endif
 
 // Workaround for Linux timeval
 #if defined (TOOLCHAIN_GCC)


### PR DESCRIPTION
## Description
lwipopts_conf.h is used by target dependent Ethernet drivers for
configuring various parameters.
By default, Ethernet is enabled and in this case lwipopts_conf.h
will be included.
In case of PPP  being enabled, it is desirable to not pull in any Ethernet
related code.


## Status
**READY**


## Migrations
 NO
