### PR TITLE
Parse and use custom targets in exporters

### DIFF
--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -103,7 +103,7 @@ def mcu_ide_matrix(verbose_html=False):
         row = [target]  # First column is platform name
         for ide in supported_ides:
             text = "-"
-            if target in EXPORTERS[ide].TARGETS:
+            if EXPORTERS[ide].is_target_supported(target):
                 if verbose_html:
                     text = "&#10003;"
                 else:

--- a/tools/export/cmsis/__init__.py
+++ b/tools/export/cmsis/__init__.py
@@ -103,8 +103,11 @@ class DeviceCMSIS():
 class CMSIS(Exporter):
     NAME = 'cmsis'
     TOOLCHAIN = 'ARM'
-    TARGETS = [target for target, obj in TARGET_MAP.iteritems()
-               if "ARM" in obj.supported_toolchains]
+
+    @classmethod
+    def is_target_supported(cls, target_name):
+        target = TARGET_MAP[target_name]
+        return cls.TOOLCHAIN in target.supported_toolchains
 
     def make_key(self, src):
         """turn a source file into its group name"""

--- a/tools/export/embitz/__init__.py
+++ b/tools/export/embitz/__init__.py
@@ -16,7 +16,7 @@ limitations under the License.
 """
 from os.path import splitext, basename
 from tools.targets import TARGET_MAP
-from tools.export.exporters import Exporter, filter_supported
+from tools.export.exporters import Exporter, apply_supported_whitelist
 
 
 POST_BINARY_WHITELIST = set([
@@ -30,9 +30,6 @@ class EmBitz(Exporter):
     NAME = 'EmBitz'
     TOOLCHAIN = 'GCC_ARM'
 
-
-    TARGETS = filter_supported("GCC_ARM", POST_BINARY_WHITELIST)
-
     MBED_CONFIG_HEADER_SUPPORTED = True
 
     FILE_TYPES = {
@@ -42,6 +39,11 @@ class EmBitz(Exporter):
         'cpp_sources': 'cpp'
     }
 
+    @classmethod
+    def is_target_supported(cls, target_name):
+        target = TARGET_MAP[target_name]
+        return apply_supported_whitelist(
+            cls.TOOLCHAIN, POST_BINARY_WHITELIST, target)
 
     @staticmethod
     def _remove_symbols(sym_list):

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -36,7 +36,7 @@ class Exporter(object):
     TEMPLATE_DIR = dirname(__file__)
     DOT_IN_RELATIVE_PATH = False
     NAME = None
-    TARGETS = None
+    TARGETS = set()
     TOOLCHAIN = None
 
 
@@ -178,19 +178,33 @@ class Exporter(object):
         """Generate an IDE/tool specific project file"""
         raise NotImplemented("Implement a generate function in Exporter child class")
 
+    @classmethod
+    def is_target_supported(cls, target_name):
+        """Query support for a particular target
 
