### PR TITLE
fatfs: Fixed initialization of block device in mount/unmount functions

### DIFF
--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -247,10 +247,10 @@ FATFileSystem::~FATFileSystem()
 
 int FATFileSystem::mount(BlockDevice *bd) {
     // requires duplicate definition to allow virtual overload to work
-    return mount(bd, false);
+    return mount(bd, true);
 }
 
-int FATFileSystem::mount(BlockDevice *bd, bool force) {
+int FATFileSystem::mount(BlockDevice *bd, bool mount) {
     lock();
     if (_id != -1) {
         unlock();
@@ -265,7 +265,7 @@ int FATFileSystem::mount(BlockDevice *bd, bool force) {
             _fsid[1] = ':';
             _fsid[2] = '\0';
             debug_if(FFS_DBG, "Mounting [%s] on ffs drive [%s]\n", getName(), _fsid);
-            FRESULT res = f_mount(&_fs, _fsid, force);
+            FRESULT res = f_mount(&_fs, _fsid, mount);
             unlock();
             return fat_error_remap(res);
         }

--- a/features/filesystem/fat/FATFileSystem.h
+++ b/features/filesystem/fat/FATFileSystem.h
@@ -69,14 +69,6 @@ public:
      */
     virtual int mount(BlockDevice *bd);
 
-    /** Mounts a filesystem to a block device
-     *
-     *  @param bd       BlockDevice to mount to
-     *  @param force    Flag to force the underlying filesystem to force mounting the filesystem
-     *  @return         0 on success, negative error code on failure
-     */
-    virtual int mount(BlockDevice *bd, bool force);
-
     /** Unmounts a filesystem from the underlying block device
      *
      *  @return         0 on success, negative error code on failure
@@ -235,6 +227,7 @@ private:
 protected:
     virtual void lock();
     virtual void unlock();
+    virtual int mount(BlockDevice *bd, bool mount);
 };
 
 #endif


### PR DESCRIPTION
At some point the "mount" parameter for "f_mount" was name "force". This led to a bit of confusion that ended with the default mount function never calling block device init.

This is fine, since the block device can be manually initialized, but a better user experience is where the filesystem initializes the block device for the user.

This is backwards compatible due to the repeatability of the block device init functions.

related issues #4526, https://github.com/ARMmbed/mbed-os/issues/4407