### PR TITLE
IAR: remove stm32f413 from definitions

### DIFF
--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -110,9 +110,6 @@
     "STM32F411RE": {
         "OGChipSelectEditMenu": "STM32F411RE\tST STM32F411RE"
     },
-    "STM32F413ZH": {
-        "OGChipSelectEditMenu": "STM32F413ZH\tST STM32F413ZH"
-    },
     "STM32L053C8": {
         "OGChipSelectEditMenu": "STM32L053x8\tST STM32L053x8"
     },


### PR DESCRIPTION
This definition requires IAR 7.80.2 and higher.
It will be readded once we all update to the latest IAR 7.80 patch release. For
future, please any new target should state what are the requirements on tools to
avoid this suprises. + run export build to verify this requirement

Tested locally, now with this patch - `project.py: error: DISCO_F413ZH not supported by iar`

cc @adbridge @studavekar 

@adustm @bcostm @LMESTM @jeromecoutant Just that you know, I'll send another patch reenabling this that will get in once we all update