### PR TITLE
events: Adopt osEventFlags from RTX 5

### DIFF
--- a/events/equeue/equeue_mbed.cpp
+++ b/events/equeue/equeue_mbed.cpp
@@ -86,18 +86,21 @@ void equeue_mutex_unlock(equeue_mutex_t *m) {
 #ifdef MBED_CONF_RTOS_PRESENT
 
 int equeue_sema_create(equeue_sema_t *s) {
-    MBED_STATIC_ASSERT(sizeof(equeue_sema_t) >= sizeof(Semaphore),
-            "The equeue_sema_t must fit the class Semaphore");
-    new (s) Semaphore(0);
-    return 0;
+    osEventFlagsAttr_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.cb_mem = &s->mem;
+    attr.cb_size = sizeof(s->mem);
+
+    s->id = osEventFlagsNew(&attr);
+    return !s->id ? -1 : 0;
 }
 
 void equeue_sema_destroy(equeue_sema_t *s) {
-    reinterpret_cast<Semaphore*>(s)->~Semaphore();
+    osEventFlagsDelete(s->id);
 }
 
 void equeue_sema_signal(equeue_sema_t *s) {
-    reinterpret_cast<Semaphore*>(s)->release();
+    osEventFlagsSet(s->id, 1);
 }
 
 bool equeue_sema_wait(equeue_sema_t *s, int ms) {
@@ -105,7 +108,7 @@ bool equeue_sema_wait(equeue_sema_t *s, int ms) {
         ms = osWaitForever;
     }
 
-    return (reinterpret_cast<Semaphore*>(s)->wait(ms) > 0);
+    return (osEventFlagsWait(s->id, 1, osFlagsWaitAny, ms) == 1);
 }
 
 #else

--- a/events/equeue/equeue_platform.h
+++ b/events/equeue/equeue_platform.h
@@ -49,6 +49,9 @@ extern "C" {
 // Platform includes
 #if defined(EQUEUE_PLATFORM_POSIX)
 #include <pthread.h>
+#elif defined(EQUEUE_PLATFORM_MBED)
+#include "cmsis_os2.h"
+#include "rtx_lib.h"
 #endif
 
 
@@ -112,7 +115,10 @@ typedef struct equeue_sema {
     bool signal;
 } equeue_sema_t;
 #elif defined(EQUEUE_PLATFORM_MBED) && defined(MBED_CONF_RTOS_PRESENT)
-typedef unsigned equeue_sema_t[9];
+typedef struct equeue_sema {
+    osEventFlagsId_t id;
+    os_event_flags_t mem;
+} equeue_sema_t;
 #elif defined(EQUEUE_PLATFORM_MBED)
 typedef volatile int equeue_sema_t;
 #endif


### PR DESCRIPTION
This provides the correct binary semaphore behaviour that was expected by the equeue layer, removes concerns around semaphore overflow, and reduces the number of spurious wakeups which may save a bit of power.

This also fixes some issues we were seeing around the RTX 5 changes to semaphore behaviour.

related issue https://github.com/ARMmbed/mbed-os/pull/4500
cc @pan-, @tomasfrisbergublox, @hesolium 

## Tests
- [ ] /morph test-nightly