### PR TITLE
Fix unresolved include of mbed_config.h in Eclipse

### DIFF
--- a/tools/export/gnuarmeclipse/.cproject.tmpl
+++ b/tools/export/gnuarmeclipse/.cproject.tmpl
@@ -182,7 +182,7 @@
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.assembler.include.files.{{u.id}}" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.assembler.include.files" useByScannerDiscovery="true" valueType="includeFiles">
 									{% for file in opts['common']['include_files'] %}
-									<listOptionValue builtIn="false" value="&quot;{{file}}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/{{file}}&quot;"/>
 									{% endfor %}
 								</option>
 								{% if opts['as']['otherwarnings'] != '' %}
@@ -212,7 +212,7 @@
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.files.{{u.id}}" name="Include files (-include)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.files" useByScannerDiscovery="true" valueType="includeFiles">
 									{% for file in opts['common']['include_files'] %}
-									<listOptionValue builtIn="false" value="&quot;{{file}}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/{{file}}&quot;"/>
 									{% endfor %}
 								</option>
 								{% if opts['c']['compiler.std'] %}
@@ -260,7 +260,7 @@
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.files.{{u.id}}" name="Include files (-include)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.files" useByScannerDiscovery="true" valueType="includeFiles">
 									{% for file in opts['common']['include_files'] %}
-									<listOptionValue builtIn="false" value="&quot;{{file}}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/{{file}}&quot;"/>
 									{% endfor %}
 								</option>
 								{% if opts['cpp']['compiler.std'] %}


### PR DESCRIPTION
Notes:
* I have accepted the Contributor Agreement on Tue 25 Oct 2016.

## Description
There is a minor issue with the Eclipse exporter which causes a warning of an unresolved include of `mbed_config.h`. This PR solves it by adding the project directory path to the include. Actually, all includes have the project directory path, just not this one.


## Status
**READY**


## Migrations

NO