### PR TITLE
Correct DAC pin assignment

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/PeripheralPins.c
@@ -58,7 +58,7 @@ const PinMap PinMap_ADC[] = {
 //*** DAC ***
 
 const PinMap PinMap_DAC[] = {
-    {PA_4, DAC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 0, 0)}, // DAC_OUT
+    {PA_4, DAC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 1, 0)}, // DAC_OUT
     {NC,   NC,    0}
 };
 

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/PeripheralPins.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/PeripheralPins.c
@@ -64,7 +64,7 @@ const PinMap PinMap_ADC[] = {
 //*** DAC ***
 
 const PinMap PinMap_DAC[] = {
-    {PA_4, DAC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 0, 0)}, // DAC_OUT
+    {PA_4, DAC_1, STM_PIN_DATA_EXT(STM_MODE_ANALOG, GPIO_NOPULL, 0, 1, 0)}, // DAC_OUT
     {NC,   NC,    0}
 };
 


### PR DESCRIPTION
### Description
- Type: Bug
- Related issue: https://developer.mbed.org/questions/78531/DAC-error-Unknown-DAC-channel/
- Priority: Blocker

---------------------------------------------------------------
## Bug

**Target**
DISCO_L053C8
NUCLEO_L053R8

**Toolchain:**
ALL

**mbed-os sha:**
efc5c47e55b8a30c2acb366808975411e4bae7fd

Resolves #4730 

@bcostm @LMESTM Could you review?