### PR TITLE
Double escape defines in gnuarmeclipse export

### DIFF
--- a/tools/export/gnuarmeclipse/.cproject.tmpl
+++ b/tools/export/gnuarmeclipse/.cproject.tmpl
@@ -177,7 +177,7 @@
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.assembler.defs.{{u.id}}" name="Defined symbols (-D)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.assembler.defs" useByScannerDiscovery="true" valueType="definedSymbols">
 									{% for s in opts['as']['defines'] %}
-									<listOptionValue builtIn="false" value="{{s}}"/>
+									<listOptionValue builtIn="false" value="{{s|replace("\"", "\\\"")|escape}}"/>
 									{% endfor %}
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.assembler.include.files.{{u.id}}" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.assembler.include.files" useByScannerDiscovery="true" valueType="includeFiles">
@@ -207,7 +207,7 @@
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.defs.{{u.id}}" name="Defined symbols (-D)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.defs" useByScannerDiscovery="true" valueType="definedSymbols">
 									{% for s in opts['c']['defines'] %}
-									<listOptionValue builtIn="false" value="{{s}}"/>
+									<listOptionValue builtIn="false" value="{{s|replace("\"", "\\\"")|escape}}"/>
 									{% endfor %}
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.files.{{u.id}}" name="Include files (-include)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.files" useByScannerDiscovery="true" valueType="includeFiles">
@@ -255,7 +255,7 @@
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.defs.{{u.id}}" name="Defined symbols (-D)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.defs" useByScannerDiscovery="true" valueType="definedSymbols">
 									{% for s in opts['cpp']['defines'] %}
-									<listOptionValue builtIn="false" value="{{s}}"/>
+									<listOptionValue builtIn="false" value="{{s|replace("\"", "\\\"")|escape}}"/>
 									{% endfor %}
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.files.{{u.id}}" name="Include files (-include)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.files" useByScannerDiscovery="true" valueType="includeFiles">


### PR DESCRIPTION
Fixes a bug where quoting gets stripped by the shell used in the makefile
and another bug where the lack of escaping would cause parser errors in
eclipse.

Resolves #4622