-def filter_supported(compiler, whitelist):
+        NOTE: override this method if your exporter does not provide a static list of targets
+
+        Positional Arguments:
+        target_name - the name of the target.
+        """
+        target = TARGET_MAP[target_name]
+        return bool(set(target.resolution_order_names).intersection(set(cls.TARGETS))) \
+            and cls.TOOLCHAIN in target.supported_toolchains
+
+
+    @classmethod
+    def all_supported_targets(cls):
+        return [t for t in TARGET_MAP.keys() if cls.is_target_supported(t)]
+
+
+def apply_supported_whitelist(compiler, whitelist, target):
     """Generate a list of supported targets for a given compiler and post-binary hook
     white-list."""
-    def supported_p(obj):
-        """Internal inner function used for filtering"""
-        if compiler not in obj.supported_toolchains:
-            return False
-        if not hasattr(obj, "post_binary_hook"):
-            return True
-        if obj.post_binary_hook['function'] in whitelist:
-            return True
-        else:
-            return False
-    return list(target for target, obj in TARGET_MAP.iteritems()
-                if supported_p(obj))
+    if compiler not in target.supported_toolchains:
+        return False
+    if not hasattr(target, "post_binary_hook"):
+        return True
+    if target.post_binary_hook['function'] in whitelist:
+        return True
+    else:
+        return False

--- a/tools/export/gnuarmeclipse/__init__.py
+++ b/tools/export/gnuarmeclipse/__init__.py
@@ -33,7 +33,7 @@ from os.path import splitext, basename, relpath, dirname, exists, join, dirname
 from random import randint
 from json import load
 
-from tools.export.exporters import Exporter, filter_supported
+from tools.export.exporters import Exporter, apply_supported_whitelist
 from tools.options import list_profiles
 from tools.targets import TARGET_MAP
 from tools.utils import NotSupportedException
@@ -69,7 +69,11 @@ class GNUARMEclipse(Exporter):
     NAME = 'GNU ARM Eclipse'
     TOOLCHAIN = 'GCC_ARM'
 
-    TARGETS = filter_supported("GCC_ARM", POST_BINARY_WHITELIST)
+    @classmethod
+    def is_target_supported(cls, target_name):
+        target = TARGET_MAP[target_name]
+        return apply_supported_whitelist(
+            cls.TOOLCHAIN, POST_BINARY_WHITELIST, target)
 
     # override
     @property

--- a/tools/export/iar/__init__.py
+++ b/tools/export/iar/__init__.py
@@ -30,15 +30,15 @@ _iar_defs = os.path.join(
 with open(_iar_defs, 'r') as f:
     _GUI_OPTIONS = json.load(f)
 
-_IAR_TARGETS = [target for target, obj in TARGET_MAP.iteritems() if
-                _supported(obj, _GUI_OPTIONS.keys())]
-
 
 class IAR(Exporter):
     NAME = 'iar'
     TOOLCHAIN = 'IAR'
 
-    TARGETS = _IAR_TARGETS
+    @classmethod
+    def is_target_supported(cls, target_name):
+        target = TARGET_MAP[target_name]
+        return _supported(target, _GUI_OPTIONS.keys())
 
 
     def iar_groups(self, grouped_src):

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -21,7 +21,7 @@ import sys
 from subprocess import check_output, CalledProcessError, Popen, PIPE
 import shutil
 from jinja2.exceptions import TemplateNotFound
-from tools.export.exporters import Exporter, filter_supported
+from tools.export.exporters import Exporter, apply_supported_whitelist
 from tools.utils import NotSupportedException
 from tools.targets import TARGET_MAP
 
@@ -41,6 +41,12 @@ class Makefile(Exporter):
         "LPCTargetCode.lpc_patch",
         "LPC4088Code.binary_hook"
     ])
+
+    @classmethod
+    def is_target_supported(cls, target_name):
+        target = TARGET_MAP[target_name]
+        return apply_supported_whitelist(
+            cls.TOOLCHAIN, cls.POST_BINARY_WHITELIST, target)
 
     def generate(self):
         """Generate the makefile
@@ -186,7 +192,6 @@ class Makefile(Exporter):
 
 class GccArm(Makefile):
     """GCC ARM specific makefile target"""
-    TARGETS = filter_supported("GCC_ARM", Makefile.POST_BINARY_WHITELIST)
     NAME = 'Make-GCC-ARM'
     TEMPLATE = 'make-gcc-arm'
     TOOLCHAIN = "GCC_ARM"
@@ -204,7 +209,6 @@ class GccArm(Makefile):
 
 class Armc5(Makefile):
     """ARM Compiler 5 specific makefile target"""
-    TARGETS = filter_supported("ARM", Makefile.POST_BINARY_WHITELIST)
     NAME = 'Make-ARMc5'
     TEMPLATE = 'make-armc5'
     TOOLCHAIN = "ARM"
@@ -222,7 +226,6 @@ class Armc5(Makefile):
 
 class IAR(Makefile):
     """IAR specific makefile target"""
