### PR TITLE
Increase L0 ADC sample time

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L0/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/analogin_api.c
@@ -73,7 +73,7 @@ void analogin_init(analogin_t *obj, PinName pin)
         AdcHandle.Init.OversamplingMode      = DISABLE;
         AdcHandle.Init.ClockPrescaler        = ADC_CLOCKPRESCALER_PCLK_DIV1;
         AdcHandle.Init.Resolution            = ADC_RESOLUTION12b;
-        AdcHandle.Init.SamplingTime          = ADC_SAMPLETIME_41CYCLES_5;
+        AdcHandle.Init.SamplingTime          = ADC_SAMPLETIME_239CYCLES_5;
         AdcHandle.Init.ScanConvMode          = ADC_SCAN_DIRECTION_FORWARD;
         AdcHandle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
         AdcHandle.Init.ContinuousConvMode    = DISABLE;


### PR DESCRIPTION
## Description
With default sampling time, the MBED2 and CI test shield tests would fail
because the stabilization slope of ADC is relatively slow.
ERROR (out:0.8000) - (in:0.7407) = (0.0593)
ERROR (out:0.9000) - (in:0.8354) = (0.0646)
ERROR (out:1.0000) - (in:0.9289) = (0.0711)

This is related to the 10kOhms resistors used to connect Ain to
Aout mounted on the CI shileds, and internal capacitance of L0 targets.
If connecting Ain and Aout with wires, bypassing the resistors, the test
is passed. So we're increasing the sampling time to let the automated
ci shiled tests PASS.

OK    (out:0.8000) - (in:0.7863) = (0.0137)
OK    (out:0.9000) - (in:0.8869) = (0.0131)
OK    (out:1.0000) - (in:0.9844) = (0.0156)

Notes:
* Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
* This is just a template, so feel free to use/remove the unnecessary things



## Status
**READY/IN DEVELOPMENT/HOLD**

## Tests results
![image](https://user-images.githubusercontent.com/17590297/27580213-44f51114-5b2a-11e7-8b2f-4b757b6d6960.png)

