### PR TITLE
RTX4 target configuration for backward compatibility - fixes #4654

### DIFF
--- a/targets/TARGET_ARM_SSG/mbed_rtx.h
+++ b/targets/TARGET_ARM_SSG/mbed_rtx.h
@@ -22,6 +22,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              7
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          112
 #endif

--- a/targets/TARGET_ARM_SSG/mbed_rtx.h
+++ b/targets/TARGET_ARM_SSG/mbed_rtx.h
@@ -22,6 +22,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          112
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                24000000
+#endif
 
 #endif
 

--- a/targets/TARGET_Freescale/mbed_rtx.h
+++ b/targets/TARGET_Freescale/mbed_rtx.h
@@ -22,6 +22,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10008000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -33,6 +39,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -46,6 +58,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20010000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -57,6 +75,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20030000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -70,6 +94,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20003000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif
@@ -81,6 +111,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20006000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -94,6 +130,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20000C00UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif
@@ -105,6 +147,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20003000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
@@ -118,6 +166,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20003000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif
@@ -130,6 +184,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20006000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -141,6 +201,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20012000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -155,10 +221,15 @@
 #define INITIAL_SP              (0x20030000UL)
 #endif
 
+// RTX 4 only config below, for backward-compability
+
 #if defined(__CC_ARM) || defined(__GNUC__)
 #define ISR_STACK_SIZE          (0x1000)
 #endif
 
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -170,6 +241,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -183,6 +260,9 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20018000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
 #ifndef OS_TASKCNT
 #define OS_TASKCNT              14
 #endif
@@ -198,6 +278,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20030000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -210,6 +296,8 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20030000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
 
 #if defined(__CC_ARM) || defined(__GNUC__)
 #define ISR_STACK_SIZE          (0x1000)

--- a/targets/TARGET_Freescale/mbed_rtx.h
+++ b/targets/TARGET_Freescale/mbed_rtx.h
@@ -22,11 +22,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10008000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                96000000
+#endif
 
 #elif defined(TARGET_TEENSY3_1)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                96000000
 #endif
 
 #elif defined(TARGET_MCU_K22F)
@@ -34,11 +46,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20010000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                80000000
+#endif
 
 #elif defined(TARGET_K66F)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20030000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                120000000
 #endif
 
 #elif defined(TARGET_KL27Z)
@@ -46,11 +70,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20003000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
+#endif
 
 #elif defined(TARGET_KL43Z)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20006000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
 #endif
 
 #elif defined(TARGET_KL05Z)
@@ -58,11 +94,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20000C00UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
+#endif
 
 #elif defined(TARGET_KL25Z)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20003000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
 #endif
 
 #elif defined(TARGET_KL26Z)
@@ -70,17 +118,35 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20003000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
+#endif
 
 #elif defined(TARGET_KL46Z)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20006000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
+#endif
 
 #elif defined(TARGET_KL82Z)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20012000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                72000000
 #endif
 
 #elif defined(TARGET_K64F)
@@ -89,10 +155,27 @@
 #define INITIAL_SP              (0x20030000UL)
 #endif
 
+#if defined(__CC_ARM) || defined(__GNUC__)
+#define ISR_STACK_SIZE          (0x1000)
+#endif
+
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                120000000
+#endif
+
 #elif defined(TARGET_KW24D)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
 #endif
 
 #elif defined(TARGET_KW41Z)
@@ -100,17 +183,46 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20018000UL)
 #endif
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                40000000
+#endif
 
 #elif defined(TARGET_K82F)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20030000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                120000000
+#endif
 
 #elif defined(TARGET_RO359B)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20030000UL)
+#endif
+
+#if defined(__CC_ARM) || defined(__GNUC__)
+#define ISR_STACK_SIZE          (0x1000)
+#endif
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                96000000
 #endif
 
 #endif

--- a/targets/TARGET_Maxim/mbed_rtx.h
+++ b/targets/TARGET_Maxim/mbed_rtx.h
@@ -22,11 +22,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                24000000
+#endif
 
 #elif defined(TARGET_MAX32610)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                24000000
 #endif
 
 #elif defined(TARGET_MAX32620)
@@ -34,17 +46,32 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20040000UL)
 #endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
+#endif
 
 #elif defined(TARGET_MAX32625)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20028000UL)
 #endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                96000000
