### PR TITLE
Cellular: not-supported error if MODEM_ON_BOARD not defined

### DIFF
--- a/features/netsocket/cellular/generic_modem_driver/TESTS/unit_tests/default/main.cpp
+++ b/features/netsocket/cellular/generic_modem_driver/TESTS/unit_tests/default/main.cpp
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-#if MODEM_ON_BOARD
+#if !MODEM_ON_BOARD
+#error [NOT_SUPPORTED] MODEM_ON_BOARD should be set for this test to be functional
+#endif
 
 #include "mbed.h"
 #include "gmd_ut_config_header.h"
@@ -436,14 +438,3 @@ static void unlock()
 {
     mtx.unlock();
 }
-
-#else
-
-int main ()
-{
-    return 0;
-}
-
-#endif //MODEM_ON_BOARD
-// End Of File
-


### PR DESCRIPTION
If a test is empty, it leads to undef. Therefore if a test requires additional
details, it should print an error [NOT SUPPORTED].

This will require nighlty to verify.

This is the fix for the patch came from #4446

@hasnainvirk