### PR TITLE
FlashIAP: Add explicit read function to flash_api.h

### DIFF
--- a/drivers/FlashIAP.cpp
+++ b/drivers/FlashIAP.cpp
@@ -55,7 +55,7 @@ int FlashIAP::init()
     int ret = 0;
     _mutex->lock();
     if (flash_init(&_flash)) {
-        ret = -1; 
+        ret = -1;
     }
     _mutex->unlock();
     return ret;
@@ -66,7 +66,7 @@ int FlashIAP::deinit()
     int ret = 0;
     _mutex->lock();
     if (flash_free(&_flash)) {
-        ret = -1; 
+        ret = -1;
     }
     _mutex->unlock();
     return ret;
@@ -75,10 +75,11 @@ int FlashIAP::deinit()
 
 int FlashIAP::read(void *buffer, uint32_t addr, uint32_t size)
 {
+    int32_t ret = -1;
     _mutex->lock();
-    memcpy(buffer, (const void *)addr, size);
+    ret = flash_read(&_flash, addr, (uint8_t *) buffer, size);
     _mutex->unlock();
-    return 0;
+    return ret;
 }
 
 int FlashIAP::program(const void *buffer, uint32_t addr, uint32_t size)

--- a/hal/flash_api.h
+++ b/hal/flash_api.h
@@ -42,14 +42,14 @@ extern "C" {
  */
 
 /** Initialize the flash peripheral and the flash_t object
- * 
+ *
  * @param obj The flash object
  * @return 0 for success, -1 for error
  */
 int32_t flash_init(flash_t *obj);
 
 /** Uninitialize the flash peripheral and the flash_t object
- * 
+ *
  * @param obj The flash object
  * @return 0 for success, -1 for error
  */
@@ -64,9 +64,20 @@ int32_t flash_free(flash_t *obj);
  */
 int32_t flash_erase_sector(flash_t *obj, uint32_t address);
 
+/** Read data starting at defined address
+ *
+ * This function has a WEAK implementation using memcpy for backwards compatibility.
+ * @param obj The flash object
+ * @param address Address to begin reading from
+ * @param data The buffer to read data into
+ * @param size The number of bytes to read
+ * @return 0 for success, -1 for error
+ */
+int32_t flash_read(flash_t *obj, uint32_t address, uint8_t *data, uint32_t size);
+
 /** Program one page starting at defined address
- * 
- * The page should be at page boundary, should not cross multiple sectors. 
+ *
+ * The page should be at page boundary, should not cross multiple sectors.
  * This function does not do any check for address alignments or if size is aligned to a page size.
  * @param obj The flash object
  * @param address The sector starting address
@@ -77,7 +88,7 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address);
 int32_t flash_program_page(flash_t *obj, uint32_t address, const uint8_t *data, uint32_t size);
 
 /** Get sector size
- * 
+ *
  * @param obj The flash object
  * @param address The sector starting address
  * @return The size of a sector
@@ -85,7 +96,7 @@ int32_t flash_program_page(flash_t *obj, uint32_t address, const uint8_t *data, 
 uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address);
 
 /** Get page size
- * 
+ *
  * @param obj The flash object
  * @param address The page starting address
  * @return The size of a page
@@ -93,14 +104,14 @@ uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address);
 uint32_t flash_get_page_size(const flash_t *obj);
 
 /** Get start address for the flash region
- * 
+ *
  * @param obj The flash object
  * @return The start address for the flash region
  */
 uint32_t flash_get_start_address(const flash_t *obj);
 
 /** Get the flash region size
- * 
+ *
  * @param obj The flash object
  * @return The flash region size
  */

--- a/hal/mbed_flash_api.c
+++ b/hal/mbed_flash_api.c
@@ -1,0 +1,30 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hal/flash_api.h"
+
+#if DEVICE_FLASH
+
+#include "platform/mbed_toolchain.h"
+#include <string.h>
+
+MBED_WEAK int32_t flash_read(flash_t *obj, uint32_t address, uint8_t *data, uint32_t size)
+{
+    memcpy(data, (const void *)address, size);
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
On some platforms, the in-application memory is not memory mapped
and therefore cannot be accessed using memcpy.

The flash_read function added to flash_api.h (with a weak
implementation using memcpy in mbed_flash_api.c) can be used for
reading data from areas that are not memory mapped.
