### PR TITLE
RTOS: Fix semaphore

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1014,6 +1014,11 @@ extern "C" void EvrRtxMutexError (osMutexId_t mutex_id, int32_t status)
 
 extern "C" void EvrRtxSemaphoreError (osSemaphoreId_t semaphore_id, int32_t status)
 {
+    // Ignore semaphore overflow, the count will saturate with a returned error
+    if (status == osRtxErrorSemaphoreCountLimit) {
+        return;
+    }
+
     error("Semaphore %p error %i\r\n", semaphore_id, status);
 }
 

--- a/rtos/Semaphore.cpp
+++ b/rtos/Semaphore.cpp
@@ -27,7 +27,7 @@
 namespace rtos {
 
 Semaphore::Semaphore(int32_t count) {
-    constructor(count, 1024);
+    constructor(count, 0xffff);
 }
 
 Semaphore::Semaphore(int32_t count, uint16_t max_count) {


### PR DESCRIPTION
Before RTX 5, the semaphore count limit was UINT16_MAX as a side effect of using a uint16_t ([here](https://github.com/ARMmbed/mbed-os/blob/5fff7e1daeb395aa3d1ecf3f9ec3f4fead3de0c2/rtos/rtx/TARGET_CORTEX_M/rt_TypeDef.h#L139)). After https://github.com/ARMmbed/mbed-os/pull/4294 was merged, the count limit was dropped to the arbitrary value 1024 ([here](https://github.com/ARMmbed/mbed-os/blob/master/rtos/Semaphore.cpp#L30)). Additionally, https://github.com/ARMmbed/mbed-os/pull/4389 added an assert that would halt if the semaphore count exceeded this limit ([here](https://github.com/ARMmbed/mbed-os/blob/master/rtos/rtx5/TARGET_CORTEX_M/rtx_semaphore.c#L285) and [here](https://github.com/ARMmbed/mbed-os/blob/master/platform/mbed_retarget.cpp#L1017)).

This is especially problematic for applications that are using the semaphore for signaling. In RTX 4, the semaphore was the only library-friendly mechanism available for signaling, and in RTX 5 it is still the only option for the C++ layer.

This has already broken several higher-level apis, and we haven't even made the 5.5 release yet:
- https://github.com/ARMmbed/mbed-os/pull/4449 The emac layer for the lpc1768 broke. Looking around it's possible quite a few other emacs are broken as well ([k64f](https://github.com/ARMmbed/mbed-os/blob/master/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_Freescale/k64f_emac.c#L122), [rz_a1h](https://github.com/ARMmbed/mbed-os/blob/master/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_RZ_A1H/rza1_emac.c#L139)). Workaround seems to be keeping a track of the number of buffers that could possibly be enqueued.
- https://github.com/ARMmbed/mbed-os/pull/4571 The event queue broke, workaround is to adopt the osEventFlags in the C layer.
- https://github.com/ARMmbed/mbed-os/issues/4575 Sockets broke, no workaround available yet.

If we're already having breakages internally, I'm not really looking forward to next week when the release is out.

---

On top of the breakage, we don't really have a path for users. In the C++ api, a semaphore is the _only_ library friendly signaling mechanism. RTX has thread signals, but these are limited to a single bit-field that is shared with users. @YarivCol is working on a wrapper for the osEventFlags https://github.com/ARMmbed/mbed-os/pull/4517, but it's not ready to merge yet. 

Lets look at how other libraries handle semaphore overflow:
- Linux returns EOVERFLOW, but otherwise saturates ([ref](http://man7.org/linux/man-pages/man3/sem_post.3.html))
- Windows returns false, but otherwise saturates ([ref](https://msdn.microsoft.com/en-us/library/ms919171.aspx))
- FreeRTOS returns errQUEUE_FULL, but otherwise saturates ([ref](http://www.freertos.org/a00124.html))
- Java, an exception heavy language, just saturates without warning ([ref](https://docs.oracle.com/javase/6/docs/api/java/util/concurrent/Semaphore.html))

By changing the semaphores behaviour and ruling out the use of semaphores for signaling, we're challenging the user's expectations rather than providing a tool they are familiar with.

---

This patch removes the assertion on semaphore overflow and instead relies on the semaphore saturation introduced in RTX 5. This should match how a user expects a semaphore to behave and returns the ability to use semaphores for signaling.

related issues https://github.com/ARMmbed/mbed-os/pull/4580, https://github.com/ARMmbed/mbed-os/issues/4575, https://github.com/ARMmbed/mbed-os/pull/4571, https://github.com/ARMmbed/mbed-os/pull/4560, https://github.com/ARMmbed/mbed-os/pull/4517, https://github.com/ARMmbed/mbed-os/pull/4500, https://github.com/ARMmbed/mbed-os/issues/4492, https://github.com/ARMmbed/mbed-os/pull/4449
cc @sg-, @c1728p9, @deepikabhavnani, @pan-, @kjbracey-arm 