-    TARGETS = filter_supported("IAR", Makefile.POST_BINARY_WHITELIST)
     NAME = 'Make-IAR'
     TEMPLATE = 'make-iar'
     TOOLCHAIN = "IAR"

--- a/tools/export/qtcreator/__init__.py
+++ b/tools/export/qtcreator/__init__.py
@@ -16,14 +16,11 @@ limitations under the License.
 """
 from os.path import splitext, basename
 from tools.targets import TARGET_MAP
-from tools.export.exporters import Exporter, filter_supported
+from tools.export.exporters import Exporter
 from tools.export.makefile import GccArm
 
 class QtCreator(GccArm):
     NAME = 'QtCreator'
-    TOOLCHAIN = 'GCC_ARM'
-
-    TARGETS = filter_supported("GCC_ARM", set())
 
     MBED_CONFIG_HEADER_SUPPORTED = True
 

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -9,7 +9,7 @@ import re
 
 from tools.arm_pack_manager import Cache
 from tools.targets import TARGET_MAP
-from tools.export.exporters import Exporter, filter_supported
+from tools.export.exporters import Exporter, apply_supported_whitelist
 from tools.export.cmsis import DeviceCMSIS
 
 cache_d = False
@@ -129,8 +129,13 @@ class Uvision(Exporter):
         "MTSCode.combine_bins_mts_dragonfly",
         "NCS36510TargetCode.ncs36510_addfib"
     ])
-    TARGETS = [tgt for tgt in filter_supported("ARM", POST_BINARY_WHITELIST)
-               if DeviceCMSIS.check_supported(tgt)]
+
+    @classmethod
+    def is_target_supported(cls, target_name):
+        target = TARGET_MAP[target_name]
+        return apply_supported_whitelist(
+            cls.TOOLCHAIN, cls.POST_BINARY_WHITELIST, target) and\
+            DeviceCMSIS.check_supported(target_name)
 
     #File associations within .uvprojx file
     file_types = {'.cpp': 8, '.c': 1, '.s': 2,

--- a/tools/project.py
+++ b/tools/project.py
@@ -107,7 +107,7 @@ def main():
 
     parser.add_argument("-m", "--mcu",
                         metavar="MCU",
-                        type=argparse_force_uppercase_type(targetnames, "MCU"),
+                        type=str.upper,
                         help="generate project for the given MCU ({})".format(
                             ', '.join(targetnames)))
 
@@ -235,19 +235,17 @@ def main():
         if exists(EXPORT_DIR):
             rmtree(EXPORT_DIR)
 
-    for mcu in options.mcu:
-        zip_proj = not bool(options.source_dir)
+    zip_proj = not bool(options.source_dir)
 
     if (options.program is None) and (not options.source_dir):
         args_error(parser, "one of -p, -n, or --source is required")
-        # Export to selected toolchain
     exporter, toolchain_name = get_exporter_toolchain(options.ide)
-    if options.mcu not in exporter.TARGETS:
-        args_error(parser, "%s not supported by %s"%(options.mcu,options.ide))
+    mcu = extract_mcus(parser, options)[0]
+    if not exporter.is_target_supported(mcu):
+        args_error(parser, "%s not supported by %s"%(mcu,options.ide))
     profile = extract_profile(parser, options, toolchain_name, fallback="debug")
     if options.clean:
         rmtree(BUILD_DIR)
-    mcu = extract_mcus(parser, options)[0]
     export(mcu, options.ide, build=options.build,
            src=options.source_dir, macros=options.macros,
            project_id=options.program, zip_proj=zip_proj,


### PR DESCRIPTION
Resolves #4709

Also changes the API of the exporters to be more flexible WRT changes in
TARGET_MAP. The old API would pre-compute a supported list at import time.
This new API includes a class method for computing support for one target
or all targets. This might improve performace for single exports, as only
the current combination of support is checked instead of the whole matrix.