### PR TITLE
 Fix the issue #4357: NRF52 doesn't support simultaneous use of I2C and SPI.

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/spi_api.c
@@ -305,9 +305,9 @@ void spi_init(spi_t *obj,
                 p_spi_info->initialized = true;
                 p_spi_info->master      = true;
                 p_spi_info->flag.busy   = false;
-            #if DEVICE_SPI_ASYNCH
+#if DEVICE_SPI_ASYNCH
                 p_spi_info->handler     = 0;
-            #endif
+#endif
                 SPI_IDX(obj) = i;
                 NVIC_SetVector(spi_handler_desc[i].IRQn, spi_handler_desc[i].vector);
                 return;

--- a/targets/TARGET_NORDIC/TARGET_NRF5/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/spi_api.c
@@ -277,9 +277,11 @@ void spi_init(spi_t *obj,
         }
     }
 
-    for (i = 0; i < SPI_COUNT; ++i) {
+    for (i = SPI_COUNT - 1; i >= 0; i--) {
         spi_info_t *p_spi_info = &m_spi_info[i];
+
         if (!p_spi_info->initialized) {
+
             p_spi_info->sck_pin   = (uint8_t)sclk;
             p_spi_info->mosi_pin  = (mosi != NC) ?
                 (uint8_t)mosi : NRF_DRV_SPI_PIN_NOT_USED;
@@ -289,8 +291,6 @@ void spi_init(spi_t *obj,
                 (uint8_t)ssel : NRF_DRV_SPI_PIN_NOT_USED;
             p_spi_info->spi_mode  = (uint8_t)NRF_DRV_SPI_MODE_0;
             p_spi_info->frequency = NRF_DRV_SPI_FREQ_1M;
-
-            NVIC_SetVector(spi_handler_desc[i].IRQn, spi_handler_desc[i].vector);
 
             // By default each SPI instance is initialized to work as a master.
             // Should the slave mode be used, the instance will be reconfigured
@@ -309,7 +309,7 @@ void spi_init(spi_t *obj,
                 p_spi_info->handler     = 0;
             #endif
                 SPI_IDX(obj) = i;
-
+                NVIC_SetVector(spi_handler_desc[i].IRQn, spi_handler_desc[i].vector);
                 return;
             }
         }


### PR DESCRIPTION
## Description
Add Support for sharing resources between SPI and TWI instancess.
This fix the issue #4357: NRF52 doesn't support simultaneous use of I2C and SPI.
Now this resources are reserved by each of hal driver using nRF5 SDK's serial-box mechanism.


## Status
**READY**