### PR TITLE
Avoid data loss with serial interrupt used at high baudrates 

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
@@ -273,8 +273,7 @@ static void uart_irq(int id)
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
             if (__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) {
                 irq_handler(serial_irq_ids[id], RxIrq);
-                volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE flag
-                UNUSED(tmpval);
+                /*  Flag has been cleared when reading the content */
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {

--- a/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
@@ -264,10 +264,9 @@ static void uart_irq(int id)
     UART_HandleTypeDef * huart = &uart_handlers[id];
     
     if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-            if (__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET) {
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+            if (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) {
                 irq_handler(serial_irq_ids[id], TxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
@@ -418,7 +417,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         if (irq == RxIrq) {
             __HAL_UART_ENABLE_IT(huart, UART_IT_RXNE);
         } else { // TxIrq
-            __HAL_UART_ENABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
         }
         NVIC_SetVector(irq_n, vector);
         NVIC_EnableIRQ(irq_n);
@@ -432,7 +431,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
                 all_disabled = 1;
             }
         } else { // TxIrq
-            __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
             // Check if RxIrq is disabled too
             if ((huart->Instance->CR1 & USART_CR1_RXNEIE) == 0) {
                 all_disabled = 1;

--- a/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
@@ -159,10 +159,9 @@ static void uart_irq(int id)
     UART_HandleTypeDef * huart = &uart_handlers[id];
     
     if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TC) != RESET) {
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TXE) != RESET) {
                 irq_handler(serial_irq_ids[id], TxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
@@ -228,7 +227,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         if (irq == RxIrq) {
             __HAL_UART_ENABLE_IT(huart, UART_IT_RXNE);
         } else { // TxIrq
-            __HAL_UART_ENABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
         }
         NVIC_SetVector(irq_n, vector);
         NVIC_EnableIRQ(irq_n);
@@ -242,7 +241,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
                 all_disabled = 1;
             }
         } else { // TxIrq
-            __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
             // Check if RxIrq is disabled too
             if ((huart->Instance->CR1 & USART_CR1_RXNEIE) == 0) {
                 all_disabled = 1;

--- a/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
@@ -168,7 +168,7 @@ static void uart_irq(int id)
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET) {
                 irq_handler(serial_irq_ids[id], RxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
+                /*  Flag has been cleared when reading the content */
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {

--- a/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
@@ -255,7 +255,7 @@ static void uart_irq(int id)
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET) {
                 irq_handler(serial_irq_ids[id], RxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
+                /*  Flag has been cleared when reading the content */
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {

--- a/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
@@ -246,10 +246,9 @@ static void uart_irq(int id)
     UART_HandleTypeDef * huart = &uart_handlers[id];
     
     if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TC) != RESET) {
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TXE) != RESET) {
                 irq_handler(serial_irq_ids[id], TxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
@@ -385,7 +384,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         if (irq == RxIrq) {
             __HAL_UART_ENABLE_IT(huart, UART_IT_RXNE);
         } else { // TxIrq
-            __HAL_UART_ENABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
         }
             NVIC_SetVector(irq_n, vector);
             NVIC_EnableIRQ(irq_n);
@@ -399,7 +398,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
                 all_disabled = 1;
             }
         } else { // TxIrq
-            __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
             // Check if RxIrq is disabled too
             if ((huart->Instance->CR1 & USART_CR1_RXNEIE) == 0) {
                 all_disabled = 1;

--- a/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
@@ -210,10 +210,9 @@ static void uart_irq(int id)
     UART_HandleTypeDef * huart = &uart_handlers[id];
     
     if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-            if (__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET) {
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+            if (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) {
             irq_handler(serial_irq_ids[id], TxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
         }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
@@ -311,7 +310,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         if (irq == RxIrq) {
             __HAL_UART_ENABLE_IT(huart, UART_IT_RXNE);
         } else { // TxIrq
-            __HAL_UART_ENABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
         }
         NVIC_SetVector(irq_n, vector);
         NVIC_EnableIRQ(irq_n);
@@ -325,7 +324,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
                 all_disabled = 1;
             }
         } else { // TxIrq
-            __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
             // Check if RxIrq is disabled too
             if ((huart->Instance->CR1 & USART_CR1_RXNEIE) == 0) {
                 all_disabled = 1;

--- a/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
@@ -218,9 +218,8 @@ static void uart_irq(int id)
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
             if (__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) {
-            irq_handler(serial_irq_ids[id], RxIrq);
-                volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE flag
-                UNUSED(tmpval);
+                irq_handler(serial_irq_ids[id], RxIrq);
+                /*  Flag has been cleared when reading the content */
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -282,7 +282,7 @@ static void uart_irq(int id)
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET) {
                 irq_handler(serial_irq_ids[id], RxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
+                /*  Flag has been cleared when reading the content */
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -273,10 +273,9 @@ static void uart_irq(int id)
     UART_HandleTypeDef * huart = &uart_handlers[id];
     
     if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TC) != RESET) {
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TXE) != RESET) {
                 irq_handler(serial_irq_ids[id], TxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
@@ -438,7 +437,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         if (irq == RxIrq) {
             __HAL_UART_ENABLE_IT(huart, UART_IT_RXNE);
         } else { // TxIrq
-            __HAL_UART_ENABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
         }
             NVIC_SetVector(irq_n, vector);
             NVIC_EnableIRQ(irq_n);
@@ -452,7 +451,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
                 all_disabled = 1;
             }
         } else { // TxIrq
-            __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
             // Check if RxIrq is disabled too
             if ((huart->Instance->CR1 & USART_CR1_RXNEIE) == 0) {
                 all_disabled = 1;

--- a/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
@@ -238,10 +238,9 @@ static void uart_irq(int id)
     UART_HandleTypeDef * huart = &uart_handlers[id];
     
     if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-            if (__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET) {
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+            if (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) {
                 irq_handler(serial_irq_ids[id], TxIrq);
-                __HAL_UART_CLEAR_IT(huart, UART_CLEAR_TCF);
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
@@ -373,7 +372,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         if (irq == RxIrq) {
             __HAL_UART_ENABLE_IT(huart, UART_IT_RXNE);
         } else { // TxIrq
-            __HAL_UART_ENABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
         }
         NVIC_SetVector(irq_n, vector);
         NVIC_EnableIRQ(irq_n);
@@ -387,7 +386,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
                 all_disabled = 1;
             }
         } else { // TxIrq
-            __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
             // Check if RxIrq is disabled too
             if ((huart->Instance->CR1 & USART_CR1_RXNEIE) == 0) {
                 all_disabled = 1;

--- a/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
@@ -247,7 +247,7 @@ static void uart_irq(int id)
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
             if (__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) {
                 irq_handler(serial_irq_ids[id], RxIrq);
-                volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE
+                /*  Flag has been cleared when reading the content */
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {

--- a/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
@@ -201,10 +201,9 @@ static void uart_irq(int id)
     UART_HandleTypeDef * huart = &uart_handlers[id];
     
     if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-            if (__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET) {
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+            if (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) {
                 irq_handler(serial_irq_ids[id], TxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
@@ -302,7 +301,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         if (irq == RxIrq) {
             __HAL_UART_ENABLE_IT(huart, UART_IT_RXNE);
         } else { // TxIrq
-            __HAL_UART_ENABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
         }
         NVIC_SetVector(irq_n, vector);
         NVIC_EnableIRQ(irq_n);
@@ -316,7 +315,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
                 all_disabled = 1;
             }
         } else { // TxIrq
-            __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
             // Check if RxIrq is disabled too
             if ((huart->Instance->CR1 & USART_CR1_RXNEIE) == 0) {
                 all_disabled = 1;

--- a/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
@@ -210,7 +210,7 @@ static void uart_irq(int id)
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
             if (__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) {
                 irq_handler(serial_irq_ids[id], RxIrq);
-                volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE flag
+                /*  Flag has been cleared when reading the content */
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {

--- a/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
@@ -199,7 +199,7 @@ static void uart_irq(int id)
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET) {
                 irq_handler(serial_irq_ids[id], RxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
+                /*  Flag has been cleared when reading the content */
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {

--- a/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
@@ -190,10 +190,9 @@ static void uart_irq(int id)
     UART_HandleTypeDef * huart = &uart_handlers[id];
     
     if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TC) != RESET) {
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TXE) != RESET) {
                 irq_handler(serial_irq_ids[id], TxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
@@ -284,7 +283,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         if (irq == RxIrq) {
             __HAL_UART_ENABLE_IT(huart, UART_IT_RXNE);
         } else { // TxIrq
-            __HAL_UART_ENABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
         }
         NVIC_SetVector(irq_n, vector);
         NVIC_EnableIRQ(irq_n);
@@ -298,7 +297,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
                 all_disabled = 1;
             }
         } else { // TxIrq
-            __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
             // Check if RxIrq is disabled too
             if ((huart->Instance->CR1 & USART_CR1_RXNEIE) == 0) {
                 all_disabled = 1;

--- a/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
@@ -217,10 +217,9 @@ static void uart_irq(int id)
     UART_HandleTypeDef * huart = &uart_handlers[id];
     
     if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TC) != RESET) {
-            if (__HAL_UART_GET_IT(huart, UART_IT_TC) != RESET) {
-            irq_handler(serial_irq_ids[id], TxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+            if (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) {
+                irq_handler(serial_irq_ids[id], TxIrq);
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
@@ -330,7 +329,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         if (irq == RxIrq) {
             __HAL_UART_ENABLE_IT(huart, UART_IT_RXNE);
         } else { // TxIrq
-            __HAL_UART_ENABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
         }
         NVIC_SetVector(irq_n, vector);
         NVIC_EnableIRQ(irq_n);
@@ -344,7 +343,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
                 all_disabled = 1;
             }
         } else { // TxIrq
-            __HAL_UART_DISABLE_IT(huart, UART_IT_TC);
+            __HAL_UART_DISABLE_IT(huart, UART_IT_TXE);
             // Check if RxIrq is disabled too
             if ((huart->Instance->CR1 & USART_CR1_RXNEIE) == 0) {
                 all_disabled = 1;

--- a/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
@@ -225,8 +225,8 @@ static void uart_irq(int id)
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
             if (__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) {
-            irq_handler(serial_irq_ids[id], RxIrq);
-                __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
+                irq_handler(serial_irq_ids[id], RxIrq);
+                /*  Flag has been cleared when reading the content */
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {


### PR DESCRIPTION
## Description
There was a hidden  bug in the uart irq handler that was seen when reaching high baud rates as described in details in #4722 .  The RXE flags shouldn't be erased in the uart_irq as erasing the flag is actually done when reading the data in the data register. At low baudrate, this has usually not effect, but at igh baud rates, this can actually erase a new newly arrived data, not yet read by application. This would cause data loss at application layer.

The 2nd commit of this PR consist in using TXE (room in byte FIFO for posting next data) flag instead of TC (transmission complete), in order to improve overall performance. Also this is now in line with TxIrq definition from SerialBAse.h : TxIrq for transmit buffer empty

## Status
**READY**

## Related PRs
Dependency to #4707 
- [x] The #4707 needs to be merged before this PR (which will need rebase) => OK, MERGED 

## Testing
- [ ] Tests
This has been tested by @RobMeades in the scope of #4722 
Unfortunately I could not find mbed tests for checking serial interrupt - this would be good enhancement on test side.