### PR TITLE
Issue#4528 K82F: Move the UART clock inititialization to board specif…

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/TARGET_FRDM/mbed_overrides.c
@@ -37,3 +37,10 @@ void rtc_setup_oscillator(RTC_Type *base)
     /* Enable the RTC oscillator */
     RTC->CR |= RTC_CR_OSCE_MASK;
 }
+
+// Set the UART clock source
+void serial_clock_init(void)
+{
+    CLOCK_SetLpuartClock(2U);
+}
+

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/TARGET_UBRIDGE/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/TARGET_UBRIDGE/mbed_overrides.c
@@ -53,3 +53,10 @@ void rtc_setup_oscillator(RTC_Type *base)
     /* Enable the RTC oscillator */
     RTC->CR |= RTC_CR_OSCE_MASK;
 }
+
+// Set the UART clock source
+void serial_clock_init(void)
+{
+    CLOCK_SetLpuartClock(1U);
+}
+

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/peripheral_clock_defines.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/peripheral_clock_defines.h
@@ -33,12 +33,6 @@
 
 #include "fsl_clock.h"
 
-/* Array for LPUART module clocks */
-#define LPUART_CLOCK_FREQS                         \
-    {                                              \
-        kCLOCK_Osc0ErClk, kCLOCK_Osc0ErClk, kCLOCK_Osc0ErClk, kCLOCK_Osc0ErClk, kCLOCK_Osc0ErClk   \
-    }
-
 /* Array for I2C module clocks */
 #define I2C_CLOCK_FREQS                                 \
     {                                              \

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/serial_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/serial_api.c
@@ -34,8 +34,8 @@ static uint32_t serial_irq_ids[FSL_FEATURE_SOC_LPUART_COUNT] = {0};
 static uart_irq_handler irq_handler;
 /* Array of UART peripheral base address. */
 static LPUART_Type *const uart_addrs[] = LPUART_BASE_PTRS;
-/* Array of LPUART bus clock frequencies */
-static clock_name_t const uart_clocks[] = LPUART_CLOCK_FREQS;
+/* LPUART bus clock frequency */
+static uint32_t lpuart_src_freq;
 
 int stdio_uart_inited = 0;
 serial_t stdio_uart;
@@ -47,10 +47,11 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     obj->index = pinmap_merge(uart_tx, uart_rx);
     MBED_ASSERT((int)obj->index != NC);
 
+    /* Set the UART clock source */
+    serial_clock_init();
+
     // since the LPuart initialization depends very much on the source clock and its
     // frequency, we do a check here and retrieve the frequency accordingly
-    // The CLOCK_SetLpuartSrc() is already done during clock init.
-    uint32_t lpuart_src_freq;
     switch (SIM->SOPT2 & SIM_SOPT2_LPUARTSRC_MASK) {
         case SIM_SOPT2_LPUARTSRC(3U): {
             lpuart_src_freq = CLOCK_GetInternalRefClkFreq();
@@ -65,9 +66,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
             break;
         }
         default: {
-            /* Set the LPUART clock source */
-            CLOCK_SetLpuartClock(1U);
-            lpuart_src_freq = CLOCK_GetFreq(uart_clocks[obj->index]);
+            lpuart_src_freq = CLOCK_GetOsc0ErClkFreq();
             break;
         }
     }
@@ -106,7 +105,7 @@ void serial_free(serial_t *obj)
 
 void serial_baud(serial_t *obj, int baudrate)
 {
-    LPUART_SetBaudRate(uart_addrs[obj->index], (uint32_t)baudrate, CLOCK_GetFreq(uart_clocks[obj->index]));
+    LPUART_SetBaudRate(uart_addrs[obj->index], (uint32_t)baudrate, lpuart_src_freq);
 }
 
 void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits)


### PR DESCRIPTION
## Description
Initialize the UART clock inside the board file. This should fix the below issue 
https://github.com/ARMmbed/mbed-os/issues/4528

## Status
**READY

- [ ] Tests
Passed mbed tests on  K82F 
