### PR TITLE
Avoid lock collision b/w SerialBase & UARTSerial

### DIFF
--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -19,7 +19,7 @@
 
 #include "platform/platform.h"
 
-#if DEVICE_SERIAL
+#if (DEVICE_SERIAL && DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
 
 #include "FileHandle.h"
 #include "SerialBase.h"
@@ -58,7 +58,7 @@ public:
     /** Write the contents of a buffer to a file
      *
      *  @param buffer   The buffer to write from
-     *  @param size     The number of bytes to write
+     *  @param length   The number of bytes to write
      *  @return         The number of bytes written, negative error on failure
      */
     virtual ssize_t write(const void* buffer, size_t length);
@@ -72,16 +72,10 @@ public:
      *  * If any data is available, call returns immediately
      *
      *  @param buffer   The buffer to read in to
-     *  @param size     The number of bytes to read
+     *  @param length   The number of bytes to read
      *  @return         The number of bytes read, 0 at end of file, negative error on failure
      */
     virtual ssize_t read(void* buffer, size_t length);
-
-    /** Acquire mutex */
-    virtual void lock(void);
-
-    /** Release mutex */
-    virtual void unlock(void);
 
     /** Close a file
      *
@@ -159,6 +153,18 @@ public:
 
 private:
 
+    /** SerialBase lock override */
+    virtual void lock(void);
+
+    /** SerialBase unlock override */
+    virtual void unlock(void);
+
+    /** Acquire mutex */
+    virtual void api_lock(void);
+
+    /** Release mutex */
+    virtual void api_unlock(void);
+
     /** Software serial buffers
      *  By default buffer size is 256 for TX and 256 for RX. Configurable through mbed_app.json
      */
@@ -191,8 +197,9 @@ private:
     void wake(void);
 
     void dcd_irq(void);
+
 };
 } //namespace mbed
 
-#endif //DEVICE_SERIAL
+#endif //(DEVICE_SERIAL && DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
 #endif //MBED_UARTSERIAL_H


### PR DESCRIPTION
## Description
Fixes issue #4537. SerialBase and UARTSerial happened to have same names
for the mutex locking that confused the system of holding a mutex in interrupt context.
UARTSerial has to change so as to provide empty implementations for lock() and unlock()
becuase it uses SerialBase from interrupt context only or from its own critical section,
so no extra locks required.
Private locks for UARTSerial itself are renamed to api_lock() and api_unlock().


## Status
**READY**


## Migrations
Doesn't change behaviour.

NO

