### PR TITLE
REALTEK_RTL8195AM: FlashIAP read and address scope

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/flash_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/flash_api.c
@@ -15,10 +15,6 @@
  */
 #include "flash_ext.h"
 
-#define FLASH_START       (SPI_FLASH_BASE + FLASH_OFS_START)
-#define FLASH_END         (SPI_FLASH_BASE + FLASH_OFS_END)
-#define FLASH_OFS(addr)   ((addr) - SPI_FLASH_BASE)
-
 int32_t flash_init(flash_t *obj)
 {
     __flash_ext_turnon();
@@ -35,20 +31,25 @@ int32_t flash_free(flash_t *obj)
 
 int32_t flash_erase_sector(flash_t *obj, uint32_t address)
 {
-    __flash_ext_erase_sector(obj, FLASH_OFS(address));
+    flash_ext_erase_sector(obj, address);
 
     return 0;
 }
 
+int32_t flash_read(flash_t *obj, uint32_t address, uint8_t *data, uint32_t size)
+{
+    return flash_ext_stream_read(obj, address, size, data);;
+}
+
 int32_t flash_program_page(flash_t *obj, uint32_t address, const uint8_t *data, uint32_t size)
 {
-    return __flash_ext_stream_write(obj, FLASH_OFS(address), size, data);
+    return flash_ext_stream_write(obj, address, size, data);
 }
 
 uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address)
 {
-    if (address < FLASH_START || address >= FLASH_END)
-        return 0;
+    if (address >= FLASH_OFS_END)
+        return MBED_FLASH_INVALID_SIZE;
 
     return FLASH_SECTOR_SIZE;
 }
@@ -60,7 +61,7 @@ uint32_t flash_get_page_size(const flash_t *obj)
 
 uint32_t flash_get_start_address(const flash_t *obj)
 {
-    return FLASH_START;
+    return FLASH_OFS_START;
 }
 
 uint32_t flash_get_size(const flash_t *obj)

