### PR TITLE
Introduce mbed::NonCopyable traits

### DIFF
--- a/drivers/BusIn.h
+++ b/drivers/BusIn.h
@@ -19,6 +19,7 @@
 #include "platform/platform.h"
 #include "drivers/DigitalIn.h"
 #include "platform/PlatformMutex.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -28,7 +29,7 @@ namespace mbed {
  * @note Synchronization level: Thread safe
  * @ingroup drivers
  */
-class BusIn {
+class BusIn : private NonCopyable<BusIn> {
 
 public:
     /* Group: Configuration Methods */
@@ -115,12 +116,9 @@ protected:
 
     PlatformMutex _mutex;
 
-    /* disallow copy constructor and assignment operators */
 private:
     virtual void lock();
     virtual void unlock();
-    BusIn(const BusIn&);
-    BusIn & operator = (const BusIn&);
 };
 
 } // namespace mbed

--- a/drivers/BusInOut.h
+++ b/drivers/BusInOut.h
@@ -18,6 +18,7 @@
 
 #include "drivers/DigitalInOut.h"
 #include "platform/PlatformMutex.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -27,7 +28,7 @@ namespace mbed {
  * @note Synchronization level: Thread safe
  * @ingroup drivers
  */
-class BusInOut {
+class BusInOut : private NonCopyable<BusInOut> {
 
 public:
 
@@ -135,11 +136,6 @@ protected:
     int _nc_mask;
 
     PlatformMutex _mutex;
-
-    /* disallow copy constructor and assignment operators */
-private:
-    BusInOut(const BusInOut&);
-    BusInOut & operator = (const BusInOut&);
 };
 
 } // namespace mbed

--- a/drivers/BusOut.h
+++ b/drivers/BusOut.h
@@ -18,6 +18,7 @@
 
 #include "drivers/DigitalOut.h"
 #include "platform/PlatformMutex.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -25,7 +26,7 @@ namespace mbed {
 /** A digital output bus, used for setting the state of a collection of pins
  * @ingroup drivers
  */
-class BusOut {
+class BusOut : private NonCopyable<BusOut> {
 
 public:
 
@@ -119,11 +120,6 @@ protected:
     int _nc_mask;
 
     PlatformMutex _mutex;
-
-   /* disallow copy constructor and assignment operators */
-private:
-    BusOut(const BusOut&);
-    BusOut & operator = (const BusOut&);
 };
 
 } // namespace mbed

--- a/drivers/CAN.h
+++ b/drivers/CAN.h
@@ -23,6 +23,7 @@
 #include "hal/can_api.h"
 #include "platform/Callback.h"
 #include "platform/PlatformMutex.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -78,7 +79,7 @@ public:
 /** A can bus client, used for communicating with can devices
  * @ingroup drivers
  */
