### PR TITLE
Boot: Make ARMC library mutexes dynamic

### DIFF
--- a/rtos/rtx5/TARGET_CORTEX_M/rtx_lib.c
+++ b/rtos/rtx5/TARGET_CORTEX_M/rtx_lib.c
@@ -597,7 +597,7 @@ typedef void *mutex;
 // Initialize mutex
 __USED
 int _mutex_initialize(mutex *m);
-int _mutex_initialize(mutex *m) {
+__WEAK int _mutex_initialize(mutex *m) {
   *m = osMutexNew(NULL);
   if (*m == NULL) {
     osRtxErrorNotify(osRtxErrorClibMutex, m);
@@ -609,7 +609,7 @@ int _mutex_initialize(mutex *m) {
 // Acquire mutex
 __USED
 void _mutex_acquire(mutex *m);
-void _mutex_acquire(mutex *m) {
+__WEAK void _mutex_acquire(mutex *m) {
   if (os_kernel_is_active()) {
     osMutexAcquire(*m, osWaitForever);
   }
@@ -618,7 +618,7 @@ void _mutex_acquire(mutex *m) {
 // Release mutex
 __USED
 void _mutex_release(mutex *m);
-void _mutex_release(mutex *m) {
+__WEAK void _mutex_release(mutex *m) {
   if (os_kernel_is_active()) {
     osMutexRelease(*m);
   }
@@ -627,7 +627,7 @@ void _mutex_release(mutex *m) {
 // Free mutex
 __USED
 void _mutex_free(mutex *m);
-void _mutex_free(mutex *m) {
+__WEAK void _mutex_free(mutex *m) {
   osMutexDelete(*m);
 }
 

--- a/rtos/rtx5/mbed_rtx_conf.h
+++ b/rtos/rtx5/mbed_rtx_conf.h
@@ -39,6 +39,7 @@
 #define OS_DYNAMIC_MEM_SIZE         0
 
 #if defined(__CC_ARM)
+/* ARM toolchain uses up to 8 static mutexes, any further mutexes will be allocated on the heap. */
 #define OS_MUTEX_OBJ_MEM            1
 #define OS_MUTEX_NUM                8
 #endif


### PR DESCRIPTION
ARMC requires variable number of dynamic mutexes. We use combination of RTX mutex pool and heap allocation to achieve that.

## Status
**READY**

CC: @0x6d61726b @c1728p9 

Closes #4688 
