### PR TITLE
[ONME-3089] - Adjust lowpan ND interface connect timeout

### DIFF
--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/LoWPANNDInterface.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/LoWPANNDInterface.cpp
@@ -39,7 +39,8 @@ int LoWPANNDInterface::connect()
     // Release mutex before blocking
     nanostack_unlock();
 
-    int32_t count = connect_semaphore.wait(30000);
+    // wait connection for ever
+    int32_t count = connect_semaphore.wait(osWaitForever);
 
     if (count <= 0) {
         return NSAPI_ERROR_DHCP_FAILURE; // sort of...


### PR DESCRIPTION
Thread already changed interface connection timeout to wait forever, 
so the lowpan ND needs to change too.

Device needs to wait for connectivity:
-routers will create new network and get local connectivity
-end device will get connectivity once attached to existing network
-devices without network settings gets connectivity once
 commissioned and attached to network