### PR TITLE
test: add us ticker test

### DIFF
--- a/TESTS/mbed_hal/lp_us_tickers/main.cpp
+++ b/TESTS/mbed_hal/lp_us_tickers/main.cpp
@@ -1,0 +1,110 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+
+#include "mbed.h"
+#include "us_ticker_api.h"
+#include "ticker_api.h"
+
+using namespace utest::v1;
+
+namespace {
+    volatile bool complete;
+    const ticker_interface_t* intf;
+}
+
+/* Ticker init should be run just once, thus read should always return a value that 
+ * increases (no reset).
+ */
+void test_ticker_init(void)
+{
+    intf->init();
+    uint32_t previous = intf->read();
+
+    intf->init();
+    uint32_t current = intf->read();
+    TEST_ASSERT_TRUE_MESSAGE(previous <= current, "init() changed the counter");
+
+    previous = intf->read();
+    intf->init();
+    current = intf->read();
+    TEST_ASSERT_TRUE_MESSAGE(previous <= current, "init() changed the counter");
+}
+
+/* Read multiple times, each returned time should be bigger than the previous one
+ * Counter up.
+ */
+void test_ticker_read(void)
+{
+    // this test assumes that to wrap around we would need to run >60 minutes
+    // therefore wrapping should not happen - previous <= current
+    const uint32_t test_loop = 15000;
+    uint32_t previous = intf->read();
+    uint32_t current;
+    for (uint32_t i = 0UL; i < test_loop; i++) {
+        current = intf->read();
+        TEST_ASSERT_TRUE_MESSAGE(previous <= current, "us ticker counter wrapped around");
+    }
+}
+
+/* Implement simple read while loop to check if time is increasing (counter up)
+ */
+void test_ticker_read_loop()
+{
+    uint32_t future_time = intf->read() + 10000UL;
+    while (intf->read() < future_time);
+    TEST_ASSERT_TRUE_MESSAGE(future_time <= intf->read(), "Future time is in the past");
+}
+
+utest::v1::status_t us_ticker_setup(const Case *const source, const size_t index_of_case)
+{
+    intf = get_us_ticker_data()->interface;
+    return greentea_case_setup_handler(source, index_of_case);
+}
+
+#if DEVICE_LOWPOWERTIMER
+utest::v1::status_t lp_ticker_setup(const Case *const source, const size_t index_of_case)
+{
+    intf = get_lp_ticker_data()->interface;
+    return greentea_case_setup_handler(source, index_of_case);
+}
+#endif
+
+Case cases[] = {
+    Case("us ticker HAL - Init", us_ticker_setup, test_ticker_init),
+    Case("us ticker HAL - Read", us_ticker_setup, test_ticker_read),
+    Case("us ticker HAL - Read in the loop", us_ticker_setup, test_ticker_read_loop),
+#if DEVICE_LOWPOWERTIMER
+    Case("lp ticker HAL - Init", lp_ticker_setup, test_ticker_init),
+    Case("lp ticker HAL - Read", lp_ticker_setup, test_ticker_read),
+    Case("lp ticker HAL - Read in the loop", lp_ticker_setup, test_ticker_read_loop),
+#endif
+};
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases) 
+{
+    GREENTEA_SETUP(20, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+
+int main() 
+{
+    Harness::run(specification);
+}


### PR DESCRIPTION
This test exercises us ticker API
- init should be executed just once
- read timestamp
- setting interrupts

Disable interrupt shall be also tested, should be proparly in its own test,
as it is the very last function to be executed (we dont have API to reenable interrupts), thus cant be in the same test unit.

Need to add documentation to this test.

This is very basic test, init version that can expand. I can add disable also but it is own file, was thinking something like this:

```
void test_us_ticker_disable_interrupt(void)
{
    // we use here ticker API to set properly callback to set our complete flag
    const ticker_data_t *us_ticker = get_us_ticker_data();
    ticker_event_t event;
    const uint32_t future_margin = 1000; // 1ms margin for interrupt to be fired 

    complete = false;
    ticker_set_handler(us_ticker, us_ticker_handler_test);
    timestamp_t future_timestamp = us_ticker_read() + 1000UL;
    ticker_insert_event_us(us_ticker, &event, future_timestamp, 1);
    us_ticker_disable_interrupt();
    while (us_ticker_read() <= (future_timestamp + future_margin));
    TEST_ASSERT_TRUE_MESSAGE(complete == false, "Interrupt was disabled and still fired");
}
```

I can refactor this to be us ticker and lp ticker tests (via that ticker data API), would our test allow it? This would be the idea:

ticker_lpus/ticker_header_test.h - would contain definitions for  both
ticker_lpus/lp_ticker/main.cpp - this would use lp ticker data
ticker_lp_us/us_ticker/main.cpp - this would use us ticker data

Tested with ARM on K64F and NCS36510 so far, more testing required.

cc @pan- @c1728p9 Anyone else interested in tickers?