### PR TITLE
STM32: Remove i2c_read() and i2c_write() redirects to HAL_I2C_IsDeviceReady()

### DIFF
--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -743,13 +743,6 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop) {
     int count = I2C_ERROR_BUS_BUSY, ret = 0;
     uint32_t timeout = 0;
 
-    if((length == 0) || (data == 0)) {
-        if(HAL_I2C_IsDeviceReady(handle, address, 1, 10) == HAL_OK)
-            return 0;
-        else
-            return I2C_ERROR_BUS_BUSY;
-    }
-
     if ((obj_s->XferOperation == I2C_FIRST_AND_LAST_FRAME) ||
         (obj_s->XferOperation == I2C_LAST_FRAME)) {
         if (stop)
@@ -801,13 +794,6 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop) {
     I2C_HandleTypeDef *handle = &(obj_s->handle);
     int count = I2C_ERROR_BUS_BUSY, ret = 0;
     uint32_t timeout = 0;
-
-    if((length == 0) || (data == 0)) {
-        if(HAL_I2C_IsDeviceReady(handle, address, 1, 10) == HAL_OK)
-            return 0;
-        else
-            return I2C_ERROR_BUS_BUSY;
-    }
 
     if ((obj_s->XferOperation == I2C_FIRST_AND_LAST_FRAME) ||
         (obj_s->XferOperation == I2C_LAST_FRAME)) {


### PR DESCRIPTION
## Description
Some I2C devices require specific zero length read/write sequences which
the HAL_I2C_IsDeviceReady() redirect interferes with.  After Removing
these redirects, it was confirmed that zero length reads and writes
would both still work correctly for detecting presence/absence of an
I2C device on a bus.

## Status
READY

## Migrations
NO

## Todos
Run I2C CI tests on all STM32 targets to confirm no regressions

## Steps to test or reproduce
Build an STM32 based target image with an instantiated I2C bus and use an oscilloscope or I2C bus analyzer to confirm that both an I2C read without data and an I2C write without data can be generated, and the expected results returned, using code such as:

`#include <mbed.h>`
...
`I2C testI2c(PA_10, PA_9);`
`printf("Write to 0x54 = %d\r\n", testI2c.write(0x54, 0, 0)); // Non-existent I2C device (expect 1 result)`
`printf("Write to 0xA0 = %d\r\n", testI2c.write(0xA0, 0, 0)); // EEPROM (expect 0 result)`
`printf("Read from 0x54 = %d\r\n", testI2c.read(0x54, 0, 0)); // Non-existent I2C device (expect 1 result)`
`printf("Read from 0xA0 = %d\r\n", testI2c.read(0xA0, 0, 0)); // EEPROM (expect 0 result)`