### PR TITLE
cmain IAR: add mbed main

### DIFF
--- a/cmsis/TOOLCHAIN_IAR/cmain.S
+++ b/cmsis/TOOLCHAIN_IAR/cmain.S
@@ -46,6 +46,7 @@
         EXTERN  exit
         EXTERN  __iar_dynamic_initialization
         EXTERN mbed_sdk_init
+        EXTERN mbed_main
         EXTERN SystemInit
         
         THUMB
@@ -86,6 +87,10 @@ _call_main:
         MOVS    r0,#0             ;  No parameters  
           FUNCALL __cmain, __iar_argc_argv
         BL      __iar_argc_argv   ; Maybe setup command line
+
+        MOVS    r0,#0             ;  No parameters  
+          FUNCALL __cmain, mbed_main
+        BL      mbed_main
 
           FUNCALL __cmain, main
         BL      main


### PR DESCRIPTION
This fixes #4602 issue, mbed_main should be invoked right before the real main

Tested on nucleo l476rg, using mbed_a21 test

Sorry for the formatting, my terminal was not set properly :)
before this patch:

```
{{timeout;20}}
              {{host_test_name;default_auto}}
                                             {{description;Call function mbed_main before main}}
                {{test_id;MBED_A21}}
                                    {{start}}
                                             MBED: main() starts now!
{{failure}}
           {{end}}
```

after this patch:

```
call before main()
{{timeout;20}}
              {{host_test_name;default_auto}}
                                             {{description;Call function mbed_main before main}}
                {{test_id;MBED_A21}}
                                    {{start}}
                                             MBED: main() starts now!
{{success}}
           {{end}}
```

cc @jeromecoutant @c1728p9 