### PR TITLE
TCP socket semaphores changed to binary sempahore

### DIFF
--- a/features/netsocket/TCPSocket.cpp
+++ b/features/netsocket/TCPSocket.cpp
@@ -18,8 +18,10 @@
 #include "Timer.h"
 #include "mbed_assert.h"
 
+// Binary sempahore
+#define BINARY_SEMAPHORE       1
 TCPSocket::TCPSocket()
-    : _pending(0), _read_sem(0), _write_sem(0),
+    : _pending(0), _read_sem(0, BINARY_SEMAPHORE), _write_sem(0, BINARY_SEMAPHORE),
       _read_in_progress(false), _write_in_progress(false)
 {
 }

--- a/features/netsocket/TCPSocket.cpp
+++ b/features/netsocket/TCPSocket.cpp
@@ -18,10 +18,10 @@
 #include "Timer.h"
 #include "mbed_assert.h"
 
-// Binary sempahore
-#define BINARY_SEMAPHORE       1
+
+// Max count for Sockets is set as 1: as we need Binary Semaphore.
 TCPSocket::TCPSocket()
-    : _pending(0), _read_sem(0, BINARY_SEMAPHORE), _write_sem(0, BINARY_SEMAPHORE),
+    : _pending(0), _read_sem(0, 1), _write_sem(0, 1),
       _read_in_progress(false), _write_in_progress(false)
 {
 }

--- a/features/netsocket/UDPSocket.cpp
+++ b/features/netsocket/UDPSocket.cpp
@@ -18,8 +18,9 @@
 #include "Timer.h"
 #include "mbed_assert.h"
 
+// Max count for Sockets is set as 1: as we need Binary Semaphore.
 UDPSocket::UDPSocket()
-    : _pending(0), _read_sem(0), _write_sem(0)
+    : _pending(0), _read_sem(0, 1), _write_sem(0, 1)
 {
 }
 

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1014,6 +1014,12 @@ extern "C" void EvrRtxMutexError (osMutexId_t mutex_id, int32_t status)
 
 extern "C" void EvrRtxSemaphoreError (osSemaphoreId_t semaphore_id, int32_t status)
 {
+    /* In case of binary sempahore do not set this failure,
+     * Binary semaphore is allowed to perform release without acquire
+     */
+    if ((osRtxErrorSemaphoreCountLimit == status) && (1 == svcRtxSemaphoreGetCount(semaphore_id))) {
+        return;
+    }
     error("Semaphore %p error %i\r\n", semaphore_id, status);
 }
 


### PR DESCRIPTION
## Description
Data from UART can come in before we are ready for wait in receive call. Hence, semaphore release happens before it gets acquired in current implementation. As release was performed for every UART event max count (1024) was reached and as a result semaphore count error was set from RTX. 

Requirement was to have a binary semaphore, allowed to perform release any times. Ignore if count is already 1.

## Status
**READY**

Issue:  
#4575 