### PR TITLE
Fix NUCLEO_L476RG linker scripts

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_ARM_MICRO/stm32l476xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_ARM_MICRO/stm32l476xx.sct
@@ -33,7 +33,7 @@
 #endif
 
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x200000
+  #define MBED_APP_SIZE 0x100000
 #endif
 
 ; 1MB FLASH (0x100000) + 128KB SRAM (0x20000)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_ARM_STD/stm32l476xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_ARM_STD/stm32l476xx.sct
@@ -33,7 +33,7 @@
 #endif
 
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x200000
+  #define MBED_APP_SIZE 0x100000
 #endif
 
 ; 1MB FLASH (0x100000) + 128KB SRAM (0x20000)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
@@ -3,7 +3,7 @@
 #endif
 
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 2048k
+  #define MBED_APP_SIZE 1024k
 #endif
 
 /* Linker script to configure memory regions. */

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
@@ -9,8 +9,7 @@
 /* Linker script to configure memory regions. */
 MEMORY
 { 
-  VECTORS (rx) : ORIGIN = MBED_APP_START, LENGTH = 0x400
-  FLASH (rx)   : ORIGIN = MBED_APP_START + 0x400, LENGTH = MBED_APP_SIZE - 0x400
+  FLASH (rx)   : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
   SRAM2 (rwx)  : ORIGIN = 0x10000188, LENGTH = 32k - 0x188
   SRAM1 (rwx)  : ORIGIN = 0x20000000, LENGTH = 96k
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_IAR/stm32l476xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_IAR/stm32l476xx.icf
@@ -1,5 +1,5 @@
 if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
-if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x200000; }
+if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x100000; }
 
 /* [ROM = 1024kb = 0x100000] */
 define symbol __intvec_start__     = MBED_APP_START;


### PR DESCRIPTION
## Description

Fix to #4553

Following Merge pull request #4063 from LMESTM/17q2_L4_bootloader
the NUCLEO_L476RG binairies could not boot anymore.

The change done in #4063 was derived from work on NUCLEO_L429ZI target
which supports uvisor. The VECTORS defintiion is introduced as part of
uvisor support and requires further changes in ld file which were missing.
As uvisor is not considered yet, we remove VECTORS for now and will
introduce only when needed.

While fixing this issue, I also found out that FLASH size was wrongly defined 
and fixed this in 2nd commit

## Status
**READY**

## Related PRs
- [x] #4543 also needed => MERGED

## Todos
- [ ] Tests
Tested with basic OS2 and OS5 localy
