### PR TITLE
Use EventFlags instead of Semaphores

### DIFF
--- a/features/netsocket/TCPSocket.h
+++ b/features/netsocket/TCPSocket.h
@@ -23,7 +23,7 @@
 #include "netsocket/Socket.h"
 #include "netsocket/NetworkStack.h"
 #include "netsocket/NetworkInterface.h"
-#include "rtos/Semaphore.h"
+#include "rtos/EventFlags.h"
 
 
 /** TCP socket connection
@@ -45,7 +45,7 @@ public:
      */
     template <typename S>
     TCPSocket(S *stack)
-        : _pending(0), _read_sem(0), _write_sem(0),
+        : _pending(0), _event_flag(0),
           _read_in_progress(false), _write_in_progress(false)
     {
         open(stack);
@@ -117,8 +117,7 @@ protected:
     virtual void event();
 
     volatile unsigned _pending;
-    rtos::Semaphore _read_sem;
-    rtos::Semaphore _write_sem;
+    rtos::EventFlags _event_flag;
     bool _read_in_progress;
     bool _write_in_progress;
 };

--- a/features/netsocket/UDPSocket.cpp
+++ b/features/netsocket/UDPSocket.cpp
@@ -18,8 +18,12 @@
 #include "Timer.h"
 #include "mbed_assert.h"
 
+#define TCP_EVENT           "UDP_Events"
+#define READ_FLAG           0x1u
+#define WRITE_FLAG          0x2u
+
 UDPSocket::UDPSocket()
-    : _pending(0), _read_sem(0), _write_sem(0)
+    : _pending(0), _event_flag()
 {
 }
 
@@ -64,16 +68,16 @@ nsapi_size_or_error_t UDPSocket::sendto(const SocketAddress &address, const void
             ret = sent;
             break;
         } else {
-            int32_t count;
+            uint32_t flag;
 
             // Release lock before blocking so other threads
             // accessing this object aren't blocked
             _lock.unlock();
-            count = _write_sem.wait(_timeout);
+            flag = _event_flag.wait_any(WRITE_FLAG, _timeout);
             _lock.lock();
 
-            if (count < 1) {
-                // Semaphore wait timed out so break out and return
+            if (flag & osFlagsError) {
+                // Timeout break
                 ret = NSAPI_ERROR_WOULD_BLOCK;
                 break;
             }
@@ -101,16 +105,16 @@ nsapi_size_or_error_t UDPSocket::recvfrom(SocketAddress *address, void *buffer, 
             ret = recv;
             break;
         } else {
-            int32_t count;
+            uint32_t flag;
 
             // Release lock before blocking so other threads
             // accessing this object aren't blocked
             _lock.unlock();
-            count = _read_sem.wait(_timeout);
+            flag = _event_flag.wait_any(READ_FLAG, _timeout);
             _lock.lock();
 
-            if (count < 1) {
-                // Semaphore wait timed out so break out and return
+            if (flag & osFlagsError) {
+                // Timeout break
                 ret = NSAPI_ERROR_WOULD_BLOCK;
                 break;
             }
@@ -123,8 +127,7 @@ nsapi_size_or_error_t UDPSocket::recvfrom(SocketAddress *address, void *buffer, 
 
 void UDPSocket::event()
 {
-    _write_sem.release();
-    _read_sem.release();
+    _event_flag.set(READ_FLAG|WRITE_FLAG);
 
     _pending += 1;
     if (_callback && _pending == 1) {

--- a/features/netsocket/UDPSocket.h
+++ b/features/netsocket/UDPSocket.h
@@ -23,7 +23,7 @@
 #include "netsocket/Socket.h"
 #include "netsocket/NetworkStack.h"
 #include "netsocket/NetworkInterface.h"
-#include "rtos/Semaphore.h"
+#include "rtos/EventFlags.h"
 
 
 /** UDP socket
@@ -45,7 +45,7 @@ public:
      */
     template <typename S>
     UDPSocket(S *stack)
-        : _pending(0), _read_sem(0), _write_sem(0)
+        : _pending(0), _event_flag(0)
     {
         open(stack);
     }
@@ -117,8 +117,7 @@ protected:
     virtual void event();
 
     volatile unsigned _pending;
-    rtos::Semaphore _read_sem;
-    rtos::Semaphore _write_sem;
+    rtos::EventFlags _event_flag;
 };
 
 


### PR DESCRIPTION
## Description
Synchronization in sockets required binary semaphores which is not available
in RTX5, hence switching to event flags.
Issue #4575

## Migrations
PR should be merged after PR #4517. EventFlags Class implementation is picked up from this PR.

## Related PRs
PR #4517 
PR #4560 

## Todos
- [x] Merge / Rebase to PR #4517 
- [x] Tests
