### PR TITLE
Deprecate unsupported exporters

### DIFF
--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -57,8 +57,6 @@ EXPORTERS = {
     'eclipse_armc5'    : cdt.EclipseArmc5,
     'gnuarmeclipse': gnuarmeclipse.GNUARMEclipse,
     'qtcreator': qtcreator.QtCreator,
-    'zip' : zip.ZIP,
-    'cmsis'    : cmsis.CMSIS,
     'vscode_gcc_arm' : vscode.VSCodeGcc,
     'vscode_iar' : vscode.VSCodeIAR,
     'vscode_armc5' : vscode.VSCodeArmc5

--- a/tools/export/atmelstudio/__init__.py
+++ b/tools/export/atmelstudio/__init__.py
@@ -17,9 +17,10 @@ limitations under the License.
 import uuid
 from os.path import splitext, basename, dirname
 
-from tools.export.exporters import Exporter
+from tools.export.exporters import Exporter, deprecated_exporter
 
 
+@deprecated_exporter
 class AtmelStudio(Exporter):
     NAME = 'AtmelStudio'
     TOOLCHAIN = 'GCC_ARM'
@@ -35,6 +36,10 @@ class AtmelStudio(Exporter):
     DOT_IN_RELATIVE_PATH = True
 
     MBED_CONFIG_HEADER_SUPPORTED = True
+
+    @classmethod
+    def is_target_supported(cls, maybe_supported):
+        return maybe_supported in cls.TARGETS
 
     def generate(self):
 

--- a/tools/export/coide/__init__.py
+++ b/tools/export/coide/__init__.py
@@ -16,9 +16,10 @@ limitations under the License.
 """
 from os.path import splitext, basename
 
-from tools.export.exporters import Exporter
+from tools.export.exporters import Exporter, deprecated_exporter
 
 
+@deprecated_exporter
 class CoIDE(Exporter):
     NAME = 'CoIDE'
     TOOLCHAIN = 'GCC_ARM'

--- a/tools/export/e2studio/__init__.py
+++ b/tools/export/e2studio/__init__.py
@@ -16,8 +16,9 @@ limitations under the License.
 """
 from os.path import splitext, basename
 
-from tools.export.exporters import Exporter
+from tools.export.exporters import Exporter, deprecated_exporter
 
+@deprecated_exporter
 class E2Studio(Exporter):
     NAME = 'e2 studio'
     TOOLCHAIN = 'GCC_ARM'

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -25,6 +25,18 @@ class ExporterTargetsProperty(object):
     def __get__(self, inst, cls):
         return self.func(cls)
 
+def deprecated_exporter(CLS):
+    old_init = CLS.__init__
+    old_name = CLS.NAME
+    def __init__(*args, **kwargs):
+        print("==================== DEPRECATION NOTICE ====================")
+        print("The exporter %s is no longer maintained, and deprecated." % old_name)
+        print("%s will be removed from mbed OS for the mbed OS 5.6 release." % old_name)
+        old_init(*args, **kwargs)
+    CLS.__init__ = __init__
+    CLS.NAME = "%s (DEPRECATED)" % old_name
+    return CLS
+
 class Exporter(object):
     """Exporter base class
 

--- a/tools/export/kds/__init__.py
+++ b/tools/export/kds/__init__.py
@@ -16,9 +16,10 @@ limitations under the License.
 """
 from os.path import splitext, basename
 
-from tools.export.exporters import Exporter
+from tools.export.exporters import Exporter, deprecated_exporter
 
 
+@deprecated_exporter
 class KDS(Exporter):
     NAME = 'Kinetis Design Studio'
     TOOLCHAIN = 'GCC_ARM'

--- a/tools/export/lpcxpresso/__init__.py
+++ b/tools/export/lpcxpresso/__init__.py
@@ -16,8 +16,9 @@ limitations under the License.
 """
 from os.path import splitext, basename
 
-from tools.export.exporters import Exporter
+from tools.export.exporters import Exporter, deprecated_exporter
 
+@deprecated_exporter
 class LPCXpresso(Exporter):
     NAME = 'LPCXpresso'
     TOOLCHAIN = 'GCC_ARM'

--- a/tools/export/simplicity/__init__.py
+++ b/tools/export/simplicity/__init__.py
@@ -16,7 +16,7 @@ limitations under the License.
 """
 from os.path import split,splitext, basename
 
-from tools.export.exporters import Exporter
+from tools.export.exporters import Exporter, deprecated_exporter
 
 class Folder:
     def __init__(self, name):
@@ -54,6 +54,7 @@ class Folder:
 
         return self.findChild(folderName)
 
+@deprecated_exporter
 class SimplicityV3(Exporter):
     NAME = 'SimplicityV3'
     TOOLCHAIN = 'GCC_ARM'


### PR DESCRIPTION
These exporters are planned for removal in mbed OS 5.6. To keep an exporter
around, a pull request to remove one of the "Deprecate *" commits should be
submitted against mbed-os along with an update to that exporer to make it
better conform to the best practices of an exporter from the
"adding exporters" documentation. For your convinience, the applicable section
is reproduced below:
> For the best user experience, an exporter:
> - Takes input from the resource scan.
> - Uses the flags in the build profiles.
> - Has a single template file for each file type they produce. For example, an eclipse CDT project would have one template for `.project` files and one for `.cproject` files.
> - Does not call mbed CLI. It is possible to export from the website, which will not include mbed CLI in the resulting zip.