+#endif
 
 #elif defined(TARGET_MAX32630)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20080000UL)
+#endif
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                96000000
 #endif
 
 #endif

--- a/targets/TARGET_Maxim/mbed_rtx.h
+++ b/targets/TARGET_Maxim/mbed_rtx.h
@@ -22,6 +22,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -33,6 +39,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -46,6 +58,15 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20040000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
 #ifndef OS_CLOCK
 #define OS_CLOCK                48000000
 #endif
@@ -54,6 +75,15 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20028000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
 #endif
 #ifndef OS_CLOCK
 #define OS_CLOCK                96000000
@@ -64,6 +94,9 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20080000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
 #ifndef OS_TASKCNT
 #define OS_TASKCNT              14
 #endif

--- a/targets/TARGET_NORDIC/mbed_rtx.h
+++ b/targets/TARGET_NORDIC/mbed_rtx.h
@@ -27,6 +27,12 @@
 #   endif
 #endif
 
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          512
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                32768
+#endif
 #ifndef OS_SYSTICK
 #define OS_SYSTICK              0
 #endif
@@ -36,11 +42,26 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20010000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          512
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                64000000
+#endif
 
 #elif defined(TARGET_MCU_NRF52840)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20040000UL)
+#endif
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              24
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          2048
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                64000000
 #endif
 
 // More than 256 bytes are needed for the idle thread stack on the NRF52840

--- a/targets/TARGET_NORDIC/mbed_rtx.h
+++ b/targets/TARGET_NORDIC/mbed_rtx.h
@@ -27,6 +27,11 @@
 #   endif
 #endif
 
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              7
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          512
 #endif
@@ -42,6 +47,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20010000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              7
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          512
 #endif
@@ -54,6 +65,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20040000UL)
 #endif
+
+// More than 256 bytes are needed for the idle thread stack on the NRF52840
+#define OS_IDLE_THREAD_STACK_SIZE  512
+
+// RTX 4 only config below, for backward-compability
+
 #ifndef OS_TASKCNT
 #define OS_TASKCNT              24
 #endif
@@ -63,9 +80,6 @@
 #ifndef OS_CLOCK
 #define OS_CLOCK                64000000
 #endif
-
-// More than 256 bytes are needed for the idle thread stack on the NRF52840
-#define OS_IDLE_THREAD_STACK_SIZE  512
 
 #endif // defined(TARGET_MCU_NRF51822)...
 

--- a/targets/TARGET_NUVOTON/mbed_rtx.h
+++ b/targets/TARGET_NUVOTON/mbed_rtx.h
@@ -21,6 +21,11 @@
 
 #if defined(TARGET_NUMAKER_PFM_NUC472)
 
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -54,6 +59,11 @@
 
 #elif defined(TARGET_NUMAKER_PFM_M453)
 
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif

--- a/targets/TARGET_NUVOTON/mbed_rtx.h
+++ b/targets/TARGET_NUVOTON/mbed_rtx.h
@@ -21,6 +21,13 @@
 
 #if defined(TARGET_NUMAKER_PFM_NUC472)
 
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                84000000
+#endif
+
 #if defined(__CC_ARM)
     extern uint32_t               Image$$ARM_LIB_HEAP$$ZI$$Base[];
     extern uint32_t               Image$$ARM_LIB_HEAP$$ZI$$Length[];
@@ -46,6 +53,13 @@
 #endif
 
 #elif defined(TARGET_NUMAKER_PFM_M453)
+
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                72000000
+#endif
 
 #if defined(__CC_ARM)
     extern uint32_t               Image$$ARM_LIB_HEAP$$ZI$$Base[];

--- a/targets/TARGET_NXP/mbed_rtx.h
+++ b/targets/TARGET_NXP/mbed_rtx.h
@@ -22,6 +22,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10008000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
+#endif
 
 #elif defined(TARGET_LPC11U24)        \
      || defined(TARGET_LPC11U35_401)  \
@@ -31,11 +37,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10002000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
+#endif
 
 #elif defined(TARGET_LPC1114)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10001000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
 #endif
 
 #elif defined(TARGET_LPC1347)
@@ -43,11 +61,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10002000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                72000000
+#endif
 
 #elif defined(TARGET_LPC1549)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x02009000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                72000000
 #endif
 
 #elif defined(TARGET_LPC1768)
