### PR TITLE
STM32: Fix the CAN initializing to the wrong frequency

### DIFF
--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -85,8 +85,8 @@ void can_init_freq (can_t *obj, PinName rd, PinName td, int hz)
         error("Cannot initialize CAN");
     }
 
-    // Set initial CAN frequency to 100 kb/s
-    if (can_frequency(obj, 100000) != 1) {
+    // Set initial CAN frequency to specified frequency
+    if (can_frequency(obj, hz) != 1) {
         error("Can frequency could not be set\n");
     }
 


### PR DESCRIPTION
…y at startup regardless of the value set in the constructor. Issue #3863

## Description
Fixing the issue described in #3863 


## Status
**READY**


## Migrations
NO