### PR TITLE
DISCO_L475VG_IOT01A: Fix startup files for cmsis5

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/system_stm32l4xx.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/system_stm32l4xx.c
@@ -83,7 +83,7 @@
   */
 
 #include "stm32l4xx.h"
-#include "hal_tick.h"
+#include "nvic_addr.h"
 
 #if !defined  (HSE_VALUE)
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
@@ -215,20 +215,9 @@ void SystemInit(void)
 #ifdef VECT_TAB_SRAM
   SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+  SCB->VTOR = NVIC_FLASH_VECTOR_ADDRESS; /* Vector Table Relocation in Internal FLASH */
 #endif
 
-  /* Configure the Cube driver */
-  SystemCoreClock = MSI_VALUE; // At this stage the MSI is used as system clock
-  HAL_Init();
-
-  /* Configure the System clock source, PLL Multiplier and Divider factors,
-     AHB/APBx prescalers and Flash settings */
-  SetSysClock();
-  
-  /* Reset the timer to avoid issues after the RAM initialization */
-  TIM_MST_RESET_ON;
-  TIM_MST_RESET_OFF;
 }
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_ARM_MICRO/stm32l475xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_ARM_MICRO/stm32l475xx.sct
@@ -1,3 +1,4 @@
+#! armcc -E
 ; Scatter-Loading Description File
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Copyright (c) 2015, STMicroelectronics
@@ -27,10 +28,18 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; 1MB FLASH (0x100000) + 128KB SRAM (0x20000)
-LR_IROM1 0x08000000 0x100000  {    ; load region size_region
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x08000000
+#endif
 
-  ER_IROM1 0x08000000 0x100000  {  ; load address = execution address
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x100000
+#endif
+
+; 1MB FLASH (0x100000) + 128KB SRAM (0x20000)
+LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+
+  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_ARM_STD/stm32l475xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_ARM_STD/stm32l475xx.sct
@@ -1,3 +1,4 @@
+#! armcc -E
 ; Scatter-Loading Description File
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Copyright (c) 2015, STMicroelectronics
@@ -27,10 +28,18 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; 1MB FLASH (0x100000) + 128KB SRAM (0x20000)
-LR_IROM1 0x08000000 0x100000  {    ; load region size_region
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x08000000
+#endif
 
-  ER_IROM1 0x08000000 0x100000  {  ; load address = execution address
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x100000
+#endif
+
+; 1MB FLASH (0x100000) + 128KB SRAM (0x20000)
+LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+
+  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_GCC_ARM/STM32L475XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_GCC_ARM/STM32L475XX.ld
@@ -1,7 +1,15 @@
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x08000000
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 1024k
+#endif
+
 /* Linker script to configure memory regions. */
 MEMORY
 { 
-  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 1024K
+  FLASH (rx)   : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
   SRAM2 (rwx)  : ORIGIN = 0x10000188, LENGTH = 32k - 0x188
   SRAM1 (rwx)  : ORIGIN = 0x20000000, LENGTH = 96k
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
@@ -1,13 +1,16 @@
-/* [ROM = 1024kb = 0x100000] */
-define symbol __intvec_start__     = 0x08000000;
-define symbol __region_ROM_start__ = 0x08000000;
-define symbol __region_ROM_end__   = 0x080FFFFF;
+if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
+if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x100000; }
 
-/* [RAM = 128kb = 96kb + 32kb = 0x20000] */
+/* [ROM = 1024kb = 0x100000] */
+define symbol __intvec_start__     = MBED_APP_START;
+define symbol __region_ROM_start__ = MBED_APP_START;
+define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
+
+/* [RAM = 96kb + 32kb = 0x20000] */
 /* Vector table dynamic copy: Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x10000000;
-define symbol __NVIC_end__            = 0x10000187;
-define symbol __region_SRAM2_start__  = 0x10000188; /* This adress is 8-byte aligned */
+define symbol __NVIC_end__            = 0x10000187; /* Aligned on 8 bytes (392 = 49 x 8) */
+define symbol __region_SRAM2_start__  = 0x10000188;
 define symbol __region_SRAM2_end__    = 0x10007FFF;
 define symbol __region_SRAM1_start__  = 0x20000000;
 define symbol __region_SRAM1_end__    = 0x20017FFF;
@@ -31,5 +34,5 @@ do not initialize  { section .noinit };
 place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
-place in SRAM1_region { readwrite, block STACKHEAP };
-place in SRAM2_region   {  };
+place in SRAM1_region   { readwrite, block STACKHEAP };
+place in SRAM2_region { };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/nvic_addr.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/nvic_addr.h
@@ -1,0 +1,40 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017-2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NVIC_ADDR_H
+#define NVIC_ADDR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__ICCARM__)
+    #pragma section=".intvec"
+    #define NVIC_FLASH_VECTOR_ADDRESS   ((uint32_t)__section_begin(".intvec"))
+#elif defined(__CC_ARM)
+    extern uint32_t Load$$LR$$LR_IROM1$$Base[];
+    #define NVIC_FLASH_VECTOR_ADDRESS   ((uint32_t)Load$$LR$$LR_IROM1$$Base)
+#elif defined(__GNUC__)
+    extern uint32_t g_pfnVectors[];
+    #define NVIC_FLASH_VECTOR_ADDRESS   ((uint32_t)g_pfnVectors)
+#else
+    #error "Flash vector address not set for this toolchain"
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
## Description
This PR updates all toolchains startup files after CMSIS5 big update. This is a copy/paste of the code present in the DISCO_L476VG platform (similar device).

Before this patch the program does not even start.

After this patch:
```
+--------+---------------------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| Result | Target                    | Toolchain | Test ID     | Test Description                      | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------+---------------------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | DTCT_1      | Simple detect test                    |        0.47        |       10      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | EXAMPLE_1   | /dev/null                             |        3.42        |       20      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_10     | Hello World                           |        0.37        |       5       |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_11     | Ticker Int                            |       11.36        |       15      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_12     | C++                                   |        1.39        |       10      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_16     | RTC                                   |        4.56        |       20      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_2      | stdio                                 |        0.75        |       20      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_23     | Ticker Int us                         |       11.39        |       15      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_24     | Timeout Int us                        |       11.56        |       15      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_25     | Time us                               |       11.39        |       15      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_26     | Integer constant division             |        1.42        |       20      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_34     | Ticker Two callbacks                  |       11.39        |       15      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_37     | Serial NC RX                          |        7.02        |       20      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_38     | Serial NC TX                          |        5.96        |       20      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_A1     | Basic                                 |        1.39        |       20      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.47        |       20      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_A9     | Serial Echo at 115200                 |        2.45        |       20      |  1/1  |
| OK     | DISCO_L475VG_IOT01A[F549] | ARM       | MBED_BUSOUT | BusOut                                |        2.31        |       30      |  1/1  |
+--------+---------------------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
Result: 18 OK

+-------------------------+---------------------+---------------------------------------------------------------+--------+--------------------+-------------+
| target                  | platform_name       | test suite                                                    | result | elapsed_time (sec) | copy_method |
+-------------------------+---------------------+---------------------------------------------------------------+--------+--------------------+-------------+
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-basic_test         | OK     | 14.51              | shell       |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-basic_test_default | OK     | 14.51              | shell       |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-integration-basic                                       | OK     | 13.71              | shell       |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbedmicro-rtos-mbed-basic                               | OK     | 24.64              | shell       |
+-------------------------+---------------------+---------------------------------------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 4 OK
mbedgt: test case report:
+-------------------------+---------------------+---------------------------------------------------------------+---------------------------------+--------+--------+--------+--------------------+
| target                  | platform_name       | test suite                                                    | test case                       | passed | failed | result | elapsed_time (sec) |
+-------------------------+---------------------+---------------------------------------------------------------+---------------------------------+--------+--------+--------+--------------------+
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-basic_test         | Repeating Test                  | 2      | 0      | OK     | 0.08               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-basic_test         | Simple Test                     | 1      | 0      | OK     | 0.03               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-basic_test_default | Repeating Test                  | 2      | 0      | OK     | 0.08               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | features-frameworks-utest-tests-unit_tests-basic_test_default | Simple Test                     | 1      | 0      | OK     | 0.03               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-integration-basic                                       | tests-integration-basic         | 1      | 0      | OK     | 13.71              |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbedmicro-rtos-mbed-basic                               | tests-mbedmicro-rtos-mbed-basic | 1      | 0      | OK     | 24.64              |
+-------------------------+---------------------+---------------------------------------------------------------+---------------------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 6 OK 
```

## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