@@ -55,11 +85,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10008000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                96000000
+#endif
 
 #elif defined(TARGET_LPC4088) || defined(TARGET_LPC4088_DM)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10010000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                120000000
 #endif
 
 #elif defined(TARGET_LPC4330) || defined(TARGET_LPC4337)
@@ -67,17 +109,35 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10008000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                204000000
+#endif
 
 #elif defined(TARGET_LPC812)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10001000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                36000000
+#endif
 
 #elif defined(TARGET_LPC824) || defined(TARGET_SSCI824)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10002000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                30000000
 #endif
 
 #endif

--- a/targets/TARGET_NXP/mbed_rtx.h
+++ b/targets/TARGET_NXP/mbed_rtx.h
@@ -22,6 +22,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10008000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -37,6 +43,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10002000UL)
 #endif
+
+     // RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif
@@ -48,6 +60,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10001000UL)
+#endif
+
+ // RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
@@ -61,6 +79,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10002000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -72,6 +96,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x02009000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -85,6 +115,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10008000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -96,6 +132,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10010000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -109,6 +151,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10008000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -121,6 +169,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10001000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif
@@ -132,6 +186,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x10002000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128

--- a/targets/TARGET_ONSEMI/mbed_rtx.h
+++ b/targets/TARGET_ONSEMI/mbed_rtx.h
@@ -22,6 +22,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x40000000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif

--- a/targets/TARGET_ONSEMI/mbed_rtx.h
+++ b/targets/TARGET_ONSEMI/mbed_rtx.h
@@ -22,6 +22,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x40000000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                32000000
+#endif
 
 #endif
 

--- a/targets/TARGET_RENESAS/mbed_rtx.h
+++ b/targets/TARGET_RENESAS/mbed_rtx.h
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2016 u-blox
+ * Copyright (c) 2016 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #ifndef MBED_MBED_RTX_H
 #define MBED_MBED_RTX_H
 
-#if defined(TARGET_HI2110)
-
-#ifndef INITIAL_SP
-#define INITIAL_SP              (0x01000000 + 0x05000 - 256)
-#endif
-
-#ifndef OS_MAINSTKSIZE
-#define OS_MAINSTKSIZE          128
-#endif
+#if defined(TARGET_RZ_A1H) || defined(TARGET_VK_RZ_A1H)
 #ifndef OS_CLOCK
-#define OS_CLOCK                48000000
+#define OS_CLOCK         12000000
 #endif
 #endif
 

--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -22,11 +22,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20002000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
+#endif
 
 #elif defined(TARGET_STM32L031K6)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20002000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          112
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                32000000
 #endif
 
 #elif defined(TARGET_STM32F070RB)
@@ -34,11 +46,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20004000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
+#endif
 
 #elif defined(TARGET_STM32F072RB)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20004000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
 #endif
 
 #elif defined(TARGET_STM32F091RC)
@@ -46,11 +70,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
+#endif
 
 #elif defined(TARGET_STM32F100RB)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20002000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                24000000
 #endif
 
 #elif defined(TARGET_STM32F103RB)
@@ -58,11 +94,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20005000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                72000000
+#endif
 
 #elif defined(TARGET_STM32F207ZG)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                120000000
 #endif
 
 #elif defined(TARGET_STM32F303VC)
@@ -70,11 +118,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x2000A000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                72000000
+#endif
 
 #elif defined(TARGET_STM32F334C8)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20003000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          112
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                72000000
 #endif
 
 #elif defined(TARGET_STM32F302R8)
@@ -82,11 +142,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20004000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                72000000
+#endif
 
 #elif defined(TARGET_STM32F303K8)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20003000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          112
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                64000000
 #endif
 
 #elif defined(TARGET_STM32F303RE)
@@ -94,11 +166,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20010000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          112
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                72000000
+#endif
 
 #elif defined(TARGET_STM32F303ZE)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20010000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          112
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                72000000
 #endif
 
 #elif defined(TARGET_STM32F334R8)
@@ -106,11 +190,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20003000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          112
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                72000000
+#endif
 
 #elif defined(TARGET_STM32F446VE)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                180000000
 #endif
 
 #elif defined(TARGET_STM32F401VC)
