### PR TITLE
Fix timing issues found in "Flash - clock and cache test"

### DIFF
--- a/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -101,7 +101,7 @@ static int time_cpu_cycles(uint32_t cycles)
 
     int timer_start = timer.read_us();
 
-    volatile uint32_t delay = (volatile uint32_t)cycles;
+    uint32_t delay = cycles;
     delay_loop(delay);
     int timer_end = timer.read_us();
 

--- a/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -53,7 +53,7 @@ static void erase_range(flash_t *flash, uint32_t addr, uint32_t size)
     }
 }
 
-static int time_cpu_cycles(uint32_t cycles)
+__attribute__((noinline)) static int time_cpu_cycles(uint32_t cycles)
 {
     Timer timer;
     timer.start();

--- a/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -52,8 +52,49 @@ static void erase_range(flash_t *flash, uint32_t addr, uint32_t size)
         size = size > sector_size ? size - sector_size : 0;
     }
 }
+#ifdef __CC_ARM
+MBED_NOINLINE
+__asm static void delay_loop(uint32_t count)
+{
+1
+  SUBS a1, a1, #1
+  BCS  %BT1
+  BX   lr
+}
+#elif defined (__ICCARM__)
+MBED_NOINLINE
+static void delay_loop(uint32_t count)
+{
+  __asm volatile(
+    "loop: \n"
+    " SUBS %0, %0, #1 \n"
+    " BCS.n  loop\n"
+    : "+r" (count)
+    :
+    : "cc"
+  );
+}
+#else // GCC
+MBED_NOINLINE
+static void delay_loop(uint32_t count)
+{
+  __asm__ volatile (
+    "%=:\n\t"
+#if defined(__thumb__) && !defined(__thumb2__)
+    "SUB  %0, #1\n\t"
+#else
+    "SUBS %0, %0, #1\n\t"
+#endif
+    "BCS  %=b\n\t"
+    : "+l" (count)
+    :
+    : "cc"
+  );
+}
+#endif
 
-__attribute__((noinline)) static int time_cpu_cycles(uint32_t cycles)
+MBED_NOINLINE
+static int time_cpu_cycles(uint32_t cycles)
 {
     Timer timer;
     timer.start();
@@ -61,8 +102,7 @@ __attribute__((noinline)) static int time_cpu_cycles(uint32_t cycles)
     int timer_start = timer.read_us();
 
     volatile uint32_t delay = (volatile uint32_t)cycles;
-    while (delay--);
-
+	delay_loop(delay);
     int timer_end = timer.read_us();
 
     timer.stop();

--- a/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -102,7 +102,7 @@ static int time_cpu_cycles(uint32_t cycles)
     int timer_start = timer.read_us();
 
     volatile uint32_t delay = (volatile uint32_t)cycles;
-	delay_loop(delay);
+    delay_loop(delay);
     int timer_end = timer.read_us();
 
     timer.stop();

--- a/platform/mbed_toolchain.h
+++ b/platform/mbed_toolchain.h
@@ -137,6 +137,27 @@
 #endif
 #endif
 
+/** MBED_NOINLINE
+ *  Declare a function that must not be inlined.
+ *
+ *  @code
+ *  #include "mbed_toolchain.h"
+ *  
+ *  MBED_NOINLINE void foo() {
+ *  
+ *  }
+ *  @endcode
+ */
+#ifndef MBED_NOINLINE
+#if defined(__GNUC__) || defined(__clang__) || defined(__CC_ARM)
+#define MBED_NOINLINE __attribute__((noinline))
+#elif defined(__ICCARM__)
+#define MBED_NOINLINE _Pragma("inline=never")
+#else
+#define MBED_NOINLINE
+#endif
+#endif
+
 /** MBED_FORCEINLINE
  *  Declare a function that must always be inlined. Failure to inline
  *  such a function will result in an error.


### PR DESCRIPTION
## Description
ARMCC seemed to be inlining time_cpu_cycles() but with a different number of clock cycles in the loop, GCC worked fine.


## Status
**READY**


## Migrations
NO


## Related PRs
#4640

## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