-class CAN {
+class CAN : private NonCopyable<CAN> {
 
 public:
     /** Creates an CAN interface connected to specific pins.

--- a/drivers/Ethernet.h
+++ b/drivers/Ethernet.h
@@ -17,6 +17,7 @@
 #define MBED_ETHERNET_H
 
 #include "platform/platform.h"
+#include "platform/NonCopyable.h"
 
 #if defined (DEVICE_ETHERNET) || defined(DOXYGEN_ONLY)
 
@@ -54,7 +55,7 @@ namespace mbed {
  * @endcode
  * @ingroup drivers
  */
-class Ethernet {
+class Ethernet : private NonCopyable<Ethernet> {
 
 public:
 

--- a/drivers/FlashIAP.h
+++ b/drivers/FlashIAP.h
@@ -27,6 +27,7 @@
 #include "flash_api.h"
 #include "platform/SingletonPtr.h"
 #include "platform/PlatformMutex.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 
@@ -37,7 +38,7 @@ namespace mbed {
  * @note Synchronization level: Thread safe
  * @ingroup drivers
  */
-class FlashIAP {
+class FlashIAP : private NonCopyable<FlashIAP> {
 public:
     FlashIAP();
     ~FlashIAP();

--- a/drivers/I2C.h
+++ b/drivers/I2C.h
@@ -23,6 +23,7 @@
 #include "hal/i2c_api.h"
 #include "platform/SingletonPtr.h"
 #include "platform/PlatformMutex.h"
+#include "platform/NonCopyable.h"
 
 #if DEVICE_I2C_ASYNCH
 #include "platform/CThunk.h"
@@ -53,7 +54,7 @@ namespace mbed {
  * @endcode
  * @ingroup drivers
  */
-class I2C {
+class I2C : private NonCopyable<I2C> {
 
 public:
     enum RxStatus {

--- a/drivers/InterruptIn.h
+++ b/drivers/InterruptIn.h
@@ -25,6 +25,7 @@
 #include "platform/Callback.h"
 #include "platform/mbed_critical.h"
 #include "platform/mbed_toolchain.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -56,7 +57,7 @@ namespace mbed {
  * @endcode
  * @ingroup drivers
  */
-class InterruptIn {
+class InterruptIn : private NonCopyable<InterruptIn> {
 
 public:
 

--- a/drivers/InterruptManager.h
+++ b/drivers/InterruptManager.h
@@ -19,6 +19,7 @@
 #include "cmsis.h"
 #include "platform/CallChain.h"
 #include "platform/PlatformMutex.h"
+#include "platform/NonCopyable.h"
 #include <string.h>
 
 namespace mbed {
@@ -53,7 +54,7 @@ namespace mbed {
  * @endcode
  * @ingroup drivers
  */
-class InterruptManager {
+class InterruptManager : private NonCopyable<InterruptManager> {
 public:
     /** Get the instance of InterruptManager Class
      *
@@ -137,12 +138,6 @@ private:
 
     void lock();
     void unlock();
-
-    // We declare the copy contructor and the assignment operator, but we don't
-    // implement them. This way, if someone tries to copy/assign our instance,
-    // he will get an error at compile time.
-    InterruptManager(const InterruptManager&);
-    InterruptManager& operator =(const InterruptManager&);
 
     template<typename T>
     pFunctionPointer_t add_common(T *tptr, void (T::*mptr)(void), IRQn_Type irq, bool front=false) {

--- a/drivers/LowPowerTicker.h
+++ b/drivers/LowPowerTicker.h
@@ -18,6 +18,7 @@
 
 #include "platform/platform.h"
 #include "drivers/Ticker.h"
+#include "platform/NonCopyable.h"
 
 #if defined (DEVICE_LOWPOWERTIMER) || defined(DOXYGEN_ONLY)
 
@@ -31,7 +32,7 @@ namespace mbed {
  * @note Synchronization level: Interrupt safe
  * @ingroup drivers
  */
-class LowPowerTicker : public Ticker {
+class LowPowerTicker : public Ticker, private NonCopyable<LowPowerTicker> {
 
 public:
     LowPowerTicker() : Ticker(get_lp_ticker_data()) {

--- a/drivers/LowPowerTimeout.h
+++ b/drivers/LowPowerTimeout.h
@@ -22,6 +22,7 @@
 
 #include "hal/lp_ticker_api.h"
 #include "drivers/LowPowerTicker.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -31,7 +32,7 @@ namespace mbed {
  * @note Synchronization level: Interrupt safe
  * @ingroup drivers
  */
-class LowPowerTimeout : public LowPowerTicker {
+class LowPowerTimeout : public LowPowerTicker, private NonCopyable<LowPowerTimeout> {
 
 private:
     virtual void handler(void) {

--- a/drivers/LowPowerTimer.h
+++ b/drivers/LowPowerTimer.h
@@ -18,6 +18,7 @@
 
 #include "platform/platform.h"
 #include "drivers/Timer.h"
+#include "platform/NonCopyable.h"
 
 #if defined (DEVICE_LOWPOWERTIMER) || defined(DOXYGEN_ONLY)
 
@@ -31,7 +32,7 @@ namespace mbed {
  * @note Synchronization level: Interrupt safe
  * @ingroup drivers
  */
-class LowPowerTimer : public Timer {
+class LowPowerTimer : public Timer, private NonCopyable<LowPowerTimer> {
 
 public:
     LowPowerTimer() : Timer(get_lp_ticker_data()) {

--- a/drivers/RawSerial.h
+++ b/drivers/RawSerial.h
@@ -22,6 +22,7 @@
 
 #include "drivers/SerialBase.h"
 #include "hal/serial_api.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -49,7 +50,7 @@ namespace mbed {
  * @endcode
  * @ingroup drivers
  */
-class RawSerial: public SerialBase {
+class RawSerial: public SerialBase, private NonCopyable<RawSerial> {
 
 public:
     /** Create a RawSerial port, connected to the specified transmit and receive pins, with the specified baud.

--- a/drivers/SPI.h
+++ b/drivers/SPI.h
@@ -23,6 +23,7 @@
 #include "platform/PlatformMutex.h"
 #include "hal/spi_api.h"
 #include "platform/SingletonPtr.h"
+#include "platform/NonCopyable.h"
 
 #if DEVICE_SPI_ASYNCH
 #include "platform/CThunk.h"
@@ -72,7 +73,7 @@ namespace mbed {
  * @endcode
  * @ingroup drivers
  */
-class SPI {
+class SPI : private NonCopyable<SPI> {
 
 public:
 

--- a/drivers/SPISlave.h
+++ b/drivers/SPISlave.h
@@ -17,6 +17,7 @@
 #define MBED_SPISLAVE_H
 
 #include "platform/platform.h"
+#include "platform/NonCopyable.h"
 
 #if defined (DEVICE_SPISLAVE) || defined(DOXYGEN_ONLY)
 
@@ -52,7 +53,7 @@ namespace mbed {
  * @endcode
  * @ingroup drivers
  */
-class SPISlave {
+class SPISlave : private NonCopyable<SPISlave> {
 
 public:
 

--- a/drivers/Serial.h
+++ b/drivers/Serial.h
@@ -24,6 +24,7 @@
 #include "SerialBase.h"
 #include "PlatformMutex.h"
 #include "serial_api.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -49,7 +50,7 @@ namespace mbed {
  * @endcode
  * @ingroup drivers
  */
-class Serial : public SerialBase, public Stream {
+class Serial : public SerialBase, public Stream, private NonCopyable<Serial> {
 
 public:
 #if DEVICE_SERIAL_ASYNCH

--- a/drivers/SerialBase.h
+++ b/drivers/SerialBase.h
@@ -23,6 +23,7 @@
 #include "Callback.h"
 #include "serial_api.h"
 #include "mbed_toolchain.h"
+#include "platform/NonCopyable.h"
 
 #if DEVICE_SERIAL_ASYNCH
 #include "CThunk.h"
@@ -38,7 +39,7 @@ namespace mbed {
  * @note Synchronization level: Set by subclass
  * @ingroup drivers
  */
-class SerialBase {
+class SerialBase : private NonCopyable<SerialBase> {
 
 public:
     /** Set the baud rate of the serial port

--- a/drivers/Ticker.h
+++ b/drivers/Ticker.h
@@ -19,6 +19,7 @@
 #include "drivers/TimerEvent.h"
 #include "platform/Callback.h"
 #include "platform/mbed_toolchain.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -59,7 +60,7 @@ namespace mbed {
  * @endcode
  * @ingroup drivers
  */
-class Ticker : public TimerEvent {
+class Ticker : public TimerEvent, private NonCopyable<Ticker> {
 
 public:
     Ticker() : TimerEvent() {

--- a/drivers/Timeout.h
+++ b/drivers/Timeout.h
@@ -17,6 +17,7 @@
 #define MBED_TIMEOUT_H
 
 #include "drivers/Ticker.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -52,7 +53,7 @@ namespace mbed {
  * @endcode
  * @ingroup drivers
  */
-class Timeout : public Ticker {
+class Timeout : public Ticker, private NonCopyable<Timeout> {
 
 protected:
     virtual void handler();

--- a/drivers/Timer.h
+++ b/drivers/Timer.h
@@ -18,6 +18,7 @@
 
 #include "platform/platform.h"
 #include "hal/ticker_api.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -46,7 +47,7 @@ namespace mbed {
  * @endcode
  * @ingroup drivers
  */
-class Timer {
+class Timer : private NonCopyable<Timer> {
 
 public:
     Timer();

--- a/drivers/TimerEvent.h
+++ b/drivers/TimerEvent.h
@@ -18,6 +18,7 @@
 
 #include "hal/ticker_api.h"
 #include "hal/us_ticker_api.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -27,7 +28,7 @@ namespace mbed {
  * @note Synchronization level: Interrupt safe
  * @ingroup drivers
  */
-class TimerEvent {
+class TimerEvent : private NonCopyable<TimerEvent> {
 public:
     TimerEvent();
     TimerEvent(const ticker_data_t *data);

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -27,6 +27,7 @@
 #include "PlatformMutex.h"
 #include "serial_api.h"
 #include "CircularBuffer.h"
+#include "platform/NonCopyable.h"
 
 #ifndef MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE
 #define MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE  256
@@ -38,7 +39,7 @@
 
 namespace mbed {
 
-class UARTSerial : private SerialBase, public FileHandle {
+class UARTSerial : private SerialBase, public FileHandle, private NonCopyable<UARTSerial> {
 
 public:
 

--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -19,6 +19,7 @@
 
 #include "equeue/equeue.h"
 #include "platform/Callback.h"
+#include "platform/NonCopyable.h"
 #include <cstddef>
 #include <new>
 
@@ -47,7 +48,7 @@ class Event;
  *  Flexible event queue for dispatching events
  * @ingroup events
  */
-class EventQueue {
+class EventQueue : private mbed::NonCopyable<EventQueue> {
 public:
     /** Create an EventQueue
      *

--- a/platform/ATCmdParser.h
+++ b/platform/ATCmdParser.h
@@ -44,7 +44,7 @@
 
 namespace mbed {
 
-class ATCmdParser
+class ATCmdParser : private NonCopyable<ATCmdParser>
 {
 private:
     // File handle
@@ -69,11 +69,6 @@ private:
         oob *next;
     };
     oob *_oobs;
-
-    // Prohibiting use of of copy constructor
-    ATCmdParser(const ATCmdParser &);
-    // Prohibiting copy assignment Operator
-    ATCmdParser &operator=(const ATCmdParser &);
 
 public:
 

--- a/platform/CallChain.h
+++ b/platform/CallChain.h
@@ -18,6 +18,7 @@
 
 #include "platform/Callback.h"
 #include "platform/mbed_toolchain.h"
+#include "platform/NonCopyable.h"
 #include <string.h>
 
 namespace mbed {
@@ -65,7 +66,7 @@ namespace mbed {
 typedef Callback<void()> *pFunctionPointer_t;
 class CallChainLink;
 
-class CallChain {
+class CallChain : private NonCopyable<CallChain> {
 public:
     /** Create an empty chain
      *
@@ -178,10 +179,7 @@ public:
         return get(i);
     }
 
-    /* disallow copy constructor and assignment operators */
 private:
-    CallChain(const CallChain&);
-    CallChain & operator = (const CallChain&);
     CallChainLink *_chain;
 };
 

--- a/platform/DirHandle.h
+++ b/platform/DirHandle.h
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include "platform/platform.h"
 #include "platform/FileHandle.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup platform */
@@ -41,7 +42,7 @@ namespace mbed {
  *  @note Synchronization level: Set by subclass
  *  @ingroup platform
  */
-class DirHandle {
+class DirHandle : private NonCopyable<DirHandle> {
 public:
     virtual ~DirHandle() {}
 

--- a/platform/FileBase.h
+++ b/platform/FileBase.h
@@ -24,6 +24,7 @@ typedef int FILEHANDLE;
 #include "platform/platform.h"
 #include "platform/SingletonPtr.h"
 #include "platform/PlatformMutex.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup platform */
@@ -39,7 +40,7 @@ typedef enum {
  * @class FileBase
  * @ingroup platform
  */
-class FileBase {
+class FileBase : private NonCopyable<FileBase> {
 public:
     FileBase(const char *name, PathType t);
     virtual ~FileBase();
@@ -59,8 +60,6 @@ private:
     FileBase   *_next;
     const char * const _name;
     const PathType _path_type;
-    FileBase(const FileBase&);
-    FileBase & operator = (const FileBase&);
 };
 
 } // namespace mbed

--- a/platform/FileHandle.h
+++ b/platform/FileHandle.h
@@ -22,6 +22,7 @@ typedef int FILEHANDLE;
 #include "Callback.h"
 #include "platform/mbed_poll.h"
 #include "platform/platform.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup platform */
@@ -37,7 +38,7 @@ namespace mbed {
  *  @note Synchronization level: Set by subclass
  *  @ingroup platform
  */
-class FileHandle {
+class FileHandle : private NonCopyable<FileHandle> {
 public:
     virtual ~FileHandle() {}
 

--- a/platform/FileLike.h
+++ b/platform/FileLike.h
@@ -19,6 +19,7 @@
 #include "platform/mbed_toolchain.h"
 #include "platform/FileBase.h"
 #include "platform/FileHandle.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup platform */
@@ -31,7 +32,7 @@ namespace mbed {
  *  @note Synchronization level: Set by subclass
  *  @ingroup platform
  */
-class FileLike : public FileHandle, public FileBase {
+class FileLike : public FileHandle, public FileBase, private NonCopyable<FileLike> {
 public:
     /** Constructor FileLike
      *

--- a/platform/FileSystemHandle.h
+++ b/platform/FileSystemHandle.h
@@ -21,6 +21,7 @@
 #include "platform/FileBase.h"
 #include "platform/FileHandle.h"
 #include "platform/DirHandle.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -35,7 +36,7 @@ namespace mbed {
  *
  * @note Synchronization level: Set by subclass
  */
-class FileSystemHandle {
+class FileSystemHandle : private NonCopyable<FileSystemHandle> {
 public:
     /** FileSystemHandle lifetime
      */

--- a/platform/FileSystemLike.h
+++ b/platform/FileSystemLike.h
@@ -21,6 +21,7 @@
 #include "platform/FileSystemHandle.h"
 #include "platform/FileHandle.h"
 #include "platform/DirHandle.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup platform */
@@ -35,7 +36,7 @@ namespace mbed {
  * @note Synchronization level: Set by subclass
  * @ingroup platform
  */
-class FileSystemLike : public FileSystemHandle, public FileBase {
+class FileSystemLike : public FileSystemHandle, public FileBase, private NonCopyable<FileSystemLike> {
 public:
     /** FileSystemLike lifetime
      */

--- a/platform/LocalFileSystem.h
+++ b/platform/LocalFileSystem.h
@@ -22,6 +22,7 @@
 
 #include "platform/FileSystemLike.h"
 #include "platform/PlatformMutex.h"
+#include "platform/NonCopyable.h"
 
 namespace mbed {
 /** \addtogroup platform */
@@ -34,7 +35,7 @@ FILEHANDLE local_file_open(const char* name, int flags);
  * @class LocalFileHandle
  * @ingroup platform
  */
-class LocalFileHandle : public FileHandle {
+class LocalFileHandle : public FileHandle, private NonCopyable<LocalFileHandle> {
 
 public:
     LocalFileHandle(FILEHANDLE fh);
@@ -98,7 +99,7 @@ protected:
  *  not exit, you will need to hold down reset on the mbed Microcontroller to be able to see the drive again!
  * @ingroup platform
  */
-class LocalFileSystem : public FileSystemLike {
+class LocalFileSystem : public FileSystemLike, private NonCopyable<LocalFileSystem> {
     // No modifiable state
 
 public:

--- a/platform/NonCopyable.h
+++ b/platform/NonCopyable.h
@@ -1,0 +1,168 @@
+/* Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_NONCOPYABLE_H_
+#define MBED_NONCOPYABLE_H_
+
+namespace mbed { 
+
+/**
+ * Inheriting from this class autogeneration of copy construction and copy 
+ * assignement operations. 
+ * 
+ * Classes which are not value type should inherit privately from this class 
+ * to avoid generation of invalid copy constructor or copy assignement operator
+ * which can lead to unoticeable programming errors. 
+ * 
+ * As an example consider the following signature: 
+ * 
+ * @code
+ * class Resource; 
+ *
+ * class Foo { 
+ * public:     
+ *   Foo() : _resource(new Resource()) { }
+ *   ~Foo() { delete _resource; } 
+ * private:
+ *   Resource* _resource;
+ * }
+ * 
+ * Foo get_foo();
+ * 
+ * Foo foo = get_foo();
+ * @endcode 
+ * 
+ * There is a bug in this function, it returns a temporary value which will be 
+ * byte copied into foo then destroyed. Unfortunately, internaly the Foo class 
+ * manage a pointer to a Resource object. This pointer will be released when the 
+ * temporary is destroyed and foo will manage a pointer to an already released 
+ * Resource.
+ * 
+ * Two issues has to be fixed in the example above: 
+ *   - Function signature has to be changed to reflect the fact that Foo 
+ *     instances cannot be copied. In that case accessor should return a 
+ *     reference to give access to objects already existing and managed. 
+ *     Generator on the other hand should return a pointer to the created object.
+ * 
+ * @code 
+ * // return a reference to an already managed Foo instance
+ * Foo& get_foo(); 
+ * Foo& foo = get_foo();
+ * 
+ * // create a new Foo instance
+ * Foo* make_foo();
+ * Foo* m = make_foo();
+ * @endcode
+ * 
+ *   - Copy constructor and copy assignement operator has to be made private 
+ *     in the Foo class. It prevents unwanted copy of Foo objects. This can be 
+ *     done by declaring copy constructor and copy assignement in the private 
+ *     section of the Foo class.
+ *     
+ * @code 
+ * class Foo { 
+ * public:     
+ *   Foo() : _resource(new Resource()) { }
+ *   ~Foo() { delete _resource; } 
+ * private:
+ *   // disallow copy operations 
+ *   Foo(const Foo&);
+ *   Foo& operator=(const Foo&);
+ *   // data members 
+ *   Resource* _resource;
+ * }
+ * @endcode
+ * 
+ * Another solution is to inherit privately from the NonCopyable class. 
+ * It reduces the boiler plate needed to avoid copy operations but more 
+ * importantly it clarifies the programer intent and the object semantic.
+ *
+ * class Foo : private NonCopyable<Foo> { 
+ * public:     
+ *   Foo() : _resource(new Resource()) { }
+ *   ~Foo() { delete _resource; } 
+ * private:
+ *   Resource* _resource;
+ * }
+ * 
+ * @tparam T The type that should be made non copyable. It prevent cases where 
+ * the empty base optimization cannot be applied and therefore ensure that the 
+ * cost of this semantic sugar is null. 
+ * 
+ * As an example, the empty base optimization is prohibited if one of the empty 
+ * base class is also a base type of the first non static data member: 
+ * 
+ * @code 
+ * struct A { };
+ * struct B : A { 
+ *    int foo;
+ * };
+ * // thanks to empty base optimization, sizeof(B) == sizeof(int)
+ * 
+ * struct C : A { 
+ *   B b;
+ * };
+ * 
+ * // empty base optimization cannot be applied here because A from C and A from
+ * // B shall have a different address. In that case, with the alignement 
+ * // sizeof(C) == 2* sizeof(int)
+ * @endcode
+ * 
+ * The solution to that problem is to templatize the empty class to makes it 
+ * unique to the type it is applied to: 
+ * 
+ * @code 
+ * template<typename T>
+ * struct A<T> { };
+ * struct B : A<B> { 
+ *    int foo;
+ * };
+ * struct C : A<C> { 
+ *   B b;
+ * };
+ * 
+ * // empty base optimization can be applied B and C does not refer to the same 
+ * // kind of A. sizeof(C) == sizeof(B) == sizeof(int).
+ * @endcode
+ */
+template<typename T>
+class NonCopyable { 
+protected:
+    /** 
+     * Disalow construction of NonCopyable objects from outside of its hierarchy.
+     */
+    NonCopyable() { }
+    /** 
+     * Disalow destruction of NonCopyable objects from outside of its hierarchy.
+     */
+    ~NonCopyable() { }
+
+private: 
+    /**
+     * Declare copy constructor as private, any attempt to copy construct 
+     * a NonCopyable will fail at compile time.
+     */
+    NonCopyable(const NonCopyable&);
+
+    /**
+     * Declare copy assignement operator as private, any attempt to copy assign 
+     * a NonCopyable will fail at compile time.
+     */
+    NonCopyable& operator=(const NonCopyable&);
+};
+
+} // namespace mbed 
+
+#endif /* MBED_NONCOPYABLE_H_ */

--- a/platform/PlatformMutex.h
+++ b/platform/PlatformMutex.h
@@ -18,6 +18,8 @@
 #ifndef PLATFORM_MUTEX_H
 #define PLATFORM_MUTEX_H
 
+#include "platform/NonCopyable.h"
+
 #ifdef MBED_CONF_RTOS_PRESENT
 #include "rtos/Mutex.h"
 typedef rtos::Mutex PlatformMutex;
@@ -25,7 +27,7 @@ typedef rtos::Mutex PlatformMutex;
 /** A stub mutex for when an RTOS is not present
  * @ingroup platform
 */
-class PlatformMutex {
+class PlatformMutex : private mbed::NonCopyable<PlatformMutex> {
 public:
     PlatformMutex() {
         // Stub

--- a/platform/Stream.h
+++ b/platform/Stream.h
@@ -19,6 +19,7 @@
 #include "platform/platform.h"
 #include "platform/FileLike.h"
 #include "platform/FileHandle.h"
+#include "platform/NonCopyable.h"
 #include <cstdio>
 #include <cstdarg>
 
@@ -36,7 +37,7 @@ extern char* mbed_gets(char *s, int size, std::FILE *_file);
  * @note Synchronization level: Set by subclass
  * @ingroup platform
  */
-class Stream : public FileLike {
+class Stream : public FileLike, private NonCopyable<Stream> {
 
 public:
     Stream(const char *name=NULL);
@@ -80,11 +81,6 @@ protected:
     virtual void unlock() {
         // Stub
     }
-
-    /* disallow copy constructor and assignment operators */
-private:
-    Stream(const Stream&);
-    Stream & operator = (const Stream&);
 };
 
 } // namespace mbed

--- a/rtos/Mail.h
+++ b/rtos/Mail.h
@@ -31,6 +31,8 @@
 #include "rtx_lib.h"
 #include "mbed_rtos1_types.h"
 
+#include "platform/NonCopyable.h"
+
 using namespace rtos;
 
 namespace rtos {
@@ -47,7 +49,7 @@ namespace rtos {
  both for the mbed OS and underlying RTOS objects (static or dynamic RTOS memory pools are not being used).
 */
 template<typename T, uint32_t queue_sz>
-class Mail {
+class Mail : private mbed::NonCopyable<Mail<T, queue_sz> > {
 public:
     /** Create and Initialise Mail queue. */
     Mail() { };

--- a/rtos/MemoryPool.h
+++ b/rtos/MemoryPool.h
@@ -28,6 +28,7 @@
 #include "cmsis_os2.h"
 #include "mbed_rtos1_types.h"
 #include "mbed_rtos_storage.h"
+#include "platform/NonCopyable.h"
 
 namespace rtos {
 /** \addtogroup rtos */
@@ -42,7 +43,7 @@ namespace rtos {
  both for the mbed OS and underlying RTOS objects (static or dynamic RTOS memory pools are not being used).
 */
 template<typename T, uint32_t pool_sz>
-class MemoryPool {
+class MemoryPool : private mbed::NonCopyable<MemoryPool<T, pool_sz> > {
 public:
     /** Create and Initialize a memory pool. */
     MemoryPool() {

--- a/rtos/Mutex.h
+++ b/rtos/Mutex.h
@@ -27,6 +27,8 @@
 #include "mbed_rtos1_types.h"
 #include "mbed_rtos_storage.h"
 
+#include "platform/NonCopyable.h"
+
 namespace rtos {
 /** \addtogroup rtos */
 /** @{*/
@@ -38,7 +40,7 @@ namespace rtos {
  Memory considerations: The mutex control structures will be created on current thread's stack, both for the mbed OS
  and underlying RTOS objects (static or dynamic RTOS memory pools are not being used).
 */
-class Mutex {
+class Mutex : private mbed::NonCopyable<Mutex> {
 public:
     /** Create and Initialize a Mutex object */
     Mutex();

--- a/rtos/Queue.h
+++ b/rtos/Queue.h
@@ -28,6 +28,7 @@
 #include "cmsis_os2.h"
 #include "mbed_rtos_storage.h"
 #include "platform/mbed_error.h"
+#include "platform/NonCopyable.h"
 #include "mbed_rtos1_types.h"
 
 namespace rtos {
@@ -45,7 +46,7 @@ namespace rtos {
  and underlying RTOS objects (static or dynamic RTOS memory pools are not being used).
 */
 template<typename T, uint32_t queue_sz>
-class Queue {
+class Queue : private mbed::NonCopyable<Queue<T, queue_sz> > {
 public:
     /** Create and initialize a message Queue. */
     Queue() {

--- a/rtos/RtosTimer.h
+++ b/rtos/RtosTimer.h
@@ -26,6 +26,7 @@
 #include "cmsis_os2.h"
 #include "rtx_lib.h"
 #include "platform/Callback.h"
+#include "platform/NonCopyable.h"
 #include "platform/mbed_toolchain.h"
 #include "mbed_rtos1_types.h"
 
@@ -79,7 +80,7 @@ namespace rtos {
  Memory considerations: The timer control structures will be created on current thread's stack, both for the mbed OS
  and underlying RTOS objects (static or dynamic RTOS memory pools are not being used).
 */
-class RtosTimer {
+class RtosTimer : private mbed::NonCopyable<RtosTimer> {
 public:
     /** Create timer.
       @param   func      function to be executed by this timer.

--- a/rtos/Semaphore.h
+++ b/rtos/Semaphore.h
@@ -26,6 +26,7 @@
 #include "cmsis_os2.h"
 #include "mbed_rtos1_types.h"
 #include "mbed_rtos_storage.h"
+#include "platform/NonCopyable.h"
 
 namespace rtos {
 /** \addtogroup rtos */
@@ -37,7 +38,7 @@ namespace rtos {
  * Memory considerations: The semaphore control structures will be created on current thread's stack, both for the mbed OS
  * and underlying RTOS objects (static or dynamic RTOS memory pools are not being used).
  */
-class Semaphore {
+class Semaphore : private mbed::NonCopyable<Semaphore> {
 public:
     /** Create and Initialize a Semaphore object used for managing resources.
       @param count      number of available resources; maximum index value is (count-1). (default: 0).

--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -29,6 +29,7 @@
 #include "mbed_rtx_conf.h"
 #include "platform/Callback.h"
 #include "platform/mbed_toolchain.h"
+#include "platform/NonCopyable.h"
 #include "rtos/Semaphore.h"
 #include "rtos/Mutex.h"
 
@@ -69,7 +70,7 @@ namespace rtos {
  * and underlying RTOS objects (static or dynamic RTOS memory pools are not being used).
  * Additionally the stack memory for this thread will be allocated on the heap, if it wasn't supplied to the constructor.
  */
-class Thread {
+class Thread : private mbed::NonCopyable<Thread> {
 public:
     /** Allocate a new thread without starting execution
       @param   priority       initial priority of the thread function. (default: osPriorityNormal).
@@ -348,10 +349,6 @@ public:
     virtual ~Thread();
 
 private:
-    /* disallow copy constructor and assignment operators */
-    Thread(const Thread&);
-    Thread& operator=(const Thread&);
-
     // Required to share definitions without
     // delegated constructors
     void constructor(osPriority priority=osPriorityNormal,


### PR DESCRIPTION
## Description

The `NonCopyable` template class disable auto generation of copy assignment operator and copy constructor for classes inheriting from it. 

It avoid the private declaration of the copy assignment operator and copy constructor in favor of an explicit element in the base class list.

It is a good practice to tag non value type as `NonCopyable`, because it inform of invalid copy operation at compile time.

As an example consider the following code: 
 
```c++
class Resource; 

class Foo { 
public:     
    Foo() : _resource(new Resource()) { }
    ~Foo() { delete _resource; } 
private:
    Resource* _resource;
};
 
Foo get_foo();
 
Foo foo = get_foo();
```

There is a bug in this function, it returns a temporary value which will be 
byte copied into `foo` then destroyed. Unfortunately, internally the Foo class 
manage a pointer to a `Resource` object. This pointer will be released when the 
temporary is destroyed and `foo` will manage a pointer to an already released 
`Resource`.

If the class `Foo` is marked as `NonCopyable` then it is not possible to write function with the signature `Foo get_foo();` because an error will be generated at compile time.

```c++
class Resource; 

class Foo : private mbed::NonCopyable<Foo>{ 
public:     
    Foo() : _resource(new Resource()) { }
    ~Foo() { delete _resource; } 
private:
    Resource* _resource;
};
 

Foo get_foo();
Foo foo = get_foo(); // compile time error 
``` 

The extensive documentation as well as the implementation details can be found in the [NonCopyable](https://github.com/ARMmbed/mbed-os/blob/e672c8cb4315804f7d9b7790de0e4914f9c7eeab/platform/Noncopyable.h) header. 

Classes in `rtos`, `platform`, `event` and `driver` have been either fixed or updated to take advantage of this new traits.

Classes in `features` have not been touched. 

## Status
**READY**

## Todos
- [ ] Review

