### PR TITLE
Enable greentea testing on CM3DS_MPS2 target

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1975,7 +1975,9 @@
         "extra_labels": ["ARM_SSG", "CM3DS_MPS2"],
         "macros": ["CMSDK_CM3DS"],
         "device_has": ["ANALOGIN", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SPI", "RTC"],
-        "release_versions": ["2", "5"]
+        "release_versions": ["2", "5"],
+        "copy_method": "mps2",
+        "reset_method": "reboot.txt"
     },
     "ARM_BEETLE_SOC": {
         "inherits": ["ARM_IOTSS_Target"],


### PR DESCRIPTION
Set copy_method and reset_method in targets.json which is needed for
htrun.

## Description
Enable greentea testing on CM3DS_MPS2 target.
Set copy_method and reset_method in targets.json which is needed for htrun.


## Status
**READY/IN DEVELOPMENT/HOLD**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Related PRs
Support reset and flash for ARM MPS2 board.: https://github.com/ARMmbed/htrun/pull/160

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ ] Documentation


## Deploy notes
Notes regarding the deployment of this PR. These should note any
required changes in the build environment, tools, compilers, etc.


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
