### PR TITLE
fatfs: Fix unaligned access in disk_ioctl

### DIFF
--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -216,8 +216,8 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
             if (_ffs[pdrv] == NULL) {
                 return RES_NOTRDY;
             } else {
-                DWORD size = _ffs[pdrv]->get_erase_size();
-                *((DWORD*)buff) = size;
+                WORD size = _ffs[pdrv]->get_erase_size();
+                *((WORD*)buff) = size;
                 return RES_OK;
             }
         case GET_BLOCK_SIZE:


### PR DESCRIPTION
Unlike the other disk_ioctl options, GET_SECTOR_SIZE is interpreted as a 16-bit WORD, instead of a 32-bit DWORD. This caused an unaligned access error on M0 platforms.

disk_ioctl documentation:
http://elm-chan.org/fsw/ff/doc/dioctl.html

related issue https://github.com/ARMmbed/mbed-os/issues/4649
cc @LMESTM