### PR TITLE
Improve management handling of multiple instances of analogin ojects

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F0/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/analogin_api.c
@@ -40,8 +40,8 @@ int adc_inited = 0;
 
 void analogin_init(analogin_t *obj, PinName pin) {
     // Get the peripheral name from the pin and assign it to the object
-    obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
-    MBED_ASSERT(obj->adc != (ADCName)NC);
+    obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
+    MBED_ASSERT(obj->handle.Instance != (ADC_TypeDef *)NC);
 
     // Get the functions (adc channel) from the pin and assign it to the object
     uint32_t function = pinmap_function(pin, PinMap_ADC);
@@ -65,7 +65,6 @@ void analogin_init(analogin_t *obj, PinName pin) {
         __ADC1_CLK_ENABLE();
 
         // Configure ADC
-        obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
         obj->handle.State = HAL_ADC_STATE_RESET;
         obj->handle.Init.ClockPrescaler        = ADC_CLOCK_SYNC_PCLK_DIV4;
         obj->handle.Init.Resolution            = ADC_RESOLUTION12b;
@@ -92,8 +91,6 @@ void analogin_init(analogin_t *obj, PinName pin) {
 
 static inline uint16_t adc_read(analogin_t *obj) {
     ADC_ChannelConfTypeDef sConfig;
-
-    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     sConfig.Rank         = ADC_RANK_CHANNEL_NUMBER;

--- a/targets/TARGET_STM/TARGET_STM32F0/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/analogin_api.c
@@ -36,15 +36,13 @@
 #include "PeripheralPins.h"
 #include "mbed_error.h"
 
-ADC_HandleTypeDef AdcHandle;
-
 int adc_inited = 0;
 
 void analogin_init(analogin_t *obj, PinName pin) {
     // Get the peripheral name from the pin and assign it to the object
     obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
     MBED_ASSERT(obj->adc != (ADCName)NC);
-    
+
     // Get the functions (adc channel) from the pin and assign it to the object
     uint32_t function = pinmap_function(pin, PinMap_ADC);
     MBED_ASSERT(function != (uint32_t)NC);
@@ -67,25 +65,26 @@ void analogin_init(analogin_t *obj, PinName pin) {
         __ADC1_CLK_ENABLE();
 
         // Configure ADC
-        AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
-        AdcHandle.Init.ClockPrescaler        = ADC_CLOCK_SYNC_PCLK_DIV4;
-        AdcHandle.Init.Resolution            = ADC_RESOLUTION12b;
-        AdcHandle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
-        AdcHandle.Init.ScanConvMode          = ADC_SCAN_DIRECTION_FORWARD;
-        AdcHandle.Init.EOCSelection          = EOC_SINGLE_CONV;
-        AdcHandle.Init.LowPowerAutoWait      = DISABLE;
-        AdcHandle.Init.LowPowerAutoPowerOff  = DISABLE;
-        AdcHandle.Init.ContinuousConvMode    = DISABLE;
-        AdcHandle.Init.DiscontinuousConvMode = DISABLE;
-        AdcHandle.Init.ExternalTrigConv      = ADC_SOFTWARE_START;
-        AdcHandle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
-        AdcHandle.Init.DMAContinuousRequests = DISABLE;
-        AdcHandle.Init.Overrun               = OVR_DATA_OVERWRITTEN;
-        if (HAL_ADC_Init(&AdcHandle) != HAL_OK) {
+        obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
+        obj->handle.State = HAL_ADC_STATE_RESET;
+        obj->handle.Init.ClockPrescaler        = ADC_CLOCK_SYNC_PCLK_DIV4;
+        obj->handle.Init.Resolution            = ADC_RESOLUTION12b;
+        obj->handle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
+        obj->handle.Init.ScanConvMode          = ADC_SCAN_DIRECTION_FORWARD;
+        obj->handle.Init.EOCSelection          = EOC_SINGLE_CONV;
+        obj->handle.Init.LowPowerAutoWait      = DISABLE;
+        obj->handle.Init.LowPowerAutoPowerOff  = DISABLE;
+        obj->handle.Init.ContinuousConvMode    = DISABLE;
+        obj->handle.Init.DiscontinuousConvMode = DISABLE;
+        obj->handle.Init.ExternalTrigConv      = ADC_SOFTWARE_START;
+        obj->handle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
+        obj->handle.Init.DMAContinuousRequests = DISABLE;
+        obj->handle.Init.Overrun               = OVR_DATA_OVERWRITTEN;
+        if (HAL_ADC_Init(&obj->handle) != HAL_OK) {
             error("Cannot initialize ADC");
         }
         // Run the ADC calibration
-        if (HAL_ADCEx_Calibration_Start(&AdcHandle) != HAL_OK) {
+        if (HAL_ADCEx_Calibration_Start(&obj->handle) != HAL_OK) {
             error("Cannot Start ADC_Calibration");
         }
     }
@@ -94,7 +93,7 @@ void analogin_init(analogin_t *obj, PinName pin) {
 static inline uint16_t adc_read(analogin_t *obj) {
     ADC_ChannelConfTypeDef sConfig;
 
-    AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
+    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     sConfig.Rank         = ADC_RANK_CHANNEL_NUMBER;
@@ -169,15 +168,15 @@ static inline uint16_t adc_read(analogin_t *obj) {
     }
 
     // Clear all channels as it is not done in HAL_ADC_ConfigChannel()
-    AdcHandle.Instance->CHSELR = 0;
+    obj->handle.Instance->CHSELR = 0;
 
-    HAL_ADC_ConfigChannel(&AdcHandle, &sConfig);
+    HAL_ADC_ConfigChannel(&obj->handle, &sConfig);
 
-    HAL_ADC_Start(&AdcHandle); // Start conversion
+    HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
-    if (HAL_ADC_PollForConversion(&AdcHandle, 10) == HAL_OK) {
-        return (HAL_ADC_GetValue(&AdcHandle));
+    if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
+        return (HAL_ADC_GetValue(&obj->handle));
     } else {
         return 0;
     }

--- a/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
@@ -111,6 +111,13 @@ struct i2c_s {
 #endif
 };
 
+struct analogin_s {
+    ADCName adc;
+    ADC_HandleTypeDef handle;
+    PinName pin;
+    uint8_t channel;
+};
+
 #include "gpio_object.h"
 
 #if DEVICE_ANALOGOUT

--- a/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
@@ -112,7 +112,6 @@ struct i2c_s {
 };
 
 struct analogin_s {
-    ADCName adc;
     ADC_HandleTypeDef handle;
     PinName pin;
     uint8_t channel;

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F1/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/analogin_api.c
@@ -42,9 +42,9 @@ void analogin_init(analogin_t *obj, PinName pin)
     RCC_PeriphCLKInitTypeDef  PeriphClkInit;
 
     // Get the peripheral name from the pin and assign it to the object
-    obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
-    MBED_ASSERT(obj->adc != (ADCName)NC);
-    
+    obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
+    MBED_ASSERT(obj->handle.Instance != (ADC_TypeDef *)NC);
+
     // Get the functions (adc channel) from the pin and assign it to the object
     uint32_t function = pinmap_function(pin, PinMap_ADC);
     MBED_ASSERT(function != (uint32_t)NC);
@@ -77,7 +77,6 @@ void analogin_init(analogin_t *obj, PinName pin)
         HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit);
 
         // Configure ADC
-        obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
         obj->handle.State = HAL_ADC_STATE_RESET;
         obj->handle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
         obj->handle.Init.ScanConvMode          = DISABLE;
@@ -93,8 +92,6 @@ void analogin_init(analogin_t *obj, PinName pin)
 static inline uint16_t adc_read(analogin_t *obj)
 {
     ADC_ChannelConfTypeDef sConfig;
-
-    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     sConfig.Rank         = 1;

--- a/targets/TARGET_STM/TARGET_STM32F1/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/analogin_api.c
@@ -35,8 +35,6 @@
 #include "pinmap.h"
 #include "PeripheralPins.h"
 
-ADC_HandleTypeDef AdcHandle;
-
 int adc_inited = 0;
 
 void analogin_init(analogin_t *obj, PinName pin)
@@ -79,15 +77,16 @@ void analogin_init(analogin_t *obj, PinName pin)
         HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit);
 
         // Configure ADC
-        AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
-        AdcHandle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
-        AdcHandle.Init.ScanConvMode          = DISABLE;
-        AdcHandle.Init.ContinuousConvMode    = DISABLE;
-        AdcHandle.Init.NbrOfConversion       = 1;
-        AdcHandle.Init.DiscontinuousConvMode = DISABLE;
-        AdcHandle.Init.NbrOfDiscConversion   = 0;
-        AdcHandle.Init.ExternalTrigConv      = ADC_SOFTWARE_START;
-        HAL_ADC_Init(&AdcHandle);
+        obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
+        obj->handle.State = HAL_ADC_STATE_RESET;
+        obj->handle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
+        obj->handle.Init.ScanConvMode          = DISABLE;
+        obj->handle.Init.ContinuousConvMode    = DISABLE;
+        obj->handle.Init.NbrOfConversion       = 1;
+        obj->handle.Init.DiscontinuousConvMode = DISABLE;
+        obj->handle.Init.NbrOfDiscConversion   = 0;
+        obj->handle.Init.ExternalTrigConv      = ADC_SOFTWARE_START;
+        HAL_ADC_Init(&obj->handle);
     }
 }
 
@@ -95,7 +94,7 @@ static inline uint16_t adc_read(analogin_t *obj)
 {
     ADC_ChannelConfTypeDef sConfig;
 
-    AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
+    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     sConfig.Rank         = 1;
@@ -160,13 +159,13 @@ static inline uint16_t adc_read(analogin_t *obj)
             return 0;
     }
 
-    HAL_ADC_ConfigChannel(&AdcHandle, &sConfig);
+    HAL_ADC_ConfigChannel(&obj->handle, &sConfig);
 
-    HAL_ADC_Start(&AdcHandle); // Start conversion
+    HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
-    if (HAL_ADC_PollForConversion(&AdcHandle, 10) == HAL_OK) {
-        return (HAL_ADC_GetValue(&AdcHandle));
+    if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
+        return (HAL_ADC_GetValue(&obj->handle));
     } else {
         return 0;
     }

--- a/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
@@ -111,7 +111,6 @@ struct i2c_s {
 };
 
 struct analogin_s {
-    ADCName adc;
     ADC_HandleTypeDef handle;
     PinName pin;
     uint8_t channel;

--- a/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
@@ -110,6 +110,13 @@ struct i2c_s {
 #endif
 };
 
+struct analogin_s {
+    ADCName adc;
+    ADC_HandleTypeDef handle;
+    PinName pin;
+    uint8_t channel;
+};
+
 #include "gpio_object.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F2/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/analogin_api.c
@@ -62,7 +62,7 @@ void analogin_init(analogin_t *obj, PinName pin)
         pinmap_pinout(pin, PinMap_ADC);
     } else {
         // Internal channels
-        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
+        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC_Internal);
         function = pinmap_function(pin, PinMap_ADC_Internal);
         // No GPIO configuration for internal channels
     }

--- a/targets/TARGET_STM/TARGET_STM32F2/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/analogin_api.c
@@ -39,7 +39,6 @@
 void analogin_init(analogin_t *obj, PinName pin)
 {
     uint32_t function = (uint32_t)NC;
-    obj->adc = (ADCName)NC;
 
 #if defined(ADC1)
     static int adc1_inited = 0;
@@ -56,18 +55,18 @@ void analogin_init(analogin_t *obj, PinName pin)
     if ((pin < 0xF0) || (pin >= 0x100)) {
         // Normal channels
         // Get the peripheral name from the pin and assign it to the object
-        obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
+        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
         // Get the functions (adc channel) from the pin and assign it to the object
         function = pinmap_function(pin, PinMap_ADC);
         // Configure GPIO
         pinmap_pinout(pin, PinMap_ADC);
     } else {
         // Internal channels
-        obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC_Internal);
+        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
         function = pinmap_function(pin, PinMap_ADC_Internal);
         // No GPIO configuration for internal channels
     }
-    MBED_ASSERT(obj->adc != (ADCName)NC);
+    MBED_ASSERT(obj->handle.Instance != (ADC_TypeDef *)NC);
     MBED_ASSERT(function != (uint32_t)NC);
 
     obj->channel = STM_PIN_CHANNEL(function);
@@ -78,28 +77,27 @@ void analogin_init(analogin_t *obj, PinName pin)
     // Check if ADC is already initialized
     // Enable ADC clock
 #if defined(ADC1)
-    if ((obj->adc == ADC_1) && adc1_inited) return;
-    if (obj->adc == ADC_1) {
+    if (((ADCName)obj->handle.Instance == ADC_1) && adc1_inited) return;
+    if ((ADCName)obj->handle.Instance == ADC_1) {
         __ADC1_CLK_ENABLE();
         adc1_inited = 1;
     }
 #endif
 #if defined(ADC2)
-    if ((obj->adc == ADC_2) && adc2_inited) return;
-    if (obj->adc == ADC_2) {
+    if (((ADCName)obj->handle.Instance == ADC_2) && adc2_inited) return;
+    if ((ADCName)obj->handle.Instance == ADC_2) {
         __ADC2_CLK_ENABLE();
         adc2_inited = 1;
     }
 #endif
 #if defined(ADC3)
-    if ((obj->adc == ADC_3) && adc3_inited) return;
-    if (obj->adc == ADC_3) {
+    if (((ADCName)obj->handle.Instance == ADC_3) && adc3_inited) return;
+    if ((ADCName)obj->handle.Instance == ADC_3) {
         __ADC3_CLK_ENABLE();
         adc3_inited = 1;
     }
 #endif
     // Configure ADC
-    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
     obj->handle.State = HAL_ADC_STATE_RESET;
     obj->handle.Init.ClockPrescaler        = ADC_CLOCKPRESCALER_PCLK_DIV2;
     obj->handle.Init.Resolution            = ADC_RESOLUTION12b;

--- a/targets/TARGET_STM/TARGET_STM32F2/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/analogin_api.c
@@ -36,8 +36,6 @@
 #include "mbed_error.h"
 #include "PeripheralPins.h"
 
-ADC_HandleTypeDef AdcHandle;
-
 void analogin_init(analogin_t *obj, PinName pin)
 {
     uint32_t function = (uint32_t)NC;
@@ -101,20 +99,21 @@ void analogin_init(analogin_t *obj, PinName pin)
     }
 #endif
     // Configure ADC
-    AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
-    AdcHandle.Init.ClockPrescaler        = ADC_CLOCKPRESCALER_PCLK_DIV2;
-    AdcHandle.Init.Resolution            = ADC_RESOLUTION12b;
-    AdcHandle.Init.ScanConvMode          = DISABLE;
-    AdcHandle.Init.ContinuousConvMode    = DISABLE;
-    AdcHandle.Init.DiscontinuousConvMode = DISABLE;
-    AdcHandle.Init.NbrOfDiscConversion   = 0;
-    AdcHandle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
-    AdcHandle.Init.ExternalTrigConv      = ADC_EXTERNALTRIGCONV_T1_CC1;
-    AdcHandle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
-    AdcHandle.Init.NbrOfConversion       = 1;
-    AdcHandle.Init.DMAContinuousRequests = DISABLE;
-    AdcHandle.Init.EOCSelection          = DISABLE;
-    if (HAL_ADC_Init(&AdcHandle) != HAL_OK) {
+    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
+    obj->handle.State = HAL_ADC_STATE_RESET;
+    obj->handle.Init.ClockPrescaler        = ADC_CLOCKPRESCALER_PCLK_DIV2;
+    obj->handle.Init.Resolution            = ADC_RESOLUTION12b;
+    obj->handle.Init.ScanConvMode          = DISABLE;
+    obj->handle.Init.ContinuousConvMode    = DISABLE;
+    obj->handle.Init.DiscontinuousConvMode = DISABLE;
+    obj->handle.Init.NbrOfDiscConversion   = 0;
+    obj->handle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
+    obj->handle.Init.ExternalTrigConv      = ADC_EXTERNALTRIGCONV_T1_CC1;
+    obj->handle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
+    obj->handle.Init.NbrOfConversion       = 1;
+    obj->handle.Init.DMAContinuousRequests = DISABLE;
+    obj->handle.Init.EOCSelection          = DISABLE;
+    if (HAL_ADC_Init(&obj->handle) != HAL_OK) {
         error("Cannot initialize ADC\n");
     }
 }
@@ -122,8 +121,6 @@ void analogin_init(analogin_t *obj, PinName pin)
 static inline uint16_t adc_read(analogin_t *obj)
 {
     ADC_ChannelConfTypeDef sConfig = {0};
-
-    AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     sConfig.Rank         = 1;
@@ -192,13 +189,13 @@ static inline uint16_t adc_read(analogin_t *obj)
             return 0;
     }
 
-    HAL_ADC_ConfigChannel(&AdcHandle, &sConfig);
+    HAL_ADC_ConfigChannel(&obj->handle, &sConfig);
 
-    HAL_ADC_Start(&AdcHandle); // Start conversion
+    HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
-    if (HAL_ADC_PollForConversion(&AdcHandle, 10) == HAL_OK) {
-        return (HAL_ADC_GetValue(&AdcHandle));
+    if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
+        return (HAL_ADC_GetValue(&obj->handle));
     } else {
         return 0;
     }

--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -55,7 +55,6 @@ struct port_s {
 };
 
 struct analogin_s {
-    ADCName adc;
     ADC_HandleTypeDef handle;
     PinName pin;
     uint8_t channel;

--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -56,6 +56,7 @@ struct port_s {
 
 struct analogin_s {
     ADCName adc;
+    ADC_HandleTypeDef handle;
     PinName pin;
     uint8_t channel;
 };

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/objects.h
@@ -54,13 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-    DAC_HandleTypeDef handle;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 #if defined (DEVICE_CAN)
 struct can_s {
     CANName can;

--- a/targets/TARGET_STM/TARGET_STM32F3/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/analogin_api.c
@@ -36,7 +36,6 @@
 #include "mbed_error.h"
 #include "PeripheralPins.h"
 
-ADC_HandleTypeDef AdcHandle;
 
 void analogin_init(analogin_t *obj, PinName pin)
 {
@@ -76,7 +75,6 @@ void analogin_init(analogin_t *obj, PinName pin)
 #if defined(ADC1)
     if ((obj->adc == ADC_1) && adc1_inited) return;
     if (obj->adc == ADC_1) {
-        AdcHandle.State = HAL_ADC_STATE_RESET;
         __ADC1_CLK_ENABLE();
         adc1_inited = 1;
     }
@@ -84,7 +82,6 @@ void analogin_init(analogin_t *obj, PinName pin)
 #if defined(ADC2)
     if ((obj->adc == ADC_2) && adc2_inited) return;
     if (obj->adc == ADC_2) {
-        AdcHandle.State = HAL_ADC_STATE_RESET;
         __ADC2_CLK_ENABLE();
         adc2_inited = 1;
     }
@@ -92,7 +89,6 @@ void analogin_init(analogin_t *obj, PinName pin)
 #if defined(ADC3)
     if ((obj->adc == ADC_3) && adc3_inited) return;
     if (obj->adc == ADC_3) {
-        AdcHandle.State = HAL_ADC_STATE_RESET;
         __ADC34_CLK_ENABLE();
         adc3_inited = 1;
     }
@@ -100,30 +96,30 @@ void analogin_init(analogin_t *obj, PinName pin)
 #if defined(ADC4)
     if ((obj->adc == ADC_4) && adc4_inited) return;
     if (obj->adc == ADC_4) {
-        AdcHandle.State = HAL_ADC_STATE_RESET;
         __ADC34_CLK_ENABLE();
         adc4_inited = 1;
     }
 #endif
 
     // Configure ADC
-    AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
-    AdcHandle.Init.ClockPrescaler        = ADC_CLOCKPRESCALER_PCLK_DIV2;
-    AdcHandle.Init.Resolution            = ADC_RESOLUTION12b;
-    AdcHandle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
-    AdcHandle.Init.ScanConvMode          = DISABLE;
-    AdcHandle.Init.EOCSelection          = EOC_SINGLE_CONV;
-    AdcHandle.Init.LowPowerAutoWait      = DISABLE;
-    AdcHandle.Init.ContinuousConvMode    = DISABLE;
-    AdcHandle.Init.NbrOfConversion       = 1;
-    AdcHandle.Init.DiscontinuousConvMode = DISABLE;
-    AdcHandle.Init.NbrOfDiscConversion   = 0;
-    AdcHandle.Init.ExternalTrigConv      = ADC_EXTERNALTRIGCONV_T1_CC1;
-    AdcHandle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
-    AdcHandle.Init.DMAContinuousRequests = DISABLE;
-    AdcHandle.Init.Overrun               = OVR_DATA_OVERWRITTEN;
+    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
+    obj->handle.State = HAL_ADC_STATE_RESET;
+    obj->handle.Init.ClockPrescaler        = ADC_CLOCKPRESCALER_PCLK_DIV2;
+    obj->handle.Init.Resolution            = ADC_RESOLUTION12b;
+    obj->handle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
+    obj->handle.Init.ScanConvMode          = DISABLE;
+    obj->handle.Init.EOCSelection          = EOC_SINGLE_CONV;
+    obj->handle.Init.LowPowerAutoWait      = DISABLE;
+    obj->handle.Init.ContinuousConvMode    = DISABLE;
+    obj->handle.Init.NbrOfConversion       = 1;
+    obj->handle.Init.DiscontinuousConvMode = DISABLE;
+    obj->handle.Init.NbrOfDiscConversion   = 0;
+    obj->handle.Init.ExternalTrigConv      = ADC_EXTERNALTRIGCONV_T1_CC1;
+    obj->handle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
+    obj->handle.Init.DMAContinuousRequests = DISABLE;
+    obj->handle.Init.Overrun               = OVR_DATA_OVERWRITTEN;
 
-    if (HAL_ADC_Init(&AdcHandle) != HAL_OK) {
+    if (HAL_ADC_Init(&obj->handle) != HAL_OK) {
         error("Cannot initialize ADC");
     }
 }
@@ -132,7 +128,7 @@ static inline uint16_t adc_read(analogin_t *obj)
 {
     ADC_ChannelConfTypeDef sConfig = {0};
 
-    AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
+    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     sConfig.Rank         = ADC_REGULAR_RANK_1;
@@ -200,13 +196,13 @@ static inline uint16_t adc_read(analogin_t *obj)
             return 0;
     }
 
-    HAL_ADC_ConfigChannel(&AdcHandle, &sConfig);
+    HAL_ADC_ConfigChannel(&obj->handle, &sConfig);
 
-    HAL_ADC_Start(&AdcHandle); // Start conversion
+    HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
-    if (HAL_ADC_PollForConversion(&AdcHandle, 10) == HAL_OK) {
-        return (HAL_ADC_GetValue(&AdcHandle));
+    if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
+        return (HAL_ADC_GetValue(&obj->handle));
     } else {
         return 0;
     }

--- a/targets/TARGET_STM/TARGET_STM32F3/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/analogin_api.c
@@ -53,8 +53,8 @@ void analogin_init(analogin_t *obj, PinName pin)
 #endif
 
     // Get the peripheral name from the pin and assign it to the object
-    obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
-    MBED_ASSERT(obj->adc != (ADCName)NC);
+    obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
+    MBED_ASSERT(obj->handle.Instance != (ADC_TypeDef *)NC);
 
     // Get the pin function and assign the used channel to the object
     uint32_t function = pinmap_function(pin, PinMap_ADC);
@@ -73,36 +73,35 @@ void analogin_init(analogin_t *obj, PinName pin)
     // Check if ADC is already initialized
     // Enable ADC clock
 #if defined(ADC1)
-    if ((obj->adc == ADC_1) && adc1_inited) return;
-    if (obj->adc == ADC_1) {
+    if (((ADCName)obj->handle.Instance == ADC_1) && adc1_inited) return;
+    if ((ADCName)obj->handle.Instance == ADC_1) {
         __ADC1_CLK_ENABLE();
         adc1_inited = 1;
     }
 #endif
 #if defined(ADC2)
-    if ((obj->adc == ADC_2) && adc2_inited) return;
-    if (obj->adc == ADC_2) {
+    if (((ADCName)obj->handle.Instance == ADC_2) && adc2_inited) return;
+    if ((ADCName)obj->handle.Instance == ADC_2) {
         __ADC2_CLK_ENABLE();
         adc2_inited = 1;
     }
 #endif
 #if defined(ADC3)
-    if ((obj->adc == ADC_3) && adc3_inited) return;
-    if (obj->adc == ADC_3) {
+    if (((ADCName)obj->handle.Instance == ADC_3) && adc3_inited) return;
+    if ((ADCName)obj->handle.Instance == ADC_3) {
         __ADC34_CLK_ENABLE();
         adc3_inited = 1;
     }
 #endif
 #if defined(ADC4)
-    if ((obj->adc == ADC_4) && adc4_inited) return;
-    if (obj->adc == ADC_4) {
+    if (((ADCName)obj->handle.Instance == ADC_4) && adc4_inited) return;
+    if ((ADCName)obj->handle.Instance == ADC_4) {
         __ADC34_CLK_ENABLE();
         adc4_inited = 1;
     }
 #endif
 
     // Configure ADC
-    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
     obj->handle.State = HAL_ADC_STATE_RESET;
     obj->handle.Init.ClockPrescaler        = ADC_CLOCKPRESCALER_PCLK_DIV2;
     obj->handle.Init.Resolution            = ADC_RESOLUTION12b;
@@ -127,8 +126,6 @@ void analogin_init(analogin_t *obj, PinName pin)
 static inline uint16_t adc_read(analogin_t *obj)
 {
     ADC_ChannelConfTypeDef sConfig = {0};
-
-    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     sConfig.Rank         = ADC_REGULAR_RANK_1;

--- a/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
@@ -118,6 +118,13 @@ struct dac_s {
     DAC_HandleTypeDef handle;
 };
 
+struct analogin_s {
+    ADCName adc;
+    ADC_HandleTypeDef handle;
+    PinName pin;
+    uint8_t channel;
+};
+
 #include "gpio_object.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
@@ -119,7 +119,6 @@ struct dac_s {
 };
 
 struct analogin_s {
-    ADCName adc;
     ADC_HandleTypeDef handle;
     PinName pin;
     uint8_t channel;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xC/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xC/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/objects.h
@@ -40,12 +40,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/objects.h
@@ -40,12 +40,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
@@ -62,7 +62,7 @@ void analogin_init(analogin_t *obj, PinName pin)
         pinmap_pinout(pin, PinMap_ADC);
     } else {
         // Internal channels
-        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
+        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC_Internal);
         function = pinmap_function(pin, PinMap_ADC_Internal);
         // No GPIO configuration for internal channels
     }

--- a/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
@@ -36,8 +36,6 @@
 #include "mbed_error.h"
 #include "PeripheralPins.h"
 
-ADC_HandleTypeDef AdcHandle;
-
 void analogin_init(analogin_t *obj, PinName pin)
 {
     uint32_t function = (uint32_t)NC;
@@ -101,21 +99,22 @@ void analogin_init(analogin_t *obj, PinName pin)
     }
 #endif
     // Configure ADC
-    AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
-    AdcHandle.Init.ClockPrescaler        = ADC_CLOCK_SYNC_PCLK_DIV2;
-    AdcHandle.Init.Resolution            = ADC_RESOLUTION_12B;
-    AdcHandle.Init.ScanConvMode          = DISABLE;
-    AdcHandle.Init.ContinuousConvMode    = DISABLE;
-    AdcHandle.Init.DiscontinuousConvMode = DISABLE;
-    AdcHandle.Init.NbrOfDiscConversion   = 0;
-    AdcHandle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
-    AdcHandle.Init.ExternalTrigConv      = ADC_EXTERNALTRIGCONV_T1_CC1;
-    AdcHandle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
-    AdcHandle.Init.NbrOfConversion       = 1;
-    AdcHandle.Init.DMAContinuousRequests = DISABLE;
-    AdcHandle.Init.EOCSelection          = DISABLE;
+    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
+    obj->handle.State = HAL_ADC_STATE_RESET;
+    obj->handle.Init.ClockPrescaler        = ADC_CLOCK_SYNC_PCLK_DIV2;
+    obj->handle.Init.Resolution            = ADC_RESOLUTION_12B;
+    obj->handle.Init.ScanConvMode          = DISABLE;
+    obj->handle.Init.ContinuousConvMode    = DISABLE;
+    obj->handle.Init.DiscontinuousConvMode = DISABLE;
+    obj->handle.Init.NbrOfDiscConversion   = 0;
+    obj->handle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
+    obj->handle.Init.ExternalTrigConv      = ADC_EXTERNALTRIGCONV_T1_CC1;
+    obj->handle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
+    obj->handle.Init.NbrOfConversion       = 1;
+    obj->handle.Init.DMAContinuousRequests = DISABLE;
+    obj->handle.Init.EOCSelection          = DISABLE;
 
-    if (HAL_ADC_Init(&AdcHandle) != HAL_OK) {
+    if (HAL_ADC_Init(&obj->handle) != HAL_OK) {
         error("Cannot initialize ADC\n");
     }
 }
@@ -124,7 +123,7 @@ static inline uint16_t adc_read(analogin_t *obj)
 {
     ADC_ChannelConfTypeDef sConfig = {0};
 
-    AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
+    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     sConfig.Rank         = 1;
@@ -202,13 +201,13 @@ static inline uint16_t adc_read(analogin_t *obj)
     // so VBAT readings are returned in place of temperature.
     ADC->CCR &= ~(ADC_CCR_VBATE | ADC_CCR_TSVREFE);
 
-    HAL_ADC_ConfigChannel(&AdcHandle, &sConfig);
+    HAL_ADC_ConfigChannel(&obj->handle, &sConfig);
 
-    HAL_ADC_Start(&AdcHandle); // Start conversion
+    HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
-    if (HAL_ADC_PollForConversion(&AdcHandle, 10) == HAL_OK) {
-        return (uint16_t)HAL_ADC_GetValue(&AdcHandle);
+    if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
+        return (uint16_t)HAL_ADC_GetValue(&obj->handle);
     } else {
         return 0;
     }

--- a/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
@@ -39,7 +39,6 @@
 void analogin_init(analogin_t *obj, PinName pin)
 {
     uint32_t function = (uint32_t)NC;
-    obj->adc = (ADCName)NC;
 
 #if defined(ADC1)
     static int adc1_inited = 0;
@@ -56,18 +55,18 @@ void analogin_init(analogin_t *obj, PinName pin)
     if (pin < 0xF0) {
         // Normal channels
         // Get the peripheral name from the pin and assign it to the object
-        obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
+        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
         // Get the functions (adc channel) from the pin and assign it to the object
         function = pinmap_function(pin, PinMap_ADC);
         // Configure GPIO
         pinmap_pinout(pin, PinMap_ADC);
     } else {
         // Internal channels
-        obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC_Internal);
+        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
         function = pinmap_function(pin, PinMap_ADC_Internal);
         // No GPIO configuration for internal channels
     }
-    MBED_ASSERT(obj->adc != (ADCName)NC);
+    MBED_ASSERT(obj->handle.Instance != (ADC_TypeDef *)NC);
     MBED_ASSERT(function != (uint32_t)NC);
 
     obj->channel = STM_PIN_CHANNEL(function);
@@ -78,28 +77,27 @@ void analogin_init(analogin_t *obj, PinName pin)
     // Check if ADC is already initialized
     // Enable ADC clock
 #if defined(ADC1)
-    if ((obj->adc == ADC_1) && adc1_inited) return;
-    if (obj->adc == ADC_1) {
+    if (((ADCName)obj->handle.Instance == ADC_1) && adc1_inited) return;
+    if ((ADCName)obj->handle.Instance == ADC_1) {
         __HAL_RCC_ADC1_CLK_ENABLE();
         adc1_inited = 1;
     }
 #endif
 #if defined(ADC2)
-    if ((obj->adc == ADC_2) && adc2_inited) return;
-    if (obj->adc == ADC_2) {
+    if (((ADCName)obj->handle.Instance == ADC_2) && adc2_inited) return;
+    if ((ADCName)obj->handle.Instance == ADC_2) {
         __HAL_RCC_ADC2_CLK_ENABLE();
         adc2_inited = 1;
     }
 #endif
 #if defined(ADC3)
-    if ((obj->adc == ADC_3) && adc3_inited) return;
-    if (obj->adc == ADC_3) {
+    if (((ADCName)obj->handle.Instance == ADC_3) && adc3_inited) return;
+    if ((ADCName)obj->handle.Instance == ADC_3) {
         __HAL_RCC_ADC3_CLK_ENABLE();
         adc3_inited = 1;
     }
 #endif
     // Configure ADC
-    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
     obj->handle.State = HAL_ADC_STATE_RESET;
     obj->handle.Init.ClockPrescaler        = ADC_CLOCK_SYNC_PCLK_DIV2;
     obj->handle.Init.Resolution            = ADC_RESOLUTION_12B;
@@ -122,8 +120,6 @@ void analogin_init(analogin_t *obj, PinName pin)
 static inline uint16_t adc_read(analogin_t *obj)
 {
     ADC_ChannelConfTypeDef sConfig = {0};
-
-    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     sConfig.Rank         = 1;

--- a/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
@@ -117,7 +117,6 @@ struct flash_s {
 #endif
 
 struct analogin_s {
-    ADCName adc;
     ADC_HandleTypeDef handle;
     PinName pin;
     uint8_t channel;

--- a/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
@@ -109,11 +109,20 @@ struct i2c_s {
     uint8_t available_events;
 #endif
 };
+
 #if DEVICE_FLASH
 struct flash_s {
     uint32_t dummy;
 };
 #endif
+
+struct analogin_s {
+    ADCName adc;
+    ADC_HandleTypeDef handle;
+    PinName pin;
+    uint8_t channel;
+};
+
 #define GPIO_IP_WITHOUT_BRR
 #include "gpio_object.h"
 

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint8_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32F7/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/analogin_api.c
@@ -61,7 +61,7 @@ void analogin_init(analogin_t *obj, PinName pin)
         pinmap_pinout(pin, PinMap_ADC);
     } else {
         // Internal channels
-        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
+        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC_Internal);
         function = pinmap_function(pin, PinMap_ADC_Internal);
         // No GPIO configuration for internal channels
     }

--- a/targets/TARGET_STM/TARGET_STM32F7/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/analogin_api.c
@@ -36,8 +36,6 @@
 #include "PeripheralPins.h"
 #include "mbed_error.h"
 
-ADC_HandleTypeDef AdcHandle;
-
 void analogin_init(analogin_t *obj, PinName pin)
 {
     uint32_t function = (uint32_t)NC;
@@ -102,21 +100,22 @@ void analogin_init(analogin_t *obj, PinName pin)
 #endif
 
     // Configure ADC
-    AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
-    AdcHandle.Init.ClockPrescaler        = ADC_CLOCKPRESCALER_PCLK_DIV4;
-    AdcHandle.Init.Resolution            = ADC_RESOLUTION_12B;
-    AdcHandle.Init.ScanConvMode          = DISABLE;
-    AdcHandle.Init.ContinuousConvMode    = DISABLE;
-    AdcHandle.Init.DiscontinuousConvMode = DISABLE;
-    AdcHandle.Init.NbrOfDiscConversion   = 0;
-    AdcHandle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
-    AdcHandle.Init.ExternalTrigConv      = ADC_EXTERNALTRIGCONV_T1_CC1;
-    AdcHandle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
-    AdcHandle.Init.NbrOfConversion       = 1;
-    AdcHandle.Init.DMAContinuousRequests = DISABLE;
-    AdcHandle.Init.EOCSelection          = DISABLE;
+    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
+    obj->handle.State = HAL_ADC_STATE_RESET;
+    obj->handle.Init.ClockPrescaler        = ADC_CLOCKPRESCALER_PCLK_DIV4;
+    obj->handle.Init.Resolution            = ADC_RESOLUTION_12B;
+    obj->handle.Init.ScanConvMode          = DISABLE;
+    obj->handle.Init.ContinuousConvMode    = DISABLE;
+    obj->handle.Init.DiscontinuousConvMode = DISABLE;
+    obj->handle.Init.NbrOfDiscConversion   = 0;
+    obj->handle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
+    obj->handle.Init.ExternalTrigConv      = ADC_EXTERNALTRIGCONV_T1_CC1;
+    obj->handle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
+    obj->handle.Init.NbrOfConversion       = 1;
+    obj->handle.Init.DMAContinuousRequests = DISABLE;
+    obj->handle.Init.EOCSelection          = DISABLE;
 
-    if (HAL_ADC_Init(&AdcHandle) != HAL_OK) {
+    if (HAL_ADC_Init(&obj->handle) != HAL_OK) {
         error("Cannot initialize ADC");
     }
 }
@@ -125,7 +124,7 @@ static inline uint16_t adc_read(analogin_t *obj)
 {
     ADC_ChannelConfTypeDef sConfig = {0};
 
-    AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
+    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     sConfig.Rank         = 1;
@@ -194,16 +193,16 @@ static inline uint16_t adc_read(analogin_t *obj)
             return 0;
     }
 
-    if (HAL_ADC_ConfigChannel(&AdcHandle, &sConfig) != HAL_OK) {
+    if (HAL_ADC_ConfigChannel(&obj->handle, &sConfig) != HAL_OK) {
         error("Cannot configure ADC channel");
     }
 
-    HAL_ADC_Start(&AdcHandle); // Start conversion
+    HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
-    HAL_ADC_PollForConversion(&AdcHandle, 10);
-    if (HAL_ADC_GetState(&AdcHandle) & HAL_ADC_STATE_EOC_REG) {
-        return (HAL_ADC_GetValue(&AdcHandle));
+    HAL_ADC_PollForConversion(&obj->handle, 10);
+    if (HAL_ADC_GetState(&obj->handle) & HAL_ADC_STATE_EOC_REG) {
+        return (HAL_ADC_GetValue(&obj->handle));
     } else {
         return 0;
     }

--- a/targets/TARGET_STM/TARGET_STM32F7/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/analogin_api.c
@@ -39,7 +39,6 @@
 void analogin_init(analogin_t *obj, PinName pin)
 {
     uint32_t function = (uint32_t)NC;
-    obj->adc = (ADCName)NC;
 
 #if defined(ADC1)
     static int adc1_inited = 0;
@@ -56,18 +55,17 @@ void analogin_init(analogin_t *obj, PinName pin)
     if (pin < 0xF0) {
         // Normal channels
         // Get the peripheral name from the pin and assign it to the object
-        obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
-        // Get the functions (adc channel) from the pin and assign it to the object
+        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
         function = pinmap_function(pin, PinMap_ADC);
         // Configure GPIO
         pinmap_pinout(pin, PinMap_ADC);
     } else {
         // Internal channels
-        obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC_Internal);
+        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
         function = pinmap_function(pin, PinMap_ADC_Internal);
         // No GPIO configuration for internal channels
     }
-    MBED_ASSERT(obj->adc != (ADCName)NC);
+    MBED_ASSERT(obj->handle.Instance != (ADC_TypeDef *)NC);
     MBED_ASSERT(function != (uint32_t)NC);
 
     obj->channel = STM_PIN_CHANNEL(function);
@@ -78,29 +76,28 @@ void analogin_init(analogin_t *obj, PinName pin)
     // Check if ADC is already initialized
     // Enable ADC clock
 #if defined(ADC1)
-    if ((obj->adc == ADC_1) && adc1_inited) return;
-    if (obj->adc == ADC_1) {
+    if (((ADCName)obj->handle.Instance == ADC_1) && adc1_inited) return;
+    if ((ADCName)obj->handle.Instance == ADC_1) {
         __HAL_RCC_ADC1_CLK_ENABLE();
         adc1_inited = 1;
     }
 #endif
 #if defined(ADC2)
-    if ((obj->adc == ADC_2) && adc2_inited) return;
-    if (obj->adc == ADC_2) {
+    if (((ADCName)obj->handle.Instance == ADC_2) && adc2_inited) return;
+    if ((ADCName)obj->handle.Instance == ADC_2) {
         __HAL_RCC_ADC2_CLK_ENABLE();
         adc2_inited = 1;
     }
 #endif
 #if defined(ADC3)
-    if ((obj->adc == ADC_3) && adc3_inited) return;
-    if (obj->adc == ADC_3) {
+    if (((ADCName)obj->handle.Instance == ADC_3) && adc3_inited) return;
+    if ((ADCName)obj->handle.Instance == ADC_3) {
         __HAL_RCC_ADC3_CLK_ENABLE();
         adc3_inited = 1;
     }
 #endif
 
     // Configure ADC
-    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
     obj->handle.State = HAL_ADC_STATE_RESET;
     obj->handle.Init.ClockPrescaler        = ADC_CLOCKPRESCALER_PCLK_DIV4;
     obj->handle.Init.Resolution            = ADC_RESOLUTION_12B;
@@ -123,8 +120,6 @@ void analogin_init(analogin_t *obj, PinName pin)
 static inline uint16_t adc_read(analogin_t *obj)
 {
     ADC_ChannelConfTypeDef sConfig = {0};
-
-    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     sConfig.Rank         = 1;

--- a/targets/TARGET_STM/TARGET_STM32F7/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/common_objects.h
@@ -111,6 +111,13 @@ struct i2c_s {
 #endif
 };
 
+struct analogin_s {
+    ADCName adc;
+    ADC_HandleTypeDef handle;
+    PinName pin;
+    uint8_t channel;
+};
+
 #define GPIO_IP_WITHOUT_BRR
 #include "gpio_object.h"
 

--- a/targets/TARGET_STM/TARGET_STM32F7/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/common_objects.h
@@ -112,7 +112,6 @@ struct i2c_s {
 };
 
 struct analogin_s {
-    ADCName adc;
     ADC_HandleTypeDef handle;
     PinName pin;
     uint8_t channel;

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L072CZ_LRWAN1/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L072CZ_LRWAN1/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32L0/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/analogin_api.c
@@ -49,18 +49,18 @@ void analogin_init(analogin_t *obj, PinName pin)
     if (pin < 0xF0) {
         // Normal channels
         // Get the peripheral name from the pin and assign it to the object
-        obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
+        obj->handle.Instance = (ADC_TypeDef *)pinmap_peripheral(pin, PinMap_ADC);
         // Get the functions (adc channel) from the pin and assign it to the object
         function = pinmap_function(pin, PinMap_ADC);
         // Configure GPIO
         pinmap_pinout(pin, PinMap_ADC);
     } else {
         // Internal channels
-        obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC_Internal);
+        obj->handle.Instance = (ADC_TypeDef *)pinmap_peripheral(pin, PinMap_ADC_Internal);
         function = pinmap_function(pin, PinMap_ADC_Internal);
         // No GPIO configuration for internal channels
     }
-    MBED_ASSERT(obj->adc != (ADCName)NC);
+    MBED_ASSERT(obj->handle.Instance != (ADC_TypeDef *)NC);
     MBED_ASSERT(function != (uint32_t)NC);
 
     obj->channel = STM_PIN_CHANNEL(function);
@@ -72,9 +72,7 @@ void analogin_init(analogin_t *obj, PinName pin)
     if (adc_inited == 0) {
         adc_inited = 1;
 
-        obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
         obj->handle.State = HAL_ADC_STATE_RESET;
-
         // Enable ADC clock
         __ADC1_CLK_ENABLE();
 
@@ -110,8 +108,6 @@ void analogin_init(analogin_t *obj, PinName pin)
 static inline uint16_t adc_read(analogin_t *obj)
 {
     ADC_ChannelConfTypeDef sConfig = {0};
-
-    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     sConfig.Rank = ADC_RANK_CHANNEL_NUMBER;

--- a/targets/TARGET_STM/TARGET_STM32L0/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/analogin_api.c
@@ -36,8 +36,6 @@
 #include "mbed_error.h"
 #include "PeripheralPins.h"
 
-ADC_HandleTypeDef AdcHandle;
-
 int adc_inited = 0;
 
 void analogin_init(analogin_t *obj, PinName pin)
@@ -74,37 +72,38 @@ void analogin_init(analogin_t *obj, PinName pin)
     if (adc_inited == 0) {
         adc_inited = 1;
 
-        AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
+        obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
+        obj->handle.State = HAL_ADC_STATE_RESET;
 
         // Enable ADC clock
         __ADC1_CLK_ENABLE();
 
         // Configure ADC
-        AdcHandle.Init.OversamplingMode      = DISABLE;
-        AdcHandle.Init.ClockPrescaler        = ADC_CLOCKPRESCALER_PCLK_DIV1;
-        AdcHandle.Init.Resolution            = ADC_RESOLUTION12b;
-        AdcHandle.Init.SamplingTime          = ADC_SAMPLETIME_239CYCLES_5;
-        AdcHandle.Init.ScanConvMode          = ADC_SCAN_DIRECTION_FORWARD;
-        AdcHandle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
-        AdcHandle.Init.ContinuousConvMode    = DISABLE;
-        AdcHandle.Init.DiscontinuousConvMode = DISABLE;
-        AdcHandle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIG_EDGE_NONE;
-        AdcHandle.Init.ExternalTrigConv      = ADC_EXTERNALTRIG0_T6_TRGO; // Not used here
-        AdcHandle.Init.DMAContinuousRequests = DISABLE;
-        AdcHandle.Init.EOCSelection          = EOC_SINGLE_CONV;
-        AdcHandle.Init.Overrun               = OVR_DATA_OVERWRITTEN;
-        AdcHandle.Init.LowPowerAutoWait      = ENABLE;
-        AdcHandle.Init.LowPowerFrequencyMode = DISABLE; // To be enabled only if ADC clock < 2.8 MHz
-        AdcHandle.Init.LowPowerAutoPowerOff  = DISABLE;
+        obj->handle.Init.OversamplingMode      = DISABLE;
+        obj->handle.Init.ClockPrescaler        = ADC_CLOCKPRESCALER_PCLK_DIV1;
+        obj->handle.Init.Resolution            = ADC_RESOLUTION12b;
+        obj->handle.Init.SamplingTime          = ADC_SAMPLETIME_239CYCLES_5;
+        obj->handle.Init.ScanConvMode          = ADC_SCAN_DIRECTION_FORWARD;
+        obj->handle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
+        obj->handle.Init.ContinuousConvMode    = DISABLE;
+        obj->handle.Init.DiscontinuousConvMode = DISABLE;
+        obj->handle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIG_EDGE_NONE;
+        obj->handle.Init.ExternalTrigConv      = ADC_EXTERNALTRIG0_T6_TRGO; // Not used here
+        obj->handle.Init.DMAContinuousRequests = DISABLE;
+        obj->handle.Init.EOCSelection          = EOC_SINGLE_CONV;
+        obj->handle.Init.Overrun               = OVR_DATA_OVERWRITTEN;
+        obj->handle.Init.LowPowerAutoWait      = ENABLE;
+        obj->handle.Init.LowPowerFrequencyMode = DISABLE; // To be enabled only if ADC clock < 2.8 MHz
+        obj->handle.Init.LowPowerAutoPowerOff  = DISABLE;
 
-        if (HAL_ADC_Init(&AdcHandle) != HAL_OK) {
+        if (HAL_ADC_Init(&obj->handle) != HAL_OK) {
             error("Cannot initialize ADC");
         }
 
         // Calibration
-        HAL_ADCEx_Calibration_Start(&AdcHandle, ADC_SINGLE_ENDED);
+        HAL_ADCEx_Calibration_Start(&obj->handle, ADC_SINGLE_ENDED);
 
-        __HAL_ADC_ENABLE(&AdcHandle);
+        __HAL_ADC_ENABLE(&obj->handle);
     }
 }
 
@@ -112,7 +111,7 @@ static inline uint16_t adc_read(analogin_t *obj)
 {
     ADC_ChannelConfTypeDef sConfig = {0};
 
-    AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
+    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     sConfig.Rank = ADC_RANK_CHANNEL_NUMBER;
@@ -181,13 +180,13 @@ static inline uint16_t adc_read(analogin_t *obj)
     }
 
     ADC1->CHSELR = 0; // [TODO] Workaround. To be removed after Cube driver is corrected.
-    HAL_ADC_ConfigChannel(&AdcHandle, &sConfig);
+    HAL_ADC_ConfigChannel(&obj->handle, &sConfig);
 
-    HAL_ADC_Start(&AdcHandle); // Start conversion
+    HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
-    if (HAL_ADC_PollForConversion(&AdcHandle, 10) == HAL_OK) {
-        return (HAL_ADC_GetValue(&AdcHandle));
+    if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
+        return (HAL_ADC_GetValue(&obj->handle));
     } else {
         return 0;
     }

--- a/targets/TARGET_STM/TARGET_STM32L0/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/analogin_api.c
@@ -41,7 +41,7 @@ int adc_inited = 0;
 void analogin_init(analogin_t *obj, PinName pin)
 {
     uint32_t function = (uint32_t)NC;
-    obj->adc = (ADCName)NC;
+    obj->handle.Instance = (ADC_TypeDef *)NC;
 
     // ADC Internal Channels "pins"  (Temperature, Vref, Vbat, ...)
     //   are described in PinNames.h and PeripheralPins.c

--- a/targets/TARGET_STM/TARGET_STM32L0/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/common_objects.h
@@ -117,7 +117,6 @@ struct flash_s {
 };
 
 struct analogin_s {
-    ADCName adc;
     ADC_HandleTypeDef handle;
     PinName pin;
     uint8_t channel;

--- a/targets/TARGET_STM/TARGET_STM32L0/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/common_objects.h
@@ -116,6 +116,13 @@ struct flash_s {
     uint32_t dummy;
 };
 
+struct analogin_s {
+    ADCName adc;
+    ADC_HandleTypeDef handle;
+    PinName pin;
+    uint8_t channel;
+};
+
 #include "gpio_object.h"
 
 #if DEVICE_ANALOGOUT

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 #define GPIO_IP_WITHOUT_BRR
 #include "common_objects.h"
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 #define GPIO_IP_WITHOUT_BRR
 #include "common_objects.h"
 

--- a/targets/TARGET_STM/TARGET_STM32L1/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/analogin_api.c
@@ -36,8 +36,6 @@
 #include "mbed_error.h"
 #include "PeripheralPins.h"
 
-ADC_HandleTypeDef AdcHandle;
-
 int adc_inited = 0;
 
 void analogin_init(analogin_t *obj, PinName pin)
@@ -73,29 +71,30 @@ void analogin_init(analogin_t *obj, PinName pin)
         RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
         HAL_RCC_OscConfig(&RCC_OscInitStruct);
 
-        AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
+        obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
+        obj->handle.State = HAL_ADC_STATE_RESET;
 
         // Enable ADC clock
         __ADC1_CLK_ENABLE();
 
         // Configure ADC
-        AdcHandle.Init.ClockPrescaler        = ADC_CLOCK_ASYNC_DIV4;
-        AdcHandle.Init.Resolution            = ADC_RESOLUTION12b;
-        AdcHandle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
-        AdcHandle.Init.ScanConvMode          = DISABLE;                       // Sequencer disabled (ADC conversion on only 1 channel: channel set on rank 1)
-        AdcHandle.Init.EOCSelection          = EOC_SINGLE_CONV;               // On STM32L1xx ADC, overrun detection is enabled only if EOC selection is set to each conversion (or transfer by DMA enabled, this is not the case in this example).
-        AdcHandle.Init.LowPowerAutoWait      = ADC_AUTOWAIT_UNTIL_DATA_READ;  // Enable the dynamic low power Auto Delay: new conversion start only when the previous conversion (for regular group) or previous sequence (for injected group) has been treated by user software.
-        AdcHandle.Init.LowPowerAutoPowerOff  = ADC_AUTOPOWEROFF_IDLE_PHASE;   // Enable the auto-off mode: the ADC automatically powers-off after a conversion and automatically wakes-up when a new conversion is triggered (with startup time between trigger and start of sampling).
-        AdcHandle.Init.ChannelsBank          = ADC_CHANNELS_BANK_A;
-        AdcHandle.Init.ContinuousConvMode    = DISABLE;                       // Continuous mode disabled to have only 1 conversion at each conversion trig
-        AdcHandle.Init.NbrOfConversion       = 1;                             // Parameter discarded because sequencer is disabled
-        AdcHandle.Init.DiscontinuousConvMode = DISABLE;                       // Parameter discarded because sequencer is disabled
-        AdcHandle.Init.NbrOfDiscConversion   = 1;                             // Parameter discarded because sequencer is disabled
-        AdcHandle.Init.ExternalTrigConv      = 0;                             // Not used
-        AdcHandle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
-        AdcHandle.Init.DMAContinuousRequests = DISABLE;
+        obj->handle.Init.ClockPrescaler        = ADC_CLOCK_ASYNC_DIV4;
+        obj->handle.Init.Resolution            = ADC_RESOLUTION12b;
+        obj->handle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
+        obj->handle.Init.ScanConvMode          = DISABLE;                       // Sequencer disabled (ADC conversion on only 1 channel: channel set on rank 1)
+        obj->handle.Init.EOCSelection          = EOC_SINGLE_CONV;               // On STM32L1xx ADC, overrun detection is enabled only if EOC selection is set to each conversion (or transfer by DMA enabled, this is not the case in this example).
+        obj->handle.Init.LowPowerAutoWait      = ADC_AUTOWAIT_UNTIL_DATA_READ;  // Enable the dynamic low power Auto Delay: new conversion start only when the previous conversion (for regular group) or previous sequence (for injected group) has been treated by user software.
+        obj->handle.Init.LowPowerAutoPowerOff  = ADC_AUTOPOWEROFF_IDLE_PHASE;   // Enable the auto-off mode: the ADC automatically powers-off after a conversion and automatically wakes-up when a new conversion is triggered (with startup time between trigger and start of sampling).
+        obj->handle.Init.ChannelsBank          = ADC_CHANNELS_BANK_A;
+        obj->handle.Init.ContinuousConvMode    = DISABLE;                       // Continuous mode disabled to have only 1 conversion at each conversion trig
+        obj->handle.Init.NbrOfConversion       = 1;                             // Parameter discarded because sequencer is disabled
+        obj->handle.Init.DiscontinuousConvMode = DISABLE;                       // Parameter discarded because sequencer is disabled
+        obj->handle.Init.NbrOfDiscConversion   = 1;                             // Parameter discarded because sequencer is disabled
+        obj->handle.Init.ExternalTrigConv      = 0;                             // Not used
+        obj->handle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
+        obj->handle.Init.DMAContinuousRequests = DISABLE;
 
-        if (HAL_ADC_Init(&AdcHandle) != HAL_OK) {
+        if (HAL_ADC_Init(&obj->handle) != HAL_OK) {
             error("Cannot initialize ADC");
         }
     }
@@ -105,7 +104,7 @@ static inline uint16_t adc_read(analogin_t *obj)
 {
     ADC_ChannelConfTypeDef sConfig = {0};
 
-    AdcHandle.Instance = (ADC_TypeDef *)(obj->adc);
+    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     switch (obj->channel) {
@@ -222,13 +221,13 @@ static inline uint16_t adc_read(analogin_t *obj)
     sConfig.Rank         = ADC_REGULAR_RANK_1;
     sConfig.SamplingTime = ADC_SAMPLETIME_16CYCLES;
 
-    HAL_ADC_ConfigChannel(&AdcHandle, &sConfig);
+    HAL_ADC_ConfigChannel(&obj->handle, &sConfig);
 
-    HAL_ADC_Start(&AdcHandle); // Start conversion
+    HAL_ADC_Start(&obj->handle); // Start conversion
 
     // Wait end of conversion and get value
-    if (HAL_ADC_PollForConversion(&AdcHandle, 10) == HAL_OK) {
-        return (HAL_ADC_GetValue(&AdcHandle));
+    if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
+        return (HAL_ADC_GetValue(&obj->handle));
     } else {
         return 0;
     }

--- a/targets/TARGET_STM/TARGET_STM32L1/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/analogin_api.c
@@ -43,8 +43,8 @@ void analogin_init(analogin_t *obj, PinName pin)
     RCC_OscInitTypeDef RCC_OscInitStruct;
 
     // Get the peripheral name from the pin and assign it to the object
-    obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
-    MBED_ASSERT(obj->adc != (ADCName)NC);
+    obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
+    MBED_ASSERT(obj->handle.Instance != (ADC_TypeDef *)NC);
 
     // Get the pin function and assign the used channel to the object
     uint32_t function = pinmap_function(pin, PinMap_ADC);
@@ -71,9 +71,7 @@ void analogin_init(analogin_t *obj, PinName pin)
         RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
         HAL_RCC_OscConfig(&RCC_OscInitStruct);
 
-        obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
         obj->handle.State = HAL_ADC_STATE_RESET;
-
         // Enable ADC clock
         __ADC1_CLK_ENABLE();
 
@@ -103,8 +101,6 @@ void analogin_init(analogin_t *obj, PinName pin)
 static inline uint16_t adc_read(analogin_t *obj)
 {
     ADC_ChannelConfTypeDef sConfig = {0};
-
-    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     switch (obj->channel) {

--- a/targets/TARGET_STM/TARGET_STM32L1/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/common_objects.h
@@ -117,6 +117,13 @@ struct dac_s {
     DAC_HandleTypeDef handle;
 };
 
+struct analogin_s {
+    ADCName adc;
+    ADC_HandleTypeDef handle;
+    PinName pin;
+    uint8_t channel;
+};
+
 #include "gpio_object.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32L1/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/common_objects.h
@@ -118,7 +118,6 @@ struct dac_s {
 };
 
 struct analogin_s {
-    ADCName adc;
     ADC_HandleTypeDef handle;
     PinName pin;
     uint8_t channel;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;

--- a/targets/TARGET_STM/TARGET_STM32L4/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/analogin_api.c
@@ -55,7 +55,7 @@ void analogin_init(analogin_t *obj, PinName pin)
         pinmap_pinout(pin, PinMap_ADC);
     } else {
         // Internal channels
-        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
+        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC_Internal);
         function = pinmap_function(pin, PinMap_ADC_Internal);
         // No GPIO configuration for internal channels
     }

--- a/targets/TARGET_STM/TARGET_STM32L4/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/analogin_api.c
@@ -41,7 +41,6 @@ int adc_inited = 0;
 void analogin_init(analogin_t *obj, PinName pin)
 {
     uint32_t function = (uint32_t)NC;
-    obj->adc = (ADCName)NC;
 
     // ADC Internal Channels "pins"  (Temperature, Vref, Vbat, ...)
     //   are described in PinNames.h and PeripheralPins.c
@@ -49,18 +48,18 @@ void analogin_init(analogin_t *obj, PinName pin)
     if (pin < 0xF0) {
         // Normal channels
         // Get the peripheral name from the pin and assign it to the object
-        obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC);
+        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
         // Get the functions (adc channel) from the pin and assign it to the object
         function = pinmap_function(pin, PinMap_ADC);
         // Configure GPIO
         pinmap_pinout(pin, PinMap_ADC);
     } else {
         // Internal channels
-        obj->adc = (ADCName)pinmap_peripheral(pin, PinMap_ADC_Internal);
+        obj->handle.Instance = (ADC_TypeDef *) pinmap_peripheral(pin, PinMap_ADC);
         function = pinmap_function(pin, PinMap_ADC_Internal);
         // No GPIO configuration for internal channels
     }
-    MBED_ASSERT(obj->adc != (ADCName)NC);
+    MBED_ASSERT(obj->handle.Instance != (ADC_TypeDef *)NC);
     MBED_ASSERT(function != (uint32_t)NC);
 
     obj->channel = STM_PIN_CHANNEL(function);
@@ -76,9 +75,7 @@ void analogin_init(analogin_t *obj, PinName pin)
         __HAL_RCC_ADC_CLK_ENABLE();
         __HAL_RCC_ADC_CONFIG(RCC_ADCCLKSOURCE_SYSCLK);
 
-        obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
         obj->handle.State = HAL_ADC_STATE_RESET;
-
         // Configure ADC
         obj->handle.Init.ClockPrescaler        = ADC_CLOCK_ASYNC_DIV2;          // Asynchronous clock mode, input ADC clock
         obj->handle.Init.Resolution            = ADC_RESOLUTION_12B;
@@ -105,8 +102,6 @@ void analogin_init(analogin_t *obj, PinName pin)
 static inline uint16_t adc_read(analogin_t *obj)
 {
     ADC_ChannelConfTypeDef sConfig = {0};
-
-    obj->handle.Instance = (ADC_TypeDef *)(obj->adc);
 
     // Configure ADC channel
     switch (obj->channel) {

--- a/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
@@ -117,7 +117,6 @@ struct flash_s {
 };
 
 struct analogin_s {
-    ADCName adc;
     ADC_HandleTypeDef handle;
     PinName pin;
     uint8_t channel;

--- a/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
@@ -116,6 +116,13 @@ struct flash_s {
     uint32_t dummy;
 };
 
+struct analogin_s {
+    ADCName adc;
+    ADC_HandleTypeDef handle;
+    PinName pin;
+    uint8_t channel;
+};
+
 #include "gpio_object.h"
 
 struct dac_s {


### PR DESCRIPTION
## Description
Few reports has raised issue related to multiple instances of analogin objects:
https://developer.mbed.org/questions/67841/Multiple-analogIn-not-working/

This PR solves the issue by replacing usage of a single global variable to store the adc handle by a new handle members in the analogin_s object.

## Status
**READY**

## Tests
CI shield tests PASSED OK. (no regression found)

![image](https://user-images.githubusercontent.com/17590297/27484716-8d14cf3c-582a-11e7-8b11-37aa7c7dbb22.png)

