### PR TITLE
Add thread terminate hook

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
@@ -656,7 +656,7 @@ void test_thread_prio() {
 }
 
 utest::v1::status_t test_setup(const size_t number_of_cases) {
-    GREENTEA_SETUP(15, "default_auto");
+    GREENTEA_SETUP(20, "default_auto");
     return verbose_test_setup_handler(number_of_cases);
 }
 


### PR DESCRIPTION
## Description
Hook was added in RTX4 code to assist test framework to log thread info on thread terminate, which was not working with RTX5.

## Status
**READY**

## Steps to test or reproduce
Execute test mbed-os-tests-mbedmicro-rtos-mbed-threads with MBED_STACK_STATS_ENABLED set to 1.

@c1728p9 @bulislaw 