### PR TITLE
Add set_baud() method to UARTSerial().

### DIFF
--- a/drivers/UARTSerial.cpp
+++ b/drivers/UARTSerial.cpp
@@ -43,6 +43,11 @@ void UARTSerial::dcd_irq()
     wake();
 }
 
+void UARTSerial::set_baud(int baud)
+{
+    SerialBase::baud(baud);
+}
+
 void UARTSerial::set_data_carrier_detect(PinName dcd_pin, bool active_high)
 {
      delete _dcd_irq;

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -157,6 +157,12 @@ public:
      */
     void set_data_carrier_detect(PinName dcd_pin, bool active_high = false);
 
+    /** Set the baud rate
+     *
+     *  @param baud   The baud rate
+     */
+    void set_baud(int baud);
+
 private:
 
     /** Software serial buffers


### PR DESCRIPTION
## Description
Add a `set_baud()` method to `UARTSerial()`, simply handing it on to `SerialBase:baud()`.  See #4609 for reasons why this is necessary.

With this in place the `CellularInterface` can instantiate the file handle it requires with `UARTSerial()` running at a baud rate of 115200 (which all modems can be relied upon to auto-baud at).  Then, once the modem is up and running, it can send the modem an `AT+IPR` command giving a higher baud rate that the modem supports but would not be able to auto-baud at (e.g. 460800).  This way we can get nice fast connections.

This has been tested on the u-blox C030 board with a Sara-U201 modem, eventually running at 460800 bits/s.