### PR TITLE
Correct comments in flash api for STM32 L0 targets

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L0/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/flash_api.c
@@ -119,16 +119,15 @@ int32_t flash_program_page(flash_t *obj, uint32_t address,
 }
 
 uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address) {
-    /*  considering 1 sector = 1 page */
     if ((address >= (FLASH_BASE + FLASH_SIZE)) || (address < FLASH_BASE)) {
         return MBED_FLASH_INVALID_SIZE;
     } else {
+        /*  sector composed of N pages */
         return (NUM_PAGES_IN_SECTOR * FLASH_PAGE_SIZE);
     }
 }
 
 uint32_t flash_get_page_size(const flash_t *obj) {
-    /*  considering 1 sector = 1 page */
     return FLASH_PAGE_SIZE;
 }
 


### PR DESCRIPTION
## Description
The initial comments were copied from L4 implementation but do not apply
to L0 targets where 1 sector is composed of a constant number of pages.

