### PR TITLE
Sort the config parameters before printing them

### DIFF
--- a/tools/get_config.py
+++ b/tools/get_config.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
         if params:
             print "Configuration parameters"
             print "------------------------"
-            for p in params:
+            for p in sorted(params):
                 for s in options.prefix:
                     if p.startswith(s):
                         print(str(params[p]) if not options.verbose else params[p].get_verbose_description())


### PR DESCRIPTION
## Description
This annoyed me! I fixed it!

When running `mbed compile --config`, the config options would be printed unsorted. This PR makes all the config options sorted!

Before:
```
C:\Users\bridan01\Documents\dev\m_mbed\mbed>mbed compile --config
Scan: .
Scan: FEATURE_BLE
Scan: FEATURE_COMMON_PAL
Scan: FEATURE_LWIP
Scan: FEATURE_UVISOR
Scan: FEATURE_ETHERNET_HOST
Scan: FEATURE_LOWPAN_BORDER_ROUTER
Scan: FEATURE_LOWPAN_HOST
Scan: FEATURE_LOWPAN_ROUTER
Scan: FEATURE_NANOSTACK
Scan: FEATURE_NANOSTACK_FULL
Scan: FEATURE_THREAD_BORDER_ROUTER
Scan: FEATURE_THREAD_END_DEVICE
Scan: FEATURE_THREAD_ROUTER
Scan: FEATURE_STORAGE
Configuration parameters
------------------------
lwip.enable-ppp-trace = 0 (macro name: "MBED_CONF_LWIP_ENABLE_PPP_TRACE")
lwip.addr-timeout = 5 (macro name: "MBED_CONF_LWIP_ADDR_TIMEOUT")
lwip.ipv4-enabled = 1 (macro name: "MBED_CONF_LWIP_IPV4_ENABLED")
lwip.default-thread-stacksize = 512 (macro name: "MBED_CONF_LWIP_DEFAULT_THREAD_STACKSIZE")
ppp-cell-iface.apn-lookup = 0 (macro name: "MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP")
events.present = 1 (macro name: "MBED_CONF_EVENTS_PRESENT")
lwip.tcpip-thread-stacksize = 1200 (macro name: "MBED_CONF_LWIP_TCPIP_THREAD_STACKSIZE")
lwip.ppp-thread-stacksize = 512 (macro name: "MBED_CONF_LWIP_PPP_THREAD_STACKSIZE")
platform.stdio-flush-at-exit = 1 (macro name: "MBED_CONF_PLATFORM_STDIO_FLUSH_AT_EXIT")
drivers.uart-serial-rxbuf-size = 256 (macro name: "MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE")
nsapi.present = 1 (macro name: "MBED_CONF_NSAPI_PRESENT")
filesystem.present = 1 (macro name: "MBED_CONF_FILESYSTEM_PRESENT")
ppp-cell-iface.baud-rate = 115200 (macro name: "MBED_CONF_PPP_CELL_IFACE_BAUD_RATE")
ppp-cell-iface.at-parser-timeout = 8000 (macro name: "MBED_CONF_PPP_CELL_IFACE_AT_PARSER_TIMEOUT")
ppp-cell-iface.at-parser-buffer-size = 256 (macro name: "MBED_CONF_PPP_CELL_IFACE_AT_PARSER_BUFFER_SIZE")
platform.stdio-baud-rate = 9600 (macro name: "MBED_CONF_PLATFORM_STDIO_BAUD_RATE")
lwip.ipv6-enabled = 0 (macro name: "MBED_CONF_LWIP_IPV6_ENABLED")
lwip.ip-ver-pref = 4 (macro name: "MBED_CONF_LWIP_IP_VER_PREF")
lwip.tcp-server-max = 4 (macro name: "MBED_CONF_LWIP_TCP_SERVER_MAX")
platform.default-serial-baud-rate = 9600 (macro name: "MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE")
lwip.tcp-socket-max = 4 (macro name: "MBED_CONF_LWIP_TCP_SOCKET_MAX")
rtos.present = 1 (macro name: "MBED_CONF_RTOS_PRESENT")
lwip.tcp-enabled = 1 (macro name: "MBED_CONF_LWIP_TCP_ENABLED")
lwip.debug-enabled = 0 (macro name: "MBED_CONF_LWIP_DEBUG_ENABLED")
configuration-store.storage_disable = 0 (macro name: "CFSTORE_STORAGE_DISABLE")
lwip.ppp-enabled = 0 (macro name: "NSAPI_PPP_AVAILABLE")
drivers.uart-serial-txbuf-size = 256 (macro name: "MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE")
lwip.udp-socket-max = 4 (macro name: "MBED_CONF_LWIP_UDP_SOCKET_MAX")
lwip.use-mbed-trace = 0 (macro name: "MBED_CONF_LWIP_USE_MBED_TRACE")
platform.stdio-convert-newlines = 0 (macro name: "MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES")
lwip.ethernet-enabled = 1 (macro name: "MBED_CONF_LWIP_ETHERNET_ENABLED")
lwip.socket-max = 4 (macro name: "MBED_CONF_LWIP_SOCKET_MAX")

Macros
------
Defined with "macros": ['UNITY_INCLUDE_CONFIG_H']
Generated from configuration parameters: ['MBED_CONF_LWIP_ENABLE_PPP_TRACE=0', 'MBED_CONF_LWIP_ADDR_TIMEOUT=5', 'MBED_CONF_LWIP_IPV4_ENABLED=1', 'MBED_CONF_LWIP_DEFAULT_THREAD_STACKSIZE=512', 'MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP=0', 'MBED_CONF_EVENTS_PRESENT=1', 'MBED_CONF_LWIP_TCPIP_THREAD_STACKSIZE=1200', 'MBED_CONF_LWIP_PPP_THREAD_STACKSIZE=512', 'MBED_CONF_PLATFORM_STDIO_FLUSH_AT_EXIT=1', 'MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE=256', 'MBED_CONF_NSAPI_PRESENT=1', 'MBED_CONF_FILESYSTEM_PRESENT=1', 'MBED_CONF_PPP_CELL_IFACE_BAUD_RATE=115200', 'MBED_CONF_PPP_CELL_IFACE_AT_PARSER_TIMEOUT=8000', 'MBED_CONF_PPP_CELL_IFACE_AT_PARSER_BUFFER_SIZE=256', 'MBED_CONF_PLATFORM_STDIO_BAUD_RATE=9600', 'MBED_CONF_LWIP_IPV6_ENABLED=0', 'MBED_CONF_LWIP_IP_VER_PREF=4', 'MBED_CONF_LWIP_TCP_SERVER_MAX=4', 'MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE=9600', 'MBED_CONF_LWIP_TCP_SOCKET_MAX=4', 'MBED_CONF_RTOS_PRESENT=1', 'MBED_CONF_LWIP_TCP_ENABLED=1', 'MBED_CONF_LWIP_DEBUG_ENABLED=0', 'CFSTORE_STORAGE_DISABLE=0', 'NSAPI_PPP_AVAILABLE=0', 'MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE=256', 'MBED_CONF_LWIP_UDP_SOCKET_MAX=4', 'MBED_CONF_LWIP_USE_MBED_TRACE=0', 'MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES=0', 'MBED_CONF_LWIP_ETHERNET_ENABLED=1', 'MBED_CONF_LWIP_SOCKET_MAX=4']
```

