### PR TITLE
rtos: Fix MemoryPool and Queue destructor

### DIFF
--- a/rtos/MemoryPool.h
+++ b/rtos/MemoryPool.h
@@ -57,6 +57,11 @@ public:
         MBED_ASSERT(_id);
     }
 
+    /** Destroy a memory pool */
+    ~MemoryPool() {
+        osMemoryPoolDelete(_id);
+    }
+
     /** Allocate a memory block of type T from a memory pool.
       @return  address of the allocated memory block or NULL in case of no memory available.
     */

--- a/rtos/Queue.h
+++ b/rtos/Queue.h
@@ -59,6 +59,10 @@ public:
         MBED_ASSERT(_id);
     }
 
+    ~Queue() {
+        osMessageQueueDelete(_id);
+    }
+
     /** Put a message in a Queue.
       @param   data      message pointer.
       @param   millisec  timeout value or 0 in case of no time-out. (default: 0)


### PR DESCRIPTION
## Description
Destructors of `MemoryPool` and `Queue` were not defined leaving a resource leak after destruction of any instance of this kind of objects. 

This PR adds a destructor for these types which correctly release the resources. As a side effect it also fix the default destructor of the `Mail` class.

## Status
**READY**


## Migrations
NO


## Todos
- [ ] Review