### PR TITLE
STM32: fix us ticker set event timestamp double ISR possibility

### DIFF
--- a/targets/TARGET_STM/us_ticker_32b.c
+++ b/targets/TARGET_STM/us_ticker_32b.c
@@ -44,14 +44,16 @@ uint32_t us_ticker_read()
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
     TimMasterHandle.Instance = TIM_MST;
+    // disable IT while we are handling the correct timestamp
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC1);
     // Set new output compare value
     __HAL_TIM_SET_COMPARE(&TimMasterHandle, TIM_CHANNEL_1, (uint32_t)timestamp);
-    // Enable IT
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC1);
     // Check if timestamp has already passed, and if so, set the event immediately
     if ((int32_t)(timestamp - TIM_MST->CNT) <= 0) {
         LL_TIM_GenerateEvent_CC1(TimMasterHandle.Instance);
     }
+    // Enable IT
+    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC1);
 }
 
 void us_ticker_disable_interrupt(void)


### PR DESCRIPTION
This fixes setting the new event for us ticker. As it was, the interrupt would
fire 2x. It should either fire ISR immediately or set it in the future.

Tested with ODIN target and a test case for setting events in the past that will come as a separate PR.

As I understood the code, we either generate event and enable it OR set new compare value and enable it. This fixes the failures we have seen in #4628 and possibly in our CI for basic timer tests.

before this patch:
```
+-----------------------+-------------------+----------------------------+--------+--------------------+-------------+
| target                | platform_name     | test suite                 | result | elapsed_time (sec) | copy_method |
+-----------------------+-------------------+----------------------------+--------+--------------------+-------------+
| UBLOX_EVK_ODIN_W2-ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-ticker_port | FAIL   | 9.3                | shell       |
+-----------------------+-------------------+----------------------------+--------+--------------------+-------------+
```

after this patch:
```
+-----------------------+-------------------+----------------------------+--------+--------------------+-------------+
| target                | platform_name     | test suite                 | result | elapsed_time (sec) | copy_method |
+-----------------------+-------------------+----------------------------+--------+--------------------+-------------+
| UBLOX_EVK_ODIN_W2-ARM | UBLOX_EVK_ODIN_W2 | tests-mbed_hal-ticker_port | OK     | 9.93               | shell       |
+-----------------------+-------------------+----------------------------+--------+--------------------+-------------+
```

This was the failure `[1498475248.69][CONN][RXD] Testing interrupt 0 us in the past
[1498475248.77][CONN][RXD] :86::FAIL: Expected 1 Was 2` . we can see that first event in the past should produce just one IRQ call, but actually was 2x.

Is this the same problem for 16 bit ticker, I can see negative delta handling but prior that we are again setting the new match value (timestamp), is that correct?

I can rebase this on top of the test addition, and t hen rebase once the test is integrated if that helps.

cc @bcostm @adustm @LMESTM @jeromecoutant @c1728p9 @andreaslarssonublox 