After:
```
C:\Users\bridan01\Documents\dev\m_mbed\mbed>mbed compile --config
Scan: .
Scan: FEATURE_BLE
Scan: FEATURE_COMMON_PAL
Scan: FEATURE_LWIP
Scan: FEATURE_UVISOR
Scan: FEATURE_ETHERNET_HOST
Scan: FEATURE_LOWPAN_BORDER_ROUTER
Scan: FEATURE_LOWPAN_HOST
Scan: FEATURE_LOWPAN_ROUTER
Scan: FEATURE_NANOSTACK
Scan: FEATURE_NANOSTACK_FULL
Scan: FEATURE_THREAD_BORDER_ROUTER
Scan: FEATURE_THREAD_END_DEVICE
Scan: FEATURE_THREAD_ROUTER
Scan: FEATURE_STORAGE
Configuration parameters
------------------------
configuration-store.storage_disable = 0 (macro name: "CFSTORE_STORAGE_DISABLE")
drivers.uart-serial-rxbuf-size = 256 (macro name: "MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE")
drivers.uart-serial-txbuf-size = 256 (macro name: "MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE")
events.present = 1 (macro name: "MBED_CONF_EVENTS_PRESENT")
filesystem.present = 1 (macro name: "MBED_CONF_FILESYSTEM_PRESENT")
lwip.addr-timeout = 5 (macro name: "MBED_CONF_LWIP_ADDR_TIMEOUT")
lwip.debug-enabled = 0 (macro name: "MBED_CONF_LWIP_DEBUG_ENABLED")
lwip.default-thread-stacksize = 512 (macro name: "MBED_CONF_LWIP_DEFAULT_THREAD_STACKSIZE")
lwip.enable-ppp-trace = 0 (macro name: "MBED_CONF_LWIP_ENABLE_PPP_TRACE")
lwip.ethernet-enabled = 1 (macro name: "MBED_CONF_LWIP_ETHERNET_ENABLED")
lwip.ip-ver-pref = 4 (macro name: "MBED_CONF_LWIP_IP_VER_PREF")
lwip.ipv4-enabled = 1 (macro name: "MBED_CONF_LWIP_IPV4_ENABLED")
lwip.ipv6-enabled = 0 (macro name: "MBED_CONF_LWIP_IPV6_ENABLED")
lwip.ppp-enabled = 0 (macro name: "NSAPI_PPP_AVAILABLE")
lwip.ppp-thread-stacksize = 512 (macro name: "MBED_CONF_LWIP_PPP_THREAD_STACKSIZE")
lwip.socket-max = 4 (macro name: "MBED_CONF_LWIP_SOCKET_MAX")
lwip.tcp-enabled = 1 (macro name: "MBED_CONF_LWIP_TCP_ENABLED")
lwip.tcp-server-max = 4 (macro name: "MBED_CONF_LWIP_TCP_SERVER_MAX")
lwip.tcp-socket-max = 4 (macro name: "MBED_CONF_LWIP_TCP_SOCKET_MAX")
lwip.tcpip-thread-stacksize = 1200 (macro name: "MBED_CONF_LWIP_TCPIP_THREAD_STACKSIZE")
lwip.udp-socket-max = 4 (macro name: "MBED_CONF_LWIP_UDP_SOCKET_MAX")
lwip.use-mbed-trace = 0 (macro name: "MBED_CONF_LWIP_USE_MBED_TRACE")
nsapi.present = 1 (macro name: "MBED_CONF_NSAPI_PRESENT")
platform.default-serial-baud-rate = 9600 (macro name: "MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE")
platform.stdio-baud-rate = 9600 (macro name: "MBED_CONF_PLATFORM_STDIO_BAUD_RATE")
platform.stdio-convert-newlines = 0 (macro name: "MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES")
platform.stdio-flush-at-exit = 1 (macro name: "MBED_CONF_PLATFORM_STDIO_FLUSH_AT_EXIT")
ppp-cell-iface.apn-lookup = 0 (macro name: "MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP")
ppp-cell-iface.at-parser-buffer-size = 256 (macro name: "MBED_CONF_PPP_CELL_IFACE_AT_PARSER_BUFFER_SIZE")
ppp-cell-iface.at-parser-timeout = 8000 (macro name: "MBED_CONF_PPP_CELL_IFACE_AT_PARSER_TIMEOUT")
ppp-cell-iface.baud-rate = 115200 (macro name: "MBED_CONF_PPP_CELL_IFACE_BAUD_RATE")
rtos.present = 1 (macro name: "MBED_CONF_RTOS_PRESENT")

Macros
------
Defined with "macros": ['UNITY_INCLUDE_CONFIG_H']
Generated from configuration parameters: ['MBED_CONF_LWIP_ENABLE_PPP_TRACE=0', 'MBED_CONF_LWIP_ADDR_TIMEOUT=5', 'MBED_CONF_LWIP_IPV4_ENABLED=1', 'MBED_CONF_LWIP_DEFAULT_THREAD_STACKSIZE=512', 'MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP=0', 'MBED_CONF_EVENTS_PRESENT=1', 'MBED_CONF_LWIP_TCPIP_THREAD_STACKSIZE=1200', 'MBED_CONF_LWIP_PPP_THREAD_STACKSIZE=512', 'MBED_CONF_PLATFORM_STDIO_FLUSH_AT_EXIT=1', 'MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE=256', 'MBED_CONF_NSAPI_PRESENT=1', 'MBED_CONF_FILESYSTEM_PRESENT=1', 'MBED_CONF_PPP_CELL_IFACE_BAUD_RATE=115200', 'MBED_CONF_PPP_CELL_IFACE_AT_PARSER_TIMEOUT=8000', 'MBED_CONF_PPP_CELL_IFACE_AT_PARSER_BUFFER_SIZE=256', 'MBED_CONF_PLATFORM_STDIO_BAUD_RATE=9600', 'MBED_CONF_LWIP_IPV6_ENABLED=0', 'MBED_CONF_LWIP_IP_VER_PREF=4', 'MBED_CONF_LWIP_TCP_SERVER_MAX=4', 'MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE=9600', 'MBED_CONF_LWIP_TCP_SOCKET_MAX=4', 'MBED_CONF_RTOS_PRESENT=1', 'MBED_CONF_LWIP_TCP_ENABLED=1', 'MBED_CONF_LWIP_DEBUG_ENABLED=0', 'CFSTORE_STORAGE_DISABLE=0', 'NSAPI_PPP_AVAILABLE=0', 'MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE=256', 'MBED_CONF_LWIP_UDP_SOCKET_MAX=4', 'MBED_CONF_LWIP_USE_MBED_TRACE=0', 'MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES=0', 'MBED_CONF_LWIP_ETHERNET_ENABLED=1', 'MBED_CONF_LWIP_SOCKET_MAX=4']
```

## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO



## Todos
No morph tests necessary (no coverage added). Travis should be good enough. I tested this locally and everything was ok!
