### PR TITLE
NRF52832: Extend idle thread stack size to 512 bytes.

### DIFF
--- a/targets/TARGET_NORDIC/mbed_rtx.h
+++ b/targets/TARGET_NORDIC/mbed_rtx.h
@@ -37,6 +37,8 @@
 #define INITIAL_SP              (0x20010000UL)
 #endif
 
+#define OS_IDLE_THREAD_STACK_SIZE  512
+
 #elif defined(TARGET_MCU_NRF52840)
 
 #ifndef INITIAL_SP


### PR DESCRIPTION
## Description
Fix a crash where the idle thread stack size overflows. This crash
was depending on the compiler and standard library used.

## Status
**READY**

## Migrations
NO


