### PR TITLE
Enable verbose builds when running example build tests

### DIFF
--- a/tools/test/examples/examples_lib.py
+++ b/tools/test/examples/examples_lib.py
@@ -356,7 +356,7 @@ def compile_repos(config, toolchains, targets, examples):
                                                                 example['features']):
                     print("Compiling %s for %s, %s" % (name, target, toolchain))
                     proc = subprocess.Popen(["mbed-cli", "compile", "-t", toolchain,
-                                             "-m", target, "--silent"])
+                                             "-m", target, "-v"])
                     proc.wait()
                     example_summary = "{} {} {}".format(name, target, toolchain)
                     if proc.returncode:


### PR DESCRIPTION
## Description
Currently when building examples in CI, the following command is run for each TARGET, TOOLCHAIN, and EXAMPLE combination:

```
cd <EXAMPLE> && mbed compile -t <TOOLCHAIN> -m <TARGET> --silent
```

The `--silent` hides valuable debug information when certain errors occur. This PR enables verbose mode to reveal this information. The command will now become:

```
cd <EXAMPLE> && mbed compile -t <TOOLCHAIN> -m <TARGET> -v
```

## Status
**READY**


## Todos
- [x] morph test

FYI @c1728p9 
