### PR TITLE
Correctly enable / disable InterruptIn Edges detection

### DIFF
--- a/targets/TARGET_STM/gpio_irq_api.c
+++ b/targets/TARGET_STM/gpio_irq_api.c
@@ -297,8 +297,7 @@ void gpio_irq_enable(gpio_irq_t *obj)
         LL_EXTI_EnableRisingTrig_0_31(1 << STM_PIN(obj->pin));
     }
     if (obj->event & IRQ_FALL) {
-            LL_EXTI_EnableFallingTrig_0_31(1 << STM_PIN(obj->pin));
-
+        LL_EXTI_EnableFallingTrig_0_31(1 << STM_PIN(obj->pin));
     }
 
     NVIC_EnableIRQ(obj->irq_n);

--- a/targets/TARGET_STM/gpio_irq_api.c
+++ b/targets/TARGET_STM/gpio_irq_api.c
@@ -290,6 +290,8 @@ void gpio_irq_enable(gpio_irq_t *obj)
 void gpio_irq_disable(gpio_irq_t *obj)
 {
     /* Clear EXTI line configuration */
+    LL_EXTI_DisableRisingTrig_0_31(1 << STM_PIN(obj->pin));
+    LL_EXTI_DisableFallingTrig_0_31(1 << STM_PIN(obj->pin));
     LL_EXTI_DisableIT_0_31(1 << STM_PIN(obj->pin));
     NVIC_DisableIRQ(obj->irq_n);
     NVIC_ClearPendingIRQ(obj->irq_n);

--- a/targets/TARGET_STM/gpio_irq_api.c
+++ b/targets/TARGET_STM/gpio_irq_api.c
@@ -90,8 +90,9 @@ static void handle_interrupt_in(uint32_t irq_index, uint32_t max_num_pin_line)
             if (__HAL_GPIO_EXTI_GET_FLAG(pin) != RESET) {
                 __HAL_GPIO_EXTI_CLEAR_FLAG(pin);
 
-                if (gpio_channel->channel_ids[gpio_idx] == 0)
+                if (gpio_channel->channel_ids[gpio_idx] == 0) {
                     continue;
+                }
 
                 // Check which edge has generated the irq
                 if ((gpio->IDR & pin) == 0) {
@@ -99,9 +100,11 @@ static void handle_interrupt_in(uint32_t irq_index, uint32_t max_num_pin_line)
                 } else {
                     irq_handler(gpio_channel->channel_ids[gpio_idx], IRQ_RISE);
                 }
+                return;
             }
         }
     }
+    error("Unexpected Spurious interrupt, index %d\r\n", irq_index);
 }
 
 


### PR DESCRIPTION
## Description
When disabling GPIO irq, also the falling / rising edge settings need
to be reset (EXTI_RTSR and EXTI_FTSR registers).

See #2959:
If not reset, the same EXTI line can be later enabled again with a wrong
Rising / Falling configuration. This was especially seen and reported in 
ci-test tests-api-interruptin on NUCLEO_F446RE target where DIO2=PA_10 and
DIO6=PB_10 were successively tested: as they are sharing the same EXTI_LINE
(EXTI_10), this resulted in calling the irq_handler with wrong
IRQ_FALL/IRQ_RAISE parameter and donothing being called in loop

Also after correctly disabling, another commit handles the save restore part.

Finally en error is added in case of spurious interrupt to make it easily detectable.

## Status
**READY**

## Tests results
NUCLEO_F446RE ci-test-shield passed ok
+-----------------------+---------------+-----------------------------+--------+--------------------+-------------+
| target                | platform_name | test suite                  | result | elapsed_time (sec) | copy_method |
+-----------------------+---------------+-----------------------------+--------+--------------------+-------------+
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-analogin          | OK     | 12.3               | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-analogout         | OK     | 11.27              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-businout          | OK     | 27.7               | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-digitalio         | OK     | 12.94              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-i2c               | OK     | 13.87              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-interruptin       | OK     | 12.72              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-pwm               | OK     | 176.18             | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-spi               | OK     | 15.53              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-assumptions-analogin  | OK     | 15.12              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-assumptions-analogout | OK     | 10.99              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-assumptions-digitalio | OK     | 13.72              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-assumptions-i2c       | OK     | 11.36              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-assumptions-pwm       | OK     | 11.86              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-assumptions-pwmout    | OK     | 11.19              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-assumptions-spi       | OK     | 11.81              | shell       |
+-----------------------+---------------+-----------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 15 OK

All families Interrupt-in tests passed 
+-----------------------+---------------+-----------------------+--------+--------------------+-------------+
| target                | platform_name | test suite            | result | elapsed_time (sec) | copy_method |
+-----------------------+---------------+-----------------------+--------+--------------------+-------------+
| NUCLEO_F091RC-ARM     | NUCLEO_F091RC | tests-api-interruptin | OK     | 57.33              | shell       |
| NUCLEO_F091RC-GCC_ARM | NUCLEO_F091RC | tests-api-interruptin | OK     | 58.05              | shell       |
| NUCLEO_F103RB-ARM     | NUCLEO_F103RB | tests-api-interruptin | OK     | 58.64              | shell       |
| NUCLEO_F103RB-GCC_ARM | NUCLEO_F103RB | tests-api-interruptin | OK     | 60.54              | shell       |
| NUCLEO_F207ZG-ARM     | NUCLEO_F207ZG | tests-api-interruptin | OK     | 54.88              | shell       |
| NUCLEO_F207ZG-GCC_ARM | NUCLEO_F207ZG | tests-api-interruptin | OK     | 57.05              | shell       |
| NUCLEO_F303ZE-ARM     | NUCLEO_F303ZE | tests-api-interruptin | OK     | 57.77              | shell       |
| NUCLEO_F303ZE-GCC_ARM | NUCLEO_F303ZE | tests-api-interruptin | OK     | 57.77              | shell       |
| NUCLEO_F446RE-ARM     | NUCLEO_F446RE | tests-api-interruptin | OK     | 56.6               | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-interruptin | OK     | 57.0               | shell       |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-api-interruptin | OK     | 56.52              | shell       |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-api-interruptin | OK     | 56.04              | shell       |
| NUCLEO_L073RZ-ARM     | NUCLEO_L073RZ | tests-api-interruptin | OK     | 59.84              | shell       |
| NUCLEO_L073RZ-GCC_ARM | NUCLEO_L073RZ | tests-api-interruptin | OK     | 60.43              | shell       |
| NUCLEO_L152RE-ARM     | NUCLEO_L152RE | tests-api-interruptin | OK     | 57.28              | shell       |
| NUCLEO_L152RE-GCC_ARM | NUCLEO_L152RE | tests-api-interruptin | OK     | 58.14              | shell       |
| NUCLEO_L476RG-ARM     | NUCLEO_L476RG | tests-api-interruptin | OK     | 57.24              | shell       |
| NUCLEO_L476RG-GCC_ARM | NUCLEO_L476RG | tests-api-interruptin | OK     | 57.45              | shell       |
+-----------------------+---------------+-----------------------+--------+--------------------+-------------+