@@ -118,11 +214,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20010000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                84000000
+#endif
 
 #elif (defined(TARGET_STM32F429ZI) || defined(TARGET_STM32F439ZI))
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20030000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                168000000
 #endif
 
 #elif defined(TARGET_UBLOX_EVK_ODIN_W2)
@@ -130,11 +238,26 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20030000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          512
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                168000000
+#endif
 
 #elif defined(TARGET_UBLOX_C030)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20030000UL)
+#endif
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          512
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                168000000
 #endif
 
 #elif defined(TARGET_STM32F469NI)
@@ -142,11 +265,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20050000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                168000000
+#endif
 
 #elif defined(TARGET_STM32F405RG)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                48000000
 #endif
 
 #elif defined(TARGET_STM32F401RE)
@@ -154,11 +289,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20018000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                84000000
+#endif
 
 #elif defined(TARGET_STM32F410RB)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                100000000
 #endif
 
 #elif defined(TARGET_MTS_MDOT_F411RE) || defined (TARGET_MTS_DRAGONFLY_F411RE)
@@ -166,17 +313,38 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          1024
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                96000000
+#endif
 
 #elif defined(TARGET_STM32F411RE)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                100000000
+#endif
 
 #elif defined(TARGET_STM32F412ZG)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20040000UL)
+#endif
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                100000000
 #endif
 
 #elif defined(TARGET_STM32F413ZH)
@@ -200,11 +368,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                180000000
+#endif
 
 #elif defined(TARGET_STM32F446ZE)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                180000000
 #endif
 
 #elif defined(TARGET_STM32F407VG)
@@ -212,11 +392,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                168000000
+#endif
 
 #elif defined(TARGET_STM32F746NG)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20050000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                216000000
 #endif
 
 #elif (defined(TARGET_STM32F746ZG) || defined(TARGET_STM32F756ZG))
@@ -224,11 +416,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20050000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                216000000
+#endif
 
 #elif defined(TARGET_STM32F767ZI)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20080000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                216000000
 #endif
 
 #elif defined(TARGET_STM32F769NI)
@@ -236,11 +440,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20080000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                216000000
+#endif
 
 #elif defined(TARGET_STM32L053C8)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20002000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          112
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                32000000
 #endif
 
 #elif defined(TARGET_STM32L031K6)
@@ -248,11 +464,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20002000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          112
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                32000000
+#endif
 
 #elif defined(TARGET_STM32L053R8)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20002000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          112
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                32000000
 #endif
 
 #elif defined(TARGET_STM32L072CZ)
@@ -260,11 +488,26 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20005000UL)
 #endif
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          112
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                32000000
+#endif
 
 #elif defined(TARGET_STM32L073RZ)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20005000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          112
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                32000000
 #endif
 
 #elif defined(TARGET_STM32L152RC)
@@ -272,11 +515,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                24000000
+#endif
 
 #elif defined(TARGET_STM32L152RE)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20014000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                32000000
 #endif
 
 #elif defined(TARGET_NZ32_SC151)
@@ -284,11 +539,23 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                32000000
+#endif
 
 #elif defined(TARGET_XDOT_L151CC)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                32000000
 #endif
 
 #elif defined(TARGET_STM32L476VG) || defined(TARGET_STM32L475VG)
@@ -296,17 +563,35 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20018000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                80000000
+#endif
 
 #elif defined(TARGET_STM32L432KC)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x2000C000UL)
 #endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                80000000
+#endif
 
 #elif (defined(TARGET_STM32L476RG) || defined(TARGET_STM32L486RG))
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20018000UL)
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                80000000
 #endif
 
 #endif

--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -22,6 +22,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20002000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif
@@ -33,6 +39,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20002000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          112
@@ -46,6 +58,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20004000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif
@@ -57,6 +75,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20004000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
@@ -70,6 +94,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif
@@ -81,6 +111,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20002000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
@@ -94,6 +130,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20005000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif
@@ -105,6 +147,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -118,6 +166,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x2000A000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -129,6 +183,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20003000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          112
@@ -142,6 +202,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20004000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif
@@ -153,6 +219,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20003000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          112
@@ -166,6 +238,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20010000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          112
 #endif
@@ -177,6 +255,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20010000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          112
@@ -190,6 +274,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20003000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          112
 #endif
