### PR TITLE
Turn off "browse information" in Uvision template

### DIFF
--- a/tools/export/uvision/uvision.tmpl
+++ b/tools/export/uvision/uvision.tmpl
@@ -52,7 +52,7 @@
           <CreateLib>0</CreateLib>
           <CreateHexFile>0</CreateHexFile>
           <DebugInformation>1</DebugInformation>
-          <BrowseInformation>1</BrowseInformation>
+          <BrowseInformation>0</BrowseInformation>
           <ListingPath>.\BUILD\</ListingPath>
           <HexFormatSelection>1</HexFormatSelection>
           <Merge32K>0</Merge32K>


### PR DESCRIPTION
## Description
We were seeing extraordinarily long build times in Uvision 5.24. Sometimes > than 20 minutes for blinky. @bridadan reported 10 minute builds during export-build tests, even on the CI machines. I've found that enabling Uvision's "browse information," which is essentially their indexer, is responsible for this. With this option turned off, I saw a **19** minute reduction in build time when compiling blinky for NUCLEO_F439ZI.

As a note, I realize this is an important feature for the IDE. If a user tries to use it when the option is turned off, Uvision provides instructions for turning it on. 


## Status
**READY**


## Steps to test or reproduce
In uvision, go to: options for target > output> browse information. Try compiling with it on/off. 

@theotherjimmy 
