### PR TITLE
retarget: fix microlib for mbed 2

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -177,6 +177,20 @@ static inline int openmode_to_posix(int openmode) {
  * */
 extern "C" FILEHANDLE PREFIX(_open)(const char* name, int openmode) {
     #if defined(__MICROLIB) && (__ARMCC_VERSION>5030000)
+#if !defined(MBED_CONF_RTOS_PRESENT)
+    // valid only for mbed 2
+    // for ulib, this is invoked after RAM init, prior c++
+    // used as hook, as post stack/heap is not active there
+    extern void mbed_copy_nvic(void);
+    extern void mbed_sdk_init(void);
+
+    static int mbed_sdk_inited = 0;
+    if (!mbed_sdk_inited) {
+        mbed_copy_nvic();
+        mbed_sdk_init();
+        mbed_sdk_inited = 1;
+    }
+#endif
     // Before version 5.03, we were using a patched version of microlib with proper names
     // This is the workaround that the microlib author suggested us
     static int n = 0;


### PR DESCRIPTION
only for mbed 2 needed.

This is as it used to be, reverting the removal. uARM does not have any hook
that we could use for mbed sdk init and copy nvic, therefore _open is used that
should be sufficient, but not ideal.

For more information, visit https://github.com/ARMmbed/mbed-os/pull/2160/files#r76563844.

cc @c1728p9 @bulislaw @jeromecoutant @LMESTM 