--- a/targets/TARGET_Realtek/TARGET_AMEBA/flash_ext.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/flash_ext.c
@@ -128,7 +128,7 @@ int flash_ext_stream_read(flash_t *obj, uint32_t addr, uint32_t len, uint8_t *da
     __flash_ext_turnon();
 
     SpicWaitWipDoneRefinedRtl8195A(flashobj.SpicInitPara);
-    
+
     offset = addr & 0x03;
     addr = addr & ~0x03;
     pbuf = data;
@@ -189,13 +189,13 @@ int __flash_ext_stream_write(flash_t *obj, uint32_t addr, uint32_t len, const ui
     uint32_t i, offset, word;
     const uint8_t*pbuf;
     uint8_t *ptr;
-    u8 flashtype = 0; 
+    u8 flashtype = 0;
 
     offset = addr & 0x03;
     addr = addr & ~0x03;
     pbuf = data;
     flashtype = flashobj.SpicInitPara.flashtype;
-    
+
     if (offset != 0) {
         word = HAL_READ32(SPI_FLASH_BASE, addr);
         ptr = (uint8_t *)&word + offset;
@@ -207,7 +207,7 @@ int __flash_ext_stream_write(flash_t *obj, uint32_t addr, uint32_t len, const ui
         }
         HAL_WRITE32(SPI_FLASH_BASE, addr, word);
         SpicWaitBusyDoneRtl8195A();
-        
+
         if(flashtype == FLASH_MICRON){
             SpicWaitOperationDoneRtl8195A(flashobj.SpicInitPara);
         } else {
@@ -222,7 +222,7 @@ int __flash_ext_stream_write(flash_t *obj, uint32_t addr, uint32_t len, const ui
                 ((uint32_t)(*(pbuf+2)) << 16) | ((uint32_t)(*(pbuf+3)) << 24);
             HAL_WRITE32(SPI_FLASH_BASE, addr, word);
             SpicWaitBusyDoneRtl8195A();
-            
+
             if(flashtype == FLASH_MICRON){
                 SpicWaitOperationDoneRtl8195A(flashobj.SpicInitPara);
             } else {
@@ -237,7 +237,7 @@ int __flash_ext_stream_write(flash_t *obj, uint32_t addr, uint32_t len, const ui
         while (len >= 4) {
             HAL_WRITE32(SPI_FLASH_BASE, addr, (uint32_t)*((uint32_t *)pbuf));
             SpicWaitBusyDoneRtl8195A();
-            
+
             if(flashtype == FLASH_MICRON){
                 SpicWaitOperationDoneRtl8195A(flashobj.SpicInitPara);
             } else {
@@ -260,7 +260,7 @@ int __flash_ext_stream_write(flash_t *obj, uint32_t addr, uint32_t len, const ui
 
         HAL_WRITE32(SPI_FLASH_BASE, addr, word);
         SpicWaitBusyDoneRtl8195A();
-        
+
         if(flashtype == FLASH_MICRON){
             SpicWaitOperationDoneRtl8195A(flashobj.SpicInitPara);
         } else {
@@ -271,7 +271,7 @@ int __flash_ext_stream_write(flash_t *obj, uint32_t addr, uint32_t len, const ui
     return 0;
 }
 
-int flash_ext_stream_write(flash_t *obj, uint32_t addr, uint32_t len, uint8_t *data)
+int flash_ext_stream_write(flash_t *obj, uint32_t addr, uint32_t len, const uint8_t *data)
 {
     int32_t status;
 
@@ -287,7 +287,7 @@ int flash_stream_read(flash_t *obj, uint32_t addr, uint32_t len, uint8_t *data)
     return flash_ext_stream_read(obj, addr, len, data);
 }
 
-int flash_stream_write(flash_t *obj, uint32_t addr, uint32_t len, uint8_t *data)
+int flash_stream_write(flash_t *obj, uint32_t addr, uint32_t len, const uint8_t *data)
 {
     return flash_ext_stream_write(obj, addr, len, data);
 }
@@ -308,7 +308,7 @@ Users can use either of functions depending on their needs.
 */
 
 int flash_ext_burst_write(flash_t *obj, uint32_t address ,uint32_t length, uint8_t *data)
-{    
+{
     u32 OccuSize;
     u32 ProgramSize;
     u32 PageSize;
@@ -340,7 +340,7 @@ int flash_ext_burst_write(flash_t *obj, uint32_t address ,uint32_t length, uint8
             }
 
             address += ProgramSize;
-            data += ProgramSize;   
+            data += ProgramSize;
             length -= ProgramSize;
             OccuSize = 0;
         } else{
@@ -435,7 +435,7 @@ This function aims to reset the status register, please make sure the operation 
 void flash_ext_reset_status(flash_t *obj)
 {
     __flash_ext_turnon();
-    SpicSetFlashStatusRefinedRtl8195A(0, flashobj.SpicInitPara);    
+    SpicSetFlashStatusRefinedRtl8195A(0, flashobj.SpicInitPara);
     SpicWaitWipDoneRefinedRtl8195A(flashobj.SpicInitPara);
     __flash_ext_turnoff();
 }

--- a/targets/TARGET_Realtek/TARGET_AMEBA/flash_ext.h
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/flash_ext.h
@@ -25,17 +25,17 @@ extern "C" {
 
 #define FLASH_PAGE_SIZE 256
 #define FLASH_SIZE        0x100000
-#define FLASH_OFS_START   0xc0000
+#define FLASH_OFS_START   0x0
 #define FLASH_OFS_END     (FLASH_OFS_START + FLASH_SIZE)
 
 extern void flash_ext_erase_sector(flash_t *obj, uint32_t address);
 extern void flash_ext_erase_block(flash_t * obj, uint32_t address);
-extern int flash_ext_read_word(flash_t *obj, uint32_t address, uint32_t * data);
+extern int flash_ext_read_word(flash_t *obj, uint32_t address, uint32_t *data);
 extern int flash_ext_write_word(flash_t *obj, uint32_t address, uint32_t data);
-extern int flash_ext_stream_read(flash_t *obj, uint32_t address, uint32_t len, uint8_t * data);
-extern int flash_ext_stream_write(flash_t *obj, uint32_t address, uint32_t len, uint8_t * data);
+extern int flash_ext_stream_read(flash_t *obj, uint32_t address, uint32_t len, uint8_t *data);
+extern int flash_ext_stream_write(flash_t *obj, uint32_t address, uint32_t len, const uint8_t *data);
 extern int flash_stream_read(flash_t *obj, uint32_t addr, uint32_t len, uint8_t *data);
-extern int flash_stream_write(flash_t *obj, uint32_t addr, uint32_t len, uint8_t *data);
+extern int flash_stream_write(flash_t *obj, uint32_t addr, uint32_t len, const uint8_t *data);
 extern void flash_ext_write_protect(flash_t *obj, uint32_t protect);
 extern int flash_ext_get_status(flash_t *obj);
 extern int flash_ext_set_status(flash_t *obj, uint32_t data);


### PR DESCRIPTION
## Description

The FlashIAP is supposed to have access to the full application
memory, so the address scope has been changed to encompass
the entire external flash.

The address translation has also been changed to reflect the memory
layout in the documentation:

 Realtek Ameba1 Memory Layout: 5.1 Flash Memory

## Related PRs

Needs API change from https://github.com/ARMmbed/mbed-os/pull/4720 to work.

## Tests

Tested using GCC and ARM.

```
+---------------------------+-------------------+-----------------------------+---------------------------+--------+--------+--------+--------------------+
| target                    | platform_name     | test suite                  | test case                 | passed | failed | result | elapsed_time (sec) |
+---------------------------+-------------------+-----------------------------+---------------------------+--------+--------+--------+--------------------+
| REALTEK_RTL8195AM-ARM     | REALTEK_RTL8195AM | tests-mbed_drivers-flashiap | FlashIAP - init           | 1      | 0      | OK     | 0.01               |
| REALTEK_RTL8195AM-ARM     | REALTEK_RTL8195AM | tests-mbed_drivers-flashiap | FlashIAP - program        | 1      | 0      | OK     | 0.17               |
| REALTEK_RTL8195AM-ARM     | REALTEK_RTL8195AM | tests-mbed_drivers-flashiap | FlashIAP - program errors | 1      | 0      | OK     | 0.02               |
| REALTEK_RTL8195AM-GCC_ARM | REALTEK_RTL8195AM | tests-mbed_drivers-flashiap | FlashIAP - init           | 1      | 0      | OK     | 0.01               |
| REALTEK_RTL8195AM-GCC_ARM | REALTEK_RTL8195AM | tests-mbed_drivers-flashiap | FlashIAP - program        | 1      | 0      | OK     | 0.17               |
| REALTEK_RTL8195AM-GCC_ARM | REALTEK_RTL8195AM | tests-mbed_drivers-flashiap | FlashIAP - program errors | 1      | 0      | OK     | 0.02               |
+---------------------------+-------------------+-----------------------------+---------------------------+--------+--------+--------+--------------------+
```