### PR TITLE
Fix LED4 for UBLOX_EVK_NINA_B1

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TARGET_UBLOX_EVK_NINA_B1/PinNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TARGET_UBLOX_EVK_NINA_B1/PinNames.h
@@ -77,7 +77,7 @@ typedef enum {
     LED1 = NINA_B1_GPIO_1, // Red
     LED2 = NINA_B1_GPIO_7, // Green/SW1
     LED3 = NINA_B1_GPIO_8, // Blue
-    LED4 = NC,
+    LED4 = NINA_B1_GPIO_8,
     SW1 = NINA_B1_GPIO_7,
     SW2 = NINA_B1_GPIO_18,
     D0 = NINA_B1_GPIO_23,


### PR DESCRIPTION
## Description
Set LED4 the same as LED3 to get tests-mbedmicro-rtos-mbed-timer to pass for UBLOX_EVK_NINA_B1
This is part of getting the target pass mbed Enabled tests.

If not fixed the test will fail with:
[1498813581.77][CONN][RXD] mbed assertation failed: obj->pin != (PinName)NC, file: C:\git\ARMmbed\mCMSIS-RTOS error: User Timer Callback Queue overflow (status: 0x3, task ID: 0x0, timer ID: 0x200053EC)

## Status
READY

## Migrations
NO

## Related PRs
None

## Todos
None

## Deploy notes
N/A

## Steps to test or reproduce
N/A