@@ -201,6 +291,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -214,6 +310,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20010000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -225,6 +327,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20030000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -238,6 +346,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20030000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          512
 #endif
@@ -250,6 +364,9 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20030000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
 #ifndef OS_TASKCNT
 #define OS_TASKCNT              14
 #endif
@@ -265,6 +382,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20050000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -276,6 +399,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -289,6 +418,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20018000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -300,6 +435,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -313,6 +454,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          1024
 #endif
@@ -324,6 +471,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -337,6 +490,9 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20040000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
 #ifndef OS_TASKCNT
 #define OS_TASKCNT              14
 #endif
@@ -352,6 +508,9 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20050000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
 #ifndef OS_TASKCNT
 #define OS_TASKCNT              14
 #endif
@@ -368,6 +527,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -379,6 +544,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -392,6 +563,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -403,6 +580,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20050000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -416,6 +599,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20050000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -427,6 +616,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20080000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -440,6 +635,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20080000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -451,6 +652,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20002000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          112
@@ -464,6 +671,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20002000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          112
 #endif
@@ -475,6 +688,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20002000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          112
@@ -488,6 +707,9 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20005000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
 #ifndef OS_TASKCNT
 #define OS_TASKCNT              6
 #endif
@@ -503,6 +725,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20005000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          112
 #endif
@@ -514,6 +742,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -527,6 +761,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20014000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -538,6 +778,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
@@ -551,6 +797,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif
@@ -562,6 +814,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20018000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
@@ -575,6 +833,12 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x2000C000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -586,6 +850,12 @@
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20018000UL)
+#endif
+
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
 #endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256

--- a/targets/TARGET_Silicon_Labs/mbed_rtx.h
+++ b/targets/TARGET_Silicon_Labs/mbed_rtx.h
@@ -24,26 +24,17 @@
 #define OS_CLOCK                  REFERENCE_FREQUENCY
 #endif
 
-#if defined(__CC_ARM)
-extern uint32_t HEAP$$Base;
-extern uint32_t HEAP$$Limit;
-extern uint32_t STACK$$Limit;
-extern uint32_t STACK$$Base;
-#ifndef INITIAL_SP
-#define INITIAL_SP            ((uint32_t)&STACK$$Limit)
-#endif
-#define ISR_STACK_START       ((uint32_t)&STACK$$Base)
-#define ISR_STACK_SIZE        ((uint32_t) ((uint32_t)&STACK$$Limit - (uint32_t)&STACK$$Base))
-#define HEAP_START            ((unsigned char*) ((uint32_t)&HEAP$$Base))
-#define HEAP_SIZE             ((uint32_t) ((uint32_t)&HEAP$$Limit - (uint32_t)&HEAP$$Base))
-#endif
-
 #if defined(TARGET_EFM32GG_STK3700)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
 #endif
 
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          256
 #endif
@@ -54,6 +45,11 @@ extern uint32_t STACK$$Base;
 #define INITIAL_SP              (0x20002000UL)
 #endif
 
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          112
 #endif
@@ -64,6 +60,11 @@ extern uint32_t STACK$$Base;
 #define INITIAL_SP              (0x20008000UL)
 #endif
 
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif
@@ -74,6 +75,11 @@ extern uint32_t STACK$$Base;
 #define INITIAL_SP              (0x20008000UL)
 #endif
 
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif
@@ -84,6 +90,11 @@ extern uint32_t STACK$$Base;
 #define INITIAL_SP              (0x20008000UL)
 #endif
 
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif
@@ -93,6 +104,8 @@ extern uint32_t STACK$$Base;
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20007C00UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
 
 #ifndef OS_TASKCNT
 #define OS_TASKCNT              5
@@ -106,6 +119,8 @@ extern uint32_t STACK$$Base;
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20040000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
 
 #ifndef OS_TASKCNT
 #define OS_TASKCNT              14

--- a/targets/TARGET_Silicon_Labs/mbed_rtx.h
+++ b/targets/TARGET_Silicon_Labs/mbed_rtx.h
@@ -20,10 +20,32 @@
 #include <stdint.h>
 #include "clocking.h"
 
