### PR TITLE
STM32: F4: Increase ADC sampling time for VBAT

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
@@ -188,6 +188,9 @@ static inline uint16_t adc_read(analogin_t *obj)
             break;
         case 18:
             sConfig.Channel = ADC_CHANNEL_VBAT;
+            /*  From experiment, VBAT measurement needs max
+             *  sampling time to be avlid */
+            sConfig.SamplingTime = ADC_SAMPLETIME_480CYCLES;
             break;
         default:
             return 0;


### PR DESCRIPTION
## Description
To get a valid VBAT measurement on F4 targets, it is required to increase
the sampling time to its maximum value.

This PR solves the issue reported here #4326

## Status
**READY**

## Tests
Tested on NUCLEO_F446RE target with VBAT measurements and non-regression OK

+-----------------------+---------------+-----------------------+--------+--------------------+-------------+
| target                | platform_name | test suite            | result | elapsed_time (sec) | copy_method |
+-----------------------+---------------+-----------------------+--------+--------------------+-------------+
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-analogin    | OK     | 12.65              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-analogout   | OK     | 11.8               | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-businout    | OK     | 28.27              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-digitalio   | OK     | 13.17              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-i2c         | OK     | 14.54              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-interruptin | OK     | 13.77              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-pwm         | OK     | 176.65             | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-spi         | OK     | 16.15              | shell       |
+-----------------------+---------------+-----------------------+--------+--------------------+-------------+


## More thoughts
Increasing the sample time may have impacts on performances (e.g. max number of samples per sec),
but this PR aims at getting valid sample first. There is way for improvement in MBED API to allow 
configuration of this sampling time parameter. An issue will be entered accordingly.
Submitted #4692