### PR TITLE
RTX: Fixed RTXv5 mutex owner list handling.

### DIFF
--- a/rtos/rtx5/TARGET_CORTEX_M/rtx_mutex.c
+++ b/rtos/rtx5/TARGET_CORTEX_M/rtx_mutex.c
@@ -187,6 +187,9 @@ osStatus_t svcRtxMutexAcquire (osMutexId_t mutex_id, uint32_t timeout) {
     mutex->owner_thread = runnig_thread;
     mutex->owner_next   = runnig_thread->mutex_list;
     mutex->owner_prev   = NULL;
+    if (runnig_thread->mutex_list != NULL) {
+        runnig_thread->mutex_list->owner_prev = mutex;
+    }
     runnig_thread->mutex_list = mutex;
     mutex->lock = 1U;
     EvrRtxMutexAcquired(mutex, mutex->lock);


### PR DESCRIPTION
The prev-pointer of the running threads mutex list was not set when
multiple mutexes are acquired at a time. This leads to a corrupted list
if the mutexes are not freed in reversed order.

Original commit for CMSIS_5:
commit 729f6ab08540342b7de7612fac103539d5b2f168
Author: Jonatan Antoni <jonatan.antoni@arm.com>
Date:   Wed Apr 19 15:38:43 2017 +0200

Fix ported from CMSIS_5 repo to address #4630 
## Status
**READY**

Close #4630 

It's a point fix brought over from CMSIS repo, but we should still think about having some process to update CMSIS in regular intervals (eg each CMSIS patch release?)

@0xc0170 @c1728p9 