### PR TITLE
Nordic: Fix multiple defined symbol.

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/us_ticker.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/us_ticker.c
@@ -303,22 +303,6 @@ static uint32_t os_rtc_period;
 static uint32_t frozen_sub_tick = 0;
      
 
-/*
- RTX provide the following definitions which are used by the tick code:
-   * osRtxConfig.tick_freq: The RTX tick frequency.
-   * osRtxInfo.kernel.tick: Count of RTX ticks.
-   
-   * SysTick_Handler: The function which handle a tick event.
-     This function is special because it never returns.
- Those definitions are used by the code which handle the os tick.
- To allow compilation of us_ticker programs without RTOS, those symbols are
- exported from this module as weak ones.
- */
-MBED_WEAK void SysTick_Handler(void)
-{
-}
-
-
 #ifdef MBED_CONF_RTOS_PRESENT
     #include "rtx_os.h" //import osRtxInfo, SysTick_Handler()
     


### PR DESCRIPTION
## Description

The symbol Systick_Handler was defined as a weak symbol in us_ticker.c and
startup_nRF51822.s. While it work as expected when an application is compiled
from mbed OS source code it creates a duplicate symbol issue when mbed OS is
bundled as a library.


## Status
**READY**


## Migrations
 NO


