### PR TITLE
added the missing verbose=verbose to printout the command line correctly at build_api.py

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -992,7 +992,7 @@ def build_mbed_libs(target, toolchain_name, verbose=False,
         mkdir(tmp_path)
 
         toolchain = prepare_toolchain(
-            [""], tmp_path, target, toolchain_name, macros=macros,
+            [""], tmp_path, target, toolchain_name, macros=macros,verbose=verbose,
             notify=notify, silent=silent, extra_verbose=extra_verbose,
             build_profile=build_profile, jobs=jobs, clean=clean)
 


### PR DESCRIPTION
Notes:
* Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
Done it with the online ide

## Description
This is a simple fix, it seems last time it was changed the verbose option went missing, and it masks others


## Status
READY (trivial fix for the build system)


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

 NO


## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ ] Documentation


## Deploy notes
Notes regarding the deployment of this PR. These should note any
required changes in the build environment, tools, compilers, etc.


## Steps to test or reproduce
Outline the steps to test or reproduce the PR here.