+#ifndef OS_CLOCK
+#define OS_CLOCK                  REFERENCE_FREQUENCY
+#endif
+
+#if defined(__CC_ARM)
+extern uint32_t HEAP$$Base;
+extern uint32_t HEAP$$Limit;
+extern uint32_t STACK$$Limit;
+extern uint32_t STACK$$Base;
+#ifndef INITIAL_SP
+#define INITIAL_SP            ((uint32_t)&STACK$$Limit)
+#endif
+#define ISR_STACK_START       ((uint32_t)&STACK$$Base)
+#define ISR_STACK_SIZE        ((uint32_t) ((uint32_t)&STACK$$Limit - (uint32_t)&STACK$$Base))
+#define HEAP_START            ((unsigned char*) ((uint32_t)&HEAP$$Base))
+#define HEAP_SIZE             ((uint32_t) ((uint32_t)&HEAP$$Limit - (uint32_t)&HEAP$$Base))
+#endif
+
 #if defined(TARGET_EFM32GG_STK3700)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
+#endif
+
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
 #endif
 
 #elif defined(TARGET_EFM32HG_STK3400)
@@ -32,10 +54,18 @@
 #define INITIAL_SP              (0x20002000UL)
 #endif
 
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          112
+#endif
+
 #elif defined(TARGET_EFM32LG_STK3600)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
+#endif
+
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
 #endif
 
 #elif defined(TARGET_EFM32PG_STK3401)
@@ -44,10 +74,18 @@
 #define INITIAL_SP              (0x20008000UL)
 #endif
 
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+
 #elif defined(TARGET_EFM32WG_STK3800)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
+#endif
+
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
 #endif
 
 #elif defined(TARGET_EFR32MG1)
@@ -56,10 +94,24 @@
 #define INITIAL_SP              (0x20007C00UL)
 #endif
 
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              5
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
+#endif
+
 #elif defined(TARGET_EFR32MG12) || defined(TARGET_EFM32PG12)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20040000UL)
+#endif
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              14
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          256
 #endif
 
 #endif

--- a/targets/TARGET_WIZNET/mbed_rtx.h
+++ b/targets/TARGET_WIZNET/mbed_rtx.h
@@ -22,6 +22,9 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20004000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
 #ifndef OS_TASKCNT
 #define OS_TASKCNT              6
 #endif
@@ -37,6 +40,9 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20004000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
 #ifndef OS_TASKCNT
 #define OS_TASKCNT              6
 #endif
@@ -52,6 +58,9 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20004000UL)
 #endif
+
+// RTX 4 only config below, for backward-compability
+
 #ifndef OS_TASKCNT
 #define OS_TASKCNT              6
 #endif

--- a/targets/TARGET_WIZNET/mbed_rtx.h
+++ b/targets/TARGET_WIZNET/mbed_rtx.h
@@ -22,18 +22,44 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20004000UL)
 #endif
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                20000000
+#endif
 
 #elif defined(TARGET_WIZWIKI_W7500P)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20004000UL)
 #endif
-
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                20000000
+#endif
 
 #elif defined(TARGET_WIZWIKI_W7500ECO)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20004000UL)
+#endif
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
+#ifndef OS_MAINSTKSIZE
+#define OS_MAINSTKSIZE          128
+#endif
+#ifndef OS_CLOCK
+#define OS_CLOCK                20000000
 #endif
 
 #endif //

--- a/targets/TARGET_ublox/mbed_rtx.h
+++ b/targets/TARGET_ublox/mbed_rtx.h
@@ -23,6 +23,11 @@
 #define INITIAL_SP              (0x01000000 + 0x05000 - 256)
 #endif
 
+// RTX 4 only config below, for backward-compability
+
+#ifndef OS_TASKCNT
+#define OS_TASKCNT              6
+#endif
 #ifndef OS_MAINSTKSIZE
 #define OS_MAINSTKSIZE          128
 #endif


### PR DESCRIPTION
Includes 2 commits as these rtx4 removals were done in two commits previously, one was not completely separated (lot of changes due to rtx5) so I pulled only few changes from that commit to make this complete - as it used to be. All info is in the 70ef409 commit message.

These 3 symbols that we are adding back are not used in the new rtos, thus should have no affect, only for the old version.

My understanding is that mbed 2 + rtx should be still functional, and this shall be fixed. If it is not the case, let me know.

Still needs to be tested in the online IDE, I'll run some compilation tests with rtx4 to be certain all is working. @toyowata Please test

@bulislaw @c1728p9 @toyowata 