### PR TITLE
Increase default PPP stack size from 512 bytes to 768 bytes.

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwipopts.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwipopts.h
@@ -108,7 +108,7 @@
 
 // Thread stack size for private PPP thread
 #ifndef MBED_CONF_LWIP_PPP_THREAD_STACKSIZE
-#define MBED_CONF_LWIP_PPP_THREAD_STACKSIZE    512
+#define MBED_CONF_LWIP_PPP_THREAD_STACKSIZE    768
 #endif
 
 #if LWIP_DEBUG

--- a/features/FEATURE_LWIP/lwip-interface/mbed_lib.json
+++ b/features/FEATURE_LWIP/lwip-interface/mbed_lib.json
@@ -68,7 +68,7 @@
         },
         "ppp-thread-stacksize": {
             "help": "Thread stack size for PPP",
-            "value": 512
+            "value": 768
         }
     }
 }


### PR DESCRIPTION
## Description
PPP is running close to the edge of its default thread stack size of 512 bytes.  When it experiences an FCS error on the incoming data (caused by character loss when the incoming serial rate is too high for it to process in time) it performs some additional work which overruns the thread's stack, hitting the OS "stack underflow" check.

Increasing the  PPP stack size to 768 bytes resolves this problem.

Note: this change already discussed at some length with @kjbracey-arm.

## Steps to reproduce
Run `PPPCellularInterface` with the UART serial port running at 460800 or higher and wait for the OS stack check to be hit.